### PR TITLE
fix(channels): normalize phone identities with stray plus signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 - **Source build portability:** keep tsdown configuration self-contained so builds do not depend on resolving the tsdown package from unrun's temporary module directory.
 - **Gateway event dispatch:** catch and log lazy subscriber setup and handler failures instead of leaking unhandled promise rejections. (#100401) Thanks @cxbAsDev.
+- **Phone identity normalization:** canonicalize stray plus signs, preserve non-phone iMessage handles, and reject digit-free Signal identities across shared channel routing. (#100467) Thanks @morluto.
 - **Diffs rendering:** render viewer and image output from one SSR preload, preserve language-pack highlighting through hydration, normalize language hints case-insensitively, skip identical before/after inputs with an explicit `changed` result, report truthful file-render and input errors, cache hash-pinned viewer runtimes, and prefer canonical file settings over stale aliases. (#100487)
 - **Remote browser reliability:** bound persistent Playwright tab enumeration by the existing remote CDP timeout budget and retire timed-out connection attempts so late completions cannot restore a stuck connection. (#80147, #58968) Thanks @HemantSudarshan and @KeaneYan.
 - **Managed browser cookie persistence:** initialize new isolated macOS headless profiles with a non-interactive encryption key while preserving existing profile keys, and close Chromium through CDP before bounded signal fallback so persistent logins survive graceful browser and Gateway restarts. (#96704, #98284) Thanks @TurboTheTurtle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@ Docs: https://docs.openclaw.ai
 - **Control UI tool-result images:** render direct image content blocks from Gateway history and make the delayed-send scroll E2E setup deterministic. (#100295) Thanks @lzyyzznl.
 - **Plugin approval diagnostics:** distinguish request validation rejections, expired wait decisions, and unavailable Gateways while keeping approval failures fail-closed. (#100337) Thanks @tzy-17.
 - **IRC Unicode messages:** split outbound PRIVMSG payloads on UTF-16 code-point boundaries so emoji cannot be cut into lone surrogates. (#96572) Thanks @llagy009.
-- **Phone identity normalization:** canonicalize stray plus signs, preserve non-phone iMessage handles, and reject digit-free Signal identities across shared channel routing. (#100467) Thanks @morluto.
 - **OpenAI realtime voice greetings:** prevent server VAD from creating a second outbound greeting while an explicit greeting response owns the turn, without disabling caller interruption. (#86285) Thanks @giodl73-repo.
 - **Realtime voice tools:** filter malformed tool names at each OpenAI, Azure, and Google realtime payload boundary while preserving provider-specific valid names. (#89175) Thanks @vincentkoc.
 - **Discord voice status:** treat Discord error 10065 as a normal disconnected state while preserving unrelated REST failures. (#90969) Thanks @asock.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ Docs: https://docs.openclaw.ai
 
 - **Source build portability:** keep tsdown configuration self-contained so builds do not depend on resolving the tsdown package from unrun's temporary module directory.
 - **Gateway event dispatch:** catch and log lazy subscriber setup and handler failures instead of leaking unhandled promise rejections. (#100401) Thanks @cxbAsDev.
-- **Phone identity normalization:** canonicalize stray plus signs, preserve non-phone iMessage handles, and reject digit-free Signal identities across shared channel routing. (#100467) Thanks @morluto.
 - **Diffs rendering:** render viewer and image output from one SSR preload, preserve language-pack highlighting through hydration, normalize language hints case-insensitively, skip identical before/after inputs with an explicit `changed` result, report truthful file-render and input errors, cache hash-pinned viewer runtimes, and prefer canonical file settings over stale aliases. (#100487)
 - **Remote browser reliability:** bound persistent Playwright tab enumeration by the existing remote CDP timeout budget and retire timed-out connection attempts so late completions cannot restore a stuck connection. (#80147, #58968) Thanks @HemantSudarshan and @KeaneYan.
 - **Managed browser cookie persistence:** initialize new isolated macOS headless profiles with a non-interactive encryption key while preserving existing profile keys, and close Chromium through CDP before bounded signal fallback so persistent logins survive graceful browser and Gateway restarts. (#96704, #98284) Thanks @TurboTheTurtle.
@@ -41,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI tool-result images:** render direct image content blocks from Gateway history and make the delayed-send scroll E2E setup deterministic. (#100295) Thanks @lzyyzznl.
 - **Plugin approval diagnostics:** distinguish request validation rejections, expired wait decisions, and unavailable Gateways while keeping approval failures fail-closed. (#100337) Thanks @tzy-17.
 - **IRC Unicode messages:** split outbound PRIVMSG payloads on UTF-16 code-point boundaries so emoji cannot be cut into lone surrogates. (#96572) Thanks @llagy009.
+- **Phone identity normalization:** canonicalize stray plus signs, preserve non-phone iMessage handles, and reject digit-free Signal identities across shared channel routing. (#100467) Thanks @morluto.
 - **OpenAI realtime voice greetings:** prevent server VAD from creating a second outbound greeting while an explicit greeting response owns the turn, without disabling caller interruption. (#86285) Thanks @giodl73-repo.
 - **Realtime voice tools:** filter malformed tool names at each OpenAI, Azure, and Google realtime payload boundary while preserving provider-specific valid names. (#89175) Thanks @vincentkoc.
 - **Discord voice status:** treat Discord error 10065 as a normal disconnected state while preserving unrelated REST failures. (#90969) Thanks @asock.

--- a/extensions/imessage/src/normalize.test.ts
+++ b/extensions/imessage/src/normalize.test.ts
@@ -9,6 +9,11 @@ describe("normalizeIMessageMessagingTarget", () => {
 
   it("preserves service prefixes for handles", () => {
     expect(normalizeIMessageMessagingTarget("sms:+1 (555) 222-3333")).toBe("sms:+15552223333");
+    expect(normalizeIMessageMessagingTarget("sms:++1 (555) 222-3333")).toBe("sms:+15552223333");
+  });
+
+  it("preserves non-phone handles instead of collapsing them to a plus sign", () => {
+    expect(normalizeIMessageMessagingTarget("auto:Alice Smith")).toBe("auto:AliceSmith");
   });
 
   it("drops service prefixes for chat targets", () => {

--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -16,6 +16,7 @@ import * as clientModule from "./client-adapter.js";
 import { classifySignalCliLogLine } from "./daemon.js";
 import {
   looksLikeUuid,
+  normalizeSignalAllowRecipient,
   resolveSignalPeerId,
   resolveSignalRecipient,
   resolveSignalSender,
@@ -71,6 +72,22 @@ describe("signal sender identity", () => {
       kind: "uuid",
       raw: "123e4567-e89b-12d3-a456-426614174000",
     });
+  });
+
+  it("falls back to sourceUuid when sourceNumber has no digits", () => {
+    const sender = resolveSignalSender({
+      sourceNumber: "not a phone number",
+      sourceUuid: "123e4567-e89b-12d3-a456-426614174000",
+    });
+    expect(sender).toEqual({
+      kind: "uuid",
+      raw: "123e4567-e89b-12d3-a456-426614174000",
+    });
+  });
+
+  it("normalizes noisy allowlist numbers and rejects digit-free entries", () => {
+    expect(normalizeSignalAllowRecipient("signal:++1 (555) 000-1111")).toBe("+15550001111");
+    expect(normalizeSignalAllowRecipient("signal:not a phone number")).toBeUndefined();
   });
 
   it("maps uuid senders to recipient and peer ids", () => {

--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -860,7 +860,9 @@ describe("signal setup parsing", () => {
 
   it("parses e164, uuid and wildcard entries", () => {
     expect(
-      parseSignalAllowFromEntries("+15555550123, uuid:123e4567-e89b-12d3-a456-426614174000, *"),
+      parseSignalAllowFromEntries(
+        "signal:+15555550123, uuid:123e4567-e89b-12d3-a456-426614174000, *",
+      ),
     ).toEqual({
       entries: ["+15555550123", "uuid:123e4567-e89b-12d3-a456-426614174000", "*"],
     });

--- a/extensions/signal/src/identity.ts
+++ b/extensions/signal/src/identity.ts
@@ -24,11 +24,10 @@ export function resolveSignalSender(params: {
 }): SignalSender | null {
   const sourceNumber = params.sourceNumber?.trim();
   if (sourceNumber) {
-    return {
-      kind: "phone",
-      raw: sourceNumber,
-      e164: normalizeE164(sourceNumber),
-    };
+    const e164 = normalizeE164(sourceNumber);
+    if (e164) {
+      return { kind: "phone", raw: sourceNumber, e164 };
+    }
   }
   const sourceUuid = params.sourceUuid?.trim();
   if (sourceUuid) {
@@ -83,7 +82,8 @@ function parseSignalAllowEntry(entry: string): SignalAllowEntry | null {
     return { kind: "uuid", raw: stripped };
   }
 
-  return { kind: "phone", e164: normalizeE164(stripped) };
+  const e164 = normalizeE164(stripped);
+  return e164 ? { kind: "phone", e164 } : null;
 }
 
 export function normalizeSignalAllowRecipient(entry: string): string | undefined {

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -41,6 +41,11 @@ export function normalizeSignalAccountInput(value: string | null | undefined): s
   if (!trimmed) {
     return null;
   }
+  // Setup accepts formatting punctuation, but embedded or duplicate pluses are invalid input.
+  const plusCount = trimmed.match(/\+/g)?.length ?? 0;
+  if (plusCount > 1 || (plusCount === 1 && !trimmed.startsWith("+"))) {
+    return null;
+  }
   const normalized = normalizeE164(trimmed);
   const digits = normalized.slice(1);
   if (!DIGITS_ONLY.test(digits)) {

--- a/extensions/signal/src/setup-core.ts
+++ b/extensions/signal/src/setup-core.ts
@@ -41,12 +41,13 @@ export function normalizeSignalAccountInput(value: string | null | undefined): s
   if (!trimmed) {
     return null;
   }
+  const phoneInput = trimmed.replace(/^signal:/i, "").trim();
   // Setup accepts formatting punctuation, but embedded or duplicate pluses are invalid input.
-  const plusCount = trimmed.match(/\+/g)?.length ?? 0;
-  if (plusCount > 1 || (plusCount === 1 && !trimmed.startsWith("+"))) {
+  const plusCount = phoneInput.match(/\+/g)?.length ?? 0;
+  if (plusCount > 1 || (plusCount === 1 && !phoneInput.startsWith("+"))) {
     return null;
   }
-  const normalized = normalizeE164(trimmed);
+  const normalized = normalizeE164(phoneInput);
   const digits = normalized.slice(1);
   if (!DIGITS_ONLY.test(digits)) {
     return null;

--- a/extensions/whatsapp/src/channel.setup.test.ts
+++ b/extensions/whatsapp/src/channel.setup.test.ts
@@ -63,8 +63,8 @@ vi.mock("openclaw/plugin-sdk/setup", async () => {
     if (!raw) {
       return "";
     }
-    const digits = raw.replace(/[^\d+]/g, "");
-    return digits.startsWith("+") ? digits : `+${digits}`;
+    const digits = raw.replace(/\D/g, "");
+    return digits ? `+${digits}` : "";
   };
   return {
     ...actual,

--- a/extensions/whatsapp/src/channel.setup.test.ts
+++ b/extensions/whatsapp/src/channel.setup.test.ts
@@ -58,14 +58,6 @@ vi.mock("openclaw/plugin-sdk/setup", async () => {
   const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/setup")>(
     "openclaw/plugin-sdk/setup",
   );
-  const normalizeE164 = (value?: string | null) => {
-    const raw = (value ?? "").trim();
-    if (!raw) {
-      return "";
-    }
-    const digits = raw.replace(/\D/g, "");
-    return digits ? `+${digits}` : "";
-  };
   return {
     ...actual,
     DEFAULT_ACCOUNT_ID,
@@ -80,7 +72,6 @@ vi.mock("openclaw/plugin-sdk/setup", async () => {
       }
       return [...normalized];
     },
-    normalizeE164,
     splitSetupEntries: splitSetupEntriesForMock,
     setSetupChannelEnabled: (cfg: OpenClawConfig, channel: string, enabled: boolean) => ({
       ...cfg,

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -8,6 +8,7 @@ import { withEnv } from "./test-utils/env.js";
 import {
   CONFIG_DIR,
   ensureDir,
+  normalizeE164,
   pinConfigDir,
   resolveConfigDir,
   resolveHomeDir,
@@ -53,6 +54,19 @@ describe("sleep", () => {
       setTimeoutSpy.mockRestore();
       vi.useRealTimers();
     }
+  });
+});
+
+describe("normalizeE164", () => {
+  it.each([
+    ["+1234567890", "+1234567890"],
+    ["++1234567890", "+1234567890"],
+    ["1+234+567", "+1234567"],
+    ["whatsapp:+1 (234) 567-8900", "+12345678900"],
+    ["signal: 1 234 567", "+1234567"],
+    ["not a phone number", ""],
+  ])("normalizes %s", (input, expected) => {
+    expect(normalizeE164(input)).toBe(expected);
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,11 +55,8 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
 /** Normalizes phone-like input into the loose E.164 shape used by channel helpers. */
 export function normalizeE164(number: string): string {
   const withoutPrefix = number.replace(/^[a-z][a-z0-9-]*:/i, "").trim();
-  const digits = withoutPrefix.replace(/[^\d+]/g, "");
-  if (digits.startsWith("+")) {
-    return `+${digits.slice(1)}`;
-  }
-  return `+${digits}`;
+  const digits = withoutPrefix.replace(/\D/g, "");
+  return digits ? `+${digits}` : "";
 }
 
 // Surrogate-safe slicing helpers live in a node-free leaf module so browser/UI


### PR DESCRIPTION
## What Problem This Solves

Phone-based channel identities could normalize to unusable values when copied input contained doubled or embedded `+` characters. Digit-free input could also become the truthy identity `+`, causing incorrect routing comparisons instead of a clean invalid-input result.

## Why This Change Was Made

The shared `normalizeE164` helper now strips provider prefixes and formatting, keeps digits only, returns exactly one leading `+`, and returns an empty string when no digits remain.

The maintainer rewrite also closes sibling cases exposed by that shared invariant:

- iMessage keeps non-phone `auto:` handles instead of collapsing them.
- Signal falls back to UUID identity when a source number contains no digits and rejects digit-free allowlist entries.
- Signal operator account setup remains strict about embedded or duplicate plus signs.
- WhatsApp setup tests exercise the real shared normalizer instead of a policy-copying mock.

## User Impact

Equivalent phone identities compare canonically across shared channel routing even when copied input contains stray plus signs. Invalid digit-free identities fail closed, while valid non-phone iMessage handles and Signal UUID senders retain intended routing.

## Evidence

- Exact head: `aea114112f975285bdf4c7bbf9ba163ca171e372`.
- Sanitized AWS Crabbox run `run_2cb4c42e20e4` found the prefixed Signal setup regression after 96 focused assertions passed. The branch was repaired to preserve strict setup validation and gained a focused regression.
- Source-blind final-code runtime contract passed: noisy UK/US numbers canonicalized; digit-free input returned empty; `auto:Alice Smith` remained `auto:AliceSmith`; digit-free Signal phone identity fell back to UUID; prefixed allowlist input parsed; embedded-plus setup input was rejected.
- Exact-head hosted CI run `28761404940`: all required checks passed.
- Fresh exact-head autoreview: clean, no actionable findings, confidence 0.93.
- Contributor-credit changelog entry is carried by final batch closeout PR #100376, sequenced after this merge.
- Targeted `oxfmt` and `git diff --check`: pass.
- Focused duplicate search found no competing open shared E.164, WhatsApp, iMessage, or Signal normalization fix.

## Risk checklist

- User-visible behavior: yes, malformed copied phone identities now canonicalize or fail closed.
- Config/environment/migration: no change.
- Security/auth/network/tool execution: no change.
- Highest risk: channel identity matching and operator input validation.
- Mitigation: one permissive shared normalizer, strict Signal setup boundary, sibling channel regressions.

## AI-assisted disclosure

- [x] AI-assisted maintainer rewrite and review
- [x] Source-blind behavior proof
- [x] Fresh structured autoreview
