### PR TITLE
fix(transcripts): handle read stream errors gracefully in TranscriptsStore

### DIFF
--- a/scripts/proof/transcripts-store-stream-errors.mts
+++ b/scripts/proof/transcripts-store-stream-errors.mts
@@ -1,31 +1,53 @@
-// Real behavior proof: `TranscriptsStore.readUtterancesFromDir` handles
-// readline/file stream errors gracefully instead of crashing.
+// Real behavior proof: TranscriptsStore handles a real filesystem stream error
+// gracefully instead of leaking an unhandled rejection.
 //
-// The regression test mocks `createReadStream` to emit an `error` event after
-// a valid transcript line and verifies that the store returns the utterances
-// parsed so far. Before the fix the unhandled stream error would reject.
+// The proof creates a real transcript session directory where `transcript.jsonl`
+// is a directory instead of a file. `fs.createReadStream` on a directory emits
+// an EISDIR error on the stream. With the fix, `readUtterancesFromSessionDir`
+// catches that error and returns the utterances parsed so far (none, in this
+// case). Before the fix the unhandled stream error would reject the promise.
 
-import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+const { TranscriptsStore } = await import(path.join(repoRoot, "src/transcripts/store.js"));
+
+const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-proof-transcripts-"));
+
+const session = {
+  sessionId: "proof-session",
+  startedAt: "2026-07-01T00:00:00Z",
+};
+
+const store = new TranscriptsStore(tmpDir);
+const sessionDir = store.sessionDir(session);
+await fs.mkdir(sessionDir, { recursive: true });
+
+// Make transcript.jsonl a directory. createReadStream on a directory emits
+// EISDIR, which exercises the stream error handler in readUtterancesFromDir.
+const transcriptPath = path.join(sessionDir, "transcript.jsonl");
+await fs.mkdir(transcriptPath);
 
 console.log("=== Proof: transcripts store stream error catch ===\n");
-console.log("Running regression test suite: src/transcripts/store.test.ts\n");
+console.log(`Created directory-as-file at: ${transcriptPath}`);
+console.log("Calling readUtterancesFromSessionDir with maxUtterances...\n");
 
-const result = spawnSync(
-  "node",
-  ["scripts/run-vitest.mjs", "src/transcripts/store.test.ts"],
-  { cwd: process.cwd(), encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
-);
-
-if (result.stdout) {
-  console.log(result.stdout);
-}
-if (result.stderr) {
-  console.error(result.stderr);
-}
-
-if (result.status === 0 && result.error === undefined) {
-  console.log("\nPASS: transcript store stream errors return parsed utterances.");
-} else {
-  console.log("\nFAIL: regression test suite did not pass.");
+try {
+  const result = await store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 });
+  console.log(`Result: ${JSON.stringify(result)}`);
+  if (Array.isArray(result) && result.length === 0) {
+    console.log("\nPASS: EISDIR stream error was caught and returned an empty array.");
+  } else {
+    console.log("\nFAIL: unexpected result shape.");
+    process.exitCode = 1;
+  }
+} catch (err) {
+  console.error("\nFAIL: readUtterancesFromSessionDir rejected with:");
+  console.error(err);
   process.exitCode = 1;
+} finally {
+  await fs.rm(tmpDir, { recursive: true, force: true });
 }

--- a/scripts/proof/transcripts-store-stream-errors.mts
+++ b/scripts/proof/transcripts-store-stream-errors.mts
@@ -1,11 +1,12 @@
-// Real behavior proof: TranscriptsStore handles a real filesystem stream error
-// gracefully instead of leaking an unhandled rejection.
+// Real behavior proof: TranscriptsStore rejects non-ENOENT stream errors
+// gracefully instead of leaking an unhandled rejection or returning partial data.
 //
 // The proof creates a real transcript session directory where `transcript.jsonl`
 // is a directory instead of a file. `fs.createReadStream` on a directory emits
 // an EISDIR error on the stream. With the fix, `readUtterancesFromSessionDir`
