### PR TITLE
fix(test): bound local full-suite RAM

### DIFF
--- a/scripts/lib/vitest-local-scheduling.d.mts
+++ b/scripts/lib/vitest-local-scheduling.d.mts
@@ -2,6 +2,7 @@ export type VitestHostInfo = {
   cpuCount?: number;
   loadAverage1m?: number;
   totalMemoryBytes?: number;
+  freeMemoryBytes?: number;
 };
 
 export type LocalVitestScheduling = {
@@ -25,10 +26,6 @@ export function resolveLocalVitestScheduling(
   system?: VitestHostInfo,
   pool?: "forks" | "threads",
 ): LocalVitestScheduling;
-export function shouldUseLargeLocalFullSuiteProfile(
-  env?: Record<string, string | undefined>,
-  system?: VitestHostInfo,
-): boolean;
 export function resolveLocalFullSuiteProfile(
   env?: Record<string, string | undefined>,
   system?: VitestHostInfo,

--- a/scripts/lib/vitest-local-scheduling.mjs
+++ b/scripts/lib/vitest-local-scheduling.mjs
@@ -3,10 +3,7 @@
 
 import os from "node:os";
 
-const DEFAULT_LOCAL_FULL_SUITE_PARALLELISM = 4;
-const LARGE_LOCAL_FULL_SUITE_PARALLELISM = 10;
-const DEFAULT_LOCAL_FULL_SUITE_VITEST_WORKERS = 1;
-const LARGE_LOCAL_FULL_SUITE_VITEST_WORKERS = 2;
+const MAX_LOCAL_FULL_SUITE_PARALLELISM = 10;
 
 const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 
@@ -189,42 +186,12 @@ export function resolveLocalVitestScheduling(
   };
 }
 
-export function shouldUseLargeLocalFullSuiteProfile(
-  env = process.env,
-  system = detectVitestHostInfo(),
-) {
-  if (isCiLikeEnv(env)) {
-    return false;
-  }
-  const scheduling = resolveLocalVitestScheduling(env, system, "threads");
-  return scheduling.maxWorkers >= 5 && !scheduling.throttledBySystem;
-}
-
 export function resolveLocalFullSuiteProfile(env = process.env, system = detectVitestHostInfo()) {
-  if (!isSystemThrottleDisabled(env)) {
-    const memoryPressureLimit = resolveMemoryPressureWorkerLimit(system);
-    if (memoryPressureLimit === 1) {
-      return {
-        shardParallelism: 1,
-        vitestMaxWorkers: 1,
-      };
-    }
-    if (memoryPressureLimit === 2) {
-      return {
-        shardParallelism: 2,
-        vitestMaxWorkers: 1,
-      };
-    }
-  }
-
-  if (shouldUseLargeLocalFullSuiteProfile(env, system)) {
-    return {
-      shardParallelism: LARGE_LOCAL_FULL_SUITE_PARALLELISM,
-      vitestMaxWorkers: LARGE_LOCAL_FULL_SUITE_VITEST_WORKERS,
-    };
-  }
+  const scheduling = resolveLocalVitestScheduling(env, system, "threads");
   return {
-    shardParallelism: DEFAULT_LOCAL_FULL_SUITE_PARALLELISM,
-    vitestMaxWorkers: DEFAULT_LOCAL_FULL_SUITE_VITEST_WORKERS,
+    // Each shard is a separate Vitest process with its own module graph. Spend the
+    // host worker budget once across shards instead of multiplying it inside them.
+    shardParallelism: Math.min(scheduling.maxWorkers, MAX_LOCAL_FULL_SUITE_PARALLELISM),
+    vitestMaxWorkers: 1,
   };
 }

--- a/scripts/test-projects.mjs
+++ b/scripts/test-projects.mjs
@@ -313,7 +313,6 @@ async function main() {
       );
     }
     if (concurrency > 1) {
-      const localFullSuiteProfile = resolveLocalFullSuiteProfile(baseEnv);
       const shardTimings = readShardTimings(process.cwd(), baseEnv);
       const parallelSpecs = applyDefaultParallelVitestWorkerBudget(
         applyParallelVitestCachePaths(orderFullSuiteSpecsForParallelRun(runSpecs, shardTimings), {
@@ -322,16 +321,6 @@ async function main() {
         }),
         baseEnv,
       );
-      if (
-        !isCiLikeEnv(baseEnv) &&
-        !baseEnv.OPENCLAW_TEST_PROJECTS_PARALLEL &&
-        !baseEnv.OPENCLAW_VITEST_MAX_WORKERS &&
-        !baseEnv.OPENCLAW_TEST_WORKERS &&
-        localFullSuiteProfile.shardParallelism === 10 &&
-        localFullSuiteProfile.vitestMaxWorkers === 2
-      ) {
-        console.error("[test] using host-aware local full-suite profile: shards=10 workers=2");
-      }
       console.error(
         `[test] running ${parallelSpecs.length} Vitest shards with parallelism ${concurrency}`,
       );

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -104,6 +104,7 @@ const {
       cpuCount?: number;
       loadAverage1m?: number;
       totalMemoryBytes?: number;
+      freeMemoryBytes?: number;
     },
   ) => number;
 };
@@ -583,7 +584,7 @@ describe("test-projects args", () => {
     ).toBe(3);
   });
 
