### PR TITLE
fix(secrets): suppress unhandled stdout/stderr stream errors in exec resolver

### DIFF
--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -1,8 +1,20 @@
 /** Tests SecretRef provider resolution for env, file, and exec sources. */
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) =>
+      spawnMock(...args) ?? actual.spawn(...args),
+  };
+});
 import type { OpenClawConfig } from "../config/config.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import {
@@ -644,5 +656,72 @@ describe("secret ref resolver", () => {
         /ACL verification unavailable on Windows/,
       );
     });
+  });
+});
+
+describe("runExecResolver stream error handling", () => {
+  function createFakeChild(): ChildProcess {
+    const child = new EventEmitter() as EventEmitter & ChildProcess;
+    child.stdout = new EventEmitter() as EventEmitter & NonNullable<ChildProcess["stdout"]>;
+    child.stderr = new EventEmitter() as EventEmitter & NonNullable<ChildProcess["stderr"]>;
+    child.stdin = new EventEmitter() as EventEmitter & NonNullable<ChildProcess["stdin"]>;
+    child.stdin.write = vi.fn(() => true) as NonNullable<ChildProcess["stdin"]>["write"];
+    child.stdin.end = vi.fn() as NonNullable<ChildProcess["stdin"]>["end"];
+    Object.defineProperties(child, {
+      pid: { configurable: true, enumerable: true, get: () => 1234 },
+      killed: { configurable: true, enumerable: true, get: () => false },
+    });
+    child.kill = vi.fn(() => true) as ChildProcess["kill"];
+    return child;
+  }
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it("swallows stdout and stderr stream errors without rejecting", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-secrets-resolve-stream-"));
+    const scriptPath = path.join(dir, "resolver.cjs");
+    await fs.writeFile(scriptPath, "module.exports = {};", "utf8");
+    await fs.chmod(scriptPath, 0o700);
+
+    spawnMock.mockImplementation(() => {
+      const child = createFakeChild();
+      const response = Buffer.from(
+        JSON.stringify({ protocolVersion: 1, values: { "openai/api-key": "ok" } }),
+      );
+      queueMicrotask(() => {
+        child.stdout?.emit("error", new Error("stdout read failed"));
+        child.stdout?.emit("data", response);
+        child.stderr?.emit("error", new Error("stderr read failed"));
+        child.emit("close", 0, null);
+      });
+      return child;
+    });
+
+    await expect(
+      resolveSecretRefString(
+        { source: "exec", provider: "execmain", id: "openai/api-key" },
+        {
+          config: {
+            secrets: {
+              providers: {
+                execmain: {
+                  source: "exec",
+                  command: scriptPath,
+                  args: [],
+                  allowInsecurePath: true,
+                  timeoutMs: 5_000,
+                  noOutputTimeoutMs: 5_000,
+                  maxOutputBytes: 16 * 1024,
+                },
+              },
+            },
+          },
+        },
+      ),
+    ).resolves.toBe("ok");
+
+    await fs.rm(dir, { recursive: true, force: true });
   });
 });

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -568,7 +568,9 @@ async function runExecResolver(params: {
       clearTimers();
       reject(error);
     });
+    child.stdout?.on("error", () => {});
     child.stdout?.on("data", (chunk) => append(chunk, "stdout"));
+    child.stderr?.on("error", () => {});
     child.stderr?.on("data", (chunk) => append(chunk, "stderr"));
     child.on("close", (code, signal) => {
       if (settled) {


### PR DESCRIPTION
## What Problem This Solves

`runExecResolver` attaches `data` listeners to `child.stdout` and `child.stderr`, but does not attach `error` listeners. If either stream emits an `error` event, the unhandled error can crash the OpenClaw process during secret resolution.

## Why This Change Was Made

Add no-op `error` handlers to both stdout and stderr streams before the data handlers, mirroring the existing stdin error handling pattern. This prevents unhandled stream errors from propagating as uncaught exceptions.

## User Impact

More robust exec-based secret resolution: transient stream read errors no longer crash the process.

## Evidence

- Added a regression test in `src/secrets/resolve.test.ts` that mocks `spawn`, emits `error` events on both stdout and stderr, and verifies `resolveSecretRefString` still resolves successfully.
- Verified the test fails on `main` (times out with an unhandled `Error: stdout read failed`) and passes with this fix.
- `oxlint` passes on the changed files.
