### PR TITLE
fix(agents): catch subagent sweeper errors instead of leaking unhandled rejections

### DIFF
--- a/scripts/proof/subagent-registry-sweeper-catch.mts
+++ b/scripts/proof/subagent-registry-sweeper-catch.mts
@@ -1,0 +1,33 @@
+// Real behavior proof: the subagent registry sweeper catches internal errors
+// instead of leaking them as unhandled rejections from the periodic interval.
+//
+// The regression test registers a subagent run, poisons the session store loader,
+// and asserts that awaiting the sweep resolves. Before the fix, the sweep rejects
+// and would become an unhandled rejection in the production interval.
+
+import { spawnSync } from "node:child_process";
+
+const testName = "catches and logs sweep errors instead of leaking unhandled rejections";
+
+console.log("=== Proof: subagent-registry sweeper rejection catch ===\n");
+console.log(`Running focused regression test: ${testName}\n`);
+
+const result = spawnSync(
+  "node",
+  ["scripts/run-vitest.mjs", "src/agents/subagent-registry.test.ts", "-t", testName],
+  { cwd: process.cwd(), encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+);
+
+if (result.stdout) {
+  console.log(result.stdout);
+}
+if (result.stderr) {
+  console.error(result.stderr);
+}
+
+if (result.status === 0) {
+  console.log("\nPASS: subagent sweep error is caught and does not leak.");
+} else {
+  console.log("\nFAIL: focused regression test did not pass.");
+  process.exitCode = 1;
+}

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -5713,4 +5713,24 @@ describe("subagent registry seam flow", () => {
     expect(runs[41]?.delivery?.status).toBe("suspended");
     expect(mocks.persistSubagentRunsToDisk).toHaveBeenCalled();
   });
+
+  it("catches and logs sweep errors instead of leaking unhandled rejections", async () => {
+    mod.registerSubagentRun({
+      runId: "run-sweep-error",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "sweep error",
+      cleanup: "delete",
+    });
+    const run = mod.getSubagentRunByChildSessionKey("agent:main:subagent:child");
+    expect(run).toBeDefined();
+    run!.startedAt = Date.now() - 2_000;
+
+    mocks.loadSessionStore.mockImplementation(() => {
+      throw new Error("simulated sweep failure");
+    });
+
+    await expect(mod.testing.sweepOnceForTests()).resolves.toBeUndefined();
+  });
 });

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1394,6 +1394,8 @@ async function sweepSubagentRuns() {
     if (subagentRuns.size === 0) {
       stopSweeper();
     }
+  } catch (err) {
+    log.warn(`subagent run sweep failed: ${err instanceof Error ? err.message : String(err)}`);
   } finally {
     sweepInProgress = false;
   }


### PR DESCRIPTION
## What Problem This Solves\n\n`startSweeper` schedules a periodic interval that calls `void sweepSubagentRuns()`. The sweep function has a `try/finally` but no `catch`, so any error thrown while loading session stores or completing runs becomes an unhandled rejection and can crash the agent runtime.\n\n## Why This Change Was Made\n\nAdded a `catch` around the sweep body that logs the error and still resets the in-flight flag. The next interval can retry instead of leaking the rejection.\n\n## User Impact\n\nLong-running agent gateways are more resilient to transient subagent session-store errors.\n\n## Evidence\n\nRegression test:\n\n```bash\nnode scripts/run-vitest.mjs src/agents/subagent-registry.test.ts -t "catches and logs sweep errors instead of leaking unhandled rejections"\n```\n\nThe test fails on current main (`sweepSubagentRuns` rejects with the simulated store error) and passes with the fix.\n\nReal behavior proof:\n\n```bash\nnode_modules/.bin/tsx scripts/proof/subagent-registry-sweeper-catch.mts\n```\n\nPASS: subagent sweep error is caught and does not leak.