### PR TITLE
docs(changelog): stage remote browser reliability fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Remote browser reliability:** bound persistent Playwright tab enumeration by the existing remote CDP timeout budget and retire timed-out connection attempts so late completions cannot restore a stuck connection. (#80147, #58968) Thanks @HemantSudarshan and @KeaneYan.
 - **Control UI approval prompts:** keep stale resolve failures and busy-state cleanup from leaking across newer approvals or Gateway reconnects. (#98394) Thanks @haruaiclone-droid.
 - **Agent empty replies:** surface a visible failure when a completed interactive turn has no deliverable reply, including queued follow-ups, while preserving explicit silence, pending continuations, and committed side effects. (#100456) Thanks @mushuiyu886.
 - **Child process output safety:** prevent stdout/stderr pipe failures from crashing agent exec sessions, local TUI shell commands, and bounded process execution. (#100407, #100406, #100410) Thanks @cxbAsDev.


### PR DESCRIPTION
## What Problem This Solves

PR #80147 needs a maintainer-owned changelog entry, but repeated unrelated `CHANGELOG.md` updates on `main` keep invalidating that contributor branch after its exact-head Browser gates pass.

## Why This Change Was Made

Stage the required user-visible entry on `main` as a changelog-only maintainer change. PR #80147 can then rebase without carrying a `CHANGELOG.md` diff, so later release-note churn does not force another full Browser CI cycle.

## User Impact

Documentation only. This records the remote CDP reliability fix and credits the contributor and reporter; runtime behavior is unchanged by this PR.

## Evidence

- `git diff --check`
- one `CHANGELOG.md` insertion under current `Unreleased` fixes
- wording matches the reviewed behavior and references #80147 and #58968