-// catches that error and returns the utterances parsed so far (none, in this
-// case). Before the fix the unhandled stream error would reject the promise.
+// rejects with that error after the stream closes. Missing files (ENOENT) still
+// resolve to an empty array. Before the fix the unhandled stream error would
+// reject the promise before listeners were attached.
 
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -36,18 +37,18 @@ console.log(`Created directory-as-file at: ${transcriptPath}`);
 console.log("Calling readUtterancesFromSessionDir with maxUtterances...\n");
 
 try {
-  const result = await store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 });
-  console.log(`Result: ${JSON.stringify(result)}`);
-  if (Array.isArray(result) && result.length === 0) {
-    console.log("\nPASS: EISDIR stream error was caught and returned an empty array.");
+  await store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 });
+  console.log("\nFAIL: readUtterancesFromSessionDir should have rejected for EISDIR.");
+  process.exitCode = 1;
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.log(`Rejected with: ${message}`);
+  if (message.includes("EISDIR") || message.includes("is a directory")) {
+    console.log("\nPASS: EISDIR stream error was caught and rejected after stream close.");
   } else {
-    console.log("\nFAIL: unexpected result shape.");
+    console.log("\nFAIL: unexpected rejection reason.");
     process.exitCode = 1;
   }
-} catch (err) {
-  console.error("\nFAIL: readUtterancesFromSessionDir rejected with:");
-  console.error(err);
-  process.exitCode = 1;
 } finally {
   await fs.rm(tmpDir, { recursive: true, force: true });
 }

--- a/scripts/proof/transcripts-store-stream-errors.mts
+++ b/scripts/proof/transcripts-store-stream-errors.mts
@@ -1,0 +1,31 @@
+// Real behavior proof: `TranscriptsStore.readUtterancesFromDir` handles
+// readline/file stream errors gracefully instead of crashing.
+//
+// The regression test mocks `createReadStream` to emit an `error` event after
+// a valid transcript line and verifies that the store returns the utterances
+// parsed so far. Before the fix the unhandled stream error would reject.
+
+import { spawnSync } from "node:child_process";
+
+console.log("=== Proof: transcripts store stream error catch ===\n");
+console.log("Running regression test suite: src/transcripts/store.test.ts\n");
+
+const result = spawnSync(
+  "node",
+  ["scripts/run-vitest.mjs", "src/transcripts/store.test.ts"],
+  { cwd: process.cwd(), encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+);
+
+if (result.stdout) {
+  console.log(result.stdout);
+}
+if (result.stderr) {
+  console.error(result.stderr);
+}
+
+if (result.status === 0 && result.error === undefined) {
+  console.log("\nPASS: transcript store stream errors return parsed utterances.");
+} else {
+  console.log("\nFAIL: regression test suite did not pass.");
+  process.exitCode = 1;
+}

--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -1,7 +1,18 @@
-// Tests TranscriptsStore stream cleanup and transcript reading behavior.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+// Tests TranscriptsStore stream cleanup and transcript reading behavior.
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const createReadStreamMock = vi.hoisted(() => vi.fn());
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    createReadStream: (...args: Parameters<typeof actual.createReadStream>) =>
+      createReadStreamMock(...args) ?? actual.createReadStream(...args),
+  };
+});
 import { listOpenFileDescriptorsForPath } from "../../src/infra/open-file-descriptors.test-support.js";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { TranscriptsStore } from "./store.js";
@@ -105,4 +116,26 @@ describe("TranscriptsStore.readUtterancesFromSessionDir", () => {
       expect(leaked).toHaveLength(0);
     },
   );
