### PR TITLE
fix(macos): reduce idle CPU wakeups

### DIFF
--- a/.github/workflows/mantis-slack-desktop-smoke.yml
+++ b/.github/workflows/mantis-slack-desktop-smoke.yml
@@ -364,7 +364,6 @@ jobs:
           checkpoint_required=false
           if [[ "$APPROVAL_CHECKPOINTS" == "true" ]]; then
             evidence_summary="Mantis ran Slack native approval QA inside a Crabbox Linux VNC desktop, rendered pending/resolved approval checkpoints from the Slack API messages, and stored Slack QA artifacts."
-            expected_result="Slack native exec and plugin approval checkpoints pass"
             screenshot_required=false
             desktop_capture_inline=false
             if [[ "$status" == "pass" ]]; then
@@ -373,8 +372,10 @@ jobs:
             checkpoint_scenarios=()
             if [[ "$scenario_label" == "approval-checkpoints" ]]; then
               checkpoint_scenarios=("slack-approval-exec-native" "slack-approval-plugin-native")
+              expected_result="Slack native exec and plugin approval checkpoints pass"
             else
               checkpoint_scenarios=("$scenario_label")
+              expected_result="Slack approval checkpoint passes for $scenario_label"
             fi
             checkpoint_scenarios_json="$(printf '%s\n' "${checkpoint_scenarios[@]}" | jq -R . | jq -s .)"
             checkpoint_artifacts="$(
@@ -383,12 +384,16 @@ jobs:
                 --argjson scenario_ids "$checkpoint_scenarios_json" \
                 '
                   def scenario_kind($id):
-                    if $id == "slack-approval-exec-native" then "exec"
-                    elif $id == "slack-approval-plugin-native" then "plugin"
+                    if ($id | endswith("-exec-native")) then "exec"
+                    elif ($id | endswith("-plugin-native")) then "plugin"
                     else error("unsupported approval checkpoint scenario: \($id)")
                     end;
                   def scenario_title($id):
