### PR TITLE
fix: warn when transcript byte guard is inactive

### DIFF
--- a/src/config/compaction-byte-guard-warning.ts
+++ b/src/config/compaction-byte-guard-warning.ts
@@ -1,0 +1,34 @@
+// Reports compaction byte guards that are configured but cannot run.
+import { parseNonNegativeByteSize } from "./byte-size.js";
+import type { ConfigValidationIssue, OpenClawConfig } from "./types.js";
+
+export const INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_CHECK_ID = "core/doctor/compaction-byte-guard";
+export const INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_PATH =
+  "agents.defaults.compaction.maxActiveTranscriptBytes";
+
+export const INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_MESSAGE =
+  "maxActiveTranscriptBytes is set, but truncateAfterCompaction is not true; the active transcript byte guard is inactive.";
+
+export const INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_FIX_HINT =
+  "Enable agents.defaults.compaction.truncateAfterCompaction or unset agents.defaults.compaction.maxActiveTranscriptBytes.";
+
+export function collectInactiveMaxActiveTranscriptBytesWarnings(
+  cfg: OpenClawConfig,
+): ConfigValidationIssue[] {
+  const compaction = cfg.agents?.defaults?.compaction;
+  const maxActiveTranscriptBytes = parseNonNegativeByteSize(compaction?.maxActiveTranscriptBytes);
+  if (
+    typeof maxActiveTranscriptBytes !== "number" ||
+    maxActiveTranscriptBytes <= 0 ||
+    compaction?.truncateAfterCompaction === true
+  ) {
+    return [];
+  }
+
+  return [
+    {
+      path: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_PATH,
+      message: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_MESSAGE,
+    },
+  ];
+}

--- a/src/config/config.compaction-settings.test.ts
+++ b/src/config/config.compaction-settings.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { applyCompactionDefaults } from "./defaults.js";
 import type { OpenClawConfig } from "./types.js";
