### PR TITLE
Add presentation buttons to approval packets

### DIFF
--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -933,6 +933,39 @@ describe("createTelegramBot", () => {
     });
   });
 
+  it("accepts command pagination no-op callbacks without dispatching chat text", async () => {
+    onSpy.mockClear();
+    editMessageTextSpy.mockClear();
+    commandSpy.mockClear();
+    listSkillCommandsForAgents.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+    expect(callbackHandler).toBeDefined();
+
+    await callbackHandler({
+      callbackQuery: {
+        id: "cbq-noop",
+        data: "commands_page_noop:kan199-smoke-a",
+        from: { id: 9, first_name: "Ada", username: "ada_bot" },
+        message: {
+          chat: { id: 1234, type: "private" },
+          date: 1736380800,
+          message_id: 15,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-noop");
+    expect(listSkillCommandsForAgents).not.toHaveBeenCalled();
+    expect(editMessageTextSpy).not.toHaveBeenCalled();
+    expect(commandSpy).not.toHaveBeenCalled();
+  });
+
   it("falls back to default agent for pagination callbacks without agent suffix", async () => {
     onSpy.mockClear();
     listSkillCommandsForAgents.mockClear();

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -282,6 +282,7 @@ describe("exec approval reply helpers", () => {
         },
       ],
     });
+    expect(payload.presentation).toEqual(payload.interactive);
     expect(payload.text).toContain("Heads up.");
     expect(payload.text).toContain("```txt\n/approve slug-1 allow-once\n```");
     expect(payload.text).toContain("```sh\necho ok\n```");
@@ -343,6 +344,7 @@ describe("exec approval reply helpers", () => {
         },
       ],
     });
+    expect(payload.presentation).toEqual(payload.interactive);
   });
 
   it("stores agent and session metadata for downstream suppression checks", () => {

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -1,5 +1,10 @@
 import type { ReplyPayload } from "../auto-reply/types.js";
-import type { InteractiveReply, InteractiveReplyButton } from "../interactive/payload.js";
+import type {
+  InteractiveReply,
+  InteractiveReplyButton,
+  MessagePresentation,
+} from "../interactive/payload.js";
+import { interactiveReplyToPresentation } from "../interactive/payload.js";
 import { formatHumanList } from "../shared/human-list.js";
 import {
   normalizeOptionalLowercaseString,
@@ -169,12 +174,33 @@ export function buildApprovalInteractiveReplyFromActionDescriptors(
   return buttons.length > 0 ? { blocks: [{ type: "buttons", buttons }] } : undefined;
 }
 
+export function buildApprovalPresentationFromActionDescriptors(
+  actions: readonly ExecApprovalActionDescriptor[],
+): MessagePresentation | undefined {
+  const interactive = buildApprovalInteractiveReplyFromActionDescriptors(actions);
+  return interactive ? interactiveReplyToPresentation(interactive) : undefined;
+}
+
 export function buildApprovalInteractiveReply(params: {
   approvalId: string;
   ask?: string | null;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
 }): InteractiveReply | undefined {
   return buildApprovalInteractiveReplyFromActionDescriptors(
+    buildExecApprovalActionDescriptors({
+      approvalCommandId: params.approvalId,
+      ask: params.ask,
+      allowedDecisions: params.allowedDecisions,
+    }),
+  );
+}
+
+export function buildApprovalPresentation(params: {
+  approvalId: string;
+  ask?: string | null;
+  allowedDecisions?: readonly ExecApprovalReplyDecision[];
+}): MessagePresentation | undefined {
+  return buildApprovalPresentationFromActionDescriptors(
     buildExecApprovalActionDescriptors({
       approvalCommandId: params.approvalId,
       ask: params.ask,
@@ -333,12 +359,14 @@ export function buildExecApprovalPendingReplyPayload(
   info.push(`Full id: \`${params.approvalId}\``);
   lines.push(info.join("\n"));
 
+  const interactive = buildApprovalInteractiveReply({
+    approvalId: params.approvalId,
+    allowedDecisions,
+  });
   return {
     text: lines.join("\n\n"),
-    interactive: buildApprovalInteractiveReply({
-      approvalId: params.approvalId,
-      allowedDecisions,
-    }),
+    presentation: interactive ? interactiveReplyToPresentation(interactive) : undefined,
+    interactive,
     channelData: {
       execApproval: {
         approvalId: params.approvalId,

--- a/src/plugin-sdk/approval-renderers.test.ts
+++ b/src/plugin-sdk/approval-renderers.test.ts
@@ -152,6 +152,7 @@ describe("plugin-sdk/approval-renderers", () => {
     if (payload.text !== undefined) {
       textExpected(payload.text);
     }
+    expect(payload.presentation).toEqual(interactiveExpected);
     if (interactiveExpected) {
       expect(payload.interactive).toEqual(interactiveExpected);
     }

--- a/src/plugin-sdk/approval-renderers.ts
+++ b/src/plugin-sdk/approval-renderers.ts
@@ -1,5 +1,6 @@
 import {
   buildApprovalInteractiveReply,
+  buildApprovalPresentation,
   type ExecApprovalReplyDecision,
 } from "../infra/exec-approval-reply.js";
 import {
@@ -24,12 +25,17 @@ export function buildApprovalPendingReplyPayload(params: {
   channelData?: Record<string, unknown>;
 }): ReplyPayload {
   const allowedDecisions = params.allowedDecisions ?? DEFAULT_ALLOWED_DECISIONS;
+  const interactive = buildApprovalInteractiveReply({
+    approvalId: params.approvalId,
+    allowedDecisions,
+  });
   return {
     text: params.text,
-    interactive: buildApprovalInteractiveReply({
+    presentation: buildApprovalPresentation({
       approvalId: params.approvalId,
       allowedDecisions,
     }),
+    interactive,
     channelData: {
       execApproval: {
         approvalId: params.approvalId,


### PR DESCRIPTION
## Summary
- add semantic `presentation` button blocks to shared exec/plugin approval pending payloads while retaining legacy `interactive`
- keep Telegram callback smoke coverage for inert `commands_page_noop:*` test buttons

## Tests
- `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot.test.ts src/infra/exec-approval-reply.ts src/infra/exec-approval-reply.test.ts src/plugin-sdk/approval-renderers.ts src/plugin-sdk/approval-renderers.test.ts`
- `pnpm test src/infra/exec-approval-reply.test.ts src/plugin-sdk/approval-renderers.test.ts`
- `pnpm test extensions/telegram/src/action-runtime.test.ts`
- `pnpm test extensions/telegram/src/bot.test.ts`

KAN-199
