### PR TITLE
feat(ios): haptic feedback for chat send, completion, and failure

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatHaptics.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatHaptics.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+#if canImport(UIKit) && !os(watchOS)
+import UIKit
+#endif
+
+public struct OpenClawChatHaptics: Sendable {
+    public enum Event: Sendable, Equatable {
+        case messageSent
+        case runCompleted
+        case runFailed
+        case actionConfirmed
+    }
+
+    private let performer: @Sendable (Event) -> Void
+
+    public init() {
+        self.performer = Self.defaultPerformer
+    }
+
+    public init(performer: @escaping @Sendable (Event) -> Void) {
+        self.performer = performer
+    }
+
+    public func perform(_ event: Event) {
+        self.performer(event)
+    }
+
+    private static let defaultPerformer: @Sendable (Event) -> Void = { event in
+        #if canImport(UIKit) && !os(watchOS)
+        Task { @MainActor in
+            switch event {
+            case .messageSent:
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            case .runCompleted:
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+            case .runFailed:
+                UINotificationFeedbackGenerator().notificationOccurred(.error)
+            case .actionConfirmed:
+                UISelectionFeedbackGenerator().selectionChanged()
+            }
+        }
+        #else
+        // NSHapticFeedbackManager only fires reliably from gesture contexts, so macOS is a no-op.
+        _ = event
+        #endif
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -49,6 +49,7 @@ public final class OpenClawChatViewModel {
     private(set) var timelineRevision: UInt64 = 0
     public private(set) var sessions: [OpenClawChatSessionEntry] = []
     private let transport: any OpenClawChatTransport
+    let haptics: OpenClawChatHaptics
     private var sessionDefaults: OpenClawChatSessionsDefaults?
     private let prefersExplicitThinkingLevel: Bool
     private let onSessionChanged: (@MainActor (String) -> Void)?
@@ -164,6 +165,7 @@ public final class OpenClawChatViewModel {
     public init(
         sessionKey: String,
         transport: any OpenClawChatTransport,
+        haptics: OpenClawChatHaptics = OpenClawChatHaptics(),
         initialThinkingLevel: String? = nil,
         onSessionChanged: (@MainActor (String) -> Void)? = nil,
         onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)? = nil,
@@ -171,6 +173,7 @@ public final class OpenClawChatViewModel {
     {
         self.sessionKey = sessionKey
         self.transport = transport
+        self.haptics = haptics
         let normalizedThinkingLevel = Self.normalizedThinkingLevel(initialThinkingLevel)
         let initialResolvedThinkingLevel = normalizedThinkingLevel ?? "off"
         self.thinkingLevel = initialResolvedThinkingLevel
@@ -571,8 +574,8 @@ public final class OpenClawChatViewModel {
         await self.refreshHistoryAfterRun(historyRequest: context)
         await self.pollHealthIfNeeded(force: true, sessionSnapshot: context.session)
         guard self.isCurrentSession(context.session) else { return }
-        if self.hasAssistantMessageAfterLatestUser() {
-            self.clearPendingRuns(reason: nil)
+        if let hapticEvent = self.assistantHapticEventAfterLatestUser() {
+            self.clearPendingRuns(reason: nil, hapticEvent: hapticEvent)
             self.pendingToolCallsById = [:]
             self.updateStreamingAssistantText(nil)
         }
@@ -1491,6 +1494,9 @@ public final class OpenClawChatViewModel {
             self.logDiagnostic(
                 "chat.ui transport send accepted sessionKey=\(sessionKey) "
                     + "localRunId=\(runId) remoteRunId=\(response.runId)")
+            if response.status != "error", response.status != "timeout" {
+                self.haptics.perform(.messageSent)
+            }
             var reusedRunAlreadyFinal = false
             if response.runId != runId {
                 let pendingUserMessageID = self.pendingLocalUserEchoMessageIDsByRunID.removeValue(forKey: runId)
@@ -1509,7 +1515,7 @@ public final class OpenClawChatViewModel {
                 self.rescopeProvisionalFinalMessages(runId: response.runId, scope: remoteRunScope)
                 reusedRunAlreadyFinal = self.hasRecordedFinalMessage(runId: response.runId)
                 if reusedRunAlreadyFinal {
-                    self.clearPendingRun(response.runId)
+                    self.clearPendingRun(response.runId, hapticEvent: .runCompleted)
                     self.pendingToolCallsById = [:]
                     self.updateStreamingAssistantText(nil)
                 } else {
@@ -1545,8 +1551,8 @@ public final class OpenClawChatViewModel {
             guard self.isCurrentSession(sessionSnapshot) else { return }
             self.removePendingLocalUserEcho(for: runId)
             self.runMessageScopesByRunID.removeValue(forKey: runId)
-            self.clearPendingRun(runId)
             self.errorText = error.localizedDescription
+            self.clearPendingRun(runId, hapticEvent: .runFailed)
             self.logDiagnostic(
                 "chat.ui send failed sessionKey=\(sessionKey) "
                     + "localRunId=\(runId) error=\(error.localizedDescription)")
@@ -2227,10 +2233,15 @@ public final class OpenClawChatViewModel {
             if chat.state == "error" {
                 self.errorText = chat.errorMessage ?? "Chat failed"
             }
+            let hapticEvent: OpenClawChatHaptics.Event? = switch chat.state {
+            case "final": .runCompleted
+            case "error": .runFailed
+            default: nil
+            }
             if let runId = chat.runId {
-                self.clearPendingRun(runId)
+                self.clearPendingRun(runId, hapticEvent: hapticEvent)
             } else if self.pendingRuns.count <= 1 {
-                self.clearPendingRuns(reason: nil)
+                self.clearPendingRuns(reason: nil, hapticEvent: hapticEvent)
             }
             self.pendingToolCallsById = [:]
             self.updateStreamingAssistantText(nil)
@@ -2371,7 +2382,9 @@ public final class OpenClawChatViewModel {
             self.errorText = Self.agentLifecycleErrorMessage(evt, aborted: aborted)
         }
         if isPendingRun {
-            self.clearPendingRun(evt.runId)
+            self.clearPendingRun(
+                evt.runId,
+                hapticEvent: isFailure || aborted ? .runFailed : .runCompleted)
         }
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
@@ -2411,7 +2424,7 @@ public final class OpenClawChatViewModel {
     }
 
     private func finishPendingRunAfterTerminalOkSendAck(_ response: OpenClawChatSendResponse) {
-        self.clearPendingRun(response.runId)
+        self.clearPendingRun(response.runId, hapticEvent: .runCompleted)
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
         self.logDiagnostic(
@@ -2423,20 +2436,20 @@ public final class OpenClawChatViewModel {
         switch response.status {
         case "timeout":
             self.removePendingLocalUserEcho(for: response.runId)
-            self.clearPendingRun(response.runId)
             self.pendingToolCallsById = [:]
             self.updateStreamingAssistantText(nil)
             self.errorText = "Chat failed before the run started; try again."
+            self.clearPendingRun(response.runId, hapticEvent: .runFailed)
             self.logDiagnostic(
                 "chat.ui send terminal ack sessionKey=\(self.sessionKey) "
                     + "runId=\(response.runId) status=timeout")
             return true
         case "error":
             self.removePendingLocalUserEcho(for: response.runId)
-            self.clearPendingRun(response.runId)
             self.pendingToolCallsById = [:]
             self.updateStreamingAssistantText(nil)
             self.errorText = "Chat failed before the run started; try again."
+            self.clearPendingRun(response.runId, hapticEvent: .runFailed)
             self.logDiagnostic(
                 "chat.ui send terminal ack sessionKey=\(self.sessionKey) "
                     + "runId=\(response.runId) status=error")
@@ -2519,15 +2532,11 @@ public final class OpenClawChatViewModel {
 
     @discardableResult
     private func clearPendingRunIfAssistantMessagePresent(runId: String, after timestamp: Double) -> Bool {
-        guard self.hasAssistantMessage(after: timestamp) else { return false }
-        self.clearPendingRun(runId)
+        guard let hapticEvent = self.assistantHapticEvent(after: timestamp) else { return false }
+        self.clearPendingRun(runId, hapticEvent: hapticEvent)
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
         return true
-    }
-
-    private func hasAssistantMessageAfterLatestUser() -> Bool {
-        Self.hasAssistantMessageAfterLatestUser(in: self.messages)
     }
 
     private static func hasUnansweredLatestUser(in messages: [OpenClawChatMessage]) -> Bool {
@@ -2637,16 +2646,31 @@ public final class OpenClawChatViewModel {
         }
     }
 
-    private func hasAssistantMessage(after timestamp: Double) -> Bool {
-        self.messages.contains { message in
-            guard message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "assistant" else {
-                return false
-            }
-            guard (message.timestamp ?? 0) >= timestamp else { return false }
-            let text = message.content.compactMap(\.text).joined(separator: "\n")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            return !text.isEmpty || message.errorMessage != nil
+    private static func assistantHapticEvent(
+        for message: OpenClawChatMessage) -> OpenClawChatHaptics.Event?
+    {
+        guard message.role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "assistant" else {
+            return nil
         }
+        let text = message.content.compactMap(\.text).joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty || message.errorMessage != nil else { return nil }
+        let stopReason = message.stopReason?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return stopReason == "error" || stopReason == "aborted" ? .runFailed : .runCompleted
+    }
+
+    private func assistantHapticEventAfterLatestUser() -> OpenClawChatHaptics.Event? {
+        guard let userIndex = self.messages.lastIndex(where: { $0.role.lowercased() == "user" }) else { return nil }
+        let nextIndex = self.messages.index(after: userIndex)
+        guard nextIndex < self.messages.endIndex else { return nil }
+        return self.messages[nextIndex...].reversed().lazy.compactMap(Self.assistantHapticEvent).first
+    }
+
+    private func assistantHapticEvent(after timestamp: Double) -> OpenClawChatHaptics.Event? {
+        self.messages.reversed().lazy.compactMap { message in
+            guard (message.timestamp ?? 0) >= timestamp else { return nil }
+            return Self.assistantHapticEvent(for: message)
+        }.first
     }
 
     @discardableResult
@@ -2675,13 +2699,16 @@ public final class OpenClawChatViewModel {
                 self.logDiagnostic(
                     "chat.ui pending timeout sessionKey=\(self.sessionKey) "
                         + "runId=\(runId)")
-                self.clearPendingRun(runId)
                 self.errorText = "Timed out waiting for a reply; try again or refresh."
+                self.clearPendingRun(runId, hapticEvent: .runFailed)
             }
         }
     }
 
-    private func clearPendingRun(_ runId: String) {
+    private func clearPendingRun(
+        _ runId: String,
+        hapticEvent: OpenClawChatHaptics.Event? = nil)
+    {
         let wasPending = self.pendingRuns.contains(runId)
         self.pendingRuns.remove(runId)
         self.pendingLocalUserEchoMessageIDsByRunID[runId] = nil
@@ -2691,10 +2718,16 @@ public final class OpenClawChatViewModel {
             self.logDiagnostic(
                 "chat.ui pending cleared sessionKey=\(self.sessionKey) "
                     + "runId=\(runId)")
+            if self.pendingRuns.isEmpty, let hapticEvent {
+                self.haptics.perform(hapticEvent)
+            }
         }
     }
 
-    private func clearPendingRuns(reason: String?) {
+    private func clearPendingRuns(
+        reason: String?,
+        hapticEvent: OpenClawChatHaptics.Event? = nil)
+    {
         let runIds = Array(pendingRuns)
         for runId in self.pendingRuns {
             self.pendingRunTimeoutTasks[runId]?.cancel()
@@ -2702,6 +2735,9 @@ public final class OpenClawChatViewModel {
         self.pendingRunTimeoutTasks.removeAll()
         self.pendingRuns.removeAll()
         self.pendingLocalUserEchoMessageIDsByRunID.removeAll()
+        if !runIds.isEmpty, let hapticEvent {
+            self.haptics.perform(hapticEvent)
+        }
         if let reason, !reason.isEmpty {
             self.errorText = reason
             for runId in runIds {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatHapticsTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatHapticsTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClawChatUI
+
+private final class HapticRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedEvents: [OpenClawChatHaptics.Event] = []
+
+    var events: [OpenClawChatHaptics.Event] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.recordedEvents
+    }
+
+    func record(_ event: OpenClawChatHaptics.Event) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.recordedEvents.append(event)
+    }
+}
+
+private final class HapticsTestTransport: @unchecked Sendable, OpenClawChatTransport {
+    private let response: OpenClawChatSendResponse
+    private let historyMessages: [AnyCodable]
+    private let stream: AsyncStream<OpenClawChatTransportEvent>
+    private let continuation: AsyncStream<OpenClawChatTransportEvent>.Continuation
+
+    init(status: String, historyMessages: [AnyCodable] = []) {
+        self.response = OpenClawChatSendResponse(runId: "run-1", status: status)
+        self.historyMessages = historyMessages
+        var continuation: AsyncStream<OpenClawChatTransportEvent>.Continuation!
+        self.stream = AsyncStream { continuation = $0 }
+        self.continuation = continuation
+    }
+
+    func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
+        OpenClawChatHistoryPayload(
+            sessionKey: sessionKey,
+            sessionId: "session-1",
+            messages: self.historyMessages,
+            thinkingLevel: "off")
+    }
+
+    func sendMessage(
+        sessionKey _: String,
+        message _: String,
+        thinking _: String,
+        idempotencyKey _: String,
+        attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+    {
+        self.response
+    }
+
+    func requestHealth(timeoutMs _: Int) async throws -> Bool {
+        true
+    }
+
+    func events() -> AsyncStream<OpenClawChatTransportEvent> {
+        self.stream
+    }
+
+    func emit(_ event: OpenClawChatTransportEvent) {
+        self.continuation.yield(event)
+    }
+}
+
+private func makeHapticsViewModel(status: String, historyMessages: [AnyCodable] = []) async -> (
+    HapticsTestTransport,
+    OpenClawChatViewModel,
+    HapticRecorder)
+{
+    let transport = HapticsTestTransport(status: status, historyMessages: historyMessages)
+    let recorder = HapticRecorder()
+    let haptics = OpenClawChatHaptics(performer: recorder.record)
+    let viewModel = await MainActor.run {
+        OpenClawChatViewModel(sessionKey: "main", transport: transport, haptics: haptics)
+    }
+    return (transport, viewModel, recorder)
+}
+
+private func sendHapticsTestMessage(_ viewModel: OpenClawChatViewModel) async {
+    await MainActor.run {
+        viewModel.input = "hello"
+        viewModel.send()
+    }
+}
+
+struct ChatHapticsTests {
+    @Test func `send acceptance fires message sent exactly once`() async throws {
+        let (_, viewModel, recorder) = await makeHapticsViewModel(status: "started")
+        await sendHapticsTestMessage(viewModel)
+        try await waitUntil("message sent haptic") { recorder.events == [.messageSent] }
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(recorder.events == [.messageSent])
+    }
+
+    @Test func `completion fires once for duplicate terminal events`() async throws {
+        let (transport, viewModel, recorder) = await makeHapticsViewModel(status: "started")
+        await sendHapticsTestMessage(viewModel)
+        try await waitUntil("message accepted") { recorder.events == [.messageSent] }
+
+        let final = OpenClawChatTransportEvent.chat(OpenClawChatEventPayload(
+            runId: "run-1",
+            sessionKey: "main",
+            state: "final",
+            message: nil,
+            errorMessage: nil))
+        transport.emit(final)
+        transport.emit(final)
+        try await waitUntil("completion haptic") {
+            recorder.events == [.messageSent, .runCompleted]
+        }
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(recorder.events == [.messageSent, .runCompleted])
+    }
+
+    @Test(arguments: ["error", "aborted"])
+    func `durable assistant failure fires run failed`(stopReason: String) async throws {
+        let error = AnyCodable([
+            "role": "assistant",
+            "content": [],
+            "timestamp": Date().timeIntervalSince1970 * 1000 + 1000,
+            "stopReason": stopReason,
+            "errorMessage": "provider failed",
+        ] as [String: Any])
+        let (_, viewModel, recorder) = await makeHapticsViewModel(
+            status: "started",
+            historyMessages: [error])
+        await sendHapticsTestMessage(viewModel)
+        try await waitUntil("run failed haptic") {
+            recorder.events == [.messageSent, .runFailed]
+        }
+        #expect(recorder.events == [.messageSent, .runFailed])
+    }
+}


### PR DESCRIPTION
Part of #100415

## What Problem This Solves

Chat lifecycle moments on iOS — sending a message, a run completing, a run failing — have no tactile feedback, making the app feel less native than platform peers.

## Why This Change Was Made

Adds `OpenClawChatHaptics` to the shared chat package: a small injectable-performer type (UIKit feedback generators on iOS behind platform conditionals; macOS is a deliberate no-op since NSHapticFeedbackManager only fires from gesture contexts). Wiring goes through a single choke point — every pending-run clear site passes its haptic event through `clearPendingRun(hapticEvent:)` — so completion/failure feedback fires exactly once even under duplicate terminal-event delivery, and durable assistant rows are classified by stop reason (error/aborted → failure). Send feedback fires on accepted sends only.

## User Impact

iOS users feel a light tap when a message sends, a success tap when the assistant finishes, and an error buzz when a run fails or times out. No settings surface added in v1; macOS behavior unchanged.

## Evidence

- `cd apps/shared/OpenClawKit && swift test --filter "ChatHapticsTests|ChatViewModelTests"` — 108 tests, 2 suites, all pass (new suite covers send, duplicate-completion single-fire, durable error/aborted ordering).
- Codex autoreview during development: accepted findings on durable error/aborted classification fixed; one suggestion consciously rejected (abort-event path that never surfaces errorText — outside the failure contract). 
- Implementation by Codex (gpt-5.5) from a frozen spec; reviewed line-by-line by the orchestrating session.

Known deferral: the offline-outbox enqueue haptic waits for the outbox PR (#100331) to land, since that code is not on main yet.
