### PR TITLE
fix(codex): ignore missing mirrored session history

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -41,29 +41,6 @@ describe("Codex app-server attempt context", () => {
     }
   });
 
-  it("keeps malformed mirrored session history on the hook warning path", async () => {
-    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
-    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-attempt-context-history-"));
-    const sessionFile = path.join(dir, "session.jsonl");
-    try {
-      await fs.writeFile(sessionFile, JSON.stringify({ type: "message", id: "orphan" }) + "\n");
-
-      await expect(
-        readMirroredSessionHistoryMessages({
-          sessionFile,
-          sessionId: "codex-session",
-          sessionKey: "codex-session",
-        }),
-      ).resolves.toBeUndefined();
-      expect(warn).toHaveBeenCalledWith(
-        "failed to read mirrored session history for codex harness hooks",
-        { sessionFile },
-      );
-    } finally {
-      await fs.rm(dir, { recursive: true, force: true });
-    }
-  });
-
   it("returns a run context report without deferred Codex dynamic tool schemas", () => {
     const tools = [
       {

--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -2,19 +2,68 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { describe, expect, it } from "vitest";
+import {
+  embeddedAgentLog,
+  type EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildCodexWorkspaceBootstrapContext,
   buildCodexSystemPromptReport,
   readContextEngineThreadBootstrapProjection,
+  readMirroredSessionHistoryMessages,
   remapCodexContextFilePath,
   resolveContextEngineBootstrapProjectionDecision,
 } from "./attempt-context.js";
 import type { CodexDynamicToolSpec } from "./protocol.js";
 import type { CodexAppServerContextEngineBinding } from "./session-binding.js";
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("Codex app-server attempt context", () => {
+  it("treats missing mirrored session history as empty without hook warning", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-attempt-context-history-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    try {
+      await expect(
+        readMirroredSessionHistoryMessages({
+          sessionFile,
+          sessionId: "codex-session",
+          sessionKey: "codex-session",
+        }),
+      ).resolves.toEqual([]);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps malformed mirrored session history on the hook warning path", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-attempt-context-history-"));
+    const sessionFile = path.join(dir, "session.jsonl");
+    try {
+      await fs.writeFile(sessionFile, JSON.stringify({ type: "message", id: "orphan" }) + "\n");
+
+      await expect(
+        readMirroredSessionHistoryMessages({
+          sessionFile,
+          sessionId: "codex-session",
+          sessionKey: "codex-session",
+        }),
+      ).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        "failed to read mirrored session history for codex harness hooks",
+        { sessionFile },
+      );
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("returns a run context report without deferred Codex dynamic tool schemas", () => {
     const tools = [
       {

--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -63,6 +63,27 @@ function mirroredTarget(sessionFile: string) {
 }
 
 describe("readCodexMirroredSessionHistoryMessages", () => {
+  it("treats a missing mirrored session file as empty history", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-session-history-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+
+    await expect(
+      readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
+    ).resolves.toEqual([]);
+  });
+
+  it("returns undefined for malformed non-empty mirrored session files", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-session-history-"));
+    tempDirs.push(dir);
+    const sessionFile = path.join(dir, "session.jsonl");
+    await fs.writeFile(sessionFile, JSON.stringify({ type: "message", id: "orphan" }) + "\n");
+
+    await expect(
+      readCodexMirroredSessionHistoryMessages(mirroredTarget(sessionFile)),
+    ).resolves.toBeUndefined();
+  });
+
   it("replays only the branch selected by a leaf control", async () => {
     const sessionFile = await writeSession([
       messageEntry({ id: "root", parentId: null, role: "user", content: "root prompt" }),

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -16,6 +16,15 @@ import {
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { sanitizeCodexHistoryImagePayloads } from "./image-payload-sanitizer.js";
 
+function isMissingFileError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT",
+  );
+}
+
 export type CodexMirroredSessionHistoryTarget = {
   agentId?: string;
   sessionFile: string;
@@ -51,7 +60,10 @@ export async function readCodexMirroredSessionHistoryMessages(
       buildSessionContext(sessionEntries).messages,
       "codex mirrored history",
     );
-  } catch {
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return [];
+    }
     return undefined;
   }
 }

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -17,12 +17,7 @@ import {
 import { sanitizeCodexHistoryImagePayloads } from "./image-payload-sanitizer.js";
 
 function isMissingFileError(error: unknown): boolean {
-  return Boolean(
-    error &&
-    typeof error === "object" &&
-    "code" in error &&
-    (error as { code?: unknown }).code === "ENOENT",
-  );
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
 }
 
 export type CodexMirroredSessionHistoryTarget = {
@@ -61,6 +56,7 @@ export async function readCodexMirroredSessionHistoryMessages(
       "codex mirrored history",
     );
   } catch (error) {
+    // A new Codex session can be read before its transcript exists; other failures still warn.
     if (isMissingFileError(error)) {
       return [];
     }


### PR DESCRIPTION
## What Problem This Solves

Codex startup can read mirrored session history before the transcript file exists. The missing file was treated like malformed history, which emitted a misleading warning during a normal new-session race.

Related: #99575

## Why This Change Was Made

Treat only `ENOENT` as empty mirrored history. Existing but unreadable or malformed transcripts still return the warning-triggering failure result.

This is a clean maintainer replacement for #99575 after GitHub's `createCommitOnBranch` mutation returned HTTP 499 while updating the contributor fork to current `main`. The original contributor commits and Alex Tang's authorship are preserved; the maintainer commit only narrows the tests and documents the lifecycle invariant.

## User Impact

New Codex sessions no longer emit a false missing-history warning during startup. Real transcript read or parse failures remain visible.

## Evidence

- Local focused proof: 2 files, 11 tests passed.
- Crabbox delegated Testbox proof: provider `blacksmith-testbox`, id `tbx_01kwt620rby5h12z4e32wq1shd`, 2 files and 11 tests passed.
- The same Testbox ran `pnpm check:changed`; all selected extension production/test typecheck, lint, boundary, database-first, sidecar, and import-cycle gates passed.
- Fresh branch autoreview reported no findings and rated the patch correct with 0.87 confidence.
- Direct Codex app-server contract inspection confirmed `thread/start` creates new history while resume history is a separate API.
