### PR TITLE
feat(goals): keep active session goals in per-turn context + continuance QA scenarios

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -9204,6 +9204,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Statuses
   - H2: Token budgets
   - H2: Model tools
+  - H2: Goal context on every turn
   - H2: TUI
   - H2: Channel behavior
   - H2: Troubleshooting

--- a/docs/tools/goal.md
+++ b/docs/tools/goal.md
@@ -143,6 +143,18 @@ actually achieved. It should mark a goal `blocked` only after the same
 blocking condition recurs for at least three consecutive goal turns, not for
 ordinary difficulty or missing polish.
 
+## Goal context on every turn
+
+Every user/chat turn with an active goal includes this user-role context line:
+
+```text
+Active goal: <objective> — advance it or update its status (get_goal/update_goal).
+```
+
+OpenClaw keeps the line compact by truncating long objectives. Paused,
+blocked, budget-limited, usage-limited, and complete goals are not injected,
+so an operator stop remains in effect until the goal is resumed.
+
 ## TUI
 
 The TUI footer keeps the active session's goal visible next to the agent,

--- a/qa/scenarios/goals/goal-context-next-turn.yaml
+++ b/qa/scenarios/goals/goal-context-next-turn.yaml
@@ -1,0 +1,117 @@
+title: Active goal context on the next turn
+
+scenario:
+  id: goal-context-next-turn
+  surface: goals
+  category: session-memory-and-context-engine.context-engine
+  coverage:
+    primary:
+      - goals.context-injection
+    secondary:
+      - goals.continuance
+  objective: Verify an active session goal is injected into the next unrelated turn sent to the model.
+  successCriteria:
+    - An authorized channel turn starts a session goal through the public `/goal start` command.
+    - A later unrelated inbound message reaches the mock model in the same session.
+    - The later request contains the exact active-goal context line and objective.
+    - The assertion reads the captured provider request rather than inferring context from the visible reply.
+  docsRefs:
+    - docs/tools/goal.md
+    - docs/channels/qa-channel.md
+  codeRefs:
+    - src/auto-reply/reply/inbound-meta.ts
+    - src/config/sessions/goals.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+  execution:
+    kind: flow
+    channel: qa-channel
+    summary: Start a goal, send an unrelated next turn, and inspect the exact mock-provider request payload.
+    config:
+      requiredProviderMode: mock-openai
+      conversationId: goal-context-next-turn
+      senderId: qa-goal-operator
+      goalObjective: Compile the QA release evidence bundle
+      expectedGoalContext: "Active goal: Compile the QA release evidence bundle — advance it or update its status (get_goal/update_goal)."
+      secondMessage: GOAL-CONTEXT-NEXT-TURN unrelated weather question
+
+flow:
+  steps:
+    - name: injects active goal context into the next unrelated turn
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: this request-payload assertion requires mock-openai
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - resetTransport: true
+        - set: conversationId
+          value:
+            expr: "`${config.conversationId}-${randomUUID().slice(0, 8)}`"
+        - set: firstOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Goal Operator
+            text:
+              expr: "`/goal start ${config.goalObjective}`"
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: firstOutboundIndex
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+          saveAs: goalStartReply
+        - set: requestCountBeforeSecondTurn
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests`)).length"
+        - set: secondOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Goal Operator
+            text:
+              ref: config.secondMessage
+        - call: waitForCondition
+          saveAs: secondTurnRequest
+          args:
+            - lambda:
+                async: true
+                expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests`)).slice(requestCountBeforeSecondTurn).find((request) => String(request.prompt ?? '').includes(config.secondMessage))"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 100
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: secondOutboundIndex
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+          saveAs: secondReply
+        - assert:
+            expr: "String(secondTurnRequest.prompt ?? '').includes(config.expectedGoalContext)"
+            message:
+              expr: "`second-turn provider prompt missed active goal context: ${String(secondTurnRequest.prompt ?? '')}`"
+      detailsExpr: "`goal start reply=${goalStartReply.text}; second reply=${secondReply.text}`"

--- a/qa/scenarios/goals/goal-context-next-turn.yaml
+++ b/qa/scenarios/goals/goal-context-next-turn.yaml
@@ -24,9 +24,9 @@ scenario:
     - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
-    channel: qa-channel
     summary: Start a goal, send an unrelated next turn, and inspect the exact mock-provider request payload.
     config:
+      requiredChannelDriver: qa-channel
       requiredProviderMode: mock-openai
       conversationId: goal-context-next-turn
       senderId: qa-goal-operator

--- a/qa/scenarios/goals/goal-context-survives-compaction.yaml
+++ b/qa/scenarios/goals/goal-context-survives-compaction.yaml
@@ -32,9 +32,9 @@ scenario:
     - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
-    channel: qa-channel
     summary: Start a goal, compact the session, then inspect the next mock-provider request for active-goal context.
     config:
+      requiredChannelDriver: qa-channel
       requiredProviderMode: mock-openai
       conversationId: goal-context-compaction
       senderId: qa-goal-operator

