### PR TITLE
fix(secrets): suppress unhandled stdout/stderr stream errors in exec resolver

### DIFF
--- a/scripts/proof/secrets-resolve-stream-errors.mts
+++ b/scripts/proof/secrets-resolve-stream-errors.mts
@@ -1,31 +1,86 @@
-// Real behavior proof: `runExecResolver` catches stdout/stderr stream errors
-// instead of letting them crash the OpenClaw process during secret resolution.
+// Real behavior proof: `runExecResolver` handles real stdout/stderr stream
+// error events without crashing the agent during secret resolution.
 //
-// The regression test mocks `spawn` to emit `error` events on the child's
-// stdout and stderr streams and verifies that secret resolution still
-// succeeds. Before the fix the unhandled stream error would reject.
+// The proof configures a real exec secret provider, calls the production
+// `resolveSecretRefString` path, and patches `child_process.spawn` so the exec
+// child is a real process whose stdout/stderr streams emit `error` events
+// after the fix's listeners are attached. With the fix the secret still
+// resolves; without the stream error listeners the unhandled errors would
+// terminate the process.
 
-import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process");
+const originalSpawn = childProcess.spawn;
+
+const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-proof-secrets-"));
+const fakeSecret = path.join(tmpDir, "secret-provider");
+
+// Fake exec secret provider that returns the requested secret as JSON.
+await fs.writeFile(
+  fakeSecret,
+  `#!/bin/sh
+echo '{"protocolVersion":1,"values":{"my-secret":"super-secret-value"}}'
+`,
+  "utf8",
+);
+await fs.chmod(fakeSecret, 0o755);
+
+// Patch spawn so the exec child is a real process whose streams we can make
+// emit error events after runExecResolver attaches listeners.
+childProcess.spawn = (...args: Parameters<typeof originalSpawn>) => {
+  const child = originalSpawn.apply(childProcess, args);
+  const cmd = String(args[0] ?? "");
+  if (cmd === fakeSecret) {
+    setTimeout(() => {
+      child.stdout?.emit("error", new Error("stdout read failed"));
+      child.stderr?.emit("error", new Error("stderr read failed"));
+    }, 50);
+  }
+  return child;
+};
+
+const { resolveSecretRefString } = await import(path.join(repoRoot, "src/secrets/resolve.js"));
+
+const config = {
+  secrets: {
+    providers: {
+      default: {
+        source: "exec" as const,
+        command: fakeSecret,
+      },
+    },
+    defaults: {
+      exec: "default",
+    },
+  },
+};
 
 console.log("=== Proof: secrets resolve stream error catch ===\n");
-console.log("Running regression test suite: src/secrets/resolve.test.ts\n");
 
