### PR TITLE
docs: credit empty-reply fix contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent empty replies:** surface a visible failure when a completed interactive turn has no deliverable reply, including queued follow-ups, while preserving explicit silence, pending continuations, and committed side effects. (#100456) Thanks @mushuiyu886.
 - **Child process output safety:** prevent stdout/stderr pipe failures from crashing agent exec sessions, local TUI shell commands, and bounded process execution. (#100407, #100406, #100410) Thanks @cxbAsDev.
 - **Background refresh isolation:** keep remote skill-bin refreshes running when one node fails, and contain periodic subagent-sweeper failures without hiding errors from direct callers. (#100393, #100390) Thanks @cxbAsDev.
 - **Skill scan diagnostics:** report directory enumeration failures through the existing resource diagnostics instead of silently dropping affected skills. (#100380) Thanks @wendy-chsy.


### PR DESCRIPTION
Related: #100456

## What Problem This Solves

The runtime fix in #100456 intentionally landed without a changelog edit because continuous mainline changelog changes were repeatedly invalidating its exact-head landing proof. Its contributor credit still needs to appear in the release notes.

## Why This Change Was Made

Add the deferred one-line Unreleased entry now that the runtime change is on `main`, preserving contributor credit for @mushuiyu886 without coupling the runtime merge to a fast-moving file.

## User Impact

Release notes now describe the visible empty-interactive-reply failure behavior and credit the original contributor. No runtime behavior changes.

## Evidence

- Runtime fix landed in #100456 as `f0093b7020e772c0ac3237b25b149d369c604915`.
- `git diff --check`
- Changelog-only diff: one insertion, no deletions.
