### PR TITLE
fix: report effective sandbox workspace in explain

### DIFF
--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -4,7 +4,6 @@
  * Prepares workspace layout, backend handle, filesystem bridge, browser bridge, and registry state for one run.
  */
 import fs from "node:fs/promises";
-import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   ensureBrowserControlAuth,
@@ -16,18 +15,14 @@ import {
 } from "../../plugin-sdk/browser-profiles.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { SkillEligibilityContext } from "../../skills/types.js";
-import { resolveUserPath } from "../../utils.js";
-import { DEFAULT_AGENT_WORKSPACE_DIR } from "../workspace.js";
 import { getSandboxBackendWorkdirResolver, requireSandboxBackendFactory } from "./backend.js";
 import { ensureSandboxBrowser } from "./browser.js";
 import { resolveSandboxConfigForAgent } from "./config.js";
-import { SANDBOX_STATE_DIR } from "./constants.js";
 import { createSandboxFsBridge } from "./fs-bridge.js";
 import { updateRegistry } from "./registry.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
-import { resolveSandboxScopeKey, resolveSandboxWorkspaceDir } from "./shared.js";
+import { resolveSandboxWorkspaceLayoutPaths } from "./shared.js";
 import type { SandboxContext, SandboxDockerConfig, SandboxWorkspaceInfo } from "./types.js";
-import { resolveMaterializedSandboxSkillsWorkspaceDir } from "./workspace-mounts.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
 
 async function syncSandboxSkillsToWorkspace(params: {
@@ -83,23 +78,12 @@ async function ensureSandboxWorkspaceLayout(params: {
   workspaceDir: string;
 }> {
   const { cfg, rawSessionKey } = params;
-
-  const agentWorkspaceDir = resolveUserPath(
-    params.workspaceDir?.trim() || DEFAULT_AGENT_WORKSPACE_DIR,
-  );
-  const workspaceRoot = resolveUserPath(cfg.workspaceRoot);
-  const scopeKey = resolveSandboxScopeKey(cfg.scope, rawSessionKey);
-  const sandboxWorkspaceDir =
-    cfg.scope === "shared" ? workspaceRoot : resolveSandboxWorkspaceDir(workspaceRoot, scopeKey);
-  const workspaceDir = cfg.workspaceAccess === "rw" ? agentWorkspaceDir : sandboxWorkspaceDir;
-  const materializedSkillsRoot = resolveSandboxWorkspaceDir(
-    path.join(SANDBOX_STATE_DIR, "skills-workspaces"),
-    scopeKey,
-  );
-  const skillsWorkspaceDir =
-    cfg.workspaceAccess === "rw"
-      ? resolveMaterializedSandboxSkillsWorkspaceDir(materializedSkillsRoot)
-      : sandboxWorkspaceDir;
+  const { agentWorkspaceDir, sandboxWorkspaceDir, scopeKey, skillsWorkspaceDir, workspaceDir } =
+    resolveSandboxWorkspaceLayoutPaths({
+      cfg,
+      rawSessionKey,
+      workspaceDir: params.workspaceDir,
+    });
 
   let skillsEligibility: SkillEligibilityContext | undefined;
   if (cfg.workspaceAccess !== "rw") {

--- a/src/agents/sandbox/shared.ts
+++ b/src/agents/sandbox/shared.ts
@@ -8,7 +8,11 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { resolveUserPath } from "../../utils.js";
 import { resolveAgentIdFromSessionKey } from "../agent-scope.js";
+import { DEFAULT_AGENT_WORKSPACE_DIR } from "../workspace.js";
+import { SANDBOX_STATE_DIR } from "./constants.js";
 import { hashTextSha256 } from "./hash.js";
+import type { SandboxConfig } from "./types.js";
+import { resolveMaterializedSandboxSkillsWorkspaceDir } from "./workspace-mounts.js";
 
 /** Converts an arbitrary session key into a bounded filesystem/container-safe slug. */
 export function slugifySessionKey(value: string) {
@@ -52,4 +56,39 @@ export function resolveSandboxAgentId(scopeKey: string): string | undefined {
     return normalizeAgentId(parts[1]);
   }
   return resolveAgentIdFromSessionKey(trimmed);
+}
+
+export function resolveSandboxWorkspaceLayoutPaths(params: {
+  cfg: Pick<SandboxConfig, "scope" | "workspaceAccess" | "workspaceRoot">;
+  rawSessionKey: string;
+  workspaceDir?: string;
+}) {
+  const agentWorkspaceDir = resolveUserPath(
+    params.workspaceDir?.trim() || DEFAULT_AGENT_WORKSPACE_DIR,
+  );
+  const workspaceRoot = resolveUserPath(params.cfg.workspaceRoot);
+  const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.rawSessionKey);
+  const sandboxWorkspaceDir =
+    params.cfg.scope === "shared"
+      ? workspaceRoot
+      : resolveSandboxWorkspaceDir(workspaceRoot, scopeKey);
+  const workspaceDir =
+    params.cfg.workspaceAccess === "rw" ? agentWorkspaceDir : sandboxWorkspaceDir;
+  const materializedSkillsRoot = resolveSandboxWorkspaceDir(
+    path.join(SANDBOX_STATE_DIR, "skills-workspaces"),
+    scopeKey,
+  );
+  const skillsWorkspaceDir =
+    params.cfg.workspaceAccess === "rw"
+      ? resolveMaterializedSandboxSkillsWorkspaceDir(materializedSkillsRoot)
+      : sandboxWorkspaceDir;
+
+  return {
+    agentWorkspaceDir,
+    scopeKey,
+    sandboxWorkspaceDir,
+    skillsWorkspaceDir,
+    workspaceDir,
+    workspaceSource: params.cfg.workspaceAccess === "rw" ? "agent" : "sandbox",
+  } as const;
 }

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -1,4 +1,5 @@
 // Sandbox explain tests cover command output for sandbox browser and container diagnostics.
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { sandboxExplainCommand } from "./sandbox-explain.js";
 
@@ -98,5 +99,51 @@ describe("sandbox explain command", () => {
       source: "agent",
       key: "agents.list[].tools.sandbox.tools.alsoAllow",
     });
+  });
+
+  it("reports the rw agent workspace as the effective workspace mount", async () => {
+    mockCfg = {
+      agents: {
+        defaults: {
+          sandbox: {
+            mode: "all",
+            scope: "agent",
+            workspaceAccess: "rw",
+            workspaceRoot: "/tmp/openclaw-sandboxes",
+          },
+        },
+        list: [
+          {
+            id: "builder",
+            workspace: "/tmp/openclaw-agent-workspace",
+          },
+        ],
+      },
+      session: { store: "/tmp/openclaw-test-sessions-{agentId}.json" },
+    };
+
+    const logs: string[] = [];
+    await sandboxExplainCommand({ json: true, agent: "builder" }, {
+      log: (msg: string) => logs.push(msg),
+      error: (msg: string) => logs.push(msg),
+      exit: (_code: number) => {},
+    } as unknown as Parameters<typeof sandboxExplainCommand>[1]);
+
+    const parsed = JSON.parse(logs.join(""));
+    const agentWorkspace = path.resolve("/tmp/openclaw-agent-workspace");
+    expect(parsed.sandbox.workspaceAccess).toBe("rw");
+    expect(parsed.sandbox.workspaceRoot).toBe(agentWorkspace);
+    expect(parsed.sandbox.configuredWorkspaceRoot).toBe("/tmp/openclaw-sandboxes");
+    expect(parsed.sandbox.agentWorkspaceRoot).toBe(agentWorkspace);
+    expect(parsed.sandbox.workspaceSource).toBe("agent");
+    expect(parsed.sandbox.containerWorkdir).toBe("/workspace");
+    expect(parsed.sandbox.workspaceMounts).toEqual([
+      {
+        hostRoot: agentWorkspace,
+        containerRoot: "/workspace",
+        writable: true,
+        source: "workspace",
+      },
+    ]);
   });
 });

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -12,6 +12,9 @@ import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { resolveAgentConfig } from "../agents/agent-scope.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
+import { getSandboxBackendWorkdirResolver } from "../agents/sandbox/backend.js";
+import { buildSandboxFsMounts } from "../agents/sandbox/fs-paths.js";
+import { resolveSandboxWorkspaceLayoutPaths } from "../agents/sandbox/shared.js";
 import { resolveSandboxToolPolicyForAgent } from "../agents/sandbox/tool-policy.js";
 import { normalizeAnyChannelId } from "../channels/registry.js";
 import { getRuntimeConfig } from "../config/config.js";
