### PR TITLE
perf(agents): slim Skill Workshop prompt section to its routing contract

### DIFF
--- a/src/agents/skill-workshop-prompt.ts
+++ b/src/agents/skill-workshop-prompt.ts
@@ -8,18 +8,8 @@ export const SKILL_WORKSHOP_TOOL_NAME = "skill_workshop";
 export function buildSkillWorkshopPromptSection(): string[] {
   return [
     "## Skill Workshop",
-    "Use `skill_workshop` when the user wants to create, update, revise, list, inspect, apply, reject, or quarantine a reusable skill, Skill Workshop proposal, playbook, workflow, procedure, or durable instruction.",
-    "Treat a request as durable when it should be saved, repeated, proposed, installed later, shared as a skill, or used as a standing workflow instead of answered once in chat.",
-    "Do not create or change skill proposal files manually with `write`, `edit`, `exec`, shell commands, or direct filesystem operations. The final proposal artifact must go through `skill_workshop`.",
-    "Use `action=create` for a new skill, `action=update` for an existing approved/live skill, and `action=revise` for an existing pending proposal; keep `description` under 160 bytes and `proposal_content` within the configured body limit.",
-    "For `action=update`, pass a concise `description` when the existing live skill description should be shortened in the proposal listing.",
-    "For `action=revise`, pass `proposal_id` when known. If it is not known, pass the proposal or skill name in `name` so `skill_workshop` can resolve the pending proposal or return candidates.",
-    "Use `action=list` or `action=inspect` only for pending proposal discovery/inspection. Do not use filesystem search for proposal discovery.",
-    "If the user names an existing live skill, read or view that skill when needed for context, but create the update proposal through `skill_workshop`.",
-    "Generated skills are pending proposals by default. Do not apply, install, approve, enable, or write into live skills unless the user explicitly asks for that separate action.",
-    "Use `action=apply`, `action=reject`, or `action=quarantine` only after the user explicitly asks to approve/use/apply, reject, or quarantine a specific proposal. Pass `proposal_id`; if it is not known, use `action=list` or `action=inspect` first.",
-    "Do not apply, reject, or quarantine proposals manually with filesystem operations or shell commands. Proposal lifecycle changes must use `skill_workshop`.",
-    "You may gather context first, but the durable proposal write or lifecycle change must use `skill_workshop`.",
+    "Route durable skill work — creating, updating, or managing reusable skills, playbooks, or standing workflows — through the `skill_workshop` tool; never write proposal or skill files directly.",
+    "Generated skills are pending proposals. Apply, reject, or quarantine only when the user explicitly asks.",
     "",
   ];
 }

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -6,6 +6,7 @@ import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { typedCases } from "../test-utils/typed-cases.js";
 import { listDeliverableMessageChannels } from "../utils/message-channel.js";
 import { resolveAgentPromptSurfaceForSessionKey } from "./prompt-surface.js";
