### PR TITLE
feat(android): reconnect gateway when validated network returns

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -387,7 +387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1200,
+      "line": 1229,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -395,7 +395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1200,
+      "line": 1229,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -195,7 +195,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 577,
+      "line": 578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2444,
+      "line": 2457,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2446,
+      "line": 2459,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2448,
+      "line": 2461,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -6,6 +6,8 @@ The OpenClaw mascot now comes alive across onboarding and the app headers with t
 
 Adds read-only Cron Job details in Settings, including schedule, payload and delivery state, job ID copy, refresh, and nested back navigation.
 
+Gateway sessions now retry immediately when Android regains a validated network, without waiting for the current reconnect backoff.
+
 ## 2026.6.11 - 2026-07-01
 
 Improves Android gateway setup with localized onboarding, QR pairing fixes, and support for local mDNS gateway hosts.

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -22,6 +22,7 @@ import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.GatewayTlsProbeFailure
 import ai.openclaw.app.gateway.GatewayTlsProbeResult
 import ai.openclaw.app.gateway.GatewayUpdateAvailableSummary
+import ai.openclaw.app.gateway.NetworkMonitor
 import ai.openclaw.app.gateway.NodeEventSendOutcome
 import ai.openclaw.app.gateway.formatGatewayAuthority
 import ai.openclaw.app.gateway.normalizeGatewayApprovalRequestId
@@ -874,6 +875,14 @@ class NodeRuntime private constructor(
         prefs.saveGatewayTlsFingerprint(stableId, fingerprint)
       },
     )
