### PR TITLE
fix(gateway): catch lazy import rejections in runtime event subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Source build portability:** keep tsdown configuration self-contained so builds do not depend on resolving the tsdown package from unrun's temporary module directory.
+- **Gateway event dispatch:** catch and log lazy subscriber setup and handler failures instead of leaking unhandled promise rejections. (#100401) Thanks @cxbAsDev.
 - **Diffs rendering:** render viewer and image output from one SSR preload, preserve language-pack highlighting through hydration, normalize language hints case-insensitively, skip identical before/after inputs with an explicit `changed` result, report truthful file-render and input errors, cache hash-pinned viewer runtimes, and prefer canonical file settings over stale aliases. (#100487)
 - **Remote browser reliability:** bound persistent Playwright tab enumeration by the existing remote CDP timeout budget and retire timed-out connection attempts so late completions cannot restore a stuck connection. (#80147, #58968) Thanks @HemantSudarshan and @KeaneYan.
 - **Managed browser cookie persistence:** initialize new isolated macOS headless profiles with a non-interactive encryption key while preserving existing profile keys, and close Chromium through CDP before bounded signal fallback so persistent logins survive graceful browser and Gateway restarts. (#96704, #98284) Thanks @TurboTheTurtle.

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -1,7 +1,6 @@
 // Tests for gateway runtime subscription wiring.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { emitAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
-import { emitHeartbeatEvent, resetHeartbeatEventsForTest } from "../infra/heartbeat-events.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import {
@@ -30,85 +29,69 @@ const mockLog: SubsystemLogger = {
 };
 
 vi.mock("./server-chat.js", () => {
-  return {
-    createAgentEventHandler: () => {
-      throw new Error("server-chat lazy load failure");
-    },
-  };
+  throw new Error("server-chat lazy load failure");
 });
 
-vi.mock("./server-session-key.js", () => {
-  return {
-    resolveSessionKeyForRun: () => "agent:main:main",
-  };
-});
+vi.mock("./server-session-key.js", () => ({
+  resolveSessionKeyForRun: () => "agent:main:main",
+}));
 
-vi.mock("./server-session-events.js", () => {
-  return {
-    createTranscriptUpdateBroadcastHandler: () => {
-      throw new Error("server-session-events lazy load failure");
-    },
-    createLifecycleEventBroadcastHandler: () => {
-      throw new Error("server-session-events lazy load failure");
-    },
-  };
-});
+vi.mock("./server-session-events.js", () => ({
+  createTranscriptUpdateBroadcastHandler: () => () => {
+    throw new Error("transcript handler failure");
+  },
+  createLifecycleEventBroadcastHandler: () => () => {
+    throw new Error("lifecycle handler failure");
+  },
+}));
 
 const { startGatewayEventSubscriptions } = await import("./server-runtime-subscriptions.js");
+type SubscriptionParams = Parameters<typeof startGatewayEventSubscriptions>[0];
 
-function createParams() {
+function createParams(): SubscriptionParams {
   return {
     log: mockLog,
     broadcast: vi.fn(),
     broadcastToConnIds: vi.fn(),
     nodeSendToSession: vi.fn(),
-    agentRunSeq: new Map<string, number>(),
+    agentRunSeq: new Map(),
     chatRunState: createChatRunState(),
     toolEventRecipients: createToolEventRecipientRegistry(),
     sessionEventSubscribers: createSessionEventSubscriberRegistry(),
     sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
-    chatAbortControllers: new Map<string, unknown>(),
-    restartRecoveryCandidates: new Map<string, unknown>(),
+    chatAbortControllers: new Map(),
+    restartRecoveryCandidates: new Map(),
   };
 }
 
 describe("startGatewayEventSubscriptions", () => {
-  let unsubs: ReturnType<typeof startGatewayEventSubscriptions>;
-  const unhandledRejections: unknown[] = [];
-  let unhandledHandler: (reason: unknown) => void;
+  let unsubs: ReturnType<typeof startGatewayEventSubscriptions> | undefined;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    unhandledHandler = (reason: unknown) => {
-      unhandledRejections.push(reason);
-    };
-    process.on("unhandledRejection", unhandledHandler);
   });
 
   afterEach(() => {
-    process.off("unhandledRejection", unhandledHandler);
     unsubs?.agentUnsub();
     unsubs?.heartbeatUnsub();
     unsubs?.transcriptUnsub();
     unsubs?.lifecycleUnsub();
     resetAgentEventsForTest();
-    resetHeartbeatEventsForTest();
   });
 
-  it("logs a warning when the lazy agent event handler import rejects", async () => {
+  it("logs lazy agent event module failures", async () => {
     unsubs = startGatewayEventSubscriptions(createParams());
 
     emitAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "start" } });
 
     await vi.waitFor(() => expect(warn).toHaveBeenCalledTimes(1));
     expect(warn).toHaveBeenCalledWith(
-      "Failed to handle agent event: lazy handler load rejected",
+      "Agent event dispatch failed",
       expect.objectContaining({ runId: "run-1", stream: "lifecycle" }),
     );
-    expect(unhandledRejections).toHaveLength(0);
   });
 
-  it("logs a warning when the lazy transcript update handler import rejects", async () => {
+  it("logs transcript handler failures", async () => {
     unsubs = startGatewayEventSubscriptions(createParams());
 
     emitInternalSessionTranscriptUpdate({
@@ -118,35 +101,20 @@ describe("startGatewayEventSubscriptions", () => {
 
     await vi.waitFor(() => expect(warn).toHaveBeenCalledTimes(1));
     expect(warn).toHaveBeenCalledWith(
-      "Failed to handle transcript update: lazy handler load rejected",
+      "Transcript update dispatch failed",
       expect.objectContaining({ sessionKey: "agent:main:main" }),
     );
-    expect(unhandledRejections).toHaveLength(0);
   });
 
-  it("logs a warning when the lazy lifecycle event handler import rejects", async () => {
+  it("logs lifecycle handler failures", async () => {
     unsubs = startGatewayEventSubscriptions(createParams());
 
     emitSessionLifecycleEvent({ sessionKey: "agent:main:main", reason: "created" });
 
     await vi.waitFor(() => expect(warn).toHaveBeenCalledTimes(1));
     expect(warn).toHaveBeenCalledWith(
-      "Failed to handle lifecycle event: lazy handler load rejected",
+      "Lifecycle event dispatch failed",
       expect.objectContaining({ sessionKey: "agent:main:main" }),
     );
-    expect(unhandledRejections).toHaveLength(0);
-  });
-
-  it("still broadcasts heartbeat events directly without lazy loading", async () => {
-    const params = createParams();
-    unsubs = startGatewayEventSubscriptions(params);
-
-    emitHeartbeatEvent({ status: "ok-empty" });
-
-    await vi.waitFor(() => expect(params.broadcast).toHaveBeenCalledTimes(1));
-    expect(params.broadcast).toHaveBeenCalledWith("heartbeat", expect.anything(), {
-      dropIfSlow: true,
-    });
-    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -1,0 +1,152 @@
+// Tests for gateway runtime subscription wiring.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
+import { emitHeartbeatEvent, resetHeartbeatEventsForTest } from "../infra/heartbeat-events.js";
+import type { SubsystemLogger } from "../logging/subsystem.js";
+import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
+import {
+  emitInternalSessionTranscriptUpdate,
+  type InternalSessionTranscriptUpdate,
+} from "../sessions/transcript-events.js";
+import {
+  createChatRunState,
+  createSessionEventSubscriberRegistry,
+  createSessionMessageSubscriberRegistry,
+  createToolEventRecipientRegistry,
+} from "./server-chat-state.js";
+
+const warn = vi.fn();
+const mockLog: SubsystemLogger = {
+  subsystem: "gateway-test",
+  isEnabled: () => true,
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn,
+  error: vi.fn(),
+  fatal: vi.fn(),
+  raw: vi.fn(),
+  child: () => mockLog,
+};
+
+vi.mock("./server-chat.js", () => {
+  return {
+    createAgentEventHandler: () => {
+      throw new Error("server-chat lazy load failure");
+    },
+  };
+});
+
+vi.mock("./server-session-key.js", () => {
+  return {
+    resolveSessionKeyForRun: () => "agent:main:main",
+  };
+});
+
+vi.mock("./server-session-events.js", () => {
+  return {
+    createTranscriptUpdateBroadcastHandler: () => {
+      throw new Error("server-session-events lazy load failure");
+    },
+    createLifecycleEventBroadcastHandler: () => {
+      throw new Error("server-session-events lazy load failure");
+    },
+  };
+});
+
+const { startGatewayEventSubscriptions } = await import("./server-runtime-subscriptions.js");
+
+function createParams() {
+  return {
+    log: mockLog,
+    broadcast: vi.fn(),
+    broadcastToConnIds: vi.fn(),
+    nodeSendToSession: vi.fn(),
+    agentRunSeq: new Map<string, number>(),
+    chatRunState: createChatRunState(),
+    toolEventRecipients: createToolEventRecipientRegistry(),
+    sessionEventSubscribers: createSessionEventSubscriberRegistry(),
+    sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
+    chatAbortControllers: new Map<string, unknown>(),
+    restartRecoveryCandidates: new Map<string, unknown>(),
+  };
+}
+
+describe("startGatewayEventSubscriptions", () => {
+  let unsubs: ReturnType<typeof startGatewayEventSubscriptions>;
+  const unhandledRejections: unknown[] = [];
+  let unhandledHandler: (reason: unknown) => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    unhandledHandler = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on("unhandledRejection", unhandledHandler);
+  });
+
+  afterEach(() => {
+    process.off("unhandledRejection", unhandledHandler);
+    unsubs?.agentUnsub();
+    unsubs?.heartbeatUnsub();
+    unsubs?.transcriptUnsub();
+    unsubs?.lifecycleUnsub();
+    resetAgentEventsForTest();
+    resetHeartbeatEventsForTest();
+  });
+
+  it("logs a warning when the lazy agent event handler import rejects", async () => {
+    unsubs = startGatewayEventSubscriptions(createParams());
+
+    emitAgentEvent({ runId: "run-1", stream: "lifecycle", data: { phase: "start" } });
+
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledTimes(1));
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to handle agent event: lazy handler load rejected",
+      expect.objectContaining({ runId: "run-1", stream: "lifecycle" }),
+    );
+    expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it("logs a warning when the lazy transcript update handler import rejects", async () => {
+    unsubs = startGatewayEventSubscriptions(createParams());
+
+    emitInternalSessionTranscriptUpdate({
+      sessionFile: "/tmp/sess.jsonl",
+      sessionKey: "agent:main:main",
+    } as InternalSessionTranscriptUpdate);
+
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledTimes(1));
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to handle transcript update: lazy handler load rejected",
+      expect.objectContaining({ sessionKey: "agent:main:main" }),
+    );
+    expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it("logs a warning when the lazy lifecycle event handler import rejects", async () => {
+    unsubs = startGatewayEventSubscriptions(createParams());
+
+    emitSessionLifecycleEvent({ sessionKey: "agent:main:main", reason: "created" });
+
+    await vi.waitFor(() => expect(warn).toHaveBeenCalledTimes(1));
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to handle lifecycle event: lazy handler load rejected",
+      expect.objectContaining({ sessionKey: "agent:main:main" }),
+    );
+    expect(unhandledRejections).toHaveLength(0);
+  });
+
+  it("still broadcasts heartbeat events directly without lazy loading", async () => {
+    const params = createParams();
+    unsubs = startGatewayEventSubscriptions(params);
+
+    emitHeartbeatEvent({ status: "ok-empty" });
+
+    await vi.waitFor(() => expect(params.broadcast).toHaveBeenCalledTimes(1));
+    expect(params.broadcast).toHaveBeenCalledWith("heartbeat", expect.anything(), {
+      dropIfSlow: true,
+    });
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -1,6 +1,7 @@
 // Gateway event subscription wiring for agent, heartbeat, transcript, and lifecycle broadcasts.
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
+import type { SubsystemLogger } from "../logging/subsystem.js";
 import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
@@ -18,6 +19,7 @@ import type {
 
 /** Register gateway runtime event subscriptions and return unsubscribe handles. */
 export function startGatewayEventSubscriptions(params: {
+  log: SubsystemLogger;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
   broadcastToConnIds: (
     event: string,
@@ -234,7 +236,15 @@ export function startGatewayEventSubscriptions(params: {
         }
       }
     }
-    void getAgentEventHandler().then((handler) => handler(evt));
+    void getAgentEventHandler()
+      .then((handler) => handler(evt))
+      .catch((err: unknown) => {
+        params.log.warn("Failed to handle agent event: lazy handler load rejected", {
+          runId: evt.runId,
+          stream: evt.stream,
+          error: err,
+        });
+      });
   });
 
   const heartbeatUnsub = onHeartbeatEvent((evt) => {
@@ -242,11 +252,25 @@ export function startGatewayEventSubscriptions(params: {
   });
 
   const transcriptUnsub = onInternalSessionTranscriptUpdate((evt) => {
-    void getTranscriptUpdateHandler().then((handler) => handler(evt));
+    void getTranscriptUpdateHandler()
+      .then((handler) => handler(evt))
+      .catch((err: unknown) => {
+        params.log.warn("Failed to handle transcript update: lazy handler load rejected", {
+          sessionKey: evt.sessionKey,
+          error: err,
+        });
+      });
   });
 
   const lifecycleUnsub = onSessionLifecycleEvent((evt) => {
-    void getLifecycleEventHandler().then((handler) => handler(evt));
+    void getLifecycleEventHandler()
+      .then((handler) => handler(evt))
+      .catch((err: unknown) => {
+        params.log.warn("Failed to handle lifecycle event: lazy handler load rejected", {
+          sessionKey: evt.sessionKey,
+          error: err,
+        });
+      });
   });
 
   return {

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -17,6 +17,21 @@ import type {
   ToolEventRecipientRegistry,
 } from "./server-chat-state.js";
 
+function dispatchEventHandler<TEvent>(params: {
+  loadHandler: () => Promise<(event: TEvent) => unknown>;
+  event: TEvent;
+  log: SubsystemLogger;
+  failureMessage: string;
+  context: Record<string, unknown>;
+}) {
+  void params
+    .loadHandler()
+    .then((handler) => handler(params.event))
+    .catch((error: unknown) => {
+      params.log.warn(params.failureMessage, { ...params.context, error });
+    });
+}
+
 /** Register gateway runtime event subscriptions and return unsubscribe handles. */
 export function startGatewayEventSubscriptions(params: {
   log: SubsystemLogger;
@@ -236,15 +251,13 @@ export function startGatewayEventSubscriptions(params: {
         }
       }
     }
-    void getAgentEventHandler()
-      .then((handler) => handler(evt))
-      .catch((err: unknown) => {
-        params.log.warn("Failed to handle agent event: lazy handler load rejected", {
-          runId: evt.runId,
-          stream: evt.stream,
-          error: err,
-        });
-      });
+    dispatchEventHandler({
+      loadHandler: getAgentEventHandler,
+      event: evt,
+      log: params.log,
+      failureMessage: "Agent event dispatch failed",
+      context: { runId: evt.runId, stream: evt.stream },
+    });
   });
 
   const heartbeatUnsub = onHeartbeatEvent((evt) => {
@@ -252,25 +265,23 @@ export function startGatewayEventSubscriptions(params: {
   });
 
   const transcriptUnsub = onInternalSessionTranscriptUpdate((evt) => {
-    void getTranscriptUpdateHandler()
-      .then((handler) => handler(evt))
-      .catch((err: unknown) => {
-        params.log.warn("Failed to handle transcript update: lazy handler load rejected", {
-          sessionKey: evt.sessionKey,
-          error: err,
-        });
-      });
+    dispatchEventHandler({
+      loadHandler: getTranscriptUpdateHandler,
+      event: evt,
+      log: params.log,
+      failureMessage: "Transcript update dispatch failed",
+      context: { sessionKey: evt.sessionKey },
+    });
   });
 
   const lifecycleUnsub = onSessionLifecycleEvent((evt) => {
-    void getLifecycleEventHandler()
-      .then((handler) => handler(evt))
-      .catch((err: unknown) => {
-        params.log.warn("Failed to handle lifecycle event: lazy handler load rejected", {
-          sessionKey: evt.sessionKey,
-          error: err,
-        });
-      });
+    dispatchEventHandler({
+      loadHandler: getLifecycleEventHandler,
+      event: evt,
+      log: params.log,
+      failureMessage: "Lifecycle event dispatch failed",
+      context: { sessionKey: evt.sessionKey },
+    });
   });
 
   return {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1178,6 +1178,7 @@ export async function startGatewayServer(
       );
     const runtimeSubscriptions = await startupTrace.measure("runtime.subscriptions", () =>
       startGatewayEventSubscriptions({
+        log,
         broadcast,
         broadcastToConnIds,
         nodeSendToSession,


### PR DESCRIPTION
## What Problem This Solves

Gateway runtime subscriptions deliberately fire three lazy event handlers without awaiting them. On current main, a rejected module load, handler construction, synchronous handler call, or returned promise can escape that fire-and-forget boundary as an unhandled rejection.

## Why This Change Was Made

The final implementation keeps event delivery asynchronous but routes agent, transcript, and lifecycle dispatch through one local helper that owns the rejection boundary. Failures are logged with the relevant run or session identifiers. The existing Gateway subsystem logger is passed from the only production caller.

The maintainer fixup also corrects the original warning semantics: the catch covers handler execution as well as lazy loading, so the log reports a dispatch failure rather than claiming every failure came from an import. Typed test parameters repair the original `check-test-types` failure.

## User Impact

Transient Gateway event-handler failures no longer surface as unexplained process-level unhandled rejections. Operators get an actionable warning while unrelated Gateway subscriptions continue running.

## Evidence

- Regression test: `src/gateway/server-runtime-subscriptions.test.ts` covers a rejected dynamic import plus transcript and lifecycle handler execution failures.
- The test fixture now uses `Parameters<typeof startGatewayEventSubscriptions>[0]`, satisfying the concrete chat-abort and restart-recovery map types.
- Exact-head structured AutoReview on `007793be877c51c4fc095ac2a342f029f5faaf1f`: clean, no actionable findings.
- `git diff --check origin/main...HEAD`: passed.
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/28760630435

AI assistance: Codex performed maintainer review, implementation cleanup, focused proof selection, and landing preparation.
