### PR TITLE
fix(agents): suppress unhandled stdout/stderr stream errors in waitForChildProcess

### DIFF
--- a/src/agents/utils/child-process.test.ts
+++ b/src/agents/utils/child-process.test.ts
@@ -75,4 +75,20 @@ describe.skipIf(process.platform === "win32")("waitForChildProcess", () => {
       vi.useRealTimers();
     }
   });
+
+  it("swallows stdout and stderr stream errors without rejecting", async () => {
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const fakeChild = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+    }) as unknown as ChildProcess;
+
+    const completion = waitForChildProcess(fakeChild);
+    stdout.emit("error", new Error("stdout read failed"));
+    stderr.emit("error", new Error("stderr read failed"));
+    fakeChild.emit("exit", 0);
+
+    await expect(completion).resolves.toBe(0);
+  });
 });

--- a/src/agents/utils/child-process.ts
+++ b/src/agents/utils/child-process.ts
@@ -41,6 +41,8 @@ export function waitForChildProcess(child: ChildProcess): Promise<number | null>
       child.stderr?.removeListener("end", onStderrEnd);
       child.stdout?.removeListener("data", onData);
       child.stderr?.removeListener("data", onData);
+      child.stdout?.removeListener("error", onStreamError);
+      child.stderr?.removeListener("error", onStreamError);
     };
 
     const finalize = (code: number | null) => {
@@ -95,6 +97,11 @@ export function waitForChildProcess(child: ChildProcess): Promise<number | null>
       reject(err);
     };
 
+    const onStreamError = () => {
+      // Stream read errors on stdout/stderr are non-fatal; the child process
+      // error/exit/close handlers report the real outcome.
+    };
+
     const onExit = (code: number | null) => {
       exited = true;
       exitCode = code;
@@ -113,6 +120,8 @@ export function waitForChildProcess(child: ChildProcess): Promise<number | null>
 
     child.stdout?.once("end", onStdoutEnd);
     child.stderr?.once("end", onStderrEnd);
+    child.stdout?.on("error", onStreamError);
+    child.stderr?.on("error", onStreamError);
     child.stdout?.on("data", onData);
     child.stderr?.on("data", onData);
     child.once("error", onError);


### PR DESCRIPTION
## What Problem This Solves

`waitForChildProcess` attaches `data` listeners to `child.stdout` and `child.stderr`, but does not attach `error` listeners. If either stream emits an `error` event, the unhandled error can crash the OpenClaw process even though the child process exit has already been observed.

## Why This Change Was Made

Add no-op `error` handlers to both stdout and stderr streams before the data handlers. Stream read errors are treated as non-fatal because the child process `error`/`exit`/`close` handlers report the real outcome. The new listeners are also removed in `cleanup` to avoid leaks.

## User Impact

More robust child process waiting: transient stream read errors no longer crash the agent runtime.

## Evidence

- Added a regression test in `src/agents/utils/child-process.test.ts` that creates a fake child with `PassThrough` stdout/stderr, emits `error` events on both streams, and verifies `waitForChildProcess` still resolves successfully.
- Verified the test fails on `main` with `Error: stdout read failed` and passes with this fix.
- `oxlint` passes on the changed files.
