### PR TITLE
fix(plugins): preserve jiti native module config

### DIFF
--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -2041,6 +2041,15 @@ describe("plugin sdk alias helpers", () => {
     expect("alias" in options).toBe(false);
   });
 
+  it("preserves configured jiti native modules while adding openclaw", () => {
+    const options = withEnv(
+      { JITI_NATIVE_MODULES: JSON.stringify(["native-addon", "openclaw"]) },
+      () => buildPluginLoaderJitiOptions({}),
+    );
+
+    expect(options.nativeModules).toEqual(["native-addon", "openclaw"]);
+  });
+
   it("uses transpiled module loads for source TypeScript plugin entries", () => {
     expect(shouldPreferNativeModuleLoad("/repo/dist/plugins/runtime/index.js")).toBe(true);
     expect(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -80,6 +80,18 @@ function shouldUseJitiFsCache(): boolean {
   return readJitiBooleanEnv("JITI_FS_CACHE", readJitiBooleanEnv("JITI_CACHE", true));
 }
 
+function resolvePluginLoaderJitiNativeModules(): string[] {
+  try {
+    const configured: unknown = JSON.parse(process.env.JITI_NATIVE_MODULES ?? "[]");
+    const nativeModules = Array.isArray(configured)
+      ? configured.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    return [...new Set([...nativeModules, "openclaw"])];
+  } catch {
+    return ["openclaw"];
+  }
+}
+
 export function normalizeJitiAliasTargetPath(targetPath: string): string {
   return process.platform === "win32" ? targetPath.replace(/\\/g, "/") : targetPath;
 }
@@ -2033,7 +2045,7 @@ export function buildPluginLoaderJitiOptions(
     tryNative: true,
     // When jiti must transform a plugin entry, keep OpenClaw's own package
     // chunks on the native module graph instead of re-evaluating them in jiti.
-    nativeModules: ["openclaw"],
+    nativeModules: resolvePluginLoaderJitiNativeModules(),
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
     ...(hasAliases
       ? {


### PR DESCRIPTION
## What Problem This Solves

The #88384 fix correctly keeps OpenClaw package chunks on jiti's native module graph, but passing `nativeModules` replaces jiti 2.7.0's `JITI_NATIVE_MODULES` defaults. Operators using that documented jiti environment variable would silently lose their configured native-only modules.

Follow-up to #88384 and #85057.

## Why This Change Was Made

Parse jiti's documented JSON array with the same invalid-JSON fallback, preserve valid configured entries, de-duplicate them, and append `openclaw`. This keeps the shared plugin-loader boundary canonical without adding a caller-specific path.

## User Impact

Plugin loading still prevents duplicate OpenClaw evaluation while retaining operator-configured native-module exceptions.

## Evidence

- jiti 2.7.0 source: `resolveJitiOptions` reads `JITI_NATIVE_MODULES`, then caller options override defaults.
- Trusted Blacksmith Testbox `tbx_01kws9w18sekhj655x6qn24jc7`: `src/plugins/sdk-alias.test.ts`, 77/77 passed.
- Same Testbox: targeted oxfmt and `git diff --check` passed.
- Fresh Codex autoreview: clean, correctness 0.90.
