### PR TITLE
feat(telegram): offer BotFather web app flow next to the chat flow in onboarding

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -23,7 +23,11 @@ Production-ready for bot DMs and groups via grammY. Long polling is the default 
 
 <Steps>
   <Step title="Create the bot token in BotFather">
-    Open Telegram, chat with **@BotFather** (confirm the handle is exactly `@BotFather`), run `/newbot`, follow the prompts, and save the token.
+    Both flows end with a token you paste into OpenClaw — pick one:
+
+    - **Chat flow**: open Telegram, chat with **@BotFather** (confirm the handle is exactly `@BotFather`), run `/newbot`, follow the prompts, and save the token.
+    - **Web flow**: open [BotFather's web app](https://t.me/BotFather?startapp) — it runs in every Telegram client, including [web.telegram.org](https://web.telegram.org) — create the bot in the UI, and copy its token.
+
   </Step>
 
   <Step title="Configure token and DM policy">
@@ -98,6 +102,8 @@ Token resolution is account-aware: `tokenFile` beats `botToken` beats env, and c
 
     - `/setjoingroups` — allow/deny group adds
     - `/setprivacy` — group visibility behavior
+
+    The same settings are available in [BotFather's web app](https://t.me/BotFather?startapp) if you prefer a UI over chat commands.
 
   </Accordion>
 </AccordionGroup>

--- a/extensions/telegram/src/setup-core.ts
+++ b/extensions/telegram/src/setup-core.ts
@@ -22,6 +22,9 @@ export function getTelegramTokenHelpLines(): string[] {
     t("wizard.telegram.tokenHelpOpenBotFather"),
     t("wizard.telegram.tokenHelpNewBot"),
     t("wizard.telegram.tokenHelpCopyToken"),
+    // Telegram's documented BotFather Mini App deep link (core.telegram.org/bots/features);
+    // web-based alternative to the /newbot chat flow, also works on web.telegram.org.
+    t("wizard.telegram.tokenHelpWebApp", { url: "https://t.me/BotFather?startapp" }),
     t("wizard.telegram.tokenEnvTip"),
     t("wizard.channels.docs", { link: formatDocsLink("/telegram") }),
     t("wizard.telegram.website", { url: "https://openclaw.ai" }),

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -481,6 +481,7 @@ export const en = {
       tokenHelpCopyToken: "3) Copy the token (looks like 123456:ABC...)",
       tokenHelpNewBot: "2) Run /newbot (or /mybots)",
       tokenHelpOpenBotFather: "1) Open Telegram and chat with @BotFather",
+      tokenHelpWebApp: "Prefer a UI? BotFather's web app: {url} (create a bot, copy its token)",
       tokenInputPrompt: "Enter Telegram bot token",
       tokenKeepPrompt: "Telegram token already configured. Keep it?",
       userIdHelpGetUpdates:

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -468,6 +468,7 @@ export const zh_CN = {
       tokenHelpCopyToken: "3) 复制 token（格式类似 123456:ABC...）",
       tokenHelpNewBot: "2) 运行 /newbot（或 /mybots）",
       tokenHelpOpenBotFather: "1) 打开 Telegram 并与 @BotFather 对话",
+      tokenHelpWebApp: "更喜欢图形界面？BotFather 网页应用：{url}（创建 bot 后复制 token）",
       tokenInputPrompt: "输入 Telegram bot token",
       tokenKeepPrompt: "Telegram token 已配置。保留当前值？",
       userIdHelpGetUpdates:

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -468,6 +468,7 @@ export const zh_TW = {
       tokenHelpCopyToken: "3) 複製 token（格式類似 123456:ABC...）",
       tokenHelpNewBot: "2) 執行 /newbot（或 /mybots）",
       tokenHelpOpenBotFather: "1) 打開 Telegram 並與 @BotFather 對話",
+      tokenHelpWebApp: "偏好圖形介面？BotFather 網頁應用程式：{url}（建立 bot 後複製 token）",
       tokenInputPrompt: "輸入 Telegram bot token",
       tokenKeepPrompt: "Telegram token 已設定。保留目前值？",
       userIdHelpGetUpdates:


### PR DESCRIPTION
Closes #100538

## What Problem This Solves

Telegram onboarding only describes the chat-command way to get a bot token: DM @BotFather, run `/newbot`, copy the token. Telegram now ships an official web-based flow — the BotFather web app (Mini App) at `https://t.me/BotFather?startapp` — which runs in every Telegram client including web.telegram.org. Neither `openclaw onboard telegram` nor the docs quick-setup mention it, so users who prefer a UI (or are on Telegram Web, where the chat flow is clumsy) never find it.

## Why This Change Was Made

Surfaces the web flow next to the existing chat flow without changing any behavior: one new help line in the setup wizard's token help (all three wizard locales), and the docs quick-setup step now presents both flows. Both paths end the same way — the user pastes a token — so the wizard structure, config surface, and token validation are untouched.

Deeper integration via Telegram managed bots (Bot API 9.6+ `t.me/newbot/...` deep link + `getManagedBotToken`, fully removing token copy-paste) is intentionally out of scope; it needs a product decision about operating a manager bot and token custody — context and API details are in #100538.

## User Impact

Users setting up the Telegram channel see both token-creation paths in `openclaw onboard telegram` and in the docs, and can create their bot entirely from a web UI. The BotFather toggles accordion in the docs also points at the web app as the GUI alternative for settings like `/setprivacy`.

## Evidence

- Wizard help line source: Telegram's documented BotFather Mini App deep link (https://core.telegram.org/bots/features).
- Focused tests (local, via `node scripts/run-vitest.mjs`): `src/wizard/i18n/index.test.ts` 5 passed (includes the shipped-locale key-parity check covering the new `tokenHelpWebApp` key in en/zh-CN/zh-TW) and `extensions/telegram/src/setup-surface.test.ts` 12 passed.
- `oxfmt --check` and `oxlint` clean on the touched files; `git diff --check` clean.
