### PR TITLE
fix(channels): catch typing keepalive tick errors instead of leaking unhandled rejection

### DIFF
--- a/scripts/proof/typing-lifecycle-catch.mts
+++ b/scripts/proof/typing-lifecycle-catch.mts
@@ -1,0 +1,44 @@
+// Real behavior proof: a rejecting typing keepalive tick is caught and routed
+// through onError instead of becoming an unhandled rejection.
+
+import { createTypingKeepaliveLoop } from "../../src/channels/typing-lifecycle.js";
+
+const unhandled: unknown[] = [];
+const onUnhandled = (reason: unknown) => {
+  unhandled.push(reason);
+  console.error("UNHANDLED_REJECTION:", String(reason));
+};
+process.on("unhandledRejection", onUnhandled);
+
+const error = new Error("simulated typing tick failure");
+const errors: unknown[] = [];
+
+const loop = createTypingKeepaliveLoop({
+  intervalMs: 10,
+  onTick: async () => {
+    throw error;
+  },
+  onError: (err) => {
+    errors.push(err);
+    console.log("Caught tick error:", String(err));
+  },
+});
+
+loop.start();
+
+setTimeout(() => {
+  loop.stop();
+  process.off("unhandledRejection", onUnhandled);
+
+  if (unhandled.length > 0) {
+    console.log("\nFAIL: unhandled rejections were leaked.");
+    process.exitCode = 1;
+    return;
+  }
+  if (errors.length === 0) {
+    console.log("\nFAIL: onError was not called for the rejected tick.");
+    process.exitCode = 1;
+    return;
+  }
+  console.log("\nPASS: rejected tick was caught and reported via onError with no unhandled rejection.");
+}, 100);

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -166,6 +166,7 @@ export function createTypingController(params: {
   const typingLoop = createTypingKeepaliveLoop({
     intervalMs: typingIntervalMs,
     onTick: triggerTyping,
+    onError: (err) => log?.(`typing keepalive tick failed: ${String(err)}`),
   });
 
   const ensureStart = async () => {

--- a/src/channels/typing-lifecycle.test.ts
+++ b/src/channels/typing-lifecycle.test.ts
@@ -1,0 +1,73 @@
+// Typing keepalive loop tests cover interval timing and error containment.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createTypingKeepaliveLoop } from "./typing-lifecycle.js";
+
+describe("createTypingKeepaliveLoop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls onTick on each interval", async () => {
+    const onTick = vi.fn().mockResolvedValue(undefined);
+    const loop = createTypingKeepaliveLoop({ intervalMs: 1_000, onTick });
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onTick).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onTick).toHaveBeenCalledTimes(2);
+
+    loop.stop();
+  });
+
+  it("suppresses tick overlap when a previous tick is still in flight", async () => {
+    let resolveTick: (() => void) | undefined;
+    const onTick = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTick = resolve;
+        }),
+    );
+    const loop = createTypingKeepaliveLoop({ intervalMs: 1_000, onTick });
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onTick).toHaveBeenCalledTimes(1);
+
+    // Fire several intervals while the first tick is still pending.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(onTick).toHaveBeenCalledTimes(1);
+
+    resolveTick?.();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onTick).toHaveBeenCalledTimes(2);
+
+    loop.stop();
+  });
+
+  it("reports tick errors through onError without leaking an unhandled rejection", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    const error = new Error("typing tick failed");
+    const onTick = vi.fn().mockRejectedValue(error);
+    const onError = vi.fn();
+    const loop = createTypingKeepaliveLoop({ intervalMs: 1_000, onTick, onError });
+
+    loop.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(onTick).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+    expect(unhandled).toHaveLength(0);
+
+    loop.stop();
+    process.off("unhandledRejection", onUnhandled);
+  });
+});

--- a/src/channels/typing-lifecycle.ts
+++ b/src/channels/typing-lifecycle.ts
@@ -12,6 +12,7 @@ type TypingKeepaliveLoop = {
 export function createTypingKeepaliveLoop(params: {
   intervalMs: number;
   onTick: AsyncTick;
+  onError?: (err: unknown) => void;
 }): TypingKeepaliveLoop {
   let timer: ReturnType<typeof setInterval> | undefined;
   let tickInFlight = false;
@@ -24,6 +25,8 @@ export function createTypingKeepaliveLoop(params: {
     tickInFlight = true;
     try {
       await params.onTick();
+    } catch (err) {
+      params.onError?.(err);
     } finally {
       tickInFlight = false;
     }

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -63,6 +63,7 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
   const keepaliveLoop = createTypingKeepaliveLoop({
     intervalMs: keepaliveIntervalMs,
     onTick: fireStart,
+    onError: params.onStartError,
   });
 
   const startTtlTimer = () => {


### PR DESCRIPTION
## What Problem This Solves

`createTypingKeepaliveLoop` schedules an interval that calls `void tick()`. Inside `tick`, the awaited `onTick` rejection was not caught, so any channel error during a typing keepalive update would become an unhandled rejection and could crash the reply dispatcher.

## Why This Change Was Made

Added an `onError` callback to the loop and caught tick errors inside `tick`, routing them to the caller instead of leaking them. Wired the existing `onStartError` / log callbacks in the two production callers so errors remain visible.

## User Impact

Typing indicator keepalives no longer risk crashing the channel reply flow when the underlying send fails.

## Evidence

Regression test:

```bash
node scripts/run-vitest.mjs src/channels/typing-lifecycle.test.ts
```

All 3 tests pass. The new rejection test fails on current main because `onError` is never called.

Real behavior proof:

```bash
node_modules/.bin/tsx scripts/proof/typing-lifecycle-catch.mts
```

Output:

```
Caught tick error: Error: simulated typing tick failure
...
PASS: rejected tick was caught and reported via onError with no unhandled rejection.
```
