### PR TITLE
test(macos): deflake browser proxy gate tests via injectable browser control

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -9,6 +9,9 @@ actor MacNodeRuntime {
     private let cameraCapture = CameraCaptureService()
     private let makeMainActorServices: () async -> any MacNodeRuntimeMainActorServices
     private let browserProxyRequest: @Sendable (String?) async throws -> String
+    // Injectable so tests can pin the gate instead of racing on process-global
+    // OPENCLAW_CONFIG_PATH; config parsing is covered by OpenClawConfigFileTests.
+    private let browserControlEnabled: @Sendable () -> Bool
     private let canvasSurfaceUrl: @Sendable () async -> String?
     private let refreshCanvasSurfaceUrl: @Sendable () async -> String?
     private var cachedMainActorServices: (any MacNodeRuntimeMainActorServices)?
@@ -22,6 +25,9 @@ actor MacNodeRuntime {
         browserProxyRequest: @escaping @Sendable (String?) async throws -> String = { paramsJSON in
             try await MacNodeBrowserProxy.shared.request(paramsJSON: paramsJSON)
         },
+        browserControlEnabled: @escaping @Sendable () -> Bool = {
+            OpenClawConfigFile.browserControlEnabled()
+        },
         canvasSurfaceUrl: @escaping @Sendable () async -> String? = {
             await GatewayConnection.shared.canvasPluginSurfaceUrl()
         },
@@ -29,6 +35,7 @@ actor MacNodeRuntime {
     {
         self.makeMainActorServices = makeMainActorServices
         self.browserProxyRequest = browserProxyRequest
+        self.browserControlEnabled = browserControlEnabled
         self.canvasSurfaceUrl = canvasSurfaceUrl
         self.refreshCanvasSurfaceUrl = refreshCanvasSurfaceUrl
     }
@@ -185,7 +192,7 @@ actor MacNodeRuntime {
     }
 
     private func handleBrowserProxyInvoke(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {
-        guard OpenClawConfigFile.browserControlEnabled() else {
+        guard self.browserControlEnabled() else {
             return BridgeInvokeResponse(
                 id: req.id,
                 ok: false,

--- a/apps/macos/Tests/OpenClawIPCTests/LogLocatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LogLocatorTests.swift
@@ -1,21 +1,19 @@
-import Darwin
 import Foundation
 import Testing
 @testable import OpenClaw
 
 struct LogLocatorTests {
-    @Test func `launchd gateway log path ensures tmp dir exists`() {
+    @Test func `launchd gateway log path ensures tmp dir exists`() async {
         let fm = FileManager()
         let baseDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
         let logDir = baseDir.appendingPathComponent("openclaw-tests-\(UUID().uuidString)")
+        defer { try? fm.removeItem(at: logDir) }
 
-        setenv("OPENCLAW_LOG_DIR", logDir.path, 1)
-        defer {
-            unsetenv("OPENCLAW_LOG_DIR")
-            try? fm.removeItem(at: logDir)
+        // Env mutation must hold TestIsolationLock; raw setenv races parallel
+        // tests scanning environ (e.g. OPENCLAW_CONFIG_PATH readers).
+        await TestIsolation.withEnvValues(["OPENCLAW_LOG_DIR": logDir.path]) {
+            _ = LogLocator.launchdGatewayLogPath
         }
-
-        _ = LogLocator.launchdGatewayLogPath
 
         var isDir: ObjCBool = false
         #expect(fm.fileExists(atPath: logDir.path, isDirectory: &isDir))

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -564,10 +564,12 @@ struct MacNodeRuntimeTests {
     }
 
     @Test func `handle invoke browser proxy uses injected request`() async {
-        let runtime = MacNodeRuntime(browserProxyRequest: { paramsJSON in
-            #expect(paramsJSON?.contains("/tabs") == true)
-            return #"{"result":{"ok":true,"tabs":[{"id":"tab-1"}]}}"#
-        })
+        let runtime = MacNodeRuntime(
+            browserProxyRequest: { paramsJSON in
+                #expect(paramsJSON?.contains("/tabs") == true)
+                return #"{"result":{"ok":true,"tabs":[{"id":"tab-1"}]}}"#
+            },
+            browserControlEnabled: { true })
         let paramsJSON = #"{"method":"GET","path":"/tabs","timeoutMs":2500}"#
         let response = await runtime.handleInvoke(
             BridgeInvokeRequest(
@@ -579,24 +581,20 @@ struct MacNodeRuntimeTests {
         #expect(response.payloadJSON == #"{"result":{"ok":true,"tabs":[{"id":"tab-1"}]}}"#)
     }
 
-    @Test func `handle invoke browser proxy rejects disabled browser control`() async throws {
-        let override = TestIsolation.tempConfigPath()
-        try await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": override]) {
-            try JSONSerialization.data(withJSONObject: ["browser": ["enabled": false]])
-                .write(to: URL(fileURLWithPath: override))
-
-            let runtime = MacNodeRuntime(browserProxyRequest: { _ in
+    @Test func `handle invoke browser proxy rejects disabled browser control`() async {
+        let runtime = MacNodeRuntime(
+            browserProxyRequest: { _ in
                 Issue.record("browserProxyRequest should not run when browser control is disabled")
                 return "{}"
-            })
-            let response = await runtime.handleInvoke(
-                BridgeInvokeRequest(
-                    id: "req-browser-disabled",
-                    command: OpenClawBrowserCommand.proxy.rawValue,
-                    paramsJSON: #"{"method":"GET","path":"/tabs"}"#))
+            },
+            browserControlEnabled: { false })
+        let response = await runtime.handleInvoke(
+            BridgeInvokeRequest(
+                id: "req-browser-disabled",
+                command: OpenClawBrowserCommand.proxy.rawValue,
+                paramsJSON: #"{"method":"GET","path":"/tabs"}"#))
 
-            #expect(response.ok == false)
-            #expect(response.error?.message.contains("BROWSER_DISABLED") == true)
-        }
+        #expect(response.ok == false)
+        #expect(response.error?.message.contains("BROWSER_DISABLED") == true)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
@@ -22,6 +22,20 @@ struct OpenClawConfigFileTests {
 
     @MainActor
     @Test
+    func `browser control enabled reads config flag`() async {
+        let override = self.makeConfigOverridePath()
+
+        await TestIsolation.withEnvValues(["OPENCLAW_CONFIG_PATH": override]) {
+            #expect(OpenClawConfigFile.browserControlEnabled() == true)
+            OpenClawConfigFile.saveDict(["browser": ["enabled": false]])
+            #expect(OpenClawConfigFile.browserControlEnabled() == false)
+            OpenClawConfigFile.setBrowserControlEnabled(true)
+            #expect(OpenClawConfigFile.browserControlEnabled() == true)
+        }
+    }
+
+    @MainActor
+    @Test
     func `remote gateway port parses and matches host`() async {
         let override = self.makeConfigOverridePath()
 

--- a/apps/macos/Tests/OpenClawIPCTests/WideAreaGatewayDiscoveryTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WideAreaGatewayDiscoveryTests.swift
@@ -1,4 +1,3 @@
-import Darwin
 import Foundation
 import Testing
 @testable import OpenClawDiscovery
@@ -22,16 +21,7 @@ private final class NameserverQueryLog: @unchecked Sendable {
 
 @Suite(.serialized)
 struct WideAreaGatewayDiscoveryTests {
-    @Test func `discovers beacon from tailnet dns sd fallback`() {
-        let originalWideAreaDomain = getenv("OPENCLAW_WIDE_AREA_DOMAIN").map { String(cString: $0) }
-        setenv("OPENCLAW_WIDE_AREA_DOMAIN", "openclaw.internal", 1)
-        defer {
-            if let originalWideAreaDomain {
-                setenv("OPENCLAW_WIDE_AREA_DOMAIN", originalWideAreaDomain, 1)
-            } else {
-                unsetenv("OPENCLAW_WIDE_AREA_DOMAIN")
-            }
-        }
+    @Test func `discovers beacon from tailnet dns sd fallback`() async {
         let statusJson = """
         {
           "Self": { "TailscaleIPs": ["100.69.232.64"] },
@@ -61,9 +51,15 @@ struct WideAreaGatewayDiscoveryTests {
                 return ""
             })
 
-        let beacons = WideAreaGatewayDiscovery.discover(
-            timeoutSeconds: 2.0,
-            context: context)
+        // Env mutation must hold TestIsolationLock; raw setenv races parallel
+        // tests scanning environ (e.g. OPENCLAW_CONFIG_PATH readers).
+        let beacons = await TestIsolation.withEnvValues(
+            ["OPENCLAW_WIDE_AREA_DOMAIN": "openclaw.internal"])
+        {
+            WideAreaGatewayDiscovery.discover(
+                timeoutSeconds: 2.0,
+                context: context)
+        }
 
         #expect(beacons.count == 1)
         let beacon = beacons[0]
@@ -75,16 +71,7 @@ struct WideAreaGatewayDiscoveryTests {
         #expect(beacon.cliPath == "/Users/steipete/openclaw/src/entry.ts")
     }
 
-    @Test func `attacker peer cannot become nameserver`() {
-        let originalWideAreaDomain = getenv("OPENCLAW_WIDE_AREA_DOMAIN").map { String(cString: $0) }
-        setenv("OPENCLAW_WIDE_AREA_DOMAIN", "openclaw.internal", 1)
-        defer {
-            if let originalWideAreaDomain {
-                setenv("OPENCLAW_WIDE_AREA_DOMAIN", originalWideAreaDomain, 1)
-            } else {
-                unsetenv("OPENCLAW_WIDE_AREA_DOMAIN")
-            }
-        }
+    @Test func `attacker peer cannot become nameserver`() async {
         let statusJson = """
         {
           "Self": { "TailscaleIPs": ["100.64.0.1"] },
@@ -117,9 +104,13 @@ struct WideAreaGatewayDiscoveryTests {
                 return ""
             })
 
-        let beacons = WideAreaGatewayDiscovery.discover(
-            timeoutSeconds: 2.0,
-            context: context)
+        let beacons = await TestIsolation.withEnvValues(
+            ["OPENCLAW_WIDE_AREA_DOMAIN": "openclaw.internal"])
+        {
+            WideAreaGatewayDiscovery.discover(
+                timeoutSeconds: 2.0,
+                context: context)
+        }
 
         #expect(queriedNameservers.count(matching: "@100.64.0.2") == 0)
         #expect(queriedNameservers.count(matching: "@100.100.100.100") == 1)


### PR DESCRIPTION
## What Problem This Solves

`MacNodeRuntimeTests` "handle invoke browser proxy rejects disabled browser control" intermittently fails under `swift test --package-path apps/macos --parallel` but passes in isolation. The CI macOS lane's swift-test retry loop has been masking it.

Root cause: the browser proxy gate resolves `OPENCLAW_CONFIG_PATH` via `getenv` at invoke time. All `TestIsolation.withEnvValues` users serialize env mutation through `TestIsolationLock`, but `LogLocatorTests` and `WideAreaGatewayDiscoveryTests` called raw `setenv`/`unsetenv` outside that lock. Concurrent `environ` mutation can make an unlocked `getenv` scan transiently miss `OPENCLAW_CONFIG_PATH`, so `MacNodeRuntime` reads the real host config (browser enabled) instead of the test override and the test trips at `MacNodeRuntimeTests.swift` lines 589/598/599. The sibling test "handle invoke browser proxy uses injected request" had the inverse latent flake: it asserted the gate is open while reading whatever config a concurrently locked test had installed.

## Why This Change Was Made

- `MacNodeRuntime` gains an injectable `browserControlEnabled` closure (defaulting to `OpenClawConfigFile.browserControlEnabled()`), so both browser proxy gate tests pin the gate state instead of racing on process-global env. The prod call site (`MacNodeModeCoordinator`) uses the default and is unchanged.
- Config-flag parsing coverage moved to where it belongs: a new `OpenClawConfigFileTests` case exercises `browserControlEnabled()` / `setBrowserControlEnabled(_:)` against an env-overridden config under `TestIsolationLock`.
- The remaining raw `setenv` users (`LogLocatorTests`, `WideAreaGatewayDiscoveryTests`) now route through `TestIsolation.withEnvValues`, so all env mutation in the test target holds `TestIsolationLock`.

## User Impact

None at runtime; test-only behavior. Removes a flaky macOS CI failure currently hidden by the retry loop.

## Evidence

- `swift build --package-path apps/macos --build-tests` — clean.
- `swift test --package-path apps/macos --parallel --filter "MacNodeRuntimeTests|OpenClawConfigFileTests|LogLocatorTests|WideAreaGatewayDiscoveryTests"` — 38 tests in 4 suites passed.
- Codex autoreview (`gpt-5.5`) on the diff: no accepted/actionable findings.
