### PR TITLE
fix(anthropic): normalize tuple tool schemas for Opus 4.8

### DIFF
--- a/packages/ai/src/providers/anthropic-tool-projection.test.ts
+++ b/packages/ai/src/providers/anthropic-tool-projection.test.ts
@@ -89,4 +89,34 @@ describe("projectAnthropicTools", () => {
       additionalItems: { type: "number" },
     });
   });
+
+  it("does not rewrite instance data that resembles a tuple schema", () => {
+    const tupleLikeValue = {
+      items: ["first", "second"],
+      additionalItems: false,
+    };
+    const projection = projectAnthropicTools(
+      [
+        {
+          name: "Match",
+          description: "Match a literal value",
+          parameters: {
+            type: "object",
+            properties: {
+              value: {
+                const: tupleLikeValue,
+                default: tupleLikeValue,
+              },
+            },
+          },
+        },
+      ],
+      (name) => name,
+    );
+
+    expect(projection.tools[0]?.inputSchema.properties.value).toEqual({
+      const: tupleLikeValue,
+      default: tupleLikeValue,
+    });
+  });
 });

--- a/packages/ai/src/providers/anthropic-tool-projection.test.ts
+++ b/packages/ai/src/providers/anthropic-tool-projection.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { projectAnthropicTools } from "./anthropic-tool-projection.js";
+
+describe("projectAnthropicTools", () => {
+  it("converts draft-07 tuple items to draft 2020-12 prefixItems for Anthropic", () => {
+    const projection = projectAnthropicTools(
+      [
+        {
+          name: "Edit",
+          description: "Apply an edit",
+          parameters: {
+            type: "object",
+            properties: {
+              ranges: {
+                type: "array",
+                items: [
+                  { type: "integer", minimum: 0 },
+                  { type: "integer", minimum: 0 },
+                ],
+                additionalItems: false,
+              },
+            },
+            required: ["ranges"],
+          },
+        },
+      ],
+      (name) => name,
+    );
+
+    expect(projection.unavailableOriginalNames.size).toBe(0);
+    expect(projection.tools).toHaveLength(1);
+    expect(projection.tools[0]?.inputSchema).toEqual({
+      type: "object",
+      properties: {
+        ranges: {
+          type: "array",
+          prefixItems: [
+            { type: "integer", minimum: 0 },
+            { type: "integer", minimum: 0 },
+          ],
+          items: false,
+        },
+      },
+      required: ["ranges"],
+    });
+  });
+
+  it("normalizes nested draft-07 tuple schemas without mutating the original descriptor", () => {
+    const tupleSchema = {
+      type: "object",
+      properties: {
+        patch: {
+          type: "object",
+          properties: {
+            spans: {
+              type: "array",
+              items: [{ type: "string" }],
+              additionalItems: { type: "number" },
+            },
+          },
+        },
+      },
+    };
+
+    const projection = projectAnthropicTools(
+      [
+        {
+          name: "Write",
+          description: "Write a file",
+          parameters: tupleSchema,
+        },
+      ],
+      (name) => name,
+    );
+
+    expect(projection.tools[0]?.inputSchema.properties.patch).toEqual({
+      type: "object",
+      properties: {
+        spans: {
+          type: "array",
+          prefixItems: [{ type: "string" }],
+          items: { type: "number" },
+        },
+      },
+    });
+    expect(tupleSchema.properties.patch.properties.spans).toEqual({
+      type: "array",
+      items: [{ type: "string" }],
+      additionalItems: { type: "number" },
+    });
+  });
+});

--- a/packages/ai/src/providers/anthropic-tool-projection.ts
+++ b/packages/ai/src/providers/anthropic-tool-projection.ts
@@ -38,35 +38,76 @@ function isProviderSupportedViolation(violation: string): boolean {
   return violation.endsWith(".$dynamicRef") || violation.endsWith(".$dynamicAnchor");
 }
 
