### PR TITLE
fix(agents): time out stalled Claude live turns

### DIFF
--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -3449,6 +3449,296 @@ ${JSON.stringify({
     }
   });
 
+  it("times out Claude live sessions that only emit thinking progress", async () => {
+    vi.useFakeTimers();
+    const cancel = vi.fn();
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const stdin = {
+      write: vi.fn((_dataValue: string, cb?: (err?: Error | null) => void) => {
+        stdoutListener?.(
+          `${JSON.stringify({
+            type: "system",
+            subtype: "init",
+            session_id: "live-thinking-stall",
+          })}\n`,
+        );
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-thinking-stall",
+        pid: 4401,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn((reason: string) => {
+          cancel(reason);
+        }),
+      };
+    });
+
+    const context = buildPreparedCliRunContext({
+      provider: "claude-cli",
+      model: "sonnet",
+      runId: "run-live-thinking-stall",
+      timeoutMs: 10_000,
+      backend: {
+        liveSession: "claude-stdio",
+      },
+    });
+    const run = runClaudeLiveSessionTurn({
+      context,
+      args: context.preparedBackend.backend.args ?? [],
+      env: {},
+      prompt: "think forever",
+      useResume: false,
+      noOutputTimeoutMs: 1_000,
+      getProcessSupervisor: () => ({
+        spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+          supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+        cancel: vi.fn(),
+        cancelScope: vi.fn(),
+        getRecord: vi.fn(),
+      }),
+      onAssistantDelta: () => {},
+      onThinkingDelta: () => {},
+      cleanup: async () => {},
+    });
+    const runExpectation = expectRejectsWithFields(run, {
+      name: "FailoverError",
+      message: "CLI made no assistant or tool progress for 1s and was terminated.",
+      code: "cli_semantic_progress_timeout",
+    });
+
+    await vi.waitFor(() => expect(stdin.write).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(500);
+    stdoutListener?.(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "thinking" },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "thinking_delta", thinking: "still thinking" },
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    await vi.advanceTimersByTimeAsync(500);
+
+    await runExpectation;
+    expect(cancel).toHaveBeenCalledWith("manual-cancel");
+  });
+
+  it("keeps Claude live sessions alive for buffered commentary text", async () => {
+    vi.useFakeTimers();
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const stdin = {
+      write: vi.fn((_dataValue: string, cb?: (err?: Error | null) => void) => {
+        stdoutListener?.(
+          `${JSON.stringify({
+            type: "system",
+            subtype: "init",
+            session_id: "live-commentary-text",
+          })}\n`,
+        );
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-commentary-text",
+        pid: 4402,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const context = buildPreparedCliRunContext({
+      provider: "claude-cli",
+      model: "sonnet",
+      runId: "run-live-commentary-text",
+      timeoutMs: 10_000,
+      backend: {
+        liveSession: "claude-stdio",
+      },
+    });
+    const run = runClaudeLiveSessionTurn({
+      context,
+      args: context.preparedBackend.backend.args ?? [],
+      env: {},
+      prompt: "stream commentary before answering",
+      useResume: false,
+      noOutputTimeoutMs: 1_000,
+      getProcessSupervisor: () => ({
+        spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+          supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+        cancel: vi.fn(),
+        cancelScope: vi.fn(),
+        getRecord: vi.fn(),
+      }),
+      onAssistantDelta: () => {},
+      onCommentaryText: () => {},
+      cleanup: async () => {},
+    });
+
+    await vi.waitFor(() => expect(stdin.write).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(500);
+    stdoutListener?.(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "still working" },
+          },
+        }),
+      ].join("\n") + "\n",
+    );
+    await vi.advanceTimersByTimeAsync(600);
+    stdoutListener?.(
+      [
+        JSON.stringify({
+          type: "result",
+          session_id: "live-commentary-text",
+          result: "done",
+        }),
+      ].join("\n") + "\n",
+    );
+
+    await expect(run).resolves.toMatchObject({ output: { text: "done" } });
+  });
+
+  it("keeps Claude live sessions alive while tool input is streaming", async () => {
+    vi.useFakeTimers();
+    let stdoutListener: ((chunk: string) => void) | undefined;
+    const stdin = {
+      write: vi.fn((_dataValue: string, cb?: (err?: Error | null) => void) => {
+        stdoutListener?.(
+          [
+            JSON.stringify({
+              type: "system",
+              subtype: "init",
+              session_id: "live-tool-input",
+            }),
+            JSON.stringify({
+              type: "stream_event",
+              event: {
+                type: "content_block_start",
+                index: 0,
+                content_block: {
+                  type: "tool_use",
+                  id: "tool-stream-1",
+                  name: "Bash",
+                },
+              },
+            }),
+          ].join("\n") + "\n",
+        );
+        cb?.();
+      }),
+      end: vi.fn(),
+    };
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { onStdout?: (chunk: string) => void };
+      stdoutListener = input.onStdout;
+      return {
+        runId: "live-tool-input",
+        pid: 4403,
+        startedAtMs: Date.now(),
+        stdin,
+        wait: vi.fn(() => new Promise(() => {})),
+        cancel: vi.fn(),
+      };
+    });
+
+    const context = buildPreparedCliRunContext({
+      provider: "claude-cli",
+      model: "sonnet",
+      runId: "run-live-tool-input",
+      timeoutMs: 10_000,
+      backend: {
+        liveSession: "claude-stdio",
+      },
+    });
+    const run = runClaudeLiveSessionTurn({
+      context,
+      args: context.preparedBackend.backend.args ?? [],
+      env: {},
+      prompt: "stream a tool call",
+      useResume: false,
+      noOutputTimeoutMs: 1_000,
+      getProcessSupervisor: () => ({
+        spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+          supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+        cancel: vi.fn(),
+        cancelScope: vi.fn(),
+        getRecord: vi.fn(),
+      }),
+      onAssistantDelta: () => {},
+      onToolUseStart: () => {},
+      cleanup: async () => {},
+    });
+
+    await vi.waitFor(() => expect(stdin.write).toHaveBeenCalledOnce());
+    await vi.advanceTimersByTimeAsync(500);
+    stdoutListener?.(
+      `${JSON.stringify({
+        type: "stream_event",
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '{"command":' },
+        },
+      })}\n`,
+    );
+    await vi.advanceTimersByTimeAsync(600);
+    stdoutListener?.(
+      [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "input_json_delta", partial_json: '"pwd"}' },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_stop",
+            index: 0,
+          },
+        }),
+        JSON.stringify({
+          type: "result",
+          session_id: "live-tool-input",
+          result: "done",
+        }),
+      ].join("\n") + "\n",
+    );
+
+    await expect(run).resolves.toMatchObject({ output: { text: "done" } });
+  });
+
   it("restarts Claude live sessions when selected skills change", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-skills-"));
     const weatherDir = path.join(workspaceDir, "skills", "weather");

--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -58,6 +58,7 @@ type ClaudeLiveTurn = {
   rawChars: number;
   sessionId?: string;
   noOutputTimer: NodeJS.Timeout | null;
+  semanticProgressTimer: NodeJS.Timeout | null;
   timeoutTimer: NodeJS.Timeout | null;
   activeToolTimer: NodeJS.Timeout | null;
   activeTools: Map<string, ClaudeLiveActiveTool>;
@@ -365,6 +366,10 @@ function clearTurnTimers(turn: ClaudeLiveTurn): void {
     clearTimeout(turn.noOutputTimer);
     turn.noOutputTimer = null;
   }
+  if (turn.semanticProgressTimer) {
+    clearTimeout(turn.semanticProgressTimer);
+    turn.semanticProgressTimer = null;
+  }
   if (turn.timeoutTimer) {
     clearTimeout(turn.timeoutTimer);
     turn.timeoutTimer = null;
@@ -598,6 +603,66 @@ function stopClaudeLiveActiveToolHeartbeatIfIdle(turn: ClaudeLiveTurn): void {
   turn.activeToolTimer = null;
 }
 
+function isClaudeLiveToolUseBlockType(type: unknown): boolean {
+  return type === "tool_use" || type === "server_tool_use" || type === "mcp_tool_use";
+}
+
+function isClaudeLiveAssistantToolResultBlockType(type: unknown): boolean {
+  return typeof type === "string" && type.endsWith("_tool_result") && type !== "tool_result";
+}
+
+function hasClaudeLiveTextBlock(content: unknown): boolean {
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some(
+    (block) =>
+      isRecord(block) &&
+      block.type === "text" &&
+      typeof block.text === "string" &&
+      block.text.length > 0,
+  );
+}
+
+function hasClaudeLiveToolUseOrResultBlock(content: unknown): boolean {
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some(
+    (block) =>
+      isRecord(block) &&
+      (isClaudeLiveToolUseBlockType(block.type) ||
+        isClaudeLiveAssistantToolResultBlockType(block.type) ||
+        block.type === "tool_result"),
+  );
+}
+
+function isClaudeLiveSemanticProgressEvent(parsed: Record<string, unknown>): boolean {
+  if (parsed.type === "stream_event" && isRecord(parsed.event)) {
+    const event = parsed.event;
+    if (event.type === "content_block_start" && isRecord(event.content_block)) {
+      return isClaudeLiveToolUseBlockType(event.content_block.type);
+    }
+    if (event.type !== "content_block_delta" || !isRecord(event.delta)) {
+      return false;
+    }
+    const delta = event.delta;
+    if (delta.type === "text_delta") {
+      return typeof delta.text === "string" && delta.text.length > 0;
+    }
+    return (
+      delta.type === "input_json_delta" &&
+      typeof delta.partial_json === "string" &&
+      delta.partial_json.length > 0
+    );
+  }
+  if ((parsed.type === "assistant" || parsed.type === "user") && isRecord(parsed.message)) {
+    const content = parsed.message.content;
+    return hasClaudeLiveTextBlock(content) || hasClaudeLiveToolUseOrResultBlock(content);
+  }
+  return false;
+}
+
 function markClaudeLiveToolStarted(turn: ClaudeLiveTurn, tool: ClaudeLiveToolUse): void {
   const now = Date.now();
   turn.activeTools.set(tool.toolCallId, {
@@ -705,6 +770,39 @@ function resetNoOutputTimer(session: ClaudeLiveSession): void {
       ),
     );
   }, session.noOutputTimeoutMs);
+}
+
+function armSemanticProgressTimer(params: {
+  session: ClaudeLiveSession;
+  turn: ClaudeLiveTurn | null;
+  timeoutMs: number;
+}): void {
+  const { session, turn, timeoutMs } = params;
+  if (!turn) {
+    return;
+  }
+  if (turn.semanticProgressTimer) {
+    clearTimeout(turn.semanticProgressTimer);
+  }
+  turn.semanticProgressTimer = setTimeout(() => {
+    closeLiveSession(
+      session,
+      "abort",
+      createTimeoutError(
+        session,
+        `CLI made no assistant or tool progress for ${Math.round(timeoutMs / 1000)}s and was terminated.`,
+        "cli_semantic_progress_timeout",
+      ),
+    );
+  }, timeoutMs);
+}
+
+function resetSemanticProgressTimer(session: ClaudeLiveSession): void {
+  armSemanticProgressTimer({
+    session,
+    turn: session.currentTurn,
+    timeoutMs: session.noOutputTimeoutMs,
+  });
 }
 
 function parseSessionId(parsed: Record<string, unknown>): string | undefined {
@@ -868,6 +966,9 @@ function handleClaudeLiveLine(session: ClaudeLiveSession, line: string): void {
     return;
   }
   turn.rawLines.push(trimmed);
+  if (isClaudeLiveSemanticProgressEvent(parsed)) {
+    resetSemanticProgressTimer(session);
+  }
   turn.streamingParser.push(`${trimmed}\n`);
   turn.sessionId = parseSessionId(parsed) ?? turn.sessionId;
   noteClaudeLiveProgress(turn, parsed);
@@ -1121,6 +1222,7 @@ function createTurn(params: {
     rawLines: [],
     rawChars: 0,
     noOutputTimer: null,
+    semanticProgressTimer: null,
     timeoutTimer: null,
     activeToolTimer: null,
     activeTools: new Map(),
@@ -1128,12 +1230,26 @@ function createTurn(params: {
     streamingParser: createCliJsonlStreamingParser({
       backend: params.context.preparedBackend.backend,
       providerId: params.context.backendResolved.id,
-      onAssistantDelta: params.onAssistantDelta,
+      onAssistantDelta: (delta) => {
+        resetSemanticProgressTimer(params.session);
+        params.onAssistantDelta(delta);
+      },
       onThinkingDelta: params.onThinkingDelta,
       onThinkingProgress: params.onThinkingProgress,
-      onToolUseStart: params.onToolUseStart,
-      onToolResult: params.onToolResult,
-      onCommentaryText: params.onCommentaryText,
+      onToolUseStart: (delta) => {
+        resetSemanticProgressTimer(params.session);
+        params.onToolUseStart?.(delta);
+      },
+      onToolResult: (delta) => {
+        resetSemanticProgressTimer(params.session);
+        params.onToolResult?.(delta);
+      },
+      onCommentaryText: params.onCommentaryText
+        ? (text) => {
+            resetSemanticProgressTimer(params.session);
+            params.onCommentaryText?.(text);
+          }
+        : undefined,
     }),
     execPermission: params.execPermission,
     resolve: params.resolve,
@@ -1150,6 +1266,11 @@ function createTurn(params: {
       ),
     );
   }, params.noOutputTimeoutMs);
+  armSemanticProgressTimer({
+    session: params.session,
+    turn,
+    timeoutMs: params.noOutputTimeoutMs,
+  });
   turn.timeoutTimer = setTimeout(() => {
     closeLiveSession(
       params.session,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Claude CLI-backed agent turns could keep emitting thinking/progress output until the overall 600s turn budget expired, causing users to see `CLI subprocess: timed out after 600s` instead of failing earlier as a stalled turn.

## Why This Change Was Made

Claude live sessions now track semantic progress separately from raw subprocess output. Assistant text, commentary text, tool-call starts, streamed tool input, and tool results keep the turn alive; thinking-only output no longer prevents the live-session watchdog from terminating a wedged turn before the hard overall budget.

## User Impact

Users get faster recovery from stuck Claude CLI turns. Legitimate streamed assistant text and tool-call construction continue to work, while thinking-only stalls now fail with a more specific timeout that can participate in the normal failover path.

## Evidence

- `node_modules/.bin/oxfmt --write --threads=1 src/agents/cli-runner/claude-live-session.ts src/agents/cli-runner.spawn.test.ts`
- `git diff --check`
- `node scripts/run-vitest.mjs src/agents/cli-runner.spawn.test.ts` -> 69 tests passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
- Crabbox/Testbox best-effort: warmed `blacksmith-testbox` lease `tbx_01kwtdjejc7k5v1qy94h55t5c2`, but focused remote test was blocked because synced Testbox checkout had no `node_modules`; per relaunch instructions this did not block opening the PR.

AI-assisted: yes.
