### PR TITLE
fix(slack): react action rejects emoji glyphs; member-info userId affordance unclear

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -611,6 +611,9 @@ Scenarios (`extensions/qa-lab/src/live-transports/slack/slack-live.runtime.ts`):
 - `slack-restart-resume`
 - `slack-thread-follow-up`
 - `slack-thread-isolation`
+- `slack-reaction-glyph-native` - opt-in live message-tool reaction scenario.
+  Instructs the agent to pass the exact `✅` glyph and confirms Slack stored
+  `white_check_mark` for the SUT bot on the target message.
 - `slack-approval-exec-native` - opt-in native Slack exec approval scenario.
   Requests an exec approval through the gateway, verifies the Slack message
   has native approval buttons, resolves it, and verifies the resolved Slack

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -77,10 +77,11 @@ describe("Slack live QA runtime helpers", () => {
     ]);
   });
 
-  it("selects native approval scenarios by id without changing standard scenario coverage", () => {
+  it("selects opt-in native scenarios by id without changing standard scenario coverage", () => {
     expect(
       testing
         .findScenario([
+          "slack-reaction-glyph-native",
           "slack-approval-exec-native",
           "slack-approval-plugin-native",
           "slack-codex-approval-exec-native",
@@ -88,12 +89,14 @@ describe("Slack live QA runtime helpers", () => {
         ])
         .map((scenario) => scenario.id),
     ).toEqual([
+      "slack-reaction-glyph-native",
       "slack-approval-exec-native",
       "slack-approval-plugin-native",
       "slack-codex-approval-exec-native",
       "slack-codex-approval-plugin-native",
     ]);
     expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain("slack-approval-exec-native");
+    expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain("slack-reaction-glyph-native");
     expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain(
       "slack-codex-approval-exec-native",
     );
@@ -269,6 +272,92 @@ describe("Slack live QA runtime helpers", () => {
     expect(testing.resolveCodexFileApprovalTargetPath("MARKER")).toMatch(
       /\.openclaw-qa-codex-file-approval-marker\.txt$/u,
     );
+  });
+
+  it("instructs the live reaction scenario to preserve the exact emoji glyph", () => {
+    const scenario = testing.findScenario(["slack-reaction-glyph-native"])[0];
+    const run = scenario?.buildRun("U999999999");
+
+    expect(run).toMatchObject({ expectReply: true });
+    expect(run && "input" in run ? run.input : "").toContain('emoji to exactly "✅"');
+    expect(run && "input" in run ? run.input : "").toContain("Do not substitute a shortcode");
+  });
+
+  it("enables the message tool for the live reaction scenario", () => {
+    const scenario = testing.findScenario(["slack-reaction-glyph-native"])[0];
+    const cfg = testing.buildSlackQaConfig(
+      {},
+      {
+        channelId: "C123456789",
+        driverBotUserId: "U999999999",
+        overrides: scenario?.configOverrides,
+        sutAccountId: "sut",
+        sutAppToken: "xapp-sut",
+        sutBotToken: "xoxb-sut",
+      },
+    );
+
+    expect(cfg.tools?.alsoAllow).toContain("message");
+  });
+
+  it("adds the message tool to an explicit allowlist without mixing tool policies", () => {
+    const scenario = testing.findScenario(["slack-reaction-glyph-native"])[0];
+    const cfg = testing.buildSlackQaConfig(
+      { tools: { allow: ["read"] } },
+      {
+        channelId: "C123456789",
+        driverBotUserId: "U999999999",
+        overrides: scenario?.configOverrides,
+        sutAccountId: "sut",
+        sutAppToken: "xapp-sut",
+        sutBotToken: "xoxb-sut",
+      },
+    );
+
+    expect(cfg.tools?.allow).toEqual(["read", "message"]);
+    expect(cfg.tools?.alsoAllow).toBeUndefined();
+  });
+
+  it("preserves an empty allowlist as allow-all when enabling the message tool", () => {
+    const scenario = testing.findScenario(["slack-reaction-glyph-native"])[0];
+    const cfg = testing.buildSlackQaConfig(
+      { tools: { allow: [] } },
+      {
+        channelId: "C123456789",
+        driverBotUserId: "U999999999",
+        overrides: scenario?.configOverrides,
+        sutAccountId: "sut",
+        sutAppToken: "xapp-sut",
+        sutBotToken: "xoxb-sut",
+      },
+    );
+
+    expect(cfg.tools?.allow).toEqual([]);
+    expect(cfg.tools?.alsoAllow).toEqual(["message"]);
+  });
+
+  it("requires the SUT-owned normalized Slack reaction", async () => {
+    const get = vi.fn(async () => ({
+      message: {
+        reactions: [{ count: 1, name: "white_check_mark", users: ["U999999999"] }],
+      },
+    }));
+
+    await expect(
+      testing.waitForSlackReaction({
+        channelId: "C123456789",
+        client: { reactions: { get } } as never,
+        expectedReactionName: "white_check_mark",
+        messageId: "123.456",
+        sutUserId: "U999999999",
+        timeoutMs: 0,
+      }),
+    ).resolves.toMatchObject({ name: "white_check_mark" });
+    expect(get).toHaveBeenCalledWith({
+      channel: "C123456789",
+      full: true,
+      timestamp: "123.456",
+    });
   });
 
   it("reads the accepted asynchronous Gateway agent run id", () => {

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.ts
@@ -3,7 +3,11 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { createSlackWebClient, createSlackWriteClient } from "@openclaw/slack/api.js";
+import {
+  createSlackWebClient,
+  createSlackWriteClient,
+  listSlackReactions,
+} from "@openclaw/slack/api.js";
 import type { WebClient } from "@slack/web-api";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -68,6 +72,7 @@ const SLACK_QA_GATEWAY_STOP_SETTLE_MS = 3_000;
 const SLACK_QA_RETRYABLE_SCENARIO_ATTEMPTS = 2;
 const SLACK_QA_APPROVAL_DECISION_TIMEOUT_MS = 30_000;
 const SLACK_QA_APPROVAL_CHECKPOINT_DEFAULT_TIMEOUT_MS = 120_000;
+const SLACK_QA_REACTION_VERIFY_TIMEOUT_MS = 15_000;
 // These scenarios force the Codex harness, whose default provider set is intentionally narrow.
 const SLACK_QA_CODEX_PROVIDER_IDS = new Set(["codex", "openai"]);
 
@@ -79,6 +84,7 @@ type SlackQaScenarioId =
   | "slack-codex-approval-exec-native"
   | "slack-codex-approval-plugin-native"
   | "slack-mention-gating"
+  | "slack-reaction-glyph-native"
   | "slack-restart-resume"
   | "slack-thread-follow-up"
   | "slack-thread-isolation"
@@ -150,6 +156,7 @@ type SlackQaConfigOverrides = {
     target?: "both" | "channel" | "dm";
   };
   codexApproval?: boolean;
+  messageTool?: boolean;
   replyToMode?: "all" | "off";
   users?: string[];
 };
@@ -398,6 +405,36 @@ const SLACK_QA_SCENARIOS: SlackQaScenarioDefinition[] = [
               `expected top-level Slack reply without thread_ts; got ${message.thread_ts}`,
             );
           }
+        },
+      };
+    },
+  },
+  {
+    id: "slack-reaction-glyph-native",
+    title: "Slack message tool normalizes an emoji glyph reaction",
+    timeoutMs: 90_000,
+    configOverrides: { messageTool: true },
+    buildRun: (sutUserId) => {
+      const token = `SLACK_QA_REACTION_${randomUUID().slice(0, 8).toUpperCase()}`;
+      return {
+        expectReply: true,
+        input: [
+          `<@${sutUserId}> use the message tool exactly once to react to this message.`,
+          'Set action to "react", channel to "slack", and emoji to exactly "✅".',
+          "Do not substitute a shortcode.",
+          `After the reaction succeeds, reply with only this exact marker: ${token}`,
+        ].join(" "),
+        matchText: token,
+        afterReply: async (_message, context) => {
+          await waitForSlackReaction({
+            channelId: context.channelId,
+            client: context.sutReadClient,
+            expectedReactionName: "white_check_mark",
+            messageId: context.sentTs,
+            sutUserId: context.sutIdentity.userId,
+            timeoutMs: SLACK_QA_REACTION_VERIFY_TIMEOUT_MS,
+          });
+          return "verified SUT white_check_mark reaction from exact glyph instruction";
         },
       };
     },
@@ -714,9 +751,33 @@ function buildSlackQaConfig(
         target: approvalOverrides.target ?? ("channel" as const),
       }
     : undefined;
+  const explicitToolAllow = baseCfg.tools?.allow;
+  const messageToolPolicy = params.overrides?.messageTool
+    ? explicitToolAllow && explicitToolAllow.length > 0
+      ? { allow: uniqueStrings([...explicitToolAllow, "message"]) }
+      : { alsoAllow: uniqueStrings([...(baseCfg.tools?.alsoAllow ?? []), "message"]) }
+    : {};
+  const toolsConfig =
+    codexApprovalConfig || params.overrides?.messageTool
+      ? {
+          tools: {
+            ...baseCfg.tools,
+            ...messageToolPolicy,
+            ...(codexApprovalConfig
+              ? {
+                  exec: {
+                    ...baseCfg.tools?.exec,
+                    mode: "ask" as const,
+                  },
+                }
+              : {}),
+          },
+        }
+      : {};
   return {
     ...baseCfg,
     ...approvalForwardingConfig,
+    ...toolsConfig,
     plugins: {
       ...baseCfg.plugins,
       allow: pluginAllow,
@@ -745,13 +806,6 @@ function buildSlackQaConfig(
           agents: {
             ...baseCfg.agents,
             ...(codexAgentDefaults ? { defaults: codexAgentDefaults } : {}),
-          },
-          tools: {
-            ...baseCfg.tools,
-            exec: {
-              ...baseCfg.tools?.exec,
-              mode: "ask" as const,
-            },
           },
         }
       : {}),
@@ -1706,6 +1760,38 @@ function readAgentWaitStatus(result: unknown) {
   }
   const status = (result as { status?: unknown }).status;
   return typeof status === "string" && status.trim() ? status : "unknown";
+}
+
+async function waitForSlackReaction(params: {
+  channelId: string;
+  client: WebClient;
+  expectedReactionName: string;
+  messageId: string;
+  sutUserId: string;
+  timeoutMs: number;
+}) {
+  const deadline = Date.now() + params.timeoutMs;
+  while (true) {
+    const reactions = await listSlackReactions(params.channelId, params.messageId, {
+      client: params.client,
+    });
+    const reaction = reactions?.find(
+      (entry) =>
+        entry.name === params.expectedReactionName && entry.users?.includes(params.sutUserId),
+    );
+    if (reaction) {
+      return reaction;
+    }
+    if (Date.now() >= deadline) {
+      break;
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1_000);
+    });
+  }
+  throw new Error(
+    `Slack message ${params.messageId} did not receive ${params.expectedReactionName} from ${params.sutUserId}`,
+  );
 }
 
 function assertCodexApprovalTranscriptSucceeded(
@@ -2892,5 +2978,6 @@ export const testing = {
   SLACK_QA_STANDARD_SCENARIO_IDS,
   toSlackQaScenarioArtifactResults,
   waitForSlackNoReply,
+  waitForSlackReaction,
 };
 export { testing as __testing };

--- a/extensions/slack/src/actions.reactions.test.ts
+++ b/extensions/slack/src/actions.reactions.test.ts
@@ -79,6 +79,80 @@ describe("reactSlackMessage", () => {
   });
 });
 
