### PR TITLE
fix: land ten small reliability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **iOS Voice Wake cleanup:** avoid initializing the microphone audio pipeline while disabling inactive Voice Wake, preventing simulator launch aborts and unnecessary audio setup.
+- **Cron duration validation:** reject positive durations that truncate below one millisecond instead of silently scheduling a zero-duration interval. (#100311) Thanks @qingminglong.
+- **Skill workshop proposals:** preserve the terminal newline in generated proposal Markdown while still rejecting blank raw content. (#100293) Thanks @anyech.
+- **Agent tool inputs and LSP startup:** treat blank optional integer arguments as absent, and fail embedded LSP startup immediately when its child process cannot spawn. (#100273, #99922) Thanks @snotty and @cxbAsDev.
+- **Gateway and memory diagnostics:** report failed start-session persistence and close-time memory work instead of silently discarding those failures. (#100313, #100308) Thanks @masatohoshino and @lin-hongkuan.
+- **Unicode and plugin package verification:** match native slice semantics for reversed UTF-16 bounds, and reject published plugin packages that omit `openclaw.plugin.json`. (#100014, #99904) Thanks @Simon-XYDT and @849261680.
+- **Android invoke cancellation:** preserve coroutine cancellation through camera handlers and the Gateway invoke boundary so cancelled work cannot emit a stale result. (#99916) Thanks @xialonglee.
+- **Codex native hook relay diagnostics:** avoid bridge registry writes before the local relay server begins listening. (#100300) Thanks @nankingjing.
 - **Agent stop recovery:** prevent late-aborting prompts from reacquiring orphaned session locks after teardown, so `/stop` leaves the conversation ready for the next turn.
 - **Message delivery status:** report failed and partially failed best-effort channel delivery instead of returning a success-shaped message-tool result. (#99928) Thanks @masatohoshino.
 - **WhatsApp credential recovery:** restore malformed primary auth state from a valid backup during startup. (#99070) Thanks @LeonidasLux.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -371,7 +371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1096,
+      "line": 1098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -379,7 +379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1096,
+      "line": 1098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -1015,6 +1015,8 @@ class GatewaySession(
           try {
             onInvoke?.invoke(InvokeRequest(id, nodeId, command, params, timeoutMs))
               ?: InvokeResult.error("UNAVAILABLE", "invoke handler missing")
+          } catch (err: CancellationException) {
+            throw err
           } catch (err: Throwable) {
             invokeErrorFromThrowable(err)
           }

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/CameraHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/CameraHandler.kt
@@ -6,6 +6,7 @@ import ai.openclaw.app.gateway.GatewaySession
 import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
@@ -55,6 +56,8 @@ class CameraHandler(
           )
         }.toString()
       GatewaySession.InvokeResult.ok(payload)
+    } catch (err: CancellationException) {
+      throw err
     } catch (err: Throwable) {
       val (code, message) = invokeErrorFromThrowable(err)
       GatewaySession.InvokeResult.error(code = code, message = message)
@@ -83,6 +86,8 @@ class CameraHandler(
           val r = camera.snap(paramsJson)
           camLog("success, payload size=${r.payloadJson.length}")
           r
+        } catch (err: CancellationException) {
+          throw err
         } catch (err: Throwable) {
           camLog("inner error: ${err::class.java.simpleName}: ${err.message}")
           camLog("stack: ${err.stackTraceToString().take(2000)}")
@@ -93,6 +98,8 @@ class CameraHandler(
       camLog("returning result")
       showCameraHud("Photo captured", CameraHudKind.Success, 1600)
       return GatewaySession.InvokeResult.ok(res.payloadJson)
+    } catch (err: CancellationException) {
+      throw err
     } catch (err: Throwable) {
       camLog("outer error: ${err::class.java.simpleName}: ${err.message}")
       camLog("stack: ${err.stackTraceToString().take(2000)}")
@@ -123,6 +130,8 @@ class CameraHandler(
           val r = camera.clip(paramsJson)
           clipLog("success, file size=${r.file.length()}")
           r
+        } catch (err: CancellationException) {
+          throw err
         } catch (err: Throwable) {
           clipLog("inner error: ${err::class.java.simpleName}: ${err.message}")
           clipLog("stack: ${err.stackTraceToString().take(2000)}")
@@ -157,6 +166,8 @@ class CameraHandler(
       return GatewaySession.InvokeResult.ok(
         """{"format":"mp4","base64":"$base64","durationMs":${filePayload.durationMs},"hasAudio":${filePayload.hasAudio}}""",
       )
+    } catch (err: CancellationException) {
+      throw err
     } catch (err: Throwable) {
       clipLog("outer error: ${err::class.java.simpleName}: ${err.message}")
       clipLog("stack: ${err.stackTraceToString().take(2000)}")

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -764,6 +764,47 @@ class GatewaySessionInvokeTest {
     }
 
   @Test
+  fun nodeInvokeRequest_doesNotSendResultAfterCancellation() =
+    runBlocking {
+      val json = testJson()
+      val connected = CompletableDeferred<Unit>()
+      val invokeStarted = CompletableDeferred<Unit>()
+      val invokeResult = CompletableDeferred<Unit>()
+      val lastDisconnect = AtomicReference("")
+      val serverWebSocket = AtomicReference<WebSocket?>(null)
+      val server =
+        startGatewayServer(json) { webSocket, id, method, _ ->
+          serverWebSocket.set(webSocket)
+          when (method) {
+            "connect" -> {
+              webSocket.send(connectResponseFrame(id))
+              webSocket.send(
+                """{"type":"event","event":"node.invoke.request","payload":{"id":"invoke-cancelled","nodeId":"node-1","command":"camera.snap","timeoutMs":5000}}""",
+              )
+            }
+            "node.invoke.result" -> invokeResult.complete(Unit)
+          }
+        }
+      val harness =
+        createNodeHarness(connected = connected, lastDisconnect = lastDisconnect) {
+          invokeStarted.complete(Unit)
+          throw CancellationException("cancelled")
+        }
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        awaitConnectedOrThrow(connected, lastDisconnect, server)
+        withTimeout(TEST_TIMEOUT_MS) { invokeStarted.await() }
+
+        assertNull(withTimeoutOrNull(250) { invokeResult.await() })
+      } finally {
+        serverWebSocket.get()?.close(1000, "done")
+        delay(100)
+        shutdownHarness(harness, server)
+      }
+    }
+
+  @Test
   fun sendNodeEventDetailed_sendsPresenceAlivePayloadAndReturnsStructuredResponse() =
     runBlocking {
       val json = testJson()

--- a/extensions/memory-core/src/memory/manager-async-state.ts
+++ b/extensions/memory-core/src/memory/manager-async-state.ts
@@ -19,15 +19,20 @@ export async function startAsyncSearchSync(params: {
 export async function awaitPendingManagerWork(params: {
   pendingSync?: Promise<void> | null;
   pendingProviderInit?: Promise<void> | null;
+  onError?: (err: unknown) => void;
 }): Promise<void> {
   if (params.pendingSync) {
     try {
       await params.pendingSync;
-    } catch {}
+    } catch (err: unknown) {
+      params.onError?.(err);
+    }
   }
   if (params.pendingProviderInit) {
     try {
       await params.pendingProviderInit;
-    } catch {}
+    } catch (err: unknown) {
+      params.onError?.(err);
+    }
   }
 }

--- a/extensions/memory-core/src/memory/manager.async-search.test.ts
+++ b/extensions/memory-core/src/memory/manager.async-search.test.ts
@@ -72,6 +72,42 @@ describe("memory search async sync", () => {
     await closePromise;
   });
 
+  it("reports pending sync failures during close", async () => {
+    const onError = vi.fn();
+    const syncError = new Error("sync failed");
+
+    await awaitPendingManagerWork({
+      pendingSync: Promise.reject(syncError),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith(syncError);
+  });
+
+  it("reports pending provider initialization failures during close", async () => {
+    const onError = vi.fn();
+    const providerError = new Error("provider init failed");
+
+    await awaitPendingManagerWork({
+      pendingProviderInit: Promise.reject(providerError),
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith(providerError);
+  });
+
+  it("does not report errors for completed pending close work", async () => {
+    const onError = vi.fn();
+
+    await awaitPendingManagerWork({
+      pendingSync: Promise.resolve(),
+      pendingProviderInit: Promise.resolve(),
+      onError,
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("skips background search sync when search-triggered sync is disabled", async () => {
     const syncMock = vi.fn(async () => {});
     await startAsyncSearchSync({

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -1364,14 +1364,23 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         }
       }
     };
+    const reportPendingWorkError = (err: unknown) => {
+      log.warn(`memory close: pending manager work failed: ${formatErrorMessage(err)}`);
+    };
     const awaitCurrentSync = async () => {
       const pendingSync = this.syncing;
       if (!pendingSync) {
         return;
       }
-      await awaitPendingManagerWork({ pendingSync });
+      await awaitPendingManagerWork({
+        pendingSync,
+        onError: reportPendingWorkError,
+      });
     };
-    await awaitPendingManagerWork({ pendingProviderInit });
+    await awaitPendingManagerWork({
+      pendingProviderInit,
+      onError: reportPendingWorkError,
+    });
     rememberCurrentProvider();
     try {
       await awaitCurrentSync();

--- a/packages/normalization-core/src/utf16-slice.test.ts
+++ b/packages/normalization-core/src/utf16-slice.test.ts
@@ -23,8 +23,8 @@ describe("sliceUtf16Safe", () => {
     expect(sliceUtf16Safe("hello", 0, 10)).toBe("hello");
   });
 
-  it("swaps start and end when start > end", () => {
-    expect(sliceUtf16Safe("hello", 3, 1)).toBe("el");
+  it("returns empty when start > end, matching String.prototype.slice", () => {
+    expect(sliceUtf16Safe("hello", 3, 1)).toBe("");
   });
 
   it("preserves emoji with surrogate pairs", () => {

--- a/packages/normalization-core/src/utf16-slice.ts
+++ b/packages/normalization-core/src/utf16-slice.ts
@@ -19,10 +19,8 @@ export function sliceUtf16Safe(input: string, start: number, end?: number): stri
   let from = start < 0 ? Math.max(len + start, 0) : Math.min(start, len);
   let to = end === undefined ? len : end < 0 ? Math.max(len + end, 0) : Math.min(end, len);
 
-  if (to < from) {
-    const tmp = from;
-    from = to;
-    to = tmp;
+  if (to <= from) {
+    return "";
   }
 
   if (from > 0 && from < len) {

--- a/scripts/verify-plugin-npm-published-runtime.mjs
+++ b/scripts/verify-plugin-npm-published-runtime.mjs
@@ -129,6 +129,10 @@ export function collectPluginNpmPublishedRuntimeErrors(params) {
   if (errors.length > 0) {
     return errors;
   }
+  if (!hasPackedFile(packageFiles, "openclaw.plugin.json")) {
+    errors.push(`${packageLabel} plugin npm package must include openclaw.plugin.json`);
+    return errors;
+  }
   const extensions = extensionsResult.entries;
   const runtimeExtensions = runtimeExtensionsResult.entries;
   const setupEntry = setupEntryResult.entry;

--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -122,6 +122,22 @@ describe("bundle LSP runtime", () => {
     expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000 });
   });
 
+  it("fails LSP startup immediately when the child process cannot spawn", async () => {
+    configureSingleLspServer();
+    const child = new MockChildProcess();
+    spawnMock.mockImplementation(() => {
+      queueMicrotask(() => child.emit("error", new Error("spawn ENOENT")));
+      return child;
+    });
+    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
+
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+
+    expect(runtime.sessions).toEqual([]);
+    expect(runtime.tools).toEqual([]);
+    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000 });
+  });
+
   it("keeps LSP framing aligned after multibyte messages in the same chunk", async () => {
     configureSingleLspServer();
     const prefix = encodeLspMessage({

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -30,7 +30,8 @@ type LspSession = {
   initialized: boolean;
   capabilities: LspServerCapabilities;
   disposed: boolean;
-  // Preserve a spawn failure so requests created after the event reject immediately.
+  // Preserve a spawn failure so requests created after the event reject immediately
+  // instead of waiting for the per-request timeout.
   failure?: Error;
 };
 

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -30,6 +30,7 @@ type LspSession = {
   initialized: boolean;
   capabilities: LspServerCapabilities;
   disposed: boolean;
+  // Preserve a spawn failure so requests created after the event reject immediately.
   failure?: Error;
 };
 

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -30,6 +30,7 @@ type LspSession = {
   initialized: boolean;
   capabilities: LspServerCapabilities;
   disposed: boolean;
+  failure?: Error;
 };
 
 type PendingLspRequest = {
@@ -108,6 +109,14 @@ function registerActiveLspSession(session: LspSession): void {
 }
 
 function attachLspProcessHandlers(session: LspSession): void {
+  session.process.on("error", (error) => {
+    session.failure = error;
+    for (const pending of session.pendingRequests.values()) {
+      clearTimeout(pending.timeout);
+      pending.reject(error);
+    }
+    session.pendingRequests.clear();
+  });
   session.process.stdout?.on("data", (chunk: Buffer | string) =>
     handleIncomingData(session, chunk),
   );
@@ -163,6 +172,9 @@ function parseLspMessages(buffer: Buffer): { messages: unknown[]; remaining: Buf
 }
 
 function sendRequest(session: LspSession, method: string, params?: unknown): Promise<unknown> {
+  if (session.failure) {
+    return Promise.reject(session.failure);
+  }
   const id = ++session.requestId;
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => {

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -474,7 +474,7 @@ export function registerNativeHookRelay(
       current.expiresAtMs = renewedExpiresAtMs;
       handle.expiresAtMs = renewedExpiresAtMs;
       const bridge = relayBridges.get(relayId);
-      if (bridge) {
+      if (bridge && bridge.server.listening) {
         writeNativeHookRelayBridgeRecordForRegistration(current, bridge);
       }
     },
@@ -992,9 +992,6 @@ function registerNativeHookRelayBridge(registration: ActiveNativeHookRelayRegist
     }
     writeNativeHookRelayBridgeRecordForRegistration(registration, bridge);
   });
-  if (relayBridges.get(registration.relayId) === bridge) {
-    writeNativeHookRelayBridgeRecordForRegistration(registration, bridge);
-  }
   server.unref();
 }
 

--- a/src/agents/tools/common.params.test.ts
+++ b/src/agents/tools/common.params.test.ts
@@ -132,6 +132,37 @@ describe("readNumberParam", () => {
     ).toThrow("deleteDays must be an integer from 0 to 7");
   });
 
+  it("treats empty or whitespace-only strings as unset for optional positive integer params", () => {
+    // Tool-calling models routinely emit empty-string defaults for optional
+    // params (e.g. Telegram replyTo/threadId) they are not actually setting.
+    // An empty/whitespace string carries no value and must not throw.
+    expect(readPositiveIntegerParam({ replyTo: "" }, "replyTo")).toBeUndefined();
+    expect(readPositiveIntegerParam({ threadId: "   " }, "threadId")).toBeUndefined();
+    expect(readPositiveIntegerParam({ replyTo: "\t\n" }, "replyTo")).toBeUndefined();
+    // Genuinely invalid present values must still throw.
+    expect(() => readPositiveIntegerParam({ replyTo: "0" }, "replyTo")).toThrow(
+      "replyTo must be a positive integer",
+    );
+    expect(() => readPositiveIntegerParam({ replyTo: 0 }, "replyTo")).toThrow(
+      "replyTo must be a positive integer",
+    );
+    expect(() => readPositiveIntegerParam({ replyTo: "-3" }, "replyTo")).toThrow(
+      "replyTo must be a positive integer",
+    );
+  });
+
+  it("treats empty or whitespace-only strings as unset for optional non-negative integer params", () => {
+    expect(readNonNegativeIntegerParam({ position: "" }, "position")).toBeUndefined();
+    expect(readNonNegativeIntegerParam({ position: "  " }, "position")).toBeUndefined();
+    // A present, valid zero is still a real value.
+    expect(readNonNegativeIntegerParam({ position: "0" }, "position")).toBe(0);
+    expect(readNonNegativeIntegerParam({ position: 0 }, "position")).toBe(0);
+    // Genuinely invalid present values must still throw.
+    expect(() => readNonNegativeIntegerParam({ position: "4.5" }, "position")).toThrow(
+      "position must be a non-negative integer",
+    );
+  });
+
   it("throws for invalid present bounded finite number params", () => {
     expect(readFiniteNumberParam({ quality: "0.75" }, "quality")).toBe(0.75);
     expect(readFiniteNumberParam({ quality: null }, "quality")).toBeUndefined();

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -112,6 +112,19 @@ function readParamRaw(params: Record<string, unknown>, key: string): unknown {
   return readSnakeCaseParamRaw(params, key);
 }
 
+/**
+ * True when a raw tool-param value should be treated as "not provided".
+ *
+ * Tool-calling models frequently populate every optional field with an empty
+ * or whitespace-only string default even when the caller did not set it. Such
+ * a value carries no information and must not be treated as an invalid present
+ * value. This mirrors how {@link readStringParam} / {@link readNumberParam}
+ * already ignore empty/whitespace strings.
+ */
+function isBlankParamValue(raw: unknown): boolean {
+  return typeof raw === "string" && raw.trim() === "";
+}
+
 export function readStringParam(
   params: Record<string, unknown>,
   key: string,
@@ -244,8 +257,11 @@ export function readPositiveIntegerParam(
     positiveInteger: true,
     strict: true,
   });
-  if (value === undefined && readParamRaw(params, key) != null) {
-    throw new ToolInputError(options.message ?? `${key} must be a positive integer`);
+  if (value === undefined) {
+    const raw = readParamRaw(params, key);
+    if (raw != null && !isBlankParamValue(raw)) {
+      throw new ToolInputError(options.message ?? `${key} must be a positive integer`);
+    }
   }
   if (value !== undefined && options.max !== undefined && value > options.max) {
     throw new ToolInputError(options.message ?? `${key} must be a positive integer`);
@@ -265,8 +281,11 @@ export function readNonNegativeIntegerParam(
     nonNegativeInteger: true,
     strict: true,
   });
-  if (value === undefined && readParamRaw(params, key) != null) {
-    throw new ToolInputError(options.message ?? `${key} must be a non-negative integer`);
+  if (value === undefined) {
+    const raw = readParamRaw(params, key);
+    if (raw != null && !isBlankParamValue(raw)) {
+      throw new ToolInputError(options.message ?? `${key} must be a non-negative integer`);
+    }
   }
   if (value !== undefined && options.max !== undefined && value > options.max) {
     throw new ToolInputError(options.message ?? `${key} must be a non-negative integer`);

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -112,15 +112,8 @@ function readParamRaw(params: Record<string, unknown>, key: string): unknown {
   return readSnakeCaseParamRaw(params, key);
 }
 
-/**
- * True when a raw tool-param value should be treated as "not provided".
- *
- * Tool-calling models frequently populate every optional field with an empty
- * or whitespace-only string default even when the caller did not set it. Such
- * a value carries no information and must not be treated as an invalid present
- * value. This mirrors how {@link readStringParam} / {@link readNumberParam}
- * already ignore empty/whitespace strings.
- */
+// Models may emit blank defaults for optional numeric fields. Treat them as
+// absent while still rejecting nonblank invalid input.
 function isBlankParamValue(raw: unknown): boolean {
   return typeof raw === "string" && raw.trim() === "";
 }

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -272,6 +272,45 @@ describe("skill_workshop tool", () => {
     );
   });
 
+  it("rejects whitespace-only proposal content while preserving raw valid markdown", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
+    const tool = createSkillWorkshopTool({
+      workspaceDir,
+      config: {},
+      agentId: "main",
+    });
+
+    await expect(
+      tool.execute("call-blank", {
+        action: "create",
+        name: "Blank Proposal",
+        description: "Rejected blank content",
+        proposal_content: " \n\t\n ",
+      }),
+    ).rejects.toThrow("proposal_content required");
+
+    const result = await tool.execute("call-valid", {
+      action: "create",
+      name: "Raw Markdown",
+      description: "Valid content keeps trailing newline",
+      proposal_content: "# Raw Markdown\n\nKeep this terminal newline.\n",
+    });
+
+    await expect(
+      fs
+        .readFile(
+          path.join(
+            stateDir,
+            "skill-workshop",
+            "proposals",
+            (result.details as { id: string }).id,
+            "PROPOSAL.md",
+          ),
+        )
+        .then((buffer) => buffer.at(-1)),
+    ).resolves.toBe(0x0a);
+  });
+
   it("applies, rejects, and quarantines proposals through the workshop service", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
     const tool = createSkillWorkshopTool({ workspaceDir, config: {}, agentId: "main" });

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -128,6 +128,19 @@ describe("skill_workshop tool", () => {
             "skill-workshop",
             "proposals",
             (result.details as { id: string }).id,
+            "PROPOSAL.md",
+          ),
+        )
+        .then((buffer) => buffer.at(-1)),
+    ).resolves.toBe(0x0a);
+    await expect(
+      fs
+        .readFile(
+          path.join(
+            stateDir,
+            "skill-workshop",
+            "proposals",
+            (result.details as { id: string }).id,
             "proposal.json",
           ),
           "utf8",

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -207,6 +207,9 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
         label: "proposal_content",
         trim: false,
       });
+      if (proposalContent.trim().length === 0) {
+        throw new ToolInputError("proposal_content required");
+      }
       const supportFiles = readSupportFilesParam(params);
       const goal = readStringParam(params, "goal");
       const evidence = readStringParam(params, "evidence");

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -205,6 +205,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
       const proposalContent = readStringParam(params, "proposal_content", {
         required: true,
         label: "proposal_content",
+        trim: false,
       });
       const supportFiles = readSupportFilesParam(params);
       const goal = readStringParam(params, "goal");

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -347,6 +347,8 @@ describe("parseDurationMs", () => {
 
   it("rejects non-positive and malformed durations", () => {
     expect(parseDurationMs("0s")).toBeNull();
+    expect(parseDurationMs("0.5ms")).toBeNull();
+    expect(parseDurationMs("0.001ms")).toBeNull();
     expect(parseDurationMs("-5s")).toBeNull();
     expect(parseDurationMs("abc")).toBeNull();
     expect(parseDurationMs("")).toBeNull();

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -227,9 +227,9 @@ export function parseDurationMs(input: string): number | null {
             ? 3_600_000
             : 86_400_000;
   const result = Math.floor(n * factor);
-  if (!Number.isFinite(result)) {
+  if (!Number.isFinite(result) || result <= 0) {
     // A finite mantissa can still overflow to Infinity for a large unit (e.g. a long
-    // pure-digit string with "d"); reject it instead of returning Infinity ms.
+    // pure-digit string with "d"); tiny positive values can also floor to 0ms.
     return null;
   }
   return result;

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -3395,6 +3395,32 @@ describe("agent event handler", () => {
     );
   });
 
+  it("logs when start session persistence fails", async () => {
+    const { chatRunState, handler, sessionEventSubscribers } = createHarness();
+    sessionEventSubscribers.subscribe("conn-1");
+    chatRunState.registry.add("run-global-work", {
+      sessionKey: "global",
+      agentId: "work",
+      clientRunId: "client-global-work",
+    });
+    persistGatewaySessionLifecycleEventMock.mockRejectedValueOnce(new Error("start disk full"));
+
+    handler({
+      runId: "run-global-work",
+      seq: 1,
+      stream: "lifecycle",
+      ts: Date.now(),
+      data: { phase: "start" },
+    });
+
+    await vi.waitFor(() => {
+      expect(logErrorMock).toHaveBeenCalledTimes(1);
+    });
+    expect(logErrorMock).toHaveBeenCalledWith(
+      "gateway: start session persistence failed session=global run=run-global-work error=Error: start disk full",
+    );
+  });
+
   it("routes hidden selected-agent global chat events only to matching subscribers", () => {
     const { broadcastToConnIds, chatRunState, handler, sessionMessageSubscribers } =
       createHarness();

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1475,7 +1475,14 @@ export function createAgentEventHandler({
         sessionKey,
         agentId: sessionAgentId,
         event: evt,
-      }).catch(() => undefined);
+      }).catch((err: unknown) => {
+        // Surface the swallowed start-phase persistence failure: a silent write
+        // failure drops the run's start marker from restart-recovery accounting
+        // with no operator trace, matching the terminal-phase log below.
+        logError(
+          `gateway: start session persistence failed session=${formatForLog(sessionKey)} run=${formatForLog(evt.runId)} error=${formatForLog(err)}`,
+        );
+      });
       const sessionEventConnIds = sessionEventSubscribers.getAll();
       if (sessionEventConnIds.size > 0) {
         broadcastToConnIds(

--- a/src/skills/workshop/frontmatter.ts
+++ b/src/skills/workshop/frontmatter.ts
@@ -47,7 +47,8 @@ export function renderProposalMarkdown(params: {
   ]
     .filter(Boolean)
     .join("\n");
-  return `---\n${frontmatter}\n---\n\n${body}`;
+  const markdown = `---\n${frontmatter}\n---\n\n${body}`;
+  return markdown.endsWith("\n") ? markdown : `${markdown}\n`;
 }
 
 export function readProposalFrontmatter(content: string): ProposalFrontmatter | null {

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -13,6 +13,7 @@ import {
   resetSkillsRefreshStateForTest,
 } from "../runtime/refresh-state.js";
 import { writeSkill } from "../test-support/e2e-test-helpers.js";
+import { renderProposalMarkdown } from "./frontmatter.js";
 import {
   applySkillProposal,
   inspectSkillProposal,
@@ -50,6 +51,17 @@ async function makeWorkspace(): Promise<string> {
 }
 
 describe("skill workshop proposals", () => {
+  it("renders proposal markdown with a terminal newline", () => {
+    expect(
+      renderProposalMarkdown({
+        name: "example",
+        description: "Example proposal",
+        content: "# Example",
+        date: "2026-07-05T00:00:00.000Z",
+      }).endsWith("\n"),
+    ).toBe(true);
+  });
+
   it("creates a pending proposal under the workshop and applies it as an active workspace skill", async () => {
     const workspaceDir = await makeWorkspace();
     const proposal = await proposeCreateSkill({

--- a/test/scripts/verify-plugin-npm-published-runtime.test.ts
+++ b/test/scripts/verify-plugin-npm-published-runtime.test.ts
@@ -139,7 +139,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             extensions: ["./index.ts"],
           },
         },
-        files: ["package.json", "index.ts"],
+        files: ["package.json", "openclaw.plugin.json", "index.ts"],
       }),
     ).toEqual([
       "@openclaw/discord@2026.5.2 requires compiled runtime output for TypeScript entry ./index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, ./index.js, ./index.mjs, ./index.cjs",
@@ -157,9 +157,42 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeExtensions: ["./dist/index.js"],
           },
         },
-        files: ["package.json", "index.ts", "dist/index.js"],
+        files: ["package.json", "openclaw.plugin.json", "index.ts", "dist/index.js"],
       }),
     ).toStrictEqual([]);
+  });
+
+  it("flags plugin npm packages without an OpenClaw plugin manifest", () => {
+    expect(
+      collectPluginNpmPublishedRuntimeErrors({
+        packageJson: {
+          name: "@openclaw/searxng-plugin",
+          version: "2026.6.11",
+          openclaw: {
+            extensions: ["./index.ts"],
+            runtimeExtensions: ["./dist/index.js"],
+          },
+        },
+        files: ["package.json", "dist/index.js"],
+      }),
+    ).toEqual([
+      "@openclaw/searxng-plugin@2026.6.11 plugin npm package must include openclaw.plugin.json",
+    ]);
+  });
+
+  it("flags reservation packages before they can pass plugin runtime verification", () => {
+    expect(
+      collectPluginNpmPublishedRuntimeErrors({
+        packageJson: {
+          name: "@openclaw/tavily-plugin",
+          version: "0.0.0",
+          description: "Bootstrap reservation",
+        },
+        files: ["package.json", "README.md"],
+      }),
+    ).toEqual([
+      "@openclaw/tavily-plugin@0.0.0 plugin npm package must include openclaw.plugin.json",
+    ]);
   });
 
   it("flags missing explicit runtimeExtensions outputs", () => {
@@ -173,7 +206,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeExtensions: ["./dist/index.js"],
           },
         },
-        files: ["package.json", "src/index.ts"],
+        files: ["package.json", "openclaw.plugin.json", "src/index.ts"],
       }),
     ).toEqual(["@openclaw/line@2026.5.3 runtime extension entry not found: ./dist/index.js"]);
   });
@@ -189,7 +222,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeExtensions: ["./dist/index.js"],
           },
         },
-        files: ["package.json", "dist/index.js"],
+        files: ["package.json", "openclaw.plugin.json", "dist/index.js"],
       }),
     ).toEqual([
       "@openclaw/acpx@2026.5.3 package.json openclaw.runtimeExtensions length (1) must match openclaw.extensions length (2)",
@@ -207,7 +240,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeExtensions: [" "],
           },
         },
-        files: ["package.json", "src/index.ts", "dist/index.js"],
+        files: ["package.json", "openclaw.plugin.json", "src/index.ts", "dist/index.js"],
       }),
     ).toEqual([
       "@openclaw/whatsapp@2026.5.3 package.json openclaw.runtimeExtensions[0] must be a non-empty string",
@@ -226,7 +259,13 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             setupEntry: "./setup-entry.ts",
           },
         },
-        files: ["package.json", "index.ts", "dist/index.js", "setup-entry.ts"],
+        files: [
+          "package.json",
+          "openclaw.plugin.json",
+          "index.ts",
+          "dist/index.js",
+          "setup-entry.ts",
+        ],
       }),
     ).toEqual([
       "@openclaw/line@2026.5.3 requires compiled runtime output for TypeScript entry ./setup-entry.ts: expected ./dist/setup-entry.js, ./dist/setup-entry.mjs, ./dist/setup-entry.cjs, ./setup-entry.js, ./setup-entry.mjs, ./setup-entry.cjs",
@@ -246,7 +285,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeSetupEntry: "./dist/setup-entry.js",
           },
         },
-        files: ["package.json", "dist/index.js", "dist/setup-entry.js"],
+        files: ["package.json", "openclaw.plugin.json", "dist/index.js", "dist/setup-entry.js"],
       }),
     ).toStrictEqual([]);
   });
@@ -264,7 +303,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeSetupEntry: "./dist/setup-entry.js",
           },
         },
-        files: ["package.json", "dist/index.js"],
+        files: ["package.json", "openclaw.plugin.json", "dist/index.js"],
       }),
     ).toEqual(["@openclaw/matrix@2026.5.3 runtime setup entry not found: ./dist/setup-entry.js"]);
   });
@@ -281,7 +320,7 @@ describe("collectPluginNpmPublishedRuntimeErrors", () => {
             runtimeSetupEntry: "./dist/setup-entry.js",
           },
         },
-        files: ["package.json", "dist/index.js", "dist/setup-entry.js"],
+        files: ["package.json", "openclaw.plugin.json", "dist/index.js", "dist/setup-entry.js"],
       }),
     ).toEqual([
       "@openclaw/twitch@2026.5.3 package.json openclaw.runtimeSetupEntry requires openclaw.setupEntry",


### PR DESCRIPTION
## What Problem This Solves

Ten small, independently reported reliability defects were ready for maintainer cleanup but split across contributor branches. The original LSP patch also swallowed spawn failures and waited for timeout, while the Codex relay patch was described more broadly than its actual diagnostic cleanup.

Source PRs: #100311, #100293, #100273, #100313, #100308, #100014, #99904, #99916, #100300, #99922.

## Why This Change Was Made

This takeover preserves the contributor implementations and credit, then adds maintainer fixups:

- fail embedded LSP initialization immediately with the child-process spawn error;
- prove Android invoke cancellation does not emit a stale result;
- trim an overlong tool-parameter comment;
- describe #100300 narrowly as preventing pre-listen registry writes; it does not claim to resolve #98650;
- add Unreleased changelog entries and contributor thanks.

## User Impact

Cron rejects sub-millisecond schedules, skill proposals retain their terminal newline, blank optional integer tool arguments behave as absent, persistence and memory close failures become visible, UTF-16 slicing matches native semantics, malformed plugin packages fail verification, Android cancellations propagate, LSP startup fails quickly, and native hook relay records are written only after the server is listening.

## Evidence

- Blacksmith Testbox focused Vitest run: 431 tests passed across six shards: https://github.com/openclaw/openclaw/actions/runs/28747640046
- Blacksmith Testbox Android `GatewaySessionInvokeTest`: 18 tests passed: https://github.com/openclaw/openclaw/actions/runs/28747804774
- Live npm package verification: `@openclaw/searxng-plugin@2026.6.11` passed with its published manifest and runtime files.
- `git diff --check`
- Fresh autoreview: clean; no accepted/actionable findings.
- Direct Codex contract inspection: command hooks inherit the Codex process environment, execute via the configured login shell, receive JSON on stdin, and interpret PreToolUse output in `codex-rs/hooks/src/engine/command_runner.rs` and `codex-rs/hooks/src/events/pre_tool_use.rs`.
