### PR TITLE
fix(gateway): advertise exec approval node commands

### DIFF
--- a/src/gateway/node-command-policy.test.ts
+++ b/src/gateway/node-command-policy.test.ts
@@ -18,6 +18,7 @@ import {
   isNodeCommandAllowed,
   normalizeDeclaredNodeCommands,
   resolveNodeCommandAllowlist,
+  resolveNodePairingCommandAllowlist,
 } from "./node-command-policy.js";
 
 describe("gateway/node-command-policy", () => {
@@ -175,10 +176,32 @@ describe("gateway/node-command-policy", () => {
       expect(allowlist.has("system.run")).toBe(false);
       expect(allowlist.has("system.run.prepare")).toBe(false);
       expect(allowlist.has("system.which")).toBe(false);
+      expect(allowlist.has("system.execApprovals.get")).toBe(false);
+      expect(allowlist.has("system.execApprovals.set")).toBe(false);
       expect(allowlist.has("browser.proxy")).toBe(false);
       expect(allowlist.has("screen.snapshot")).toBe(false);
       expect(allowlist.has("system.notify")).toBe(true);
     }
+  });
+
+  it("allows exec approval commands only through desktop node pairing approval", () => {
+    const cfg = {} as OpenClawConfig;
+    const desktopNode = { platform: "windows", deviceFamily: "Windows" };
+
+    const pairingAllowlist = resolveNodePairingCommandAllowlist(cfg, desktopNode);
+    expect(pairingAllowlist.has("system.execApprovals.get")).toBe(true);
+    expect(pairingAllowlist.has("system.execApprovals.set")).toBe(true);
+
+    const unapprovedRuntimeAllowlist = resolveNodeCommandAllowlist(cfg, desktopNode);
+    expect(unapprovedRuntimeAllowlist.has("system.execApprovals.get")).toBe(false);
+    expect(unapprovedRuntimeAllowlist.has("system.execApprovals.set")).toBe(false);
+
+    const approvedRuntimeAllowlist = resolveNodeCommandAllowlist(cfg, {
+      ...desktopNode,
+      approvedCommands: ["system.execApprovals.get", "system.execApprovals.set"],
+    });
+    expect(approvedRuntimeAllowlist.has("system.execApprovals.get")).toBe(true);
+    expect(approvedRuntimeAllowlist.has("system.execApprovals.set")).toBe(true);
   });
 
   it("keeps defaults for first-party native platform labels with matching families", () => {

--- a/src/gateway/node-command-policy.ts
+++ b/src/gateway/node-command-policy.ts
@@ -5,6 +5,7 @@ import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/strin
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   NODE_BROWSER_PROXY_COMMAND,
+  NODE_EXEC_APPROVALS_COMMANDS,
   NODE_SYSTEM_NOTIFY_COMMAND,
   NODE_SYSTEM_RUN_COMMANDS,
 } from "../infra/node-commands.js";
@@ -54,11 +55,13 @@ const IOS_SYSTEM_COMMANDS = [NODE_SYSTEM_NOTIFY_COMMAND];
 
 const SYSTEM_COMMANDS = [
   ...NODE_SYSTEM_RUN_COMMANDS,
+  ...NODE_EXEC_APPROVALS_COMMANDS,
   NODE_SYSTEM_NOTIFY_COMMAND,
   NODE_BROWSER_PROXY_COMMAND,
 ];
 const DESKTOP_HOST_COMMANDS = new Set<string>([
   ...NODE_SYSTEM_RUN_COMMANDS,
+  ...NODE_EXEC_APPROVALS_COMMANDS,
   NODE_BROWSER_PROXY_COMMAND,
   ...SCREEN_COMMANDS,
 ]);

--- a/src/gateway/node-connect-reconcile.test.ts
+++ b/src/gateway/node-connect-reconcile.test.ts
@@ -118,6 +118,55 @@ describe("reconcileNodePairingOnConnect", () => {
     );
   });
 
+  it("reapproves and then preserves Windows exec approval commands", async () => {
+    const commands = [
+      "system.run.prepare",
+      "system.run",
+      "system.which",
+      "system.execApprovals.get",
+      "system.execApprovals.set",
+    ];
+    const previouslyApprovedCommands = ["system.run.prepare", "system.run", "system.which"];
+    const connectParams = makeNodeConnectParams({
+      client: {
+        id: GATEWAY_CLIENT_IDS.NODE_HOST,
+        version: "test",
+        platform: "windows",
+        deviceFamily: "Windows",
+        mode: GATEWAY_CLIENT_MODES.NODE,
+      },
+      caps: ["system"],
+      commands,
+    });
+    const requestPairing = makePendingPairingRequest("req-windows");
+
+    const upgrade = await reconcileNodePairingOnConnect({
+      cfg: {} as never,
+      connectParams,
+      pairedNode: makePairedNode({ caps: ["system"], commands: previouslyApprovedCommands }),
+      requestPairing,
+    });
+
+    expect(upgrade.declaredCommands).toEqual(commands);
+    expect(upgrade.effectiveCommands).toEqual(previouslyApprovedCommands);
+    expect(requestPairing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commands,
+      }),
+    );
+
+    const approvedPairingRequest = vi.fn();
+    const approvedReconnect = await reconcileNodePairingOnConnect({
+      cfg: {} as never,
+      connectParams,
+      pairedNode: makePairedNode({ caps: ["system"], commands }),
+      requestPairing: approvedPairingRequest,
+    });
+
+    expect(approvedReconnect.effectiveCommands).toEqual(commands);
+    expect(approvedPairingRequest).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["conflicts with device family", { deviceFamily: "iPhone" }],
     ["omits device family", {}],

--- a/src/gateway/server-methods/exec-approvals.test.ts
+++ b/src/gateway/server-methods/exec-approvals.test.ts
@@ -79,4 +79,138 @@ describe("exec approvals gateway methods", () => {
       }),
     );
   });
