### PR TITLE
feat(ios): richer Settings About screen with mascot hero and project links

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -9451,7 +9451,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 621,
+      "line": 625,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "OpenClaw",
+      "surface": "apple",
+      "id": "native.apple.fc49f9b63e160581"
+    },
+    {
+      "kind": "ui-call",
+      "line": 627,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Personal AI on your devices",
+      "surface": "apple",
+      "id": "native.apple.eaa4fe72f3730f3f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 641,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "OpenClaw app version",
       "surface": "apple",
@@ -9459,15 +9475,63 @@
     },
     {
       "kind": "ui-call",
-      "line": 623,
+      "line": 643,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "iOS",
       "surface": "apple",
       "id": "native.apple.bbb2c589c2049217"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 648,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Website",
+      "surface": "apple",
+      "id": "native.apple.9f71c5c00d1bba49"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 653,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Docs",
+      "surface": "apple",
+      "id": "native.apple.7d10fb0ea5b704fa"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 658,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "GitHub",
+      "surface": "apple",
+      "id": "native.apple.e501402343d42f4d"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 663,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Discord",
+      "surface": "apple",
+      "id": "native.apple.ee880812d92bcacf"
+    },
+    {
       "kind": "ui-call",
-      "line": 647,
+      "line": 668,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "© 2026 OpenClaw Foundation — MIT License.",
+      "surface": "apple",
+      "id": "native.apple.b962116ff5bf1905"
+    },
+    {
+      "kind": "ui-call",
+      "line": 674,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Title",
+      "surface": "apple",
+      "id": "native.apple.106434d1305d153b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 716,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Controls whether location can be shared with gateway tools.",
       "surface": "apple",
@@ -9475,7 +9539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 659,
+      "line": 728,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Location",
       "surface": "apple",
@@ -9483,7 +9547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 660,
+      "line": 729,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Off",
       "surface": "apple",
@@ -9491,7 +9555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 663,
+      "line": 732,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "While Using",
       "surface": "apple",
@@ -9499,7 +9563,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 666,
+      "line": 735,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Always",
       "surface": "apple",
@@ -9507,7 +9571,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 689,
+      "line": 758,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Agent",
       "surface": "apple",
@@ -9515,7 +9579,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 690,
+      "line": 759,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default",
       "surface": "apple",
@@ -9523,7 +9587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 700,
+      "line": 769,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Used for new Chat and Talk sessions.",
       "surface": "apple",
@@ -9531,7 +9595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 707,
+      "line": 776,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Paste setup code",
       "surface": "apple",
@@ -9539,7 +9603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 713,
+      "line": 782,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Scan QR",
       "surface": "apple",
@@ -9547,7 +9611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 723,
+      "line": 792,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect",
       "surface": "apple",
@@ -9555,7 +9619,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 732,
+      "line": 801,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Setup Code",
       "surface": "apple",
@@ -9563,7 +9627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 745,
+      "line": 814,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovered Gateways",
       "surface": "apple",
@@ -9571,7 +9635,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 747,
+      "line": 816,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "No gateways found yet. Use manual setup if Bonjour is blocked.",
       "surface": "apple",
@@ -9579,7 +9643,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 786,
+      "line": 855,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Manual Gateway",
       "surface": "apple",
@@ -9587,7 +9651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 788,
+      "line": 857,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use Manual Gateway",
       "surface": "apple",
@@ -9595,7 +9659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 791,
+      "line": 860,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Host",
       "surface": "apple",
@@ -9603,7 +9667,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 795,
+      "line": 864,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Port",
       "surface": "apple",
@@ -9611,7 +9675,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 799,
+      "line": 868,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Use TLS",
       "surface": "apple",
@@ -9619,7 +9683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 803,
+      "line": 872,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Connect Manual",
       "surface": "apple",
@@ -9627,7 +9691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 819,
+      "line": 888,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Auto-connect on launch",
       "surface": "apple",
@@ -9635,7 +9699,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 822,
+      "line": 891,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Auth Token",
       "surface": "apple",
@@ -9643,7 +9707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 823,
+      "line": 892,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Password",
       "surface": "apple",
@@ -9651,7 +9715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 827,
+      "line": 896,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reset Onboarding",
       "surface": "apple",
@@ -9659,7 +9723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 854,
+      "line": 923,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Wake",
       "surface": "apple",
@@ -9667,7 +9731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 857,
+      "line": 926,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Talk Mode",
       "surface": "apple",
@@ -9675,7 +9739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 865,
+      "line": 934,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speech Language",
       "surface": "apple",
@@ -9683,7 +9747,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 872,
+      "line": 941,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speakerphone",
       "surface": "apple",
@@ -9691,7 +9755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 877,
+      "line": 946,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Wake Words",
       "surface": "apple",
@@ -9699,7 +9763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 897,
+      "line": 966,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice",
       "surface": "apple",
@@ -9707,7 +9771,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 898,
+      "line": 967,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Provider",
       "surface": "apple",
@@ -9715,7 +9779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 905,
+      "line": 974,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -9723,7 +9787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 906,
+      "line": 975,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -9731,7 +9795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 913,
+      "line": 982,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Mode",
       "surface": "apple",
@@ -9739,7 +9803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 914,
+      "line": 983,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Voice",
       "surface": "apple",
@@ -9747,7 +9811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 916,
+      "line": 985,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Last Voice Issue",
       "surface": "apple",
@@ -9755,7 +9819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 918,
+      "line": 987,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Transport",
       "surface": "apple",
@@ -9763,7 +9827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 919,
+      "line": 988,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "API Key",
       "surface": "apple",
@@ -9771,7 +9835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 927,
+      "line": 996,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Show Talk Control",
       "surface": "apple",
@@ -9779,7 +9843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 930,
+      "line": 999,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Share Instruction",
       "surface": "apple",
@@ -9787,7 +9851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 937,
+      "line": 1006,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Share Self-Test",
       "surface": "apple",
@@ -9795,7 +9859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 954,
+      "line": 1023,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Debug Logs",
       "surface": "apple",
@@ -9803,7 +9867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 957,
+      "line": 1026,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Debug Screen Status",
       "surface": "apple",
@@ -9811,7 +9875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 961,
+      "line": 1030,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Logs",
       "surface": "apple",
@@ -9819,7 +9883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 967,
+      "line": 1036,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device",
       "surface": "apple",
@@ -9827,7 +9891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 968,
+      "line": 1037,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device Name",
       "surface": "apple",
@@ -9835,7 +9899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 970,
+      "line": 1039,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Instance ID",
       "surface": "apple",

--- a/apps/ios/CHANGELOG.md
+++ b/apps/ios/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Redesigned the Settings About screen with the animated mascot, app tagline, and Website/Docs/GitHub/Discord links.
 - Fixed startup aborts caused by inactive Voice Wake initializing the simulator audio pipeline.
 - Debug builds now use separate app, extension, widget, and Watch identifiers plus a distinct debug icon, so they can remain installed beside release builds.
 - Animated the OpenClaw mascot (float, blink, antenna wiggle, claw snaps) across onboarding, sidebar, and command center, matching openclaw.ai.

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -616,12 +616,81 @@ extension SettingsProTab {
     }
 
     var aboutDestination: some View {
-        // Concise public details only; deep hardware identifiers live in Diagnostics.
-        detailListCard {
-            self.detailRow("OpenClaw app version", value: DeviceInfoHelper.openClawVersionString())
-            self.detailRow("Device", value: DeviceInfoHelper.deviceFamily())
-            self.detailRow("iOS", value: DeviceInfoHelper.iOSVersionStringForDisplay())
+        Group {
+            Section {
+                VStack(spacing: 12) {
+                    OpenClawProMark(size: 96, shadowRadius: 18)
+                        .accessibilityHidden(true)
+                    VStack(spacing: 2) {
+                        Text("OpenClaw")
+                            .font(OpenClawType.title2SemiBold)
+                        Text("Personal AI on your devices")
+                            .font(OpenClawType.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.top, 4)
+                .accessibilityElement(children: .combine)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+            }
+
+            // Concise public details only; deep hardware identifiers live in Diagnostics.
+            detailListCard {
+                self.detailRow("OpenClaw app version", value: DeviceInfoHelper.openClawVersionString())
+                self.detailRow("Device", value: DeviceInfoHelper.deviceFamily())
+                self.detailRow("iOS", value: DeviceInfoHelper.iOSVersionStringForDisplay())
+            }
+
+            Section {
+                self.aboutLinkRow(
+                    title: "Website",
+                    icon: "globe",
+                    color: .blue,
+                    url: URL(string: "https://openclaw.ai")!)
+                self.aboutLinkRow(
+                    title: "Docs",
+                    icon: "book.fill",
+                    color: .orange,
+                    url: URL(string: "https://docs.openclaw.ai")!)
+                self.aboutLinkRow(
+                    title: "GitHub",
+                    icon: "chevron.left.slash.chevron.right",
+                    color: .gray,
+                    url: URL(string: "https://github.com/openclaw/openclaw")!)
+                self.aboutLinkRow(
+                    title: "Discord",
+                    icon: "bubble.left.and.bubble.right.fill",
+                    color: .indigo,
+                    url: URL(string: "https://discord.gg/clawd")!)
+            } footer: {
+                Text("© 2026 OpenClaw Foundation — MIT License.")
+                    .font(OpenClawType.footnote)
+            }
         }
+    }
+
+    /// About link row with explicit branded label; shorthand `Link("Title", ...)`
+    /// would bypass the typography audit and OpenClawType styling.
+    func aboutLinkRow(title: String, icon: String, color: Color, url: URL) -> some View {
+        Link(destination: url) {
+            HStack {
+                Label {
+                    Text(title)
+                        .font(OpenClawType.subheadSemiBold)
+                        .foregroundStyle(.primary)
+                } icon: {
+                    SettingsIcon(systemName: icon, color: color)
+                }
+                Spacer()
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .contentShape(Rectangle())
+        }
+        .accessibilityLabel(title)
     }
 
     func toggleCard(title: String, isOn: Binding<Bool>) -> some View {


### PR DESCRIPTION
## What Problem This Solves

The Settings → About screen in the iOS app was a bare three-row table (app version, device, iOS version) with no branding, product identity, or way to reach the project. For an app whose mascot and brand treatment already animate across onboarding, sidebar, and command center, About was the one place that still looked like a debug page.

## Why This Change Was Made

Rebuilds the About destination around existing brand components instead of adding new surface: the animated `OpenClawProMark` mascot hero with the App Store tagline ("Personal AI on your devices"), the same concise version/device rows as before, a new links section (Website, Docs, GitHub, Discord) using the settings-native `SettingsIcon` row style, and the OpenClaw Foundation MIT footer matching the macOS About pane. Deep hardware identifiers stay in Diagnostics; the guarded "concise public details" contract (`RootTabsSourceGuardTests`) is unchanged and passes verbatim. Link rows use explicit `Link(destination:)` label builders with `OpenClawType` fonts so the typography audit still covers them.

## User Impact

The About screen now shows who made the app and where to get help: users can jump straight to openclaw.ai, docs.openclaw.ai, the GitHub repo, or the Discord community, and the app identity is presented with the same animated mascot treatment as the rest of the app.

## Evidence

- `pnpm ios:build` (Debug, iPhone 17 simulator, Xcode 26 toolchain) — **BUILD SUCCEEDED**
- Focused tests `OpenClawTests/RootTabsSourceGuardTests`, `OpenClawTests/OpenClawTypographyTests`, `OpenClawTests/SwiftUIRenderSmokeTests` (includes the About light/dark render smoke test) — result posted in PR comment before merge
- `swiftformat --lint` + `swiftlint` on the touched file — 0 violations
- Codex autoreview (gpt-5.5): clean, no actionable findings
- Verified live on an iPhone 17 Pro simulator (iOS 27.0) in light and dark mode via `--openclaw-screenshot-mode`: mascot hero with glow, tagline, version rows, all four link rows, and MIT footer render correctly; About row navigation from Settings works. (Screenshot upload blocked by unconfigured Crabbox artifact broker; captures retained locally.)
