### PR TITLE
fix: protect hasTailscaleFunnelRouteForPort from unhandled JSON parse errors

### DIFF
--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -263,12 +263,12 @@ describe("tailscale helpers", () => {
     await expect(hasTailscaleFunnelRouteForPort(18789, exec)).resolves.toBe(true);
   });
 
-  it("hasTailscaleFunnelRouteForPort preserves malformed status parse failures", async () => {
+  it("hasTailscaleFunnelRouteForPort handles malformed status parse failures gracefully", async () => {
     const exec = vi.fn().mockResolvedValue({
       stdout: "warning: stale state\n{not json}\n",
     });
 
-    await expect(hasTailscaleFunnelRouteForPort(18789, exec)).rejects.toThrow(SyntaxError);
+    await expect(hasTailscaleFunnelRouteForPort(18789, exec)).resolves.toBe(false);
   });
 });
 

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -288,18 +288,17 @@ export async function hasTailscaleFunnelRouteForPort(
   port: number,
   exec: typeof runExec = runExec,
 ): Promise<boolean> {
-  let stdout: string;
+  let parsed: Record<string, unknown>;
   try {
     const tailscaleBin = await getTailscaleBinary();
     const result = await exec(tailscaleBin, ["funnel", "status", "--json"], {
       maxBuffer: 200_000,
       timeoutMs: 5_000,
     });
-    stdout = result.stdout;
+    parsed = result.stdout ? parsePossiblyNoisyJsonObject(result.stdout) : {};
   } catch {
     return false;
   }
-  const parsed = stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
   return tailscaleFunnelStatusCoversPort(parsed, port);
 }
 


### PR DESCRIPTION
Closing this PR. The same change was already attempted and rejected in PR #63321. The canonical behavior (commit bd10e1998b) intentionally treats malformed Tailscale funnel status as an unknown state (throw) rather than a confirmed no-route (false). The calling layer in `server-tailscale.ts` handles the error by preserving existing Funnel routes, which is the correct fail-closed behavior.