### PR TITLE
fix(ci): install release packaging dependencies

### DIFF
--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -538,7 +538,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
-          install-deps: "false"
+          install-deps: "true"
 
       - name: Resolve release package artifact
         id: package

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2410,6 +2410,12 @@ describe("package artifact reuse", () => {
     );
     expect(fullRelease.jobs?.prepare_release_package).toBeUndefined();
     expect(releaseChecks.jobs?.prepare_release_package?.["timeout-minutes"]).toBe(15);
+    expect(
+      workflowStep(
+        workflowJob(RELEASE_CHECKS_WORKFLOW, "prepare_release_package"),
+        "Setup Node environment",
+      ).with?.["install-deps"],
+    ).toBe("true");
     expect(crossOs.jobs?.cross_os_release_checks?.["timeout-minutes"]).toBe(60);
     expect(liveE2e.jobs?.validate_release_live_cache?.["timeout-minutes"]).toBe(20);
     expect(readFileSync(LIVE_E2E_WORKFLOW, "utf8")).toContain(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where stable release validation could not prepare the package-under-test after trusted-main packaging started importing `tar`, because the package preparation job explicitly skipped installing the trusted workflow checkout's dependencies.

## Why This Change Was Made

The package artifact job executes trusted-main release scripts before building a candidate from another ref. It now installs the trusted checkout's pinned dependencies through the existing setup action, and a workflow contract test prevents the dependency setup from being disabled again.

## User Impact

No product behavior changes. Maintainers can run full release validation and build candidate package artifacts without an immediate `ERR_MODULE_NOT_FOUND` failure.

## Evidence

- Before: Full Release Validation child run https://github.com/openclaw/openclaw/actions/runs/28754540904 failed in `Prepare release package artifact` with `Cannot find package 'tar' imported from scripts/package-openclaw-for-docker.mjs`.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` - 40 tests passed.
- `pnpm check:changed` via Blacksmith Testbox `tbx_01kwt1etxjgz18w7fc6vp6rq3q` - passed; Actions run https://github.com/openclaw/openclaw/actions/runs/28754813721.
- Autoreview: clean, no accepted/actionable findings.
