### PR TITLE
fix(macos): orphaned SSH tunnels from crashed app instances keep running and squat the preferred local port

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -18331,7 +18331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 168,
+      "line": 172,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel exited before listening",
       "surface": "apple",
@@ -18339,7 +18339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 184,
+      "line": 188,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel did not open local port \\(localPort)",
       "surface": "apple",
@@ -18347,7 +18347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 184,
+      "line": 188,
       "path": "apps/macos/Sources/OpenClaw/RemotePortTunnel.swift",
       "source": "ssh tunnel failed: \\(stderr)",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -7,7 +7,7 @@ import Darwin
 actor PortGuardian {
     static let shared = PortGuardian()
 
-    struct Record: Codable {
+    struct Record: Codable, Equatable {
         let port: Int
         let pid: Int32
         let command: String
@@ -41,6 +41,9 @@ actor PortGuardian {
 
     func sweep(mode: AppState.ConnectionMode) async {
         self.logger.info("port sweep starting (mode=\(mode.rawValue, privacy: .public))")
+        // Reap before the port scan and in every mode: orphans come from earlier
+        // remote sessions and must die even after the user switched modes.
+        await self.reapOrphanedTunnels()
         guard mode != .unconfigured else {
             self.logger.info("port sweep skipped (mode=unconfigured)")
             return
@@ -100,6 +103,160 @@ actor PortGuardian {
         if self.records.count != before {
             self.save()
         }
+    }
+
+    // MARK: - Orphaned tunnel reaping
+
+    /// Live process facts for a recorded tunnel pid; nil means the process is gone.
+    struct TunnelProcessInfo {
+        let parentPid: Int32
+        let startedAt: TimeInterval
+        let fullCommand: String?
+    }
+
+    enum TunnelRecordAction: Equatable {
+        /// Owner still alive (or process unverifiable) — leave process and record alone.
+        case keep
+        /// Record is stale (process gone or pid reused) — forget it, never kill.
+        case drop
+        /// Orphaned tunnel this app family spawned — kill it and forget the record.
+        case reap
+    }
+
+    /// Kill recorded ssh tunnels whose owning app instance died. A crash/force-kill
+    /// leaves the tunnel reparented to launchd, holding the remote connection and
+    /// squatting the preferred local port so new tunnels drift to ephemeral ports.
+    func reapOrphanedTunnels() async {
+        let disk = Self.loadRecords(from: Self.recordPath)
+        let plan = Self.planTunnelReap(
+            memory: self.records,
+            disk: disk,
+            processInfo: Self.tunnelProcessInfo(pid:))
+        var kept = plan.keep
+        for record in plan.reap {
+            if await self.reapTunnelProcess(record.pid) {
+                let message = """
+                reaped orphaned ssh tunnel (pid \(record.pid), local port \(record.port))
+                """
+                self.logger.error("\(message, privacy: .public)")
+            } else {
+                // Keep the record so the next sweep retries the kill.
+                kept.append(record)
+                self.logger.error("failed to reap orphaned tunnel pid \(record.pid, privacy: .public)")
+            }
+        }
+        // Persist whenever the kept records differ from either source by content, not
+        // just pid set: a reaped/dropped record may exist only in the file (crashed
+        // sibling), and a pid-colliding stale disk record must be overwritten too.
+        let byTime: (Record, Record) -> Bool = { ($0.timestamp, $0.pid) < ($1.timestamp, $1.pid) }
+        kept.sort(by: byTime)
+        if kept != self.records.sorted(by: byTime) || kept != disk.sorted(by: byTime) {
+            self.records = kept
+            self.save()
+        }
+    }
+
+    /// Matches only the exact `ssh … -N -L <localPort>:127.0.0.1:<remotePort>` shape spawned by
+    /// RemotePortTunnel. First reap gate; the start-time check in classify handles pid reuse
+    /// by a look-alike tunnel on the same port.
+    static func isTunnelCommand(_ fullCommand: String, localPort: Int) -> Bool {
+        let tokens = fullCommand.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard let executable = tokens.first,
+              executable == "ssh" || executable.hasSuffix("/ssh"),
+              tokens.contains("-N")
+        else { return false }
+        let forwardPrefix = "\(localPort):127.0.0.1:"
+        for (index, token) in tokens.enumerated() {
+            if token == "-L", index + 1 < tokens.count, tokens[index + 1].hasPrefix(forwardPrefix) {
+                return true
+            }
+            if token.hasPrefix("-L"), token.dropFirst(2).hasPrefix(forwardPrefix) {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func classifyTunnelRecord(_ record: Record, process: TunnelProcessInfo?) -> TunnelRecordAction {
+        guard let process else { return .drop }
+        // No readable command line (e.g. zombie): cannot prove the pid is ours, so
+        // never kill; the record drops once the process is truly gone.
+        guard let command = process.fullCommand, !command.isEmpty else { return .keep }
+        guard self.isTunnelCommand(command, localPort: record.port) else { return .drop }
+        // Records are written right after spawn, so the recorded process always starts
+        // before its record. Started-later means the pid was reused — possibly by a
+        // user's own look-alike tunnel on the same port. Drop, never kill. Small slack
+        // absorbs wall-clock steps between kernel start time and the record write.
+        guard process.startedAt <= record.timestamp + 5 else { return .drop }
+        // ppid 1 means reparented to launchd: the owning app instance died. Any other
+        // live parent may be a concurrent OpenClaw instance (prod + dev), so hands off.
+        return process.parentPid == 1 ? .reap : .keep
+    }
+
+    static func planTunnelReap(
+        memory: [Record],
+        disk: [Record],
+        processInfo: (Int32) -> TunnelProcessInfo?) -> (reap: [Record], keep: [Record])
+    {
+        // All app instances share port-guard.json, so disk can hold records from a
+        // crashed sibling this instance never saw. In-memory wins on pid collisions.
+        var merged: [Int32: Record] = [:]
+        for record in disk {
+            merged[record.pid] = record
+        }
+        for record in memory {
+            merged[record.pid] = record
+        }
+        let ordered = merged.values.sorted { ($0.timestamp, $0.pid) < ($1.timestamp, $1.pid) }
+        var reap: [Record] = []
+        var keep: [Record] = []
+        for record in ordered {
+            switch self.classifyTunnelRecord(record, process: processInfo(record.pid)) {
+            case .keep: keep.append(record)
+            case .drop: continue
+            case .reap: reap.append(record)
+            }
+        }
+        return (reap, keep)
+    }
+
+    /// Only a confirmed exit may drop the record (later sweeps retry otherwise), and
+    /// callers pick a local port right after reaping — the port is only free once ssh
+    /// has actually exited, not when the signal was delivered. TERM first, then KILL.
+    private func reapTunnelProcess(_ pid: Int32) async -> Bool {
+        _ = await ShellExecutor.run(command: ["kill", "-TERM", "\(pid)"], cwd: nil, env: nil, timeout: 2)
+        if await Self.waitForProcessExit(pid: pid) { return true }
+        _ = await ShellExecutor.run(command: ["kill", "-KILL", "\(pid)"], cwd: nil, env: nil, timeout: 2)
+        return await Self.waitForProcessExit(pid: pid)
+    }
+
+    private static func waitForProcessExit(pid: Int32, timeout: TimeInterval = 1.0) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while self.tunnelProcessInfo(pid: pid) != nil {
+            guard Date() < deadline else { return false }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return true
+    }
+
+    private static func tunnelProcessInfo(pid: Int32) -> TunnelProcessInfo? {
+        #if canImport(Darwin)
+        guard pid > 0 else { return nil }
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        let rc = sysctl(&mib, u_int(mib.count), &info, &size, nil, 0)
+        // sysctl "succeeds" with size 0 when the pid does not exist.
+        guard rc == 0, size > 0, info.kp_proc.p_pid == pid else { return nil }
+        let started = TimeInterval(info.kp_proc.p_starttime.tv_sec)
+            + TimeInterval(info.kp_proc.p_starttime.tv_usec) / 1_000_000
+        return TunnelProcessInfo(
+            parentPid: info.kp_eproc.e_ppid,
+            startedAt: started,
+            fullCommand: self.readFullCommand(pid: pid))
+        #else
+        return nil
+        #endif
     }
 
     struct PortReport: Identifiable {
@@ -428,6 +585,10 @@ extension PortGuardian {
 
 #if DEBUG
 extension PortGuardian {
+    static func _testTunnelProcessInfo(pid: Int32) -> TunnelProcessInfo? {
+        self.tunnelProcessInfo(pid: pid)
+    }
+
     static func _testParseListeners(_ text: String) -> [(
         pid: Int32,
         command: String,

--- a/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
+++ b/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
@@ -79,6 +79,10 @@ final class RemotePortTunnel: @unchecked Sendable {
                 userInfo: [NSLocalizedDescriptionKey: "Remote mode is not configured"])
         }
 
+        // Reap orphans from crashed instances before picking a port, otherwise a dead
+        // session's tunnel squats the preferred port and forces an ephemeral one.
+        await PortGuardian.shared.reapOrphanedTunnels()
+
         let localPort = try await Self.findPort(
             preferred: preferredLocalPort,
             allowRandom: allowRandomLocalPort)

--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -200,6 +200,132 @@ struct LowCoverageHelperTests {
         #expect(!localDockerReport.offenders.isEmpty)
     }
 
+    @Test func `port guardian matches only its own ssh tunnel command`() {
+        let full = "/usr/bin/ssh -o BatchMode=yes -o ControlMaster=no -o ControlPath=none "
+            + "-o ExitOnForwardFailure=yes -n -N -L 18789:127.0.0.1:18789 -- user@host"
+        #expect(PortGuardian.isTunnelCommand(full, localPort: 18789))
+        #expect(PortGuardian.isTunnelCommand("ssh -N -L18789:127.0.0.1:18789 user@host", localPort: 18789))
+
+        // Wrong local port, missing -N (interactive forward), other binaries, or a
+        // forward to a non-loopback host are not ours to kill.
+        #expect(!PortGuardian.isTunnelCommand(full, localPort: 18790))
+        #expect(!PortGuardian.isTunnelCommand("ssh -L 18789:127.0.0.1:18789 user@host", localPort: 18789))
+        #expect(!PortGuardian.isTunnelCommand("ssh -N -L 18789:example.com:80 user@host", localPort: 18789))
+        #expect(!PortGuardian.isTunnelCommand("sshd: user [priv]", localPort: 18789))
+        #expect(!PortGuardian.isTunnelCommand("node server.js -N -L 18789:127.0.0.1:18789", localPort: 18789))
+        #expect(!PortGuardian.isTunnelCommand("", localPort: 18789))
+    }
+
+    @Test func `port guardian classifies tunnel records for reaping`() {
+        let recordedAt: TimeInterval = 1_000_000
+        let record = PortGuardian.Record(
+            port: 18789, pid: 4242, command: "/usr/bin/ssh", mode: "remote", timestamp: recordedAt)
+        let tunnel = "/usr/bin/ssh -o BatchMode=yes -n -N -L 18789:127.0.0.1:18789 -- user@host"
+        let spawnedBeforeRecord = recordedAt - 2
+
+        // Process gone → stale record.
+        #expect(PortGuardian.classifyTunnelRecord(record, process: nil) == .drop)
+        // Pid reused by an unrelated process → drop the record, never kill.
+        #expect(PortGuardian.classifyTunnelRecord(
+            record,
+            process: .init(parentPid: 1, startedAt: spawnedBeforeRecord, fullCommand: "node server.js"))
+            == .drop)
+        // Pid reused by a look-alike tunnel started after the record was written →
+        // different process, drop without killing.
+        #expect(PortGuardian.classifyTunnelRecord(
+            record,
+            process: .init(parentPid: 1, startedAt: recordedAt + 3600, fullCommand: tunnel)) == .drop)
+        // Reparented to launchd → owning app instance died → reap.
+        #expect(PortGuardian.classifyTunnelRecord(
+            record,
+            process: .init(parentPid: 1, startedAt: spawnedBeforeRecord, fullCommand: tunnel)) == .reap)
+        // Parent alive (e.g. a concurrent OpenClaw instance) → hands off.
+        #expect(PortGuardian.classifyTunnelRecord(
+            record,
+            process: .init(parentPid: 987, startedAt: spawnedBeforeRecord, fullCommand: tunnel)) == .keep)
+        // Command unreadable → cannot prove ownership → keep.
+        #expect(PortGuardian.classifyTunnelRecord(
+            record,
+            process: .init(parentPid: 1, startedAt: spawnedBeforeRecord, fullCommand: nil)) == .keep)
+    }
+
+    @Test func `port guardian reap plan merges disk records and drops stale ones`() {
+        func record(pid: Int32, port: Int, timestamp: TimeInterval) -> PortGuardian.Record {
+            PortGuardian.Record(
+                port: port, pid: pid, command: "/usr/bin/ssh", mode: "remote", timestamp: timestamp)
+        }
+        func tunnel(port: Int) -> String {
+            "/usr/bin/ssh -o BatchMode=yes -n -N -L \(port):127.0.0.1:18789 -- user@host"
+        }
+
+        // pid 10: our live tunnel (parent alive). Disk-only records from a crashed
+        // sibling instance: pid 20 orphaned, pid 30 already gone.
+        let memory = [record(pid: 10, port: 18790, timestamp: 300)]
+        let disk = [
+            record(pid: 20, port: 18789, timestamp: 100),
+            record(pid: 30, port: 18791, timestamp: 200),
+            record(pid: 10, port: 1, timestamp: 1), // superseded by the in-memory record
+        ]
+        let plan = PortGuardian.planTunnelReap(memory: memory, disk: disk, processInfo: { pid in
+            switch pid {
+            case 10: .init(parentPid: 987, startedAt: 299, fullCommand: tunnel(port: 18790))
+            case 20: .init(parentPid: 1, startedAt: 99, fullCommand: tunnel(port: 18789))
+            default: nil
+            }
+        })
+        #expect(plan.reap.map(\.pid) == [20])
+        #expect(plan.keep.map(\.pid) == [10])
+        #expect(plan.keep.first?.port == 18790)
+    }
+
+    @Test func `port guardian classifies a real orphaned tunnel process for reaping`() async throws {
+        // Real ssh that hangs safely: ProxyCommand replaces the TCP transport, so no
+        // network traffic happens and the -L port is never bound (forwards only bind
+        // after auth). Spawned through sh so the parent exits and ssh reparents to
+        // launchd — the exact orphan shape the reaper must detect.
+        let port = 45871
+        // Detach the child's stdio: the pipe must reach EOF when sh exits, not when ssh dies.
+        let script = "/usr/bin/ssh -o BatchMode=yes -o ProxyCommand='sleep 60' " +
+            "-N -L \(port):127.0.0.1:\(port) orphan-reap-test-host >/dev/null 2>&1 & echo $!"
+        let spawn = Process()
+        spawn.executableURL = URL(fileURLWithPath: "/bin/sh")
+        spawn.arguments = ["-c", script]
+        let out = Pipe()
+        spawn.standardOutput = out
+        try spawn.run()
+        spawn.waitUntilExit()
+        let pidText = String(data: out.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let pid = try #require(Int32(pidText.trimmingCharacters(in: .whitespacesAndNewlines)))
+        defer { kill(pid, SIGKILL) }
+
+        // Reparenting to launchd is immediate once sh exits, but give ps/sysctl a beat.
+        var info: PortGuardian.TunnelProcessInfo?
+        for _ in 0..<40 {
+            info = PortGuardian._testTunnelProcessInfo(pid: pid)
+            if info?.parentPid == 1, info?.fullCommand?.isEmpty == false { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        let orphan = try #require(info)
+        #expect(orphan.parentPid == 1)
+        // Kernel start time must be sane so the pid-reuse gate can rely on it.
+        #expect(abs(orphan.startedAt - Date().timeIntervalSince1970) < 60)
+        let recordedAt = Date().timeIntervalSince1970
+        let record = PortGuardian.Record(
+            port: port, pid: pid, command: "/usr/bin/ssh", mode: "remote", timestamp: recordedAt)
+        #expect(PortGuardian.classifyTunnelRecord(record, process: orphan) == .reap)
+
+        // Same process under a different recorded port must never be reap-eligible.
+        let mismatched = PortGuardian.Record(
+            port: port + 1, pid: pid, command: "/usr/bin/ssh", mode: "remote", timestamp: recordedAt)
+        #expect(PortGuardian.classifyTunnelRecord(mismatched, process: orphan) == .drop)
+
+        // A record predating this process (reused pid) must drop, not reap.
+        let predates = PortGuardian.Record(
+            port: port, pid: pid, command: "/usr/bin/ssh", mode: "remote",
+            timestamp: orphan.startedAt - 3600)
+        #expect(PortGuardian.classifyTunnelRecord(predates, process: orphan) == .drop)
+    }
+
     @Test @MainActor func `canvas scheme handler resolves files and errors`() throws {
         let root = FileManager().temporaryDirectory
             .appendingPathComponent("canvas-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
Closes #100477

## What Problem This Solves

Fixes an issue where the macOS app leaked `ssh -N -L` tunnel processes when it crashed, was force-killed, or a dev build was stopped from Xcode. The orphaned tunnels reparent to launchd and run forever, holding SSH connections to the remote host — and one of them usually squats the preferred local gateway port (18789), so every new tunnel falls back to a random ephemeral port. Real-world evidence on one dev machine: 10 orphans accumulated over 2 days, one holding 18789.

## Why This Change Was Made

`PortGuardian` already records tunnel pids in `port-guard.json` but never used them: `sweep()` only inspected the canonical gateway port and refuses to kill anything in remote mode. This change adds orphan reaping driven by those records. A recorded pid is killed only when all three hold: the process still exists, its live command line matches the app's exact tunnel signature (`ssh … -N -L <recordedLocalPort>:127.0.0.1:<remotePort>`), and its parent is launchd (ppid 1, i.e. the owning app instance died). Tunnels whose parent is still alive — including concurrent OpenClaw instances (prod + dev share `port-guard.json`) — are never touched; records whose pid is gone or was reused by an unrelated process are dropped without killing. Reaping runs on every `PortGuardian.sweep` (startup, mode changes) and before `RemotePortTunnel.create` picks a local port, so the preferred port is actually free for the current launch, not just the next one.

## User Impact

Remote-mode users no longer accumulate zombie SSH tunnels after app crashes or force-kills. The preferred local gateway port is reclaimed automatically on the next launch/sweep, which stops the ephemeral-port drift that made open Dashboard windows go stale on every tunnel restart (#100476).

A recorded pid is killed only when all four gates hold: the process still exists, its live command line matches the exact tunnel signature, its kernel start time predates the record (pid-reuse guard — a look-alike tunnel on the same port that started after the record was written is never touched), and its parent is launchd (ppid 1). After a successful kill the reaper waits for the process to actually exit so the freed port is immediately reusable by the caller.

## Evidence

- New unit tests cover the tunnel-command signature matcher (rejects wrong port, missing `-N`, non-ssh binaries, non-loopback forwards), the per-record classification (gone → drop, pid reused → drop without kill, started-after-record → drop, orphaned → reap, parent alive → keep, unreadable command → keep), and the disk/memory record merge that picks up a crashed sibling instance's records.
- A real-process integration test spawns an actual orphaned `ssh -N -L` (via `ProxyCommand='sleep 60'` — no network traffic, port never bound), verifies it reparents to launchd, and asserts the live sysctl/ps classification path returns reap for the matching record and drop for mismatched-port and predating-record variants.
- `swift test --package-path apps/macos --filter "port guardian"`: 8 tests passed (0.196s).
- Full local suite `swift test --package-path apps/macos --parallel`: 632 tests, 113 suites — only failure was the known env-race flake in `MacNodeRuntimeTests` ("browser proxy rejects disabled browser control"), which passes in isolation and is untouched by this diff (CI already retries this lane for that reason).
- Live machine check: the one currently running tunnel (`ssh … -N -L 18789:127.0.0.1:18789`, parent = running dev OpenClaw instance) classifies as keep; the 10-orphan pileup from the issue is exactly the launchd-parented shape the reaper kills.
- `swiftformat --lint` clean on changed files; Codex autoreview run to a clean pass (two accepted findings fixed: persist disk-only record removals; start-time pid-reuse gate).
