### PR TITLE
fix(build): make tsdown configs self-contained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Source build portability:** keep tsdown configuration self-contained so builds do not depend on resolving the tsdown package from unrun's temporary module directory.
 - **Diffs rendering:** render viewer and image output from one SSR preload, preserve language-pack highlighting through hydration, normalize language hints case-insensitively, skip identical before/after inputs with an explicit `changed` result, report truthful file-render and input errors, cache hash-pinned viewer runtimes, and prefer canonical file settings over stale aliases. (#100487)
 - **Remote browser reliability:** bound persistent Playwright tab enumeration by the existing remote CDP timeout budget and retire timed-out connection attempts so late completions cannot restore a stuck connection. (#80147, #58968) Thanks @HemantSudarshan and @KeaneYan.
 - **MCP OAuth response bounds:** reject body-less foreign error bodies without calling their inherently unbounded `text()` fallback, while preserving HTTP status and headers for safe SDK diagnostics. (#98143) Thanks @Pick-cat.

--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -1,4 +1,5 @@
 // Tsdown config tests protect package artifact build contracts.
+import fs from "node:fs";
 import { describe, expect, it } from "vitest";
 import config from "../../tsdown.config.ts";
 
@@ -8,6 +9,14 @@ type TsdownConfig = (typeof configs)[number];
 type OutExtensions = NonNullable<TsdownConfig["outExtensions"]>;
 
 describe("tsdown config", () => {
+  it.each(["tsdown.config.ts", "tsdown.ai.config.ts"])(
+    "keeps %s free of runtime imports from tsdown",
+    (configPath) => {
+      const source = fs.readFileSync(configPath, "utf8");
+      expect(source).not.toMatch(/^import(?!\s+type\b).*from ["']tsdown["'];?$/mu);
+    },
+  );
+
   it("enables declaration output explicitly for package artifact builds", () => {
     expect(configs).not.toHaveLength(0);
     expect(configs.map((entry) => entry.dts)).toEqual(configs.map(() => true));

--- a/tsdown.ai.config.ts
+++ b/tsdown.ai.config.ts
@@ -1,6 +1,6 @@
 // Builds the reusable AI package separately to keep provider bundling out of
 // the already-parallel main package graph.
-import { defineConfig } from "tsdown";
+import type { UserConfig } from "tsdown";
 
 const externalDependencies = [
   "@anthropic-ai/sdk",
@@ -10,7 +10,7 @@ const externalDependencies = [
   "typebox",
 ] as const;
 
-export default defineConfig({
+const config = {
   clean: true,
   dts: process.env.OPENCLAW_RUN_NODE_SKIP_DTS_BUILD === "1" ? false : true,
   entry: {
@@ -36,4 +36,6 @@ export default defineConfig({
       );
     },
   },
-});
+} satisfies UserConfig;
+
+export default config;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,7 @@
 // tsdown config defines package build entrypoints and output options.
 import fs from "node:fs";
 import path from "node:path";
-import { defineConfig, type UserConfig } from "tsdown";
+import type { UserConfig } from "tsdown";
 import {
   collectBundledPluginBuildEntries,
   NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
@@ -664,7 +664,7 @@ function buildUnifiedDistEntries(): Record<string, string> {
   };
 }
 
-export default defineConfig([
+const configs = [
   nodeBuildConfig({
     clean: true,
     dts: TSDOWN_DECLARATIONS,
@@ -792,4 +792,6 @@ export default defineConfig([
       dts: { neverBundle: shouldNeverBundleDependency },
     },
   }),
-]);
+] satisfies UserConfig[];
+
+export default configs;


### PR DESCRIPTION
## Summary

- remove the unnecessary runtime `defineConfig` import from both tsdown configs
- preserve type checking with `satisfies UserConfig`
- add a regression test preventing runtime imports from `tsdown`

## Why

`scripts/tsdown-build.mjs` deliberately uses the `unrun` config loader. `unrun` evaluates a generated module from a temporary directory, where a bare runtime import of `tsdown` can fail package resolution. `defineConfig` is an identity helper, so exporting typed config values directly preserves behavior and makes the configs self-contained.

## Proof

- `pnpm exec vitest run test/scripts/tsdown-config.test.ts` (4 passed)
- `ALLOW_ADHOC_SIGNING=1 pnpm mac:package`
- autoreview: implementation accepted; changelog-removal suggestion rejected because repository instructions require changelog entries for user-facing fixes
