### PR TITLE
fix(hooks): suppress unhandled stdout/stderr stream errors in gmail watcher

### DIFF
--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -362,4 +362,31 @@ describe("startGmailWatcher", () => {
       vi.useRealTimers();
     }
   });
+
+  it("swallows stdout and stderr stream errors without crashing", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    let stdout: EventEmitter | undefined;
+    let stderr: EventEmitter | undefined;
+    mocks.spawn.mockImplementation(() => {
+      const child = new EventEmitter();
+      stdout = new EventEmitter();
+      stderr = new EventEmitter();
+      const mockedChild = Object.assign(child, {
+        stdout,
+        stderr,
+        kill: vi.fn(() => {
+          queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+          return true;
+        }),
+        killed: false,
+      });
+      queueMicrotask(() => {
+        stdout?.emit("error", new Error("stdout read failed"));
+        stderr?.emit("error", new Error("stderr read failed"));
+      });
+      return mockedChild;
+    });
+
+    await expect(startGmailWatcher(createGmailConfig())).resolves.toEqual({ started: true });
+  });
 });

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -79,6 +79,9 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
 
+  child.stdout?.on("error", (err) => {
+    log.error(`gog stdout error: ${String(err)}`);
+  });
   child.stdout?.on("data", (data: Buffer) => {
     const line = data.toString().trim();
     if (line) {
@@ -86,6 +89,9 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
     }
   });
 
+  child.stderr?.on("error", (err) => {
+    log.error(`gog stderr error: ${String(err)}`);
+  });
   child.stderr?.on("data", (data: Buffer) => {
     const line = data.toString().trim();
     if (!line) {


### PR DESCRIPTION
## What Problem This Solves

`spawnGogServe` attaches `data` listeners to `child.stdout` and `child.stderr`, but does not attach `error` listeners. If either stream emits an `error` event, the unhandled error can crash the OpenClaw process even though the watcher startup itself would otherwise succeed.

## Why This Change Was Made

Add `error` handlers to both stdout and stderr streams before the data handlers. The handlers log the error and continue, mirroring the existing `child.on("error", ...)` logging pattern.

## User Impact

More robust Gmail watcher startup: transient stream read errors no longer crash the process.

## Evidence

- Added a regression test in `src/hooks/gmail-watcher.test.ts` that mocks `spawn` to return a fake child with stdout/stderr `EventEmitter`s, emits `error` events on both streams, and verifies `startGmailWatcher` still resolves successfully.
- Verified that without this fix, the test run reports an uncaught `Error: stdout read failed`; with the fix, no unhandled error is reported.
- `oxlint` passes on the changed files.