+describe("reactSlackMessage emoji normalization", () => {
+  it("maps a Unicode emoji glyph to its Slack shortname", async () => {
+    const client = createClient();
+
+    await reactSlackMessage("C1", "123.456", "✅", { client, token: "xoxb-test" });
+
+    expect(client.reactions.add).toHaveBeenCalledWith({
+      channel: "C1",
+      timestamp: "123.456",
+      name: "white_check_mark",
+    });
+  });
+
+  it("passes through a colon-wrapped shortname unchanged", async () => {
+    const client = createClient();
+
+    await reactSlackMessage("C1", "123.456", ":fire:", { client, token: "xoxb-test" });
+
+    expect(client.reactions.add).toHaveBeenCalledWith({
+      channel: "C1",
+      timestamp: "123.456",
+      name: "fire",
+    });
+  });
+
+  it("passes through a plain shortname unchanged", async () => {
+    const client = createClient();
+
+    await reactSlackMessage("C1", "123.456", "rocket", { client, token: "xoxb-test" });
+
+    expect(client.reactions.add).toHaveBeenCalledWith({
+      channel: "C1",
+      timestamp: "123.456",
+      name: "rocket",
+    });
+  });
+
+  it("passes through an unmapped emoji glyph unchanged", async () => {
+    const client = createClient();
+
+    await reactSlackMessage("C1", "123.456", "🦄", { client, token: "xoxb-test" });
+
+    expect(client.reactions.add).toHaveBeenCalledWith({
+      channel: "C1",
+      timestamp: "123.456",
+      name: "🦄",
+    });
+  });
+
+  it("strips a skin-tone modifier before mapping to a shortname", async () => {
+    const client = createClient();
+
+    await reactSlackMessage("C1", "123.456", "👍🏽", { client, token: "xoxb-test" });
+
+    expect(client.reactions.add).toHaveBeenCalledWith({
+      channel: "C1",
+      timestamp: "123.456",
+      name: "thumbsup",
+    });
+  });
+
+  it("strips a variation selector before mapping to a shortname", async () => {
+    const client = createClient();
+
+    await reactSlackMessage("C1", "123.456", "⚠️", { client, token: "xoxb-test" });
+
+    expect(client.reactions.add).toHaveBeenCalledWith({
+      channel: "C1",
+      timestamp: "123.456",
+      name: "warning",
+    });
+  });
+});
+
 describe("removeSlackReaction", () => {
   it("treats no_reaction as idempotent success", async () => {
     const client = createClient();

--- a/extensions/slack/src/actions.reactions.test.ts
+++ b/extensions/slack/src/actions.reactions.test.ts
@@ -80,75 +80,22 @@ describe("reactSlackMessage", () => {
 });
 
 describe("reactSlackMessage emoji normalization", () => {
-  it("maps a Unicode emoji glyph to its Slack shortname", async () => {
+  it.each([
+    { input: "✅", expected: "white_check_mark" },
+    { input: ":fire:", expected: "fire" },
+    { input: "rocket", expected: "rocket" },
+    { input: "🦄", expected: "🦄" },
+    { input: "👍🏽", expected: "thumbsup::skin-tone-4" },
+    { input: "⚠️", expected: "warning" },
+  ])("normalizes $input to $expected", async ({ input, expected }) => {
     const client = createClient();
 
-    await reactSlackMessage("C1", "123.456", "✅", { client, token: "xoxb-test" });
+    await reactSlackMessage("C1", "123.456", input, { client, token: "xoxb-test" });
 
     expect(client.reactions.add).toHaveBeenCalledWith({
       channel: "C1",
       timestamp: "123.456",
-      name: "white_check_mark",
-    });
-  });
-
-  it("passes through a colon-wrapped shortname unchanged", async () => {
-    const client = createClient();
-
-    await reactSlackMessage("C1", "123.456", ":fire:", { client, token: "xoxb-test" });
-
-    expect(client.reactions.add).toHaveBeenCalledWith({
-      channel: "C1",
-      timestamp: "123.456",
-      name: "fire",
-    });
-  });
-
-  it("passes through a plain shortname unchanged", async () => {
-    const client = createClient();
-
-    await reactSlackMessage("C1", "123.456", "rocket", { client, token: "xoxb-test" });
-
-    expect(client.reactions.add).toHaveBeenCalledWith({
-      channel: "C1",
-      timestamp: "123.456",
-      name: "rocket",
-    });
-  });
-
-  it("passes through an unmapped emoji glyph unchanged", async () => {
-    const client = createClient();
-
-    await reactSlackMessage("C1", "123.456", "🦄", { client, token: "xoxb-test" });
-
-    expect(client.reactions.add).toHaveBeenCalledWith({
-      channel: "C1",
-      timestamp: "123.456",
-      name: "🦄",
-    });
-  });
-
-  it("strips a skin-tone modifier before mapping to a shortname", async () => {
-    const client = createClient();
-
-    await reactSlackMessage("C1", "123.456", "👍🏽", { client, token: "xoxb-test" });
-
-    expect(client.reactions.add).toHaveBeenCalledWith({
-      channel: "C1",
-      timestamp: "123.456",
-      name: "thumbsup",
-    });
-  });
-
-  it("strips a variation selector before mapping to a shortname", async () => {
-    const client = createClient();
-
-    await reactSlackMessage("C1", "123.456", "⚠️", { client, token: "xoxb-test" });
-
-    expect(client.reactions.add).toHaveBeenCalledWith({
-      channel: "C1",
-      timestamp: "123.456",
-      name: "warning",
+      name: expected,
     });
   });
 });

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -71,12 +71,61 @@ function resolveToken(explicit?: string, accountId?: string, cfg?: OpenClawConfi
   return token;
 }
 
-function normalizeEmoji(raw: string) {
+const SLACK_EMOJI_SKIN_TONE_MODIFIER_RE = /[\u{1F3FB}-\u{1F3FF}]/gu;
+const SLACK_EMOJI_VARIATION_SELECTOR_RE = /[\uFE0E\uFE0F]/g;
+
+// Slack's reactions.add/remove accept only shortcode names, never a raw
+// Unicode glyph. Models keep passing the glyph because the `emoji` param
+// reads as "an emoji"; map the common ones so the reaction is not silently
+// dropped. Unknown glyphs still pass through unchanged (no regression).
+const SLACK_EMOJI_SHORTNAME_BY_GLYPH: Record<string, string> = {
+  "✅": "white_check_mark",
+  "❌": "x",
+  "👍": "thumbsup",
+  "👎": "thumbsdown",
+  "🎉": "tada",
+  "❤": "heart",
+  "😄": "smile",
+  "😂": "joy",
+  "🚀": "rocket",
+  "👀": "eyes",
+  "🙏": "pray",
+  "🔥": "fire",
+  "💯": "100",
+  "⚠": "warning",
+  "➕": "heavy_plus_sign",
+  "➖": "heavy_minus_sign",
+  "🤔": "thinking_face",
+  "👨‍💻": "male-technologist",
+  "👨💻": "male-technologist",
+  "👩‍💻": "female-technologist",
+  "⚡": "zap",
+  "🌐": "globe_with_meridians",
+  "😱": "scream",
+  "🥱": "yawning_face",
+  "😨": "fearful",
+  "⏳": "hourglass_flowing_sand",
+  "✍": "writing_hand",
+  "🗜": "compression",
+  "🧠": "brain",
+  "🛠": "hammer_and_wrench",
+  "💻": "computer",
+};
+
+function stripSlackEmojiGlyphModifiers(value: string): string {
+  return value
+    .replace(SLACK_EMOJI_SKIN_TONE_MODIFIER_RE, "")
+    .replace(SLACK_EMOJI_VARIATION_SELECTOR_RE, "");
+}
+
+export function normalizeSlackEmojiName(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
     throw new Error("Emoji is required for Slack reactions");
   }
-  return trimmed.replace(/^:+|:+$/g, "");
+  const withoutColons = trimmed.replace(/^:+|:+$/g, "");
+  const glyphKey = stripSlackEmojiGlyphModifiers(withoutColons);
+  return SLACK_EMOJI_SHORTNAME_BY_GLYPH[glyphKey] ?? withoutColons;
 }
 
 const SLACK_TIMESTAMP_RE = /^\d+(?:\.\d+)?$/;
@@ -153,7 +202,7 @@ export async function reactSlackMessage(
     await client.reactions.add({
       channel: channelId,
       timestamp: messageId,
-      name: normalizeEmoji(emoji),
+      name: normalizeSlackEmojiName(emoji),
     });
   } catch (err) {
     if (hasSlackPlatformError(err, "already_reacted")) {
@@ -174,7 +223,7 @@ export async function removeSlackReaction(
     await client.reactions.remove({
       channel: channelId,
       timestamp: messageId,
-      name: normalizeEmoji(emoji),
+      name: normalizeSlackEmojiName(emoji),
     });
   } catch (err) {
     if (hasSlackPlatformError(err, "no_reaction")) {

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -71,8 +71,15 @@ function resolveToken(explicit?: string, accountId?: string, cfg?: OpenClawConfi
   return token;
 }
 
-const SLACK_EMOJI_SKIN_TONE_MODIFIER_RE = /[\u{1F3FB}-\u{1F3FF}]/gu;
+const SLACK_EMOJI_SKIN_TONE_MODIFIER_RE = /[\u{1F3FB}-\u{1F3FF}]/u;
 const SLACK_EMOJI_VARIATION_SELECTOR_RE = /[\uFE0E\uFE0F]/g;
+const SLACK_EMOJI_SKIN_TONE_BY_MODIFIER = new Map([
+  ["🏻", 2],
+  ["🏼", 3],
+  ["🏽", 4],
+  ["🏾", 5],
+  ["🏿", 6],
+]);
 
 // Slack's reactions.add/remove accept only shortcode names, never a raw
 // Unicode glyph. Models keep passing the glyph because the `emoji` param
@@ -112,20 +119,22 @@ const SLACK_EMOJI_SHORTNAME_BY_GLYPH: Record<string, string> = {
   "💻": "computer",
 };
 
-function stripSlackEmojiGlyphModifiers(value: string): string {
-  return value
-    .replace(SLACK_EMOJI_SKIN_TONE_MODIFIER_RE, "")
-    .replace(SLACK_EMOJI_VARIATION_SELECTOR_RE, "");
-}
-
-export function normalizeSlackEmojiName(raw: string): string {
+function normalizeSlackEmojiName(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
     throw new Error("Emoji is required for Slack reactions");
   }
   const withoutColons = trimmed.replace(/^:+|:+$/g, "");
-  const glyphKey = stripSlackEmojiGlyphModifiers(withoutColons);
-  return SLACK_EMOJI_SHORTNAME_BY_GLYPH[glyphKey] ?? withoutColons;
+  const modifier = withoutColons.match(SLACK_EMOJI_SKIN_TONE_MODIFIER_RE)?.[0];
+  const glyphKey = withoutColons
+    .replace(SLACK_EMOJI_SKIN_TONE_MODIFIER_RE, "")
+    .replace(SLACK_EMOJI_VARIATION_SELECTOR_RE, "");
+  const shortname = SLACK_EMOJI_SHORTNAME_BY_GLYPH[glyphKey];
+  const skinTone = modifier ? SLACK_EMOJI_SKIN_TONE_BY_MODIFIER.get(modifier) : undefined;
+  if (!shortname || !skinTone) {
+    return shortname ?? withoutColons;
+  }
+  return `${shortname}::skin-tone-${skinTone}`;
 }
 
 const SLACK_TIMESTAMP_RE = /^\d+(?:\.\d+)?$/;

--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -57,6 +57,31 @@ function elementAt(block: Record<string, unknown>, index: number) {
 }
 
 describe("handleSlackMessageAction", () => {
+  it("defaults reactions to the current inbound Slack message", async () => {
+    const invoke = createInvokeSpy();
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "react",
+        cfg: {},
+        params: {
+          channelId: "C1",
+          emoji: "✅",
+        },
+        toolContext: { currentMessageId: "171234.567" },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    expect(firstAction(invoke)).toMatchObject({
+      action: "react",
+      channelId: "C1",
+      emoji: "✅",
+      messageId: "171234.567",
+    });
+  });
+
   it("merges presentation and interactive blocks when sending", async () => {
     const invoke = createInvokeSpy();
 

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -2,6 +2,7 @@
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-resolution";
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import { readBooleanParam } from "openclaw/plugin-sdk/boolean-param";
+import { resolveReactionMessageId } from "openclaw/plugin-sdk/channel-actions";
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import {
   normalizeInteractiveReply,
@@ -92,9 +93,16 @@ export async function handleSlackMessageAction(params: {
   }
 
   if (action === "react") {
-    const messageId = readStringParam(actionParams, "messageId", {
-      required: true,
+    const messageIdRaw = resolveReactionMessageId({
+      args: actionParams,
+      toolContext: ctx.toolContext,
     });
+    if (messageIdRaw == null) {
+      throw new Error(
+        "messageId required. Provide messageId explicitly or react to the current inbound message.",
+      );
+    }
+    const messageId = String(messageIdRaw);
     const emoji = readStringParam(actionParams, "emoji", { allowEmpty: true });
     const remove = typeof actionParams.remove === "boolean" ? actionParams.remove : undefined;
     return await invoke(

--- a/extensions/slack/src/message-tool-api.ts
+++ b/extensions/slack/src/message-tool-api.ts
@@ -22,6 +22,17 @@ function createSlackFileActionSchema(): Record<string, TSchema> {
   };
 }
 
+function createSlackReactionEmojiSchema(): Record<string, TSchema> {
+  return {
+    emoji: Type.Optional(
+      Type.String({
+        description:
+          'Slack emoji shortcode name (for example "white_check_mark" or "+1"), not the emoji character. Colons are optional: "white_check_mark" and ":white_check_mark:" both work.',
+      }),
+    ),
+  };
+}
+
 function createSlackMessageIdActionSchema(): Record<string, TSchema> {
   const description =
     'Slack message timestamp/message id (for example "1777423717.666499"). Used by react, reactions, edit, delete, pin, and unpin actions. Not used by download-file, which requires fileId from event.files[].id.';
@@ -90,6 +101,12 @@ export function describeSlackMessageTool({
     schema.push({
       properties: createSlackTopLevelActionSchema(),
       actions: ["upload-file"],
+    });
+  }
+  if (actions.includes("react")) {
+    schema.push({
+      properties: createSlackReactionEmojiSchema(),
+      actions: ["react", "reactions"],
     });
   }
   const messageIdActions: ChannelMessageActionName[] = [];

--- a/extensions/slack/src/message-tool-api.ts
+++ b/extensions/slack/src/message-tool-api.ts
@@ -27,7 +27,7 @@ function createSlackReactionEmojiSchema(): Record<string, TSchema> {
     emoji: Type.Optional(
       Type.String({
         description:
-          'Slack emoji shortcode name (for example "white_check_mark" or "+1"), not the emoji character. Colons are optional: "white_check_mark" and ":white_check_mark:" both work.',
+          'Slack emoji shortcode name (for example "white_check_mark" or "+1") or common emoji character (for example "✅"). Colons are optional around shortcodes.',
       }),
     ),
   };

--- a/extensions/slack/src/message-tool-api.ts
+++ b/extensions/slack/src/message-tool-api.ts
@@ -35,7 +35,7 @@ function createSlackReactionEmojiSchema(): Record<string, TSchema> {
 
 function createSlackMessageIdActionSchema(): Record<string, TSchema> {
   const description =
-    'Slack message timestamp/message id (for example "1777423717.666499"). Used by react, reactions, edit, delete, pin, and unpin actions. Not used by download-file, which requires fileId from event.files[].id.';
+    'Slack message timestamp/message id (for example "1777423717.666499"). Used by react, reactions, edit, delete, pin, and unpin actions. React defaults to the current inbound message when available. Not used by download-file, which requires fileId from event.files[].id.';
   return {
     messageId: Type.Optional(Type.String({ description })),
     message_id: Type.Optional(Type.String({ description: `${description} Alias for messageId.` })),

--- a/extensions/slack/src/message-tools.test.ts
+++ b/extensions/slack/src/message-tools.test.ts
@@ -206,6 +206,7 @@ describe("Slack message tools", () => {
     expect(schema.actions).toEqual(["react", "reactions", "edit", "delete", "pin", "unpin"]);
     expect(schema.actions).not.toContain("unsend");
     expect(property.description).toContain("1777423717.666499");
+    expect(property.description).toMatch(/React defaults to the current inbound message/i);
     expect(property.description).toMatch(/Not used by download-file/i);
     expect(alias.description).toMatch(/Alias for messageId/i);
   });

--- a/extensions/slack/src/message-tools.test.ts
+++ b/extensions/slack/src/message-tools.test.ts
@@ -210,7 +210,7 @@ describe("Slack message tools", () => {
     expect(alias.description).toMatch(/Alias for messageId/i);
   });
 
-  it("describes the react emoji param as a Slack shortcode, not a raw character", () => {
+  it("describes Slack shortcode and common glyph reaction inputs", () => {
     const discovery = describeSlackMessageTool({
       cfg: {
         channels: {
@@ -225,7 +225,7 @@ describe("Slack message tools", () => {
 
     expect(schema.actions).toEqual(["react", "reactions"]);
     expect(property.description).toContain("white_check_mark");
-    expect(property.description).toMatch(/not the emoji character/i);
+    expect(property.description).toContain("✅");
   });
 
   it("omits the react emoji schema when reactions are disabled", () => {

--- a/extensions/slack/src/message-tools.test.ts
+++ b/extensions/slack/src/message-tools.test.ts
@@ -210,6 +210,47 @@ describe("Slack message tools", () => {
     expect(alias.description).toMatch(/Alias for messageId/i);
   });
 
+  it("describes the react emoji param as a Slack shortcode, not a raw character", () => {
+    const discovery = describeSlackMessageTool({
+      cfg: {
+        channels: {
+          slack: {
+            botToken: "xoxb-test",
+          },
+        },
+      },
+    });
+
+    const { schema, property } = requireSchemaProperty(discovery, "emoji");
+
+    expect(schema.actions).toEqual(["react", "reactions"]);
+    expect(property.description).toContain("white_check_mark");
+    expect(property.description).toMatch(/not the emoji character/i);
+  });
+
+  it("omits the react emoji schema when reactions are disabled", () => {
+    const discovery = describeSlackMessageTool({
+      cfg: {
+        channels: {
+          slack: {
+            botToken: "xoxb-test",
+            actions: {
+              reactions: false,
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    const schemas = Array.isArray(discovery.schema)
+      ? discovery.schema
+      : discovery.schema
+        ? [discovery.schema]
+        : [];
+    const propertyNames = schemas.flatMap((entry) => Object.keys(entry.properties));
+    expect(propertyNames).not.toContain("emoji");
+  });
+
   it("describes Slack reply broadcasts as send-only thread hints", () => {
     const discovery = describeSlackMessageTool({
       cfg: {

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -672,7 +672,7 @@ describe("monitorSlackProvider tool results", () => {
     expect(reactMock).toHaveBeenCalledWith({
       channel: "C1",
       timestamp: "456",
-      name: "👀",
+      name: "eyes",
     });
   });
 

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -53,7 +53,7 @@ import { danger, logVerbose, shouldLogVerbose, sleep } from "openclaw/plugin-sdk
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
-import { reactSlackMessage, removeSlackReaction } from "../../actions.js";
+import { normalizeSlackEmojiName, reactSlackMessage, removeSlackReaction } from "../../actions.js";
 import { createSlackDraftStream } from "../../draft-stream.js";
 import { formatSlackError } from "../../errors.js";
 import { normalizeSlackOutboundText } from "../../format.js";
@@ -97,31 +97,6 @@ import { finalizeSlackPreviewEdit } from "./preview-finalize.js";
 import { resolveSlackTimestampMs } from "./timestamp.js";
 import type { PreparedSlackMessage } from "./types.js";
 
-// Slack reactions.add/remove expect shortcode names, not raw unicode emoji.
-const UNICODE_TO_SLACK: Record<string, string> = {
-  "👀": "eyes",
-  "🤔": "thinking_face",
-  "🔥": "fire",
-  "👨‍💻": "male-technologist",
-  "👨💻": "male-technologist",
-  "👩‍💻": "female-technologist",
-  "⚡": "zap",
-  "🌐": "globe_with_meridians",
-  "✅": "white_check_mark",
-  "👍": "thumbsup",
-  "❌": "x",
-  "😱": "scream",
-  "🥱": "yawning_face",
-  "😨": "fearful",
-  "⏳": "hourglass_flowing_sand",
-  "⚠️": "warning",
-  "✍": "writing_hand",
-  "🗜️": "compression",
-  "🗜": "compression",
-  "🧠": "brain",
-  "🛠️": "hammer_and_wrench",
-  "💻": "computer",
-};
 const SLACK_REASONING_TAG_RE =
   /<\s*(\/?)\s*(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)\b[^<>]*>/gi;
 const SLACK_REASONING_LABEL_PREFIX_RE = /^\s*(?:>\s*)?Reasoning:\s*/iu;
@@ -167,17 +142,6 @@ function resolveSlackBotLoopProtection(
     defaultEnabled: true,
     nowMs: resolveSlackMessageTimestampMs(prepared.message),
   };
-}
-
-function toSlackEmojiName(emoji: string): string {
-  let trimmed = emoji.trim();
-  while (trimmed.startsWith(":")) {
-    trimmed = trimmed.slice(1);
-  }
-  while (trimmed.endsWith(":")) {
-    trimmed = trimmed.slice(0, -1);
-  }
-  return UNICODE_TO_SLACK[trimmed] ?? trimmed;
 }
 
 export function isSlackStreamingEnabled(params: {
@@ -553,10 +517,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     cfg.messages?.statusReactions?.enabled === true;
   const slackStatusAdapter: StatusReactionAdapter = {
     setReaction: async (emoji) => {
-      await reactSlackMessage(message.channel, reactionMessageTs ?? "", toSlackEmojiName(emoji), {
-        token: ctx.botToken,
-        client: ctx.app.client,
-      }).catch((err: unknown) => {
+      await reactSlackMessage(
+        message.channel,
+        reactionMessageTs ?? "",
+        normalizeSlackEmojiName(emoji),
+        {
+          token: ctx.botToken,
+          client: ctx.app.client,
+        },
+      ).catch((err: unknown) => {
         if (formatErrorMessage(err).includes("already_reacted")) {
           return;
         }
@@ -564,10 +533,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       });
     },
     removeReaction: async (emoji) => {
-      await removeSlackReaction(message.channel, reactionMessageTs ?? "", toSlackEmojiName(emoji), {
-        token: ctx.botToken,
-        client: ctx.app.client,
-      }).catch((err: unknown) => {
+      await removeSlackReaction(
+        message.channel,
+        reactionMessageTs ?? "",
+        normalizeSlackEmojiName(emoji),
+        {
+          token: ctx.botToken,
+          client: ctx.app.client,
+        },
+      ).catch((err: unknown) => {
         if (formatErrorMessage(err).includes("no_reaction")) {
           return;
         }

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -53,7 +53,7 @@ import { danger, logVerbose, shouldLogVerbose, sleep } from "openclaw/plugin-sdk
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
-import { normalizeSlackEmojiName, reactSlackMessage, removeSlackReaction } from "../../actions.js";
+import { reactSlackMessage, removeSlackReaction } from "../../actions.js";
 import { createSlackDraftStream } from "../../draft-stream.js";
 import { formatSlackError } from "../../errors.js";
 import { normalizeSlackOutboundText } from "../../format.js";
@@ -517,15 +517,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     cfg.messages?.statusReactions?.enabled === true;
   const slackStatusAdapter: StatusReactionAdapter = {
     setReaction: async (emoji) => {
-      await reactSlackMessage(
-        message.channel,
-        reactionMessageTs ?? "",
-        normalizeSlackEmojiName(emoji),
-        {
-          token: ctx.botToken,
-          client: ctx.app.client,
-        },
-      ).catch((err: unknown) => {
+      await reactSlackMessage(message.channel, reactionMessageTs ?? "", emoji, {
+        token: ctx.botToken,
+        client: ctx.app.client,
+      }).catch((err: unknown) => {
         if (formatErrorMessage(err).includes("already_reacted")) {
           return;
         }
@@ -533,15 +528,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       });
     },
     removeReaction: async (emoji) => {
-      await removeSlackReaction(
-        message.channel,
-        reactionMessageTs ?? "",
-        normalizeSlackEmojiName(emoji),
-        {
-          token: ctx.botToken,
-          client: ctx.app.client,
-        },
-      ).catch((err: unknown) => {
+      await removeSlackReaction(message.channel, reactionMessageTs ?? "", emoji, {
+        token: ctx.botToken,
+        client: ctx.app.client,
+      }).catch((err: unknown) => {
         if (formatErrorMessage(err).includes("no_reaction")) {
           return;
         }

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -2290,6 +2290,17 @@ describe("message tool description", () => {
     expect(target?.description).toContain("Telegram chat id/@username");
   });
 
+  it("describes userId as required directly for member-info, not via target", () => {
+    const tool = createMessageTool({
+      config: {} as never,
+    });
+    const properties = getToolProperties(tool);
+    const userId = properties.userId as { description?: string } | undefined;
+
+    expect(userId?.description).toMatch(/member-info/i);
+    expect(userId?.description).toMatch(/not.*`target`|does not accept.*target/i);
+  });
+
   it("hides iMessage group actions for DM targets", () => {
     setActivePluginRegistry(
       createTestRegistry([{ pluginId: "imessage", source: "test", plugin: imessagePlugin }]),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -692,7 +692,7 @@ function buildChannelTargetSchema() {
     userId: Type.Optional(
       Type.String({
         description:
-          "User id for member-info and moderation/participant actions (kick, ban, timeout, addParticipant, removeParticipant; channel-dependent). These take userId directly; they do not accept `target`.",
+          "User id for member-info and channel-specific moderation or participant actions. For member-info, pass userId directly; the action does not accept target.",
       }),
     ),
     openId: Type.Optional(Type.String()),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -689,7 +689,12 @@ function buildChannelTargetSchema() {
     memberId: Type.Optional(Type.String()),
     memberIdType: Type.Optional(Type.String()),
     guildId: Type.Optional(Type.String()),
-    userId: Type.Optional(Type.String()),
+    userId: Type.Optional(
+      Type.String({
+        description:
+          "User id for member-info and moderation/participant actions (kick, ban, timeout, addParticipant, removeParticipant; channel-dependent). These take userId directly; they do not accept `target`.",
+      }),
+    ),
     openId: Type.Optional(Type.String()),
     unionId: Type.Optional(Type.String()),
     authorId: Type.Optional(Type.String()),


### PR DESCRIPTION
## What Problem This Solves

Slack message-tool affordances invited calls that the runtime rejected or handled inconsistently:

1. `react` accepted an `emoji` parameter without explaining Slack's shortcode requirement, so models could pass a glyph such as `✅` and receive `invalid_name` from Slack.
2. Slack `react` required an explicit `messageId` even though the shared channel-action contract says reaction-like actions default to the current inbound message when available.
3. `member-info` requires `userId` directly and does not accept the generic `target` field, but the schema did not make that distinction clear.

## Why This Change Was Made

The fix now lives at the existing owners instead of relying on prompt steering:

- Slack reaction add/remove calls share one glyph-to-shortcode normalizer.
- Slack adopts the shared current-message resolver already used by sibling channel adapters.
- Slack-specific schema contributions document glyph, shortcode, `messageId`, and `member-info` behavior.
- An opt-in QA-lab scenario forces the exact `✅` glyph and verifies Slack stores `white_check_mark` for the SUT bot.

The repair also preserves skin-tone modifiers, variation selectors, idempotency, unknown-input pass-through, and all three valid QA tool-policy shapes: absent allowlist, empty allow-all, and non-empty explicit allowlist.

## User Impact

- Slack reactions work when the model supplies a supported common emoji glyph, a colon-wrapped shortcode, or a plain shortcode.
- `react` can target the current inbound Slack message without redundantly copying its timestamp into the tool call.
- `member-info` calls receive clearer `userId` guidance without changing participant or moderation target contracts.
- No new config surface or compatibility shim is added.

## Evidence

Final head: `7ba8612a999b675f66fe7bbf6a5132c1abcbd0fb`.

- Blacksmith Testbox `tbx_01kwsnnqmv5n15q3zv7emek7ny`: 117 agent message-tool tests and 52 Slack reaction/discovery/monitor tests passed.
- [AWS Crabbox run `run_79de363c0e44`](https://crabbox.openclaw.ai/portal/runs/run_79de363c0e44), lease `cbx_775bc2f22b5d`: 207 focused agent, QA-lab, and Slack tests passed on Node 24.15.0 with pnpm 11.2.2; lease released.
- Exact latest QA-lab patch: 39 tests passed via `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts`.
- `oxfmt --check` and `git diff --check` passed.
- Final whole-branch Codex autoreview: no accepted/actionable findings, confidence 0.86.
- [Exact-head hosted CI run `28757633677`](https://github.com/openclaw/openclaw/actions/runs/28757633677) passed on attempt 2, including QA Smoke CI, build artifacts, and both whole compact shards. One unrelated TUI PTY session-adoption timeout passed on focused rerun.
- Rebase proof: stable patch-id `04f8ecef02e063fdc6183716cb1449b23bd9253c`; all seven reviewed repair files are byte-identical before and after rebase.

### Live-proof boundary

[Mantis run `28757276392`](https://github.com/openclaw/openclaw/actions/runs/28757276392) stopped at the workflow's intentional trust gate because this is a fork PR. No VM started and no secrets were exposed. Secret-backed live Slack proof requires explicit maintainer approval through a trusted same-repo candidate path; this is a proof gap, not a product test failure.

## Left Out

No new `member-info` target mode was added. Translating a generic user target into channel-specific member lookup remains ambiguous across channels and would expand a shared public contract beyond this fix.