-const result = spawnSync(
-  "node",
-  ["scripts/run-vitest.mjs", "src/secrets/resolve.test.ts"],
-  { cwd: process.cwd(), encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
-);
-
-if (result.stdout) {
-  console.log(result.stdout);
-}
-if (result.stderr) {
-  console.error(result.stderr);
-}
-
-if (result.status === 0 && result.error === undefined) {
-  console.log("\nPASS: secrets resolve stream errors are caught and ignored.");
-} else {
-  console.log("\nFAIL: regression test suite did not pass.");
+try {
+  const value = await resolveSecretRefString(
+    { source: "exec", provider: "default", id: "my-secret" },
+    { config: config as never },
+  );
+  console.log(`Resolved secret value: ${value}`);
+  if (value === "super-secret-value") {
+    console.log("\nPASS: stream errors were caught and secret resolution still succeeded.");
+  } else {
+    console.log("\nFAIL: unexpected secret value.");
+    process.exitCode = 1;
+  }
+} catch (err) {
+  console.error("\nFAIL: resolveSecretRefString rejected with:");
+  console.error(err);
   process.exitCode = 1;
+} finally {
+  await fs.rm(tmpDir, { recursive: true, force: true });
 }

--- a/scripts/proof/secrets-resolve-stream-errors.mts
+++ b/scripts/proof/secrets-resolve-stream-errors.mts
@@ -1,0 +1,31 @@
+// Real behavior proof: `runExecResolver` catches stdout/stderr stream errors
+// instead of letting them crash the OpenClaw process during secret resolution.
+//
+// The regression test mocks `spawn` to emit `error` events on the child's
+// stdout and stderr streams and verifies that secret resolution still
+// succeeds. Before the fix the unhandled stream error would reject.
+
+import { spawnSync } from "node:child_process";
+
+console.log("=== Proof: secrets resolve stream error catch ===\n");
+console.log("Running regression test suite: src/secrets/resolve.test.ts\n");
+
+const result = spawnSync(
+  "node",
+  ["scripts/run-vitest.mjs", "src/secrets/resolve.test.ts"],
+  { cwd: process.cwd(), encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+);
+
+if (result.stdout) {
+  console.log(result.stdout);
+}
+if (result.stderr) {
+  console.error(result.stderr);
+}
+
+if (result.status === 0 && result.error === undefined) {
+  console.log("\nPASS: secrets resolve stream errors are caught and ignored.");
+} else {
+  console.log("\nFAIL: regression test suite did not pass.");
+  process.exitCode = 1;
+}

--- a/scripts/proof/secrets-resolve-stream-errors.mts
+++ b/scripts/proof/secrets-resolve-stream-errors.mts
@@ -8,8 +8,8 @@
 // resolves; without the stream error listeners the unhandled errors would
 // terminate the process.
 
-import { createRequire } from "node:module";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,7 +17,7 @@ import { fileURLToPath } from "node:url";
 const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
 
 const require = createRequire(import.meta.url);
-const childProcess = require("node:child_process");
+const childProcess = require("node:child_process") as typeof import("node:child_process");
 const originalSpawn = childProcess.spawn;
 
 const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-proof-secrets-"));
@@ -37,7 +37,7 @@ await fs.chmod(fakeSecret, 0o755);
 // emit error events after runExecResolver attaches listeners.
 childProcess.spawn = (...args: Parameters<typeof originalSpawn>) => {
   const child = originalSpawn.apply(childProcess, args);
-  const cmd = String(args[0] ?? "");
+  const cmd = args[0] ?? "";
   if (cmd === fakeSecret) {
     setTimeout(() => {
       child.stdout?.emit("error", new Error("stdout read failed"));

--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -1,8 +1,20 @@
 /** Tests SecretRef provider resolution for env, file, and exec sources. */
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) =>
+      spawnMock(...args) ?? actual.spawn(...args),
+  };
+});
 import type { OpenClawConfig } from "../config/config.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import {
@@ -644,5 +656,72 @@ describe("secret ref resolver", () => {
         /ACL verification unavailable on Windows/,
       );
     });
+  });
+});
+
+describe("runExecResolver stream error handling", () => {
+  function createFakeChild(): ChildProcess {
+    const child = new EventEmitter() as EventEmitter & ChildProcess;
+    child.stdout = new EventEmitter() as EventEmitter & NonNullable<ChildProcess["stdout"]>;
+    child.stderr = new EventEmitter() as EventEmitter & NonNullable<ChildProcess["stderr"]>;
+    child.stdin = new EventEmitter() as EventEmitter & NonNullable<ChildProcess["stdin"]>;
+    child.stdin.write = vi.fn(() => true) as NonNullable<ChildProcess["stdin"]>["write"];
+    child.stdin.end = vi.fn() as NonNullable<ChildProcess["stdin"]>["end"];
+    Object.defineProperties(child, {
+      pid: { configurable: true, enumerable: true, get: () => 1234 },
+      killed: { configurable: true, enumerable: true, get: () => false },
+    });
+    child.kill = vi.fn(() => true) as ChildProcess["kill"];
+    return child;
+  }
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it("swallows stdout and stderr stream errors without rejecting", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-secrets-resolve-stream-"));
+    const scriptPath = path.join(dir, "resolver.cjs");
+    await fs.writeFile(scriptPath, "module.exports = {};", "utf8");
+    await fs.chmod(scriptPath, 0o700);
+
+    spawnMock.mockImplementation(() => {
+      const child = createFakeChild();
+      const response = Buffer.from(
+        JSON.stringify({ protocolVersion: 1, values: { "openai/api-key": "ok" } }),
+      );
+      queueMicrotask(() => {
+        child.stdout?.emit("error", new Error("stdout read failed"));
+        child.stdout?.emit("data", response);
+        child.stderr?.emit("error", new Error("stderr read failed"));
+        child.emit("close", 0, null);
+      });
+      return child;
+    });
+
+    await expect(
+      resolveSecretRefString(
+        { source: "exec", provider: "execmain", id: "openai/api-key" },
+        {
+          config: {
+            secrets: {
+              providers: {
+                execmain: {
+                  source: "exec",
+                  command: scriptPath,
+                  args: [],
+                  allowInsecurePath: true,
+                  timeoutMs: 5_000,
+                  noOutputTimeoutMs: 5_000,
+                  maxOutputBytes: 16 * 1024,
+                },
+              },
+            },
+          },
+        },
+      ),
+    ).resolves.toBe("ok");
+
+    await fs.rm(dir, { recursive: true, force: true });
   });
 });

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -568,7 +568,9 @@ async function runExecResolver(params: {
       clearTimers();
       reject(error);
     });
+    child.stdout?.on("error", () => {});
     child.stdout?.on("data", (chunk) => append(chunk, "stdout"));
+    child.stderr?.on("error", () => {});
     child.stderr?.on("data", (chunk) => append(chunk, "stderr"));
     child.on("close", (code, signal) => {
       if (settled) {


### PR DESCRIPTION
Re-submission of #100419, which was closed automatically when the active PR queue was limited. The branch has been rebased onto the latest `main`.

## What Problem This Solves

`runExecResolver` attaches `data` listeners to `child.stdout` and `child.stderr`, but does not attach `error` listeners. If either stream emits an `error` event, the unhandled error can crash the OpenClaw process during secret resolution.

## Why This Change Was Made

Add no-op `error` handlers to both stdout and stderr streams before the data handlers, mirroring the existing stdin error handling pattern. This prevents unhandled stream errors from propagating as uncaught exceptions.

## User Impact

More robust exec-based secret resolution: transient stream read errors no longer crash the process.

## Evidence

Regression test:

```bash
node scripts/run-vitest.mjs src/secrets/resolve.test.ts
```

```
Test Files  1 passed (1)
     Tests  26 passed (26)
```

Real behavior proof:

```bash
node_modules/.bin/tsx scripts/proof/secrets-resolve-stream-errors.mts
```

The proof configures a real exec secret provider, calls the production `resolveSecretRefString` path, and emits real `error` events on the exec child's stdout and stderr. With the fix the secret still resolves:

```
Resolved secret value: super-secret-value

PASS: stream errors were caught and secret resolution still succeeded.
```
