### PR TITLE
fix(hooks): suppress unhandled stdout/stderr stream errors in gmail watcher

### DIFF
--- a/scripts/proof/gmail-watcher-stream-errors.mts
+++ b/scripts/proof/gmail-watcher-stream-errors.mts
@@ -7,8 +7,8 @@
 // listeners are attached. With the fix the watcher still starts; without the
 // stream error listeners the unhandled errors would terminate the process.
 
-import { createRequire } from "node:module";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
 
 const require = createRequire(import.meta.url);
-const childProcess = require("node:child_process");
+const childProcess = require("node:child_process") as typeof import("node:child_process");
 const originalSpawn = childProcess.spawn;
 
 const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-proof-gog-"));
@@ -48,7 +48,7 @@ process.env.PATH = `${tmpDir}${path.delimiter}${process.env.PATH ?? ""}`;
 // emit error events after startGmailWatcher attaches listeners.
 childProcess.spawn = (...args: Parameters<typeof originalSpawn>) => {
   const child = originalSpawn.apply(childProcess, args);
-  const cmd = String(args[0] ?? "");
+  const cmd = args[0] ?? "";
   const argv = args[1] as string[] | undefined;
   if (cmd === "gog" || argv?.[0] === "gmail") {
     setTimeout(() => {

--- a/scripts/proof/gmail-watcher-stream-errors.mts
+++ b/scripts/proof/gmail-watcher-stream-errors.mts
@@ -1,0 +1,32 @@
+// Real behavior proof: `spawnGogServe` catches stdout/stderr stream errors
+// instead of letting them crash the OpenClaw process.
+//
+// The regression test mocks `spawn` to emit `error` events on the child's
+// stdout and stderr streams and verifies that `startGmailWatcher` still
+// resolves. Before the fix the unhandled stream error would reject the
+// watcher promise.
+
+import { spawnSync } from "node:child_process";
+
+console.log("=== Proof: gmail-watcher stream error catch ===\n");
+console.log("Running regression test suite: src/hooks/gmail-watcher.test.ts\n");
+
+const result = spawnSync(
+  "node",
+  ["scripts/run-vitest.mjs", "src/hooks/gmail-watcher.test.ts"],
+  { cwd: process.cwd(), encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+);
+
+if (result.stdout) {
+  console.log(result.stdout);
+}
+if (result.stderr) {
+  console.error(result.stderr);
+}
+
+if (result.status === 0 && result.error === undefined) {
+  console.log("\nPASS: gmail-watcher stream errors are caught and logged.");
+} else {
+  console.log("\nFAIL: regression test suite did not pass.");
+  process.exitCode = 1;
+}

--- a/scripts/proof/gmail-watcher-stream-errors.mts
+++ b/scripts/proof/gmail-watcher-stream-errors.mts
@@ -1,32 +1,102 @@
-// Real behavior proof: `spawnGogServe` catches stdout/stderr stream errors
-// instead of letting them crash the OpenClaw process.
+// Real behavior proof: `spawnGogServe` handles real stdout/stderr stream
+// error events without crashing the gateway.
 //
-// The regression test mocks `spawn` to emit `error` events on the child's
-// stdout and stderr streams and verifies that `startGmailWatcher` still
-// resolves. Before the fix the unhandled stream error would reject the
-// watcher promise.
+// The proof prepends a fake `gog` binary to PATH so `startGmailWatcher` can
+// reach `spawnGogServe`, then patches `child_process.spawn` so the serve child
+// is a real process whose streams emit real `error` events after the fix's
+// listeners are attached. With the fix the watcher still starts; without the
+// stream error listeners the unhandled errors would terminate the process.
 
-import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-console.log("=== Proof: gmail-watcher stream error catch ===\n");
-console.log("Running regression test suite: src/hooks/gmail-watcher.test.ts\n");
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
 
-const result = spawnSync(
-  "node",
-  ["scripts/run-vitest.mjs", "src/hooks/gmail-watcher.test.ts"],
-  { cwd: process.cwd(), encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process");
+const originalSpawn = childProcess.spawn;
+
+const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-proof-gog-"));
+const fakeGog = path.join(tmpDir, "gog");
+
+// Fake gog that succeeds for `watch start` and sleeps for `watch serve`.
+await fs.writeFile(
+  fakeGog,
+  `#!/bin/sh
+if [ "$1" = "gmail" ] && [ "$2" = "watch" ]; then
+  if [ "$3" = "start" ]; then
+    echo "watch started"
+    exit 0
+  fi
+  if [ "$3" = "serve" ]; then
+    while true; do sleep 1; done
+  fi
+fi
+echo "unknown command" >&2
+exit 1
+`,
+  "utf8",
+);
+await fs.chmod(fakeGog, 0o755);
+
+process.env.PATH = `${tmpDir}${path.delimiter}${process.env.PATH ?? ""}`;
+
+// Patch spawn so the serve child is a real process whose streams we can make
+// emit error events after startGmailWatcher attaches listeners.
+childProcess.spawn = (...args: Parameters<typeof originalSpawn>) => {
+  const child = originalSpawn.apply(childProcess, args);
+  const cmd = String(args[0] ?? "");
+  const argv = args[1] as string[] | undefined;
+  if (cmd === "gog" || argv?.[0] === "gmail") {
+    setTimeout(() => {
+      child.stdout?.emit("error", new Error("gog stdout read failed"));
+      child.stderr?.emit("error", new Error("gog stderr read failed"));
+    }, 100);
+  }
+  return child;
+};
+
+const { startGmailWatcher, stopGmailWatcher } = await import(
+  path.join(repoRoot, "src/hooks/gmail-watcher.js")
 );
 
-if (result.stdout) {
-  console.log(result.stdout);
-}
-if (result.stderr) {
-  console.error(result.stderr);
-}
+const config = {
+  hooks: {
+    enabled: true,
+    token: "hook-token",
+    gmail: {
+      account: "me@example.com",
+      topic: "projects/demo/topics/gmail",
+      pushToken: "push-token",
+      renewEveryMinutes: 1,
+      tailscale: { mode: "off" },
+    },
+  },
+};
 
-if (result.status === 0 && result.error === undefined) {
-  console.log("\nPASS: gmail-watcher stream errors are caught and logged.");
-} else {
-  console.log("\nFAIL: regression test suite did not pass.");
+console.log("=== Proof: gmail-watcher stream error catch ===\n");
+
+try {
+  const result = await startGmailWatcher(config);
+  if (result.started) {
+    console.log("Watcher started successfully.");
+    console.log("\nPASS: stream errors were caught and startGmailWatcher still resolved.");
+  } else {
+    console.log(`\nFAIL: watcher did not start: ${result.reason ?? "unknown"}`);
+    process.exitCode = 1;
+  }
+} catch (err) {
+  console.error("\nFAIL: startGmailWatcher rejected with:");
+  console.error(err);
   process.exitCode = 1;
+} finally {
+  try {
+    await stopGmailWatcher();
+  } catch {
+    // ignore
+  }
+  await fs.rm(tmpDir, { recursive: true, force: true });
 }

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -362,4 +362,31 @@ describe("startGmailWatcher", () => {
       vi.useRealTimers();
     }
   });
+
+  it("swallows stdout and stderr stream errors without crashing", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    let stdout: EventEmitter | undefined;
+    let stderr: EventEmitter | undefined;
+    mocks.spawn.mockImplementation(() => {
+      const child = new EventEmitter();
+      stdout = new EventEmitter();
+      stderr = new EventEmitter();
+      const mockedChild = Object.assign(child, {
+        stdout,
+        stderr,
+        kill: vi.fn(() => {
+          queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+          return true;
+        }),
+        killed: false,
+      });
+      queueMicrotask(() => {
+        stdout?.emit("error", new Error("stdout read failed"));
+        stderr?.emit("error", new Error("stderr read failed"));
+      });
+      return mockedChild;
+    });
+
+    await expect(startGmailWatcher(createGmailConfig())).resolves.toEqual({ started: true });
+  });
 });

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -79,6 +79,9 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
 
+  child.stdout?.on("error", (err) => {
+    log.error(`gog stdout error: ${String(err)}`);
+  });
   child.stdout?.on("data", (data: Buffer) => {
     const line = data.toString().trim();
     if (line) {
@@ -86,6 +89,9 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
     }
   });
 
+  child.stderr?.on("error", (err) => {
+    log.error(`gog stderr error: ${String(err)}`);
+  });
   child.stderr?.on("data", (data: Buffer) => {
     const line = data.toString().trim();
     if (!line) {


### PR DESCRIPTION
Re-submission of #100414, which was closed automatically when the active PR queue was limited. The branch has been rebased onto the latest `main`.

## What Problem This Solves

`spawnGogServe` attaches `data` listeners to `child.stdout` and `child.stderr`, but does not attach `error` listeners. If either stream emits an `error` event, the unhandled error can crash the OpenClaw process even though the watcher startup itself would otherwise succeed.

## Why This Change Was Made

Add `error` handlers to both stdout and stderr streams before the data handlers. The handlers log the error and continue, mirroring the existing `child.on("error", ...)` logging pattern.

## User Impact

More robust Gmail watcher startup: transient stream read errors no longer crash the process.

## Evidence

Regression test:

```bash
node scripts/run-vitest.mjs src/hooks/gmail-watcher.test.ts
```

```
Test Files  1 passed (1)
     Tests  9 passed (9)
```

Real behavior proof:

```bash
node_modules/.bin/tsx scripts/proof/gmail-watcher-stream-errors.mts
```

The proof prepends a fake `gog` binary to PATH, starts the real `startGmailWatcher`, then emits real `error` events on the serve child's stdout and stderr streams. With the fix the watcher still starts and the errors are logged:

```
[gmail-watcher] gmail watcher started for me@example.com (renew every 1m)
Watcher started successfully.

PASS: stream errors were caught and startGmailWatcher still resolved.
...
[gmail-watcher] gog stdout error: Error: gog stdout read failed
[gmail-watcher] gog stderr error: Error: gog stderr read failed
```
