### PR TITLE
fix(twitch): channel status keeps reporting connected after the chat transport drops

### DIFF
--- a/extensions/twitch/src/monitor.status.test.ts
+++ b/extensions/twitch/src/monitor.status.test.ts
@@ -1,0 +1,110 @@
+// Twitch tests cover the monitor transport-status bridge behavior.
+import { describe, expect, it, vi } from "vitest";
+import type { TwitchAccountConfig } from "./types.js";
+
+const hoisted = vi.hoisted(() => {
+  const connectionHandlers: Array<(status: { connected: boolean; reason?: string }) => void> = [];
+  return {
+    connectionHandlers,
+    getClient: vi.fn(async () => ({})),
+    onMessage: vi.fn(() => () => {}),
+    onConnectionChange: vi.fn(
+      (_account: unknown, handler: (status: { connected: boolean; reason?: string }) => void) => {
+        connectionHandlers.push(handler);
+        return () => {};
+      },
+    ),
+  };
+});
+
+vi.mock("./client-manager-registry.js", () => ({
+  getOrCreateClientManager: () => ({
+    getClient: hoisted.getClient,
+    onMessage: hoisted.onMessage,
+    onConnectionChange: hoisted.onConnectionChange,
+  }),
+}));
+
+vi.mock("./runtime.js", () => ({
+  getTwitchRuntime: () => ({
+    logging: {
+      getChildLogger: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      }),
+      shouldLogVerbose: () => false,
+    },
+  }),
+}));
+
+const { monitorTwitchProvider } = await import("./monitor.js");
+
+function buildAccount(): TwitchAccountConfig {
+  return {
+    username: "testbot",
+    accessToken: "oauth:test-token",
+    clientId: "test-client-id",
+    channel: "testchannel",
+    enabled: true,
+  };
+}
+
+describe("monitorTwitchProvider transport-status bridge", () => {
+  it("emits connected on start and forwards ChatClient disconnects to the status sink", async () => {
+    const patches: Array<Record<string, unknown>> = [];
+    const abort = new AbortController();
+
+    const { stop } = await monitorTwitchProvider({
+      account: buildAccount(),
+      accountId: "default",
+      config: {},
+      runtime: { error: vi.fn() } as never,
+      abortSignal: abort.signal,
+      statusSink: (patch) => patches.push({ ...patch }),
+    });
+
+    // getClient resolving marks the transport connected.
+    expect(patches.some((patch) => patch.connected === true)).toBe(true);
+    expect(hoisted.onConnectionChange).toHaveBeenCalledOnce();
+
+    // A persistent ChatClient disconnect flows through onConnectionChange.
+    hoisted.connectionHandlers.at(-1)?.({ connected: false, reason: "connection reset" });
+    const dropped = patches.at(-1);
+    expect(dropped?.connected).toBe(false);
+    expect(dropped?.lastError).toBe("connection reset");
+    // We intentionally do not publish lastTransportActivityAt (would trip the
+    // health monitor's stale-socket restart without a real heartbeat).
+    expect(dropped).not.toHaveProperty("lastTransportActivityAt");
+
+    stop();
+  });
+
+  it("clears the prior disconnect error when the transport reconnects", async () => {
+    const patches: Array<Record<string, unknown>> = [];
+    const abort = new AbortController();
+
+    const { stop } = await monitorTwitchProvider({
+      account: buildAccount(),
+      accountId: "default",
+      config: {},
+      runtime: { error: vi.fn() } as never,
+      abortSignal: abort.signal,
+      statusSink: (patch) => patches.push({ ...patch }),
+    });
+    const notify = hoisted.connectionHandlers.at(-1);
+
+    // Drop the transport (records an error), then reconnect.
+    notify?.({ connected: false, reason: "connection reset" });
+    expect(patches.at(-1)?.lastError).toBe("connection reset");
+
+    notify?.({ connected: true });
+    // Status patches merge, so the reconnect must explicitly null out the error.
+    const reconnected = patches.at(-1);
+    expect(reconnected?.connected).toBe(true);
+    expect(reconnected?.lastError).toBe(null);
+
+    stop();
+  });
+});

--- a/extensions/twitch/src/monitor.status.test.ts
+++ b/extensions/twitch/src/monitor.status.test.ts
@@ -107,4 +107,33 @@ describe("monitorTwitchProvider transport-status bridge", () => {
 
     stop();
   });
