### PR TITLE
fix(macos): dashboard window keeps a dead SSH tunnel port after tunnel restart

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardManager.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardManager.swift
@@ -10,9 +10,44 @@ final class DashboardManager {
     static let shared = DashboardManager()
 
     private var controller: DashboardWindowController?
+    private var endpointTask: Task<Void, Never>?
     private static let failureURL = URL(string: "about:blank")!
 
     private init() {}
+
+    /// The remote SSH tunnel can be recreated on a new ephemeral local port while
+    /// the dashboard stays open; without following endpoint changes the WebView
+    /// keeps reconnecting to the dead old port forever (#100476).
+    private func observeEndpointChanges() {
+        guard self.endpointTask == nil else { return }
+        self.endpointTask = Task { [weak self] in
+            let stream = await GatewayEndpointStore.shared.subscribe()
+            for await state in stream {
+                guard let self else { return }
+                await self.handleEndpointState(state)
+            }
+        }
+    }
+
+    func handleEndpointState(_ state: GatewayEndpointState) async {
+        guard case let .ready(mode, url, token, password) = state else { return }
+        guard let controller, controller.isWindowOpen else { return }
+        let config: GatewayConnection.Config = (url, token, password)
+        let authToken = await GatewayConnection.shared.controlUiAutoAuthToken(config: config)
+        guard let dashboardURL = try? GatewayEndpointStore.dashboardURL(for: config, mode: mode, authToken: authToken),
+              dashboardURL != controller.currentURL
+        else {
+            return
+        }
+        let auth = DashboardWindowAuth(
+            gatewayUrl: Self.websocketURLString(for: dashboardURL),
+            token: authToken,
+            password: password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
+        guard auth.hasCredential, controller.isWindowOpen else { return }
+        dashboardManagerLogger.info(
+            "dashboard endpoint changed; reloading url=\(dashboardLogString(for: dashboardURL), privacy: .public)")
+        controller.update(url: dashboardURL, auth: auth)
+    }
 
     @discardableResult
     func showConfiguredWindowIfPossible() -> Bool {
@@ -39,6 +74,7 @@ final class DashboardManager {
             self.controller = controller
             controller.show(url: url, auth: auth)
         }
+        self.observeEndpointChanges()
         Task { _ = try? await ControlChannel.shared.health(timeout: 3) }
         return true
     }
@@ -56,15 +92,17 @@ final class DashboardManager {
             password: config.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty)
 
         if let controller {
-            dashboardManagerLogger.info("dashboard reuse window url=\(url.absoluteString, privacy: .public)")
+            dashboardManagerLogger.info("dashboard reuse window url=\(dashboardLogString(for: url), privacy: .public)")
             controller.show(url: url, auth: auth)
+            self.observeEndpointChanges()
             return
         }
 
-        dashboardManagerLogger.info("dashboard create window url=\(url.absoluteString, privacy: .public)")
+        dashboardManagerLogger.info("dashboard create window url=\(dashboardLogString(for: url), privacy: .public)")
         let controller = DashboardWindowController(url: url, auth: auth)
         self.controller = controller
         controller.show(url: url, auth: auth)
+        self.observeEndpointChanges()
 
         // Refresh the cached hello payload without blocking window creation.
         Task { _ = try? await ControlChannel.shared.health(timeout: 3) }
@@ -77,6 +115,9 @@ final class DashboardManager {
             url: Self.failureURL,
             auth: DashboardWindowAuth(gatewayUrl: nil, token: nil, password: nil))
         self.controller = controller
+        // Keep observing while the failure page is up so a recovered tunnel
+        // swaps the window back to the live dashboard.
+        self.observeEndpointChanges()
         controller.showFailure(
             title: "Dashboard unavailable",
             message: message,
@@ -133,3 +174,17 @@ final class DashboardManager {
         return nil
     }
 }
+
+#if DEBUG
+extension DashboardManager {
+    /// Test instances skip `observeEndpointChanges()` so the shared endpoint
+    /// store cannot race test-driven `handleEndpointState` calls.
+    static func _testMake() -> DashboardManager {
+        DashboardManager()
+    }
+
+    func _testSetController(_ controller: DashboardWindowController?) {
+        self.controller = controller
+    }
+}
+#endif

--- a/apps/macos/Sources/OpenClaw/DashboardWindow.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindow.swift
@@ -19,3 +19,13 @@ struct DashboardWindowAuth: Equatable {
             self.password?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
     }
 }
+
+/// Dashboard URLs carry the auth token in the `#token=...` fragment; strip the
+/// fragment before logging so credentials never land in unified logs.
+func dashboardLogString(for url: URL) -> String {
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        return "<unparseable-url>"
+    }
+    components.fragment = nil
+    return components.url?.absoluteString ?? "<unparseable-url>"
+}

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController.swift
@@ -21,7 +21,7 @@ private final class DashboardWindowDragRegionView: NSView {
 @MainActor
 final class DashboardWindowController: NSWindowController, WKNavigationDelegate, WKUIDelegate, NSWindowDelegate {
     private let webView: WKWebView
-    private var currentURL: URL
+    private(set) var currentURL: URL
     private var auth: DashboardWindowAuth
 
     init(url: URL, auth: DashboardWindowAuth) {
@@ -81,11 +81,27 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     func show(url: URL, auth: DashboardWindowAuth) {
+        self.update(url: url, auth: auth)
+        self.show()
+    }
+
+    /// Swap the dashboard to a new gateway endpoint without reordering the window:
+    /// re-injects the native auth script for the new origin and reloads. Used when
+    /// the remote tunnel is recreated on a new local port while the window stays
+    /// open; ordering the window front here would steal focus on background
+    /// tunnel recreation.
+    func update(url: URL, auth: DashboardWindowAuth) {
         self.currentURL = url
         self.auth = auth
         self.refreshNativeAuthScript(url: url, auth: auth)
         self.load(url)
-        self.show()
+    }
+
+    /// Miniaturized windows report `isVisible == false` but must still follow
+    /// endpoint changes so deminiaturizing does not land on a dead port.
+    var isWindowOpen: Bool {
+        guard let window else { return false }
+        return window.isVisible || window.isMiniaturized
     }
 
     func show() {
@@ -120,7 +136,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
     }
 
     private func load(_ url: URL) {
-        dashboardWindowLogger.debug("dashboard load \(url.absoluteString, privacy: .public)")
+        dashboardWindowLogger.debug("dashboard load \(dashboardLogString(for: url), privacy: .public)")
         self.webView.load(URLRequest(url: url))
     }
 
@@ -320,7 +336,7 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled { return }
         dashboardWindowLogger.error(
-            "dashboard load failed url=\(self.currentURL.absoluteString, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            "dashboard load failed url=\(dashboardLogString(for: self.currentURL), privacy: .public) error=\(error.localizedDescription, privacy: .public)")
         let html = Self.failureHTML(
             title: "Dashboard unavailable",
             message: error.localizedDescription,
@@ -437,3 +453,11 @@ final class DashboardWindowController: NSWindowController, WKNavigationDelegate,
             .replacingOccurrences(of: "'", with: "&#39;")
     }
 }
+
+#if DEBUG
+extension DashboardWindowController {
+    var _testUserScripts: [WKUserScript] {
+        self.webView.configuration.userContentController.userScripts
+    }
+}
+#endif

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift
@@ -38,6 +38,11 @@ struct DashboardWindowSmokeTests {
         #expect(DashboardWindowController.originString(for: url) == "http://[fd12:3456:789a::1]:18789")
     }
 
+    @Test func `dashboard log string strips token fragment`() throws {
+        let url = try #require(URL(string: "http://127.0.0.1:18789/control/#token=sekret")) // pragma: allowlist secret
+        #expect(dashboardLogString(for: url) == "http://127.0.0.1:18789/control/")
+    }
+
     @Test func `dashboard failure state opens in dashboard window`() throws {
         let url = try #require(URL(string: "http://127.0.0.1:18789/control/"))
         let controller = DashboardWindowController(
@@ -50,5 +55,78 @@ struct DashboardWindowSmokeTests {
         #expect(controller.window?.isVisible == true)
         #expect(controller.window?.styleMask.contains(.closable) == true)
         controller.closeDashboard()
+    }
+
+    private func makeShownController() throws -> DashboardWindowController {
+        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=device-token"))
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(
+                gatewayUrl: "ws://127.0.0.1:60001/",
+                token: "device-token",
+                password: nil))
+        controller.show()
+        return controller
+    }
+
+    @Test func `dashboard follows ready endpoint to a new tunnel port`() async throws {
+        let controller = try self.makeShownController()
+        defer { controller.closeDashboard() }
+        let manager = DashboardManager._testMake()
+        manager._testSetController(controller)
+
+        await manager.handleEndpointState(.ready(
+            mode: .remote,
+            url: try #require(URL(string: "ws://127.0.0.1:60002")),
+            token: "device-token",
+            password: nil))
+
+        #expect(controller.currentURL.absoluteString == "http://127.0.0.1:60002/#token=device-token")
+        let authScripts = controller._testUserScripts
+            .filter { $0.source.contains("__OPENCLAW_NATIVE_CONTROL_AUTH__") }
+        #expect(authScripts.count == 1)
+        // JSONSerialization escapes "/" so match on host:port, not the full origin.
+        #expect(authScripts.first?.source.contains("127.0.0.1:60002") == true)
+        #expect(authScripts.first?.source.contains("60001") == false)
+    }
+
+    @Test func `dashboard keeps endpoint when ready state matches current URL`() async throws {
+        let controller = try self.makeShownController()
+        defer { controller.closeDashboard() }
+        let manager = DashboardManager._testMake()
+        manager._testSetController(controller)
+        let scriptsBefore = controller._testUserScripts
+
+        await manager.handleEndpointState(.ready(
+            mode: .remote,
+            url: try #require(URL(string: "ws://127.0.0.1:60001")),
+            token: "device-token",
+            password: nil))
+        await manager.handleEndpointState(.connecting(mode: .remote, detail: "Connecting…"))
+        await manager.handleEndpointState(.unavailable(mode: .remote, reason: "tunnel down"))
+
+        #expect(controller.currentURL.absoluteString == "http://127.0.0.1:60001/#token=device-token")
+        // Identity check: an unchanged endpoint must not re-inject scripts or reload.
+        #expect(controller._testUserScripts.elementsEqual(scriptsBefore) { $0 === $1 })
+    }
+
+    @Test func `dashboard ignores endpoint changes while window is closed`() async throws {
+        let url = try #require(URL(string: "http://127.0.0.1:60001/#token=device-token"))
+        let controller = DashboardWindowController(
+            url: url,
+            auth: DashboardWindowAuth(
+                gatewayUrl: "ws://127.0.0.1:60001/",
+                token: "device-token",
+                password: nil))
+        let manager = DashboardManager._testMake()
+        manager._testSetController(controller)
+
+        await manager.handleEndpointState(.ready(
+            mode: .remote,
+            url: try #require(URL(string: "ws://127.0.0.1:60002")),
+            token: "device-token",
+            password: nil))
+
+        #expect(controller.currentURL == url)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -110,15 +110,6 @@ struct OnboardingViewSmokeTests {
             installing: false))
     }
 
-    @Test func `Crestodian setup requires a nonempty auth value`() {
-        #expect(!OnboardingView.hasCrestodianSetupAuth([:]))
-        #expect(!OnboardingView.hasCrestodianSetupAuth(["token": "  "]))
-        #expect(OnboardingView.hasCrestodianSetupAuth(["mode": "token"]))
-        #expect(OnboardingView.hasCrestodianSetupAuth([
-            "token": ["source": "env", "provider": "default", "id": "GATEWAY_TOKEN"],
-        ]))
-    }
-
     @Test func `select remote gateway clears stale ssh target when endpoint unresolved`() async {
         let override = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-config-\(UUID().uuidString)")


### PR DESCRIPTION
Closes #100476

## What Problem This Solves

Fixes an issue where remote-mode (SSH transport) users with the macOS Dashboard window open would see the Control UI drop to a permanent "Could not connect" gate after any tunnel churn (sleep/wake is enough). The window baked the forwarded tunnel's local port into the WebView URL and the injected `__OPENCLAW_NATIVE_CONTROL_AUTH__` payload at open time; when `RemoteTunnelManager` recreated the tunnel on a new ephemeral port, the open window never learned the new endpoint and its reconnect loop targeted the dead port forever. Only manually reopening the window recovered.

## Why This Change Was Made

`DashboardManager` now subscribes to `GatewayEndpointStore.subscribe()` (started when the first dashboard window is created). When a `.ready` state resolves to a dashboard URL different from the one currently shown while the window is open (or miniaturized), it re-derives the auth payload for the new origin and swaps the WebView via a new `DashboardWindowController.update(url:auth:)` — the same re-inject-auth-and-reload path `show(url:auth:)` uses, minus window ordering, so a background tunnel restart never steals focus. The failure page also observes, so a recovered tunnel swaps the window back to the live dashboard. While touching these paths, dashboard log lines now strip the `#token=` fragment (new `dashboardLogString(for:)`) so endpoint changes never write credentials to unified logs (flagged by pre-land review; the same leak existed in the pre-existing open/load log lines).

Also includes one unbreak commit: `main`'s macOS test target failed to compile because #100288 removed `OnboardingView.hasCrestodianSetupAuth` but left its test behind; the stale test is deleted.

## User Impact

Remote-mode users can leave the Dashboard window open across tunnel restarts: the Control UI reconnects to the new forwarded port automatically instead of dying until a manual reopen. Complements the web-side reconnect banner (#100479), which keeps the UI mounted but cannot fix a stale endpoint by itself. Dashboard auth tokens no longer appear in macOS unified logs.

## Evidence

- New tests in `apps/macos/Tests/OpenClawIPCTests/DashboardWindowSmokeTests.swift`: a `.ready` endpoint on a new port reloads the open window and re-injects the auth script for the new origin (old port gone from user scripts); an unchanged endpoint and non-`.ready` states do not re-inject (script identity check); endpoint changes are ignored while the window is closed; `dashboardLogString` strips the token fragment.
- `swift test --package-path apps/macos --parallel`: 631 tests in 113 suites passed (this also proves the compile unbreak — the same command fails on current `main` with `type 'OnboardingView' has no member 'hasCrestodianSetupAuth'`).
- `swiftformat --lint --config config/swiftformat` clean on touched sources.
- Codex autoreview (gpt-5.5): one accepted finding (token fragment in the new log line) fixed; final run clean.