-  it("uses a bounded local default for full-suite project parallelism", () => {
+  it("uses the global host worker budget for full-suite project parallelism", () => {
     expect(
       resolveParallelFullSuiteConcurrency(
         58,
@@ -596,7 +597,7 @@ describe("test-projects args", () => {
           totalMemoryBytes: 16 * 1024 ** 3,
         },
       ),
-    ).toBe(4);
+    ).toBe(2);
   });
 
   it("gives parallel Vitest shards separate filesystem module caches", () => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -3820,7 +3820,7 @@ describe("scripts/test-projects full-suite sharding", () => {
     ]);
   });
 
-  it("uses the large host-aware local profile on roomy local hosts", () => {
+  it("uses the global host worker budget for roomy local hosts", () => {
     expect(
       resolveParallelFullSuiteConcurrency(
         61,
@@ -3831,7 +3831,7 @@ describe("scripts/test-projects full-suite sharding", () => {
           totalMemoryBytes: 48 * 1024 ** 3,
         },
       ),
-    ).toBe(10);
+    ).toBe(6);
   });
 
   it("keeps CI full-suite runs serial even on roomy hosts", () => {

--- a/test/scripts/vitest-local-scheduling.test.ts
+++ b/test/scripts/vitest-local-scheduling.test.ts
@@ -4,7 +4,6 @@ import {
   resolveLocalVitestEnv,
   resolveLocalFullSuiteProfile,
   resolveLocalVitestScheduling,
-  shouldUseLargeLocalFullSuiteProfile,
 } from "../../scripts/lib/vitest-local-scheduling.mjs";
 
 describe("vitest local full-suite profile", () => {
@@ -33,7 +32,7 @@ describe("vitest local full-suite profile", () => {
     });
   });
 
-  it("selects the large local profile on roomy hosts that are not throttled", () => {
+  it("spends the host worker budget once across full-suite shards", () => {
     const env = {};
     const hostInfo = {
       cpuCount: 14,
@@ -46,14 +45,13 @@ describe("vitest local full-suite profile", () => {
       fileParallelism: true,
       throttledBySystem: false,
     });
-    expect(shouldUseLargeLocalFullSuiteProfile(env, hostInfo)).toBe(true);
     expect(resolveLocalFullSuiteProfile(env, hostInfo)).toEqual({
-      shardParallelism: 10,
-      vitestMaxWorkers: 2,
+      shardParallelism: 6,
+      vitestMaxWorkers: 1,
     });
   });
 
-  it("keeps the smaller local profile when the host is already throttled", () => {
+  it("reduces full-suite shard concurrency when the host is already throttled", () => {
     const hostInfo = {
       cpuCount: 14,
       loadAverage1m: 14,
@@ -61,23 +59,21 @@ describe("vitest local full-suite profile", () => {
       freeMemoryBytes: 32 * 1024 ** 3,
     };
 
-    expect(shouldUseLargeLocalFullSuiteProfile({}, hostInfo)).toBe(false);
     expect(resolveLocalFullSuiteProfile({}, hostInfo)).toEqual({
-      shardParallelism: 4,
+      shardParallelism: 1,
       vitestMaxWorkers: 1,
     });
   });
 
-  it("never selects the large local profile in CI", () => {
+  it("caps full-suite process fanout on the largest hosts", () => {
     const hostInfo = {
-      cpuCount: 14,
+      cpuCount: 64,
       loadAverage1m: 0,
-      totalMemoryBytes: 48 * 1024 ** 3,
+      totalMemoryBytes: 512 * 1024 ** 3,
     };
 
-    expect(shouldUseLargeLocalFullSuiteProfile({ CI: "true" }, hostInfo)).toBe(false);
-    expect(resolveLocalFullSuiteProfile({ CI: "true" }, hostInfo)).toEqual({
-      shardParallelism: 4,
+    expect(resolveLocalFullSuiteProfile({}, hostInfo)).toEqual({
+      shardParallelism: 10,
       vitestMaxWorkers: 1,
     });
   });


### PR DESCRIPTION
Closes #100429

## What Problem This Solves

Fixes an issue where developers running the full local test suite on roomy machines could experience excessive RAM pressure or OOM failures because the automatic profile multiplied its host-aware worker budget across nested Vitest processes.

## Why This Change Was Made

The full-suite scheduler now spends the inferred host worker budget once across shard processes and keeps each shard to one Vitest worker. This removes the separate large/small nested profiles while preserving the ten-process ceiling, explicit operator overrides, memory/load throttling, and serial CI behavior.

## User Impact

Default local full-suite runs use substantially less peak aggregate RAM and interfere less with other workstation workloads. Targeted tests, explicit concurrency overrides, and CI execution retain their existing contracts.

## Evidence

- Focused scheduling regression tests: `node scripts/run-vitest.mjs test/scripts/vitest-local-scheduling.test.ts test/scripts/test-projects.test.ts`
- Fresh Blacksmith Testbox isolated inventory: [Actions run](https://github.com/openclaw/openclaw/actions/runs/28750522378), `tbx_01kwsr7r7b5kpech5rd6vtp2ak`; individual two-worker leaves reached 2.69 GB RSS.
- Paired 250-shard full-suite aggregate RSS on [Actions run](https://github.com/openclaw/openclaw/actions/runs/28750897071), `tbx_01kwss62hrm0qvyzrkvdde29aj`: 22,907.4 MiB at 10 shards × 2 workers versus 13,722.1 MiB at 6 × 1, a 40.1% reduction. The final run passed and improved from 9m05s to 7m25s.
- Exact-head changed gate on the same Testbox: passed typecheck, core-test lint, script lint, dependency/patch guards, and boundary checks in 1m55s.
- Fresh Codex autoreview against `origin/main`: clean, no accepted or actionable findings (0.95 confidence).
