### PR TITLE
fix(sessions): handle mid-stream read errors in transcript streaming

### DIFF
--- a/src/config/sessions/transcript-stream.test.ts
+++ b/src/config/sessions/transcript-stream.test.ts
@@ -2,11 +2,26 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   streamSessionTranscriptLines,
   streamSessionTranscriptLinesReverse,
 } from "./transcript-stream.js";
+
+const actualReadFileRangeAsync = vi.hoisted(
+  () => vi.fn() as typeof import("./file-range.js").readFileRangeAsync,
+);
+const readFileRangeAsyncMock = vi.fn();
+
+vi.mock("./file-range.js", async () => {
+  const actual = await vi.importActual<typeof import("./file-range.js")>("./file-range.js");
+  actualReadFileRangeAsync.mockImplementation(actual.readFileRangeAsync);
+  return {
+    ...actual,
+    readFileRangeAsync: (...args: unknown[]) => readFileRangeAsyncMock(...args),
+  };
+});
 
 // Regression coverage for #54296: the transcript readers must stay correct and
 // memory-bounded as session files grow into the multi-MB / 100s of MB range.
@@ -20,6 +35,7 @@ let transcriptPath = "";
 beforeEach(() => {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "transcript-stream-"));
   transcriptPath = path.join(tempDir, "session.jsonl");
+  readFileRangeAsyncMock.mockReset().mockImplementation(actualReadFileRangeAsync);
 });
 
 afterEach(() => {
@@ -94,6 +110,21 @@ describe("streamSessionTranscriptLines", () => {
     const lines = await collect(streamSessionTranscriptLines(transcriptPath));
 
     expect(lines).toEqual([longLine, "short"]);
+  });
+
+  it("returns an empty iterator when the read stream errors mid-stream", async () => {
+    fs.writeFileSync(transcriptPath, "one\ntwo\nthree\n", "utf-8");
+    const expectedError = new Error("simulated read failure");
+    vi.spyOn(fs, "createReadStream").mockImplementation(() => {
+      const stream = new Readable({
+        read() {
+          this.destroy(expectedError);
+        },
+      });
+      return stream as ReturnType<typeof fs.createReadStream>;
+    });
+
+    await expect(collect(streamSessionTranscriptLines(transcriptPath))).resolves.toEqual([]);
   });
 });
 
@@ -198,5 +229,12 @@ describe("streamSessionTranscriptLinesReverse", () => {
     const parsed = lines.map((line) => JSON.parse(line) as { id: string });
 
     expect(parsed.map((entry) => entry.id)).toEqual(["third", "second", "first"]);
+  });
+
+  it("returns an empty iterator when a reverse chunk read fails mid-stream", async () => {
+    fs.writeFileSync(transcriptPath, "one\ntwo\nthree\n", "utf-8");
+    readFileRangeAsyncMock.mockRejectedValue(new Error("simulated read failure"));
+
+    await expect(collect(streamSessionTranscriptLinesReverse(transcriptPath))).resolves.toEqual([]);
   });
 });

--- a/src/config/sessions/transcript-stream.ts
+++ b/src/config/sessions/transcript-stream.ts
@@ -62,6 +62,10 @@ export async function* streamSessionTranscriptLines(
       }
       yield trimmed;
     }
+  } catch {
+    // Transient read errors (e.g. file truncated or permissions changed after
+    // stat) are treated like a missing file: stop yielding so callers do not
+    // crash mid-stream.
   } finally {
     rl.close();
     stream.destroy();
@@ -105,7 +109,13 @@ export async function* streamSessionTranscriptLinesReverse(
       }
       const readLength = Math.min(position, chunkBytes);
       position -= readLength;
-      const chunk = await readFileRangeAsync(fileHandle, position, readLength);
+      let chunk: Buffer;
+      try {
+        chunk = await readFileRangeAsync(fileHandle, position, readLength);
+      } catch {
+        // Treat mid-stream read failures like a missing file so callers do not crash.
+        return;
+      }
       const combined = carry.length > 0 ? Buffer.concat([chunk, carry]) : chunk;
       let lineEnd = combined.length;
       // Split on newline bytes before decoding so UTF-8 characters crossing chunk boundaries stay


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `streamSessionTranscriptLines` and `streamSessionTranscriptLinesReverse` could throw unhandled errors if the underlying file became unreadable mid-stream (e.g. permissions changed, file truncated, or media fault after the initial stat/open succeeded). Callers such as `transcript-append.ts` do not wrap the stream in try/catch, so a mid-stream read error would propagate and crash the calling operation.

## Why This Change Was Made

The forward reader already returned empty for missing/empty files, but only caught open-time errors. The reverse reader only caught open errors. Both now treat mid-stream read failures the same way as a missing file: stop yielding and clean up, matching the documented "returns an empty iterator" contract for unreadable transcripts.

## User Impact

Long session compaction, append-validation, and transcript reads are more resilient to transient file-system faults. A transcript that becomes unreadable after streaming starts no longer crashes the caller.

## Evidence

Regression tests added to `src/config/sessions/transcript-stream.test.ts`:

- Forward stream: mocks `fs.createReadStream` to emit a read error immediately and asserts the iterator resolves to empty.
- Reverse stream: mocks `readFileRangeAsync` to reject and asserts the iterator resolves to empty.

Both tests fail on current main (the read error propagates) and pass with the fix.

```bash
node scripts/run-vitest.mjs src/config/sessions/transcript-stream.test.ts
```

Result: `16 passed`.

Lint clean:

```bash
npx oxlint --config .oxlintrc.json src/config/sessions/transcript-stream.ts src/config/sessions/transcript-stream.test.ts
```

Result: `Found 0 warnings and 0 errors.`