+
+  it("handles read stream errors without rejecting", async () => {
+    const tmpDir = makeTempDir(tempRoots, "openclaw-transcript-test-");
+    const store = new TranscriptsStore(tmpDir);
+    const sessionDir = path.join(tmpDir, "2026-07-01", "session-1");
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionDir, "transcript.jsonl"), "");
+
+    createReadStreamMock.mockImplementation(() => {
+      const stream = new PassThrough();
+      setTimeout(() => {
+        stream.write(JSON.stringify({ text: "hello", sessionId: "session-1" }) + "\n");
+        stream.emit("error", new Error("read failed"));
+        stream.end();
+      }, 10);
+      return stream;
+    });
+
+    await expect(
+      store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 }),
+    ).resolves.toEqual([expect.objectContaining({ text: "hello" })]);
+  });
 });

--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -117,7 +117,7 @@ describe("TranscriptsStore.readUtterancesFromSessionDir", () => {
     },
   );
 
-  it("handles read stream errors without rejecting", async () => {
+  it("rejects non-ENOENT read stream errors", async () => {
     const tmpDir = makeTempDir(tempRoots, "openclaw-transcript-test-");
     const store = new TranscriptsStore(tmpDir);
     const sessionDir = path.join(tmpDir, "2026-07-01", "session-1");
@@ -128,14 +128,13 @@ describe("TranscriptsStore.readUtterancesFromSessionDir", () => {
       const stream = new PassThrough();
       setTimeout(() => {
         stream.write(JSON.stringify({ text: "hello", sessionId: "session-1" }) + "\n");
-        stream.emit("error", new Error("read failed"));
-        stream.end();
+        stream.destroy(new Error("read failed"));
       }, 10);
       return stream;
     });
 
     await expect(
       store.readUtterancesFromSessionDir(sessionDir, { maxUtterances: 10 }),
-    ).resolves.toEqual([expect.objectContaining({ text: "hello" })]);
+    ).rejects.toThrow("read failed");
   });
 });

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -188,40 +188,61 @@ export class TranscriptsStore {
     const transcriptPath = path.join(dir, "transcript.jsonl");
     const maxUtterances = resolveOptionalIntegerOption(options.maxUtterances, { min: 1 });
     if (maxUtterances !== undefined) {
-      const utterances: TranscriptUtterance[] = [];
-      try {
+      return await new Promise<TranscriptUtterance[]>((resolve, reject) => {
+        const utterances: TranscriptUtterance[] = [];
         const stream = createReadStream(transcriptPath, { encoding: "utf8" });
         const lines = createInterface({
           input: stream,
           crlfDelay: Infinity,
         });
-        try {
-          for await (const line of lines) {
-            if (!line) {
-              continue;
-            }
-            utterances.push(JSON.parse(line) as TranscriptUtterance);
-            if (utterances.length > maxUtterances) {
-              // Stream and keep only the tail so large transcripts do not require full-file memory.
-              utterances.shift();
-            }
-          }
-        } finally {
+        let settled = false;
+
+        const cleanup = () => {
           lines.close();
           stream.destroy();
-          if (!stream.closed) {
-            await new Promise<void>((resolve) => {
-              stream.once("close", () => resolve());
-            });
+        };
+        const finish = (value: TranscriptUtterance[]) => {
+          if (settled) {
+            return;
           }
-        }
-      } catch (err) {
-        if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
-          return [];
-        }
-        throw err;
-      }
-      return utterances;
+          settled = true;
+          cleanup();
+          resolve(value);
+        };
+        const fail = (err: unknown) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          reject(err);
+        };
+
+        stream.on("error", (err) => {
+          if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+            finish([]);
+            return;
+          }
+          finish(utterances);
+        });
+        lines.on("error", () => finish(utterances));
+        lines.on("line", (line) => {
+          if (!line) {
+            return;
+          }
+          try {
+            utterances.push(JSON.parse(line) as TranscriptUtterance);
+          } catch (err) {
+            fail(err);
+            return;
+          }
+          if (utterances.length > maxUtterances) {
+            // Stream and keep only the tail so large transcripts do not require full-file memory.
+            utterances.shift();
+          }
+        });
+        lines.on("close", () => finish(utterances));
+      });
     }
     let raw: string;
     try {

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -196,36 +196,47 @@ export class TranscriptsStore {
           crlfDelay: Infinity,
         });
         let settled = false;
