### PR TITLE
fix(status): keep diagnostics config reads read-only

### DIFF
--- a/src/commands/status.scan-overview.test.ts
+++ b/src/commands/status.scan-overview.test.ts
@@ -103,6 +103,7 @@ describe("collectStatusScanOverview", () => {
       useGatewayCallOverridesForChannelsStatus: true,
     });
 
+    expect(mocks.readBestEffortConfig).toHaveBeenCalledWith({ readOnly: true });
     expect(mocks.callGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "channels.status",

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -163,7 +163,8 @@ export async function collectStatusScanOverview(params: {
   } = await loadStatusScanCommandConfig({
     commandName: params.commandName,
     allowMissingConfigFastPath: params.allowMissingConfigFastPath,
-    readBestEffortConfig: async () => (await loadConfigModule()).readBestEffortConfig(),
+    readBestEffortConfig: async () =>
+      (await loadConfigModule()).readBestEffortConfig({ readOnly: true }),
     resolveConfig: async (loadedConfig) =>
       await (
         await loadCommandConfigResolutionModule()

--- a/src/config/io.best-effort.test.ts
+++ b/src/config/io.best-effort.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   readBestEffortConfig,
@@ -34,6 +36,24 @@ describe("readBestEffortConfig", () => {
       expect(
         bestEffort.agents?.defaults?.models?.["anthropic/claude-opus-4-6"]?.params?.cacheRetention,
       ).toBe("short");
+    });
+  });
+
+  it("can read diagnostics config without writing read-side state", async () => {
+    await withTempHome(async (home) => {
+      const configPath = await writeOpenClawConfig(home, {
+        commands: { ownerDisplay: "hash" },
+        gateway: { mode: "local" },
+      });
+      const healthStatePath = path.join(home, ".openclaw", "logs", "config-health.json");
+      const before = await fs.readFile(configPath, "utf-8");
+
+      const bestEffort = await readBestEffortConfig({ readOnly: true });
+
+      expect(bestEffort.gateway?.mode).toBe("local");
+      expect(bestEffort.commands?.ownerDisplaySecret).toEqual(expect.any(String));
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(before);
+      await expect(fs.stat(healthStatePath)).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 });

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -226,6 +226,15 @@ export type ConfigWriteOptions = {
   afterWrite?: ConfigWriteAfterWrite;
 };
 
+export type ReadBestEffortConfigOptions = {
+  /**
+   * Disable read-side repairs and cache writes. Use for diagnostic surfaces
+   * that must keep working when the OpenClaw state directory is mounted
+   * read-only.
+   */
+  readOnly?: boolean;
+};
+
 export type ReadConfigFileSnapshotForWriteResult = {
   snapshot: ConfigFileSnapshot;
   writeOptions: ConfigWriteOptions;
@@ -1200,8 +1209,11 @@ function createConfigFileSnapshot(params: {
 async function finalizeReadConfigSnapshotInternalResult(
   deps: Required<ConfigIoDeps>,
   result: ReadConfigFileSnapshotInternalResult,
+  options: { observeConfigSnapshot?: boolean } = {},
 ): Promise<ReadConfigFileSnapshotInternalResult> {
-  await observeConfigSnapshot(deps, result.snapshot);
+  if (options.observeConfigSnapshot !== false) {
+    await observeConfigSnapshot(deps, result.snapshot);
+  }
   return result;
 }
 
@@ -1216,7 +1228,10 @@ export function createConfigIO(
     return snapshot;
   }
 
-  function finalizeLoadedRuntimeConfig(cfg: OpenClawConfig): OpenClawConfig {
+  function finalizeLoadedRuntimeConfig(
+    cfg: OpenClawConfig,
+    options: { persistGeneratedOwnerDisplaySecret?: boolean } = {},
+  ): OpenClawConfig {
     const duplicates = findDuplicateAgentDirs(cfg, {
       env: deps.env,
       homedir: deps.homedir,
@@ -1243,6 +1258,9 @@ export function createConfigIO(
       cfg,
       () => pendingSecret ?? crypto.randomBytes(32).toString("hex"),
     );
+    if (options.persistGeneratedOwnerDisplaySecret === false) {
+      return applyConfigOverrides(ownerDisplaySecretResolution.config);
+    }
     const cfgWithOwnerDisplaySecret = persistGeneratedOwnerDisplaySecret({
       config: ownerDisplaySecretResolution.config,
       configPath,
@@ -1620,7 +1638,11 @@ export function createConfigIO(
   }
 
   async function readConfigFileSnapshotInternal(
-    options: { persistShippedPluginInstallMigration?: boolean } = {},
+    options: {
+      persistShippedPluginInstallMigration?: boolean;
+      observeConfigSnapshot?: boolean;
+      recoverSuspiciousConfigRead?: boolean;
+    } = {},
   ): Promise<ReadConfigFileSnapshotInternalResult> {
     maybeLoadDotEnvForConfig(deps.env);
     const exists = deps.fs.existsSync(configPath);
@@ -1628,21 +1650,25 @@ export function createConfigIO(
       const hash = hashConfigRaw(null);
       const config = {};
       const legacyIssues: LegacyConfigIssue[] = [];
-      return await finalizeReadConfigSnapshotInternalResult(deps, {
-        snapshot: createConfigFileSnapshot({
-          path: configPath,
-          exists: false,
-          raw: null,
-          parsed: {},
-          sourceConfig: {},
-          valid: true,
-          runtimeConfig: config,
-          hash,
-          issues: [],
-          warnings: [],
-          legacyIssues,
-        }),
-      });
+      return await finalizeReadConfigSnapshotInternalResult(
+        deps,
+        {
+          snapshot: createConfigFileSnapshot({
+            path: configPath,
+            exists: false,
+            raw: null,
+            parsed: {},
+            sourceConfig: {},
+            valid: true,
+            runtimeConfig: config,
+            hash,
+            issues: [],
+            warnings: [],
+            legacyIssues,
+          }),
+        },
+        options,
+      );
     }
 
     let fallbackRaw: string | null = null;
@@ -1661,34 +1687,41 @@ export function createConfigIO(
         parseConfigJson5(raw, deps.json5),
       );
       if (!parsedRes.ok) {
-        return await finalizeReadConfigSnapshotInternalResult(deps, {
-          snapshot: createConfigFileSnapshot({
-            path: configPath,
-            exists: true,
-            raw,
-            parsed: {},
-            sourceConfig: {},
-            valid: false,
-            runtimeConfig: {},
-            hash: rawHash,
-            issues: [{ path: "", message: `JSON5 parse failed: ${parsedRes.error}` }],
-            warnings: [],
-            legacyIssues: [],
-          }),
-        });
+        return await finalizeReadConfigSnapshotInternalResult(
+          deps,
+          {
+            snapshot: createConfigFileSnapshot({
+              path: configPath,
+              exists: true,
+              raw,
+              parsed: {},
+              sourceConfig: {},
+              valid: false,
+              runtimeConfig: {},
+              hash: rawHash,
+              issues: [{ path: "", message: `JSON5 parse failed: ${parsedRes.error}` }],
+              warnings: [],
+              legacyIssues: [],
+            }),
+          },
+          options,
+        );
       }
       fallbackParsed = parsedRes.parsed;
       fallbackSourceConfig = coerceConfig(parsedRes.parsed);
 
       // Resolve $include directives
-      const recovered = await deps.measure("config.snapshot.read.recovery-check", () =>
-        maybeRecoverSuspiciousConfigRead({
-          deps,
-          configPath,
-          raw,
-          parsed: parsedRes.parsed,
-        }),
-      );
+      const recovered =
+        options.recoverSuspiciousConfigRead === false
+          ? { raw, parsed: parsedRes.parsed }
+          : await deps.measure("config.snapshot.read.recovery-check", () =>
+              maybeRecoverSuspiciousConfigRead({
+                deps,
+                configPath,
+                raw,
+                parsed: parsedRes.parsed,
+              }),
+            );
       const effectiveRaw = recovered.raw;
       const effectiveParsed = recovered.parsed;
       const hash = hashConfigRaw(effectiveRaw);
@@ -1707,22 +1740,26 @@ export function createConfigIO(
           err instanceof ConfigIncludeError
             ? err.message
             : `Include resolution failed: ${String(err)}`;
-        return await finalizeReadConfigSnapshotInternalResult(deps, {
-          snapshot: createConfigFileSnapshot({
-            path: configPath,
-            exists: true,
-            raw: effectiveRaw,
-            parsed: effectiveParsed,
-            // Keep the recovered root file payload here when read healing kicked in.
-            sourceConfig: coerceConfig(effectiveParsed),
-            valid: false,
-            runtimeConfig: coerceConfig(effectiveParsed),
-            hash,
-            issues: [{ path: "", message }],
-            warnings: [],
-            legacyIssues: [],
-          }),
-        });
+        return await finalizeReadConfigSnapshotInternalResult(
+          deps,
+          {
+            snapshot: createConfigFileSnapshot({
+              path: configPath,
+              exists: true,
+              raw: effectiveRaw,
+              parsed: effectiveParsed,
+              // Keep the recovered root file payload here when read healing kicked in.
+              sourceConfig: coerceConfig(effectiveParsed),
+              valid: false,
+              runtimeConfig: coerceConfig(effectiveParsed),
+              hash,
+              issues: [{ path: "", message }],
+              warnings: [],
+              legacyIssues: [],
+            }),
+          },
+          options,
+        );
       }
 
       const readResolution = await deps.measure("config.snapshot.read.env", () =>
@@ -1777,21 +1814,25 @@ export function createConfigIO(
         }),
       );
       if (!validated.ok) {
-        return await finalizeReadConfigSnapshotInternalResult(deps, {
-          snapshot: createConfigFileSnapshot({
-            path: configPath,
-            exists: true,
-            raw: snapshotRaw,
-            parsed: snapshotParsed,
-            sourceConfig: coerceConfig(effectiveConfigRaw),
-            valid: false,
-            runtimeConfig: coerceConfig(effectiveConfigRaw),
-            hash: snapshotHash,
-            issues: validated.issues,
-            warnings: [...validated.warnings, ...envVarWarnings],
-            legacyIssues: legacyResolution.sourceLegacyIssues,
-          }),
-        });
+        return await finalizeReadConfigSnapshotInternalResult(
+          deps,
+          {
+            snapshot: createConfigFileSnapshot({
+              path: configPath,
+              exists: true,
+              raw: snapshotRaw,
+              parsed: snapshotParsed,
+              sourceConfig: coerceConfig(effectiveConfigRaw),
+              valid: false,
+              runtimeConfig: coerceConfig(effectiveConfigRaw),
+              hash: snapshotHash,
+              issues: validated.issues,
+              warnings: [...validated.warnings, ...envVarWarnings],
+              legacyIssues: legacyResolution.sourceLegacyIssues,
+            }),
+          },
+          options,
+        );
       }
 
       warnIfConfigFromFuture(validated.config, deps.logger);
@@ -1799,25 +1840,29 @@ export function createConfigIO(
         materializeRuntimeConfig(validated.config, "snapshot"),
       );
       return await deps.measure("config.snapshot.read.observe", () =>
-        finalizeReadConfigSnapshotInternalResult(deps, {
-          snapshot: createConfigFileSnapshot({
-            path: configPath,
-            exists: true,
-            raw: snapshotRaw,
-            parsed: snapshotParsed,
-            // Use resolvedConfigRaw (after $include and ${ENV} substitution but BEFORE runtime defaults)
-            // for config set/unset operations (issue #6070)
-            sourceConfig: coerceConfig(effectiveConfigRaw),
-            valid: true,
-            runtimeConfig: snapshotConfig,
-            hash: snapshotHash,
-            issues: [],
-            warnings: [...validated.warnings, ...envVarWarnings],
-            legacyIssues: legacyResolution.sourceLegacyIssues,
-          }),
-          envSnapshotForRestore: readResolution.envSnapshotForRestore,
-          pluginMetadataSnapshot,
-        }),
+        finalizeReadConfigSnapshotInternalResult(
+          deps,
+          {
+            snapshot: createConfigFileSnapshot({
+              path: configPath,
+              exists: true,
+              raw: snapshotRaw,
+              parsed: snapshotParsed,
+              // Use resolvedConfigRaw (after $include and ${ENV} substitution but BEFORE runtime defaults)
+              // for config set/unset operations (issue #6070)
+              sourceConfig: coerceConfig(effectiveConfigRaw),
+              valid: true,
+              runtimeConfig: snapshotConfig,
+              hash: snapshotHash,
+              issues: [],
+              warnings: [...validated.warnings, ...envVarWarnings],
+              legacyIssues: legacyResolution.sourceLegacyIssues,
+            }),
+            envSnapshotForRestore: readResolution.envSnapshotForRestore,
+            pluginMetadataSnapshot,
+          },
+          options,
+        ),
       );
     } catch (err) {
       const nodeErr = err as NodeJS.ErrnoException;
@@ -1839,21 +1884,25 @@ export function createConfigIO(
       } else {
         message = `read failed: ${String(err)}`;
       }
-      return await finalizeReadConfigSnapshotInternalResult(deps, {
-        snapshot: createConfigFileSnapshot({
-          path: configPath,
-          exists: true,
-          raw: fallbackRaw,
-          parsed: fallbackParsed,
-          sourceConfig: fallbackSourceConfig,
-          valid: false,
-          runtimeConfig: fallbackSourceConfig,
-          hash: fallbackHash,
-          issues: [{ path: "", message }],
-          warnings: [],
-          legacyIssues: [],
-        }),
-      });
+      return await finalizeReadConfigSnapshotInternalResult(
+        deps,
+        {
+          snapshot: createConfigFileSnapshot({
+            path: configPath,
+            exists: true,
+            raw: fallbackRaw,
+            parsed: fallbackParsed,
+            sourceConfig: fallbackSourceConfig,
+            valid: false,
+            runtimeConfig: fallbackSourceConfig,
+            hash: fallbackHash,
+            issues: [{ path: "", message }],
+            warnings: [],
+            legacyIssues: [],
+          }),
+        },
+        options,
+      );
     }
   }
 
@@ -1915,13 +1964,21 @@ export function createConfigIO(
     };
   }
 
-  async function readBestEffortConfig(): Promise<OpenClawConfig> {
-    const result = await readConfigFileSnapshotInternal();
+  async function readBestEffortConfig(
+    options: ReadBestEffortConfigOptions = {},
+  ): Promise<OpenClawConfig> {
+    const readOnly = options.readOnly === true;
+    const result = await readConfigFileSnapshotInternal({
+      observeConfigSnapshot: readOnly ? false : undefined,
+      recoverSuspiciousConfigRead: readOnly ? false : undefined,
+      persistShippedPluginInstallMigration: readOnly ? false : undefined,
+    });
     if (!result.snapshot.valid) {
       return result.snapshot.config;
     }
     return finalizeLoadedRuntimeConfig(
       materializeRuntimeConfig(result.snapshot.sourceConfig, "load"),
+      { persistGeneratedOwnerDisplaySecret: readOnly ? false : undefined },
     );
   }
 
@@ -2356,8 +2413,10 @@ export function getRuntimeConfig(): OpenClawConfig {
   return loadConfig();
 }
 
-export async function readBestEffortConfig(): Promise<OpenClawConfig> {
-  return await createConfigIO().readBestEffortConfig();
+export async function readBestEffortConfig(
+  options: ReadBestEffortConfigOptions = {},
+): Promise<OpenClawConfig> {
+  return await createConfigIO().readBestEffortConfig(options);
 }
 
 export async function readSourceConfigBestEffort(): Promise<OpenClawConfig> {


### PR DESCRIPTION
## Summary

- add an explicit read-only mode to `readBestEffortConfig` for diagnostic callers
- route `openclaw status` scans through that read-only config path
- cover the path with a regression test that verifies diagnostics reads do not rewrite config or create `logs/config-health.json`

## Why

KAN-180/KAN-176 showed sandboxed diagnostic workers could read user-unit listings, but `openclaw status --json` failed before collecting evidence because config reads attempted read-side state writes under the worker's read-only OpenClaw state mount. Status documentation already describes these surfaces as read-only, so this keeps the status path non-mutating while preserving normal config health observation and repair behavior elsewhere.

## Verification

- `pnpm exec oxfmt --check --threads=1 src/config/io.ts src/config/io.best-effort.test.ts src/commands/status.scan-overview.ts src/commands/status.scan-overview.test.ts`
- `pnpm test src/config/io.best-effort.test.ts src/commands/status.scan-overview.test.ts -- --reporter=verbose`
- `pnpm changed:lanes --json` -> core + coreTests
- `/home/coolmann/.local/bin/gitnexus-openai analyze --embeddings --skip-agents-md` -> Already up to date
- `systemctl --user list-units 'openclaw-gateway.service' --all --no-pager --plain --no-legend` -> `openclaw-gateway.service loaded active running OpenClaw Gateway (v2026.6.11)`
- `systemctl --user list-units '*lcm*' '*lossless*' '*rewrite*' --all --no-pager --plain --no-legend` -> no matching user units visible from this sandbox
- `timeout 30s pnpm openclaw status --json` -> exited 0 and emitted JSON; gateway RPC degraded with `protocol mismatch`, but local status evidence included `gatewayService.runtime.status=running`, PID `612419`

Testbox note: attempted `blacksmith testbox warmup ci-check-testbox.yml --ref main --idle-timeout 90`, but this worker is not authenticated to Blacksmith (`not authenticated — run 'blacksmith auth login' first`).
