### PR TITLE
fix(agents): suppress unhandled stdout/stderr stream errors in execDockerRaw

### DIFF
--- a/src/agents/sandbox/docker.test.ts
+++ b/src/agents/sandbox/docker.test.ts
@@ -21,6 +21,7 @@ const spawnState = vi.hoisted(() => ({
   calls: [] as SpawnCall[],
   imageExists: true,
   inspectError: "",
+  emitStreamError: false,
 }));
 
 function createMockDockerChild(): MockDockerChild {
@@ -54,6 +55,10 @@ function spawnDockerProcess(command: string, args: string[]) {
   }
 
   queueMicrotask(() => {
+    if (spawnState.emitStreamError) {
+      child.stdout.emit("error", new Error("stdout read failed"));
+      child.stderr.emit("error", new Error("stderr read failed"));
+    }
     if (stderr) {
       child.stderr.emit("data", Buffer.from(stderr));
     }
@@ -73,11 +78,12 @@ async function createChildProcessMock() {
 vi.mock("node:child_process", async () => createChildProcessMock());
 
 let ensureDockerImage: typeof import("./docker.js").ensureDockerImage;
+let execDockerRaw: typeof import("./docker.js").execDockerRaw;
 
 async function loadFreshDockerModuleForTest() {
   vi.resetModules();
   vi.doMock("node:child_process", async () => createChildProcessMock());
-  ({ ensureDockerImage } = await import("./docker.js"));
+  ({ ensureDockerImage, execDockerRaw } = await import("./docker.js"));
 }
 
 describe("ensureDockerImage", () => {
@@ -85,6 +91,7 @@ describe("ensureDockerImage", () => {
     spawnState.calls.length = 0;
     spawnState.imageExists = true;
     spawnState.inspectError = "";
+    spawnState.emitStreamError = false;
     await loadFreshDockerModuleForTest();
   });
 
@@ -137,5 +144,25 @@ describe("ensureDockerImage", () => {
         args: ["image", "inspect", DEFAULT_SANDBOX_IMAGE],
       },
     ]);
+  });
+});
+
+describe("execDockerRaw", () => {
+  beforeEach(async () => {
+    spawnState.calls.length = 0;
+    spawnState.imageExists = true;
+    spawnState.inspectError = "";
+    spawnState.emitStreamError = false;
+    await loadFreshDockerModuleForTest();
+  });
+
+  it("swallows stdout and stderr stream errors without rejecting", async () => {
+    spawnState.emitStreamError = true;
+
+    await expect(execDockerRaw(["image", "inspect", DEFAULT_SANDBOX_IMAGE])).resolves.toEqual(
+      expect.objectContaining({
+        code: 0,
+      }),
+    );
   });
 });

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -98,9 +98,11 @@ export function execDockerRaw(
       }
     }
 
+    child.stdout?.on("error", () => {});
     child.stdout?.on("data", (chunk) => {
       stdoutChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     });
+    child.stderr?.on("error", () => {});
     child.stderr?.on("data", (chunk) => {
       stderrChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     });
@@ -134,7 +136,7 @@ export function execDockerRaw(
       const stdout = Buffer.concat(stdoutChunks);
       const stderr = Buffer.concat(stderrChunks);
       if (aborted || signal?.aborted) {
-      reject(createAbortError("Aborted"));
+        reject(createAbortError("Aborted"));
         return;
       }
       const exitCode = code ?? 0;


### PR DESCRIPTION
## What Problem This Solves

`execDockerRaw` attaches `data` listeners to `child.stdout` and `child.stderr`, but does not attach `error` listeners. If either stream emits an `error` event, the unhandled error can crash the OpenClaw process during Docker sandbox operations.

## Why This Change Was Made

Add no-op `error` handlers to both stdout and stderr streams before the data handlers, mirroring the existing `child.on("error", ...)` pattern. This prevents unhandled stream errors from propagating as uncaught exceptions.

## User Impact

More robust Docker sandbox operations: transient stream read errors no longer crash the agent runtime.

## Evidence

- Added a regression test in `src/agents/sandbox/docker.test.ts` that exercises `execDockerRaw` with a mocked `spawn` that emits `error` events on both stdout and stderr, and verifies the promise still resolves successfully.
- Verified the test fails on `main` (times out with an unhandled stream error) and passes with this fix.
- `oxlint` passes on the changed files.