--- a/qa/scenarios/goals/goal-context-survives-compaction.yaml
+++ b/qa/scenarios/goals/goal-context-survives-compaction.yaml
@@ -1,0 +1,174 @@
+title: Active goal context survives compaction
+
+scenario:
+  id: goal-context-survives-compaction
+  surface: goals
+  category: session-memory-and-context-engine.context-engine
+  coverage:
+    primary:
+      - goals.context-injection
+    secondary:
+      - goals.continuance
+      - runtime.compaction
+  objective: Verify compaction does not remove active session-goal context from the next model turn.
+  successCriteria:
+    - An authorized channel turn starts a session goal through `/goal start`.
+    - The same session completes a manual `/compact` operation.
+    - The first post-compaction inbound turn reaches the mock model with the exact active-goal context line.
+    - The assertion uses the captured post-compaction provider request.
+  gatewayConfigPatch:
+    agents:
+      defaults:
+        compaction:
+          reserveTokens: 64
+          reserveTokensFloor: 0
+          keepRecentTokens: 64
+  docsRefs:
+    - docs/tools/goal.md
+    - docs/concepts/compaction.md
+  codeRefs:
+    - src/auto-reply/reply/inbound-meta.ts
+    - src/auto-reply/reply/commands-compact.ts
+    - extensions/qa-lab/src/providers/mock-openai/server.ts
+  execution:
+    kind: flow
+    channel: qa-channel
+    summary: Start a goal, compact the session, then inspect the next mock-provider request for active-goal context.
+    config:
+      requiredProviderMode: mock-openai
+      conversationId: goal-context-compaction
+      senderId: qa-goal-operator
+      goalObjective: Preserve the deployment audit objective
+      expectedGoalContext: "Active goal: Preserve the deployment audit objective — advance it or update its status (get_goal/update_goal)."
+      contextSeedMarker: GOAL-COMPACTION-CONTEXT-SEED
+      postCompactionMessage: GOAL-CONTEXT-POST-COMPACTION unrelated lunch question
+
+flow:
+  steps:
+    - name: injects active goal context after manual compaction
+      actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: this request-payload assertion requires mock-openai
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - resetTransport: true
+        - set: conversationId
+          value:
+            expr: "`${config.conversationId}-${randomUUID().slice(0, 8)}`"
+        - set: outboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Goal Operator
+            text:
+              expr: "`/goal start ${config.goalObjective}`"
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: outboundIndex
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+        - set: seedOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Goal Operator
+            text:
+              expr: "`${config.contextSeedMarker} ${'retain this audit context '.repeat(80)}`"
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: seedOutboundIndex
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+        - set: compactOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Goal Operator
+            text: /compact
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: compactOutboundIndex
+            textIncludes: Compact
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+          saveAs: compactReply
+        - assert:
+            expr: "!normalizeLowercaseStringOrEmpty(compactReply.text).includes('skipped')"
+            message:
+              expr: "`manual compaction did not compact the seeded session: ${compactReply.text}`"
+        - set: requestCountBeforePostCompactionTurn
+          value:
+            expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests`)).length"
+        - set: postCompactOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Goal Operator
+            text:
+              ref: config.postCompactionMessage
+        - call: waitForCondition
+          saveAs: postCompactionRequest
+          args:
+            - lambda:
+                async: true
+                expr: "(await fetchJson(`${env.mock.baseUrl}/debug/requests`)).slice(requestCountBeforePostCompactionTurn).find((request) => String(request.prompt ?? '').includes(config.postCompactionMessage))"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 100
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: postCompactOutboundIndex
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 60000)
+          saveAs: postCompactionReply
+        - assert:
+            expr: "String(postCompactionRequest.prompt ?? '').includes(config.expectedGoalContext)"
+            message:
+              expr: "`post-compaction provider prompt missed active goal context: ${String(postCompactionRequest.prompt ?? '')}`"
+      detailsExpr: "`compact=${compactReply.text}; post-compaction=${postCompactionReply.text}`"

--- a/qa/scenarios/goals/goal-followthrough-live.yaml
+++ b/qa/scenarios/goals/goal-followthrough-live.yaml
@@ -1,0 +1,139 @@
+title: Active goal followthrough on bare continue
+
+scenario:
+  id: goal-followthrough-live
+  surface: goals
+  category: session-memory-and-context-engine.context-engine
+  runtimeParityTier: live-only
+  coverage:
+    primary:
+      - goals.continuance
+    secondary:
+      - goals.context-injection
+      - runtime.first-action
+  objective: Verify a live model advances the next concrete step of an active multi-step goal on a later bare continue turn.
+  successCriteria:
+    - The first goal turn acknowledges the staged first step without creating the second-step artifact early.
+    - A later inbound message contains only `continue`.
+    - The continue turn creates the required artifact in the workspace instead of returning another plan.
+    - The continue turn does not ask for permission or approval before the feasible write.
+    - The final reply reports the completed artifact step.
+  docsRefs:
+    - docs/tools/goal.md
+    - docs/channels/qa-channel.md
+  codeRefs:
+    - src/auto-reply/reply/inbound-meta.ts
+    - src/auto-reply/reply/commands-goal.ts
+    - src/agents/tools/goal-tools.ts
+  execution:
+    kind: flow
+    channel: qa-channel
+    summary: Stage a two-step active goal, then require a bare continue turn to write the next artifact without replanning.
+    config:
+      conversationId: goal-followthrough-live
+      senderId: qa-goal-operator
+      artifactFilePrefix: goal-continuance-live
+      artifactText: Goal continuance advanced the concrete next step.
+      readyMarker: GOAL-CONTINUANCE-READY
+      doneMarker: GOAL-CONTINUANCE-DONE
+      forbiddenNeedles:
+        - need permission
+        - need your approval
+        - can you approve
+        - would you like me to
+        - next i would
+
+flow:
+  steps:
+    - name: advances the staged artifact step on bare continue
+      actions:
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForQaChannelReady
+          args:
+            - ref: env
+            - 60000
+        - resetTransport: true
+        - set: runSuffix
+          value:
+            expr: randomUUID().slice(0, 8)
+        - set: conversationId
+          value:
+            expr: "`${config.conversationId}-${runSuffix}`"
+        - set: artifactFile
+          value:
+            expr: "`${config.artifactFilePrefix}-${runSuffix}.txt`"
+        - set: artifactPath
+          value:
+            expr: "path.join(env.gateway.workspaceDir, artifactFile)"
+        - set: firstOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Goal Operator
+            text:
+              expr: "`/goal start Two-step goal. Step 1: reply exactly ${config.readyMarker} without creating ${artifactFile}. Step 2, only on a later bare continue turn: create ${artifactFile} containing exactly '${config.artifactText}', then reply with ${config.doneMarker}.`"
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: firstOutboundIndex
+            textIncludes:
+              ref: config.readyMarker
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 90000)
+          saveAs: readyReply
+        - set: artifactBeforeContinue
+          value:
+            expr: "await fs.readFile(artifactPath, 'utf8').catch(() => undefined)"
+        - assert:
+            expr: "artifactBeforeContinue === undefined"
+            message:
+              expr: "`goal created the second-step artifact before continue: ${String(artifactBeforeContinue)}`"
+        - set: continueOutboundIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
+        - sendInbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Goal Operator
+            text: continue
+        - call: waitForCondition
+          saveAs: artifact
+          args:
+            - lambda:
+                async: true
+                expr: "fs.readFile(artifactPath, 'utf8').then((value) => value.trim() === config.artifactText ? value : undefined).catch(() => undefined)"
+            - expr: liveTurnTimeoutMs(env, 90000)
+            - 250
+        - waitForOutbound:
+            conversation:
+              id:
+                ref: conversationId
+              kind: direct
+            sinceIndex:
+              ref: continueOutboundIndex
+            textIncludes:
+              ref: config.doneMarker
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 90000)
+          saveAs: doneReply
+        - assert:
+            expr: "!config.forbiddenNeedles.some((needle) => normalizeLowercaseStringOrEmpty(doneReply.text).includes(needle))"
+            message:
+              expr: "`goal followthrough replanned or asked permission: ${doneReply.text}`"
+      detailsExpr: "`ready=${readyReply.text}; done=${doneReply.text}; artifact=${artifact.trim()}`"

--- a/qa/scenarios/goals/goal-followthrough-live.yaml
+++ b/qa/scenarios/goals/goal-followthrough-live.yaml
@@ -27,9 +27,9 @@ scenario:
     - src/agents/tools/goal-tools.ts
   execution:
     kind: flow
-    channel: qa-channel
     summary: Stage a two-step active goal, then require a bare continue turn to write the next artifact without replanning.
     config:
+      requiredChannelDriver: qa-channel
       conversationId: goal-followthrough-live
       senderId: qa-goal-operator
       artifactFilePrefix: goal-continuance-live

--- a/qa/scenarios/index.yaml
+++ b/qa/scenarios/index.yaml
@@ -59,6 +59,7 @@ title: OpenClaw QA Scenario Pack
 # - `channels/` - DM, shared channel, thread, and message-action behavior
 # - `character/` - persona and style eval scenarios
 # - `config/` - config patch, apply, and restart behavior
+# - `goals/` - active-goal context and cross-turn followthrough
 # - `media/` - image understanding and generation
 # - `memory/` - recall, ranking, active memory, and thread isolation
 # - `models/` - provider capabilities and model switching

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -53,6 +53,8 @@ export type CurrentInboundPromptContext = {
   text: string;
   resumableText?: string;
   promptJoiner?: "\n\n" | "\n" | " ";
+  /** Generated goal blocks owned by inbound-context assembly, never user text. */
+  injectedGoalContexts?: string[];
 };
 
 export type RunEmbeddedAgentParams = {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -625,6 +625,67 @@ function createQueuedRun(
 }
 
 describe("createFollowupRunner reply-lane admission", () => {
+  it("drops stale active-goal context after the persisted goal completes", async () => {
+    runEmbeddedAgentMock.mockResolvedValueOnce({ payloads: [], meta: {} });
+    const storePath = "/tmp/openclaw-followup-completed-goal.json";
+    const activeEntry: SessionEntry = {
+      sessionId: "session-completed-goal",
+      updatedAt: 1,
+      goal: {
+        schemaVersion: 1,
+        id: "goal-1",
+        objective: "Publish the release evidence",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 1,
+        tokenStart: 0,
+        tokensUsed: 0,
+        continuationTurns: 0,
+      },
+    };
+    const completedEntry: SessionEntry = {
+      ...activeEntry,
+      updatedAt: 2,
+      goal: { ...activeEntry.goal!, status: "complete", updatedAt: 2 },
+    };
+    registerFollowupTestSessionStore(storePath, { main: completedEntry });
+    const runner = createFollowupRunner({
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      sessionEntry: activeEntry,
+      sessionStore: { main: activeEntry },
+      sessionKey: "main",
+      storePath,
+      defaultModel: "anthropic/claude",
+    });
+
+    await runner(
+      createQueuedRun({
+        currentInboundContext: {
+          injectedGoalContexts: [
+            "Active goal: Publish the release evidence — advance it or update its status (get_goal/update_goal).",
+          ],
+          text: [
+            "Conversation info (untrusted metadata):",
+            "Active goal: Publish the release evidence — advance it or update its status (get_goal/update_goal).",
+            "Current message:\nmessage_id=next-turn",
+          ].join("\n\n"),
+        },
+        run: {
+          sessionId: "session-completed-goal",
+          sessionKey: "main",
+          provider: "anthropic",
+          model: "claude",
+        },
+      }),
+    );
+
+    const call = requireLastMockCallArg(runEmbeddedAgentMock, "run embedded agent");
+    const context = requireRecord(call.currentInboundContext, "current inbound context");
+    expect(context.text).toContain("Current message:\nmessage_id=next-turn");
+    expect(context.text).not.toContain("Active goal:");
+  });
+
   it("notifies queued owners after admission and before model execution", async () => {
     const events: string[] = [];
     runEmbeddedAgentMock.mockImplementationOnce(async () => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -96,6 +96,7 @@ import {
   type CompactionNoticePhase,
 } from "./compaction-notice.js";
 import { resolveFollowupDeliveryPayloads } from "./followup-delivery.js";
+import { refreshActiveGoalContext } from "./inbound-meta.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import {
   completeFollowupRunLifecycle,
@@ -717,6 +718,15 @@ export function createFollowupRunner(params: {
         }
         return sendFollowupPayloads(...args);
       };
+      // Admission already loads the latest entry under the lifecycle fence.
+      const goalContextSessionEntry = admission.sessionEntry ?? activeSessionEntry;
+      const currentInboundContext =
+        opts?.isHeartbeat === true
+          ? effectiveQueued.currentInboundContext
+          : refreshActiveGoalContext(
+              effectiveQueued.currentInboundContext,
+              goalContextSessionEntry,
+            );
       const runId = crypto.randomUUID();
       const shouldSurfaceToControlUi = isInternalMessageChannel(
         resolveOriginMessageProvider({
@@ -1174,7 +1184,7 @@ export function createFollowupRunner(params: {
                     storePath,
                     currentInboundEventKind: queued.currentInboundEventKind,
                     currentInboundAudio: queued.currentInboundAudio,
-                    currentInboundContext: queued.currentInboundContext,
+                    currentInboundContext,
                     inputProvenance: run.inputProvenance,
                     provider: cliExecutionProvider,
                     model,
@@ -1290,7 +1300,7 @@ export function createFollowupRunner(params: {
                 userTurnTranscriptRecorder,
                 currentInboundEventKind: queued.currentInboundEventKind,
                 currentInboundAudio: queued.currentInboundAudio,
-                currentInboundContext: queued.currentInboundContext,
+                currentInboundContext,
                 extraSystemPrompt: run.extraSystemPrompt,
                 silentReplyPromptMode: run.silentReplyPromptMode,
                 sourceReplyDeliveryMode: run.sourceReplyDeliveryMode,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -38,7 +38,16 @@ vi.mock("../../config/sessions/paths.js", () => ({
 
 const storeRuntimeLoads = vi.hoisted(() => vi.fn());
 const updateSessionStore = vi.hoisted(() => vi.fn());
+const loadSessionEntryMock = vi.hoisted(() => vi.fn());
 const updateAmbientTranscriptWatermarkMock = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+
+vi.mock(import("../../config/sessions/session-accessor.js"), async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions/session-accessor.js")>();
+  return {
+    ...actual,
+    loadSessionEntry: loadSessionEntryMock,
+  };
+});
 
 vi.mock("../../config/sessions/ambient-transcript-watermark.js", () => ({
   updateAmbientTranscriptWatermark: updateAmbientTranscriptWatermarkMock,
@@ -109,6 +118,7 @@ vi.mock("./groups.js", () => ({
 vi.mock("./inbound-meta.js", () => ({
   buildInboundMetaSystemPrompt: vi.fn().mockReturnValue(""),
   buildInboundUserContextPrefix: vi.fn().mockReturnValue(""),
+  formatActiveGoalContext: vi.fn().mockReturnValue(undefined),
   resolveInboundUserContextPromptJoiner: vi.fn().mockReturnValue(undefined),
 }));
 
@@ -307,6 +317,7 @@ describe("runPreparedReply media-only handling", () => {
   beforeEach(async () => {
     storeRuntimeLoads.mockClear();
     updateSessionStore.mockReset();
+    loadSessionEntryMock.mockReset();
     updateAmbientTranscriptWatermarkMock.mockClear();
     vi.clearAllMocks();
     vi.mocked(buildDirectChatContext).mockReturnValue("");
@@ -555,6 +566,7 @@ describe("runPreparedReply media-only handling", () => {
         ThreadStarterBody: undefined,
       },
       expect.anything(),
+      undefined,
     );
   });
 
@@ -1452,6 +1464,70 @@ describe("runPreparedReply media-only handling", () => {
 
     await expect(runPromise).resolves.toEqual({ text: "ok" });
     expect(vi.mocked(runReplyAgent)).toHaveBeenCalledOnce();
+  });
+  it("refreshes goal context after interrupt admission waits", async () => {
+    const queueSettings = await import("./queue/settings-runtime.js");
+    const inboundMeta = await import("./inbound-meta.js");
+    const activeEntry: SessionEntry = {
+      sessionId: "session-goal-interrupt",
+      updatedAt: 1,
+      goal: {
+        schemaVersion: 1,
+        id: "goal-interrupt",
+        objective: "Finish the interrupted work",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 1,
+        tokenStart: 0,
+        tokenStartFresh: true,
+        tokensUsed: 0,
+        continuationTurns: 0,
+      },
+    };
+    const completeEntry: SessionEntry = {
+      ...activeEntry,
+      goal: { ...activeEntry.goal!, status: "complete" },
+    };
+    vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({ mode: "interrupt" });
+    vi.mocked(inboundMeta.formatActiveGoalContext).mockImplementation((entry) =>
+      entry?.goal?.status === "active" ? "Active goal: Finish the interrupted work" : undefined,
+    );
+    vi.mocked(inboundMeta.buildInboundUserContextPrefix).mockImplementation(
+      (_ctx, _envelope, entry) =>
+        entry?.goal?.status === "active" ? "Active goal: Finish the interrupted work" : "",
+    );
+    loadSessionEntryMock.mockReturnValue(completeEntry);
+    const activeRun = createReplyOperation({
+      sessionId: "session-goal-interrupt",
+      sessionKey: "session-key",
+      resetTriggered: false,
+    });
+    activeRun.setPhase("running");
+
+    const runPromise = runPreparedReply(
+      baseParams({
+        isNewSession: false,
+        sessionId: "session-goal-interrupt",
+        sessionEntry: activeEntry,
+        sessionStore: { "session-key": activeEntry },
+        storePath: "/tmp/openclaw-session-store.json",
+      }),
+    );
+    while (!activeRun.abortSignal.aborted) {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+    }
+    activeRun.complete();
+
+    await expect(runPromise).resolves.toEqual({ text: "ok" });
+    expect(loadSessionEntryMock).toHaveBeenCalledWith({
+      storePath: "/tmp/openclaw-session-store.json",
+      sessionKey: "session-key",
+      readConsistency: "latest",
+    });
+    const call = requireLastRunReplyAgentCall();
+    expect(call.followupRun.currentInboundContext?.text ?? "").not.toContain("Active goal:");
   });
   it("treats reset-triggered followup mode as interrupt when the session lane is empty", async () => {
     const queueSettings = await import("./queue/settings-runtime.js");
@@ -2532,6 +2608,38 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.prompt).toContain(heartbeatPrompt);
     expect(call?.transcriptCommandBody).toBe("[OpenClaw heartbeat poll]");
     expect(call?.followupRun.transcriptPrompt).toBe("[OpenClaw heartbeat poll]");
+  });
+
+  it("keeps active goal context out of background heartbeat turns", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "heartbeat-goal-session",
+      updatedAt: 1,
+      goal: {
+        schemaVersion: 1,
+        id: "heartbeat-goal",
+        objective: "Finish the interactive task",
+        status: "active",
+        createdAt: 1,
+        updatedAt: 1,
+        tokenStart: 0,
+        tokensUsed: 0,
+        continuationTurns: 0,
+      },
+    };
+
+    await runPreparedReply(
+      baseParams({
+        opts: { isHeartbeat: true },
+        sessionEntry,
+        sessionStore: { "session-key": sessionEntry },
+      }),
+    );
+
+    expect(buildInboundUserContextPrefix).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+    );
   });
 
   it("uses persisted Discord chat metadata for system-event CLI static prompt identity", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -26,6 +26,7 @@ import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
 } from "../../config/sessions/paths.js";
+import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
 import { resolveSessionStoreEntry } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import { resolveSilentReplySettings } from "../../config/silent-reply.js";
@@ -86,6 +87,7 @@ import { hasInboundAudio, hasInboundMedia } from "./inbound-media.js";
 import {
   buildInboundMetaSystemPrompt,
   buildInboundUserContextPrefix,
+  formatActiveGoalContext,
   resolveInboundUserContextPromptJoiner,
 } from "./inbound-meta.js";
 import type { createModelSelectionState } from "./model-selection.js";
@@ -754,17 +756,38 @@ export async function runPreparedReply(
     ? (bareResetPromptState?.prompt ?? "")
     : stripPromptThinkingDirectives(baseBody);
   const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
-  const inboundUserContext = buildInboundUserContextPrefix(
-    isNewSession
-      ? {
-          ...sessionCtx,
-          ...(normalizeOptionalString(sessionCtx.ThreadHistoryBody)
-            ? { InboundHistory: undefined, ThreadStarterBody: undefined }
-            : {}),
-        }
-      : { ...sessionCtx, ThreadStarterBody: undefined },
+  const inboundUserContextSessionCtx = isNewSession
+    ? {
+        ...sessionCtx,
+        ...(normalizeOptionalString(sessionCtx.ThreadHistoryBody)
+          ? { InboundHistory: undefined, ThreadStarterBody: undefined }
+          : {}),
+      }
+    : { ...sessionCtx, ThreadStarterBody: undefined };
+  let goalContextSessionEntry = isHeartbeat
+    ? undefined
+    : (sessionStore?.[sessionKey] ?? sessionEntryHandle?.getCurrent() ?? sessionEntry);
+  let activeGoalContext = formatActiveGoalContext(goalContextSessionEntry);
+  let inboundUserContext = buildInboundUserContextPrefix(
+    inboundUserContextSessionCtx,
     envelopeOptions,
+    goalContextSessionEntry,
   );
+  const refreshGoalContextAfterAdmissionWait = () => {
+    if (isHeartbeat) {
+      return;
+    }
+    goalContextSessionEntry =
+      storePath && sessionKey
+        ? loadSessionEntry({ storePath, sessionKey, readConsistency: "latest" })
+        : (sessionEntryHandle?.getCurrent() ?? sessionStore?.[sessionKey] ?? sessionEntry);
+    activeGoalContext = formatActiveGoalContext(goalContextSessionEntry);
+    inboundUserContext = buildInboundUserContextPrefix(
+      inboundUserContextSessionCtx,
+      envelopeOptions,
+      goalContextSessionEntry,
+    );
+  };
   const inboundUserContextPromptJoiner = resolveInboundUserContextPromptJoiner(sessionCtx);
   const hasUserBody =
     baseBodyFinal.trim().length > 0 ||
@@ -791,6 +814,7 @@ export async function runPreparedReply(
     baseBody: baseBodyFinal,
     hasUserBody,
     inboundUserContext,
+    activeGoalContext,
     inboundUserContextPromptJoiner,
     isBareSessionReset,
     startupAction,
@@ -873,6 +897,7 @@ export async function runPreparedReply(
       prefixedBody: prefixedBodyCore,
       hasUserBody,
       inboundUserContext,
+      activeGoalContext,
       inboundUserContextPromptJoiner,
       isBareSessionReset,
       startupAction,
@@ -1223,6 +1248,8 @@ export async function runPreparedReply(
         preparedSessionState = resolvePreparedSessionState();
         ({ authProfileId, authProfileIdSource } = await resolveRuntimeAuthProfile());
         preparedSessionState = resolvePreparedSessionState();
+        // The interrupted run may have stopped or started a goal while admission waited.
+        refreshGoalContextAfterAdmissionWait();
         ({
           prefixedCommandBody,
           queuedBody,

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -1,10 +1,15 @@
 // Tests inbound metadata normalization before prompt injection.
 import { describe, expect, it, vi } from "vitest";
+import type { SessionEntry, SessionGoalStatus } from "../../config/sessions/types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { withEnv } from "../../test-utils/env.js";
 import type { TemplateContext } from "../templating.js";
-import { buildInboundMetaSystemPrompt, buildInboundUserContextPrefix } from "./inbound-meta.js";
+import {
+  buildInboundMetaSystemPrompt,
+  buildInboundUserContextPrefix,
+  refreshActiveGoalContext,
+} from "./inbound-meta.js";
 
 vi.mock("../../channels/plugins/registry-loaded.js", () => ({
   getLoadedChannelPluginById: (channelId: string) =>
@@ -77,6 +82,28 @@ function parseHistoryPayload(text: string): Array<Record<string, unknown>> {
 
 function parseLocationPayload(text: string): Record<string, unknown> {
   return parseUntrustedJsonBlock(text, "Location (untrusted metadata):") as Record<string, unknown>;
+}
+
+function createGoalSessionEntry(
+  status: SessionGoalStatus,
+  objective = "Publish the release evidence",
+): SessionEntry {
+  return {
+    sessionId: "goal-context-session",
+    updatedAt: 1,
+    goal: {
+      schemaVersion: 1,
+      id: "goal-context",
+      objective,
+      status,
+      createdAt: 1,
+      updatedAt: 1,
+      tokenStart: 0,
+      tokenStartFresh: true,
+      tokensUsed: 0,
+      continuationTurns: 0,
+    },
+  };
 }
 
 describe("buildInboundMetaSystemPrompt", () => {
@@ -263,6 +290,120 @@ describe("buildInboundMetaSystemPrompt", () => {
 });
 
 describe("buildInboundUserContextPrefix", () => {
+  it("injects an active goal into the current user-role context", () => {
+    const text = buildInboundUserContextPrefix(
+      {} as TemplateContext,
+      undefined,
+      createGoalSessionEntry("active"),
+    );
+
+    expect(text).toBe(
+      "Active goal: Publish the release evidence — advance it or update its status (get_goal/update_goal).",
+    );
+  });
+
+  it.each(["paused", "blocked", "usage_limited", "budget_limited", "complete"] as const)(
+    "does not inject a %s goal",
+    (status) => {
+      expect(
+        buildInboundUserContextPrefix(
+          {} as TemplateContext,
+          undefined,
+          createGoalSessionEntry(status),
+        ),
+      ).toBe("");
+    },
+  );
+
+  it("bounds and normalizes the active goal objective", () => {
+    const text = buildInboundUserContextPrefix(
+      {} as TemplateContext,
+      undefined,
+      createGoalSessionEntry("active", `${"x".repeat(205)}\nmore`),
+    );
+
+    expect(text).toBe(
+      `Active goal: ${"x".repeat(199)}… — advance it or update its status (get_goal/update_goal).`,
+    );
+    expect(text).not.toContain("\n");
+  });
+
+  it("projects a budget limit without mutating the stored goal", () => {
+    const entry = createGoalSessionEntry("active");
+    entry.totalTokens = 10;
+    entry.totalTokensFresh = true;
+    entry.goal = { ...entry.goal!, tokenBudget: 10 };
+
+    expect(buildInboundUserContextPrefix({} as TemplateContext, undefined, entry)).toBe("");
+    expect(entry.goal.status).toBe("active");
+  });
+
+  it("removes a captured goal line when a queued turn is admitted after completion", () => {
+    const goalContext =
+      "Active goal: Publish the release evidence — advance it or update its status (get_goal/update_goal).";
+    const context = {
+      text: [
+        "Conversation info (untrusted metadata):",
+        goalContext,
+        "Current message:\nmessage_id=next-turn",
+      ].join("\n\n"),
+      injectedGoalContexts: [goalContext],
+    };
+
+    const refreshed = refreshActiveGoalContext(context, createGoalSessionEntry("complete"));
+
+    expect(refreshed?.text).toContain("Conversation info (untrusted metadata):");
+    expect(refreshed?.text).toContain("Current message:\nmessage_id=next-turn");
+    expect(refreshed?.text).not.toContain("Active goal:");
+  });
+
+  it("adds a goal activated while a queued turn waited for admission", () => {
+    const refreshed = refreshActiveGoalContext(
+      { text: "Current message:\nmessage_id=queued-turn" },
+      createGoalSessionEntry("active"),
+    );
+
+    expect(refreshed?.text).toBe(
+      "Active goal: Publish the release evidence — advance it or update its status (get_goal/update_goal).\n\nCurrent message:\nmessage_id=queued-turn",
+    );
+  });
+
+  it("keeps the current-message anchor last when refreshing a queued goal", () => {
+    const goalContext =
+      "Active goal: Publish the release evidence — advance it or update its status (get_goal/update_goal).";
+    const refreshed = refreshActiveGoalContext(
+      {
+        text: `${goalContext}\n\nCurrent message:\n#34975 obviyus:`,
+        promptJoiner: " ",
+        injectedGoalContexts: [goalContext],
+      },
+      createGoalSessionEntry("active"),
+    );
+
+    expect(refreshed?.text).toBe(`${goalContext}\n\nCurrent message:\n#34975 obviyus:`);
+    expect(refreshed?.promptJoiner).toBe(" ");
+  });
+
+  it("does not remove a user event that matches the generated goal wording", () => {
+    const goalContext =
+      "Active goal: Publish the release evidence — advance it or update its status (get_goal/update_goal).";
+    const refreshed = refreshActiveGoalContext(
+      {
+        text: `${goalContext}\n\nCurrent event:\n${goalContext}`,
+        injectedGoalContexts: [goalContext],
+      },
+      createGoalSessionEntry("complete"),
+    );
+
+    expect(refreshed?.text).toBe(`Current event:\n${goalContext}`);
+  });
+
+  it("leaves the inbound context unchanged when the session has no goal", () => {
+    const entry: SessionEntry = { sessionId: "no-goal", updatedAt: 1 };
+
+    expect(buildInboundUserContextPrefix({} as TemplateContext, undefined, entry)).toBe("");
+  });
+
   it("omits conversation label block for direct chats", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "direct",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -2,10 +2,13 @@
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { CurrentInboundPromptContext } from "../../agents/embedded-agent-runner/run/params.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { getLoadedChannelPluginById } from "../../channels/plugins/registry-loaded.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
+import { resolveSessionGoalDisplayState } from "../../config/sessions/goals.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import { sliceUtf16Safe, truncateUtf16Safe } from "../../utils.js";
 import type { EnvelopeFormatOptions } from "../envelope.js";
 import { formatEnvelopeTimestamp } from "../envelope.js";
@@ -14,7 +17,100 @@ import type { TemplateContext } from "../templating.js";
 const MAX_UNTRUSTED_JSON_STRING_CHARS = 2_000;
 const MAX_UNTRUSTED_HISTORY_ENTRIES = 20;
 const MAX_UNTRUSTED_TRANSCRIPT_FIELD_CHARS = 500;
+const MAX_ACTIVE_GOAL_OBJECTIVE_CHARS = 200;
+const ACTIVE_GOAL_CONTEXT_PREFIX = "Active goal: ";
+const ACTIVE_GOAL_CONTEXT_SUFFIX = " — advance it or update its status (get_goal/update_goal).";
 const INBOUND_SOURCE_MODALITIES = new Set(["text", "voice", "audio", "image", "video", "document"]);
+
+export function formatActiveGoalContext(sessionEntry?: SessionEntry): string | undefined {
+  const goal = sessionEntry ? resolveSessionGoalDisplayState(sessionEntry) : undefined;
+  if (goal?.status !== "active") {
+    return undefined;
+  }
+  const objective = goal.objective.replace(/\s+/g, " ").trim();
+  const boundedObjective =
+    objective.length <= MAX_ACTIVE_GOAL_OBJECTIVE_CHARS
+      ? objective
+      : `${truncateUtf16Safe(objective, MAX_ACTIVE_GOAL_OBJECTIVE_CHARS - 1).trimEnd()}…`;
+  return `${ACTIVE_GOAL_CONTEXT_PREFIX}${boundedObjective}${ACTIVE_GOAL_CONTEXT_SUFFIX}`;
+}
+
+function isQueuedGoalOnlyBlock(block: string, injectedGoals: ReadonlySet<string>): boolean {
+  const [label, goal, ...rest] = block.split("\n");
+  return (
+    rest.length === 0 &&
+    /^Queued #\d+ context:$/u.test(label ?? "") &&
+    injectedGoals.has(goal ?? "")
+  );
+}
+
+function refreshActiveGoalContextText(params: {
+  text: string;
+  injectedGoals: ReadonlySet<string>;
+  activeGoalContext: string | undefined;
+}): string {
+  const blocks = params.text.split(/\n{2,}/u);
+  let insertionIndex: number | undefined;
+  const retained: string[] = [];
+  for (const block of blocks) {
+    const isInjected =
+      params.injectedGoals.has(block) || isQueuedGoalOnlyBlock(block, params.injectedGoals);
+    if (isInjected && insertionIndex === undefined) {
+      insertionIndex = retained.length;
+    }
+    if (!isInjected) {
+      retained.push(block);
+    }
+  }
+  if (!params.activeGoalContext) {
+    return retained.join("\n\n");
+  }
+  if (insertionIndex === undefined) {
+    const anchorIndex = retained.findLastIndex(
+      (block) => block.startsWith("Current message:") || block.startsWith("Current event:"),
+    );
+    insertionIndex = anchorIndex >= 0 ? anchorIndex : retained.length;
+  }
+  retained.splice(Math.min(insertionIndex, retained.length), 0, params.activeGoalContext);
+  return retained.join("\n\n");
+}
+
+/** Refreshes only a previously injected goal line when a queued turn is admitted. */
+export function refreshActiveGoalContext(
+  context: CurrentInboundPromptContext | undefined,
+  sessionEntry: SessionEntry | undefined,
+): CurrentInboundPromptContext | undefined {
+  const activeGoalContext = formatActiveGoalContext(sessionEntry);
+  if (!context) {
+    return activeGoalContext
+      ? { text: activeGoalContext, injectedGoalContexts: [activeGoalContext] }
+      : undefined;
+  }
+  const injectedGoals = new Set(context.injectedGoalContexts ?? []);
+  const refreshedText = refreshActiveGoalContextText({
+    text: context.text,
+    injectedGoals,
+    activeGoalContext,
+  });
+  const refreshedResumableText = context.resumableText
+    ? refreshActiveGoalContextText({
+        text: context.resumableText,
+        injectedGoals,
+        activeGoalContext,
+      })
+    : undefined;
+  if (!refreshedText) {
+    return undefined;
+  }
+  return {
+    ...context,
+    text: refreshedText,
+    ...(refreshedResumableText !== undefined
+      ? { resumableText: refreshedResumableText || undefined }
+      : {}),
+    injectedGoalContexts: activeGoalContext ? [activeGoalContext] : undefined,
+  };
+}
 
 function stripNullBytes(value: string): string {
   return value.replaceAll("\u0000", "");
@@ -533,6 +629,7 @@ export function buildInboundMetaSystemPrompt(
 export function buildInboundUserContextPrefix(
   ctx: TemplateContext,
   envelope?: EnvelopeFormatOptions,
+  sessionEntry?: SessionEntry,
 ): string {
   const blocks: string[] = [];
   const chatType = normalizeChatType(ctx.ChatType);
@@ -707,6 +804,11 @@ export function buildInboundUserContextPrefix(
         }),
       ),
     );
+  }
+
+  const activeGoalContext = formatActiveGoalContext(sessionEntry);
+  if (activeGoalContext) {
+    blocks.push(activeGoalContext);
   }
 
   if (currentMessageContext) {

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -106,6 +106,7 @@ type ReplyPromptEnvelopeBaseParams = {
   baseBody: string;
   hasUserBody: boolean;
   inboundUserContext: string;
+  activeGoalContext?: string;
   inboundUserContextPromptJoiner?: CurrentInboundPromptContext["promptJoiner"];
   isBareSessionReset: boolean;
   startupAction: ReplyPromptEnvelopeStartupAction;
@@ -243,6 +244,7 @@ export function buildReplyPromptEnvelopeBase(
           text: currentInboundContextText,
           ...(resumableRoomEventContext ? { resumableText: resumableRoomEventContext } : {}),
           promptJoiner: params.inboundUserContextPromptJoiner,
+          ...(params.activeGoalContext ? { injectedGoalContexts: [params.activeGoalContext] } : {}),
         }
       : undefined;
 

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -466,10 +466,14 @@ function collectCurrentInboundContext(items: FollowupRun[]): FollowupRun["curren
     return undefined;
   }
   const resumableText = renderField("resumableText");
+  const injectedGoalContexts = [
+    ...new Set(contexts.flatMap(({ context }) => context.injectedGoalContexts ?? [])),
+  ];
   return {
     text,
     ...(resumableText ? { resumableText } : {}),
     promptJoiner: "\n\n",
+    ...(injectedGoalContexts.length > 0 ? { injectedGoalContexts } : {}),
   };
 }
 

--- a/src/auto-reply/reply/reply-turn-admission.ts
+++ b/src/auto-reply/reply/reply-turn-admission.ts
@@ -1,6 +1,7 @@
 // Decides whether an inbound turn may start, queue, or abort a reply run.
 import { resolveSessionWorkStartError } from "../../config/sessions/lifecycle.js";
 import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import {
   beginSessionWorkAdmission,
   type SessionWorkAdmissionLease,
@@ -22,7 +23,7 @@ export type ReplyTurnKind = "visible" | "heartbeat" | "queued_followup" | "contr
 
 /** Admission result for a reply turn attempting to own the session run slot. */
 export type ReplyTurnAdmission =
-  | { status: "owned"; operation: ReplyOperation }
+  | { status: "owned"; operation: ReplyOperation; sessionEntry?: SessionEntry }
   | {
       status: "skipped";
       reason: "active-run" | "aborted" | "lifecycle-invalidated";
@@ -91,6 +92,7 @@ export async function admitReplyTurn(params: {
     try {
       const storePath = params.storePath;
       let operation: ReplyOperation | undefined;
+      let admittedSessionEntry: SessionEntry | undefined;
       let interruptedBeforeOperation = false;
       const admission = storePath
         ? await beginSessionWorkAdmission({
@@ -108,6 +110,7 @@ export async function admitReplyTurn(params: {
                 sessionKey: params.sessionKey,
                 readConsistency: "latest",
               });
+              admittedSessionEntry = currentEntry;
               if (expectedSessionId && !currentEntry) {
                 rejectLifecycleInvalidatedWork({
                   kind: params.kind,
@@ -211,6 +214,7 @@ export async function admitReplyTurn(params: {
       return {
         status: "owned",
         operation,
+        ...(admittedSessionEntry ? { sessionEntry: admittedSessionEntry } : {}),
       };
     } catch (error) {
       if (isAbortSignalAborted(params.upstreamAbortSignal)) {

--- a/taxonomy.yaml
+++ b/taxonomy.yaml
@@ -1612,10 +1612,14 @@ surfaces:
           - name: Runtime Assembly
             coverageIds: [agents.openclaw-harness, models.codex-cli, workspace.planning]
             description: Covers Runtime Assembly across context-engine selection, registry, host compatibility, legacy fallback, assemble/ingest/after-turn/compact lifecycle, runtime context projection, and the boundary between OpenClaw context assembly and native harness history.
+          - name: Goal continuance
+            coverageIds: [goals.context-injection, goals.continuance]
+            description: Active session goals remain visible in current-turn context and drive concrete followthrough across later turns and compaction.
         docs:
           - docs/concepts/context.md
           - docs/concepts/context-engine.md
           - docs/plan/codex-context-engine-harness.md
+          - docs/tools/goal.md
         search_anchors:
           - Context Engine
           - Runtime Assembly


### PR DESCRIPTION
## What Problem This Solves

A session goal (docs/tools/goal.md) persists as session state, but nothing surfaces it to the model on later turns: after a few turns or a compaction, the agent only rediscovers the objective if it happens to call `get_goal`. Persistence of the goal record is not persistence of pursuit — long-form work silently stalls and operators end up re-prompting "continue". There was also zero QA coverage proving multi-turn goal followthrough, so continuance regressions were invisible.

Closes #100409.

## Why This Change Was Made

**Per-turn goal context (active goals only).** `buildInboundUserContextPrefix` (`src/auto-reply/reply/inbound-meta.ts`) now appends one bounded line when the session goal is `active`:

```
Active goal: <objective> — advance it or update its status (get_goal/update_goal).
```

- User-role, current-turn context only — system prompt and prior transcript bytes untouched, so prompt caching is preserved.
- `paused`/`blocked`/`budget_limited`/`usage_limited`/`complete` inject nothing: an operator stop stays stopped. Heartbeat turns are excluded.
- Objectives are whitespace-normalized and truncated at 200 chars.
- No goal-state writes from this path, no new config surface.

**Staleness across queueing/interrupts.** Queued turns build their context early; a goal can complete/pause/start while they wait. Admission (`reply-turn-admission.ts`) already loads the latest session entry under the lifecycle fence, so it now exposes that entry, and queued/interrupt-delayed turns refresh only the previously injected goal line at admission (`refreshActiveGoalContext`, provenance-tracked via `injectedGoalContexts` so only generated lines are ever touched — never user text). Interrupt-race path in `get-reply-run.ts` re-resolves after an actual admission wait.

**QA continuance scenarios** (`qa/scenarios/goals/`, new theme + `goals.context-injection`/`goals.continuance` coverage IDs in `taxonomy.yaml`):

1. `goal-context-next-turn` — `/goal start`, then an unrelated turn; asserts the exact goal line in the captured mock-provider request payload.
2. `goal-context-survives-compaction` — goal line still present on the post-compaction turn.
3. `goal-followthrough-live` (live-only tier) — with an active multi-step goal, a bare "continue" turn must advance the next concrete step instead of re-planning, mirroring the instruction-followthrough contract.

## User Impact

Sessions with an active `/goal` keep pursuing it: the objective is visible to the model on every turn and survives compaction, queueing, and interruptions. Operator semantics unchanged — pausing/completing a goal immediately stops injection. Documented in the new "Goal context on every turn" section of [goal docs](https://docs.openclaw.ai/tools/goal).

## Evidence

- Focused Testbox run: 399 tests passed (366 reply-path + 33 QA catalog/schema); repository guards + full typecheck passed; targeted lint clean; import-cycle check and `git diff --check` clean.
- Local focused rerun of `inbound-meta.test.ts`, `followup-runner.test.ts`, `get-reply-run.media-only.test.ts` (active/inactive/no-goal/truncation, queued-refresh staleness, heartbeat exclusion, interrupt-race regression).
- Prompt snapshots unchanged (no system-prompt/tool-catalog changes).
- Structured second-model review (Codex, gpt-5.5): no actionable findings.
- Live-only QA scenario is catalog-validated; not executed against a paid live model in this PR.
- Release-note context: user-facing `feat` — active session goals now stay in per-turn context and are covered by continuance QA scenarios.
