### PR TITLE
fix(gateway): cap pendingFinalDelivery retries and prevent delivery wedge

### DIFF
--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -1054,7 +1054,14 @@ describe("main-session-restart-recovery", () => {
 
     const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
 
-    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
+    // Attempt 2 backs off 60s; the deferral tells the startup scheduler when
+    // to run its follow-up pass instead of waiting for the next restart.
+    expect(result).toEqual({
+      recovered: 0,
+      failed: 0,
+      skipped: 0,
+      deferred: { count: 1, nextEligibleAtMs: lastAttemptAt + 60_000 },
+    });
     expect(callGateway).not.toHaveBeenCalled();
 
     const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
@@ -1064,6 +1071,79 @@ describe("main-session-restart-recovery", () => {
     expect(entry?.pendingFinalDeliveryText).toBe("retry me later");
     expect(entry?.pendingFinalDeliveryAttemptCount).toBe(2);
     expect(entry?.pendingFinalDeliveryLastAttemptAt).toBe(lastAttemptAt);
+  });
+
+  it("retries a backoff-deferred pending final delivery after expiry without a restart", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    try {
+      const sessionsDir = await makeSessionsDir();
+      const lastAttemptAt = Date.now();
+      await writeStore(sessionsDir, {
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: lastAttemptAt - 10_000,
+          status: "running",
+          abortedLastRun: true,
+          pendingFinalDelivery: true,
+          pendingFinalDeliveryText: "retry me after backoff",
+          pendingFinalDeliveryCreatedAt: lastAttemptAt - 60_000,
+          pendingFinalDeliveryLastAttemptAt: lastAttemptAt,
+          pendingFinalDeliveryAttemptCount: 2,
+          pendingFinalDeliveryLastError: null,
+          pendingFinalDeliveryContext: {
+            channel: "discord",
+            to: "discord:dm:final",
+            accountId: "main",
+          },
+        },
+      });
+      // setImmediate stays real so store/transcript IO can settle while the
+      // fake clock controls the scheduler's recovery and follow-up timers.
+      const flushAsyncWork = async () => {
+        for (let i = 0; i < 25; i++) {
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+        }
+      };
+
+      scheduleRestartAbortedMainSessionRecovery({ stateDir: tmpDir, delayMs: 10 });
+
+      // First pass runs inside the 60s attempt-2 backoff and defers.
+      await vi.advanceTimersByTimeAsync(10);
+      await flushAsyncWork();
+      expect(callGateway).not.toHaveBeenCalled();
+
+      // Crossing the backoff expiry fires the scheduled follow-up pass. Its
+      // store write settles a few async hops after callGateway resolves (the
+      // recovery runs inside the gateway work-admission wrapper), so drain
+      // setImmediate rounds until the retried attempt is durably recorded
+      // rather than guessing a fixed flush count that can race.
+      await vi.advanceTimersByTimeAsync(61_000);
+      const loadMainEntry = () =>
+        loadSessionStore(path.join(sessionsDir, "sessions.json"))["agent:main:main"];
+      let entry = loadMainEntry();
+      for (let i = 0; i < 200 && entry?.pendingFinalDeliveryAttemptCount !== 3; i++) {
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        entry = loadMainEntry();
+      }
+      expect(callGateway).toHaveBeenCalledOnce();
+      expect(firstGatewayParams()).toMatchObject({
+        deliver: true,
+        bestEffortDeliver: true,
+        channel: "discord",
+        to: "discord:dm:final",
+        accountId: "main",
+      });
+      expect(entry?.abortedLastRun).toBe(false);
+      expect(entry?.pendingFinalDelivery).toBe(true);
+      expect(entry?.pendingFinalDeliveryText).toBe("retry me after backoff");
+      expect(entry?.pendingFinalDeliveryAttemptCount).toBe(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not back off pending final delivery when the last attempt is in the future", async () => {

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -980,6 +980,92 @@ describe("main-session-restart-recovery", () => {
     );
   });
 
+  it("dead-letters pending final delivery after the restart recovery attempt cap", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "stale final",
+        pendingFinalDeliveryCreatedAt: Date.now() - 60_000,
+        pendingFinalDeliveryLastAttemptAt: Date.now() - 60_000,
+        pendingFinalDeliveryAttemptCount: 10,
+        pendingFinalDeliveryLastError: null,
+        pendingFinalDeliveryContext: {
+          channel: "discord",
+          to: "discord:dm:final",
+          accountId: "main",
+        },
+        pendingFinalDeliveryIntentId: "intent-stale-final",
+        restartRecoveryDeliveryContext: {
+          channel: "discord",
+          to: "discord:dm:final",
+          accountId: "main",
+        },
+        restartRecoveryDeliveryRunId: "run-stale-final",
+      },
+    });
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
+    expect(callGateway).not.toHaveBeenCalled();
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    const entry = store["agent:main:main"];
+    expect(entry?.abortedLastRun).toBe(false);
+    expect(entry?.pendingFinalDelivery).toBeUndefined();
+    expect(entry?.pendingFinalDeliveryText).toBeUndefined();
+    expect(entry?.pendingFinalDeliveryCreatedAt).toBeUndefined();
+    expect(entry?.pendingFinalDeliveryLastAttemptAt).toBeUndefined();
+    expect(entry?.pendingFinalDeliveryAttemptCount).toBeUndefined();
+    expect(entry?.pendingFinalDeliveryLastError).toBeUndefined();
+    expect(entry?.pendingFinalDeliveryContext).toBeUndefined();
+    expect(entry?.pendingFinalDeliveryIntentId).toBeUndefined();
+    expect(entry?.restartRecoveryDeliveryContext).toBeUndefined();
+    expect(entry?.restartRecoveryDeliveryRunId).toBeUndefined();
+  });
+
+  it("backs off recent pending final delivery restart recovery attempts", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const lastAttemptAt = Date.now();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: lastAttemptAt - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "retry me later",
+        pendingFinalDeliveryCreatedAt: lastAttemptAt - 60_000,
+        pendingFinalDeliveryLastAttemptAt: lastAttemptAt,
+        pendingFinalDeliveryAttemptCount: 2,
+        pendingFinalDeliveryLastError: null,
+        pendingFinalDeliveryContext: {
+          channel: "discord",
+          to: "discord:dm:final",
+          accountId: "main",
+        },
+      },
+    });
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 0, failed: 0, skipped: 1 });
+    expect(callGateway).not.toHaveBeenCalled();
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    const entry = store["agent:main:main"];
+    expect(entry?.abortedLastRun).toBe(true);
+    expect(entry?.pendingFinalDelivery).toBe(true);
+    expect(entry?.pendingFinalDeliveryText).toBe("retry me later");
+    expect(entry?.pendingFinalDeliveryAttemptCount).toBe(2);
+    expect(entry?.pendingFinalDeliveryLastAttemptAt).toBe(lastAttemptAt);
+  });
+
   it("sanitizes durable pending final delivery payloads before resume prompts", async () => {
     const sessionsDir = await makeSessionsDir();
     const pendingPayload = [

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -1066,6 +1066,54 @@ describe("main-session-restart-recovery", () => {
     expect(entry?.pendingFinalDeliveryLastAttemptAt).toBe(lastAttemptAt);
   });
 
+  it("does not back off pending final delivery when the last attempt is in the future", async () => {
+    const sessionsDir = await makeSessionsDir();
+    const now = Date.now();
+    const futureLastAttemptAt = now + 60_000;
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: now - 10_000,
+        status: "running",
+        abortedLastRun: true,
+        pendingFinalDelivery: true,
+        pendingFinalDeliveryText: "clock skew should retry now",
+        pendingFinalDeliveryCreatedAt: now - 60_000,
+        pendingFinalDeliveryLastAttemptAt: futureLastAttemptAt,
+        pendingFinalDeliveryAttemptCount: 2,
+        pendingFinalDeliveryLastError: null,
+        pendingFinalDeliveryContext: {
+          channel: "discord",
+          to: "discord:dm:final",
+          accountId: "main",
+        },
+      },
+    });
+
+    const result = await recoverRestartAbortedMainSessions({ stateDir: tmpDir });
+
+    expect(result).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+    expect(callGateway).toHaveBeenCalledOnce();
+    expect(firstGatewayParams()).toMatchObject({
+      deliver: true,
+      bestEffortDeliver: true,
+      channel: "discord",
+      to: "discord:dm:final",
+      accountId: "main",
+    });
+
+    const beforeStoreRead = Date.now();
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    const entry = store["agent:main:main"];
+    expect(entry?.abortedLastRun).toBe(false);
+    expect(entry?.pendingFinalDelivery).toBe(true);
+    expect(entry?.pendingFinalDeliveryText).toBe("clock skew should retry now");
+    expect(entry?.pendingFinalDeliveryAttemptCount).toBe(3);
+    expect(entry?.pendingFinalDeliveryLastError).toBeNull();
+    expect(entry?.pendingFinalDeliveryLastAttemptAt).toBeLessThanOrEqual(beforeStoreRead);
+    expect(entry?.pendingFinalDeliveryLastAttemptAt).toBeLessThan(futureLastAttemptAt);
+  });
+
   it("sanitizes durable pending final delivery payloads before resume prompts", async () => {
     const sessionsDir = await makeSessionsDir();
     const pendingPayload = [

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -53,6 +53,9 @@ const log = createSubsystemLogger("main-session-restart-recovery");
 const DEFAULT_RECOVERY_DELAY_MS = 5_000;
 const MAX_RECOVERY_RETRIES = 3;
 const RETRY_BACKOFF_MULTIPLIER = 2;
+const DEFAULT_PENDING_FINAL_DELIVERY_MAX_RECOVERY_ATTEMPTS = 10;
+const PENDING_FINAL_DELIVERY_RECOVERY_BACKOFF_BASE_MS = 30_000;
+const PENDING_FINAL_DELIVERY_RECOVERY_BACKOFF_MAX_MS = 30 * 60_000;
 const UNRESUMABLE_SESSION_NOTICE =
   "I was interrupted by a gateway restart and couldn't safely resume the previous turn. " +
   "Please send that last request again and I'll pick it up cleanly.";
@@ -82,6 +85,34 @@ function normalizeStringSet(values: Iterable<string> | undefined): Set<string> {
 
 function normalizeFiniteTimestamp(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeAttemptCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function resolvePendingFinalDeliveryRecoveryBackoffMs(attemptCount: number): number {
+  if (attemptCount <= 0) {
+    return 0;
+  }
+  const exponent = Math.max(0, Math.min(attemptCount - 1, 20));
+  return Math.min(
+    PENDING_FINAL_DELIVERY_RECOVERY_BACKOFF_BASE_MS * 2 ** exponent,
+    PENDING_FINAL_DELIVERY_RECOVERY_BACKOFF_MAX_MS,
+  );
+}
+
+function isPendingFinalDeliveryRecoveryBackoffActive(params: {
+  entry: SessionEntry;
+  nowMs: number;
+}): boolean {
+  const attemptCount = normalizeAttemptCount(params.entry.pendingFinalDeliveryAttemptCount);
+  const lastAttemptAt = normalizeFiniteTimestamp(params.entry.pendingFinalDeliveryLastAttemptAt);
+  if (attemptCount <= 0 || lastAttemptAt === undefined) {
+    return false;
+  }
+  const backoffMs = resolvePendingFinalDeliveryRecoveryBackoffMs(attemptCount);
+  return params.nowMs - lastAttemptAt < backoffMs;
 }
 
 function hasCurrentProcessOwner(params: {
@@ -472,6 +503,46 @@ async function markSessionFailed(params: {
   log.warn(`marked interrupted main session failed: ${params.sessionKey} (${params.reason})`);
 }
 
+async function deadLetterPendingFinalDelivery(params: {
+  attemptCount: number;
+  maxAttempts: number;
+  storePath: string;
+  sessionKey: string;
+}): Promise<boolean> {
+  const cleared = await applySessionEntryReplacements({
+    storePath: params.storePath,
+    update: (entries) => {
+      const current = entries.find((entry) => entry.sessionKey === params.sessionKey);
+      const entry = current?.entry;
+      if (!entry || (!entry.pendingFinalDelivery && !entry.pendingFinalDeliveryText)) {
+        return { result: false };
+      }
+      entry.abortedLastRun = false;
+      entry.updatedAt = Date.now();
+      entry.pendingFinalDelivery = undefined;
+      entry.pendingFinalDeliveryText = undefined;
+      entry.pendingFinalDeliveryCreatedAt = undefined;
+      entry.pendingFinalDeliveryLastAttemptAt = undefined;
+      entry.pendingFinalDeliveryAttemptCount = undefined;
+      entry.pendingFinalDeliveryLastError = undefined;
+      entry.pendingFinalDeliveryContext = undefined;
+      entry.pendingFinalDeliveryIntentId = undefined;
+      entry.restartRecoveryDeliveryContext = undefined;
+      entry.restartRecoveryDeliveryRunId = undefined;
+      return {
+        result: true,
+        replacements: [{ sessionKey: params.sessionKey, entry }],
+      };
+    },
+  });
+  if (cleared) {
+    log.warn(
+      `dead-lettered pending final delivery for ${params.sessionKey} after ${params.attemptCount}/${params.maxAttempts} restart recovery attempts`,
+    );
+  }
+  return cleared;
+}
+
 async function sendUnresumableSessionNotice(params: {
   cfg?: OpenClawConfig;
   entry: SessionEntry;
@@ -725,8 +796,11 @@ async function recoverStore(params: {
   resumedSessionKeys: Set<string>;
   activeSessionIds?: Iterable<string>;
   activeSessionKeys?: Iterable<string>;
+  maxPendingFinalDeliveryAttempts?: number;
 }): Promise<{ recovered: number; failed: number; skipped: number }> {
   const result = { recovered: 0, failed: 0, skipped: 0 };
+  const maxPendingFinalDeliveryAttempts =
+    params.maxPendingFinalDeliveryAttempts ?? DEFAULT_PENDING_FINAL_DELIVERY_MAX_RECOVERY_ATTEMPTS;
   const providedActiveSessionIds =
     params.activeSessionIds === undefined ? undefined : normalizeStringSet(params.activeSessionIds);
   const providedActiveSessionKeys =
@@ -784,6 +858,23 @@ async function recoverStore(params: {
     }
 
     if (entry.pendingFinalDelivery === true && entry.pendingFinalDeliveryText) {
+      const pendingFinalDeliveryAttemptCount = normalizeAttemptCount(
+        entry.pendingFinalDeliveryAttemptCount,
+      );
+      if (pendingFinalDeliveryAttemptCount >= maxPendingFinalDeliveryAttempts) {
+        await deadLetterPendingFinalDelivery({
+          attemptCount: pendingFinalDeliveryAttemptCount,
+          maxAttempts: maxPendingFinalDeliveryAttempts,
+          storePath: params.storePath,
+          sessionKey,
+        });
+        result.skipped++;
+        continue;
+      }
+      if (isPendingFinalDeliveryRecoveryBackoffActive({ entry, nowMs: Date.now() })) {
+        result.skipped++;
+        continue;
+      }
       const resumed = await resumeMainSession({
         cfg: params.cfg,
         entry,
@@ -882,6 +973,7 @@ export async function recoverRestartAbortedMainSessions(
     resumedSessionKeys?: Set<string>;
     activeSessionIds?: Iterable<string>;
     activeSessionKeys?: Iterable<string>;
+    maxPendingFinalDeliveryAttempts?: number;
   } = {},
 ): Promise<{ recovered: number; failed: number; skipped: number }> {
   const result = { recovered: 0, failed: 0, skipped: 0 };
@@ -894,6 +986,7 @@ export async function recoverRestartAbortedMainSessions(
       resumedSessionKeys,
       activeSessionIds: params.activeSessionIds,
       activeSessionKeys: params.activeSessionKeys,
+      maxPendingFinalDeliveryAttempts: params.maxPendingFinalDeliveryAttempts,
     });
     result.recovered += storeResult.recovered;
     result.failed += storeResult.failed;
@@ -916,6 +1009,7 @@ export async function recoverStartupOrphanedMainSessions(
     activeSessionKeys?: Iterable<string>;
     updatedBeforeMs?: number;
     resumedSessionKeys?: Set<string>;
+    maxPendingFinalDeliveryAttempts?: number;
   } = {},
 ): Promise<{ marked: number; recovered: number; failed: number; skipped: number }> {
   const startupRecoveryCutoffMs = params.updatedBeforeMs ?? Date.now();
@@ -932,6 +1026,7 @@ export async function recoverStartupOrphanedMainSessions(
     resumedSessionKeys: params.resumedSessionKeys,
     activeSessionIds: params.activeSessionIds,
     activeSessionKeys: params.activeSessionKeys,
+    maxPendingFinalDeliveryAttempts: params.maxPendingFinalDeliveryAttempts,
   });
   return {
     marked: marked.marked,
@@ -947,6 +1042,7 @@ export function scheduleRestartAbortedMainSessionRecovery(
     delayMs?: number;
     maxRetries?: number;
     stateDir?: string;
+    maxPendingFinalDeliveryAttempts?: number;
   } = {},
 ): void {
   const initialDelay = params.delayMs ?? DEFAULT_RECOVERY_DELAY_MS;
@@ -966,6 +1062,7 @@ export function scheduleRestartAbortedMainSessionRecovery(
           stateDir: params.stateDir,
           resumedSessionKeys,
           updatedBeforeMs: startupRecoveryCutoffMs,
+          maxPendingFinalDeliveryAttempts: params.maxPendingFinalDeliveryAttempts,
         }),
     )
       .then((result) => {

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -112,7 +112,8 @@ function isPendingFinalDeliveryRecoveryBackoffActive(params: {
     return false;
   }
   const backoffMs = resolvePendingFinalDeliveryRecoveryBackoffMs(attemptCount);
-  return params.nowMs - lastAttemptAt < backoffMs;
+  const elapsedMs = params.nowMs - lastAttemptAt;
+  return elapsedMs >= 0 && elapsedMs < backoffMs;
 }
 
 function hasCurrentProcessOwner(params: {
@@ -872,6 +873,9 @@ async function recoverStore(params: {
         continue;
       }
       if (isPendingFinalDeliveryRecoveryBackoffActive({ entry, nowMs: Date.now() })) {
+        log.info(
+          `pending final delivery restart recovery backoff active for ${sessionKey} after ${pendingFinalDeliveryAttemptCount}/${maxPendingFinalDeliveryAttempts} attempts`,
+        );
         result.skipped++;
         continue;
       }

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -102,18 +102,49 @@ function resolvePendingFinalDeliveryRecoveryBackoffMs(attemptCount: number): num
   );
 }
 
-function isPendingFinalDeliveryRecoveryBackoffActive(params: {
+// Returns when a backoff-deferred pending final becomes eligible again, or
+// undefined when no backoff applies. Future last-attempt timestamps (clock
+// skew) retry immediately instead of stalling recovery until they pass.
+function resolvePendingFinalDeliveryBackoffEligibleAtMs(params: {
   entry: SessionEntry;
   nowMs: number;
-}): boolean {
+}): number | undefined {
   const attemptCount = normalizeAttemptCount(params.entry.pendingFinalDeliveryAttemptCount);
   const lastAttemptAt = normalizeFiniteTimestamp(params.entry.pendingFinalDeliveryLastAttemptAt);
-  if (attemptCount <= 0 || lastAttemptAt === undefined) {
-    return false;
+  if (attemptCount <= 0 || lastAttemptAt === undefined || lastAttemptAt > params.nowMs) {
+    return undefined;
   }
-  const backoffMs = resolvePendingFinalDeliveryRecoveryBackoffMs(attemptCount);
-  const elapsedMs = params.nowMs - lastAttemptAt;
-  return elapsedMs >= 0 && elapsedMs < backoffMs;
+  const nextEligibleAtMs =
+    lastAttemptAt + resolvePendingFinalDeliveryRecoveryBackoffMs(attemptCount);
+  return nextEligibleAtMs > params.nowMs ? nextEligibleAtMs : undefined;
+}
+
+type PendingFinalDeliveryDeferral = {
+  count: number;
+  nextEligibleAtMs: number;
+};
+
+type MainSessionRecoveryCounts = {
+  recovered: number;
+  failed: number;
+  skipped: number;
+  // Present only when backoff deferred at least one pending final delivery;
+  // the scheduler uses nextEligibleAtMs to run one follow-up pass so deferred
+  // entries retry in this process instead of waiting for the next restart.
+  deferred?: PendingFinalDeliveryDeferral;
+};
+
+function mergePendingFinalDeliveryDeferral(
+  current: PendingFinalDeliveryDeferral | undefined,
+  next: PendingFinalDeliveryDeferral | undefined,
+): PendingFinalDeliveryDeferral | undefined {
+  if (!current || !next) {
+    return current ?? next;
+  }
+  return {
+    count: current.count + next.count,
+    nextEligibleAtMs: Math.min(current.nextEligibleAtMs, next.nextEligibleAtMs),
+  };
 }
 
 function hasCurrentProcessOwner(params: {
@@ -798,8 +829,8 @@ async function recoverStore(params: {
   activeSessionIds?: Iterable<string>;
   activeSessionKeys?: Iterable<string>;
   maxPendingFinalDeliveryAttempts?: number;
-}): Promise<{ recovered: number; failed: number; skipped: number }> {
-  const result = { recovered: 0, failed: 0, skipped: 0 };
+}): Promise<MainSessionRecoveryCounts> {
+  const result: MainSessionRecoveryCounts = { recovered: 0, failed: 0, skipped: 0 };
   const maxPendingFinalDeliveryAttempts =
     params.maxPendingFinalDeliveryAttempts ?? DEFAULT_PENDING_FINAL_DELIVERY_MAX_RECOVERY_ATTEMPTS;
   const providedActiveSessionIds =
@@ -872,11 +903,18 @@ async function recoverStore(params: {
         result.skipped++;
         continue;
       }
-      if (isPendingFinalDeliveryRecoveryBackoffActive({ entry, nowMs: Date.now() })) {
+      const backoffEligibleAtMs = resolvePendingFinalDeliveryBackoffEligibleAtMs({
+        entry,
+        nowMs: Date.now(),
+      });
+      if (backoffEligibleAtMs !== undefined) {
         log.info(
           `pending final delivery restart recovery backoff active for ${sessionKey} after ${pendingFinalDeliveryAttemptCount}/${maxPendingFinalDeliveryAttempts} attempts`,
         );
-        result.skipped++;
+        result.deferred = mergePendingFinalDeliveryDeferral(result.deferred, {
+          count: 1,
+          nextEligibleAtMs: backoffEligibleAtMs,
+        });
         continue;
       }
       const resumed = await resumeMainSession({
@@ -979,8 +1017,8 @@ export async function recoverRestartAbortedMainSessions(
     activeSessionKeys?: Iterable<string>;
     maxPendingFinalDeliveryAttempts?: number;
   } = {},
-): Promise<{ recovered: number; failed: number; skipped: number }> {
-  const result = { recovered: 0, failed: 0, skipped: 0 };
+): Promise<MainSessionRecoveryCounts> {
+  const result: MainSessionRecoveryCounts = { recovered: 0, failed: 0, skipped: 0 };
   const resumedSessionKeys = params.resumedSessionKeys ?? new Set<string>();
 
   for (const storePath of await resolveRestartRecoveryStorePaths(params)) {
@@ -995,6 +1033,7 @@ export async function recoverRestartAbortedMainSessions(
     result.recovered += storeResult.recovered;
     result.failed += storeResult.failed;
     result.skipped += storeResult.skipped;
+    result.deferred = mergePendingFinalDeliveryDeferral(result.deferred, storeResult.deferred);
   }
 
   if (result.recovered > 0 || result.failed > 0) {
@@ -1015,7 +1054,7 @@ export async function recoverStartupOrphanedMainSessions(
     resumedSessionKeys?: Set<string>;
     maxPendingFinalDeliveryAttempts?: number;
   } = {},
-): Promise<{ marked: number; recovered: number; failed: number; skipped: number }> {
+): Promise<{ marked: number } & MainSessionRecoveryCounts> {
   const startupRecoveryCutoffMs = params.updatedBeforeMs ?? Date.now();
   const marked = await markStartupOrphanedMainSessionsForRecovery({
     cfg: params.cfg,
@@ -1037,6 +1076,7 @@ export async function recoverStartupOrphanedMainSessions(
     recovered: recovered.recovered,
     failed: recovered.failed,
     skipped: marked.skipped + recovered.skipped,
+    deferred: recovered.deferred,
   };
 }
 
@@ -1071,7 +1111,13 @@ export function scheduleRestartAbortedMainSessionRecovery(
     )
       .then((result) => {
         if (result.failed > 0 && attempt < maxRetries) {
+          // The failed-retry pass recomputes deferrals, so do not also
+          // schedule a deferred follow-up here; that would double-schedule.
           scheduleAttempt(attempt + 1, delay * RETRY_BACKOFF_MULTIPLIER);
+          return;
+        }
+        if (result.deferred) {
+          scheduleDeferredFollowUp(result.deferred.nextEligibleAtMs);
         }
       })
       .catch((err: unknown) => {
@@ -1092,6 +1138,19 @@ export function scheduleRestartAbortedMainSessionRecovery(
     setTimeout(() => {
       runRecoveryAttempt(attempt, delay);
     }, delay).unref?.();
+  };
+
+  // Backoff-deferred pending finals are not failures, so the failed-retry
+  // ladder never re-runs them; without this follow-up they would wait for the
+  // next gateway restart. One pass per deferral, naturally bounded by the
+  // per-entry attempt cap (dead-letter) and the backoff ceiling.
+  const scheduleDeferredFollowUp = (nextEligibleAtMs: number) => {
+    const followUpDelay = Math.max(0, nextEligibleAtMs - Date.now());
+    setTimeout(() => {
+      // Fresh attempt ladder: deferred follow-ups do not consume the
+      // failed-retry budget of the pass that scheduled them.
+      runRecoveryAttempt(1, initialDelay);
+    }, followUpDelay).unref?.();
   };
 
   scheduleAttempt(1, initialDelay);


### PR DESCRIPTION
## What Problem This Solves

A gateway restart while a final reply was pending could wedge that delivery forever. Restart recovery replayed stale `pendingFinalDelivery` payloads with no cap and no backoff, and a payload that a downstream route never cleared was replayed on every subsequent restart. This PR bounds that recovery:

- Recent attempts back off exponentially (30s base, 30 min ceiling) and payloads are dead-lettered after 10 recovery attempts by default, clearing the pending-final and restart-recovery fields so the session no longer stays restart-recoverable forever.
- Future persisted `pendingFinalDeliveryLastAttemptAt` values are treated as no active backoff, so clock skew, VM resume, or NTP correction cannot preserve the wedge.
- Backoff-deferred entries are surfaced from `recoverStore` as a closed `deferred` shape (count plus earliest `nextEligibleAtMs`), and the startup scheduler runs one bounded follow-up recovery pass when the earliest backoff expires. This addresses the ClawSweeper P1: previously a backoff-active entry only counted as skipped and the scheduler re-queued only on `failed > 0`, so the entry waited for the next gateway restart. Follow-up passes do not consume the failed-retry budget and are naturally bounded by the per-entry attempt cap (dead-letter) and the backoff ceiling.
- The cap is threaded through the restart recovery entry points so tests and callers can tune it.

## Context

This follows up on #92082 and the July 5, 2026 restart incident where pending final delivery state was part of the delivery wedge investigation. Current `main` already carries the v2026.6.5 fixes for bounded heartbeat scheduling and preserved delivery context; this patch closes the remaining startup-recovery path that could keep replaying a durable pending final across gateway restarts.

The Telegram ingress fixes requested alongside this work (#93281, #96962, #97118) are already ancestors of current `main`, so there was no scoped upstream backport diff to open for that part.

## Evidence

All commands run on `37fb71f5b07067f4023527a8d3e3667f9bd155c8` (rebased on current `main` 827f2c44225e):

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/main-session-restart-recovery.test.ts` — 1 file, 38 tests passed, including the new scheduler-level regression: a pending final inside backoff is retried after expiry without a restart (fake timers drive the scheduler; the resume fires only after the 60s attempt-2 backoff elapses).
- `pnpm exec oxfmt --check --threads=1 src/agents/main-session-restart-recovery.ts src/agents/main-session-restart-recovery.test.ts` — all files correctly formatted.
- `node scripts/run-oxlint.mjs src/agents/main-session-restart-recovery.ts src/agents/main-session-restart-recovery.test.ts` — clean.
- `git diff --check` — clean.
- `pnpm build` — full build green (tsdown + postbuild + plugin assets).

Live restart-recovery proof, re-run after the scheduler fix: an isolated Node process imported the rebuilt `dist` recovery module with a temp `OPENCLAW_STATE_DIR` and a localhost-only minimal fake gateway (connect challenge + hello-ok + `agent` acceptor). Seeded one pending final at `attemptCount=1` with `lastAttemptAt` 25s old (30s backoff, eligible in ~5s), then called `scheduleRestartAbortedMainSessionRecovery`. The production gateway was not restarted or contacted. Redacted output:

```text
PROOF phase=schedule start attemptCount=1 lastAttemptAt=25s-old backoff=30s eligibleIn~5s port=65180
[main-session-restart-recovery] pending final delivery restart recovery backoff active for agent:main:proof-pending-final after 1/10 attempts
PROOF phase=deferred result acceptedAgentRequests=0 persistedAttemptCount=1 abortedLastRun=true
PROOF fake-gateway accepted agent request #1
[main-session-restart-recovery] resumed interrupted main session: agent:main:proof-pending-final (with pending payload)
[main-session-restart-recovery] main-session restart recovery complete: recovered=1 failed=0 skipped=0
PROOF phase=follow-up result acceptedAgentRequests=1 persistedAttemptCount=2 abortedLastRun=false pendingFinalDelivery=true
PROOF verdict=PASS
```

The deferred entry was not retried by the first pass, and the scheduler's follow-up pass retried it in-process once the backoff expired: attempt count 1 -> 2, `abortedLastRun` cleared, exactly one `agent` request accepted.

## Real behavior proof

- Behavior addressed: a pending final delivery inside its restart-recovery backoff window was never retried in the same process because the startup scheduler only re-queued failed passes; it stayed wedged until the next gateway restart.
- Real environment tested: macOS (Darwin 25.5.0), Node 26.4.0, isolated Node process driving the rebuilt `dist` recovery module from this branch with a temp state dir and a localhost-only fake gateway; no production gateway involved.
- Exact steps or command run after this patch: seeded `sessions.json` with `pendingFinalDelivery=true`, `pendingFinalDeliveryAttemptCount=1`, `pendingFinalDeliveryLastAttemptAt` 25s old; ran `scheduleRestartAbortedMainSessionRecovery({ stateDir, delayMs: 200 })` from `dist/main-session-restart-recovery-*.js`; also ran `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/main-session-restart-recovery.test.ts`.
- Evidence after fix: redacted live output above (`PROOF verdict=PASS`) plus vitest `Test Files 1 passed (1), Tests 38 passed (38)`.
- Observed result after fix: first recovery pass deferred the backoff-active entry without calling the gateway; the scheduled follow-up pass fired after backoff expiry, the fake gateway accepted exactly one `agent` retry, and the store showed `pendingFinalDeliveryAttemptCount` 1 -> 2 with `abortedLastRun=false`.
- What was not tested: live gateway restart-recovery soak on upstream main.
