### PR TITLE
fix(agents): handle blank numeric params and LSP exits

### DIFF
--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -47,7 +47,10 @@ class MockChildProcess extends EventEmitter {
   readonly stderr = new PassThrough();
   readonly stdin: Writable;
 
-  constructor(private readonly initializeResponsePrefix = "") {
+  constructor(
+    private readonly initializeResponsePrefix = "",
+    private readonly respondMethods?: ReadonlySet<string>,
+  ) {
     super();
     this.stdin = new Writable({
       write: (chunk, _encoding, callback) => {
@@ -68,6 +71,9 @@ class MockChildProcess extends EventEmitter {
   private respondToRequest(text: string): void {
     const body = parseWrittenLspBody(text);
     if (!body || typeof body.id !== "number" || typeof body.method !== "string") {
+      return;
+    }
+    if (this.respondMethods && !this.respondMethods.has(body.method)) {
       return;
     }
     const result = body.method === "initialize" ? { capabilities: { hoverProvider: true } } : null;
@@ -136,6 +142,38 @@ describe("bundle LSP runtime", () => {
     expect(runtime.sessions).toEqual([]);
     expect(runtime.tools).toEqual([]);
     expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000 });
+  });
+
+  it("rejects pending LSP requests immediately when the child process exits", async () => {
+    configureSingleLspServer();
+    const child = new MockChildProcess("", new Set(["initialize"]));
+    spawnMock.mockReturnValue(child);
+    const { createBundleLspToolRuntime } = await import("./agent-bundle-lsp-runtime.js");
+
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+    const hoverTool = runtime.tools.find((tool) => tool.name === "lsp_hover_typescript");
+    if (!hoverTool) {
+      throw new Error("expected hover tool");
+    }
+
+    const request = hoverTool.execute("call-1", {
+      uri: "file:///tmp/workspace/index.ts",
+      line: 0,
+      character: 0,
+    });
+    child.exitCode = 1;
+    child.emit("exit", 1, null);
+
+    await expect(request).rejects.toThrow('LSP server "typescript" exited (1)');
+    await expect(
+      hoverTool.execute("call-2", {
+        uri: "file:///tmp/workspace/index.ts",
+        line: 0,
+        character: 0,
+      }),
+    ).rejects.toThrow('LSP server "typescript" exited (1)');
+
+    await runtime.dispose();
   });
 
   it("keeps LSP framing aligned after multibyte messages in the same chunk", async () => {

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -110,14 +110,27 @@ function registerActiveLspSession(session: LspSession): void {
   activeBundleLspSessions.add(session);
 }
 
+function failLspSession(session: LspSession, error: Error): void {
+  if (session.failure) {
+    return;
+  }
+  session.failure = error;
+  for (const pending of session.pendingRequests.values()) {
+    clearTimeout(pending.timeout);
+    pending.reject(error);
+  }
+  session.pendingRequests.clear();
+}
+
 function attachLspProcessHandlers(session: LspSession): void {
   session.process.on("error", (error) => {
-    session.failure = error;
-    for (const pending of session.pendingRequests.values()) {
-      clearTimeout(pending.timeout);
-      pending.reject(error);
-    }
-    session.pendingRequests.clear();
+    failLspSession(session, error);
+  });
+  session.process.on("exit", (code, signal) => {
+    failLspSession(
+      session,
+      new Error(`LSP server "${session.serverName}" exited (${signal ?? code ?? "unknown"})`),
+    );
   });
   session.process.stdout?.on("data", (chunk: Buffer | string) =>
     handleIncomingData(session, chunk),

--- a/src/agents/tools/common.params.test.ts
+++ b/src/agents/tools/common.params.test.ts
@@ -166,6 +166,8 @@ describe("readNumberParam", () => {
   it("throws for invalid present bounded finite number params", () => {
     expect(readFiniteNumberParam({ quality: "0.75" }, "quality")).toBe(0.75);
     expect(readFiniteNumberParam({ quality: null }, "quality")).toBeUndefined();
+    expect(readFiniteNumberParam({ quality: "" }, "quality")).toBeUndefined();
+    expect(readFiniteNumberParam({ quality: " \t\n" }, "quality")).toBeUndefined();
     expect(() => readFiniteNumberParam({ quality: "0.8jpg" }, "quality")).toThrow(
       "quality must be a finite number",
     );

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -301,7 +301,8 @@ export function readFiniteNumberParam(
     strict: true,
   });
   if (value === undefined) {
-    if (readParamRaw(params, key) != null) {
+    const raw = readParamRaw(params, key);
+    if (raw != null && !isBlankParamValue(raw)) {
       throw new ToolInputError(options.message ?? `${key} must be a finite number`);
     }
     return undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where model-generated tool calls could fail when optional numeric fields were emitted as empty-string defaults instead of being omitted.

This affected finite-number inputs such as media quality, FPS, temperature, confidence, scoring thresholds, and file-size limits. It also fixes a bundled LSP runtime path where requests could wait for the full timeout if a language server started successfully and then exited.

## Why This Change Was Made

This follows up on #100399, which fixed the same blank optional parameter behavior for positive and non-negative integer readers and added buffered LSP spawn-failure handling. The remaining sibling gaps were finite-number parameters and LSP processes that start successfully but then exit.

The finite-number reader now treats blank and whitespace-only strings as unset, while still rejecting nonblank invalid values. The bundled LSP runtime now routes process exits through the same session failure path as process errors, so pending and future requests reject immediately.

## User Impact

Optional numeric tool fields can be left blank by model-generated tool calls without causing avoidable validation failures.

LSP-backed tools fail faster and more clearly when their server process exits unexpectedly, instead of waiting for the per-request timeout.

## Evidence

- Real behavior proof with a scratch Node script exercising production `createImageTool` and `createBundleLspToolRuntime` outside Vitest. The script used a repo-relative media input plus a temporary bundle `.lsp.json` whose stdio LSP child exits during hover:

```text
REAL_BEHAVIOR_PROOF pr=100450 branch=codex/blank-numeric-lsp-exits
proofRoot=<temp proof dir redacted>
image blank optional finite-number maxBytesMb: errorAfterMs=1539 message="Unsupported media type: document"
image invalid nonblank finite-number maxBytesMb: errorAfterMs=1 message="maxBytesMb must be greater than 0"
lsp sessions=1 tools=lsp_hover_proof
lsp hover after child exit: errorAfterMs=8 message="LSP server \"proof\" exited (7)"
lsp hover retry after child exit: errorAfterMs=0 message="LSP server \"proof\" exited (7)"
```

- `node scripts/run-vitest.mjs src/agents/tools/common.params.test.ts src/agents/agent-bundle-lsp-runtime.test.ts` - passed, 2 files
- `pnpm exec oxfmt --check --threads=1 src/agents/tools/common.ts src/agents/tools/common.params.test.ts src/agents/agent-bundle-lsp-runtime.ts src/agents/agent-bundle-lsp-runtime.test.ts` - passed
- `git diff --check` - passed
- Fresh autoreview - clean; no accepted/actionable findings
