### PR TITLE
feat(android): restore in-flight runs after reconnect

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -89,8 +89,13 @@ class ChatController internal constructor(
   private var lastHealthPollAtMs: Long? = null
   private var commandsAgentId: String? = null
 
+  // Armed on disconnect so the next health event refetches history and re-adopts
+  // any run the gateway still reports in flight (chat.history `inFlightRun`).
+  private var restoreRunStateOnReconnect = false
+
   /** Clears transient chat state when the operator gateway session disconnects. */
   fun onDisconnected(message: String) {
+    restoreRunStateOnReconnect = true
     _healthOk.value = false
     _errorText.value = null
     _commands.value = emptyList()
@@ -421,10 +426,19 @@ class ChatController internal constructor(
       "health" -> {
         _healthOk.value = true
         refreshCommandsAfterReconnect()
+        if (restoreRunStateOnReconnect) {
+          restoreRunStateOnReconnect = false
+          refreshHistoryForRecovery()
+        }
       }
       "seqGap" -> {
-        _errorText.value = "Event stream interrupted; try refreshing."
+        // Missed events may include deltas or the terminal state of a pending run;
+        // refetch history and rebuild run state from the gateway snapshot.
         clearPendingRuns()
+        pendingToolCallsById.clear()
+        publishPendingToolCalls()
+        _streamingAssistantText.value = null
+        refreshHistoryForRecovery()
       }
       "chat" -> {
         if (payloadJson.isNullOrBlank()) return
@@ -448,6 +462,21 @@ class ChatController internal constructor(
     }
   }
 
+  /**
+   * Reconnect/seq-gap recovery: refetch history for the current session without the
+   * beginHistoryLoad transient-state reset. Disconnect (or the seqGap handler) already
+   * cleared run state, and resetting healthOk here would block sends after reconnect.
+   */
+  private fun refreshHistoryForRecovery() {
+    val key = normalizeRequestedSessionKey(_sessionKey.value)
+    val generation = historyLoadGeneration.incrementAndGet()
+    _sessionKey.value = key
+    _historyLoading.value = true
+    scope.launch {
+      bootstrap(sessionKey = key, generation = generation, forceHealth = false, refreshSessions = true)
+    }
+  }
+
   private suspend fun bootstrap(
     sessionKey: String,
     generation: Long,
@@ -466,6 +495,7 @@ class ChatController internal constructor(
       prunePersistedOptimisticMessages(history.messages)
       _messages.value = mergeOptimisticMessages(incoming = history.messages, optimistic = optimisticMessagesByRunId.values)
       _sessionId.value = history.sessionId
+      adoptInFlightRun(history.inFlightRun)
       _historyLoading.value = false
       history.thinkingLevel
         ?.trim()
@@ -709,6 +739,28 @@ class ChatController internal constructor(
       pendingToolCallsById.values.sortedBy { it.startedAtMs }
   }
 
+  /**
+   * Adopts the run the gateway reports still streaming for this session so reconnect,
+   * cold start, and seq-gap recovery restore pending/streaming UI state. Snapshot absence
+   * never clears local state: live terminal events and the pending-run timeout own
+   * completion, and a snapshot fetched before our own send must not cancel that run.
+   */
+  private fun adoptInFlightRun(run: ChatInFlightRun?) {
+    if (run == null) return
+    val runId = run.runId.trim()
+    if (runId.isEmpty()) return
+    synchronized(pendingRuns) {
+      // A different locally-owned run means this snapshot predates it; ignore.
+      if (pendingRuns.isNotEmpty() && runId !in pendingRuns) return
+      pendingRuns.add(runId)
+      _pendingRunCount.value = pendingRuns.size
+    }
+    armPendingRunTimeout(runId)
+    if (run.text.isNotEmpty()) {
+      _streamingAssistantText.value = run.text
+    }
+  }
+
   private fun armPendingRunTimeout(runId: String) {
     pendingRunTimeoutJobs[runId]?.cancel()
     pendingRunTimeoutJobs[runId] =
@@ -832,7 +884,14 @@ class ChatController internal constructor(
       thinkingLevel = thinkingLevel,
       messages = reconcileMessageIds(previous = previousMessages, incoming = messages),
       sessionInfo = sessionInfo,
+      inFlightRun = parseInFlightRun(root),
     )
+  }
+
+  private fun parseInFlightRun(root: JsonObject): ChatInFlightRun? {
+    val obj = root["inFlightRun"].asObjectOrNull() ?: return null
+    val runId = obj["runId"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    return ChatInFlightRun(runId = runId, text = obj["text"].asStringOrNull().orEmpty())
   }
 
   private fun parseSessions(jsonString: String): List<ChatSessionEntry> {

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -59,6 +59,15 @@ data class ChatCommandEntry(
 
 
 /**
+ * Run still streaming on the gateway when a chat.history snapshot was captured;
+ * [text] is the assistant text buffered so far (may be empty for runs without deltas).
+ */
+data class ChatInFlightRun(
+  val runId: String,
+  val text: String,
+)
+
+/**
  * Snapshot of one chat session, including optional thinking level selected on the gateway.
  */
 data class ChatHistory(
@@ -67,6 +76,7 @@ data class ChatHistory(
   val thinkingLevel: String?,
   val messages: List<ChatMessage>,
   val sessionInfo: ChatSessionEntry? = null,
+  val inFlightRun: ChatInFlightRun? = null,
 )
 
 /**

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -1,0 +1,172 @@
+package ai.openclaw.app.chat
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Reconnect recovery scenarios: after a gateway disconnect, the next health event
+ * refetches chat.history and re-adopts the run the gateway still reports in flight
+ * (`inFlightRun`), matching the reconnect snapshot contract the TUI consumes.
+ */
+class ChatControllerReconnectRestoreTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun TestScope.newController(gateway: ScriptedGateway): ChatController =
+    ChatController(scope = this, json = json, requestGateway = gateway::request)
+
+  private val userTurn = ReplayHistoryMessage("user", "keep working", 1_000)
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectAdoptsInFlightRunAndConsumesLiveEvents() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("chat.history", historyResponse("session-1", listOf(userTurn)))
+      val controller = newController(gateway)
+      controller.load("main")
+      runCurrent()
+      assertEquals(0, controller.pendingRunCount.value)
+
+      controller.onDisconnected("Reconnecting…")
+      gateway.respondWith(
+        "chat.history",
+        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "partial reply"),
+      )
+      controller.handleGatewayEvent("health", null)
+      runCurrent()
+
+      assertEquals(1, controller.pendingRunCount.value)
+      assertEquals("partial reply", controller.streamingAssistantText.value)
+      assertEquals(1, controller.messages.value.size)
+
+      // The adopted run keeps consuming live deltas and its terminal event.
+      controller.handleGatewayEvent(
+        "chat",
+        chatDeltaPayload("main", "run-active", 5, " more", "partial reply more"),
+      )
+      assertEquals("partial reply more", controller.streamingAssistantText.value)
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          "session-1",
+          listOf(userTurn, ReplayHistoryMessage("assistant", "partial reply more", 2_000)),
+        ),
+      )
+      controller.handleGatewayEvent("chat", chatTerminalPayload("main", "run-active", seq = 6))
+      runCurrent()
+
+      assertEquals(0, controller.pendingRunCount.value)
+      assertNull(controller.streamingAssistantText.value)
+      assertEquals(2, controller.messages.value.size)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectWithoutInFlightRunStaysClean() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("chat.history", historyResponse("session-1", listOf(userTurn)))
+      val controller = newController(gateway)
+      controller.load("main")
+      runCurrent()
+      val historyCallsAfterLoad = gateway.callCount("chat.history")
+
+      controller.onDisconnected("Offline")
+      controller.handleGatewayEvent("health", null)
+      runCurrent()
+
+      // Reconnect refetched history once and restored nothing.
+      assertEquals(historyCallsAfterLoad + 1, gateway.callCount("chat.history"))
+      assertEquals(0, controller.pendingRunCount.value)
+      assertNull(controller.streamingAssistantText.value)
+      assertNull(controller.errorText.value)
+      assertTrue(controller.healthOk.value)
+      assertEquals(1, controller.messages.value.size)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun repeatedReconnectsDoNotDuplicateRunOrRows() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "chat.history",
+        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "partial"),
+      )
+      val controller = newController(gateway)
+      controller.load("main")
+      runCurrent()
+      assertEquals(1, controller.pendingRunCount.value)
+
+      repeat(2) {
+        controller.onDisconnected("Reconnecting…")
+        assertEquals(0, controller.pendingRunCount.value)
+        controller.handleGatewayEvent("health", null)
+        runCurrent()
+      }
+
+      assertEquals(1, controller.pendingRunCount.value)
+      assertEquals("partial", controller.streamingAssistantText.value)
+      assertEquals(1, controller.messages.value.size)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun staleSnapshotRunDoesNotReplaceLocallyOwnedSend() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("chat.history", historyResponse("session-1", emptyList()))
+      gateway.respondChatSend(status = "started")
+      val controller = newController(gateway)
+      controller.load("main")
+      runCurrent()
+
+      // Reconnect arms a recovery refresh, then a send lands before it executes.
+      controller.onDisconnected("Reconnecting…")
+      gateway.respondWith(
+        "chat.history",
+        historyResponse("session-1", emptyList(), inFlightRun = "run-stale" to "old text"),
+      )
+      controller.handleGatewayEvent("health", null)
+      assertTrue(controller.sendMessageAwaitAcceptance("new work", "off", emptyList()))
+      val localRunId = requireNotNull(gateway.lastRunId)
+      runCurrent()
+
+      assertEquals(1, controller.pendingRunCount.value)
+      controller.handleGatewayEvent(
+        "chat",
+        chatDeltaPayload("main", localRunId, 1, "ours", "ours"),
+      )
+      assertEquals("ours", controller.streamingAssistantText.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun seqGapRefetchesHistoryAndRestoresInFlightRun() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith(
+        "chat.history",
+        historyResponse("session-1", listOf(userTurn), inFlightRun = "run-active" to "still going"),
+      )
+      val controller = newController(gateway)
+      controller.load("main")
+      runCurrent()
+      assertEquals(1, controller.pendingRunCount.value)
+
+      controller.handleGatewayEvent("seqGap", null)
+      runCurrent()
+
+      assertEquals(1, controller.pendingRunCount.value)
+      assertEquals("still going", controller.streamingAssistantText.value)
+      assertNull(controller.errorText.value)
+      assertEquals(1, controller.messages.value.size)
+    }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
@@ -89,9 +89,20 @@ internal data class ReplayHistoryMessage(
 internal fun historyResponse(
   sessionId: String,
   messages: List<ReplayHistoryMessage>,
+  inFlightRun: Pair<String, String>? = null,
 ): String =
   buildJsonObject {
     put("sessionId", JsonPrimitive(sessionId))
+    if (inFlightRun != null) {
+      put(
+        "inFlightRun",
+        buildJsonObject {
+          put("runId", JsonPrimitive(inFlightRun.first))
+          put("text", JsonPrimitive(inFlightRun.second))
+        },
+      )
+      put("sessionInfo", buildJsonObject { put("hasActiveRun", JsonPrimitive(true)) })
+    }
     put(
       "messages",
       JsonArray(


### PR DESCRIPTION
Part of #100197. Android twin of #100277: consumes the existing gateway reconnect snapshot contract — no protocol changes.

## What Problem This Solves

When the Android app's gateway connection drops while an agent run is streaming, `ChatController.onDisconnected` clears all transient run state (pending runs, streaming text, tool placeholders). After reconnect, the app never rediscovered the run: the chat looked idle while the gateway was still streaming, and the reply only appeared after a manual refresh or the next event. Missed-event gaps (`seqGap`) had the same blind spot and only surfaced a "try refreshing" error.

## Why This Change Was Made

The gateway already ships a canonical reconnect snapshot: `chat.history` carries `inFlightRun { runId, text }` (the run still streaming for the session plus its buffered assistant text; see `src/gateway/chat-abort.ts` `resolveInFlightRunSnapshot`) and `sessionInfo.hasActiveRun`. The TUI (`src/tui/tui-session-actions.ts`) and, since #100277, iOS/macOS consume this contract. Android now does the same instead of inventing a parallel mechanism; the earlier protocol-cursor approach was rejected in favor of this existing contract.

## User Impact

- After a reconnect (or app cold start, or a `seqGap` event-stream gap) while a run is active, the Android chat immediately shows the run as pending again with the buffered assistant text, and keeps consuming its live deltas and terminal event.
- Reconnect with no active run stays clean — no phantom pending state, no duplicate transcript rows.
- `seqGap` now recovers automatically by refetching history instead of only showing "Event stream interrupted; try refreshing."

Implementation notes:
- `parseHistory` now decodes `inFlightRun`; bootstrap adopts it via `adoptInFlightRun` (adds the run to `pendingRuns`, arms the existing 120s pending-run timeout, restores buffered streaming text). Snapshot absence never clears local state — live terminal events and the timeout own completion — and a snapshot that reports a different run than a locally-owned pending send is ignored as stale.
- Reconnect refresh is armed by `onDisconnected` and fired on the next `health` event via `refreshHistoryForRecovery`, which reuses the existing bootstrap/reconciliation path without the session-switch state reset (so `healthOk` does not flicker and sends are not blocked).
- Sessions-list surfacing of `hasActiveRun` is not wired: the Android sessions UI currently has no active-run indicator to feed.

## Evidence

- New `ChatControllerReconnectRestoreTest` (ScriptedGateway replay harness): reconnect adopts the in-flight run and keeps consuming live deltas/terminal; reconnect without a run stays clean (single extra history fetch, no state); repeated reconnects do not duplicate the run or transcript rows; a stale recovery snapshot does not replace a locally-owned send; `seqGap` refetches and restores.
- `cd apps/android && ./gradlew :app:testPlayDebugUnitTest` — full unit suite green (all chat tests: 47 passed).
- Structured autoreview (Codex, gpt-5.5) on the diff: clean, no actionable findings.