+import { buildSkillWorkshopPromptSection } from "./skill-workshop-prompt.js";
 import { buildSubagentSystemPrompt } from "./subagent-system-prompt.js";
 import {
   buildAgentBootstrapSystemContext,
@@ -733,12 +734,20 @@ describe("buildAgentSystemPrompt", () => {
   });
 
   it("instructs models to use skill_workshop only when the tool is available", () => {
+    const section = buildSkillWorkshopPromptSection();
+    const sectionText = section.join("\n");
+    expect(section.length).toBeLessThanOrEqual(4);
+    expect(sectionText).toContain("Route durable skill work");
+    expect(sectionText).toContain("through the `skill_workshop` tool");
+    expect(sectionText).toContain("Generated skills are pending proposals.");
+    expect(sectionText).toContain("only when the user explicitly asks");
+
     const withoutTool = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
       toolNames: ["read"],
     });
     expect(withoutTool).not.toContain("## Skill Workshop");
-    expect(withoutTool).not.toContain("use `skill_workshop`");
+    expect(withoutTool).not.toContain("Route durable skill work");
 
     const withTool = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
@@ -748,32 +757,8 @@ describe("buildAgentSystemPrompt", () => {
       "- skill_workshop: Create, update, revise, list, inspect, apply, reject, or quarantine Skill Workshop proposals",
     );
     expect(withTool).toContain("## Skill Workshop");
-    expect(withTool).toContain(
-      "Use `skill_workshop` when the user wants to create, update, revise, list, inspect, apply, reject, or quarantine a reusable skill, Skill Workshop proposal, playbook, workflow, procedure, or durable instruction.",
-    );
-    expect(withTool).toContain(
-      "Treat a request as durable when it should be saved, repeated, proposed, installed later, shared as a skill, or used as a standing workflow instead of answered once in chat.",
-    );
-    expect(withTool).toContain(
-      "Do not create or change skill proposal files manually with `write`, `edit`, `exec`, shell commands, or direct filesystem operations.",
-    );
-    expect(withTool).toContain("keep `description` under 160 bytes");
-    expect(withTool).toContain("`proposal_content` within the configured body limit");
-    expect(withTool).toContain(
-      "Use `action=list` or `action=inspect` only for pending proposal discovery/inspection. Do not use filesystem search for proposal discovery.",
-    );
-    expect(withTool).toContain("`action=revise` for an existing pending proposal");
-    expect(withTool).toContain("pass the proposal or skill name in `name`");
-    expect(withTool).toContain(
-      "Use `action=apply`, `action=reject`, or `action=quarantine` only after the user explicitly asks to approve/use/apply, reject, or quarantine a specific proposal.",
-    );
-    expect(withTool).toContain("Generated skills are pending proposals by default.");
-    expect(withTool).toContain(
-      "Do not apply, reject, or quarantine proposals manually with filesystem operations or shell commands.",
-    );
-    expect(withTool).toContain(
-      "You may gather context first, but the durable proposal write or lifecycle change must use `skill_workshop`.",
-    );
+    expect(withTool).toContain("Route durable skill work");
+    expect(withTool).toContain("Generated skills are pending proposals.");
   });
 
   it("appends available skills when provided", () => {

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -29,6 +29,20 @@ afterEach(async () => {
 });
 
 describe("skill_workshop tool", () => {
+  it("describes action selection and pending-proposal discovery in its schema", () => {
+    const tool = createSkillWorkshopTool({ workspaceDir: "/tmp/openclaw" });
+    const schema = JSON.stringify(tool.parameters);
+
+    expect(schema).toContain("create = new skill");
+    expect(schema).toContain("update = existing live skill");
+    expect(schema).toContain("revise = existing pending proposal");
+    expect(schema).toContain("not filesystem search");
+    expect(schema).toContain("when proposal_id is unknown");
+    expect(schema).toContain("returns candidates");
+    expect(schema).toContain("max 160 bytes");
+    expect(schema).toContain("shortens the proposal listing entry");
+  });
+
   it("is exposed in the OpenClaw tool set", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-workshop-tool-");
     const tools = createOpenClawTools({

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -55,7 +55,7 @@ const SkillWorkshopToolSchema = Type.Object(
   {
     action: stringEnum(SKILL_WORKSHOP_ACTIONS, {
       description:
-        "create for a new skill proposal, update for an existing skill, revise for a pending proposal, list or inspect proposals for proposal discovery, apply/reject/quarantine for explicit proposal lifecycle actions.",
+        "create = new skill; update = existing live skill; revise = existing pending proposal; list/inspect discover pending proposals (not filesystem search); apply/reject/quarantine are explicit lifecycle actions.",
     }),
     proposal_id: Type.Optional(
       Type.String({
@@ -66,7 +66,7 @@ const SkillWorkshopToolSchema = Type.Object(
     name: Type.Optional(
       Type.String({
         description:
-          "Skill/proposal name. Required for action=create; optional resolver for action=inspect or action=revise when proposal_id is unknown.",
+          "Skill/proposal name. Required for create; for inspect/revise when proposal_id is unknown, resolves a pending proposal or returns candidates.",
       }),
     ),
     query: Type.Optional(Type.String({ description: "Optional query for action=list." })),
@@ -86,7 +86,7 @@ const SkillWorkshopToolSchema = Type.Object(
       Type.String({
         maxLength: 160,
         description:
-          "Skill description for action=create, action=update, or action=revise. Keep it concise; max 160 bytes.",
+          "Skill description for create/update/revise; max 160 bytes. On update, concise text shortens the proposal listing entry.",
       }),
     ),
     skill_name: Type.Optional(


### PR DESCRIPTION
## What Problem This Solves

Whenever the `skill_workshop` tool is available, every conversation carries a 13-line system-prompt section that restates the manual-write prohibition three times and embeds per-action mechanics (create/update/revise selection, `proposal_id` resolution, the 160-byte description limit, list/inspect rules) that only matter mid-tool-use. That is recurring token cost on every API call, and community feedback on the tone has been blunt — the workaround being shared is disabling the `skill_workshop` tool entirely, which silently kills proposal review.

Closes #100449.

## Why This Change Was Made

- `src/agents/skill-workshop-prompt.ts`: the section body is now two lines — route durable skill work through `skill_workshop` / never write proposal or skill files directly, and proposals stay pending unless the user explicitly asks to apply/reject/quarantine. The injection gate (section present only when the tool is available) is unchanged.
- `src/agents/tools/skill-workshop-tool.ts`: action-selection semantics, name-based proposal resolution, and the description limit now live in the tool's parameter descriptions — the surface the model reads at tool-use time — compressed so the schema grew only marginally.
- Net effect (UTF-8 prompt text + compact JSON schema): prompt section 2,128 → 319 bytes; tool schema 2,273 → 2,298 bytes; **combined −1,784 bytes per request** for affected sessions.
- The routing contract itself is intentionally preserved: durable skill writes still go through the reviewable proposal flow. This PR changes how much prompt real estate that contract occupies, not what it enforces.

## User Impact

- Every session with the workshop tool pays ~1.8KB less prompt per API call.
- The system prompt reads as one clear rule instead of a page of prohibitions — the main tone complaint from the community thread that prompted #100449.
- No behavior change to the tool, approval policy, or proposal lifecycle.

## Evidence

- Prompt snapshots regenerated: byte-identical, no fixture drift (`pnpm prompt:snapshots:check` passed — snapshot fixtures do not enable the workshop tool).
- Focused tests updated to behavior contracts (section ≤4 lines, routing + pending-by-default rules present; schema describes action selection and discovery) and passing on Blacksmith Testbox: `src/agents/system-prompt.test.ts`, `src/agents/tools/skill-workshop-tool.test.ts`.
- Structured second-model review (Codex, gpt-5.5): no actionable findings.
- Release-note context: user-facing `perf`/`fix` — Skill Workshop system-prompt section slimmed to its routing contract (~1.8KB/request saved); action mechanics moved into the tool schema.