+
+  /**
+   * Triggers an immediate gateway reconnect when Android reports a validated transport
+   * restore, instead of waiting for the time-based backoff slot in [GatewaySession].
+   * Reuses the foreground reconnect path so all existing guards (already-connected,
+   * pending trust decision, endpoint resolution) still apply.
+   */
+  private val networkMonitor = NetworkMonitor(appContext, ::reconnectPreferredGatewayOnForeground)
 
   private val notificationOutbox: NotificationNodeEventOutbox by lazy {
     NotificationNodeEventOutbox(

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -879,10 +879,14 @@ class NodeRuntime private constructor(
   /**
    * Triggers an immediate gateway reconnect when Android reports a validated transport
    * restore, instead of waiting for the time-based backoff slot in [GatewaySession].
-   * Reuses the foreground reconnect path so all existing guards (already-connected,
-   * pending trust decision, endpoint resolution) still apply.
+   * Each session keeps ownership of desired-connection and auth-pause decisions.
    */
-  private val networkMonitor = NetworkMonitor(appContext, ::reconnectPreferredGatewayOnForeground)
+  private val networkMonitor = NetworkMonitor(appContext, ::retryGatewaySessionsAfterNetworkRestore)
+
+  private fun retryGatewaySessionsAfterNetworkRestore() {
+    operatorSession.retryAfterNetworkRestore()
+    nodeSession.retryAfterNetworkRestore()
+  }
 
   private val notificationOutbox: NotificationNodeEventOutbox by lazy {
     NotificationNodeEventOutbox(

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -12,13 +12,13 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -248,6 +248,9 @@ class GatewaySession(
 
   @Volatile private var reconnectPausedForAuthFailure = false
 
+  // Network recovery must interrupt the current backoff without creating a parallel loop.
+  private val reconnectSignal = Channel<Unit>(Channel.CONFLATED)
+
   /** Starts or replaces the desired gateway connection and launches the reconnect loop. */
   fun connect(
     endpoint: GatewayEndpoint,
@@ -266,6 +269,8 @@ class GatewaySession(
       connectionToClose = currentConnection
       if (job?.isActive != true) {
         job = scope.launch(Dispatchers.IO) { runLoop() }
+      } else {
+        reconnectSignal.trySend(Unit)
       }
     }
     connectionToClose?.closeQuietly()
@@ -290,6 +295,7 @@ class GatewaySession(
       pendingDeviceTokenRetry = false
       deviceTokenRetryBudgetUsed = false
       reconnectPausedForAuthFailure = false
+      drainReconnectSignals()
       connectionToClose = currentConnection
       jobToCancel = job
       job = null
@@ -314,8 +320,31 @@ class GatewaySession(
 
   /** Forces the current socket closed so the loop reconnects to the current desired endpoint. */
   fun reconnect() {
-    reconnectPausedForAuthFailure = false
-    currentConnection?.closeQuietly()
+    signalReconnect(resumeAuthPaused = true)
+  }
+
+  /** Wakes transport backoff without overriding a deliberate auth-failure pause. */
+  internal fun retryAfterNetworkRestore() {
+    signalReconnect(resumeAuthPaused = false)
+  }
+
+  private fun signalReconnect(resumeAuthPaused: Boolean) {
+    synchronized(lifecycleLock) {
+      if (resumeAuthPaused) {
+        reconnectPausedForAuthFailure = false
+      } else if (reconnectPausedForAuthFailure) {
+        return
+      }
+      if (desired == null) return
+      currentConnection?.closeQuietly()
+      reconnectSignal.trySend(Unit)
+    }
+  }
+
+  private fun drainReconnectSignals() {
+    while (reconnectSignal.tryReceive().isSuccess) {
+      // A newly ready connection already incorporates every earlier retry request.
+    }
   }
 
   private fun readyConnection(): Connection? = currentConnection?.takeIf { it.isReady() }
@@ -1188,16 +1217,17 @@ class GatewaySession(
       if (target == null) {
         currentConnection?.closeQuietly()
         currentConnection = null
-        delay(250)
+        withTimeoutOrNull(250) { reconnectSignal.receive() }
         continue
       }
       if (reconnectPausedForAuthFailure) {
-        delay(250)
+        withTimeoutOrNull(250) { reconnectSignal.receive() }
         continue
       }
 
       try {
         onDisconnected(if (attempt == 0) "Connecting…" else "Reconnecting…")
+        drainReconnectSignals()
         connectOnce(target)
         attempt = 0
       } catch (err: Throwable) {
@@ -1211,11 +1241,13 @@ class GatewaySession(
           onConnectFailure(gatewayConnectFailure.gatewayError, pauseForAuthFailure)
         }
         if (pauseForAuthFailure) {
-          reconnectPausedForAuthFailure = true
+          synchronized(lifecycleLock) {
+            reconnectPausedForAuthFailure = true
+          }
           continue
         }
         val sleepMs = minOf(8_000L, (350.0 * Math.pow(1.7, attempt.toDouble())).toLong())
-        delay(sleepMs)
+        withTimeoutOrNull(sleepMs) { reconnectSignal.receive() }
       }
     }
   }
@@ -1263,6 +1295,7 @@ class GatewaySession(
           conn.closeQuietly()
           return@withContext
         }
+        drainReconnectSignals()
         conn.awaitClose()
       } finally {
         // Callback failures and cancellation must drain this socket's owned work before the loop

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -26,7 +26,7 @@ class NetworkMonitor(
   // Tracks the last emitted transport state so capability churn (e.g. signal strength
   // changes) does not re-fire the reconnect path. Only a lost->validated transition
   // should signal.
-  @Volatile private var lastOnline = isCurrentlyOnline()
+  private val validatedNetworks = ValidatedNetworkState<Network>(initialValidatedNetworks())
 
   private val callback =
     object : ConnectivityManager.NetworkCallback() {
@@ -41,12 +41,14 @@ class NetworkMonitor(
         capabilities: NetworkCapabilities,
       ) {
         if (isTransportValidated(capabilities)) {
-          markOnline()
+          markOnline(network)
+        } else {
+          markLost(network)
         }
       }
 
       override fun onLost(network: Network) {
-        lastOnline = false
+        markLost(network)
       }
     }
 
@@ -73,16 +75,15 @@ class NetworkMonitor(
         null
       } ?: return
     if (isTransportValidated(caps)) {
-      markOnline()
+      markOnline(network)
     }
   }
 
-  private fun markOnline() {
+  private fun markOnline(network: Network) {
     // Dedupe via the pure transition rule so the semantics stay unit-testable.
-    if (!shouldEmitOnlineTransition(lastOnline)) {
+    if (!validatedNetworks.markValidated(network)) {
       return
     }
-    lastOnline = true
     try {
       onAvailable()
     } catch (err: Throwable) {
@@ -90,15 +91,38 @@ class NetworkMonitor(
     }
   }
 
-  private fun isCurrentlyOnline(): Boolean =
-    try {
-      val cm = connectivity ?: return false
-      val active = cm.activeNetwork ?: return false
-      val caps = cm.getNetworkCapabilities(active) ?: return false
-      isTransportValidated(caps)
+  private fun markLost(network: Network) {
+    validatedNetworks.markLost(network)
+  }
+
+  private fun initialValidatedNetworks(): Set<Network> {
+    return try {
+      val cm = connectivity ?: return emptySet()
+      val active = cm.activeNetwork ?: return emptySet()
+      val caps = cm.getNetworkCapabilities(active) ?: return emptySet()
+      if (isTransportValidated(caps)) setOf(active) else emptySet()
     } catch (_: Throwable) {
-      false
+      emptySet()
     }
+  }
+}
+
+internal class ValidatedNetworkState<T>(
+  initialValidatedNetworks: Set<T> = emptySet(),
+) {
+  private val validatedNetworks = initialValidatedNetworks.toMutableSet()
+
+  @Synchronized
+  fun markValidated(network: T): Boolean {
+    val wasOnline = validatedNetworks.isNotEmpty()
+    validatedNetworks.add(network)
+    return shouldEmitOnlineTransition(wasOnline)
+  }
+
+  @Synchronized
+  fun markLost(network: T) {
+    validatedNetworks.remove(network)
+  }
 }
 
 /**

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -1,0 +1,115 @@
+﻿package ai.openclaw.app.gateway
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.util.Log
+
+/**
+ * Listens for Android transport restores and signals [onAvailable] when the device
+ * regains a validated internet connection. Used to trigger an immediate gateway
+ * reconnect instead of waiting out the time-based backoff slot in [GatewaySession].
+ *
+ * The receiver MUST already guard against the already-connected case: this monitor only
+ * reports "transport came back", it does not decide whether a reconnect is wanted.
+ * The application context is used so the callback survives the NodeRuntime lifetime.
+ */
+class NetworkMonitor(
+  context: Context,
+  private val onAvailable: () -> Unit,
+) {
+  private val connectivity = context.getSystemService(ConnectivityManager::class.java)
+  private val logTag = "OpenClaw/NetworkMonitor"
+
+  // Tracks the last emitted transport state so capability churn (e.g. signal strength
+  // changes) does not re-fire the reconnect path. Only a lost->validated transition
+  // should signal.
+  @Volatile private var lastOnline = isCurrentlyOnline()
+
+  private val callback =
+    object : ConnectivityManager.NetworkCallback() {
+      override fun onAvailable(network: Network) {
+        // Captive portals can report onAvailable before NET_CAPABILITY_VALIDATED;
+        // read capabilities for this network instead of treating availability alone as online.
+        markOnlineWhenValidated(network)
+      }
+
+      override fun onCapabilitiesChanged(
+        network: Network,
+        capabilities: NetworkCapabilities,
+      ) {
+        if (isTransportValidated(capabilities)) {
+          markOnline()
+        }
+      }
+
+      override fun onLost(network: Network) {
+        lastOnline = false
+      }
+    }
+
+  init {
+    start()
+  }
+
+  private fun start() {
+    val cm = connectivity ?: return
+    try {
+      // Equivalent to the default request used by GatewayDiscovery: match any network.
+      cm.registerNetworkCallback(NetworkRequest.Builder().build(), callback)
+    } catch (err: Throwable) {
+      Log.w(logTag, "registerNetworkCallback failed: ${err.message ?: err::class.java.simpleName}")
+    }
+  }
+
+  private fun markOnlineWhenValidated(network: Network) {
+    val cm = connectivity ?: return
+    val caps =
+      try {
+        cm.getNetworkCapabilities(network)
+      } catch (_: Throwable) {
+        null
+      } ?: return
+    if (isTransportValidated(caps)) {
+      markOnline()
+    }
+  }
+
+  private fun markOnline() {
+    // Dedupe via the pure transition rule so the semantics stay unit-testable.
+    if (!shouldEmitOnlineTransition(lastOnline)) {
+      return
+    }
+    lastOnline = true
+    try {
+      onAvailable()
+    } catch (err: Throwable) {
+      Log.w(logTag, "onAvailable callback threw: ${err.message ?: err::class.java.simpleName}")
+    }
+  }
+
+  private fun isCurrentlyOnline(): Boolean =
+    try {
+      val cm = connectivity ?: return false
+      val active = cm.activeNetwork ?: return false
+      val caps = cm.getNetworkCapabilities(active) ?: return false
+      isTransportValidated(caps)
+    } catch (_: Throwable) {
+      false
+    }
+}
+
+/**
+ * True when the network reports a validated internet capability. Exposed internal so the
+ * predicate can be unit-tested without a Robolectric ConnectivityManager shadow.
+ */
+internal fun isTransportValidated(capabilities: NetworkCapabilities): Boolean =
+  capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+
+/**
+ * True only on the first transition out of an offline state. Repeated onAvailable /
+ * onCapabilitiesChanged calls while already online must not re-fire the reconnect path.
+ */
+internal fun shouldEmitOnlineTransition(previouslyOnline: Boolean): Boolean = !previouslyOnline

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -1,4 +1,4 @@
-﻿package ai.openclaw.app.gateway
+package ai.openclaw.app.gateway
 
 import android.content.Context
 import android.net.ConnectivityManager
@@ -8,17 +8,17 @@ import android.net.NetworkRequest
 import android.util.Log
 
 /**
- * Listens for Android transport restores and signals [onAvailable] when the device
+ * Listens for Android transport restores and signals [onValidatedNetworkAvailable] when the device
  * regains a validated internet connection. Used to trigger an immediate gateway
  * reconnect instead of waiting out the time-based backoff slot in [GatewaySession].
  *
- * The receiver MUST already guard against the already-connected case: this monitor only
- * reports "transport came back", it does not decide whether a reconnect is wanted.
- * The application context is used so the callback survives the NodeRuntime lifetime.
+ * This monitor only reports "transport came back". Each gateway session still owns
+ * desired-connection and auth-pause decisions. The application context keeps this
+ * process-lifetime callback aligned with the process-lifetime NodeRuntime.
  */
-class NetworkMonitor(
+internal class NetworkMonitor(
   context: Context,
-  private val onAvailable: () -> Unit,
+  private val onValidatedNetworkAvailable: () -> Unit,
 ) {
   private val connectivity = context.getSystemService(ConnectivityManager::class.java)
   private val logTag = "OpenClaw/NetworkMonitor"
@@ -30,25 +30,17 @@ class NetworkMonitor(
 
   private val callback =
     object : ConnectivityManager.NetworkCallback() {
-      override fun onAvailable(network: Network) {
-        // Captive portals can report onAvailable before NET_CAPABILITY_VALIDATED;
-        // read capabilities for this network instead of treating availability alone as online.
-        markOnlineWhenValidated(network)
-      }
-
       override fun onCapabilitiesChanged(
         network: Network,
         capabilities: NetworkCapabilities,
       ) {
-        if (isTransportValidated(capabilities)) {
-          markOnline(network)
-        } else {
-          markLost(network)
+        if (validatedNetworks.update(network, isTransportValidated(capabilities))) {
+          notifyValidatedNetworkAvailable()
         }
       }
 
       override fun onLost(network: Network) {
-        markLost(network)
+        validatedNetworks.update(network, isValidated = false)
       }
     }
 
@@ -66,33 +58,12 @@ class NetworkMonitor(
     }
   }
 
-  private fun markOnlineWhenValidated(network: Network) {
-    val cm = connectivity ?: return
-    val caps =
-      try {
-        cm.getNetworkCapabilities(network)
-      } catch (_: Throwable) {
-        null
-      } ?: return
-    if (isTransportValidated(caps)) {
-      markOnline(network)
-    }
-  }
-
-  private fun markOnline(network: Network) {
-    // Dedupe via the pure transition rule so the semantics stay unit-testable.
-    if (!validatedNetworks.markValidated(network)) {
-      return
-    }
+  private fun notifyValidatedNetworkAvailable() {
     try {
-      onAvailable()
+      onValidatedNetworkAvailable()
     } catch (err: Throwable) {
-      Log.w(logTag, "onAvailable callback threw: ${err.message ?: err::class.java.simpleName}")
+      Log.w(logTag, "network restore callback threw: ${err.message ?: err::class.java.simpleName}")
     }
-  }
-
-  private fun markLost(network: Network) {
-    validatedNetworks.markLost(network)
   }
 
   private fun initialValidatedNetworks(): Set<Network> {
@@ -113,15 +84,17 @@ internal class ValidatedNetworkState<T>(
   private val validatedNetworks = initialValidatedNetworks.toMutableSet()
 
   @Synchronized
-  fun markValidated(network: T): Boolean {
+  fun update(
+    network: T,
+    isValidated: Boolean,
+  ): Boolean {
     val wasOnline = validatedNetworks.isNotEmpty()
-    validatedNetworks.add(network)
-    return shouldEmitOnlineTransition(wasOnline)
-  }
-
-  @Synchronized
-  fun markLost(network: T) {
-    validatedNetworks.remove(network)
+    if (isValidated) {
+      validatedNetworks.add(network)
+    } else {
+      validatedNetworks.remove(network)
+    }
+    return !wasOnline && validatedNetworks.isNotEmpty()
   }
 }
 
@@ -131,9 +104,3 @@ internal class ValidatedNetworkState<T>(
  */
 internal fun isTransportValidated(capabilities: NetworkCapabilities): Boolean =
   capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
-
-/**
- * True only on the first transition out of an offline state. Repeated onAvailable /
- * onCapabilitiesChanged calls while already online must not re-fire the reconnect path.
- */
-internal fun shouldEmitOnlineTransition(previouslyOnline: Boolean): Boolean = !previouslyOnline

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/NetworkMonitor.kt
@@ -26,7 +26,7 @@ internal class NetworkMonitor(
   // Tracks the last emitted transport state so capability churn (e.g. signal strength
   // changes) does not re-fire the reconnect path. Only a lost->validated transition
   // should signal.
-  private val validatedNetworks = ValidatedNetworkState<Network>(initialValidatedNetworks())
+  private val validatedNetworks = ValidatedNetworkState<Network>()
 
   private val callback =
     object : ConnectivityManager.NetworkCallback() {
@@ -45,7 +45,10 @@ internal class NetworkMonitor(
     }
 
   init {
+    // Register first so a network lost during initial seeding still has an owning callback.
+    // The seed suppresses the initial snapshot when it wins; session guards handle the other race.
     start()
+    seedActiveValidatedNetwork()
   }
 
   private fun start() {
@@ -66,14 +69,16 @@ internal class NetworkMonitor(
     }
   }
 
-  private fun initialValidatedNetworks(): Set<Network> {
-    return try {
-      val cm = connectivity ?: return emptySet()
-      val active = cm.activeNetwork ?: return emptySet()
-      val caps = cm.getNetworkCapabilities(active) ?: return emptySet()
-      if (isTransportValidated(caps)) setOf(active) else emptySet()
+  private fun seedActiveValidatedNetwork() {
+    try {
+      val cm = connectivity ?: return
+      val active = cm.activeNetwork ?: return
+      val caps = cm.getNetworkCapabilities(active) ?: return
+      if (isTransportValidated(caps)) {
+        validatedNetworks.update(active, isValidated = true)
+      }
     } catch (_: Throwable) {
-      emptySet()
+      // Callback delivery remains the source of truth when the initial snapshot races.
     }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
@@ -1,4 +1,4 @@
-﻿package ai.openclaw.app.gateway
+package ai.openclaw.app.gateway
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -6,36 +6,37 @@ import org.junit.Test
 class NetworkMonitorTest {
   @Test
   fun emitsOnceOnOfflineToOnline() {
-    // First validated transition after being offline fires the reconnect signal.
-    assertEquals(true, shouldEmitOnlineTransition(previouslyOnline = false))
+    val state = ValidatedNetworkState<String>()
+
+    assertEquals(true, state.update("wifi", isValidated = true))
+    assertEquals(false, state.update("wifi", isValidated = true))
   }
 
   @Test
-  fun suppressesDuplicateOnline() {
-    // Capability churn (signal strength, dual-stack validation) while already online
-    // must not re-fire; the gateway reconnect path guards on its own isConnected anyway.
-    assertEquals(false, shouldEmitOnlineTransition(previouslyOnline = true))
-  }
+  fun emitsAgainAfterAllValidatedNetworksAreLost() {
+    val state = ValidatedNetworkState<String>()
 
-  @Test
-  fun emitsAgainAfterALost() {
-    // onLost clears the lastOnline flag so a later restore is treated as fresh.
-    // Simulate the state machine: offline -> online (emit) -> lost -> online (emit).
-    var online = false
-    assertEquals(true, shouldEmitOnlineTransition(online))
-    online = true
-    assertEquals(false, shouldEmitOnlineTransition(online))
-    online = false // onLost
-    assertEquals(true, shouldEmitOnlineTransition(online))
+    assertEquals(true, state.update("wifi", isValidated = true))
+    assertEquals(false, state.update("wifi", isValidated = false))
+    assertEquals(true, state.update("wifi", isValidated = true))
   }
 
   @Test
   fun suppressesReconnectWhenOneOfMultipleValidatedNetworksIsLost() {
     val state = ValidatedNetworkState<String>()
 
-    assertEquals(true, state.markValidated("wifi"))
-    assertEquals(false, state.markValidated("cellular"))
-    state.markLost("wifi")
-    assertEquals(false, state.markValidated("cellular"))
+    assertEquals(true, state.update("wifi", isValidated = true))
+    assertEquals(false, state.update("cellular", isValidated = true))
+    assertEquals(false, state.update("wifi", isValidated = false))
+    assertEquals(false, state.update("cellular", isValidated = true))
+    assertEquals(false, state.update("cellular", isValidated = false))
+    assertEquals(true, state.update("wifi", isValidated = true))
+  }
+
+  @Test
+  fun initialValidatedNetworkSuppressesRegistrationSnapshot() {
+    val state = ValidatedNetworkState(setOf("wifi"))
+
+    assertEquals(false, state.update("wifi", isValidated = true))
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
@@ -1,0 +1,31 @@
+﻿package ai.openclaw.app.gateway
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NetworkMonitorTest {
+  @Test
+  fun emitsOnceOnOfflineToOnline() {
+    // First validated transition after being offline fires the reconnect signal.
+    assertEquals(true, shouldEmitOnlineTransition(previouslyOnline = false))
+  }
+
+  @Test
+  fun suppressesDuplicateOnline() {
+    // Capability churn (signal strength, dual-stack validation) while already online
+    // must not re-fire; the gateway reconnect path guards on its own isConnected anyway.
+    assertEquals(false, shouldEmitOnlineTransition(previouslyOnline = true))
+  }
+
+  @Test
+  fun emitsAgainAfterALost() {
+    // onLost clears the lastOnline flag so a later restore is treated as fresh.
+    // Simulate the state machine: offline -> online (emit) -> lost -> online (emit).
+    var online = false
+    assertEquals(true, shouldEmitOnlineTransition(online))
+    online = true
+    assertEquals(false, shouldEmitOnlineTransition(online))
+    online = false // onLost
+    assertEquals(true, shouldEmitOnlineTransition(online))
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/NetworkMonitorTest.kt
@@ -28,4 +28,14 @@ class NetworkMonitorTest {
     online = false // onLost
     assertEquals(true, shouldEmitOnlineTransition(online))
   }
+
+  @Test
+  fun suppressesReconnectWhenOneOfMultipleValidatedNetworksIsLost() {
+    val state = ValidatedNetworkState<String>()
+
+    assertEquals(true, state.markValidated("wifi"))
+    assertEquals(false, state.markValidated("cellular"))
+    state.markLost("wifi")
+    assertEquals(false, state.markValidated("cellular"))
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

When Android lost and regained network connectivity, OpenClaw could remain disconnected from the gateway until the app foregrounded or the current `GatewaySession` backoff elapsed. That left node/operator sessions offline longer than necessary after Wi-Fi or cellular recovery.

## Why This Change Was Made

Android now tracks validated networks and wakes existing desired gateway sessions only when the validated-network set moves from empty to non-empty.

The maintainer rewrite keeps each responsibility at its owner:

- `NetworkMonitor` consumes the ordered `onCapabilitiesChanged` callback and only reports a validated offline-to-online transition. It does not synchronously query capabilities from `onAvailable`; [Android documents that pattern as race-prone](https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback#onAvailable(android.net.Network)).
- `GatewaySession` owns a conflated wake signal for its single reconnect loop, so restoration actually interrupts an active delay without creating a parallel loop.
- Network restoration cannot create a desired connection or clear an authentication-failure pause. Explicit refresh retains its existing ability to resume an auth-paused session.
- Multiple validated networks remain deduped: losing Wi-Fi while another validated transport remains available does not retry.
- Callback registration precedes the initial active-network snapshot so a network lost during startup cannot remain as a ghost validated entry.

No permission, config, migration, protocol, dependency, or command surface is added. The existing `ACCESS_NETWORK_STATE` permission is reused.

## User Impact

After all validated networks disappear and one returns, Android retries saved gateway sessions immediately instead of waiting for the current backoff slot. Routine capability churn, partial network loss, captive/unvalidated networks, explicit disconnects, and deliberate authentication pauses do not trigger a retry.

## Evidence

Final rewritten head: `0bdf7e34a542220b813587bb95ac49848dbc5f32`.

- Sanitized AWS Crabbox `cbx_1fdce258694b`, run `run_91884324b24a`: bootstrap verified rewritten head `bf37f31e61aa1d266d5f9f8efc5c5cdd0740b842`, no IAM credentials endpoint, public networking with no Tailscale, pinned Node/pnpm, and isolated HOME; `testThirdPartyDebugUnitTest`, `testPlayDebugUnitTest`, and `assemblePlayDebug` passed (82 tasks, Gradle 2m51s). The final head is the same reviewed implementation cleanly rebased over current `main`, plus regenerated native i18n inventory.
- Final-head hosted [CI `28771116526`](https://github.com/openclaw/openclaw/actions/runs/28771116526) and Workflow Sanity `28771116539`: passed.
- `node --import tsx scripts/native-app-i18n.ts check`: passed.
- `git diff --check`: passed.
- Four GPT-5.5 autoreview closeout passes, including focused reruns after the startup ordering fix and final rebase: no actionable findings.

Contributor real-emulator proof used airplane mode against a local mock WebSocket gateway:

```text
Device: emulator-5554 device product:sdk_gphone16k_x86_64 model:sdk_gphone16k_x86_64
Gateway: local mock WebSocket gateway on host 127.0.0.1:18789, reached by emulator as 10.0.2.2:18789
Initial Android debug receiver result: {"ok":true,"mode":"connect","connected":true}
Network action: adb shell cmd connectivity airplane-mode enable; then adb shell cmd connectivity airplane-mode disable
Final airplane mode state: disabled
Mock gateway observation: completed gateway connections increased after restoration.
```

Source-blind limitation: no interactive emulator was available for the exact maintainer rewrite, so exact timing, per-session attribution, auth-pause, captive-portal, multi-network, and explicit-disconnect probes remain unclaimed. Those branches have source-aware state coverage, full Android unit/build proof, and maintainer review.

AI-assisted: yes. The contributor implementation was reviewed and substantially rewritten by a maintainer agent, then independently autoreviewed and remotely validated.
