### PR TITLE
fix(ui): sidebar Settings entry scrolls away instead of staying pinned in the footer

### DIFF
--- a/ui/src/app-navigation-groups.test.ts
+++ b/ui/src/app-navigation-groups.test.ts
@@ -4,17 +4,16 @@ import {
   SETTINGS_NAVIGATION_ROUTES,
   SIDEBAR_SECTIONS,
   isSettingsNavigationRoute,
-  isRouteInSidebarSection,
 } from "./app-navigation.ts";
 import { routeIdFromPath } from "./app-routes.ts";
 
 describe("SIDEBAR_SECTIONS", () => {
-  it("collapses detailed settings slices into one sidebar entry", () => {
-    const settings = SIDEBAR_SECTIONS.find((group) => group.label === "settings");
-    expect(settings?.routes).toEqual(["config"]);
+  it("keeps settings out of the scrollable sections; the footer pins it", () => {
+    expect(SIDEBAR_SECTIONS.flatMap((group) => group.routes)).not.toContain("config");
     expect(SETTINGS_NAVIGATION_ROUTES.every((routeId) => isSettingsNavigationRoute(routeId))).toBe(
       true,
     );
+    expect(isSettingsNavigationRoute("chat")).toBe(false);
   });
 
   it("keeps channel management out of the primary control sidebar", () => {
@@ -29,18 +28,6 @@ describe("SIDEBAR_SECTIONS", () => {
       "cron",
     ]);
     expect(SETTINGS_NAVIGATION_ROUTES).toContain("channels");
-  });
-
-  it("keeps the settings group active for nested settings routes", () => {
-    const settings = SIDEBAR_SECTIONS.find((group) => group.label === "settings");
-    if (!settings) {
-      throw new Error("Expected settings group");
-    }
-
-    expect(isRouteInSidebarSection(settings, "appearance")).toBe(true);
-    expect(isRouteInSidebarSection(settings, "channels")).toBe(true);
-    expect(isRouteInSidebarSection(settings, "debug")).toBe(true);
-    expect(isRouteInSidebarSection(settings, "chat")).toBe(false);
   });
 
   it("routes every published settings slice", () => {

--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -268,7 +268,7 @@ describe("plugin tabs route", () => {
 
 describe("SIDEBAR_SECTIONS", () => {
   it("contains all expected groups", () => {
-    expect(SIDEBAR_SECTIONS.map((g) => g.label)).toEqual(["chat", "control", "agent", "settings"]);
+    expect(SIDEBAR_SECTIONS.map((g) => g.label)).toEqual(["chat", "control", "agent"]);
   });
 
   it("all routes are unique", () => {
@@ -278,8 +278,7 @@ describe("SIDEBAR_SECTIONS", () => {
   });
 
   it("keeps detailed settings slices routed but out of the root sidebar", () => {
-    const settings = SIDEBAR_SECTIONS.find((group) => group.label === "settings");
-    expect(settings?.routes).toEqual(["config"]);
+    expect(SIDEBAR_SECTIONS.flatMap((g) => g.routes)).not.toContain("config");
     expect(SETTINGS_NAVIGATION_ROUTES).toEqual([
       "config",
       "channels",

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -14,6 +14,7 @@ type NavigationItem = {
   [TRouteId in NavigationRouteId]: IconName;
 };
 
+// Settings ("config") is not a scrollable section; the sidebar footer pins it.
 export const SIDEBAR_SECTIONS = [
   { label: "chat", routes: ["chat"] },
   {
@@ -21,7 +22,6 @@ export const SIDEBAR_SECTIONS = [
     routes: ["overview", "activity", "workboard", "instances", "sessions", "usage", "cron"],
   },
   { label: "agent", routes: ["agents", "skills", "skill-workshop", "nodes", "dreams"] },
-  { label: "settings", routes: ["config"] },
 ] as const satisfies readonly SidebarSection[];
 
 export const SETTINGS_NAVIGATION_ROUTES = [
@@ -66,16 +66,6 @@ const NAVIGATION_ICONS: NavigationItem = {
 
 export function isSettingsNavigationRoute(routeId: NavigationRouteId): boolean {
   return (SETTINGS_NAVIGATION_ROUTES as readonly NavigationRouteId[]).includes(routeId);
-}
-
-export function isRouteInSidebarSection(
-  section: SidebarSection,
-  routeId: NavigationRouteId,
-): boolean {
-  if (section.label === "settings") {
-    return isSettingsNavigationRoute(routeId);
-  }
-  return section.routes.includes(routeId);
 }
 
 export function navigationIconForRoute(routeId: NavigationRouteId): IconName {

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -759,6 +759,7 @@ export class AppSidebar extends LitElement {
           </div>
           <div class="sidebar-shell__footer">
             <div class="sidebar-utility-group">
+              ${this.renderRoute("config")}
               ${this.collapsed
                 ? html`
                     <openclaw-tooltip


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI sidebar rendered Settings as its own collapsible "SETTINGS" group inside the scrollable navigation area. With enough nav items (or a short window) the Settings entry scrolled out of view, while the footer (Docs, connection status) stayed pinned — Settings belongs with those fixed utility entries.

## Why This Change Was Made

The `settings` group carried a single route (`config`), so a whole scrollable section (with collapse toggle) was overhead for one entry. The Settings nav item now renders inside the fixed sidebar footer, above Docs. The scrollable sections are reduced to chat/control/agent, and the now-unused `isRouteInSidebarSection` helper (test-only after this change) is deleted. Active-state highlighting for nested settings routes is unchanged — `renderRoute("config")` already resolves it via `isSettingsNavigationRoute`.

## User Impact

Settings is always visible at the bottom of the sidebar (expanded and collapsed rail), pinned with Docs and the connection status instead of scrolling with the nav. No route, URL, or behavior changes otherwise.

## Evidence

- Focused tests: `ui/src/app-navigation.test.ts` + `ui/src/app-navigation-groups.test.ts` — 34 passed.
- Visual check on the Vite dev server: expanded sidebar footer renders Settings → Docs → Online pinned below the nav divider; collapsed rail shows gear → book → pair → status dot. DOM assertion confirmed scrollable nav items no longer include Settings and footer order is `["Settings", "Docs", "Online"]`.
- Plugin sidebar tabs are unaffected: declared tab groups are limited to `control`/`agent` (`ui/src/api/gateway.ts`), so nothing routed to the removed group.
- Codex autoreview (gpt-5.5): clean, no actionable findings.


### Before / After

Same window height (760px). Before: Settings lives in a scrollable "SETTINGS" group and is scrolled out of view; after: Settings is pinned in the fixed footer above Docs and the connection status.

| Before | After |
|---|---|
| <img src="https://gist.githubusercontent.com/steipete/60df5704eddc2c67b1324a31486308aa/raw/before-expanded.png" width="280" alt="Before: Settings scrolled out of view in the nav" /> | <img src="https://gist.githubusercontent.com/steipete/60df5704eddc2c67b1324a31486308aa/raw/after-expanded.png" width="280" alt="After: Settings pinned in the footer above Docs" /> |
| <img src="https://gist.githubusercontent.com/steipete/60df5704eddc2c67b1324a31486308aa/raw/before-collapsed.png" width="120" alt="Before: collapsed rail" /> | <img src="https://gist.githubusercontent.com/steipete/60df5704eddc2c67b1324a31486308aa/raw/after-collapsed.png" width="120" alt="After: collapsed rail with pinned gear icon" /> |
