### PR TITLE
fix(tui): suppress unhandled stdout/stderr stream errors in local shell

### DIFF
--- a/src/tui/tui-local-shell.test.ts
+++ b/src/tui/tui-local-shell.test.ts
@@ -162,4 +162,32 @@ describe("createLocalShellRunner", () => {
     // the previous head-cut kept all stdout and dropped stderr entirely.
     expect(harness.messages.some((m) => m.includes("FATAL"))).toBe(true);
   });
+
+  it("does not crash when stdout or stderr emit an error event", async () => {
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const spawnCommand = vi.fn(() => ({
+      stdout,
+      stderr,
+      on: (event: string, callback: (...args: unknown[]) => void) => {
+        if (event === "close") {
+          setImmediate(() => callback(0, null));
+        }
+      },
+    }));
+
+    const harness = createShellHarness({
+      spawnCommand: spawnCommand as unknown as typeof import("node:child_process").spawn,
+    });
+
+    const run = harness.runLocalShellLine("!cmd");
+    harness.getLastSelector()?.onSelect?.({ value: "yes", label: "Yes" });
+
+    await vi.waitFor(() => expect(spawnCommand).toHaveBeenCalledTimes(1));
+    stdout.emit("error", new Error("EPIPE"));
+    stderr.emit("error", new Error("EIO"));
+
+    await expect(run).resolves.toBeUndefined();
+    expect(harness.messages.some((m) => m.includes("exit 0"))).toBe(true);
+  });
 });

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -117,6 +117,12 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
 
       let stdout = "";
       let stderr = "";
+      // stdout/stderr can emit 'error' (EPIPE, resource limits) before close.
+      // Swallow these stream errors so they do not become unhandled rejections;
+      // child close/error remains the authoritative completion signal.
+      const ignoreOutputStreamError = () => {};
+      child.stdout.on("error", ignoreOutputStreamError);
+      child.stderr.on("error", ignoreOutputStreamError);
       child.stdout.on("data", (buf) => {
         stdout = appendWithCap(stdout, buf.toString("utf8"));
       });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the TUI local shell runner attaches `data` listeners to the child `stdout` and `stderr` streams but no `error` listeners. If either stream emits an `error` event (EPIPE, resource limits, I/O faults), the error is unhandled and can crash the TUI process.

## Why This Change Was Made

Added no-op `error` handlers to `child.stdout` and `child.stderr`, matching the supervisor child adapter pattern. The authoritative completion signal remains the child `close`/`error` event; the output stream handlers only prevent unhandled stream errors from escaping.

## User Impact

TUI local shell commands (`!cmd`) no longer risk crashing the TUI when the child process output streams fault.

## Evidence

Regression test added to `src/tui/tui-local-shell.test.ts`:

- Spawns a local shell command, waits for the spawn to occur, then emits `error` events on both `stdout` and `stderr`.
- Asserts the runner resolves normally and still logs the exit message.

This test fails on current main (the emitted stream error is unhandled) and passes with the fix.

```bash
node scripts/run-vitest.mjs src/tui/tui-local-shell.test.ts
```

Result: `4 passed`.

Lint clean:

```bash
npx oxlint --config .oxlintrc.json src/tui/tui-local-shell.ts src/tui/tui-local-shell.test.ts
```

Result: `Found 0 warnings and 0 errors.`