-                    if scenario_kind($id) == "exec" then "Exec" else "Plugin" end;
+                    if ($id | startswith("slack-codex-")) then
+                      "Codex \(scenario_kind($id))"
+                    elif scenario_kind($id) == "exec" then "Exec"
+                    else "Plugin"
+                    end;
                   [
                     $scenario_ids[] as $id
                     | ["pending", "resolved"][] as $state

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -538,7 +538,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "true"
-          install-deps: "false"
+          install-deps: "true"
 
       - name: Resolve release package artifact
         id: package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI approval prompts:** keep stale resolve failures and busy-state cleanup from leaking across newer approvals or Gateway reconnects. (#98394) Thanks @haruaiclone-droid.
 - **Agent empty replies:** surface a visible failure when a completed interactive turn has no deliverable reply, including queued follow-ups, while preserving explicit silence, pending continuations, and committed side effects. (#100456) Thanks @mushuiyu886.
 - **Child process output safety:** prevent stdout/stderr pipe failures from crashing agent exec sessions, local TUI shell commands, and bounded process execution. (#100407, #100406, #100410) Thanks @cxbAsDev.
 - **Background refresh isolation:** keep remote skill-bin refreshes running when one node fails, and contain periodic subagent-sweeper failures without hiding errors from direct callers. (#100393, #100390) Thanks @cxbAsDev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent empty replies:** surface a visible failure when a completed interactive turn has no deliverable reply, including queued follow-ups, while preserving explicit silence, pending continuations, and committed side effects. (#100456) Thanks @mushuiyu886.
 - **Child process output safety:** prevent stdout/stderr pipe failures from crashing agent exec sessions, local TUI shell commands, and bounded process execution. (#100407, #100406, #100410) Thanks @cxbAsDev.
 - **Background refresh isolation:** keep remote skill-bin refreshes running when one node fails, and contain periodic subagent-sweeper failures without hiding errors from direct callers. (#100393, #100390) Thanks @cxbAsDev.
 - **Skill scan diagnostics:** report directory enumeration failures through the existing resource diagnostics instead of silently dropping affected skills. (#100380) Thanks @wendy-chsy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.
 - **Control UI Talk controls:** keep voice, model, and sensitivity in the composer while moving provider, transport, VAD timing, and reasoning defaults to Settings → Communications → Talk.
 - **Logbook work journal:** add a disabled-by-default bundled plugin that turns paired-node screen snapshots into a private timeline, daily standup, and timeline-grounded Q&A in a plugin-contributed Control UI tab. (#99930)
 - **Control UI message context:** reveal per-message token, context, and model details from the timestamp on hover or activation instead of showing a separate Context button.
@@ -30,6 +31,9 @@ Docs: https://docs.openclaw.ai
 - **Plugin approval diagnostics:** distinguish request validation rejections, expired wait decisions, and unavailable Gateways while keeping approval failures fail-closed. (#100337) Thanks @tzy-17.
 - **IRC Unicode messages:** split outbound PRIVMSG payloads on UTF-16 code-point boundaries so emoji cannot be cut into lone surrogates. (#96572) Thanks @llagy009.
 - **OpenAI realtime voice greetings:** prevent server VAD from creating a second outbound greeting while an explicit greeting response owns the turn, without disabling caller interruption. (#86285) Thanks @giodl73-repo.
+- **Realtime voice tools:** filter malformed tool names at each OpenAI, Azure, and Google realtime payload boundary while preserving provider-specific valid names. (#89175) Thanks @vincentkoc.
+- **Discord voice status:** treat Discord error 10065 as a normal disconnected state while preserving unrelated REST failures. (#90969) Thanks @asock.
+- **Discord voice accounts:** isolate `@discordjs/voice` connections by Discord account and recover auto-join when gateway readiness predates listener registration. (#87530) Thanks @geekhuashan.
 - **iOS Voice Wake cleanup:** avoid initializing the microphone audio pipeline while disabling inactive Voice Wake, preventing simulator launch aborts and unnecessary audio setup.
 - **Cron duration validation:** reject positive durations that truncate below one millisecond instead of silently scheduling a zero-duration interval. (#100311) Thanks @qingminglong.
 - **Skill workshop proposals:** preserve the terminal newline in generated proposal Markdown while still rejecting blank raw content. (#100293) Thanks @anyech.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -187,7 +187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2100,
+      "line": 2102,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2102,
+      "line": 2104,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2104,
+      "line": 2106,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -13027,7 +13027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 641,
+      "line": 642,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host)",
       "surface": "apple",
@@ -13035,7 +13035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 641,
+      "line": 642,
       "path": "apps/macos/Sources/OpenClaw/AppState.swift",
       "source": "\\(user)@\\(host):\\(port)",
       "surface": "apple",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -4539,6 +4539,21 @@
       "translated": "جاهز"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "تعذّر تصدير النص"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "موافق"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "تعذّر على OpenClaw إعداد ملف Markdown."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "ما الذي ترغب في العمل عليه؟"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "يفتح Settings / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "تصدير النص"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "إجراءات المحادثة"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -4539,6 +4539,21 @@
       "translated": "Bereit"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Transkript kann nicht exportiert werden"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw konnte die Markdown-Datei nicht vorbereiten."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Woran möchten Sie arbeiten?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Öffnet Einstellungen / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Transkript exportieren"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Chat-Aktionen"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -4539,6 +4539,21 @@
       "translated": "Listo"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "No se puede exportar la transcripción"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "Aceptar"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw no pudo preparar el archivo Markdown."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "¿En qué te gustaría trabajar?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Abre Configuración / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Exportar transcripción"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Acciones del chat"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -4539,6 +4539,21 @@
       "translated": "آماده"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "امکان خروجی گرفتن از رونوشت وجود ندارد"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "تأیید"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw نتوانست فایل Markdown را آماده کند."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "دوست دارید روی چه چیزی کار کنید؟"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Settings / Gateway را باز می‌کند"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "خروجی گرفتن از رونوشت"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "اقدام‌های چت"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -4539,6 +4539,21 @@
       "translated": "Prêt"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Impossible d’exporter la transcription"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw n’a pas pu préparer le fichier Markdown."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Sur quoi souhaitez-vous travailler ?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Ouvre Réglages / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Exporter la transcription"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Actions de chat"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -4539,6 +4539,21 @@
       "translated": "तैयार"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "प्रतिलेख निर्यात नहीं किया जा सका"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "ठीक है"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw Markdown फ़ाइल तैयार नहीं कर सका।"
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "आप किस पर काम करना चाहेंगे?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Settings / Gateway खोलता है"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "प्रतिलेख निर्यात करें"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "चैट कार्रवाइयाँ"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -4539,6 +4539,21 @@
       "translated": "Siap"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Tidak Dapat Mengekspor Transkrip"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw tidak dapat menyiapkan file Markdown."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Apa yang ingin Anda kerjakan?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Membuka Pengaturan / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Ekspor Transkrip"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Tindakan chat"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -4539,6 +4539,21 @@
       "translated": "Pronto"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Impossibile esportare la trascrizione"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw non ha potuto preparare il file Markdown."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Su cosa vorresti lavorare?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Apre Impostazioni / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Esporta trascrizione"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Azioni chat"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -4539,6 +4539,21 @@
       "translated": "準備完了"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "トランスクリプトをエクスポートできません"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw は Markdown ファイルを準備できませんでした。"
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "何に取り組みますか？"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "設定 / Gateway を開きます"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "トランスクリプトをエクスポート"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "チャットアクション"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -4539,6 +4539,21 @@
       "translated": "준비됨"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "대화 기록을 내보낼 수 없음"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "확인"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw에서 Markdown 파일을 준비할 수 없습니다."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "무엇을 작업하시겠어요?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "설정 / Gateway를 엽니다"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "대화 기록 내보내기"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "채팅 작업"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -4539,6 +4539,21 @@
       "translated": "Gereed"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Kan transcript niet exporteren"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw kon het Markdown-bestand niet voorbereiden."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Waar wilt u aan werken?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Opent Instellingen / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Transcript exporteren"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Chatacties"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -4539,6 +4539,21 @@
       "translated": "Gotowe"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Nie można wyeksportować transkrypcji"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw nie mógł przygotować pliku Markdown."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Nad czym chcesz popracować?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Otwiera Ustawienia / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Eksportuj transkrypcję"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Działania czatu"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -4539,6 +4539,21 @@
       "translated": "Pronto"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Não foi possível exportar a transcrição"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "O OpenClaw não conseguiu preparar o arquivo Markdown."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Em que você gostaria de trabalhar?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Abre Ajustes / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Exportar transcrição"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Ações do chat"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -4539,6 +4539,21 @@
       "translated": "Готово"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Не удалось экспортировать стенограмму"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "ОК"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw не удалось подготовить файл Markdown."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Над чем вы хотите поработать?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Открывает Settings / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Экспортировать стенограмму"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Действия чата"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -4539,6 +4539,21 @@
       "translated": "Redo"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Det gick inte att exportera transkript"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw kunde inte förbereda Markdown-filen."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Vad vill du arbeta med?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Öppnar Inställningar / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Exportera transkript"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Chattåtgärder"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -4539,6 +4539,21 @@
       "translated": "พร้อม"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "ไม่สามารถส่งออกบันทึกการสนทนาได้"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "ตกลง"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw ไม่สามารถเตรียมไฟล์ Markdown ได้"
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "คุณต้องการทำงานอะไร?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "เปิด Settings / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "ส่งออกบันทึกการสนทนา"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "การดำเนินการของแชท"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -4539,6 +4539,21 @@
       "translated": "Hazır"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Döküm dışa aktarılamıyor"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "Tamam"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw Markdown dosyasını hazırlayamadı."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Ne üzerinde çalışmak istersiniz?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Ayarlar / Gateway’i açar"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Dökümü dışa aktar"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Sohbet eylemleri"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -4539,6 +4539,21 @@
       "translated": "Готово"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Не вдалося експортувати транскрипт"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw не вдалося підготувати файл Markdown."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Над чим ви хотіли б попрацювати?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Відкриває Settings / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Експортувати транскрипт"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Дії чату"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -4539,6 +4539,21 @@
       "translated": "Sẵn sàng"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "Không thể xuất bản ghi cuộc trò chuyện"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "OK"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw không thể chuẩn bị tệp Markdown."
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "Bạn muốn làm việc gì?"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "Mở Cài đặt / Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "Xuất bản ghi cuộc trò chuyện"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "Thao tác trò chuyện"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -4539,6 +4539,21 @@
       "translated": "就绪"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "无法导出转录"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "确定"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw 无法准备 Markdown 文件。"
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "你想处理什么？"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "打开“设置”/“Gateway”"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "导出转录"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "聊天操作"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -4539,6 +4539,21 @@
       "translated": "就緒"
     },
     {
+      "id": "native.apple.e5524d5756a62744",
+      "source": "Unable to Export Transcript",
+      "translated": "無法匯出逐字稿"
+    },
+    {
+      "id": "native.apple.942d6a10fd90d6e3",
+      "source": "OK",
+      "translated": "確定"
+    },
+    {
+      "id": "native.apple.3548c8d1ab43e85e",
+      "source": "OpenClaw could not prepare the Markdown file.",
+      "translated": "OpenClaw 無法準備 Markdown 檔案。"
+    },
+    {
       "id": "native.apple.202b97e93b938049",
       "source": "What would you like to work on?",
       "translated": "你想要處理什麼？"
@@ -4552,6 +4567,16 @@
       "id": "native.apple.d19c9577e0fdfea7",
       "source": "Opens Settings / Gateway",
       "translated": "開啟「設定」/ Gateway"
+    },
+    {
+      "id": "native.apple.ced228bb4d20a726",
+      "source": "Export Transcript",
+      "translated": "匯出逐字稿"
+    },
+    {
+      "id": "native.apple.940e1f943750c94b",
+      "source": "Chat actions",
+      "translated": "聊天動作"
     },
     {
       "id": "native.apple.b635acd93246d67b",

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -870,13 +870,15 @@ class NodeRuntime(
    */
   private fun chatCacheGatewayId(): String? {
     connectedEndpoint?.stableId?.let { return it }
-    if (manualEnabled.value) {
-      val host = manualHost.value.trim()
-      val port = manualPort.value
+    // Chat bootstrap can call this during construction, before the public preference aliases below
+    // initialize. Read their owner directly or onboarding can crash on a null StateFlow field.
+    if (prefs.manualEnabled.value) {
+      val host = prefs.manualHost.value.trim()
+      val port = prefs.manualPort.value
       if (host.isEmpty() || port !in 1..65535) return null
       return GatewayEndpoint.manual(host = host, port = port).stableId
     }
-    return lastDiscoveredStableId.value.trim().takeIf { it.isNotEmpty() }
+    return prefs.lastDiscoveredStableId.value.trim().takeIf { it.isNotEmpty() }
   }
 
   private fun chatCacheScope(): ChatCacheScope? =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawNavigation.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawNavigation.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
@@ -104,6 +105,7 @@ internal fun ClawBottomNav(
       Row(
         modifier =
           Modifier
+            .fillMaxWidth()
             .windowInsetsPadding(safeInsets)
             .padding(horizontal = 8.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -131,18 +133,25 @@ private fun ClawBottomNavItem(
 ) {
   Surface(
     onClick = onClick,
-    modifier = modifier.heightIn(min = 48.dp),
+    modifier = modifier.heightIn(min = 52.dp),
     shape = RoundedCornerShape(ClawTheme.radii.control),
     color = if (selected) ClawTheme.colors.surfacePressed.copy(alpha = 0.72f) else Color.Transparent,
     contentColor = if (selected) ClawTheme.colors.text else ClawTheme.colors.textMuted,
   ) {
     Column(
-      modifier = Modifier.padding(horizontal = 5.dp, vertical = 5.dp),
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 5.dp, vertical = 5.dp),
       horizontalAlignment = Alignment.CenterHorizontally,
       verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-      Icon(imageVector = item.icon, contentDescription = item.label, modifier = Modifier.size(18.dp))
-      Text(text = item.label, style = ClawTheme.type.caption, maxLines = 1, overflow = TextOverflow.Ellipsis)
+      Icon(imageVector = item.icon, contentDescription = item.label, modifier = Modifier.size(20.dp))
+      Text(
+        modifier = Modifier.fillMaxWidth(),
+        text = item.label,
+        style = ClawTheme.type.caption,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Center,
+      )
     }
   }
 }

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -580,6 +580,7 @@ final class AppState {
     private func applyConfigFromDisk() {
         let root = OpenClawConfigFile.loadDict()
         self.applyConfigOverrides(root)
+        MacNodeModeCoordinator.shared.refresh()
     }
 
     private func applyConfigOverrides(_ root: [String: Any]) {

--- a/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
+++ b/apps/macos/Sources/OpenClaw/CritterStatusLabel+Behavior.swift
@@ -7,7 +7,7 @@ extension CritterStatusLabel {
     }
 
     private var effectiveAnimationsEnabled: Bool {
-        self.animationsEnabled && !self.isSleeping
+        self.animationsEnabled && !self.isSleeping && !self.isPaused
     }
 
     var body: some View {
@@ -24,10 +24,14 @@ extension CritterStatusLabel {
                         return
                     }
 
+                    await MainActor.run { self.rescheduleElapsedAnimationTimers(from: Date()) }
                     while !Task.isCancelled {
                         let now = Date()
-                        await MainActor.run { self.tick(now) }
-                        try? await Task.sleep(nanoseconds: 350_000_000)
+                        let delay = await MainActor.run {
+                            self.tick(now)
+                            return self.nextTickDelay(after: now)
+                        }
+                        try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
                     }
                 }
                 .onChange(of: self.isPaused) { _, _ in self.resetMotion() }
@@ -77,7 +81,27 @@ extension CritterStatusLabel {
 
     private var tickTaskID: Int {
         // Ensure SwiftUI restarts (and cancels) the task when these change.
-        (self.effectiveAnimationsEnabled ? 1 : 0) | (self.earBoostActive ? 2 : 0)
+        (self.effectiveAnimationsEnabled ? 1 : 0) |
+            (self.earBoostActive ? 2 : 0) |
+            (self.isWorkingNow ? 4 : 0)
+    }
+
+    private func nextTickDelay(after now: Date) -> TimeInterval {
+        Self.nextAnimationTickDelay(
+            now: now,
+            isWorking: self.isWorkingNow,
+            deadlines: [self.nextBlink, self.nextWiggle, self.nextLegWiggle, self.nextEarWiggle])
+    }
+
+    static func nextAnimationTickDelay(
+        now: Date,
+        isWorking: Bool,
+        deadlines: [Date]) -> TimeInterval
+    {
+        // Working motion needs a steady cadence; idle motion only wakes for its next visible event.
+        if isWorking { return 0.35 }
+        guard let nextDeadline = deadlines.min() else { return 1 }
+        return max(0.05, nextDeadline.timeIntervalSince(now))
     }
 
     private func tick(_ now: Date) {
@@ -213,6 +237,12 @@ extension CritterStatusLabel {
         self.nextWiggle = date.addingTimeInterval(Double.random(in: 6.5...14))
         self.nextLegWiggle = date.addingTimeInterval(Double.random(in: 5.0...11.0))
         self.nextEarWiggle = date.addingTimeInterval(Double.random(in: 7.0...14.0))
+    }
+
+    private func rescheduleElapsedAnimationTimers(from date: Date) {
+        let deadlines = [self.nextBlink, self.nextWiggle, self.nextLegWiggle, self.nextEarWiggle]
+        guard deadlines.contains(where: { $0 <= date }) else { return }
+        self.scheduleRandomTimers(from: date)
     }
 
     private var gatewayNeedsAttention: Bool {

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import OpenClawKit
 import OSLog
@@ -40,7 +41,7 @@ struct MacNodeGatewayTLSSessionCache {
 }
 
 @MainActor
-final class MacNodeModeCoordinator {
+final class MacNodeModeCoordinator: NSObject {
     static let shared = MacNodeModeCoordinator()
     static var nodeIdentityProfile: GatewayDeviceIdentityProfile {
         self.resolveNodeIdentityProfile(
@@ -73,17 +74,46 @@ final class MacNodeModeCoordinator {
 
     private let logger = Logger(subsystem: "ai.openclaw", category: "mac-node")
     private var task: Task<Void, Never>?
+    private var endpointRefreshTask: Task<Void, Never>?
+    private var reconnectProbeTask: Task<Void, Never>?
     private let runtime: MacNodeRuntime
     private let session: GatewayNodeSession
+    private let refreshEvents: AsyncStream<Void>
+    private let refreshContinuation: AsyncStream<Void>.Continuation
     private var autoRepairedTLSFingerprintsByStoreKey: [String: String] = [:]
     private var tlsSessionCache = MacNodeGatewayTLSSessionCache()
 
-    private init() {
+    override private init() {
         let session = GatewayNodeSession()
+        let refreshEvents = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
         self.session = session
         self.runtime = MacNodeRuntime(
             canvasSurfaceUrl: { await session.currentCanvasHostUrl() },
             refreshCanvasSurfaceUrl: { await session.refreshCanvasHostUrl() })
+        self.refreshEvents = refreshEvents.stream
+        self.refreshContinuation = refreshEvents.continuation
+        super.init()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.refreshNodeConfiguration),
+            name: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.refreshNodeConfiguration),
+            name: NSApplication.didBecomeActiveNotification,
+            object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.refreshNodeConfiguration),
+            name: .openclawPermissionsChanged,
+            object: nil)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+        self.refreshContinuation.finish()
     }
 
     func start() {
@@ -91,53 +121,61 @@ final class MacNodeModeCoordinator {
         self.task = Task { [weak self] in
             await self?.run()
         }
+        self.endpointRefreshTask = Task { [weak self] in
+            let states = await GatewayEndpointStore.shared.subscribe()
+            var previousState: GatewayEndpointState?
+            for await state in states {
+                if let previousState, state != previousState {
+                    self?.refresh()
+                }
+                previousState = state
+            }
+        }
     }
 
     func stop() {
         self.task?.cancel()
         self.task = nil
+        self.endpointRefreshTask?.cancel()
+        self.endpointRefreshTask = nil
+        self.reconnectProbeTask?.cancel()
+        self.reconnectProbeTask = nil
         Task { await self.session.disconnect() }
     }
 
     func setPreferredGatewayStableID(_ stableID: String?) {
         GatewayDiscoveryPreferences.setPreferredStableID(stableID)
-        Task { await self.session.disconnect() }
+        Task {
+            await self.session.disconnect()
+            self.refresh()
+        }
+    }
+
+    func refresh() {
+        self.refreshContinuation.yield()
     }
 
     private func run() async {
         var retryDelay: UInt64 = 1_000_000_000
-        var lastCameraEnabled: Bool?
-        var lastBrowserControlEnabled: Bool?
+        var refreshIterator = self.refreshEvents.makeAsyncIterator()
         let defaults = UserDefaults.standard
 
         while !Task.isCancelled {
             if await MainActor.run(body: { AppStateStore.shared.isPaused }) {
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard await refreshIterator.next() != nil else { return }
                 continue
             }
 
             let cameraEnabled = defaults.object(forKey: cameraEnabledKey) as? Bool ?? false
-            if lastCameraEnabled == nil {
-                lastCameraEnabled = cameraEnabled
-            } else if lastCameraEnabled != cameraEnabled {
-                lastCameraEnabled = cameraEnabled
-                await self.session.disconnect()
-                try? await Task.sleep(nanoseconds: 200_000_000)
-            }
             let browserControlEnabled = OpenClawConfigFile.browserControlEnabled()
-            if lastBrowserControlEnabled == nil {
-                lastBrowserControlEnabled = browserControlEnabled
-            } else if lastBrowserControlEnabled != browserControlEnabled {
-                lastBrowserControlEnabled = browserControlEnabled
-                await self.session.disconnect()
-                try? await Task.sleep(nanoseconds: 200_000_000)
-            }
 
             var attemptedURL: URL?
             do {
                 let config = try await GatewayEndpointStore.shared.requireConfig()
                 attemptedURL = config.url
-                let caps = self.currentCaps()
+                let caps = self.currentCaps(
+                    browserControlEnabled: browserControlEnabled,
+                    cameraEnabled: cameraEnabled)
                 let commands = self.currentCommands(caps: caps)
                 let permissions = await self.currentPermissions()
                 let connectOptions = GatewayConnectOptions(
@@ -163,6 +201,7 @@ final class MacNodeModeCoordinator {
                     sessionBox: sessionBox,
                     onConnected: { [weak self] in
                         guard let self else { return }
+                        await self.cancelReconnectProbe()
                         self.logger.info("mac node connected to gateway")
                         let mainSessionKey = await GatewayConnection.shared.mainSessionKey()
                         await self.runtime.updateMainSessionKey(mainSessionKey)
@@ -174,6 +213,7 @@ final class MacNodeModeCoordinator {
                     onDisconnected: { [weak self] reason in
                         guard let self else { return }
                         await self.runtime.setEventSender(nil)
+                        await self.scheduleReconnectProbe()
                         self.logger.error("mac node disconnected: \(reason, privacy: .public)")
                     },
                     onInvoke: { [weak self] req in
@@ -187,7 +227,9 @@ final class MacNodeModeCoordinator {
                     })
 
                 retryDelay = 1_000_000_000
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                // GatewayNodeSession owns transport reconnects. Wait until inputs can
+                // actually change instead of rereading config and TCC state every second.
+                guard await refreshIterator.next() != nil else { return }
             } catch {
                 if await self.autoRepairStaleTLSPinIfNeeded(error: error, url: attemptedURL) {
                     retryDelay = 1_000_000_000
@@ -197,6 +239,28 @@ final class MacNodeModeCoordinator {
                 try? await Task.sleep(nanoseconds: min(retryDelay, 10_000_000_000))
                 retryDelay = min(retryDelay * 2, 10_000_000_000)
             }
+        }
+    }
+
+    private func scheduleReconnectProbe() {
+        self.reconnectProbeTask?.cancel()
+        // GatewayChannel reconnects normally, but pauses after auth or pairing failures.
+        // Probe only while disconnected so recovery does not restore steady idle polling.
+        self.reconnectProbeTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(30))
+            guard !Task.isCancelled else { return }
+            self?.refresh()
+        }
+    }
+
+    private func cancelReconnectProbe() {
+        self.reconnectProbeTask?.cancel()
+        self.reconnectProbeTask = nil
+    }
+
+    @objc private nonisolated func refreshNodeConfiguration(_: Notification) {
+        Task { @MainActor [weak self] in
+            self?.refresh()
         }
     }
 
@@ -222,11 +286,11 @@ final class MacNodeModeCoordinator {
         return caps
     }
 
-    private func currentCaps() -> [String] {
+    private func currentCaps(browserControlEnabled: Bool, cameraEnabled: Bool) -> [String] {
         let rawLocationMode = UserDefaults.standard.string(forKey: locationModeKey) ?? "off"
         return Self.resolvedCaps(
-            browserControlEnabled: OpenClawConfigFile.browserControlEnabled(),
-            cameraEnabled: UserDefaults.standard.object(forKey: cameraEnabledKey) as? Bool ?? false,
+            browserControlEnabled: browserControlEnabled,
+            cameraEnabled: cameraEnabled,
             locationMode: OpenClawLocationMode(rawValue: rawLocationMode) ?? .off,
             connectionMode: AppStateStore.shared.connectionMode)
     }

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -9,6 +9,10 @@ import OpenClawIPC
 import Speech
 import UserNotifications
 
+extension Notification.Name {
+    static let openclawPermissionsChanged = Notification.Name("openclaw.permissions.changed")
+}
+
 enum PermissionManager {
     static func isLocationAuthorized(status: CLAuthorizationStatus, requireAlways: Bool) -> Bool {
         if requireAlways { return status == .authorizedAlways }
@@ -26,6 +30,11 @@ enum PermissionManager {
         var results: [Capability: Bool] = [:]
         for cap in caps {
             results[cap] = await self.ensureCapability(cap, interactive: interactive)
+        }
+        if interactive {
+            await MainActor.run {
+                NotificationCenter.default.post(name: .openclawPermissionsChanged, object: nil)
+            }
         }
         return results
     }
@@ -458,6 +467,7 @@ final class PermissionMonitor {
         let latest = await PermissionManager.status()
         if latest != self.status {
             self.status = latest
+            NotificationCenter.default.post(name: .openclawPermissionsChanged, object: nil)
         }
         self.lastCheck = Date()
 

--- a/apps/macos/Tests/OpenClawIPCTests/CritterIconRendererTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CritterIconRendererTests.swift
@@ -33,4 +33,29 @@ struct CritterIconRendererTests {
     @Test func `critter status label exercises helpers`() async {
         await CritterStatusLabel.exerciseForTesting()
     }
+
+    @Test func `idle critter sleeps until its next animation`() {
+        let now = Date(timeIntervalSinceReferenceDate: 100)
+        let delay = CritterStatusLabel.nextAnimationTickDelay(
+            now: now,
+            isWorking: false,
+            deadlines: [
+                now.addingTimeInterval(8),
+                now.addingTimeInterval(5),
+                now.addingTimeInterval(11),
+                now.addingTimeInterval(7),
+            ])
+
+        #expect(delay == 5)
+    }
+
+    @Test func `working critter keeps its animation cadence`() {
+        let now = Date(timeIntervalSinceReferenceDate: 100)
+        let delay = CritterStatusLabel.nextAnimationTickDelay(
+            now: now,
+            isWorking: true,
+            deadlines: [now.addingTimeInterval(8)])
+
+        #expect(delay == 0.35)
+    }
 }

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-b887966926bb95be077f02fc7f6273ffea54cdcbc4525416b332e67cfdf805a2  plugin-sdk-api-baseline.json
-d9a38711124ec6f121e373a65e44e14409b56c30468d87236aed978815b1864a  plugin-sdk-api-baseline.jsonl
+ff9754cd53ed77f33d8b4509736286b690675945b90b9a923ee7d4270f504fdd  plugin-sdk-api-baseline.json
+25bc1c31b2f1b3215db392296f5e8b8b41495016428f15eb879fe1fb0df84836  plugin-sdk-api-baseline.jsonl

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1080,6 +1080,8 @@ When a `message` tool call runs inside a Slack thread and targets the same chann
 
 `ackReaction` sends an acknowledgement emoji while OpenClaw is processing an inbound message. `ackReactionScope` decides _when_ that emoji is actually sent.
 
+By default, the acknowledgement stays static while Slack's native assistant thread status shows progress with rotating loading messages. Set `messages.statusReactions.enabled: true` to opt into the queued/thinking/tool/done/error reaction lifecycle instead.
+
 ### Emoji (`ackReaction`)
 
 Resolution order:

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -288,6 +288,14 @@ empty. Cold CI leases may still show Slack sign-in in
 `slack-desktop-smoke.png`; the approval checkpoint images are the visual
 proof for this lane.
 
+The default checkpoint run keeps the two standard Slack approval scenarios.
+To capture either opt-in Codex approval route, select it explicitly with
+`--scenario slack-codex-approval-exec-native` or
+`--scenario slack-codex-approval-plugin-native`; Mantis accepts both and emits
+the same pending/resolved screenshot pair. The runner expands its checkpoint
+and remote-command deadlines for each selected Codex route so the full
+approval, agent completion, and resolved-update sequence can finish.
+
 The operator checklist, GitHub workflow dispatch command, evidence-comment
 contract, hydrate-mode decision table, timing interpretation, and failure
 handling steps live in
@@ -611,6 +619,23 @@ Scenarios (`extensions/qa-lab/src/live-transports/slack/slack-live.runtime.ts`):
   scenario. Enables exec and plugin approval forwarding together so plugin
   events are not suppressed by exec approval routing, then verifies the same
   pending/resolved native Slack UI path.
+- `slack-codex-approval-exec-native` - opt-in Codex Guardian command approval
+  scenario. Enables the Codex plugin in Guardian mode, routes a
+  Slack-originated Gateway agent turn through the Codex app-server harness,
+  waits for the native Slack plugin approval prompt for
+  `openclaw-codex-app-server`, resolves it, and verifies the Codex turn
+  finishes with the expected command-output and assistant markers.
+- `slack-codex-approval-plugin-native` - opt-in Codex Guardian file approval
+  scenario. Uses an outside-workspace `apply_patch` instruction so Codex emits
+  the app-server file-change approval route, then verifies the same native
+  Slack pending/resolved approval path, final assistant marker, and exact file
+  contents before cleanup.
+
+The Codex approval scenarios require an `openai/*` or `codex/*` `--model`, the
+normal live model credentials, and Codex auth or API-key auth accepted by the Codex plugin.
+The Slack report includes the Codex app-server method, selected Codex model key,
+final Codex turn status, and operation-marker verification alongside the
+redacted Slack approval metadata.
 
 Output artifacts:
 

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1400,8 +1400,9 @@ Variables are case-insensitive. `{think}` is an alias for `{thinkingLevel}`.
 - Scope: `group-mentions` (default), `group-all`, `direct`, `all`, or `off`/`none` (disables ack reactions entirely).
 - `removeAckAfterReply`: removes ack after reply on reaction-capable channels such as Slack, Discord, Signal, Telegram, WhatsApp, and iMessage.
 - `messages.statusReactions.enabled`: enables lifecycle status reactions on Slack, Discord, Signal, Telegram, and WhatsApp.
-  On Slack and Discord, unset keeps status reactions enabled when ack reactions are active.
-  On Signal, Telegram, and WhatsApp, set it explicitly to `true` to enable lifecycle status reactions.
+  On Discord, unset keeps status reactions enabled when ack reactions are active.
+  On Slack, Signal, Telegram, and WhatsApp, set it explicitly to `true` to enable lifecycle status reactions.
+  Slack uses its native assistant thread status and rotating loading messages for progress by default, while keeping the configured ack reaction static.
 - `messages.statusReactions.emojis`: overrides lifecycle emoji keys:
   `queued`, `thinking`, `compacting`, `tool`, `coding`, `web`, `deploy`, `build`,
   `concierge`, `done`, `error`, `stallSoft`, and `stallHard`.

--- a/extensions/codex/src/app-server/transport-stdio.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { CodexAppServerStartOptions } from "./config.js";
 import {
+  resolveCodexAppServerDetachedMode,
   resolveCodexAppServerSpawnEnv,
   resolveCodexAppServerSpawnInvocation,
 } from "./transport-stdio.js";
@@ -183,5 +184,21 @@ describe("resolveCodexAppServerSpawnEnv", () => {
     expect(Object.hasOwn(env, "__proto__")).toBe(false);
     expect(Object.hasOwn(env, "constructor")).toBe(false);
     expect(Object.hasOwn(env, "prototype")).toBe(false);
+  });
+});
+
+describe("resolveCodexAppServerDetachedMode", () => {
+  it("detaches normal POSIX app-server processes", () => {
+    expect(resolveCodexAppServerDetachedMode({}, "darwin")).toBe(true);
+  });
+
+  it("keeps QA app-server processes in the gateway process group", () => {
+    expect(resolveCodexAppServerDetachedMode({ OPENCLAW_QA_PARENT_PID: "12345" }, "linux")).toBe(
+      false,
+    );
+  });
+
+  it("does not detach Windows app-server processes", () => {
+    expect(resolveCodexAppServerDetachedMode({}, "win32")).toBe(false);
   });
 });

--- a/extensions/codex/src/app-server/transport-stdio.ts
+++ b/extensions/codex/src/app-server/transport-stdio.ts
@@ -11,6 +11,7 @@ import type { CodexAppServerStartOptions } from "./config.js";
 import type { CodexAppServerTransport } from "./transport.js";
 
 const UNSAFE_ENVIRONMENT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+const QA_PARENT_PID_ENV = "OPENCLAW_QA_PARENT_PID";
 
 type CodexAppServerSpawnRuntime = {
   platform: NodeJS.Platform;
@@ -73,6 +74,14 @@ export function resolveCodexAppServerSpawnEnv(
   return env;
 }
 
+/** Keeps QA-owned app-server processes inside the gateway process-group cleanup boundary. */
+export function resolveCodexAppServerDetachedMode(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform !== "win32" && !env[QA_PARENT_PID_ENV]?.trim();
+}
+
 function normalizedEnvironmentKeys(rawKeys: readonly string[]): string[] {
   const keys: string[] = [];
   for (const rawKey of rawKeys) {
@@ -106,7 +115,7 @@ export function createStdioTransport(options: CodexAppServerStartOptions): Codex
   });
   return spawn(invocation.command, invocation.args, {
     env,
-    detached: process.platform !== "win32",
+    detached: resolveCodexAppServerDetachedMode(env),
     shell: invocation.shell,
     stdio: ["pipe", "pipe", "pipe"],
     windowsHide: invocation.windowsHide,

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -276,6 +276,27 @@ describe("runDiscordGatewayLifecycle", () => {
     });
   });
 
+  it("owns and cleans up auto-join when READY preceded voice listener registration", async () => {
+    waitForDiscordGatewayStopMock.mockRejectedValueOnce(new Error("gateway wait failed"));
+    const { lifecycleParams } = createLifecycleHarness();
+    const autoJoin = vi.fn(async () => undefined);
+    const destroy = vi.fn(async () => undefined);
+    const voiceManager = {
+      autoJoin,
+      destroy,
+    } as unknown as NonNullable<LifecycleParams["voiceManager"]>;
+    lifecycleParams.voiceManager = voiceManager;
+    lifecycleParams.voiceManagerRef.current = voiceManager;
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).rejects.toThrow(
+      "gateway wait failed",
+    );
+
+    expect(autoJoin).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(lifecycleParams.voiceManagerRef.current).toBeNull();
+  });
+
   it("pushes connected status when gateway is already connected at lifecycle start", async () => {
     const { emitter, gateway } = createGatewayHarness();
     gateway.isConnected = true;

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -6,6 +6,7 @@ import {
 import { asDateTimestampMs, parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { attachDiscordGatewayLogging } from "../gateway-logging.js";
 import { getDiscordGatewayEmitter, waitForDiscordGatewayStop } from "../monitor.gateway.js";
 import type { DiscordVoiceManager } from "../voice/manager.js";
@@ -420,6 +421,7 @@ export async function runDiscordGatewayLifecycle(params: {
   gatewayRuntimeReadyTimeoutMs?: number;
 }) {
   const gateway = params.gateway;
+  const gatewayReadyAtLifecycleStart = gateway?.isConnected === true;
   if (gateway) {
     registerGateway(params.accountId, gateway);
   }
@@ -513,6 +515,18 @@ export async function runDiscordGatewayLifecycle(params: {
     // Drain gateway errors emitted before lifecycle listeners were attached.
     if (drainPendingGatewayErrors() === "stop") {
       return;
+    }
+
+    if (gatewayReadyAtLifecycleStart && params.voiceManager) {
+      // READY may precede lazy voice-listener registration. Reconcile only after lifecycle
+      // ownership begins so every startup failure still destroys the manager in `finally`.
+      void params.voiceManager
+        .autoJoin()
+        .catch((err: unknown) =>
+          params.runtime.error?.(
+            danger(`discord voice: autoJoin failed: ${formatErrorMessage(err)}`),
+          ),
+        );
     }
 
     await waitForGatewayReady({

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -39,6 +39,10 @@ const {
   voiceRuntimeModuleLoadedMock,
 } = getProviderMonitorTestMocks();
 
+const { voiceAutoJoinMock } = vi.hoisted(() => ({
+  voiceAutoJoinMock: vi.fn(async () => undefined),
+}));
+
 let monitorDiscordProvider: typeof import("./provider.js").monitorDiscordProvider;
 let providerTesting: typeof import("./provider.js").testing;
 let runtimeEnvModule: typeof import("openclaw/plugin-sdk/runtime-env");
@@ -140,7 +144,9 @@ function expectMessagesContainAll(messages: string[], expected: string[]): void 
 vi.mock("../voice/manager.runtime.js", () => {
   voiceRuntimeModuleLoadedMock();
   return {
-    DiscordVoiceManager: function DiscordVoiceManager() {},
+    DiscordVoiceManager: function DiscordVoiceManager() {
+      return { autoJoin: voiceAutoJoinMock };
+    },
     DiscordVoiceReadyListener: function DiscordVoiceReadyListener() {},
     DiscordVoiceResumedListener: function DiscordVoiceResumedListener() {},
     DiscordVoiceStateUpdateListener: function DiscordVoiceStateUpdateListener() {},
@@ -252,6 +258,7 @@ describe("monitorDiscordProvider", () => {
 
   beforeEach(() => {
     resetDiscordProviderMonitorMocks();
+    voiceAutoJoinMock.mockClear();
     vi.mocked(runtimeEnvModule.logVerbose).mockClear();
     providerTesting.setFetchDiscordApplicationId(async () => "app-1");
     providerTesting.setCreateDiscordNativeCommand(((
@@ -270,7 +277,9 @@ describe("monitorDiscordProvider", () => {
     providerTesting.setLoadDiscordVoiceRuntime(async () => {
       voiceRuntimeModuleLoadedMock();
       return {
-        DiscordVoiceManager: function DiscordVoiceManager() {},
+        DiscordVoiceManager: function DiscordVoiceManager() {
+          return { autoJoin: voiceAutoJoinMock };
+        },
         DiscordVoiceReadyListener: function DiscordVoiceReadyListener() {},
         DiscordVoiceResumedListener: function DiscordVoiceResumedListener() {},
         DiscordVoiceStateUpdateListener: function DiscordVoiceStateUpdateListener() {},

--- a/extensions/discord/src/voice/manager.e2e.test.ts
+++ b/extensions/discord/src/voice/manager.e2e.test.ts
@@ -402,12 +402,13 @@ describe("DiscordVoiceManager", () => {
     >[0]["discordConfig"] = { voice: { enabled: true, mode: "stt-tts" } },
     clientOverride?: ReturnType<typeof createClient>,
     cfgOverride: ConstructorParameters<typeof managerModule.DiscordVoiceManager>[0]["cfg"] = {},
+    accountId = "default",
   ) =>
     new managerModule.DiscordVoiceManager({
       client: (clientOverride ?? createClient()) as never,
       cfg: cfgOverride,
       discordConfig,
-      accountId: "default",
+      accountId,
       runtime: createRuntime(),
     });
 
@@ -1020,9 +1021,28 @@ describe("DiscordVoiceManager", () => {
 
     await manager.join({ guildId: "g1", channelId: "1001" });
 
-    expect(getVoiceConnectionMock).toHaveBeenCalledWith("g1");
+    expect(getVoiceConnectionMock).toHaveBeenCalledWith("g1", "openclaw:default");
     expect(staleConnection.destroy).toHaveBeenCalledTimes(1);
     expectConnectedStatus(manager, "1001");
+  });
+
+  it("isolates voice connections by Discord account", async () => {
+    const firstManager = createManager(undefined, undefined, undefined, "first");
+    const secondManager = createManager(undefined, undefined, undefined, "second");
+
+    await firstManager.join({ guildId: "g1", channelId: "1001" });
+    await secondManager.join({ guildId: "g1", channelId: "1002" });
+
+    expect(getVoiceConnectionMock).toHaveBeenNthCalledWith(1, "g1", "openclaw:first");
+    expect(getVoiceConnectionMock).toHaveBeenNthCalledWith(2, "g1", "openclaw:second");
+    expect(joinVoiceChannelMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ group: "openclaw:first" }),
+    );
+    expect(joinVoiceChannelMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ group: "openclaw:second" }),
+    );
   });
 
   it("autoJoin uses the last configured channel for duplicate guild entries", async () => {

--- a/extensions/discord/src/voice/manager.ts
+++ b/extensions/discord/src/voice/manager.ts
@@ -212,6 +212,10 @@ function startAutoJoin(manager: Pick<DiscordVoiceManager, "autoJoin">) {
     );
 }
 
+function resolveVoiceConnectionGroup(accountId: string): string {
+  return `openclaw:${accountId}`;
+}
+
 function resolveDiscordVoiceAgentRoute(params: {
   cfg: OpenClawConfig;
   accountId: string;
@@ -554,7 +558,8 @@ export class DiscordVoiceManager {
       existingEntry.stop();
       this.sessions.delete(guildId);
     }
-    const staleConnection = voiceSdk.getVoiceConnection(guildId);
+    const voiceConnectionGroup = resolveVoiceConnectionGroup(this.params.accountId);
+    const staleConnection = voiceSdk.getVoiceConnection(guildId, voiceConnectionGroup);
     if (staleConnection) {
       destroyVoiceConnectionSafely({
         connection: staleConnection,
@@ -568,6 +573,7 @@ export class DiscordVoiceManager {
       const joinedConnection = voiceSdk.joinVoiceChannel({
         channelId,
         guildId,
+        group: voiceConnectionGroup,
         adapterCreator,
         selfDeaf: false,
         selfMute: false,
@@ -995,7 +1001,10 @@ export class DiscordVoiceManager {
       await this.leave({ guildId });
     } else {
       const voiceSdk = loadDiscordVoiceSdk();
-      const connection = voiceSdk.getVoiceConnection(guildId);
+      const connection = voiceSdk.getVoiceConnection(
+        guildId,
+        resolveVoiceConnectionGroup(this.params.accountId),
+      );
       if (connection) {
         destroyVoiceConnectionSafely({
           connection,

--- a/extensions/google/realtime-voice-provider.test.ts
+++ b/extensions/google/realtime-voice-provider.test.ts
@@ -1,5 +1,6 @@
 // Google tests cover realtime voice provider plugin behavior.
 import { REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ } from "openclaw/plugin-sdk/realtime-voice";
+import type { RealtimeVoiceTool } from "openclaw/plugin-sdk/realtime-voice";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildGoogleRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 
@@ -88,6 +89,35 @@ function requireFirstError(mock: ReturnType<typeof vi.fn>): { message?: string }
 
 function requireFirstAudio(mock: ReturnType<typeof vi.fn>): unknown {
   return requireFirstMockArg(mock, "Google Live audio");
+}
+
+function createRealtimeTool(name: string): RealtimeVoiceTool {
+  return {
+    type: "function",
+    name,
+    description: "Contract test tool",
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+function createUnreadableToolName(): RealtimeVoiceTool {
+  return {
+    type: "function",
+    get name(): string {
+      throw new Error("unreadable tool name");
+    },
+    description: "Contract test tool",
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+function createMalformedToolName(name: unknown): RealtimeVoiceTool {
+  return {
+    type: "function",
+    name,
+    description: "Contract test tool",
+    parameters: { type: "object", properties: {} },
+  } as unknown as RealtimeVoiceTool;
 }
 
 describe("buildGoogleRealtimeVoiceProvider", () => {
@@ -300,6 +330,36 @@ describe("buildGoogleRealtimeVoiceProvider", () => {
       required: ["question"],
     });
     expect(declarations[1]?.behavior).toBe("NON_BLOCKING");
+  });
+
+  it("omits tool names that Google Live cannot accept", async () => {
+    const provider = buildGoogleRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "gemini-key" },
+      tools: [
+        createRealtimeTool("_lookup"),
+        createRealtimeTool("calendar.lookup:next"),
+        createRealtimeTool("1_lookup"),
+        createRealtimeTool("bad/name"),
+        createRealtimeTool(`x${"a".repeat(128)}`),
+        createMalformedToolName(undefined),
+        createMalformedToolName(null),
+        createMalformedToolName(42),
+        createUnreadableToolName(),
+      ],
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+
+    await bridge.connect();
+
+    const config = lastConnectParams().config as {
+      tools?: Array<{ functionDeclarations?: Array<{ name?: string }> }>;
+    };
+    expect(config.tools?.[0]?.functionDeclarations?.map((declaration) => declaration.name)).toEqual([
+      "_lookup",
+      "calendar.lookup:next",
+    ]);
   });
 
   it("omits zero temperature for native audio responses", async () => {

--- a/extensions/google/realtime-voice-provider.ts
+++ b/extensions/google/realtime-voice-provider.ts
@@ -22,6 +22,7 @@ import {
   timestampMsToIsoString,
 } from "openclaw/plugin-sdk/number-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
+import { warn } from "openclaw/plugin-sdk/runtime-env";
 import type {
   RealtimeVoiceAudioFormat,
   RealtimeVoiceBridge,
@@ -63,6 +64,8 @@ const GOOGLE_REALTIME_BROWSER_NEW_SESSION_TTL_MS = 60 * 1000;
 const GOOGLE_REALTIME_RECONNECT_MAX_ATTEMPTS = 3;
 const GOOGLE_REALTIME_RECONNECT_BASE_DELAY_MS = 250;
 const GOOGLE_REALTIME_RECONNECT_MAX_DELAY_MS = 2_000;
+// Google Live requires a leading letter/underscore and caps function names at 128 characters.
+const GOOGLE_REALTIME_TOOL_NAME_RE = /^[A-Za-z_][A-Za-z0-9_.:-]{0,127}$/;
 const MULAW_LINEAR_SAMPLES = new Int16Array(256);
 
 for (let i = 0; i < MULAW_LINEAR_SAMPLES.length; i += 1) {
@@ -339,19 +342,34 @@ function buildRealtimeInputConfig(
 }
 
 function buildFunctionDeclarations(tools: RealtimeVoiceTool[] | undefined): FunctionDeclaration[] {
-  return (tools ?? []).map((tool) => {
-    // Live preview models honor the OpenAPI `parameters` field; the SDK normalizes
-    // our lowercase JSON Schema types before sending the mutually exclusive field.
-    const declaration: FunctionDeclaration = {
-      name: tool.name,
-      description: tool.description,
-      parameters: tool.parameters as unknown as FunctionDeclaration["parameters"],
-    };
-    if (tool.name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-      declaration.behavior = "NON_BLOCKING" as Behavior;
+  const declarations: FunctionDeclaration[] = [];
+  let omitted = 0;
+  for (const tool of tools ?? []) {
+    try {
+      const name = tool.name;
+      if (typeof name !== "string" || !GOOGLE_REALTIME_TOOL_NAME_RE.test(name)) {
+        omitted += 1;
+        continue;
+      }
+      // Live preview models honor the OpenAPI `parameters` field; the SDK normalizes
+      // our lowercase JSON Schema types before sending the mutually exclusive field.
+      const declaration: FunctionDeclaration = {
+        name,
+        description: tool.description,
+        parameters: tool.parameters as unknown as FunctionDeclaration["parameters"],
+      };
+      if (name === REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
+        declaration.behavior = "NON_BLOCKING" as Behavior;
+      }
+      declarations.push(declaration);
+    } catch {
+      omitted += 1;
     }
-    return declaration;
-  });
+  }
+  if (omitted > 0) {
+    warn(`google realtime: omitted ${omitted} tool definition(s) with unsupported names`);
+  }
+  return declarations;
 }
 
 function buildGoogleLiveConnectConfig(config: GoogleRealtimeLiveConfig): LiveConnectConfig {

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -10,6 +10,7 @@ import { monitorIMessageProvider } from "./monitor.js";
 import {
   advanceIMessageRecoveryCursor,
   loadIMessageRecoveryCursor,
+  resolveIMessageRecoveryCursorDbIdentity,
 } from "./monitor/recovery-cursor.js";
 import {
   clearCachedIMessagePrivateApiStatus,
@@ -1125,7 +1126,11 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("recovers over a remote cliPath: replays from the cursor even without a local chat.db boundary", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ remoteHost: "user@gateway-host" }),
+      4990,
+    );
     const client = {
       request: vi.fn(async () => ({ subscription: 1 })),
       waitForClose: vi.fn(async () => {}),
@@ -1213,10 +1218,14 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("recovers downtime messages: replays from the cursor and delivers replay rows older than the live fence", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
+      4990,
+    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1445,11 +1454,15 @@ describe("iMessage monitor last-route updates", () => {
   });
 
   it("does not advance the recovery cursor past a failed replay row", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
     debouncerControl.holdEntries = true;
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-failed-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
+      4990,
+    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1516,15 +1529,21 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(() => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
     });
-    expect(loadIMessageRecoveryCursor("default")).toBe(4994);
+    expect(
+      loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
+    ).toBe(4994);
   });
 
   it("advances the recovery cursor after lower pending replay rows complete", async () => {
-    advanceIMessageRecoveryCursor("default", 4990);
     debouncerControl.holdEntries = true;
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-imsg-recovery-ordered-"));
     tempDirs.push(stateDir);
     const dbPath = path.join(stateDir, "chat.db");
+    advanceIMessageRecoveryCursor(
+      "default",
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath }),
+      4990,
+    );
     const { DatabaseSync } = await import("node:sqlite");
     const database = new DatabaseSync(dbPath);
     try {
@@ -1584,7 +1603,9 @@ describe("iMessage monitor last-route updates", () => {
     await vi.waitFor(() => {
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
     });
-    expect(loadIMessageRecoveryCursor("default")).toBe(4996);
+    expect(
+      loadIMessageRecoveryCursor("default", resolveIMessageRecoveryCursorDbIdentity({ dbPath })),
+    ).toBe(4996);
   });
 
   it("repairs anchorless group watch payloads before routing or cursor updates", async () => {

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -108,7 +108,11 @@ import { parseIMessageNotification } from "./parse-notification.js";
 import { createPollCommentFolder } from "./poll-comment.js";
 import { renderIMessagePollBody } from "./poll-render.js";
 import { enqueueIMessageReactionSystemEvent } from "./reaction-system-event.js";
-import { advanceIMessageRecoveryCursor, loadIMessageRecoveryCursor } from "./recovery-cursor.js";
+import {
+  advanceIMessageRecoveryCursor,
+  loadIMessageRecoveryCursor,
+  resolveIMessageRecoveryCursorDbIdentity,
+} from "./recovery-cursor.js";
 import { normalizeAllowList, resolveRuntime } from "./runtime.js";
 import { createSelfChatCache } from "./self-chat-cache.js";
 import type { IMessageAttachment, IMessagePayload, MonitorIMessageOpts } from "./types.js";
@@ -542,9 +546,18 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
   const recoveryBoundaryRowid = watchSourceDbPath
     ? await resolveIMessageStartupRowidWatermark(watchSourceDbPath)
     : null;
-  const recoveryCursorRowid = loadIMessageRecoveryCursor(accountInfo.accountId, {
-    migrateLegacyCatchup: !catchupCfg.enabled,
+  // Scope the cursor to the resolved database so a dbPath/remoteHost change
+  // starts from the new DB's watermark instead of a stale high-water (#99638).
+  const recoveryCursorDbIdentity = resolveIMessageRecoveryCursorDbIdentity({
+    cliPath,
+    dbPath,
+    remoteHost,
   });
+  const recoveryCursorRowid = loadIMessageRecoveryCursor(
+    accountInfo.accountId,
+    recoveryCursorDbIdentity,
+    { migrateLegacyCatchup: !catchupCfg.enabled },
+  );
   const watchSinceRowid = catchupCfg.enabled
     ? null
     : recoveryCursorRowid !== null
@@ -655,7 +668,11 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       holdFloor !== null && maxHandledRowid >= holdFloor ? holdFloor - 1 : maxHandledRowid;
 
     if (nextCursorRowid >= 0 && nextCursorRowid > latestAdvancedRecoveryCursorRowid) {
-      advanceIMessageRecoveryCursor(accountInfo.accountId, nextCursorRowid);
+      advanceIMessageRecoveryCursor(
+        accountInfo.accountId,
+        recoveryCursorDbIdentity,
+        nextCursorRowid,
+      );
       latestAdvancedRecoveryCursorRowid = nextCursorRowid;
       for (const rowid of handledRecoveryCursorRowids) {
         if (rowid <= nextCursorRowid) {

--- a/extensions/imessage/src/monitor/recovery-cursor.test.ts
+++ b/extensions/imessage/src/monitor/recovery-cursor.test.ts
@@ -1,9 +1,22 @@
 // Imessage tests cover the downtime-recovery cursor.
 import { createHash } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import { getIMessageRuntime } from "../runtime.js";
 import { installIMessageStateRuntimeForTest } from "../test-support/runtime.js";
-import { advanceIMessageRecoveryCursor, loadIMessageRecoveryCursor } from "./recovery-cursor.js";
+import {
+  advanceIMessageRecoveryCursor,
+  IMESSAGE_RECOVERY_CURSOR_MAX_ENTRIES,
+  IMESSAGE_RECOVERY_CURSOR_NAMESPACE,
+  loadIMessageRecoveryCursor,
+  resolveIMessageRecoveryCursorDbIdentity,
+} from "./recovery-cursor.js";
+
+// Default database identity used by tests that are not exercising the db-scoping
+// behavior directly.
+const DB = "local:/db-a";
+const DB_B = "local:/db-b";
 
 function writeLegacyCatchupCursor(accountId: string, lastSeenRowid: number): void {
   const store = getIMessageRuntime().state.openSyncKeyedStore<{
@@ -14,58 +27,140 @@ function writeLegacyCatchupCursor(accountId: string, lastSeenRowid: number): voi
   store.register(key, { lastSeenMs: Date.now(), lastSeenRowid });
 }
 
+// Writes a pre-database-scoping recovery cursor: keyed by accountId alone, with
+// no database identity, as older builds persisted it.
+function writeLegacyRecoveryCursor(accountId: string, lastRowid: number): void {
+  getIMessageRuntime()
+    .state.openSyncKeyedStore<{ lastRowid: number }>({
+      namespace: IMESSAGE_RECOVERY_CURSOR_NAMESPACE,
+      maxEntries: IMESSAGE_RECOVERY_CURSOR_MAX_ENTRIES,
+    })
+    .register(accountId, { lastRowid });
+}
+
 describe("iMessage recovery cursor", () => {
   beforeEach(() => {
     installIMessageStateRuntimeForTest();
   });
 
   it("returns null before anything is recorded", () => {
-    expect(loadIMessageRecoveryCursor("default")).toBeNull();
+    expect(loadIMessageRecoveryCursor("default", DB)).toBeNull();
   });
 
   it("persists the last dispatched rowid", () => {
-    advanceIMessageRecoveryCursor("default", 100);
-    expect(loadIMessageRecoveryCursor("default")).toBe(100);
+    advanceIMessageRecoveryCursor("default", DB, 100);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(100);
   });
 
   it("advances forward only and never rewinds", () => {
-    advanceIMessageRecoveryCursor("default", 100);
-    advanceIMessageRecoveryCursor("default", 50);
-    expect(loadIMessageRecoveryCursor("default")).toBe(100);
-    advanceIMessageRecoveryCursor("default", 150);
-    expect(loadIMessageRecoveryCursor("default")).toBe(150);
+    advanceIMessageRecoveryCursor("default", DB, 100);
+    advanceIMessageRecoveryCursor("default", DB, 50);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(100);
+    advanceIMessageRecoveryCursor("default", DB, 150);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(150);
   });
 
   it("scopes the cursor per account", () => {
-    advanceIMessageRecoveryCursor("work", 10);
-    advanceIMessageRecoveryCursor("home", 20);
-    expect(loadIMessageRecoveryCursor("work")).toBe(10);
-    expect(loadIMessageRecoveryCursor("home")).toBe(20);
+    advanceIMessageRecoveryCursor("work", DB, 10);
+    advanceIMessageRecoveryCursor("home", DB, 20);
+    expect(loadIMessageRecoveryCursor("work", DB)).toBe(10);
+    expect(loadIMessageRecoveryCursor("home", DB)).toBe(20);
+  });
+
+  it("ignores a cursor recorded against a different database (#99638)", () => {
+    // A high-water from db-a must not seed since_rowid after repointing to db-b,
+    // or every lower rowid in db-b is silently suppressed forever.
+    advanceIMessageRecoveryCursor("default", DB, 12396);
+    expect(loadIMessageRecoveryCursor("default", DB_B, { migrateLegacyCatchup: false })).toBeNull();
+    // The original database still reports its cursor.
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(12396);
+  });
+
+  it("re-scopes the cursor to the new database on advance", () => {
+    advanceIMessageRecoveryCursor("default", DB, 12396);
+    // Advancing on db-b starts fresh (not blocked by db-a's higher monotonic value).
+    advanceIMessageRecoveryCursor("default", DB_B, 15);
+    expect(loadIMessageRecoveryCursor("default", DB_B)).toBe(15);
+    // db-a keeps its own high-water; switching back does not lose it.
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(12396);
+  });
+
+  it("adopts a pre-database-scoping cursor once for the active database (#99638)", () => {
+    writeLegacyRecoveryCursor("default", 12396);
+    // Upgrade restart: the identity-less cursor is adopted for the active
+    // database so downtime replay still works (not dropped to the watermark).
+    expect(loadIMessageRecoveryCursor("default", DB, { migrateLegacyCatchup: false })).toBe(12396);
+    // It is consumed and re-scoped, so a different database does not inherit it.
+    expect(loadIMessageRecoveryCursor("default", DB_B, { migrateLegacyCatchup: false })).toBeNull();
+    // The adopted database keeps it across reloads.
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(12396);
   });
 
   it("ignores non-finite rowids", () => {
-    advanceIMessageRecoveryCursor("default", Number.NaN);
-    expect(loadIMessageRecoveryCursor("default")).toBeNull();
+    advanceIMessageRecoveryCursor("default", DB, Number.NaN);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBeNull();
   });
 
   it("seeds from the retired catchup cursor once on upgrade, then consumes it", () => {
     writeLegacyCatchupCursor("default", 4321);
     // First load with no recovery cursor seeds from the legacy catchup cursor.
-    expect(loadIMessageRecoveryCursor("default")).toBe(4321);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(4321);
     // The legacy entry is consumed and the value is now the recovery cursor, so
     // a later load still returns it without re-reading the legacy store.
-    expect(loadIMessageRecoveryCursor("default")).toBe(4321);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(4321);
   });
 
   it("can skip legacy catchup cursor migration when compatibility catchup still owns it", () => {
     writeLegacyCatchupCursor("default", 4321);
-    expect(loadIMessageRecoveryCursor("default", { migrateLegacyCatchup: false })).toBeNull();
-    expect(loadIMessageRecoveryCursor("default")).toBe(4321);
+    expect(loadIMessageRecoveryCursor("default", DB, { migrateLegacyCatchup: false })).toBeNull();
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(4321);
   });
 
   it("prefers an existing recovery cursor over the legacy catchup cursor", () => {
-    advanceIMessageRecoveryCursor("default", 9000);
+    advanceIMessageRecoveryCursor("default", DB, 9000);
     writeLegacyCatchupCursor("default", 10);
-    expect(loadIMessageRecoveryCursor("default")).toBe(9000);
+    expect(loadIMessageRecoveryCursor("default", DB)).toBe(9000);
+  });
+
+  it("unifies the implicit default with explicit spellings of the same chat.db (#99638)", () => {
+    const home = (process.env.HOME || os.homedir()).trim();
+    const defaultIdentity = `local:${path.resolve(path.join(home, "Library", "Messages", "chat.db"))}`;
+
+    // Implicit default (imsg binary, no dbPath) and any explicit spelling of the
+    // same file resolve to one identity, so switching between them does not drop
+    // the cursor and skip downtime messages.
+    expect(resolveIMessageRecoveryCursorDbIdentity({ cliPath: "imsg" })).toBe(defaultIdentity);
+    expect(resolveIMessageRecoveryCursorDbIdentity({ cliPath: "/opt/homebrew/bin/imsg" })).toBe(
+      defaultIdentity,
+    );
+    expect(
+      resolveIMessageRecoveryCursorDbIdentity({
+        dbPath: path.join(home, "Library/Messages/chat.db"),
+      }),
+    ).toBe(defaultIdentity);
+    expect(resolveIMessageRecoveryCursorDbIdentity({ dbPath: "~/Library/Messages/chat.db" })).toBe(
+      defaultIdentity,
+    );
+  });
+
+  it("keeps distinct databases, wrappers, and remotes on separate identities", () => {
+    const defaultId = resolveIMessageRecoveryCursorDbIdentity({ cliPath: "imsg" });
+    const otherDb = resolveIMessageRecoveryCursorDbIdentity({ dbPath: "/Users/other/chat.db" });
+    // Distinct wrappers with no dbPath/remoteHost must not collapse together.
+    const wrapperA = resolveIMessageRecoveryCursorDbIdentity({
+      cliPath: "/usr/local/bin/imsg-a.sh",
+    });
+    const wrapperB = resolveIMessageRecoveryCursorDbIdentity({
+      cliPath: "/usr/local/bin/imsg-b.sh",
+    });
+    const remote = resolveIMessageRecoveryCursorDbIdentity({
+      remoteHost: "bot@host",
+      dbPath: "/Users/b/chat.db",
+    });
+    expect(new Set([defaultId, otherDb, wrapperA, wrapperB, remote]).size).toBe(5);
+    // Stable for the same inputs.
+    expect(otherDb).toBe(
+      resolveIMessageRecoveryCursorDbIdentity({ dbPath: "/Users/other/chat.db" }),
+    );
   });
 });

--- a/extensions/imessage/src/monitor/recovery-cursor.ts
+++ b/extensions/imessage/src/monitor/recovery-cursor.ts
@@ -1,10 +1,15 @@
-// Per-account high-water of the last dispatched chat.db rowid. On startup it is
-// passed to imsg `watch.subscribe` as `since_rowid` so imsg replays the rows
-// that landed while the gateway was down (downtime recovery), then tails live.
-// The GUID dedupe makes this safe — anything already handled is dropped — so
-// this needs none of the cursor/retry bookkeeping the old catchup subsystem
-// carried. Single number per account.
+// Per-(account, database) high-water of the last dispatched chat.db rowid. On
+// startup it is passed to imsg `watch.subscribe` as `since_rowid` so imsg
+// replays the rows that landed while the gateway was down (downtime recovery),
+// then tails live. The GUID dedupe makes over-replay safe — anything already
+// handled is dropped — so this needs none of the cursor/retry bookkeeping the
+// old catchup subsystem carried. The database identity is part of the store key
+// (not just a number per account): a high-water from one chat.db must never seed
+// since_rowid for a different one, or repointing `dbPath`/`remoteHost` to a
+// lower-rowid database silently suppresses every row in it forever (#99638).
 import { createHash } from "node:crypto";
+import os from "node:os";
+import path from "node:path";
 import { getIMessageRuntime } from "../runtime.js";
 
 export const IMESSAGE_RECOVERY_CURSOR_NAMESPACE = "imessage.recovery-cursor";
@@ -25,12 +30,95 @@ function openRecoveryCursorStore() {
   });
 }
 
-function readRecoveryCursor(accountId: string): number | null {
+// Mirrors monitor-provider's local Messages home resolution (HOME first, then
+// os.homedir) so the identity's default path matches the database the monitor
+// actually watches.
+function localMessagesHomeDir(): string | undefined {
+  const home = process.env.HOME?.trim();
+  if (home) {
+    return home;
+  }
   try {
-    const value = openRecoveryCursorStore().lookup(accountId);
-    return typeof value?.lastRowid === "number" && Number.isFinite(value.lastRowid)
-      ? value.lastRowid
-      : null;
+    return os.homedir().trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Canonicalize a local chat.db path (expand a leading ~, then resolve) so the
+// implicit default and any explicit spelling of the same file share one identity.
+function normalizeLocalDbPath(dbPath: string): string {
+  let resolved = dbPath.trim();
+  if (resolved.startsWith("~")) {
+    const home = localMessagesHomeDir();
+    if (home) {
+      resolved = path.join(home, resolved.slice(1).replace(/^\/+/, ""));
+    }
+  }
+  return path.resolve(resolved);
+}
+
+/**
+ * Stable identity for the watched Messages database. A changed identity means a
+ * different chat.db (different `dbPath`, custom `cliPath`, or a remote host),
+ * whose rowids share no ordering with the previous one, so the cursor must not
+ * carry across. Local paths are canonicalized so the implicit default and an
+ * explicit path to the same chat.db resolve to one identity.
+ */
+export function resolveIMessageRecoveryCursorDbIdentity(params: {
+  cliPath?: string;
+  dbPath?: string;
+  remoteHost?: string;
+}): string {
+  const remoteHost = params.remoteHost?.trim();
+  if (remoteHost) {
+    // Remote paths cannot be resolved locally; key by host + raw remote path.
+    return `remote:${remoteHost}:${params.dbPath?.trim() || "default"}`;
+  }
+  const dbPath = params.dbPath?.trim();
+  if (dbPath) {
+    return `local:${normalizeLocalDbPath(dbPath)}`;
+  }
+  // No explicit dbPath: the default imsg binary watches the default chat.db, so
+  // resolve it to the same concrete path an explicit config would spell. A
+  // custom cliPath (e.g. an SSH wrapper whose host is not auto-detected) can
+  // front a distinct database, so keep those distinct instead.
+  const cliPath = params.cliPath?.trim();
+  const isDefaultCli = !cliPath || cliPath === "imsg" || path.basename(cliPath) === "imsg";
+  if (isDefaultCli) {
+    const home = localMessagesHomeDir();
+    return home
+      ? `local:${normalizeLocalDbPath(path.join(home, "Library", "Messages", "chat.db"))}`
+      : "local:default";
+  }
+  return `local:cli:${cliPath}`;
+}
+
+// Composite key: one high-water per (account, database). The NUL separator
+// cannot appear in an account id or identity string, so a composite key never
+// collides with the legacy account-only key adopted below.
+function recoveryCursorStoreKey(accountId: string, dbIdentity: string): string {
+  return `${accountId}\u0000${dbIdentity}`;
+}
+
+function readRecoveryCursor(accountId: string, dbIdentity: string): number | null {
+  try {
+    const store = openRecoveryCursorStore();
+    const key = recoveryCursorStoreKey(accountId, dbIdentity);
+    const value = store.lookup(key);
+    if (value) {
+      return Number.isFinite(value.lastRowid) ? value.lastRowid : null;
+    }
+    // One-time upgrade adoption: cursors written before database scoping were
+    // keyed by accountId alone. Adopt such an entry for the active database so
+    // the upgrade restart still replays downtime rows, then consume it so a
+    // later dbPath change cannot inherit this database's high-water.
+    const legacy = store.consume(accountId);
+    if (legacy && Number.isFinite(legacy.lastRowid)) {
+      store.register(key, { lastRowid: legacy.lastRowid });
+      return legacy.lastRowid;
+    }
+    return null;
   } catch {
     return null;
   }
@@ -39,7 +127,7 @@ function readRecoveryCursor(accountId: string): number | null {
 // One-time, self-cleaning migration: when the recovery cursor is empty (first
 // startup after upgrade or a fresh install), seed it from the retired catchup
 // cursor's lastSeenRowid and consume the legacy entry so this never runs again.
-function migrateLegacyCatchupCursor(accountId: string): number | null {
+function migrateLegacyCatchupCursor(accountId: string, dbIdentity: string): number | null {
   try {
     const legacy = getIMessageRuntime().state.openSyncKeyedStore<{ lastSeenRowid?: unknown }>({
       namespace: LEGACY_CATCHUP_CURSOR_NAMESPACE,
@@ -52,7 +140,7 @@ function migrateLegacyCatchupCursor(accountId: string): number | null {
         ? value.lastSeenRowid
         : null;
     if (rowid !== null) {
-      advanceIMessageRecoveryCursor(accountId, rowid);
+      advanceIMessageRecoveryCursor(accountId, dbIdentity, rowid);
     }
     return rowid;
   } catch {
@@ -60,33 +148,43 @@ function migrateLegacyCatchupCursor(accountId: string): number | null {
   }
 }
 
-/** Last dispatched rowid for this account, or null when none is recorded yet. */
+/**
+ * Last dispatched rowid for this account on `dbIdentity`, or null when none is
+ * recorded yet (including when the only stored cursor belongs to a different
+ * database).
+ */
 export function loadIMessageRecoveryCursor(
   accountId: string,
+  dbIdentity: string,
   options: { migrateLegacyCatchup?: boolean } = {},
 ): number | null {
-  const current = readRecoveryCursor(accountId);
+  const current = readRecoveryCursor(accountId, dbIdentity);
   if (current !== null) {
     return current;
   }
   if (options.migrateLegacyCatchup === false) {
     return null;
   }
-  return migrateLegacyCatchupCursor(accountId);
+  return migrateLegacyCatchupCursor(accountId, dbIdentity);
 }
 
-/** Advance the cursor forward to `rowid` (monotonic; never rewinds). */
-export function advanceIMessageRecoveryCursor(accountId: string, rowid: number): void {
+/** Advance the cursor forward to `rowid` (monotonic per database; never rewinds). */
+export function advanceIMessageRecoveryCursor(
+  accountId: string,
+  dbIdentity: string,
+  rowid: number,
+): void {
   if (!Number.isFinite(rowid)) {
     return;
   }
   try {
     const store = openRecoveryCursorStore();
-    const current = store.lookup(accountId);
+    const key = recoveryCursorStoreKey(accountId, dbIdentity);
+    const current = store.lookup(key);
     if (current && current.lastRowid >= rowid) {
       return;
     }
-    store.register(accountId, { lastRowid: rowid });
+    store.register(key, { lastRowid: rowid });
   } catch {
     // Best effort: a failed cursor write just means we replay a little more
     // next startup, which the dedupe absorbs.

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -145,6 +145,72 @@ describe("sendMessageIMessage receipts", () => {
     expect(result.receipt.parts[0]?.replyToId).toBeUndefined();
   });
 
+  it("resends unthreaded when the transport cannot deliver a threaded reply (#99638)", async () => {
+    const sendParams: Array<Record<string, unknown>> = [];
+    const client = {
+      request: vi.fn(async (_method: string, params: Record<string, unknown>) => {
+        sendParams.push(params);
+        if (params.reply_to) {
+          throw new Error(
+            "reply_to requires bridge transport; AppleScript fallback cannot send threaded replies",
+          );
+        }
+        return { guid: "p:0/imsg-plain-fallback" };
+      }),
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+
+    const result = await sendMessageIMessage("chat_id:42", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      replyToId: "reply-1",
+    });
+
+    // First attempt carried reply_to and hard-failed on the AppleScript-only
+    // transport; the retry drops reply_to and delivers rather than losing it.
+    expect(sendParams).toHaveLength(2);
+    expect(sendParams[0]).toHaveProperty("reply_to", "reply-1");
+    expect(sendParams[1]).not.toHaveProperty("reply_to");
+    expect(result.messageId).toBe("p:0/imsg-plain-fallback");
+    expect(result.sentText).toBe("hello");
+    // The receipt reflects the unthreaded send that was actually delivered.
+    expect(result.receipt.replyToId).toBeUndefined();
+    expect(result.receipt.parts[0]?.replyToId).toBeUndefined();
+  });
+
+  it("resends a media reply unthreaded when threaded replies are unsupported (#99638)", async () => {
+    const sendParams: Array<Record<string, unknown>> = [];
+    const client = {
+      request: vi.fn(async (_method: string, params: Record<string, unknown>) => {
+        sendParams.push(params);
+        if (params.reply_to) {
+          throw new Error(
+            "reply_to requires bridge transport; AppleScript fallback cannot send threaded replies",
+          );
+        }
+        return { guid: "p:0/media-plain-fallback" };
+      }),
+      stop: vi.fn(async () => {}),
+    } as unknown as IMessageRpcClient;
+
+    // A media reply (file + reply_to) takes the main send path, not send-attachment.
+    const result = await sendMessageIMessage("chat_id:42", "caption", {
+      config: IMESSAGE_TEST_CFG,
+      client,
+      replyToId: "reply-1",
+      mediaUrl: "/tmp/image.png",
+      resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+    });
+
+    expect(sendParams).toHaveLength(2);
+    expect(sendParams[0]).toMatchObject({ reply_to: "reply-1", file: "/tmp/image.png" });
+    expect(sendParams[1]).not.toHaveProperty("reply_to");
+    // The media itself is still delivered on the retry, just unthreaded.
+    expect(sendParams[1]).toHaveProperty("file", "/tmp/image.png");
+    expect(result.messageId).toBe("p:0/media-plain-fallback");
+    expect(result.receipt.replyToId).toBeUndefined();
+  });
+
   it("passes the default RPC send transport", async () => {
     const client = createClient({ guid: "p:0/imsg-transport-default" });
 

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -712,6 +712,16 @@ function isAttachmentCommandFallbackError(error: unknown): boolean {
   );
 }
 
+// A threaded reply (reply_to) needs the private-API bridge transport; on an
+// AppleScript-only deployment imsg rejects it outright. Detect that specific
+// error so we can resend the message unthreaded instead of dropping it (#99638).
+function isThreadedReplyUnsupportedError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /reply_to requires bridge transport|cannot send threaded repl|threaded repl(?:y|ies)\b.*(?:unsupported|not supported|requires|unavailable)|requires bridge transport/iu.test(
+    message,
+  );
+}
+
 async function resolveAttachmentChatTarget(params: {
   target: ReturnType<typeof parseIMessageTarget>;
   service?: IMessageService;
@@ -946,6 +956,10 @@ export async function sendMessageIMessage(
   const echoText = resolveOutboundEchoText(message, filePath ? mediaContentType : undefined);
   const replyActionsEnabled = createActionGate(account.config.actions)("reply");
   const resolvedReplyToId = replyActionsEnabled ? sanitizeReplyToId(opts.replyToId) : undefined;
+  // The reply id actually delivered. The threaded-reply fallback below clears it
+  // so the receipt and approval binding report the unthreaded send it became,
+  // not the threaded reply the transport rejected (#99638).
+  let effectiveReplyToId = resolvedReplyToId;
   const runCliJson =
     opts.runCliJson ??
     ((args: readonly string[]) => runIMessageCliJson(cliPath, dbPath, args, timeoutMs));
@@ -1054,10 +1068,20 @@ export async function sendMessageIMessage(
         timeoutMs,
       });
     } catch (error) {
-      if (filePath || !isIMessageRpcSendTimeout(error)) {
+      if (resolvedReplyToId && isThreadedReplyUnsupportedError(error)) {
+        // #99638: the transport cannot deliver a threaded reply, so resend the
+        // message unthreaded rather than dropping it. Covers text and media
+        // replies alike (both carry reply_to through this send). One retry with
+        // reply_to stripped, keeping any file; a further failure propagates.
+        const plainParams = { ...params };
+        delete plainParams.reply_to;
+        result = await client.request<Record<string, unknown>>("send", plainParams, {
+          timeoutMs,
+        });
+        effectiveReplyToId = undefined;
+      } else if (filePath || !isIMessageRpcSendTimeout(error)) {
         throw error;
-      }
-      if (
+      } else if (
         !shouldRecoverApprovalPromptGuid({
           message,
           filePath,
@@ -1069,18 +1093,19 @@ export async function sendMessageIMessage(
         })
       ) {
         throw error;
-      }
-      const recoveredGuid = await resolveFallbackSentMessageGuid({
-        dbPath: chatDbLookupPath,
-        target,
-        text: message,
-        sentAfterMs: sendStartedAtMs,
-        resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
-      });
-      if (recoveredGuid) {
-        result = { guid: recoveredGuid, status: "sent" };
       } else {
-        throw error;
+        const recoveredGuid = await resolveFallbackSentMessageGuid({
+          dbPath: chatDbLookupPath,
+          target,
+          text: message,
+          sentAfterMs: sendStartedAtMs,
+          resolveSentMessageGuidImpl: opts.resolveSentMessageGuidImpl,
+        });
+        if (recoveredGuid) {
+          result = { guid: recoveredGuid, status: "sent" };
+        } else {
+          throw error;
+        }
       }
     }
     const resolvedId = resolveMessageId(result);
@@ -1102,7 +1127,7 @@ export async function sendMessageIMessage(
       shouldRecoverApprovalPromptGuid({
         message,
         filePath,
-        replyToId: resolvedReplyToId,
+        replyToId: effectiveReplyToId,
       })
     ) {
       approvalBindingMessageId = await resolveFallbackSentMessageGuid({
@@ -1165,7 +1190,7 @@ export async function sendMessageIMessage(
         messageId,
         target,
         kind: filePath ? "media" : "text",
-        ...(resolvedReplyToId ? { replyToId: resolvedReplyToId } : {}),
+        ...(effectiveReplyToId ? { replyToId: effectiveReplyToId } : {}),
       }),
     };
   } catch (error) {

--- a/extensions/openai/realtime-voice-provider.test.ts
+++ b/extensions/openai/realtime-voice-provider.test.ts
@@ -1,6 +1,9 @@
 // Openai tests cover realtime voice provider plugin behavior.
 import { REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ } from "openclaw/plugin-sdk/realtime-voice";
-import type { RealtimeVoiceBridge } from "openclaw/plugin-sdk/realtime-voice";
+import type {
+  RealtimeVoiceBridge,
+  RealtimeVoiceTool,
+} from "openclaw/plugin-sdk/realtime-voice";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 
@@ -123,6 +126,7 @@ type SentRealtimeEvent = {
       create_response?: boolean;
     };
     output_modalities?: string[];
+    tools?: Array<{ name?: string }>;
     audio?: {
       input?: {
         format?: Record<string, unknown>;
@@ -237,6 +241,35 @@ function requireSession(socket: FakeWebSocketInstance, index = 0): Record<string
 
 function hasSentEventType(socket: FakeWebSocketInstance, type: string): boolean {
   return parseSent(socket).some((event) => event.type === type);
+}
+
+function createRealtimeTool(name: string): RealtimeVoiceTool {
+  return {
+    type: "function",
+    name,
+    description: "Contract test tool",
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+function createUnreadableToolName(): RealtimeVoiceTool {
+  return {
+    type: "function",
+    get name(): string {
+      throw new Error("unreadable tool name");
+    },
+    description: "Contract test tool",
+    parameters: { type: "object", properties: {} },
+  };
+}
+
+function createMalformedToolName(name: unknown): RealtimeVoiceTool {
+  return {
+    type: "function",
+    name,
+    description: "Contract test tool",
+    parameters: { type: "object", properties: {} },
+  } as unknown as RealtimeVoiceTool;
 }
 
 describe("buildOpenAIRealtimeVoiceProvider", () => {
@@ -470,6 +503,31 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     // api.openai.com passes the CORS preflight (only authorization,content-type
     // allowed — #76435). All three are filtered, leaving no browser offer headers.
     expect((session as { offerHeaders?: Record<string, string> }).offerHeaders).toBeUndefined();
+  });
+
+  it("omits unsupported OpenAI tool names from browser sessions", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: createJsonResponse({ client_secret: { value: "client-secret-123" } }),
+      release: vi.fn(async () => undefined),
+    });
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    if (!provider.createBrowserSession) {
+      throw new Error("expected OpenAI realtime provider to support browser sessions");
+    }
+
+    await provider.createBrowserSession({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      tools: [
+        createRealtimeTool("1_lookup"),
+        createRealtimeTool("calendar.lookup:next"),
+        createMalformedToolName(undefined),
+        createUnreadableToolName(),
+      ],
+    });
+
+    const bodySession = requireRecord(requireFetchJsonBody().session, "fetch session");
+    const tools = bodySession.tools as Array<{ name?: string }>;
+    expect(tools.map((tool) => tool.name)).toEqual(["1_lookup"]);
   });
 
   it("resolves keychain OPENAI_API_KEY refs before creating browser sessions", async () => {
@@ -866,6 +924,40 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     );
   });
 
+  it("omits unsupported OpenAI tool names from GA session updates", async () => {
+    const provider = buildOpenAIRealtimeVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
+      tools: [
+        createRealtimeTool("1_lookup"),
+        createRealtimeTool("calendar.lookup:next"),
+        createRealtimeTool("bad/name"),
+        createRealtimeTool("x".repeat(65)),
+        createMalformedToolName(null),
+        createMalformedToolName(42),
+        createUnreadableToolName(),
+      ],
+      onAudio: vi.fn(),
+      onClearAudio: vi.fn(),
+    });
+    const connecting = bridge.connect();
+    const socket = FakeWebSocket.instances[0];
+    if (!socket) {
+      throw new Error("expected bridge to create a websocket");
+    }
+
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.emit("open");
+
+    const tools = requireSession(socket).tools as Array<{ name?: string }>;
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "1_lookup",
+      "x".repeat(65),
+    ]);
+    socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
+    await connecting;
+  });
+
   it("rotates realtime bridges on provider max-duration events without reporting an error", async () => {
     vi.useFakeTimers();
     const provider = buildOpenAIRealtimeVoiceProvider();
@@ -953,6 +1045,11 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
       },
       audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
       instructions: "Be helpful.",
+      tools: [
+        createRealtimeTool("1_lookup"),
+        createRealtimeTool("calendar.lookup:next"),
+        createRealtimeTool("x".repeat(65)),
+      ],
       onAudio: vi.fn(),
       onClearAudio: vi.fn(),
     });
@@ -989,6 +1086,8 @@ describe("buildOpenAIRealtimeVoiceProvider", () => {
     );
     expect(session).not.toHaveProperty("type");
     expect(session).not.toHaveProperty("audio");
+    const tools = session.tools as Array<{ name?: string }>;
+    expect(tools.map((tool) => tool.name)).toEqual(["1_lookup"]);
 
     socket.emit("message", Buffer.from(JSON.stringify({ type: "session.updated" })));
     await connecting;

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -23,6 +23,7 @@ import type {
   RealtimeVoiceTool,
   RealtimeVoiceToolResultOptions,
 } from "openclaw/plugin-sdk/realtime-voice";
+import { warn } from "openclaw/plugin-sdk/runtime-env";
 import {
   REALTIME_VOICE_AUDIO_FORMAT_G711_ULAW_8KHZ,
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
@@ -93,6 +94,10 @@ const OPENAI_REALTIME_NO_ACTIVE_RESPONSE_CANCEL_ERROR =
   "Cancellation failed: no active response found";
 const OPENAI_REALTIME_MAX_SESSION_DURATION_FRAGMENT = "maximum duration";
 const OPENAI_REALTIME_DEFAULT_MIN_BARGE_IN_AUDIO_END_MS = 250;
+// Realtime validates this character set but accepts names beyond the 64-character
+// cap used by other OpenAI tool surfaces.
+const OPENAI_REALTIME_TOOL_NAME_RE = /^[A-Za-z0-9_-]+$/;
+const AZURE_OPENAI_REALTIME_TOOL_NAME_MAX_LENGTH = 64;
 const OPENAI_REALTIME_VOICES = [
   "alloy",
   "ash",
@@ -334,6 +339,40 @@ function hasOpenAIRealtimeApiKeyInput(configuredApiKey: string | undefined): boo
     normalizeSecretInputString(configuredApiKey) ??
     normalizeSecretInputString(process.env.OPENAI_API_KEY),
   );
+}
+
+function normalizeOpenAIRealtimeTools(
+  tools: RealtimeVoiceTool[] | undefined,
+  maxNameLength?: number,
+): RealtimeVoiceTool[] | undefined {
+  const normalized: RealtimeVoiceTool[] = [];
+  let omitted = 0;
+  for (const tool of tools ?? []) {
+    try {
+      const name = tool.name;
+      if (typeof name !== "string") {
+        omitted += 1;
+        continue;
+      }
+      const exceedsLengthLimit = maxNameLength !== undefined && name.length > maxNameLength;
+      if (exceedsLengthLimit || !OPENAI_REALTIME_TOOL_NAME_RE.test(name)) {
+        omitted += 1;
+        continue;
+      }
+      normalized.push({
+        type: "function",
+        name,
+        description: tool.description,
+        parameters: tool.parameters,
+      });
+    } catch {
+      omitted += 1;
+    }
+  }
+  if (omitted > 0) {
+    warn(`openai realtime: omitted ${omitted} tool definition(s) with unsupported names`);
+  }
+  return normalized.length > 0 ? normalized : undefined;
 }
 
 async function resolveOpenAIRealtimePlatformApiKey(params: {
@@ -846,6 +885,7 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
 
   private buildGaSessionUpdate(): RealtimeGaSessionUpdate {
     const cfg = this.config;
+    const tools = normalizeOpenAIRealtimeTools(cfg.tools);
     return {
       type: "session.update",
       session: {
@@ -866,9 +906,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
           },
         },
         ...(cfg.reasoningEffort ? { reasoning: { effort: cfg.reasoningEffort } } : {}),
-        ...(cfg.tools && cfg.tools.length > 0
+        ...(tools
           ? {
-              tools: cfg.tools,
+              tools,
               tool_choice: "auto",
             }
           : {}),
@@ -883,6 +923,10 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
   private buildAzureDeploymentSessionUpdate(): RealtimeAzureDeploymentSessionUpdate {
     const cfg = this.config;
     const format = this.resolveLegacyRealtimeAudioFormat();
+    const tools = normalizeOpenAIRealtimeTools(
+      cfg.tools,
+      AZURE_OPENAI_REALTIME_TOOL_NAME_MAX_LENGTH,
+    );
     return {
       type: "session.update",
       session: {
@@ -894,9 +938,9 @@ class OpenAIRealtimeVoiceBridge implements RealtimeVoiceBridge {
         input_audio_transcription: { model: "whisper-1" },
         turn_detection: this.buildTurnDetectionConfig(),
         temperature: cfg.temperature ?? 0.8,
-        ...(cfg.tools && cfg.tools.length > 0
+        ...(tools
           ? {
-              tools: cfg.tools,
+              tools,
               tool_choice: "auto",
             }
           : {}),
@@ -1399,6 +1443,7 @@ async function createOpenAIRealtimeBrowserSession(
     cfg: req.cfg,
   });
   const voice = normalizeOpenAIRealtimeVoice(req.voice) ?? config.voice ?? "alloy";
+  const tools = normalizeOpenAIRealtimeTools(req.tools);
   const session: Record<string, unknown> = {
     type: "realtime",
     model,
@@ -1425,8 +1470,8 @@ async function createOpenAIRealtimeBrowserSession(
       output: { voice },
     },
   };
-  if (req.tools && req.tools.length > 0) {
-    session.tools = req.tools;
+  if (tools) {
+    session.tools = tools;
     session.tool_choice = "auto";
   }
   const reasoningEffort = trimToUndefined(req.reasoningEffort) ?? config.reasoningEffort;

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -989,6 +989,9 @@ describe("buildQaRuntimeEnv", () => {
         child.signalCode = "SIGKILL";
         queueMicrotask(() => child.emit("exit"));
       }
+      if (signal === 0 && child.signalCode) {
+        throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+      }
       return true;
     });
 
@@ -1009,6 +1012,26 @@ describe("buildQaRuntimeEnv", () => {
     }
     expect([child.exitCode, child.signalCode]).not.toEqual([null, null]);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "fails closed when forced gateway process-group shutdown times out",
+    async () => {
+      const child = Object.assign(new EventEmitter(), {
+        pid: 12345,
+        exitCode: null as number | null,
+        signalCode: null as string | null,
+        kill: vi.fn(() => true),
+      });
+      vi.spyOn(process, "kill").mockImplementation(() => true);
+
+      await expect(
+        testing.stopQaGatewayChildProcessTree(child as never, {
+          gracefulTimeoutMs: 1,
+          forceTimeoutMs: 1,
+        }),
+      ).rejects.toThrow("qa gateway process tree remained alive after forced shutdown");
+    },
+  );
 
   it("force-kills Windows gateway process trees when graceful taskkill fails", () => {
     const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -413,11 +413,11 @@ function isQaGatewayChildProcessTreeAlive(child: ChildProcess) {
     process.kill(-child.pid, 0);
     return true;
   } catch (error) {
-    if (isProcessAlreadyExitedError(error)) {
-      return false;
+    if (!isProcessAlreadyExitedError(error) && !hasChildExited(child)) {
+      return true;
     }
-    return !hasChildExited(child);
   }
+  return false;
 }
 
 type QaGatewayTaskkillRunner = typeof spawnSync;
@@ -498,7 +498,10 @@ async function stopQaGatewayChildProcessTree(
     return;
   }
   signalQaGatewayChildProcessTree(child, "SIGKILL");
-  await waitForQaGatewayChildExit(child, opts?.forceTimeoutMs ?? 2_000);
+  const stopped = await waitForQaGatewayChildExit(child, opts?.forceTimeoutMs ?? 2_000);
+  if (!stopped) {
+    throw new Error("qa gateway process tree remained alive after forced shutdown");
+  }
 }
 
 function isQaModelProviderConfig(value: unknown): value is ModelProviderConfig {

--- a/extensions/qa-lab/src/gateway-log-sentinel.test.ts
+++ b/extensions/qa-lab/src/gateway-log-sentinel.test.ts
@@ -2,12 +2,20 @@
 import { describe, expect, it } from "vitest";
 import {
   assertNoGatewayLogSentinels,
+  extractGatewayMessageText,
   formatGatewayLogSentinelSummary,
   scanDirectReplyTranscriptSentinels,
   scanGatewayLogSentinels,
 } from "./gateway-log-sentinel.js";
 
 describe("gateway log sentinels", () => {
+  it.each([
+    [{ content: [{ type: "toolResult", content: "codex output" }] }, "codex output"],
+    [{ content: [{ type: "text", text: "standard output" }] }, "standard output"],
+  ])("extracts message text from tool result shapes", (message, expected) => {
+    expect(extractGatewayMessageText(message)).toBe(expected);
+  });
+
   it("classifies May 13 beta.5 operational failure signatures", () => {
     const findings = scanGatewayLogSentinels(
       [

--- a/extensions/qa-lab/src/gateway-log-sentinel.ts
+++ b/extensions/qa-lab/src/gateway-log-sentinel.ts
@@ -169,9 +169,13 @@ export function extractGatewayMessageText(message: Record<string, unknown>) {
       continue;
     }
     const nestedText = readNonEmptyString(block.content);
+    const normalizedType = readNonEmptyString(block.type)?.toLowerCase().replace(/_/g, "");
     if (
       nestedText &&
-      (block.type === "output_text" || block.type === "text" || block.type === "message")
+      (normalizedType === "outputtext" ||
+        normalizedType === "text" ||
+        normalizedType === "message" ||
+        normalizedType === "toolresult")
     ) {
       parts.push(nestedText);
     }

--- a/extensions/qa-lab/src/live-transports/shared/live-gateway.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-gateway.runtime.test.ts
@@ -268,4 +268,44 @@ describe("startQaLiveLaneGateway", () => {
       "failed to stop QA live lane resources:\ngateway stop failed: gateway down\nmock provider stop failed: mock down",
     );
   });
+
+  it("retries only mock cleanup after gateway preservation succeeds", async () => {
+    mockStop.mockRejectedValueOnce(new Error("mock down"));
+    const harness = await startQaLiveLaneGateway({
+      repoRoot: "/tmp/openclaw-repo",
+      transport: createStubTransport(),
+      transportBaseUrl: "http://127.0.0.1:43123",
+      providerMode: "mock-openai",
+      primaryModel: "mock-openai/gpt-5.5",
+      alternateModel: "mock-openai/gpt-5.5-alt",
+      controlUiEnabled: false,
+    });
+    const stopOptions = { preserveToDir: ".artifacts/qa-e2e/debug" };
+
+    await expect(harness.stop(stopOptions)).rejects.toThrow("mock provider stop failed: mock down");
+    await expect(harness.stop(stopOptions)).resolves.toBeUndefined();
+
+    expect(gatewayStop).toHaveBeenCalledTimes(1);
+    expect(gatewayStop).toHaveBeenCalledWith(stopOptions);
+    expect(mockStop).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries only gateway cleanup after mock shutdown succeeds", async () => {
+    gatewayStop.mockRejectedValueOnce(new Error("gateway down"));
+    const harness = await startQaLiveLaneGateway({
+      repoRoot: "/tmp/openclaw-repo",
+      transport: createStubTransport(),
+      transportBaseUrl: "http://127.0.0.1:43123",
+      providerMode: "mock-openai",
+      primaryModel: "mock-openai/gpt-5.5",
+      alternateModel: "mock-openai/gpt-5.5-alt",
+      controlUiEnabled: false,
+    });
+
+    await expect(harness.stop()).rejects.toThrow("gateway stop failed: gateway down");
+    await expect(harness.stop()).resolves.toBeUndefined();
+
+    expect(gatewayStop).toHaveBeenCalledTimes(2);
+    expect(mockStop).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/qa-lab/src/live-transports/shared/live-gateway.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/shared/live-gateway.runtime.ts
@@ -12,20 +12,24 @@ import { appendQaLiveLaneIssue as appendLiveLaneIssue } from "./live-artifacts.j
 
 async function stopQaLiveLaneResources(
   resources: {
-    gateway: Awaited<ReturnType<typeof startQaGatewayChild>>;
+    gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | null;
     mock: { baseUrl: string; stop(): Promise<void> } | null;
   },
   opts?: { keepTemp?: boolean; preserveToDir?: string },
 ) {
   const errors: string[] = [];
-  try {
-    await resources.gateway.stop(opts);
-  } catch (error) {
-    appendLiveLaneIssue(errors, "gateway stop failed", error);
+  if (resources.gateway) {
+    try {
+      await resources.gateway.stop(opts);
+      resources.gateway = null;
+    } catch (error) {
+      appendLiveLaneIssue(errors, "gateway stop failed", error);
+    }
   }
   if (resources.mock) {
     try {
       await resources.mock.stop();
+      resources.mock = null;
     } catch (error) {
       appendLiveLaneIssue(errors, "mock provider stop failed", error);
     }
@@ -122,11 +126,12 @@ export async function startQaLiveLaneGateway(params: {
       mutateConfig: (cfg) =>
         prepareLiveTransportGatewayConfig(params.mutateConfig ? params.mutateConfig(cfg) : cfg),
     });
+    const resources = { gateway, mock };
     return {
       gateway,
       mock,
       async stop(opts?: { keepTemp?: boolean; preserveToDir?: string }) {
-        await stopQaLiveLaneResources({ gateway, mock }, opts);
+        await stopQaLiveLaneResources(resources, opts);
       },
     };
   } catch (error) {

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -38,6 +38,11 @@ describe("Slack live QA runtime helpers", () => {
     ).toThrow("OPENCLAW_QA_SLACK channelId must be a Slack id like C123 or U123.");
   });
 
+  it("canonicalizes the SUT account before config and approval routing", () => {
+    expect(testing.resolveSlackQaSutAccountId(" QA-SUT ")).toBe("qa-sut");
+    expect(testing.resolveSlackQaSutAccountId()).toBe("sut");
+  });
+
   it("parses Convex credential payloads", () => {
     expect(
       testing.parseSlackQaCredentialPayload({
@@ -75,10 +80,47 @@ describe("Slack live QA runtime helpers", () => {
   it("selects native approval scenarios by id without changing standard scenario coverage", () => {
     expect(
       testing
-        .findScenario(["slack-approval-exec-native", "slack-approval-plugin-native"])
+        .findScenario([
+          "slack-approval-exec-native",
+          "slack-approval-plugin-native",
+          "slack-codex-approval-exec-native",
+          "slack-codex-approval-plugin-native",
+        ])
         .map((scenario) => scenario.id),
-    ).toEqual(["slack-approval-exec-native", "slack-approval-plugin-native"]);
+    ).toEqual([
+      "slack-approval-exec-native",
+      "slack-approval-plugin-native",
+      "slack-codex-approval-exec-native",
+      "slack-codex-approval-plugin-native",
+    ]);
     expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain("slack-approval-exec-native");
+    expect(testing.SLACK_QA_STANDARD_SCENARIO_IDS).not.toContain(
+      "slack-codex-approval-exec-native",
+    );
+  });
+
+  it("accepts only Codex harness providers for Codex approval scenarios", () => {
+    expect(() => testing.assertSlackCodexApprovalModelSupported("openai/gpt-5.5")).not.toThrow();
+    expect(() => testing.assertSlackCodexApprovalModelSupported("codex/gpt-5.5")).not.toThrow();
+    expect(() =>
+      testing.assertSlackCodexApprovalModelSupported("anthropic/claude-sonnet-4-6"),
+    ).toThrow(
+      'Slack Codex approval scenarios require an openai/* or codex/* model; received "anthropic/claude-sonnet-4-6".',
+    );
+  });
+
+  it("rejects an incompatible Codex approval model before credential acquisition", async () => {
+    const outputDir = await fs.mkdtemp(path.join(tmpdir(), "openclaw-slack-codex-model-"));
+    await expect(
+      runSlackQaLive({
+        credentialSource: "convex",
+        outputDir,
+        primaryModel: "anthropic/claude-sonnet-4-6",
+        scenarioIds: ["slack-codex-approval-exec-native"],
+      }),
+    ).rejects.toThrow(
+      'Slack Codex approval scenarios require an openai/* or codex/* model; received "anthropic/claude-sonnet-4-6".',
+    );
   });
 
   it("enables Slack native exec and plugin approval delivery for approval scenarios", () => {
@@ -110,6 +152,58 @@ describe("Slack live QA runtime helpers", () => {
       target: "channel",
     });
     expect(account?.channels?.C123456789?.users).toEqual(["U999999999"]);
+  });
+
+  it("enables Codex guardian runtime and native plugin approval delivery for Codex approval scenarios", () => {
+    const cfg = testing.buildSlackQaConfig(
+      {
+        agents: {
+          defaults: {},
+          list: [
+            {
+              id: "qa",
+              model: { primary: "openai/gpt-5.5" },
+            },
+          ],
+        },
+      },
+      {
+        channelId: "C123456789",
+        driverBotUserId: "U999999999",
+        overrides: {
+          approvals: {
+            exec: true,
+            plugin: true,
+            target: "channel",
+          },
+          codexApproval: true,
+        },
+        primaryModel: "openai/gpt-5.5",
+        sutAccountId: "sut",
+        sutAppToken: "xapp-sut",
+        sutBotToken: "xoxb-sut",
+      },
+    );
+
+    expect(cfg.plugins?.allow).toEqual(["slack", "codex"]);
+    expect(cfg.plugins?.entries?.codex).toEqual({
+      enabled: true,
+      config: {
+        appServer: {
+          mode: "guardian",
+        },
+      },
+    });
+    expect(cfg.tools?.exec?.mode).toBe("ask");
+    expect(cfg.agents?.defaults?.models?.["openai/gpt-5.5"]?.agentRuntime).toEqual({
+      id: "codex",
+    });
+    expect(cfg.approvals?.plugin).toEqual({ enabled: true, mode: "session" });
+    expect(cfg.channels?.slack?.accounts?.sut?.execApprovals).toEqual({
+      enabled: true,
+      approvers: ["U999999999"],
+      target: "channel",
+    });
   });
 
   it("overrides both owner and channel allowlists for block scenarios", () => {
@@ -148,6 +242,230 @@ describe("Slack live QA runtime helpers", () => {
         },
       ]),
     ).toEqual(["/approve plugin:abc allow-once"]);
+  });
+
+  it("extracts plugin approval ids from native Slack approval action values", () => {
+    expect(
+      testing.extractSlackNativeApprovalId({
+        actionValues: ["/approve plugin:abc123 allow-once", "/approve plugin:abc123 deny"],
+        decision: "allow-once",
+      }),
+    ).toBe("plugin:abc123");
+  });
+
+  it("builds Codex approval instructions for command and file-change routes", () => {
+    expect(
+      testing.buildCodexApprovalInstruction({
+        appServerMethod: "item/commandExecution/requestApproval",
+        token: "SLACK_QA_CODEX_EXEC_APPROVAL_ABC123",
+      }),
+    ).toContain("Use the shell tool exactly once");
+    expect(
+      testing.buildCodexApprovalInstruction({
+        appServerMethod: "item/fileChange/requestApproval",
+        token: "SLACK_QA_CODEX_FILE_APPROVAL_ABC123",
+      }),
+    ).toContain("Do not ask for approval in chat");
+    expect(testing.resolveCodexFileApprovalTargetPath("MARKER")).toMatch(
+      /\.openclaw-qa-codex-file-approval-marker\.txt$/u,
+    );
+  });
+
+  it("reads the accepted asynchronous Gateway agent run id", () => {
+    expect(
+      testing.readAcceptedAgentRunId({
+        runId: "run-123",
+        status: "accepted",
+      }),
+    ).toBe("run-123");
+    expect(() =>
+      testing.readAcceptedAgentRunId({
+        runId: "run-123",
+        status: "started",
+      }),
+    ).toThrow("instead of accepted");
+  });
+
+  it("requires the Codex command transcript to prove the approved operation", () => {
+    const run = {
+      approvalKind: "plugin" as const,
+      appServerMethod: "item/commandExecution/requestApproval" as const,
+      decision: "allow-once" as const,
+      kind: "codex-approval" as const,
+      token: "SLACK_QA_CODEX_EXEC_APPROVAL_ABC123",
+    };
+    expect(() =>
+      testing.assertCodexApprovalTranscriptSucceeded(
+        [
+          {
+            role: "toolResult",
+            isError: false,
+            content: [
+              {
+                type: "toolResult",
+                content: "SLACK_QA_CODEX_EXEC_APPROVAL_ABC123",
+              },
+            ],
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "SLACK_QA_CODEX_EXEC_APPROVAL_ABC123" }],
+          },
+        ],
+        run,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      testing.assertCodexApprovalTranscriptSucceeded(
+        [
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "SLACK_QA_CODEX_EXEC_APPROVAL_ABC123" }],
+          },
+        ],
+        run,
+      ),
+    ).toThrow("Codex command result did not contain marker");
+  });
+
+  it("aborts, awaits terminal cleanup, and stops the gateway process tree before cleanup", async () => {
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce({ aborted: true, runIds: ["run-123"] })
+      .mockResolvedValueOnce({ endedAt: 123, runId: "run-123", status: "ok" });
+    const stopGateway = vi.fn();
+
+    await testing.quiesceCodexApprovalAgentRun({
+      context: { gateway: { call } } as never,
+      preserveDebugArtifacts: false,
+      runId: "run-123",
+      sessionKey: "agent:qa:approval",
+      stopGateway,
+    });
+
+    expect(call).toHaveBeenNthCalledWith(
+      1,
+      "chat.abort",
+      { runId: "run-123", sessionKey: "agent:qa:approval" },
+      { timeoutMs: 10_000 },
+    );
+    expect(call).toHaveBeenNthCalledWith(
+      2,
+      "agent.wait",
+      { runId: "run-123", timeoutMs: 10_000 },
+      { timeoutMs: 15_000 },
+    );
+    expect(stopGateway).toHaveBeenCalledWith(false);
+  });
+
+  it("preserves debug artifacts when abort and terminal acknowledgements fail", async () => {
+    const call = vi.fn().mockRejectedValue(new Error("gateway unavailable"));
+    const stopGateway = vi.fn();
+
+    await testing.quiesceCodexApprovalAgentRun({
+      context: { gateway: { call } } as never,
+      preserveDebugArtifacts: true,
+      runId: "run-123",
+      sessionKey: "agent:qa:approval",
+      stopGateway,
+    });
+
+    expect(stopGateway).toHaveBeenCalledWith(true);
+  });
+
+  it("matches pending Codex plugin approvals by id, route, and Slack turn source", () => {
+    expect(
+      testing.findPendingCodexPluginApprovalRecord({
+        approvalId: "plugin:abc123",
+        appServerMethod: "item/fileChange/requestApproval",
+        channelId: "C123456789",
+        records: [
+          {
+            id: "plugin:abc123",
+            request: {
+              pluginId: "openclaw-codex-app-server",
+              title: "Codex app-server file approval",
+              toolName: "codex_file_approval",
+              sessionKey: "agent:qa:slack-codex-approval-plugin-native-token",
+              turnSourceChannel: "slack",
+              turnSourceTo: "channel:C123456789",
+              turnSourceAccountId: "sut",
+            },
+          },
+        ],
+        sessionKey: "agent:qa:slack-codex-approval-plugin-native-token",
+        sutAccountId: "sut",
+      }),
+    ).toBeDefined();
+    expect(
+      testing.findPendingCodexPluginApprovalRecord({
+        approvalId: "plugin:abc123",
+        appServerMethod: "item/commandExecution/requestApproval",
+        channelId: "C123456789",
+        records: [
+          {
+            id: "plugin:abc123",
+            request: {
+              pluginId: "openclaw-codex-app-server",
+              title: "Codex app-server file approval",
+              toolName: "codex_file_approval",
+              sessionKey: "agent:qa:slack-codex-approval-plugin-native-token",
+              turnSourceChannel: "slack",
+              turnSourceTo: "channel:C123456789",
+              turnSourceAccountId: "sut",
+            },
+          },
+        ],
+        sessionKey: "agent:qa:slack-codex-approval-plugin-native-token",
+        sutAccountId: "sut",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("matches resolved Codex approvals without pending-only marker text", () => {
+    expect(
+      testing.matchesSlackApprovalResolvedUpdate({
+        actionValues: [],
+        approvalKind: "plugin",
+        decision: "allow-once",
+        extraTextMatches: ["openclaw-codex-app-server", "Codex app-server file approval"],
+        text: [
+          "Plugin approval: Allowed once",
+          "Codex app-server file approval",
+          "Plugin: openclaw-codex-app-server",
+        ].join("\n"),
+      }),
+    ).toBe(true);
+    expect(
+      testing.matchesSlackApprovalResolvedUpdate({
+        actionValues: ["/approve plugin:abc allow-once"],
+        approvalKind: "plugin",
+        decision: "allow-once",
+        extraTextMatches: ["Codex app-server file approval"],
+        text: "Plugin approval: Allowed once\nCodex app-server file approval",
+      }),
+    ).toBe(false);
+  });
+
+  it("matches pending Codex approvals by stable renderer fields without marker text", () => {
+    expect(
+      testing.matchesSlackApprovalPromptText({
+        approvalKind: "plugin",
+        extraTextMatches: ["openclaw-codex-app-server", "Codex app-server command approval"],
+        text: [
+          "Plugin approval required",
+          "Codex app-server command approval",
+          "Plugin: openclaw-codex-app-server",
+        ].join("\n"),
+      }),
+    ).toBe(true);
+    expect(
+      testing.matchesSlackApprovalPromptText({
+        approvalKind: "plugin",
+        extraTextMatches: ["Codex app-server file approval"],
+        text: "Plugin approval required\nCodex app-server command approval",
+      }),
+    ).toBe(false);
   });
 
   it("builds approval checkpoint message evidence from Slack blocks", () => {
@@ -340,8 +658,12 @@ describe("Slack live QA runtime helpers", () => {
     ).toEqual({
       approvalId: "<redacted>",
       approvalKind: "plugin",
+      appServerMethod: undefined,
       channelId: undefined,
+      codexModelKey: undefined,
       decision: "allow-once",
+      finalCodexTurnStatus: undefined,
+      operationVerified: undefined,
       pendingActionValues: undefined,
       pendingCheckpointPath: undefined,
       pendingMessageTs: undefined,
@@ -351,6 +673,54 @@ describe("Slack live QA runtime helpers", () => {
       resolvedCheckpointPath: undefined,
       resolvedMessageTs: undefined,
       resolvedScreenshotPath: undefined,
+      resolvedText: undefined,
+      threadTs: undefined,
+    });
+  });
+
+  it("keeps Codex approval route metadata while redacting Slack metadata", () => {
+    expect(
+      testing.toSlackQaScenarioArtifactResults({
+        includeContent: false,
+        redactMetadata: true,
+        scenarios: [
+          {
+            approval: {
+              approvalId: "plugin:abc",
+              approvalKind: "plugin",
+              appServerMethod: "item/fileChange/requestApproval",
+              channelId: "C123456789",
+              codexModelKey: "openai/gpt-5.5",
+              decision: "allow-once",
+              finalCodexTurnStatus: "ok",
+              operationVerified: true,
+              pendingActionValues: ["/approve plugin:abc allow-once"],
+              pendingMessageTs: "1.000000",
+              pendingText: "Plugin approval required",
+              resolvedActionValues: [],
+              resolvedMessageTs: "1.000000",
+              resolvedText: "Plugin approval: Allowed once",
+              threadTs: "1.000000",
+            },
+            details: "codex plugin approval resolved",
+            id: "slack-codex-approval-plugin-native",
+            status: "pass",
+            title: "Slack native Codex file approval prompt resolves",
+          },
+        ],
+      })[0]?.approval,
+    ).toMatchObject({
+      approvalId: "<redacted>",
+      appServerMethod: "item/fileChange/requestApproval",
+      channelId: undefined,
+      codexModelKey: "openai/gpt-5.5",
+      finalCodexTurnStatus: "ok",
+      operationVerified: true,
+      pendingActionValues: undefined,
+      pendingMessageTs: undefined,
+      pendingText: undefined,
+      resolvedActionValues: undefined,
+      resolvedMessageTs: undefined,
       resolvedText: undefined,
       threadTs: undefined,
     });

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.ts
@@ -1,9 +1,11 @@
 // Qa Lab plugin module implements slack live behavior.
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { createSlackWebClient, createSlackWriteClient } from "@openclaw/slack/api.js";
 import type { WebClient } from "@slack/web-api";
+import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
@@ -12,7 +14,9 @@ import { z } from "zod";
 import { createQaArtifactRunId } from "../../artifact-run-id.js";
 import { QA_EVIDENCE_FILENAME, buildLiveTransportEvidenceSummary } from "../../evidence-summary.js";
 import { startQaGatewayChild } from "../../gateway-child.js";
+import { extractGatewayMessageText } from "../../gateway-log-sentinel.js";
 import { isTruthyOptIn } from "../../mantis-options.runtime.js";
+import { splitQaModelRef } from "../../model-selection.js";
 import { DEFAULT_QA_LIVE_PROVIDER_MODE } from "../../providers/index.js";
 import {
   defaultQaModelForMode,
@@ -64,12 +68,16 @@ const SLACK_QA_GATEWAY_STOP_SETTLE_MS = 3_000;
 const SLACK_QA_RETRYABLE_SCENARIO_ATTEMPTS = 2;
 const SLACK_QA_APPROVAL_DECISION_TIMEOUT_MS = 30_000;
 const SLACK_QA_APPROVAL_CHECKPOINT_DEFAULT_TIMEOUT_MS = 120_000;
+// These scenarios force the Codex harness, whose default provider set is intentionally narrow.
+const SLACK_QA_CODEX_PROVIDER_IDS = new Set(["codex", "openai"]);
 
 type SlackQaScenarioId =
   | "slack-allowlist-block"
   | "slack-approval-exec-native"
   | "slack-approval-plugin-native"
   | "slack-canary"
+  | "slack-codex-approval-exec-native"
+  | "slack-codex-approval-plugin-native"
   | "slack-mention-gating"
   | "slack-restart-resume"
   | "slack-thread-follow-up"
@@ -78,6 +86,23 @@ type SlackQaScenarioId =
 
 type SlackQaApprovalKind = "exec" | "plugin";
 type SlackQaApprovalDecision = "allow-always" | "allow-once" | "deny";
+type SlackQaCodexApprovalMethod =
+  | "item/commandExecution/requestApproval"
+  | "item/fileChange/requestApproval";
+
+function assertSlackCodexApprovalModelSupported(modelRef: string) {
+  const provider = splitQaModelRef(modelRef)?.provider.trim().toLowerCase();
+  if (provider && SLACK_QA_CODEX_PROVIDER_IDS.has(provider)) {
+    return;
+  }
+  throw new Error(
+    `Slack Codex approval scenarios require an openai/* or codex/* model; received "${modelRef}".`,
+  );
+}
+
+function resolveSlackQaSutAccountId(value?: string) {
+  return normalizeAccountId(value?.trim() || "sut");
+}
 
 type SlackQaMessageScenarioRun = {
   kind?: "message";
@@ -96,7 +121,18 @@ type SlackQaApprovalScenarioRun = {
   token: string;
 };
 
-type SlackQaScenarioRun = SlackQaApprovalScenarioRun | SlackQaMessageScenarioRun;
+type SlackQaCodexApprovalScenarioRun = {
+  approvalKind: "plugin";
+  appServerMethod: SlackQaCodexApprovalMethod;
+  decision: "allow-once";
+  kind: "codex-approval";
+  token: string;
+};
+
+type SlackQaScenarioRun =
+  | SlackQaApprovalScenarioRun
+  | SlackQaCodexApprovalScenarioRun
+  | SlackQaMessageScenarioRun;
 
 type SlackQaBeforeRunResult =
   | string
@@ -113,6 +149,7 @@ type SlackQaConfigOverrides = {
     plugin?: boolean;
     target?: "both" | "channel" | "dm";
   };
+  codexApproval?: boolean;
   replyToMode?: "all" | "off";
   users?: string[];
 };
@@ -181,8 +218,12 @@ type SlackObservedMessageArtifact = {
 type SlackApprovalArtifact = {
   approvalId: string;
   approvalKind: SlackQaApprovalKind;
+  appServerMethod?: SlackQaCodexApprovalMethod;
   channelId?: string;
+  codexModelKey?: string;
   decision: SlackQaApprovalDecision;
+  finalCodexTurnStatus?: string;
+  operationVerified?: boolean;
   pendingActionValues?: string[];
   pendingCheckpointPath?: string;
   pendingMessageTs?: string;
@@ -397,6 +438,46 @@ const SLACK_QA_SCENARIOS: SlackQaScenarioDefinition[] = [
     }),
   },
   {
+    id: "slack-codex-approval-exec-native",
+    title: "Slack native Codex command approval prompt resolves",
+    timeoutMs: 180_000,
+    configOverrides: {
+      approvals: {
+        exec: true,
+        plugin: true,
+        target: "channel",
+      },
+      codexApproval: true,
+    },
+    buildRun: () => ({
+      approvalKind: "plugin",
+      appServerMethod: "item/commandExecution/requestApproval",
+      decision: "allow-once",
+      kind: "codex-approval",
+      token: `SLACK_QA_CODEX_EXEC_APPROVAL_${randomUUID().slice(0, 8).toUpperCase()}`,
+    }),
+  },
+  {
+    id: "slack-codex-approval-plugin-native",
+    title: "Slack native Codex file approval prompt resolves",
+    timeoutMs: 180_000,
+    configOverrides: {
+      approvals: {
+        exec: true,
+        plugin: true,
+        target: "channel",
+      },
+      codexApproval: true,
+    },
+    buildRun: () => ({
+      approvalKind: "plugin",
+      appServerMethod: "item/fileChange/requestApproval",
+      decision: "allow-once",
+      kind: "codex-approval",
+      token: `SLACK_QA_CODEX_FILE_APPROVAL_${randomUUID().slice(0, 8).toUpperCase()}`,
+    }),
+  },
+  {
     id: "slack-restart-resume",
     standardId: "restart-resume",
     title: "Slack replies after gateway restart",
@@ -558,19 +639,35 @@ function findScenario(ids?: string[]) {
   });
 }
 
+function asPlainRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
 function buildSlackQaConfig(
   baseCfg: OpenClawConfig,
   params: {
     channelId: string;
     driverBotUserId: string;
     overrides?: SlackQaConfigOverrides;
+    primaryModel?: string;
     sutAccountId: string;
     sutAppToken: string;
     sutBotToken: string;
   },
 ): OpenClawConfig {
-  const pluginAllow = uniqueStrings([...(baseCfg.plugins?.allow ?? []), "slack"]);
+  const codexApprovalConfig = params.overrides?.codexApproval === true;
+  const primaryModel = params.primaryModel;
+  const pluginAllow = uniqueStrings([
+    ...(baseCfg.plugins?.allow ?? []),
+    "slack",
+    ...(codexApprovalConfig ? ["codex"] : []),
+  ]);
   const approvalOverrides = params.overrides?.approvals;
+  const codexEntry = baseCfg.plugins?.entries?.codex;
+  const codexEntryConfig = asPlainRecord(codexEntry?.config);
+  const codexAppServerConfig = asPlainRecord(codexEntryConfig.appServer);
   const approvalForwardingConfig =
     approvalOverrides?.exec || approvalOverrides?.plugin
       ? {
@@ -597,6 +694,19 @@ function buildSlackQaConfig(
           },
         }
       : {};
+  const codexAgentDefaults =
+    codexApprovalConfig && primaryModel
+      ? {
+          ...baseCfg.agents?.defaults,
+          models: {
+            ...baseCfg.agents?.defaults?.models,
+            [primaryModel]: {
+              ...baseCfg.agents?.defaults?.models?.[primaryModel],
+              agentRuntime: { id: "codex" as const },
+            },
+          },
+        }
+      : baseCfg.agents?.defaults;
   const execApprovalsConfig = approvalOverrides
     ? {
         enabled: true,
@@ -613,8 +723,38 @@ function buildSlackQaConfig(
       entries: {
         ...baseCfg.plugins?.entries,
         slack: { enabled: true },
+        ...(codexApprovalConfig
+          ? {
+              codex: {
+                ...codexEntry,
+                enabled: true,
+                config: {
+                  ...codexEntryConfig,
+                  appServer: {
+                    ...codexAppServerConfig,
+                    mode: "guardian" as const,
+                  },
+                },
+              },
+            }
+          : {}),
       },
     },
+    ...(codexApprovalConfig
+      ? {
+          agents: {
+            ...baseCfg.agents,
+            ...(codexAgentDefaults ? { defaults: codexAgentDefaults } : {}),
+          },
+          tools: {
+            ...baseCfg.tools,
+            exec: {
+              ...baseCfg.tools?.exec,
+              mode: "ask" as const,
+            },
+          },
+        }
+      : {}),
     messages: {
       ...baseCfg.messages,
       groupChat: {
@@ -796,15 +936,31 @@ function buildSlackApprovalCheckpointMessage(
 
 function hasSlackNativeApprovalActions(params: {
   actionValues: string[];
-  approvalId: string;
+  approvalId?: string;
   decision: SlackQaApprovalDecision;
 }) {
   return params.actionValues.some(
     (value) =>
       value.includes("/approve") &&
-      value.includes(params.approvalId) &&
+      (!params.approvalId || value.includes(params.approvalId)) &&
       value.includes(params.decision),
   );
+}
+
+function extractSlackNativeApprovalId(params: {
+  actionValues: string[];
+  decision: SlackQaApprovalDecision;
+}) {
+  for (const value of params.actionValues) {
+    if (!value.includes("/approve") || !value.includes(params.decision)) {
+      continue;
+    }
+    const match = value.match(/\b((?:exec|plugin):[^\s]+)/);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return undefined;
 }
 
 function isSutSlackMessage(message: SlackMessage, sutIdentity: SlackAuthIdentity) {
@@ -1012,7 +1168,7 @@ function pushObservedApprovalMessage(params: {
 }
 
 async function waitForSlackApprovalPrompt(params: {
-  approvalId: string;
+  approvalId?: string;
   approvalKind: SlackQaApprovalKind;
   channelId: string;
   client: WebClient;
@@ -1023,7 +1179,8 @@ async function waitForSlackApprovalPrompt(params: {
   scenarioTitle: string;
   sutIdentity: SlackAuthIdentity;
   timeoutMs: number;
-  token: string;
+  token?: string;
+  extraTextMatches?: string[];
 }) {
   const startedAt = Date.now();
   const seenObservedMessages = new Set<string>();
@@ -1040,17 +1197,19 @@ async function waitForSlackApprovalPrompt(params: {
       }
       const text = getSlackMessageSearchText(message);
       const actionValues = collectSlackActionValues(message.blocks);
-      const hasHeading = text.includes(
-        resolveApprovalHeading({ approvalKind: params.approvalKind, state: "pending" }),
-      );
-      const hasToken = text.includes(params.token);
+      const matchedScenario = matchesSlackApprovalPromptText({
+        approvalKind: params.approvalKind,
+        extraTextMatches: params.extraTextMatches,
+        text,
+        token: params.token,
+      });
       const observedKey = `${message.ts}:${message.text ?? ""}:${actionValues.join("|")}`;
-      if (hasHeading || hasToken || hasSlackNativeApprovalActions({ ...params, actionValues })) {
+      if (matchedScenario || hasSlackNativeApprovalActions({ ...params, actionValues })) {
         if (!seenObservedMessages.has(observedKey)) {
           seenObservedMessages.add(observedKey);
           pushObservedApprovalMessage({
             channelId: params.channelId,
-            matchedScenario: hasHeading && hasToken,
+            matchedScenario,
             message,
             observedMessages: params.observedMessages,
             scenarioId: params.scenarioId,
@@ -1058,7 +1217,7 @@ async function waitForSlackApprovalPrompt(params: {
           });
         }
       }
-      if (!hasHeading || !hasToken) {
+      if (!matchedScenario) {
         continue;
       }
       if (
@@ -1073,6 +1232,12 @@ async function waitForSlackApprovalPrompt(params: {
       }
       return {
         actionValues,
+        approvalId:
+          params.approvalId ??
+          extractSlackNativeApprovalId({
+            actionValues,
+            decision: params.decision,
+          }),
         message,
         observedAt: new Date().toISOString(),
       };
@@ -1091,6 +1256,21 @@ async function waitForSlackApprovalPrompt(params: {
   );
 }
 
+function matchesSlackApprovalPromptText(params: {
+  approvalKind: SlackQaApprovalKind;
+  extraTextMatches?: string[];
+  text: string;
+  token?: string;
+}) {
+  return (
+    params.text.includes(
+      resolveApprovalHeading({ approvalKind: params.approvalKind, state: "pending" }),
+    ) &&
+    (!params.token || params.text.includes(params.token)) &&
+    (params.extraTextMatches ?? []).every((match) => params.text.includes(match))
+  );
+}
+
 async function waitForSlackApprovalResolvedUpdate(params: {
   approvalKind: SlackQaApprovalKind;
   channelId: string;
@@ -1103,7 +1283,8 @@ async function waitForSlackApprovalResolvedUpdate(params: {
   scenarioTitle: string;
   sutIdentity: SlackAuthIdentity;
   timeoutMs: number;
-  token: string;
+  token?: string;
+  extraTextMatches?: string[];
 }) {
   const startedAt = Date.now();
   const seenObservedMessages = new Set<string>();
@@ -1117,29 +1298,27 @@ async function waitForSlackApprovalResolvedUpdate(params: {
     if (message && isSutSlackMessage(message, params.sutIdentity)) {
       const text = getSlackMessageSearchText(message);
       const actionValues = collectSlackActionValues(message.blocks);
+      const matchedScenario = matchesSlackApprovalResolvedUpdate({
+        actionValues,
+        approvalKind: params.approvalKind,
+        decision: params.decision,
+        extraTextMatches: params.extraTextMatches,
+        text,
+        token: params.token,
+      });
       const observedKey = `${message.ts}:${message.text ?? ""}:${actionValues.join("|")}`;
       if (!seenObservedMessages.has(observedKey)) {
         seenObservedMessages.add(observedKey);
         pushObservedApprovalMessage({
           channelId: params.channelId,
-          matchedScenario: text.includes(params.token),
+          matchedScenario,
           message,
           observedMessages: params.observedMessages,
           scenarioId: params.scenarioId,
           scenarioTitle: params.scenarioTitle,
         });
       }
-      if (
-        text.includes(
-          resolveApprovalHeading({
-            approvalKind: params.approvalKind,
-            decision: params.decision,
-            state: "resolved",
-          }),
-        ) &&
-        text.includes(params.token) &&
-        !actionValues.some((value) => value.includes("/approve"))
-      ) {
+      if (matchedScenario) {
         return {
           actionValues,
           message,
@@ -1153,6 +1332,28 @@ async function waitForSlackApprovalResolvedUpdate(params: {
   }
   throw new Error(
     `timed out after ${params.timeoutMs}ms waiting for Slack ${params.approvalKind} approval resolution update`,
+  );
+}
+
+function matchesSlackApprovalResolvedUpdate(params: {
+  actionValues: string[];
+  approvalKind: SlackQaApprovalKind;
+  decision: SlackQaApprovalDecision;
+  extraTextMatches?: string[];
+  text: string;
+  token?: string;
+}) {
+  return (
+    params.text.includes(
+      resolveApprovalHeading({
+        approvalKind: params.approvalKind,
+        decision: params.decision,
+        state: "resolved",
+      }),
+    ) &&
+    (!params.token || params.text.includes(params.token)) &&
+    (params.extraTextMatches ?? []).every((match) => params.text.includes(match)) &&
+    !params.actionValues.some((value) => value.includes("/approve"))
   );
 }
 
@@ -1458,6 +1659,470 @@ async function runSlackApprovalScenario(params: {
   };
 }
 
+function buildCodexApprovalInstruction(params: {
+  appServerMethod: SlackQaCodexApprovalMethod;
+  token: string;
+}) {
+  if (params.appServerMethod === "item/commandExecution/requestApproval") {
+    return [
+      "Slack QA Codex command approval scenario.",
+      `Marker: ${params.token}`,
+      "Use the shell tool exactly once and request approval before running it.",
+      `Run exactly: printf '${params.token}\\n'`,
+      `After the command succeeds, reply exactly ${params.token} and nothing else.`,
+    ].join("\n");
+  }
+  const targetPath = resolveCodexFileApprovalTargetPath(params.token);
+  return [
+    "Slack QA Codex file approval scenario.",
+    `Marker: ${params.token}`,
+    "Use apply_patch exactly once to create this file outside the workspace.",
+    `Target file: ${targetPath}`,
+    `File contents: ${params.token}`,
+    "Invoke apply_patch now. Do not ask for approval in chat; the harness will resolve the native tool approval.",
+    `After the file change succeeds, reply exactly ${params.token} and nothing else.`,
+  ].join("\n");
+}
+
+function readAcceptedAgentRunId(result: unknown) {
+  const started =
+    typeof result === "object" && result !== null
+      ? (result as { runId?: unknown; status?: unknown })
+      : null;
+  if (started?.status !== "accepted") {
+    throw new Error(
+      `Codex agent run status was ${formatApprovalResultValue(started?.status)} instead of accepted`,
+    );
+  }
+  if (typeof started.runId !== "string" || started.runId.trim().length === 0) {
+    throw new Error(`Codex agent run id was ${formatApprovalResultValue(started.runId)}`);
+  }
+  return started.runId;
+}
+
+function readAgentWaitStatus(result: unknown) {
+  if (typeof result !== "object" || result === null) {
+    return "unknown";
+  }
+  const status = (result as { status?: unknown }).status;
+  return typeof status === "string" && status.trim() ? status : "unknown";
+}
+
+function assertCodexApprovalTranscriptSucceeded(
+  messages: unknown,
+  run: SlackQaCodexApprovalScenarioRun,
+) {
+  const records = Array.isArray(messages) ? messages.map(asPlainRecord) : [];
+  const assistantReply = records
+    .toReversed()
+    .find((message) => message.role === "assistant" && extractGatewayMessageText(message));
+  if (!assistantReply || extractGatewayMessageText(assistantReply) !== run.token) {
+    throw new Error(`Codex approval run did not finish with assistant marker ${run.token}`);
+  }
+  if (run.appServerMethod !== "item/commandExecution/requestApproval") {
+    return;
+  }
+  const commandSucceeded = records.some((message) => {
+    if (message.role !== "toolResult" || message.isError === true) {
+      return false;
+    }
+    return extractGatewayMessageText(message)
+      .split(/\r?\n/u)
+      .some((line) => line.trim() === run.token);
+  });
+  if (!commandSucceeded) {
+    throw new Error(`Codex command result did not contain marker ${run.token}`);
+  }
+}
+
+async function assertCodexApprovalOperationSucceeded(params: {
+  context: Omit<SlackQaScenarioContext, "sentTs">;
+  run: SlackQaCodexApprovalScenarioRun;
+  sessionKey: string;
+}) {
+  const history = asPlainRecord(
+    await params.context.gateway.call(
+      "chat.history",
+      { sessionKey: params.sessionKey, limit: 24 },
+      { timeoutMs: 10_000 },
+    ),
+  );
+  assertCodexApprovalTranscriptSucceeded(history.messages, params.run);
+  if (params.run.appServerMethod !== "item/fileChange/requestApproval") {
+    return;
+  }
+  const targetPath = resolveCodexFileApprovalTargetPath(params.run.token);
+  const contents = await fs.readFile(targetPath, "utf8");
+  if (contents.trim() !== params.run.token) {
+    throw new Error(`Codex file result at ${targetPath} did not contain the expected marker`);
+  }
+}
+
+function findPendingCodexPluginApprovalRecord(params: {
+  approvalId: string;
+  appServerMethod: SlackQaCodexApprovalMethod;
+  channelId: string;
+  records: unknown;
+  sessionKey: string;
+  sutAccountId: string;
+}) {
+  const list = Array.isArray(params.records) ? params.records : [];
+  const expectedTitle =
+    params.appServerMethod === "item/commandExecution/requestApproval"
+      ? "Codex app-server command approval"
+      : "Codex app-server file approval";
+  const expectedToolName =
+    params.appServerMethod === "item/commandExecution/requestApproval"
+      ? "codex_command_approval"
+      : "codex_file_approval";
+  for (const entry of list) {
+    const record = asPlainRecord(entry);
+    if (record.id !== params.approvalId) {
+      continue;
+    }
+    const request = asPlainRecord(record.request);
+    if (
+      request.pluginId === "openclaw-codex-app-server" &&
+      request.title === expectedTitle &&
+      request.toolName === expectedToolName &&
+      request.sessionKey === params.sessionKey &&
+      request.turnSourceChannel === "slack" &&
+      request.turnSourceTo === `channel:${params.channelId}` &&
+      request.turnSourceAccountId === params.sutAccountId
+    ) {
+      return record;
+    }
+  }
+  return undefined;
+}
+
+async function assertPendingCodexPluginApproval(params: {
+  approvalId: string;
+  appServerMethod: SlackQaCodexApprovalMethod;
+  channelId: string;
+  context: Omit<SlackQaScenarioContext, "sentTs">;
+  sessionKey: string;
+  sutAccountId: string;
+}) {
+  const records = await params.context.gateway.call(
+    "plugin.approval.list",
+    {},
+    {
+      timeoutMs: SLACK_QA_APPROVAL_DECISION_TIMEOUT_MS,
+    },
+  );
+  const record = findPendingCodexPluginApprovalRecord({
+    approvalId: params.approvalId,
+    appServerMethod: params.appServerMethod,
+    channelId: params.channelId,
+    records,
+    sessionKey: params.sessionKey,
+    sutAccountId: params.sutAccountId,
+  });
+  if (!record) {
+    throw new Error(
+      `Pending Codex plugin approval ${params.approvalId} did not match the expected app-server route and Slack turn source.`,
+    );
+  }
+}
+
+async function startCodexApprovalAgentRun(params: {
+  channelId: string;
+  context: Omit<SlackQaScenarioContext, "sentTs">;
+  primaryModel: string;
+  run: SlackQaCodexApprovalScenarioRun;
+  runId: string;
+  scenario: SlackQaScenarioDefinition;
+  sessionKey: string;
+  sutAccountId: string;
+}) {
+  const result = await params.context.gateway.call(
+    "agent",
+    {
+      accountId: params.sutAccountId,
+      agentId: "qa",
+      channel: "slack",
+      cleanupBundleMcpOnRunEnd: true,
+      deliver: false,
+      idempotencyKey: params.runId,
+      message: buildCodexApprovalInstruction({
+        appServerMethod: params.run.appServerMethod,
+        token: params.run.token,
+      }),
+      model: params.primaryModel,
+      sessionKey: params.sessionKey,
+      thinking: "low",
+      timeout: Math.ceil(params.scenario.timeoutMs / 1_000),
+      to: `channel:${params.channelId}`,
+    },
+    {
+      timeoutMs: SLACK_QA_APPROVAL_DECISION_TIMEOUT_MS + 5_000,
+    },
+  );
+  const acceptedRunId = readAcceptedAgentRunId(result);
+  if (acceptedRunId !== params.runId) {
+    throw new Error(`Codex agent run id was ${acceptedRunId} instead of ${params.runId}`);
+  }
+}
+
+function buildCodexApprovalSessionKey(params: {
+  scenario: SlackQaScenarioDefinition;
+  token: string;
+}) {
+  return `agent:qa:${params.scenario.id}-${params.token.toLowerCase()}`;
+}
+
+async function waitForCodexApprovalAgentRun(params: {
+  context: Omit<SlackQaScenarioContext, "sentTs">;
+  runId: string;
+  timeoutMs: number;
+}) {
+  const result = await params.context.gateway.call(
+    "agent.wait",
+    {
+      runId: params.runId,
+      timeoutMs: params.timeoutMs,
+    },
+    {
+      timeoutMs: params.timeoutMs + 5_000,
+    },
+  );
+  return readAgentWaitStatus(result);
+}
+
+async function quiesceCodexApprovalAgentRun(params: {
+  context: Omit<SlackQaScenarioContext, "sentTs">;
+  preserveDebugArtifacts: boolean;
+  runId: string;
+  sessionKey: string;
+  stopGateway: (preserveDebugArtifacts: boolean) => Promise<void>;
+}) {
+  try {
+    await params.context.gateway.call(
+      "chat.abort",
+      { runId: params.runId, sessionKey: params.sessionKey },
+      { timeoutMs: 10_000 },
+    );
+  } catch {
+    // The bounded terminal wait and gateway process-group teardown do not depend on this ack.
+  }
+  try {
+    await params.context.gateway.call(
+      "agent.wait",
+      { runId: params.runId, timeoutMs: 10_000 },
+      { timeoutMs: 15_000 },
+    );
+  } catch {
+    // QA-owned Codex app-server processes inherit the gateway cleanup process group.
+  }
+  await params.stopGateway(params.preserveDebugArtifacts);
+}
+
+async function runSlackCodexApprovalScenario(params: {
+  channelId: string;
+  context: Omit<SlackQaScenarioContext, "sentTs">;
+  observedMessages: SlackObservedMessage[];
+  primaryModel: string;
+  run: SlackQaCodexApprovalScenarioRun;
+  scenario: SlackQaScenarioDefinition;
+  stopGateway: (preserveDebugArtifacts: boolean) => Promise<void>;
+  sutAccountId: string;
+}) {
+  const codexRun = {
+    runId: `slack-qa-codex-approval-${randomUUID()}`,
+    sessionKey: buildCodexApprovalSessionKey({
+      scenario: params.scenario,
+      token: params.run.token,
+    }),
+  };
+  const targetPath =
+    params.run.appServerMethod === "item/fileChange/requestApproval"
+      ? resolveCodexFileApprovalTargetPath(params.run.token)
+      : undefined;
+  if (targetPath) {
+    await fs.rm(targetPath, { force: true });
+  }
+  const outcome = await runSlackCodexApprovalScenarioInner({ ...params, codexRun }).then(
+    (result) => ({ kind: "success", result }) as const,
+    (error: unknown) => ({ error, kind: "failure" }) as const,
+  );
+  // Kill the gateway process tree before deleting the probe. Agent completion
+  // does not prove the native Codex turn has stopped writing after an interrupt.
+  const cleanupErrors: unknown[] = [];
+  try {
+    await quiesceCodexApprovalAgentRun({
+      context: params.context,
+      preserveDebugArtifacts: outcome.kind === "failure",
+      stopGateway: params.stopGateway,
+      ...codexRun,
+    });
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  if (cleanupErrors.length === 0 && targetPath) {
+    try {
+      await fs.rm(targetPath, { force: true });
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+  }
+  if (cleanupErrors.length > 0) {
+    const cleanupSummary = cleanupErrors.map(formatErrorMessage).join("; ");
+    if (outcome.kind === "failure") {
+      throw new AggregateError(
+        [outcome.error, ...cleanupErrors],
+        `Codex approval scenario failed: ${formatErrorMessage(outcome.error)}; cleanup also failed: ${cleanupSummary}`,
+        { cause: outcome.error },
+      );
+    }
+    throw new AggregateError(cleanupErrors, `Codex approval cleanup failed: ${cleanupSummary}`);
+  }
+  if (outcome.kind === "failure") {
+    throw outcome.error;
+  }
+  return outcome.result;
+}
+
+function resolveCodexFileApprovalTargetPath(token: string) {
+  return path.join(os.homedir(), `.openclaw-qa-codex-file-approval-${token.toLowerCase()}.txt`);
+}
+
+async function runSlackCodexApprovalScenarioInner(params: {
+  channelId: string;
+  codexRun: { runId: string; sessionKey: string };
+  context: Omit<SlackQaScenarioContext, "sentTs">;
+  observedMessages: SlackObservedMessage[];
+  primaryModel: string;
+  run: SlackQaCodexApprovalScenarioRun;
+  scenario: SlackQaScenarioDefinition;
+  sutAccountId: string;
+}) {
+  const requestStartedAt = new Date();
+  const oldestTs = ((requestStartedAt.getTime() - 5_000) / 1_000).toFixed(6);
+  await startCodexApprovalAgentRun({
+    channelId: params.channelId,
+    context: params.context,
+    primaryModel: params.primaryModel,
+    run: params.run,
+    runId: params.codexRun.runId,
+    scenario: params.scenario,
+    sessionKey: params.codexRun.sessionKey,
+    sutAccountId: params.sutAccountId,
+  });
+  const expectedTitle =
+    params.run.appServerMethod === "item/commandExecution/requestApproval"
+      ? "Codex app-server command approval"
+      : "Codex app-server file approval";
+  const pending = await waitForSlackApprovalPrompt({
+    approvalKind: params.run.approvalKind,
+    channelId: params.channelId,
+    client: params.context.sutReadClient,
+    decision: params.run.decision,
+    extraTextMatches: ["openclaw-codex-app-server", expectedTitle],
+    observedMessages: params.observedMessages,
+    oldestTs,
+    scenarioId: params.scenario.id,
+    scenarioTitle: params.scenario.title,
+    sutIdentity: params.context.sutIdentity,
+    timeoutMs: params.scenario.timeoutMs,
+  });
+  const approvalId = pending.approvalId;
+  if (!approvalId) {
+    throw new Error(
+      "Codex Slack approval prompt exposed native actions but no plugin approval id.",
+    );
+  }
+  await assertPendingCodexPluginApproval({
+    approvalId,
+    appServerMethod: params.run.appServerMethod,
+    channelId: params.channelId,
+    context: params.context,
+    sessionKey: params.codexRun.sessionKey,
+    sutAccountId: params.sutAccountId,
+  });
+  const pendingCheckpoint = await writeSlackApprovalCheckpoint({
+    approvalId,
+    approvalKind: params.run.approvalKind,
+    channelId: params.channelId,
+    message: pending.message,
+    observedAt: pending.observedAt,
+    scenarioId: params.scenario.id,
+    state: "pending",
+  });
+  await resolveApprovalDecision({
+    approvalId,
+    context: params.context,
+    decision: params.run.decision,
+    kind: params.run.approvalKind,
+  });
+  const finalCodexTurnStatus = await waitForCodexApprovalAgentRun({
+    context: params.context,
+    runId: params.codexRun.runId,
+    timeoutMs: params.scenario.timeoutMs,
+  });
+  if (finalCodexTurnStatus !== "ok") {
+    throw new Error(
+      `Codex approval run ${params.codexRun.runId} finished with status ${finalCodexTurnStatus}`,
+    );
+  }
+  await assertCodexApprovalOperationSucceeded({
+    context: params.context,
+    run: params.run,
+    sessionKey: params.codexRun.sessionKey,
+  });
+  const resolved = await waitForSlackApprovalResolvedUpdate({
+    approvalKind: params.run.approvalKind,
+    channelId: params.channelId,
+    client: params.context.sutReadClient,
+    decision: params.run.decision,
+    messageTs: pending.message.ts,
+    observedMessages: params.observedMessages,
+    oldestTs,
+    scenarioId: params.scenario.id,
+    scenarioTitle: params.scenario.title,
+    sutIdentity: params.context.sutIdentity,
+    timeoutMs: params.scenario.timeoutMs,
+    extraTextMatches: ["openclaw-codex-app-server", expectedTitle],
+  });
+  const resolvedCheckpoint = await writeSlackApprovalCheckpoint({
+    approvalId,
+    approvalKind: params.run.approvalKind,
+    channelId: params.channelId,
+    decision: params.run.decision,
+    message: resolved.message,
+    observedAt: resolved.observedAt,
+    scenarioId: params.scenario.id,
+    state: "resolved",
+  });
+  const responseObservedAt = new Date(resolved.observedAt);
+  return {
+    artifact: {
+      approvalId,
+      approvalKind: params.run.approvalKind,
+      appServerMethod: params.run.appServerMethod,
+      channelId: params.channelId,
+      codexModelKey: params.primaryModel,
+      decision: params.run.decision,
+      finalCodexTurnStatus,
+      operationVerified: true,
+      pendingActionValues: pending.actionValues,
+      pendingCheckpointPath: pendingCheckpoint?.checkpointPath,
+      pendingMessageTs: pending.message.ts,
+      pendingScreenshotPath: pendingCheckpoint?.screenshotPath,
+      pendingText: pending.message.text,
+      resolvedActionValues: resolved.actionValues,
+      resolvedCheckpointPath: resolvedCheckpoint?.checkpointPath,
+      resolvedMessageTs: resolved.message.ts,
+      resolvedScreenshotPath: resolvedCheckpoint?.screenshotPath,
+      resolvedText: resolved.message.text,
+      threadTs: pending.message.thread_ts,
+    } satisfies SlackApprovalArtifact,
+    requestStartedAt,
+    responseObservedAt,
+    rttMs: responseObservedAt.getTime() - requestStartedAt.getTime(),
+  };
+}
+
 async function waitForSlackChannelRunning(
   gateway: Awaited<ReturnType<typeof startQaGatewayChild>>,
   accountId: string,
@@ -1619,8 +2284,12 @@ function toSlackQaScenarioArtifactResults(params: {
       approval: {
         approvalId: params.redactMetadata ? "<redacted>" : approval.approvalId,
         approvalKind: approval.approvalKind,
+        appServerMethod: approval.appServerMethod,
         channelId: params.redactMetadata ? undefined : approval.channelId,
+        codexModelKey: approval.codexModelKey,
         decision: approval.decision,
+        finalCodexTurnStatus: approval.finalCodexTurnStatus,
+        operationVerified: approval.operationVerified,
         pendingActionValues: params.includeContent ? approval.pendingActionValues : undefined,
         pendingCheckpointPath: approval.pendingCheckpointPath,
         pendingMessageTs: params.redactMetadata ? undefined : approval.pendingMessageTs,
@@ -1675,6 +2344,18 @@ function renderSlackQaMarkdown(params: {
     }
     if (scenario.approval) {
       lines.push(`- Approval kind: ${scenario.approval.approvalKind}`);
+      if (scenario.approval.appServerMethod) {
+        lines.push(`- Codex app-server method: \`${scenario.approval.appServerMethod}\``);
+      }
+      if (scenario.approval.codexModelKey) {
+        lines.push(`- Codex model: \`${scenario.approval.codexModelKey}\``);
+      }
+      if (scenario.approval.finalCodexTurnStatus) {
+        lines.push(`- Codex turn status: ${scenario.approval.finalCodexTurnStatus}`);
+      }
+      if (scenario.approval.operationVerified) {
+        lines.push("- Codex operation marker: verified");
+      }
       lines.push(`- Approval ID: \`${scenario.approval.approvalId}\``);
       lines.push(`- Decision: ${scenario.approval.decision}`);
       if (scenario.approval.pendingScreenshotPath) {
@@ -1694,11 +2375,13 @@ async function preserveSlackGatewayDebugArtifacts(params: {
   gatewayDebugDirPath: string;
   gatewayHarness: SlackQaGatewayHarness;
 }) {
-  await params.gatewayHarness
-    .stop({ preserveToDir: params.gatewayDebugDirPath })
-    .catch((error: unknown) => {
-      appendLiveLaneIssue(params.cleanupIssues, "gateway debug preservation failed", error);
-    });
+  try {
+    await params.gatewayHarness.stop({ preserveToDir: params.gatewayDebugDirPath });
+    return true;
+  } catch (error) {
+    appendLiveLaneIssue(params.cleanupIssues, "gateway debug preservation failed", error);
+    return false;
+  }
 }
 
 export async function runSlackQaLive(params: {
@@ -1724,8 +2407,11 @@ export async function runSlackQaLive(params: {
   );
   const primaryModel = params.primaryModel?.trim() || defaultQaModelForMode(providerMode);
   const alternateModel = params.alternateModel?.trim() || defaultQaModelForMode(providerMode, true);
-  const sutAccountId = params.sutAccountId?.trim() || "sut";
+  const sutAccountId = resolveSlackQaSutAccountId(params.sutAccountId);
   const scenarios = findScenario(params.scenarioIds);
+  if (scenarios.some((scenario) => scenario.configOverrides?.codexApproval === true)) {
+    assertSlackCodexApprovalModelSupported(primaryModel);
+  }
   const requestedCredentialSource = inferSlackCredentialSource(params.credentialSource);
   const redactPublicMetadata = isTruthyOptIn(process.env[QA_REDACT_PUBLIC_METADATA_ENV]);
   const includeObservedMessageContent = isTruthyOptIn(process.env[SLACK_QA_CAPTURE_CONTENT_ENV]);
@@ -1772,6 +2458,9 @@ export async function runSlackQaLive(params: {
       let scenarioAttempt = 1;
       while (true) {
         let gatewayHarness: SlackQaGatewayHarness | undefined;
+        let codexProbeCleanupPath: string | undefined;
+        let preserveAttemptGatewayDebug = false;
+        let retryScenario = false;
         try {
           assertLeaseHealthy();
           gatewayHarness = await startQaLiveLaneGateway({
@@ -1791,6 +2480,7 @@ export async function runSlackQaLive(params: {
                 channelId: activeRuntimeEnv.channelId,
                 driverBotUserId: driverIdentity.userId,
                 overrides: scenario.configOverrides,
+                primaryModel,
                 sutAccountId,
                 sutAppToken: activeRuntimeEnv.sutAppToken,
                 sutBotToken: activeRuntimeEnv.sutBotToken,
@@ -1798,8 +2488,16 @@ export async function runSlackQaLive(params: {
           });
           const activeGatewayHarness = gatewayHarness;
           const scenarioRun = scenario.buildRun(sutIdentity.userId);
+          if (
+            scenarioRun.kind === "codex-approval" &&
+            scenarioRun.appServerMethod === "item/fileChange/requestApproval"
+          ) {
+            codexProbeCleanupPath = resolveCodexFileApprovalTargetPath(scenarioRun.token);
+          }
           const readinessMode: SlackChannelReadinessMode =
-            scenarioRun.kind === "approval" ? "started" : "connected";
+            scenarioRun.kind === "approval" || scenarioRun.kind === "codex-approval"
+              ? "started"
+              : "connected";
           await waitForSlackChannelStable(
             activeGatewayHarness.gateway,
             sutAccountId,
@@ -1842,6 +2540,51 @@ export async function runSlackQaLive(params: {
               status: "pass",
               details: [
                 `${scenarioRun.approvalKind} approval resolved ${scenarioRun.decision} in ${approval.rttMs}ms`,
+                scenarioAttempt > 1 ? `retried ${scenarioAttempt - 1}x` : undefined,
+              ]
+                .filter(Boolean)
+                .join("; "),
+              rttMs: approval.rttMs,
+              requestStartedAt: approval.requestStartedAt.toISOString(),
+              responseObservedAt: approval.responseObservedAt.toISOString(),
+              rttMeasurement: {
+                finalMatchedReplyRttMs: approval.rttMs,
+                requestStartedAt: approval.requestStartedAt.toISOString(),
+                responseObservedAt: approval.responseObservedAt.toISOString(),
+                source: "approval-request-to-resolution",
+              },
+            });
+            break;
+          }
+          if (scenarioRun.kind === "codex-approval") {
+            const approval = await runSlackCodexApprovalScenario({
+              channelId: activeRuntimeEnv.channelId,
+              context: baseScenarioContext,
+              observedMessages,
+              primaryModel,
+              run: scenarioRun,
+              scenario,
+              stopGateway: async (preserveDebugArtifacts) => {
+                await activeGatewayHarness.stop(
+                  preserveDebugArtifacts ? { preserveToDir: gatewayDebugDirPath } : undefined,
+                );
+                await new Promise((resolve) => {
+                  setTimeout(resolve, SLACK_QA_GATEWAY_STOP_SETTLE_MS);
+                });
+                gatewayHarness = undefined;
+                if (preserveDebugArtifacts) {
+                  preservedGatewayDebugArtifacts = true;
+                }
+              },
+              sutAccountId,
+            });
+            scenarioResults.push({
+              approval: approval.artifact,
+              id: scenario.id,
+              title: scenario.title,
+              status: "pass",
+              details: [
+                `Codex ${scenarioRun.appServerMethod} approval resolved ${scenarioRun.decision} in ${approval.rttMs}ms`,
                 scenarioAttempt > 1 ? `retried ${scenarioAttempt - 1}x` : undefined,
               ]
                 .filter(Boolean)
@@ -1943,40 +2686,80 @@ export async function runSlackQaLive(params: {
             isRetryableSlackQaScenarioError(error)
           ) {
             scenarioAttempt += 1;
-            continue;
-          }
-          scenarioResults.push({
-            id: scenario.id,
-            title: scenario.title,
-            standardId: scenario.standardId,
-            status: "fail",
-            details:
-              scenarioAttempt > 1
-                ? `${formatErrorMessage(error)}; retried ${scenarioAttempt - 1}x`
-                : formatErrorMessage(error),
-          });
-          preservedGatewayDebugArtifacts = true;
-          if (gatewayHarness) {
-            await preserveSlackGatewayDebugArtifacts({
-              cleanupIssues,
-              gatewayDebugDirPath,
-              gatewayHarness,
+            retryScenario = true;
+          } else {
+            scenarioResults.push({
+              id: scenario.id,
+              title: scenario.title,
+              standardId: scenario.standardId,
+              status: "fail",
+              details:
+                scenarioAttempt > 1
+                  ? `${formatErrorMessage(error)}; retried ${scenarioAttempt - 1}x`
+                  : formatErrorMessage(error),
             });
+            preserveAttemptGatewayDebug = true;
+            preservedGatewayDebugArtifacts = true;
+            if (gatewayHarness) {
+              const stopped = await preserveSlackGatewayDebugArtifacts({
+                cleanupIssues,
+                gatewayDebugDirPath,
+                gatewayHarness,
+              });
+              if (stopped) {
+                gatewayHarness = undefined;
+              }
+            }
           }
-          break;
         } finally {
-          if (!preservedGatewayDebugArtifacts && gatewayHarness) {
-            await gatewayHarness.stop().catch((error: unknown) => {
-              appendLiveLaneIssue(cleanupIssues, "gateway stop failed", error);
-            });
-            await new Promise((resolve) => {
-              setTimeout(resolve, SLACK_QA_GATEWAY_STOP_SETTLE_MS);
+          if (gatewayHarness) {
+            await gatewayHarness
+              .stop(
+                preserveAttemptGatewayDebug ? { preserveToDir: gatewayDebugDirPath } : undefined,
+              )
+              .then(() => {
+                gatewayHarness = undefined;
+                if (preserveAttemptGatewayDebug) {
+                  preservedGatewayDebugArtifacts = true;
+                }
+              })
+              .catch((error: unknown) => {
+                appendLiveLaneIssue(cleanupIssues, "gateway stop failed", error);
+                retryScenario = false;
+                const details = `gateway stop failed: ${formatErrorMessage(error)}`;
+                const currentResult = scenarioResults.at(-1);
+                if (currentResult?.id === scenario.id) {
+                  scenarioResults[scenarioResults.length - 1] = {
+                    ...currentResult,
+                    status: "fail",
+                    details: `${currentResult.details}; ${details}`,
+                  };
+                } else {
+                  scenarioResults.push({
+                    id: scenario.id,
+                    title: scenario.title,
+                    standardId: scenario.standardId,
+                    status: "fail",
+                    details,
+                  });
+                }
+              });
+            if (!gatewayHarness) {
+              await new Promise((resolve) => {
+                setTimeout(resolve, SLACK_QA_GATEWAY_STOP_SETTLE_MS);
+              });
+            }
+          }
+          if (!gatewayHarness && codexProbeCleanupPath) {
+            await fs.rm(codexProbeCleanupPath, { force: true }).catch((error: unknown) => {
+              appendLiveLaneIssue(cleanupIssues, "Codex approval probe cleanup failed", error);
             });
           }
         }
-        if (scenarioResults.at(-1)?.id === scenario.id) {
-          break;
+        if (retryScenario) {
+          continue;
         }
+        break;
       }
       if (scenarioResults.at(-1)?.status === "fail") {
         break;
@@ -2081,19 +2864,30 @@ export async function runSlackQaLive(params: {
 }
 
 export const testing = {
+  assertSlackCodexApprovalModelSupported,
+  assertCodexApprovalTranscriptSucceeded,
+  buildCodexApprovalInstruction,
   buildSlackApprovalCheckpointMessage,
   buildSlackQaConfig,
   collectSlackActionValues,
   collectSlackButtonLabels,
   collectSlackBlockText,
+  extractSlackNativeApprovalId,
+  findPendingCodexPluginApprovalRecord,
   findScenario,
   isSlackChannelReadyForQa,
+  matchesSlackApprovalResolvedUpdate,
+  matchesSlackApprovalPromptText,
   parseSlackQaCredentialPayload,
   preserveSlackGatewayDebugArtifacts,
+  quiesceCodexApprovalAgentRun,
+  readAcceptedAgentRunId,
+  resolveCodexFileApprovalTargetPath,
   resolveSlackChannelReadySince,
   resolveSlackQaReadyTimeoutMs,
   resolveSlackApprovalCheckpointConfig,
   resolveApprovalDecision,
+  resolveSlackQaSutAccountId,
   resolveSlackQaRuntimeEnv,
   SLACK_QA_STANDARD_SCENARIO_IDS,
   toSlackQaScenarioArtifactResults,

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.test.ts
@@ -198,6 +198,21 @@ describe("mantis Slack desktop smoke runtime", () => {
     expect(remoteScript).toContain("${CHROME_BIN:-}");
     expect(remoteScript).toContain("PNPM_STORE_DIR");
     expect(remoteScript).toContain("build-essential python3");
+    expect(remoteScript).toContain("node_supports_type_stripping");
+    expect(remoteScript).toContain("scripts/crabbox-untrusted-bootstrap.sh");
+    expect(remoteScript).toContain("https://nodejs.org/dist/v$node_version");
+    expect(remoteScript).toContain('grep "  $node_archive$" SHASUMS256.txt | sha256sum -c -');
+    expect(remoteScript).toContain('export PATH="$node_root/bin:$PATH"');
+    expect(remoteScript).toContain("packageManager ??");
+    expect(remoteScript).toContain("[0-9a-f]{128}");
+    expect(remoteScript).toContain('console.log(match[1] + " " + match[2])');
+    expect(remoteScript).toContain('active_pnpm_version="$(pnpm --version 2>/dev/null || true)"');
+    expect(remoteScript).toContain("https://registry.npmjs.org/pnpm/-/pnpm-$pnpm_version.tgz");
+    expect(remoteScript).toContain('sha512sum "$pnpm_archive"');
+    expect(remoteScript).toContain('chmod +x "$pnpm_cli"');
+    expect(remoteScript).toContain('ln -sfn "$pnpm_cli" "$pnpm_bin_dir/pnpm"');
+    expect(remoteScript).toContain('export PATH="$pnpm_bin_dir:$PATH"');
+    expect(remoteScript).toContain("Expected pnpm $pnpm_version, got $active_pnpm_version.");
     expect(remoteScript).toContain("pnpm install --frozen-lockfile --prefer-offline");
     expect(remoteScript).toContain("pnpm build");
     expect(remoteScript).toContain("ffmpeg");
@@ -369,6 +384,87 @@ describe("mantis Slack desktop smoke runtime", () => {
       }),
     ).rejects.toThrow("--approval-checkpoints only supports approval checkpoint scenarios");
   });
+
+  it.each([
+    {
+      expectedScenarioIds: ["slack-codex-approval-exec-native"],
+      label: "command",
+      remoteTimeoutSeconds: 1_250,
+      requestedScenarioIds: ["slack-codex-approval-exec-native"],
+    },
+    {
+      expectedScenarioIds: ["slack-codex-approval-plugin-native"],
+      label: "file",
+      remoteTimeoutSeconds: 1_250,
+      requestedScenarioIds: ["slack-codex-approval-plugin-native"],
+    },
+    {
+      expectedScenarioIds: [
+        "slack-codex-approval-exec-native",
+        "slack-codex-approval-plugin-native",
+      ],
+      label: "command and file",
+      remoteTimeoutSeconds: 1_900,
+      requestedScenarioIds: [
+        "slack-codex-approval-plugin-native",
+        "slack-codex-approval-exec-native",
+        "slack-codex-approval-plugin-native",
+      ],
+    },
+  ])(
+    "accepts the opt-in Codex $label checkpoint scenarios",
+    async ({ expectedScenarioIds, remoteTimeoutSeconds, requestedScenarioIds }) => {
+      const commands: { args: readonly string[]; command: string }[] = [];
+      const runner = vi.fn(async (command: string, args: readonly string[]) => {
+        commands.push({ command, args });
+        if (command === "/tmp/crabbox" && args[0] === "warmup") {
+          return { stdout: "ready lease cbx_123abc\n", stderr: "" };
+        }
+        if (command === "/tmp/crabbox" && args[0] === "inspect") {
+          return {
+            stdout: `${JSON.stringify({
+              host: "203.0.113.10",
+              id: "cbx_123abc",
+              provider: "hetzner",
+              sshKey: "/tmp/key",
+              sshPort: "2222",
+              sshUser: "crabbox",
+              state: "active",
+            })}\n`,
+            stderr: "",
+          };
+        }
+        if (command === "/tmp/crabbox" && args[0] === "run") {
+          throw new Error("stop after remote script capture");
+        }
+        return { stdout: "", stderr: "" };
+      });
+
+      const result = await runMantisSlackDesktopSmoke({
+        approvalCheckpoints: true,
+        commandRunner: runner,
+        crabboxBin: "/tmp/crabbox",
+        outputDir: `.artifacts/qa-e2e/mantis/${requestedScenarioIds.join("-")}`,
+        repoRoot,
+        scenarioIds: requestedScenarioIds,
+      });
+
+      expect(result.status).toBe("fail");
+      const remoteScript = commands
+        .find((entry) => entry.command === "/tmp/crabbox" && entry.args[0] === "run")
+        ?.args.at(-1);
+      for (const scenarioId of expectedScenarioIds) {
+        expect(remoteScript?.split(`--scenario '${scenarioId}'`)).toHaveLength(3);
+      }
+      expect(remoteScript).toContain(
+        expectedScenarioIds.map((scenarioId) => `--scenario '${scenarioId}'`).join(" "),
+      );
+      expect(remoteScript).toContain("OPENCLAW_QA_SLACK_APPROVAL_CHECKPOINT_TIMEOUT_MS:-470000");
+      expect(remoteScript).toContain(
+        `OPENCLAW_MANTIS_REMOTE_COMMAND_TIMEOUT_SECONDS:-${remoteTimeoutSeconds}`,
+      );
+    },
+  );
 
   it("fails approval checkpoint mode when ack metadata does not match the expected state", async () => {
     const expectedScenarios = ["slack-approval-exec-native", "slack-approval-plugin-native"];

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
@@ -8,6 +8,7 @@ import {
   acquireQaCredentialLease,
   startQaCredentialLeaseHeartbeat,
 } from "../live-transports/shared/credential-lease.runtime.js";
+import { listSlackQaScenarioCatalog } from "../live-transports/slack/slack-live.runtime.js";
 import { isTruthyOptIn, trimToValue } from "../mantis-options.runtime.js";
 import { createPhaseTimer, type MantisPhaseTimings } from "../mantis-phase-timer.runtime.js";
 import {
@@ -142,6 +143,27 @@ const DEFAULT_APPROVAL_CHECKPOINT_SCENARIOS = [
   "slack-approval-exec-native",
   "slack-approval-plugin-native",
 ] as const;
+const SUPPORTED_APPROVAL_CHECKPOINT_SCENARIOS = [
+  ...DEFAULT_APPROVAL_CHECKPOINT_SCENARIOS,
+  "slack-codex-approval-exec-native",
+  "slack-codex-approval-plugin-native",
+] as const;
+const DEFAULT_APPROVAL_CHECKPOINT_TIMEOUT_MS = 120_000;
+const CODEX_APPROVAL_PENDING_TIMEOUT_MS = 180_000;
+const CODEX_APPROVAL_RESOLVE_TIMEOUT_MS = 35_000;
+const CODEX_APPROVAL_AGENT_WAIT_TIMEOUT_MS = 185_000;
+const CODEX_APPROVAL_HISTORY_TIMEOUT_MS = 10_000;
+const CODEX_APPROVAL_RESOLVED_UPDATE_TIMEOUT_MS = 180_000;
+const CODEX_APPROVAL_CAPTURE_HEADROOM_MS = 60_000;
+const CODEX_APPROVAL_POST_PENDING_BUDGET_MS =
+  CODEX_APPROVAL_RESOLVE_TIMEOUT_MS +
+  CODEX_APPROVAL_AGENT_WAIT_TIMEOUT_MS +
+  CODEX_APPROVAL_HISTORY_TIMEOUT_MS +
+  CODEX_APPROVAL_RESOLVED_UPDATE_TIMEOUT_MS +
+  CODEX_APPROVAL_CAPTURE_HEADROOM_MS;
+const CODEX_APPROVAL_SCENARIO_BUDGET_MS =
+  CODEX_APPROVAL_PENDING_TIMEOUT_MS + CODEX_APPROVAL_POST_PENDING_BUDGET_MS;
+const DEFAULT_REMOTE_COMMAND_TIMEOUT_SECONDS = 600;
 const CRABBOX_BIN_ENV = "OPENCLAW_MANTIS_CRABBOX_BIN";
 const CRABBOX_PROVIDER_ENV = "OPENCLAW_MANTIS_CRABBOX_PROVIDER";
 const CRABBOX_CLASS_ENV = "OPENCLAW_MANTIS_CRABBOX_CLASS";
@@ -183,15 +205,21 @@ function resolveScenarioIds(params: {
         ? [...DEFAULT_APPROVAL_CHECKPOINT_SCENARIOS]
         : [];
   if (params.approvalCheckpoints) {
-    const allowed = new Set<string>(DEFAULT_APPROVAL_CHECKPOINT_SCENARIOS);
+    const allowed = new Set<string>(SUPPORTED_APPROVAL_CHECKPOINT_SCENARIOS);
     const unsupported = scenarioIds.filter((scenarioId) => !allowed.has(scenarioId));
     if (unsupported.length > 0) {
       throw new Error(
         `--approval-checkpoints only supports approval checkpoint scenarios: ${[
-          ...DEFAULT_APPROVAL_CHECKPOINT_SCENARIOS,
+          ...SUPPORTED_APPROVAL_CHECKPOINT_SCENARIOS,
         ].join(", ")}. Unsupported: ${unsupported.join(", ")}.`,
       );
     }
+    const requested = new Set(scenarioIds);
+    // Slack selects scenarios from catalog order, not CLI order. The watcher
+    // must mirror that order or both sides can block on different checkpoints.
+    return listSlackQaScenarioCatalog()
+      .map((scenario) => scenario.id)
+      .filter((scenarioId) => requested.has(scenarioId));
   }
   return scenarioIds;
 }
@@ -518,6 +546,20 @@ function renderRemoteScript(params: {
   const slackChannelId = shellQuote(params.slackChannelId);
   const scenarioArgs = params.scenarioIds.flatMap((id) => ["--scenario", shellQuote(id)]).join(" ");
   const checkpointScenarioJson = shellQuote(JSON.stringify(params.scenarioIds));
+  const codexScenarioCount = params.scenarioIds.filter((id) =>
+    id.startsWith("slack-codex-approval-"),
+  ).length;
+  // The watcher starts before gateway setup, then waits for pending and resolved
+  // sequentially. The resolved phase includes approval, agent, history, and Slack waits.
+  const approvalCheckpointTimeoutMs =
+    codexScenarioCount > 0
+      ? CODEX_APPROVAL_POST_PENDING_BUDGET_MS
+      : DEFAULT_APPROVAL_CHECKPOINT_TIMEOUT_MS;
+  // Preserve the existing hydration/startup budget, then add every selected
+  // Codex scenario's complete sequential approval budget.
+  const remoteCommandTimeoutSeconds =
+    DEFAULT_REMOTE_COMMAND_TIMEOUT_SECONDS +
+    Math.ceil((codexScenarioCount * CODEX_APPROVAL_SCENARIO_BUDGET_MS) / 1_000);
   return `set -euo pipefail
 out=${shellOutputDir}
 slack_url_override=${slackUrl}
@@ -532,7 +574,7 @@ setup_gateway=${setupGateway}
 approval_checkpoints=${approvalCheckpoints}
 slack_channel_id=${slackChannelId}
 approval_checkpoint_scenarios_json=${checkpointScenarioJson}
-remote_command_timeout_seconds="\${OPENCLAW_MANTIS_REMOTE_COMMAND_TIMEOUT_SECONDS:-600}"
+remote_command_timeout_seconds="\${OPENCLAW_MANTIS_REMOTE_COMMAND_TIMEOUT_SECONDS:-${remoteCommandTimeoutSeconds}}"
 if [ -z "\${OPENCLAW_QA_SLACK_CHANNEL_ID:-}" ] && [ -n "$slack_channel_id" ]; then
   export OPENCLAW_QA_SLACK_CHANNEL_ID="$slack_channel_id"
 fi
@@ -652,7 +694,90 @@ qa_status=0
 run_mantis_remote_body() {
   set -e
   echo "remote pwd: $(pwd)"
-  sudo corepack enable || sudo npm install -g pnpm@11
+  node_supports_type_stripping() {
+    node_probe="$(mktemp --suffix=.ts)"
+    printf 'const value: number = 1;\nif (value !== 1) process.exit(1);\n' >"$node_probe"
+    node --experimental-strip-types "$node_probe" >/dev/null 2>&1
+    probe_status=$?
+    rm -f "$node_probe"
+    return "$probe_status"
+  }
+  if ! node_supports_type_stripping; then
+    # Distro Node builds can satisfy the version range while omitting native
+    # TypeScript stripping, which the repository build requires.
+    node_version="$(sed -n 's/^node_version="\\([0-9][0-9.]*\\)"$/\\1/p' scripts/crabbox-untrusted-bootstrap.sh)"
+    case "$node_version" in
+      ''|*[!0-9.]*)
+        echo "Could not resolve the trusted Crabbox Node version." >&2
+        exit 3
+        ;;
+    esac
+    case "$(uname -m)" in
+      x86_64) node_arch=x64 ;;
+      aarch64|arm64) node_arch=arm64 ;;
+      *)
+        echo "Unsupported Node bootstrap architecture: $(uname -m)" >&2
+        exit 3
+        ;;
+    esac
+    node_root="$HOME/.cache/openclaw-mantis/node-v$node_version-linux-$node_arch"
+    if [ ! -x "$node_root/bin/node" ]; then
+      node_tmp="$(mktemp -d)"
+      node_archive="node-v$node_version-linux-$node_arch.tar.xz"
+      node_base_url="https://nodejs.org/dist/v$node_version"
+      curl -fsSL --retry 3 --retry-all-errors "$node_base_url/SHASUMS256.txt" \
+        -o "$node_tmp/SHASUMS256.txt"
+      curl -fsSL --retry 3 --retry-all-errors "$node_base_url/$node_archive" \
+        -o "$node_tmp/$node_archive"
+      (cd "$node_tmp" && grep "  $node_archive$" SHASUMS256.txt | sha256sum -c -)
+      rm -rf "$node_root"
+      mkdir -p "$node_root"
+      tar -xJf "$node_tmp/$node_archive" -C "$node_root" --strip-components=1
+      rm -rf "$node_tmp"
+    fi
+    export PATH="$node_root/bin:$PATH"
+    node_supports_type_stripping || {
+      echo "Official Node $node_version lacks required TypeScript stripping." >&2
+      exit 3
+    }
+  fi
+  node --version
+  read -r pnpm_version pnpm_sha512 < <(node -e '
+const value = require("./package.json").packageManager ?? "";
+const match = /^pnpm@([0-9]+\\.[0-9]+\\.[0-9]+)\\+sha512\\.([0-9a-f]{128})$/.exec(value);
+if (!match) process.exit(1);
+console.log(match[1] + " " + match[2]);
+')
+  active_pnpm_version="$(pnpm --version 2>/dev/null || true)"
+  if [ "$active_pnpm_version" != "$pnpm_version" ]; then
+    # Some desktop images ship an old distro Corepack that enables its shim but
+    # cannot execute current pnpm and may omit npm. Download the exact package,
+    # verify the repository-pinned digest, and run its bundled CLI with Node.
+    pnpm_root="$out/pnpm-$pnpm_version"
+    pnpm_archive="$pnpm_root/pnpm.tgz"
+    mkdir -p "$pnpm_root"
+    curl -fsSL --retry 3 --retry-all-errors \
+      "https://registry.npmjs.org/pnpm/-/pnpm-$pnpm_version.tgz" \
+      -o "$pnpm_archive"
+    downloaded_pnpm_sha512="$(sha512sum "$pnpm_archive" | awk '{print $1}')"
+    if [ "$downloaded_pnpm_sha512" != "$pnpm_sha512" ]; then
+      echo "pnpm $pnpm_version SHA-512 mismatch." >&2
+      exit 3
+    fi
+    tar -xzf "$pnpm_archive" -C "$pnpm_root"
+    pnpm_cli="$pnpm_root/package/bin/pnpm.cjs"
+    chmod +x "$pnpm_cli"
+    pnpm_bin_dir="$pnpm_root/bin"
+    mkdir -p "$pnpm_bin_dir"
+    ln -sfn "$pnpm_cli" "$pnpm_bin_dir/pnpm"
+    export PATH="$pnpm_bin_dir:$PATH"
+    hash -r
+    active_pnpm_version="$(pnpm --version)"
+  fi
+  if [ "$active_pnpm_version" != "$pnpm_version" ]; then
+    echo "Expected pnpm $pnpm_version, got $active_pnpm_version." >&2
+    exit 3
+  fi
   if [ "$hydrate_mode" = "source" ]; then
     if ! command -v make >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
       sudo apt-get update -y >>"$out/apt.log" 2>&1 || true
@@ -739,7 +864,7 @@ MANTIS_SLACK_PATCH
       checkpoint_dir="$out/approval-checkpoints"
       mkdir -p "$checkpoint_dir"
       export OPENCLAW_QA_SLACK_APPROVAL_CHECKPOINT_DIR="$checkpoint_dir"
-      export OPENCLAW_QA_SLACK_APPROVAL_CHECKPOINT_TIMEOUT_MS="\${OPENCLAW_QA_SLACK_APPROVAL_CHECKPOINT_TIMEOUT_MS:-120000}"
+      export OPENCLAW_QA_SLACK_APPROVAL_CHECKPOINT_TIMEOUT_MS="\${OPENCLAW_QA_SLACK_APPROVAL_CHECKPOINT_TIMEOUT_MS:-${approvalCheckpointTimeoutMs}}"
       export OPENCLAW_MANTIS_APPROVAL_CHECKPOINT_SCENARIOS_JSON="$approval_checkpoint_scenarios_json"
       export OPENCLAW_MANTIS_APPROVAL_BROWSER_BIN="$browser_bin"
       cat >"$out/approval-checkpoint-watcher.mjs" <<'MANTIS_APPROVAL_WATCHER'
@@ -749,7 +874,7 @@ MANTIS_SLACK_PATCH
 
 const checkpointDir = process.env.OPENCLAW_QA_SLACK_APPROVAL_CHECKPOINT_DIR;
 const timeoutMs = Number.parseInt(
-  process.env.OPENCLAW_QA_SLACK_APPROVAL_CHECKPOINT_TIMEOUT_MS || "120000",
+  process.env.OPENCLAW_QA_SLACK_APPROVAL_CHECKPOINT_TIMEOUT_MS || "${approvalCheckpointTimeoutMs}",
   10,
 );
 	const scenarioIds = JSON.parse(

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1796,6 +1796,22 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(statusReactionControllerMock.setDone).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps Slack lifecycle reactions off by default when an ack reaction exists", async () => {
+    await dispatchPreparedSlackMessage(
+      createPreparedSlackMessage({
+        ackReactionMessageTs: "171234.111",
+        ackReactionPromise: Promise.resolve(true),
+      }),
+    );
+
+    expectRecordFields(requireRecord(capturedStatusReactionOptions, "status reaction options"), {
+      enabled: false,
+      initialEmoji: "eyes",
+    });
+    expect(statusReactionControllerMock.setQueued).not.toHaveBeenCalled();
+    expect(statusReactionControllerMock.setDone).not.toHaveBeenCalled();
+  });
+
   it("escapes Slack mrkdwn in tool progress preview labels", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -550,7 +550,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const statusReactionsEnabled =
     Boolean(prepared.ackReactionPromise) &&
     Boolean(reactionMessageTs) &&
-    cfg.messages?.statusReactions?.enabled !== false;
+    cfg.messages?.statusReactions?.enabled === true;
   const slackStatusAdapter: StatusReactionAdapter = {
     setReaction: async (emoji) => {
       await reactSlackMessage(message.channel, reactionMessageTs ?? "", toSlackEmojiName(emoji), {

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -860,6 +860,45 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(await prepared.ackReactionPromise).toBe(true);
   });
 
+  it("defaults Slack to a static ack reaction while native thread status handles progress", async () => {
+    const addReaction = vi.fn().mockResolvedValue({ ok: true });
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        messages: {
+          ackReaction: "eyes",
+        },
+        channels: {
+          slack: {
+            enabled: true,
+            groupPolicy: "open",
+          },
+        },
+      } as OpenClawConfig,
+      appClient: {
+        reactions: { add: addReaction },
+      } as unknown as App["client"],
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const prepared = await prepareMessageWith(slackCtx, defaultAccount, {
+      channel: "C123",
+      channel_type: "channel",
+      user: "U1",
+      text: "<@B1> hi",
+      ts: "1.000",
+    } as SlackMessageEvent);
+
+    assertPrepared(prepared);
+    expect(prepared.ackReactionPromise).toBeInstanceOf(Promise);
+    expect(await prepared.ackReactionPromise).toBe(true);
+    expect(addReaction).toHaveBeenCalledWith({
+      channel: "C123",
+      timestamp: "1.000",
+      name: "eyes",
+    });
+  });
+
   it("keeps unmentioned room events quiet even when group replies are automatic", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1138,7 +1138,7 @@ export async function prepareSlackMessage(params: {
     shouldAckReaction() && (!sourceRepliesAreToolOnly || allowToolOnlyStatusReaction);
   const statusReactionsWillHandle =
     Boolean(ackReactionMessageTs) &&
-    cfg.messages?.statusReactions?.enabled !== false &&
+    statusReactionsExplicitlyEnabled &&
     shouldSendAckReaction;
   const ackReactionPromise =
     !statusReactionsWillHandle && shouldSendAckReaction && ackReactionMessageTs && ackReactionValue

--- a/scripts/package-openclaw-for-docker.mjs
+++ b/scripts/package-openclaw-for-docker.mjs
@@ -435,6 +435,7 @@ export async function prepareBundledAiRuntimePackage(
   options = {},
 ) {
   const packageJsonPath = path.join(sourceDir, "package.json");
+  const aiRuntimePackageJsonPath = path.join(sourceDir, "packages", "ai", "package.json");
   const aiRuntimePath = path.join(sourceDir, "node_modules", "@openclaw", "ai");
   const aiRuntimeBackupPath = path.join(
     sourceDir,
@@ -453,7 +454,24 @@ export async function prepareBundledAiRuntimePackage(
   } catch (error) {
     throw new Error(`failed to parse ${packageJsonPath}`, { cause: error });
   }
-  if (typeof packageJson.dependencies?.[AI_RUNTIME_PACKAGE] !== "string") {
+  const aiRuntimeDependency = packageJson.dependencies?.[AI_RUNTIME_PACKAGE];
+  let hasAiRuntimeWorkspace = false;
+  try {
+    await fs.access(aiRuntimePackageJsonPath);
+    hasAiRuntimeWorkspace = true;
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw error;
+    }
+  }
+  // Release checks can package refs from before the AI runtime was split into a workspace package.
+  if (!hasAiRuntimeWorkspace && aiRuntimeDependency === undefined) {
+    return async () => {};
+  }
+  if (!hasAiRuntimeWorkspace) {
+    throw new Error("@openclaw/ai dependency requires the packages/ai workspace");
+  }
+  if (typeof aiRuntimeDependency !== "string") {
     throw new Error("root package.json must declare @openclaw/ai as a dependency");
   }
 

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -72,7 +72,7 @@ export function mergeEmbeddedAgentRunResultForModelFallbackExhaustion(params: {
   };
 }
 
-function hasDeliberateSilentTerminalReply(result: EmbeddedAgentRunResult): boolean {
+export function hasDeliberateSilentTerminalReply(result: EmbeddedAgentRunResult): boolean {
   if (result.meta.error?.kind === "hook_block") {
     return true;
   }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -806,7 +806,12 @@ type ExternalRunFailureReply = {
 
 type ExternalRunFailureInput = string | { message: string; error?: unknown };
 
-function isNonDirectConversationContext(ctx: TemplateContext): boolean {
+type ExternalFailureConversationContext = Pick<
+  TemplateContext,
+  "ChatType" | "Provider" | "SessionKey" | "Surface"
+>;
+
+function isNonDirectConversationContext(ctx: ExternalFailureConversationContext): boolean {
   const chatType = normalizeLowercaseStringOrEmpty(ctx.ChatType);
   return chatType === "group" || chatType === "channel";
 }
@@ -817,7 +822,7 @@ function isVerboseFailureDetailEnabled(level: VerboseLevel | undefined): boolean
 
 function resolveExternalRunFailureTextForConversation(params: {
   text: string;
-  sessionCtx: TemplateContext;
+  sessionCtx: ExternalFailureConversationContext;
   isGenericRunnerFailure: boolean;
   cfg?: OpenClawConfig;
 }): string {
@@ -1045,6 +1050,57 @@ function markAgentRunFailureReplyPayload<T extends ReplyPayload>(payload: T): T 
     marked.isError = true;
   }
   return marked;
+}
+
+export function buildTerminalAgentRunFailureReplyPayload(params: {
+  isHeartbeat?: boolean;
+  sessionCtx: ExternalFailureConversationContext;
+  cfg?: OpenClawConfig;
+}): ReplyPayload {
+  return markAgentRunFailureReplyPayload({
+    text: resolveExternalRunFailureTextForConversation({
+      text: params.isHeartbeat
+        ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
+        : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      sessionCtx: params.sessionCtx,
+      isGenericRunnerFailure: true,
+      cfg: params.cfg,
+    }),
+  });
+}
+
+export function buildEmptyInteractiveReplyPayload(params: {
+  isInteractive: boolean;
+  isHeartbeat?: boolean;
+  silentExpected?: boolean;
+  allowEmptyAssistantReplyAsSilent?: boolean;
+  isMessageToolOnly: boolean;
+  hasPendingContinuation: boolean;
+  hasExplicitSilentReply: boolean;
+  hasCommittedDelivery: boolean;
+  sessionCtx: ExternalFailureConversationContext;
+  cfg?: OpenClawConfig;
+}): ReplyPayload | undefined {
+  if (
+    !params.isInteractive ||
+    params.isHeartbeat === true ||
+    params.silentExpected === true ||
+    params.allowEmptyAssistantReplyAsSilent === true ||
+    params.isMessageToolOnly ||
+    params.hasPendingContinuation ||
+    params.hasExplicitSilentReply ||
+    params.hasCommittedDelivery
+  ) {
+    return undefined;
+  }
+  return markAgentRunFailureReplyPayload({
+    text: resolveExternalRunFailureTextForConversation({
+      text: "I finished the turn, but it did not produce a visible reply. Please try again, or start a new session if this keeps happening.",
+      sessionCtx: params.sessionCtx,
+      isGenericRunnerFailure: true,
+      cfg: params.cfg,
+    }),
+  });
 }
 
 /** Converts known agent-run failures into user-facing reply payloads. */
@@ -3530,15 +3586,10 @@ async function runAgentTurnWithFallbackInternal(
     }
   }
   const terminalFailurePayload = terminalRunFailed
-    ? markAgentRunFailureReplyPayload({
-        text: resolveExternalRunFailureTextForConversation({
-          text: params.isHeartbeat
-            ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
-            : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
-          sessionCtx: params.sessionCtx,
-          isGenericRunnerFailure: true,
-          cfg: params.followupRun.run.config,
-        }),
+    ? buildTerminalAgentRunFailureReplyPayload({
+        isHeartbeat: params.isHeartbeat,
+        sessionCtx: params.sessionCtx,
+        cfg: params.followupRun.run.config,
       })
     : undefined;
 

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -38,7 +38,12 @@ type AgentRunParams = {
   onPartialReply?: (payload: { text?: string }) => Promise<void> | void;
   onAssistantMessageStart?: () => Promise<void> | void;
   onReasoningStream?: (payload: { text?: string }) => Promise<void> | void;
-  onBlockReply?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
+  onBlockReply?: (payload: {
+    text?: string;
+    mediaUrls?: string[];
+    isReasoning?: boolean;
+    isCommentary?: boolean;
+  }) => Promise<void> | void;
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
@@ -183,6 +188,7 @@ function createMinimalRun(params?: {
   shouldSteer?: boolean;
   shouldFollowup?: boolean;
   resolvedQueueMode?: string;
+  currentInboundEventKind?: FollowupRun["currentInboundEventKind"];
   sessionCtx?: Partial<TemplateContext>;
   runOverrides?: Partial<FollowupRun["run"]>;
 }) {
@@ -201,6 +207,7 @@ function createMinimalRun(params?: {
     prompt: "hello",
     summaryLine: "hello",
     enqueuedAt: Date.now(),
+    currentInboundEventKind: params?.currentInboundEventKind,
     run: {
       sessionId: "session",
       sessionKey,
@@ -1410,6 +1417,108 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it.each([
+    { label: "empty output", payloads: [] },
+    { label: "reasoning-only output", payloads: [{ text: "internal", isReasoning: true }] },
+    { label: "commentary-only output", payloads: [{ text: "internal", isCommentary: true }] },
+    { label: "directive-only output", payloads: [{ text: "[[reply_to_current]]" }] },
+  ])("surfaces successful $label through normal reply delivery", async ({ payloads }) => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({ payloads, meta: {} });
+    const { run } = createMinimalRun({
+      runOverrides: { config: { channels: { whatsapp: { replyToMode: "first" } } } },
+    });
+
+    const result = await run();
+    const payloadsResult = Array.isArray(result) ? result : [result];
+
+    expect(payloadsResult).toContainEqual(
+      expect.objectContaining({
+        text: expect.stringContaining("did not produce a visible reply"),
+        isError: true,
+        replyToId: "msg",
+      }),
+    );
+  });
+
+  it.each([
+    { lane: "reasoning", payload: { text: "internal", isReasoning: true } },
+    { lane: "commentary", payload: { text: "internal", isCommentary: true } },
+  ])("does not let streamed $lane suppress the empty-reply fallback", async ({ payload }) => {
+    const onBlockReply = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onBlockReply?.(payload);
+      return { payloads: [], meta: {} };
+    });
+    const { run } = createMinimalRun({
+      blockStreamingEnabled: true,
+      opts: {
+        onBlockReply,
+        reasoningPayloadsEnabled: true,
+        commentaryPayloadsEnabled: true,
+      },
+    });
+
+    const result = await run();
+    const payloads = Array.isArray(result) ? result : [result];
+
+    expect(onBlockReply).toHaveBeenCalled();
+    expect(onBlockReply.mock.calls[0]?.[0]).toEqual(expect.objectContaining(payload));
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        text: expect.stringContaining("did not produce a visible reply"),
+        isError: true,
+      }),
+    );
+  });
+
+  it.each([
+    {
+      label: "NO_REPLY",
+      result: {
+        payloads: [{ text: "NO_REPLY" }],
+        meta: { finalAssistantVisibleText: "NO_REPLY" },
+      },
+    },
+    {
+      label: "accepted child spawn",
+      result: {
+        payloads: [],
+        meta: {},
+        acceptedSessionSpawns: [{ runId: "child", childSessionKey: "agent:main:child" }],
+      },
+    },
+    { label: "yielded continuation", result: { payloads: [], meta: { yielded: true } } },
+    {
+      label: "pending tool continuation",
+      result: { payloads: [], meta: { pendingToolCalls: [{ name: "hosted_tool" }] } },
+    },
+  ])("keeps successful $label completions silent", async ({ result }) => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce(result);
+    const { run } = createMinimalRun();
+
+    await expect(run()).resolves.toBeUndefined();
+  });
+
+  it.each([
+    {
+      label: "room event",
+      params: { currentInboundEventKind: "room_event" as const },
+    },
+    {
+      label: "internal handoff",
+      params: {
+        runOverrides: {
+          inputProvenance: { kind: "internal_system" as const, sourceTool: "restart-sentinel" },
+        },
+      },
+    },
+  ])("keeps successful empty $label completions silent", async ({ params }) => {
+    state.runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
+    const { run } = createMinimalRun(params);
+
+    await expect(run()).resolves.toBeUndefined();
+  });
+
+  it.each([
     {
       label: "silent token",
       payload: { text: "NO_REPLY" },
@@ -1750,10 +1859,40 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
-  it("surfaces a configured backend failure when fallback produces no visible reply", async () => {
-    state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "NO_REPLY" }],
-      meta: {},
+  it.each([
+    {
+      label: "NO_REPLY",
+      payload: { text: "NO_REPLY" },
+      opts: undefined,
+      streamed: false,
+    },
+    {
+      label: "reasoning-only output with reasoning enabled",
+      payload: { text: "internal reasoning", isReasoning: true },
+      opts: { reasoningPayloadsEnabled: true },
+      streamed: false,
+    },
+    {
+      label: "streamed reasoning-only output with reasoning enabled",
+      payload: { text: "internal reasoning", isReasoning: true },
+      opts: { reasoningPayloadsEnabled: true, onBlockReply: vi.fn() },
+      streamed: true,
+    },
+    {
+      label: "commentary-only output with commentary enabled",
+      payload: { text: "internal commentary", isCommentary: true },
+      opts: { commentaryPayloadsEnabled: true },
+      streamed: false,
+    },
+  ])("surfaces a configured backend failure when fallback produces $label", async (testCase) => {
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      if (testCase.streamed) {
+        await params.onBlockReply?.(testCase.payload);
+      }
+      return {
+        payloads: [testCase.payload],
+        meta: {},
+      };
     });
     const fallbackSpy = vi
       .spyOn(modelFallbackModule, "runWithModelFallback")
@@ -1776,6 +1915,8 @@ describe("runReplyAgent typing (heartbeat)", () => {
 
     try {
       const { run } = createMinimalRun({
+        opts: testCase.opts,
+        blockStreamingEnabled: testCase.streamed,
         runOverrides: {
           provider: "lmstudio",
           model: "gemma-4-e4b-it",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import {
   hasSessionAutoModelFallbackProvenance,
   hasConfiguredModelFallbacks,
@@ -11,6 +12,7 @@ import {
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { hasVisibleAgentPayload } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import { hasDeliberateSilentTerminalReply } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import {
   formatEmbeddedAgentQueueFailureSummary,
   queueEmbeddedAgentMessageWithOutcomeAsync,
@@ -67,6 +69,7 @@ import type { VerboseLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
+  buildEmptyInteractiveReplyPayload,
   buildKnownAgentRunFailureReplyPayload,
   runAgentTurnWithFallback,
 } from "./agent-runner-execution.js";
@@ -163,7 +166,7 @@ function buildSilentFallbackFailurePayload(params: {
   fallbackTransition: ReturnType<typeof resolveFallbackTransition>;
   fallbackFailureKnown: boolean;
   isHeartbeat: boolean;
-  hasSuccessfulSideEffectDelivery: boolean;
+  hasSuccessfulTerminalDelivery: boolean;
   allowEmptyAssistantReplyAsSilent?: boolean;
   silentExpected?: boolean;
 }): ReplyPayload | undefined {
@@ -171,7 +174,7 @@ function buildSilentFallbackFailurePayload(params: {
     params.isHeartbeat ||
     params.allowEmptyAssistantReplyAsSilent === true ||
     params.silentExpected === true ||
-    params.hasSuccessfulSideEffectDelivery ||
+    params.hasSuccessfulTerminalDelivery ||
     !params.fallbackTransition.fallbackActive ||
     !params.fallbackFailureKnown
   ) {
@@ -238,6 +241,22 @@ function resolveReplyRunDeliveryContext(params: {
   });
 }
 
+function hasSuccessfulSourceReplyDelivery(params: {
+  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
+  directlySentBlockKeys?: Set<string>;
+  messagingToolSentTexts?: string[];
+  messagingToolSentMediaUrls?: string[];
+  messagingToolSentTargets?: unknown[];
+}): boolean {
+  return (
+    (params.blockReplyPipeline?.didStream() && !params.blockReplyPipeline.isAborted()) ||
+    (params.directlySentBlockKeys?.size ?? 0) > 0 ||
+    hasNonEmptyStringArray(params.messagingToolSentTexts) ||
+    hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
+    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets)
+  );
+}
+
 function hasNonEmptyStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.some((entry) => typeof entry === "string" && entry.trim());
 }
@@ -261,37 +280,24 @@ function hasCommittedMessagingTargetDeliveryEvidence(value: unknown): boolean {
   });
 }
 
-function hasSuccessfulSideEffectDelivery(params: {
-  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
-  directlySentBlockKeys?: Set<string>;
-  messagingToolSentTexts?: string[];
-  messagingToolSentMediaUrls?: string[];
-  messagingToolSentTargets?: unknown[];
-  didSendViaMessagingTool?: boolean;
-  successfulCronAdds?: number;
-  didSendDeterministicApprovalPrompt?: boolean;
+function hasSuccessfulTerminalSourceReplyDelivery(params: {
+  blockReplyPipeline: {
+    didStreamTerminalReply?: () => boolean;
+    isAborted: () => boolean;
+  } | null;
+  directlySentBlockPayloads?: ReplyPayload[];
 }): boolean {
-  return (
-    params.didSendViaMessagingTool === true ||
-    hasSuccessfulSourceReplyDelivery(params) ||
-    (params.successfulCronAdds ?? 0) > 0 ||
-    params.didSendDeterministicApprovalPrompt === true
+  const sentTerminalBlock = params.directlySentBlockPayloads?.some(
+    (payload) =>
+      payload.isReasoning !== true &&
+      payload.isCommentary !== true &&
+      !isReplyPayloadStatusNotice(payload) &&
+      normalizeReplyPayload(payload, { applyChannelTransforms: false }) !== null,
   );
-}
-
-function hasSuccessfulSourceReplyDelivery(params: {
-  blockReplyPipeline: { didStream: () => boolean; isAborted: () => boolean } | null;
-  directlySentBlockKeys?: Set<string>;
-  messagingToolSentTexts?: string[];
-  messagingToolSentMediaUrls?: string[];
-  messagingToolSentTargets?: unknown[];
-}): boolean {
   return (
-    (params.blockReplyPipeline?.didStream() && !params.blockReplyPipeline.isAborted()) ||
-    (params.directlySentBlockKeys?.size ?? 0) > 0 ||
-    hasNonEmptyStringArray(params.messagingToolSentTexts) ||
-    hasNonEmptyStringArray(params.messagingToolSentMediaUrls) ||
-    hasCommittedMessagingTargetDeliveryEvidence(params.messagingToolSentTargets)
+    (params.blockReplyPipeline?.didStreamTerminalReply?.() === true &&
+      !params.blockReplyPipeline.isAborted()) ||
+    sentTerminalBlock === true
   );
 }
 
@@ -1973,16 +1979,23 @@ export async function runReplyAgent(params: {
       preserveFreshTotalTokensOnStaleUsage: preflightCompactionApplied,
     });
 
-    const successfulSideEffectDelivery = hasSuccessfulSideEffectDelivery({
-      blockReplyPipeline,
-      directlySentBlockKeys,
-      messagingToolSentTexts: runResult.messagingToolSentTexts,
-      messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
-      messagingToolSentTargets: runResult.messagingToolSentTargets,
-      didSendViaMessagingTool: runResult.didSendViaMessagingTool,
-      successfulCronAdds: runResult.successfulCronAdds,
-      didSendDeterministicApprovalPrompt: runResult.didSendDeterministicApprovalPrompt,
-    });
+    const committedOutboundDelivery =
+      runResult.didSendViaMessagingTool === true ||
+      hasNonEmptyStringArray(runResult.messagingToolSentTexts) ||
+      hasNonEmptyStringArray(runResult.messagingToolSentMediaUrls) ||
+      hasCommittedMessagingTargetDeliveryEvidence(runResult.messagingToolSentTargets) ||
+      hasAcceptedSessionSpawn(runResult.acceptedSessionSpawns) ||
+      (runResult.successfulCronAdds ?? 0) > 0 ||
+      runResult.didSendDeterministicApprovalPrompt === true;
+    const successfulSideEffectDelivery =
+      committedOutboundDelivery ||
+      hasSuccessfulSourceReplyDelivery({ blockReplyPipeline, directlySentBlockKeys });
+    const successfulTerminalEffectDelivery =
+      committedOutboundDelivery ||
+      hasSuccessfulTerminalSourceReplyDelivery({
+        blockReplyPipeline,
+        directlySentBlockPayloads,
+      });
     const successfulSourceReplyDelivery = hasSuccessfulSourceReplyDelivery({
       blockReplyPipeline,
       directlySentBlockKeys,
@@ -1995,9 +2008,33 @@ export async function runReplyAgent(params: {
       hasVisibleAgentPayload({ payloads: runResult.messagingToolSourceReplyPayloads });
     const shouldDeliverTerminalFailure = Boolean(
       terminalFailurePayload &&
-      !successfulSideEffectDelivery &&
+      !successfulTerminalEffectDelivery &&
       !committedMessagingToolSourceReplyDelivery,
     );
+    const fallbackFailureKnown =
+      fallbackAttempts.length > 0 || configuredFallbackModel.persistedAutoFallback;
+    const hasSpecificFallbackFailure = fallbackTransition.fallbackActive && fallbackFailureKnown;
+    const emptyInteractiveReplyPayload = terminalFailurePayload
+      ? undefined
+      : buildEmptyInteractiveReplyPayload({
+          isInteractive:
+            followupRun.currentInboundEventKind !== "room_event" &&
+            (followupRun.run.inputProvenance?.kind === undefined ||
+              followupRun.run.inputProvenance.kind === "external_user"),
+          isHeartbeat,
+          silentExpected: followupRun.run.silentExpected,
+          allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
+          isMessageToolOnly:
+            (opts?.sourceReplyDeliveryMode ?? followupRun.run.sourceReplyDeliveryMode) ===
+            "message_tool_only",
+          hasPendingContinuation:
+            runResult.meta?.yielded === true || (runResult.meta?.pendingToolCalls?.length ?? 0) > 0,
+          hasExplicitSilentReply: hasDeliberateSilentTerminalReply(runResult),
+          hasCommittedDelivery:
+            successfulTerminalEffectDelivery || committedMessagingToolSourceReplyDelivery,
+          sessionCtx,
+          cfg,
+        });
     if (
       opts?.sourceReplyDeliveryMode === "message_tool_only" &&
       committedMessagingToolSourceReplyDelivery
@@ -2007,10 +2044,9 @@ export async function runReplyAgent(params: {
     const returnSilentFallbackFailureIfNeeded = async (): Promise<ReplyPayload | undefined> => {
       const silentFallbackFailurePayload = buildSilentFallbackFailurePayload({
         fallbackTransition,
-        fallbackFailureKnown:
-          fallbackAttempts.length > 0 || configuredFallbackModel.persistedAutoFallback,
+        fallbackFailureKnown,
         isHeartbeat,
-        hasSuccessfulSideEffectDelivery: successfulSideEffectDelivery,
+        hasSuccessfulTerminalDelivery: successfulTerminalEffectDelivery,
         allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,
         silentExpected: followupRun.run.silentExpected,
       });
@@ -2101,7 +2137,8 @@ export async function runReplyAgent(params: {
     if (
       payloadArray.length === 0 &&
       fallbackNoticePayloads.length === 0 &&
-      !shouldDeliverTerminalFailure
+      !shouldDeliverTerminalFailure &&
+      (!emptyInteractiveReplyPayload || hasSpecificFallbackFailure)
     ) {
       const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
       if (silentFallbackFailurePayload) {
@@ -2177,6 +2214,22 @@ export async function runReplyAgent(params: {
       const terminalPayloadResult = await buildFinalPayloads([terminalFailurePayload]);
       replyPayloads = [...replyPayloads, ...terminalPayloadResult.replyPayloads];
       didLogHeartbeatStrip = terminalPayloadResult.didLogHeartbeatStrip;
+    } else if (hasSpecificFallbackFailure && !hasTerminalReplyPayload) {
+      const silentFallbackFailurePayload = await returnSilentFallbackFailureIfNeeded();
+      if (silentFallbackFailurePayload) {
+        return silentFallbackFailurePayload;
+      }
+    } else if (emptyInteractiveReplyPayload && !hasTerminalReplyPayload) {
+      const emptyPayloadResult = await buildFinalPayloads([emptyInteractiveReplyPayload]);
+      replyPayloads = [...replyPayloads, ...emptyPayloadResult.replyPayloads];
+      didLogHeartbeatStrip = emptyPayloadResult.didLogHeartbeatStrip;
+      if (emptyPayloadResult.replyPayloads.length > 0) {
+        replyOperation.retainFailureUntilComplete();
+        replyOperation.fail(
+          "run_failed",
+          new Error("interactive agent run completed without a visible reply"),
+        );
+      }
     }
 
     const hasReplyPayloadBeyondFallbackNotice = replyPayloads.some(

--- a/src/auto-reply/reply/block-reply-pipeline.test.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.test.ts
@@ -101,6 +101,26 @@ describe("createBlockReplyContentKey", () => {
 });
 
 describe("createBlockReplyPipeline dedup with threading", () => {
+  it("does not count reasoning or commentary as a terminal reply", async () => {
+    const pipeline = createBlockReplyPipeline({
+      onBlockReply: async () => {},
+      timeoutMs: 5000,
+    });
+
+    pipeline.enqueue({ text: "reasoning", isReasoning: true });
+    pipeline.enqueue({ text: "commentary", isCommentary: true });
+    pipeline.enqueue({ audioAsVoice: true });
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.didStream()).toBe(true);
+    expect(pipeline.didStreamTerminalReply?.()).toBe(false);
+
+    pipeline.enqueue({ text: "final answer" });
+    await pipeline.flush({ force: true });
+
+    expect(pipeline.didStreamTerminalReply?.()).toBe(true);
+  });
+
   it("keeps separate deliveries for same text with different replyToId", async () => {
     const sent: Array<{ text?: string; replyToId?: string }> = [];
     const pipeline = createBlockReplyPipeline({

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -17,6 +17,8 @@ export type BlockReplyPipeline = {
   stop: () => void;
   hasBuffered: () => boolean;
   didStream: () => boolean;
+  /** True only after a final-answer lane payload is sent. */
+  didStreamTerminalReply?: () => boolean;
   isAborted: () => boolean;
   hasSentPayload: (payload: ReplyPayload) => boolean;
   hasSentExactPayload?: (payload: ReplyPayload) => boolean;
@@ -125,6 +127,7 @@ export function createBlockReplyPipeline(params: {
   let sendChain: Promise<void> = Promise.resolve();
   let aborted = false;
   let didStream = false;
+  let didStreamTerminalReply = false;
   let didLogTimeout = false;
 
   const hasSeenOrQueuedPayloadKey = (payloadKey: string) =>
@@ -193,6 +196,13 @@ export function createBlockReplyPipeline(params: {
         }
         if (!isStatusNotice) {
           didStream = true;
+          if (
+            payload.isReasoning !== true &&
+            payload.isCommentary !== true &&
+            hasOutboundReplyContent(payload, { trimText: true })
+          ) {
+            didStreamTerminalReply = true;
+          }
         }
       })
       .catch((err: unknown) => {
@@ -324,6 +334,7 @@ export function createBlockReplyPipeline(params: {
     stop,
     hasBuffered: () => coalescer?.hasBuffered() || bufferedPayloads.length > 0,
     didStream: () => didStream,
+    didStreamTerminalReply: () => didStreamTerminalReply,
     isAborted: () => aborted,
     hasSentExactPayload: (payload) => sentContentKeys.has(createBlockReplyContentKey(payload)),
     hasSentPayload: (payload) => {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -12,6 +12,7 @@ import {
   createUserTurnTranscriptRecorder,
   type PersistedUserTurnMessage,
 } from "../../sessions/user-turn-transcript.js";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "./agent-runner-failure-copy.js";
 import type { FollowupRun, QueueSettings } from "./queue.js";
 
 const runEmbeddedAgentMock = vi.fn();
@@ -360,6 +361,8 @@ async function loadFreshFollowupRunnerModuleForTest() {
   vi.resetModules();
   vi.doUnmock("../../config/config.js");
   vi.doMock("../../agents/model-fallback.js", () => ({
+    isFallbackSummaryError: (err: unknown) =>
+      err instanceof Error && err.name === "FallbackSummaryError",
     runWithModelFallback: (params: unknown) => runWithModelFallbackMock(params),
   }));
   vi.doMock("../../agents/session-write-lock.js", () => ({
@@ -4329,13 +4332,19 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       sessionStore: Record<string, SessionEntry>;
       sessionKey: string;
       storePath: string;
+      reasoningPayloadsEnabled: boolean;
+      commentaryPayloadsEnabled: boolean;
     }> = {},
   ) {
     if (overrides.storePath && overrides.sessionStore) {
       registerFollowupTestSessionStore(overrides.storePath, overrides.sessionStore);
     }
     return createFollowupRunner({
-      opts: { onBlockReply },
+      opts: {
+        onBlockReply,
+        reasoningPayloadsEnabled: overrides.reasoningPayloadsEnabled,
+        commentaryPayloadsEnabled: overrides.commentaryPayloadsEnabled,
+      },
       typing: createMockTypingController(),
       typingMode: "instant",
       defaultModel: "anthropic/claude-opus-4-6",
@@ -4354,6 +4363,8 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       sessionStore: Record<string, SessionEntry>;
       sessionKey: string;
       storePath: string;
+      reasoningPayloadsEnabled: boolean;
+      commentaryPayloadsEnabled: boolean;
     }>;
   }) {
     const onBlockReply = createAsyncReplySpy();
@@ -4373,6 +4384,259 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       ...overrides,
     };
   }
+
+  it.each([
+    { label: "empty", payloads: [], runnerOverrides: undefined },
+    { label: "empty-envelope", payloads: [{}], runnerOverrides: undefined },
+    { label: "blank-text", payloads: [{ text: "" }], runnerOverrides: undefined },
+    {
+      label: "reasoning-only",
+      payloads: [{ text: "internal", isReasoning: true }],
+      runnerOverrides: undefined,
+    },
+    {
+      label: "reasoning-only with reasoning enabled",
+      payloads: [{ text: "internal", isReasoning: true }],
+      runnerOverrides: { reasoningPayloadsEnabled: true },
+    },
+    {
+      label: "commentary-only",
+      payloads: [{ text: "internal", isCommentary: true }],
+      runnerOverrides: undefined,
+    },
+    {
+      label: "commentary-only with commentary enabled",
+      payloads: [{ text: "internal", isCommentary: true }],
+      runnerOverrides: { commentaryPayloadsEnabled: true },
+    },
+    {
+      label: "directive-only",
+      payloads: [{ text: "[[reply_to_current]]" }],
+      runnerOverrides: undefined,
+    },
+  ])(
+    "routes a visible fallback for successful $label followups",
+    async ({ payloads, runnerOverrides }) => {
+      const queued = baseQueuedRun("discord");
+      const { onBlockReply } = await runMessagingCase({
+        agentResult: { payloads },
+        runnerOverrides,
+        queued: {
+          ...queued,
+          currentInboundEventKind: "user_request",
+          originatingChannel: "discord",
+          originatingTo: "channel:C1",
+          originatingReplyToMode: "first",
+          messageId: "message-1",
+        },
+      });
+
+      expect(onBlockReply).not.toHaveBeenCalled();
+      const fallbackCall = routeReplyMock.mock.calls.find((call) => {
+        const payload = requireRecord(
+          requireRecord(call[0], "route reply params").payload,
+          "payload",
+        );
+        return payload.isError === true;
+      });
+      expect(fallbackCall).toBeDefined();
+      expect(requireRecord(fallbackCall?.[0], "fallback route reply params").payload).toMatchObject(
+        {
+          text: expect.stringContaining("did not produce a visible reply"),
+          isError: true,
+        },
+      );
+    },
+  );
+
+  it("routes the shared terminal failure for empty failed followups", async () => {
+    const queued = baseQueuedRun("discord");
+    await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        meta: { error: { kind: "tool_result_mismatch", message: "private detail" } },
+      },
+      queued: {
+        ...queued,
+        currentInboundEventKind: "user_request",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      },
+    });
+
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toMatchObject({
+      text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      isError: true,
+    });
+  });
+
+  it("routes a terminal failure when a classified empty result exhausts model fallback", async () => {
+    runWithModelFallbackMock.mockImplementationOnce(
+      async (params: {
+        provider: string;
+        model: string;
+        run: (provider: string, model: string) => Promise<unknown>;
+        classifyResult: (attempt: {
+          result: unknown;
+          provider: string;
+          model: string;
+          attempt: number;
+          total: number;
+        }) => Promise<Record<string, unknown>> | Record<string, unknown>;
+      }) => {
+        const result = await params.run(params.provider, params.model);
+        const classification = await params.classifyResult({
+          result,
+          provider: params.provider,
+          model: params.model,
+          attempt: 1,
+          total: 1,
+        });
+        expect(classification).toMatchObject({
+          code: "empty_result",
+          preserveResultOnExhaustion: true,
+          preserveResultPriority: -1,
+        });
+        return {
+          outcome: "exhausted",
+          result,
+          provider: params.provider,
+          model: params.model,
+          attempts: [{ reason: "format", code: "empty_result" }],
+        };
+      },
+    );
+    const queued = baseQueuedRun("discord");
+    await runMessagingCase({
+      agentResult: {
+        payloads: [],
+        meta: { agentHarnessResultClassification: "empty" },
+      },
+      queued: {
+        ...queued,
+        currentInboundEventKind: "user_request",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      },
+    });
+
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toMatchObject({
+      text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      isError: true,
+    });
+  });
+
+  it("routes a terminal failure when model fallback exhausts without a preserved result", async () => {
+    const exhaustionError = new Error("All model fallback candidates failed");
+    exhaustionError.name = "FallbackSummaryError";
+    runWithModelFallbackMock.mockRejectedValueOnce(exhaustionError);
+    const queued = baseQueuedRun("discord");
+    await runMessagingCase({
+      agentResult: { payloads: [] },
+      queued: {
+        ...queued,
+        currentInboundEventKind: "user_request",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+      },
+    });
+
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toMatchObject({
+      text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+      isError: true,
+    });
+  });
+
+  it.each([
+    {
+      label: "NO_REPLY",
+      agentResult: {
+        payloads: [{ text: "NO_REPLY" }],
+        meta: { finalAssistantVisibleText: "NO_REPLY" },
+      },
+      queuedOverrides: {},
+    },
+    {
+      label: "accepted child spawn",
+      agentResult: {
+        payloads: [],
+        acceptedSessionSpawns: [{ runId: "child", childSessionKey: "agent:main:child" }],
+      },
+      queuedOverrides: {},
+    },
+    {
+      label: "cron side effect",
+      agentResult: { payloads: [], successfulCronAdds: 1 },
+      queuedOverrides: {},
+    },
+    {
+      label: "approval prompt",
+      agentResult: { payloads: [], didSendDeterministicApprovalPrompt: true },
+      queuedOverrides: {},
+    },
+    {
+      label: "source delivery",
+      agentResult: { payloads: [], didDeliverSourceReplyViaMessageTool: true },
+      queuedOverrides: {},
+    },
+    {
+      label: "message-tool-only mode",
+      agentResult: { payloads: [] },
+      queuedOverrides: { run: { sourceReplyDeliveryMode: "message_tool_only" } },
+    },
+    {
+      label: "explicit silent policy",
+      agentResult: { payloads: [] },
+      queuedOverrides: { run: { silentExpected: true } },
+    },
+    {
+      label: "allowed empty reply",
+      agentResult: { payloads: [] },
+      queuedOverrides: { run: { allowEmptyAssistantReplyAsSilent: true } },
+    },
+    {
+      label: "yielded continuation",
+      agentResult: { payloads: [], meta: { yielded: true } },
+      queuedOverrides: {},
+    },
+    {
+      label: "pending tool continuation",
+      agentResult: { payloads: [], meta: { pendingToolCalls: [{ name: "hosted_tool" }] } },
+      queuedOverrides: {},
+    },
+    {
+      label: "room event",
+      agentResult: { payloads: [] },
+      queuedOverrides: { currentInboundEventKind: "room_event" },
+    },
+    {
+      label: "default-silent group",
+      agentResult: { payloads: [] },
+      queuedOverrides: { originatingChatType: "group" },
+    },
+    {
+      label: "internal handoff",
+      agentResult: { payloads: [] },
+      queuedOverrides: {
+        run: { inputProvenance: { kind: "inter_session", sourceTool: "subagent_announce" } },
+      },
+    },
+  ])("keeps successful $label followups silent", async ({ agentResult, queuedOverrides }) => {
+    const queued = baseQueuedRun("discord");
+    await runMessagingCase({
+      agentResult,
+      queued: {
+        ...queued,
+        currentInboundEventKind: "user_request",
+        originatingChannel: "discord",
+        originatingTo: "channel:C1",
+        ...queuedOverrides,
+        run: { ...queued.run, ...queuedOverrides.run },
+      } as FollowupRun,
+    });
+
+    expect(routeReplyMock).not.toHaveBeenCalled();
+  });
 
   it("persists usage even when replies are suppressed", async () => {
     const storePath = "/tmp/openclaw-followup-usage.json";
@@ -5096,7 +5360,7 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
 
     await runner(queued);
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(2);
+    expect(routeReplyMock).toHaveBeenCalledTimes(3);
     const startRoute = requireMockCallArg(routeReplyMock, 0);
     const endRoute = requireMockCallArg(routeReplyMock, 1);
     expect(startRoute).toMatchObject({
@@ -5120,6 +5384,12 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       replyToId: "current-msg-1",
       replyToCurrent: true,
       isCompactionNotice: true,
+    });
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 2).payload, "final fallback"),
+    ).toMatchObject({
+      text: expect.stringContaining("did not produce a visible reply"),
+      isError: true,
     });
   });
 
@@ -5201,7 +5471,7 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(4);
+    expect(routeReplyMock).toHaveBeenCalledTimes(5);
     expect(
       requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "hook start"),
     ).toMatchObject({
@@ -5231,6 +5501,12 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       replyToId: "current-msg-1",
       replyToCurrent: true,
       isCompactionNotice: true,
+    });
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 4).payload, "final fallback"),
+    ).toMatchObject({
+      text: expect.stringContaining("did not produce a visible reply"),
+      isError: true,
     });
   });
 
@@ -5269,13 +5545,19 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).toHaveBeenCalledTimes(1);
+    expect(routeReplyMock).toHaveBeenCalledTimes(2);
     const payload = requireRecord(requireMockCallArg(routeReplyMock, 0).payload, "notice payload");
     expect(payload).toMatchObject({
       text: "🧹 Compacting context...",
       isCompactionNotice: true,
     });
     expect(payload.replyToId).toBeUndefined();
+    expect(
+      requireRecord(requireMockCallArg(routeReplyMock, 1).payload, "final fallback"),
+    ).toMatchObject({
+      text: expect.stringContaining("did not produce a visible reply"),
+      isError: true,
+    });
   });
 
   it("plans queued compaction notices with the active fallback candidate", async () => {
@@ -5364,7 +5646,11 @@ describe("createFollowupRunner messaging delivery and dedupe", () => {
       }),
     );
 
-    expect(routeReplyMock).not.toHaveBeenCalled();
+    expect(routeReplyMock).toHaveBeenCalledOnce();
+    expect(requireMockCallArg(routeReplyMock, 0).payload).toMatchObject({
+      text: expect.stringContaining("did not produce a visible reply"),
+      isError: true,
+    });
   });
 });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -11,11 +11,22 @@ import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-bu
 import { getCliSessionBinding } from "../../agents/cli-session.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
-import { mergeEmbeddedAgentRunResultForModelFallbackExhaustion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import {
+  hasCommittedOutboundDeliveryEvidence,
+  hasVisibleAgentPayload,
+} from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import {
+  hasDeliberateSilentTerminalReply,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { runEmbeddedAgent } from "../../agents/embedded-agent.js";
 import type { FastModeAutoProgressState } from "../../agents/fast-mode.js";
 import { ensureSelectedAgentHarnessPlugin } from "../../agents/harness/runtime-plugin.js";
-import { runWithModelFallback } from "../../agents/model-fallback.js";
+import {
+  isFallbackSummaryError,
+  runWithModelFallback,
+  type ModelFallbackResultClassification,
+} from "../../agents/model-fallback.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import { isCliProvider } from "../../agents/model-selection-cli.js";
 import {
@@ -43,6 +54,7 @@ import { shouldPreserveUserFacingSessionStateForInputProvenance } from "../../se
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import {
   getReplyPayloadMetadata,
+  isReplyPayloadStatusNotice,
   markReplyPayloadForSourceSuppressionDelivery,
 } from "../reply-payload.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
@@ -59,8 +71,10 @@ import {
   runCliAgentWithLifecycle,
 } from "./agent-runner-cli-dispatch.js";
 import {
+  buildEmptyInteractiveReplyPayload,
   buildCommandOutputFromToolResultEvent,
   buildPreflightCompactionFailureText,
+  buildTerminalAgentRunFailureReplyPayload,
   resolveRunAfterAutoFallbackPrimaryProbeRecheck,
   resolveSessionRuntimeOverrideForProvider,
 } from "./agent-runner-execution.js";
@@ -99,6 +113,33 @@ import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 type EmbeddedAgentRunResult = Awaited<ReturnType<typeof runEmbeddedAgent>>;
+
+const PRESERVED_FOLLOWUP_RESULT_CODES = new Set([
+  "empty_result",
+  "reasoning_only_result",
+  "planning_only_result",
+]);
+
+function preserveNonVisibleFollowupResult(
+  classification: ModelFallbackResultClassification,
+): ModelFallbackResultClassification {
+  if (
+    !classification ||
+    !("code" in classification) ||
+    !classification.code ||
+    !PRESERVED_FOLLOWUP_RESULT_CODES.has(classification.code)
+  ) {
+    return classification;
+  }
+  // Follow-up delivery owns its terminal fallback. Preserve the classified result
+  // so that owner can route a visible failure instead of losing it to a thrown summary.
+  return {
+    ...classification,
+    preserveResultOnExhaustion: true,
+    // Prefer any earlier result that carries a user-facing terminal presentation.
+    preserveResultPriority: -1,
+  };
+}
 
 function resolveFollowupAbortSignal(
   run: Pick<FollowupRun, "abortSignal" | "queueAbortSignal">,
@@ -664,6 +705,7 @@ export function createFollowupRunner(params: {
       let fallbackProvider = run.provider;
       let fallbackModel = run.model;
       let fallbackExhausted = false;
+      let terminalRunFailed = false;
       const resolveFollowupCurrentMessageId = () =>
         run.inputProvenance?.kind === "internal_system" &&
         run.inputProvenance.sourceTool === "restart-sentinel"
@@ -914,7 +956,9 @@ export function createFollowupRunner(params: {
             });
           },
           classifyResult: ({ result, provider, model }) =>
-            outcomePlan.classifyRunResult({ result, provider, model }),
+            preserveNonVisibleFollowupResult(
+              outcomePlan.classifyRunResult({ result, provider, model }),
+            ),
           mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
           run: async (provider, model, runOptions) => {
             const suppressQueuedUserPersistenceForCandidate =
@@ -1373,11 +1417,13 @@ export function createFollowupRunner(params: {
           });
           replyOperation.retainFailureUntilComplete();
           replyOperation.fail("run_failed", exhaustionError);
+          terminalRunFailed = true;
         } else if (deferredLifecycleError || runResult.meta?.error) {
           const terminalError = new Error(terminalErrorMessage ?? "Agent run failed");
           emitSettledLifecycleError(terminalError, terminalMetadata);
           replyOperation.retainFailureUntilComplete();
           replyOperation.fail("run_failed", terminalError);
+          terminalRunFailed = true;
         } else {
           settledLifecycleTerminal?.emit("end", runResult);
         }
@@ -1401,16 +1447,27 @@ export function createFollowupRunner(params: {
           return;
         }
         const message = formatErrorMessage(err);
+        const shouldRouteFallbackExhaustion = isFallbackSummaryError(err);
         replyOperation.freezeAbort();
+        if (shouldRouteFallbackExhaustion) {
+          replyOperation.retainFailureUntilComplete();
+        }
         replyOperation.fail("run_failed", err);
         pendingLifecycleTerminal?.backstop.emit("error", err);
         pendingLifecycleTerminal = undefined;
         if (lifecycleGeneration !== getAgentEventLifecycleGeneration()) {
           clearAgentRunContext(runId, lifecycleGeneration);
         }
-        await drainProgressDeliveries();
         defaultRuntime.error?.(`Followup agent failed before reply: ${message}`);
-        return;
+        if (!shouldRouteFallbackExhaustion) {
+          await drainProgressDeliveries();
+          return;
+        }
+        // Fallback exhaustion can throw without a preserved candidate result.
+        // Continue through the owner delivery path so interactive turns still get safe failure copy.
+        runResult = { payloads: [], meta: { durationMs: 0 } };
+        fallbackExhausted = true;
+        terminalRunFailed = true;
       }
 
       await drainProgressDeliveries();
@@ -1455,28 +1512,103 @@ export function createFollowupRunner(params: {
         });
       }
 
-      const payloadArray = runResult.payloads ?? [];
-      if (payloadArray.length === 0) {
-        return;
-      }
-      const finalPayloads = resolveFollowupDeliveryPayloads({
-        cfg: runtimeConfig,
-        payloads: payloadArray,
-        messageProvider: run.messageProvider,
-        originatingAccountId: queued.originatingAccountId ?? run.agentAccountId,
-        originatingChannel: queued.originatingChannel,
-        originatingChatType: queued.originatingChatType,
-        originatingReplyToMode: queued.originatingReplyToMode,
-        originatingTo: queued.originatingTo,
-        originatingThreadId: queued.originatingThreadId,
-        reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
-        sentMediaUrls: runResult.messagingToolSentMediaUrls,
-        sentTargets: runResult.messagingToolSentTargets,
-        sentTexts: runResult.messagingToolSentTexts,
+      const hasCommittedDelivery =
+        hasCommittedOutboundDeliveryEvidence(runResult) ||
+        runResult.didDeliverSourceReplyViaMessageTool === true ||
+        hasVisibleAgentPayload({ payloads: runResult.messagingToolSourceReplyPayloads }) ||
+        runResult.didSendDeterministicApprovalPrompt === true;
+      const hasDeliveryDestination = Boolean(
+        (isRoutableChannel(queued.originatingChannel) && queued.originatingTo) ||
+        opts?.onBlockReply,
+      );
+      const isInteractive =
+        hasDeliveryDestination &&
+        queued.currentInboundEventKind !== "room_event" &&
+        (run.inputProvenance?.kind === undefined || run.inputProvenance.kind === "external_user");
+      const isMessageToolOnly = run.sourceReplyDeliveryMode === "message_tool_only";
+      const failureConversationContext = {
+        ChatType: queued.originatingChatType,
+        Provider: run.messageProvider,
+        SessionKey: replySessionKey,
+        Surface: queued.originatingChannel,
+      };
+      const fallbackPayload =
+        isInteractive && !isMessageToolOnly && !hasCommittedDelivery
+          ? terminalRunFailed
+            ? buildTerminalAgentRunFailureReplyPayload({
+                isHeartbeat: opts?.isHeartbeat,
+                sessionCtx: failureConversationContext,
+                cfg: runtimeConfig,
+              })
+            : buildEmptyInteractiveReplyPayload({
+                isInteractive,
+                isHeartbeat: opts?.isHeartbeat,
+                silentExpected: run.silentExpected,
+                allowEmptyAssistantReplyAsSilent: run.allowEmptyAssistantReplyAsSilent,
+                isMessageToolOnly,
+                hasPendingContinuation:
+                  runResult.meta?.yielded === true ||
+                  (runResult.meta?.pendingToolCalls?.length ?? 0) > 0,
+                hasExplicitSilentReply: hasDeliberateSilentTerminalReply(runResult),
+                hasCommittedDelivery,
+                sessionCtx: failureConversationContext,
+                cfg: runtimeConfig,
+              })
+          : undefined;
+      const payloadArray = (runResult.payloads ?? []).filter(
+        (payload) => payload.isCommentary !== true || opts?.commentaryPayloadsEnabled === true,
+      );
+      const deliveryPlan = buildAgentRuntimeDeliveryPlan({
+        provider: providerUsed,
+        modelId: modelUsed,
+        config: runtimeConfig,
+        workspaceDir: run.workspaceDir,
+        agentDir: run.agentDir,
       });
+      const resolveDeliveryPayloads = (payloads: ReplyPayload[]) =>
+        resolveFollowupDeliveryPayloads({
+          cfg: runtimeConfig,
+          payloads,
+          messageProvider: run.messageProvider,
+          originatingAccountId: queued.originatingAccountId ?? run.agentAccountId,
+          originatingChannel: queued.originatingChannel,
+          originatingChatType: queued.originatingChatType,
+          originatingReplyToMode: queued.originatingReplyToMode,
+          originatingTo: queued.originatingTo,
+          originatingThreadId: queued.originatingThreadId,
+          reasoningPayloadsEnabled: opts?.reasoningPayloadsEnabled === true,
+          sentMediaUrls: runResult.messagingToolSentMediaUrls,
+          sentTargets: runResult.messagingToolSentTargets,
+          sentTexts: runResult.messagingToolSentTexts,
+        }).filter(
+          (payload) => hasOutboundReplyContent(payload) && !deliveryPlan.isSilentPayload(payload),
+        );
+      let finalPayloads = resolveDeliveryPayloads(payloadArray);
+      const hasTerminalReplyPayload = finalPayloads.some(
+        (payload) =>
+          payload.isReasoning !== true &&
+          payload.isCommentary !== true &&
+          !isReplyPayloadStatusNotice(payload),
+      );
+      if (!hasTerminalReplyPayload && fallbackPayload) {
+        finalPayloads = [...finalPayloads, ...resolveDeliveryPayloads([fallbackPayload])];
+      }
 
       if (finalPayloads.length === 0) {
         return;
+      }
+      if (
+        !terminalRunFailed &&
+        fallbackPayload &&
+        finalPayloads.some(
+          (payload) => payload.isError === true && payload.text === fallbackPayload.text,
+        )
+      ) {
+        replyOperation.retainFailureUntilComplete();
+        replyOperation.fail(
+          "run_failed",
+          new Error("interactive follow-up completed without a visible reply"),
+        );
       }
 
       let deliveryPayloads = finalPayloads;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -2012,7 +2012,7 @@ export const FIELD_HELP: Record<string, string> = {
   "messages.statusReactions":
     "Lifecycle status reactions that update the emoji on the trigger message as the agent progresses (queued → thinking → tool → done/error).",
   "messages.statusReactions.enabled":
-    "Enable lifecycle status reactions on supported channels. Slack and Discord treat unset as enabled when ack reactions are active; Signal, Telegram, and WhatsApp require this to be true before lifecycle reactions are used.",
+    "Enable lifecycle status reactions on supported channels. Discord treats unset as enabled when ack reactions are active; Slack, Signal, Telegram, and WhatsApp require this to be true before lifecycle reactions are used. Slack uses native assistant thread status for progress by default.",
   "messages.statusReactions.emojis":
     "Override default status reaction emojis. Keys: queued, thinking, compacting, tool, coding, web, deploy, build, concierge, done, error, stallSoft, stallHard. Telegram chooses the first supported fallback when a configured emoji is not available in the chat.",
   "messages.statusReactions.timing":

--- a/src/talk/agent-consult-tool.test.ts
+++ b/src/talk/agent-consult-tool.test.ts
@@ -1,5 +1,6 @@
 // Agent consult tool tests cover tool payload validation for consult requests.
 import { describe, expect, it } from "vitest";
+import type { RealtimeVoiceTool } from "./provider-types.js";
 import {
   buildRealtimeVoiceAgentConsultChatMessage,
   buildRealtimeVoiceAgentConsultPrompt,
@@ -114,5 +115,39 @@ describe("realtime voice agent consult tool", () => {
       resolveRealtimeVoiceAgentConsultTools("safe-read-only", [duplicateConsultTool, customTool]),
     ).toStrictEqual([REALTIME_VOICE_AGENT_CONSULT_TOOL, customTool]);
     expect(resolveRealtimeVoiceAgentConsultTools("none", [customTool])).toEqual([customTool]);
+  });
+
+  it("quarantines custom realtime tools with unreadable names before dedupe", () => {
+    const unreadableNameTool: RealtimeVoiceTool = {
+      type: "function" as const,
+      get name(): string {
+        throw new Error("unreadable tool name");
+      },
+      description: "Unreadable custom tool",
+      parameters: { type: "object" as const, properties: {} },
+    };
+    const nonStringNameTool = {
+      type: "function" as const,
+      name: undefined,
+      description: "Malformed custom tool",
+      parameters: { type: "object" as const, properties: {} },
+    } as unknown as RealtimeVoiceTool;
+    const customTool: RealtimeVoiceTool = {
+      type: "function" as const,
+      name: "custom_lookup",
+      description: "Custom lookup",
+      parameters: { type: "object" as const, properties: {} },
+    };
+
+    expect(
+      resolveRealtimeVoiceAgentConsultTools("safe-read-only", [
+        unreadableNameTool,
+        nonStringNameTool,
+        customTool,
+      ]),
+    ).toStrictEqual([REALTIME_VOICE_AGENT_CONSULT_TOOL, customTool]);
+    expect(resolveRealtimeVoiceAgentConsultTools("none", [unreadableNameTool, customTool])).toEqual(
+      [customTool],
+    );
   });
 });

--- a/src/talk/agent-consult-tool.ts
+++ b/src/talk/agent-consult-tool.ts
@@ -113,11 +113,21 @@ export function resolveRealtimeVoiceAgentConsultTools(
   // Keep the built-in consult tool first and prevent custom tools from
   // replacing its provider-facing contract by name.
   for (const tool of customTools) {
-    if (!tools.has(tool.name)) {
-      tools.set(tool.name, tool);
+    const name = readRealtimeVoiceCustomToolName(tool);
+    if (name !== undefined && !tools.has(name)) {
+      tools.set(name, tool);
     }
   }
   return [...tools.values()];
+}
+
+function readRealtimeVoiceCustomToolName(tool: RealtimeVoiceTool): string | undefined {
+  try {
+    const name = tool.name;
+    return typeof name === "string" ? name : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 /** Resolve the OpenClaw tool allowlist paired with the consult exposure policy. */

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -370,13 +370,14 @@ async function startLocalModeTui(opts: { invalidEditLoop?: boolean } = {}) {
 
 async function startGatewayModeTui(params: {
   queueMode: "followup" | "collect";
+  firstReplyText?: string;
   firstResponseDelayMs?: number;
   queueDebounceMs?: number;
   invalidEditLoop?: boolean;
 }) {
   const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-tui-pty-gateway-"));
   const workspaceDir = path.join(tempDir, "workspace");
-  const mockModel = await startMockModelServer("FIRST_RUN_ACTIVE", {
+  const mockModel = await startMockModelServer(params.firstReplyText ?? "FIRST_RUN_ACTIVE", {
     firstResponseDelayMs: params.firstResponseDelayMs ?? 2_500,
     followupReplyText: "FOLLOWUP_RUN_COMPLETE",
     invalidEditLoop: params.invalidEditLoop,
@@ -680,6 +681,60 @@ describe("TUI PTY real backends", () => {
         expect(JSON.stringify(fixture.mockModel.requests()[2]?.body)).toContain(
           "turn after queued followup",
         );
+
+        await fixture.run.write("/exit\r", { delay: false });
+        expect((await fixture.run.waitForExit()).exitCode).toBe(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "renders a non-deliverable direct reply failure through the real Gateway and TUI",
+    async () => {
+      const fixture = await startGatewayModeTui({
+        queueMode: "followup",
+        firstReplyText: "[[reply_to_current]]",
+        firstResponseDelayMs: 0,
+      });
+      try {
+        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
+        await fixture.run.write("non-deliverable first turn\r");
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length === 1 ? true : null),
+          onTimeout: () =>
+            new Error(`first prompt did not reach the model\n${fixture.run.output()}`),
+        });
+
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () =>
+            fixture.run.output().includes("did not produce a visible reply") ? true : null,
+          onTimeout: () =>
+            new Error(
+              `empty-reply fallback was not rendered\nrequests=${JSON.stringify(
+                fixture.mockModel.requests(),
+                null,
+                2,
+              )}\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
+            ),
+        });
+        expect(fixture.mockModel.requests()).toHaveLength(1);
+        expect(fixture.run.output()).not.toContain("[[reply_to_current]]");
+
+        await fixture.run.write("turn after empty reply\r");
+        await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => (fixture.mockModel.requests().length === 2 ? true : null),
+          onTimeout: () =>
+            new Error(
+              `TUI stayed blocked after empty-reply fallback\n${fixture.gateway.logs()}\n${fixture.run.output()}`,
+            ),
+        });
+        await fixture.run.waitForOutput("FOLLOWUP_RUN_COMPLETE");
 
         await fixture.run.write("/exit\r", { delay: false });
         expect((await fixture.run.waitForExit()).exitCode).toBe(0);

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -234,6 +234,7 @@ describe("package-openclaw-for-docker", () => {
     )}\n`;
     const installedAiPath = path.join(sourceDir, "node_modules", "@openclaw", "ai");
     fs.mkdirSync(path.join(sourceDir, "packages", "ai"), { recursive: true });
+    fs.writeFileSync(path.join(sourceDir, "packages", "ai", "package.json"), "{}\n");
     fs.mkdirSync(installedAiPath, { recursive: true });
     fs.writeFileSync(path.join(installedAiPath, "original-marker"), "workspace package");
     fs.writeFileSync(packageJsonPath, originalPackageJson);
@@ -288,6 +289,67 @@ describe("package-openclaw-for-docker", () => {
     } finally {
       fs.rmSync(sourceDir, { recursive: true, force: true });
       fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves pre-AI-workspace package sources unchanged", async () => {
+    const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-legacy-source-"));
+    const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-legacy-output-"));
+    const packageJsonPath = path.join(sourceDir, "package.json");
+    const originalPackageJson = `${JSON.stringify({
+      dependencies: { "dep-a": "1.2.3" },
+      name: "openclaw",
+      version: "2026.7.1",
+    })}\n`;
+    fs.writeFileSync(packageJsonPath, originalPackageJson);
+    const runCapture = vi.fn();
+
+    try {
+      const cleanup = await prepareBundledAiRuntimePackage(sourceDir, outputDir, runCapture);
+
+      expect(runCapture).not.toHaveBeenCalled();
+      expect(fs.readFileSync(packageJsonPath, "utf8")).toBe(originalPackageJson);
+      await cleanup();
+    } finally {
+      fs.rmSync(sourceDir, { recursive: true, force: true });
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects incomplete AI workspace package sources", async () => {
+    const cases = [
+      {
+        dependencies: { "@openclaw/ai": "workspace:*" },
+        expected: "@openclaw/ai dependency requires the packages/ai workspace",
+        withWorkspace: false,
+      },
+      {
+        dependencies: {},
+        expected: "root package.json must declare @openclaw/ai as a dependency",
+        withWorkspace: true,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-invalid-source-"));
+      const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-docker-invalid-output-"));
+      fs.writeFileSync(
+        path.join(sourceDir, "package.json"),
+        `${JSON.stringify({ dependencies: testCase.dependencies, name: "openclaw" })}\n`,
+      );
+      if (testCase.withWorkspace) {
+        fs.mkdirSync(path.join(sourceDir, "packages", "ai"), { recursive: true });
+        fs.writeFileSync(path.join(sourceDir, "packages", "ai", "package.json"), "{}\n");
+      }
+
+      try {
+        await expect(prepareBundledAiRuntimePackage(sourceDir, outputDir, vi.fn())).rejects.toThrow(
+          testCase.expected,
+        );
+      } finally {
+        fs.rmSync(sourceDir, { recursive: true, force: true });
+        fs.rmSync(outputDir, { recursive: true, force: true });
+      }
     }
   });
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2410,6 +2410,12 @@ describe("package artifact reuse", () => {
     );
     expect(fullRelease.jobs?.prepare_release_package).toBeUndefined();
     expect(releaseChecks.jobs?.prepare_release_package?.["timeout-minutes"]).toBe(15);
+    expect(
+      workflowStep(
+        workflowJob(RELEASE_CHECKS_WORKFLOW, "prepare_release_package"),
+        "Setup Node environment",
+      ).with?.["install-deps"],
+    ).toBe("true");
     expect(crossOs.jobs?.cross_os_release_checks?.["timeout-minutes"]).toBe(60);
     expect(liveE2e.jobs?.validate_release_live_cache?.["timeout-minutes"]).toBe(20);
     expect(readFileSync(LIVE_E2E_WORKFLOW, "utf8")).toContain(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1550,6 +1550,17 @@ describe("package artifact reuse", () => {
     }
   });
 
+  it("maps every supported Slack approval checkpoint scenario family", () => {
+    const workflow = readFileSync(MANTIS_SLACK_DESKTOP_SMOKE_WORKFLOW, "utf8");
+
+    expectTextToIncludeAll(workflow, [
+      'endswith("-exec-native")',
+      'endswith("-plugin-native")',
+      'startswith("slack-codex-")',
+      'expected_result="Slack approval checkpoint passes for $scenario_label"',
+    ]);
+  });
+
   it("fails Docker E2E release lanes when summary artifacts are missing", () => {
     const cases = [
       {

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -1,0 +1,144 @@
+// Control UI tests cover application-owned overlay races.
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayBrowserClient, GatewayEventFrame } from "../api/gateway.ts";
+import type { ApplicationGateway, ApplicationGatewaySnapshot } from "./gateway.ts";
+import { createApplicationOverlays } from "./overlays.ts";
+
+type RequestFn = (method: string, params?: unknown) => Promise<unknown>;
+
+function deferred<T = unknown>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+function approval(id: string, createdAtMs: number) {
+  return {
+    id,
+    createdAtMs,
+    expiresAtMs: Date.now() + 60_000,
+    request: { command: `echo ${id}` },
+  };
+}
+
+function createGatewayHarness(initialClient: GatewayBrowserClient) {
+  let snapshot: ApplicationGatewaySnapshot = {
+    assistantAgentId: "main",
+    client: initialClient,
+    connected: true,
+    hello: null,
+    lastError: null,
+    lastErrorCode: null,
+    sessionKey: "main",
+  };
+  const snapshotListeners = new Set<(next: ApplicationGatewaySnapshot) => void>();
+  const eventListeners = new Set<(event: GatewayEventFrame) => void>();
+  const gateway = {
+    get snapshot() {
+      return snapshot;
+    },
+    connection: { gatewayUrl: "ws://gateway.test", password: "", token: "" },
+    eventLog: [],
+    connect() {},
+    setSessionKey() {},
+    start() {},
+    stop() {},
+    subscribe(listener: (next: ApplicationGatewaySnapshot) => void) {
+      snapshotListeners.add(listener);
+      return () => snapshotListeners.delete(listener);
+    },
+    subscribeEventLog() {
+      return () => {};
+    },
+    subscribeEvents(listener: (event: GatewayEventFrame) => void) {
+      eventListeners.add(listener);
+      return () => eventListeners.delete(listener);
+    },
+  } satisfies ApplicationGateway;
+  return {
+    emitApproval(id: string, createdAtMs: number) {
+      const event: GatewayEventFrame = {
+        event: "exec.approval.requested",
+        payload: approval(id, createdAtMs),
+        type: "event",
+      };
+      for (const listener of eventListeners) {
+        listener(event);
+      }
+    },
+    gateway,
+    update(next: Partial<ApplicationGatewaySnapshot>) {
+      snapshot = { ...snapshot, ...next };
+      for (const listener of snapshotListeners) {
+        listener(snapshot);
+      }
+    },
+  };
+}
+
+function client(request: RequestFn): GatewayBrowserClient {
+  return { request } as unknown as GatewayBrowserClient;
+}
+
+describe("application approval overlays", () => {
+  it("does not attach an older resolve failure to a newer approval", async () => {
+    const resolveAttempt = deferred();
+    const request = vi.fn<RequestFn>((method) =>
+      method.endsWith(".list") ? Promise.resolve([]) : resolveAttempt.promise,
+    );
+    const harness = createGatewayHarness(client(request));
+    const overlays = createApplicationOverlays(harness.gateway);
+
+    harness.emitApproval("approval-active", 1_000);
+    const decision = overlays.decideApproval("allow-once");
+    harness.emitApproval("approval-newer", 2_000);
+    resolveAttempt.reject(new Error("gateway unavailable"));
+    await decision;
+
+    expect(overlays.snapshot.approvalQueue.map((entry) => entry.id)).toEqual([
+      "approval-newer",
+      "approval-active",
+    ]);
+    expect(overlays.snapshot.approvalError).toBeNull();
+    expect(overlays.snapshot.approvalBusy).toBe(false);
+    overlays.dispose();
+  });
+
+  it("does not release a new client's busy state when an old resolve settles", async () => {
+    const oldResolve = deferred();
+    const oldRequest = vi.fn<RequestFn>((method) =>
+      method.endsWith(".list") ? Promise.resolve([]) : oldResolve.promise,
+    );
+    const harness = createGatewayHarness(client(oldRequest));
+    const overlays = createApplicationOverlays(harness.gateway);
+
+    harness.emitApproval("approval-old", 1_000);
+    const oldDecision = overlays.decideApproval("allow-once");
+    harness.update({ client: null, connected: false });
+
+    const newResolve = deferred();
+    const newClient = client((method) =>
+      method.endsWith(".list") ? Promise.resolve([]) : newResolve.promise,
+    );
+    harness.update({ client: newClient, connected: true });
+    await Promise.resolve();
+    harness.emitApproval("approval-new", 2_000);
+    const newDecision = overlays.decideApproval("deny");
+    expect(overlays.snapshot.approvalBusy).toBe(true);
+
+    oldResolve.reject(new Error("gateway client stopped"));
+    await oldDecision;
+    expect(overlays.snapshot.approvalBusy).toBe(true);
+    expect(overlays.snapshot.approvalError).toBeNull();
+
+    newResolve.resolve({ ok: true });
+    await newDecision;
+    expect(overlays.snapshot.approvalBusy).toBe(false);
+    expect(overlays.snapshot.approvalQueue).toEqual([]);
+    overlays.dispose();
+  });
+});

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -216,6 +216,7 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
   let updateVerificationGeneration = 0;
   let updateVerificationTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
   let devicePairPendingCountGeneration = 0;
+  let approvalDecision: { client: NonNullable<typeof activeClient>; id: string } | null = null;
   const devicePairSetupState: DevicePairSetupState & { pendingCount: number } = {
     client: gateway.snapshot.client,
     connected: gateway.snapshot.connected,
@@ -253,6 +254,12 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
   };
   promptState.execApprovalExpired = publish;
 
+  const isCurrentClient = (client: NonNullable<typeof activeClient>) =>
+    !disposed &&
+    activeClient === client &&
+    gateway.snapshot.client === client &&
+    gateway.snapshot.connected;
+
   const refreshDevicePairPendingCount = async () => {
     const client = gateway.snapshot.client;
     if (
@@ -285,12 +292,7 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
 
   const refreshApprovals = async (client: NonNullable<typeof activeClient>) => {
     const applied = await refreshPendingApprovalQueue(promptState, {
-      isCurrentClient: (requestClient) =>
-        !disposed &&
-        requestClient === client &&
-        activeClient === client &&
-        gateway.snapshot.client === client &&
-        gateway.snapshot.connected,
+      isCurrentClient: (requestClient) => requestClient === client && isCurrentClient(client),
     });
     if (applied && !disposed) {
       publish();
@@ -411,6 +413,7 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
     devicePairSetupState.client = next.client;
     devicePairSetupState.connected = next.connected;
     if (previousClient !== next.client || !next.connected) {
+      approvalDecision = null;
       devicePairPendingCountGeneration += 1;
       closeDevicePairSetupState(devicePairSetupState);
       devicePairSetupState.pendingCount = 0;
@@ -571,47 +574,40 @@ export function createApplicationOverlays(gateway: ApplicationGateway): Applicat
       }
       promptState.execApprovalBusy = true;
       promptState.execApprovalError = null;
+      const operation = { client, id: active.id };
+      approvalDecision = operation;
       publish();
       try {
         const method =
           active.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
         await client.request(method, { id: active.id, decision });
-        if (
-          disposed ||
-          activeClient !== client ||
-          gateway.snapshot.client !== client ||
-          !gateway.snapshot.connected
-        ) {
+        if (!isCurrentClient(client)) {
           return;
         }
         dismissExecApprovalPrompt(promptState, active.id);
       } catch (error) {
         if (isStaleApprovalResolutionError(error)) {
-          if (
-            disposed ||
-            activeClient !== client ||
-            gateway.snapshot.client !== client ||
-            !gateway.snapshot.connected
-          ) {
+          if (!isCurrentClient(client)) {
             return;
           }
           dismissExecApprovalPrompt(promptState, active.id);
           const currentClient = activeClient;
-          if (
-            currentClient &&
-            gateway.snapshot.client === currentClient &&
-            gateway.snapshot.connected
-          ) {
+          if (currentClient && isCurrentClient(currentClient)) {
             await refreshApprovals(currentClient);
           }
           return;
         }
-        if (promptState.execApprovalQueue.some((entry) => entry.id === active.id)) {
+        if (isCurrentClient(client) && promptState.execApprovalQueue[0]?.id === active.id) {
           promptState.execApprovalError = `Approval failed: ${error instanceof Error ? error.message : String(error)}`;
         }
       } finally {
-        promptState.execApprovalBusy = false;
-        publish();
+        // Reconnect can admit a new decision while this request is still settling.
+        // Only the operation that owns the busy state may release it.
+        if (approvalDecision === operation) {
+          approvalDecision = null;
+          promptState.execApprovalBusy = false;
+          publish();
+        }
       }
     },
     async openDevicePairSetup() {

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -1,0 +1,81 @@
+// Control UI E2E tests cover approval queue behavior through the Gateway WebSocket.
+import { chromium, type Browser, type Page } from "playwright";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser | undefined;
+let page: Page | undefined;
+let server: ControlUiE2eServer | undefined;
+
+function approval(id: string, command: string, createdAtMs: number) {
+  return {
+    id,
+    createdAtMs,
+    expiresAtMs: Date.now() + 60_000,
+    request: { command },
+  };
+}
+
+describeControlUiE2e("Control UI approval flow", () => {
+  beforeAll(async () => {
+    server = await startControlUiE2eServer();
+  });
+
+  afterEach(async () => {
+    await page
+      ?.context()
+      .close()
+      .catch(() => {});
+    await browser?.close().catch(() => {});
+    page = undefined;
+    browser = undefined;
+  });
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  it("keeps an older resolve failure off the newly active approval", async () => {
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const currentPage = await context.newPage();
+    page = currentPage;
+    const gateway = await installMockGateway(currentPage);
+
+    await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await gateway.waitForRequest("sessions.list");
+    await gateway.deferNext("exec.approval.resolve");
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-active", "echo active", 1_000),
+    );
+    await currentPage.getByText("echo active", { exact: true }).waitFor();
+    await currentPage.getByRole("button", { name: "Allow once" }).click();
+
+    await gateway.emitGatewayEvent(
+      "exec.approval.requested",
+      approval("approval-newer", "echo newer", 2_000),
+    );
+    await currentPage.getByText("echo newer", { exact: true }).waitFor();
+    await gateway.rejectDeferred("exec.approval.resolve", {
+      code: "UNAVAILABLE",
+      message: "gateway unavailable",
+    });
+
+    await expect.poll(() => currentPage.locator(".exec-approval-error").count()).toBe(0);
+    await expect
+      .poll(() => currentPage.getByRole("button", { name: "Deny" }).isEnabled())
+      .toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #100451

## What Problem This Solves

The macOS menu-bar app performed avoidable work while idle. Its node-mode coordinator reread configuration and queried macOS permissions once per second even while connected, and the critter animation task woke every 350 ms even when its next randomized idle animation was seconds away.

## Why This Change Was Made

Node registration refresh is now event-driven for configuration, endpoint, permission, preference, and app-activation changes. A disconnected-only 30-second probe preserves recovery for Gateway sessions paused by authentication or pairing failures without polling during normal connected operation.

The critter now sleeps until its nearest animation deadline while idle, retains the existing 350 ms working cadence, and reschedules elapsed animation deadlines after a pause.

This adds some coordinator code while removing the steady-state polling path and consolidating node input gathering into one canonical refresh flow.

## User Impact

Users can leave the macOS app running with fewer idle CPU wakeups and less repeated configuration/TCC work. Node registration still refreshes when relevant inputs change, and active-work animation behavior is unchanged.

## Evidence

- Developer ID-signed branch app passed deep/strict `codesign` verification and launched successfully.
- Installed-build 45-second Time Profiler baseline showed the one-second node loop repeatedly entering `MacNodeModeCoordinator`, config loading, and permission checks.
- Signed branch-build 30-second idle sample recorded zero matching frames for `MacNodeModeCoordinator`, `OpenClawConfigFile`, `PermissionManager.status`, `AppleScriptPermission`, or `CritterStatusLabel` tick/body work. At 39 seconds it reported 0.0% CPU and 0:00.35 total CPU time including startup; sampled top stacks were sleeping syscalls.
- `swift build --package-path apps/macos --build-path apps/macos/.build/arm64`
- `swift test --package-path apps/macos --build-path apps/macos/.build/arm64 --filter CritterIconRendererTests` — 5 passed. The current `main` test target has an unrelated missing `OnboardingView.hasCrestodianSetupAuth` symbol, so this focused run used and then removed a test-only compile bridge.
- Targeted SwiftFormat and SwiftLint — clean, 0 violations.
- Blacksmith Testbox `tbx_01kwsydbsd5yg0vprs6pb21rhp` (`coral-prawn`) — `check:changed` apps lane passed all 5 shards.
- Fresh autoreview — no accepted/actionable findings after fixes for endpoint changes, pause/resume deadlines, live permission changes, notification isolation, and paused Gateway reconnect recovery.

Known proof gap: this host's configured localhost Gateway was unavailable/rejected its existing configuration, so sustained connected-state and live node-registration refresh observation were not possible. The signed app launch, disconnected backoff, focused tests, review, and idle samples passed.

No changelog entry: this repository updates the changelog during release preparation.

Agent transcript: not included.
