### PR TITLE
fix: remove sidebar usage quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Control UI sidebar usage:** remove the provider usage quota row from the expanded sidebar while keeping usage details available in the chat composer and Usage page. Thanks @shakkernerd.
+
 ### Fixes
 
 - **Message delivery status:** report failed and partially failed best-effort channel delivery instead of returning a success-shaped message-tool result. (#99928) Thanks @masatohoshino.

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -2,7 +2,7 @@ import { consume } from "@lit/context";
 import { LitElement, html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
-import type { ModelAuthStatusResult, SessionsListResult } from "../api/types.ts";
+import type { SessionsListResult } from "../api/types.ts";
 import {
   cancelRoutePreload,
   isSettingsNavigationRoute,
@@ -44,8 +44,6 @@ import {
   resolveSessionAgentFilterOptions,
 } from "../lib/sessions/session-options.ts";
 import { icons } from "./icons.ts";
-
-type ProviderQuotaPillRenderer = typeof import("./provider-quota-pill.ts").renderProviderQuotaPill;
 
 type SidebarRecentSession = {
   key: string;
@@ -98,15 +96,13 @@ export class AppSidebar extends LitElement {
   @state() private sessionsResult: SessionsListResult | null = null;
   @state() private sessionsAgentId: string | null = null;
   @state() private sessionsLoading = false;
-  @state() private modelAuthStatusResult: ModelAuthStatusResult | null = null;
-  @state() private providerQuotaPillRenderer: ProviderQuotaPillRenderer | null = null;
 
   private stopSessionsSubscription: (() => void) | undefined;
   private stopAgentsSubscription: (() => void) | undefined;
   private stopAgentSelectionSubscription: (() => void) | undefined;
   private stopGatewaySubscription: (() => void) | undefined;
   private sessionRowsByAgent: Record<string, SessionsListResult["sessions"]> = {};
-  private modelAuthClient: GatewayBrowserClient | null = null;
+  private gatewayClient: GatewayBrowserClient | null = null;
   private readonly routePreloadTimers = new Map<
     EventTarget,
     ReturnType<typeof globalThis.setTimeout>
@@ -127,7 +123,7 @@ export class AppSidebar extends LitElement {
     this.stopAgentSelectionSubscription = undefined;
     this.stopGatewaySubscription?.();
     this.stopGatewaySubscription = undefined;
-    this.modelAuthClient = null;
+    this.gatewayClient = null;
     for (const timer of this.routePreloadTimers.values()) {
       globalThis.clearTimeout(timer);
     }
@@ -146,7 +142,7 @@ export class AppSidebar extends LitElement {
     ) {
       return;
     }
-    this.updateModelAuthStatus(context.gateway.snapshot);
+    this.updateGatewayClient(context.gateway.snapshot);
     this.updateSessions(context.sessions.state);
     this.stopSessionsSubscription = context.sessions.subscribe((snapshot) => {
       this.updateSessions(snapshot);
@@ -158,7 +154,7 @@ export class AppSidebar extends LitElement {
       this.requestUpdate();
     });
     this.stopGatewaySubscription = context.gateway.subscribe((snapshot) => {
-      this.updateModelAuthStatus(snapshot);
+      this.updateGatewayClient(snapshot);
       this.requestUpdate();
     });
   }
@@ -180,44 +176,16 @@ export class AppSidebar extends LitElement {
     }
   };
 
-  private updateModelAuthStatus(snapshot: {
+  private updateGatewayClient(snapshot: {
     client: GatewayBrowserClient | null;
     connected: boolean;
   }) {
     const client = snapshot.connected ? snapshot.client : null;
-    if (client === this.modelAuthClient) {
+    if (client === this.gatewayClient) {
       return;
     }
     this.sessionRowsByAgent = {};
-    this.modelAuthClient = client;
-    this.modelAuthStatusResult = null;
-    if (!client) {
-      return;
-    }
-    void import("../lib/model-auth.ts")
-      .then(async ({ isMonitoredAuthProvider, loadModelAuthStatus }) => {
-        const result = await loadModelAuthStatus(client);
-        if (this.modelAuthClient !== client) {
-          return;
-        }
-        this.modelAuthStatusResult = result;
-        const hasQuota = result.providers.some(
-          (provider) =>
-            isMonitoredAuthProvider(provider) && Boolean(provider.usage?.windows?.length),
-        );
-        if (!hasQuota || this.providerQuotaPillRenderer) {
-          return;
-        }
-        const { renderProviderQuotaPill } = await import("./provider-quota-pill.ts");
-        if (this.modelAuthClient === client) {
-          this.providerQuotaPillRenderer = renderProviderQuotaPill;
-        }
-      })
-      .catch(() => {
-        if (this.modelAuthClient === client) {
-          this.modelAuthStatusResult = null;
-        }
-      });
+    this.gatewayClient = client;
   }
 
   private getRouteSessionKey(): string {
@@ -678,12 +646,6 @@ export class AppSidebar extends LitElement {
     const gatewayStatus = t("chat.gatewayStatus", {
       status: this.connected ? t("common.online") : t("common.offline"),
     });
-    const quotaPill = this.collapsed
-      ? ""
-      : (this.providerQuotaPillRenderer?.({
-          basePath: this.basePath,
-          modelAuthStatusResult: this.modelAuthStatusResult,
-        }) ?? "");
     return html`
       <aside class="sidebar ${this.collapsed ? "sidebar--collapsed" : ""}">
         <div class="sidebar-shell">
@@ -749,7 +711,6 @@ export class AppSidebar extends LitElement {
           </div>
           <div class="sidebar-shell__footer">
             <div class="sidebar-utility-group">
-              ${quotaPill ? html`<div class="sidebar-quota">${quotaPill}</div>` : nothing}
               ${this.collapsed
                 ? html`
                     <openclaw-tooltip

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -618,15 +618,6 @@
   padding: 0 8px 2px;
 }
 
-.sidebar-quota {
-  display: grid;
-  padding: 0 2px 4px;
-}
-
-.sidebar-quota .chat-controls__quota {
-  justify-content: space-between;
-}
-
 .sidebar-agent-filter .chat-controls__agent {
   width: 100%;
 }


### PR DESCRIPTION
## What Problem This Solves

The expanded Control UI sidebar displayed a provider usage quota row that duplicated usage information available elsewhere and added unnecessary visual weight.

## Why This Change Was Made

Remove the quota row from the sidebar while keeping the existing usage surfaces in the chat composer, Overview, and Usage page.

The change also removes the sidebar-specific `models.authStatus` loading and lazy quota-renderer import. Gateway client tracking remains in place because it still invalidates cached per-agent session rows when the client changes.

## User Impact

The expanded sidebar no longer shows the provider usage quota row. Provider usage remains available from the chat composer and Usage page.

## Evidence

- Focused mocked Chromium E2E: 2 tests passed
  - `ui/src/e2e/chat-quota-pill-93041.e2e.test.ts`
  - Blacksmith Testbox through Crabbox: `tbx_01kwsbrf223rnz7782430686yd`
- Core and core-test TypeScript checks passed
- `pnpm exec oxlint ui/src/components/app-sidebar.ts`
- Scoped `oxfmt --check`
- `git diff --check`
- Codex autoreview: no actionable findings