@@ -171,6 +174,33 @@ export async function sandboxExplainCommand(
   });
 
   const sandboxCfg = resolveSandboxConfigForAgent(cfg, resolvedAgentId);
+  const agentConfig = resolveAgentConfig(cfg, resolvedAgentId);
+  const workspaceLayout = resolveSandboxWorkspaceLayoutPaths({
+    cfg: sandboxCfg,
+    rawSessionKey: sessionKey,
+    workspaceDir: agentConfig?.workspace,
+  });
+  const containerWorkdir =
+    getSandboxBackendWorkdirResolver(sandboxCfg.backend)?.({
+      sessionKey,
+      scopeKey: workspaceLayout.scopeKey,
+      workspaceDir: workspaceLayout.workspaceDir,
+      agentWorkspaceDir: workspaceLayout.agentWorkspaceDir,
+      skillsWorkspaceDir: workspaceLayout.skillsWorkspaceDir,
+      cfg: sandboxCfg,
+    }) ?? sandboxCfg.docker.workdir;
+  const workspaceMounts =
+    sandboxCfg.backend === "docker"
+      ? buildSandboxFsMounts({
+          workspaceDir: workspaceLayout.workspaceDir,
+          agentWorkspaceDir: workspaceLayout.agentWorkspaceDir,
+          skillsWorkspaceDir: workspaceLayout.skillsWorkspaceDir,
+          workspaceAccess: sandboxCfg.workspaceAccess,
+          containerName: "",
+          containerWorkdir,
+          docker: sandboxCfg.docker,
+        })
+      : [];
   const toolPolicy = resolveSandboxToolPolicyForAgent(cfg, resolvedAgentId);
   const mainSessionKey = resolveAgentMainSessionKey({
     cfg,
@@ -189,7 +219,6 @@ export async function sandboxExplainCommand(
     sessionKey,
   });
 
-  const agentConfig = resolveAgentConfig(cfg, resolvedAgentId);
   const elevatedGlobal = cfg.tools?.elevated;
   const elevatedAgent = agentConfig?.tools?.elevated;
   const elevatedGlobalEnabled = elevatedGlobal?.enabled !== false;
@@ -264,7 +293,13 @@ export async function sandboxExplainCommand(
       mode: sandboxCfg.mode,
       scope: sandboxCfg.scope,
       workspaceAccess: sandboxCfg.workspaceAccess,
-      workspaceRoot: sandboxCfg.workspaceRoot,
+      workspaceRoot: workspaceLayout.workspaceDir,
+      configuredWorkspaceRoot: sandboxCfg.workspaceRoot,
+      sandboxWorkspaceRoot: workspaceLayout.sandboxWorkspaceDir,
+      agentWorkspaceRoot: workspaceLayout.agentWorkspaceDir,
+      containerWorkdir,
+      workspaceMounts,
+      workspaceSource: workspaceLayout.workspaceSource,
       sessionIsSandboxed,
       tools: {
         allow: toolPolicy.allow,
@@ -318,6 +353,24 @@ export async function sandboxExplainCommand(
       payload.sandbox.workspaceAccess,
     )} ${key("workspaceRoot:")} ${value(payload.sandbox.workspaceRoot)}`,
   );
+  lines.push(
+    `  ${key("configuredWorkspaceRoot:")} ${value(payload.sandbox.configuredWorkspaceRoot)}`,
+  );
+  lines.push(
+    `  ${key("containerWorkdir:")} ${value(
+      payload.sandbox.containerWorkdir,
+    )} ${key("workspaceSource:")} ${value(payload.sandbox.workspaceSource)}`,
+  );
+  if (payload.sandbox.workspaceMounts.length > 0) {
+    lines.push(`  ${key("workspaceMounts:")}`);
+    for (const mount of payload.sandbox.workspaceMounts) {
+      lines.push(
+        `    - ${value(mount.hostRoot)} -> ${value(mount.containerRoot)} ${key(
+          mount.writable ? "rw" : "ro",
+        )} ${key(`(${mount.source})`)}`,
+      );
+    }
+  }
   lines.push("");
   lines.push(heading("Sandbox tool policy:"));
   lines.push(


### PR DESCRIPTION
Closes #100423

## What Problem This Solves

Fixes an issue where users running `openclaw sandbox explain --agent <id>` with `workspaceAccess: "rw"` would see `workspaceRoot` reported as the configured sandbox root even though sandbox commands write through the agent workspace mounted at `/workspace`.

## Why This Change Was Made

The sandbox workspace path selection is now shared between runtime setup and `sandbox explain`, and the explain output includes the effective host workspace, configured sandbox root, container workdir, workspace source, and Docker mount table. This is a diagnostics-only change; it does not change sandbox creation or mount behavior.

## User Impact

Users can now rely on `sandbox explain` to find where files actually land for `rw` workspaces instead of looking under the configured sandbox root by mistake.

## Evidence

Before: on `upstream/main`, `src/commands/sandbox-explain.ts` set `sandbox.workspaceRoot` directly from `sandboxCfg.workspaceRoot`, while `src/agents/sandbox/context.ts` selected the agent workspace as `workspaceDir` when `workspaceAccess === "rw"`.

After, with an isolated config using `workspaceAccess: "rw"`, `workspaceRoot: "/tmp/openclaw-sandboxes"`, and agent workspace `"/tmp/openclaw-agent-workspace"`:

```json
{
  "workspaceAccess": "rw",
  "workspaceRoot": "/tmp/openclaw-agent-workspace",
  "configuredWorkspaceRoot": "/tmp/openclaw-sandboxes",
  "sandboxWorkspaceRoot": "/tmp/openclaw-sandboxes/agent-builder-c4974941",
  "agentWorkspaceRoot": "/tmp/openclaw-agent-workspace",
  "containerWorkdir": "/workspace",
  "workspaceMounts": [
    {
      "hostRoot": "/tmp/openclaw-agent-workspace",
      "containerRoot": "/workspace",
      "writable": true,
      "source": "workspace"
    }
  ],
  "workspaceSource": "agent"
}
```

Commands run:

```text
node scripts/run-vitest.mjs src/commands/sandbox-explain.test.ts src/agents/sandbox/workspace-mounts.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-oxlint.mjs src/agents/sandbox/shared.ts src/agents/sandbox/context.ts src/commands/sandbox-explain.ts src/commands/sandbox-explain.test.ts
pnpm build
```

Real agent proof also ran locally with `deepseek/deepseek-v4-pro` through `openclaw agent --local`; the run returned `sandbox explain proof ok` with provider `deepseek`, model `deepseek-v4-pro`, and `stopReason=stop`.

AI-assisted.
