### PR TITLE
fix(process): suppress unhandled stdout/stderr stream errors in runCommandWithTimeout

### DIFF
--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -346,6 +346,21 @@ describe("runCommandWithTimeout", () => {
     },
   );
 
+  it("swallows stdout and stderr stream errors without rejecting", async () => {
+    await loadExecModules({ mockSpawn: true });
+    const child = createKilledChild();
+    spawnMock.mockReturnValue(child);
+    const resultPromise = runCommandWithTimeout(createSilentIdleArgv(), { timeoutMs: 2_000 });
+    child.stdout?.emit("error", new Error("stdout read failed"));
+    child.stderr?.emit("error", new Error("stderr read failed"));
+    child.emit("exit", 0, null);
+    child.emit("close", 0, null);
+    await expect(resultPromise).resolves.toMatchObject({
+      code: 0,
+      termination: "exit",
+    });
+  });
+
   it("preserves matching output lines even when the tail capture truncates them", async () => {
     await loadExecModules();
     const result = await runCommandWithTimeout(

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -612,6 +612,7 @@ export async function runCommandWithTimeout(
       child.stdin.end();
     }
 
+    child.stdout?.on("error", () => {});
     child.stdout?.on("data", (d) => {
       appendPreservedOutputLines({
         capture: stdoutCapture,
@@ -624,6 +625,7 @@ export async function runCommandWithTimeout(
       appendCapturedOutput(stdoutCapture, d, maxOutputBytes);
       armNoOutputTimer();
     });
+    child.stderr?.on("error", () => {});
     child.stderr?.on("data", (d) => {
       appendPreservedOutputLines({
         capture: stderrCapture,


### PR DESCRIPTION
## What Problem This Solves

`runCommandWithTimeout` attaches `data` listeners to `child.stdout` and `child.stderr`, but does not attach `error` listeners. If either stream emits an `error` event (e.g., pipe read failure, premature close), the unhandled error can crash the process even though the command itself would otherwise complete normally.

## Why This Change Was Made

Add no-op `error` handlers to both stdout and stderr streams before the data handlers, mirroring the existing stdin EPIPE swallowing pattern. This prevents unhandled stream errors from propagating as uncaught exceptions.

## User Impact

More robust subprocess execution: transient stream read errors no longer crash the OpenClaw process.

## Evidence

- Added a regression test in `src/process/exec.test.ts` that emits `error` events on both stdout and stderr and verifies `runCommandWithTimeout` still resolves successfully.
- Verified the test fails on `main` with `Error: stdout read failed` and passes with this fix.
- `oxlint` passes on the changed files.

