### PR TITLE
fix(imessage): plain-send fallback for threaded replies + db-scoped recovery cursor (#99638)

### DIFF
--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -10,6 +10,7 @@ import { monitorIMessageProvider } from "./monitor.js";
 import {
   advanceIMessageRecoveryCursor,
   loadIMessageRecoveryCursor,
+  resolveIMessageRecoveryCursorDbIdentity,
 } from "./monitor/recovery-cursor.js";
 import {
   clearCachedIMessagePrivateApiStatus,
@@ -1125,7 +1126,11 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("recovers over a remote cliPath: replays from the cursor even without a local chat.db boundary", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ remoteHost: "user@gateway-host" }),
+      4990,
+    );
     const client = {
       request: vi.fn(async () => ({ subscription: 1 })),
       waitForClose: vi.fn(async () => {}),
@@ -1213,10 +1218,14 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("recovers downtime messages: replays from the cursor and delivers replay rows older than the live fence", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
+      4990,
+    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1445,11 +1454,15 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("does not advance the recovery cursor past a failed replay row", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
     debouncerControl.holdEntries = true;
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-failed-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
+      4990,
+    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1516,15 +1529,21 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(() => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
     });
-    expect(loadIMessageRecoveryCursor("default")).toBe(4994);
+    expect(
+      loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
+    ).toBe(4994);
   });
 
   it("advances the recovery cursor after lower pending replay rows complete", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
     debouncerControl.holdEntries = true;
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-ordered-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
+      4990,
+    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1584,7 +1603,9 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(() => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
     });
