### PR TITLE
fix(devices): recover unknown requestId approvals in password mode

### DIFF
--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -308,6 +308,11 @@ function isDevicePairingApprovalDenied(error: unknown): boolean {
   );
 }
 
+function isMissingOperatorScopeError(error: unknown, scope: OperatorScope): boolean {
+  const message = normalizeLowercaseStringOrEmpty(normalizeErrorMessage(error));
+  return message.includes("missing scope") && message.includes(scope);
+}
+
 function isUnknownRequestIdError(error: unknown): boolean {
   const maybeGatewayError =
     typeof error === "object" && error !== null
@@ -503,6 +508,16 @@ async function listPairingWithFallback(opts: DevicesRpcOpts): Promise<DevicePair
   } catch (error) {
     const fallback = resolveLocalPairingFallback(opts, error);
     if (!fallback) {
+      if (isMissingOperatorScopeError(error, PAIRING_SCOPE) && isLocalLoopbackGateway(opts)) {
+        const local = await listDevicePairing();
+        if (opts.json !== true) {
+          defaultRuntime.log(theme.warn(FALLBACK_NOTICE));
+        }
+        return {
+          pending: local.pending as PendingDevice[],
+          paired: local.paired.map((device) => redactLocalPairedDevice(device)),
+        };
+      }
       throw error;
     }
     const local = await listDevicePairing();
@@ -558,6 +573,15 @@ async function approvePairingWithFallback(
     }
     const fallback = resolveLocalPairingFallback(opts, error);
     if (!fallback) {
+      if (isMissingOperatorScopeError(error, PAIRING_SCOPE)) {
+        // Password/shared-secret loopback auth can connect device-less but lose
+        // operator scopes before the gateway reaches requestId validation.
+        const localApproved = await tryLocalApproveForLoopback(opts, requestId, originalRequest);
+        if (localApproved !== undefined) {
+          return localApproved;
+        }
+        return null;
+      }
       if (isUnknownRequestIdError(error)) {
         // Password auth mode: the gateway accepted the connection but returned
         // a method-level unknown-requestId error (the pending request was

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -330,30 +330,135 @@ function isScopeUpgradePendingApproval(error: unknown): boolean {
   );
 }
 
+/**
+ * Whether the CLI is targeting a local loopback gateway, making it safe to
+ * read/write pairing files directly as a fallback.
+ */
+function isLocalLoopbackGateway(opts: DevicesRpcOpts): boolean {
+  if (typeof opts.url === "string" && opts.url.trim().length > 0) {
+    return false;
+  }
+  const connection = buildGatewayConnectionDetails();
+  if (connection.urlSource !== "local loopback") {
+    return false;
+  }
+  try {
+    return isLoopbackHost(new URL(connection.url).hostname);
+  } catch {
+    return false;
+  }
+}
+
 function resolveLocalPairingFallback(
   opts: DevicesRpcOpts,
   error: unknown,
 ): { details: ConnectPairingRequiredDetails } | null {
-  // Local fallback is only safe for implicit loopback gateway URLs.
   const message = normalizeLowercaseStringOrEmpty(normalizeErrorMessage(error));
   const details = readConnectPairingRequiredMessage(message);
   if (!details) {
     return null;
   }
-  if (typeof opts.url === "string" && opts.url.trim().length > 0) {
-    // Explicit --url might point at a remote/tunneled gateway; never silently
-    // switch to local pairing files in that case.
+  if (!isLocalLoopbackGateway(opts)) {
     return null;
   }
-  const connection = buildGatewayConnectionDetails();
-  if (connection.urlSource !== "local loopback") {
-    return null;
+  return { details };
+}
+
+/**
+ * Attempt local file-based approval when the gateway returns `unknown requestId`
+ * (password auth mode). In password mode the CLI connects successfully, but the
+ * pending request may have been refreshed by a node-host reconnect before the
+ * approval lands — producing a method-level error instead of the connection-level
+ * `pairing required` error that {@link resolveLocalPairingFallback} expects.
+ *
+ * Returns the approval result on success, `null` if the request is genuinely
+ * absent from local state, or `undefined` if local fallback is not applicable
+ * (non-loopback or no local pending entries).
+ */
+async function tryLocalApproveForLoopback(
+  opts: DevicesRpcOpts,
+  requestId: string,
+  originalRequest: PendingDevice | null,
+): Promise<Record<string, unknown> | null | undefined> {
+  if (!isLocalLoopbackGateway(opts)) {
+    return undefined;
   }
-  try {
-    return isLoopbackHost(new URL(connection.url).hostname) ? { details } : null;
-  } catch {
-    return null;
+  const local = await listDevicePairing();
+  const localPending = local.pending as PendingDevice[];
+  const localPaired = local.paired.map((device) => redactLocalPairedDevice(device));
+
+  // Case 1: the original requestId still exists in local pending state.
+  if (findPendingRequestById(localPending, requestId)) {
+    const approved = await approveDevicePairing(requestId, {
+      callerScopes: ["operator.admin"],
+    });
+    if (!approved) {
+      return null;
+    }
+    if (approved.status === "forbidden") {
+      throw new Error(formatDevicePairingForbiddenMessage(approved));
+    }
+    if (opts.json !== true) {
+      defaultRuntime.log(theme.warn(FALLBACK_NOTICE));
+    }
+    return {
+      requestId,
+      device: redactLocalPairedDevice(approved.device),
+    };
   }
+
+  // Case 2: node-host already refreshed the request. Use the existing
+  // compatibility gate to find a safe same-device replacement.
+  if (originalRequest) {
+    const replacement = localPending
+      .filter(
+        (req) =>
+          normalizeOptionalString(req.deviceId) ===
+            normalizeOptionalString(originalRequest.deviceId) &&
+          normalizeOptionalString(req.requestId) !== requestId,
+      )
+      .map((candidate) =>
+        findSameDeviceReplacementRequest({
+          originalRequest,
+          originalRequestId: requestId,
+          gatewayRequestId: normalizeOptionalString(candidate.requestId) ?? "",
+          pending: localPending,
+          paired: localPaired,
+        }),
+      )
+      .find((result): result is PendingDevice => result !== null);
+
+    if (replacement) {
+      const approved = await approveDevicePairing(replacement.requestId, {
+        callerScopes: ["operator.admin"],
+      });
+      if (!approved) {
+        return null;
+      }
+      if (approved.status === "forbidden") {
+        throw new Error(formatDevicePairingForbiddenMessage(approved));
+      }
+      if (opts.json !== true) {
+        defaultRuntime.log(
+          theme.warn(
+            `Pending request ${sanitizeForLog(requestId)} was replaced by same-device repair ${sanitizeForLog(replacement.requestId)}; approving latest compatible request.`,
+          ),
+        );
+        defaultRuntime.log(theme.warn(FALLBACK_NOTICE));
+      }
+      return {
+        requestId: replacement.requestId,
+        resolved: {
+          kind: "same-device-replacement" as const,
+          requestedRequestId: requestId,
+          approvedRequestId: replacement.requestId,
+        },
+        device: redactLocalPairedDevice(approved.device),
+      };
+    }
+  }
+
+  return undefined;
 }
 
 function buildFallbackStateMismatchError(details: ConnectPairingRequiredDetails): Error {
@@ -436,6 +541,16 @@ async function approvePairingWithFallback(
         );
       } catch (adminError) {
         if (isUnknownRequestIdError(adminError)) {
+          // Password auth: gateway connection succeeded but the pending request
+          // was refreshed before approval. Try local file-based fallback.
+          const localApproved = await tryLocalApproveForLoopback(
+            opts,
+            requestId,
+            originalRequest,
+          );
+          if (localApproved !== undefined) {
+            return localApproved;
+          }
           return null;
         }
         throw adminError;
@@ -444,6 +559,18 @@ async function approvePairingWithFallback(
     const fallback = resolveLocalPairingFallback(opts, error);
     if (!fallback) {
       if (isUnknownRequestIdError(error)) {
+        // Password auth mode: the gateway accepted the connection but returned
+        // a method-level unknown-requestId error (the pending request was
+        // rotated by node-host reconnect). Resolve via local pairing files
+        // when operating against a loopback gateway.
+        const localApproved = await tryLocalApproveForLoopback(
+          opts,
+          requestId,
+          originalRequest,
+        );
+        if (localApproved !== undefined) {
+          return localApproved;
+        }
         return null;
       }
       throw error;

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -1508,6 +1508,77 @@ describe("devices cli password-mode fallback", () => {
     );
   }
 
+  function rejectGatewayWithMissingPairingScope() {
+    callGateway.mockRejectedValueOnce(new Error("missing scope: operator.pairing"));
+  }
+
+  it("falls back to local list when password loopback auth lacks pairing scope", async () => {
+    rejectGatewayWithMissingPairingScope();
+    const localPairing = {
+      pending: [
+        {
+          requestId: "req-1",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          ts: 1,
+        },
+      ],
+      paired: [],
+    };
+    listDevicePairing.mockResolvedValueOnce(localPairing).mockResolvedValueOnce(localPairing);
+
+    await runDevicesCommand(["list"]);
+
+    expect(listDevicePairing).toHaveBeenCalledTimes(1);
+    expect(readRuntimeOutput()).toContain(fallbackNotice);
+    expect(readRuntimeOutput()).toContain("req-1");
+  });
+
+  it("falls back to local approve when password loopback auth lacks pairing scope", async () => {
+    rejectGatewayWithMissingPairingScope();
+    rejectGatewayWithMissingPairingScope();
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-1",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.pairing"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          ts: 1,
+        },
+      ],
+      paired: [],
+    });
+    approveDevicePairing.mockResolvedValueOnce({
+      status: "approved",
+      requestId: "req-1",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        roles: ["operator"],
+        scopes: ["operator.pairing"],
+        approvedAtMs: 100,
+        createdAtMs: 1,
+      },
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesApprove(["req-1"]);
+
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-1", {
+      callerScopes: ["operator.admin"],
+    });
+    expect(readRuntimeOutput()).toContain(fallbackNotice);
+    expect(readRuntimeOutput()).toContain("Approved");
+  });
+
   it("falls back to local approve when gateway returns unknown requestId on loopback", async () => {
     callGateway.mockResolvedValueOnce({
       pending: [

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   listDevicePairing: vi.fn(),
   approveDevicePairing: vi.fn(),
   summarizeDeviceTokens: vi.fn(),
+  formatDevicePairingForbiddenMessage: vi.fn(() => "invalid scope for requested roles"),
   withProgress: vi.fn(async (_opts: unknown, fn: () => Promise<unknown>) => await fn()),
 }));
 
@@ -48,6 +49,7 @@ vi.mock("../infra/device-pairing.js", () => ({
   listDevicePairing: mocks.listDevicePairing,
   approveDevicePairing: mocks.approveDevicePairing,
   summarizeDeviceTokens: mocks.summarizeDeviceTokens,
+  formatDevicePairingForbiddenMessage: mocks.formatDevicePairingForbiddenMessage,
 }));
 
 vi.mock("../runtime.js", () => ({
@@ -1487,6 +1489,205 @@ describe("devices cli local fallback", () => {
       runDevicesCommand(["list", "--json", "--url", "ws://127.0.0.1:18789"]),
     ).rejects.toThrow("pairing required");
     expect(listDevicePairing).not.toHaveBeenCalled();
+  });
+});
+
+describe("devices cli password-mode fallback", () => {
+  const fallbackNotice = "Direct scope access failed; using local fallback.";
+
+  /**
+   * In password auth mode the CLI connects successfully, so the gateway
+   * returns a method-level error object rather than a connection-level
+   * pairing-required error.
+   */
+  function rejectGatewayWithUnknownRequestId() {
+    callGateway.mockRejectedValueOnce(
+      Object.assign(new Error("unknown requestId"), {
+        gatewayCode: "INVALID_REQUEST",
+      }),
+    );
+  }
+
+  it("falls back to local approve when gateway returns unknown requestId on loopback", async () => {
+    callGateway.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-1",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.admin"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          ts: 1,
+        },
+      ],
+      paired: [],
+    });
+    rejectGatewayWithUnknownRequestId();
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-1",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.admin"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          ts: 1,
+        },
+      ],
+      paired: [],
+    });
+    // Local approve succeeds
+    approveDevicePairing.mockResolvedValueOnce({
+      status: "approved",
+      requestId: "req-1",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        roles: ["operator"],
+        scopes: ["operator.admin"],
+        approvedAtMs: 100,
+        createdAtMs: 1,
+      },
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesApprove(["req-1"]);
+
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-1", {
+      callerScopes: ["operator.admin"],
+    });
+    expect(readRuntimeOutput()).toContain(fallbackNotice);
+    expect(readRuntimeOutput()).toContain("Approved");
+  });
+
+  it("approves a same-device replacement when original requestId is gone (password mode)", async () => {
+    callGateway.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-old",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.read"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          isRepair: true,
+          ts: 1,
+        },
+        {
+          requestId: "req-new",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.read", "operator.pairing"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          isRepair: true,
+          ts: 2,
+        },
+      ],
+      paired: [],
+    });
+    rejectGatewayWithUnknownRequestId();
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-new",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.read", "operator.pairing"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          isRepair: true,
+          ts: 2,
+        },
+      ],
+      paired: [],
+    });
+    approveDevicePairing.mockResolvedValueOnce({
+      status: "approved",
+      requestId: "req-new",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk",
+        roles: ["operator"],
+        scopes: ["operator.read", "operator.pairing"],
+        approvedAtMs: 200,
+        createdAtMs: 1,
+      },
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await runDevicesApprove(["req-old"]);
+
+    expect(approveDevicePairing).toHaveBeenCalledWith("req-new", {
+      callerScopes: ["operator.admin"],
+    });
+    const output = readRuntimeOutput();
+    expect(output).toContain("same-device repair");
+    expect(output).toContain("req-new");
+    expect(output).toContain(fallbackNotice);
+  });
+
+  it("surfaces forbidden error when local replacement approval is denied (password mode)", async () => {
+    callGateway.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-1",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.read"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          isRepair: true,
+          ts: 1,
+        },
+      ],
+      paired: [],
+    });
+    rejectGatewayWithUnknownRequestId();
+    listDevicePairing.mockResolvedValueOnce({
+      pending: [
+        {
+          requestId: "req-1",
+          deviceId: "device-1",
+          publicKey: "pk",
+          role: "operator",
+          scopes: ["operator.read"],
+          clientId: "openclaw-macos",
+          clientMode: "cli",
+          isRepair: true,
+          ts: 1,
+        },
+      ],
+      paired: [],
+    });
+    approveDevicePairing.mockResolvedValueOnce({
+      status: "forbidden",
+      reason: "scope-outside-requested-roles",
+      scope: "operator.wrong",
+    });
+    summarizeDeviceTokens.mockReturnValue(undefined);
+
+    await expect(runDevicesApprove(["req-1"])).rejects.toThrow("invalid scope");
+  });
+
+  it("does not fall back locally when --url points at a remote gateway", async () => {
+    callGateway.mockResolvedValueOnce({ pending: [], paired: [] });
+    rejectGatewayWithUnknownRequestId();
+
+    await runDevicesApprove(["req-1", "--url", "ws://10.0.0.5:18789"]);
+
+    expect(readRuntimeErrorOutput()).toContain("No pending device request matches req-1");
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(listDevicePairing).not.toHaveBeenCalled();
+    expect(approveDevicePairing).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw devices approve <requestId>` still deadlocks for local loopback gateways in password auth mode when node-host refreshes the pending device repair request before approval lands.

PR #85342 fixed the compatible replacement-request path after local fallback has already been triggered by a connection-level `pairing required` error. Password auth mode is different: the CLI can connect successfully, then the gateway can fail at method time instead of reaching the connection-level fallback. In real loopback password auth, the CLI can also connect device-less and lose `operator.pairing` before requestId validation.

Repro path:

1. Local loopback gateway uses password auth.
2. Node-host reconnect refreshes a pending device repair request before approval lands, or the password-auth CLI reaches a device-less method authorization failure.
3. `openclaw devices approve <requestId>` connects to the local gateway.
4. Gateway returns method-level `unknown requestId` or `missing scope: operator.pairing` rather than a connection-level `pairing required` error.
5. Current main returns `null`/prints an approval failure; it never attempts local file fallback.

## Changes

- Extract `isLocalLoopbackGateway()` so fallback eligibility can be reused without requiring a pairing-required connect error.
- Add `tryLocalApproveForLoopback()` for method-level password auth failures.
- Recover both method-level `unknown requestId` and real loopback password-auth `missing scope: operator.pairing` denials.
- Reuse the existing strict `findSameDeviceReplacementRequest()` compatibility gate for refreshed requests.
- Surface forbidden approval results instead of silently returning null.
- Keep fallback loopback-only and disabled for explicit `--url` remote gateways.

## Evidence

Local validation on this branch:

```text
npx pnpm@latest exec vitest run src/cli/devices-cli.test.ts
Test Files  1 passed (1)
Tests  55 passed (55)

npx pnpm@latest check:test-types
exit 0
```

Focused tests cover:

- password loopback `missing scope: operator.pairing` falling back to local list
- password loopback `missing scope: operator.pairing` falling back to local approve
- unknown requestId approving the original local pending request
- unknown requestId approving a compatible refreshed replacement
- forbidden approval surfacing clearly
- explicit remote `--url` not using local fallback

Redacted live proof against a running local password-mode gateway:

```text
OpenClaw source branch: 37babcd0 + f8c65b74
Gateway auth mode: password (running gateway)
Temporary HOME/OPENCLAW_STATE_DIR: [redacted temp dir]
Temporary config has no gateway.remote.url, so CLI target is implicit local loopback.
Created local pending request: 1781c97f-82d1-47a9-98ba-c78d329cfaa7

$ HOME=[temp] OPENCLAW_STATE_DIR=[temp]/state OPENCLAW_CONFIG_PATH=[temp]/openclaw.json node dist/index.js devices approve 1781c97f-82d1-47a9-98ba-c78d329cfaa7 --password [redacted]
Direct scope access failed; using local fallback.
Direct scope access failed; using local fallback.
Approved proof-device-pr100546 (1781c97f-82d1-47a9-98ba-c78d329cfaa7)

$ HOME=[temp] OPENCLAW_STATE_DIR=[temp]/state node --import tsx -e "listDevicePairing()"
{
  "pendingCount": 0,
  "paired": [
    {
      "deviceId": "proof-device-pr100546",
      "roles": ["operator"],
      "scopes": ["operator.pairing"],
      "tokenRoles": ["operator"]
    }
  ]
}
```

Fixes #59889.
Supersedes the incomplete coverage in #100455.
Related #85342, #31041, #37749.