+const schemaValueKeywords = new Set([
+  "additionalProperties",
+  "contains",
+  "contentSchema",
+  "else",
+  "if",
+  "items",
+  "not",
+  "propertyNames",
+  "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+]);
+const schemaArrayKeywords = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
+const schemaMapKeywords = new Set([
+  "$defs",
+  "definitions",
+  "dependencies",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+]);
+
 function normalizeAnthropicJsonSchema(schema: unknown): unknown {
-  if (Array.isArray(schema)) {
-    return schema.map(normalizeAnthropicJsonSchema);
-  }
   if (!isRecord(schema)) {
     return schema;
   }
 
-  const normalized: Record<string, unknown> = {};
+  let changed = false;
+  const normalized: Record<string, unknown> = { ...schema };
   for (const [key, value] of Object.entries(schema)) {
-    if (key === "additionalItems" && Array.isArray(schema.items)) {
+    if (schemaValueKeywords.has(key) && !Array.isArray(value)) {
+      const next = normalizeAnthropicJsonSchema(value);
+      normalized[key] = next;
+      changed ||= next !== value;
       continue;
     }
-    normalized[key] = normalizeAnthropicJsonSchema(value);
+    if (schemaArrayKeywords.has(key) && Array.isArray(value)) {
+      const next = value.map(normalizeAnthropicJsonSchema);
+      normalized[key] = next;
+      changed ||= next.some((entry, index) => entry !== value[index]);
+      continue;
+    }
+    if (schemaMapKeywords.has(key) && isRecord(value)) {
+      const next = Object.fromEntries(
+        Object.entries(value).map(([entryKey, entryValue]) => [
+          entryKey,
+          normalizeAnthropicJsonSchema(entryValue),
+        ]),
+      );
+      normalized[key] = next;
+      changed ||= Object.entries(value).some(
+        ([entryKey, entryValue]) => next[entryKey] !== entryValue,
+      );
+    }
   }
 
   if (Array.isArray(schema.items)) {
     normalized.prefixItems = schema.items.map(normalizeAnthropicJsonSchema);
     const additionalItems = schema.additionalItems;
-    if (additionalItems === false) {
-      normalized.items = false;
-    } else if (isRecord(additionalItems) || Array.isArray(additionalItems)) {
+    if (typeof additionalItems === "boolean" || isRecord(additionalItems)) {
       normalized.items = normalizeAnthropicJsonSchema(additionalItems);
     } else {
       delete normalized.items;
     }
+    delete normalized.additionalItems;
+    changed = true;
   }
 
-  return normalized;
+  return changed ? normalized : schema;
 }
 
 /** Snapshots direct/custom tool descriptors before Anthropic payload construction. */

--- a/packages/ai/src/providers/anthropic-tool-projection.ts
+++ b/packages/ai/src/providers/anthropic-tool-projection.ts
@@ -38,6 +38,37 @@ function isProviderSupportedViolation(violation: string): boolean {
   return violation.endsWith(".$dynamicRef") || violation.endsWith(".$dynamicAnchor");
 }
 
+function normalizeAnthropicJsonSchema(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    return schema.map(normalizeAnthropicJsonSchema);
+  }
+  if (!isRecord(schema)) {
+    return schema;
+  }
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === "additionalItems" && Array.isArray(schema.items)) {
+      continue;
+    }
+    normalized[key] = normalizeAnthropicJsonSchema(value);
+  }
+
+  if (Array.isArray(schema.items)) {
+    normalized.prefixItems = schema.items.map(normalizeAnthropicJsonSchema);
+    const additionalItems = schema.additionalItems;
+    if (additionalItems === false) {
+      normalized.items = false;
+    } else if (isRecord(additionalItems) || Array.isArray(additionalItems)) {
+      normalized.items = normalizeAnthropicJsonSchema(additionalItems);
+    } else {
+      delete normalized.items;
+    }
+  }
+
+  return normalized;
+}
+
 /** Snapshots direct/custom tool descriptors before Anthropic payload construction. */
 export function projectAnthropicTools(
   tools: readonly AnthropicToolDescriptor[],
@@ -62,8 +93,13 @@ export function projectAnthropicTools(
         unavailableOriginalNames.add(name);
         continue;
       }
-      const properties = schemaProjection.schema.properties;
-      const required = schemaProjection.schema.required;
+      const anthropicSchema = normalizeAnthropicJsonSchema(schemaProjection.schema);
+      if (!isRecord(anthropicSchema)) {
+        unavailableOriginalNames.add(name);
+        continue;
+      }
+      const properties = anthropicSchema.properties;
+      const required = anthropicSchema.required;
       if (
         (properties !== undefined && properties !== null && !isRecord(properties)) ||
         (required !== undefined &&

--- a/src/agents/anthropic-transport-stream.live.test.ts
+++ b/src/agents/anthropic-transport-stream.live.test.ts
@@ -16,6 +16,8 @@ const describeLive = LIVE ? describe : describe.skip;
 const ANTHROPIC_KEY = process.env.ANTHROPIC_API_KEY ?? "";
 const PROVIDER_LIVE = isLiveTestEnabled(["ANTHROPIC_LIVE_TEST"]) && Boolean(ANTHROPIC_KEY);
 const describeProviderLive = PROVIDER_LIVE ? describe : describe.skip;
+const OPUS_TUPLE_LIVE = isLiveTestEnabled(["ANTHROPIC_LIVE_TEST"]) && Boolean(ANTHROPIC_KEY);
+const describeOpusTupleLive = OPUS_TUPLE_LIVE ? describe : describe.skip;
 
 type AnthropicMessagesModel = Model<"anthropic-messages">;
 type AnthropicStreamFn = ReturnType<typeof createAnthropicMessagesTransportStreamFn>;
@@ -159,6 +161,69 @@ describeLive("anthropic transport stream live", () => {
       await closeServer(server);
     }
   }, 10_000);
+});
+
+describeOpusTupleLive("anthropic Opus tuple schema provider live", () => {
+  it("accepts a draft-07 tuple tool after Anthropic projection", async () => {
+    const model: AnthropicMessagesModel = {
+      id: "claude-opus-4-8",
+      name: "Claude Opus 4.8",
+      api: "anthropic-messages",
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 512,
+    };
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "Call tuple_probe with range [1, 2]." }],
+          tools: [
+            {
+              name: "tuple_probe",
+              description: "Return a pair of integers.",
+              parameters: {
+                type: "object",
+                properties: {
+                  range: {
+                    type: "array",
+                    items: [{ type: "integer" }, { type: "integer" }],
+                    additionalItems: false,
+                  },
+                },
+                required: ["range"],
+              },
+            },
+          ],
+        } as unknown as AnthropicStreamContext,
+        {
+          apiKey: ANTHROPIC_KEY,
+          maxTokens: 128,
+          toolChoice: { type: "tool", name: "tuple_probe" },
+        } as AnthropicStreamOptions,
+      ),
+    );
+
+    const result = await stream.result();
+    if (skipAnthropicBillingDrift("Opus tuple schema", result)) {
+      return;
+    }
+    const toolCall = result.content.find(
+      (block) => block.type === "toolCall" && block.name === "tuple_probe",
+    );
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(toolCall).toMatchObject({
+      type: "toolCall",
+      name: "tuple_probe",
+      arguments: { range: [1, 2] },
+    });
+  }, 45_000);
 });
 
 describeProviderLive("anthropic transport stream provider live", () => {


### PR DESCRIPTION
## Summary

Normalize Anthropic tool input schemas so draft-07 tuple arrays are emitted as JSON Schema draft 2020-12 `prefixItems` before the Anthropic Messages payload is built.

## Issue/Motivation

Fixes #98588.

Anthropic Opus 4.8 validates tool `input_schema` using JSON Schema draft 2020-12 semantics and rejects schemas that still use the draft-07 tuple form:

```json
{
  "type": "array",
  "items": [{ "type": "integer" }, { "type": "integer" }],
  "additionalItems": false
}
```

The existing Anthropic projection already serializes/quarantines unsupported tool schemas, but it was forwarding tuple-array `items` unchanged. That can make `tools.profile: "coding"` unusable with Opus 4.8 even though the same tool surface works with older Anthropic-compatible models.

## What Problem This Solves

This keeps OpenClaw's coding-profile/runtime tools available on Anthropic Opus 4.8 by converting tuple schemas to the draft 2020-12 representation Anthropic accepts:

- `items: [schemaA, schemaB]` -> `prefixItems: [schemaA, schemaB]`
- `additionalItems: false` -> `items: false`
- schema-valued `additionalItems` -> schema-valued `items`

The normalization is Anthropic-specific and runs after the existing JSON-safe projection, so other provider projections keep their current behavior.

## Changes

- Add an Anthropic JSON Schema normalization step in `projectAnthropicTools`.
- Recursively convert nested draft-07 tuple array schemas to draft 2020-12 `prefixItems`.
- Preserve the original tool descriptor object by normalizing the serialized projection copy.
- Add regression coverage for top-level and nested tuple schemas.

## Testing

- `node scripts/run-vitest.mjs run packages/ai/src/providers/anthropic-tool-projection.test.ts` — passed, 2 tests.
- `node scripts/run-vitest.mjs run packages/ai/src/providers/anthropic-tool-projection.test.ts packages/ai/src/providers/anthropic.test.ts` — passed, 52 tests.
- `git diff --check` — passed.
- Diff secret scan for token/API-key/password/private-key patterns — no matches.

Additional type-check attempt:

- `corepack pnpm exec tsc --noEmit --pretty false --project packages/ai/tsconfig.json` initially aborted with Node heap OOM.
- Retried with `NODE_OPTIONS=--max-old-space-size=4096`; TypeScript then reached pre-existing missing declaration errors for `web-push` and `qrcode` in `src/infra/push-web.ts` / `src/media/qr-runtime.ts`, unrelated to this Anthropic provider change.

## Evidence

Targeted Vitest output from this branch:

```text
✓  unit  packages/ai/src/providers/anthropic-tool-projection.test.ts (2 tests) 208ms
✓  unit  packages/ai/src/providers/anthropic.test.ts (50 tests) 102ms

Test Files  2 passed (2)
Tests  52 passed (52)
```

Regression assertions prove that an Anthropic-projected tool schema now contains `prefixItems` and does not retain the draft-07 tuple-array `items` shape that Opus 4.8 rejects.
