### PR TITLE
fix(ui): remove redundant file-preview Escape hint

### DIFF
--- a/ui/src/components/file-preview-modal.test.ts
+++ b/ui/src/components/file-preview-modal.test.ts
@@ -67,6 +67,17 @@ describe("openclaw-file-preview-modal", () => {
     expect(shadowText(modal)).toContain("noreply@example.com");
   });
 
+  it("shows the Escape shortcut only on the close button", async () => {
+    const modal = await renderPreview();
+    const state = modal.shadowRoot?.querySelector<HTMLElement>(".state");
+    const closeButton = modal.shadowRoot?.querySelector<HTMLButtonElement>(".button");
+
+    expect(state?.textContent?.trim()).toBe("2 files");
+    expect(state?.querySelector(".kbd")).toBeNull();
+    expect(closeButton?.textContent?.replace(/\s+/g, " ").trim()).toBe("Close esc");
+    expect(closeButton?.querySelector(".kbd")?.textContent).toBe("esc");
+  });
+
   it("emits controlled query, select, and close events", async () => {
     const modal = await renderPreview();
     const onQuery = vi.fn();

--- a/ui/src/components/file-preview-modal.ts
+++ b/ui/src/components/file-preview-modal.ts
@@ -124,18 +124,10 @@ export class OpenClawFilePreviewModal extends LitElement {
       background: var(--bg-elevated);
     }
 
-    .esc,
     .kbd {
       font-family: var(--mono);
       border: 1px solid var(--border);
       color: var(--muted);
-    }
-
-    .esc {
-      font-size: 10px;
-      padding: 1px 5px;
-      border-radius: 3px;
-      background: var(--bg);
     }
 
     .body {
@@ -404,7 +396,7 @@ export class OpenClawFilePreviewModal extends LitElement {
             @input=${this.handleQueryInput}
             autofocus
           />
-          <span class="state">${fileCount} <span class="esc">esc</span></span>
+          <span class="state">${fileCount}</span>
         </header>
         <div class="body">
           <aside class="list">


### PR DESCRIPTION
## What Problem This Solves

The Control UI file preview modal displayed the Escape shortcut twice: once beside the file-count header and again on the Close button.

Fixes #99027. Supersedes #99029 after its contributor fork could not retain clean rebased ancestry; contributor credit is preserved through co-authorship and the maintainer release-note batch.

## Why This Change Was Made

The header-only badge and its orphaned style are removed. The Close button remains the single visible shortcut hint beside the action it documents, and the existing document-level Escape handler remains unchanged. A focused regression test asserts that only the Close button contains the hint.

## User Impact

File previews show one clear Escape shortcut hint without changing keyboard behavior.

## Evidence

- Blacksmith Testbox `tbx_01kwtdcpm4pefrxn940m0gy2mf`: 5 focused file-preview component tests passed.
- Same Testbox: `pnpm check:changed` passed.
- In-app browser against the reviewed component: dialog role present, ready state true, zero header `esc` badges, Close button text `Close esc`, and Escape close behavior retained.
- `git diff --check` passed.
- Fresh autoreview found no accepted/actionable findings.

One focused maintainer commit; original contributor preserved with `Co-authored-by: 咸士山 0668001391 <xian.shishan@xydigit.com>`.

AI-assisted: Yes (Codex).
