### PR TITLE
fix(ios): keep While Using selected after approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **iOS location permissions:** keep the first While Using selection pending through the system prompt so approval no longer snaps the setting back to Off.
 - **Source build portability:** keep tsdown configuration self-contained so builds do not depend on resolving the tsdown package from unrun's temporary module directory.
 - **Gateway event dispatch:** catch and log lazy subscriber setup and handler failures instead of leaking unhandled promise rejections. (#100401) Thanks @cxbAsDev.
 - **Diffs rendering:** render viewer and image output from one SSR preload, preserve language-pack highlighting through hydration, normalize language hints case-insensitively, skip identical before/after inputs with an explicit `changed` result, report truthful file-render and input errors, cache hash-pinned viewer runtimes, and prefer canonical file settings over stale aliases. (#100487)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **iOS location permissions:** keep the first While Using selection pending through the system prompt so approval no longer snaps the setting back to Off.
 - **Source build portability:** keep tsdown configuration self-contained so builds do not depend on resolving the tsdown package from unrun's temporary module directory.
 - **Gateway event dispatch:** catch and log lazy subscriber setup and handler failures instead of leaking unhandled promise rejections. (#100401) Thanks @cxbAsDev.
 - **Diffs rendering:** render viewer and image output from one SSR preload, preserve language-pack highlighting through hydration, normalize language hints case-insensitively, skip identical before/after inputs with an explicit `changed` result, report truthful file-render and input errors, cache hash-pinned viewer runtimes, and prefer canonical file settings over stale aliases. (#100487)

--- a/apps/ios/Sources/Location/LocationService.swift
+++ b/apps/ios/Sources/Location/LocationService.swift
@@ -12,6 +12,7 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
 
     private let manager = CLLocationManager()
     private var authWaitID: UUID?
+    private var authWaitRequiresDeterminedStatus = false
     private var authContinuation: CheckedContinuation<CLAuthorizationStatus, Never>?
     private var locationContinuation: CheckedContinuation<CLLocation, Swift.Error>?
     private var authorizationChangeHandler: (@MainActor @Sendable (CLAuthorizationStatus) -> Void)?
@@ -37,16 +38,18 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
 
         let status = self.manager.authorizationStatus
         if status == .notDetermined {
-            self.manager.requestWhenInUseAuthorization()
-            let updated = await self.awaitAuthorizationChange()
+            let updated = await self.requestAuthorization(requiresDeterminedStatus: true) {
+                self.manager.requestWhenInUseAuthorization()
+            }
             if mode != .always { return updated }
         }
 
         if mode == .always {
             let current = self.manager.authorizationStatus
             if current == .authorizedWhenInUse {
-                self.manager.requestAlwaysAuthorization()
-                return await self.awaitAuthorizationChange()
+                return await self.requestAuthorization(requiresDeterminedStatus: false) {
+                    self.manager.requestAlwaysAuthorization()
+                }
             }
             return current
         }
@@ -72,11 +75,17 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
             })
     }
 
-    private func awaitAuthorizationChange() async -> CLAuthorizationStatus {
+    private func requestAuthorization(
+        requiresDeterminedStatus: Bool,
+        request: () -> Void) async -> CLAuthorizationStatus
+    {
         await withCheckedContinuation { cont in
             let waitID = UUID()
             self.authWaitID = waitID
+            self.authWaitRequiresDeterminedStatus = requiresDeterminedStatus
             self.authContinuation = cont
+            // Install the waiter before requesting permission so a fast delegate callback cannot be lost.
+            request()
             Task { @MainActor in
                 let clock = ContinuousClock()
                 let noPromptDeadline = clock.now.advanced(by: .milliseconds(1500))
@@ -91,15 +100,32 @@ final class LocationService: NSObject, CLLocationManagerDelegate, LocationServic
                         continue
                     }
                     guard observedPrompt || clock.now >= noPromptDeadline else { continue }
-                    self.finishAuthorizationWait(waitID: waitID, status: self.manager.authorizationStatus)
+                    let status = self.manager.authorizationStatus
+                    guard Self.shouldCompleteAuthorizationWait(
+                        status: status,
+                        requiresDeterminedStatus: requiresDeterminedStatus)
+                    else { continue }
+                    self.finishAuthorizationWait(waitID: waitID, status: status)
                 }
             }
         }
     }
 
+    nonisolated static func shouldCompleteAuthorizationWait(
+        status: CLAuthorizationStatus,
+        requiresDeterminedStatus: Bool) -> Bool
+    {
+        !requiresDeterminedStatus || status != .notDetermined
+    }
+
     private func finishAuthorizationWait(waitID: UUID, status: CLAuthorizationStatus) {
         guard self.authWaitID == waitID, let cont = self.authContinuation else { return }
+        guard Self.shouldCompleteAuthorizationWait(
+            status: status,
+            requiresDeterminedStatus: self.authWaitRequiresDeterminedStatus)
+        else { return }
         self.authWaitID = nil
+        self.authWaitRequiresDeterminedStatus = false
         self.authContinuation = nil
         cont.resume(returning: status)
     }

--- a/apps/ios/Tests/LocationPermissionSummaryTests.swift
+++ b/apps/ios/Tests/LocationPermissionSummaryTests.swift
@@ -88,6 +88,21 @@ import Testing
         #expect(summary.detailText == "Location Services are off in iOS Settings.")
     }
 
