### PR TITLE
fix(channel): claude-cli live render UX (progress preview) on native thinking parser

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -477,12 +477,22 @@ function renderTelegramProgressDraftPreview(
   richMessages: boolean,
 ): TelegramDraftPreview {
   const trimmed = text.trimEnd();
+  // formatChannelProgressDraftText writes the draft label as `${label}\n\n${content}`
+  // and joins content lines with `\n`. Extract the heading only when the compositor
+  // actually wrote a label: either the draft is label-only (no structured content
+  // lines) or the text contains the blank-line separator. Without this guard a
+  // labelless draft (progress.label: false, or the label sliced off by maxLines)
+  // treats the first content line as a heading AND re-renders it from `lines`,
+  // which duplicates the first preview line — once with the formatLine backticks
+  // and once as the plain bold structured line.
+  const separatorIndex = trimmed.indexOf("\n\n");
+  const heading =
+    lines.length === 0
+      ? trimmed
+      : separatorIndex >= 0
+        ? trimmed.slice(0, separatorIndex)
+        : undefined;
   const renderedLines = lines.map(renderTelegramProgressLine).filter(Boolean);
-  const textLines = trimmed
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter(Boolean);
-  const heading = textLines.length > renderedLines.length ? textLines[0] : undefined;
   const htmlParts = heading
     ? [`<b>${escapeTelegramProgressHtml(heading)}</b>`, ...renderedLines]
     : renderedLines;
@@ -1468,6 +1478,21 @@ export const dispatchTelegramMessage = async ({
     const split = splitTextIntoLaneSegments(update, isReasoning);
     for (const segment of split.segments) {
       if (segment.lane === "answer") {
+        // In progress mode the answer lane is owned by the live progress draft.
+        // updateDraftFromPartial() below already no-ops answer partials here (its
+        // streamMode==="progress" guard returns before rendering), so the only
+        // remaining effect of preparing the answer lane would be
+        // rotateAnswerLaneAfterToolProgress() -> suppressProgressDraftState(),
+        // which sets progressSuppressed and silently drops EVERY later tool
+        // start/result for the rest of the turn (the trace's repeated
+        // note.DROP ... suppressed=true). claude-cli streams inter-tool
+        // commentary ("now I'll run the next command") as partial answer text;
+        // that transient text must not freeze the tool preview. Skip the answer
+        // lane while streaming progress — tool/reasoning lines keep driving it,
+        // and final-answer delivery still clears the draft via its own path.
+        if (streamMode === "progress") {
+          continue;
+        }
         await prepareAnswerLaneForText();
       }
       if (segment.lane === "reasoning") {
@@ -2435,6 +2460,34 @@ export const dispatchTelegramMessage = async ({
                       }
 
                       if (segment.lane === "answer" && info.kind === "block") {
+                        // In progress mode an intermediate assistant text block is
+                        // preamble/commentary the model emits before calling tools
+                        // (claude-cli: thinking -> "I'll run the commands" ->
+                        // tool_use). It is transient, not a durable message. Route
+                        // it into the live progress draft exactly like the tool-text
+                        // path above, so the reasoning/tool preview stays alive
+                        // instead of being wiped by resetProgressDraftState() before
+                        // the tools even run. The final answer still clears the draft
+                        // at info.kind === "final".
+                        // (NOTE: claude-cli emits no content during tool execution,
+                        // only system/task_* notifications — those could later drive
+                        // a keepalive but are intentionally left untouched here.)
+                        if (streamMode === "progress" && !verboseProgressActive()) {
+                          const canRepresentBlockAsTransientProgress =
+                            !reply.hasMedia &&
+                            telegramButtons === undefined &&
+                            !hasExecApprovalPayload(effectivePayload);
+                          if (
+                            canRepresentBlockAsTransientProgress &&
+                            answerLane.stream &&
+                            (await pushStreamToolProgress(segment.update.text, {
+                              startImmediately: true,
+                            }))
+                          ) {
+                            blockDelivered = true;
+                            continue;
+                          }
+                        }
                         const preparedAnswerLane = await prepareAnswerLaneForText();
                         const shouldRotateQueuedBlock = takeQueuedAnswerBlockRotation(
                           lanePayload,
@@ -2704,6 +2757,20 @@ export const dispatchTelegramMessage = async ({
                   commentaryProgressEnabled:
                     streamMode === "progress" ? progressDraft.commentaryProgressEnabled : undefined,
                   reasoningPayloadsEnabled: durableReasoningPayloadsEnabled,
+                  onAgentRunStart: () => {
+                    // Arm the progress gate as soon as the agent run begins so the
+                    // delayed-start debounce elapses during claude-cli's initial
+                    // silent thinking window (it can think for a minute before its
+                    // first emit). The compositor still defers the first DELIVERED
+                    // frame until a real tool/reasoning line exists — it never sends
+                    // a bare label — so this only makes the first such line appear
+                    // immediately instead of waiting out the debounce.
+                    if (streamMode === "progress") {
+                      void enqueueDraftLaneEvent(async () => {
+                        await progressDraft.noteActivity();
+                      });
+                    }
+                  },
                   onToolStart: async (payload) => {
                     const toolName = payload.name?.trim();
                     // Only the "start" phase is a boundary (later phases of the same

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -263,6 +263,13 @@ export function createTelegramDraftStream(params: {
   let messageSendAttempted = false;
   let suspendedUntilMs = 0;
   let consecutivePreviewFailures = 0;
+  // Flood-suspend holds (Date.now() < suspendedUntilMs) return false, and the
+  // throttle loop only re-attempts a held edit on the next update(). claude-cli
+  // emits nothing while a tool runs, so a tool-line edit held during that silent
+  // window would otherwise strand the preview on the previous frame for the rest
+  // of the turn. A single-slot timer re-flushes the held text once the suspend
+  // window elapses, with no fresh update() needed.
+  let heldRetryTimer: ReturnType<typeof setTimeout> | undefined;
   let streamMessageId: number | undefined;
   let streamVisibleSinceMs: number | undefined;
   let lastSentPreviewKey = "";
@@ -428,6 +435,7 @@ export function createTelegramDraftStream(params: {
     // so the first tick after retry_after delivers it. Final flushes still try
     // so the last text has a chance to land.
     if (!streamState.final && Date.now() < suspendedUntilMs) {
+      scheduleHeldRetry(suspendedUntilMs - Date.now());
       return false;
     }
     const trimmed = text.trimEnd();
@@ -515,6 +523,7 @@ export function createTelegramDraftStream(params: {
         lastDeliveredText = trimmed;
         consecutivePreviewFailures = 0;
         suspendedUntilMs = 0;
+        clearHeldRetry();
       }
       return sent;
     } catch (err) {
@@ -523,30 +532,43 @@ export function createTelegramDraftStream(params: {
         // Telegram already shows exactly this text; count the edit as delivered.
         consecutivePreviewFailures = 0;
         lastDeliveredText = trimmed;
+        clearHeldRetry();
         return true;
       }
       // Roll back the dedupe snapshot so the retried tick is not skipped as a no-op.
       lastSentPreviewKey = previousSentPreviewKey;
-      // Flood control is always retryable: Telegram rejected the call outright.
-      // Beyond that, edits retry on any transient network error (re-editing the
-      // same content is idempotent) while an unsent first preview retries only
-      // on provably pre-connect failures — anything ambiguous could duplicate
-      // the preview message.
-      const retryable =
-        isTelegramRateLimitError(err) ||
-        (isEdit ? isRecoverableTelegramNetworkError(err) : isSafeToRetrySendError(err));
+      // Flood control is backpressure, not a preview failure: Telegram is asking
+      // us to slow down, not signalling a broken stream. Suspend for retry_after
+      // and re-arm a self-flush so the held text still lands during a silent tool
+      // window, but NEVER count it toward the permanent-stop budget — a long turn
+      // of ~1s edits would otherwise trip the breaker and kill the preview for the
+      // rest of the run.
+      if (isTelegramRateLimitError(err)) {
+        const retryAfterMs = readTelegramRetryAfterMs(err) ?? throttleMs;
+        suspendedUntilMs = Date.now() + Math.min(retryAfterMs, MAX_PREVIEW_FLOOD_SUSPEND_MS);
+        scheduleHeldRetry(suspendedUntilMs - Date.now());
+        params.warn?.(
+          `telegram stream preview ${isEdit ? "edit" : "send"} flood-suspended (retrying): ${formatErrorMessage(err)}`,
+        );
+        return false;
+      }
+      // Non-flood transient errors retry on a bounded budget; a persistent outage
+      // stops the preview so a broken stream does not warn-spam for the whole run.
+      // Edits retry on any transient network error (re-editing the same content is
+      // idempotent) while an unsent first preview retries only on provably
+      // pre-connect failures — anything ambiguous could duplicate the preview.
+      const retryable = isEdit
+        ? isRecoverableTelegramNetworkError(err)
+        : isSafeToRetrySendError(err);
       consecutivePreviewFailures += 1;
       if (retryable && consecutivePreviewFailures <= MAX_CONSECUTIVE_PREVIEW_FAILURES) {
-        const retryAfterMs = readTelegramRetryAfterMs(err);
-        if (retryAfterMs !== undefined) {
-          suspendedUntilMs = Date.now() + Math.min(retryAfterMs, MAX_PREVIEW_FLOOD_SUSPEND_MS);
-        }
         params.warn?.(
           `telegram stream preview ${isEdit ? "edit" : "send"} failed (retrying): ${formatErrorMessage(err)}`,
         );
         return false;
       }
       streamState.stopped = true;
+      clearHeldRetry();
       params.warn?.(`telegram stream preview failed: ${formatErrorMessage(err)}`);
       return false;
     }
@@ -561,6 +583,31 @@ export function createTelegramDraftStream(params: {
     state: streamState,
     sendOrEditStreamMessage,
   });
+
+  // Single-slot self-retry: re-flush the held pending text once the flood-suspend
+  // window elapses, even when no further update() arrives (claude-cli is silent
+  // while a tool runs). flush() is single-flight and re-checks every hold gate, so
+  // this is idempotent against the loop's own throttle timer; a still-suspended
+  // tick simply re-arms it. Skipped once stopped/final so a stray late edit can
+  // never resurrect the preview underneath the final reply.
+  function scheduleHeldRetry(delayMs: number): void {
+    if (heldRetryTimer !== undefined || streamState.stopped || streamState.final) {
+      return;
+    }
+    heldRetryTimer = setTimeout(
+      () => {
+        heldRetryTimer = undefined;
+        void loop.flush();
+      },
+      Math.max(0, delayMs),
+    );
+  }
+  function clearHeldRetry(): void {
+    if (heldRetryTimer !== undefined) {
+      clearTimeout(heldRetryTimer);
+      heldRetryTimer = undefined;
+    }
+  }
 
   const requestDraftUpdate = (text: string, preview?: TelegramDraftPreview) => {
     if (streamState.stopped || streamState.final) {
@@ -585,6 +632,7 @@ export function createTelegramDraftStream(params: {
 
   const stop = async () => {
     streamState.final = true;
+    clearHeldRetry();
     await loop.flush();
     if (streamState.stopped) {
       return;
@@ -603,6 +651,7 @@ export function createTelegramDraftStream(params: {
   }) => void = (options) => {
     streamState.stopped = false;
     streamState.final = options?.keepFinal === true;
+    clearHeldRetry();
     generation += 1;
     messageSendAttempted = false;
     streamMessageId = undefined;
@@ -653,6 +702,7 @@ export function createTelegramDraftStream(params: {
   const clear = async () => {
     // Capture before the stop; takeMessageIdAfterStop resets streamVisibleSinceMs.
     const visibleSince = streamVisibleSinceMs;
+    clearHeldRetry();
     const messageId = await takeMessageIdAfterStop({
       stopForClear,
       readMessageId: () => streamMessageId,
@@ -697,6 +747,7 @@ export function createTelegramDraftStream(params: {
   };
 
   const discard = async () => {
+    clearHeldRetry();
     await stopForClear();
   };
 

--- a/src/channels/progress-draft-compositor.ts
+++ b/src/channels/progress-draft-compositor.ts
@@ -98,6 +98,15 @@ export function createChannelProgressDraftCompositor(params: {
     if (!params.active || params.mode !== "progress" || finalReplyStarted || finalReplyDelivered) {
       return false;
     }
+    // Tool-progress previews use the label only as a header above tool/reasoning
+    // lines, so a draft with no content lines is not a deliverable frame. The gate
+    // arms early (run-start activity) and its timer can fire during claude-cli's
+    // initial silent window before any line exists — without this guard the first
+    // delivered frame would be a bare label instead of the first tool line. Label-
+    // only previews (toolProgress disabled) keep delivering the standalone label.
+    if (previewToolProgressEnabled && lines.length === 0) {
+      return false;
+    }
     const text = formatDraftText();
     if (!text || text === lastRenderedText) {
       return false;
@@ -280,6 +289,13 @@ export function createChannelProgressDraftCompositor(params: {
         params.mode !== "progress" ||
         !text ||
         progressSuppressed ||
+        // Freeze on final-reply START, not just delivery — same teardown gate as
+        // pushToolProgress/pushCommentaryProgress/noteActivity. claude-cli resends
+        // the full reasoning-so-far (snapshot) on every thinking delta, so a late
+        // snapshot can land in the window after the final answer began delivering;
+        // without this it would still mutate the reasoning buffer/lines (the live
+        // draft kept "active") instead of collapsing into the final reply.
+        finalReplyStarted ||
         finalReplyDelivered ||
         !thinkingProgressEnabled
       ) {
@@ -481,15 +497,22 @@ function compactReasoningProgressDisplayLine(text: string, maxChars: number): st
   if (maxChars <= 1) {
     return "…";
   }
-  const head = chars
-    .slice(0, maxChars - 1)
+  // Reasoning streams keep growing across a turn (snapshot/cumulative providers
+  // resend the full thinking-so-far). Truncating from the head would pin the
+  // preview on the OLDEST thought and hide what the model is currently reasoning
+  // about, so the draft looks frozen/stale once it exceeds the line budget.
+  // Keep the TAIL instead, so the preview always reflects the latest thought.
+  const tail = chars
+    .slice(-(maxChars - 1))
     .join("")
-    .trimEnd();
-  const boundary = head.search(/\s+\S*$/u);
-  if (boundary > Math.floor(maxChars * 0.6)) {
-    return `${head.slice(0, boundary).trimEnd()}…`;
+    .trimStart();
+  const boundary = tail.search(/\s/u);
+  if (boundary >= 0 && boundary < Math.floor(maxChars * 0.4)) {
+    // Drop a leading partial word so the preview starts on a clean word boundary.
+    const aligned = tail.slice(boundary).trimStart();
+    return aligned ? `…${aligned}` : `…${tail}`;
   }
-  return `${head}…`;
+  return `…${tail}`;
 }
 
 function normalizeCommentaryProgressText(text: string): string {

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -329,8 +329,15 @@ function buildNamedProgressLine(
   });
   const display = resolveToolDisplay({ name: normalizedName });
   const prefix = `${display.emoji} ${display.label}`;
+  // Match formatToolAggregate's compact-command detection, which keys on the
+  // case-insensitive tool name. Comparing display.name verbatim missed
+  // capitalized command tools (claude-cli's "Bash"), dropping their command
+  // detail here while the text above was still compacted — so the line kept the
+  // command only inside `text`, and the channel renderer showed BOTH the bold
+  // label and that text (a redundant "🛠️ Bash 🛠️ <cmd>" double render).
+  const toolNameKey = normalizeOptionalLowercaseString(display.name);
   const compactCommandDetail =
-    (display.name === "exec" || display.name === "bash") && text.startsWith(`${display.emoji} `)
+    (toolNameKey === "exec" || toolNameKey === "bash") && text.startsWith(`${display.emoji} `)
       ? text.slice(display.emoji.length + 1).trim()
       : undefined;
   const compactCommandPrefix =
@@ -348,7 +355,10 @@ function buildNamedProgressLine(
     icon: display.emoji,
     ...(detail ? { detail } : {}),
     ...(fields?.status ? { status: fields.status } : {}),
-    toolName: display.name,
+    // Store the normalized command-family name so downstream compact-command
+    // detection (getProgressDraftLineText, mergeProgressDraftLineUpdate) matches
+    // regardless of the provider's tool-name casing.
+    toolName: toolNameKey || display.name,
   };
   setProgressDraftLineCorrelationKey(line, fields?.correlationKey);
   return line;


### PR DESCRIPTION
Related: #97526 · Supersedes #97565

## What Problem This Solves

On `claude-cli` live-session models, the message-based progress preview (Telegram et al.) rendered the tool/answer stream worse than the Codex runtime does for the same turn on the same channels. Three concrete defects remained after the parser landed natively:

1. A tool-progress preview could emit a **bare label frame before the first tool line existed**, and the compositor kept fighting the published answer instead of freezing when the final reply began.
2. A labelless draft **duplicated its first preview line** (heading emitted twice).
3. Inter-tool commentary and silent tool windows **froze or erased the live tool preview**, so it went stale between tool calls instead of refreshing in place.

This is the **render-UX remainder** of the original work (#97565), rescoped after the layers underneath it merged upstream:

- **#99401** merged the native `claude-cli` stream-json thinking parser (block-index `ThinkingTracker`, `/reasoning` gating) — so the earlier parser port #97565 carried is now native and is **dropped** here.
- **#100148** merged the reasoning plumbing for queued/followup runs plus thinking-token progress (`onAgentRunStart`, `reasoningPayloadsEnabled`) — this PR is a **consumer** of that hook, not a redefiner, so the arm-gate rides #100148's followup wiring for free.

Parser and `/reasoning` gating come entirely from #99401; this PR is render-side behaviour only.

## What Changed

Three behaviours in `src/channels/` + `extensions/telegram/`:

1. **First-frame guard (silent-window arming)** — `progress-draft-compositor`: never emit a bare label before the first tool line; freeze the compositor on final-reply start.
2. **First-line dedup** — `bot-message-dispatch`: separator-based heading extraction so a labelless draft no longer duplicates the first preview line.
3. **Keep preview alive across inter-tool commentary / silent tool windows** — `draft-stream` / `streaming`: the preview stays live and refreshes in place, keyed by `toolCallId`.

No config change; non-`claude-cli` providers unaffected.

## Evidence

- **Scope:** 4 files, +177/−26 — `extensions/telegram/src/bot-message-dispatch.ts`, `extensions/telegram/src/draft-stream.ts`, `src/channels/progress-draft-compositor.ts`, `src/channels/streaming.ts`.
- **Rebase integrity:** base is exactly `origin/main` (including #99401 and #100148) + this one commit; `git diff --check` reports zero conflict markers.
- **Types:** `tsgo` (core + extensions) is clean on the changed files. A hook whose firing trigger is not yet in-tree (`onToolProgressKeepAlive`) was trimmed so no dead/dangling reference ships — `git grep` confirms it is fully removed; it will land as a separate follow-up alongside its firing commit.
- **CI:** all required checks green on this PR head (lint, prod/test types, contracts, node compact shards, security/boundary gates).
- **Live observation:** this exact render-UX is the patch running in production on my own OpenClaw gateway (custom `v2026.6.11`-based dist). Live on Telegram the three defects above are gone: preview arms only after the first real tool line, the first heading is not duplicated, and the tool preview stays live/refreshing across inter-tool commentary through to a clean in-place final publish.