### PR TITLE
fix(android): harden offline cache lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 - **Android microphone capture:** treat negative `AudioRecord.read` results as fatal shared-session errors so both transcription and Talk capture stop cleanly after device loss. (#100028) Thanks @NianJiuZst.
 - **Lean local-model tools:** trim media generation, TTS, and PDF tools from lean agent surfaces while preserving explicit config and runtime opt-ins. (#88881) Thanks @vincentkoc.
 - **iOS development app identity:** keep the development app labeled OpenClaw while using its distinct debug icon to differentiate it from release builds.
+- **Android offline chat cache:** serialize Gateway teardown and cache writes during pairing changes, purge SQLite companion files before credential reset, and prevent old sockets or explicit new credentials from restoring another identity's cached conversations.
 - **iOS QR gateway handoff:** stop VisionKit before delivering scanned setup codes, and keep deferred auth, approval, Watch, and foreground-node work bound to its originating gateway across reconnects. (#99572) Thanks @PollyBot13.
 - **Agent terminal failures:** surface a safe interactive reply when an agent run ends without visible output, while preserving completed message-tool delivery and heartbeat-specific guidance. (#99304) Thanks @moeedahmed.
 - **MCP loopback tool results:** preserve schema-valid text, image, and embedded-resource content through HTTP tool calls while rendering malformed or protocol-incompatible blocks as safe text. (#100336) Thanks @tzy-17.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Docs: https://docs.openclaw.ai
 - **Android microphone capture:** treat negative `AudioRecord.read` results as fatal shared-session errors so both transcription and Talk capture stop cleanly after device loss. (#100028) Thanks @NianJiuZst.
 - **Lean local-model tools:** trim media generation, TTS, and PDF tools from lean agent surfaces while preserving explicit config and runtime opt-ins. (#88881) Thanks @vincentkoc.
 - **iOS development app identity:** keep the development app labeled OpenClaw while using its distinct debug icon to differentiate it from release builds.
-- **Android offline chat cache:** serialize Gateway teardown and cache writes during pairing changes, purge SQLite companion files before credential reset, and prevent old sockets or explicit new credentials from restoring another identity's cached conversations.
 - **iOS QR gateway handoff:** stop VisionKit before delivering scanned setup codes, and keep deferred auth, approval, Watch, and foreground-node work bound to its originating gateway across reconnects. (#99572) Thanks @PollyBot13.
 - **Agent terminal failures:** surface a safe interactive reply when an agent run ends without visible output, while preserving completed message-tool delivery and heartbeat-specific guidance. (#99304) Thanks @moeedahmed.
 - **MCP loopback tool results:** preserve schema-valid text, image, and embedded-resource content through HTTP tool calls while rendering malformed or protocol-incompatible blocks as safe text. (#100336) Thanks @tzy-17.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -123,7 +123,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 104,
+      "line": 101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -131,7 +131,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 193,
+      "line": 190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -139,7 +139,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 203,
+      "line": 200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -179,7 +179,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 519,
+      "line": 570,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -187,7 +187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2102,
+      "line": 2223,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2104,
+      "line": 2225,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2106,
+      "line": 2227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -371,7 +371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1098,
+      "line": 1185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -379,7 +379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1098,
+      "line": 1185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -1195,7 +1195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 293,
+      "line": 299,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code points to an insecure remote gateway. $remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
@@ -1203,7 +1203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 295,
+      "line": 301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code points to an insecure remote gateway. $remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
@@ -1211,7 +1211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 297,
+      "line": 303,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "$remoteGatewaySecurityRule $remoteGatewaySecurityFix",
       "surface": "android",
@@ -1219,7 +1219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 302,
+      "line": 308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code uses an IPv6 zone ID. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
@@ -1227,7 +1227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 304,
+      "line": 310,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code uses an IPv6 zone ID. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
@@ -1235,7 +1235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 306,
+      "line": 312,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "IPv6 zone IDs are not supported. Use an unscoped IPv6 address or a LAN hostname.",
       "surface": "android",
@@ -1243,7 +1243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 311,
+      "line": 317,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Setup code has invalid gateway URL.",
       "surface": "android",
@@ -1251,7 +1251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 312,
+      "line": 318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "QR code did not contain a valid setup code.",
       "surface": "android",
@@ -1259,7 +1259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 313,
+      "line": 319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt",
       "source": "Enter a valid manual endpoint to connect.",
       "surface": "android",

--- a/apps/android/THIRD_PARTY_LICENSES/openclaw/licenses/AndroidX Room.txt
+++ b/apps/android/THIRD_PARTY_LICENSES/openclaw/licenses/AndroidX Room.txt
@@ -1,0 +1,182 @@
+AndroidX Room
+Artifacts:
+- androidx.room:room-common
+- androidx.room:room-runtime
+License: Apache License 2.0
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -6,9 +6,6 @@ import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.OutgoingAttachment
-import ai.openclaw.app.chat.deleteChatTranscriptCacheDatabase
-import ai.openclaw.app.gateway.DeviceAuthStore
-import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewayUpdateAvailableSummary
 import ai.openclaw.app.node.CameraCaptureManager
@@ -299,18 +296,10 @@ class MainViewModel(
   }
 
   /** Clears setup credentials without starting the runtime just to discard first-run pairing auth. */
-  private suspend fun resetGatewaySetupAuth() {
-    runtimeRef.value?.resetGatewaySetupAuth() ?: resetGatewaySetupAuthWithoutRuntime()
-  }
-
-  private fun resetGatewaySetupAuthWithoutRuntime() {
-    prefs.clearGatewaySetupAuth()
-    val deviceId = DeviceIdentityStore(nodeApp).loadOrCreate().deviceId
-    val deviceAuthStore = DeviceAuthStore(prefs)
-    deviceAuthStore.clearToken(deviceId, "node")
-    deviceAuthStore.clearToken(deviceId, "operator")
-    // No runtime means no open Room handle, so the cache file can be deleted directly.
-    deleteChatTranscriptCacheDatabase(nodeApp)
+  private suspend fun resetGatewaySetupAuth(): Boolean {
+    val reset = nodeApp.resetGatewaySetupAuth()
+    nodeApp.peekRuntime()?.let { runtimeRef.value = it }
+    return reset
   }
 
   internal fun saveGatewayConfigAndConnect(plan: GatewayConnectPlan) {
@@ -319,11 +308,7 @@ class MainViewModel(
     viewModelScope.launch(Dispatchers.Default) {
       val config = plan.config
       val replacesSavedAuth = plan.savedAuthAction != GatewaySavedAuthAction.PRESERVE
-      val hasExplicitAuth =
-        config.token.isNotEmpty() || config.bootstrapToken.isNotEmpty() || config.password.isNotEmpty()
-      if (replacesSavedAuth) {
-        resetGatewaySetupAuth()
-      }
+      if (replacesSavedAuth && !resetGatewaySetupAuth()) return@launch
       prefs.setManualEnabled(true)
       prefs.setManualHost(config.host)
       prefs.setManualPort(config.port)
@@ -331,7 +316,7 @@ class MainViewModel(
 
       // A blank same-endpoint save means "keep access". Secrets remain runtime-owned,
       // including password-only setups that Compose deliberately cannot read back.
-      if (replacesSavedAuth || hasExplicitAuth) {
+      if (replacesSavedAuth) {
         prefs.setGatewayBootstrapToken(config.bootstrapToken)
         prefs.setGatewayToken(config.token)
         prefs.setGatewayPassword(config.password)
@@ -339,7 +324,7 @@ class MainViewModel(
 
       val runtime = ensureRuntime()
       val endpoint = GatewayEndpoint.manual(host = config.host, port = config.port)
-      if (replacesSavedAuth || hasExplicitAuth) {
+      if (replacesSavedAuth) {
         runtime.connect(
           endpoint,
           NodeRuntime.GatewayConnectAuth(
@@ -365,8 +350,7 @@ class MainViewModel(
   /** Re-enters gateway setup after disconnecting and clearing one-time setup credentials. */
   fun pairNewGateway() {
     viewModelScope.launch(Dispatchers.Default) {
-      runtimeRef.value?.disconnect()
-      resetGatewaySetupAuth()
+      if (!resetGatewaySetupAuth()) return@launch
       prefs.setOnboardingCompleted(false)
       _startOnboardingAtGatewaySetup.value = true
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeApp.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeApp.kt
@@ -1,5 +1,8 @@
 package ai.openclaw.app
 
+import ai.openclaw.app.chat.deleteChatTranscriptCacheDatabase
+import ai.openclaw.app.gateway.DeviceAuthStore
+import ai.openclaw.app.gateway.DeviceIdentityStore
 import android.app.Application
 import android.os.StrictMode
 
@@ -9,22 +12,44 @@ import android.os.StrictMode
 class NodeApp : Application() {
   val prefs: SecurePrefs by lazy { SecurePrefs(this) }
 
-  @Volatile private var runtimeInstance: NodeRuntime? = null
+  private val runtimeLock = Any()
+  private var runtimeInstance: NodeRuntime? = null
 
   /**
    * Returns the single NodeRuntime for this process, creating it on first use.
    */
-  fun ensureRuntime(): NodeRuntime {
-    runtimeInstance?.let { return it }
-    return synchronized(this) {
+  fun ensureRuntime(): NodeRuntime =
+    synchronized(runtimeLock) {
       runtimeInstance ?: NodeRuntime(this, prefs).also { runtimeInstance = it }
     }
-  }
 
   /**
    * Reads the runtime without forcing startup, used by lifecycle probes and services.
    */
-  fun peekRuntime(): NodeRuntime? = runtimeInstance
+  fun peekRuntime(): NodeRuntime? = synchronized(runtimeLock) { runtimeInstance }
+
+  /** Clears pairing auth without racing lazy process-runtime construction. */
+  suspend fun resetGatewaySetupAuth(): Boolean {
+    val runtime =
+      synchronized(runtimeLock) {
+        runtimeInstance?.let { return@synchronized it }
+        // Keep runtime construction blocked through the direct purge: a runtime built from the old
+        // credentials could otherwise reconnect and rewrite device auth after this reset returns.
+        return runCatching { resetGatewaySetupAuthBeforeRuntime() }.getOrDefault(false)
+      }
+    return runtime.resetGatewaySetupAuth()
+  }
+
+  private fun resetGatewaySetupAuthBeforeRuntime(): Boolean {
+    // Delete first: credential destruction must not strand an unreadable cache after a failed purge.
+    if (!deleteChatTranscriptCacheDatabase(this)) return false
+    prefs.clearGatewaySetupAuth()
+    val deviceId = DeviceIdentityStore(this).loadOrCreate().deviceId
+    val deviceAuthStore = DeviceAuthStore(prefs)
+    deviceAuthStore.clearToken(deviceId, "node")
+    deviceAuthStore.clearToken(deviceId, "operator")
+    return true
+  }
 
   override fun onCreate() {
     super.onCreate()

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2,8 +2,8 @@ package ai.openclaw.app
 
 import ai.openclaw.app.chat.ChatCacheDatabase
 import ai.openclaw.app.chat.ChatCacheScope
-import ai.openclaw.app.chat.ChatCommandOutbox
 import ai.openclaw.app.chat.ChatCommandEntry
+import ai.openclaw.app.chat.ChatCommandOutbox
 import ai.openclaw.app.chat.ChatController
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatOutboxItem

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2,12 +2,14 @@ package ai.openclaw.app
 
 import ai.openclaw.app.chat.ChatCacheDatabase
 import ai.openclaw.app.chat.ChatCacheScope
+import ai.openclaw.app.chat.ChatCommandOutbox
 import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatController
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.chat.ChatTranscriptCache
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.chat.RoomChatCommandOutbox
 import ai.openclaw.app.chat.RoomChatTranscriptCache
@@ -66,10 +68,12 @@ import android.os.SystemClock
 import android.util.Base64
 import android.util.Log
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -294,11 +298,58 @@ internal fun gatewayConnectionDisplay(
   }
 }
 
-class NodeRuntime(
+private data class AndroidChatStores(
+  val transcriptCache: ChatTranscriptCache,
+  val commandOutbox: ChatCommandOutbox,
+)
+
+private fun openAndroidChatStores(context: Context): AndroidChatStores {
+  val database = ChatCacheDatabase.open(context.applicationContext)
+  return AndroidChatStores(
+    transcriptCache = RoomChatTranscriptCache(database),
+    commandOutbox = RoomChatCommandOutbox(database),
+  )
+}
+
+class NodeRuntime private constructor(
   context: Context,
-  val prefs: SecurePrefs = SecurePrefs(context.applicationContext),
-  private val tlsFingerprintProbe: suspend (String, Int) -> GatewayTlsProbeResult = ::probeGatewayTlsFingerprint,
+  val prefs: SecurePrefs,
+  private val tlsFingerprintProbe: suspend (String, Int) -> GatewayTlsProbeResult,
+  chatStores: AndroidChatStores,
 ) {
+  private val chatTranscriptCache = chatStores.transcriptCache
+  private val chatCommandOutbox = chatStores.commandOutbox
+  private val gatewayAuthLifecycleLock = Any()
+  private var gatewayAuthResetInProgress = false
+  private var gatewayConnectOperationsInFlight = 0
+  private var gatewayConnectOperationsDrained = CompletableDeferred(Unit)
+
+  constructor(
+    context: Context,
+    prefs: SecurePrefs = SecurePrefs(context.applicationContext),
+    tlsFingerprintProbe: suspend (String, Int) -> GatewayTlsProbeResult = ::probeGatewayTlsFingerprint,
+  ) : this(
+    context = context,
+    prefs = prefs,
+    tlsFingerprintProbe = tlsFingerprintProbe,
+    chatStores = openAndroidChatStores(context),
+  )
+
+  internal constructor(
+    context: Context,
+    prefs: SecurePrefs,
+    chatTranscriptCache: ChatTranscriptCache,
+  ) : this(
+    context = context,
+    prefs = prefs,
+    tlsFingerprintProbe = ::probeGatewayTlsFingerprint,
+    chatStores =
+      AndroidChatStores(
+        transcriptCache = chatTranscriptCache,
+        commandOutbox = RoomChatCommandOutbox(ChatCacheDatabase.open(context.applicationContext)),
+      ),
+  )
+
   /**
    * Authentication material supplied by setup/manual connect flows before gateway session routing.
    */
@@ -843,15 +894,6 @@ class NodeRuntime(
     }
   }
 
-  // One Room handle owns both chat stores (disposable transcript cache + durable command outbox).
-  private val chatCacheDatabase: ChatCacheDatabase = ChatCacheDatabase.open(appContext)
-
-  private val chatTranscriptCache: RoomChatTranscriptCache =
-    RoomChatTranscriptCache(database = chatCacheDatabase)
-
-  private val chatCommandOutbox: RoomChatCommandOutbox =
-    RoomChatCommandOutbox(database = chatCacheDatabase)
-
   private val chat: ChatController =
     ChatController(
       scope = scope,
@@ -1280,16 +1322,43 @@ class NodeRuntime(
   fun setGatewayPassword(value: String) = prefs.setGatewayPassword(value)
 
   /** Clears setup credentials plus paired device tokens for both Android gateway roles. */
-  suspend fun resetGatewaySetupAuth() {
-    prefs.clearGatewaySetupAuth()
-    val deviceId = identityStore.loadOrCreate().deviceId
-    deviceAuthStore.clearToken(deviceId, "node")
-    deviceAuthStore.clearToken(deviceId, "operator")
-    // A pairing/auth reset can precede pairing a different gateway principal at the same
-    // endpoint id. The purge must complete before pairing continues: queued commands are
-    // replayed on reconnect, so an async purge could flush stale rows to the new principal.
-    runCatching { chatTranscriptCache.clearAll() }
-    runCatching { chatCommandOutbox.clearAll() }
+  suspend fun resetGatewaySetupAuth(): Boolean {
+    val connectOperationsDrained =
+      synchronized(gatewayAuthLifecycleLock) {
+        if (gatewayAuthResetInProgress) {
+          null
+        } else {
+          gatewayAuthResetInProgress = true
+          gatewayConnectOperationsDrained
+        }
+      }
+        ?: return false
+    return try {
+      connectOperationsDrained.await()
+      // Quiesce authenticated sockets before purging. The controller serializes cache mutations,
+      // so any old write finishes before clear and queued old writes self-reject.
+      disconnectAndJoin()
+      // An old socket callback may have started cache work after prepareDisconnect() advanced the
+      // generation. Advance it again after both terminal callbacks so that work self-rejects.
+      connectAttemptSeq.incrementAndGet()
+      chat.onGatewayScopeChanging()
+      // Purge before destroying credentials. A database failure can abort re-pairing safely while
+      // the old authentication remains recoverable, instead of leaving a half-reset identity.
+      val cacheCleared =
+        runCatching { chat.clearTranscriptCache() }
+          .onFailure { err ->
+            Log.e("OpenClawRuntime", "Failed to purge offline chat cache before auth reset", err)
+            setStandaloneGatewayStatus("Failed: couldn't clear offline chat data. Retry sign out.")
+          }.isSuccess
+      if (!cacheCleared) return false
+      prefs.clearGatewaySetupAuth()
+      val deviceId = identityStore.loadOrCreate().deviceId
+      deviceAuthStore.clearToken(deviceId, "node")
+      deviceAuthStore.clearToken(deviceId, "operator")
+      true
+    } finally {
+      synchronized(gatewayAuthLifecycleLock) { gatewayAuthResetInProgress = false }
+    }
   }
 
   /** Persists onboarding state; callers decide whether runtime startup is needed first. */
@@ -1921,54 +1990,86 @@ class NodeRuntime(
     endpoint: GatewayEndpoint,
     auth: GatewayConnectAuth,
     reconnect: Boolean = false,
-  ) {
-    activeGatewayAuth = auth
-    val tls = connectionManager.resolveTlsParams(endpoint)
-    val storedOperatorEntry = loadStoredRoleDeviceAuthEntry("operator")
-    refreshGatewayControlPage(endpoint, auth, storedOperatorEntry?.token)
-    val usesStoredOperatorDeviceToken =
-      operatorSessionUsesStoredDeviceToken(auth, storedOperatorEntry?.token)
-    val operatorAuth =
-      resolveOperatorSessionConnectAuth(
-        auth = auth,
-        storedOperatorToken = storedOperatorEntry?.token,
-      )
-    if (operatorAuth == null) {
-      updateStatus {
-        operatorConnected = false
-        operatorStatusText = "Offline"
-        operatorConnectionProblem = null
+    beforeConnect: () -> Unit = {},
+  ): Boolean =
+    runGatewayConnectOperation {
+      beforeConnect()
+      activeGatewayAuth = auth
+      val tls = connectionManager.resolveTlsParams(endpoint)
+      val storedOperatorEntry = loadStoredRoleDeviceAuthEntry("operator")
+      refreshGatewayControlPage(endpoint, auth, storedOperatorEntry?.token)
+      val usesStoredOperatorDeviceToken =
+        operatorSessionUsesStoredDeviceToken(auth, storedOperatorEntry?.token)
+      val operatorAuth =
+        resolveOperatorSessionConnectAuth(
+          auth = auth,
+          storedOperatorToken = storedOperatorEntry?.token,
+        )
+      if (operatorAuth == null) {
+        updateStatus {
+          operatorConnected = false
+          operatorStatusText = "Offline"
+          operatorConnectionProblem = null
+        }
+        operatorSession.disconnect()
+      } else {
+        operatorSession.connect(
+          endpoint,
+          operatorAuth.token,
+          operatorAuth.bootstrapToken,
+          operatorAuth.password,
+          connectionManager.buildOperatorConnectOptions(
+            scopes =
+              operatorConnectScopesForAuth(
+                usesStoredDeviceToken = usesStoredOperatorDeviceToken,
+                storedOperatorScopes = storedOperatorEntry?.scopes,
+              ),
+          ),
+          tls,
+        )
       }
-      operatorSession.disconnect()
-    } else {
-      operatorSession.connect(
+      nodeSession.connect(
         endpoint,
-        operatorAuth.token,
-        operatorAuth.bootstrapToken,
-        operatorAuth.password,
-        connectionManager.buildOperatorConnectOptions(
-          scopes =
-            operatorConnectScopesForAuth(
-              usesStoredDeviceToken = usesStoredOperatorDeviceToken,
-              storedOperatorScopes = storedOperatorEntry?.scopes,
-            ),
-        ),
+        auth.token,
+        auth.bootstrapToken,
+        auth.password,
+        connectionManager.buildNodeConnectOptions(),
         tls,
       )
+      if (reconnect && operatorAuth != null) {
+        operatorSession.reconnect()
+      }
+      if (reconnect) {
+        nodeSession.reconnect()
+      }
     }
-    nodeSession.connect(
-      endpoint,
-      auth.token,
-      auth.bootstrapToken,
-      auth.password,
-      connectionManager.buildNodeConnectOptions(),
-      tls,
-    )
-    if (reconnect && operatorAuth != null) {
-      operatorSession.reconnect()
-    }
-    if (reconnect) {
-      nodeSession.reconnect()
+
+  // Auth reset waits for claimed connection starts before disconnecting. Session calls stay outside
+  // this monitor because GatewaySession invokes callbacks while holding its own lifecycle monitor.
+  private fun runGatewayConnectOperation(block: () -> Unit): Boolean {
+    val claimed =
+      synchronized(gatewayAuthLifecycleLock) {
+        if (gatewayAuthResetInProgress) {
+          false
+        } else {
+          if (gatewayConnectOperationsInFlight == 0) {
+            gatewayConnectOperationsDrained = CompletableDeferred()
+          }
+          gatewayConnectOperationsInFlight += 1
+          true
+        }
+      }
+    if (!claimed) return false
+    try {
+      block()
+      return true
+    } finally {
+      val drained =
+        synchronized(gatewayAuthLifecycleLock) {
+          gatewayConnectOperationsInFlight -= 1
+          gatewayConnectOperationsDrained.takeIf { gatewayConnectOperationsInFlight == 0 }
+        }
+      drained?.complete(Unit)
     }
   }
 
@@ -1976,6 +2077,9 @@ class NodeRuntime(
     endpoint: GatewayEndpoint,
     auth: GatewayConnectAuth,
   ) {
+    synchronized(gatewayAuthLifecycleLock) {
+      if (gatewayAuthResetInProgress) return
+    }
     // A user-selected connect target must never inherit notification content from another gateway.
     notificationOutbox.clear()
     invalidateNodeCapabilityApprovalState()
@@ -2007,13 +2111,16 @@ class NodeRuntime(
             ?: fp
         val previousFingerprint = expectedFingerprint?.takeUnless { it == observedFingerprint }
         if (expectedFingerprint == null || previousFingerprint != null) {
-          _pendingGatewayTrust.value =
-            GatewayTrustPrompt(
-              endpoint = endpoint,
-              fingerprintSha256 = observedFingerprint,
-              auth = auth,
-              previousFingerprintSha256 = previousFingerprint,
-            )
+          publishGatewayTrustPromptIfCurrent(
+            connectAttemptId = connectAttemptId,
+            prompt =
+              GatewayTrustPrompt(
+                endpoint = endpoint,
+                fingerprintSha256 = observedFingerprint,
+                auth = auth,
+                previousFingerprintSha256 = previousFingerprint,
+              ),
+          )
           return@launch
         }
         connectAfterTlsCheck(endpoint = endpoint, auth = auth, connectAttemptId = connectAttemptId)
@@ -2025,6 +2132,19 @@ class NodeRuntime(
   }
 
   private fun isCurrentConnectAttempt(connectAttemptId: Long): Boolean = connectAttemptSeq.get() == connectAttemptId
+
+  private fun publishGatewayTrustPromptIfCurrent(
+    connectAttemptId: Long,
+    prompt: GatewayTrustPrompt,
+  ): Boolean =
+    synchronized(gatewayAuthLifecycleLock) {
+      if (gatewayAuthResetInProgress || !isCurrentConnectAttempt(connectAttemptId)) {
+        false
+      } else {
+        _pendingGatewayTrust.value = prompt
+        true
+      }
+    }
 
   private fun refreshGatewayControlPage(
     endpoint: GatewayEndpoint? = connectedEndpoint,
@@ -2050,14 +2170,15 @@ class NodeRuntime(
     connectAttemptId: Long,
   ) {
     if (!isCurrentConnectAttempt(connectAttemptId)) return
-    connectedEndpoint = endpoint
-    updateStatus {
-      operatorConnectionProblem = null
-      nodeConnectionProblem = null
-      operatorStatusText = "Connecting…"
-      nodeStatusText = "Connecting…"
+    connectWithAuth(endpoint = endpoint, auth = auth) {
+      connectedEndpoint = endpoint
+      updateStatus {
+        operatorConnectionProblem = null
+        nodeConnectionProblem = null
+        operatorStatusText = "Connecting…"
+        nodeStatusText = "Connecting…"
+      }
     }
-    connectWithAuth(endpoint = endpoint, auth = auth)
   }
 
   fun connect(endpoint: GatewayEndpoint) {
@@ -2132,38 +2253,54 @@ class NodeRuntime(
     endpoint: GatewayEndpoint,
     auth: GatewayConnectAuth,
   ) {
-    if (operatorConnected) {
-      return
+    runGatewayConnectOperation {
+      if (operatorConnected) return@runGatewayConnectOperation
+      val storedOperatorEntry = loadStoredRoleDeviceAuthEntry("operator")
+      val usesStoredOperatorDeviceToken =
+        operatorSessionUsesStoredDeviceToken(auth, storedOperatorEntry?.token)
+      val operatorAuth =
+        resolveOperatorSessionConnectAuth(
+          auth = auth,
+          storedOperatorToken = storedOperatorEntry?.token,
+        ) ?: return@runGatewayConnectOperation
+      updateStatus {
+        operatorStatusText = "Connecting…"
+        operatorConnectionProblem = null
+      }
+      operatorSession.connect(
+        endpoint,
+        operatorAuth.token,
+        operatorAuth.bootstrapToken,
+        operatorAuth.password,
+        connectionManager.buildOperatorConnectOptions(
+          scopes =
+            operatorConnectScopesForAuth(
+              usesStoredDeviceToken = usesStoredOperatorDeviceToken,
+              storedOperatorScopes = storedOperatorEntry?.scopes,
+            ),
+        ),
+        connectionManager.resolveTlsParams(endpoint),
+      )
     }
-    val storedOperatorEntry = loadStoredRoleDeviceAuthEntry("operator")
-    val usesStoredOperatorDeviceToken =
-      operatorSessionUsesStoredDeviceToken(auth, storedOperatorEntry?.token)
-    val operatorAuth =
-      resolveOperatorSessionConnectAuth(
-        auth = auth,
-        storedOperatorToken = storedOperatorEntry?.token,
-      ) ?: return
-    updateStatus {
-      operatorStatusText = "Connecting…"
-      operatorConnectionProblem = null
-    }
-    operatorSession.connect(
-      endpoint,
-      operatorAuth.token,
-      operatorAuth.bootstrapToken,
-      operatorAuth.password,
-      connectionManager.buildOperatorConnectOptions(
-        scopes =
-          operatorConnectScopesForAuth(
-            usesStoredDeviceToken = usesStoredOperatorDeviceToken,
-            storedOperatorScopes = storedOperatorEntry?.scopes,
-          ),
-      ),
-      connectionManager.resolveTlsParams(endpoint),
-    )
   }
 
   fun disconnect() {
+    prepareDisconnect()
+    operatorSession.disconnect()
+    nodeSession.disconnect()
+  }
+
+  private suspend fun disconnectAndJoin() {
+    prepareDisconnect()
+    // Both sockets close before either reconnect loop is joined, so no authenticated role stays
+    // live while reset waits for the other role's terminal callback.
+    coroutineScope {
+      launch { operatorSession.disconnectAndJoin() }
+      launch { nodeSession.disconnectAndJoin() }
+    }
+  }
+
+  private fun prepareDisconnect() {
     notificationOutbox.clear()
     connectAttemptSeq.incrementAndGet()
     chat.onGatewayScopeChanging()
@@ -2176,8 +2313,6 @@ class NodeRuntime(
       nodeConnectionProblem = null
     }
     _pendingGatewayTrust.value = null
-    operatorSession.disconnect()
-    nodeSession.disconnect()
   }
 
   fun handleCanvasA2UIActionFromWebView(payloadJson: String) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -1,8 +1,8 @@
 package ai.openclaw.app.chat
 
-import ai.openclaw.app.resolveAgentIdFromMainSessionKey
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.parseChatSendAck
+import ai.openclaw.app.resolveAgentIdFromMainSessionKey
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -11,6 +11,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -54,6 +56,7 @@ class ChatController internal constructor(
   )
 
   private var appliedMainSessionKey = "main"
+  private val cacheMutationMutex = Mutex()
   private val _sessionKey = MutableStateFlow("main")
   val sessionKey: StateFlow<String> = _sessionKey.asStateFlow()
 
@@ -159,6 +162,15 @@ class ChatController internal constructor(
       _sessions.value = emptyList()
       // Outbox rows are gateway-scoped too; the next publish repopulates them for the new scope.
       _outboxItems.value = emptyList()
+    }
+  }
+
+  /** Purges cached transcripts and queued sends after old-scope writes finish. */
+  internal suspend fun clearTranscriptCache() {
+    val cache = transcriptCache ?: return
+    cacheMutationMutex.withLock {
+      cache.clearAll()
+      commandOutbox?.clearAll()
     }
   }
 
@@ -312,8 +324,7 @@ class ChatController internal constructor(
     return key
   }
 
-  private fun resolveAgentIdForSessionKey(parentKey: String): String =
-    resolveAgentIdFromMainSessionKey(parentKey) ?: "main"
+  private fun resolveAgentIdForSessionKey(parentKey: String): String = resolveAgentIdFromMainSessionKey(parentKey) ?: "main"
 
   /** Queues a chat send without waiting for gateway acceptance. */
   fun sendMessage(
@@ -647,17 +658,24 @@ class ChatController internal constructor(
     messages: List<ChatMessage>,
   ) {
     val cache = transcriptCache ?: return
-    val gatewayId = requestCacheScope?.gatewayId ?: return
-    runCatching { cache.saveTranscript(gatewayId, sessionKey, messages) }
+    val capturedScope = requestCacheScope ?: return
+    cacheMutationMutex.withLock {
+      if (capturedScope != currentCacheScope()) return@withLock
+      runCatching { cache.saveTranscript(capturedScope.gatewayId, sessionKey, messages) }
+    }
   }
 
   private suspend fun persistSessions(
     requestCacheScope: ChatCacheScope?,
     sessions: List<ChatSessionEntry>,
+    retainedSessionKey: String?,
   ) {
     val cache = transcriptCache ?: return
-    val gatewayId = requestCacheScope?.gatewayId ?: return
-    runCatching { cache.saveSessions(gatewayId, sessions) }
+    val capturedScope = requestCacheScope ?: return
+    cacheMutationMutex.withLock {
+      if (capturedScope != currentCacheScope()) return@withLock
+      runCatching { cache.saveSessions(capturedScope.gatewayId, sessions, retainedSessionKey) }
+    }
   }
 
   private suspend fun fetchSessions(limit: Int?) {
@@ -670,15 +688,19 @@ class ChatController internal constructor(
           if (limit != null && limit > 0) put("limit", JsonPrimitive(limit))
         }
       val res = requestGateway("sessions.list", params.toString())
-      val sessions = parseSessions(res)
-      val applied =
+      val result = parseSessions(res)
+      val retainedSessionKey =
         synchronized(gatewayScopeApplyLock) {
-          if (requestCacheScope != currentCacheScope()) return@synchronized false
-          _sessions.value = sessions
-          true
+          if (requestCacheScope != currentCacheScope()) return
+          _sessions.value = result.sessions
+          val activeSessionKey = _sessionKey.value
+          val activeOutsideLocalWindow =
+            result.sessions
+              .drop(MAX_CACHED_SESSIONS)
+              .any { session -> session.key == activeSessionKey }
+          activeSessionKey.takeIf { result.isTruncated || activeOutsideLocalWindow }
         }
-      if (!applied) return
-      persistSessions(requestCacheScope, sessions)
+      persistSessions(requestCacheScope, result.sessions, retainedSessionKey)
     } catch (_: Throwable) {
       // best-effort
     }
@@ -1241,10 +1263,25 @@ class ChatController internal constructor(
     return ChatInFlightRun(runId = runId, text = obj["text"].asStringOrNull().orEmpty())
   }
 
-  private fun parseSessions(jsonString: String): List<ChatSessionEntry> {
-    val root = json.parseToJsonElement(jsonString).asObjectOrNull() ?: return emptyList()
-    val sessions = root["sessions"].asArrayOrNull() ?: return emptyList()
-    return sessions.mapNotNull { item -> parseSessionEntry(item.asObjectOrNull()) }
+  private data class SessionListResult(
+    val sessions: List<ChatSessionEntry>,
+    val isTruncated: Boolean,
+  )
+
+  private fun parseSessions(jsonString: String): SessionListResult {
+    val root =
+      json.parseToJsonElement(jsonString).asObjectOrNull()
+        ?: return SessionListResult(emptyList(), isTruncated = false)
+    val sessions =
+      root["sessions"]
+        .asArrayOrNull()
+        ?.mapNotNull { item -> parseSessionEntry(item.asObjectOrNull()) }
+        .orEmpty()
+    val totalCount = root["totalCount"].asLongOrNull()
+    val isTruncated =
+      root["hasMore"].asBooleanOrNull() == true ||
+         (totalCount != null && totalCount > sessions.size)
+    return SessionListResult(sessions, isTruncated)
   }
 
   private fun parseSessionEntry(
@@ -1311,11 +1348,12 @@ class ChatController internal constructor(
     // reappear on the next offline cold open. Queued commands for the session die with it too.
     val requestCacheScope = currentCacheScope() ?: return
     scope.launch {
-      transcriptCache?.let { runCatching { it.deleteSession(requestCacheScope.gatewayId, key) } }
-      commandOutbox?.let {
-        runCatching { it.deleteForSession(requestCacheScope.gatewayId, key) }
-        publishOutbox()
+      cacheMutationMutex.withLock {
+        if (requestCacheScope != currentCacheScope()) return@withLock
+        transcriptCache?.let { runCatching { it.deleteSession(requestCacheScope.gatewayId, key) } }
+        commandOutbox?.let { runCatching { it.deleteForSession(requestCacheScope.gatewayId, key) } }
       }
+      publishOutbox()
     }
   }
 
@@ -1397,8 +1435,14 @@ internal fun parseChatMessageContents(obj: JsonObject): List<ChatMessageContent>
   return emptyList()
 }
 
-private fun parseCreatedSessionKey(json: Json, sessionJson: String): String? {
-  val root = runCatching { json.parseToJsonElement(sessionJson).asObjectOrNull() }.getOrNull() ?: return null
+private fun parseCreatedSessionKey(
+  json: Json,
+  sessionJson: String,
+): String? {
+  val root =
+    runCatching { json.parseToJsonElement(sessionJson).asObjectOrNull() }.getOrNull()
+      ?: return null
+
   fun clean(value: String?): String? = value?.trim()?.takeIf { it.isNotEmpty() }
   return clean(root["key"].asStringOrNull())
     ?: clean(root["sessionKey"].asStringOrNull())

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -1280,7 +1280,7 @@ class ChatController internal constructor(
     val totalCount = root["totalCount"].asLongOrNull()
     val isTruncated =
       root["hasMore"].asBooleanOrNull() == true ||
-         (totalCount != null && totalCount > sessions.size)
+        (totalCount != null && totalCount > sessions.size)
     return SessionListResult(sessions, isTruncated)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
@@ -39,7 +39,7 @@ internal fun deleteDatabaseFiles(
       File(databasePath.path + "-journal"),
       File(databasePath.path + "-shm"),
       File(databasePath.path + "-wal"),
-  )
+    )
   if (fixedFiles.any(File::exists)) return false
   val parent = databasePath.parentFile ?: return true
   val siblings = parent.listFiles() ?: return !parent.exists()

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
@@ -13,6 +13,7 @@ import androidx.room.withTransaction
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
+import java.io.File
 import java.util.UUID
 
 /** Upper bound of cached session rows per gateway; oldest list positions are evicted on write. */
@@ -21,11 +22,29 @@ internal const val MAX_CACHED_SESSIONS = 50
 internal const val CHAT_TRANSCRIPT_CACHE_DB_NAME = "chat-transcript-cache.db"
 
 /**
- * Deletes the cache database file outright. Only safe while no [RoomChatTranscriptCache] is open
- * in this process; used by pairing-reset paths that run before the node runtime exists.
+ * Deletes the cache database and every SQLite-owned companion file. Only safe while no
+ * [RoomChatTranscriptCache] is open in this process; used before the node runtime exists.
  */
-internal fun deleteChatTranscriptCacheDatabase(context: Context) {
-  context.deleteDatabase(CHAT_TRANSCRIPT_CACHE_DB_NAME)
+internal fun deleteChatTranscriptCacheDatabase(context: Context): Boolean = deleteDatabaseFiles(context, CHAT_TRANSCRIPT_CACHE_DB_NAME)
+
+internal fun deleteDatabaseFiles(
+  context: Context,
+  databaseName: String,
+): Boolean {
+  val databasePath = context.getDatabasePath(databaseName)
+  context.deleteDatabase(databaseName)
+  val fixedFiles =
+    listOf(
+      databasePath,
+      File(databasePath.path + "-journal"),
+      File(databasePath.path + "-shm"),
+      File(databasePath.path + "-wal"),
+  )
+  if (fixedFiles.any(File::exists)) return false
+  val parent = databasePath.parentFile ?: return true
+  val siblings = parent.listFiles() ?: return !parent.exists()
+  val masterJournalPrefix = databasePath.name + "-mj"
+  return siblings.none { file -> file.name.startsWith(masterJournalPrefix) }
 }
 
 /** Upper bound of cached transcript rows per session; only the newest messages are kept. */
@@ -35,7 +54,8 @@ internal const val MAX_CACHED_MESSAGES_PER_SESSION = 200
  * Read-only offline cache of chat sessions and transcripts.
  *
  * The cache is disposable: it only speeds up cold open and enables offline browsing.
- * Live `chat.history` / `sessions.list` responses always replace cached data wholesale.
+ * Live responses replace cached data; the active deep session may be retained outside the newest
+ * session-list window so its transcript remains available offline.
  */
 interface ChatTranscriptCache {
   suspend fun loadSessions(gatewayId: String): List<ChatSessionEntry>
@@ -48,6 +68,7 @@ interface ChatTranscriptCache {
   suspend fun saveSessions(
     gatewayId: String,
     sessions: List<ChatSessionEntry>,
+    retainedSessionKey: String? = null,
   )
 
   suspend fun saveTranscript(
@@ -93,6 +114,12 @@ internal data class CachedMessageEntity(
 internal interface ChatCacheDao {
   @Query("SELECT * FROM cached_sessions WHERE gatewayId = :gatewayId ORDER BY rowOrder ASC")
   suspend fun sessions(gatewayId: String): List<CachedSessionEntity>
+
+  @Query("SELECT * FROM cached_sessions WHERE gatewayId = :gatewayId AND sessionKey = :sessionKey")
+  suspend fun session(
+    gatewayId: String,
+    sessionKey: String,
+  ): CachedSessionEntity?
 
   @Query(
     "SELECT * FROM cached_messages WHERE gatewayId = :gatewayId AND sessionKey = :sessionKey ORDER BY rowOrder ASC",
@@ -221,22 +248,43 @@ class RoomChatTranscriptCache internal constructor(
   override suspend fun saveSessions(
     gatewayId: String,
     sessions: List<ChatSessionEntry>,
+    retainedSessionKey: String?,
   ) {
     val gateway = scopedGatewayId(gatewayId) ?: return
-    val rows =
-      sessions.take(MAX_CACHED_SESSIONS).mapIndexed { index, session ->
-        CachedSessionEntity(
-          gatewayId = gateway,
-          sessionKey = session.key,
-          displayName = session.displayName,
-          updatedAtMs = session.updatedAtMs,
-          rowOrder = index,
-        )
-      }
+    val retainedKey = retainedSessionKey?.trim()?.takeIf { it.isNotEmpty() }
     val dao = database.dao()
     database.withTransaction {
+      val initialSessions = sessions.take(MAX_CACHED_SESSIONS)
+      val needsRetainedRow = retainedKey != null && initialSessions.none { it.key == retainedKey }
+      val retainedEntry = if (needsRetainedRow) sessions.firstOrNull { it.key == retainedKey } else null
+      val retainedRow =
+        if (needsRetainedRow) {
+          retainedEntry?.let { entry ->
+            CachedSessionEntity(
+              gatewayId = gateway,
+              sessionKey = entry.key,
+              displayName = entry.displayName,
+              updatedAtMs = entry.updatedAtMs,
+              rowOrder = 0,
+            )
+          } ?: dao.session(gateway, retainedKey)
+        } else {
+          null
+        }
+      val listedSessionLimit = MAX_CACHED_SESSIONS - if (retainedRow == null) 0 else 1
+      val rows =
+        sessions.take(listedSessionLimit).mapIndexed { index, session ->
+          CachedSessionEntity(
+            gatewayId = gateway,
+            sessionKey = session.key,
+            displayName = session.displayName,
+            updatedAtMs = session.updatedAtMs,
+            rowOrder = index,
+          )
+        }
       dao.deleteSessions(gateway)
       dao.insertSessions(rows)
+      retainedRow?.let { dao.insertSessions(listOf(it.copy(rowOrder = rows.size))) }
       dao.evictOrphanedTranscripts(gateway)
     }
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -4,8 +4,11 @@ import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
@@ -31,6 +34,7 @@ import okhttp3.WebSocketListener
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -217,6 +221,10 @@ class GatewaySession(
 
   private var job: Job? = null
 
+  // Disconnect cleanups form one ordered tail so an awaited auth reset also waits for any earlier
+  // fire-and-forget disconnect that already detached the reconnect job from this session.
+  private var disconnectTail: Job? = null
+
   @Volatile private var currentConnection: Connection? = null
 
   // One reconnect can retry a shared-token mismatch by pairing the shared token with the stored device token.
@@ -252,8 +260,18 @@ class GatewaySession(
 
   /** Clears desired connection state, closes the socket, and stops reconnect attempts. */
   fun disconnect() {
+    scheduleDisconnect()
+  }
+
+  /** Disconnects and waits until the old reconnect loop and its final callback have stopped. */
+  suspend fun disconnectAndJoin() {
+    scheduleDisconnect().join()
+  }
+
+  private fun scheduleDisconnect(): Job {
     val jobToCancel: Job?
     val connectionToClose: Connection?
+    val cleanup: Job
     synchronized(lifecycleLock) {
       desired = null
       pendingDeviceTokenRetry = false
@@ -262,16 +280,23 @@ class GatewaySession(
       connectionToClose = currentConnection
       jobToCancel = job
       job = null
+      val previousCleanup = disconnectTail
+      cleanup =
+        scope.launch(Dispatchers.IO, start = CoroutineStart.LAZY) {
+          previousCleanup?.join()
+          jobToCancel?.cancelAndJoin()
+          connectionToClose?.joinOwnedWork()
+          if (desired == null) {
+            pluginSurfaceUrls = emptyMap()
+            mainSessionKey = null
+            onDisconnected("Offline")
+          }
+        }
+      disconnectTail = cleanup
     }
     connectionToClose?.closeQuietly()
-    scope.launch(Dispatchers.IO) {
-      jobToCancel?.cancelAndJoin()
-      if (desired == null) {
-        pluginSurfaceUrls = emptyMap()
-        mainSessionKey = null
-      }
-      onDisconnected("Offline")
-    }
+    cleanup.start()
+    return cleanup
   }
 
   /** Forces the current socket closed so the loop reconnects to the current desired endpoint. */
@@ -420,11 +445,21 @@ class GatewaySession(
     private val options: GatewayConnectOptions,
     val tls: GatewayTlsParams?,
   ) {
+    private val connectionJob = SupervisorJob(scope.coroutineContext[Job])
+    private val connectionScope = CoroutineScope(scope.coroutineContext + connectionJob)
     private val state = AtomicReference(ConnectionState.CONNECTING)
     private val connectDeferred = CompletableDeferred<ConnectedGateway>()
     private val closedDeferred = CompletableDeferred<Unit>()
     private val connectNonceDeferred = CompletableDeferred<String>()
+    private val terminalCallbackClaimed = AtomicBoolean(false)
+
+    @Volatile
+    private var connectHandshakeJob: Job? = null
+
+    @Volatile
+    private var connectRequestId: String? = null
     private val client: OkHttpClient = buildClient()
+    private val listener = Listener()
     private var socket: WebSocket? = null
     private val loggerTag = "OpenClawGateway"
     private val incomingMessages = Channel<String>(Channel.UNLIMITED)
@@ -434,7 +469,7 @@ class GatewaySession(
 
     private val pendingLock = Any()
     private val messagePumpJob =
-      scope.launch(Dispatchers.IO) {
+      connectionScope.launch(Dispatchers.IO) {
         for (text in incomingMessages) {
           try {
             handleMessage(text)
@@ -454,7 +489,7 @@ class GatewaySession(
     suspend fun connect(): ConnectedGateway {
       val url = buildGatewayWebSocketUrl(endpoint.host, endpoint.port, tls != null)
       val request = Request.Builder().url(url).build()
-      socket = client.newWebSocket(request, Listener())
+      socket = client.newWebSocket(request, listener)
       return connectDeferred.await()
     }
 
@@ -464,6 +499,7 @@ class GatewaySession(
       timeoutMs: Long,
     ): RpcResponse {
       val id = UUID.randomUUID().toString()
+      if (method == "connect") connectRequestId = id
       val deferred = registerPending(id)
       try {
         sendJson(buildRequestFrame(id = id, method = method, params = params))
@@ -472,6 +508,7 @@ class GatewaySession(
         throw IllegalStateException("request timeout")
       } finally {
         pending.remove(id)
+        if (connectRequestId == id) connectRequestId = null
       }
     }
 
@@ -489,7 +526,7 @@ class GatewaySession(
         pending.remove(id)
         throw err
       }
-      scope.launch(Dispatchers.IO) {
+      connectionScope.launch(Dispatchers.IO) {
         try {
           val response =
             try {
@@ -545,6 +582,18 @@ class GatewaySession(
 
     suspend fun awaitClose() = closedDeferred.await()
 
+    suspend fun joinOwnedWork() {
+      // Close the inbound channel before joining so already accepted frames drain in order. A
+      // connect response may contain the one-time device token needed after bootstrap auth.
+      messagePumpJob.join()
+      closedDeferred.await()
+      failPending()
+      // handleResponse() completes the request deferred; the separate handshake continuation must
+      // still parse and persist its issued token before remaining connection work is cancelled.
+      connectHandshakeJob?.join()
+      connectionJob.cancelAndJoin()
+    }
+
     fun isReady(): Boolean = state.get() == ConnectionState.READY
 
     fun markReady(): Boolean = state.compareAndSet(ConnectionState.CONNECTING, ConnectionState.READY)
@@ -552,12 +601,22 @@ class GatewaySession(
     fun closeQuietly() {
       if (state.getAndSet(ConnectionState.CLOSED) != ConnectionState.CLOSED) {
         incomingMessages.close()
-        messagePumpJob.cancel()
         if (!connectDeferred.isCompleted) {
           connectDeferred.completeExceptionally(IllegalStateException("Gateway closed"))
         }
-        failPending()
-        socket?.close(1000, "bye")
+      }
+      // Explicit retirement is immediate. WebSocket.close() only queues a close frame and can
+      // leave the old transport live for OkHttp's full close timeout.
+      socket?.cancel() ?: closedDeferred.complete(Unit)
+    }
+
+    private fun finishTransport(message: String) {
+      if (!terminalCallbackClaimed.compareAndSet(false, true)) return
+      val shouldNotify = state.getAndSet(ConnectionState.CLOSED) != ConnectionState.CLOSED
+      incomingMessages.close()
+      try {
+        if (shouldNotify) onDisconnected(message)
+      } finally {
         socket = null
         closedDeferred.complete(Unit)
       }
@@ -586,15 +645,16 @@ class GatewaySession(
         webSocket: WebSocket,
         response: Response,
       ) {
-        scope.launch {
-          try {
-            val nonce = awaitConnectNonce()
-            sendConnect(nonce)
-          } catch (err: Throwable) {
-            connectDeferred.completeExceptionally(err)
-            closeQuietly()
+        connectHandshakeJob =
+          connectionScope.launch {
+            try {
+              val nonce = awaitConnectNonce()
+              sendConnect(nonce)
+            } catch (err: Throwable) {
+              connectDeferred.completeExceptionally(err)
+              closeQuietly()
+            }
           }
-        }
       }
 
       override fun onMessage(
@@ -612,12 +672,7 @@ class GatewaySession(
         if (!connectDeferred.isCompleted) {
           connectDeferred.completeExceptionally(t)
         }
-        if (state.getAndSet(ConnectionState.CLOSED) != ConnectionState.CLOSED) {
-          incomingMessages.close()
-          failPending()
-          closedDeferred.complete(Unit)
-          onDisconnected("Gateway error: ${t.message ?: t::class.java.simpleName}")
-        }
+        finishTransport("Gateway error: ${t.message ?: t::class.java.simpleName}")
       }
 
       override fun onClosed(
@@ -628,12 +683,7 @@ class GatewaySession(
         if (!connectDeferred.isCompleted) {
           connectDeferred.completeExceptionally(IllegalStateException("Gateway closed: $reason"))
         }
-        if (state.getAndSet(ConnectionState.CLOSED) != ConnectionState.CLOSED) {
-          incomingMessages.close()
-          failPending()
-          closedDeferred.complete(Unit)
-          onDisconnected("Gateway closed: $reason")
-        }
+        finishTransport("Gateway closed: $reason")
       }
     }
 
@@ -929,7 +979,14 @@ class GatewaySession(
 
     private suspend fun handleMessage(text: String) {
       val frame = json.parseToJsonElement(text).asObjectOrNull() ?: return
-      when (frame["type"].asStringOrNull()) {
+      val frameType = frame["type"].asStringOrNull()
+      if (
+        state.get() == ConnectionState.CLOSED &&
+        (frameType != "res" || frame["id"].asStringOrNull() != connectRequestId)
+      ) {
+        return
+      }
+      when (frameType) {
         "res" -> handleResponse(frame)
         "event" -> handleEvent(frame)
       }
@@ -1010,7 +1067,7 @@ class GatewaySession(
         payload["paramsJSON"].asStringOrNull()
           ?: payload["params"]?.let { value -> if (value is JsonNull) null else value.toString() }
       val timeoutMs = payload["timeoutMs"].asLongOrNull()
-      scope.launch {
+      connectionScope.launch {
         val result =
           try {
             onInvoke?.invoke(InvokeRequest(id, nodeId, command, params, timeoutMs))
@@ -1140,6 +1197,7 @@ class GatewaySession(
         }
       if (!shouldConnect) {
         conn.closeQuietly()
+        conn.joinOwnedWork()
         return@withContext
       }
       try {
@@ -1162,8 +1220,12 @@ class GatewaySession(
         }
         conn.awaitClose()
       } finally {
-        // Callback failures and cancellation must close this socket before the loop replaces it.
-        conn.closeQuietly()
+        // Callback failures and cancellation must drain this socket's owned work before the loop
+        // forgets it. Otherwise a retired connect can restore device auth after a later reset.
+        withContext(NonCancellable) {
+          conn.closeQuietly()
+          conn.joinOwnedWork()
+        }
         synchronized(lifecycleLock) {
           if (currentConnection === conn) {
             currentConnection = null

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -452,6 +452,7 @@ class GatewaySession(
     private val closedDeferred = CompletableDeferred<Unit>()
     private val connectNonceDeferred = CompletableDeferred<String>()
     private val terminalCallbackClaimed = AtomicBoolean(false)
+    private val connectResponseAccepted = AtomicBoolean(false)
 
     @Volatile
     private var connectHandshakeJob: Job? = null
@@ -610,16 +611,35 @@ class GatewaySession(
       socket?.cancel() ?: closedDeferred.complete(Unit)
     }
 
-    private fun finishTransport(message: String) {
+    private fun finishTransport(
+      message: String,
+      connectError: Throwable,
+    ) {
       if (!terminalCallbackClaimed.compareAndSet(false, true)) return
       val shouldNotify = state.getAndSet(ConnectionState.CLOSED) != ConnectionState.CLOSED
       incomingMessages.close()
       try {
         if (shouldNotify) onDisconnected(message)
       } finally {
-        socket = null
-        closedDeferred.complete(Unit)
+        messagePumpJob.invokeOnCompletion {
+          // OkHttp can deliver onClosed immediately after onMessage. Let an accepted connect
+          // response finish so auth retry state and issued device tokens survive the close.
+          if (connectResponseAccepted.get()) {
+            connectHandshakeJob?.invokeOnCompletion {
+              finalizeTransport(connectError)
+            } ?: finalizeTransport(connectError)
+          } else {
+            connectNonceDeferred.completeExceptionally(connectError)
+            finalizeTransport(connectError)
+          }
+        }
       }
+    }
+
+    private fun finalizeTransport(connectError: Throwable) {
+      if (!connectDeferred.isCompleted) connectDeferred.completeExceptionally(connectError)
+      socket = null
+      closedDeferred.complete(Unit)
     }
 
     private fun buildClient(): OkHttpClient {
@@ -669,10 +689,19 @@ class GatewaySession(
         t: Throwable,
         response: Response?,
       ) {
-        if (!connectDeferred.isCompleted) {
-          connectDeferred.completeExceptionally(t)
-        }
-        finishTransport("Gateway error: ${t.message ?: t::class.java.simpleName}")
+        finishTransport(
+          message = "Gateway error: ${t.message ?: t::class.java.simpleName}",
+          connectError = t,
+        )
+      }
+
+      override fun onClosing(
+        webSocket: WebSocket,
+        code: Int,
+        reason: String,
+      ) {
+        // OkHttp requires the client to acknowledge a peer-initiated close before onClosed fires.
+        webSocket.close(code, reason)
       }
 
       override fun onClosed(
@@ -680,10 +709,10 @@ class GatewaySession(
         code: Int,
         reason: String,
       ) {
-        if (!connectDeferred.isCompleted) {
-          connectDeferred.completeExceptionally(IllegalStateException("Gateway closed: $reason"))
-        }
-        finishTransport("Gateway closed: $reason")
+        finishTransport(
+          message = "Gateway closed: $reason",
+          connectError = IllegalStateException("Gateway closed: $reason"),
+        )
       }
     }
 
@@ -994,6 +1023,7 @@ class GatewaySession(
 
     private fun handleResponse(frame: JsonObject) {
       val id = frame["id"].asStringOrNull() ?: return
+      if (id == connectRequestId) connectResponseAccepted.set(true)
       val ok = frame["ok"].asBooleanOrNull() ?: false
       val payloadJson = frame["payload"]?.let { payload -> payload.toString() }
       val error =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -39,6 +39,7 @@ internal data class GatewayConnectConfig(
 /** How a connection attempt may update credentials already owned by the runtime. */
 internal enum class GatewaySavedAuthAction {
   PRESERVE,
+  REPLACE_CREDENTIALS,
   REPLACE_ENDPOINT,
   REPLACE_SETUP,
 }
@@ -180,10 +181,10 @@ internal fun resolveGatewayConnectPlan(
     composeGatewayManualUrl(savedManualHost, savedManualPort, savedManualTls)
       ?.let { parseGatewayEndpointResult(it).config }
   val action =
-    if (savedManualEndpoint?.sameEndpoint(config) == true) {
-      GatewaySavedAuthAction.PRESERVE
-    } else {
-      GatewaySavedAuthAction.REPLACE_ENDPOINT
+    when {
+      savedManualEndpoint?.sameEndpoint(config) != true -> GatewaySavedAuthAction.REPLACE_ENDPOINT
+      config.token.isNotEmpty() || config.password.isNotEmpty() -> GatewaySavedAuthAction.REPLACE_CREDENTIALS
+      else -> GatewaySavedAuthAction.PRESERVE
     }
   return GatewayConnectPlan(config, action)
 }
@@ -200,9 +201,14 @@ internal fun parseGatewayEndpointResult(rawInput: String): GatewayEndpointParseR
 
   val normalized = if (raw.contains("://")) raw else "https://$raw"
   val uri =
-    runCatching { URI(normalized) }.getOrNull()
+    runCatching { URI(normalized) }
+      .getOrNull()
       ?: return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INVALID_URL)
-  val host = uri.host?.trim()?.trim('[', ']').orEmpty()
+  val host =
+    uri.host
+      ?.trim()
+      ?.trim('[', ']')
+      .orEmpty()
   if (host.isEmpty()) return GatewayEndpointParseResult(error = GatewayEndpointValidationError.INVALID_URL)
   // OkHttp rejects scoped IPv6 hosts after URI decoding, so fail before saving an endpoint that can never dial.
   if (host.contains(':') && host.contains('%')) {
@@ -332,7 +338,12 @@ internal fun resolveDefaultManualGatewayPort(
   hostInput: String,
   tls: Boolean,
 ): Int {
-  val host = hostInput.trim().trimEnd('/').removeSuffix(".").lowercase(Locale.US)
+  val host =
+    hostInput
+      .trim()
+      .trimEnd('/')
+      .removeSuffix(".")
+      .lowercase(Locale.US)
   return if (tls && host.endsWith(".ts.net")) tailnetTlsGatewayPort else defaultManualGatewayPort
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/AndroidLicenseNoticesTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AndroidLicenseNoticesTest.kt
@@ -36,6 +36,7 @@ class AndroidLicenseNoticesTest {
 
     assertEquals(
       listOf(
+        "AndroidX Room",
         "Bouncy Castle Provider",
         "CommonMark Java",
         "dnsjava",

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -2,8 +2,10 @@ package ai.openclaw.app
 
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatMessageContent
+import ai.openclaw.app.chat.ChatOutboxEnqueueResult
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatTranscriptCache
+import ai.openclaw.app.chat.RoomChatCommandOutbox
 import ai.openclaw.app.chat.RoomChatTranscriptCache
 import ai.openclaw.app.gateway.DeviceAuthStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
@@ -691,6 +693,7 @@ class GatewayBootstrapAuthTest {
       val deviceId = DeviceIdentityStore(app).loadOrCreate().deviceId
       val authStore = DeviceAuthStore(prefs)
       val transcriptCache = readField<RoomChatTranscriptCache>(runtime, "chatTranscriptCache")
+      val commandOutbox = readField<RoomChatCommandOutbox>(runtime, "chatCommandOutbox")
       val cacheGatewayId = "gateway-${UUID.randomUUID()}"
       prefs.setGatewayToken("stale-shared-token")
       prefs.setGatewayBootstrapToken("stale-bootstrap-token")
@@ -711,6 +714,15 @@ class GatewayBootstrapAuthTest {
             ),
           ),
       )
+      assertTrue(
+        commandOutbox.enqueue(
+          gatewayId = cacheGatewayId,
+          sessionKey = "main",
+          text = "stale queued command",
+          thinkingLevel = "off",
+          nowMs = 1L,
+        ) is ChatOutboxEnqueueResult.Queued,
+      )
       val connectionGeneration = readField<AtomicLong>(runtime, "connectAttemptSeq")
       val generationBeforeReset = connectionGeneration.get()
 
@@ -723,6 +735,7 @@ class GatewayBootstrapAuthTest {
       assertNull(authStore.loadToken(deviceId, "operator"))
       assertNull(readField<GatewayEndpoint?>(runtime, "connectedEndpoint"))
       assertTrue(transcriptCache.loadTranscript(cacheGatewayId, "main").isEmpty())
+      assertTrue(commandOutbox.load(cacheGatewayId).isEmpty())
       assertEquals(generationBeforeReset + 2, connectionGeneration.get())
     }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -19,9 +19,10 @@ import ai.openclaw.app.voice.TalkModeManager
 import android.Manifest
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
@@ -39,6 +40,7 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import java.lang.reflect.Field
 import java.util.UUID
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 
 private class FailingClearTranscriptCache : ChatTranscriptCache {
@@ -827,8 +829,9 @@ class GatewayBootstrapAuthTest {
       connectWithAuth.isAccessible = true
       val lockHeld = CompletableDeferred<Unit>()
       val releaseLock = CompletableDeferred<Unit>()
+      val lifecycleDispatcher = Executors.newFixedThreadPool(3).asCoroutineDispatcher()
       val lockHolder =
-        async(Dispatchers.Default) {
+        async(lifecycleDispatcher) {
           synchronized(lifecycleLock) {
             lockHeld.complete(Unit)
             runBlocking { releaseLock.await() }
@@ -837,7 +840,7 @@ class GatewayBootstrapAuthTest {
       lockHeld.await()
 
       val connect =
-        async(Dispatchers.Default) {
+        async(lifecycleDispatcher) {
           connectWithAuth.invoke(runtime, endpoint, auth, false, { Unit })
         }
       try {
@@ -845,7 +848,7 @@ class GatewayBootstrapAuthTest {
           while (readField<Int>(runtime, "gatewayConnectOperationsInFlight") == 0) delay(10)
         }
         val callback =
-          async(Dispatchers.Default) {
+          async(lifecycleDispatcher) {
             val method =
               runtime.javaClass.getDeclaredMethod(
                 "maybeStartOperatorSessionAfterNodeConnect",
@@ -858,11 +861,18 @@ class GatewayBootstrapAuthTest {
         withTimeout(1_000) { callback.await() }
       } finally {
         releaseLock.complete(Unit)
-        withTimeout(5_000) {
-          lockHolder.await()
-          connect.await()
+        try {
+          withTimeout(5_000) {
+            lockHolder.await()
+            connect.await()
+          }
+        } finally {
+          lifecycleDispatcher.close()
+          runtime.disconnect()
+          withTimeout(5_000) {
+            readField<CoroutineScope>(runtime, "scope").coroutineContext[Job]?.cancelAndJoin()
+          }
         }
-        runtime.disconnect()
       }
       Unit
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -1,5 +1,10 @@
 package ai.openclaw.app
 
+import ai.openclaw.app.chat.ChatMessage
+import ai.openclaw.app.chat.ChatMessageContent
+import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.chat.ChatTranscriptCache
+import ai.openclaw.app.chat.RoomChatTranscriptCache
 import ai.openclaw.app.gateway.DeviceAuthStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewayConnectErrorDetails
@@ -14,9 +19,13 @@ import ai.openclaw.app.voice.TalkModeManager
 import android.Manifest
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -30,10 +39,90 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import java.lang.reflect.Field
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicLong
+
+private class FailingClearTranscriptCache : ChatTranscriptCache {
+  override suspend fun loadSessions(gatewayId: String): List<ChatSessionEntry> = emptyList()
+
+  override suspend fun loadTranscript(
+    gatewayId: String,
+    sessionKey: String,
+  ): List<ChatMessage> = emptyList()
+
+  override suspend fun saveSessions(
+    gatewayId: String,
+    sessions: List<ChatSessionEntry>,
+    retainedSessionKey: String?,
+  ) = Unit
+
+  override suspend fun saveTranscript(
+    gatewayId: String,
+    sessionKey: String,
+    messages: List<ChatMessage>,
+  ) = Unit
+
+  override suspend fun deleteSession(
+    gatewayId: String,
+    sessionKey: String,
+  ) = Unit
+
+  override suspend fun clearAll(): Unit = error("cache unavailable")
+}
+
+private class BlockingClearTranscriptCache : ChatTranscriptCache {
+  val clearStarted = CompletableDeferred<Unit>()
+  val allowClear = CompletableDeferred<Unit>()
+
+  override suspend fun loadSessions(gatewayId: String): List<ChatSessionEntry> = emptyList()
+
+  override suspend fun loadTranscript(
+    gatewayId: String,
+    sessionKey: String,
+  ): List<ChatMessage> = emptyList()
+
+  override suspend fun saveSessions(
+    gatewayId: String,
+    sessions: List<ChatSessionEntry>,
+    retainedSessionKey: String?,
+  ) = Unit
+
+  override suspend fun saveTranscript(
+    gatewayId: String,
+    sessionKey: String,
+    messages: List<ChatMessage>,
+  ) = Unit
+
+  override suspend fun deleteSession(
+    gatewayId: String,
+    sessionKey: String,
+  ) = Unit
+
+  override suspend fun clearAll() {
+    clearStarted.complete(Unit)
+    allowClear.await()
+  }
+}
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class GatewayBootstrapAuthTest {
+  @Test
+  fun recreatedViewModelResetsProcessOwnedRuntime() {
+    val app = RuntimeEnvironment.getApplication() as NodeApp
+    val runtime = app.ensureRuntime()
+    writeField(runtime, "connectedEndpoint", GatewayEndpoint.manual("old-gateway.example", 18789))
+    val viewModel = MainViewModel(app)
+
+    viewModel.pairNewGateway()
+    runBlocking {
+      withTimeout(5_000) {
+        while (readField<GatewayEndpoint?>(runtime, "connectedEndpoint") != null) delay(10)
+      }
+    }
+
+    assertNull(readField<GatewayEndpoint?>(runtime, "connectedEndpoint"))
+  }
+
   @Test
   fun standaloneStatusPreservesLiveOperatorConnection() {
     val runtime = NodeRuntime(RuntimeEnvironment.getApplication())
@@ -587,31 +676,196 @@ class GatewayBootstrapAuthTest {
   }
 
   @Test
-  fun resetGatewaySetupAuth_clearsStoredGatewayAndDeviceTokens() {
-    val app = RuntimeEnvironment.getApplication()
-    val securePrefs =
-      app.getSharedPreferences(
-        "openclaw.node.secure.test.${UUID.randomUUID()}",
-        android.content.Context.MODE_PRIVATE,
+  fun resetGatewaySetupAuth_clearsStoredGatewayAndDeviceTokens() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      val securePrefs =
+        app.getSharedPreferences(
+          "openclaw.node.secure.test.${UUID.randomUUID()}",
+          android.content.Context.MODE_PRIVATE,
+        )
+      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+      val runtime = NodeRuntime(app, prefs)
+      val deviceId = DeviceIdentityStore(app).loadOrCreate().deviceId
+      val authStore = DeviceAuthStore(prefs)
+      val transcriptCache = readField<RoomChatTranscriptCache>(runtime, "chatTranscriptCache")
+      val cacheGatewayId = "gateway-${UUID.randomUUID()}"
+      prefs.setGatewayToken("stale-shared-token")
+      prefs.setGatewayBootstrapToken("stale-bootstrap-token")
+      prefs.setGatewayPassword("stale-password")
+      authStore.saveToken(deviceId, "node", "stale-node-token")
+      authStore.saveToken(deviceId, "operator", "stale-operator-token")
+      writeField(runtime, "connectedEndpoint", GatewayEndpoint.manual("old-gateway.example", 18789))
+      transcriptCache.saveTranscript(
+        gatewayId = cacheGatewayId,
+        sessionKey = "main",
+        messages =
+          listOf(
+            ChatMessage(
+              id = "cached",
+              role = "assistant",
+              content = listOf(ChatMessageContent(type = "text", text = "stale transcript")),
+              timestampMs = 1L,
+            ),
+          ),
       )
-    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-    val runtime = NodeRuntime(app, prefs)
-    val deviceId = DeviceIdentityStore(app).loadOrCreate().deviceId
-    val authStore = DeviceAuthStore(prefs)
-    prefs.setGatewayToken("stale-shared-token")
-    prefs.setGatewayBootstrapToken("stale-bootstrap-token")
-    prefs.setGatewayPassword("stale-password")
-    authStore.saveToken(deviceId, "node", "stale-node-token")
-    authStore.saveToken(deviceId, "operator", "stale-operator-token")
+      val connectionGeneration = readField<AtomicLong>(runtime, "connectAttemptSeq")
+      val generationBeforeReset = connectionGeneration.get()
 
-    runBlocking { runtime.resetGatewaySetupAuth() }
+      assertTrue(runtime.resetGatewaySetupAuth())
 
-    assertNull(prefs.loadGatewayToken())
-    assertNull(prefs.loadGatewayBootstrapToken())
-    assertNull(prefs.loadGatewayPassword())
-    assertNull(authStore.loadToken(deviceId, "node"))
-    assertNull(authStore.loadToken(deviceId, "operator"))
-  }
+      assertNull(prefs.loadGatewayToken())
+      assertNull(prefs.loadGatewayBootstrapToken())
+      assertNull(prefs.loadGatewayPassword())
+      assertNull(authStore.loadToken(deviceId, "node"))
+      assertNull(authStore.loadToken(deviceId, "operator"))
+      assertNull(readField<GatewayEndpoint?>(runtime, "connectedEndpoint"))
+      assertTrue(transcriptCache.loadTranscript(cacheGatewayId, "main").isEmpty())
+      assertEquals(generationBeforeReset + 2, connectionGeneration.get())
+    }
+
+  @Test
+  fun resetGatewaySetupAuth_preservesCredentialsWhenCachePurgeFails() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      val securePrefs =
+        app.getSharedPreferences(
+          "openclaw.node.secure.test.${UUID.randomUUID()}",
+          android.content.Context.MODE_PRIVATE,
+        )
+      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+      val runtime = NodeRuntime(app, prefs, FailingClearTranscriptCache())
+      val deviceId = DeviceIdentityStore(app).loadOrCreate().deviceId
+      val authStore = DeviceAuthStore(prefs)
+      prefs.setGatewayToken("stale-shared-token")
+      authStore.saveToken(deviceId, "operator", "stale-operator-token")
+      assertFalse(runtime.resetGatewaySetupAuth())
+
+      assertEquals("stale-shared-token", prefs.loadGatewayToken())
+      assertEquals("stale-operator-token", authStore.loadToken(deviceId, "operator"))
+      assertEquals("Failed: couldn't clear offline chat data. Retry sign out.", runtime.statusText.value)
+    }
+
+  @Test
+  fun resetGatewaySetupAuthRejectsReplacementConnectionUntilResetCompletes() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      val securePrefs =
+        app.getSharedPreferences(
+          "openclaw.node.secure.test.${UUID.randomUUID()}",
+          android.content.Context.MODE_PRIVATE,
+        )
+      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+      val transcriptCache = BlockingClearTranscriptCache()
+      val runtime = NodeRuntime(app, prefs, transcriptCache)
+      val reset = async { runtime.resetGatewaySetupAuth() }
+      withTimeout(5_000) { transcriptCache.clearStarted.await() }
+
+      runtime.connect(GatewayEndpoint.manual("replacement.example", 18789))
+
+      val nodeSession = readField<GatewaySession>(runtime, "nodeSession")
+      assertNull(readField<Any?>(nodeSession, "desired"))
+      transcriptCache.allowClear.complete(Unit)
+      assertTrue(withTimeout(5_000) { reset.await() })
+      assertNull(readField<Any?>(nodeSession, "desired"))
+    }
+
+  @Test
+  fun resetGatewaySetupAuthRejectsTlsTrustPromptPublication() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      val securePrefs =
+        app.getSharedPreferences(
+          "openclaw.node.secure.test.${UUID.randomUUID()}",
+          android.content.Context.MODE_PRIVATE,
+        )
+      val transcriptCache = BlockingClearTranscriptCache()
+      val runtime = NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs), transcriptCache)
+      val reset = async { runtime.resetGatewaySetupAuth() }
+      withTimeout(5_000) { transcriptCache.clearStarted.await() }
+      val connectAttemptId = readField<AtomicLong>(runtime, "connectAttemptSeq").get()
+      val staleAuth = NodeRuntime.GatewayConnectAuth(token = "stale-token", bootstrapToken = null, password = null)
+      val prompt =
+        NodeRuntime.GatewayTrustPrompt(
+          endpoint = GatewayEndpoint.manual("stale.example", 18789),
+          fingerprintSha256 = "AA:BB",
+          auth = staleAuth,
+        )
+      val method =
+        runtime.javaClass.getDeclaredMethod(
+          "publishGatewayTrustPromptIfCurrent",
+          Long::class.javaPrimitiveType,
+          NodeRuntime.GatewayTrustPrompt::class.java,
+        )
+      method.isAccessible = true
+
+      assertFalse(method.invoke(runtime, connectAttemptId, prompt) as Boolean)
+      assertNull(runtime.pendingGatewayTrust.value)
+      transcriptCache.allowClear.complete(Unit)
+      assertTrue(withTimeout(5_000) { reset.await() })
+      assertNull(runtime.pendingGatewayTrust.value)
+    }
+
+  @Test
+  fun gatewayConnectDoesNotHoldAuthMonitorWhileWaitingForSessionLifecycle() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      val securePrefs =
+        app.getSharedPreferences(
+          "openclaw.node.secure.test.${UUID.randomUUID()}",
+          android.content.Context.MODE_PRIVATE,
+        )
+      val runtime = NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs))
+      val endpoint = GatewayEndpoint.manual("127.0.0.1", 18789)
+      val auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "bootstrap", password = null)
+      val nodeSession = readField<GatewaySession>(runtime, "nodeSession")
+      val lifecycleLock = readField<Any>(nodeSession, "lifecycleLock")
+      val connectWithAuth =
+        runtime.javaClass.declaredMethods.single { method ->
+          method.name == "connectWithAuth" && method.parameterTypes.size == 4
+        }
+      connectWithAuth.isAccessible = true
+      val lockHeld = CompletableDeferred<Unit>()
+      val releaseLock = CompletableDeferred<Unit>()
+      val lockHolder =
+        async(Dispatchers.Default) {
+          synchronized(lifecycleLock) {
+            lockHeld.complete(Unit)
+            runBlocking { releaseLock.await() }
+          }
+        }
+      lockHeld.await()
+
+      val connect =
+        async(Dispatchers.Default) {
+          connectWithAuth.invoke(runtime, endpoint, auth, false, { Unit })
+        }
+      try {
+        withTimeout(5_000) {
+          while (readField<Int>(runtime, "gatewayConnectOperationsInFlight") == 0) delay(10)
+        }
+        val callback =
+          async(Dispatchers.Default) {
+            val method =
+              runtime.javaClass.getDeclaredMethod(
+                "maybeStartOperatorSessionAfterNodeConnect",
+                GatewayEndpoint::class.java,
+                NodeRuntime.GatewayConnectAuth::class.java,
+              )
+            method.isAccessible = true
+            method.invoke(runtime, endpoint, auth)
+          }
+        withTimeout(1_000) { callback.await() }
+      } finally {
+        releaseLock.complete(Unit)
+        withTimeout(5_000) {
+          lockHolder.await()
+          connect.await()
+        }
+        runtime.disconnect()
+      }
+      Unit
+    }
 
   @Test
   fun restoredManualMicWithoutRecordAudioClearsStalePreference() {

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerTranscriptCacheTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerTranscriptCacheTest.kt
@@ -20,6 +20,7 @@ class ChatControllerTranscriptCacheTest {
     var sessions: List<ChatSessionEntry> = emptyList()
     val savedTranscripts = mutableListOf<Triple<String, String, List<ChatMessage>>>()
     val savedSessions = mutableListOf<Pair<String, List<ChatSessionEntry>>>()
+    val retainedSessionKeys = mutableListOf<String?>()
     val deletedSessions = mutableListOf<Pair<String, String>>()
 
     override suspend fun loadSessions(gatewayId: String): List<ChatSessionEntry> = sessions
@@ -32,8 +33,10 @@ class ChatControllerTranscriptCacheTest {
     override suspend fun saveSessions(
       gatewayId: String,
       sessions: List<ChatSessionEntry>,
+      retainedSessionKey: String?,
     ) {
       savedSessions += gatewayId to sessions
+      retainedSessionKeys += retainedSessionKey
     }
 
     override suspend fun saveTranscript(
@@ -258,7 +261,66 @@ class ChatControllerTranscriptCacheTest {
           .second
           .map { it.key },
       )
+      assertEquals(null, cache.retainedSessionKeys.last())
       assertEquals(listOf("main"), controller.sessions.value.map { it.key })
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun truncatedSessionListRetainsActiveDeepTranscript() =
+    runTest {
+      val cache = FakeTranscriptCache()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, _ ->
+            when (method) {
+              "sessions.list" ->
+                """{"totalCount":2,"hasMore":true,"sessions":[{"key":"main","updatedAt":7}]}"""
+              "chat.history" -> """{"sessionId":"session-1","messages":[]}"""
+              else -> "{}"
+            }
+          },
+          transcriptCache = cache,
+          cacheScope = { gatewayScope },
+        )
+
+      controller.load("deep-session")
+      advanceUntilIdle()
+
+      assertEquals("deep-session", cache.retainedSessionKeys.last())
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun completeSessionListRetainsActiveTranscriptBeyondLocalCacheWindow() =
+    runTest {
+      val cache = FakeTranscriptCache()
+      val sessions =
+        (0 until MAX_CACHED_SESSIONS + 10).joinToString(",") { index ->
+          """{"key":"session-$index","updatedAt":${100 - index}}"""
+        }
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, _ ->
+            when (method) {
+              "sessions.list" ->
+                """{"totalCount":60,"hasMore":false,"sessions":[$sessions]}"""
+              "chat.history" -> """{"sessionId":"session-55","messages":[]}"""
+              else -> "{}"
+            }
+          },
+          transcriptCache = cache,
+          cacheScope = { gatewayScope },
+        )
+
+      controller.load("session-55")
+      advanceUntilIdle()
+
+      assertEquals("session-55", cache.retainedSessionKeys.last())
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatTranscriptCacheTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatTranscriptCacheTest.kt
@@ -1,14 +1,18 @@
 package ai.openclaw.app.chat
 
+import android.content.ContextWrapper
 import androidx.room.Room
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import java.io.File
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class RoomChatTranscriptCacheTest {
@@ -23,6 +27,41 @@ class RoomChatTranscriptCacheTest {
   }
 
   private fun cache(): RoomChatTranscriptCache = RoomChatTranscriptCache(database = database)
+
+  @Test
+  fun databaseDeleteFailsWhenCompanionFileSurvives() {
+    val app = RuntimeEnvironment.getApplication()
+    val databaseName = "chat-cache-delete-test-${UUID.randomUUID()}.db"
+    val databasePath = app.getDatabasePath(databaseName)
+    databasePath.parentFile?.mkdirs()
+    val walFile = File(databasePath.path + "-wal")
+    walFile.writeText("stale cache")
+    val noOpDeleteContext =
+      object : ContextWrapper(app) {
+        override fun deleteDatabase(name: String): Boolean = true
+      }
+
+    assertFalse(deleteDatabaseFiles(noOpDeleteContext, databaseName))
+    assertTrue(walFile.exists())
+    assertTrue(deleteDatabaseFiles(app, databaseName))
+    assertFalse(walFile.exists())
+  }
+
+  @Test
+  fun databaseDeleteSucceedsBeforeDatabaseDirectoryExists() {
+    val app = RuntimeEnvironment.getApplication()
+    val missingParent = File(app.cacheDir, "missing-database-dir-${UUID.randomUUID()}")
+    val databasePath = File(missingParent, "chat-cache.db")
+    val freshInstallContext =
+      object : ContextWrapper(app) {
+        override fun getDatabasePath(name: String): File = databasePath
+
+        override fun deleteDatabase(name: String): Boolean = true
+      }
+
+    assertFalse(missingParent.exists())
+    assertTrue(deleteDatabaseFiles(freshInstallContext, databasePath.name))
+  }
 
   private fun message(
     text: String,
@@ -124,6 +163,58 @@ class RoomChatTranscriptCacheTest {
       val sessionKeys = store.loadSessions("gateway-a").map { it.key }
       assertEquals(MAX_CACHED_SESSIONS, sessionKeys.size)
       assertTrue(sessionKeys.contains("deep-session"))
+    }
+
+  @Test
+  fun activeDeepTranscriptSurvivesSessionListRefresh() =
+    runTest {
+      val store = cache()
+      val listedSessions =
+        (0 until MAX_CACHED_SESSIONS).map { index ->
+          ChatSessionEntry(key = "session-$index", updatedAtMs = 1000L - index)
+        }
+      store.saveSessions(gatewayId = "gateway-a", sessions = listedSessions)
+      store.saveTranscript(
+        gatewayId = "gateway-a",
+        sessionKey = "deep-session",
+        messages = listOf(message("deep text")),
+      )
+
+      store.saveSessions(
+        gatewayId = "gateway-a",
+        sessions = listedSessions,
+        retainedSessionKey = "deep-session",
+      )
+
+      assertEquals(MAX_CACHED_SESSIONS, store.loadSessions("gateway-a").size)
+      assertTrue(store.loadSessions("gateway-a").any { it.key == "deep-session" })
+      assertEquals(
+        listOf("deep text"),
+        store.loadTranscript("gateway-a", "deep-session").map { it.content.single().text },
+      )
+    }
+
+  @Test
+  fun completeSessionListRefreshDropsMissingDeepTranscript() =
+    runTest {
+      val store = cache()
+      store.saveSessions(
+        gatewayId = "gateway-a",
+        sessions = listOf(ChatSessionEntry(key = "deep-session", updatedAtMs = 1)),
+      )
+      store.saveTranscript(
+        gatewayId = "gateway-a",
+        sessionKey = "deep-session",
+        messages = listOf(message("deleted remotely")),
+      )
+
+      store.saveSessions(
+        gatewayId = "gateway-a",
+        sessions = listOf(ChatSessionEntry(key = "main", updatedAtMs = 2)),
+      )
+
+      assertEquals(listOf("main"), store.loadSessions("gateway-a").map { it.key })
+      assertTrue(store.loadTranscript("gateway-a", "deep-session").isEmpty())
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -484,7 +484,6 @@ class GatewaySessionInvokeTest {
                     secondConnectAuth.complete(auth)
                   }
                   webSocket.send(connectResponseFrame(id))
-                  webSocket.close(1000, "done")
                 }
               }
             }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -35,7 +35,11 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import java.io.IOException
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 private const val LIFECYCLE_TEST_TIMEOUT_MS = 8_000L
@@ -54,6 +58,54 @@ private class ReconnectDeviceAuthStore : DeviceAuthTokenStore {
     token: String,
     scopes: List<String>,
   ) = Unit
+
+  override fun clearToken(
+    deviceId: String,
+    role: String,
+  ) = Unit
+}
+
+private class BlockingSaveDeviceAuthStore : DeviceAuthTokenStore {
+  val saveStarted = CountDownLatch(1)
+  val allowSave = CountDownLatch(1)
+
+  override fun loadEntry(
+    deviceId: String,
+    role: String,
+  ): DeviceAuthEntry? = null
+
+  override fun saveToken(
+    deviceId: String,
+    role: String,
+    token: String,
+    scopes: List<String>,
+  ) {
+    saveStarted.countDown()
+    allowSave.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+  }
+
+  override fun clearToken(
+    deviceId: String,
+    role: String,
+  ) = Unit
+}
+
+private class RecordingDeviceAuthStore : DeviceAuthTokenStore {
+  val savedToken = CompletableDeferred<String>()
+
+  override fun loadEntry(
+    deviceId: String,
+    role: String,
+  ): DeviceAuthEntry? = null
+
+  override fun saveToken(
+    deviceId: String,
+    role: String,
+    token: String,
+    scopes: List<String>,
+  ) {
+    savedToken.complete(token)
+  }
 
   override fun clearToken(
     deviceId: String,
@@ -88,6 +140,199 @@ private data class ReconnectServer(
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class GatewaySessionReconnectTest {
+  @Test
+  fun disconnectAndJoinWaitsForNaturalFailureCallback() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val connected = CompletableDeferred<Unit>()
+      val terminalCallbackStarted = CountDownLatch(1)
+      val allowTerminalCallback = CountDownLatch(1)
+      val blockNextTerminalCallback = AtomicBoolean(true)
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") webSocket.send(connectResponseFrame(id))
+        }
+      val harness =
+        createReconnectHarness(
+          onConnected = { connected.complete(Unit) },
+          onDisconnected = { message ->
+            val shouldBlock =
+              message.startsWith("Gateway ") &&
+                blockNextTerminalCallback.compareAndSet(true, false)
+            if (shouldBlock) {
+              terminalCallbackStarted.countDown()
+              allowTerminalCallback.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            }
+          },
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
+        val connection = readField<Any>(harness.session, "currentConnection")
+        val listener = readField<WebSocketListener>(connection, "listener")
+        val socket = readField<WebSocket>(connection, "socket")
+        val failure =
+          launch(Dispatchers.IO) {
+            listener.onFailure(socket, IOException("test failure"), null)
+          }
+        assertTrue(
+          terminalCallbackStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+        )
+
+        val disconnect = async { harness.session.disconnectAndJoin() }
+        delay(100)
+        assertFalse(disconnect.isCompleted)
+
+        allowTerminalCallback.countDown()
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { disconnect.await() }
+        failure.join()
+      } finally {
+        allowTerminalCallback.countDown()
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun disconnectAndJoinWaitsForTerminalCallback() =
+    runBlocking {
+      val disconnected = CompletableDeferred<String>()
+      val harness = createReconnectHarness(onDisconnected = { disconnected.complete(it) })
+
+      try {
+        harness.session.disconnectAndJoin()
+
+        assertEquals("Offline", disconnected.await())
+      } finally {
+        harness.sessionJob.cancelAndJoin()
+      }
+    }
+
+  @Test
+  fun disconnectAndJoinWaitsForInFlightIssuedTokenPersistence() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val authStore = BlockingSaveDeviceAuthStore()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") {
+            webSocket.send(
+              """{"type":"res","id":"$id","ok":true,"payload":{"auth":{"deviceToken":"issued-token","role":"node","scopes":[]},"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}""",
+            )
+          }
+        }
+      val harness = createReconnectHarness(deviceAuthStore = authStore)
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        assertTrue(authStore.saveStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+
+        val disconnect = async { harness.session.disconnectAndJoin() }
+        delay(100)
+        assertFalse(disconnect.isCompleted)
+
+        authStore.allowSave.countDown()
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { disconnect.await() }
+      } finally {
+        authStore.allowSave.countDown()
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun reconnectDoesNotRetireConnectionBeforeIssuedTokenPersistenceFinishes() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val authStore = BlockingSaveDeviceAuthStore()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") {
+            webSocket.send(
+              """{"type":"res","id":"$id","ok":true,"payload":{"auth":{"deviceToken":"issued-token","role":"node","scopes":[]},"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}""",
+            )
+          }
+        }
+      val harness = createReconnectHarness(deviceAuthStore = authStore)
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        assertTrue(authStore.saveStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+        val connection = readField<Any>(harness.session, "currentConnection")
+
+        harness.session.reconnect()
+        delay(200)
+
+        assertTrue(readField<Any?>(harness.session, "currentConnection") === connection)
+        authStore.allowSave.countDown()
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { harness.session.disconnectAndJoin() }
+      } finally {
+        authStore.allowSave.countDown()
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
+  fun failureDrainsAcceptedConnectResponseBeforeCancellingOwnedWork() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val authStore = RecordingDeviceAuthStore()
+      val connectRequestId = CompletableDeferred<String>()
+      val blockEventStarted = CountDownLatch(1)
+      val allowBlockEvent = CountDownLatch(1)
+      val terminalCallback = CompletableDeferred<Unit>()
+      val retiredInvokeCount = AtomicInteger()
+      val server =
+        startGatewayServer(json = json) { _, id, method ->
+          if (method == "connect") connectRequestId.complete(id)
+        }
+      val harness =
+        createReconnectHarness(
+          onDisconnected = { message ->
+            if (message.startsWith("Gateway error:")) terminalCallback.complete(Unit)
+          },
+          deviceAuthStore = authStore,
+          onEvent = { event, _ ->
+            if (event == "block") {
+              blockEventStarted.countDown()
+              allowBlockEvent.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            }
+          },
+          onInvoke = {
+            retiredInvokeCount.incrementAndGet()
+            GatewaySession.InvokeResult.ok("{}")
+          },
+        )
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        val requestId = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connectRequestId.await() }
+        val connection = readField<Any>(harness.session, "currentConnection")
+        val listener = readField<WebSocketListener>(connection, "listener")
+        val socket = readField<WebSocket>(connection, "socket")
+        listener.onMessage(socket, """{"type":"event","event":"block","payload":{}}""")
+        assertTrue(blockEventStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
+        listener.onMessage(
+          socket,
+          """{"type":"event","event":"node.invoke.request","payload":{"id":"retired-invoke","nodeId":"node-1","command":"notification.action"}}""",
+        )
+        listener.onMessage(
+          socket,
+          """{"type":"res","id":"$requestId","ok":true,"payload":{"auth":{"deviceToken":"issued-token","role":"node","scopes":[]},"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}""",
+        )
+        listener.onFailure(socket, IOException("test failure"), null)
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { terminalCallback.await() }
+
+        allowBlockEvent.countDown()
+
+        assertEquals("issued-token", withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { authStore.savedToken.await() })
+        assertEquals(0, retiredInvokeCount.get())
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { harness.session.disconnectAndJoin() }
+      } finally {
+        allowBlockEvent.countDown()
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
   @Test
   fun definitelyUnsentNodeEventRemainsQueued() =
     runBlocking {
@@ -622,6 +867,12 @@ class GatewaySessionReconnectTest {
 
   private fun createReconnectHarness(
     onConnected: () -> Unit = {},
+    onDisconnected: (String) -> Unit = {},
+    deviceAuthStore: DeviceAuthTokenStore = ReconnectDeviceAuthStore(),
+    onEvent: (String, String?) -> Unit = { _, _ -> },
+    onInvoke: suspend (GatewaySession.InvokeRequest) -> GatewaySession.InvokeResult = {
+      GatewaySession.InvokeResult.ok("""{"handled":true}""")
+    },
     onConnectFailure: (GatewaySession.ErrorShape, Boolean) -> Unit = { _, _ -> },
   ): ReconnectHarness {
     val app = RuntimeEnvironment.getApplication()
@@ -630,12 +881,12 @@ class GatewaySessionReconnectTest {
       GatewaySession(
         scope = CoroutineScope(sessionJob + Dispatchers.Default),
         identityStore = DeviceIdentityStore(app),
-        deviceAuthStore = ReconnectDeviceAuthStore(),
+        deviceAuthStore = deviceAuthStore,
         onConnected = { onConnected() },
-        onDisconnected = { _ -> },
+        onDisconnected = onDisconnected,
         onConnectFailure = onConnectFailure,
-        onEvent = { _, _ -> },
-        onInvoke = { GatewaySession.InvokeResult.ok("""{"handled":true}""") },
+        onEvent = onEvent,
+        onInvoke = onInvoke,
       )
     return ReconnectHarness(session = session, sessionJob = sessionJob)
   }
@@ -734,6 +985,14 @@ class GatewaySessionReconnectTest {
                     webSocket: WebSocket,
                     code: Int,
                     reason: String,
+                  ) {
+                    onClosed()
+                  }
+
+                  override fun onFailure(
+                    webSocket: WebSocket,
+                    t: Throwable,
+                    response: Response?,
                   ) {
                     onClosed()
                   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -191,14 +191,13 @@ class GatewayConfigResolverTest {
   @Test
   fun parseGatewayEndpointReportsUnsupportedIpv6ZoneIds() {
     listOf(
-        "ws://[fe80::1%25eth0]",
-        "wss://[fe80::1%25wlan0]:443",
-      )
-      .forEach { url ->
-        val parsed = parseGatewayEndpointResult(url)
-        assertNull(url, parsed.config)
-        assertEquals(url, GatewayEndpointValidationError.IPV6_ZONE_ID_UNSUPPORTED, parsed.error)
-      }
+      "ws://[fe80::1%25eth0]",
+      "wss://[fe80::1%25wlan0]:443",
+    ).forEach { url ->
+      val parsed = parseGatewayEndpointResult(url)
+      assertNull(url, parsed.config)
+      assertEquals(url, GatewayEndpointValidationError.IPV6_ZONE_ID_UNSUPPORTED, parsed.error)
+    }
   }
 
   @Test
@@ -661,6 +660,7 @@ class GatewayConfigResolverTest {
     assertEquals("token", plan?.config?.token)
     assertEquals("", plan?.config?.bootstrapToken)
     assertEquals("", plan?.config?.password)
+    assertEquals(GatewaySavedAuthAction.REPLACE_CREDENTIALS, plan?.savedAuthAction)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -1188,7 +1188,7 @@ class OnboardingFlowLogicTest {
         password = "shared-password",
       )
 
-    assertEquals(GatewaySavedAuthAction.PRESERVE, plan?.savedAuthAction)
+    assertEquals(GatewaySavedAuthAction.REPLACE_CREDENTIALS, plan?.savedAuthAction)
     assertEquals("127.0.0.1", plan?.config?.host)
     assertEquals(18789, plan?.config?.port)
     assertEquals(false, plan?.config?.tls)


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #100227: the Android offline cache shipped before its pairing-reset and WebSocket lifecycle hardening. A pairing or explicit credential change could race old connection callbacks, preserve endpoint-keyed cache across identities, or delete credentials before SQLite cache cleanup was verified.

Advances #100194.

## Why This Change Was Made

This makes auth reset and cache ownership one bounded lifecycle. Gateway connection starts are counted without holding the auth monitor across session calls; reset drains starts, retires and joins old sockets/callback work, advances the cache generation, then verifies cache deletion before clearing credentials. Explicit credentials on the same endpoint now replace cached identity state instead of preserving it.

Room cleanup uses the app's single production database handle and clears both transcripts and durable queued commands before verifying the database, journal, WAL, SHM, and master-journal files. Gateway terminal ownership drains accepted connect responses and acknowledges peer closes before teardown. Fresh installs with no database directory remain a successful no-op. The Android Room license notice is included in the app inventory.

## User Impact

- Pairing a new Gateway cannot inherit the previous identity's cached sessions, transcript, or queued commands.
- Retired sockets cannot restore old auth or write stale cache state after reset.
- Failed cache cleanup leaves the old credentials recoverable and reports a retryable failure instead of creating a half-reset identity.
- First-run pairing remains unblocked when the cache database has never been opened.

## Evidence

- Blacksmith Testbox `tbx_01kwtaq7dakscv93rrmz0jbrb9` ([run 28759024321](https://github.com/openclaw/openclaw/actions/runs/28759024321)): focused Play-debug cache, auth-reset, reconnect, terminal-callback, config-resolution, queued-command purge, and license-notice suites passed after the final rebase.
- Earlier Testbox race proof covered lock inversion, device-token retry, and failure-path draining of accepted connect responses.
- Native app i18n inventory check and `git diff --check` passed.
- Fresh Codex autoreview on exact head `606cf3c440606edc1af8a0eca0c91dbfcc1242d7`: clean with no accepted or actionable findings, confidence 0.82.
- GitHub Actions [run 28761404072](https://github.com/openclaw/openclaw/actions/runs/28761404072): all exact-head jobs passed, including Android unit/build lanes and QA smoke.
