### PR TITLE
fix(gateway): clarify URL override auth recovery

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -2246,7 +2246,7 @@ describe("callGateway url override auth requirements", () => {
 
     await expect(
       callGateway({ method: "health", url: "wss://override.example/ws" }),
-    ).rejects.toThrow("explicit credentials");
+    ).rejects.toThrow(/remove --url to use the configured target/i);
   });
 
   it("throws when env URL override is set without env credentials", async () => {
@@ -2258,7 +2258,9 @@ describe("callGateway url override auth requirements", () => {
       },
     });
 
-    await expect(callGateway({ method: "health" })).rejects.toThrow("explicit credentials");
+    await expect(callGateway({ method: "health" })).rejects.toThrow(
+      /OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD/i,
+    );
   });
 });
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -616,9 +616,16 @@ export function ensureExplicitGatewayAuth(params: {
   if (params.urlOverrideSource === "env" && hasResolvedAuth) {
     return;
   }
+  const sourceHint =
+    params.urlOverrideSource === "env"
+      ? "Set OPENCLAW_GATEWAY_TOKEN or OPENCLAW_GATEWAY_PASSWORD alongside OPENCLAW_GATEWAY_URL; config credentials are intentionally not reused."
+      : params.urlOverrideSource === "cli"
+        ? "For the default local or SSH-tunneled Gateway, remove --url to use the configured target."
+        : undefined;
   const message = [
     "gateway url override requires explicit credentials",
     params.errorHint,
+    sourceHint,
     params.configPath ? `Config: ${params.configPath}` : undefined,
   ]
     .filter(Boolean)
@@ -1149,7 +1156,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     urlOverrideSource: context.urlOverrideSource,
     explicitAuth: context.explicitAuth,
     resolvedAuth: resolvedCredentials,
-    errorHint: "Fix: pass --token or --password (or gatewayToken in tools).",
+    errorHint: "Fix: pass --token or --password with --url (or gatewayToken in tools).",
     configPath: context.configPath,
   });
   ensureRemoteModeUrlConfigured(context);

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -141,7 +141,7 @@ describe("resolveGatewayConnection", () => {
     loadConfig.mockReturnValue({ gateway: { mode: "local" } });
 
     await expect(resolveGatewayConnection({ url: "wss://override.example/ws" })).rejects.toThrow(
-      "explicit credentials",
+      /remove --url to use the configured target/i,
     );
   });
 


### PR DESCRIPTION
## What Problem This Solves

Gateway URL overrides deliberately refuse implicit configuration/device credentials, but the generic error did not tell users how recovery differs between CLI `--url` and `OPENCLAW_GATEWAY_URL`. This made a correct security boundary look like a broken token lookup in CLI, TUI, container, and SSH-tunnel workflows.

This is the clean maintainer replacement for #54692. The contributor branch could no longer be updated after final-base drift; this branch preserves Gabriel A. Mays's authorship with `Co-authored-by` and carries only the reviewed three-file fix.

## Why This Change Was Made

Keep the existing authentication decisions unchanged and add source-specific recovery text inside the existing guard. CLI overrides explain both explicit `--token`/`--password` and removing `--url` for the configured local/tunneled target. Environment overrides name the paired environment credentials and state that config credentials are intentionally not reused.

## User Impact

The failure remains fail-closed, but now points directly to the safe fix for the override source. No credential precedence, fallback, configuration, or protocol behavior changes.

Release note: Improved Gateway URL override authentication errors with direct recovery guidance for CLI and environment-based targets.

## Evidence

- Blacksmith Testbox `tbx_01kwsk3hcn6vvycz4w38neampv`, [run 28747758963](https://github.com/openclaw/openclaw/actions/runs/28747758963): gateway matrix 468/468 passed; TUI gateway 29/29 passed.
- Same Testbox: `corepack pnpm check:changed` passed for the exact three-file core/coreTests scope.
- Live tmux proof on Testbox `tbx_01kwsjkjbed1es2qrvgym31y8d`: real `gateway health --url`, env URL override, and `tui --url` commands each rendered the correct source-specific recovery text; combined build + live run exited 0.
- Fresh autoreview: no accepted/actionable findings; correctness confidence 0.98.
- `git diff --check` passed.

No config, protocol, dependency, or storage surface changes.
