### PR TITLE
fix(skills): propagate directory scan errors as diagnostics instead of silent catch

### DIFF
--- a/src/skills/loading/session.test.ts
+++ b/src/skills/loading/session.test.ts
@@ -1,0 +1,63 @@
+// Session skill loading tests cover directory scanning and error propagation.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { writeSkill } from "../test-support/e2e-test-helpers.js";
+import { loadSkillsFromDir } from "./session.js";
+
+describe("loadSkillsFromDir", () => {
+  let tmpDir: string;
+  let skillsDir: string;
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-skills-session-"));
+    skillsDir = path.join(tmpDir, "skills");
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loads a valid skill from a subdirectory", async () => {
+    await writeSkill({
+      dir: path.join(skillsDir, "my-skill"),
+      name: "my-skill",
+      description: "A valid test skill",
+    });
+
+    const result = loadSkillsFromDir({ dir: skillsDir, source: "test" });
+
+    expect(result.skills).toHaveLength(1);
+    expect(result.skills[0].name).toBe("my-skill");
+    expect(result.skills[0].description).toBe("A valid test skill");
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it("captures unreadable subdirectory errors as diagnostics", async () => {
+    // Create a subdirectory that exists but cannot be listed
+    const badDir = path.join(skillsDir, "unreadable");
+    await fs.mkdir(badDir, { recursive: true });
+    await writeSkill({
+      dir: path.join(badDir, "hidden-skill"),
+      name: "hidden-skill",
+      description: "This should not load",
+    });
+    // Remove all permissions so readdirSync fails with EACCES
+    await fs.chmod(badDir, 0o000);
+
+    try {
+      const result = loadSkillsFromDir({ dir: skillsDir, source: "test" });
+
+      // The symptom fixed by bug-010: previously the EACCES error was silently
+      // swallowed by an empty catch {} and no diagnostic was produced.
+      expect(result.diagnostics.length).toBeGreaterThanOrEqual(1);
+      expect(result.diagnostics.some((d) => d.path === badDir)).toBe(true);
+      // Every diagnostic from this code path has type "warning"
+      expect(result.diagnostics.every((d) => d.type === "warning")).toBe(true);
+    } finally {
+      // Restore permissions so cleanup can delete it
+      await fs.chmod(badDir, 0o755).catch(() => {});
+    }
+  });
+});

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -225,7 +225,10 @@ function loadSkillsFromDirInternal(
       }
       diagnostics.push(...result.diagnostics);
     }
-  } catch {}
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "failed to scan skill directory";
+    diagnostics.push({ type: "warning", message, path: dir });
+  }
 
   return { skills, diagnostics };
 }


### PR DESCRIPTION
## Summary

- Empty `catch {}` in `loadSkillsFromDirInternal` silently swallowed all directory scanning errors (`readdirSync`, `statSync`, etc.)
- When a skills directory could not be scanned (permissions, deletion mid-scan, etc.), skills silently disappeared with no indication
- The error is now captured as a `ResourceDiagnostic` warning, making failures visible through the existing diagnostics pipeline

## Real behavior proof

**Behavior or issue addressed:** Empty catch block in `src/skills/loading/session.ts:228` catches all errors thrown during directory scanning of skill files without any logging or diagnostics. If `readdirSync` fails (e.g., directory permissions changed, race condition), the function silently returns an empty skill list with no diagnostics.

**Real environment tested:** Linux x64 (local dev), Vitest integration test

**Exact steps or command run after this patch:**
```bash
# Test 1: valid skill loads without regression
pnpm test src/skills/loading/session.test.ts

# Test 2: existing install tests still pass
pnpm test src/skills/lifecycle/install.test.ts

# Build passes
pnpm build
```

**Evidence after fix — new integration test (session.test.ts):**

The test creates a temp directory with a valid skill (`my-skill`) and an unreadable subdirectory (`chmod 000`):
```typescript
const badDir = path.join(skillsDir, "unreadable");
await fs.mkdir(badDir, { recursive: true });
await writeSkill({ dir: path.join(badDir, "hidden-skill"), name: "hidden-skill", description: "..." });
await fs.chmod(badDir, 0o000);  // remove all permissions → readdirSync throws EACCES

const result = loadSkillsFromDir({ dir: skillsDir, source: "test" });

// BEFORE (empty catch): errors silently swallowed, diagnostics = []
// AFTER fix:
expect(result.diagnostics.length).toBeGreaterThanOrEqual(1);
expect(result.diagnostics.some((d) => d.path === badDir)).toBe(true);
```

**Test output:**
```
✓ loads a valid skill from a subdirectory
✓ captures unreadable subdirectory errors as diagnostics

Test Files  1 passed (1)
Tests  2 passed (2)
```

**Observed result after fix:** The EACCES error from the unreadable subdirectory is captured as a `{ type: "warning", message: "EACCES: permission denied, scandir ...", path: "..." }` diagnostic instead of being silently swallowed.

**What was not tested:** Full E2E test with a genuinely disappearing directory race condition. Permission-based test covers the real failure mode.

## Tests and validation
- `pnpm build` ✓
- `pnpm test src/skills/loading/session.test.ts` — 2/2 passed ✓
- `pnpm test src/skills/lifecycle/install.test.ts` — 6/6 passed ✓
- `pnpm format:check` — all files correct ✓
- `pnpm check:import-cycles` — 0 runtime cycles ✓

## Risk checklist
- [x] No user-visible config or behavior changes under normal conditions
- [x] No new dependencies
- [x] No breaking API changes
- [x] AI-assisted code (Claude Code)