+        let emptyForENOENT = false;
+        let pendingError: Error | undefined;
 
-        const cleanup = () => {
+        const settle = () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
           lines.close();
           stream.destroy();
-        };
-        const finish = (value: TranscriptUtterance[]) => {
-          if (settled) {
-            return;
+          if (pendingError) {
+            reject(pendingError);
+          } else if (emptyForENOENT) {
+            resolve([]);
+          } else {
+            resolve(utterances);
           }
-          settled = true;
-          cleanup();
-          resolve(value);
         };
-        const fail = (err: unknown) => {
-          if (settled) {
-            return;
+        const setError = (err: unknown) => {
+          if (!pendingError) {
+            pendingError = err instanceof Error ? err : new Error(String(err));
           }
-          settled = true;
-          cleanup();
-          reject(err instanceof Error ? err : new Error(String(err)));
         };
 
+        stream.on("close", settle);
         stream.on("error", (err) => {
           if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
-            finish([]);
+            emptyForENOENT = true;
             return;
           }
-          finish(utterances);
+          setError(err);
+          stream.destroy();
         });
-        lines.on("error", () => finish(utterances));
+        lines.on("error", (err) => {
+          if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+            emptyForENOENT = true;
+            return;
+          }
+          setError(err);
+          stream.destroy();
+        });
         lines.on("line", (line) => {
           if (!line) {
             return;
@@ -233,7 +244,8 @@ export class TranscriptsStore {
           try {
             utterances.push(JSON.parse(line) as TranscriptUtterance);
           } catch (err) {
-            fail(err);
+            setError(err);
+            stream.destroy();
             return;
           }
           if (utterances.length > maxUtterances) {
@@ -241,7 +253,6 @@ export class TranscriptsStore {
             utterances.shift();
           }
         });
-        lines.on("close", () => finish(utterances));
       });
     }
     let raw: string;

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -215,7 +215,7 @@ export class TranscriptsStore {
           }
           settled = true;
           cleanup();
-          reject(err);
+          reject(err instanceof Error ? err : new Error(String(err)));
         };
 
         stream.on("error", (err) => {


### PR DESCRIPTION
Re-submission of #100431, which was closed automatically when the active PR queue was limited. The branch has been rebased onto the latest `main`.

## What Problem This Solves

`TranscriptsStore.readUtterancesFromSessionDir` uses `createReadStream` + `readline.createInterface` without attaching `error` handlers. If the file stream or readline interface emits an `error` event, the unhandled error rejects the promise and can crash the OpenClaw process.

## Why This Change Was Made

Refactor the stream reading path to use event-based handling (`line`, `close`, `error`) instead of `for await`, so that stream/readline errors are caught explicitly. Only `ENOENT` is treated as "no utterances" and resolves to `[]`. Every other stream/readline error (e.g. `EISDIR`, `EACCES`) is held until the read stream emits `close`, then rejected. JSON parse errors are still rejected so callers can distinguish malformed transcript data.

## User Impact

More robust transcript loading: missing transcript files still return an empty array, while real filesystem read errors are surfaced as rejections only after the file descriptor is closed, preventing unhandled rejections and FD leaks.

## Evidence

Regression test:

```bash
node scripts/run-vitest.mjs src/transcripts/store.test.ts
```

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

Real behavior proof:

```bash
node_modules/.bin/tsx scripts/proof/transcripts-store-stream-errors.mts
```

The proof creates a real `TranscriptsStore`, makes `transcript.jsonl` an actual directory (so `fs.createReadStream` emits a real `EISDIR` error), and calls `readUtterancesFromSessionDir`. With the fix the function rejects with the `EISDIR` error after the stream closes:

```
Created directory-as-file at: /tmp/openclaw-proof-transcripts-.../2026-07-01/proof-session/transcript.jsonl
Calling readUtterancesFromSessionDir with maxUtterances...

Rejected with: EISDIR: illegal operation on a directory, read

PASS: EISDIR stream error was caught and rejected after stream close.
```