### PR TITLE
fix(auto-reply): surface empty interactive completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 - **iOS QR gateway handoff:** stop VisionKit before delivering scanned setup codes, and keep deferred auth, approval, Watch, and foreground-node work bound to its originating gateway across reconnects. (#99572) Thanks @PollyBot13.
 - **Agent terminal failures:** surface a safe interactive reply when an agent run ends without visible output, while preserving completed message-tool delivery and heartbeat-specific guidance. (#99304) Thanks @moeedahmed.
+- **Agent empty replies:** surface a visible failure when a completed interactive turn has no deliverable reply, including queued follow-ups, while preserving explicit silence, pending continuations, and committed side effects. (#99824) Thanks @mushuiyu886.
 - **MCP loopback tool results:** preserve schema-valid text, image, and embedded-resource content through HTTP tool calls while rendering malformed or protocol-incompatible blocks as safe text. (#100336) Thanks @tzy-17.
 - **Control UI tool-result images:** render direct image content blocks from Gateway history and make the delayed-send scroll E2E setup deterministic. (#100295) Thanks @lzyyzznl.
 - **Plugin approval diagnostics:** surface Gateway validation rejection reasons while keeping transport and availability failures fail-closed. (#100337) Thanks @tzy-17.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Docs: https://docs.openclaw.ai
 
 - **iOS QR gateway handoff:** stop VisionKit before delivering scanned setup codes, and keep deferred auth, approval, Watch, and foreground-node work bound to its originating gateway across reconnects. (#99572) Thanks @PollyBot13.
 - **Agent terminal failures:** surface a safe interactive reply when an agent run ends without visible output, while preserving completed message-tool delivery and heartbeat-specific guidance. (#99304) Thanks @moeedahmed.
-- **Agent empty replies:** surface a visible failure when a completed interactive turn has no deliverable reply, including queued follow-ups, while preserving explicit silence, pending continuations, and committed side effects. (#99824) Thanks @mushuiyu886.
 - **MCP loopback tool results:** preserve schema-valid text, image, and embedded-resource content through HTTP tool calls while rendering malformed or protocol-incompatible blocks as safe text. (#100336) Thanks @tzy-17.
 - **Control UI tool-result images:** render direct image content blocks from Gateway history and make the delayed-send scroll E2E setup deterministic. (#100295) Thanks @lzyyzznl.
 - **Plugin approval diagnostics:** surface Gateway validation rejection reasons while keeping transport and availability failures fail-closed. (#100337) Thanks @tzy-17.

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -72,7 +72,7 @@ export function mergeEmbeddedAgentRunResultForModelFallbackExhaustion(params: {
   };
 }
 
-function hasDeliberateSilentTerminalReply(result: EmbeddedAgentRunResult): boolean {
+export function hasDeliberateSilentTerminalReply(result: EmbeddedAgentRunResult): boolean {
   if (result.meta.error?.kind === "hook_block") {
     return true;
   }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -806,7 +806,12 @@ type ExternalRunFailureReply = {
 
 type ExternalRunFailureInput = string | { message: string; error?: unknown };
 
-function isNonDirectConversationContext(ctx: TemplateContext): boolean {
+type ExternalFailureConversationContext = Pick<
+  TemplateContext,
+  "ChatType" | "Provider" | "SessionKey" | "Surface"
+>;
+
+function isNonDirectConversationContext(ctx: ExternalFailureConversationContext): boolean {
   const chatType = normalizeLowercaseStringOrEmpty(ctx.ChatType);
   return chatType === "group" || chatType === "channel";
 }
@@ -817,7 +822,7 @@ function isVerboseFailureDetailEnabled(level: VerboseLevel | undefined): boolean
 
 function resolveExternalRunFailureTextForConversation(params: {
   text: string;
-  sessionCtx: TemplateContext;
+  sessionCtx: ExternalFailureConversationContext;
   isGenericRunnerFailure: boolean;
   cfg?: OpenClawConfig;
 }): string {
@@ -1045,6 +1050,57 @@ function markAgentRunFailureReplyPayload<T extends ReplyPayload>(payload: T): T 
     marked.isError = true;
   }
   return marked;
+}
+
+export function buildTerminalAgentRunFailureReplyPayload(params: {
+  isHeartbeat?: boolean;
+  sessionCtx: ExternalFailureConversationContext;
+  cfg?: OpenClawConfig;
+}): ReplyPayload {
+  return markAgentRunFailureReplyPayload({
+    text: resolveExternalRunFailureTextForConversation({
+      text: params.isHeartbeat
+        ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
+        : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      sessionCtx: params.sessionCtx,
+      isGenericRunnerFailure: true,
+      cfg: params.cfg,
+    }),
+  });
+}
+
+export function buildEmptyInteractiveReplyPayload(params: {
+  isInteractive: boolean;
+  isHeartbeat?: boolean;
+  silentExpected?: boolean;
+  allowEmptyAssistantReplyAsSilent?: boolean;
+  isMessageToolOnly: boolean;
+  hasPendingContinuation: boolean;
+  hasExplicitSilentReply: boolean;
+  hasCommittedDelivery: boolean;
+  sessionCtx: ExternalFailureConversationContext;
+  cfg?: OpenClawConfig;
+}): ReplyPayload | undefined {
+  if (
+    !params.isInteractive ||
+    params.isHeartbeat === true ||
+    params.silentExpected === true ||
+    params.allowEmptyAssistantReplyAsSilent === true ||
+    params.isMessageToolOnly ||
+    params.hasPendingContinuation ||
+    params.hasExplicitSilentReply ||
+    params.hasCommittedDelivery
+  ) {
+    return undefined;
+  }
+  return markAgentRunFailureReplyPayload({
+    text: resolveExternalRunFailureTextForConversation({
+      text: "I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.",
+      sessionCtx: params.sessionCtx,
+      isGenericRunnerFailure: true,
+      cfg: params.cfg,
+    }),
+  });
 }
 
 /** Converts known agent-run failures into user-facing reply payloads. */
@@ -3530,15 +3586,10 @@ async function runAgentTurnWithFallbackInternal(
     }
   }
   const terminalFailurePayload = terminalRunFailed
-    ? markAgentRunFailureReplyPayload({
-        text: resolveExternalRunFailureTextForConversation({
-          text: params.isHeartbeat
-            ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
-            : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
-          sessionCtx: params.sessionCtx,
-          isGenericRunnerFailure: true,
-          cfg: params.followupRun.run.config,
-        }),
+    ? buildTerminalAgentRunFailureReplyPayload({
+        isHeartbeat: params.isHeartbeat,
+        sessionCtx: params.sessionCtx,
+        cfg: params.followupRun.run.config,
       })
     : undefined;
 

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -38,7 +38,12 @@ type AgentRunParams = {
   onPartialReply?: (payload: { text?: string }) => Promise<void> | void;
   onAssistantMessageStart?: () => Promise<void> | void;
   onReasoningStream?: (payload: { text?: string }) => Promise<void> | void;
-  onBlockReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
+  onBlockReply?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    isReasoning?: boolean;
+    isCommentary?: boolean;
+  }) => Promise<void> | void;
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
@@ -183,6 +188,7 @@ function createMinimalRun(params?: {
   shouldSteer?: boolean;
   shouldFollowup?: boolean;
   resolvedQueueMode?: string;
+  currentInboundEventKind?: FollowupRun["currentInboundEventKind"];
   sessionCtx?: Partial<TemplateContext>;
   runOverrides?: Partial<FollowupRun["run"]>;
 }) {
@@ -201,6 +207,7 @@ function createMinimalRun(params?: {
     prompt: "hello",
     summaryLine: "hello",
     enqueuedAt: Date.now(),
+    currentInboundEventKind: params?.currentInboundEventKind,
     run: {
       sessionId: "session",
       sessionKey,
@@ -1410,6 +1417,108 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it.each([
+    { label: "empty output", payloads: [] },
+    { label: "reasoning-only output", payloads: [{ text: "internal", isReasoning: true }] },
+    { label: "commentary-only output", payloads: [{ text: "internal", isCommentary: true }] },
+    { label: "directive-only output", payloads: [{ text: "[[reply_to_current]]" }] },
+  ])("surfaces successful $label through normal reply delivery", async ({ payloads }) => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({ payloads, meta: {} });
+    const { run } = createMinimalRun({
+      runOverrides: { config: { channels: { whatsapp: { replyToMode: "first" } } } },
+    });
+
+    const result = await run();
+    const payloadsResult = Array.isArray(result) ? result : [result];
+
+    expect(payloadsResult).toContainEqual(
+      expect.objectContaining({
+        text: expect.stringContaining("did not produce a visible reply"),
+        isError: true,
+        replyToId: "msg",
+      }),
+    );
+  });
+
+  it.each([
+    { lane: "reasoning", payload: { text: "internal", isReasoning: true } },
+    { lane: "commentary", payload: { text: "internal", isCommentary: true } },
+  ])("does not let streamed $lane suppress the empty-reply fallback", async ({ payload }) => {
+    const onBlockReply = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onBlockReply?.(payload);
+      return { payloads: [], meta: {} };
+    });
+    const { run } = createMinimalRun({
+      blockStreamingEnabled: true,
+      opts: {
+        onBlockReply,
+        reasoningPayloadsEnabled: true,
+        commentaryPayloadsEnabled: true,
+      },
+    });
+
+    const result = await run();
+    const payloads = Array.isArray(result) ? result : [result];
+
+    expect(onBlockReply).toHaveBeenCalled();
+    expect(onBlockReply.mock.calls[0]?.[0]).toEqual(expect.objectContaining(payload));
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        text: expect.stringContaining("did not produce a visible reply"),
+        isError: true,
+      }),
+    );
+  });
+
+  it.each([
+    {
+      label: "NO_REPLY",
+      result: {
+        payloads: [{ text: "NO_REPLY" }],
+        meta: { finalAssistantVisibleText: "NO_REPLY" },
+      },
+    },
+    {
+      label: "accepted child spawn",
+      result: {
+        payloads: [],
+        meta: {},
+        acceptedSessionSpawns: [{ runId: "child", childSessionKey: "agent:main:child" }],
+      },
+    },
+    { label: "yielded continuation", result: { payloads: [], meta: { yielded: true } } },
+    {
+      label: "pending tool continuation",
+      result: { payloads: [], meta: { pendingToolCalls: [{ name: "hosted_tool" }] } },
+    },
+  ])("keeps successful $label completions silent", async ({ result }) => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce(result);
+    const { run } = createMinimalRun();
+
+    await expect(run()).resolves.toBeUndefined();
+  });
+
+  it.each([
+    {
+      label: "room event",
+      params: { currentInboundEventKind: "room_event" as const },
+    },
+    {
+      label: "internal handoff",
+      params: {
+        runOverrides: {
+          inputProvenance: { kind: "internal_system" as const, sourceTool: "restart-sentinel" },
+        },
+      },
+    },
+  ])("keeps successful empty $label completions silent", async ({ params }) => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
+    const { run } = createMinimalRun(params);
+
+    await expect(run()).resolves.toBeUndefined();
+  });
+
+  it.each([
     {
       label: "silent token",
       payload: { text: "NO_REPLY" },
@@ -1750,10 +1859,40 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
-  it("surfaces a configured backend failure when fallback produces no visible reply", async () => {
-    state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "NO_REPLY" }],
-      meta: {},
+  it.each([
+    {
+      label: "NO_REPLY",
+      payload: { text: "NO_REPLY" },
+      opts: undefined,
+      streamed: false,
+    },
+    {
+      label: "reasoning-only output with reasoning enabled",
+      payload: { text: "internal reasoning", isReasoning: true },
+      opts: { reasoningPayloadsEnabled: true },
+      streamed: false,
+    },
+    {
+      label: "streamed reasoning-only output with reasoning enabled",
+      payload: { text: "internal reasoning", isReasoning: true },
+      opts: { reasoningPayloadsEnabled: true, onBlockReply: vi.fn() },
+      streamed: true,
+    },
+    {
+      label: "commentary-only output with commentary enabled",
+      payload: { text: "internal commentary", isCommentary: true },
+      opts: { commentaryPayloadsEnabled: true },
+      streamed: false,
+    },
+  ])("surfaces a configured backend failure when fallback produces $label", async (testCase) => {
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      if (testCase.streamed) {
+        await params.onBlockReply?.(testCase.payload);
+      }
+      return {
+        payloads: [testCase.payload],
+        meta: {},
+      };
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
@@ -1776,6 +1915,8 @@ describe("runReplyAgent typing (heartbeat)", () => {
 
     try {
       const { run } = createMinimalRun({
+        opts: testCase.opts,
+        blockStreamingEnabled: testCase.streamed,
         runOverrides: {
           provider: "lmstudio",
           model: "gemma-4-e4b-it",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import {
   hasSessionAutoModelFallbackProvenance,
   hasConfiguredModelFallbacks,
@@ -11,6 +12,7 @@ import {
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { hasVisibleAgentPayload } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import { hasDeliberateSilentTerminalReply } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import {
   formatEmbeddedAgentQueueFailureSummary,
   queueEmbeddedAgentMessageWithOutcomeAsync,
@@ -67,6 +69,7 @@ import type { VerboseLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
+  buildEmptyInteractiveReplyPayload,
   buildKnownAgentRunFailureReplyPayload,
   runAgentTurnWithFallback,
 } from "./agent-runner-execution.js";
@@ -163,7 +166,7 @@ function buildSilentFallbackFailurePayload(params: {
   fallbackTransition: ReturnType<typeof resolveFallbackTransition>;
   fallbackFailureKnown: boolean;
   isHeartbeat: boolean;
-  hasSuccessfulSideEffectDelivery: boolean;
+  hasSuccessfulTerminalDelivery: boolean;
   allowEmptyAssistantReplyAsSilent?: boolean;
   silentExpected?: boolean;
 }): ReplyPayload | undefined {
@@ -171,7 +174,7 @@ function buildSilentFallbackFailurePayload(params: {
     params.isHeartbeat ||
     params.allowEmptyAssistantReplyAsSilent === true ||
     params.silentExpected === true ||
-    params.hasSuccessfulSideEffectDelivery ||
+    params.hasSuccessfulTerminalDelivery ||
     !params.fallbackTransition.fallbackActive ||
     !params.fallbackFailureKnown
   ) {
@@ -238,6 +241,22 @@ function resolveReplyRunDeliveryContext(params: {
   });
 }
 
+function hasSuccessfulSourceReplyDelivery(params: {
+  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
+  directlySentBlockKeys?: Set<string>;
+  messagingToolSentTexts?: string[];
+  messagingToolSentMediaUrls?: string[];
+  messagingToolSentTargets?: unknown[];
+}): boolean {
+  return (
+    (params.blockReplyPipeline?.didStream() && !params.blockReplyPipeline.isAborted()) ||
+    (params.directlySentBlockKeys?.size ?? 0) > 0 ||
+    hasNonEmptyStringArray(params.messagingToolSentTexts) ||
+    hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
+    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets)
+  );
+}
+
 function hasNonEmptyStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.some((entry) => typeof entry === "string" && entry.trim());
 }
@@ -261,37 +280,24 @@ function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
   });
 }
 
-function hasSuccessfulSideEffectDelivery(params: {
-  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
-  directlySentBlockKeys?: Set<string>;
-  messagingToolSentTexts?: string[];
-  messagingToolSentMediaUrls?: string[];
-  messagingToolSentTargets?: unknown[];
-  didSendViaMessagingTool?: boolean;
-  successfulCronAdds?: number;
-  didSendDeterministicApprovalPrompt?: boolean;
+function hasSuccessfulTerminalSourceReplyDelivery(params: {
+  blockReplyPipeline: {
+    didStreamTerminalReply?: () => boolean;
+    isAborted: () => boolean;
+  } | null;
+  directlySentBlockPayloads?: ReplyPayload[];
 }): boolean {
-  return (
-    params.didSendViaMessagingTool === true ||
-    hasSuccessfulSourceReplyDelivery(params) ||
-    (params.successfulCronAdds ?? 0) > 0 ||
-    params.didSendDeterministicApprovalPrompt === true
+  const sentTerminalBlock = params.directlySentBlockPayloads?.some(
+    (payload) =>
+      payload.isReasoning !== true &&
+      payload.isCommentary !== true &&
+      !isReplyPayloadStatusNotice(payload) &&
+      normalizeReplyPayload(payload, { applyChannelTransforms: false }) !== null,
   );
-}
-
-function hasSuccessfulSourceReplyDelivery(params: {
-  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
-  directlySentBlockKeys?: Set<string>;
-  messagingToolSentTexts?: string[];
-  messagingToolSentMediaUrls?: string[];
-  messagingToolSentTargets?: unknown[];
-}): boolean {
   return (
-    (params.blockReplyPipeline?.didStream() && !params.blockReplyPipeline.isAborted()) ||
-    (params.directlySentBlockKeys?.size ?? 0) > 0 ||
-    hasNonEmptyStringArray(params.messagingToolSentTexts) ||
-    hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
-    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets)
+    (params.blockReplyPipeline?.didStreamTerminalReply?.() === true &&
+      !params.blockReplyPipeline.isAborted()) ||
+    sentTerminalBlock === true
   );
 }
 
@@ -1973,16 +1979,23 @@ export async function runReplyAgent(params: {
       preserveFreshTotalTokensOnStaleUsage: preflightCompactionApplied,
     });
 
-    const successfulSideEffectDelivery = hasSuccessfulSideEffectDelivery({
-      blockReplyPipeline,
-      directlySentBlockKeys,
-      messagingToolSentTexts: runResult.messagingToolSentTexts,
-      messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
-      messagingToolSentTargets: runResult.messagingToolSentTargets,
-      didSendViaMessagingTool: runResult.didSendViaMessagingTool,
-      successfulCronAdds: runResult.successfulCronAdds,
-      didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
-    });
+    const committedOutboundDelivery =
+      runResult.didSendViaMessagingTool === true ||
+      hasNonEmptyStringArray(runResult.messagingToolSentTexts) ||
+      hasNonEmptyStringArray(runResult.messagingToolSentMediaUrls) ||
+      hasCommittedMessagingTargetDeliveryEvidence(runResult.messagingToolSentTargets) ||
+      hasAcceptedSessionSpawn(runResult.acceptedSessionSpawns) ||
+      (runResult.successfulCronAdds ?? 0) > 0 ||
+      runResult.didSendDeterministicApprovalPrompt === true;
+    const successfulSideEffectDelivery =
+      committedOutboundDelivery ||
+      hasSuccessfulSourceReplyDelivery({ blockReplyPipeline, directlySentBlockKeys });
+    const successfulTerminalEffectDelivery =
+      committedOutboundDelivery ||
+      hasSuccessfulTerminalSourceReplyDelivery({
+        blockReplyPipeline,
+        directlySentBlockPayloads,
+      });
     const successfulSourceReplyDelivery = hasSuccessfulSourceReplyDelivery({
       blockReplyPipeline,
       directlySentBlockKeys,
@@ -1995,9 +2008,33 @@ export async function runReplyAgent(params: {
       hasVisibleAgentPayload({ payloads: runResult.messagingToolSourceReplyPayloads });
     const shouldDeliverTerminalFailure = Boolean(
       terminalFailurePayload &&
-      !successfulSideEffectDelivery &&
+      !successfulTerminalEffectDelivery &&
       !committedMessagingToolSourceReplyDelivery,
     );
+    const fallbackFailureKnown =
+      fallbackAttempts.length > 0 || configuredFallbackModel.persistedAutoFallback;
+    const hasSpecificFallbackFailure = fallbackTransition.fallbackActive && fallbackFailureKnown;
+    const emptyInteractiveReplyPayload = terminalFailurePayload
+      ? undefined
+      : buildEmptyInteractiveReplyPayload({
+          isInteractive:
+            followupRun.currentInboundEventKind !== "room_event" &&
+            (followupRun.run.inputProvenance?.kind === undefined ||
+              followupRun.run.inputProvenance.kind === "external_user"),
+          isHeartbeat,
+          silentExpected: followupRun.run.silentExpected,
+          allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
+          isMessageToolOnly:
+            (opts?.sourceReplyDeliveryMode ?? followupRun.run.sourceReplyDeliveryMode) ===
+            "message_tool_only",
+          hasPendingContinuation:
+            runResult.meta?.yielded === true || (runResult.meta?.pendingToolCalls?.length ?? 0) > 0,
+          hasExplicitSilentReply: hasDeliberateSilentTerminalReply(runResult),
+          hasCommittedDelivery:
+            successfulTerminalEffectDelivery || committedMessagingToolSourceReplyDelivery,
+          sessionCtx,
+          cfg,
+        });
     if (
       opts?.sourceReplyDeliveryMode === "message_tool_only" &&
       committedMessagingToolSourceReplyDelivery
@@ -2007,10 +2044,9 @@ export async function runReplyAgent(params: {
     const returnSilentFallbackFailureIfNeeded = async (): Promise<ReplyPayload | undefined> => {
       const silentFallbackFailurePayload = buildSilentFallbackFailurePayload({
         fallbackTransition,
-        fallbackFailureKnown:
-          fallbackAttempts.length > 0 || configuredFallbackModel.persistedAutoFallback,
+        fallbackFailureKnown,
         isHeartbeat,
-        hasSuccessfulSideEffectDelivery: successfulSideEffectDelivery,
+        hasSuccessfulTerminalDelivery: successfulTerminalEffectDelivery,
         allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
         silentExpected: followupRun.run.silentExpected,
       });
@@ -2101,7 +2137,8 @@ export async function runReplyAgent(params: {
     if (
       payloadArray.length === 0 &&
       fallbackNoticePayloads.length === 0 &&
-      !shouldDeliverTerminalFailure
+      !shouldDeliverTerminalFailure &&
+      (!emptyInteractiveReplyPayload || hasSpecificFallbackFailure)
     ) {
       const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
       if (silentFallbackFailurePayload) {
@@ -2177,6 +2214,22 @@ export async function runReplyAgent(params: {
       const terminalPayloadResult = await buildFinalPayloads([terminalFailurePayload]);
       replyPayloads = [...replyPayloads, ...terminalPayloadResult.replyPayloads];
       didLogHeartbeatStrip = terminalPayloadResult.didLogHeartbeatStrip;
+    } else if (hasSpecificFallbackFailure && !hasTerminalReplyPayload) {
+      const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
+      if (silentFallbackFailurePayload) {
+        return silentFallbackFailurePayload;
+      }
+    } else if (emptyInteractiveReplyPayload && !hasTerminalReplyPayload) {
+      const emptyPayloadResult = await buildFinalPayloads([emptyInteractiveReplyPayload]);
+      replyPayloads = [...replyPayloads, ...emptyPayloadResult.replyPayloads];
+      didLogHeartbeatStrip = emptyPayloadResult.didLogHeartbeatStrip;
+      if (emptyPayloadResult.replyPayloads.length > 0) {
+        replyOperation.retainFailureUntilComplete();
+        replyOperation.fail(
+          "run_failed",
+          new Error("interactive agent run completed without a visible reply"),
+        );
+      }
     }
 
     const hasReplyPayloadBeyondFallbackNotice = replyPayloads.some(

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -101,6 +101,26 @@ describe("createBlockReplyContentKey", () => {
 });
 
 describe("createBlockReplyPipeline dedup with threading", () => {
+  it("does not count reasoning or commentary as a terminal reply", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "reasoning", isReasoning: true });
+    pipeline.enqueue({ text: "commentary", isCommentary: true });
+    pipeline.enqueue({ audioAsVoice: true });
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.didStream()).toBe(true);
+    expect(pipeline.didStreamTerminalReply?.()).toBe(false);
+
+    pipeline.enqueue({ text: "final answer" });
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.didStreamTerminalReply?.()).toBe(true);
+  });
+
   it("keeps separate deliveries for same text with different replyToId", async () => {
     const sent: Array<{ text?: string; replyToId?: string }> = [];
     const pipeline = createBlockReplyPipeline({

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -17,6 +17,8 @@ export type BlockReplyPipeline = {
   stop: () => void;
   hasBuffered: () => boolean;
   didStream: () => boolean;
+  /** True only after a final-answer lane payload is sent. */
+  didStreamTerminalReply?: () => boolean;
   isAborted: () => boolean;
   hasSentPayload: (payload: ReplyPayload) => boolean;
   hasSentExactPayload?: (payload: ReplyPayload) => boolean;
@@ -125,6 +127,7 @@ export function createBlockReplyPipeline(params: {
   let sendChain: Promise<void> = Promise.resolve();
   let aborted = false;
   let didStream = false;
+  let didStreamTerminalReply = false;
   let didLogTimeout = false;
 
   const hasSeenOrQueuedPayloadKey = (payloadKey: string) =>
@@ -193,6 +196,13 @@ export function createBlockReplyPipeline(params: {
         }
         if (!isStatusNotice) {
           didStream = true;
+          if (
+            payload.isReasoning !== true &&
+            payload.isCommentary !== true &&
+            hasOutboundReplyContent(payload, { trimText: true })
+          ) {
+            didStreamTerminalReply = true;
+          }
         }
       })
       .catch((err: unknown) => {
@@ -324,6 +334,7 @@ export function createBlockReplyPipeline(params: {
     stop,
     hasBuffered: () => coalescer?.hasBuffered() || bufferedPayloads.length > 0,
     didStream: () => didStream,
+    didStreamTerminalReply: () => didStreamTerminalReply,
     isAborted: () => aborted,
     hasSentExactPayload: (payload) => sentContentKeys.has(createBlockReplyContentKey(payload)),
     hasSentPayload: (payload) => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -12,6 +12,7 @@ import {
   createUserTurnTranscriptRecorder,
   type PersistedUserTurnMessage,
 } from "../../sessions/user-turn-transcript.js";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "./agent-runner-failure-copy.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 
 const runEmbeddedAgentMock = vi.fn();
@@ -360,6 +361,8 @@ async function loadFreshFollowupRunnerModuleForTest() {
   vi.resetModules();
   vi.doUnmock("../../config/config.js");
   vi.doMock("../../agents/model-fallback.js", () => ({
+    isFallbackSummaryError: (err: unknown) =>
+      err instanceof Error && err.name === "FallbackSummaryError",
     runWithModelFallback: (params: unknown) => runWithModelFallbackMock(params),
   }));
   vi.doMock("../../agents/session-write-lock.js", () => ({
@@ -4329,13 +4332,19 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       sessionStore: Record<string, SessionEntry>;
       sessionKey: string;
       storePath: string;
+      reasoningPayloadsEnabled: boolean;
+      commentaryPayloadsEnabled: boolean;
     }> = {},
   ) {
     if (overrides.storePath && overrides.sessionStore) {
       registerFollowupTestSessionStore(overrides.storePath, overrides.sessionStore);
     }
     return createFollowupRunner({
-      opts: { onBlockReply },
+      opts: {
+        onBlockReply,
+        reasoningPayloadsEnabled: overrides.reasoningPayloadsEnabled,
+        commentaryPayloadsEnabled: overrides.commentaryPayloadsEnabled,
+      },
       typing: createMockTypingController(),
       typingMode: "instant",
       defaultModel: "anthropic/claude-opus-4-6",
@@ -4354,6 +4363,8 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       sessionStore: Record<string, SessionEntry>;
       sessionKey: string;
       storePath: string;
+      reasoningPayloadsEnabled: boolean;
+      commentaryPayloadsEnabled: boolean;
     }>;
   }) {
     const onBlockReply = createAsyncReplySpy();
@@ -4373,6 +4384,259 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       ...overrides,
     };
   }
+
+  it.each([
+    { label: "empty", payloads: [], runnerOverrides: undefined },
+    { label: "empty-envelope", payloads: [{}], runnerOverrides: undefined },
+    { label: "blank-text", payloads: [{ text: "" }], runnerOverrides: undefined },
+    {
+      label: "reasoning-only",
+      payloads: [{ text: "internal", isReasoning: true }],
+      runnerOverrides: undefined,
+    },
+    {
+      label: "reasoning-only with reasoning enabled",
+      payloads: [{ text: "internal", isReasoning: true }],
+      runnerOverrides: { reasoningPayloadsEnabled: true },
+    },
+    {
+      label: "commentary-only",
+      payloads: [{ text: "internal", isCommentary: true }],
+      runnerOverrides: undefined,
+    },
+    {
+      label: "commentary-only with commentary enabled",
+      payloads: [{ text: "internal", isCommentary: true }],
+      runnerOverrides: { commentaryPayloadsEnabled: true },
+    },
+    {
+      label: "directive-only",
+      payloads: [{ text: "[[reply_to_current]]" }],
+      runnerOverrides: undefined,
+    },
+  ])(
+    "routes a visible fallback for successful $label followups",
+    async ({ payloads, runnerOverrides }) => {
+      const queued = baseQueuedRun("discord");
+      const { onBlockReply } = await runMessagingCase({
+        agentResult: { payloads },
+        runnerOverrides,
+        queued: {
+          ...queued,
+          currentInboundEventKind: "user_request",
+          originatingChannel: "discord",
+          originatingTo: "channel:C1",
+          originatingReplyToMode: "first",
+          messageId: "message-1",
+        },
+      });
+
+      expect(onBlockReply).not.toHaveBeenCalled();
+      const fallbackCall = routeReplyMock.mock.calls.find((call) => {
+        const payload = requireRecord(
+          requireRecord(call[0], "route reply params").payload,
+          "payload",
+        );
+        return payload.isError === true;
+      });
+      expect(fallbackCall).toBeDefined();
+      expect(requireRecord(fallbackCall?.[0], "fallback route reply params").payload).toMatchObject(
+        {
+          text: expect.stringContaining("did not produce a visible reply"),
+          isError: true,
+        },
+      );
+    },
+  );
+
+  it("routes the shared terminal failure for empty failed followups", async () => {
+    const queued = baseQueuedRun("discord");
+    await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        meta: { error: { kind: "tool_result_mismatch", message: "private detail" } },
+      },
+      queued: {
+        ...queued,
+        currentInboundEventKind: "user_request",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      },
+    });
+
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toMatchObject({
+      text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      isError: true,
+    });
+  });
+
+  it("routes a terminal failure when a classified empty result exhausts model fallback", async () => {
+    runWithModelFallbackMock.mockImplementationOnce(
+      async (params: {
+        provider: string;
+        model: string;
+        run: (provider: string, model: string) => Promise<unknown>;
+        classifyResult: (attempt: {
+          result: unknown;
+          provider: string;
+          model: string;
+          attempt: number;
+          total: number;
+        }) => Promise<Record<string, unknown>> | Record<string, unknown>;
+      }) => {
+        const result = await params.run(params.provider, params.model);
+        const classification = await params.classifyResult({
+          result,
+          provider: params.provider,
+          model: params.model,
+          attempt: 1,
+          total: 1,
+        });
+        expect(classification).toMatchObject({
+          code: "empty_result",
+          preserveResultOnExhaustion: true,
+          preserveResultPriority: -1,
+        });
+        return {
+          outcome: "exhausted",
+          result,
+          provider: params.provider,
+          model: params.model,
+          attempts: [{ reason: "format", code: "empty_result" }],
+        };
+      },
+    );
+    const queued = baseQueuedRun("discord");
+    await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        meta: { agentHarnessResultClassification: "empty" },
+      },
+      queued: {
+        ...queued,
+        currentInboundEventKind: "user_request",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      },
+    });
+
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toMatchObject({
+      text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      isError: true,
+    });
+  });
+
+  it("routes a terminal failure when model fallback exhausts without a preserved result", async () => {
+    const exhaustionError = new Error("All model fallback candidates failed");
+    exhaustionError.name = "FallbackSummaryError";
+    runWithModelFallbackMock.mockRejectedValueOnce(exhaustionError);
+    const queued = baseQueuedRun("discord");
+    await runMessagingCase({
+      agentResult: { payloads: [] },
+      queued: {
+        ...queued,
+        currentInboundEventKind: "user_request",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      },
+    });
+
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toMatchObject({
+      text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      isError: true,
+    });
+  });
+
+  it.each([
+    {
+      label: "NO_REPLY",
+      agentResult: {
+        payloads: [{ text: "NO_REPLY" }],
+        meta: { finalAssistantVisibleText: "NO_REPLY" },
+      },
+      queuedOverrides: {},
+    },
+    {
+      label: "accepted child spawn",
+      agentResult: {
+        payloads: [],
+        acceptedSessionSpawns: [{ runId: "child", childSessionKey: "agent:main:child" }],
+      },
+      queuedOverrides: {},
+    },
+    {
+      label: "cron side effect",
+      agentResult: { payloads: [], successfulCronAdds: 1 },
+      queuedOverrides: {},
+    },
+    {
+      label: "approval prompt",
+      agentResult: { payloads: [], didSendDeterministicApprovalPrompt: true },
+      queuedOverrides: {},
+    },
+    {
+      label: "source delivery",
+      agentResult: { payloads: [], didDeliverSourceReplyViaMessageTool: true },
+      queuedOverrides: {},
+    },
+    {
+      label: "message-tool-only mode",
+      agentResult: { payloads: [] },
+      queuedOverrides: { run: { sourceReplyDeliveryMode: "message_tool_only" } },
+    },
+    {
+      label: "explicit silent policy",
+      agentResult: { payloads: [] },
+      queuedOverrides: { run: { silentExpected: true } },
+    },
+    {
+      label: "allowed empty reply",
+      agentResult: { payloads: [] },
+      queuedOverrides: { run: { allowEmptyAssistantReplyAsSilent: true } },
+    },
+    {
+      label: "yielded continuation",
+      agentResult: { payloads: [], meta: { yielded: true } },
+      queuedOverrides: {},
+    },
+    {
+      label: "pending tool continuation",
+      agentResult: { payloads: [], meta: { pendingToolCalls: [{ name: "hosted_tool" }] } },
+      queuedOverrides: {},
+    },
+    {
+      label: "room event",
+      agentResult: { payloads: [] },
+      queuedOverrides: { currentInboundEventKind: "room_event" },
+    },
+    {
+      label: "default-silent group",
+      agentResult: { payloads: [] },
+      queuedOverrides: { originatingChatType: "group" },
+    },
+    {
+      label: "internal handoff",
+      agentResult: { payloads: [] },
+      queuedOverrides: {
+        run: { inputProvenance: { kind: "inter_session", sourceTool: "subagent_announce" } },
+      },
+    },
+  ])("keeps successful $label followups silent", async ({ agentResult, queuedOverrides }) => {
+    const queued = baseQueuedRun("discord");
+    await runMessagingCase({
+      agentResult,
+      queued: {
+        ...queued,
+        currentInboundEventKind: "user_request",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        ...queuedOverrides,
+        run: { ...queued.run, ...queuedOverrides.run },
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+  });
 
   it("persists usage even when replies are suppressed", async () => {
     const storePath = "/tmp/openclaw-followup-usage.json";
@@ -5096,7 +5360,7 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
 
     await runner(queued);
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(2);
+    expect(routeReplyMock).toHaveBeenCalledTimes(3);
     const startRoute = requireMockCallArg(routeReplyMock, 0);
     const endRoute = requireMockCallArg(routeReplyMock, 1);
     expect(startRoute).toMatchObject({
@@ -5120,6 +5384,12 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       replyToId: "current-msg-1",
       replyToCurrent: true,
       isCompactionNotice: true,
+    });
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 2).payload, "final fallback"),
+    ).toMatchObject({
+      text: expect.stringContaining("did not produce a visible reply"),
+      isError: true,
     });
   });
 
@@ -5201,7 +5471,7 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(4);
+    expect(routeReplyMock).toHaveBeenCalledTimes(5);
     expect(
       requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "hook start"),
     ).toMatchObject({
@@ -5231,6 +5501,12 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       replyToId: "current-msg-1",
       replyToCurrent: true,
       isCompactionNotice: true,
+    });
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 4).payload, "final fallback"),
+    ).toMatchObject({
+      text: expect.stringContaining("did not produce a visible reply"),
+      isError: true,
     });
   });
 
@@ -5269,13 +5545,19 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    expect(routeReplyMock).toHaveBeenCalledTimes(2);
     const payload = requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "notice payload");
     expect(payload).toMatchObject({
       text: "🧹 Compacting context...",
       isCompactionNotice: true,
     });
     expect(payload.replyToId).toBeUndefined();
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 1).payload, "final fallback"),
+    ).toMatchObject({
+      text: expect.stringContaining("did not produce a visible reply"),
+      isError: true,
+    });
   });
 
   it("plans queued compaction notices with the active fallback candidate", async () => {
@@ -5364,7 +5646,11 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(routeReplyMock).toHaveBeenCalledOnce();
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toMatchObject({
+      text: expect.stringContaining("did not produce a visible reply"),
+      isError: true,
+    });
   });
 });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -11,11 +11,22 @@ import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-bu
 import { getCliSessionBinding } from "../../agents/cli-session.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
-import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import {
+  hasCommittedOutboundDeliveryEvidence,
+  hasVisibleAgentPayload,
+} from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import {
+  hasDeliberateSilentTerminalReply,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
-import { runWithModelFallback } from "../../agents/model-fallback.js";
+import {
+  isFallbackSummaryError,
+  runWithModelFallback,
+  type ModelFallbackResultClassification,
+} from "../../agents/model-fallback.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection-cli.js";
 import {
@@ -43,6 +54,7 @@ import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../se
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import {
   getReplyPayloadMetadata,
+  isReplyPayloadStatusNotice,
   markReplyPayloadForSourceSuppressionDelivery,
 } from "../reply-payload.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -59,8 +71,10 @@ import {
   runCliAgentWithLifecycle,
 } from "./agent-runner-cli-dispatch.js";
 import {
+  buildEmptyInteractiveReplyPayload,
   buildCommandOutputFromToolResultEvent,
   buildPreflightCompactionFailureText,
+  buildTerminalAgentRunFailureReplyPayload,
   resolveRunAfterAutoFallbackPrimaryProbeRecheck,
   resolveSessionRuntimeOverrideForProvider,
 } from "./agent-runner-execution.js";
@@ -99,6 +113,33 @@ import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 type EmbeddedAgentRunResult = Awaited<ReturnType<typeof runEmbeddedAgent>>;
+
+const PRESERVED_FOLLOWUP_RESULT_CODES = new Set([
+  "empty_result",
+  "reasoning_only_result",
+  "planning_only_result",
+]);
+
+function preserveNonVisibleFollowupResult(
+  classification: ModelFallbackResultClassification,
+): ModelFallbackResultClassification {
+  if (
+    !classification ||
+    !("code" in classification) ||
+    !classification.code ||
+    !PRESERVED_FOLLOWUP_RESULT_CODES.has(classification.code)
+  ) {
+    return classification;
+  }
+  // Follow-up delivery owns its terminal fallback. Preserve the classified result
+  // so that owner can route a visible failure instead of losing it to a thrown summary.
+  return {
+    ...classification,
+    preserveResultOnExhaustion: true,
+    // Prefer any earlier result that carries a user-facing terminal presentation.
+    preserveResultPriority: -1,
+  };
+}
 
 function resolveFollowupAbortSignal(
   run: Pick<FollowupRun, "abortSignal" | "queueAbortSignal">,
@@ -664,6 +705,7 @@ export function createFollowupRunner(params: {
       let fallbackProvider = run.provider;
       let fallbackModel = run.model;
       let fallbackExhausted = false;
+      let terminalRunFailed = false;
       const resolveFollowupCurrentMessageId = () =>
         run.inputProvenance?.kind === "internal_system" &&
         run.inputProvenance.sourceTool === "restart-sentinel"
@@ -914,7 +956,9 @@ export function createFollowupRunner(params: {
             });
           },
           classifyResult: ({ result, provider, model }) =>
-            outcomePlan.classifyRunResult({ result, provider, model }),
+            preserveNonVisibleFollowupResult(
+              outcomePlan.classifyRunResult({ result, provider, model }),
+            ),
           mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
           run: async (provider, model, runOptions) => {
             const suppressQueuedUserPersistenceForCandidate =
@@ -1373,11 +1417,13 @@ export function createFollowupRunner(params: {
           });
           replyOperation.retainFailureUntilComplete();
           replyOperation.fail("run_failed", exhaustionError);
+          terminalRunFailed = true;
         } else if (deferredLifecycleError || runResult.meta?.error) {
           const terminalError = new Error(terminalErrorMessage ?? "Agent run failed");
           emitSettledLifecycleError(terminalError, terminalMetadata);
           replyOperation.retainFailureUntilComplete();
           replyOperation.fail("run_failed", terminalError);
+          terminalRunFailed = true;
         } else {
           settledLifecycleTerminal?.emit("end", runResult);
         }
@@ -1401,16 +1447,27 @@ export function createFollowupRunner(params: {
           return;
         }
         const message = formatErrorMessage(err);
+        const shouldRouteFallbackExhaustion = isFallbackSummaryError(err);
         replyOperation.freezeAbort();
+        if (shouldRouteFallbackExhaustion) {
+          replyOperation.retainFailureUntilComplete();
+        }
         replyOperation.fail("run_failed", err);
         pendingLifecycleTerminal?.backstop.emit("error", err);
         pendingLifecycleTerminal = undefined;
         if (lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
           clearAgentRunContext(runId, lifecycleGeneration);
         }
-        await drainProgressDeliveries();
         defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);
-        return;
+        if (!shouldRouteFallbackExhaustion) {
+          await drainProgressDeliveries();
+          return;
+        }
+        // Fallback exhaustion can throw without a preserved candidate result.
+        // Continue through the owner delivery path so interactive turns still get safe failure copy.
+        runResult = { payloads: [], meta: { durationMs: 0 } };
+        fallbackExhausted = true;
+        terminalRunFailed = true;
       }
 
       await drainProgressDeliveries();
@@ -1455,28 +1512,103 @@ export function createFollowupRunner(params: {
         });
       }
 
-      const payloadArray = runResult.payloads ?? [];
-      if (payloadArray.length === 0) {
-        return;
-      }
-      const finalPayloads = resolveFollowupDeliveryPayloads({
-        cfg: runtimeConfig,
-        payloads: payloadArray,
-        messageProvider: run.messageProvider,
-        originatingAccountId: queued.originatingAccountId ?? run.agentAccountId,
-        originatingChannel: queued.originatingChannel,
-        originatingChatType: queued.originatingChatType,
-        originatingReplyToMode: queued.originatingReplyToMode,
-        originatingTo: queued.originatingTo,
-        originatingThreadId: queued.originatingThreadId,
-        reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
-        sentMediaUrls: runResult.messagingToolSentMediaUrls,
-        sentTargets: runResult.messagingToolSentTargets,
-        sentTexts: runResult.messagingToolSentTexts,
+      const hasCommittedDelivery =
+        hasCommittedOutboundDeliveryEvidence(runResult) ||
+        runResult.didDeliverSourceReplyViaMessageTool === true ||
+        hasVisibleAgentPayload({ payloads: runResult.messagingToolSourceReplyPayloads }) ||
+        runResult.didSendDeterministicApprovalPrompt === true;
+      const hasDeliveryDestination = Boolean(
+        (isRoutableChannel(queued.originatingChannel) && queued.originatingTo) ||
+        opts?.onBlockReply,
+      );
+      const isInteractive =
+        hasDeliveryDestination &&
+        queued.currentInboundEventKind !== "room_event" &&
+        (run.inputProvenance?.kind === undefined || run.inputProvenance.kind === "external_user");
+      const isMessageToolOnly = run.sourceReplyDeliveryMode === "message_tool_only";
+      const failureConversationContext = {
+        ChatType: queued.originatingChatType,
+        Provider: run.messageProvider,
+        SessionKey: replySessionKey,
+        Surface: queued.originatingChannel,
+      };
+      const fallbackPayload =
+        isInteractive && !isMessageToolOnly && !hasCommittedDelivery
+          ? terminalRunFailed
+            ? buildTerminalAgentRunFailureReplyPayload({
+                isHeartbeat: opts?.isHeartbeat,
+                sessionCtx: failureConversationContext,
+                cfg: runtimeConfig,
+              })
+            : buildEmptyInteractiveReplyPayload({
+                isInteractive,
+                isHeartbeat: opts?.isHeartbeat,
+                silentExpected: run.silentExpected,
+                allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
+                isMessageToolOnly,
+                hasPendingContinuation:
+                  runResult.meta?.yielded === true ||
+                  (runResult.meta?.pendingToolCalls?.length ?? 0) > 0,
+                hasExplicitSilentReply: hasDeliberateSilentTerminalReply(runResult),
+                hasCommittedDelivery,
+                sessionCtx: failureConversationContext,
+                cfg: runtimeConfig,
+              })
+          : undefined;
+      const payloadArray = (runResult.payloads ?? []).filter(
+        (payload) => payload.isCommentary !== true || opts?.commentaryPayloadsEnabled === true,
+      );
+      const deliveryPlan = buildAgentRuntimeDeliveryPlan({
+        provider: providerUsed,
+        modelId: modelUsed,
+        config: runtimeConfig,
+        workspaceDir: run.workspaceDir,
+        agentDir: run.agentDir,
       });
+      const resolveDeliveryPayloads = (payloads: ReplyPayload[]) =>
+        resolveFollowupDeliveryPayloads({
+          cfg: runtimeConfig,
+          payloads,
+          messageProvider: run.messageProvider,
+          originatingAccountId: queued.originatingAccountId ?? run.agentAccountId,
+          originatingChannel: queued.originatingChannel,
+          originatingChatType: queued.originatingChatType,
+          originatingReplyToMode: queued.originatingReplyToMode,
+          originatingTo: queued.originatingTo,
+          originatingThreadId: queued.originatingThreadId,
+          reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
+          sentMediaUrls: runResult.messagingToolSentMediaUrls,
+          sentTargets: runResult.messagingToolSentTargets,
+          sentTexts: runResult.messagingToolSentTexts,
+        }).filter(
+          (payload) => hasOutboundReplyContent(payload) && !deliveryPlan.isSilentPayload(payload),
+        );
+      let finalPayloads = resolveDeliveryPayloads(payloadArray);
+      const hasTerminalReplyPayload = finalPayloads.some(
+        (payload) =>
+          payload.isReasoning !== true &&
+          payload.isCommentary !== true &&
+          !isReplyPayloadStatusNotice(payload),
+      );
+      if (!hasTerminalReplyPayload && fallbackPayload) {
+        finalPayloads = [...finalPayloads, ...resolveDeliveryPayloads([fallbackPayload])];
+      }
 
       if (finalPayloads.length === 0) {
         return;
+      }
+      if (
+        !terminalRunFailed &&
+        fallbackPayload &&
+        finalPayloads.some(
+          (payload) => payload.isError === true && payload.text === fallbackPayload.text,
+        )
+      ) {
+        replyOperation.retainFailureUntilComplete();
+        replyOperation.fail(
+          "run_failed",
+          new Error("interactive follow-up completed without a visible reply"),
+        );
       }
 
       let deliveryPayloads = finalPayloads;

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -370,13 +370,14 @@ async function startLocalModeTui(opts: { invalidEditLoop?: boolean } = {}) {
 
 async function startGatewayModeTui(params: {
   queueMode: "followup" | "collect";
+  firstReplyText?: string;
   firstResponseDelayMs?: number;
   queueDebounceMs?: number;
   invalidEditLoop?: boolean;
 }) {
   const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-tui-pty-gateway-"));
   const workspaceDir = path.join(tempDir, "workspace");
-  const mockModel = await startMockModelServer("FIRST_RUN_ACTIVE", {
+  const mockModel = await startMockModelServer(params.firstReplyText ?? "FIRST_RUN_ACTIVE", {
     firstResponseDelayMs: params.firstResponseDelayMs ?? 2_500,
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
     invalidEditLoop: params.invalidEditLoop,
@@ -680,6 +681,60 @@ describe("TUI PTY real backends", () => {
         expect(JSON.stringify(fixture.mockModel.requests()[2]?.body)).toContain(
           "turn after queued followup",
         );
+
+        await fixture.run.write("/exit\r", { delay: false });
+        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "renders a non-deliverable direct reply failure through the real Gateway and TUI",
+    async () => {
+      const fixture = await startGatewayModeTui({
+        queueMode: "followup",
+        firstReplyText: "[[reply_to_current]]",
+        firstResponseDelayMs: 0,
+      });
+      try {
+        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
+        await fixture.run.write("non-deliverable first turn\r");
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length === 1 ? true : null),
+          onTimeout: () =>
+            new Error(`first prompt did not reach the model\n${fixture.run.output()}`),
+        });
+
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () =>
+            fixture.run.output().includes("did not produce a visible reply") ? true : null,
+          onTimeout: () =>
+            new Error(
+              `empty-reply fallback was not rendered\nrequests=${JSON.stringify(
+                fixture.mockModel.requests(),
+                null,
+                2,
+              )}\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
+            ),
+        });
+        expect(fixture.mockModel.requests()).toHaveLength(1);
+        expect(fixture.run.output()).not.toContain("[[reply_to_current]]");
+
+        await fixture.run.write("turn after empty reply\r");
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length === 2 ? true : null),
+          onTimeout: () =>
+            new Error(
+              `TUI stayed blocked after empty-reply fallback\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
+            ),
+        });
+        await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
 
         await fixture.run.write("/exit\r", { delay: false });
         expect((await fixture.run.waitForExit()).exitCode).toBe(0);


### PR DESCRIPTION
## What Problem This Solves

Closes #99712.

Maintainer replacement for #99824. The commit preserves contributor credit; a companion changelog PR will land immediately after the runtime change to avoid unrelated mainline changelog drift.

An interactive agent turn could complete successfully but leave no deliverable final reply after directive stripping, reasoning/commentary filtering, model-fallback exhaustion, queued follow-up routing, or block-stream dedupe. The user then saw a completed turn with no explanation.

## Why This Change Was Made

This rewrite keeps the policy at the reply-delivery owner boundary instead of teaching the TUI or individual providers about empty results:

- direct and queued follow-up paths share safe failure copy and conversation-silence policy;
- terminal delivery evidence is distinct from reasoning, commentary, status notices, and empty voice markers;
- explicit `NO_REPLY`, heartbeats, pending continuations, message-tool-only runs, room/internal events, and committed side effects remain silent;
- fallback exhaustion without a preserved result still routes through the normal safe terminal-failure path;
- model fallback preserves only the non-visible follow-up results needed by that owner path.

## User Impact

Interactive users now receive a visible, sanitized failure when a completed turn produced no deliverable reply. Existing deliberate-silence and side-effect contracts are unchanged.

## Evidence

- Focused Testbox: 236/236 tests passed across direct reply, queued follow-up, and block-stream suites — https://github.com/openclaw/openclaw/actions/runs/28754109271
- Exact changed gate: typecheck, lint, focused tests, and changed-surface checks — https://github.com/openclaw/openclaw/actions/runs/28754110416
- Exact-head hosted CI for `0be75376a2b234a08d67308ed75a3999b2eb14ba`: all required shards and QA smoke passed — https://github.com/openclaw/openclaw/actions/runs/28754577268
- Source-blind real Gateway + TUI PTY: visible failure, raw directive absent, next turn completed, clean exit — https://github.com/openclaw/openclaw/actions/runs/28753546491
- Upstream Codex contract checked at `be33f80bc65159c094ecd06bf155afa3061ce23d`: `codex-rs/app-server/src/bespoke_event_handling.rs:1348-1369` emits an empty item list for completed turns; `codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs:231-263` defines `NotLoaded` as intentionally empty.
- Fresh Codex autoreview: no actionable findings after accepted fixes.
