### PR TITLE
feat(ui): preview GitHub issues and pull requests on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Docs: https://docs.openclaw.ai
 - **Control UI message context:** reveal per-message token, context, and model details from the timestamp on hover or activation instead of showing a separate Context button.
 - **Control UI session titles:** reveal truncated recent-session names with a reduced-motion-safe hover animation.
 - **Control UI sidebar navigation:** show a small customizable pinned destination set, keep the remaining pages under More, move Settings to the footer, and persist sidebar customization in the browser. (#100296)
-- **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards.
 - **Control UI sidebar usage:** remove the provider usage quota row from the expanded sidebar while keeping usage details available in the chat composer and Usage page. Thanks @shakkernerd.
 - **Android chat code highlighting:** render fenced Kotlin, Swift, TypeScript, JavaScript, Python, Bash, and JSON blocks with bounded, theme-aware syntax colors while preserving plain rendering for unknown, partial, or oversized blocks. (#100217)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI message context:** reveal per-message token, context, and model details from the timestamp on hover or activation instead of showing a separate Context button.
 - **Control UI session titles:** reveal truncated recent-session names with a reduced-motion-safe hover animation.
 - **Control UI sidebar navigation:** show a small customizable pinned destination set, keep the remaining pages under More, move Settings to the footer, and persist sidebar customization in the browser. (#100296)
+- **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards.
 - **Control UI sidebar usage:** remove the provider usage quota row from the expanded sidebar while keeping usage details available in the chat composer and Usage page. Thanks @shakkernerd.
 - **Android chat code highlighting:** render fenced Kotlin, Swift, TypeScript, JavaScript, Python, Bash, and JSON blocks with bounded, theme-aware syntax colors while preserving plain rendering for unknown, partial, or oversized blocks. (#100217)
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -123,6 +123,7 @@ The compact footer keeps connection status, **Settings**, **Docs**, and mobile p
   <Accordion title="Chat and Talk">
     - Chat with the model via Gateway WS (`chat.history`, `chat.send`, `chat.abort`, `chat.inject`).
     - Chat history refreshes request a bounded recent window with per-message text caps, so large sessions do not force the browser to render a full transcript payload before chat becomes usable.
+    - Hovering or keyboard-focusing a public GitHub issue or pull request link shows its state, title, author, recent activity, comments, and change statistics. The connected Gateway fetches and caches public metadata without changing the link target, including when the UI uses a remote Gateway. The Gateway uses `GH_TOKEN` or `GITHUB_TOKEN` when available, after confirming the repository is public; otherwise it uses GitHub's anonymous API with a longer cache.
     - Talk through browser realtime sessions. OpenAI uses direct WebRTC, Google Live uses a constrained one-use browser token over WebSocket, and backend-only realtime voice plugins use the Gateway relay transport. Client-owned provider sessions start with `talk.client.create`; Gateway relay sessions start with `talk.session.create`. The relay keeps provider credentials on the Gateway while the browser streams microphone PCM through `talk.session.appendAudio`, forwards `openclaw_agent_consult` provider tool calls through `talk.client.toolCall` for Gateway policy and the larger configured OpenClaw model, and routes active-run voice steering through `talk.client.steer` or `talk.session.steer`.
     - Stream tool calls and live tool output cards in Chat (agent events).
     - Activity tab with browser-local, redaction-first summaries of live tool activity from existing `session.tool` / tool event delivery.
@@ -450,6 +451,7 @@ In practice:
 - Avatars and images served under relative paths (for example `/avatars/<id>`) still render, including authenticated avatar routes the UI fetches and converts into local `blob:` URLs.
 - Inline `data:image/...` URLs still render.
 - Local `blob:` URLs created by the Control UI still render.
+- GitHub link preview avatars are fetched by the Gateway from GitHub's fixed avatar host and returned as bounded `data:` URLs; the operator browser never contacts the remote avatar host.
 - Remote avatar URLs emitted by channel metadata are stripped at the Control UI's avatar helpers and replaced with the built-in logo/badge, so a compromised or malicious channel cannot force arbitrary remote image fetches from an operator browser.
 
 This is always on and not configurable.

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -9,6 +9,28 @@ export const CONTROL_UI_TERMINAL_ENABLED_ATTRIBUTE = "data-openclaw-terminal-ena
 /** Sandbox policy for assistant-provided embed surfaces inside Control UI. */
 export type ControlUiEmbedSandboxMode = "strict" | "scripts" | "trusted";
 
+/** Public GitHub metadata rendered by Control UI link hover cards. */
+export type ControlUiGitHubPreview = {
+  additions?: number;
+  avatarDataUrl?: string;
+  changedFiles?: number;
+  closedAt?: string;
+  comments?: number;
+  createdAt: string;
+  deletions?: number;
+  draft?: boolean;
+  kind: "issue" | "pull";
+  login: string;
+  mergedAt?: string;
+  number: number;
+  owner: string;
+  repo: string;
+  state: string;
+  stateReason?: string;
+  title: string;
+  updatedAt: string;
+};
+
 /** Runtime config consumed by the browser Control UI during bootstrap. */
 export type ControlUiBootstrapConfig = {
   basePath: string;

--- a/src/gateway/control-ui-github-preview.test.ts
+++ b/src/gateway/control-ui-github-preview.test.ts
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ControlUiGitHubPreviewError,
+  loadControlUiGitHubPreview,
+  parseControlUiGitHubPreviewTarget,
+} from "./control-ui-github-preview.js";
+
+function githubJson(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function requestUrl(input: RequestInfo | URL | undefined): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input?.url ?? "";
+}
+
+function previewPayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    additions: 101,
+    changed_files: 3,
+    closed_at: "2026-07-04T09:53:52Z",
+    created_at: "2026-07-04T05:03:47Z",
+    deletions: 12,
+    draft: false,
+    merged_at: "2026-07-04T09:53:52Z",
+    state: "closed",
+    title: "fix(agents): derive conversation scope from trusted group facts",
+    updated_at: "2026-07-04T09:53:55Z",
+    base: { repo: { url: "https://api.github.com/repos/openclaw/openclaw" } },
+    repository_url: "https://api.github.com/repos/openclaw/openclaw",
+    user: {
+      avatar_url: "https://avatars.githubusercontent.com/u/58493?v=4",
+      login: "steipete",
+    },
+    ...overrides,
+  };
+}
+
+describe("parseControlUiGitHubPreviewTarget", () => {
+  it("accepts bounded GitHub issue and pull request targets", () => {
+    const target = parseControlUiGitHubPreviewTarget({
+      kind: "pull",
+      number: 99816,
+      owner: "openclaw",
+      repo: "openclaw",
+    });
+    expect(target).toEqual({ kind: "pull", number: 99816, owner: "openclaw", repo: "openclaw" });
+  });
+
+  it("rejects invalid repository paths and item numbers", () => {
+    expect(
+      parseControlUiGitHubPreviewTarget({
+        kind: "issue",
+        number: 1,
+        owner: "openclaw/evil",
+        repo: "openclaw",
+      }),
+    ).toBeNull();
+    expect(
+      parseControlUiGitHubPreviewTarget({
+        kind: "issue",
+        number: 0,
+        owner: "openclaw",
+        repo: "..",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("loadControlUiGitHubPreview", () => {
+  beforeEach(() => {
+    vi.stubEnv("GH_TOKEN", "");
+    vi.stubEnv("GITHUB_TOKEN", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("normalizes public metadata and embeds a bounded GitHub avatar", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(githubJson(previewPayload()))
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([137, 80, 78, 71]), {
+          headers: { "Content-Type": "image/png" },
+        }),
+      );
+    const target = { kind: "pull" as const, number: 99816, owner: "openclaw", repo: "openclaw" };
+
+    const first = await loadControlUiGitHubPreview(target, fetchMock);
+    const second = await loadControlUiGitHubPreview(target, fetchMock);
+
+    expect(first).toMatchObject({
+      additions: 101,
+      avatarDataUrl: "data:image/png;base64,iVBORw==",
+      changedFiles: 3,
+      deletions: 12,
+      kind: "pull",
+      login: "steipete",
+      mergedAt: "2026-07-04T09:53:52Z",
+      number: 99816,
+      owner: "openclaw",
+      repo: "openclaw",
+    });
+    expect(second).toEqual(first);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://api.github.com/repos/openclaw/openclaw/pulls/99816",
+    );
+    const avatarRequest = fetchMock.mock.calls[1]?.[0];
+    expect(avatarRequest).toBeInstanceOf(URL);
+    expect(avatarRequest instanceof URL ? avatarRequest.href : "").toContain(
+      "avatars.githubusercontent.com/u/58493",
+    );
+    expect(avatarRequest instanceof URL ? avatarRequest.searchParams.get("s") : null).toBe("64");
+  });
+
+  it("does not fetch avatar URLs outside GitHub's avatar host", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      githubJson(
+        previewPayload({
+          user: { avatar_url: "https://example.com/avatar.png", login: "octocat" },
+        }),
+      ),
+    );
+
+    const preview = await loadControlUiGitHubPreview(
+      { kind: "issue", number: 70001, owner: "openclaw", repo: "avatar-safety" },
+      fetchMock,
+    );
+
+    expect(preview.avatarDataUrl).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("discards rejected avatar response bodies", async () => {
+    const avatarResponse = new Response("not an image", {
+      headers: { "Content-Type": "text/plain" },
+    });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(githubJson(previewPayload()))
+      .mockResolvedValueOnce(avatarResponse);
+
+    const preview = await loadControlUiGitHubPreview(
+      { kind: "pull", number: 70009, owner: "openclaw", repo: "bad-avatar" },
+      fetchMock,
+    );
+
+    expect(preview.avatarDataUrl).toBeUndefined();
+    expect(avatarResponse.bodyUsed).toBe(true);
+  });
+
+  it("returns token-backed metadata only after public repository proofs", async () => {
+    vi.stubEnv("GH_TOKEN", "github-test-token");
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(githubJson({ private: false }))
+      .mockResolvedValueOnce(
+        githubJson(
+          previewPayload({
+            repository_url: "https://api.github.com/repos/openclaw/public",
+            user: { login: "octocat" },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(githubJson({ private: false }));
+    const target = { kind: "issue" as const, number: 70003, owner: "openclaw", repo: "public" };
+
+    await loadControlUiGitHubPreview(target, fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.github.com/repos/openclaw/public");
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://api.github.com/repos/openclaw/public/issues/70003",
+    );
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("https://api.github.com/repos/openclaw/public");
+    for (const call of fetchMock.mock.calls) {
+      expect(call[1]?.headers).toHaveProperty("Authorization", "Bearer github-test-token");
+    }
+  });
+
+  it("follows GitHub API redirects for renamed public repositories", async () => {
+    vi.stubEnv("GH_TOKEN", "github-test-token");
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(githubJson({ private: false }))
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 301,
+          headers: { Location: "/repos/openclaw/renamed/issues/70007" },
+        }),
+      )
+      .mockResolvedValueOnce(githubJson({ private: false }))
+      .mockResolvedValueOnce(
+        githubJson(
+          previewPayload({
+            repository_url: "https://api.github.com/repos/openclaw/renamed",
+            user: { login: "octocat" },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(githubJson({ private: false }));
+
+    const preview = await loadControlUiGitHubPreview(
+      { kind: "issue", number: 70007, owner: "openclaw", repo: "old-name" },
+      fetchMock,
+    );
+
+    expect(preview.login).toBe("octocat");
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(requestUrl(fetchMock.mock.calls[3]?.[0])).toBe(
+      "https://api.github.com/repos/openclaw/renamed/issues/70007",
+    );
+    expect(requestUrl(fetchMock.mock.calls[4]?.[0])).toBe(
+      "https://api.github.com/repos/openclaw/renamed",
+    );
+    for (const call of fetchMock.mock.calls) {
+      expect(new URL(requestUrl(call[0])).origin).toBe("https://api.github.com");
+      const headers = (call[1]?.headers ?? {}) as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer github-test-token");
+      expect(call[1]?.redirect).toBe("manual");
+    }
+  });
+
+  it("rejects cross-origin GitHub API redirects before forwarding credentials", async () => {
+    vi.stubEnv("GH_TOKEN", "github-test-token");
+    const redirectResponse = new Response("discard me", {
+      status: 301,
+      headers: { Location: "https://example.com/repos/openclaw/private" },
+    });
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(githubJson({ private: false }))
+      .mockResolvedValueOnce(redirectResponse);
+
+    await expect(
+      loadControlUiGitHubPreview(
+        { kind: "pull", number: 70008, owner: "openclaw", repo: "unsafe-redirect" },
+        fetchMock,
+      ),
+    ).rejects.toMatchObject({ statusCode: 502 } satisfies Partial<ControlUiGitHubPreviewError>);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(new URL(requestUrl(fetchMock.mock.calls[1]?.[0])).origin).toBe(
+      "https://api.github.com",
+    );
+    expect(redirectResponse.bodyUsed).toBe(true);
+  });
+
+  it("stops private and missing repositories before fetching item metadata", async () => {
+    vi.stubEnv("GH_TOKEN", "github-test-token");
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(githubJson({ private: true }))
+      .mockResolvedValueOnce(githubJson({ message: "Not Found" }, 404));
+
+    for (const [repo, number] of [
+      ["private", 70010],
+      ["missing", 70011],
+    ] as const) {
+      await expect(
+        loadControlUiGitHubPreview(
+          { kind: "issue", number, owner: "openclaw", repo },
+          fetchMock,
+        ),
+      ).rejects.toMatchObject({ statusCode: 404 } satisfies Partial<ControlUiGitHubPreviewError>);
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map((call) => requestUrl(call[0]))).toEqual([
+      "https://api.github.com/repos/openclaw/private",
+      "https://api.github.com/repos/openclaw/missing",
+    ]);
+  });
+
+  it("does not expose metadata transferred into a private repository", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "github-test-token");
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(githubJson({ private: false }))
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 301,
+          headers: { Location: "/repos/openclaw/private/issues/70004" },
+        }),
+      )
+      .mockResolvedValueOnce(githubJson({ private: true }));
+
+    await expect(
+      loadControlUiGitHubPreview(
+        { kind: "issue", number: 70004, owner: "openclaw", repo: "public-source" },
+        fetchMock,
+      ),
+    ).rejects.toMatchObject({ statusCode: 404 } satisfies Partial<ControlUiGitHubPreviewError>);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).toHaveProperty(
+      "Authorization",
+      "Bearer github-test-token",
+    );
+    expect(fetchMock.mock.calls[2]?.[1]?.headers).toHaveProperty(
+      "Authorization",
+      "Bearer github-test-token",
+    );
+  });
+
+  it("rechecks public visibility for every authenticated preview cache miss", async () => {
+    vi.stubEnv("GH_TOKEN", "github-test-token");
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(githubJson({ private: false }))
+      .mockResolvedValueOnce(
+        githubJson(
+          previewPayload({
+            repository_url: "https://api.github.com/repos/openclaw/visibility-change",
+            user: { login: "octocat" },
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(githubJson({ private: false }))
+      .mockResolvedValueOnce(githubJson({ private: true }));
+
+    await loadControlUiGitHubPreview(
+      { kind: "issue", number: 70005, owner: "openclaw", repo: "visibility-change" },
+      fetchMock,
+    );
+    await expect(
+      loadControlUiGitHubPreview(
+        { kind: "issue", number: 70006, owner: "openclaw", repo: "visibility-change" },
+        fetchMock,
+      ),
+    ).rejects.toMatchObject({ statusCode: 404 } satisfies Partial<ControlUiGitHubPreviewError>);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("maps missing GitHub items to a safe not-found error", async () => {
+    const missingResponse = githubJson({ message: "Not Found" }, 404);
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(missingResponse);
+
+    await expect(
+      loadControlUiGitHubPreview(
+        { kind: "issue", number: 70002, owner: "openclaw", repo: "missing-preview" },
+        fetchMock,
+      ),
+    ).rejects.toMatchObject({ statusCode: 404 } satisfies Partial<ControlUiGitHubPreviewError>);
+    expect(missingResponse.bodyUsed).toBe(true);
+  });
+});

--- a/src/gateway/control-ui-github-preview.ts
+++ b/src/gateway/control-ui-github-preview.ts
@@ -1,0 +1,443 @@
+// Same-origin GitHub metadata adapter for Control UI link previews.
+import { readResponseWithLimit } from "../infra/http-body.js";
+import type { ControlUiGitHubPreview } from "./control-ui-contract.js";
+
+const GITHUB_API_ORIGIN = "https://api.github.com";
+const GITHUB_AVATAR_HOST = "avatars.githubusercontent.com";
+const GITHUB_API_VERSION = "2022-11-28";
+const GITHUB_JSON_MAX_BYTES = 256 * 1024;
+const GITHUB_AVATAR_MAX_BYTES = 256 * 1024;
+const GITHUB_REQUEST_TIMEOUT_MS = 8_000;
+const GITHUB_API_MAX_REDIRECTS = 3;
+const AUTHENTICATED_SUCCESS_CACHE_MS = 5 * 60_000;
+const ANONYMOUS_SUCCESS_CACHE_MS = 60 * 60_000;
+const FAILURE_CACHE_MS = 30_000;
+const CACHE_LIMIT = 200;
+
+type GitHubLinkKind = "issue" | "pull";
+
+export type ControlUiGitHubPreviewTarget = {
+  kind: GitHubLinkKind;
+  number: number;
+  owner: string;
+  repo: string;
+};
+
+type CacheEntry<T> = {
+  expiresAt: number;
+  promise: Promise<T>;
+};
+
+const previewCache = new Map<string, CacheEntry<ControlUiGitHubPreview>>();
+
+export class ControlUiGitHubPreviewError extends Error {
+  readonly statusCode: number;
+
+  constructor(statusCode: number, message: string) {
+    super(message);
+    this.name = "ControlUiGitHubPreviewError";
+    this.statusCode = statusCode;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function requiredString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new ControlUiGitHubPreviewError(502, `GitHub response omitted ${key}`);
+  }
+  return value;
+}
+
+function optionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function optionalNumber(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isValidOwner(value: string): boolean {
+  return /^(?=.{1,39}$)[a-z\d](?:[a-z\d-]*[a-z\d])?$/iu.test(value);
+}
+
+function isValidRepo(value: string): boolean {
+  return value !== "." && value !== ".." && /^[a-z\d_.-]{1,100}$/iu.test(value);
+}
+
+export function parseControlUiGitHubPreviewTarget(
+  value: unknown,
+): ControlUiGitHubPreviewTarget | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const kind = value.kind;
+  const owner = typeof value.owner === "string" ? value.owner.trim() : "";
+  const repo = typeof value.repo === "string" ? value.repo.trim() : "";
+  const number = value.number;
+  if (
+    (kind !== "issue" && kind !== "pull") ||
+    !isValidOwner(owner) ||
+    !isValidRepo(repo) ||
+    typeof number !== "number" ||
+    !Number.isSafeInteger(number) ||
+    number < 1 ||
+    number > 9_999_999_999
+  ) {
+    return null;
+  }
+  return { kind, number, owner, repo };
+}
+
+function previewApiUrl(target: ControlUiGitHubPreviewTarget): string {
+  const collection = target.kind === "pull" ? "pulls" : "issues";
+  const owner = encodeURIComponent(target.owner);
+  const repo = encodeURIComponent(target.repo);
+  return `${GITHUB_API_ORIGIN}/repos/${owner}/${repo}/${collection}/${target.number}`;
+}
+
+function repositoryApiUrl(target: ControlUiGitHubPreviewTarget): string {
+  const owner = encodeURIComponent(target.owner);
+  const repo = encodeURIComponent(target.repo);
+  return `${GITHUB_API_ORIGIN}/repos/${owner}/${repo}`;
+}
+
+function githubApiToken(): string | undefined {
+  return process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim() || undefined;
+}
+
+function githubApiHeaders(token?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "OpenClaw-Control-UI",
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+function isGitHubApiRedirect(status: number): boolean {
+  return (
+    status === 301 || status === 302 || status === 303 || status === 307 || status === 308
+  );
+}
+
+function safeGitHubApiUrl(raw: string, base?: URL): URL | null {
+  try {
+    const url = new URL(raw, base);
+    if (
+      url.origin !== GITHUB_API_ORIGIN ||
+      url.username ||
+      url.password ||
+      url.port
+    ) {
+      return null;
+    }
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchGitHubApi(
+  rawUrl: string,
+  fetchImpl: typeof fetch,
+  token?: string,
+  beforeRedirect?: (url: URL) => Promise<void>,
+): Promise<Response> {
+  const initialUrl = safeGitHubApiUrl(rawUrl);
+  if (!initialUrl) {
+    throw new ControlUiGitHubPreviewError(502, "Invalid GitHub API URL");
+  }
+  let url: URL = initialUrl;
+
+  const signal = AbortSignal.timeout(GITHUB_REQUEST_TIMEOUT_MS);
+  for (let redirects = 0; ; redirects += 1) {
+    const response: Response = await fetchImpl(url.href, {
+      headers: githubApiHeaders(token),
+      redirect: "manual",
+      signal,
+    });
+    if (!isGitHubApiRedirect(response.status)) {
+      return response;
+    }
+
+    const location: string | null = response.headers.get("location");
+    const nextUrl: URL | null = location ? safeGitHubApiUrl(location, url) : null;
+    if (!nextUrl || redirects >= GITHUB_API_MAX_REDIRECTS) {
+      await discardResponse(response);
+      throw new ControlUiGitHubPreviewError(502, "GitHub API returned an unsafe redirect");
+    }
+    // Credentials stay on the fixed API origin across GitHub redirects;
+    // callers still verify the final response repository before returning it.
+    await discardResponse(response);
+    await beforeRedirect?.(nextUrl);
+    url = nextUrl;
+  }
+}
+
+async function discardResponse(response: Response): Promise<void> {
+  await response.body?.cancel().catch(() => {});
+}
+
+async function readBoundedResponse(response: Response, maxBytes: number): Promise<Buffer> {
+  try {
+    return await readResponseWithLimit(response, maxBytes);
+  } finally {
+    await discardResponse(response);
+  }
+}
+
+function upstreamErrorStatus(status: number): number {
+  if (status === 404) {
+    return 404;
+  }
+  if (status === 403 || status === 429) {
+    return 429;
+  }
+  return 502;
+}
+
+async function assertPublicRepositoryUrl(
+  repositoryUrl: string,
+  fetchImpl: typeof fetch,
+  token: string,
+): Promise<void> {
+  // Private and missing repositories stop at this same request boundary before
+  // any item fetch, so operator.read callers cannot probe private item numbers.
+  const response = await fetchGitHubApi(repositoryUrl, fetchImpl, token);
+  if (!response.ok) {
+    await discardResponse(response);
+    throw new ControlUiGitHubPreviewError(
+      upstreamErrorStatus(response.status),
+      `GitHub repository request failed (${response.status})`,
+    );
+  }
+  const body = await readBoundedResponse(response, GITHUB_JSON_MAX_BYTES);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body.toString("utf8"));
+  } catch {
+    throw new ControlUiGitHubPreviewError(502, "GitHub repository response was not valid JSON");
+  }
+  if (!isRecord(parsed) || parsed.private !== false) {
+    throw new ControlUiGitHubPreviewError(404, "GitHub repository is not public");
+  }
+}
+
+function redirectedRepositoryApiUrl(
+  target: ControlUiGitHubPreviewTarget,
+  url: URL,
+): string | null {
+  const segments = url.pathname.split("/").filter(Boolean);
+  const collection = target.kind === "pull" ? "pulls" : "issues";
+  if (
+    segments.length === 5 &&
+    segments[0] === "repos" &&
+    segments[1] &&
+    segments[2] &&
+    segments[3] === collection &&
+    /^\d+$/u.test(segments[4] ?? "")
+  ) {
+    return `${GITHUB_API_ORIGIN}/repos/${segments[1]}/${segments[2]}`;
+  }
+  if (
+    segments.length === 4 &&
+    segments[0] === "repositories" &&
+    /^\d+$/u.test(segments[1] ?? "") &&
+    segments[2] === collection &&
+    /^\d+$/u.test(segments[3] ?? "")
+  ) {
+    return `${GITHUB_API_ORIGIN}/repositories/${segments[1]}`;
+  }
+  return null;
+}
+
+function previewRepositoryApiUrl(
+  target: ControlUiGitHubPreviewTarget,
+  value: Record<string, unknown>,
+): string {
+  if (target.kind === "issue") {
+    return requiredString(value, "repository_url");
+  }
+  const base = isRecord(value.base) ? value.base : {};
+  const repository = isRecord(base.repo) ? base.repo : {};
+  return requiredString(repository, "url");
+}
+
+function parseGitHubResponse(
+  target: ControlUiGitHubPreviewTarget,
+  value: unknown,
+): { preview: ControlUiGitHubPreview; avatarUrl?: string } {
+  if (!isRecord(value)) {
+    throw new ControlUiGitHubPreviewError(502, "GitHub response was not an object");
+  }
+  const user = isRecord(value.user) ? value.user : {};
+  return {
+    preview: {
+      ...target,
+      additions: optionalNumber(value, "additions"),
+      changedFiles: optionalNumber(value, "changed_files"),
+      closedAt: optionalString(value, "closed_at"),
+      comments: optionalNumber(value, "comments"),
+      createdAt: requiredString(value, "created_at"),
+      deletions: optionalNumber(value, "deletions"),
+      draft: typeof value.draft === "boolean" ? value.draft : undefined,
+      login: optionalString(user, "login") ?? "ghost",
+      mergedAt: optionalString(value, "merged_at"),
+      state: requiredString(value, "state"),
+      stateReason: optionalString(value, "state_reason"),
+      title: requiredString(value, "title"),
+      updatedAt: requiredString(value, "updated_at"),
+    },
+    avatarUrl: optionalString(user, "avatar_url"),
+  };
+}
+
+function safeAvatarUrl(raw: string | undefined): URL | null {
+  if (!raw) {
+    return null;
+  }
+  try {
+    const url = new URL(raw);
+    if (
+      url.protocol !== "https:" ||
+      url.hostname !== GITHUB_AVATAR_HOST ||
+      url.username ||
+      url.password ||
+      url.port
+    ) {
+      return null;
+    }
+    url.searchParams.set("s", "64");
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchAvatarDataUrl(
+  rawUrl: string | undefined,
+  fetchImpl: typeof fetch,
+): Promise<string | undefined> {
+  const url = safeAvatarUrl(rawUrl);
+  if (!url) {
+    return undefined;
+  }
+  try {
+    const response = await fetchImpl(url, {
+      headers: { Accept: "image/webp,image/png,image/jpeg,image/gif" },
+      redirect: "error",
+      signal: AbortSignal.timeout(GITHUB_REQUEST_TIMEOUT_MS),
+    });
+    const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim();
+    if (
+      !response.ok ||
+      !contentType ||
+      !["image/gif", "image/jpeg", "image/png", "image/webp"].includes(contentType)
+    ) {
+      await discardResponse(response);
+      return undefined;
+    }
+    const body = await readBoundedResponse(response, GITHUB_AVATAR_MAX_BYTES);
+    return `data:${contentType};base64,${body.toString("base64")}`;
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchPreview(
+  target: ControlUiGitHubPreviewTarget,
+  fetchImpl: typeof fetch,
+  token?: string,
+): Promise<ControlUiGitHubPreview> {
+  if (token) {
+    await assertPublicRepositoryUrl(repositoryApiUrl(target), fetchImpl, token);
+  }
+  const response = await fetchGitHubApi(
+    previewApiUrl(target),
+    fetchImpl,
+    token,
+    token
+      ? async (url) => {
+          const repositoryUrl = redirectedRepositoryApiUrl(target, url);
+          if (!repositoryUrl) {
+            throw new ControlUiGitHubPreviewError(502, "GitHub item returned an unsafe redirect");
+          }
+          await assertPublicRepositoryUrl(repositoryUrl, fetchImpl, token);
+        }
+      : undefined,
+  );
+  if (!response.ok) {
+    await discardResponse(response);
+    throw new ControlUiGitHubPreviewError(
+      upstreamErrorStatus(response.status),
+      `GitHub request failed (${response.status})`,
+    );
+  }
+  const body = await readBoundedResponse(response, GITHUB_JSON_MAX_BYTES);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body.toString("utf8"));
+  } catch {
+    throw new ControlUiGitHubPreviewError(502, "GitHub response was not valid JSON");
+  }
+  if (!isRecord(parsed)) {
+    throw new ControlUiGitHubPreviewError(502, "GitHub response was not an object");
+  }
+  if (token) {
+    await assertPublicRepositoryUrl(previewRepositoryApiUrl(target, parsed), fetchImpl, token);
+  }
+  const { preview, avatarUrl } = parseGitHubResponse(target, parsed);
+  const avatarDataUrl = await fetchAvatarDataUrl(avatarUrl, fetchImpl);
+  return avatarDataUrl ? { ...preview, avatarDataUrl } : preview;
+}
+
+function cacheKey(target: ControlUiGitHubPreviewTarget): string {
+  return `${target.kind}:${target.owner.toLowerCase()}/${target.repo.toLowerCase()}#${target.number}`;
+}
+
+export function loadControlUiGitHubPreview(
+  target: ControlUiGitHubPreviewTarget,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ControlUiGitHubPreview> {
+  const key = cacheKey(target);
+  const now = Date.now();
+  const cached = previewCache.get(key);
+  if (cached && cached.expiresAt > now) {
+    previewCache.delete(key);
+    previewCache.set(key, cached);
+    return cached.promise;
+  }
+  if (cached) {
+    previewCache.delete(key);
+  }
+
+  const token = githubApiToken();
+  const successCacheMs = token ? AUTHENTICATED_SUCCESS_CACHE_MS : ANONYMOUS_SUCCESS_CACHE_MS;
+  const entry: CacheEntry<ControlUiGitHubPreview> = {
+    expiresAt: now + successCacheMs,
+    promise: fetchPreview(target, fetchImpl, token).catch((error: unknown) => {
+      // Short failure caching protects the anonymous GitHub quota when a user
+      // repeatedly crosses a private, missing, or rate-limited link.
+      entry.expiresAt = Date.now() + FAILURE_CACHE_MS;
+      throw error;
+    }),
+  };
+  previewCache.set(key, entry);
+  while (previewCache.size > CACHE_LIMIT) {
+    const oldestKey = previewCache.keys().next().value as string | undefined;
+    if (!oldestKey) {
+      break;
+    }
+    previewCache.delete(oldestKey);
+  }
+  return entry.promise;
+}

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -240,12 +240,12 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "nativeHook.invoke", scope: "operator.admin", advertise: false },
   { name: "web.login.start", scope: "operator.admin", advertise: false },
   { name: "web.login.wait", scope: "operator.admin", advertise: false },
-  // Terminal detach/reattach surface. Appended at the end (not next to the
-  // other terminal.* methods) so previously advertised method indices stay
-  // stable for older clients.
+  // Terminal detach/reattach surface. Kept together near the end so previously
+  // advertised method indices stay stable for older clients; new methods append.
   { name: "terminal.attach", scope: "operator.admin" },
   { name: "terminal.list", scope: "operator.admin" },
   { name: "terminal.text", scope: "operator.admin" },
+  { name: "controlUi.githubPreview", scope: "operator.read" },
 ] as const;
 
 const CORE_GATEWAY_METHOD_SPEC_BY_NAME: ReadonlyMap<string, CoreGatewayMethodSpec> = new Map(

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -25,6 +25,10 @@ describe("listGatewayMethods", () => {
     expect(methods).toContain("skills.skillCard");
   });
 
+  it("advertises Control UI GitHub previews", () => {
+    expect(listGatewayMethods()).toContain("controlUi.githubPreview");
+  });
+
   it("does not advertise hidden core handlers", () => {
     const methods = listGatewayMethods();
     expect(methods).not.toContain("config.openFile");

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -98,6 +98,10 @@ const loadConnectHandlers = lazyHandlerModule(
   () => import("./server-methods/connect.js"),
   (module) => module.connectHandlers,
 );
+const loadControlUiHandlers = lazyHandlerModule(
+  () => import("./server-methods/control-ui.js"),
+  (module) => module.controlUiHandlers,
+);
 const loadCronHandlers = lazyHandlerModule(
   () => import("./server-methods/cron.js"),
   (module) => module.cronHandlers,
@@ -371,6 +375,10 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...createLazyCoreHandlers({
     methods: ["diagnostics.stability"],
     loadHandlers: loadDiagnosticsHandlers,
+  }),
+  ...createLazyCoreHandlers({
+    methods: ["controlUi.githubPreview"],
+    loadHandlers: loadControlUiHandlers,
   }),
   ...createLazyCoreHandlers({
     methods: [

--- a/src/gateway/server-methods/control-ui.test.ts
+++ b/src/gateway/server-methods/control-ui.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ControlUiGitHubPreview } from "../control-ui-contract.js";
+import { ControlUiGitHubPreviewError } from "../control-ui-github-preview.js";
+import type { RespondFn } from "./types.js";
+import { createControlUiHandlers } from "./control-ui.js";
+
+function requestOptions(params: Record<string, unknown>, respond: RespondFn) {
+  return {
+    client: null,
+    context: {} as never,
+    isWebchatConnect: () => false,
+    params,
+    req: { id: "1", method: "controlUi.githubPreview", params, type: "req" as const },
+    respond,
+  };
+}
+
+describe("controlUi.githubPreview", () => {
+  it("returns bounded public GitHub metadata", async () => {
+    const preview: ControlUiGitHubPreview = {
+      comments: 4,
+      createdAt: "2026-07-05T08:00:00Z",
+      kind: "issue",
+      login: "octocat",
+      number: 99815,
+      owner: "openclaw",
+      repo: "openclaw",
+      state: "open",
+      title: "Keep hover previews compact",
+      updatedAt: "2026-07-05T09:55:00Z",
+    };
+    const loadPreview = vi.fn().mockResolvedValue(preview);
+    const handlers = createControlUiHandlers(loadPreview);
+    const respond = vi.fn<RespondFn>();
+
+    await handlers["controlUi.githubPreview"](
+      requestOptions(
+        { kind: "issue", number: 99815, owner: "openclaw", repo: "openclaw" },
+        respond,
+      ),
+    );
+
+    expect(loadPreview).toHaveBeenCalledWith({
+      kind: "issue",
+      number: 99815,
+      owner: "openclaw",
+      repo: "openclaw",
+    });
+    expect(respond).toHaveBeenCalledWith(true, preview, undefined);
+  });
+
+  it("rejects malformed targets before loading GitHub", async () => {
+    const loadPreview = vi.fn();
+    const handlers = createControlUiHandlers(loadPreview);
+    const respond = vi.fn<RespondFn>();
+
+    await handlers["controlUi.githubPreview"](
+      requestOptions(
+        { kind: "issue", number: 1, owner: "openclaw/evil", repo: "openclaw" },
+        respond,
+      ),
+    );
+
+    expect(loadPreview).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(false, undefined, {
+      code: "INVALID_REQUEST",
+      message: "invalid controlUi.githubPreview params",
+    });
+  });
+
+  it("returns a retryable unavailable error for GitHub quota failures", async () => {
+    const handlers = createControlUiHandlers(
+      vi.fn().mockRejectedValue(new ControlUiGitHubPreviewError(429, "rate limited")),
+    );
+    const respond = vi.fn<RespondFn>();
+
+    await handlers["controlUi.githubPreview"](
+      requestOptions({ kind: "pull", number: 99816, owner: "openclaw", repo: "openclaw" }, respond),
+    );
+
+    expect(respond).toHaveBeenCalledWith(false, undefined, {
+      code: "UNAVAILABLE",
+      message: "GitHub preview unavailable",
+      retryable: true,
+    });
+  });
+});

--- a/src/gateway/server-methods/control-ui.ts
+++ b/src/gateway/server-methods/control-ui.ts
@@ -1,0 +1,45 @@
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  ControlUiGitHubPreviewError,
+  loadControlUiGitHubPreview,
+  parseControlUiGitHubPreviewTarget,
+  type ControlUiGitHubPreviewTarget,
+} from "../control-ui-github-preview.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+type LoadGitHubPreview = (
+  target: ControlUiGitHubPreviewTarget,
+) => ReturnType<typeof loadControlUiGitHubPreview>;
+
+export function createControlUiHandlers(
+  loadGitHubPreview: LoadGitHubPreview = loadControlUiGitHubPreview,
+): GatewayRequestHandlers {
+  return {
+    "controlUi.githubPreview": async ({ params, respond }) => {
+      const target = parseControlUiGitHubPreviewTarget(params);
+      if (!target) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "invalid controlUi.githubPreview params"),
+        );
+        return;
+      }
+      try {
+        respond(true, await loadGitHubPreview(target), undefined);
+      } catch (error) {
+        const statusCode =
+          error instanceof ControlUiGitHubPreviewError ? error.statusCode : undefined;
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, "GitHub preview unavailable", {
+            retryable: statusCode === 429 || statusCode === 502,
+          }),
+        );
+      }
+    },
+  };
+}
+
+export const controlUiHandlers = createControlUiHandlers();

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -9,6 +9,7 @@ import "../components/app-topbar.ts";
 import "../components/connection-banner.ts";
 import "../components/exec-approval.ts";
 import "../components/gateway-url-confirmation.ts";
+import "../components/github-link-hovercard.ts";
 import "../components/login-gate.ts";
 import "../components/terminal/terminal-panel.ts";
 import "../components/tooltip.ts";
@@ -306,8 +307,13 @@ export class OpenClawApp extends LitElement {
     }
     return html`
       <openclaw-tooltip-provider>
-        ${gatewayUrlConfirmation}
-        <openclaw-app-shell .runtime=${runtime} .onboarding=${this.onboarding}></openclaw-app-shell>
+        <openclaw-github-link-hovercard-provider .client=${context.gateway.snapshot.client}>
+          ${gatewayUrlConfirmation}
+          <openclaw-app-shell
+            .runtime=${runtime}
+            .onboarding=${this.onboarding}
+          ></openclaw-app-shell>
+        </openclaw-github-link-hovercard-provider>
       </openclaw-tooltip-provider>
     `;
   }

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -1,0 +1,187 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import {
+  parseGitHubIssueOrPullRequestLink,
+  type GitHubLinkHovercardProvider,
+} from "./github-link-hovercard.ts";
+
+function createLink(href: string, label = "GitHub item") {
+  const provider = document.createElement(
+    "openclaw-github-link-hovercard-provider",
+  ) as GitHubLinkHovercardProvider;
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  anchor.textContent = label;
+  provider.append(anchor);
+  document.body.append(provider);
+  return { anchor, provider };
+}
+
+async function hover(anchor: HTMLAnchorElement): Promise<void> {
+  anchor.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+  await vi.advanceTimersByTimeAsync(250);
+}
+
+function leave(anchor: HTMLAnchorElement): void {
+  anchor.dispatchEvent(
+    new MouseEvent("pointerout", {
+      bubbles: true,
+      composed: true,
+      relatedTarget: document.body,
+    }),
+  );
+}
+
+describe("parseGitHubIssueOrPullRequestLink", () => {
+  it("parses issue and pull request links with trailing paths", () => {
+    expect(
+      parseGitHubIssueOrPullRequestLink(
+        "https://github.com/openclaw/openclaw/issues/99815#issuecomment-1",
+      ),
+    ).toMatchObject({ kind: "issue", number: 99815, owner: "openclaw", repo: "openclaw" });
+    expect(
+      parseGitHubIssueOrPullRequestLink("https://github.com/openclaw/openclaw/pull/99816/files"),
+    ).toMatchObject({ kind: "pull", number: 99816, owner: "openclaw", repo: "openclaw" });
+  });
+
+  it("rejects non-item, non-HTTPS, credentialed, and non-GitHub links", () => {
+    expect(parseGitHubIssueOrPullRequestLink("https://github.com/openclaw/openclaw")).toBeNull();
+    expect(
+      parseGitHubIssueOrPullRequestLink("http://github.com/openclaw/openclaw/issues/1"),
+    ).toBeNull();
+    expect(
+      parseGitHubIssueOrPullRequestLink("https://user@github.com/openclaw/openclaw/issues/1"),
+    ).toBeNull();
+    expect(
+      parseGitHubIssueOrPullRequestLink("https://example.com/openclaw/openclaw/issues/1"),
+    ).toBeNull();
+  });
+});
+
+describe("openclaw-github-link-hovercard-provider", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-05T10:00:00Z"));
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("renders and caches pull request details without changing the link", async () => {
+    const request = vi.fn().mockResolvedValue({
+      additions: 101,
+      avatarDataUrl:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=",
+      changedFiles: 3,
+      closedAt: "2026-07-04T09:53:52Z",
+      createdAt: "2026-07-04T05:03:47Z",
+      deletions: 12,
+      draft: false,
+      kind: "pull",
+      login: "steipete",
+      mergedAt: "2026-07-04T09:53:52Z",
+      number: 99816,
+      owner: "OpenClaw",
+      repo: "OpenClaw",
+      state: "closed",
+      title: "fix(agents): derive conversation scope from trusted group facts",
+      updatedAt: "2026-07-05T09:55:00Z",
+    });
+    const href = "https://github.com/openclaw/openclaw/pull/99816";
+    const { anchor, provider } = createLink(href, "#99816");
+    provider.client = { request } as unknown as GatewayBrowserClient;
+
+    await hover(anchor);
+
+    const card = document.querySelector<HTMLElement>(".github-link-hovercard");
+    expect(card?.textContent).toContain("Merged");
+    expect(card?.textContent).toContain("openclaw/openclaw #99816");
+    expect(card?.textContent).toContain(
+      "fix(agents): derive conversation scope from trusted group facts",
+    );
+    expect(card?.textContent).toContain("steipete");
+    expect(card?.textContent).toContain("+101");
+    expect(card?.textContent).toContain("−12");
+    expect(card?.textContent).toContain("3 files");
+    expect(card?.textContent).toContain("5m ago");
+    expect(anchor.href).toBe(href);
+    expect(anchor.getAttribute("aria-describedby")).toBe(card?.id);
+    expect(request).toHaveBeenCalledWith("controlUi.githubPreview", {
+      kind: "pull",
+      number: 99816,
+      owner: "openclaw",
+      repo: "openclaw",
+    });
+
+    leave(anchor);
+    expect(document.querySelector(".github-link-hovercard")).toBeNull();
+    await hover(anchor);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders issue comments and supports focus plus Escape", async () => {
+    const request = vi.fn().mockResolvedValue({
+      closedAt: null,
+      comments: 4,
+      createdAt: "2026-07-05T08:00:00Z",
+      kind: "issue",
+      login: "octocat",
+      number: 99815,
+      owner: "openclaw",
+      repo: "openclaw",
+      state: "open",
+      stateReason: null,
+      title: "Keep hover previews compact",
+      updatedAt: "2026-07-05T09:55:00Z",
+    });
+    const { anchor, provider } = createLink(
+      "https://github.com/openclaw/openclaw/issues/99815",
+      "#99815",
+    );
+    provider.client = { request } as unknown as GatewayBrowserClient;
+
+    anchor.dispatchEvent(new FocusEvent("focusin", { bubbles: true, composed: true }));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(document.querySelector(".github-link-hovercard")?.textContent).toContain("4 comments");
+    expect(document.querySelector(".github-link-hovercard")?.textContent).toContain("Open");
+    anchor.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(document.querySelector(".github-link-hovercard")).toBeNull();
+  });
+
+  it("ignores unsupported GitHub links and shows a quiet unavailable state", async () => {
+    const request = vi.fn().mockRejectedValue(new Error("Not Found"));
+    const unsupportedLink = createLink("https://github.com/openclaw/openclaw", "repository");
+    unsupportedLink.provider.client = { request } as unknown as GatewayBrowserClient;
+
+    await hover(unsupportedLink.anchor);
+    expect(request).not.toHaveBeenCalled();
+    expect(document.querySelector(".github-link-hovercard")).toBeNull();
+
+    const missingLink = createLink("https://github.com/openclaw/openclaw/issues/999999", "missing");
+    missingLink.provider.client = { request } as unknown as GatewayBrowserClient;
+    await hover(missingLink.anchor);
+    expect(document.querySelector(".github-link-hovercard")?.textContent).toContain(
+      "GitHub preview unavailable",
+    );
+  });
+
+  it("preserves an existing description when hover ends before opening", async () => {
+    const request = vi.fn();
+    const { anchor, provider } = createLink("https://github.com/openclaw/openclaw/issues/99815");
+    provider.client = { request } as unknown as GatewayBrowserClient;
+    anchor.setAttribute("aria-describedby", "existing-description");
+
+    anchor.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+    leave(anchor);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(anchor.getAttribute("aria-describedby")).toBe("existing-description");
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/github-link-hovercard.ts
+++ b/ui/src/components/github-link-hovercard.ts
@@ -1,0 +1,535 @@
+import type { ControlUiGitHubPreview } from "../../../src/gateway/control-ui-contract.js";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { formatRelativeTimestamp } from "../lib/format.ts";
+
+const GITHUB_HOST = "github.com";
+const OPEN_DELAY_MS = 250;
+const SUCCESS_CACHE_MS = 5 * 60_000;
+const FAILURE_CACHE_MS = 30_000;
+const CACHE_LIMIT = 100;
+const VIEWPORT_PADDING = 12;
+const CARD_GAP = 10;
+
+type GitHubLinkKind = "issue" | "pull";
+
+type GitHubLinkTarget = {
+  href: string;
+  kind: GitHubLinkKind;
+  number: number;
+  owner: string;
+  repo: string;
+};
+
+type GitHubPreview = GitHubLinkTarget & ControlUiGitHubPreview;
+
+type PreviewState = {
+  label: string;
+  tone: "danger" | "muted" | "open" | "purple";
+};
+
+type CacheEntry = {
+  expiresAt: number;
+  promise: Promise<GitHubPreview>;
+};
+
+let nextHovercardId = 0;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function requiredString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`GitHub response omitted ${key}`);
+  }
+  return value;
+}
+
+function optionalString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function optionalNumber(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function decodePathSegment(value: string): string | null {
+  try {
+    const decoded = decodeURIComponent(value).trim();
+    return decoded && decoded !== "." && decoded !== ".." ? decoded : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseGitHubIssueOrPullRequestLink(href: string): GitHubLinkTarget | null {
+  let url: URL;
+  try {
+    url = new URL(href, globalThis.location?.href ?? "http://localhost/");
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:" || url.hostname.toLowerCase() !== GITHUB_HOST) {
+    return null;
+  }
+  if (url.username || url.password || (url.port && url.port !== "443")) {
+    return null;
+  }
+  const segments = url.pathname.split("/").filter(Boolean);
+  const owner = decodePathSegment(segments[0] ?? "");
+  const repo = decodePathSegment(segments[1] ?? "");
+  const surface = segments[2];
+  const numberText = segments[3] ?? "";
+  if (!owner || !repo || !/^[1-9]\d{0,9}$/.test(numberText)) {
+    return null;
+  }
+  const kind = surface === "issues" ? "issue" : surface === "pull" ? "pull" : null;
+  if (!kind) {
+    return null;
+  }
+  return { href: url.href, kind, number: Number(numberText), owner, repo };
+}
+
+function safeAvatarDataUrl(value: unknown): string | undefined {
+  return typeof value === "string" && /^data:image\/(?:gif|jpeg|png|webp);base64,/u.test(value)
+    ? value
+    : undefined;
+}
+
+function parsePreviewResponse(target: GitHubLinkTarget, value: unknown): GitHubPreview {
+  if (!isRecord(value)) {
+    throw new Error("GitHub response was not an object");
+  }
+  if (
+    value.kind !== target.kind ||
+    typeof value.owner !== "string" ||
+    value.owner.toLowerCase() !== target.owner.toLowerCase() ||
+    typeof value.repo !== "string" ||
+    value.repo.toLowerCase() !== target.repo.toLowerCase() ||
+    value.number !== target.number
+  ) {
+    throw new Error("GitHub response did not match the requested link");
+  }
+  return {
+    ...target,
+    additions: optionalNumber(value, "additions"),
+    avatarDataUrl: safeAvatarDataUrl(value.avatarDataUrl),
+    changedFiles: optionalNumber(value, "changedFiles"),
+    closedAt: optionalString(value, "closedAt"),
+    comments: optionalNumber(value, "comments"),
+    createdAt: requiredString(value, "createdAt"),
+    deletions: optionalNumber(value, "deletions"),
+    draft: typeof value.draft === "boolean" ? value.draft : undefined,
+    kind: target.kind,
+    login: optionalString(value, "login") ?? "ghost",
+    mergedAt: optionalString(value, "mergedAt"),
+    number: target.number,
+    owner: target.owner,
+    repo: target.repo,
+    state: requiredString(value, "state"),
+    stateReason: optionalString(value, "stateReason"),
+    title: requiredString(value, "title"),
+    updatedAt: requiredString(value, "updatedAt"),
+  };
+}
+
+function previewState(preview: GitHubPreview): PreviewState {
+  if (preview.kind === "pull") {
+    if (preview.mergedAt) {
+      return { label: "Merged", tone: "purple" };
+    }
+    if (preview.draft && preview.state === "open") {
+      return { label: "Draft", tone: "muted" };
+    }
+    return preview.state === "open"
+      ? { label: "Open", tone: "open" }
+      : { label: "Closed", tone: "danger" };
+  }
+  if (preview.state === "open") {
+    return { label: "Open", tone: "open" };
+  }
+  return preview.stateReason === "not_planned"
+    ? { label: "Not planned", tone: "muted" }
+    : { label: "Closed", tone: "purple" };
+}
+
+function appendTextElement(
+  parent: HTMLElement,
+  tagName: keyof HTMLElementTagNameMap,
+  className: string,
+  text: string,
+): HTMLElement {
+  const element = document.createElement(tagName);
+  element.className = className;
+  element.textContent = text;
+  parent.append(element);
+  return element;
+}
+
+function appendMetric(parent: HTMLElement, className: string, text: string): void {
+  appendTextElement(parent, "span", `github-link-hovercard__metric ${className}`, text);
+}
+
+function renderLoading(card: HTMLDivElement): void {
+  card.replaceChildren();
+  card.dataset.loading = "true";
+  card.removeAttribute("data-state");
+  appendTextElement(card, "div", "github-link-hovercard__loading", "Loading GitHub details…");
+}
+
+function renderUnavailable(card: HTMLDivElement): void {
+  card.replaceChildren();
+  card.dataset.loading = "false";
+  card.dataset.state = "unavailable";
+  appendTextElement(
+    card,
+    "div",
+    "github-link-hovercard__unavailable",
+    "GitHub preview unavailable",
+  );
+}
+
+function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
+  card.replaceChildren();
+  card.dataset.loading = "false";
+  const state = previewState(preview);
+  card.dataset.state = state.tone;
+
+  const header = document.createElement("div");
+  header.className = "github-link-hovercard__header";
+  const badge = document.createElement("span");
+  badge.className = "github-link-hovercard__state";
+  badge.dataset.tone = state.tone;
+  const stateDot = document.createElement("span");
+  stateDot.className = "github-link-hovercard__state-dot";
+  stateDot.setAttribute("aria-hidden", "true");
+  badge.append(stateDot, document.createTextNode(state.label));
+  header.append(badge);
+  appendTextElement(
+    header,
+    "span",
+    "github-link-hovercard__repo",
+    `${preview.owner}/${preview.repo} #${preview.number}`,
+  );
+  appendTextElement(
+    header,
+    "time",
+    "github-link-hovercard__time",
+    formatRelativeTimestamp(Date.parse(preview.updatedAt)),
+  );
+
+  const title = document.createElement("div");
+  title.className = "github-link-hovercard__title";
+  title.textContent = preview.title;
+
+  const footer = document.createElement("div");
+  footer.className = "github-link-hovercard__footer";
+  const author = document.createElement("span");
+  author.className = "github-link-hovercard__author";
+  if (preview.avatarDataUrl) {
+    const avatar = document.createElement("img");
+    avatar.className = "github-link-hovercard__avatar";
+    avatar.alt = "";
+    avatar.decoding = "async";
+    avatar.referrerPolicy = "no-referrer";
+    avatar.src = preview.avatarDataUrl;
+    author.append(avatar);
+  }
+  author.append(document.createTextNode(preview.login));
+  footer.append(author);
+
+  const metrics = document.createElement("span");
+  metrics.className = "github-link-hovercard__metrics";
+  if (preview.kind === "pull") {
+    appendMetric(metrics, "github-link-hovercard__metric--additions", `+${preview.additions ?? 0}`);
+    appendMetric(metrics, "github-link-hovercard__metric--deletions", `−${preview.deletions ?? 0}`);
+    const files = preview.changedFiles ?? 0;
+    appendMetric(metrics, "", `${files} ${files === 1 ? "file" : "files"}`);
+  } else {
+    const comments = preview.comments ?? 0;
+    appendMetric(metrics, "", `${comments} ${comments === 1 ? "comment" : "comments"}`);
+  }
+  footer.append(metrics);
+  card.append(header, title, footer);
+  card.setAttribute(
+    "aria-label",
+    `${state.label} ${preview.kind === "pull" ? "pull request" : "issue"} ${preview.owner}/${preview.repo} #${preview.number}: ${preview.title}, by ${preview.login}`,
+  );
+}
+
+function anchorFromEvent(event: Event): HTMLAnchorElement | null {
+  for (const candidate of event.composedPath()) {
+    if (candidate instanceof HTMLAnchorElement) {
+      return candidate;
+    }
+    if (candidate === event.currentTarget) {
+      break;
+    }
+  }
+  return null;
+}
+
+export class GitHubLinkHovercardProvider extends HTMLElement {
+  client: GatewayBrowserClient | null = null;
+
+  private readonly cache = new Map<string, CacheEntry>();
+  private activeAnchor: HTMLAnchorElement | null = null;
+  private activeTarget: GitHubLinkTarget | null = null;
+  private card: HTMLDivElement | null = null;
+  private describedBy: string | null = null;
+  private focusInside = false;
+  private openTimer: number | null = null;
+  private pointerInside = false;
+  private requestVersion = 0;
+
+  connectedCallback(): void {
+    this.style.display = "contents";
+    this.addEventListener("pointerover", this.handlePointerOver);
+    this.addEventListener("pointerout", this.handlePointerOut);
+    this.addEventListener("focusin", this.handleFocusIn);
+    this.addEventListener("focusout", this.handleFocusOut);
+    this.addEventListener("keydown", this.handleKeyDown);
+    this.addEventListener("click", this.handleClick);
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener("pointerover", this.handlePointerOver);
+    this.removeEventListener("pointerout", this.handlePointerOut);
+    this.removeEventListener("focusin", this.handleFocusIn);
+    this.removeEventListener("focusout", this.handleFocusOut);
+    this.removeEventListener("keydown", this.handleKeyDown);
+    this.removeEventListener("click", this.handleClick);
+    this.close();
+  }
+
+  private readonly handlePointerOver = (event: Event) => {
+    const pointer = event as PointerEvent;
+    if (pointer.pointerType === "touch") {
+      return;
+    }
+    const anchor = anchorFromEvent(event);
+    const target = anchor ? parseGitHubIssueOrPullRequestLink(anchor.href) : null;
+    if (!anchor || !target) {
+      return;
+    }
+    this.activate(anchor, target, OPEN_DELAY_MS);
+    this.pointerInside = true;
+  };
+
+  private readonly handlePointerOut = (event: PointerEvent) => {
+    const anchor = anchorFromEvent(event);
+    if (!anchor || anchor !== this.activeAnchor) {
+      return;
+    }
+    if (event.relatedTarget instanceof Node && anchor.contains(event.relatedTarget)) {
+      return;
+    }
+    this.pointerInside = false;
+    if (!this.focusInside) {
+      this.close();
+    }
+  };
+
+  private readonly handleFocusIn = (event: Event) => {
+    const anchor = anchorFromEvent(event);
+    const target = anchor ? parseGitHubIssueOrPullRequestLink(anchor.href) : null;
+    if (!anchor || !target) {
+      return;
+    }
+    this.activate(anchor, target, 0);
+    this.focusInside = true;
+  };
+
+  private readonly handleFocusOut = (event: FocusEvent) => {
+    if (!this.activeAnchor) {
+      return;
+    }
+    if (event.relatedTarget instanceof Node && this.activeAnchor.contains(event.relatedTarget)) {
+      return;
+    }
+    this.focusInside = false;
+    if (!this.pointerInside) {
+      this.close();
+    }
+  };
+
+  private readonly handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      this.close();
+    }
+  };
+
+  private readonly handleClick = () => {
+    this.close();
+  };
+
+  private activate(anchor: HTMLAnchorElement, target: GitHubLinkTarget, delay: number): void {
+    if (anchor === this.activeAnchor && this.activeTarget?.href === target.href) {
+      return;
+    }
+    this.close();
+    this.activeAnchor = anchor;
+    this.activeTarget = target;
+    this.describedBy = anchor.getAttribute("aria-describedby");
+    this.openTimer = window.setTimeout(() => {
+      this.openTimer = null;
+      void this.show(anchor, target);
+    }, delay);
+  }
+
+  private async show(anchor: HTMLAnchorElement, target: GitHubLinkTarget): Promise<void> {
+    if (this.activeAnchor !== anchor || this.activeTarget?.href !== target.href) {
+      return;
+    }
+    const version = ++this.requestVersion;
+    const card = document.createElement("div");
+    nextHovercardId += 1;
+    card.id = `openclaw-github-hovercard-${nextHovercardId}`;
+    card.className = "github-link-hovercard";
+    card.dataset.open = "true";
+    card.setAttribute("role", "tooltip");
+    card.setAttribute("aria-live", "polite");
+    renderLoading(card);
+    document.body.append(card);
+    this.card = card;
+    anchor.setAttribute(
+      "aria-describedby",
+      this.describedBy ? `${this.describedBy} ${card.id}` : card.id,
+    );
+    this.listenForViewportChanges();
+    this.positionCard();
+
+    try {
+      const preview = await this.loadPreview(target);
+      if (version !== this.requestVersion || card !== this.card) {
+        return;
+      }
+      renderPreview(card, preview);
+    } catch {
+      if (version !== this.requestVersion || card !== this.card) {
+        return;
+      }
+      renderUnavailable(card);
+    }
+    this.positionCard();
+  }
+
+  private loadPreview(target: GitHubLinkTarget): Promise<GitHubPreview> {
+    const key = `${target.kind}:${target.owner.toLowerCase()}/${target.repo.toLowerCase()}#${target.number}`;
+    const now = Date.now();
+    const cached = this.cache.get(key);
+    if (cached && cached.expiresAt > now) {
+      this.cache.delete(key);
+      this.cache.set(key, cached);
+      return cached.promise;
+    }
+    if (cached) {
+      this.cache.delete(key);
+    }
+
+    const load = async (): Promise<GitHubPreview> => {
+      if (!this.client) {
+        throw new Error("GitHub preview requires a connected Gateway");
+      }
+      const response = await this.client.request<ControlUiGitHubPreview>(
+        "controlUi.githubPreview",
+        {
+          kind: target.kind,
+          number: target.number,
+          owner: target.owner,
+          repo: target.repo,
+        },
+      );
+      return parsePreviewResponse(target, response);
+    };
+
+    const entry: CacheEntry = {
+      expiresAt: now + SUCCESS_CACHE_MS,
+      promise: load().catch((error: unknown) => {
+        // Keep short-lived failures cached so repeatedly crossing a broken or
+        // private link does not burn GitHub's anonymous rate limit.
+        entry.expiresAt = Date.now() + FAILURE_CACHE_MS;
+        throw error;
+      }),
+    };
+    this.cache.set(key, entry);
+    while (this.cache.size > CACHE_LIMIT) {
+      const oldestKey = this.cache.keys().next().value as string | undefined;
+      if (!oldestKey) {
+        break;
+      }
+      this.cache.delete(oldestKey);
+    }
+    return entry.promise;
+  }
+
+  private close(): void {
+    if (this.openTimer !== null) {
+      window.clearTimeout(this.openTimer);
+      this.openTimer = null;
+    }
+    this.requestVersion += 1;
+    if (this.activeAnchor) {
+      if (this.describedBy === null) {
+        this.activeAnchor.removeAttribute("aria-describedby");
+      } else {
+        this.activeAnchor.setAttribute("aria-describedby", this.describedBy);
+      }
+    }
+    this.card?.remove();
+    this.card = null;
+    this.activeAnchor = null;
+    this.activeTarget = null;
+    this.describedBy = null;
+    this.focusInside = false;
+    this.pointerInside = false;
+    this.stopListeningForViewportChanges();
+  }
+
+  private readonly handleViewportChange = () => {
+    this.positionCard();
+  };
+
+  private listenForViewportChanges(): void {
+    window.addEventListener("resize", this.handleViewportChange);
+    window.addEventListener("scroll", this.handleViewportChange, true);
+    window.visualViewport?.addEventListener("resize", this.handleViewportChange);
+    window.visualViewport?.addEventListener("scroll", this.handleViewportChange);
+  }
+
+  private stopListeningForViewportChanges(): void {
+    window.removeEventListener("resize", this.handleViewportChange);
+    window.removeEventListener("scroll", this.handleViewportChange, true);
+    window.visualViewport?.removeEventListener("resize", this.handleViewportChange);
+    window.visualViewport?.removeEventListener("scroll", this.handleViewportChange);
+  }
+
+  private positionCard(): void {
+    const anchor = this.activeAnchor;
+    const card = this.card;
+    if (!anchor || !card) {
+      return;
+    }
+    const anchorRect = anchor.getBoundingClientRect();
+    const cardRect = card.getBoundingClientRect();
+    const fitsBelow =
+      anchorRect.bottom + CARD_GAP + cardRect.height + VIEWPORT_PADDING <= innerHeight;
+    const side = fitsBelow ? "bottom" : "top";
+    const top =
+      side === "bottom"
+        ? anchorRect.bottom + CARD_GAP
+        : anchorRect.top - cardRect.height - CARD_GAP;
+    const maxLeft = Math.max(VIEWPORT_PADDING, innerWidth - cardRect.width - VIEWPORT_PADDING);
+    const maxTop = Math.max(VIEWPORT_PADDING, innerHeight - cardRect.height - VIEWPORT_PADDING);
+    card.dataset.side = side;
+    card.style.left = `${Math.min(Math.max(VIEWPORT_PADDING, anchorRect.left), maxLeft)}px`;
+    card.style.top = `${Math.min(Math.max(VIEWPORT_PADDING, top), maxTop)}px`;
+  }
+}
+
+if (!customElements.get("openclaw-github-link-hovercard-provider")) {
+  customElements.define("openclaw-github-link-hovercard-provider", GitHubLinkHovercardProvider);
+}

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -1,0 +1,201 @@
+// Control UI tests cover GitHub link hover card behavior.
+import { chromium, type Browser, type BrowserContext, type Locator } from "playwright";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let server: ControlUiE2eServer;
+const openBrowsers = new Set<Browser>();
+
+async function newBrowserContext(): Promise<BrowserContext> {
+  const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  openBrowsers.add(browser);
+  return browser.newContext({
+    colorScheme: "light",
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport: { height: 800, width: 1180 },
+  });
+}
+
+async function closeBrowsers(): Promise<void> {
+  await Promise.all([...openBrowsers].map((browser) => browser.close().catch(() => {})));
+  openBrowsers.clear();
+}
+
+async function expectText(locator: Locator, text: string): Promise<void> {
+  await expect.poll(() => locator.textContent()).toContain(text);
+}
+
+describeControlUiE2e("GitHub link hover cards", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+  });
+
+  afterAll(async () => {
+    await closeBrowsers();
+    await server?.close();
+  });
+
+  afterEach(closeBrowsers);
+
+  it("previews issue and pull request links while preserving navigation", async () => {
+    const context = await newBrowserContext();
+    await context.route("https://github.com/**", (route) =>
+      route.fulfill({
+        contentType: "text/html",
+        body: "<!doctype html><title>GitHub item</title>",
+      }),
+    );
+
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "controlUi.githubPreview": {
+          cases: [
+            {
+              match: { kind: "pull", number: 99816 },
+              response: {
+                additions: 101,
+                avatarDataUrl:
+                  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=",
+                changedFiles: 3,
+                closedAt: "2026-07-04T09:53:52Z",
+                createdAt: "2026-07-04T05:03:47Z",
+                deletions: 12,
+                draft: false,
+                kind: "pull",
+                login: "steipete",
+                mergedAt: "2026-07-04T09:53:52Z",
+                number: 99816,
+                owner: "openclaw",
+                repo: "openclaw",
+                state: "closed",
+                title: "fix(agents): derive conversation scope from trusted group facts",
+                updatedAt: "2026-07-04T09:53:55Z",
+              },
+            },
+            {
+              match: { kind: "issue", number: 99815 },
+              response: {
+                avatarDataUrl:
+                  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=",
+                comments: 4,
+                createdAt: "2026-07-05T08:00:00Z",
+                kind: "issue",
+                login: "octocat",
+                number: 99815,
+                owner: "openclaw",
+                repo: "openclaw",
+                state: "open",
+                title: "Keep hover previews compact",
+                updatedAt: new Date().toISOString(),
+              },
+            },
+            {
+              match: { kind: "issue", number: 999999 },
+              response: {},
+            },
+          ],
+        },
+      },
+      historyMessages: [
+        {
+          content: [
+            {
+              type: "text",
+              text: [
+                "Review [#99816](https://github.com/openclaw/openclaw/pull/99816),",
+                "then [#99815](https://github.com/openclaw/openclaw/issues/99815).",
+                "A [missing item](https://github.com/openclaw/openclaw/issues/999999) stays usable.",
+                "The [repository](https://github.com/openclaw/openclaw) has no item preview.",
+              ].join(" "),
+            },
+          ],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
+    await page.goto(`${server.baseUrl}chat`);
+
+    const pullLink = page.getByRole("link", { name: "#99816" });
+    await pullLink.hover();
+    const card = page.locator(".github-link-hovercard");
+    await expectText(card, "Merged");
+    await expectText(card, "openclaw/openclaw #99816");
+    await expectText(card, "+101");
+    await expectText(card, "−12");
+    await expectText(card, "3 files");
+    await expect.poll(() => card.locator("img").count()).toBe(1);
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(1);
+    const pullBox = await card.boundingBox();
+    expect(pullBox).not.toBeNull();
+    expect(pullBox!.x).toBeGreaterThanOrEqual(0);
+    expect(pullBox!.y).toBeGreaterThanOrEqual(0);
+    expect(pullBox!.x + pullBox!.width).toBeLessThanOrEqual(1180);
+    expect(pullBox!.y + pullBox!.height).toBeLessThanOrEqual(800);
+
+    const issueLink = page.getByRole("link", { name: "#99815" });
+    await issueLink.hover();
+    await expectText(card, "Keep hover previews compact");
+    await expectText(card, "octocat");
+    await expectText(card, "4 comments");
+    await expect.poll(() => card.locator("img").count()).toBe(1);
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(2);
+
+    await page.mouse.move(1, 1);
+    await expect.poll(() => card.count()).toBe(0);
+    await issueLink.hover();
+    await expectText(card, "4 comments");
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(2);
+
+    await page.mouse.move(1, 1);
+    await page.getByRole("link", { name: "repository" }).hover();
+    await page.waitForTimeout(300);
+    await expect.poll(() => card.count()).toBe(0);
+
+    const missingLink = page.getByRole("link", { name: "missing item" });
+    await missingLink.hover();
+    await expectText(card, "GitHub preview unavailable");
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(3);
+    expect(await missingLink.getAttribute("href")).toBe(
+      "https://github.com/openclaw/openclaw/issues/999999",
+    );
+    await page.mouse.move(1, 1);
+
+    await page.emulateMedia({ colorScheme: "dark" });
+    await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("dark");
+    await pullLink.hover();
+    await expectText(card, "Merged");
+    expect((await gateway.getRequests("controlUi.githubPreview")).length).toBe(3);
+    await page.mouse.move(1, 1);
+
+    await pullLink.focus();
+    await expectText(card, "Merged");
+    await page.keyboard.press("Escape");
+    await expect.poll(() => card.count()).toBe(0);
+    await expect
+      .poll(() => pullLink.evaluate((element) => element === document.activeElement))
+      .toBe(true);
+
+    const popupPromise = page.waitForEvent("popup");
+    await pullLink.click();
+    const popup = await popupPromise;
+    await popup.waitForLoadState("domcontentloaded");
+    expect(popup.url()).toBe("https://github.com/openclaw/openclaw/pull/99816");
+  });
+});

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -618,6 +618,41 @@
       "text": "No files match."
     },
     {
+      "count": 2,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/components/github-link-hovercard.ts",
+      "text": "Closed"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/components/github-link-hovercard.ts",
+      "text": "Draft"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/components/github-link-hovercard.ts",
+      "text": "Merged"
+    },
+    {
+      "count": 1,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/components/github-link-hovercard.ts",
+      "text": "Not planned"
+    },
+    {
+      "count": 2,
+      "kind": "object-property",
+      "name": "label",
+      "path": "ui/src/components/github-link-hovercard.ts",
+      "text": "Open"
+    },
+    {
       "count": 1,
       "kind": "html-attribute",
       "name": "placeholder",

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -950,6 +950,226 @@
   transform: translateX(0);
 }
 
+.github-link-hovercard {
+  position: fixed;
+  z-index: 1990;
+  width: min(440px, calc(100vw - 24px));
+  min-height: 112px;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 88%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--card) 96%, var(--bg) 4%);
+  box-shadow:
+    0 22px 54px rgba(0, 0, 0, 0.34),
+    0 0 0 1px rgba(255, 255, 255, 0.035);
+  color: var(--text);
+  font-family: var(--font-body);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-5px) scale(0.99);
+  transform-origin: bottom left;
+  transition:
+    opacity var(--duration-normal) var(--ease-out),
+    transform var(--duration-normal) var(--ease-out);
+}
+
+.github-link-hovercard[data-side="bottom"] {
+  transform: translateY(5px) scale(0.99);
+  transform-origin: top left;
+}
+
+.github-link-hovercard[data-open="true"] {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+}
+
+.github-link-hovercard__header,
+.github-link-hovercard__footer {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.github-link-hovercard__header {
+  gap: 9px;
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+}
+
+.github-link-hovercard__state {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 9px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  font-weight: 600;
+}
+
+.github-link-hovercard__state[data-tone="open"] {
+  color: var(--ok);
+}
+
+.github-link-hovercard__state[data-tone="danger"] {
+  color: var(--danger);
+}
+
+.github-link-hovercard__state[data-tone="purple"] {
+  color: #a78bfa;
+}
+
+:root[data-theme-mode="light"] .github-link-hovercard__state[data-tone="purple"] {
+  color: #7c3aed;
+}
+
+.github-link-hovercard__state-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 0 3px color-mix(in srgb, currentColor 14%, transparent);
+}
+
+.github-link-hovercard__repo {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.github-link-hovercard__time {
+  flex: 0 0 auto;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.github-link-hovercard__title {
+  margin: 15px 0 17px;
+  color: var(--text-strong);
+  font-size: var(--control-ui-text-lg);
+  font-weight: 650;
+  letter-spacing: -0.012em;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.github-link-hovercard__footer {
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.github-link-hovercard__author,
+.github-link-hovercard__metrics {
+  display: inline-flex;
+  align-items: center;
+}
+
+.github-link-hovercard__author {
+  min-width: 0;
+  gap: 8px;
+  color: var(--muted);
+  font-size: var(--control-ui-text-md);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.github-link-hovercard__avatar {
+  width: 25px;
+  height: 25px;
+  flex: 0 0 auto;
+  border: 1px solid color-mix(in srgb, var(--border-strong) 82%, transparent);
+  border-radius: 50%;
+  background: var(--bg-muted);
+  object-fit: cover;
+}
+
+.github-link-hovercard__metrics {
+  flex: 0 0 auto;
+  gap: 6px;
+}
+
+.github-link-hovercard__metric {
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-muted) 82%, transparent);
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: var(--control-ui-text-sm);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.github-link-hovercard__metric--additions {
+  color: var(--ok);
+}
+
+.github-link-hovercard__metric--deletions {
+  color: var(--danger);
+}
+
+.github-link-hovercard__loading,
+.github-link-hovercard__unavailable {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 80px;
+  color: var(--muted);
+  font-size: var(--control-ui-text-sm);
+}
+
+.github-link-hovercard__loading::before {
+  width: 18px;
+  height: 18px;
+  margin-right: 9px;
+  border: 2px solid color-mix(in srgb, var(--muted) 25%, transparent);
+  border-top-color: var(--muted);
+  border-radius: 50%;
+  content: "";
+  animation: github-hovercard-spin 0.8s linear infinite;
+}
+
+@keyframes github-hovercard-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 520px) {
+  .github-link-hovercard {
+    padding: 14px;
+  }
+
+  .github-link-hovercard__header {
+    flex-wrap: wrap;
+  }
+
+  .github-link-hovercard__time {
+    margin-left: 0;
+  }
+
+  .github-link-hovercard__title {
+    margin: 13px 0 15px;
+  }
+
+  .github-link-hovercard__footer {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .github-link-hovercard {
+    transition: none;
+  }
+
+  .github-link-hovercard__loading::before {
+    animation: none;
+  }
+}
+
 .btn--ghost {
   border-color: transparent;
   background: transparent;


### PR DESCRIPTION
Closes #100412

## What Problem This Solves

Control UI users reviewing GitHub-heavy conversations must currently leave the chat and open every issue or pull request to learn its state, title, author, activity, and size.

## Why This Change Was Made

This adds compact hover and keyboard-focus cards for public GitHub issue and pull request links. The connected Gateway owns bounded GitHub metadata/avatar fetching and caching, so the behavior works with remote Gateways, preserves normal link navigation, and never exposes private repository metadata through ambient host credentials.

## User Impact

Users can inspect issue and pull request context without leaving the conversation. Cards show state, repository and number, title, author, recent activity, issue comments, and pull request additions, deletions, and changed files; mouse, keyboard, Escape dismissal, loading, unavailable, viewport, and theme behavior are covered.

## Evidence

- Blacksmith Testbox: `tbx_01kwss4nbev3bnqngyqt49t9e1` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/28750877286))
- Focused Gateway/UI tests: `corepack pnpm test src/gateway/control-ui-github-preview.test.ts src/gateway/server-methods/control-ui.test.ts src/gateway/server-methods-list.test.ts ui/src/components/github-link-hovercard.test.ts` — 76 tests passed across selected projects/shards.
- Browser E2E: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/github-link-hovercard.e2e.test.ts` — passed.
- Changed-surface gate: `corepack pnpm check:changed` — passed.
- Production build: `corepack pnpm build` — passed, including the Control UI bundle.
- Source-blind behavior validation: satisfies contract, confidence 0.96, no blockers.
- Fresh structured autoreview: no accepted/actionable findings.
- Visual proof is attached in the artifact comment immediately below.

AI-assisted with Codex. I understand and reviewed the implementation. Agent transcript omitted; no transcript attachment was requested.
