### PR TITLE
feat(release): add extended-stable npm closeout

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,8 +64,12 @@
 /docs/reference/secretref-user-supplied-credentials-matrix.json @openclaw/openclaw-secops
 
 # Release workflow and its supporting release-path checks.
+/.github/workflows/plugin-npm-release.yml @openclaw/openclaw-release-managers
 /.github/workflows/openclaw-npm-release.yml @openclaw/openclaw-release-managers
+/.github/workflows/openclaw-npm-extended-stable-closeout.yml @openclaw/openclaw-release-managers
 /docs/reference/RELEASING.md @openclaw/openclaw-release-managers
+/scripts/openclaw-npm-extended-stable-closeout.mjs @openclaw/openclaw-release-managers
+/scripts/openclaw-npm-extended-stable-release.mjs @openclaw/openclaw-release-managers
 /scripts/openclaw-npm-publish.sh @openclaw/openclaw-release-managers
 /scripts/openclaw-npm-release-check.ts @openclaw/openclaw-release-managers
 /scripts/release-check.ts @openclaw/openclaw-release-managers

--- a/.github/workflows/openclaw-npm-extended-stable-closeout.yml
+++ b/.github/workflows/openclaw-npm-extended-stable-closeout.yml
@@ -1,0 +1,235 @@
+name: OpenClaw NPM Extended-Stable Closeout
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Exact final extended-stable release tag (vYYYY.M.PATCH)
+        required: true
+        type: string
+      preflight_run_id:
+        description: Successful OpenClaw NPM Release preflight run id for this branch and SHA
+        required: true
+        type: string
+      plugin_npm_run_id:
+        description: Successful Plugin NPM Release run id for this branch and SHA
+        required: true
+        type: string
+      core_npm_run_id:
+        description: Core npm publication run id that owns the selector baseline
+        required: true
+        type: string
+      full_release_validation_run_id:
+        description: Successful Full Release Validation run id for this branch and SHA
+        required: true
+        type: string
+
+concurrency:
+  group: openclaw-npm-extended-stable-closeout-${{ inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  NODE_VERSION: "24.15.0"
+
+jobs:
+  closeout:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate closeout input shape
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          WORKFLOW_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v([0-9]{4})\.([1-9]|1[0-2])\.([0-9]+)$ ]]; then
+            echo "Closeout requires an exact final vYYYY.M.P release tag." >&2
+            exit 1
+          fi
+          release_year="${BASH_REMATCH[1]}"
+          release_month="${BASH_REMATCH[2]}"
+          release_patch="${BASH_REMATCH[3]}"
+          if (( release_patch < 33 )); then
+            echo "Closeout requires PATCH >= 33." >&2
+            exit 1
+          fi
+          expected_ref="refs/heads/extended-stable/${release_year}.${release_month}.33"
+          if [[ "$WORKFLOW_REF" != "$expected_ref" ]]; then
+            echo "Closeout must run from ${expected_ref}; got ${WORKFLOW_REF}." >&2
+            exit 1
+          fi
+
+      - name: Checkout exact release
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require tag at canonical branch tip
+        env:
+          WORKFLOW_BRANCH: ${{ github.ref_name }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "+refs/heads/${WORKFLOW_BRANCH}:refs/remotes/origin/${WORKFLOW_BRANCH}"
+          branch_sha="$(git rev-parse "refs/remotes/origin/${WORKFLOW_BRANCH}")"
+          release_sha="$(git rev-parse HEAD)"
+          if [[ "$release_sha" != "$branch_sha" ]]; then
+            echo "Release tag must resolve to the canonical extended-stable branch tip." >&2
+            exit 1
+          fi
+          if [[ "$release_sha" != "$WORKFLOW_SHA" ]]; then
+            echo "Release tag must resolve to the exact workflow-dispatch SHA." >&2
+            exit 1
+          fi
+
+      - name: Validate closeout release identity
+        env:
+          BYPASS_EXTENDED_STABLE_GUARD: "false"
+          NPM_WORKFLOW_REF: ${{ github.ref }}
+          RELEASE_NPM_DIST_TAG: extended-stable
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: node scripts/openclaw-npm-extended-stable-release.mjs validate-request
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          install-bun: "false"
+          install-deps: "false"
+
+      - name: Verify preflight run
+        env:
+          EXPECTED_PREFLIGHT_ARTIFACT: openclaw-npm-preflight-${{ inputs.tag }}
+          EXPECTED_EXTENDED_STABLE_BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          PREFLIGHT_RUN_ID: ${{ inputs.preflight_run_id }}
+        run: |
+          set -euo pipefail
+          EXPECTED_RELEASE_SHA="$(git rev-parse HEAD)"
+          export EXPECTED_RELEASE_SHA
+          run_json="$(gh run view "$PREFLIGHT_RUN_ID" --repo "$GITHUB_REPOSITORY" --json workflowName,headBranch,headSha,event,status,conclusion,url)"
+          jobs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${PREFLIGHT_RUN_ID}/jobs?per_page=100")"
+          artifacts_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${PREFLIGHT_RUN_ID}/artifacts?per_page=100")"
+          jq -n \
+            --argjson run "$run_json" \
+            --argjson jobs "$jobs_json" \
+            --argjson artifacts "$artifacts_json" \
+            '{run: $run, jobs: $jobs.jobs, artifacts: $artifacts.artifacts}' |
+            node scripts/openclaw-npm-extended-stable-closeout.mjs verify-preflight-run
+
+      - name: Verify plugin npm run
+        env:
+          EXPECTED_EXTENDED_STABLE_BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_NPM_DIST_TAG: extended-stable
+          RUN_ID: ${{ inputs.plugin_npm_run_id }}
+          RUN_KIND: plugin
+        run: |
+          set -euo pipefail
+          EXPECTED_RELEASE_SHA="$(git rev-parse HEAD)"
+          export EXPECTED_RELEASE_SHA
+          gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --json workflowName,displayTitle,headBranch,headSha,event,status,conclusion,url |
+            node scripts/openclaw-npm-extended-stable-release.mjs verify-run
+
+      - name: Verify Full Release Validation run
+        env:
+          EXPECTED_EXTENDED_STABLE_BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_NPM_DIST_TAG: extended-stable
+          RUN_ID: ${{ inputs.full_release_validation_run_id }}
+          RUN_KIND: validation
+        run: |
+          set -euo pipefail
+          EXPECTED_RELEASE_SHA="$(git rev-parse HEAD)"
+          export EXPECTED_RELEASE_SHA
+          gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" \
+            --json workflowName,headBranch,headSha,event,status,conclusion,url |
+            node scripts/openclaw-npm-extended-stable-release.mjs verify-run
+
+      - name: Verify core npm run
+        env:
+          CORE_NPM_RUN_ID: ${{ inputs.core_npm_run_id }}
+          EXPECTED_EXTENDED_STABLE_BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          EXPECTED_RELEASE_SHA="$(git rev-parse HEAD)"
+          export EXPECTED_RELEASE_SHA
+          run_json="$(gh run view "$CORE_NPM_RUN_ID" --repo "$GITHUB_REPOSITORY" --json workflowName,headBranch,headSha,event,status,conclusion,url)"
+          jobs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${CORE_NPM_RUN_ID}/jobs?per_page=100")"
+          jq -n --argjson run "$run_json" --argjson jobs "$jobs_json" \
+            '{run: $run, jobs: $jobs.jobs}' |
+            node scripts/openclaw-npm-extended-stable-closeout.mjs verify-core-run
+
+      - name: Download selector baseline
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: openclaw-npm-extended-stable-baseline-${{ inputs.tag }}
+          path: extended-stable-closeout
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.core_npm_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Download frozen plugin plan
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: plugin-npm-release-plan-${{ github.sha }}
+          path: extended-stable-closeout/plugin-plan
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.plugin_npm_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Verify final npm registry state
+        id: registry_closeout
+        env:
+          BASELINE_FILE: extended-stable-closeout/extended-stable-selector-baseline.json
+          EXPECTED_RELEASE_SHA: ${{ github.sha }}
+          EXPECTED_VERSION: ${{ inputs.tag }}
+          PLUGIN_PLAN_FILE: extended-stable-closeout/plugin-plan/plugin-npm-release-plan.json
+          SNAPSHOT_FILE: extended-stable-registry-snapshot.json
+        run: node scripts/openclaw-npm-extended-stable-closeout.mjs verify-registry
+
+      - name: Summarize closeout recovery
+        if: ${{ always() }}
+        env:
+          CLOSEOUT_OUTCOME: ${{ steps.registry_closeout.outcome }}
+          EXPECTED_VERSION: ${{ inputs.tag }}
+        run: |
+          {
+            echo "## npm extended-stable closeout"
+            echo "- Registry verification: ${CLOSEOUT_OUTCOME}"
+            if [[ "$CLOSEOUT_OUTCOME" != "success" ]]; then
+              echo "- If package bytes exist and either core selector is stale, run only the applicable credential-isolated command, then rerun closeout:"
+              while IFS= read -r repair_command; do
+                echo "  - \`${repair_command}\`"
+              done < <(node scripts/openclaw-npm-extended-stable-release.mjs repair-command)
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload compact registry snapshot
+        id: registry_snapshot
+        if: ${{ steps.registry_closeout.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: extended-stable-registry-snapshot-${{ inputs.tag }}
+          path: extended-stable-registry-snapshot.json
+          if-no-files-found: error
+
+      - name: Summarize registry snapshot artifact
+        if: ${{ steps.registry_snapshot.outcome == 'success' }}
+        env:
+          ARTIFACT_DIGEST: ${{ steps.registry_snapshot.outputs.artifact-digest }}
+          ARTIFACT_NAME: extended-stable-registry-snapshot-${{ inputs.tag }}
+        run: |
+          {
+            echo "## npm extended-stable registry snapshot"
+            echo "- Artifact: \`${ARTIFACT_NAME}\`"
+            echo "- GitHub artifact digest: \`${ARTIFACT_DIGEST}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -819,7 +819,19 @@ jobs:
       - name: Capture previous extended-stable selector
         id: previous_extended_stable
         if: ${{ inputs.npm_dist_tag == 'extended-stable' }}
+        env:
+          BASELINE_FILE: extended-stable-selector-baseline.json
+          EXPECTED_RELEASE_SHA: ${{ github.sha }}
+          EXPECTED_VERSION: ${{ inputs.tag }}
         run: node scripts/openclaw-npm-extended-stable-release.mjs capture-selector
+
+      - name: Upload extended-stable selector baseline
+        if: ${{ inputs.npm_dist_tag == 'extended-stable' && steps.previous_extended_stable.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: openclaw-npm-extended-stable-baseline-${{ inputs.tag }}
+          path: ${{ steps.previous_extended_stable.outputs.baseline_file }}
+          if-no-files-found: error
 
       - name: Publish
         id: publish
@@ -872,6 +884,7 @@ jobs:
           TARBALL_SHA256: ${{ steps.preflight_provenance.outputs.tarball_sha256 }}
           SELECTOR_CAPTURE_OUTCOME: ${{ steps.previous_extended_stable.outcome }}
           PREVIOUS_EXTENDED_STABLE: ${{ steps.previous_extended_stable.outputs.previous }}
+          PREVIOUS_LATEST: ${{ steps.previous_extended_stable.outputs.latest }}
           PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
           EXACT_READBACK: ${{ steps.extended_stable_readback.outputs.exact_version }}
           SELECTOR_READBACK: ${{ steps.extended_stable_readback.outputs.extended_stable_selector }}
@@ -891,6 +904,7 @@ jobs:
             echo "- Tarball: ${TARBALL_NAME:-unavailable}"
             echo "- Tarball SHA-256: ${TARBALL_SHA256:-unavailable}"
             echo "- Previous openclaw@extended-stable: ${PREVIOUS_EXTENDED_STABLE:-unavailable}"
+            echo "- Preserved openclaw@latest baseline: ${PREVIOUS_LATEST:-unavailable}"
             echo "- npm publish outcome: ${PUBLISH_OUTCOME}"
             echo "- Exact-version readback: ${EXACT_READBACK:-unavailable}"
             echo "- Extended-stable selector readback: ${SELECTOR_READBACK:-unavailable}"
@@ -898,7 +912,9 @@ jobs:
             if [[ "$SELECTOR_CAPTURE_OUTCOME" != "success" ]]; then
               echo "- Selector capture failed; npm publish did not run and no repair is required because npm was unchanged."
             else
-              repair_command="$(EXPECTED_VERSION="$RELEASE_TAG" node scripts/openclaw-npm-extended-stable-release.mjs repair-command)"
-              echo "- Repair command: \`${repair_command}\`"
+              echo "- Repair commands (run only for selectors that are stale):"
+              while IFS= read -r repair_command; do
+                echo "  - \`${repair_command}\`"
+              done < <(EXPECTED_VERSION="$RELEASE_TAG" node scripts/openclaw-npm-extended-stable-release.mjs repair-command)
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -211,6 +211,14 @@ jobs:
           echo "Already published / skipped:"
           jq -r '.skippedPublished[]? | "- \(.packageName)@\(.version)"' .local/plugin-npm-release-plan.json
 
+      - name: Upload frozen extended-stable plugin plan
+        if: github.event_name == 'workflow_dispatch' && inputs.npm_dist_tag == 'extended-stable'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: plugin-npm-release-plan-${{ steps.ref.outputs.sha }}
+          path: .local/plugin-npm-release-plan.json
+          if-no-files-found: error
+
       - name: Validate Tideclaw alpha plugin channels
         if: startsWith(github.ref, 'refs/heads/tideclaw/alpha/')
         run: |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -140,14 +140,19 @@ gh workflow run ci.yml --ref main -f target_ref=<branch-or-sha> -f include_andro
 gh workflow run full-release-validation.yml --ref main -f ref=<branch-or-sha>
 ```
 
-The monthly npm-only extended-stable path is the exception: dispatch both `OpenClaw NPM
-Release` preflight and `Full Release Validation` from the exact
-`extended-stable/YYYY.M.33` branch, preserve their run IDs, and pass both IDs to the
-direct npm publish run. See [Monthly npm-only extended-stable
-publication](/reference/RELEASING#monthly-npm-only-extended-stable-publication) for
-the commands, exact identity requirements, registry readback, and selector
-repair procedure. This path does not dispatch plugin, macOS, Windows, GitHub
-Release, private dist-tag, or other platform publication.
+The monthly npm-only extended-stable path is the exception: dispatch `OpenClaw
+NPM Release` preflight and `Full Release Validation` from the exact
+`extended-stable/YYYY.M.33` branch, publish and verify the canonical
+`all-publishable` plugin set, then pass all three run IDs to direct OIDC core
+publication. A separate five-input, read-only closeout verifies final core and
+plugin registry state plus the preserved `latest` selector and emits the
+registry snapshot consumed by the releases evidence ledger. See [Monthly
+npm-only extended-stable
+publication](/reference/RELEASING#monthly-npm-only-extended-stable-publication)
+for the commands, exact identity requirements, closeout, and repair procedure.
+This path does not dispatch ClawHub/plugin-bootstrap, macOS, Windows, GitHub
+Release, private dist-tag, Docker, mobile, website, or other platform
+publication.
 
 ## Runners
 

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -7,16 +7,16 @@ read_when:
   - Looking for version naming and cadence
 ---
 
-OpenClaw currently exposes three user-facing update channels:
+OpenClaw exposes four user-facing update channels:
 
-- stable: the existing promoted release channel, which still resolves through npm `latest` until the separate CLI/channel milestone lands
+- stable: the existing promoted release channel, which resolves through npm `latest`
+- extended-stable: the supported trailing-month npm line; core and every npm-publishable official plugin ship at one exact version
 - beta: prerelease tags that publish to npm `beta`
 - dev: the moving head of `main`
 
-Separately, release operators can publish the trailing completed month's core
-package to npm `extended-stable`, beginning at patch `33`. The current-month
-regular final line continues on npm `latest`; this operator-side publication
-split does not by itself change CLI update-channel resolution.
+`extended-stable` is additive and npm-only, beginning at patch `33`. It does
+not rename or replace the existing `stable` channel. The current-month regular
+final line continues on npm `latest`.
 
 Tideclaw alpha builds are a separate internal prerelease track (npm dist-tag `alpha`), covered under [NPM workflow inputs](#npm-workflow-inputs) and [Release test boxes](#release-test-boxes).
 
@@ -98,10 +98,10 @@ gh workflow run plugin-npm-release.yml \
 
 The workflow uses the regular prepared `all-publishable` package inventory,
 including packages whose source did not change. It verifies every exact package
-and every plugin `extended-stable` tag before succeeding. If a partial run
-fails, rerun the same command: already-published packages are reused, missing
-or stale plugin tags are reconciled under the npm release environment, and the
-final readback still covers the complete package set.
+and every plugin `extended-stable` tag before succeeding. A retry can reuse
+immutable packages and publish missing packages. If an already-published
+plugin has a stale selector, the workflow fails closed; use the
+credential-isolated selector-repair process and repeat the complete readback.
 
 After the plugin workflow succeeds and the npm release environment is ready,
 publish the exact core preflight tarball. Core publication verifies that the
@@ -130,20 +130,44 @@ equality, referenced run and manifest identity, tarball provenance,
 environment approval, registry readback, or selector repair evidence.
 
 The publish workflow verifies the referenced preflight, validation, and plugin
-run identities, the prepared tarball digest, and the core registry selectors.
-Independently confirm the result after the workflow succeeds:
+run identities, the prepared tarball digest, and the initial core registry
+selector. Publication is followed by a separate read-only closeout. Save the
+core publish run ID, then dispatch closeout with the exact five-run contract:
 
 ```bash
-npm view openclaw@YYYY.M.P version --userconfig "$(mktemp)"
-npm view openclaw@extended-stable version --userconfig "$(mktemp)"
+gh workflow run openclaw-npm-extended-stable-closeout.yml \
+  --ref extended-stable/YYYY.M.33 \
+  -f tag=vYYYY.M.P \
+  -f preflight_run_id=<npm-preflight-run-id> \
+  -f plugin_npm_run_id=<plugin-npm-run-id> \
+  -f core_npm_run_id=<core-npm-run-id> \
+  -f full_release_validation_run_id=<full-validation-run-id>
 ```
 
-Both commands must return `YYYY.M.P`. If publish succeeds but selector
-readback fails, do not republish the immutable package version. Use the
-single `npm dist-tag add openclaw@YYYY.M.P extended-stable` repair command
-printed in the failed workflow's always-run summary, then repeat both
-independent readbacks. Rollback to the prior selector is a separate operator
-decision, not the readback repair path.
+Closeout has read-only repository and Actions permissions, no npm credential,
+no OIDC publish permission, and no release environment. It verifies the exact
+package and `extended-stable` selector for `openclaw`, `@openclaw/ai`, and
+every package in the canonical `all-publishable` plan. It also proves
+`openclaw@latest` is unchanged from the prepublication baseline and remains a
+later-month regular release. Success uploads exactly one artifact named
+`extended-stable-registry-snapshot-vYYYY.M.P`, containing
+`extended-stable-registry-snapshot.json`. Attach that artifact through the
+`openclaw/releases` `OpenClaw Release Evidence` workflow in
+`extended-stable-closeout` mode so it is stored beside the existing Full
+Release Validation evidence without replacing it.
+
+If publish succeeds but either core-owned selector is stale, do not republish
+the immutable package version. Run only the applicable credential-isolated
+repair commands printed by the workflow, then rerun the read-only closeout:
+
+```bash
+npm dist-tag add openclaw@YYYY.M.P extended-stable
+npm dist-tag add @openclaw/ai@YYYY.M.P extended-stable
+```
+
+Automated protected selector repair is deferred; these commands are an
+operator recovery path, not part of the read-only closeout. Rollback to the
+prior selector is a separate operator decision.
 
 Public support documentation initially designates Slack, Discord, and Codex as
 covered extended-stable plugin surfaces. That list is a support statement, not

--- a/scripts/openclaw-npm-extended-stable-closeout.mjs
+++ b/scripts/openclaw-npm-extended-stable-closeout.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { readFileSync, statSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { parseReleaseVersion } from "./lib/npm-publish-plan.mjs";
+
+const CORE_WORKFLOW_NAME = "OpenClaw NPM Release";
+const PUBLISH_STEP = "Publish";
+const READBACK_STEP = "Verify extended-stable registry readback";
+const MAX_SNAPSHOT_BYTES = 128 * 1024;
+const NON_FAILURE_CONCLUSIONS = new Set(["success", "skipped"]);
+
+function assertRunIdentity(run, { expectedBranch, expectedSha }, label) {
+  const expected = {
+    workflowName: CORE_WORKFLOW_NAME,
+    event: "workflow_dispatch",
+    status: "completed",
+    headBranch: expectedBranch,
+    headSha: expectedSha,
+  };
+  for (const [key, value] of Object.entries(expected)) {
+    if (run?.[key] !== value) {
+      throw new Error(
+        `Referenced ${label} run must have ${key}=${value}, got ${run?.[key] ?? "<missing>"}.`,
+      );
+    }
+  }
+}
+
+export function validateExtendedStableCoreRun({ run, jobs }, expected) {
+  assertRunIdentity(run, expected, "core");
+  if (run.conclusion === "success") {
+    return { mode: "success" };
+  }
+  if (run.conclusion !== "failure") {
+    throw new Error(
+      `Referenced core run conclusion must be success or failure, got ${run.conclusion ?? "<missing>"}.`,
+    );
+  }
+  if (!Array.isArray(jobs) || jobs.length === 0) {
+    throw new Error("Failed core run validation requires its complete job list.");
+  }
+  const publishJobs = jobs.filter((job) => job.steps?.some((step) => step.name === PUBLISH_STEP));
+  if (publishJobs.length !== 1) {
+    throw new Error("Failed core run must contain exactly one publish job.");
+  }
+  const [publishJob] = publishJobs;
+  if (publishJob.conclusion !== "failure") {
+    throw new Error("Failed core run is not the single bounded publish-job readback failure.");
+  }
+  for (const job of jobs) {
+    if (job !== publishJob && !NON_FAILURE_CONCLUSIONS.has(job.conclusion)) {
+      throw new Error(
+        `Failed core run contains an unexpected ${job.conclusion ?? "missing"} job conclusion.`,
+      );
+    }
+    if (job !== publishJob) {
+      for (const step of job.steps ?? []) {
+        if (!NON_FAILURE_CONCLUSIONS.has(step.conclusion)) {
+          throw new Error(
+            `Failed core run contains an unexpected ${step.conclusion ?? "missing"} step conclusion.`,
+          );
+        }
+      }
+    }
+  }
+  const publishSteps = publishJob.steps.filter((step) => step.name === PUBLISH_STEP);
+  const readbackSteps = publishJob.steps.filter((step) => step.name === READBACK_STEP);
+  if (publishSteps.length !== 1 || readbackSteps.length !== 1) {
+    throw new Error("Failed core run must contain exactly one publish and one readback step.");
+  }
+  const [publishStep] = publishSteps;
+  const [readbackStep] = readbackSteps;
+  if (publishStep?.conclusion !== "success" || readbackStep?.conclusion !== "failure") {
+    throw new Error(
+      "Failed core run is accepted only when publish succeeded and registry readback was the only failed step.",
+    );
+  }
+  for (const step of publishJob.steps) {
+    if (step !== readbackStep && !NON_FAILURE_CONCLUSIONS.has(step.conclusion)) {
+      throw new Error(
+        `Failed core run contains an unexpected ${step.conclusion ?? "missing"} step conclusion.`,
+      );
+    }
+  }
+  return { mode: "published-readback-failed" };
+}
+
+export function validateExtendedStablePreflightRun(
+  { run, jobs, artifacts },
+  { expectedBranch, expectedSha, expectedArtifactName },
+) {
+  assertRunIdentity(run, { expectedBranch, expectedSha }, "preflight");
+  if (run.conclusion !== "success") {
+    throw new Error(
+      `Referenced preflight run conclusion must be success, got ${run.conclusion ?? "<missing>"}.`,
+    );
+  }
+  if (!Array.isArray(jobs)) {
+    throw new Error("Referenced preflight run is missing its job list.");
+  }
+  const jobsByName = new Map(jobs.map((job) => [job.name, job]));
+  if (jobsByName.size !== jobs.length) {
+    throw new Error("Referenced preflight run contains duplicate job names.");
+  }
+  const expectedJobs = new Map([
+    ["preflight_openclaw_npm", "success"],
+    ["validate_publish_request", "skipped"],
+    ["publish_openclaw_npm", "skipped"],
+  ]);
+  if (jobsByName.size !== expectedJobs.size) {
+    throw new Error("Referenced preflight run contains an unexpected job set.");
+  }
+  for (const [name, conclusion] of expectedJobs) {
+    if (jobsByName.get(name)?.conclusion !== conclusion) {
+      throw new Error(`Referenced preflight run requires ${name}=${conclusion}.`);
+    }
+  }
+  if (!Array.isArray(artifacts)) {
+    throw new Error("Referenced preflight run is missing its artifact list.");
+  }
+  const matches = artifacts.filter((artifact) => artifact.name === expectedArtifactName);
+  if (
+    matches.length !== 1 ||
+    matches[0].expired !== false ||
+    !Number.isSafeInteger(matches[0].id) ||
+    matches[0].id < 1
+  ) {
+    throw new Error(
+      `Referenced preflight run requires one unexpired ${expectedArtifactName} artifact.`,
+    );
+  }
+  return { artifactId: matches[0].id };
+}
+
+export function validateLaterMonthLatest(latest, extendedStableVersion) {
+  const parsedLatest = parseReleaseVersion(latest);
+  const parsedExtendedStable = parseReleaseVersion(extendedStableVersion);
+  if (parsedLatest === null || parsedLatest.channel !== "stable" || parsedLatest.patch >= 33) {
+    throw new Error(
+      `openclaw@latest must be a stable final or correction with base patch below 33; got ${latest}.`,
+    );
+  }
+  if (
+    parsedExtendedStable === null ||
+    parsedExtendedStable.channel !== "stable" ||
+    parsedExtendedStable.correctionNumber !== undefined
+  ) {
+    throw new Error(
+      `Extended-stable closeout requires an exact final YYYY.M.P version; got ${extendedStableVersion}.`,
+    );
+  }
+  const latestMonth = parsedLatest.year * 12 + parsedLatest.month;
+  const extendedStableMonth = parsedExtendedStable.year * 12 + parsedExtendedStable.month;
+  if (latestMonth <= extendedStableMonth) {
+    throw new Error(
+      `openclaw@latest must be in a later calendar month than ${extendedStableVersion}; got ${latest}.`,
+    );
+  }
+  return latest;
+}
+
+function validateBaseline(baseline, { expectedVersion, expectedSha }) {
+  if (
+    baseline?.schemaVersion !== 1 ||
+    baseline.version !== expectedVersion ||
+    baseline.sourceSha !== expectedSha ||
+    typeof baseline.latest !== "string" ||
+    baseline.latest.length === 0 ||
+    typeof baseline.previousExtendedStable !== "string" ||
+    baseline.previousExtendedStable.length === 0
+  ) {
+    throw new Error(
+      "Extended-stable selector baseline does not match the release version and source SHA.",
+    );
+  }
+}
+
+function normalizePlugins(plan, expectedVersion) {
+  if (!Array.isArray(plan?.all)) {
+    throw new Error("Canonical all-publishable plugin plan is missing its all array.");
+  }
+  const plugins = plan.all.map((plugin) => {
+    if (
+      typeof plugin?.packageName !== "string" ||
+      plugin.packageName.length === 0 ||
+      plugin.version !== expectedVersion
+    ) {
+      throw new Error(
+        "Canonical all-publishable plugin plan contains an invalid package or version.",
+      );
+    }
+    return { packageName: plugin.packageName, version: plugin.version };
+  });
+  if (plugins.length === 0) {
+    throw new Error("Canonical all-publishable plugin plan must not be empty.");
+  }
+  plugins.sort((left, right) => left.packageName.localeCompare(right.packageName));
+  if (new Set(plugins.map((plugin) => plugin.packageName)).size !== plugins.length) {
+    throw new Error("Canonical all-publishable plugin plan contains duplicate package names.");
+  }
+  return plugins;
+}
+
+async function readRegistryPackage({ packageName, expectedVersion, query }) {
+  const exactResult = await query(`${packageName}@${expectedVersion}`);
+  const taggedResult = await query(`${packageName}@extended-stable`);
+  return {
+    packageName,
+    exact: exactResult.status === 0 ? exactResult.stdout.trim() : "missing",
+    extendedStable: taggedResult.status === 0 ? taggedResult.stdout.trim() : "missing",
+  };
+}
+
+export async function verifyExtendedStableCloseout({
+  expectedVersion,
+  expectedSha,
+  baseline,
+  plan,
+  query,
+  sleep,
+  attempts = 12,
+  delayMs = 10_000,
+}) {
+  validateBaseline(baseline, { expectedVersion, expectedSha });
+  validateLaterMonthLatest(baseline.latest, expectedVersion);
+  const plugins = normalizePlugins(plan, expectedVersion);
+  const packageNames = ["openclaw", "@openclaw/ai", ...plugins.map((plugin) => plugin.packageName)];
+  let lastReadback = [];
+  let latest = "missing";
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    lastReadback = [];
+    for (const packageName of packageNames) {
+      lastReadback.push(await readRegistryPackage({ packageName, expectedVersion, query }));
+    }
+    const latestResult = await query("openclaw@latest");
+    latest = latestResult.status === 0 ? latestResult.stdout.trim() : "missing";
+    const packagesMatch = lastReadback.every(
+      (item) => item.exact === expectedVersion && item.extendedStable === expectedVersion,
+    );
+    if (packagesMatch && latest === baseline.latest) {
+      const byName = new Map(lastReadback.map((item) => [item.packageName, item]));
+      return {
+        schemaVersion: 1,
+        version: expectedVersion,
+        corePackages: [byName.get("openclaw"), byName.get("@openclaw/ai")].toSorted((left, right) =>
+          left.packageName.localeCompare(right.packageName),
+        ),
+        latest,
+        plugins: plugins.map((plugin) => byName.get(plugin.packageName)),
+      };
+    }
+    if (attempt < attempts) {
+      await sleep(delayMs);
+    }
+  }
+  const mismatches = lastReadback
+    .filter((item) => item.exact !== expectedVersion || item.extendedStable !== expectedVersion)
+    .map(
+      (item) => `${item.packageName}(exact=${item.exact},extended-stable=${item.extendedStable})`,
+    )
+    .join(", ");
+  throw new Error(
+    `npm registry did not satisfy extended-stable closeout after ${attempts} attempts (packages=${mismatches || "ok"}, latest=${latest}, expected-latest=${baseline.latest}).`,
+  );
+}
+
+async function main() {
+  const command = process.argv[2];
+  if (command === "verify-core-run") {
+    const payload = JSON.parse(readFileSync(0, "utf8"));
+    const result = validateExtendedStableCoreRun(payload, {
+      expectedBranch: process.env.EXPECTED_EXTENDED_STABLE_BRANCH,
+      expectedSha: process.env.EXPECTED_RELEASE_SHA,
+    });
+    console.log(`Verified referenced core run (${result.mode}).`);
+    return;
+  }
+  if (command === "verify-preflight-run") {
+    const payload = JSON.parse(readFileSync(0, "utf8"));
+    const result = validateExtendedStablePreflightRun(payload, {
+      expectedBranch: process.env.EXPECTED_EXTENDED_STABLE_BRANCH,
+      expectedSha: process.env.EXPECTED_RELEASE_SHA,
+      expectedArtifactName: process.env.EXPECTED_PREFLIGHT_ARTIFACT,
+    });
+    console.log(`Verified referenced preflight run artifact ${result.artifactId}.`);
+    return;
+  }
+  if (command === "verify-registry") {
+    const expectedVersion = (process.env.EXPECTED_VERSION ?? "").replace(/^v/u, "");
+    const snapshot = await verifyExtendedStableCloseout({
+      expectedVersion,
+      expectedSha: process.env.EXPECTED_RELEASE_SHA ?? "",
+      baseline: JSON.parse(readFileSync(process.env.BASELINE_FILE, "utf8")),
+      plan: JSON.parse(readFileSync(process.env.PLUGIN_PLAN_FILE, "utf8")),
+      query: (target) => spawnSync("npm", ["view", target, "version"], { encoding: "utf8" }),
+      sleep: (delayMs) =>
+        new Promise((resolve) => {
+          setTimeout(resolve, delayMs);
+        }),
+    });
+    const snapshotFile = process.env.SNAPSHOT_FILE ?? "extended-stable-registry-snapshot.json";
+    writeFileSync(snapshotFile, `${JSON.stringify(snapshot, null, 2)}\n`);
+    if (statSync(snapshotFile).size > MAX_SNAPSHOT_BYTES) {
+      throw new Error(`Extended-stable registry snapshot exceeds ${MAX_SNAPSHOT_BYTES} bytes.`);
+    }
+    return;
+  }
+  throw new Error(`Unknown extended-stable closeout command: ${command ?? "<missing>"}.`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  try {
+    await main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`openclaw-npm-extended-stable-closeout: ${message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/openclaw-npm-extended-stable-release.mjs
+++ b/scripts/openclaw-npm-extended-stable-release.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execFileSync, spawnSync } from "node:child_process";
-import { appendFileSync, readFileSync } from "node:fs";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { parseReleaseVersion } from "./lib/npm-publish-plan.mjs";
 
@@ -216,7 +216,7 @@ export function validateFullReleaseValidationManifest({
   return manifest;
 }
 
-export function parsePriorExtendedStableSelector(stdout) {
+function parseDistTags(stdout) {
   let tags;
   try {
     tags = JSON.parse(stdout);
@@ -229,21 +229,43 @@ export function parsePriorExtendedStableSelector(stdout) {
   if (tags === null || typeof tags !== "object" || Array.isArray(tags)) {
     throw new Error("npm dist-tags query did not return a JSON object.");
   }
-  if (!Object.hasOwn(tags, "extended-stable")) {
-    return "absent";
-  }
-  if (typeof tags["extended-stable"] !== "string" || tags["extended-stable"].trim() === "") {
-    throw new Error("npm extended-stable dist-tag was not a non-empty version string.");
-  }
-  return tags["extended-stable"];
+  return tags;
 }
 
-export function capturePriorExtendedStableSelector({ query }) {
+export function parseExtendedStableSelectorBaseline(stdout, { version, sourceSha }) {
+  const tags = parseDistTags(stdout);
+  const previousExtendedStable = Object.hasOwn(tags, "extended-stable")
+    ? tags["extended-stable"]
+    : "absent";
+  if (typeof previousExtendedStable !== "string" || previousExtendedStable.trim() === "") {
+    throw new Error("npm extended-stable dist-tag was not a non-empty version string.");
+  }
+  const latest = tags.latest;
+  if (typeof latest !== "string" || latest.trim() === "") {
+    throw new Error("npm latest dist-tag was not a non-empty version string.");
+  }
+  const parsed = parseReleaseVersion(version);
+  if (parsed === null || parsed.channel !== "stable" || parsed.correctionNumber !== undefined) {
+    throw new Error("Extended-stable selector baseline requires an exact final YYYY.M.P version.");
+  }
+  if (!/^[0-9a-f]{40}$/iu.test(sourceSha)) {
+    throw new Error("Extended-stable selector baseline requires a full 40-character source SHA.");
+  }
+  return {
+    schemaVersion: 1,
+    version,
+    sourceSha: sourceSha.toLowerCase(),
+    previousExtendedStable,
+    latest,
+  };
+}
+
+export function capturePriorExtendedStableSelector({ query, version, sourceSha }) {
   const result = query();
   if (result.status !== 0) {
     throw new Error(`npm dist-tags query failed with exit code ${result.status ?? "unknown"}.`);
   }
-  return parsePriorExtendedStableSelector(result.stdout);
+  return parseExtendedStableSelectorBaseline(result.stdout, { version, sourceSha });
 }
 
 export async function verifyExtendedStableRegistryReadback({
@@ -280,6 +302,12 @@ export function extendedStableSelectorRepairCommand(expectedVersion) {
     throw new Error("Extended-stable selector repair requires an exact final YYYY.M.P version.");
   }
   return `npm dist-tag add openclaw@${parsed.version} extended-stable`;
+}
+
+export function extendedStableSelectorRepairCommands(expectedVersion) {
+  const coreCommand = extendedStableSelectorRepairCommand(expectedVersion);
+  const version = (expectedVersion ?? "").replace(/^v/u, "");
+  return [coreCommand, `npm dist-tag add @openclaw/ai@${version} extended-stable`];
 }
 
 function git(args) {
@@ -442,11 +470,19 @@ async function main() {
     return;
   }
   if (command === "capture-selector") {
-    const previous = capturePriorExtendedStableSelector({
+    const baseline = capturePriorExtendedStableSelector({
       query: () =>
         spawnSync("npm", ["view", "openclaw", "dist-tags", "--json"], { encoding: "utf8" }),
+      version: (process.env.EXPECTED_VERSION ?? "").replace(/^v/u, ""),
+      sourceSha: process.env.EXPECTED_RELEASE_SHA ?? "",
     });
-    appendOutput({ previous });
+    const baselineFile = process.env.BASELINE_FILE ?? "extended-stable-selector-baseline.json";
+    writeFileSync(baselineFile, `${JSON.stringify(baseline, null, 2)}\n`);
+    appendOutput({
+      previous: baseline.previousExtendedStable,
+      latest: baseline.latest,
+      baseline_file: baselineFile,
+    });
     return;
   }
   if (command === "verify-readback") {
@@ -466,7 +502,7 @@ async function main() {
     return;
   }
   if (command === "repair-command") {
-    console.log(extendedStableSelectorRepairCommand(process.env.EXPECTED_VERSION));
+    console.log(extendedStableSelectorRepairCommands(process.env.EXPECTED_VERSION).join("\n"));
     return;
   }
   throw new Error(`Unknown extended-stable npm release command: ${command ?? "<missing>"}.`);

--- a/test/scripts/openclaw-npm-extended-stable-closeout-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-closeout-workflow.test.ts
@@ -1,0 +1,143 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const workflowPath = ".github/workflows/openclaw-npm-extended-stable-closeout.yml";
+
+type Step = {
+  env?: Record<string, string>;
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string>;
+};
+type Workflow = {
+  on?: { workflow_dispatch?: { inputs?: Record<string, { required?: boolean; type?: string }> } };
+  permissions?: Record<string, string>;
+  jobs?: Record<
+    string,
+    { environment?: string; permissions?: Record<string, string>; steps?: Step[]; uses?: string }
+  >;
+};
+
+function workflow(): Workflow {
+  return parse(readFileSync(workflowPath, "utf8")) as Workflow;
+}
+
+function step(name: string): Step {
+  const found = workflow().jobs?.closeout?.steps?.find((candidate) => candidate.name === name);
+  if (!found) {
+    throw new Error(`Missing workflow step: ${name}`);
+  }
+  return found;
+}
+
+describe("npm extended-stable closeout workflow", () => {
+  it("is manual, read-only, and has the five closed inputs", () => {
+    const parsed = workflow();
+    expect(Object.keys(parsed.on?.workflow_dispatch?.inputs ?? {})).toEqual([
+      "tag",
+      "preflight_run_id",
+      "plugin_npm_run_id",
+      "core_npm_run_id",
+      "full_release_validation_run_id",
+    ]);
+    expect(
+      Object.values(parsed.on?.workflow_dispatch?.inputs ?? {}).every(
+        (input) => input.required === true && input.type === "string",
+      ),
+    ).toBe(true);
+    expect(parsed.permissions).toEqual({ actions: "read", contents: "read" });
+    expect(parsed.jobs?.closeout?.environment).toBeUndefined();
+    expect(readFileSync(workflowPath, "utf8")).not.toMatch(/id-token|NPM_TOKEN|NODE_AUTH_TOKEN/u);
+  });
+
+  it("validates the canonical branch and every exact upstream run", () => {
+    expect(step("Validate closeout input shape").run).toContain(
+      'expected_ref="refs/heads/extended-stable/${release_year}.${release_month}.33"',
+    );
+    expect(step("Require tag at canonical branch tip").run).toContain(
+      'if [[ "$release_sha" != "$branch_sha" ]]',
+    );
+    expect(step("Require tag at canonical branch tip").run).toContain(
+      'if [[ "$release_sha" != "$WORKFLOW_SHA" ]]',
+    );
+    const identity = step("Validate closeout release identity");
+    expect(identity.env).toMatchObject({
+      NPM_WORKFLOW_REF: "${{ github.ref }}",
+      RELEASE_NPM_DIST_TAG: "extended-stable",
+    });
+    expect(identity.run).toContain("validate-request");
+    expect(step("Verify preflight run").run).toContain("verify-preflight-run");
+    expect(step("Verify preflight run").run).toContain("/jobs?per_page=100");
+    expect(step("Verify preflight run").run).toContain("/artifacts?per_page=100");
+    for (const name of ["Verify plugin npm run", "Verify Full Release Validation run"]) {
+      expect(step(name).run).toContain("verify-run");
+    }
+    expect(step("Verify core npm run").run).toContain("verify-core-run");
+  });
+
+  it("consumes the frozen plugin plan and uploads the exact compact artifact contract", () => {
+    const setup = step("Setup Node environment");
+    expect(setup.with?.["install-deps"]).toBe("false");
+    const downloadPlan = step("Download frozen plugin plan");
+    expect(downloadPlan.uses).toContain("actions/download-artifact@");
+    expect(downloadPlan.with).toMatchObject({
+      name: "plugin-npm-release-plan-${{ github.sha }}",
+      "run-id": "${{ inputs.plugin_npm_run_id }}",
+    });
+    expect(readFileSync(workflowPath, "utf8")).not.toContain("plugin-npm-release-plan.ts");
+    const verify = step("Verify final npm registry state");
+    expect(verify.run).toContain("verify-registry");
+    expect(verify.env?.PLUGIN_PLAN_FILE).toBe(
+      "extended-stable-closeout/plugin-plan/plugin-npm-release-plan.json",
+    );
+    expect(verify.env?.SNAPSHOT_FILE).toBe("extended-stable-registry-snapshot.json");
+    const upload = step("Upload compact registry snapshot");
+    expect(upload.id).toBe("registry_snapshot");
+    expect(upload.with).toMatchObject({
+      name: "extended-stable-registry-snapshot-${{ inputs.tag }}",
+      path: "extended-stable-registry-snapshot.json",
+      "if-no-files-found": "error",
+    });
+    const summary = step("Summarize registry snapshot artifact");
+    expect(summary.env?.ARTIFACT_NAME).toBe("extended-stable-registry-snapshot-${{ inputs.tag }}");
+    expect(summary.env?.ARTIFACT_DIGEST).toBe(
+      "${{ steps.registry_snapshot.outputs.artifact-digest }}",
+    );
+  });
+
+  it("keeps extended-stable closeout npm-only", () => {
+    const workflows = [
+      readFileSync(".github/workflows/plugin-npm-release.yml", "utf8"),
+      readFileSync(".github/workflows/openclaw-npm-release.yml", "utf8"),
+      readFileSync(workflowPath, "utf8"),
+    ];
+    const executableSurface = workflows
+      .flatMap((raw) => {
+        const parsed = parse(raw) as Workflow;
+        return Object.values(parsed.jobs ?? {}).flatMap((job) => [
+          job.uses ?? "",
+          ...(job.steps ?? []).flatMap((candidate) => [candidate.uses ?? "", candidate.run ?? ""]),
+        ]);
+      })
+      .join("\n")
+      .toLowerCase();
+    for (const forbidden of [
+      "openclaw-release-publish.yml",
+      "plugin-clawhub-release.yml",
+      "docker-release",
+      "macos-release",
+      "sparkle-release",
+      "windows-release",
+      "website-release",
+      "android-release",
+      "ios-release",
+      "gh workflow run",
+      "softprops/action-gh-release",
+    ]) {
+      expect(executableSurface).not.toContain(forbidden);
+    }
+  });
+});

--- a/test/scripts/openclaw-npm-extended-stable-closeout.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-closeout.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  validateExtendedStableCoreRun,
+  validateExtendedStablePreflightRun,
+  validateLaterMonthLatest,
+  verifyExtendedStableCloseout,
+} from "../../scripts/openclaw-npm-extended-stable-closeout.mjs";
+
+const sha = "a".repeat(40);
+const branch = "extended-stable/2026.6.33";
+const run = {
+  workflowName: "OpenClaw NPM Release",
+  event: "workflow_dispatch",
+  status: "completed",
+  conclusion: "success",
+  headBranch: branch,
+  headSha: sha,
+};
+
+describe("extended-stable core run closeout", () => {
+  it("accepts a successful exact run", () => {
+    expect(
+      validateExtendedStableCoreRun(
+        { run, jobs: [] },
+        { expectedBranch: branch, expectedSha: sha },
+      ),
+    ).toEqual({ mode: "success" });
+  });
+
+  it("accepts only the bounded publish-success/readback-failure shape", () => {
+    const payload = {
+      run: { ...run, conclusion: "failure" },
+      jobs: [
+        { name: "validate_publish_request", conclusion: "success", steps: [] },
+        {
+          name: "publish_openclaw_npm",
+          conclusion: "failure",
+          steps: [
+            { name: "Publish", conclusion: "success" },
+            { name: "Verify extended-stable registry readback", conclusion: "failure" },
+            { name: "Summarize extended-stable npm publication", conclusion: "success" },
+          ],
+        },
+      ],
+    };
+    expect(
+      validateExtendedStableCoreRun(payload, { expectedBranch: branch, expectedSha: sha }),
+    ).toEqual({ mode: "published-readback-failed" });
+    expect(() =>
+      validateExtendedStableCoreRun(
+        {
+          ...payload,
+          jobs: [
+            {
+              conclusion: "failure",
+              steps: [
+                { name: "Publish", conclusion: "failure" },
+                { name: "Verify extended-stable registry readback", conclusion: "skipped" },
+              ],
+            },
+          ],
+        },
+        { expectedBranch: branch, expectedSha: sha },
+      ),
+    ).toThrow(/publish succeeded/u);
+  });
+
+  it.each(["cancelled", "timed_out", "action_required", "neutral"])(
+    "rejects an extra %s job conclusion",
+    (conclusion) => {
+      expect(() =>
+        validateExtendedStableCoreRun(
+          {
+            run: { ...run, conclusion: "failure" },
+            jobs: [
+              { name: "unexpected", conclusion, steps: [] },
+              {
+                name: "publish_openclaw_npm",
+                conclusion: "failure",
+                steps: [
+                  { name: "Publish", conclusion: "success" },
+                  { name: "Verify extended-stable registry readback", conclusion: "failure" },
+                ],
+              },
+            ],
+          },
+          { expectedBranch: branch, expectedSha: sha },
+        ),
+      ).toThrow(/unexpected/u);
+    },
+  );
+
+  it("rejects a second non-success step conclusion", () => {
+    expect(() =>
+      validateExtendedStableCoreRun(
+        {
+          run: { ...run, conclusion: "failure" },
+          jobs: [
+            {
+              name: "publish_openclaw_npm",
+              conclusion: "failure",
+              steps: [
+                { name: "Publish", conclusion: "success" },
+                { name: "Verify extended-stable registry readback", conclusion: "failure" },
+                { name: "Post publish", conclusion: "cancelled" },
+              ],
+            },
+          ],
+        },
+        { expectedBranch: branch, expectedSha: sha },
+      ),
+    ).toThrow(/unexpected/u);
+  });
+
+  it("rejects a non-success step hidden under another successful job", () => {
+    expect(() =>
+      validateExtendedStableCoreRun(
+        {
+          run: { ...run, conclusion: "failure" },
+          jobs: [
+            {
+              name: "validate_publish_request",
+              conclusion: "success",
+              steps: [{ name: "Validate", conclusion: "timed_out" }],
+            },
+            {
+              name: "publish_openclaw_npm",
+              conclusion: "failure",
+              steps: [
+                { name: "Publish", conclusion: "success" },
+                { name: "Verify extended-stable registry readback", conclusion: "failure" },
+              ],
+            },
+          ],
+        },
+        { expectedBranch: branch, expectedSha: sha },
+      ),
+    ).toThrow(/unexpected/u);
+  });
+});
+
+describe("extended-stable preflight run closeout", () => {
+  const payload = {
+    run,
+    jobs: [
+      { name: "preflight_openclaw_npm", conclusion: "success" },
+      { name: "validate_publish_request", conclusion: "skipped" },
+      { name: "publish_openclaw_npm", conclusion: "skipped" },
+    ],
+    artifacts: [
+      { id: 42, name: "openclaw-npm-preflight-v2026.6.33", expired: false },
+      { id: 43, name: "dependency-release-evidence-v2026.6.33", expired: false },
+    ],
+  };
+
+  it("requires a successful preflight-only job shape and exact unexpired artifact", () => {
+    expect(
+      validateExtendedStablePreflightRun(payload, {
+        expectedBranch: branch,
+        expectedSha: sha,
+        expectedArtifactName: "openclaw-npm-preflight-v2026.6.33",
+      }),
+    ).toEqual({ artifactId: 42 });
+  });
+
+  it.each([
+    [
+      "publish ran",
+      {
+        jobs: payload.jobs.map((job) =>
+          job.name === "publish_openclaw_npm" ? { ...job, conclusion: "success" } : job,
+        ),
+      },
+    ],
+    ["artifact expired", { artifacts: [{ ...payload.artifacts[0], expired: true }] }],
+    ["artifact duplicated", { artifacts: [payload.artifacts[0], payload.artifacts[0]] }],
+  ])("rejects %s", (_label, override) => {
+    expect(() =>
+      validateExtendedStablePreflightRun(
+        { ...payload, ...override },
+        {
+          expectedBranch: branch,
+          expectedSha: sha,
+          expectedArtifactName: "openclaw-npm-preflight-v2026.6.33",
+        },
+      ),
+    ).toThrow();
+  });
+
+  it.each([
+    ["wrong branch", { headBranch: "main" }],
+    ["wrong SHA", { headSha: "b".repeat(40) }],
+    ["wrong workflow", { workflowName: "Full Release Validation" }],
+  ])("rejects %s", (_label, runOverride) => {
+    expect(() =>
+      validateExtendedStablePreflightRun(
+        { ...payload, run: { ...payload.run, ...runOverride } },
+        {
+          expectedBranch: branch,
+          expectedSha: sha,
+          expectedArtifactName: "openclaw-npm-preflight-v2026.6.33",
+        },
+      ),
+    ).toThrow();
+  });
+});
+
+describe("extended-stable latest preservation", () => {
+  it.each(["2026.7.2", "2026.7.2-1", "2027.1.1"])("accepts later-month %s", (latest) => {
+    expect(validateLaterMonthLatest(latest, "2026.6.33")).toBe(latest);
+  });
+
+  it.each(["2026.6.2", "2026.7.33", "2026.7.2-beta.1"])("rejects invalid latest %s", (latest) => {
+    expect(() => validateLaterMonthLatest(latest, "2026.6.33")).toThrow();
+  });
+});
+
+describe("extended-stable registry snapshot", () => {
+  it("verifies core and canonical plugins and emits a deterministic compact snapshot", async () => {
+    const query = vi.fn(async (target: string) => ({
+      status: 0,
+      stdout: target === "openclaw@latest" ? "2026.7.2-1\n" : "2026.6.33\n",
+    }));
+    const snapshot = await verifyExtendedStableCloseout({
+      expectedVersion: "2026.6.33",
+      expectedSha: sha,
+      baseline: {
+        schemaVersion: 1,
+        version: "2026.6.33",
+        sourceSha: sha,
+        previousExtendedStable: "absent",
+        latest: "2026.7.2-1",
+      },
+      plan: {
+        all: [
+          { packageName: "@openclaw/zeta", version: "2026.6.33" },
+          { packageName: "@openclaw/alpha", version: "2026.6.33" },
+        ],
+      },
+      query,
+      sleep: vi.fn(async () => {}),
+    });
+    expect(snapshot).toEqual({
+      schemaVersion: 1,
+      version: "2026.6.33",
+      corePackages: [
+        { packageName: "@openclaw/ai", exact: "2026.6.33", extendedStable: "2026.6.33" },
+        { packageName: "openclaw", exact: "2026.6.33", extendedStable: "2026.6.33" },
+      ],
+      latest: "2026.7.2-1",
+      plugins: [
+        { packageName: "@openclaw/alpha", exact: "2026.6.33", extendedStable: "2026.6.33" },
+        { packageName: "@openclaw/zeta", exact: "2026.6.33", extendedStable: "2026.6.33" },
+      ],
+    });
+    expect(query).toHaveBeenCalledWith("@openclaw/ai@extended-stable");
+  });
+
+  it("fails closed when latest moves after baseline capture", async () => {
+    await expect(
+      verifyExtendedStableCloseout({
+        expectedVersion: "2026.6.33",
+        expectedSha: sha,
+        baseline: {
+          schemaVersion: 1,
+          version: "2026.6.33",
+          sourceSha: sha,
+          previousExtendedStable: "absent",
+          latest: "2026.7.2",
+        },
+        plan: { all: [{ packageName: "@openclaw/example", version: "2026.6.33" }] },
+        query: async (target: string) => ({
+          status: 0,
+          stdout: target === "openclaw@latest" ? "2026.7.3\n" : "2026.6.33\n",
+        }),
+        sleep: vi.fn(async () => {}),
+        attempts: 1,
+      }),
+    ).rejects.toThrow(/expected-latest=2026.7.2/u);
+  });
+
+  it("rejects an empty canonical plugin inventory", async () => {
+    await expect(
+      verifyExtendedStableCloseout({
+        expectedVersion: "2026.6.33",
+        expectedSha: sha,
+        baseline: {
+          schemaVersion: 1,
+          version: "2026.6.33",
+          sourceSha: sha,
+          previousExtendedStable: "absent",
+          latest: "2026.7.2",
+        },
+        plan: { all: [] },
+        query: vi.fn(),
+        sleep: vi.fn(),
+      }),
+    ).rejects.toThrow(/must not be empty/u);
+  });
+});

--- a/test/scripts/openclaw-npm-extended-stable-release.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-release.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it, vi } from "vitest";
 import {
   capturePriorExtendedStableSelector,
   extendedStableSelectorRepairCommand,
+  extendedStableSelectorRepairCommands,
   parseExtendedStableGuardBypass,
-  parsePriorExtendedStableSelector,
+  parseExtendedStableSelectorBaseline,
   validateFullReleaseValidationManifest,
   validateNpmPublishBoundary,
   validateExtendedStableNpmReleaseRequest,
@@ -377,18 +378,64 @@ describe("Full Validation manifest identity", () => {
 
 describe("extended-stable selector capture", () => {
   it("distinguishes bootstrap absence from an existing selector", () => {
-    expect(parsePriorExtendedStableSelector('{"latest":"2026.7.1"}')).toBe("absent");
-    expect(parsePriorExtendedStableSelector('{"extended-stable":"2026.6.33"}')).toBe("2026.6.33");
+    expect(
+      parseExtendedStableSelectorBaseline('{"latest":"2026.7.1"}', {
+        version: "2026.6.33",
+        sourceSha: sha,
+      }).previousExtendedStable,
+    ).toBe("absent");
+    expect(
+      parseExtendedStableSelectorBaseline('{"latest":"2026.7.1","extended-stable":"2026.6.33"}', {
+        version: "2026.6.33",
+        sourceSha: sha,
+      }).previousExtendedStable,
+    ).toBe("2026.6.33");
   });
 
   it.each(["not json", "null", "[]", '"2026.6.33"'])("rejects invalid result %s", (value) => {
-    expect(() => parsePriorExtendedStableSelector(value)).toThrow();
+    expect(() =>
+      parseExtendedStableSelectorBaseline(value, { version: "2026.6.33", sourceSha: sha }),
+    ).toThrow();
   });
 
   it("rejects command failure rather than treating it as bootstrap", () => {
     expect(() =>
-      capturePriorExtendedStableSelector({ query: () => ({ status: 1, stdout: "" }) }),
+      capturePriorExtendedStableSelector({
+        query: () => ({ status: 1, stdout: "" }),
+        version: "2026.6.33",
+        sourceSha: sha,
+      }),
     ).toThrow(/query failed/u);
+  });
+
+  it("captures an immutable latest and release identity baseline", () => {
+    expect(
+      parseExtendedStableSelectorBaseline('{"latest":"2026.7.2-1","extended-stable":"2026.6.33"}', {
+        version: "2026.6.33",
+        sourceSha: sha,
+      }),
+    ).toEqual({
+      schemaVersion: 1,
+      version: "2026.6.33",
+      sourceSha: sha,
+      previousExtendedStable: "2026.6.33",
+      latest: "2026.7.2-1",
+    });
+  });
+
+  it("fails baseline capture when latest or release identity is invalid", () => {
+    expect(() =>
+      parseExtendedStableSelectorBaseline('{"extended-stable":"2026.6.33"}', {
+        version: "2026.6.33",
+        sourceSha: sha,
+      }),
+    ).toThrow(/latest/u);
+    expect(() =>
+      parseExtendedStableSelectorBaseline('{"latest":"2026.7.2"}', {
+        version: "2026.6.33-1",
+        sourceSha: sha,
+      }),
+    ).toThrow(/exact final/u);
   });
 });
 
@@ -432,6 +479,13 @@ describe("extended-stable selector repair", () => {
     expect(extendedStableSelectorRepairCommand("v2026.6.33")).toBe(
       "npm dist-tag add openclaw@2026.6.33 extended-stable",
     );
+  });
+
+  it("prints credential-isolated repair commands for both core-owned packages", () => {
+    expect(extendedStableSelectorRepairCommands("v2026.6.33")).toEqual([
+      "npm dist-tag add openclaw@2026.6.33 extended-stable",
+      "npm dist-tag add @openclaw/ai@2026.6.33 extended-stable",
+    ]);
   });
 
   it.each([undefined, "absent", "2026.6.33-beta.1", "2026.6.33-1"])(

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -4,7 +4,14 @@ import { parse } from "yaml";
 
 const workflowPath = ".github/workflows/plugin-npm-release.yml";
 
-type Step = { env?: Record<string, string>; name?: string; run?: string };
+type Step = {
+  env?: Record<string, string>;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string>;
+};
 type Job = {
   environment?: string;
   if?: string;
@@ -105,5 +112,19 @@ describe("plugin npm extended-stable workflow", () => {
     expect(readback.run).toContain('npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version');
     expect(readback.run).toContain('npm view "${PACKAGE_NAME}@extended-stable" version');
     expect(readback.run).toContain("OIDC-only source workflow does not mutate tags");
+  });
+
+  it("uploads the source-bound plugin plan for read-only closeout", () => {
+    const upload = step(
+      workflow().jobs?.preview_plugins_npm,
+      "Upload frozen extended-stable plugin plan",
+    );
+    expect(upload.if).toContain("inputs.npm_dist_tag == 'extended-stable'");
+    expect(upload.uses).toContain("actions/upload-artifact@");
+    expect(upload.with).toMatchObject({
+      name: "plugin-npm-release-plan-${{ steps.ref.outputs.sha }}",
+      path: ".local/plugin-npm-release-plan.json",
+      "if-no-files-found": "error",
+    });
   });
 });


### PR DESCRIPTION
Closes #100504

## What Problem This Solves

Extended-stable publication already publishes and verifies every npm-publishable official plugin before direct OIDC core publication, but it has no safe way to freeze final registry state after publication. If package bytes publish and registry readback alone fails, rerunning the publish workflow risks colliding with an immutable npm version. The release also lacks durable proof that `latest` stayed unchanged.

## Why This Change Was Made

This adds a separate five-input closeout workflow with read-only repository and Actions permissions and no npm credential, OIDC publish permission, or release environment. It authenticates the exact preflight, plugin, Full Release Validation, and core runs; accepts only a tightly bounded publish-success/readback-only failed core run; verifies `openclaw`, `@openclaw/ai`, every canonical `all-publishable` plugin, and the preserved later-month `latest`; then uploads one deterministic compact registry snapshot.

The existing plugin-first/core-last OIDC publication path is unchanged. Candidate tags, cross-repository promotion, rollback/cleanup protocols, and all non-npm release surfaces remain out of scope. Automated selector repair remains deferred; the workflow prints both applicable credential-isolated core repair commands and can be rerun without publication authority.

## User Impact

Release operators can close out a normal extended-stable publish or recover after an ambiguous registry readback without republishing immutable bytes. Existing `stable` continues to resolve npm `latest`; `extended-stable` remains an additive npm-only channel.

## Evidence

- Focused Vitest: 6 files, 119 tests passed.
- Workflow YAML parsing and Node syntax checks passed for plugin, core, and closeout surfaces.
- [Inspectable isolated Verdaccio proof](https://gist.github.com/kevinslin/88a03a634a316eaf077a6b46424b1730) passed new `.33`, patch `.34`, stale-selector rejection, repaired `.35` convergence, and unchanged `latest`.
- Static workflow contract scans plugin, core, and closeout execution surfaces and rejects GitHub Release, Docker, desktop, website, mobile, ClawHub, and broad-orchestrator dispatch.
- Independent correctness, documentation, and dead-code reviews were completed; all accepted blocker/major findings were fixed and reverified.
- Companion evidence change: https://github.com/kevinslin/releases/pull/1. The upstream `openclaw/releases` target rejects PR creation for the available personal, work, and connected-App credentials; the fork PR is a takeover-ready review artifact for commit `cb5d832bac1568ab0865fca36300563e352fe846`.
- Local Testbox execution was unavailable because the installed Crabbox is `0.16.0` while the Blacksmith provider requires `0.22.0+`; current-head CI is the broad hosted verification gate.

## AI Assistance

- [x] AI-assisted implementation and review.
- [x] I understand the workflow, registry, and evidence changes.
