### PR TITLE
fix(ui): align Skills filters

### DIFF
--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -31,9 +31,11 @@ function readUiCss(): string {
 function controlsHtml() {
   return `
     <main>
-      <label class="field"><input value="field input" /></label>
+      <label class="field"><input type="text" value="field input" /></label>
       <label class="field"><textarea>field textarea</textarea></label>
       <label class="field"><select><option>field select</option></select></label>
+      <label class="field checkbox"><input type="checkbox" /><span>field checkbox</span></label>
+      <label class="field checkbox"><input type="radio" /><span>field radio</span></label>
       <input class="config-search__input" value="search" />
       <input class="settings-theme-import__input" value="theme" />
       <label class="config-raw-field"><textarea>raw config</textarea></label>
@@ -151,6 +153,35 @@ describeBrowserLayout("touch-primary form controls", () => {
         expect(select.paddingRight).toBeGreaterThanOrEqual(32);
         expect(select.repeat).toContain("no-repeat");
       }
+    } finally {
+      await closeMobileFixture(fixture);
+    }
+  });
+
+  it("aligns text controls without stretching checkbox and radio inputs", async () => {
+    const fixture = await openMobileFixture();
+    const { page } = fixture;
+    try {
+      const dimensions = await page.evaluate(() => {
+        const height = (selector: string) => {
+          const node = document.querySelector(selector);
+          if (!(node instanceof HTMLElement)) {
+            throw new Error(`Missing control ${selector}`);
+          }
+          return node.getBoundingClientRect().height;
+        };
+        return {
+          checkbox: height('.field input[type="checkbox"]'),
+          radio: height('.field input[type="radio"]'),
+          select: height(".field select"),
+          text: height('.field input[type="text"]'),
+        };
+      });
+
+      expect(dimensions.text).toBe(38);
+      expect(dimensions.select).toBe(38);
+      expect(dimensions.checkbox).toBeLessThan(38);
+      expect(dimensions.radio).toBeLessThan(38);
     } finally {
       await closeMobileFixture(fixture);
     }

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -137,7 +137,11 @@ describe("renderSkills", () => {
     await Promise.resolve();
 
     const selector = container.querySelector<HTMLSelectElement>('select[name="skills-agent"]');
+    const filter = container.querySelector<HTMLInputElement>('input[name="skills-filter"]');
     expect(selector).toBeInstanceOf(HTMLSelectElement);
+    expect(filter).toBeInstanceOf(HTMLInputElement);
+    expect(normalizeText(selector!.closest("label")!)).toContain("Agent");
+    expect(normalizeText(filter!.closest("label")!)).toContain("Search");
     expect(selector?.value).toBe("research");
     expect(Array.from(selector!.options).map((option) => option.textContent?.trim())).toEqual([
       "Main (default)",

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -263,7 +263,7 @@ export function renderSkills(props: SkillsProps) {
         ${agents.length > 0
           ? html`
               <label class="field" style="min-width: 180px;">
-                <span>${t("common.filters.agent")}</span>
+                <span>${t("usage.filters.agent")}</span>
                 <select
                   name="skills-agent"
                   .value=${selectedAgentId}
@@ -283,6 +283,7 @@ export function renderSkills(props: SkillsProps) {
             `
           : nothing}
         <label class="field" style="flex: 1; min-width: 180px;">
+          <span>${t("common.search")}</span>
           <input
             .value=${props.filter}
             @input=${(e: Event) => props.onFilterChange((e.target as HTMLInputElement).value)}

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -940,6 +940,11 @@
     box-shadow var(--duration-fast) ease;
 }
 
+.field input:not([type="checkbox"]):not([type="radio"]),
+.field select {
+  height: 38px;
+}
+
 @media (hover: none) and (pointer: coarse) {
   .field input,
   .field textarea,


### PR DESCRIPTION
## What Problem This Solves

The Control UI Skills page rendered a raw missing translation key for the agent filter and vertically misaligned the adjacent agent and search controls. The initial CSS fix also applied a fixed height to every shared `.field input`, which would stretch unrelated checkbox and radio controls.

Fixes #99990. Supersedes #99996 after its contributor fork could not retain clean rebased ancestry; contributor credit is preserved through co-authorship and the maintainer release-note batch.

## Why This Change Was Made

- use the existing translated `usage.filters.agent` label;
- give the search field the existing translated `common.search` label so both filter fields have the same two-row structure;
- align only text-like inputs and selects at 38px;
- explicitly exclude checkbox/radio inputs from the shared fixed-height rule;
- cover translated labels and real Chromium control dimensions.

This keeps the fix at the shared form-control boundary without changing Skills filtering behavior or broadening checkbox/radio styling.

## User Impact

Skills filters now show Agent and Search with aligned controls. Checkbox and radio controls elsewhere in the Control UI retain their native sizing.

## Evidence

- Blacksmith Testbox `tbx_01kwtckpwsnnr7s7svd7jexrrp`, hosted run https://github.com/openclaw/openclaw/actions/runs/28759962471: 2 files, 11 focused UI/Chromium tests passed.
- Same Testbox: `pnpm ui:i18n:check` and `pnpm check:changed` passed.
- In-app browser against the reviewed tree: Agent select and Search input rendered at equal top/bottom coordinates with height 38; checkbox/radio remained height 13; translated labels rendered as Agent and Search.
- `git diff --check` passed.
- Fresh autoreview found no accepted/actionable findings.

One focused maintainer commit; original contributor preserved with `Co-authored-by: 杨爱文 <yang.aiwen@xydigit.com>`.

AI-assisted: Yes (Codex).
