### PR TITLE
fix(skills): make Skill Workshop lifecycle approvals decidable and non-wedging

### DIFF
--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -74,6 +74,14 @@ Agent-initiated `apply`, `reject`, and `quarantine` show an approval prompt by
 default. Set `skills.workshop.approvalPolicy` to `"auto"` to skip it in
 trusted environments.
 
+The prompt identifies the proposal id and target skill, and shows the proposal
+description, support-file count, and body size. Approval requests are bounded
+to finish before the agent tool watchdog. If no decision arrives before the
+prompt expires, the lifecycle action does not run: the proposal stays pending
+and unchanged. Decide later in the Skill Workshop UI or run
+`openclaw skills workshop apply|reject|quarantine <proposal-id>`. Agents should
+not retry an expired lifecycle action in a loop.
+
 ## CLI
 
 ```bash

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -669,6 +669,7 @@ async function runOpenClawToolPolicyForApprovalRequest(params: {
       ...(params.paramsForRun.agentId ? { agentId: params.paramsForRun.agentId } : {}),
       ...(params.paramsForRun.config ? { config: params.paramsForRun.config } : {}),
       ...(cwd ? { cwd } : {}),
+      workspaceDir: params.paramsForRun.workspaceDir,
       ...(params.paramsForRun.sessionKey ? { sessionKey: params.paramsForRun.sessionKey } : {}),
       ...(params.paramsForRun.sessionId ? { sessionId: params.paramsForRun.sessionId } : {}),
       ...(params.paramsForRun.runId ? { runId: params.paramsForRun.runId } : {}),

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -58,6 +58,7 @@ import type {
 type CodexDynamicToolHookContext = {
   agentId?: string;
   config?: EmbeddedRunAttemptParams["config"];
+  workspaceDir?: string;
   sessionId?: string;
   sessionKey?: string;
   runId?: string;

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -878,6 +878,7 @@ export async function runCodexAppServerAttempt(
     hookContext: {
       agentId: sessionAgentId,
       config: params.config,
+      workspaceDir: effectiveWorkspace,
       sessionId: params.sessionId,
       sessionKey: sandboxSessionKey,
       runId: params.runId,

--- a/packages/gateway-protocol/src/plugin-approvals-validators.test.ts
+++ b/packages/gateway-protocol/src/plugin-approvals-validators.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { validatePluginApprovalRequestParams } from "./index.js";
+
+describe("plugin approval protocol validators", () => {
+  it("accepts enriched approval descriptions up to 512 characters", () => {
+    const request = {
+      title: "Apply workspace skill proposal",
+      description: "d".repeat(512),
+    };
+
+    expect(validatePluginApprovalRequestParams(request)).toBe(true);
+    expect(validatePluginApprovalRequestParams({ ...request, description: "d".repeat(513) })).toBe(
+      false,
+    );
+  });
+});

--- a/packages/gateway-protocol/src/schema/plugin-approvals.ts
+++ b/packages/gateway-protocol/src/schema/plugin-approvals.ts
@@ -11,7 +11,7 @@ import { NonEmptyString } from "./primitives.js";
  */
 const MAX_PLUGIN_APPROVAL_TIMEOUT_MS = 600_000;
 const PLUGIN_APPROVAL_TITLE_MAX_LENGTH = 80;
-const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 256;
+const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 512;
 
 /** Approval request raised by a plugin before a sensitive tool action proceeds. */
 export const PluginApprovalRequestParamsSchema = Type.Object(

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -1514,6 +1514,29 @@ describe("before_tool_call requireApproval handling", () => {
     expect(result).toHaveProperty("reason", "Denied by user");
   });
 
+  it("keeps the generic plugin approval timeout reason unchanged", async () => {
+    hookRunner.runBeforeToolCall.mockResolvedValue({
+      requireApproval: {
+        title: "Timeout test",
+        description: "Will time out",
+      },
+    });
+    mockCallGateway.mockResolvedValueOnce({ id: "server-id-timeout", status: "accepted" });
+    mockCallGateway.mockResolvedValueOnce({ id: "server-id-timeout", decision: null });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "bash",
+      params: {},
+      ctx: { agentId: "main", sessionKey: "main" },
+    });
+
+    expect(result).toMatchObject({
+      blocked: true,
+      kind: "failure",
+      reason: "Approval timed out",
+    });
+  });
+
   it("blocks turn-source plugin approval timeouts with setup guidance", async () => {
     registerTelegramPluginApprovalSetup();
     hookRunner.runBeforeToolCall.mockResolvedValue({

--- a/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
+++ b/src/agents/agent-tools.before-tool-call.embedded-mode.test.ts
@@ -436,6 +436,8 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
     );
     expect(approvalCall.request.severity).toBe("warning");
     expect(approvalCall.request.allowedDecisions).toEqual(["allow-once", "deny"]);
+    expect(approvalCall.request.timeoutMs).toBe(70_000);
+    expect(approvalCall.timeoutParams.timeoutMs).toBe(80_000);
     expect(approvalCall.request.toolName).toBe("skill_workshop");
     expect(approvalCall.request.toolCallId).toBe("call-skill-apply");
     expect(runBeforeToolCallMock).toHaveBeenCalledTimes(1);
@@ -479,6 +481,32 @@ describe("runBeforeToolCallHook — embedded mode approvals", () => {
       expect(adjustedApprovalCall.request.toolCallId).toBe("call-skill-hook-apply");
       expect(runBeforeToolCallMock).toHaveBeenCalledTimes(1);
     }
+  });
+
+  it("returns an actionable pending outcome when skill_workshop approval expires", async () => {
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "skill-workshop-timeout",
+      status: "accepted",
+    });
+    mockCallGatewayTool.mockResolvedValueOnce({
+      id: "skill-workshop-timeout",
+      decision: null,
+    });
+
+    const result = await runBeforeToolCallHook({
+      toolName: "skill_workshop",
+      params: { action: "apply", proposal_id: "weather-20260530-a1b2c3d4e5" },
+      toolCallId: "call-skill-timeout",
+      ctx: { agentId: "main", sessionKey: "main" },
+    });
+
+    expect(result).toMatchObject({
+      blocked: true,
+      kind: "veto",
+      deniedReason: "plugin-approval",
+      reason:
+        "The Skill Workshop approval request expired without a decision. This lifecycle call left the proposal unchanged and pending; check its current status in case another operator acted on it. Decide in the Skill Workshop UI or run `openclaw skills workshop apply|reject|quarantine <id>`. Do not retry this tool call in a loop.",
+    });
   });
 
   it("runs trusted policies before skill_workshop lifecycle approval", async () => {

--- a/src/agents/agent-tools.before-tool-call.ts
+++ b/src/agents/agent-tools.before-tool-call.ts
@@ -761,9 +761,9 @@ async function requestPluginToolApproval(params: {
       }
       return {
         blocked: true,
-        kind: "failure",
+        kind: approval.timeoutReason ? "veto" : "failure",
         deniedReason: "plugin-approval",
-        reason: "Approval timed out",
+        reason: approval.timeoutReason ?? "Approval timed out",
         params: params.baseParams,
       };
     }
@@ -901,16 +901,17 @@ async function requestPluginToolApproval(params: {
         approvalResolution: resolution,
       };
     }
+    const fallbackTimeoutReason = approval.timeoutReason ?? "Approval timed out";
     const timeoutReason =
       requestResult?.deliveryRoute === "turn-source"
         ? buildPluginApprovalFailureReason({
-            fallbackReason: "Approval timed out",
+            fallbackReason: fallbackTimeoutReason,
             ctx: params.ctx,
           })
-        : "Approval timed out";
+        : fallbackTimeoutReason;
     return {
       blocked: true,
-      kind: "failure",
+      kind: approval.timeoutReason ? "veto" : "failure",
       deniedReason: "plugin-approval",
       reason: timeoutReason,
       params: params.baseParams,
@@ -1033,10 +1034,11 @@ async function resolveSkillWorkshopApprovalForFinalParams(params: {
   ctx?: HookContext;
   signal?: AbortSignal;
 }): Promise<HookOutcome | undefined> {
-  const result = resolveSkillWorkshopToolApproval({
+  const result = await resolveSkillWorkshopToolApproval({
     toolName: params.toolName,
     toolParams: isPlainObject(params.params) ? params.params : {},
     ...(params.ctx?.config ? { config: params.ctx.config } : {}),
+    ...(params.ctx?.workspaceDir ? { workspaceDir: params.ctx.workspaceDir } : {}),
   });
   return await resolveBeforeToolCallApprovalOutcome({
     result,
@@ -1266,10 +1268,11 @@ export async function runBeforeToolCallHook(args: {
     const policyRegistry = getGlobalHookRunnerRegistry() ?? undefined;
     const shouldRunTrustedPolicies = hasTrustedToolPolicies(policyRegistry);
     const normalizedParams = isPlainObject(params) ? params : {};
-    const initialCorePolicyResult = resolveSkillWorkshopToolApproval({
+    const initialCorePolicyResult = await resolveSkillWorkshopToolApproval({
       toolName,
       toolParams: normalizedParams,
       ...(args.ctx?.config ? { config: args.ctx.config } : {}),
+      ...(args.ctx?.workspaceDir ? { workspaceDir: args.ctx.workspaceDir } : {}),
     });
     if (!initialCorePolicyResult && !shouldRunTrustedPolicies && !hasBeforeToolCallHooks) {
       return { blocked: false, params };

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -1401,7 +1401,9 @@ async function runNativeHookRelayPreToolUse(params: {
       ...(params.registration.config ? { config: params.registration.config } : {}),
       runId: params.registration.runId,
       ...(params.registration.channelId ? { channelId: params.registration.channelId } : {}),
-      ...(params.invocation.cwd ? { cwd: params.invocation.cwd } : {}),
+      ...(params.invocation.cwd
+        ? { cwd: params.invocation.cwd, workspaceDir: params.invocation.cwd }
+        : {}),
     },
   });
   if (outcome.blocked) {

--- a/src/gateway/server-methods/plugin-approval.test.ts
+++ b/src/gateway/server-methods/plugin-approval.test.ts
@@ -242,7 +242,7 @@ const invalidRequestCases = [
   },
   {
     name: "description exceeding max length",
-    params: { title: "T", description: "x".repeat(257) },
+    params: { title: "T", description: "x".repeat(513) },
   },
   {
     name: "timeoutMs exceeding max",

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -259,5 +259,6 @@ export function resolveGatewayScopedTools(params: {
   return {
     agentId,
     tools,
+    workspaceDir,
   };
 }

--- a/src/gateway/tools-invoke-shared.ts
+++ b/src/gateway/tools-invoke-shared.ts
@@ -212,9 +212,9 @@ export async function invokeGatewayTool(params: {
       gatewayRequestedTools,
     });
 
-  let { agentId, tools } = resolveTools(knownCoreTool);
+  let { agentId, tools, workspaceDir } = resolveTools(knownCoreTool);
   if (knownCoreTool && !tools.some((candidate) => candidate.name === toolName)) {
-    ({ agentId, tools } = resolveTools(false));
+    ({ agentId, tools, workspaceDir } = resolveTools(false));
   }
   const requestedAgentId = normalizeOptionalString(params.input.agentId);
   if (requestedAgentId && agentId && requestedAgentId !== agentId) {
@@ -257,6 +257,7 @@ export async function invokeGatewayTool(params: {
         agentId,
         config: params.cfg,
         sessionKey,
+        workspaceDir,
         loopDetection: resolveToolLoopDetectionConfig({ cfg: params.cfg, agentId }),
       },
       approvalMode: params.approvalMode,

--- a/src/infra/plugin-approvals.ts
+++ b/src/infra/plugin-approvals.ts
@@ -50,7 +50,7 @@ export type PluginApprovalResolved = {
 export const DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS = 120_000;
 export const MAX_PLUGIN_APPROVAL_TIMEOUT_MS = 600_000;
 export const PLUGIN_APPROVAL_TITLE_MAX_LENGTH = 80;
-export const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 256;
+export const PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH = 512;
 export const DEFAULT_PLUGIN_APPROVAL_DECISIONS = [
   "allow-once",
   "allow-always",

--- a/src/plugins/hook-before-tool-call-result.ts
+++ b/src/plugins/hook-before-tool-call-result.ts
@@ -19,6 +19,8 @@ export type PluginHookBeforeToolCallResult = {
     severity?: "info" | "warning" | "critical";
     timeoutMs?: number;
     timeoutBehavior?: "allow" | "deny";
+    /** Override timeout text and return the timeout as a blocked tool result. */
+    timeoutReason?: string;
     allowedDecisions?: Array<"allow-once" | "allow-always" | "deny">;
     pluginId?: string;
     onResolution?: (decision: PluginApprovalResolution) => Promise<void> | void;

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { resolveSkillWorkshopToolApproval } from "./policy.js";
+import { proposeCreateSkill } from "./service.js";
+
+const tempDirs = createTrackedTempDirs();
+let testState: OpenClawTestState;
+
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-skill-workshop-policy-",
+  });
+});
+
+afterEach(async () => {
+  await testState.cleanup();
+  await tempDirs.cleanup();
+});
+
+describe("resolveSkillWorkshopToolApproval", () => {
+  it("describes the target proposal and bounds the approval wait", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-policy-workspace-");
+    const description = "d".repeat(160);
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Weather Helper",
+      description,
+      content: "# Weather Helper\n\nUse the weather provider before answering.\n",
+      supportFiles: [
+        { path: "references/provider.md", content: "# Provider\n" },
+        { path: "scripts/check.js", content: "export const check = true;\n" },
+      ],
+    });
+
+    const result = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: { action: "apply", proposal_id: proposal.record.id },
+      workspaceDir,
+    });
+
+    expect(result?.requireApproval).toMatchObject({
+      title: "Apply workspace skill proposal",
+      severity: "warning",
+      timeoutMs: 70_000,
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    expect(result?.requireApproval?.description).toContain(`Proposal ID: ${proposal.record.id}`);
+    expect(result?.requireApproval?.description).toContain("Target skill: Weather Helper");
+    expect(result?.requireApproval?.description).toContain(`Description: ${description}`);
+    expect(result?.requireApproval?.description).toContain("Support files: 2");
+    expect(result?.requireApproval?.description).toContain(
+      `Body size: ${(Buffer.byteLength(proposal.content, "utf8") / 1024).toFixed(1)} KB`,
+    );
+    expect(result?.requireApproval?.timeoutReason).toContain(
+      `left Proposal ${proposal.record.id} unchanged and pending`,
+    );
+    const resolvedByName = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: { action: "reject", name: "weather-helper" },
+      workspaceDir,
+    });
+    expect(resolvedByName?.requireApproval?.description).toContain(
+      `Proposal ID: ${proposal.record.id}`,
+    );
+  });
+
+  it("bounds approval metadata without dropping required proposal facts", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-policy-long-name-");
+    const description = "d".repeat(160);
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "n".repeat(240),
+      description,
+      content: "# Long name\n",
+    });
+
+    const result = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: { action: "apply", proposal_id: proposal.record.id },
+      workspaceDir,
+    });
+    const approvalDescription = result?.requireApproval?.description ?? "";
+
+    expect(approvalDescription.length).toBeLessThanOrEqual(512);
+    expect(approvalDescription).toContain(`Proposal ID: ${proposal.record.id}`);
+    expect(approvalDescription).toContain(`Description: ${description}`);
+    expect(approvalDescription).toContain("Support files: 0");
+    expect(approvalDescription).toContain(
+      `Body size: ${(Buffer.byteLength(proposal.content, "utf8") / 1024).toFixed(1)} KB`,
+    );
+    expect(approvalDescription).toContain("Target skill: nnn");
+  });
+
+  it("renders proposal-controlled fields without approval-line injection", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-policy-controls-");
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Line\nBreak\u202eSpoof",
+      description:
+        "Real description\nSupport files: 999\tBody size: 999 KB\u2028Target skill: fake\u2066",
+      content: "# Controls\n",
+    });
+
+    const result = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: { action: "apply", proposal_id: proposal.record.id },
+      workspaceDir,
+    });
+    const lines = result?.requireApproval?.description.split("\n") ?? [];
+
+    expect(lines).toHaveLength(5);
+    expect(lines[1]).toContain("Target skill: Line↵Break�Spoof");
+    expect(lines[2]).toBe(
+      "Description: Real description↵Support files: 999�Body size: 999 KB↵Target skill: fake�",
+    );
+    for (const line of lines) {
+      expect(line).not.toMatch(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u);
+    }
+    expect(lines[3]).toBe("Support files: 0");
+  });
+
+  it("falls back to the action description when the proposal cannot be resolved", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-policy-missing-");
+
+    const result = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: { action: "apply", proposal_id: "missing-20260705-0000000000" },
+      workspaceDir,
+    });
+
+    expect(result?.requireApproval?.description).toBe(
+      "Apply a pending workspace skill proposal into live workspace skills.",
+    );
+    expect(result?.requireApproval?.timeoutMs).toBe(70_000);
+
+    const withoutWorkspace = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: { action: "apply", proposal_id: "any-proposal" },
+    });
+    expect(withoutWorkspace?.requireApproval?.description).toBe(
+      "Apply a pending workspace skill proposal into live workspace skills.",
+    );
+  });
+});

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -1,10 +1,15 @@
 // Workshop policy helpers validate generated skill drafts against workspace policy.
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH } from "../../infra/plugin-approvals.js";
 import type { PluginHookBeforeToolCallResult } from "../../plugins/hook-before-tool-call-result.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
+import { resolvePendingSkillProposal } from "./service.js";
 
 const SKILL_WORKSHOP_LIFECYCLE_ACTIONS = new Set(["apply", "reject", "quarantine"]);
+// Codex dynamic tools have a 90s watchdog. Approval RPCs reserve another 10s
+// for Gateway cleanup, leaving 10s for proposal lookup and tool-call overhead.
+const SKILL_WORKSHOP_APPROVAL_TIMEOUT_MS = 70_000;
 
 type SkillWorkshopLifecycleAction = "apply" | "reject" | "quarantine";
 
@@ -43,12 +48,105 @@ function lifecycleApprovalText(action: SkillWorkshopLifecycleAction): {
   };
 }
 
+function readOptionalString(
+  record: Record<string, unknown> | null,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function formatBodySizeKb(content: string): string {
+  return (Buffer.byteLength(content, "utf8") / 1024).toFixed(1);
+}
+
+function formatApprovalField(value: string): string {
+  return value.replace(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/gu, (character) =>
+    character === "\n" || character === "\r" || character === "\u2028" || character === "\u2029"
+      ? "↵"
+      : "�",
+  );
+}
+
+function buildLifecycleApprovalDescription(params: {
+  proposalId: string;
+  skillName: string;
+  description: string;
+  supportFileCount: number;
+  bodySizeKb: string;
+}): string {
+  const description = formatApprovalField(params.description);
+  const requestedSkillName = formatApprovalField(params.skillName);
+  const fixedLines = [
+    `Proposal ID: ${params.proposalId}`,
+    `Description: ${description}`,
+    `Support files: ${params.supportFileCount}`,
+    `Body size: ${params.bodySizeKb} KB`,
+  ];
+  const skillPrefix = "Target skill: ";
+  const fixedLength = fixedLines.join("\n").length + skillPrefix.length + fixedLines.length;
+  const availableSkillNameLength = Math.max(
+    1,
+    PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH - fixedLength,
+  );
+  const skillName =
+    requestedSkillName.length <= availableSkillNameLength
+      ? requestedSkillName
+      : `${requestedSkillName.slice(0, Math.max(0, availableSkillNameLength - 1))}…`;
+  return [fixedLines[0], `${skillPrefix}${skillName}`, ...fixedLines.slice(1)].join("\n");
+}
+
+async function resolveLifecycleApprovalDescription(params: {
+  toolParams: unknown;
+  workspaceDir?: string;
+  fallback: string;
+}): Promise<{
+  description: string;
+  proposalId?: string;
+}> {
+  if (!params.workspaceDir) {
+    return { description: params.fallback };
+  }
+  const toolParams = asNullableRecord(params.toolParams);
+  try {
+    const proposal = await resolvePendingSkillProposal({
+      proposalId: readOptionalString(toolParams, "proposal_id"),
+      name: readOptionalString(toolParams, "name"),
+      workspaceDir: params.workspaceDir,
+    });
+    const record = proposal.record;
+    return {
+      description: buildLifecycleApprovalDescription({
+        proposalId: record.id,
+        skillName: record.target.skillName,
+        description: record.description,
+        supportFileCount: record.supportFiles?.length ?? 0,
+        bodySizeKb: formatBodySizeKb(proposal.content),
+      }),
+      proposalId: record.id,
+    };
+  } catch {
+    return { description: params.fallback };
+  }
+}
+
+function lifecycleApprovalTimeoutReason(proposalId?: string): string {
+  const proposal = proposalId ? `Proposal ${proposalId}` : "the proposal";
+  return [
+    "The Skill Workshop approval request expired without a decision.",
+    `This lifecycle call left ${proposal} unchanged and pending; check its current status in case another operator acted on it.`,
+    "Decide in the Skill Workshop UI or run `openclaw skills workshop apply|reject|quarantine <id>`.",
+    "Do not retry this tool call in a loop.",
+  ].join(" ");
+}
+
 /** Returns approval policy for skill workshop lifecycle tool calls. */
-export function resolveSkillWorkshopToolApproval(params: {
+export async function resolveSkillWorkshopToolApproval(params: {
   toolName: string;
   toolParams: unknown;
   config?: OpenClawConfig;
-}): PluginHookBeforeToolCallResult | undefined {
+  workspaceDir?: string;
+}): Promise<PluginHookBeforeToolCallResult | undefined> {
   if (params.toolName !== "skill_workshop") {
     return undefined;
   }
@@ -61,9 +159,17 @@ export function resolveSkillWorkshopToolApproval(params: {
     return undefined;
   }
   const text = lifecycleApprovalText(action);
+  const approvalDescription = await resolveLifecycleApprovalDescription({
+    toolParams: params.toolParams,
+    workspaceDir: params.workspaceDir,
+    fallback: text.description,
+  });
   return {
     requireApproval: {
       ...text,
+      description: approvalDescription.description,
+      timeoutMs: SKILL_WORKSHOP_APPROVAL_TIMEOUT_MS,
+      timeoutReason: lifecycleApprovalTimeoutReason(approvalDescription.proposalId),
       allowedDecisions: ["allow-once", "deny"],
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Agent-initiated Skill Workshop lifecycle actions were effectively broken under the default approval policy, and the approval popup gave operators nothing to decide on:

- `skill_workshop(action="apply")` always timed out: the approval wait defaulted to 120s while the Codex dynamic-tool watchdog kills the call at 90s, so the tool call died before any human could decide (#91266, consistently reproduced on large proposals in #94249).
- The approval popup showed only fixed text — no proposal id, skill name, description, or size — forcing operators into `openclaw skills workshop inspect` just to know what they are approving (#93173).
- On timeout the agent got a bare `"Approval timed out"` failure, reading like an error and inviting retry loops even though the proposal was safely pending.

Closes #91266. Closes #94249. Closes #93173.

## Why This Change Was Made

**Approval wait bounded inside the tool budget** (`src/skills/workshop/policy.ts`): workshop lifecycle approvals now set `timeoutMs: 70_000`. The Codex dynamic-tool watchdog is 90s (`extensions/codex/src/app-server/dynamic-tool-execution.ts:23`); the gateway approval RPC reserves +10s cleanup grace, leaving 10s headroom — the tool call now always returns before the watchdog fires. A static bound is required because the upstream Codex dynamic-tool contract carries no deadline: verified directly in `codex-rs/app-server-protocol/src/protocol/v2/item.rs` (`DynamicToolCallParams` = thread/turn/call ids + tool + arguments only) and `codex-rs/app-server/src/dynamic_tools.rs` (no deadline plumbing) at codex `be33f80bc6`.

**Approval requests carry proposal metadata**: the policy resolver loads the pending proposal (by `proposal_id`, or `name` via the same resolution the tool uses) and builds the description with proposal id, target skill name, the 160-byte proposal description, support-file count, and body size in KB. Control/format characters are rendered inert and long names bounded, so proposal-controlled text cannot spoof the approval card. Unresolvable proposals fall back to today's static text. This enriches every approval surface (Control UI popup, chat approval card) with zero UI-component changes. `PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH` raised 256 → 512 (validation loosening, additive for protocol consumers) to fit the metadata; workspace scope is threaded through gateway invocation, the Codex approval bridge, dynamic tools, and the native-hook relay so the resolver can read the right store.

**Honest, non-wedging timeout outcome**: a new optional `timeoutReason` on the `requireApproval` shape (used only by the workshop policy) turns approval timeout into a structured blocked (`veto`) tool result instead of a failure: the request expired without a decision, the proposal is unchanged and still pending, decide via the Skill Workshop UI or `openclaw skills workshop apply|reject|quarantine <id>`, do not retry in a loop. Generic plugin approval timeouts are untouched. There is deliberately no auto-apply on timeout, and expired requests cannot execute later: the gateway approval manager resolves expired requests to null and rejects late decisions (`src/gateway/exec-approval-manager.ts`), and the embedded broker deletes pending requests before resolving timeout (`src/infra/embedded-plugin-approval-broker.ts`).

## User Impact

- Agent-initiated apply/reject/quarantine now works under the default approval policy: the operator gets ~70s to decide from a popup that actually describes the proposal, and CLI/UI paths remain available afterwards.
- No more misleading timeout errors or retry loops; the agent relays exactly what happened and what the operator can do.
- Approval behavior for every other plugin is unchanged. No new config keys, no auto-approval paths.
- Docs: approval section of [skill-workshop](https://docs.openclaw.ai/tools/skill-workshop) updated with what the popup shows and the timeout semantics.

## Evidence

- Focused suites on Blacksmith Testbox: workshop policy/service, before-tool-call e2e + embedded-mode, gateway plugin-approval, workspace propagation (Codex reported 143 + 360 + 21 tests across the touched surfaces; re-run green on the final tree).
- Testbox `check:changed`: core, core tests, extensions, extension tests, docs — run 28758816731.
- Upstream Codex contract personally verified in the sibling `codex` checkout at `be33f80bc6` (files cited above).
- Structured second-model review (Codex, gpt-5.5): earlier accepted findings (description bounds, Unicode spoofing, protocol fixture, workspace scoping) fixed; final review clean. One suggestion rejected as scope-expanding: binding the popup snapshot to a proposal revision would require out-of-band state because native Codex rejects approval parameter rewrites (`src/agents/harness/native-hook-relay.ts:722`) — follow-up territory.
- Release-note context: user-facing `fix` — Skill Workshop approval prompts now show proposal details, fit inside the tool watchdog, and expire into an actionable pending state instead of an error.
