### PR TITLE
test(firecrawl): bound oversized JSON response body via readProviderJsonResponse

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.test.ts
+++ b/extensions/firecrawl/src/firecrawl-client.test.ts
@@ -1,6 +1,7 @@
 // Firecrawl tests cover firecrawl client behavior — URL safety,
 // scrape payload parsing, and search-item extraction.
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createStreamingResponse } from "../../test-support/streaming-error-response.js";
 
 let firecrawlClient: typeof import("./firecrawl-client.js").testing;
 
@@ -717,5 +718,25 @@ describe("parseFirecrawlScrapePayload", () => {
     });
 
     expect(result.title).toBeUndefined();
+  });
+});
+
+describe("readFirecrawlJsonResponse bounded read", () => {
+  it("cancels oversized JSON body via the 16 MiB provider cap", async () => {
+    const streamed = createStreamingResponse({
+      chunkCount: 32,
+      chunkSize: 1024 * 1024,
+      text: "x",
+      headers: { "content-type": "application/json" },
+    });
+    const jsonSpy = vi.spyOn(streamed.response, "json").mockRejectedValue(new Error("unbounded"));
+
+    await expect(
+      firecrawlClient.readFirecrawlJsonResponse(streamed.response, "Firecrawl Search"),
+    ).rejects.toThrow("Firecrawl Search: JSON response exceeds 16777216 bytes");
+
+    expect(streamed.getReadCount()).toBeLessThan(32);
+    expect(streamed.wasCanceled()).toBe(true);
+    expect(jsonSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

`readFirecrawlJsonResponse` delegates to `readProviderJsonResponse` (16 MiB cap) but had no test proving oversized bodies are cancelled mid-stream instead of buffered unboundedly in memory.
- Problem: No overflow test coverage for the bounded JSON response reader in firecrawl-client
- Solution: Add a streaming test that sends 32 MiB through the 16 MiB cap and verifies cancellation
- What changed: `extensions/firecrawl/src/firecrawl-client.test.ts` (21 lines added)
- What did NOT change: Production code, other test files, import structure

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A — pure test coverage improvement, no linked issue

## Motivation

The bounded-read pattern using `readProviderJsonResponse` is an established security hardening pattern across the codebase (dozens of merged PRs). Firecrawl client already uses it in production but lacked the standard overflow cancellation test. This closes the test gap.

## Real behavior proof

- Behavior addressed: Over-sized JSON body (32 MiB) read through `readFirecrawlJsonResponse` which delegates to the 16 MiB bounded reader
- Real environment tested: Linux x86_64, Node v24, branch `fix/firecrawl-bounded-read-test`
- Exact steps or command run after this patch:

```bash
pnpm test extensions/firecrawl/src/firecrawl-client.test.ts
```

- Evidence after fix:

```console
$ pnpm test extensions/firecrawl/src/firecrawl-client.test.ts

 RUN  v4.1.8

 Test Files  1 passed (1)
      Tests  53 passed (53)
```

- Observed result after fix:
  - New test "cancels oversized JSON body via the 16 MiB provider cap" passes
  - All 52 existing tests continue to pass
  - Test proves: stream cancelled before full consumption, `response.json()` never called, correct error thrown
- What was not tested: Live Firecrawl endpoint; real oversized response from Firecrawl API

## User-visible / Behavior Changes

None — test-only change.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification

- Verified scenarios: Streaming response > 16 MiB cancelled at the bounded reader boundary; error message includes label prefix; stream cancellation flag set; `response.json()` never reached
- Edge cases checked: Small valid responses pass through (existing tests cover this)
- What you did NOT verify: Live Firecrawl endpoint

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — follows the same overflow test pattern used across dozens of merged PRs
- **Refactor needed**: No
- **Alternative considered**: Testing via a real HTTP server (overkill; the streaming response fixture is the established pattern)

## AI Assistance

- **AI-assisted**: Yes
- **AI model**: DeepSeek V4
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

- **Highest-risk area**: None — test-only change, no production code modified
- **Mitigation**: Test uses the same `createStreamingResponse` fixture already used across the codebase
- **Compatibility impact**: None
