### PR TITLE
fix(security): suppress unhandled stdout/stderr stream errors in install policy

### DIFF
--- a/src/security/install-policy.test.ts
+++ b/src/security/install-policy.test.ts
@@ -1,8 +1,20 @@
 // Covers install-policy checks for packages and plugin installs.
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) =>
+      spawnMock(...args) ?? actual.spawn(...args),
+  };
+});
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   killPidIfAlive,
@@ -673,4 +685,76 @@ describe("runInstallPolicy", () => {
       );
     },
   );
+});
+
+describe("runPolicyCommand stream error handling", () => {
+  function createFakeChild(): ChildProcess {
+    const child = new EventEmitter() as EventEmitter & ChildProcess;
+    child.stdout = new EventEmitter() as EventEmitter & NonNullable<ChildProcess["stdout"]>;
+    child.stderr = new EventEmitter() as EventEmitter & NonNullable<ChildProcess["stderr"]>;
+    child.stdin = new EventEmitter() as EventEmitter & NonNullable<ChildProcess["stdin"]>;
+    child.stdin.write = vi.fn(() => true) as NonNullable<ChildProcess["stdin"]>["write"];
+    child.stdin.end = vi.fn() as NonNullable<ChildProcess["stdin"]>["end"];
+    Object.defineProperties(child, {
+      pid: { configurable: true, enumerable: true, get: () => 1234 },
+      killed: { configurable: true, enumerable: true, get: () => false },
+    });
+    child.kill = vi.fn(() => true) as ChildProcess["kill"];
+    return child;
+  }
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it("swallows stdout and stderr stream errors without rejecting", { timeout: 5_000 }, async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-install-policy-stream-"));
+    tempDirs.push(dir);
+    const policyScriptPath = path.join(dir, "policy.cjs");
+    await fs.writeFile(policyScriptPath, "module.exports = {};", "utf8");
+    await fs.chmod(policyScriptPath, 0o700);
+
+    spawnMock.mockImplementation(() => {
+      const child = createFakeChild();
+      const response = Buffer.from(JSON.stringify({ protocolVersion: 1, decision: "allow" }));
+      // Emit stream errors and response after listeners are attached in runPolicyCommand.
+      queueMicrotask(() => {
+        child.stdout?.emit("error", new Error("stdout read failed"));
+        child.stdout?.emit("data", response);
+        child.stderr?.emit("error", new Error("stderr read failed"));
+        child.emit("close", 0, null);
+      });
+      return child;
+    });
+
+    await expect(
+      runInstallPolicy({
+        config: {
+          security: {
+            installPolicy: {
+              enabled: true,
+              exec: {
+                source: "exec",
+                command: policyScriptPath,
+                args: [],
+                allowInsecurePath: true,
+                timeoutMs: 5_000,
+                noOutputTimeoutMs: 5_000,
+                maxOutputBytes: 16 * 1024,
+              },
+            },
+          },
+        },
+        request: {
+          targetType: "skill",
+          targetName: "weather",
+          sourcePath: dir,
+          sourcePathKind: "directory",
+          source: { kind: "clawhub", authority: "openclaw", mutable: false, network: true },
+          origin: { type: "clawhub" },
+          request: { kind: "skill-install", mode: "install" },
+        },
+      }),
+    ).resolves.toEqual({});
+  });
 });

--- a/src/security/install-policy.ts
+++ b/src/security/install-policy.ts
@@ -600,7 +600,9 @@ async function runPolicyCommand(params: {
       clearTimers();
       reject(error);
     });
+    child.stdout?.on("error", () => {});
     child.stdout?.on("data", (chunk) => append(chunk, "stdout"));
+    child.stderr?.on("error", () => {});
     child.stderr?.on("data", (chunk) => append(chunk, "stderr"));
     child.on("close", (code, signal) => {
       if (settled) {


### PR DESCRIPTION
## What Problem This Solves

`runPolicyCommand` attaches `data` listeners to `child.stdout` and `child.stderr`, but does not attach `error` listeners. If either stream emits an `error` event, the unhandled error can crash the process or leave the policy command hanging.

## Why This Change Was Made

Add no-op `error` handlers to both stdout and stderr streams before the data handlers, mirroring the existing stdin error handling pattern. This prevents unhandled stream errors from propagating as uncaught exceptions.

## User Impact

More robust install policy execution: transient stream read errors no longer crash the OpenClaw process during skill/plugin installs.

## Evidence

- Added a regression test in `src/security/install-policy.test.ts` that mocks `spawn`, emits `error` events on both stdout and stderr, and verifies `runInstallPolicy` still resolves successfully.
- Verified the test fails on `main` with an unhandled `Error: stdout read failed` and times out, and passes with this fix.
- `oxlint` passes on the changed files.
