### PR TITLE
fix(slack): avoid repeated thread root media

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1599,6 +1599,7 @@ When a Slack message with file attachments arrives:
 When a message arrives in a thread (has a `thread_ts` parent):
 
 - If the reply itself has no direct media and the included root message has files, Slack can hydrate the root files as thread-starter context.
+- Root files are hydrated only while seeding a new or reset thread session. Later text-only replies reuse the existing session context and do not reattach root files as fresh media.
 - Direct reply attachments take precedence over root-message attachments.
 - A root message that has only files and no text is represented with an attachment placeholder so the fallback can still include its files.
 

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -2,8 +2,9 @@
 import type { App } from "@slack/bolt";
 import { resolveEnvelopeFormatOptions } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { SlackMessageEvent } from "../../types.js";
+import * as mediaModule from "../media.js";
 import { resolveSlackThreadContextData } from "./prepare-thread-context.js";
 import {
   createInboundSlackTestContext,
@@ -20,6 +21,10 @@ describe("resolveSlackThreadContextData", () => {
 
   afterAll(() => {
     storeFixture.cleanup();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   function createThreadContext(params: { replies: unknown }) {
@@ -47,9 +52,16 @@ describe("resolveSlackThreadContextData", () => {
 
   async function resolveAllowlistedThreadContext(params: {
     repliesMessages: Array<Record<string, string>>;
-    threadStarter: { text: string; userId?: string; ts?: string; botId?: string };
+    threadStarter: {
+      text: string;
+      userId?: string;
+      ts?: string;
+      botId?: string;
+      files?: NonNullable<SlackMessageEvent["files"]>;
+    };
     allowFromLower: string[];
     allowNameMatching: boolean;
+    sessionState?: "missing" | "fresh";
   }) {
     const { storePath } = storeFixture.makeTmpStorePath();
     const replies = vi.fn().mockResolvedValue({
@@ -57,6 +69,14 @@ describe("resolveSlackThreadContextData", () => {
       response_metadata: { next_cursor: "" },
     });
     const ctx = createThreadContext({ replies });
+    if (params.sessionState) {
+      ctx.channelRuntime = {
+        ...ctx.channelRuntime!,
+        session: {
+          resolveEntryResetFreshness: () => ({ state: params.sessionState }),
+        },
+      };
+    }
     ctx.botUserId = "U_BOT";
     ctx.botId = "B1";
     ctx.resolveUserName = async (id: string) => ({
@@ -82,6 +102,49 @@ describe("resolveSlackThreadContextData", () => {
 
     return { replies, result };
   }
+
+  const starterFiles = [
+    {
+      id: "FROOT",
+      name: "root.png",
+      mimetype: "image/png",
+      url_private: "https://files.slack.com/root.png",
+    },
+  ];
+  const starterMedia = [
+    {
+      path: "/tmp/root.png",
+      contentType: "image/png",
+      placeholder: "[Slack file: root.png (fileId: FROOT)]",
+    },
+  ];
+
+  it.each([
+    {
+      title: "hydrates starter media for a new thread session",
+      sessionState: "missing" as const,
+      hydrates: true,
+    },
+    {
+      title: "does not hydrate starter media for an existing thread session",
+      sessionState: "fresh" as const,
+      hydrates: false,
+    },
+  ])("$title", async ({ sessionState, hydrates }) => {
+    const resolveSlackMedia = vi
+      .spyOn(mediaModule, "resolveSlackMedia")
+      .mockResolvedValue(starterMedia);
+    const { result } = await resolveAllowlistedThreadContext({
+      repliesMessages: [],
+      threadStarter: { text: "starter with image", userId: "U1", files: starterFiles },
+      allowFromLower: ["u1"],
+      allowNameMatching: false,
+      sessionState,
+    });
+
+    expect(result.threadStarterMedia).toEqual(hydrates ? starterMedia : null);
+    expect(resolveSlackMedia).toHaveBeenCalledTimes(hydrates ? 1 : 0);
+  });
 
   it("omits non-allowlisted starter, follow-ups, and unrelated current-bot replies", async () => {
     const { replies, result } = await resolveAllowlistedThreadContext({

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -61,7 +61,7 @@ describe("resolveSlackThreadContextData", () => {
     };
     allowFromLower: string[];
     allowNameMatching: boolean;
-    sessionState?: "missing" | "fresh";
+    sessionState?: "missing" | "fresh" | "stale";
   }) {
     const { storePath } = storeFixture.makeTmpStorePath();
     const replies = vi.fn().mockResolvedValue({
@@ -129,6 +129,11 @@ describe("resolveSlackThreadContextData", () => {
       title: "does not hydrate starter media for an existing thread session",
       sessionState: "fresh" as const,
       hydrates: false,
+    },
+    {
+      title: "hydrates starter media after a thread session reset",
+      sessionState: "stale" as const,
+      hydrates: true,
     },
   ])("$title", async ({ sessionState, hydrates }) => {
     const resolveSlackMedia = vi

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -226,7 +226,14 @@ export async function resolveSlackThreadContextData(params: {
     threadStarterBody = starter.text;
     const snippet = starter.text.replace(/\s+/g, " ").slice(0, 80);
     threadLabel = `Slack thread ${params.roomLabel}${snippet ? `: ${snippet}` : ""}`;
-    if (!params.effectiveDirectMedia && starter.files && starter.files.length > 0) {
+    // Root media seeds a new thread session once. Rehydrating it later makes
+    // old files look like current-turn uploads and repeats media processing.
+    if (
+      shouldSeedInitialThreadContext &&
+      !params.effectiveDirectMedia &&
+      starter.files &&
+      starter.files.length > 0
+    ) {
       const { resolveSlackMedia } = await loadSlackMediaModule();
       threadStarterMedia = await resolveSlackMedia({
         files: starter.files,


### PR DESCRIPTION
Closes #99886

## What Problem This Solves

Slack thread starter files were hydrated as current-turn media on every text-only reply. The same root attachment was downloaded into a fresh media path each turn, making old files appear newly uploaded and repeatedly consuming media/vision processing.

## Why This Change Was Made

Thread starter media now follows the same session-freshness boundary as starter text and bounded thread history. OpenClaw hydrates root files only when seeding a missing or reset thread session; a fresh existing session keeps its transcript and does not receive the root files again.

This preserves the documented workflow where the first reply can ask the agent to inspect a file-only thread root, while avoiding the broader behavior removal proposed by the older closed PR #60353. Direct media attached to the current reply still takes precedence.

## User Impact

Later text-only Slack replies no longer present an old thread-root attachment as fresh media. New and reset thread sessions still receive root attachment context once.

## Evidence

- `pnpm test extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts`: 13 tests passed, including missing, fresh, and stale/reset sessions.
- `pnpm test extensions/slack/src/monitor/message-handler/prepare.test.ts`: 112 tests passed.
- Testbox changed gate `tbx_01kwtewdyyavjs0h8dj16c5fdp`: extension production/test typechecks, changed-file lint, runtime import cycles, and policy guards passed before the final test-only coverage commit.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/28761118337
- Fresh Codex autoreviews: branch clean at 0.86 confidence; final test-only addition clean at 0.93 confidence.
- `git diff --check`: passed.

The Slack channel docs now state the one-shot thread-session inheritance boundary.
