### PR TITLE
fix(ios): simplify development app name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 - **Assistant visible text:** unwrap leaked standalone `<parameter>` tags while preserving their content and literal code/XML examples. (#100302) Thanks @nankingjing.
 - **Android microphone capture:** treat negative `AudioRecord.read` results as fatal shared-session errors so both transcription and Talk capture stop cleanly after device loss. (#100028) Thanks @NianJiuZst.
 - **Lean local-model tools:** trim media generation, TTS, and PDF tools from lean agent surfaces while preserving explicit config and runtime opt-ins. (#88881) Thanks @vincentkoc.
+- **iOS development app identity:** keep the development app labeled OpenClaw while using its distinct debug icon to differentiate it from release builds.
 - **iOS QR gateway handoff:** stop VisionKit before delivering scanned setup codes, and keep deferred auth, approval, Watch, and foreground-node work bound to its originating gateway across reconnects. (#99572) Thanks @PollyBot13.
 - **Agent terminal failures:** surface a safe interactive reply when an agent run ends without visible output, while preserving completed message-tool delivery and heartbeat-specific guidance. (#99304) Thanks @moeedahmed.
 - **MCP loopback tool results:** preserve schema-valid text, image, and embedded-resource content through HTTP tool calls while rendering malformed or protocol-incompatible blocks as safe text. (#100336) Thanks @tzy-17.

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -134,7 +134,7 @@ targets:
           ASSETCATALOG_COMPILER_APPICON_NAME: AppIconDebug
           CODE_SIGN_STYLE: Automatic
           OPENCLAW_ACTIVE_APP_GROUP_ID: "$(OPENCLAW_DEBUG_APP_GROUP_ID)"
-          OPENCLAW_APP_DISPLAY_NAME: OpenClaw Debug
+          OPENCLAW_APP_DISPLAY_NAME: OpenClaw
           OPENCLAW_CODE_SIGN_ENTITLEMENTS: Sources/OpenClaw.entitlements
           OPENCLAW_APNS_ENTITLEMENT_ENVIRONMENT: development
           OPENCLAW_URL_SCHEME: openclaw-debug


### PR DESCRIPTION
## What Problem This Solves

Development and release iOS apps can coexist under separate bundle identifiers. Labeling the development build `OpenClaw Debug` adds visual clutter even though its distinct debug icon already communicates the build identity.

## Why This Change Was Made

Use the normal `OpenClaw` display name for Debug builds while retaining `AppIconDebug`, the `.debug` bundle identifier, debug URL scheme, and debug app group.

## User Impact

The development app appears as `OpenClaw` on the Home Screen and remains visually distinguishable by its debug icon.

## Evidence

- `xcodegen generate`
- Physical iPhone 17 Debug build: `xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -configuration Debug -destination id=ABB203E1-BDDC-5941-ADC1-E4F18D9321AF -allowProvisioningUpdates build`
- Built app metadata: display name `OpenClaw`, icon `AppIconDebug`, bundle identifier `ai.openclawfoundation.app.test.steipete-y5pe65helj.debug`
- Installed on the physical device; removed the stale non-debug bundle; device inventory reports one OpenClaw app
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings
