### PR TITLE
fix(telegram): add missing "edit" retry context for editMessageTelegram

### DIFF
--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -140,13 +140,14 @@ describe("isRecoverableTelegramNetworkError", () => {
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "polling" })).toBe(true);
   });
 
-  it("treats delete/react (idempotent) contexts like polling, not send", () => {
+  it("treats delete/react/edit (idempotent) contexts like polling, not send", () => {
     const undiciSnippetErr = new Error("Undici: socket failure");
-    // delete and react are idempotent Telegram operations; a transient
+    // delete, react, and edit are idempotent Telegram operations; a transient
     // snippet-only error must be retried (allowMessageMatch defaults true),
     // matching polling/webhook. send stays strict as the regression guard.
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "delete" })).toBe(true);
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "react" })).toBe(true);
+    expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "edit" })).toBe(true);
     expect(isRecoverableTelegramNetworkError(undiciSnippetErr, { context: "send" })).toBe(false);
   });
 

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -147,6 +147,7 @@ export type TelegramNetworkErrorContext =
   | "webhook"
   | "delete"
   | "react"
+  | "edit"
   | "unknown";
 export type TelegramNetworkErrorOrigin = {
   method?: string | null;

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -1807,8 +1807,7 @@ export async function editMessageTelegram(
     retry: opts.retry,
     verbose: opts.verbose,
     shouldRetry: (err) =>
-      isRecoverableTelegramNetworkError(err, { allowMessageMatch: true }) ||
-      isTelegramServerError(err),
+      isRecoverableTelegramNetworkError(err, { context: "edit" }) || isTelegramServerError(err),
   });
   const requestWithEditShouldLog = <T>(
     fn: () => Promise<T>,


### PR DESCRIPTION
### What Problem This Solves

`editMessageTelegram` passed `{ allowMessageMatch: true }` directly to `isRecoverableTelegramNetworkError` instead of using a named context. Every other caller in the send funnel uses a `TelegramNetworkErrorContext` value — `"send"` for sendMessage, `"delete"` for deleteMessage, `"react"` for setMessageReaction, `"polling"` for monitor/polling paths. The edit path was the only caller that bypassed the context enum with a raw boolean flag, making the retry policy implicit where siblings are explicit.

### Why This Change Was Made

Editing a message is semantically idempotent — retrying an edit with the same content returns `MESSAGE_NOT_MODIFIED` from Telegram, so transient network errors that lack an error `code` (e.g. `socket hang up`) should trigger a retry. The current code already behaves correctly via `allowMessageMatch: true`, but uses a bare flag where every sibling operation uses a named context.

Adding `"edit"` to `TelegramNetworkErrorContext` and using it makes the retry policy explicit and consistent:

| operation          | context    | allowMessageMatch |
|--------------------|------------|-------------------|
| sendMessage        | `"send"`   | false (strict)    |
| setMessageReaction | `"react"`  | true              |
| deleteMessage      | `"delete"` | true              |
| editMessageText    | `"edit"`   | true              |

There is zero behavioral difference: `{ allowMessageMatch: true }` and `{ context: "edit" }` are equivalent in the current implementation (`context !== "send"` → `allowMessageMatch` defaults to `true`).

### User Impact

No behavioral change. Edits continue to retry on the same set of transient network errors. The retry policy is merely expressed through the context enum like all other operations.

### Real Behavior Proof

- **Behavior addressed:** `editMessageTelegram` retry predicate used raw  `allowMessageMatch: true`; no caller used an `"edit"` context.
- **Real environment:** Linux x86_64, Node 24, commit `3c180729` on branch `fix/telegram-add-edit-retry-context`.
- **Exact steps or command run after this patch:** `node --import tsx /tmp/verify-telegram-edit-context.mjs` — imports real `isRecoverableTelegramNetworkError` and checks snippet-only transient errors across all contexts plus equivalence between old and new forms.
- **Evidence after fix:**

```
scenario: transient snippet-only network errors (no error code)
fix: edit context must retry like delete/react, old allowMessageMatch:true must match

err="socket hang up" (no error code)
    send (non-idempotent)                  context:"send"           => false PASS
    delete (idempotent baseline)           context:"delete"         => true  PASS
    react (idempotent baseline)            context:"react"          => true  PASS
    edit (idempotent FIX)                  context:"edit"           => true  PASS
    edit old (allowMsgMatch:true)          context:"<none>"         => true  PASS

err="Undici: network error"
    send (non-idempotent)                  context:"send"           => false PASS
    delete (idempotent baseline)           context:"delete"         => true  PASS
    react (idempotent baseline)            context:"react"          => true  PASS
    edit (idempotent FIX)                  context:"edit"           => true  PASS
    edit old (allowMsgMatch:true)          context:"<none>"         => true  PASS

err="Request timed out after 30 seconds"
    send (non-idempotent)                  context:"send"           => false PASS
    delete (idempotent baseline)           context:"delete"         => true  PASS
    react (idempotent baseline)            context:"react"          => true  PASS
    edit (idempotent FIX)                  context:"edit"           => true  PASS
    edit old (allowMsgMatch:true)          context:"<none>"         => true  PASS

err=ECONNREFUSED (has error code)
    send                                   context:"send"           => true  PASS
    delete                                 context:"delete"         => true  PASS
    react                                  context:"react"          => true  PASS
    edit                                   context:"edit"           => true  PASS

err="invalid token" (non-network)
    send                                   context:"send"           => false PASS
    delete                                 context:"delete"         => false PASS
    react                                  context:"react"          => false PASS
    edit                                   context:"edit"           => false PASS

equivalence: { context: "edit" } === { allowMessageMatch: true }
  socket hang up: PASS
  undici error  : PASS
  timeout       : PASS

Verdict: PASS (26 assertions, 0 failures)
```

- **Observed result after fix:** `"edit"` context returns recoverable for snippet-only transient errors, matching `"delete"` / `"react"`. `"send"` stays strict. Old `allowMessageMatch: true` and new `context: "edit"` produce identical results for all tested error types. Coded recoverable errors (ECONNREFUSED) retry across all contexts; non-network errors (invalid token) never retry.
- **What was not tested:** Live end-to-end `editMessageText` against a real Telegram bot under injected transient socket error.

### Tests and Validation

```
$ pnpm test extensions/telegram/src/network-errors.test.ts
Test Files  1 passed (1)
Tests       58 passed (58)

$ pnpm tsgo:extensions:test
EXIT=0 (type check passed)
```

One regression assertion added: `"edit"` context treats snippet-only errors as recoverable (matching `"delete"` / `"react"`), while `"send"` stays strict.

### Risk Checklist

- **User-visible behavior:** No — zero behavioral change.
- **Config/env/migration behavior:** No.
- **Security/auth/secrets/network/tool execution:** No.
- **Plugins/providers/channels/SDK:** No — internal to Telegram plugin.
- **Highest-risk area:** None. The change is a pure label swap; the retry
  predicate helper produces identical results for both forms.
- **Mitigation:** Existing tests (58) + new regression case guard semantics;
  `sendMessage` keeps `"send"` (strict).

Closes: N/A
