### PR TITLE
test(macos): remove stale Crestodian onboarding test

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -110,15 +110,6 @@ struct OnboardingViewSmokeTests {
             installing: false))
     }
 
-    @Test func `Crestodian setup requires a nonempty auth value`() {
-        #expect(!OnboardingView.hasCrestodianSetupAuth([:]))
-        #expect(!OnboardingView.hasCrestodianSetupAuth(["token": "  "]))
-        #expect(OnboardingView.hasCrestodianSetupAuth(["mode": "token"]))
-        #expect(OnboardingView.hasCrestodianSetupAuth([
-            "token": ["source": "env", "provider": "default", "id": "GATEWAY_TOKEN"],
-        ]))
-    }
-
     @Test func `select remote gateway clears stale ssh target when endpoint unresolved`() async {
         let override = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-config-\(UUID().uuidString)")


### PR DESCRIPTION
## Summary

- remove a stale macOS onboarding smoke test for the deleted Crestodian auth helper
- restore compilation of the native test target on current `main`

## Test plan

- `OPENCLAW_GATEWAY_PORT=18789 swift test --package-path apps/macos --filter OnboardingViewSmokeTests`
