### PR TITLE
docs(changelog): record WhatsApp delivery fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Message delivery status:** report failed and partially failed best-effort channel delivery instead of returning a success-shaped message-tool result. (#99928) Thanks @masatohoshino.
+- **WhatsApp credential recovery:** restore malformed primary auth state from a valid backup during startup. (#99070) Thanks @LeonidasLux.
+- **WhatsApp quoted replies:** preserve bot-authored outbound quote metadata so replies to those messages keep their reply bubble in WhatsApp Desktop. (#94879) Thanks @Bartok9.
+- **WhatsApp reconnect catch-up:** admit recently missed Baileys `append` messages during a bounded reconnect window while preserving startup stale-history guards. (#80642) Thanks @VishalJ99.
 - **WhatsApp restart recovery:** stop automatic restart loops after logged-out or connection-replaced disconnects until the account reconnects. (#78511) Thanks @openperf.
 - **Local Gateway CLI auth:** keep loopback CLI token/password calls off durable device scopes so read probes cannot block later write/admin commands behind a stale pairing baseline. (#95997) Thanks @vincentkoc.
 - **Plugin module identity:** keep OpenClaw package chunks on Node's native module graph when jiti transforms plugin entries, preventing duplicate evaluation and class identity drift. (#88384) Thanks @vincentkoc.


### PR DESCRIPTION
## What Problem This Solves

Four landed user-visible delivery fixes were intentionally merged without `CHANGELOG.md` edits because active mainline release-note changes repeatedly invalidated their exact-head code CI.

Related: #80642, #94879, #99070, #99928.

## Why This Change Was Made

This maintenance closeout adds one `Unreleased` entry for each landed fix and preserves contributor credit. It contains no runtime changes.

## User Impact

The next release notes accurately describe WhatsApp reconnect catch-up, bot-authored quote replies, malformed credential recovery, and honest message delivery status.

## Evidence

- #80642 landed as `4c42815348ae336bf18e16ab049b6dbe0e4b8223`.
- #94879 landed as `ccdbb70cf09e3420c5225bda9c109230dcac19d7`.
- #99070 landed as `42464de58dca4af5982ff9a2c397ee4eba18ba74`.
- #99928 landed as `ff759b3f1abf59bb43499d78266534afd2133b0d`.
- `git diff --check` passed.

AI-assisted maintenance closeout; the author reviewed the final wording and landed behavior.
