### PR TITLE
fix(agents): suppress unhandled stdout/stderr stream errors in execCommand

### DIFF
--- a/src/agents/sessions/exec.test.ts
+++ b/src/agents/sessions/exec.test.ts
@@ -168,4 +168,20 @@ describe("execCommand", () => {
     const result = await resultPromise;
     expect(result.killed).toBe(true);
   });
+
+  it("does not crash when stdout or stderr emit an error event", async () => {
+    const child = createStubChild();
+    const wait = createDeferred<number | null>();
+    spawnMock.mockReturnValue(child);
+    waitForChildProcessMock.mockReturnValue(wait.promise);
+    const { execCommand } = await import("./exec.js");
+
+    const resultPromise = execCommand("cmd", [], "/tmp");
+    child.stdout.emit("error", new Error("EPIPE"));
+    child.stderr.emit("error", new Error("EIO"));
+    wait.resolve(0);
+
+    const result = await resultPromise;
+    expect(result.code).toBe(0);
+  });
 });

--- a/src/agents/sessions/exec.ts
+++ b/src/agents/sessions/exec.ts
@@ -172,6 +172,13 @@ export async function execCommand(
       }, options.timeout);
     }
 
+    // stdout/stderr can fault (EPIPE, resource limits) independently of the
+    // child process exit. Swallow those stream errors so they do not escape as
+    // unhandled exceptions; waitForChildProcess remains the completion source.
+    const ignoreOutputStreamError = () => {};
+    proc.stdout?.on("error", ignoreOutputStreamError);
+    proc.stderr?.on("error", ignoreOutputStreamError);
+
     proc.stdout?.on("data", (data) => {
       const before = stdout.truncatedChars;
       stdout = appendCapturedOutput(stdout, data, maxOutputChars, truncateOutput);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `execCommand` attaches `data` listeners to the child `stdout` and `stderr` streams but no `error` listeners. If either stream emits an `error` event (EPIPE, resource limits, I/O faults), the error is unhandled and can crash the agent runtime.

## Why This Change Was Made

Added no-op `error` handlers to `proc.stdout` and `proc.stderr`, matching the supervisor child adapter pattern. `waitForChildProcess` remains the authoritative completion signal; the output stream handlers only prevent unhandled stream errors from escaping.

## User Impact

Agent session `exec` tool calls no longer risk crashing the runtime when the child process output streams fault.

## Evidence

Regression test added to `src/agents/sessions/exec.test.ts`:

- Spawns a command, emits `error` events on both `stdout` and `stderr`, then resolves the process wait.
- Asserts `execCommand` resolves normally with the expected exit code.

This test fails on current main (the emitted stream error is unhandled) and passes with the fix.

```bash
node scripts/run-vitest.mjs src/agents/sessions/exec.test.ts
```

Result: `6 passed`.

Lint clean:

```bash
npx oxlint --config .oxlintrc.json src/agents/sessions/exec.ts src/agents/sessions/exec.test.ts
```

Result: `Found 0 warnings and 0 errors.`