+
+  it("preserves the auth-failure error across Twurple's reasonless retry disconnect", async () => {
+    const patches: Array<Record<string, unknown>> = [];
+    const abort = new AbortController();
+
+    const { stop } = await monitorTwitchProvider({
+      account: buildAccount(),
+      accountId: "default",
+      config: {},
+      runtime: { error: vi.fn() } as never,
+      abortSignal: abort.signal,
+      statusSink: (patch) => patches.push({ ...patch }),
+    });
+    const notify = hoisted.connectionHandlers.at(-1);
+
+    // onAuthenticationFailure surfaces the auth error as disconnected+error.
+    notify?.({ connected: false, reason: "Login authentication failed" });
+    expect(patches.at(-1)?.lastError).toBe("Login authentication failed");
+
+    // Twurple's auth-retry immediately fires a reasonless manual onDisconnect
+    // (reconnect = quit()+connect()). Its patch must omit lastError so the merge
+    // preserves the auth-failure text rather than nulling it out.
+    notify?.({ connected: false });
+    const retryDrop = patches.at(-1);
+    expect(retryDrop?.connected).toBe(false);
+    expect(retryDrop).not.toHaveProperty("lastError");
+
+    stop();
+  });
 });

--- a/extensions/twitch/src/monitor.ts
+++ b/extensions/twitch/src/monitor.ts
@@ -279,13 +279,21 @@ export async function monitorTwitchProvider(
     if (stopped) {
       return;
     }
-    statusSink?.({
-      connected: status.connected,
+    if (status.connected) {
       // Runtime status patches merge, so clear the prior disconnect error on
       // reconnect; otherwise a recovered transport keeps surfacing a stale
       // lastError in the channel summary and status issues.
-      lastError: status.connected ? null : (status.reason ?? null),
-    });
+      statusSink?.({ connected: true, lastError: null });
+      return;
+    }
+    // Surface the reason when Twurple gives one (transport error or auth
+    // failure). Twurple's auth-retry path fires a reasonless manual onDisconnect
+    // right after onAuthenticationFailure, so omit lastError on a reasonless
+    // disconnect (patch-merge preserves it) — otherwise that follow-up close
+    // would erase the auth-failure text we just surfaced.
+    statusSink?.(
+      status.reason ? { connected: false, lastError: status.reason } : { connected: false },
+    );
   });
 
   const unregisterHandler = clientManager.onMessage(account, (message) => {

--- a/extensions/twitch/src/monitor.ts
+++ b/extensions/twitch/src/monitor.ts
@@ -20,13 +20,21 @@ export type TwitchRuntimeEnv = {
   error?: (message: string) => void;
 };
 
+/** Runtime status patch emitted by the monitor to the channel status sink. */
+export type TwitchStatusPatch = {
+  lastInboundAt?: number;
+  lastOutboundAt?: number;
+  connected?: boolean;
+  lastError?: string | null;
+};
+
 export type TwitchMonitorOptions = {
   account: TwitchAccountConfig;
   accountId: string;
   config: unknown; // OpenClawConfig
   runtime: TwitchRuntimeEnv;
   abortSignal: AbortSignal;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: (patch: TwitchStatusPatch) => void;
 };
 
 export type TwitchMonitorResult = {
@@ -45,7 +53,7 @@ async function processTwitchMessage(params: {
   config: unknown;
   runtime: TwitchRuntimeEnv;
   core: TwitchCoreRuntime;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: (patch: TwitchStatusPatch) => void;
 }): Promise<void> {
   const { message, account, accountId, config, runtime, core, statusSink } = params;
   const cfg = config as OpenClawConfig;
@@ -257,6 +265,29 @@ export async function monitorTwitchProvider(
     throw error;
   }
 
+  // getClient resolves once the initial handshake succeeds; the persistent
+  // ChatClient listeners below then track later reconnects/disconnects so the
+  // channel status and the shared health monitor (via `connected`) reflect the
+  // live transport. We deliberately do not publish `lastTransportActivityAt`:
+  // Twurple has no exposed heartbeat here, so a one-shot connect timestamp would
+  // age and trip the health monitor's stale-socket restart on a quiet-but-healthy
+  // account (see channel-health-policy.ts). `connected: false` is what drives
+  // dead-transport recovery.
+  statusSink?.({ connected: true, lastError: null });
+
+  const unregisterConnection = clientManager.onConnectionChange(account, (status) => {
+    if (stopped) {
+      return;
+    }
+    statusSink?.({
+      connected: status.connected,
+      // Runtime status patches merge, so clear the prior disconnect error on
+      // reconnect; otherwise a recovered transport keeps surfacing a stale
+      // lastError in the channel summary and status issues.
+      lastError: status.connected ? null : (status.reason ?? null),
+    });
+  });
+
   const unregisterHandler = clientManager.onMessage(account, (message) => {
     if (stopped) {
       return;
@@ -297,6 +328,7 @@ export async function monitorTwitchProvider(
   const stop = () => {
     stopped = true;
     unregisterHandler();
+    unregisterConnection();
   };
 
   abortSignal.addEventListener("abort", stop, { once: true });

--- a/extensions/twitch/src/plugin.lifecycle.test.ts
+++ b/extensions/twitch/src/plugin.lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TwitchStatusPatch } from "./monitor.js";
 import type { TwitchAccountConfig } from "./types.js";
 
 const hoisted = vi.hoisted(() => ({
@@ -101,5 +102,58 @@ describe("twitch startAccount lifecycle", () => {
     await expect(task).rejects.toThrow("irc join failed");
     expectLifecyclePatch(patches, { running: true });
     expectLifecyclePatch(patches, { running: false });
+  });
+
+  it("marks the account disconnected on a transport drop while keeping running true", async () => {
+    const patches: ChannelAccountSnapshot[] = [];
+    hoisted.monitorTwitchProvider.mockImplementation(
+      async (options: { statusSink?: (patch: TwitchStatusPatch) => void }) => {
+        // Simulate the persistent ChatClient reporting a post-handshake drop.
+        options.statusSink?.({ connected: false, lastError: "connection reset" });
+        return { stop: vi.fn() };
+      },
+    );
+
+    const abort = new AbortController();
+    const task = requireStartAccount()(
+      createStartAccountContext({
+        account: buildAccount(),
+        abortSignal: abort.signal,
+        statusPatchSink: (next) => patches.push({ ...next }),
+      }),
+    );
+    // Let the monitor's synchronous statusSink patch land, then unblock the
+    // abort-pending startAccount task.
+    await Promise.resolve();
+    abort.abort();
+    await task;
+
+    // `running` is owned by the monitor lifecycle: the disconnect must not clear
+    // it, only the transport `connected` flag (mirrors qqbot #100127).
+    expectLifecyclePatch(patches, { running: true, connected: false });
+    expectLifecyclePatch(patches, { connected: false, lastError: "connection reset" });
+    expect(patches.every((patch) => patch.running !== false)).toBe(true);
+  });
+
+  it("surfaces connected in the channel status summary", () => {
+    const buildChannelSummary = twitchPlugin.status?.buildChannelSummary;
+    if (!buildChannelSummary) {
+      throw new Error("Expected Twitch status.buildChannelSummary");
+    }
+
+    const summary = buildChannelSummary({
+      snapshot: {
+        accountId: "default",
+        configured: true,
+        running: true,
+        connected: false,
+        lastError: "connection reset",
+      },
+    } as Parameters<typeof buildChannelSummary>[0]);
+
+    expect(summary).toMatchObject({
+      running: true,
+      connected: false,
+    });
   });
 });

--- a/extensions/twitch/src/plugin.ts
+++ b/extensions/twitch/src/plugin.ts
@@ -155,7 +155,12 @@ export const twitchPlugin: ChannelPlugin<ResolvedTwitchAccount> =
       },
       status: createComputedAccountStatusAdapter<ResolvedTwitchAccount>({
         defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID),
-        buildChannelSummary: ({ snapshot }) => buildPassiveProbedChannelStatusSummary(snapshot),
+        buildChannelSummary: ({ snapshot }) =>
+          // `running` tracks the monitor lifecycle; `connected` tracks the live
+          // ChatClient transport so a post-handshake disconnect stays visible.
+          buildPassiveProbedChannelStatusSummary(snapshot, {
+            connected: snapshot.connected ?? false,
+          }),
         probeAccount: async ({ account, timeoutMs }) => await probeTwitch(account, timeoutMs),
         collectStatusIssues: collectTwitchStatusIssues,
         resolveAccountSnapshot: ({ account, cfg }) => {
@@ -177,6 +182,7 @@ export const twitchPlugin: ChannelPlugin<ResolvedTwitchAccount> =
           ctx.setStatus?.({
             accountId,
             running: true,
+            connected: false,
             lastStartAt: Date.now(),
             lastError: null,
           });
@@ -198,6 +204,7 @@ export const twitchPlugin: ChannelPlugin<ResolvedTwitchAccount> =
                   config: ctx.cfg,
                   runtime: ctx.runtime,
                   abortSignal: ctx.abortSignal,
+                  statusSink: (patch) => ctx.setStatus?.({ accountId, ...patch }),
                 });
               },
             });

--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -202,8 +202,10 @@ describe("TwitchClientManager", () => {
       await Promise.resolve();
 
       expect(mockConnect).toHaveBeenCalledTimes(1);
-      expect(authSuccessHandlers).toHaveLength(1);
-      authSuccessHandlers[0]?.();
+      // setupClientHandlers registers the persistent readiness listener first,
+      // then connectClient adds the connect-phase resolver last.
+      expect(authSuccessHandlers).toHaveLength(2);
+      authSuccessHandlers.at(-1)?.();
 
       const [client1, client2] = await Promise.all([first, second]);
       expect(client1).toBe(client2);
@@ -214,7 +216,7 @@ describe("TwitchClientManager", () => {
 
       const connection = manager.getClient(testAccount);
       await Promise.resolve();
-      authFailureHandlers[0]?.("bad token", 1);
+      authFailureHandlers.at(-1)?.("bad token", 1);
 
       let settled = false;
       void connection.then(
@@ -237,7 +239,7 @@ describe("TwitchClientManager", () => {
       await Promise.resolve();
       expect(settled).toBe(false);
 
-      authSuccessHandlers[0]?.();
+      authSuccessHandlers.at(-1)?.();
       await expect(connection).resolves.toBeTruthy();
     });
 
@@ -246,7 +248,7 @@ describe("TwitchClientManager", () => {
 
       const connection = manager.getClient(testAccount);
       await Promise.resolve();
-      authFailureHandlers[0]?.("bad token", 1);
+      authFailureHandlers.at(-1)?.("bad token", 1);
       // Connect-phase listener is the last registered (see note above).
       disconnectHandlers.at(-1)?.(true);
 
@@ -260,7 +262,7 @@ describe("TwitchClientManager", () => {
       await Promise.resolve();
 
       await manager.disconnectAll();
-      authSuccessHandlers[0]?.();
+      authSuccessHandlers.at(-1)?.();
 
       await expect(connection).rejects.toThrow("Twitch connection cancelled");
       expect(mockQuit).toHaveBeenCalledTimes(2);
@@ -503,7 +505,7 @@ describe("TwitchClientManager", () => {
 
       const key = manager.getAccountKey(testAccount);
       expect((manager as any).messageHandlers.has(key)).toBe(false);
-      authSuccessHandlers[0]?.();
+      authSuccessHandlers.at(-1)?.();
       await expect(connection).rejects.toThrow("Twitch connection cancelled");
 
       messageHandlers[0]?.("#testchannel", "testuser", "stale", {
@@ -810,9 +812,10 @@ describe("TwitchClientManager", () => {
       const statuses: Array<{ connected: boolean; reason?: string }> = [];
       manager.onConnectionChange(testAccount, (status) => statuses.push(status));
 
-      // The persistent listeners registered in setupClientHandlers survive the
-      // connect handshake, so a later ChatClient disconnect still fires.
-      for (const handler of connectHandlers) {
+      // Readiness, not raw transport: the persistent listener drives
+      // connected:true from auth success (survives the connect handshake), so a
+      // later ChatClient disconnect still fires.
+      for (const handler of authSuccessHandlers) {
         handler();
       }
       expect(statuses.at(-1)).toEqual({ connected: true });
@@ -822,6 +825,25 @@ describe("TwitchClientManager", () => {
       }
       expect(statuses.at(-1)?.connected).toBe(false);
       expect(statuses.at(-1)?.reason).toContain("connection reset");
+    });
+
+    it("does not report healthy on raw transport connect before auth", async () => {
+      await manager.getClient(testAccount);
+      const statuses: Array<{ connected: boolean; reason?: string }> = [];
+      manager.onConnectionChange(testAccount, (status) => statuses.push(status));
+
+      // Twurple fires onConnect on socket open before authentication. Liveness
+      // must not wire onConnect, or a reconnect whose auth later fails would
+      // latch connected:true (false healthy). Prove no onConnect listener owns
+      // the connection status, then that a failed reconnect auth surfaces error.
+      expect(connectHandlers).toHaveLength(0);
+      for (const handler of authFailureHandlers) {
+        handler("Login authentication failed", 1);
+      }
+      expect(statuses.at(-1)).toEqual({
+        connected: false,
+        reason: "Login authentication failed",
+      });
     });
 
     it("stops notifying once the registration is removed", async () => {

--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -31,6 +31,7 @@ const messageHandlers: Array<(channel: string, user: string, message: string, ms
 const authSuccessHandlers: Array<() => void> = [];
 const authFailureHandlers: Array<(text: string, retryCount: number) => void> = [];
 const disconnectHandlers: Array<(manual: boolean, reason?: Error) => void> = [];
+const connectHandlers: Array<() => void> = [];
 
 // Mock functions that track handlers and return unbind objects
 const mockOnMessage = vi.fn((handler: any) => {
@@ -49,6 +50,10 @@ const mockOnDisconnect = vi.fn((handler: (manual: boolean, reason?: Error) => vo
   disconnectHandlers.push(handler);
   return { unbind: mockUnbind };
 });
+const mockOnConnect = vi.fn((handler: () => void) => {
+  connectHandlers.push(handler);
+  return { unbind: mockUnbind };
+});
 
 const mockAddUserForToken = vi.fn().mockResolvedValue("123456");
 const mockOnRefresh = vi.fn();
@@ -60,6 +65,7 @@ vi.mock("@twurple/chat", () => ({
     onAuthenticationSuccess = mockOnAuthenticationSuccess;
     onAuthenticationFailure = mockOnAuthenticationFailure;
     onDisconnect = mockOnDisconnect;
+    onConnect = mockOnConnect;
     connect = mockConnect;
     join = mockJoin;
     say = mockSay;
@@ -133,6 +139,7 @@ describe("TwitchClientManager", () => {
     authSuccessHandlers.length = 0;
     authFailureHandlers.length = 0;
     disconnectHandlers.length = 0;
+    connectHandlers.length = 0;
 
     // Re-set up the default token mock implementation after clearing
     resolveTwitchTokenMock.mockReturnValue({
@@ -224,7 +231,9 @@ describe("TwitchClientManager", () => {
         "Twitch authentication failed for testbot; waiting for retry, disconnect, or timeout: bad token",
       );
 
-      disconnectHandlers[0]?.(false, new Error("disconnected"));
+      // The connect-phase listener is registered last (setupClientHandlers adds
+      // the persistent liveness listener first), so target the most recent one.
+      disconnectHandlers.at(-1)?.(false, new Error("disconnected"));
       await Promise.resolve();
       expect(settled).toBe(false);
 
@@ -238,7 +247,8 @@ describe("TwitchClientManager", () => {
       const connection = manager.getClient(testAccount);
       await Promise.resolve();
       authFailureHandlers[0]?.("bad token", 1);
-      disconnectHandlers[0]?.(true);
+      // Connect-phase listener is the last registered (see note above).
+      disconnectHandlers.at(-1)?.(true);
 
       await expect(connection).rejects.toThrow("Twitch connection cancelled");
     });
@@ -791,6 +801,39 @@ describe("TwitchClientManager", () => {
       // Note: The implementation doesn't handle concurrent getClient calls,
       // so multiple connections may be created. This is expected behavior.
       expect(mockConnect).toHaveBeenCalled();
+    });
+  });
+
+  describe("onConnectionChange (transport liveness)", () => {
+    it("notifies connected:false on a post-handshake disconnect", async () => {
+      await manager.getClient(testAccount);
+      const statuses: Array<{ connected: boolean; reason?: string }> = [];
+      manager.onConnectionChange(testAccount, (status) => statuses.push(status));
+
+      // The persistent listeners registered in setupClientHandlers survive the
+      // connect handshake, so a later ChatClient disconnect still fires.
+      for (const handler of connectHandlers) {
+        handler();
+      }
+      expect(statuses.at(-1)).toEqual({ connected: true });
+
+      for (const handler of disconnectHandlers) {
+        handler(false, new Error("connection reset"));
+      }
+      expect(statuses.at(-1)?.connected).toBe(false);
+      expect(statuses.at(-1)?.reason).toContain("connection reset");
+    });
+
+    it("stops notifying once the registration is removed", async () => {
+      await manager.getClient(testAccount);
+      const statuses: Array<{ connected: boolean }> = [];
+      const unregister = manager.onConnectionChange(testAccount, (status) => statuses.push(status));
+
+      unregister();
+      for (const handler of disconnectHandlers) {
+        handler(false, new Error("ignored"));
+      }
+      expect(statuses).toHaveLength(0);
     });
   });
 });

--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -10,6 +10,9 @@ import { normalizeToken } from "./utils/twitch.js";
 
 const TWITCH_CHAT_AUTH_INTENTS = ["chat"];
 
+/** Transport-liveness change emitted to the channel status sink. */
+export type TwitchConnectionStatus = { connected: boolean; reason?: string };
+
 /**
  * Manages Twitch chat client connections
  */
@@ -19,6 +22,8 @@ export class TwitchClientManager {
   private connectionPromises = new Map<string, Promise<ChatClient>>();
   private messageHandlers = new Map<string, (message: TwitchChatMessage) => void>();
   private messageHandlerTokens = new Map<string, symbol>();
+  private connectionHandlers = new Map<string, (status: TwitchConnectionStatus) => void>();
+  private connectionHandlerTokens = new Map<string, symbol>();
 
   constructor(private logger: ChannelLogSink) {}
 
@@ -296,6 +301,21 @@ export class TwitchClientManager {
       }
     });
 
+    // Persistent transport-liveness listeners. These are separate from the
+    // connect-phase handshake listeners in connectClient(), which unbind once
+    // auth settles; without a listener that survives the handshake, a later
+    // ChatClient disconnect leaves channel status stuck reporting connected and
+    // the shared health monitor never sees the dead transport.
+    client.onConnect(() => {
+      this.connectionHandlers.get(key)?.({ connected: true });
+    });
+    client.onDisconnect((_manually, reason) => {
+      this.connectionHandlers.get(key)?.({
+        connected: false,
+        reason: reason ? formatErrorMessage(reason) : undefined,
+      });
+    });
+
     this.logger.info(`Set up handlers for ${key}`);
   }
 
@@ -321,9 +341,32 @@ export class TwitchClientManager {
     };
   }
 
-  private clearMessageHandler(key: string): void {
+  /**
+   * Subscribe to transport connection changes for an account.
+   * @returns A function that removes the registration when called.
+   */
+  onConnectionChange(
+    account: TwitchAccountConfig,
+    handler: (status: TwitchConnectionStatus) => void,
+  ): () => void {
+    const key = this.getAccountKey(account);
+    const token = Symbol(key);
+    this.connectionHandlers.set(key, handler);
+    this.connectionHandlerTokens.set(key, token);
+    return () => {
+      // Only remove the exact registration this cleanup closure owns.
+      if (this.connectionHandlerTokens.get(key) === token) {
+        this.connectionHandlers.delete(key);
+        this.connectionHandlerTokens.delete(key);
+      }
+    };
+  }
+
+  private clearAccountHandlers(key: string): void {
     this.messageHandlers.delete(key);
     this.messageHandlerTokens.delete(key);
+    this.connectionHandlers.delete(key);
+    this.connectionHandlerTokens.delete(key);
   }
 
   /**
@@ -338,13 +381,13 @@ export class TwitchClientManager {
       pendingClient.quit();
       this.pendingClients.delete(key);
       this.connectionPromises.delete(key);
-      this.clearMessageHandler(key);
+      this.clearAccountHandlers(key);
     }
 
     if (client) {
       client.quit();
       this.clients.delete(key);
-      this.clearMessageHandler(key);
+      this.clearAccountHandlers(key);
       this.logger.info(`Disconnected ${key}`);
     }
   }
@@ -360,6 +403,8 @@ export class TwitchClientManager {
     this.clients.clear();
     this.messageHandlers.clear();
     this.messageHandlerTokens.clear();
+    this.connectionHandlers.clear();
+    this.connectionHandlerTokens.clear();
     this.logger.info(" Disconnected all clients");
   }
 
@@ -407,5 +452,7 @@ export class TwitchClientManager {
     this.pendingClients.clear();
     this.connectionPromises.clear();
     this.messageHandlers.clear();
+    this.connectionHandlers.clear();
+    this.connectionHandlerTokens.clear();
   }
 }

--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -301,13 +301,22 @@ export class TwitchClientManager {
       }
     });
 
-    // Persistent transport-liveness listeners. These are separate from the
-    // connect-phase handshake listeners in connectClient(), which unbind once
-    // auth settles; without a listener that survives the handshake, a later
-    // ChatClient disconnect leaves channel status stuck reporting connected and
-    // the shared health monitor never sees the dead transport.
-    client.onConnect(() => {
+    // Persistent readiness listeners. These are separate from the connect-phase
+    // handshake listeners in connectClient(), which unbind once auth settles;
+    // without a listener that survives the handshake, a later ChatClient
+    // disconnect leaves channel status stuck reporting connected and the shared
+    // health monitor never sees the dead transport.
+    //
+    // Gate connected on auth readiness, not raw transport: Twurple fires
+    // onConnect on socket open before authentication/registration, so a
+    // reconnect whose auth then fails would latch connected:true (false
+    // healthy). Mirror the connect-phase handshake by driving connected:true
+    // from onAuthenticationSuccess and surfacing auth failures as disconnected.
+    client.onAuthenticationSuccess(() => {
       this.connectionHandlers.get(key)?.({ connected: true });
+    });
+    client.onAuthenticationFailure((text) => {
+      this.connectionHandlers.get(key)?.({ connected: false, reason: text });
     });
     client.onDisconnect((_manually, reason) => {
       this.connectionHandlers.get(key)?.({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Twitch channel keeps reporting a live connection after
its chat transport has actually dropped. Once the initial connection succeeds,
`openclaw channels status` (and the Control UI) shows the account as running
indefinitely even if the underlying chat socket is later disconnected by a
network blip, a Twitch-side close, or a failed auto-reconnect. Because the
channel never reported a transport-level `connected` state, the shared channel
health monitor also could not detect the dead transport to restart it, so a
silently disconnected Twitch account would stay dark with no operator signal.

## Why This Change Was Made

Twitch set `running: true` on start but only cleared status on a connect-time
failure or a manual stop; the sole `onDisconnect` listener lived inside the
connect handshake and unbound as soon as authentication settled, so no listener
survived to observe a later disconnect. This change registers a persistent set
of readiness listeners on the chat client and feeds a distinct `connected` flag
through the monitor's status sink, surfacing it in the channel status summary.

`connected: true` is gated on authentication readiness, not raw transport.
Twurple fires `onConnect` on socket open *before* authentication/registration,
so wiring liveness to `onConnect` would let a reconnect whose auth then fails
latch `connected: true` (a false healthy signal during an auth-failing
reconnect). Instead the persistent listener drives `connected: true` from
`onAuthenticationSuccess`, reports `onAuthenticationFailure` as
`connected: false` with the failure text, and keeps the `onDisconnect` →
`connected: false` path — mirroring the connect-phase handshake, which already
resolves on auth success and treats auth failure / disconnect as not-ready.

Because Twurple's auth-retry immediately reconnects (`quit()` + `connect()`), it
fires a reasonless manual `onDisconnect` right after `onAuthenticationFailure`.
The monitor's status sink previously mapped any reasonless disconnect to
`lastError: null`, which would erase the auth-failure text almost immediately; it
now omits `lastError` on a reasonless disconnect (patch-merge preserves the prior
error) and only clears it on `connected: true`. On a successful (re)connect the
sink clears `lastError` (runtime status patches merge, so a recovered transport
would otherwise keep surfacing the previous error). `running` is deliberately left owned by the monitor lifecycle and stays
`true` across transient reconnects — the same split the qqbot channel adopted in
#100127. This gives the shared health monitor (`evaluateChannelHealth`) the
`connected: false` signal it needs to notice and recover a dead Twitch transport.

The change deliberately does not publish `lastTransportActivityAt`: Twurple
exposes no heartbeat here, and the health monitor only runs its stale-socket
restart when `connected` is true *and* `lastTransportActivityAt` is set, so a
one-shot connect timestamp would age out and restart a quiet-but-healthy Twitch
account. Dead-transport recovery is driven by `connected: false` alone.

The other bundled channels (Discord, Slack, Mattermost, Feishu, Matrix,
WhatsApp, Telegram, and the webhook-based channels) already clear their
connection status on transport close, and the probe-based channels compute
liveness on demand — Twitch was the remaining channel that latched a live
status and never cleared it. The on-demand `probeTwitch` check is a separate,
independent throwaway-client credential test; it does not observe the live
monitor's chat client and the health monitor does not consult it, so the
persistent `connected` wiring is still required.

## User Impact

Operators running Twitch now see the account flip to disconnected in
`openclaw channels status` when its chat transport actually drops or a reconnect
fails authentication, instead of a permanently green status. This also lets the
channel health monitor detect and restart a dead Twitch transport automatically.
No configuration changes; the `running` field keeps its existing meaning.

## Evidence

**Real-behavior run.** A harness drives the real production code path —
`TwitchClientManager` (persistent readiness listeners), `monitorTwitchProvider`
(status sink), `twitchPlugin.status.buildChannelSummary`, and
`collectTwitchStatusIssues` — with only the external `@twurple/chat` transport
replaced by a controllable stub (no product code stubbed). The runtime status
store shallow patch-merges, matching the gateway status store. Output for
connect → drop → raw reconnect → auth failure → retry disconnect → auth success:

```
=== after initial connect ===
channels status -> {"running":true,"connected":true,"lastError":null}
status issues -> (none)

=== after transport drop ===
channels status -> {"running":true,"connected":false,"lastError":"connection reset"}
status issues -> [ '[runtime] Last error: connection reset' ]

=== after raw reconnect (pre-auth) ===
channels status -> {"running":true,"connected":false,"lastError":"connection reset"}
status issues -> [ '[runtime] Last error: connection reset' ]

=== after reconnect auth failure ===
channels status -> {"running":true,"connected":false,"lastError":"Login authentication failed"}
status issues -> [ '[runtime] Last error: Login authentication failed' ]

=== after Twurple reasonless retry disconnect ===
channels status -> {"running":true,"connected":false,"lastError":"Login authentication failed"}
status issues -> [ '[runtime] Last error: Login authentication failed' ]

=== after reconnect auth success ===
channels status -> {"running":true,"connected":true,"lastError":null}
status issues -> (none)
```

Before this change a raw socket reconnect flipped the status back to
`connected: true` before authentication settled, so an auth-failing reconnect
reported a false healthy status. The "reasonless retry disconnect" step models
Twurple's own `quit()`+`connect()` auth-retry, which fires a manual
reason-less `onDisconnect` immediately after the auth failure; the status sink
now preserves the auth-failure error across it instead of nulling it out.

**Note on proof scope.** The `@twurple/chat` transport is a controllable stub,
so this is not a redacted real-Twitch capture. Real connect → drop → auth-fail →
reconnect evidence from a live setup is still a pre-merge gap.

**Automated tests** (all Twitch extension tests pass):

- `extensions/twitch/src/twitch-client.test.ts` — the persistent listener drives
  `connected: true` from auth success (not raw `onConnect`); a raw transport
  connect owns no liveness listener, so it cannot report healthy pre-auth; a
  reconnect `onAuthenticationFailure` surfaces `connected: false` with the
  failure text; and a post-handshake `onDisconnect` notifies subscribers with
  `connected: false` and the disconnect reason.
- `extensions/twitch/src/monitor.status.test.ts` — the monitor forwards
  `onConnectionChange` to the status sink, and a disconnect-then-reconnect
  sequence clears the prior `lastError`.
- `extensions/twitch/src/plugin.lifecycle.test.ts` — driving the real
  `gateway.startAccount` path, a monitor-reported transport drop emits
  `connected: false` while `running` is never cleared; `buildChannelSummary`
  surfaces `connected`.
