### PR TITLE
fix(transcripts): handle read stream errors gracefully in TranscriptsStore

### DIFF
--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -1,7 +1,18 @@
-// Tests TranscriptsStore stream cleanup and transcript reading behavior.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+// Tests TranscriptsStore stream cleanup and transcript reading behavior.
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const createReadStreamMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    createReadStream: (...args: Parameters<typeof actual.createReadStream>) =>
+      createReadStreamMock(...args) ?? actual.createReadStream(...args),
+  };
+});
 import { listOpenFileDescriptorsForPath } from "../../src/infra/open-file-descriptors.test-support.js";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { TranscriptsStore } from "./store.js";
@@ -105,4 +116,26 @@ describe("TranscriptsStore.readUtterancesFromSessionDir", () => {
       expect(leaked).toHaveLength(0);
     },
   );
+
+  it("handles read stream errors without rejecting", async () => {
+    const tmpDir = makeTempDir(tempRoots, "openclaw-transcript-test-");
+    const store = new TranscriptsStore(tmpDir);
+    const sessionDir = path.join(tmpDir, "2026-07-01", "session-1");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionDir, "transcript.jsonl"), "");
+
+    createReadStreamMock.mockImplementation(() => {
+      const stream = new PassThrough();
+      setTimeout(() => {
+        stream.write(JSON.stringify({ text: "hello", sessionId: "session-1" }) + "\n");
+        stream.emit("error", new Error("read failed"));
+        stream.end();
+      }, 10);
+      return stream;
+    });
+
+    await expect(
+      store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 }),
+    ).resolves.toEqual([expect.objectContaining({ text: "hello" })]);
+  });
 });

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -188,40 +188,61 @@ export class TranscriptsStore {
     const transcriptPath = path.join(dir, "transcript.jsonl");
     const maxUtterances = resolveOptionalIntegerOption(options.maxUtterances, { min: 1 });
     if (maxUtterances !== undefined) {
-      const utterances: TranscriptUtterance[] = [];
-      try {
+      return await new Promise<TranscriptUtterance[]>((resolve, reject) => {
+        const utterances: TranscriptUtterance[] = [];
         const stream = createReadStream(transcriptPath, { encoding: "utf8" });
         const lines = createInterface({
           input: stream,
           crlfDelay: Infinity,
         });
-        try {
-          for await (const line of lines) {
-            if (!line) {
-              continue;
-            }
-            utterances.push(JSON.parse(line) as TranscriptUtterance);
-            if (utterances.length > maxUtterances) {
-              // Stream and keep only the tail so large transcripts do not require full-file memory.
-              utterances.shift();
-            }
-          }
-        } finally {
+        let settled = false;
+
+        const cleanup = () => {
           lines.close();
           stream.destroy();
-          if (!stream.closed) {
-            await new Promise<void>((resolve) => {
-              stream.once("close", () => resolve());
-            });
+        };
+        const finish = (value: TranscriptUtterance[]) => {
+          if (settled) {
+            return;
           }
-        }
-      } catch (err) {
-        if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
-          return [];
-        }
-        throw err;
-      }
-      return utterances;
+          settled = true;
+          cleanup();
+          resolve(value);
+        };
+        const fail = (err: unknown) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          reject(err);
+        };
+
+        stream.on("error", (err) => {
+          if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+            finish([]);
+            return;
+          }
+          finish(utterances);
+        });
+        lines.on("error", () => finish(utterances));
+        lines.on("line", (line) => {
+          if (!line) {
+            return;
+          }
+          try {
+            utterances.push(JSON.parse(line) as TranscriptUtterance);
+          } catch (err) {
+            fail(err);
+            return;
+          }
+          if (utterances.length > maxUtterances) {
+            // Stream and keep only the tail so large transcripts do not require full-file memory.
+            utterances.shift();
+          }
+        });
+        lines.on("close", () => finish(utterances));
+      });
     }
     let raw: string;
     try {


### PR DESCRIPTION
## What Problem This Solves

`TranscriptsStore.readUtterancesFromDir` uses `createReadStream` + `readline.createInterface` without attaching `error` handlers. If the file stream or readline interface emits an `error` event, the unhandled error rejects the promise and can crash the OpenClaw process.

## Why This Change Was Made

Refactor the stream reading path to use event-based handling (`line`, `close`, `error`) instead of `for await`, so that stream/readline errors can be caught and the function returns the utterances parsed so far. ENOENT is still treated as "no utterances". JSON parse errors are still rejected so callers can distinguish malformed transcript data.

## User Impact

More robust transcript loading: transient stream read errors no longer crash the process; instead, OpenClaw uses the transcript lines that were successfully parsed before the error.

## Evidence

- Added a regression test in `src/transcripts/store.test.ts` that mocks `createReadStream` to return a `PassThrough` that emits a stream error after a valid line, and verifies the function resolves with the parsed utterance instead of rejecting.
- Verified the test fails on `main` with `Error: read failed` and passes with this fix.
- All existing tests, including the file-descriptor leak and JSON parse error tests, still pass.
- `oxlint` passes on the changed files.
