### PR TITLE
fix: let Ollama incomplete streams use model fallback

### DIFF
--- a/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts
@@ -1666,6 +1666,18 @@ describe("classifyProviderRuntimeFailureKind", () => {
     );
   });
 
+  it("classifies Ollama incomplete stream failures as timeout", () => {
+    const message = "Ollama API stream ended without a final response";
+    expect(classifyFailoverReason(message, { provider: "ollama" })).toBe("timeout");
+    expect(classifyFailoverReason(message, { provider: "ollama-remote" })).toBe("timeout");
+    expect(classifyProviderRuntimeFailureKind({ provider: "ollama", message })).toBe("timeout");
+    expect(classifyProviderRuntimeFailureKind({ provider: "ollama-remote", message })).toBe(
+      "timeout",
+    );
+    expect(classifyProviderRuntimeFailureKind(message)).toBe("timeout");
+    expect(classifyFailoverReason(message, { provider: "openai" })).toBeNull();
+  });
+
   it("does not classify generic config errors that mention proxy settings as proxy failures", () => {
     expect(
       classifyProviderRuntimeFailureKind(

--- a/src/agents/embedded-agent-helpers/errors.ts
+++ b/src/agents/embedded-agent-helpers/errors.ts
@@ -1000,6 +1000,20 @@ export function isGenericUnknownStreamErrorMessage(raw: string): boolean {
   return /^\s*an unknown error occurred\.?\s*$/i.test(raw);
 }
 
+export function isOllamaIncompleteStreamErrorMessage(raw: string, provider?: string): boolean {
+  const normalizedProvider = normalizeOptionalLowercaseString(provider)?.trim();
+  const providerMatches =
+    !normalizedProvider ||
+    normalizedProvider === "ollama" ||
+    normalizedProvider.startsWith("ollama/") ||
+    normalizedProvider.startsWith("ollama-");
+  return (
+    providerMatches &&
+    normalizeOptionalLowercaseString(raw)?.trim() ===
+      "ollama api stream ended without a final response"
+  );
+}
+
 function isOpenRouterProviderReturnedError(raw: string, provider?: string): boolean {
   return (
     isProvider(provider, "openrouter") &&
@@ -1099,6 +1113,9 @@ function classifyFailoverClassificationFromMessage(
   }
   if (isAuthErrorMessage(raw)) {
     return toReasonClassification("auth");
+  }
+  if (isOllamaIncompleteStreamErrorMessage(raw, provider)) {
+    return toReasonClassification("timeout");
   }
   if (isGenericUnknownStreamErrorMessage(raw)) {
     return toReasonClassification("timeout");

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -318,6 +318,55 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     });
   });
 
+  it("classifies Ollama incomplete stream error payloads as fallback-worthy", () => {
+    const rawError = "Ollama API stream ended without a final response";
+
+    for (const provider of ["ollama", "ollama-remote"]) {
+      const result = classifyEmbeddedAgentRunResultForModelFallback({
+        provider,
+        model: "gpt-oss:20b",
+        result: {
+          payloads: [
+            {
+              isError: true,
+              text: rawError,
+            },
+          ],
+          meta: {
+            durationMs: 42,
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        message: `${provider}/gpt-oss:20b ended with a provider error: ${rawError}`,
+        reason: "timeout",
+        code: "embedded_error_payload",
+        rawError,
+      });
+    }
+  });
+
+  it("does not classify generic timeout payloads as fallback-worthy", () => {
+    const result = classifyEmbeddedAgentRunResultForModelFallback({
+      provider: "ollama",
+      model: "llama-3.1",
+      result: {
+        payloads: [
+          {
+            isError: true,
+            text: "socket hang up",
+          },
+        ],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("does not retry unclassified non-GPT error payloads", () => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "custom",

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -3,7 +3,10 @@
  */
 import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../../auto-reply/reply/agent-runner-failure-copy.js";
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
-import { classifyFailoverReason } from "../embedded-agent-helpers/errors.js";
+import {
+  classifyFailoverReason,
+  isOllamaIncompleteStreamErrorMessage,
+} from "../embedded-agent-helpers/errors.js";
 import type { FailoverReason } from "../embedded-agent-helpers/types.js";
 import { isGpt5ModelId } from "../gpt5-prompt-overlay.js";
 import type { ModelFallbackResultClassification } from "../model-fallback.js";
@@ -15,7 +18,7 @@ import type { EmbeddedAgentRunResult } from "./types.js";
 
 type ProviderErrorPayloadFailoverReason = Extract<
   FailoverReason,
-  "auth" | "auth_permanent" | "billing" | "rate_limit" | "server_error" | "overloaded"
+  "auth" | "auth_permanent" | "billing" | "rate_limit" | "server_error" | "overloaded" | "timeout"
 >;
 
 /**
@@ -167,6 +170,8 @@ function classifyProviderErrorPayloadReason(
     case "server_error":
     case "overloaded":
       return failoverReason;
+    case "timeout":
+      return isOllamaIncompleteStreamErrorMessage(errorText, provider) ? failoverReason : null;
     default:
       return null;
   }

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1611,6 +1611,58 @@ describe("runWithModelFallback", () => {
     });
   });
 
+  it("continues fallback after Ollama incomplete stream error payloads", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "ollama-remote/gpt-oss:20b",
+            fallbacks: ["google/gemini-2.5-flash"],
+          },
+        },
+      },
+    });
+    const rawError = "Ollama API stream ended without a final response";
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({
+        payloads: [{ text: rawError, isError: true }],
+        meta: { durationMs: 1 },
+      } satisfies EmbeddedAgentRunResult)
+      .mockResolvedValueOnce({
+        payloads: [{ text: "fallback ok" }],
+        meta: { durationMs: 1 },
+      } satisfies EmbeddedAgentRunResult);
+
+    const result = await runWithModelFallback<EmbeddedAgentRunResult>({
+      cfg,
+      provider: "ollama-remote",
+      model: "gpt-oss:20b",
+      run,
+      classifyResult: ({ provider, model, result: resultLocal }) =>
+        classifyEmbeddedAgentRunResultForModelFallback({
+          provider,
+          model,
+          result: resultLocal,
+        }),
+    });
+
+    expect(result.result.payloads).toEqual([{ text: "fallback ok" }]);
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(requireMockCall(run, 1, "fallback run")).toEqual([
+      "google",
+      "gemini-2.5-flash",
+      { isFinalFallbackAttempt: true },
+    ]);
+    expect(result.attempts[0]).toMatchObject({
+      provider: "ollama-remote",
+      model: "gpt-oss:20b",
+      reason: "timeout",
+      code: "embedded_error_payload",
+      error: rawError,
+    });
+  });
+
   it("surfaces classified terminal results when no fallback remains", async () => {
     const cfg = makeCfg({
       agents: {


### PR DESCRIPTION
Closes #100460

## What Problem This Solves

Fixes an issue where users running Ollama as the primary model provider would receive a terminal `LLM request failed` instead of moving to a configured fallback model when Ollama ended a stream with `Ollama API stream ended without a final response`.

## Why This Change Was Made

The Ollama stream reader already raises a precise provider-runtime error for this incomplete-stream case. This change classifies that exact Ollama signal as a timeout-style failover reason and lets the embedded-result fallback path continue for the same exact payload, including custom Ollama provider ids that follow the documented `ollama-*` convention such as `ollama-5080`.

The change deliberately keeps generic timeout-like embedded error payloads non-retryable, so arbitrary provider error text does not become fallback-worthy.

AI-assisted: yes.

## User Impact

Ollama users with `agents.defaults.model.fallbacks` configured can recover from this transient incomplete-stream failure by moving to the next model candidate instead of getting a dead-end channel error.

## Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-helpers.isbillingerrormessage.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.test.ts src/agents/model-fallback.test.ts`
  - 2 Vitest shards passed
  - 260 tests passed
- `git diff --check`
- Local Ollama smoke with `smollm2:135m` returned HTTP 200 and a final streamed chunk with `done: true`.
- Targeted runtime probe after the fix:
  - `ollama` exact incomplete-stream message -> `timeout`
  - `ollama-remote` exact incomplete-stream message -> `timeout`
  - `openai` plus the same message -> `null`

Proof gaps:

- Remote Crabbox/Testbox proof was not available from this machine: Blacksmith CLI was missing and AWS Crabbox broker login was not configured.
- The live Ollama smoke proves the local stream path is usable; it does not force Ollama to naturally truncate a stream before `done: true`.