+
+  it.each([
+    {
+      method: "exec.approvals.node.get" as const,
+      command: "system.execApprovals.get",
+      params: { nodeId: "node-1" },
+      commands: [],
+      config: {},
+    },
+    {
+      method: "exec.approvals.node.set" as const,
+      command: "system.execApprovals.set",
+      params: {
+        nodeId: "node-1",
+        file: { version: 1, agents: {} },
+        baseHash: "base-hash",
+      },
+      commands: ["system.execApprovals.set"],
+      config: { gateway: { nodes: { denyCommands: ["system.execApprovals.set"] } } },
+    },
+  ])("blocks $method outside the effective command policy", async (testCase) => {
+    const invoke = vi.fn();
+    const respond = vi.fn();
+
+    await execApprovalsHandlers[testCase.method]({
+      req: {
+        type: "req",
+        id: "req-node-blocked",
+        method: testCase.method,
+        params: testCase.params,
+      },
+      params: testCase.params,
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {
+        getRuntimeConfig: () => testCase.config,
+        nodeRegistry: {
+          get: () => ({
+            nodeId: "node-1",
+            connId: "conn-1",
+            platform: "windows",
+            deviceFamily: "Windows",
+            declaredCommands: [testCase.command],
+            commands: testCase.commands,
+          }),
+          invoke,
+        },
+      } as never,
+    });
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        details: expect.objectContaining({ command: testCase.command }),
+      }),
+    );
+  });
+
+  it("relays approved exec-approval commands", async () => {
+    const command = "system.execApprovals.get";
+    const invoke = vi.fn().mockResolvedValue({ ok: true, payload: { exists: true } });
+    const respond = vi.fn();
+
+    await execApprovalsHandlers["exec.approvals.node.get"]({
+      req: {
+        type: "req",
+        id: "req-node-allowed",
+        method: "exec.approvals.node.get",
+        params: { nodeId: "node-1" },
+      },
+      params: { nodeId: "node-1" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {
+        getRuntimeConfig: () => ({}),
+        nodeRegistry: {
+          get: () => ({
+            nodeId: "node-1",
+            connId: "conn-1",
+            platform: "windows",
+            deviceFamily: "Windows",
+            declaredCommands: [command],
+            commands: [command],
+          }),
+          invoke,
+        },
+      } as never,
+    });
+
+    expect(invoke).toHaveBeenCalledWith({ nodeId: "node-1", command, params: {} });
+    expect(respond).toHaveBeenCalledWith(true, { exists: true }, undefined);
+  });
+
+  it("preserves unavailable details for unknown nodes", async () => {
+    const invoke = vi.fn().mockResolvedValue({
+      ok: false,
+      error: { code: "NOT_CONNECTED", message: "node not connected" },
+    });
+    const respond = vi.fn();
+
+    await execApprovalsHandlers["exec.approvals.node.get"]({
+      req: {
+        type: "req",
+        id: "req-node-missing",
+        method: "exec.approvals.node.get",
+        params: { nodeId: "missing-node" },
+      },
+      params: { nodeId: "missing-node" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {
+        getRuntimeConfig: () => ({}),
+        nodeRegistry: { get: () => undefined, invoke },
+      } as never,
+    });
+
+    expect(invoke).toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        details: {
+          nodeError: { code: "NOT_CONNECTED", message: "node not connected" },
+        },
+      }),
+    );
+  });
 });

