### PR TITLE
docs: document context engine running summaries

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -326,6 +326,29 @@ That means there are two valid plugin patterns:
 
 A no-op `compact()` is unsafe for an active non-owning engine because it disables the normal `/compact` and overflow-recovery compaction path for that engine slot.
 
+### Running summary pattern
+
+Use a context engine, not an internal hook, when you want a plugin to keep a
+running session summary and reduce how much work happens during compaction. The
+engine has access to both sides of the lifecycle:
+
+- `afterTurn()` can update a plugin-owned summary after each successful turn,
+  when the user is no longer waiting on the current reply.
+- `assemble()` can include that summary in the next prompt, often through a
+  `systemPromptAddition` or by replacing older raw turns with a compact summary.
+- `compact()` can then reuse the stored summary when `/compact` or overflow
+  recovery needs a smaller transcript, instead of starting every summary from
+  scratch.
+
+This pattern is different from the bundled `compaction-notifier` hook. The hook
+only sends visible start and finish notices; a context engine owns prompt
+assembly and compaction strategy for the selected engine slot.
+
+Keep the stored summary bounded and session-scoped. If the summary can hide a
+large raw transcript behind a small assembled prompt, return
+`promptAuthority: "preassembly_may_overflow"` from `assemble()` so OpenClaw can
+still consider the underlying transcript size during overflow prechecks.
+
 ## Configuration reference
 
 ```json5


### PR DESCRIPTION
﻿Related: #100388

## What Problem This Solves

Resolves part of the compaction-observability gap where users and plugin authors do not have a clear documented path for reducing expensive compaction work ahead of time with the existing Context Engine lifecycle.

## Why This Change Was Made

This documents the existing running-summary context-engine pattern without adding a new WebChat event contract, Gateway diagnostics API, or product surface that still needs maintainer decision in #100388. The guidance points plugin authors at `afterTurn()`, `assemble()`, `compact()`, and `promptAuthority` so a context engine can keep bounded session summaries and reuse them during compaction.

## User Impact

Plugin authors and operators have a clearer supported route for building Session Memory-style context engines that reduce compaction latency, while the larger staged WebChat progress and diagnostics API questions remain open for maintainer design.

## Evidence

- `git diff --check HEAD~1..HEAD`

Not run: docs build. This is a single-page documentation addition; an earlier `pnpm docs:list` attempt was stopped after dependency installation retried several registry downloads from the configured mirror.
