### PR TITLE
fix(ios): chat snaps back to bottom when scrolling to top via status-bar tap

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -20555,7 +20555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 402,
+      "line": 416,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -20563,7 +20563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 417,
+      "line": 431,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -20571,7 +20571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 471,
+      "line": 485,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
@@ -20579,7 +20579,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 482,
+      "line": 496,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -20587,7 +20587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 502,
+      "line": 516,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -20595,7 +20595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 927,
+      "line": 941,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -20603,7 +20603,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1007,
+      "line": 1021,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -32,6 +32,20 @@ func chatReaderHasNewerContent(
     return messageIndex < visibleIDs.index(before: visibleIDs.endIndex) || hasTransientContent
 }
 
+/// The view's own one-shot positioning always runs in a nil-animation transaction, so
+/// `.animating` only comes from system scrolls (status-bar scroll-to-top, keyboard
+/// avoidance). Not releasing there lets the next timeline tick yank the reader back down.
+func chatReaderScrollReleasesFollow(_ phase: ScrollPhase) -> Bool {
+    switch phase {
+    case .interacting, .animating:
+        true
+    case .idle, .tracking, .decelerating:
+        false
+    @unknown default:
+        false
+    }
+}
+
 @MainActor
 public struct OpenClawChatView: View {
     public enum Style {
@@ -252,7 +266,7 @@ public struct OpenClawChatView: View {
             }
             .onScrollPhaseChange { _, phase in
                 guard self.hasPerformedInitialScroll else { return }
-                if phase == .interacting {
+                if chatReaderScrollReleasesFollow(phase) {
                     self.isUserScrolling = true
                     self.followTarget = nil
                 } else if phase == .idle, self.isUserScrolling {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatReaderScrollStateTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatReaderScrollStateTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import Testing
 @testable import OpenClawChatUI
 
@@ -58,5 +59,16 @@ struct ChatReaderScrollStateTests {
             after: userID,
             visibleIDs: [userID],
             hasTransientContent: true))
+    }
+
+    @Test func `drags and system animated scrolls release the follow target`() {
+        #expect(chatReaderScrollReleasesFollow(.interacting))
+        #expect(chatReaderScrollReleasesFollow(.animating))
+    }
+
+    @Test func `idle, touch-down, and deceleration phases keep the follow target`() {
+        #expect(!chatReaderScrollReleasesFollow(.idle))
+        #expect(!chatReaderScrollReleasesFollow(.tracking))
+        #expect(!chatReaderScrollReleasesFollow(.decelerating))
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where iPhone users on the Chat tab who trigger the system scroll-to-top (tapping the status-bar area at the top of the screen, right next to the gateway status pill) see the transcript start scrolling up and then immediately snap back to the bottom, making older messages unreachable through that gesture. Reported from a device where a tap at the top right of the chat screen produced "a quick scroll that immediately scrolls me back to the bottom."

## Why This Change Was Made

Reader-managed chat scrolling (#98258) only releases the auto-follow target on the `.interacting` scroll phase, i.e. finger drags. System-driven animated scrolls — the status-bar scroll-to-top, keyboard avoidance, accessibility scroll actions — report `.animating`, so `followTarget` stayed `.latest` and the next timeline tick (streaming delta or message refresh) re-issued a scroll to the bottom sentinel, cancelling the system scroll mid-flight. The view's own one-shot positioning always runs in a nil-animation transaction and therefore never reports `.animating`, so any `.animating` phase is reader/system-driven and now releases the follow target. This matches Android, whose `ChatReaderScrollController` already releases the follow for any scroll it did not apply itself (`isScrollInProgress` gated by `isApplyingScroll`); iOS was the outlier.

## User Impact

Tapping the status bar to scroll to the top of the iOS chat transcript now works: the view stays where the system scroll put it, and the existing "Jump to latest" pill appears for returning to the live edge. The same shared view powers macOS web chat, which picks up the identical behavior for system-animated scrolls.

## Evidence

- New phase-policy regression tests in `ChatReaderScrollStateTests` prove `.interacting`/`.animating` release the follow target while `.idle`/`.tracking`/`.decelerating` keep it.
- `swift test --package-path apps/shared/OpenClawKit --parallel`: 346 tests in 34 suites pass (rerun green on latest `main` after this change).
- `swiftformat --lint --config config/swiftformat` clean on both changed files.
- Structured autoreview (Codex, gpt-5.5): no accepted/actionable findings.
