### PR TITLE
refactor: remove duplicated skill-version reminder from the system prompt

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -219,7 +219,6 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("## Skills");
     expect(prompt).toContain("<available_skills>");
-    expect(prompt).toContain("Changed <version>: re-read");
     expect(prompt).toContain("External writes: batch safely");
   });
 
@@ -549,7 +548,6 @@ describe("buildAgentSystemPrompt", () => {
       "Scan <available_skills>. Clear match: read exact <location> with `Read`; obey.",
     );
     expect(prompt).not.toContain("<location>/SKILL.md");
-    expect(prompt).toContain("Changed <version>: re-read");
     expect(prompt).toContain("Several: most specific");
     expect(prompt).toContain("Docs: /tmp/openclaw/docs");
     expect(prompt).toContain(
@@ -810,8 +808,31 @@ describe("buildAgentSystemPrompt", () => {
       "Scan <available_skills>. Clear match: read exact <location> with `read`; obey.",
     );
     expect(prompt).not.toContain("<location>/SKILL.md");
-    expect(prompt).toContain("Changed <version>: re-read");
     expect(prompt).toContain("Several: most specific");
+  });
+
+  it("does not duplicate the skill-version reminder already carried by the skills catalog", () => {
+    // The rendered catalog (formatSkillsForPrompt/formatSkillsCompact) already carries the
+    // "<version> differs -> re-read" reminder; the header must not add a second copy.
+    const reminder = "If a skill's <version> differs from a previous turn";
+    const catalog = [
+      "The following skills provide specialized instructions for specific tasks.",
+      "Use the read tool to load a skill's file when the task matches its description.",
+      `${reminder}, re-read its SKILL.md before using it.`,
+      "",
+      "<available_skills>",
+      "  <skill>",
+      "    <name>demo</name>",
+      "  </skill>",
+      "</available_skills>",
+    ].join("\n");
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      skillsPrompt: catalog,
+    });
+
+    const occurrences = prompt.split(reminder).length - 1;
+    expect(occurrences).toBe(1);
   });
 
   it("instructs models to use skill_workshop only when the tool is available", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -290,7 +290,7 @@ function buildSkillsSection(params: { skillsPrompt?: string; readToolName: strin
   return [
     "## Skills",
     `Scan <available_skills>. Clear match: read exact <location> with \`${params.readToolName}\`; obey.`,
-    "Changed <version>: re-read. Several: most specific. None: read none.",
+    "Several: most specific. None: read none.",
     "Up-front max one. Never invent paths.",
     "External writes: batch safely; no tight loops; honor 429/Retry-After.",
     trimmed,


### PR DESCRIPTION
## What Problem This Solves

The rendered `## Skills` section of the agent system prompt repeats the same skill-version reminder twice on every skills-enabled turn: once from the section header and once from the skills catalog itself. Agents see "If a skill's `<version>` differs from a previous turn, re-read …" duplicated.

<img width="814" height="579" alt="image" src="https://github.com/user-attachments/assets/09046028-ea0c-41ba-a6da-c9fa0d702dae" />

Scope: only the embedded API runner renders this ## Skills section, so only its prompts change. The Codex app-server extension composes its own ## OpenClaw Skills section from the catalog (already a single copy), and the claude-cli backend delivers skills via Claude Code's plugin dir (no catalog in the prompt at all) — both surfaces are byte-identical before/after this change.

## Why This Change Was Made

`buildSkillsSection` (the header) hardcodes the reminder, and the catalog formatters (`formatSkillsForPrompt`, `formatSkillsCompact`) each already emit it — and one of those formatters always runs when skills are present, so the header copy is always redundant. This removes the header's copy so the reminder renders exactly once. The formatters are intentionally left untouched: `formatSkillsForPrompt` is pinned byte-for-byte to the upstream Agent Skills formatter (asserted in `compact-format.test.ts`), and the surviving wording ("re-read its SKILL.md before using it") is that upstream copy — the more precise of the two.

## User Impact

No user-facing behavior change. The skills prompt is marginally shorter and no longer duplicated; the version-invalidation guidance is still present, exactly once.

## Evidence

Scoped local validation (worktree deps hydrated via symlink to the main checkout):

- `node scripts/run-vitest.mjs src/agents/system-prompt.test.ts` → **91 passed** — includes a new regression test asserting the reminder appears exactly once in a composed prompt.
- `node scripts/run-vitest.mjs src/skills/loading/compact-format.test.ts src/skills/loading/workspace-snapshot.test.ts` → **31 passed** — confirms the guidance still reaches composed prompts via the formatters.
- `oxfmt --check` and `oxlint` clean on both changed files.

Test changes: dropped three `system-prompt.test.ts` assertions that only passed because the header emitted the line (their inputs use a bare `skillsPrompt` with no formatter preamble), and added the exactly-once regression test.

> **Rebase note:** this branch forked from `main` at `816038e`; `main` has since advanced. The diff is orthogonal to the recent `system-prompt.ts` changes (import reorg / messaging text / `Group Chat Context` → `Conversation Context` rename) — no overlap with `buildSkillsSection`. I'll rebase onto latest `main` before marking this ready.
