### PR TITLE
fix(delivery): fall back to deliveryContext.to / origin.to when session lastTo is missing

### DIFF
--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ -220,7 +220,7 @@ export function deliveryContextFromSession(
     route: entry.route,
     channel: entry.channel ?? entry.origin?.provider,
     lastChannel: entry.lastChannel,
-    lastTo: entry.lastTo,
+    lastTo: entry.lastTo ?? entry.deliveryContext?.to ?? entry.origin?.to,
     lastAccountId: entry.lastAccountId ?? entry.origin?.accountId,
     lastThreadId: entry.lastThreadId ?? entry.deliveryContext?.threadId ?? entry.origin?.threadId,
     origin: entry.origin,

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -182,6 +182,42 @@ describe("delivery context helpers", () => {
     });
   });
 
+  it("falls back to deliveryContext.to and origin.to when lastTo is missing", () => {
+    expect(
+      deliveryContextFromSession({
+        channel: "demo-channel",
+        deliveryContext: { channel: "whatsapp", to: "+1555" },
+      }),
+    ).toEqual({
+      channel: "demo-channel",
+      to: "+1555",
+      accountId: undefined,
+    });
+
+    expect(
+      deliveryContextFromSession({
+        origin: { provider: "whatsapp", to: "+1555" },
+      }),
+    ).toEqual({
+      channel: "whatsapp",
+      to: "+1555",
+      accountId: undefined,
+    });
+
+    expect(
+      deliveryContextFromSession({
+        channel: "demo-channel",
+        lastTo: "+1000",
+        deliveryContext: { channel: "demo-channel", to: "+2000" },
+        origin: { provider: "demo-channel", to: "+3000" },
+      }),
+    ).toEqual({
+      channel: "demo-channel",
+      to: "+1000",
+      accountId: undefined,
+    });
+  });
+
   it("prefers explicit external delivery context over stale webchat legacy fields", () => {
     expect(
       deliveryContextFromSession({

--- a/src/utils/delivery-context.types.ts
+++ b/src/utils/delivery-context.types.ts
@@ -45,6 +45,7 @@ export type DeliveryContextSessionSource = {
   /** Older origin fields emitted before delivery context became canonical. */
   origin?: {
     provider?: string;
+    to?: string;
     accountId?: string;
     threadId?: string | number;
   };


### PR DESCRIPTION
## What Problem This Solves

`deliveryContextFromSession` (src/utils/delivery-context.shared.ts) rebuilds a
delivery context from a persisted session entry. It already applies a fallback
chain for the thread id:

```ts
lastThreadId: entry.lastThreadId ?? entry.deliveryContext?.threadId ?? entry.origin?.threadId,
```

but the delivery **target** gets no such chain:

```ts
lastTo: entry.lastTo,
```

If a session entry was created or migrated without `lastTo` populated — while
`entry.deliveryContext.to` and/or `entry.origin.to` are present and correct —
the derived context can resolve with **no `to` target**. Downstream, the final
reply is then silently dropped: the agent run completes normally (the user sees
"typing"), but nothing is delivered. There is no error surfaced; the only trace
is a session entry whose reply never arrives.

`normalizeSessionDeliveryFields` does merge `deliveryContext.to` in the
happy path, but the merge drops it whenever the legacy channel and the
delivery-context channel conflict (`mergeDeliveryContext` refuses to mix
targets across channels), and `origin.to` is never consulted for the target at
all — it is only read for `provider`, `accountId`, and `threadId`.

We hit this in production on a WhatsApp deployment (openclaw 2026.5.28, still
reproducible on 2026.6.11): session entries rebuilt without `lastTo` caused
every final reply on those sessions to vanish until the field was manually
backfilled.

## Why This Change Was Made

Mirror the `lastThreadId` fallback chain for `lastTo`:

```diff
--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ export function deliveryContextFromSession(
   const source: DeliveryContextSessionSource = {
     route: entry.route,
     channel: entry.channel ?? entry.origin?.provider,
     lastChannel: entry.lastChannel,
-    lastTo: entry.lastTo,
+    lastTo: entry.lastTo ?? entry.deliveryContext?.to ?? entry.origin?.to,
     lastAccountId: entry.lastAccountId ?? entry.origin?.accountId,
     lastThreadId: entry.lastThreadId ?? entry.deliveryContext?.threadId ?? entry.origin?.threadId,
     origin: entry.origin,
     deliveryContext: entry.deliveryContext,
   };
```

`DeliveryContextSessionSource.origin` (src/utils/delivery-context.types.ts)
currently types only `provider` / `accountId` / `threadId`, so the type needs
the target field session entries already carry at runtime:

```diff
--- a/src/utils/delivery-context.types.ts
+++ b/src/utils/delivery-context.types.ts
@@ export type DeliveryContextSessionSource = {
   /** Older origin fields emitted before delivery context became canonical. */
   origin?: {
     provider?: string;
+    to?: string;
     accountId?: string;
     threadId?: string | number;
   };
```

Core already uses exactly this fallback chain for the same data when seeding
the reply context — src/auto-reply/reply/get-reply-run.ts (current main,
~line 321):

```ts
setIfMissing(
  "OriginatingTo",
  normalizeOptionalString(
    sessionEntry.lastTo ?? sessionEntry.deliveryContext?.to ?? sessionEntry.origin?.to,
  ),
);
```

This PR makes `deliveryContextFromSession` consistent with that, and with its
own `lastThreadId` handling two lines below. No imports change; behavior is
unchanged for any entry that has `lastTo` set.

## User Impact

Sessions whose persisted entry lacks `lastTo` (but still carries the target in
`deliveryContext.to` or `origin.to`) get their final replies delivered again
instead of silently dropped. Entries that already have `lastTo` set are
completely unaffected — precedence is unchanged.

## Evidence

Added cases to `src/utils/delivery-context.test.ts` (which already covers
`deliveryContextFromSession`):

1. entry with `lastTo` undefined but `deliveryContext: { channel: "whatsapp", to: "+1555" }`
   → derived context has `to: "+1555"` (today: can resolve without a target
   when channels conflict with the legacy channel field).
2. entry with `lastTo` and `deliveryContext.to` both undefined but
   `origin: { provider: "whatsapp", to: "+1555" }` → derived context has
   `to: "+1555"` (today: `to` is undefined).
3. entry with `lastTo` set → unchanged precedence (`lastTo` wins over both).

Ran locally: `pnpm vitest run src/utils/delivery-context.test.ts` — 12/12 pass
with the fix; the new cases 1 and 2 fail without it (verified by stashing the
src change and re-running). Full `pnpm build && pnpm check && pnpm test` was
not run locally (2-vCPU box); relying on CI for the wider lanes.

AI-assisted: prepared with Claude Code; the diff, tests, and this description
were human-reviewed before filing.

## Related

- #69010 (open) — stale-deliveryContext precedence for gateway agent sends;
  different direction (current route winning over persisted context), does not
  touch `deliveryContextFromSession`'s missing-target case.
- #95021 (closed) — heartbeat-mode `lastTo` inheritance across channel
  mismatches; fixed a different call path.