--- a/src/gateway/server-methods/exec-approvals.ts
+++ b/src/gateway/server-methods/exec-approvals.ts
@@ -17,6 +17,7 @@ import {
   type ExecApprovalsFile,
   type ExecApprovalsSnapshot,
 } from "../../infra/exec-approvals.js";
+import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
 import { resolveBaseHashParam } from "./base-hash.js";
 import {
   respondUnavailableOnNodeInvokeError,
@@ -111,6 +112,29 @@ async function respondWithExecApprovalsNodePayload<TParams extends { nodeId: str
   if (!nodeId) {
     params.respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "nodeId required"));
     return;
+  }
+  const nodeSession = params.context.nodeRegistry.get(nodeId);
+  if (nodeSession) {
+    const allowed = isNodeCommandAllowed({
+      command: params.command,
+      declaredCommands: nodeSession.commands,
+      allowlist: resolveNodeCommandAllowlist(params.context.getRuntimeConfig(), {
+        ...nodeSession,
+        approvedCommands: nodeSession.commands,
+      }),
+    });
+    if (!allowed.ok) {
+      params.respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `node command not allowed: ${params.command} (${allowed.reason})`,
+          { details: { command: params.command, reason: allowed.reason } },
+        ),
+      );
+      return;
+    }
   }
   await respondUnavailableOnThrow(params.respond, async () => {
     const res = await params.context.nodeRegistry.invoke({


### PR DESCRIPTION
## What Problem This Solves

Desktop node hosts advertise `system.execApprovals.get` and `system.execApprovals.set`, but Gateway policy removed those commands before the approved node surface reached the Control UI. The dedicated exec-approval RPCs also relayed directly to the node without rechecking the effective paired surface or live `gateway.nodes.denyCommands` policy.

Closes #57775. Maintainer replay of #88296 because the stale contributor branch could not be safely updated in place.

## Why This Change Was Made

- Add the canonical exec-approval command list to desktop pairing defaults and reconnect preservation.
- Keep new commands ineffective until pairing approval; existing nodes request reapproval and retain only their old effective surface meanwhile.
- Enforce the effective node command surface and current runtime allowlist at the dedicated exec-approval relay boundary.
- Preserve the explicit raw `node.invoke` rejection and `operator.admin` RPC scope.
- Preserve Vincent Koc's authorship with a `Co-authored-by` trailer and changelog credit.

## User Impact

The Control UI can read and update approval settings on approved capable desktop nodes. Pending pairing and operator deny rules remain fail-closed.

## Evidence

- Blacksmith Testbox focused gateway suite: 12 files, 126 tests passed.
- Blacksmith Testbox `pnpm check:changed`: passed, including core/type/lint/policy guards.
- Two fresh autoreview passes after the relay-policy fix: no actionable findings, 0.96 confidence.
- Regression coverage includes initial pairing, old-node reapproval, approved reconnect, live deny rules, successful relay, raw invoke rejection, and unknown-node errors.

