### PR TITLE
fix(anthropic): add claude-sonnet-5 to adaptive thinking and native max effort allowlists

### DIFF
--- a/packages/llm-core/src/model-contracts/anthropic.ts
+++ b/packages/llm-core/src/model-contracts/anthropic.ts
@@ -68,7 +68,7 @@ export function supportsClaudeNativeMaxEffort(ref: ClaudeModelRef): boolean {
 /** Return whether a Claude model supports native xhigh effort. */
 export function supportsClaudeNativeXhighEffort(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-(?:fable-5|opus-4-(?:7|8))(?=$|[^a-z0-9])/.test(modelId);
+  return /(?:^|-)claude-(?:fable-5|opus-4-(?:7|8)|sonnet-5)(?=$|[^a-z0-9])/.test(modelId);
 }
 
 /**

--- a/packages/llm-core/src/model-contracts/anthropic.ts
+++ b/packages/llm-core/src/model-contracts/anthropic.ts
@@ -54,7 +54,7 @@ export function resolveClaudeFable5ModelIdentity(ref: ClaudeModelRef): string | 
 /** Return whether a Claude model supports adaptive thinking. */
 export function supportsClaudeAdaptiveThinking(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-(?:fable-5|mythos-preview|opus-4-(?:6|7|8)|sonnet-4-6)(?=$|[^a-z0-9])/.test(
+  return /(?:^|-)claude-(?:fable-5|mythos-preview|opus-4-(?:6|7|8)|sonnet-(?:4-6|5))(?=$|[^a-z0-9])/.test(
     modelId,
   );
 }
@@ -62,7 +62,7 @@ export function supportsClaudeAdaptiveThinking(ref: ClaudeModelRef): boolean {
 /** Return whether a Claude model supports native max effort. */
 export function supportsClaudeNativeMaxEffort(ref: ClaudeModelRef): boolean {
   const modelId = resolveClaudeModelIdentity(ref);
-  return /(?:^|-)claude-(?:fable-5|opus-4-(?:6|7|8)|sonnet-4-6)(?=$|[^a-z0-9])/.test(modelId);
+  return /(?:^|-)claude-(?:fable-5|opus-4-(?:6|7|8)|sonnet-(?:4-6|5))(?=$|[^a-z0-9])/.test(modelId);
 }
 
 /** Return whether a Claude model supports native xhigh effort. */

--- a/proof-100254.ts
+++ b/proof-100254.ts
@@ -1,0 +1,115 @@
+/**
+ * Proof script for #100254: claude-sonnet-5 adaptive thinking allowlist
+ *
+ * Validates that claude-sonnet-5 is now recognized as supporting
+ * adaptive thinking and native max effort in the model-contracts layer.
+ *
+ * Usage: npx tsx proof-100254.ts
+ */
+
+import {
+  supportsClaudeAdaptiveThinking,
+  supportsClaudeNativeMaxEffort,
+  supportsClaudeNativeXhighEffort,
+  resolveClaudeModelIdentity,
+} from "@openclaw/llm-core";
+
+function check(name: string, fn: () => boolean, expected: boolean) {
+  const result = fn();
+  const ok = result === expected;
+  console.log(`${ok ? "PASS" : "FAIL"} ${name}: got ${result}, expected ${expected}`);
+  return ok;
+}
+
+let passed = 0;
+let failed = 0;
+
+function test(name: string, fn: () => boolean, expected: boolean) {
+  if (check(name, fn, expected)) passed++;
+  else failed++;
+}
+
+console.log("=== #100254 proof: claude-sonnet-5 model-contract allowlists ===\n");
+
+// --- Adaptive thinking (the reported bug) ---
+console.log("supportsClaudeAdaptiveThinking:");
+test("  sonnet-5 (bare)", () => supportsClaudeAdaptiveThinking({ id: "claude-sonnet-5" }), true);
+test(
+  "  sonnet-5 with anthropic/ prefix",
+  () => supportsClaudeAdaptiveThinking({ id: "anthropic/claude-sonnet-5" }),
+  true,
+);
+test(
+  "  sonnet-5 with date suffix",
+  () => supportsClaudeAdaptiveThinking({ id: "claude-sonnet-5@20260701" }),
+  true,
+);
+test(
+  "  sonnet-4-6 still works",
+  () => supportsClaudeAdaptiveThinking({ id: "claude-sonnet-4-6" }),
+  true,
+);
+test(
+  "  sonnet-4-60 not a match",
+  () => supportsClaudeAdaptiveThinking({ id: "claude-sonnet-4-60" }),
+  false,
+);
+
+// --- Native max effort (cascading: needs this for default effort) ---
+console.log("\nsupportsClaudeNativeMaxEffort:");
+test("  sonnet-5 (bare)", () => supportsClaudeNativeMaxEffort({ id: "claude-sonnet-5" }), true);
+test(
+  "  sonnet-5 with prefix",
+  () => supportsClaudeNativeMaxEffort({ id: "anthropic/claude-sonnet-5" }),
+  true,
+);
+test(
+  "  sonnet-4-6 still works",
+  () => supportsClaudeNativeMaxEffort({ id: "claude-sonnet-4-6" }),
+  true,
+);
+test("  fable-5 still works", () => supportsClaudeNativeMaxEffort({ id: "claude-fable-5" }), true);
+
+// --- Xhigh: sonnet-5 SHOULD support xhigh (added per ClawSweeper review) ---
+console.log("\nsupportsClaudeNativeXhighEffort:");
+test(
+  "  sonnet-5 DOES support xhigh",
+  () => supportsClaudeNativeXhighEffort({ id: "claude-sonnet-5" }),
+  true,
+);
+test(
+  "  sonnet-5 with date suffix supports xhigh",
+  () => supportsClaudeNativeXhighEffort({ id: "claude-sonnet-5@20260701" }),
+  true,
+);
+test(
+  "  opus-4-8 DOES support xhigh",
+  () => supportsClaudeNativeXhighEffort({ id: "claude-opus-4-8" }),
+  true,
+);
+test(
+  "  sonnet-4-6 does NOT support xhigh",
+  () => supportsClaudeNativeXhighEffort({ id: "claude-sonnet-4-6" }),
+  false,
+);
+test(
+  "  sonnet-50 does NOT match xhigh",
+  () => supportsClaudeNativeXhighEffort({ id: "claude-sonnet-50" }),
+  false,
+);
+
+// --- Model identity normalization ---
+console.log("\nresolveClaudeModelIdentity:");
+test(
+  "  anthropic/claude-sonnet-5 → claude-sonnet-5",
+  () => resolveClaudeModelIdentity({ id: "anthropic/claude-sonnet-5" }) === "claude-sonnet-5",
+  true,
+);
+test(
+  "  claude-sonnet-5 → claude-sonnet-5",
+  () => resolveClaudeModelIdentity({ id: "claude-sonnet-5" }) === "claude-sonnet-5",
+  true,
+);
+
+console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+if (failed > 0) process.exit(1);

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -44,6 +44,9 @@ describe("Claude model contracts", () => {
       "claude-fable-5@20260601",
     );
     expect(supportsClaudeAdaptiveThinking({ id: "claude-sonnet-4-6@20260301" })).toBe(true);
+    expect(supportsClaudeAdaptiveThinking({ id: "claude-sonnet-5" })).toBe(true);
+    expect(supportsClaudeAdaptiveThinking({ id: "claude-sonnet-5@20260701" })).toBe(true);
+    expect(supportsClaudeNativeMaxEffort({ id: "claude-sonnet-5" })).toBe(true);
     expect(supportsClaudeNativeXhighEffort({ id: "claude-opus-4-8@20260401" })).toBe(true);
   });
 

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -48,11 +48,13 @@ describe("Claude model contracts", () => {
     expect(supportsClaudeAdaptiveThinking({ id: "claude-sonnet-5@20260701" })).toBe(true);
     expect(supportsClaudeNativeMaxEffort({ id: "claude-sonnet-5" })).toBe(true);
     expect(supportsClaudeNativeXhighEffort({ id: "claude-opus-4-8@20260401" })).toBe(true);
+    expect(supportsClaudeNativeXhighEffort({ id: "claude-sonnet-5" })).toBe(true);
   });
 
   it("does not classify later numeric model versions as supported aliases", () => {
     expect(supportsClaudeAdaptiveThinking({ id: "claude-sonnet-4-60" })).toBe(false);
     expect(supportsClaudeNativeXhighEffort({ id: "claude-opus-4-80" })).toBe(false);
+    expect(supportsClaudeNativeXhighEffort({ id: "claude-sonnet-50" })).toBe(false);
     expect(readLevelIds(resolveClaudeThinkingProfile("claude-opus-4-80"))).toEqual([
       "off",
       "minimal",


### PR DESCRIPTION
## What Problem This Solves

Fixes #100254. `claude-sonnet-5` was missing from the `supportsClaudeAdaptiveThinking`, `supportsClaudeNativeMaxEffort`, and `supportsClaudeNativeXhighEffort` regex allowlists in `packages/llm-core/src/model-contracts/anthropic.ts`. Every non-off thinking turn using this model sent the deprecated `thinking.type="enabled"` request shape instead of the required adaptive `thinking.type="adaptive"` + `output_config.effort` shape, causing Anthropic's API to reject the request with `invalid_request_error` before any tokens were billed. Additionally, `xhigh` effort was downgraded to `high` because `mapThinkingLevelToEffort()` depends on the xhigh gate.

## Why This Change Was Made

The three regex patterns are the single source of truth for whether a Claude model supports adaptive thinking, native max effort, and native xhigh effort. Sonnet 5 supports all three (like Sonnet 4.6 for adaptive/max, and like Opus for xhigh per Anthropic's launch docs), but was omitted from the patterns. The fix adds `sonnet-5` to all three regexes.

**Update (per ClawSweeper review)**: Added `sonnet-5` to `supportsClaudeNativeXhighEffort` so `/think xhigh` maps to `output_config.effort: "xhigh"` instead of being downgraded to `high`.

## Evidence

### Updated proof (16 assertions including xhigh):
```
$ npx tsx proof-100254.ts
=== #100254 proof: claude-sonnet-5 model-contract allowlists ===

supportsClaudeAdaptiveThinking:
PASS   sonnet-5 (bare): got true, expected true
PASS   sonnet-5 with anthropic/ prefix: got true, expected true
PASS   sonnet-5 with date suffix: got true, expected true
PASS   sonnet-4-6 still works: got true, expected true
PASS   sonnet-4-60 not a match: got false, expected false

supportsClaudeNativeMaxEffort:
PASS   sonnet-5 (bare): got true, expected true
PASS   sonnet-5 with prefix: got true, expected true
PASS   sonnet-4-6 still works: got true, expected true
PASS   fable-5 still works: got true, expected true

supportsClaudeNativeXhighEffort:
PASS   sonnet-5 DOES support xhigh: got true, expected true
PASS   sonnet-5 with date suffix supports xhigh: got true, expected true
PASS   opus-4-8 DOES support xhigh: got true, expected true
PASS   sonnet-4-6 does NOT support xhigh: got false, expected false
PASS   sonnet-50 does NOT match xhigh: got false, expected false

resolveClaudeModelIdentity:
PASS   anthropic/claude-sonnet-5 → claude-sonnet-5: got true, expected true
PASS   claude-sonnet-5 → claude-sonnet-5: got true, expected true

=== Results: 16 passed, 0 failed ===
```

### Tests (including xhigh contract assertions):
- `claude-sonnet-5` passes `supportsClaudeNativeXhighEffort`
- `claude-sonnet-50` (longer numeric suffix) does NOT match xhigh
- Existing xhigh tests for opus-4-8, opus-4-80 continue to pass

## Merge Risk

Low — 3-line regex change + 4 test assertions. No logic changes, no new dependencies.