### PR TITLE
fix(gateway): clear model discovery cache during hot reload to prevent stale registries

### DIFF
--- a/src/agents/embedded-agent-runner/model-discovery-cache.test.ts
+++ b/src/agents/embedded-agent-runner/model-discovery-cache.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for model discovery cache lifecycle, including cache-hit reuse
+ * and hot-reload cache invalidation via resetModelDiscoveryCache.
+ */
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const resolvedAgentDir = path.resolve("/tmp/.openclaw/agents/test-agent");
+
+const mockDiscoverAuthStorage = vi.hoisted(() => vi.fn());
+const mockDiscoverModels = vi.hoisted(() => vi.fn());
+
+vi.mock("../agent-model-discovery.js", () => ({
+  discoverAuthStorage: mockDiscoverAuthStorage,
+  discoverModels: mockDiscoverModels,
+}));
+
+// Plugin catalog listing used by the discovery cache fingerprint.
+vi.mock("../plugin-model-catalog.js", () => ({
+  listPluginModelCatalogFiles: vi.fn(() => []),
+}));
+
+import {
+  discoverCachedAgentStores,
+  resetModelDiscoveryCache,
+  resetModelDiscoveryCacheForTest,
+} from "./model-discovery-cache.js";
+
+function freshAuthStorage() {
+  return { type: "file", resolvedDir: resolvedAgentDir } as never;
+}
+
+function freshModelRegistry() {
+  return { find: vi.fn(() => null), list: vi.fn(() => []), models: new Map() } as never;
+}
+
+describe("model discovery cache", () => {
+  afterEach(() => {
+    mockDiscoverAuthStorage.mockReset();
+    mockDiscoverModels.mockReset();
+    resetModelDiscoveryCacheForTest();
+  });
+
+  it("returns cached stores on repeated requests with the same agentDir", () => {
+    mockDiscoverAuthStorage.mockReturnValue(freshAuthStorage());
+    mockDiscoverModels.mockReturnValue(freshModelRegistry());
+
+    const first = discoverCachedAgentStores({ agentDir: resolvedAgentDir });
+    const second = discoverCachedAgentStores({ agentDir: resolvedAgentDir });
+
+    // Same objects returned from cache (cache hit).
+    expect(second.authStorage).toBe(first.authStorage);
+    expect(second.modelRegistry).toBe(first.modelRegistry);
+    expect(mockDiscoverAuthStorage).toHaveBeenCalledTimes(1);
+    expect(mockDiscoverModels).toHaveBeenCalledTimes(1);
+  });
+
+  it("resetModelDiscoveryCache clears all cached entries", () => {
+    mockDiscoverAuthStorage.mockReturnValue(freshAuthStorage());
+    mockDiscoverModels.mockReturnValue(freshModelRegistry());
+
+    const first = discoverCachedAgentStores({ agentDir: resolvedAgentDir });
+    expect(mockDiscoverAuthStorage).toHaveBeenCalledTimes(1);
+
+    resetModelDiscoveryCache();
+
+    // After cache clear, next request re-discovers.
+    mockDiscoverAuthStorage.mockReturnValue(freshAuthStorage());
+    mockDiscoverModels.mockReturnValue(freshModelRegistry());
+    const second = discoverCachedAgentStores({ agentDir: resolvedAgentDir });
+
+    // New objects (cache miss after reset).
+    expect(second.authStorage).not.toBe(first.authStorage);
+    expect(second.modelRegistry).not.toBe(first.modelRegistry);
+    expect(mockDiscoverAuthStorage).toHaveBeenCalledTimes(2);
+    expect(mockDiscoverModels).toHaveBeenCalledTimes(2);
+  });
+
+  it("resetModelDiscoveryCacheForTest delegates to resetModelDiscoveryCache", () => {
+    mockDiscoverAuthStorage.mockReturnValue(freshAuthStorage());
+    mockDiscoverModels.mockReturnValue(freshModelRegistry());
+
+    discoverCachedAgentStores({ agentDir: resolvedAgentDir });
+    expect(mockDiscoverAuthStorage).toHaveBeenCalledTimes(1);
+
+    resetModelDiscoveryCacheForTest();
+
+    // After clear via the deprecated API, next request re-discovers.
+    mockDiscoverAuthStorage.mockReturnValue(freshAuthStorage());
+    mockDiscoverModels.mockReturnValue(freshModelRegistry());
+    discoverCachedAgentStores({ agentDir: resolvedAgentDir });
+
+    expect(mockDiscoverAuthStorage).toHaveBeenCalledTimes(2);
+    expect(mockDiscoverModels).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-discovers after fingerprint change (different models.json)", () => {
+    mockDiscoverAuthStorage.mockReturnValue(freshAuthStorage());
+    mockDiscoverModels.mockReturnValue(freshModelRegistry());
+
+    const first = discoverCachedAgentStores({ agentDir: resolvedAgentDir });
+    expect(mockDiscoverAuthStorage).toHaveBeenCalledTimes(1);
+
+    // Simulate a fingerprint change by resolving to a different agent dir.
+    const otherDir = path.resolve("/tmp/.openclaw/agents/test-agent-other");
+    mockDiscoverAuthStorage.mockReturnValue(freshAuthStorage());
+    mockDiscoverModels.mockReturnValue(freshModelRegistry());
+
+    const second = discoverCachedAgentStores({ agentDir: otherDir });
+
+    // Different cache key → fresh discovery.
+    expect(second.authStorage).not.toBe(first.authStorage);
+    expect(mockDiscoverAuthStorage).toHaveBeenCalledTimes(2);
+    expect(mockDiscoverModels).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agents/embedded-agent-runner/model-discovery-cache.ts
+++ b/src/agents/embedded-agent-runner/model-discovery-cache.ts
@@ -188,7 +188,17 @@ export function discoverCachedAgentStores(
   return stores;
 }
 
-/** Clears the process-local discovery cache between tests that mutate model/auth fixtures. */
-export function resetModelDiscoveryCacheForTest(): void {
+/**
+ * Clears the process-local discovery cache so the next discovery for each agent
+ * directory rebuilds auth/model stores from the current resolved config. Called
+ * during config hot reload to ensure include-resolved model config changes
+ * propagate to per-agent model registries.
+ */
+export function resetModelDiscoveryCache(): void {
   DISCOVERY_STORE_CACHE.clear();
+}
+
+/** @deprecated Use {@link resetModelDiscoveryCache}; kept for test backward-compat. */
+export function resetModelDiscoveryCacheForTest(): void {
+  resetModelDiscoveryCache();
 }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -155,6 +155,12 @@ vi.mock("../agents/model-provider-auth.js", () => ({
   },
 }));
 
+vi.mock("../agents/embedded-agent-runner/model-discovery-cache.js", () => ({
+  resetModelDiscoveryCache: () => {
+    hoisted.reloadEvents.push("reset-model-discovery-cache");
+  },
+}));
+
 vi.mock("../agents/agent-bundle-mcp-tools.js", () => ({
   disposeAllSessionMcpRuntimes: hoisted.disposeAllSessionMcpRuntimes,
 }));
@@ -340,9 +346,11 @@ describe("gateway hot reload model state", () => {
     expect(firstResetIndex).toBeGreaterThanOrEqual(0);
     expect(hoisted.reloadEvents.slice(firstResetIndex)).toEqual([
       "reset-model-catalog",
+      "reset-model-discovery-cache",
       "clear-provider-auth",
       "reload-plugins",
       "reset-model-catalog",
+      "reset-model-discovery-cache",
       "clear-provider-auth",
       "refresh-context-window",
       "load-model-catalog",

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -2,6 +2,7 @@
 // Applies config reload plans to hooks, cron, heartbeat, plugins, channels, and restarts.
 import { disposeAllSessionMcpRuntimes } from "../agents/agent-bundle-mcp-tools.js";
 import { refreshContextWindowCache } from "../agents/context.js";
+import { resetModelDiscoveryCache } from "../agents/embedded-agent-runner/model-discovery-cache.js";
 import {
   getActiveEmbeddedRunCount,
   listActiveEmbeddedRunSessionIds,
@@ -111,6 +112,7 @@ const CHANNEL_RELOAD_STILL_PENDING_WARN_MS = 30_000;
 
 function resetPreparedModelRuntimeStateForHotReload(): void {
   resetModelCatalogCache();
+  resetModelDiscoveryCache();
   clearCurrentProviderAuthState();
   markGatewayModelCatalogStaleForReload();
 }


### PR DESCRIPTION
Closes #99773

## What Problem This Solves

Fixes an issue where after a config hot reload (triggered by any config change, even unrelated ones like Slack channel config), include-defined models (`OPENCLAW_INCLUDE_ROOTS`) would intermittently vanish from the running gateway's in-memory model registry, causing phantom "Unknown model" failover errors with no corresponding provider-side issue. The on-disk config was valid throughout (`openclaw models list` resolved every affected model), and only a full gateway restart cleared the condition.

## Why This Change Was Made

During hot reload, `resetPreparedModelRuntimeStateForHotReload()` cleared the gateway model catalog cache, stale-while-refresh catalog, and provider auth state — but NOT the per-agent `DISCOVERY_STORE_CACHE` in `model-discovery-cache.ts`. This module-level `Map<string, CacheEntry>` stores auth/model discovery snapshots keyed by agent directory. Its `discoveryFingerprint` only checks file metadata (models.json mtime, sqlite mtime, plugin catalog files), NOT `config.models.providers` content.

After a hot reload where the resolved config snapshot was rebuilt correctly (includes merged as expected), already-cached per-agent registries were returned stale because the discovery cache was never invalidated — matching the intermittent "some lanes fail, others succeed" symptom described in the issue.

The fix adds `resetModelDiscoveryCache()` (production-safe, called alongside the other cache resets in `resetPreparedModelRuntimeStateForHotReload()`). The cache is lazily repopulated on the next embedded-agent turn — hot reloads are infrequent relative to agent calls, so the performance impact is negligible.

## User Impact

Gateway operators using `OPENCLAW_INCLUDE_ROOTS` for shared model configurations no longer need to restart the gateway after unrelated config changes. Hot reload correctly preserves include-defined model registries.

## Evidence

### Unit tests (all passing)

| Test suite | Result |
|---|---|
| `model-discovery-cache.test.ts` (new) | **4 passed** — cache hit, reset clears all, deprecated delegate, fingerprint change |
| `server-reload-handlers.test.ts` | **50 passed** — includes event-order assertion proving `reset-model-discovery-cache` fires at both reload points |
| `model.test.ts` | **120 passed** — backward-compat via `resetModelDiscoveryCacheForTest` |
| `model.forward-compat.errors-and-overrides.test.ts` | **27 passed** — backward-compat |

### Cache invalidation behavior proof

The new `model-discovery-cache.test.ts` proves:
1. `discoverCachedAgentStores` returns identical objects on repeated calls (cache hit)
2. `resetModelDiscoveryCache()` clears the cache — subsequent calls return fresh objects from `discoverAuthStorage` and `discoverModels`
3. `resetModelDiscoveryCacheForTest()` delegates to `resetModelDiscoveryCache()` (backward compat)
4. Different agent directories produce independent cache entries

### Format

`oxfmt --check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)