### PR TITLE
fix(ui): use in-app confirmation for session bulk delete

### DIFF
--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -100,6 +100,7 @@ export class SessionsPage extends LitElement {
   @state() private checkpointLoadingKey: string | null = null;
   @state() private checkpointBusyKey: string | null = null;
   @state() private checkpointErrorByKey: Record<string, string> = {};
+  @state() private deleteConfirmOpen = false;
 
   private stopSessionSubscription?: () => void;
   private stopAgentIdentitySubscription?: () => void;
@@ -470,19 +471,28 @@ export class SessionsPage extends LitElement {
     void this.loadSessions();
   }
 
+  private requestDeleteSelected() {
+    if (this.selectedKeys.size === 0 || this.loading) {
+      return;
+    }
+    this.deleteConfirmOpen = true;
+  }
+
+  private cancelDeleteSelected() {
+    if (this.loading) {
+      return;
+    }
+    this.deleteConfirmOpen = false;
+  }
+
   private async deleteSelected() {
     const context = this.context;
     const keys = [...this.selectedKeys];
     if (!context || keys.length === 0 || this.loading) {
+      this.deleteConfirmOpen = false;
       return;
     }
-    if (
-      !window.confirm(
-        `Delete ${keys.length} ${keys.length === 1 ? "session" : "sessions"}?\n\nThis will delete the session entries and archive their transcripts.`,
-      )
-    ) {
-      return;
-    }
+    this.deleteConfirmOpen = false;
     this.sessionMutationPending = true;
     const result = await context.sessions
       .deleteMany(
@@ -818,8 +828,12 @@ export class SessionsPage extends LitElement {
         },
         onDeselectAll: () => {
           this.selectedKeys = new Set();
+          this.deleteConfirmOpen = false;
         },
-        onDeleteSelected: () => void this.deleteSelected(),
+        onDeleteSelected: () => this.requestDeleteSelected(),
+        deleteConfirmOpen: this.deleteConfirmOpen,
+        onConfirmDeleteSelected: () => void this.deleteSelected(),
+        onCancelDeleteSelected: () => this.cancelDeleteSelected(),
         onNavigateToChat: (sessionKey) =>
           context.navigate("chat", { search: searchForSession(sessionKey), hash: "" }),
         onAddToWorkboard: canCapture

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -3,6 +3,11 @@
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import type { SessionsListResult } from "../../api/types.ts";
+import {
+  getRenderedModalDialog,
+  installDialogPolyfill,
+  nextFrame,
+} from "../../test-helpers/modal-dialog.ts";
 import { renderSessions, type SessionsProps } from "./view.ts";
 
 function buildResult(
@@ -72,6 +77,9 @@ function buildProps(result: SessionsListResult): SessionsProps {
     onDeselectPage: () => undefined,
     onDeselectAll: () => undefined,
     onDeleteSelected: () => undefined,
+    deleteConfirmOpen: false,
+    onConfirmDeleteSelected: () => undefined,
+    onCancelDeleteSelected: () => undefined,
     onToggleCheckpointDetails: () => undefined,
     onBranchFromCheckpoint: () => undefined,
     onRestoreCheckpoint: () => undefined,
@@ -109,6 +117,49 @@ const SESSION_TABLE_HEADERS = [
 ];
 
 describe("sessions view", () => {
+  it("renders a modal delete confirmation for selected sessions", async () => {
+    const restoreDialog = installDialogPolyfill();
+    try {
+      const container = document.createElement("div");
+      document.body.append(container);
+      const onConfirmDeleteSelected = vi.fn();
+      const onCancelDeleteSelected = vi.fn();
+      render(
+        renderSessions({
+          ...buildProps(
+            buildResult({
+              key: "agent:main:dashboard:1",
+              kind: "direct",
+              updatedAt: Date.now(),
+            }),
+          ),
+          selectedKeys: new Set(["agent:main:dashboard:1", "agent:main:dashboard:2"]),
+          deleteConfirmOpen: true,
+          onConfirmDeleteSelected,
+          onCancelDeleteSelected,
+        }),
+        container,
+      );
+      await Promise.resolve();
+      const { dialog } = await getRenderedModalDialog(container);
+      expect(dialog.open).toBe(true);
+      expect(container.textContent).toContain("Delete 2 sessions?");
+
+      const buttons = Array.from(
+        container.querySelectorAll<HTMLButtonElement>(".exec-approval-actions button"),
+      );
+      buttons[0]?.click();
+      buttons[1]?.click();
+      await nextFrame();
+
+      expect(onConfirmDeleteSelected).toHaveBeenCalledTimes(1);
+      expect(onCancelDeleteSelected).toHaveBeenCalledTimes(1);
+      container.remove();
+    } finally {
+      restoreDialog();
+    }
+  });
+
   it("renders an explicit archived-session toggle", async () => {
     const container = document.createElement("div");
     const onFiltersChange = vi.fn();

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../api/types.ts";
 import { pathForRoute } from "../../app-route-paths.ts";
 import { icons } from "../../components/icons.ts";
+import "../../components/modal-dialog.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveAgentRuntimeLabel } from "../../lib/agents/display.ts";
@@ -99,6 +100,9 @@ export type SessionsProps = {
   onDeselectPage: (keys: string[]) => void;
   onDeselectAll: () => void;
   onDeleteSelected: () => void;
+  deleteConfirmOpen: boolean;
+  onConfirmDeleteSelected: () => void;
+  onCancelDeleteSelected: () => void;
   onNavigateToChat?: (sessionKey: string) => void;
   workboardSessionKeys?: Set<string>;
   workboardBusySessionKey?: string | null;
@@ -1016,6 +1020,48 @@ export function renderSessions(props: SessionsProps) {
           : nothing}
       </div>
     </section>
+    ${renderDeleteSelectedConfirmation(props)}
+  `;
+}
+
+function renderDeleteSelectedConfirmation(props: SessionsProps) {
+  if (!props.deleteConfirmOpen || props.selectedKeys.size === 0) {
+    return nothing;
+  }
+  const count = props.selectedKeys.size;
+  const title = `Delete ${count} ${count === 1 ? "session" : "sessions"}?`;
+  const description = "This will delete the session entries and archive their transcripts.";
+  return html`
+    <openclaw-modal-dialog
+      label=${title}
+      description=${description}
+      @modal-cancel=${() => {
+        if (!props.loading) {
+          props.onCancelDeleteSelected();
+        }
+      }}
+    >
+      <div class="exec-approval-card">
+        <div class="exec-approval-header">
+          <div>
+            <div class="exec-approval-title">${title}</div>
+            <div class="exec-approval-sub">${description}</div>
+          </div>
+        </div>
+        <div class="exec-approval-actions">
+          <button
+            class="btn danger"
+            ?disabled=${props.loading}
+            @click=${props.onConfirmDeleteSelected}
+          >
+            ${count === 1 ? "Delete session" : "Delete sessions"}
+          </button>
+          <button class="btn" ?disabled=${props.loading} @click=${props.onCancelDeleteSelected}>
+            ${t("common.cancel")}
+          </button>
+        </div>
+      </div>
+    </openclaw-modal-dialog>
   `;
 }
 


### PR DESCRIPTION
## Summary
- replace the sessions page bulk-delete `window.confirm(...)` flow with an in-app modal dialog
- keep the existing delete wording, but render it through `openclaw-modal-dialog` so the macOS dashboard Web UI gets a visible confirmation step
- add a sessions view test that verifies the confirmation modal renders and wires confirm/cancel actions

## Testing
- pnpm exec vitest run --config vitest.config.ts src/pages/sessions/view.test.ts
- pnpm tsgo:test:ui

Closes #99286