+import { validateConfigObjectWithPlugins } from "./validation.js";
 
 function materializeCompactionConfig(
   compaction: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["compaction"],
@@ -55,6 +56,73 @@ describe("config compaction settings", () => {
     expect(compaction?.memoryFlush?.prompt).toBe("Write notes.");
     expect(compaction?.memoryFlush?.systemPrompt).toBe("Flush memory now.");
     expect(compaction?.maxActiveTranscriptBytes).toBe("20mb");
+  });
+
+  it("warns when maxActiveTranscriptBytes is inactive without transcript rotation", () => {
+    const result = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: "20mb",
+            },
+          },
+        },
+      },
+      { pluginValidation: "skip" },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      warnings: [
+        {
+          path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+          message:
+            "maxActiveTranscriptBytes is set, but truncateAfterCompaction is not true; the active transcript byte guard is inactive.",
+        },
+      ],
+    });
+  });
+
+  it("does not warn when the active transcript byte guard can rotate transcripts", () => {
+    const result = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              truncateAfterCompaction: true,
+              maxActiveTranscriptBytes: "20mb",
+            },
+          },
+        },
+      },
+      { pluginValidation: "skip" },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      warnings: [],
+    });
+  });
+
+  it("does not warn when the active transcript byte guard is disabled", () => {
+    const result = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: 0,
+            },
+          },
+        },
+      },
+      { pluginValidation: "skip" },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      warnings: [],
+    });
   });
 
   it("preserves legacy compaction override values", () => {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -53,6 +53,7 @@ import {
   collectChannelSchemaMetadataWithOwnership,
 } from "./channel-config-metadata.js";
 import { shouldSuppressMissingCodexPluginDiagnostics } from "./codex-plugin-diagnostics.js";
+import { collectInactiveMaxActiveTranscriptBytesWarnings } from "./compaction-byte-guard-warning.js";
 import { materializeRuntimeConfig } from "./materialize.js";
 import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { coerceSecretRef } from "./types.secrets.js";
@@ -1202,16 +1203,18 @@ function validateConfigObjectWithPluginsBase(
         manifestRegistry: registryInfo?.registry,
       })
     : base.config;
+  const warnings: ConfigValidationIssue[] = [
+    ...collectInactiveMaxActiveTranscriptBytesWarnings(config),
+  ];
   if (opts.pluginValidation === "skip") {
     return {
       ok: true,
       config,
-      warnings: [],
+      warnings,
     };
   }
 
   const issues: ConfigValidationIssue[] = [];
-  const warnings: ConfigValidationIssue[] = [];
   const hasExplicitPluginsConfig = isRecord(raw) && Object.hasOwn(raw, "plugins");
   const explicitPluginReferences = collectExplicitPluginReferences(raw);
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1474,6 +1474,7 @@ describe("doctor health contributions", () => {
     expect(contributionIds).toContain("core/doctor/channel-plugin-blockers");
     expect(contributionIds).toContain("core/doctor/channel-preview-warnings");
     expect(contributionIds).toContain("core/doctor/tool-result-cap");
+    expect(contributionIds).toContain("core/doctor/compaction-byte-guard");
     expect(contributionIds).toContain("core/doctor/systemd-linger");
     expect(contributionChecks.map((check) => check.id)).toEqual(contributionIds);
   });
@@ -1595,6 +1596,44 @@ describe("doctor health contributions", () => {
       checksSkipped: 0,
     });
     expect(detect).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports inactive maxActiveTranscriptBytes in default lint selection", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const compactionByteGuardCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/compaction-byte-guard",
+    );
+    expect(compactionByteGuardCheck).toBeDefined();
+
+    const ctx = {
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: "10b",
+            },
+          },
+        },
+      },
+      mode: "lint" as const,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    };
+
+    await expect(
+      runDoctorLintChecks(ctx, { checks: [compactionByteGuardCheck!] }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [
+        expect.objectContaining({
+          checkId: "core/doctor/compaction-byte-guard",
+          path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+          requirement: "truncate-after-compaction-enabled",
+          fixHint:
+            "Enable agents.defaults.compaction.truncateAfterCompaction or unset agents.defaults.compaction.maxActiveTranscriptBytes.",
+        }),
+      ],
+    });
   });
 
   it("keeps stale plugin-runtime symlinks opt-in for structured lint selection", async () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -7,6 +7,11 @@ import {
   isLegacyParentWritableUpdateDoctorPass,
   UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
 } from "../commands/doctor/shared/update-phase.js";
+import {
+  collectInactiveMaxActiveTranscriptBytesWarnings,
+  INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_CHECK_ID,
+  INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_FIX_HINT,
+} from "../config/compaction-byte-guard-warning.js";
 import { resolveIsNixMode } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
@@ -846,6 +851,19 @@ async function collectToolResultCapFindings(
       collectToolResultCapDoctorIssues(entry).map(toolResultCapDoctorIssueToHealthFinding),
     ),
   );
