### PR TITLE
fix(bonjour): drain advertise cleanup on stop

### DIFF
--- a/extensions/bonjour/src/advertiser.test.ts
+++ b/extensions/bonjour/src/advertiser.test.ts
@@ -141,16 +141,45 @@ describe("gateway bonjour advertiser", () => {
     txt?: unknown;
   };
 
-  const prevEnv = { ...process.env };
+  const prevEnv = {
+    FLY_APP_NAME: process.env.FLY_APP_NAME,
+    FLY_MACHINE_ID: process.env.FLY_MACHINE_ID,
+    NODE_ENV: process.env.NODE_ENV,
+    OPENCLAW_DISABLE_BONJOUR: process.env.OPENCLAW_DISABLE_BONJOUR,
+    OPENCLAW_MDNS_HOSTNAME: process.env.OPENCLAW_MDNS_HOSTNAME,
+    VITEST: process.env.VITEST,
+  };
 
   afterEach(() => {
-    for (const key of Object.keys(process.env)) {
-      if (!(key in prevEnv)) {
-        delete process.env[key];
-      }
+    if (prevEnv.FLY_APP_NAME === undefined) {
+      delete process.env.FLY_APP_NAME;
+    } else {
+      process.env.FLY_APP_NAME = prevEnv.FLY_APP_NAME;
     }
-    for (const [key, value] of Object.entries(prevEnv)) {
-      process.env[key] = value;
+    if (prevEnv.FLY_MACHINE_ID === undefined) {
+      delete process.env.FLY_MACHINE_ID;
+    } else {
+      process.env.FLY_MACHINE_ID = prevEnv.FLY_MACHINE_ID;
+    }
+    if (prevEnv.NODE_ENV === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = prevEnv.NODE_ENV;
+    }
+    if (prevEnv.OPENCLAW_DISABLE_BONJOUR === undefined) {
+      delete process.env.OPENCLAW_DISABLE_BONJOUR;
+    } else {
+      process.env.OPENCLAW_DISABLE_BONJOUR = prevEnv.OPENCLAW_DISABLE_BONJOUR;
+    }
+    if (prevEnv.OPENCLAW_MDNS_HOSTNAME === undefined) {
+      delete process.env.OPENCLAW_MDNS_HOSTNAME;
+    } else {
+      process.env.OPENCLAW_MDNS_HOSTNAME = prevEnv.OPENCLAW_MDNS_HOSTNAME;
+    }
+    if (prevEnv.VITEST === undefined) {
+      delete process.env.VITEST;
+    } else {
+      process.env.VITEST = prevEnv.VITEST;
     }
 
     createService.mockClear();
@@ -215,6 +244,41 @@ describe("gateway bonjour advertiser", () => {
     await started.stop();
     expect(destroy).toHaveBeenCalledTimes(1);
     expect(shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("drains in-flight advertise work during stop without late success logs", async () => {
+    enableAdvertiserUnitMode();
+
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    let resolveAdvertise = () => {};
+    const advertise = vi.fn().mockImplementation(
+      async () =>
+        await new Promise<void>((resolve) => {
+          resolveAdvertise = resolve;
+        }),
+    );
+    mockCiaoService({ advertise, destroy });
+
+    const started = await startAdvertiser({
+      gatewayPort: 18789,
+      sshPort: 2222,
+    });
+
+    let stopSettled = false;
+    const stopPromise = started.stop().then(() => {
+      stopSettled = true;
+    });
+    await Promise.resolve();
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(stopSettled).toBe(false);
+    expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining("advertised"));
+
+    resolveAdvertise();
+    await stopPromise;
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+    expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining("advertised"));
   });
 
   it("omits cliPath and sshPort in minimal mode", async () => {

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -88,6 +88,7 @@ type BonjourAdvertiserDeps = {
 };
 
 const WATCHDOG_INTERVAL_MS = 5_000;
+const ADVERTISE_DRAIN_TIMEOUT_MS = 250;
 const REPAIR_DEBOUNCE_MS = 30_000;
 const CONFLICT_SETTLE_MS = 30_000;
 // Real-world LAN announce phase typically takes 12-13s on Mac/iOS networks. The
@@ -114,6 +115,8 @@ const defaultLogger = {
 
 const CIAO_MODULE_ID = "@homebridge/ciao";
 const CIAO_WINDOWS_SHELL_COMMANDS = new Set(['arp -a | findstr /C:"---"']);
+const nativeSetTimeout = globalThis.setTimeout;
+const nativeClearTimeout = globalThis.clearTimeout;
 let ciaoExecHidePatchDepth = 0;
 let restoreCiaoExecHidePatchOnce: (() => void) | null = null;
 
@@ -551,6 +554,9 @@ export async function startGatewayBonjourAdvertiser(
       err: unknown,
       action: "failed" | "threw",
     ) {
+      if (stopped) {
+        return;
+      }
       const classification = classifyCiaoProcessError(err);
       if (classification) {
         logger.warn(
@@ -567,17 +573,47 @@ export async function startGatewayBonjourAdvertiser(
       );
     }
 
+    async function drainAdvertiseTasks() {
+      while (advertiseTasks.size > 0) {
+        const tasks = Array.from(advertiseTasks);
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        const settled = await Promise.race([
+          Promise.allSettled(tasks).then(() => true),
+          new Promise<boolean>((resolve) => {
+            timeout = nativeSetTimeout(() => resolve(false), ADVERTISE_DRAIN_TIMEOUT_MS);
+            timeout.unref?.();
+          }),
+        ]);
+        if (timeout) {
+          nativeClearTimeout(timeout);
+        }
+        if (!settled) {
+          break;
+        }
+      }
+    }
+
+    function trackAdvertiseTask(task: Promise<void>) {
+      advertiseTasks.add(task);
+      void task.finally(() => {
+        advertiseTasks.delete(task);
+      });
+    }
+
     function startAdvertising(services: Array<{ label: string; svc: BonjourService }>) {
       for (const { label, svc } of services) {
         try {
-          void svc
+          const task = svc
             .advertise()
             .then(() => {
-              logger.info(`bonjour: advertised ${serviceSummary(label, svc)}`);
+              if (!stopped) {
+                logger.info(`bonjour: advertised ${serviceSummary(label, svc)}`);
+              }
             })
             .catch((err: unknown) => {
               handleAdvertiseFailure(label, svc, err, "failed");
             });
+          trackAdvertiseTask(task);
         } catch (err) {
           handleAdvertiseFailure(label, svc, err, "threw");
         }
@@ -593,6 +629,7 @@ export async function startGatewayBonjourAdvertiser(
     let stopped = false;
     let recreatePromise: Promise<void> | null = null;
     let disabled = false;
+    const advertiseTasks = new Set<Promise<void>>();
     let consecutiveRestarts = 0;
     let consecutiveStuckStateRestarts = 0;
     const restartTimestamps: number[] = [];
@@ -751,15 +788,20 @@ export async function startGatewayBonjourAdvertiser(
           )})`,
         );
         try {
-          void svc.advertise().catch((err: unknown) => {
-            logger.warn(
-              `bonjour: watchdog re-advertise failed (${serviceSummary(label, svc)}): ${formatBonjourError(err)}`,
-            );
+          const task = svc.advertise().catch((err: unknown) => {
+            if (!stopped) {
+              logger.warn(
+                `bonjour: watchdog re-advertise failed (${serviceSummary(label, svc)}): ${formatBonjourError(err)}`,
+              );
+            }
           });
+          trackAdvertiseTask(task);
         } catch (err) {
-          logger.warn(
-            `bonjour: watchdog re-advertise threw (${serviceSummary(label, svc)}): ${formatBonjourError(err)}`,
-          );
+          if (!stopped) {
+            logger.warn(
+              `bonjour: watchdog re-advertise threw (${serviceSummary(label, svc)}): ${formatBonjourError(err)}`,
+            );
+          }
         }
       }
     }, WATCHDOG_INTERVAL_MS);
@@ -775,6 +817,7 @@ export async function startGatewayBonjourAdvertiser(
           // ignore
         }
         await stopCycle(cycle, { shutdownResponder: true });
+        await drainAdvertiseTasks();
         restoreConsoleLog();
         restoreCiaoExecHidePatch();
         cleanupProcessHandlers();


### PR DESCRIPTION
## Summary
- track in-flight Bonjour advertise/re-advertise tasks
- suppress late advertise logging/recovery after stop begins
- drain advertise work with a bounded timeout during shutdown

## What Problem This Solves
The Bonjour advertiser could begin shutdown while ciao advertise/re-advertise promises were still in flight. That left late advertise completions able to log or trigger recovery after stop had started, and it gave ciao less deterministic cleanup time for sockets, which is the likely source of the lingering socket ResourceWarning seen during full discovery cleanup.

## Evidence
- Added a regression test that stops the advertiser while an advertise promise is unresolved, verifies shutdown waits for bounded cleanup, and verifies no late advertised log is emitted.
- Ran: `env -u OPENCLAW_DISABLE_BONJOUR node scripts/test-extension.mjs bonjour` — 5 files passed, 51 tests passed.
- Ran before rebase: `node scripts/test-projects.mjs src/plugins/loader.runtime-registry.test.ts src/plugins/loader.test.ts -- -t "discovery registration mode|tool-discovery loads"` — 2 Vitest shards passed.