+    @Test func `initial authorization wait ignores undetermined callbacks`() {
+        #expect(!LocationService.shouldCompleteAuthorizationWait(
+            status: .notDetermined,
+            requiresDeterminedStatus: true))
+        #expect(LocationService.shouldCompleteAuthorizationWait(
+            status: .authorizedWhenInUse,
+            requiresDeterminedStatus: true))
+        #expect(LocationService.shouldCompleteAuthorizationWait(
+            status: .denied,
+            requiresDeterminedStatus: true))
+        #expect(LocationService.shouldCompleteAuthorizationWait(
+            status: .notDetermined,
+            requiresDeterminedStatus: false))
+    }
+
     @MainActor @Test func `off mode stops significant location monitoring`() async {
         let locationService = MockLocationService(authorizationStatus: .authorizedAlways)
         let appModel = NodeAppModel(locationService: locationService)

--- a/apps/ios/UITests/OpenClawSnapshotUITests.swift
+++ b/apps/ios/UITests/OpenClawSnapshotUITests.swift
@@ -127,6 +127,59 @@ final class OpenClawSnapshotUITests: XCTestCase {
         self.attachScreenshot(named: "location-always-granted-after-slow-prompt")
     }
 
+    func testLocationWhileUsingStaysSelectedAfterSlowSystemPermissionResponse() throws {
+        XCUIApplication().resetAuthorizationStatus(for: .location)
+        self.launchApp(for: ScreenshotTarget(
+            initialTab: "settings",
+            initialDestination: "settings",
+            name: "location-while-using-slow-prompt"))
+
+        let permissions = try XCTUnwrap(
+            self.app?.buttons.containing(.staticText, identifier: "Permissions").firstMatch)
+        XCTAssertTrue(permissions.waitForExistence(timeout: 8))
+        permissions.tap()
+
+        let offMode = try XCTUnwrap(self.app?.buttons["Off"])
+        if !offMode.isSelected {
+            offMode.tap()
+            XCTAssertTrue(offMode.isSelected)
+        }
+        let whileUsingMode = try XCTUnwrap(self.app?.buttons["While Using"])
+        XCTAssertTrue(whileUsingMode.waitForExistence(timeout: 5))
+        whileUsingMode.tap()
+
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        let prompt = springboard.alerts.firstMatch
+        XCTAssertTrue(prompt.waitForExistence(timeout: 5))
+        Thread.sleep(forTimeInterval: 3)
+        XCTAssertTrue(prompt.exists)
+        XCTAssertTrue(whileUsingMode.isSelected)
+        XCTAssertTrue(self.app?.staticTexts["Requesting iOS location permission…"].exists == true)
+
+        let allow = prompt.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] 'While Using'")).firstMatch
+        XCTAssertTrue(allow.exists)
+        allow.tap()
+
+        self.app?.activate()
+        XCTAssertTrue(whileUsingMode.waitForExistence(timeout: 5))
+        XCTAssertTrue(whileUsingMode.isSelected)
+        XCTAssertFalse(self.app?.staticTexts["Requesting iOS location permission…"].exists == true)
+        let foregroundAllowed = try XCTUnwrap(self.app?.staticTexts.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "Foreground location requests")).firstMatch)
+        XCTAssertTrue(foregroundAllowed.waitForExistence(timeout: 5))
+
+        self.launchApp(for: ScreenshotTarget(
+            initialTab: "settings",
+            initialDestination: "settings",
+            name: "location-while-using-relaunch"))
+        let relaunchedPermissions = try XCTUnwrap(
+            self.app?.buttons.containing(.staticText, identifier: "Permissions").firstMatch)
+        XCTAssertTrue(relaunchedPermissions.waitForExistence(timeout: 8))
+        relaunchedPermissions.tap()
+        XCTAssertTrue(self.app?.buttons["While Using"].isSelected == true)
+    }
+
     func testSettingsBackReturnsToOriginatingPhoneTab() throws {
         try XCTSkipIf(UIDevice.current.userInterfaceIdiom != .phone, "Phone settings navigation only")
 


### PR DESCRIPTION
Regression from #99247.

## What Problem This Solves

Fixes an issue where users selecting Location → While Using on iOS would approve the system location prompt, but the OpenClaw setting would snap back to Off while the prompt was still resolving.

## Why This Change Was Made

The initial Core Location request now installs its waiter before showing the system prompt and refuses to complete while authorization remains `.notDetermined`. The existing bounded fallback remains for the separate Always-upgrade flow, where iOS can legitimately suppress a second prompt.

## User Impact

After approving the first While Using prompt, the setting remains selected immediately and after relaunch instead of reverting to Off.

## Evidence

- Added a unit regression test for pending `.notDetermined` callbacks.
- Added an iOS UI regression test that holds the system alert open for three seconds, approves While Using, and verifies the selection immediately and after relaunch.
- `xcodebuild build-for-testing -project apps/ios/OpenClaw.xcodeproj -scheme OpenClawUITests -destination 'platform=iOS Simulator,id=10B67EA9-8307-421B-8E49-C2778B3BB9E0' -derivedDataPath /tmp/openclaw-ios-location-derived-local -disableAutomaticPackageResolution` — passed; app and UI test targets compile.
- `pnpm check:changed` on Blacksmith Testbox `tbx_01kwtbye96qq4x8g11tyt37v98` — passed.
- Fresh local autoreview — clean.
- Live XCTest execution was attempted on three simulators, but this host's Xcode runner never materialized its install/launch workers; the test build itself succeeds.