+}
+
+function collectInactiveMaxActiveTranscriptBytesFindings(
+  cfg: OpenClawConfig,
+): readonly HealthFinding[] {
+  return collectInactiveMaxActiveTranscriptBytesWarnings(cfg).map((warning) => ({
+    checkId: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_CHECK_ID,
+    severity: "warning" as const,
+    message: warning.message,
+    path: warning.path,
+    requirement: "truncate-after-compaction-enabled",
+    fixHint: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_FIX_HINT,
+  }));
 }
 
 async function collectToolResultCapTargetAdvice(params: {
@@ -1972,13 +1990,21 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:tool-result-cap",
       label: "Tool result cap",
-      healthChecks: {
-        id: "core/doctor/tool-result-cap",
-        description:
-          "Detect explicit toolResultMaxChars settings that fight model-window defaults.",
-        defaultEnabled: false,
-        detect: async (ctx) => collectToolResultCapFindings(ctx.cfg),
-      },
+      healthChecks: [
+        {
+          id: "core/doctor/tool-result-cap",
+          description:
+            "Detect explicit toolResultMaxChars settings that fight model-window defaults.",
+          defaultEnabled: false,
+          detect: async (ctx) => collectToolResultCapFindings(ctx.cfg),
+        },
+        {
+          id: INACTIVE_MAX_ACTIVE_TRANSCRIPT_BYTES_CHECK_ID,
+          description:
+            "Detect maxActiveTranscriptBytes settings that are inactive without transcript rotation.",
+          detect: async (ctx) => collectInactiveMaxActiveTranscriptBytesFindings(ctx.cfg),
+        },
+      ],
       run: runToolResultCapHealth,
     }),
     createDoctorHealthContribution({


### PR DESCRIPTION
Closes #100529

## What Problem This Solves

Fixes an issue where operators could set `agents.defaults.compaction.maxActiveTranscriptBytes` and believe active transcript growth was bounded even though the byte guard stays inactive unless `agents.defaults.compaction.truncateAfterCompaction` is also enabled.

The runtime behavior was documented, but config loading and Doctor did not surface the inactive setting, so the misconfiguration looked valid until long sessions relied on other context-budget safeguards.

## Why This Change Was Made

This adds a non-fatal config warning for positive `maxActiveTranscriptBytes` values when transcript rotation is not enabled, and exposes the same condition as a structured `doctor --lint` finding. Runtime compaction behavior is unchanged: the byte guard still only runs when transcript rotation can shrink the active transcript.

Risk note: this touches config diagnostics only, so the main risk is noisy warnings; the check stays quiet when the guard is disabled with `0` or when `truncateAfterCompaction: true` makes the guard actionable.

## User Impact

Users now get an actionable warning instead of a silent no-op when the active transcript byte guard is configured without the required transcript rotation setting. They can either enable `truncateAfterCompaction` or unset `maxActiveTranscriptBytes`.

## Evidence

Source-level premise checked:

```text
src/auto-reply/reply/memory-flush.ts resolves maxActiveTranscriptBytes to undefined unless truncateAfterCompaction is true.
src/auto-reply/reply/agent-runner-memory.test.ts already covers that preflight compaction stays inactive without transcript rotation.
docs/concepts/compaction.md and docs/gateway/config-agents.md document the requirement.
```

Focused tests and checks:

```text
node scripts/run-vitest.mjs src/config/config.compaction-settings.test.ts src/flows/doctor-health-contributions.test.ts
[test] passed 2 Vitest shards in 8.80s

node scripts/run-oxlint.mjs src/config/compaction-byte-guard-warning.ts src/config/validation.ts src/config/config.compaction-settings.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts
# passed

pnpm exec oxfmt --check --threads=1 src/config/compaction-byte-guard-warning.ts src/config/validation.ts src/config/config.compaction-settings.test.ts src/flows/doctor-health-contributions.ts src/flows/doctor-health-contributions.test.ts
All matched files use the correct format.

git diff --check
# passed

AUTOREVIEW=.agents/skills/autoreview/scripts/autoreview .agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

Real behavior proof after the fix:

```text
OPENCLAW_CONFIG_PATH=/tmp/.../openclaw.json OPENCLAW_STATE_DIR=/tmp/.../state pnpm openclaw doctor --lint --json --only core/doctor/compaction-byte-guard
{"ok":false,"checksRun":1,"checksSkipped":48,"findings":[{"checkId":"core/doctor/compaction-byte-guard","severity":"warning","message":"maxActiveTranscriptBytes is set, but truncateAfterCompaction is not true; the active transcript byte guard is inactive.","path":"agents.defaults.compaction.maxActiveTranscriptBytes","requirement":"truncate-after-compaction-enabled","fixHint":"Enable agents.defaults.compaction.truncateAfterCompaction or unset agents.defaults.compaction.maxActiveTranscriptBytes."}]}

OPENCLAW_CONFIG_PATH=/tmp/.../openclaw.json OPENCLAW_STATE_DIR=/tmp/.../state pnpm openclaw doctor --non-interactive
Config warnings:
- agents.defaults.compaction.maxActiveTranscriptBytes: maxActiveTranscriptBytes is set, but truncateAfterCompaction is not true; the active transcript byte guard is inactive.
```

Live agent proof with the configured DeepSeek environment:

```text
OPENCLAW_CONFIG_PATH=/tmp/.../openclaw.json OPENCLAW_STATE_DIR=/tmp/.../state pnpm openclaw agent --local --model deepseek/deepseek-v4-pro --session-id proof-100529 --message 'Reply exactly: OPENCLAW_DEEPSEEK_PROOF_OK' --thinking off --json
provider=deepseek
model=deepseek-v4-pro
finalAssistantVisibleText=OPENCLAW_DEEPSEEK_PROOF_OK
stopReason=stop
```

AI-assisted.
