### PR TITLE
fix(sessions): handle replay_invalid thinking signature errors (issue…

### DIFF
--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -33,7 +33,9 @@ import type {
   Model,
   TextContent,
 } from "../../llm/types.js";
-import { isRetryableAssistantError } from "../../llm/utils/retry.js";
+import { isReplayInvalidThinkingError, isRetryableAssistantError } from "../../llm/utils/retry.js";
+import { log } from "../embedded-agent-runner/logger.js";
+import { stripStaleThinkingSignaturesForCompactionReplay } from "../embedded-agent-runner/thinking.js";
 import type {
   Agent,
   AgentEvent,
@@ -1109,6 +1111,37 @@ export class AgentSession {
     this.lastAssistantMessage = undefined;
     if (!msg) {
       return false;
+    }
+
+    // Check for replay_invalid thinking signature error first (issue #99654)
+    // This happens when session history contains thinking blocks with stale signatures
+    // (e.g., after gateway restart with thinkingDefault: off). We need to strip the
+    // stale signatures before retrying, unlike generic retryable errors.
+    if (isReplayInvalidThinkingError(msg)) {
+      log.info(
+        `[session-recovery] Detected replay_invalid thinking signature error; stripping stale signatures from session history`,
+      );
+
+      // Strip stale thinking signatures from session history
+      const messages = this.agent.state.messages;
+      const strippedMessages = stripStaleThinkingSignaturesForCompactionReplay(messages);
+
+      if (strippedMessages !== messages) {
+        // Successfully stripped some signatures - update agent state and retry once
+        this.agent.state.messages = strippedMessages;
+
+        // Remove the error message from agent state (keep in session for history)
+        if (messages.length > 0 && messages[messages.length - 1].role === "assistant") {
+          this.agent.state.messages = messages.slice(0, -1);
+        }
+
+        log.info(`[session-recovery] Stripped stale thinking signatures; retrying prompt once`);
+        return true; // Retry once after stripping
+      } else {
+        log.warn(
+          `[session-recovery] Replay_invalid thinking error detected but no stale signatures found to strip`,
+        );
+      }
     }
 
     if (this.isRetryableError(msg) && (await this.prepareRetry(msg))) {

--- a/src/llm/utils/retry.ts
+++ b/src/llm/utils/retry.ts
@@ -49,6 +49,20 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
   "please retry your request",
 ]);
 
+/** Check if an error is a replay_invalid thinking signature error. */
+function isReplayInvalidThinkingError(message: AssistantMessage): boolean {
+  if (message.stopReason !== "error" || !message.errorMessage) {
+    return false;
+  }
+  // Match replay_invalid errors that mention thinking/signature issues
+  // Examples from issue #99654:
+  // - "messages.1.content.3: Invalid `signature` in `thinking` block"
+  // - "Invalid signature in thinking block"
+  return /\breplay_invalid\b.*\bthinking\b|\bthinking\b.*\bsignature\b.*\b(?:invalid|expired)\b|\binvalid.*signature.*in.*thinking\b/i.test(
+    message.errorMessage,
+  );
+}
+
 /** Classify transient provider/transport failures for outer retry policy. */
 export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (message.stopReason !== "error" || !message.errorMessage) {
@@ -57,5 +71,13 @@ export function isRetryableAssistantError(message: AssistantMessage): boolean {
   if (NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN.test(message.errorMessage)) {
     return false;
   }
+  // Thinking signature errors need special handling (strip signatures before retry)
+  // so we don't classify them as generic retryable errors here.
+  if (isReplayInvalidThinkingError(message)) {
+    return false;
+  }
   return RETRYABLE_PROVIDER_ERROR_PATTERN.test(message.errorMessage);
 }
+
+/** Export the thinking signature checker for session-level recovery logic. */
+export { isReplayInvalidThinkingError };


### PR DESCRIPTION
… #99654)

When a gateway restart occurs with different thinkingDefault settings, existing session history may contain thinking blocks with signatures that are no longer valid. The Anthropic API rejects these with 'replay_invalid' errors, causing the session to crash instead of recovering gracefully.

This change:
- Adds isReplayInvalidThinkingError() to detect thinking signature errors
- Strips stale signatures before retrying using existing utility
- Retries the prompt once after cleaning up context
- Logs informative messages for debugging

Fixes issue #99654.

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->