-    expect(loadIMessageRecoveryCursor("default")).toBe(4996);
+    expect(
+      loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
+    ).toBe(4996);
   });
 
   it("repairs anchorless group watch payloads before routing or cursor updates", async () => {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -108,7 +108,11 @@ import { parseIMessageNotification } from "./parse-notification.js";
 import { createPollCommentFolder } from "./poll-comment.js";
 import { renderIMessagePollBody } from "./poll-render.js";
 import { enqueueIMessageReactionSystemEvent } from "./reaction-system-event.js";
-import { advanceIMessageRecoveryCursor, loadIMessageRecoveryCursor } from "./recovery-cursor.js";
+import {
+  advanceIMessageRecoveryCursor,
+  loadIMessageRecoveryCursor,
+  resolveIMessageRecoveryCursorDbIdentity,
+} from "./recovery-cursor.js";
 import { normalizeAllowList, resolveRuntime } from "./runtime.js";
 import { createSelfChatCache } from "./self-chat-cache.js";
 import type { IMessageAttachment, IMessagePayload, MonitorIMessageOpts } from "./types.js";
@@ -542,9 +546,18 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const recoveryBoundaryRowid = watchSourceDbPath
     ? await resolveIMessageStartupRowidWatermark(watchSourceDbPath)
     : null;
-  const recoveryCursorRowid = loadIMessageRecoveryCursor(accountInfo.accountId, {
-    migrateLegacyCatchup: !catchupCfg.enabled,
+  // Scope the cursor to the resolved database so a dbPath/remoteHost change
+  // starts from the new DB's watermark instead of a stale high-water (#99638).
+  const recoveryCursorDbIdentity = resolveIMessageRecoveryCursorDbIdentity({
+    cliPath,
+    dbPath,
+    remoteHost,
   });
+  const recoveryCursorRowid = loadIMessageRecoveryCursor(
+    accountInfo.accountId,
+    recoveryCursorDbIdentity,
+    { migrateLegacyCatchup: !catchupCfg.enabled },
+  );
   const watchSinceRowid = catchupCfg.enabled
     ? null
     : recoveryCursorRowid !== null
@@ -655,7 +668,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       holdFloor !== null && maxHandledRowid >= holdFloor ? holdFloor - 1 : maxHandledRowid;
 
     if (nextCursorRowid >= 0 && nextCursorRowid > latestAdvancedRecoveryCursorRowid) {
-      advanceIMessageRecoveryCursor(accountInfo.accountId, nextCursorRowid);
+      advanceIMessageRecoveryCursor(
+        accountInfo.accountId,
+        recoveryCursorDbIdentity,
+        nextCursorRowid,
+      );
       latestAdvancedRecoveryCursorRowid = nextCursorRowid;
       for (const rowid of handledRecoveryCursorRowids) {
         if (rowid <= nextCursorRowid) {

--- a/extensions/imessage/src/monitor/recovery-cursor.test.ts
+++ b/extensions/imessage/src/monitor/recovery-cursor.test.ts
@@ -1,9 +1,22 @@
 // Imessage tests cover the downtime-recovery cursor.
 import { createHash } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import { getIMessageRuntime } from "../runtime.js";
 import { installIMessageStateRuntimeForTest } from "../test-support/runtime.js";
-import { advanceIMessageRecoveryCursor, loadIMessageRecoveryCursor } from "./recovery-cursor.js";
+import {
+  advanceIMessageRecoveryCursor,
+  IMESSAGE_RECOVERY_CURSOR_MAX_ENTRIES,
+  IMESSAGE_RECOVERY_CURSOR_NAMESPACE,
+  loadIMessageRecoveryCursor,
+  resolveIMessageRecoveryCursorDbIdentity,
+} from "./recovery-cursor.js";
+
+// Default database identity used by tests that are not exercising the db-scoping
+// behavior directly.
+const DB = "local:/db-a";
+const DB_B = "local:/db-b";
 
 function writeLegacyCatchupCursor(accountId: string, lastSeenRowid: number): void {
   const store = getIMessageRuntime().state.openSyncKeyedStore<{
@@ -14,58 +27,140 @@ function writeLegacyCatchupCursor(accountId: string, lastSeenRowid: number): voi
   store.register(key, { lastSeenMs: Date.now(), lastSeenRowid });
 }
 
+// Writes a pre-database-scoping recovery cursor: keyed by accountId alone, with
+// no database identity, as older builds persisted it.
+function writeLegacyRecoveryCursor(accountId: string, lastRowid: number): void {
+  getIMessageRuntime()
+    .state.openSyncKeyedStore<{ lastRowid: number }>({
+      namespace: IMESSAGE_RECOVERY_CURSOR_NAMESPACE,
+      maxEntries: IMESSAGE_RECOVERY_CURSOR_MAX_ENTRIES,
+    })
+    .register(accountId, { lastRowid });
+}
+
 describe("iMessage recovery cursor", () => {
   beforeEach(() => {
     installIMessageStateRuntimeForTest();
   });
 
   it("returns null before anything is recorded", () => {
-    expect(loadIMessageRecoveryCursor("default")).toBeNull();
+    expect(loadIMessageRecoveryCursor("default", DB)).toBeNull();
   });
 
   it("persists the last dispatched rowid", () => {
-    advanceIMessageRecoveryCursor("default", 100);
-    expect(loadIMessageRecoveryCursor("default")).toBe(100);
+    advanceIMessageRecoveryCursor("default", DB, 100);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(100);
   });
 
   it("advances forward only and never rewinds", () => {
-    advanceIMessageRecoveryCursor("default", 100);
-    advanceIMessageRecoveryCursor("default", 50);
-    expect(loadIMessageRecoveryCursor("default")).toBe(100);
-    advanceIMessageRecoveryCursor("default", 150);
-    expect(loadIMessageRecoveryCursor("default")).toBe(150);
+    advanceIMessageRecoveryCursor("default", DB, 100);
+    advanceIMessageRecoveryCursor("default", DB, 50);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(100);
+    advanceIMessageRecoveryCursor("default", DB, 150);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(150);
   });
 
   it("scopes the cursor per account", () => {
-    advanceIMessageRecoveryCursor("work", 10);
-    advanceIMessageRecoveryCursor("home", 20);
-    expect(loadIMessageRecoveryCursor("work")).toBe(10);
-    expect(loadIMessageRecoveryCursor("home")).toBe(20);
+    advanceIMessageRecoveryCursor("work", DB, 10);
+    advanceIMessageRecoveryCursor("home", DB, 20);
+    expect(loadIMessageRecoveryCursor("work", DB)).toBe(10);
+    expect(loadIMessageRecoveryCursor("home", DB)).toBe(20);
+  });
+
+  it("ignores a cursor recorded against a different database (#99638)", () => {
+    // A high-water from db-a must not seed since_rowid after repointing to db-b,
+    // or every lower rowid in db-b is silently suppressed forever.
+    advanceIMessageRecoveryCursor("default", DB, 12396);
+    expect(loadIMessageRecoveryCursor("default", DB_B, { migrateLegacyCatchup: false })).toBeNull();
+    // The original database still reports its cursor.
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(12396);
+  });
+
+  it("re-scopes the cursor to the new database on advance", () => {
+    advanceIMessageRecoveryCursor("default", DB, 12396);
+    // Advancing on db-b starts fresh (not blocked by db-a's higher monotonic value).
+    advanceIMessageRecoveryCursor("default", DB_B, 15);
+    expect(loadIMessageRecoveryCursor("default", DB_B)).toBe(15);
+    // db-a keeps its own high-water; switching back does not lose it.
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(12396);
+  });
+
+  it("adopts a pre-database-scoping cursor once for the active database (#99638)", () => {
+    writeLegacyRecoveryCursor("default", 12396);
+    // Upgrade restart: the identity-less cursor is adopted for the active
+    // database so downtime replay still works (not dropped to the watermark).
+    expect(loadIMessageRecoveryCursor("default", DB, { migrateLegacyCatchup: false })).toBe(12396);
+    // It is consumed and re-scoped, so a different database does not inherit it.
+    expect(loadIMessageRecoveryCursor("default", DB_B, { migrateLegacyCatchup: false })).toBeNull();
+    // The adopted database keeps it across reloads.
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(12396);
   });
 
   it("ignores non-finite rowids", () => {
-    advanceIMessageRecoveryCursor("default", Number.NaN);
-    expect(loadIMessageRecoveryCursor("default")).toBeNull();
+    advanceIMessageRecoveryCursor("default", DB, Number.NaN);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBeNull();
   });
 
   it("seeds from the retired catchup cursor once on upgrade, then consumes it", () => {
     writeLegacyCatchupCursor("default", 4321);
     // First load with no recovery cursor seeds from the legacy catchup cursor.
-    expect(loadIMessageRecoveryCursor("default")).toBe(4321);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(4321);
     // The legacy entry is consumed and the value is now the recovery cursor, so
     // a later load still returns it without re-reading the legacy store.
-    expect(loadIMessageRecoveryCursor("default")).toBe(4321);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(4321);
   });
 
   it("can skip legacy catchup cursor migration when compatibility catchup still owns it", () => {
     writeLegacyCatchupCursor("default", 4321);
-    expect(loadIMessageRecoveryCursor("default", { migrateLegacyCatchup: false })).toBeNull();
-    expect(loadIMessageRecoveryCursor("default")).toBe(4321);
+    expect(loadIMessageRecoveryCursor("default", DB, { migrateLegacyCatchup: false })).toBeNull();
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(4321);
   });
 
   it("prefers an existing recovery cursor over the legacy catchup cursor", () => {
-    advanceIMessageRecoveryCursor("default", 9000);
+    advanceIMessageRecoveryCursor("default", DB, 9000);
     writeLegacyCatchupCursor("default", 10);
-    expect(loadIMessageRecoveryCursor("default")).toBe(9000);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(9000);
+  });
+
+  it("unifies the implicit default with explicit spellings of the same chat.db (#99638)", () => {
+    const home = (process.env.HOME || os.homedir()).trim();
+    const defaultIdentity = `local:${path.resolve(path.join(home, "Library", "Messages", "chat.db"))}`;
+
+    // Implicit default (imsg binary, no dbPath) and any explicit spelling of the
+    // same file resolve to one identity, so switching between them does not drop
+    // the cursor and skip downtime messages.
+    expect(resolveIMessageRecoveryCursorDbIdentity({ cliPath: "imsg" })).toBe(defaultIdentity);
+    expect(resolveIMessageRecoveryCursorDbIdentity({ cliPath: "/opt/homebrew/bin/imsg" })).toBe(
+      defaultIdentity,
+    );
+    expect(
+      resolveIMessageRecoveryCursorDbIdentity({
+        dbPath: path.join(home, "Library/Messages/chat.db"),
+      }),
+    ).toBe(defaultIdentity);
+    expect(resolveIMessageRecoveryCursorDbIdentity({ dbPath: "~/Library/Messages/chat.db" })).toBe(
+      defaultIdentity,
+    );
+  });
+
+  it("keeps distinct databases, wrappers, and remotes on separate identities", () => {
+    const defaultId = resolveIMessageRecoveryCursorDbIdentity({ cliPath: "imsg" });
+    const otherDb = resolveIMessageRecoveryCursorDbIdentity({ dbPath: "/Users/other/chat.db" });
+    // Distinct wrappers with no dbPath/remoteHost must not collapse together.
+    const wrapperA = resolveIMessageRecoveryCursorDbIdentity({
+      cliPath: "/usr/local/bin/imsg-a.sh",
+    });
+    const wrapperB = resolveIMessageRecoveryCursorDbIdentity({
+      cliPath: "/usr/local/bin/imsg-b.sh",
+    });
+    const remote = resolveIMessageRecoveryCursorDbIdentity({
+      remoteHost: "bot@host",
+      dbPath: "/Users/b/chat.db",
+    });
+    expect(new Set([defaultId, otherDb, wrapperA, wrapperB, remote]).size).toBe(5);
+    // Stable for the same inputs.
+    expect(otherDb).toBe(
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath: "/Users/other/chat.db" }),
+    );
   });
 });

--- a/extensions/imessage/src/monitor/recovery-cursor.ts
+++ b/extensions/imessage/src/monitor/recovery-cursor.ts
@@ -1,10 +1,15 @@
-// Per-account high-water of the last dispatched chat.db rowid. On startup it is
-// passed to imsg `watch.subscribe` as `since_rowid` so imsg replays the rows
-// that landed while the gateway was down (downtime recovery), then tails live.
-// The GUID dedupe makes this safe — anything already handled is dropped — so
-// this needs none of the cursor/retry bookkeeping the old catchup subsystem
-// carried. Single number per account.
+// Per-(account, database) high-water of the last dispatched chat.db rowid. On
+// startup it is passed to imsg `watch.subscribe` as `since_rowid` so imsg
+// replays the rows that landed while the gateway was down (downtime recovery),
+// then tails live. The GUID dedupe makes over-replay safe — anything already
+// handled is dropped — so this needs none of the cursor/retry bookkeeping the
+// old catchup subsystem carried. The database identity is part of the store key
+// (not just a number per account): a high-water from one chat.db must never seed
+// since_rowid for a different one, or repointing `dbPath`/`remoteHost` to a
+// lower-rowid database silently suppresses every row in it forever (#99638).
 import { createHash } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
 import { getIMessageRuntime } from "../runtime.js";
 
 export const IMESSAGE_RECOVERY_CURSOR_NAMESPACE = "imessage.recovery-cursor";
@@ -25,12 +30,95 @@ function openRecoveryCursorStore() {
   });
 }
 
-function readRecoveryCursor(accountId: string): number | null {
+// Mirrors monitor-provider's local Messages home resolution (HOME first, then
+// os.homedir) so the identity's default path matches the database the monitor
+// actually watches.
+function localMessagesHomeDir(): string | undefined {
+  const home = process.env.HOME?.trim();
+  if (home) {
+    return home;
+  }
   try {
-    const value = openRecoveryCursorStore().lookup(accountId);
-    return typeof value?.lastRowid === "number" && Number.isFinite(value.lastRowid)
-      ? value.lastRowid
-      : null;
+    return os.homedir().trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Canonicalize a local chat.db path (expand a leading ~, then resolve) so the
+// implicit default and any explicit spelling of the same file share one identity.
+function normalizeLocalDbPath(dbPath: string): string {
+  let resolved = dbPath.trim();
+  if (resolved.startsWith("~")) {
+    const home = localMessagesHomeDir();
+    if (home) {
+      resolved = path.join(home, resolved.slice(1).replace(/^\/+/, ""));
+    }
+  }
+  return path.resolve(resolved);
+}
+
+/**
+ * Stable identity for the watched Messages database. A changed identity means a
+ * different chat.db (different `dbPath`, custom `cliPath`, or a remote host),
+ * whose rowids share no ordering with the previous one, so the cursor must not
+ * carry across. Local paths are canonicalized so the implicit default and an
+ * explicit path to the same chat.db resolve to one identity.
+ */
+export function resolveIMessageRecoveryCursorDbIdentity(params: {
+  cliPath?: string;
+  dbPath?: string;
+  remoteHost?: string;
+}): string {
+  const remoteHost = params.remoteHost?.trim();
+  if (remoteHost) {
+    // Remote paths cannot be resolved locally; key by host + raw remote path.
+    return `remote:${remoteHost}:${params.dbPath?.trim() || "default"}`;
+  }
+  const dbPath = params.dbPath?.trim();
+  if (dbPath) {
+    return `local:${normalizeLocalDbPath(dbPath)}`;
+  }
+  // No explicit dbPath: the default imsg binary watches the default chat.db, so
+  // resolve it to the same concrete path an explicit config would spell. A
+  // custom cliPath (e.g. an SSH wrapper whose host is not auto-detected) can
+  // front a distinct database, so keep those distinct instead.
+  const cliPath = params.cliPath?.trim();
+  const isDefaultCli = !cliPath || cliPath === "imsg" || path.basename(cliPath) === "imsg";
+  if (isDefaultCli) {
+    const home = localMessagesHomeDir();
+    return home
+      ? `local:${normalizeLocalDbPath(path.join(home, "Library", "Messages", "chat.db"))}`
+      : "local:default";
+  }
+  return `local:cli:${cliPath}`;
+}
+
+// Composite key: one high-water per (account, database). The NUL separator
+// cannot appear in an account id or identity string, so a composite key never
+// collides with the legacy account-only key adopted below.
+function recoveryCursorStoreKey(accountId: string, dbIdentity: string): string {
+  return `${accountId}\u0000${dbIdentity}`;
+}
+
+function readRecoveryCursor(accountId: string, dbIdentity: string): number | null {
+  try {
+    const store = openRecoveryCursorStore();
+    const key = recoveryCursorStoreKey(accountId, dbIdentity);
+    const value = store.lookup(key);
+    if (value) {
+      return Number.isFinite(value.lastRowid) ? value.lastRowid : null;
+    }
+    // One-time upgrade adoption: cursors written before database scoping were
+    // keyed by accountId alone. Adopt such an entry for the active database so
+    // the upgrade restart still replays downtime rows, then consume it so a
+    // later dbPath change cannot inherit this database's high-water.
+    const legacy = store.consume(accountId);
+    if (legacy && Number.isFinite(legacy.lastRowid)) {
+      store.register(key, { lastRowid: legacy.lastRowid });
+      return legacy.lastRowid;
+    }
+    return null;
   } catch {
     return null;
   }
@@ -39,7 +127,7 @@ function readRecoveryCursor(accountId: string): number | null {
 // One-time, self-cleaning migration: when the recovery cursor is empty (first
 // startup after upgrade or a fresh install), seed it from the retired catchup
 // cursor's lastSeenRowid and consume the legacy entry so this never runs again.
-function migrateLegacyCatchupCursor(accountId: string): number | null {
+function migrateLegacyCatchupCursor(accountId: string, dbIdentity: string): number | null {
   try {
     const legacy = getIMessageRuntime().state.openSyncKeyedStore<{ lastSeenRowid?: unknown }>({
       namespace: LEGACY_CATCHUP_CURSOR_NAMESPACE,
@@ -52,7 +140,7 @@ function migrateLegacyCatchupCursor(accountId: string): number | null {
         ? value.lastSeenRowid
         : null;
     if (rowid !== null) {
-      advanceIMessageRecoveryCursor(accountId, rowid);
+      advanceIMessageRecoveryCursor(accountId, dbIdentity, rowid);
     }
     return rowid;
   } catch {
@@ -60,33 +148,43 @@ function migrateLegacyCatchupCursor(accountId: string): number | null {
   }
 }
 
-/** Last dispatched rowid for this account, or null when none is recorded yet. */
+/**
+ * Last dispatched rowid for this account on `dbIdentity`, or null when none is
+ * recorded yet (including when the only stored cursor belongs to a different
+ * database).
+ */
 export function loadIMessageRecoveryCursor(
   accountId: string,
+  dbIdentity: string,
   options: { migrateLegacyCatchup?: boolean } = {},
 ): number | null {
-  const current = readRecoveryCursor(accountId);
+  const current = readRecoveryCursor(accountId, dbIdentity);
   if (current !== null) {
     return current;
   }
   if (options.migrateLegacyCatchup === false) {
     return null;
   }
-  return migrateLegacyCatchupCursor(accountId);
+  return migrateLegacyCatchupCursor(accountId, dbIdentity);
 }
 
-/** Advance the cursor forward to `rowid` (monotonic; never rewinds). */
-export function advanceIMessageRecoveryCursor(accountId: string, rowid: number): void {
+/** Advance the cursor forward to `rowid` (monotonic per database; never rewinds). */
+export function advanceIMessageRecoveryCursor(
+  accountId: string,
+  dbIdentity: string,
+  rowid: number,
+): void {
   if (!Number.isFinite(rowid)) {
     return;
   }
   try {
     const store = openRecoveryCursorStore();
-    const current = store.lookup(accountId);
+    const key = recoveryCursorStoreKey(accountId, dbIdentity);
+    const current = store.lookup(key);
     if (current && current.lastRowid >= rowid) {
       return;
     }
-    store.register(accountId, { lastRowid: rowid });
+    store.register(key, { lastRowid: rowid });
   } catch {
     // Best effort: a failed cursor write just means we replay a little more
     // next startup, which the dedupe absorbs.

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -145,6 +145,72 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.parts[0]?.replyToId).toBeUndefined();
   });
 
+  it("resends unthreaded when the transport cannot deliver a threaded reply (#99638)", async () => {
+    const sendParams: Array<Record<string, unknown>> = [];
+    const client = {
+      request: vi.fn(async (_method: string, params: Record<string, unknown>) => {
+        sendParams.push(params);
+        if (params.reply_to) {
+          throw new Error(
+            "reply_to requires bridge transport; AppleScript fallback cannot send threaded replies",
+          );
+        }
+        return { guid: "p:0/imsg-plain-fallback" };
+      }),
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      replyToId: "reply-1",
+    });
+
+    // First attempt carried reply_to and hard-failed on the AppleScript-only
+    // transport; the retry drops reply_to and delivers rather than losing it.
+    expect(sendParams).toHaveLength(2);
+    expect(sendParams[0]).toHaveProperty("reply_to", "reply-1");
+    expect(sendParams[1]).not.toHaveProperty("reply_to");
+    expect(result.messageId).toBe("p:0/imsg-plain-fallback");
+    expect(result.sentText).toBe("hello");
+    // The receipt reflects the unthreaded send that was actually delivered.
+    expect(result.receipt.replyToId).toBeUndefined();
+    expect(result.receipt.parts[0]?.replyToId).toBeUndefined();
+  });
+
+  it("resends a media reply unthreaded when threaded replies are unsupported (#99638)", async () => {
+    const sendParams: Array<Record<string, unknown>> = [];
+    const client = {
+      request: vi.fn(async (_method: string, params: Record<string, unknown>) => {
+        sendParams.push(params);
+        if (params.reply_to) {
+          throw new Error(
+            "reply_to requires bridge transport; AppleScript fallback cannot send threaded replies",
+          );
+        }
+        return { guid: "p:0/media-plain-fallback" };
+      }),
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+
+    // A media reply (file + reply_to) takes the main send path, not send-attachment.
+    const result = await sendMessageIMessage("chat_id:42", "caption", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      replyToId: "reply-1",
+      mediaUrl: "/tmp/image.png",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+    });
+
+    expect(sendParams).toHaveLength(2);
+    expect(sendParams[0]).toMatchObject({ reply_to: "reply-1", file: "/tmp/image.png" });
+    expect(sendParams[1]).not.toHaveProperty("reply_to");
+    // The media itself is still delivered on the retry, just unthreaded.
+    expect(sendParams[1]).toHaveProperty("file", "/tmp/image.png");
+    expect(result.messageId).toBe("p:0/media-plain-fallback");
+    expect(result.receipt.replyToId).toBeUndefined();
+  });
+
   it("passes the default RPC send transport", async () => {
     const client = createClient({ guid: "p:0/imsg-transport-default" });
 

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -712,6 +712,16 @@ function isAttachmentCommandFallbackError(error: unknown): boolean {
   );
 }
 
+// A threaded reply (reply_to) needs the private-API bridge transport; on an
+// AppleScript-only deployment imsg rejects it outright. Detect that specific
+// error so we can resend the message unthreaded instead of dropping it (#99638).
+function isThreadedReplyUnsupportedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /reply_to requires bridge transport|cannot send threaded repl|threaded repl(?:y|ies)\b.*(?:unsupported|not supported|requires|unavailable)|requires bridge transport/iu.test(
+    message,
+  );
+}
+
 async function resolveAttachmentChatTarget(params: {
   target: ReturnType<typeof parseIMessageTarget>;
   service?: IMessageService;
@@ -946,6 +956,10 @@ export async function sendMessageIMessage(
   const echoText = resolveOutboundEchoText(message, filePath ? mediaContentType : undefined);
   const replyActionsEnabled = createActionGate(account.config.actions)("reply");
   const resolvedReplyToId = replyActionsEnabled ? sanitizeReplyToId(opts.replyToId) : undefined;
+  // The reply id actually delivered. The threaded-reply fallback below clears it
+  // so the receipt and approval binding report the unthreaded send it became,
+  // not the threaded reply the transport rejected (#99638).
+  let effectiveReplyToId = resolvedReplyToId;
   const runCliJson =
     opts.runCliJson ??
     ((args: readonly string[]) => runIMessageCliJson(cliPath, dbPath, args, timeoutMs));
@@ -1054,10 +1068,20 @@ export async function sendMessageIMessage(
         timeoutMs,
       });
     } catch (error) {
-      if (filePath || !isIMessageRpcSendTimeout(error)) {
+      if (resolvedReplyToId && isThreadedReplyUnsupportedError(error)) {
+        // #99638: the transport cannot deliver a threaded reply, so resend the
+        // message unthreaded rather than dropping it. Covers text and media
+        // replies alike (both carry reply_to through this send). One retry with
+        // reply_to stripped, keeping any file; a further failure propagates.
+        const plainParams = { ...params };
+        delete plainParams.reply_to;
+        result = await client.request<Record<string, unknown>>("send", plainParams, {
+          timeoutMs,
+        });
+        effectiveReplyToId = undefined;
+      } else if (filePath || !isIMessageRpcSendTimeout(error)) {
         throw error;
-      }
-      if (
+      } else if (
         !shouldRecoverApprovalPromptGuid({
           message,
           filePath,
@@ -1069,18 +1093,19 @@ export async function sendMessageIMessage(
         })
       ) {
         throw error;
-      }
-      const recoveredGuid = await resolveFallbackSentMessageGuid({
-        dbPath: chatDbLookupPath,
-        target,
-        text: message,
-        sentAfterMs: sendStartedAtMs,
-        resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
-      });
-      if (recoveredGuid) {
-        result = { guid: recoveredGuid, status: "sent" };
       } else {
-        throw error;
+        const recoveredGuid = await resolveFallbackSentMessageGuid({
+          dbPath: chatDbLookupPath,
+          target,
+          text: message,
+          sentAfterMs: sendStartedAtMs,
+          resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
+        });
+        if (recoveredGuid) {
+          result = { guid: recoveredGuid, status: "sent" };
+        } else {
+          throw error;
+        }
       }
     }
     const resolvedId = resolveMessageId(result);
@@ -1102,7 +1127,7 @@ export async function sendMessageIMessage(
       shouldRecoverApprovalPromptGuid({
         message,
         filePath,
-        replyToId: resolvedReplyToId,
+        replyToId: effectiveReplyToId,
       })
     ) {
       approvalBindingMessageId = await resolveFallbackSentMessageGuid({
@@ -1165,7 +1190,7 @@ export async function sendMessageIMessage(
         messageId,
         target,
         kind: filePath ? "media" : "text",
-        ...(resolvedReplyToId ? { replyToId: resolvedReplyToId } : {}),
+        ...(effectiveReplyToId ? { replyToId: effectiveReplyToId } : {}),
       }),
     };
   } catch (error) {


### PR DESCRIPTION
Closes #99638

## What Problem This Solves

Issue #99638 reported three failures on the dedicated bot-user / SSH-wrapped iMessage deployment. The primary one (every DM after the first failing with `reply session initialization conflicted`) was already fixed by #98835. This PR fixes the two remaining reported failures:

- **Threaded replies were dropped when the private-API bridge was unavailable.** When a reply carried `reply_to` but only AppleScript transport was available, `imsg` hard-errored (`reply_to requires bridge transport; ...`) and OpenClaw rethrew, so the reply was **lost** — for both text and media replies.
- **Repointing `dbPath` silently stopped all inbound.** The downtime-recovery cursor was keyed per account, not per database, and is monotonic. After pointing `dbPath` at a different `chat.db` with lower rowids (e.g. a fresh bot-user DB, max rowid ~15), the stale high-water (~12396) was still sent as `since_rowid`, so `imsg` replayed/emitted nothing and inbound was **silently lost forever**.

## Why This Change Was Made

Both fixes stay entirely within `extensions/imessage` (no core or config-surface changes):

- **Plain-send fallback (`send.ts`):** the send `catch` now detects the specific "threaded reply unsupported" error and, when a `reply_to` was set, retries the send once with `reply_to` stripped — delivering the message unthreaded instead of dropping it. This covers **text and media replies** alike (both carry `reply_to` through the same send path), keeps any attached file on the retry, and clears the reply id so the receipt reports the unthreaded send that was actually delivered. The match is a closed error class, so unrelated send failures still propagate.
- **DB-scoped recovery cursor (`recovery-cursor.ts`):** the cursor is keyed per **(account, database identity)**. The identity is derived from `remoteHost` / `dbPath` / custom `cliPath`, with local paths canonicalized (leading `~` expanded, then resolved) so the implicit default and an explicit path to the same `chat.db` map to one identity. A cursor recorded against a different database no longer seeds `since_rowid`, advance is monotonic only within the same database, and a pre-scoping (account-only) cursor is adopted once for the active database on upgrade so downtime replay still works. This is cache-class state (rebuilds safely via GUID dedupe), so no migration is required.

## User Impact

- On no-SIP / AppleScript-only deployments, **text and media replies are delivered (unthreaded)** instead of being silently dropped.
- Changing `dbPath` (or moving to/from a remote host, or spelling the default path explicitly) no longer wedges inbound message delivery; recovery resumes from the correct database.

## Evidence

**Unit + integration tests — all green (92 passed across the 3 touched files):**

```
node scripts/run-vitest.mjs \
  extensions/imessage/src/monitor/recovery-cursor.test.ts \
  extensions/imessage/src/send.test.ts \
  extensions/imessage/src/monitor.last-route.test.ts
 Test Files  3 passed (3)
      Tests  92 passed (92)
```

These exercise the exact runtime paths the fix changes:
- `send.test.ts`: text and media replies that hit the upstream `reply_to`-unsupported error retry once with `reply_to` stripped, deliver the message/media unthreaded, and report a non-threaded receipt.
- `recovery-cursor.test.ts`: cursor scoped per (account, database); ignores a cursor from a different database; re-scopes on advance without losing the other database's high-water; adopts a pre-scoping legacy cursor once for the active database; unifies the implicit default with explicit/`~` spellings of the same `chat.db`; keeps distinct DBs/wrappers/remotes separate.
- `monitor.last-route.test.ts`: existing downtime-recovery integration tests updated to the DB-scoped cursor (local + remote paths) and still passing.

Typecheck: `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` both clean.

Codex review (`autoreview`, gpt-5.5) run to clean over several rounds — it flagged and I fixed: legacy-cursor upgrade-drop, per-database cursor overwrite, custom-`cliPath` identity aliasing, unthreaded-fallback receipt accuracy, media-reply fallback coverage, and default-vs-explicit-path identity normalization. Final pass reports no actionable findings.

**Live behavior proof (real two-Mac SSH deployment)** — captured and posted in a PR comment:
- **Fallback:** replicating the gateway's `send` RPC against the real `imsg` binary, `reply_to` + AppleScript transport returns the exact `reply_to requires bridge transport; ...` error, and the same send with `reply_to` stripped delivers (`ok:true`, `transport:applescript`). The PR performs that retry automatically.
- **Cursor:** a real leftover pre-scoping (account-only) cursor `{"lastRowid":6597}` was adopted and re-scoped by the fixed gateway into a db-scoped composite key `default\x00remote:<host>:.../chat.db`; the persisted key embeds the database identity, and a repoint left it untouched while the new database started fresh.

**Primary bug (#98835) also verified live for context:** three sequential multi-turn DMs on the same SSH deployment all delivered replies with `outcome=completed` and zero `reply session initialization conflicted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
