### PR TITLE
fix(android): keep stale PTT from restarting capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 - **Exec output sanitization:** remove complete ANSI sequences and render residual C0/C1 controls as visible escapes instead of silently discarding output bytes. (#100327) Thanks @LavyaTandel.
 - **Assistant visible text:** unwrap leaked standalone `<parameter>` tags while preserving their content and literal code/XML examples. (#100302) Thanks @nankingjing.
 - **Android microphone capture:** treat negative `AudioRecord.read` results as fatal shared-session errors so both transcription and Talk capture stop cleanly after device loss. (#100028) Thanks @NianJiuZst.
+- **Android push-to-talk lifecycle:** serialize gateway PTT preparation with app foreground and Manual Mic ownership so stale background or retry work cannot restart, replace, or tear down a newer capture. (#99840) Thanks @xialonglee.
 - **Lean local-model tools:** trim media generation, TTS, and PDF tools from lean agent surfaces while preserving explicit config and runtime opt-ins. (#88881) Thanks @vincentkoc.
 - **iOS development app identity:** keep the development app labeled OpenClaw while using its distinct debug icon to differentiate it from release builds.
 - **Android chat recovery:** preserve optimistic user messages and locally owned runs while reconnect and sequence-gap history snapshots catch up, preventing sent messages from disappearing or stale runs from taking ownership. (#100197)

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2442,
+      "line": 2440,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2444,
+      "line": 2442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2446,
+      "line": 2444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -195,7 +195,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 570,
+      "line": 577,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2243,
+      "line": 2442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2245,
+      "line": 2444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2247,
+      "line": 2446,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -5707,7 +5707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 369,
+      "line": 476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -5715,7 +5715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 369,
+      "line": 476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -5723,7 +5723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 726,
+      "line": 863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -5731,7 +5731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 727,
+      "line": 864,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
@@ -5739,7 +5739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 728,
+      "line": 865,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
@@ -5747,7 +5747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1675,
+      "line": 1812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -5755,7 +5755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1675,
+      "line": 1812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2440,
+      "line": 2444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2442,
+      "line": 2446,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2444,
+      "line": 2448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -713,6 +713,9 @@ class NodeRuntime private constructor(
   private val voiceCaptureOwnershipEpoch = AtomicLong()
   private val talkPttCommandEpoch = AtomicLong()
   private val talkPttOwnership = AtomicReference<TalkPttOwnership?>()
+  // Keep ownership epochs and their service/capture state transitions atomic.
+  // Otherwise stale PTT cleanup can pass its epoch check before a UI mode change.
+  private val voiceCaptureOwnershipLock = Any()
   private val voiceCapturePreparationMutex = Mutex()
 
   private var didAutoRequestCanvasRehydrate = false
@@ -1736,7 +1739,7 @@ class NodeRuntime private constructor(
                   voiceCaptureOwnershipEpoch.get() == ownershipEpoch
               },
             )
-          talkPttOwnership.set(TalkPttOwnership(captureId = started.captureId, epoch = ownershipEpoch))
+          recordTalkPttOwnership(captureId = started.captureId, ownershipEpoch = ownershipEpoch)
           started
         }
       GatewaySession.InvokeResult.ok(payload.toJson())
@@ -1774,7 +1777,7 @@ class NodeRuntime private constructor(
               is TalkPttOnceStart.Busy -> started.payload.captureId
               is TalkPttOnceStart.Started -> started.captureId
             }
-          talkPttOwnership.set(TalkPttOwnership(captureId = captureId, epoch = ownershipEpoch))
+          recordTalkPttOwnership(captureId = captureId, ownershipEpoch = ownershipEpoch)
           started
         }
       val payload =
@@ -1836,24 +1839,26 @@ class NodeRuntime private constructor(
     // yields, preparation must not write capture state that backgrounding cleared.
     val ownershipEpoch =
       withContext(Dispatchers.Main) {
-        if (
-          !_isForeground.value ||
-          voiceLifecycleEpoch.get() != lifecycleEpoch ||
-          talkPttCommandEpoch.get() != commandEpoch
-        ) {
-          throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+        synchronized(voiceCaptureOwnershipLock) {
+          if (
+            !_isForeground.value ||
+            voiceLifecycleEpoch.get() != lifecycleEpoch ||
+            talkPttCommandEpoch.get() != commandEpoch
+          ) {
+            throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+          }
+          if (!hasRecordAudioPermission()) {
+            throw IllegalStateException("MIC_PERMISSION_REQUIRED: grant Microphone permission")
+          }
+          val epoch = voiceCaptureOwnershipEpoch.incrementAndGet()
+          micCapture.setMicEnabled(false)
+          stopVoicePlayback()
+          NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.TalkMode)
+          talkMode.ttsOnAllResponses = true
+          talkMode.setPlaybackEnabled(speakerEnabled.value)
+          externalAudioCaptureActive.value = true
+          epoch
         }
-        if (!hasRecordAudioPermission()) {
-          throw IllegalStateException("MIC_PERMISSION_REQUIRED: grant Microphone permission")
-        }
-        val epoch = voiceCaptureOwnershipEpoch.incrementAndGet()
-        micCapture.setMicEnabled(false)
-        stopVoicePlayback()
-        NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.TalkMode)
-        talkMode.ttsOnAllResponses = true
-        talkMode.setPlaybackEnabled(speakerEnabled.value)
-        externalAudioCaptureActive.value = true
-        epoch
       }
     try {
       talkMode.refreshConfig()
@@ -1865,17 +1870,30 @@ class NodeRuntime private constructor(
   }
 
   private fun cleanupFailedTalkCapture(ownershipEpoch: Long) {
-    // TalkModeManager owns capture-scoped cancellation. A stale invoke must not
-    // tear down a newer capture after a background/foreground transition.
-    if (voiceCaptureOwnershipEpoch.get() == ownershipEpoch) {
-      talkMode.activePushToTalkCaptureId?.let { captureId ->
-        // An idempotent retry can fail while the original capture remains live.
-        // Transfer preparation ownership so its eventual stop still cleans up.
+    synchronized(voiceCaptureOwnershipLock) {
+      // TalkModeManager owns capture-scoped cancellation. A stale invoke must not
+      // tear down a newer capture after a background/foreground transition.
+      if (voiceCaptureOwnershipEpoch.get() == ownershipEpoch) {
+        talkMode.activePushToTalkCaptureId?.let { captureId ->
+          // An idempotent retry can fail while the original capture remains live.
+          // Transfer preparation ownership so its eventual stop still cleans up.
+          talkPttOwnership.set(TalkPttOwnership(captureId = captureId, epoch = ownershipEpoch))
+          return
+        }
+      }
+      finishTalkCaptureIfIdleUnderOwnershipLock(ownershipEpoch)
+    }
+  }
+
+  private fun recordTalkPttOwnership(
+    captureId: String,
+    ownershipEpoch: Long,
+  ) {
+    synchronized(voiceCaptureOwnershipLock) {
+      if (voiceCaptureOwnershipEpoch.get() == ownershipEpoch) {
         talkPttOwnership.set(TalkPttOwnership(captureId = captureId, epoch = ownershipEpoch))
-        return
       }
     }
-    finishTalkCaptureIfIdle(ownershipEpoch)
   }
 
   private suspend fun finishTalkCaptureIfIdleAfterPreparation(captureId: String) {
@@ -1901,12 +1919,20 @@ class NodeRuntime private constructor(
     }
 
   private fun finishTalkCaptureIfIdleLocked(captureId: String) {
-    val ownership = talkPttOwnership.get()
-    if (ownership?.captureId != captureId || !talkPttOwnership.compareAndSet(ownership, null)) return
-    finishTalkCaptureIfIdle(ownership.epoch)
+    synchronized(voiceCaptureOwnershipLock) {
+      val ownership = talkPttOwnership.get()
+      if (ownership?.captureId != captureId || !talkPttOwnership.compareAndSet(ownership, null)) return
+      finishTalkCaptureIfIdleUnderOwnershipLock(ownership.epoch)
+    }
   }
 
   private fun finishTalkCaptureIfIdle(ownershipEpoch: Long) {
+    synchronized(voiceCaptureOwnershipLock) {
+      finishTalkCaptureIfIdleUnderOwnershipLock(ownershipEpoch)
+    }
+  }
+
+  private fun finishTalkCaptureIfIdleUnderOwnershipLock(ownershipEpoch: Long) {
     if (ownershipEpoch == 0L || voiceCaptureOwnershipEpoch.get() != ownershipEpoch) return
     if (!talkMode.isEnabled.value && !talkMode.isListening.value && !talkMode.isSpeaking.value) {
       talkMode.ttsOnAllResponses = false
@@ -1916,13 +1942,15 @@ class NodeRuntime private constructor(
   }
 
   private fun finishTalkModeAfterRelayClose() {
-    if (_voiceCaptureMode.value != VoiceCaptureMode.TalkMode) return
-    talkPttCommandEpoch.incrementAndGet()
-    voiceCaptureOwnershipEpoch.incrementAndGet()
-    _voiceCaptureMode.value = VoiceCaptureMode.Off
-    talkMode.ttsOnAllResponses = false
-    NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
-    externalAudioCaptureActive.value = false
+    synchronized(voiceCaptureOwnershipLock) {
+      if (_voiceCaptureMode.value != VoiceCaptureMode.TalkMode) return
+      talkPttCommandEpoch.incrementAndGet()
+      voiceCaptureOwnershipEpoch.incrementAndGet()
+      _voiceCaptureMode.value = VoiceCaptureMode.Off
+      talkMode.ttsOnAllResponses = false
+      NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
+      externalAudioCaptureActive.value = false
+    }
   }
 
   val speakerEnabled: StateFlow<Boolean>
@@ -2050,56 +2078,58 @@ class NodeRuntime private constructor(
     mode: VoiceCaptureMode,
     persistManualMic: Boolean = true,
   ) {
-    talkPttCommandEpoch.incrementAndGet()
-    voiceCaptureOwnershipEpoch.incrementAndGet()
-    if (mode.requiresMicrophonePermission && !hasRecordAudioPermission()) {
-      _voiceCaptureMode.value = VoiceCaptureMode.Off
-      prefs.setVoiceMicEnabled(false)
-      externalAudioCaptureActive.value = false
-      return
-    }
-    if (_voiceCaptureMode.value == mode && isVoiceCaptureModeActive(mode)) return
-    talkPttOwnership.set(null)
-    _voiceCaptureMode.value = mode
-    when (mode) {
-      VoiceCaptureMode.Off -> {
-        talkMode.ttsOnAllResponses = false
-        talkMode.stopAllCapture()
-        stopVoicePlayback()
-        micCapture.setMicEnabled(false)
-        if (persistManualMic) {
-          prefs.setVoiceMicEnabled(false)
-        }
-        NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
+    synchronized(voiceCaptureOwnershipLock) {
+      talkPttCommandEpoch.incrementAndGet()
+      voiceCaptureOwnershipEpoch.incrementAndGet()
+      if (mode.requiresMicrophonePermission && !hasRecordAudioPermission()) {
+        _voiceCaptureMode.value = VoiceCaptureMode.Off
+        prefs.setVoiceMicEnabled(false)
         externalAudioCaptureActive.value = false
+        return
       }
-
-      VoiceCaptureMode.ManualMic -> {
-        talkMode.ttsOnAllResponses = false
-        talkMode.stopAllCapture()
-        NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.ManualMic)
-        if (persistManualMic) {
-          prefs.setVoiceMicEnabled(true)
+      if (_voiceCaptureMode.value == mode && isVoiceCaptureModeActive(mode)) return
+      talkPttOwnership.set(null)
+      _voiceCaptureMode.value = mode
+      when (mode) {
+        VoiceCaptureMode.Off -> {
+          talkMode.ttsOnAllResponses = false
+          talkMode.stopAllCapture()
+          stopVoicePlayback()
+          micCapture.setMicEnabled(false)
+          if (persistManualMic) {
+            prefs.setVoiceMicEnabled(false)
+          }
+          NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
+          externalAudioCaptureActive.value = false
         }
-        // Tapping mic on interrupts any active TTS (barge-in).
-        stopVoicePlayback()
-        scope.launch { talkMode.refreshConfig() }
-        micCapture.setMicEnabled(true)
-        externalAudioCaptureActive.value = true
-      }
 
-      VoiceCaptureMode.TalkMode -> {
-        if (persistManualMic) {
-          prefs.setVoiceMicEnabled(false)
+        VoiceCaptureMode.ManualMic -> {
+          talkMode.ttsOnAllResponses = false
+          talkMode.stopAllCapture()
+          NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.ManualMic)
+          if (persistManualMic) {
+            prefs.setVoiceMicEnabled(true)
+          }
+          // Tapping mic on interrupts any active TTS (barge-in).
+          stopVoicePlayback()
+          scope.launch { talkMode.refreshConfig() }
+          micCapture.setMicEnabled(true)
+          externalAudioCaptureActive.value = true
         }
-        micCapture.setMicEnabled(false)
-        NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.TalkMode)
-        talkMode.ttsOnAllResponses = true
-        talkMode.setPlaybackEnabled(speakerEnabled.value)
-        scope.launch { talkMode.refreshConfig() }
-        talkMode.stopAllCapture()
-        talkMode.setEnabled(true)
-        externalAudioCaptureActive.value = true
+
+        VoiceCaptureMode.TalkMode -> {
+          if (persistManualMic) {
+            prefs.setVoiceMicEnabled(false)
+          }
+          micCapture.setMicEnabled(false)
+          NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.TalkMode)
+          talkMode.ttsOnAllResponses = true
+          talkMode.setPlaybackEnabled(speakerEnabled.value)
+          scope.launch { talkMode.refreshConfig() }
+          talkMode.stopAllCapture()
+          talkMode.setEnabled(true)
+          externalAudioCaptureActive.value = true
+        }
       }
     }
   }
@@ -2110,17 +2140,19 @@ class NodeRuntime private constructor(
   }
 
   private fun stopActiveVoiceSession() {
-    talkPttCommandEpoch.incrementAndGet()
-    voiceCaptureOwnershipEpoch.incrementAndGet()
-    talkPttOwnership.set(null)
-    talkMode.ttsOnAllResponses = false
-    talkMode.stopAllCapture()
-    stopVoicePlayback()
-    micCapture.setMicEnabled(false)
-    prefs.setVoiceMicEnabled(false)
-    NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
-    _voiceCaptureMode.value = VoiceCaptureMode.Off
-    externalAudioCaptureActive.value = false
+    synchronized(voiceCaptureOwnershipLock) {
+      talkPttCommandEpoch.incrementAndGet()
+      voiceCaptureOwnershipEpoch.incrementAndGet()
+      talkPttOwnership.set(null)
+      talkMode.ttsOnAllResponses = false
+      talkMode.stopAllCapture()
+      stopVoicePlayback()
+      micCapture.setMicEnabled(false)
+      prefs.setVoiceMicEnabled(false)
+      NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
+      _voiceCaptureMode.value = VoiceCaptureMode.Off
+      externalAudioCaptureActive.value = false
+    }
   }
 
   private fun stopVoicePlayback() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1759,6 +1759,10 @@ class NodeRuntime private constructor(
 
   private suspend fun handleTalkPttOnce(): GatewaySession.InvokeResult =
     runTalkPttCommand {
+      talkMode.activePushToTalkCaptureId?.let { captureId ->
+        val payload = TalkPttStopPayload(captureId = captureId, transcript = null, status = "busy")
+        return@runTalkPttCommand GatewaySession.InvokeResult.ok(payload.toJson())
+      }
       val lifecycleEpoch = voiceLifecycleEpoch.get()
       val commandEpoch = talkPttCommandEpoch.get()
       val start =

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -59,6 +59,7 @@ import ai.openclaw.app.node.parseHexColorArgb
 import ai.openclaw.app.protocol.OpenClawCanvasA2UIAction
 import ai.openclaw.app.voice.MicCaptureManager
 import ai.openclaw.app.voice.TalkModeManager
+import ai.openclaw.app.voice.TalkPttOnceStart
 import ai.openclaw.app.voice.VoiceConversationEntry
 import ai.openclaw.app.voice.VoiceConversationRole
 import android.Manifest
@@ -71,6 +72,7 @@ import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
@@ -81,6 +83,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -93,6 +98,7 @@ import java.util.Collections
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 private const val MAX_PENDING_NOTIFICATION_EVENTS = 128
 private const val NODE_APPROVAL_COMMAND_FRESH_MS = 30_000L
@@ -697,6 +703,16 @@ class NodeRuntime private constructor(
   private val _isForeground = MutableStateFlow(true)
   val isForeground: StateFlow<Boolean> = _isForeground.asStateFlow()
 
+  private data class TalkPttOwnership(
+    val captureId: String,
+    val epoch: Long,
+  )
+
+  private val voiceLifecycleEpoch = AtomicLong()
+  private val voiceCaptureOwnershipEpoch = AtomicLong()
+  private val talkPttOwnership = AtomicReference<TalkPttOwnership?>()
+  private val voiceCapturePreparationMutex = Mutex()
+
   private var didAutoRequestCanvasRehydrate = false
   private val canvasRehydrateSeq = AtomicLong(0)
 
@@ -926,7 +942,9 @@ class NodeRuntime private constructor(
       if (host.isEmpty() || port !in 1..65535) return null
       return GatewayEndpoint.manual(host = host, port = port).stableId
     }
-    return prefs.lastDiscoveredStableId.value.trim().takeIf { it.isNotEmpty() }
+    return prefs.lastDiscoveredStableId.value
+      .trim()
+      .takeIf { it.isNotEmpty() }
   }
 
   private fun chatCacheScope(): ChatCacheScope? =
@@ -1461,6 +1479,9 @@ class NodeRuntime private constructor(
   /** Updates foreground state and triggers reconnect/presence behavior on app visibility changes. */
   fun setForeground(value: Boolean) {
     _isForeground.value = value
+    if (!value) {
+      voiceLifecycleEpoch.incrementAndGet()
+    }
     if (value) {
       reconnectPreferredGatewayOnForeground()
       scope.launch {
@@ -1695,44 +1716,93 @@ class NodeRuntime private constructor(
 
   private suspend fun handleTalkPttStart(): GatewaySession.InvokeResult =
     runTalkPttCommand {
+      val lifecycleEpoch = voiceLifecycleEpoch.get()
       if (!_isForeground.value) {
         val payload = talkMode.beginPushToTalk(allowNewCapture = false)
         return@runTalkPttCommand GatewaySession.InvokeResult.ok(payload.toJson())
       }
-      runPreparedTalkPttCommand {
-        val payload = talkMode.beginPushToTalk(allowNewCapture = true)
-        GatewaySession.InvokeResult.ok(payload.toJson())
-      }
+      val payload =
+        withPreparedTalkPttCommand(lifecycleEpoch) { ownershipEpoch ->
+          val started =
+            talkMode.beginPushToTalk(
+              allowNewCapture = true,
+              canStartCapture = {
+                _isForeground.value &&
+                  voiceLifecycleEpoch.get() == lifecycleEpoch &&
+                  voiceCaptureOwnershipEpoch.get() == ownershipEpoch
+              },
+            )
+          talkPttOwnership.set(TalkPttOwnership(captureId = started.captureId, epoch = ownershipEpoch))
+          started
+        }
+      GatewaySession.InvokeResult.ok(payload.toJson())
     }
 
   private suspend fun handleTalkPttStop(): GatewaySession.InvokeResult =
     runTalkPttCommand {
       val payload = talkMode.endPushToTalk()
-      finishTalkCaptureIfIdle()
+      finishTalkCaptureIfIdleAfterPreparation(payload.captureId)
       GatewaySession.InvokeResult.ok(payload.toJson())
     }
 
   private suspend fun handleTalkPttCancel(): GatewaySession.InvokeResult =
     runTalkPttCommand {
       val payload = talkMode.cancelPushToTalk()
-      finishTalkCaptureIfIdle()
+      finishTalkCaptureIfIdleAfterPreparation(payload.captureId)
       GatewaySession.InvokeResult.ok(payload.toJson())
     }
 
   private suspend fun handleTalkPttOnce(): GatewaySession.InvokeResult =
-    runPreparedTalkPttCommand {
-      val payload = talkMode.runPushToTalkOnce()
-      finishTalkCaptureIfIdle()
+    runTalkPttCommand {
+      val lifecycleEpoch = voiceLifecycleEpoch.get()
+      val start =
+        withPreparedTalkPttCommand(lifecycleEpoch) { ownershipEpoch ->
+          val started =
+            talkMode.beginPushToTalkOnce(
+              canStartCapture = {
+                _isForeground.value &&
+                  voiceLifecycleEpoch.get() == lifecycleEpoch &&
+                  voiceCaptureOwnershipEpoch.get() == ownershipEpoch
+              },
+            )
+          val captureId =
+            when (started) {
+              is TalkPttOnceStart.Busy -> started.payload.captureId
+              is TalkPttOnceStart.Started -> started.captureId
+            }
+          talkPttOwnership.set(TalkPttOwnership(captureId = captureId, epoch = ownershipEpoch))
+          started
+        }
+      val payload =
+        try {
+          talkMode.awaitPushToTalkOnce(start)
+        } finally {
+          if (start is TalkPttOnceStart.Started) {
+            finishTalkCaptureIfIdleAfterPreparation(start.captureId)
+          }
+        }
       GatewaySession.InvokeResult.ok(payload.toJson())
     }
 
-  private suspend fun runPreparedTalkPttCommand(block: suspend () -> GatewaySession.InvokeResult): GatewaySession.InvokeResult =
-    runTalkPttCommand {
-      prepareTalkCapture()
+  private suspend fun <T> withPreparedTalkPttCommand(
+    lifecycleEpoch: Long,
+    block: suspend (ownershipEpoch: Long) -> T,
+  ): T =
+    voiceCapturePreparationMutex.withLock {
+      // Preparation suspends while gateway config loads. Serialize ownership so
+      // a stale command cannot clean up a newer command before capture starts.
+      val ownershipEpoch = prepareTalkCapture()
       try {
-        block()
+        if (
+          !_isForeground.value ||
+          voiceLifecycleEpoch.get() != lifecycleEpoch ||
+          voiceCaptureOwnershipEpoch.get() != ownershipEpoch
+        ) {
+          throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+        }
+        block(ownershipEpoch)
       } catch (err: Throwable) {
-        cleanupFailedTalkCapture()
+        cleanupFailedTalkCapture(ownershipEpoch)
         throw err
       }
     }
@@ -1745,30 +1815,63 @@ class NodeRuntime private constructor(
       GatewaySession.InvokeResult.error(code = code, message = message)
     }
 
-  private suspend fun prepareTalkCapture() {
-    if (!_isForeground.value) {
-      throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+  private suspend fun prepareTalkCapture(): Long {
+    // Publish preparation on Main with lifecycle shutdown. After this block
+    // yields, preparation must not write capture state that backgrounding cleared.
+    val ownershipEpoch =
+      withContext(Dispatchers.Main) {
+        if (!_isForeground.value) {
+          throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+        }
+        if (!hasRecordAudioPermission()) {
+          throw IllegalStateException("MIC_PERMISSION_REQUIRED: grant Microphone permission")
+        }
+        val epoch = voiceCaptureOwnershipEpoch.incrementAndGet()
+        micCapture.setMicEnabled(false)
+        stopVoicePlayback()
+        NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.TalkMode)
+        talkMode.ttsOnAllResponses = true
+        talkMode.setPlaybackEnabled(speakerEnabled.value)
+        externalAudioCaptureActive.value = true
+        epoch
+      }
+    try {
+      talkMode.refreshConfig()
+      return ownershipEpoch
+    } catch (err: Throwable) {
+      cleanupFailedTalkCapture(ownershipEpoch)
+      throw err
     }
-    if (!hasRecordAudioPermission()) {
-      throw IllegalStateException("MIC_PERMISSION_REQUIRED: grant Microphone permission")
-    }
-    micCapture.setMicEnabled(false)
-    stopVoicePlayback()
-    NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.TalkMode)
-    talkMode.ttsOnAllResponses = true
-    talkMode.setPlaybackEnabled(speakerEnabled.value)
-    talkMode.refreshConfig()
-    externalAudioCaptureActive.value = true
   }
 
-  private suspend fun cleanupFailedTalkCapture() {
-    runCatching { talkMode.cancelPushToTalk() }
-    talkMode.ttsOnAllResponses = false
-    NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
-    externalAudioCaptureActive.value = false
+  private fun cleanupFailedTalkCapture(ownershipEpoch: Long) {
+    // TalkModeManager owns capture-scoped cancellation. A stale invoke must not
+    // tear down a newer capture after a background/foreground transition.
+    if (voiceCaptureOwnershipEpoch.get() == ownershipEpoch) {
+      talkMode.activePushToTalkCaptureId?.let { captureId ->
+        // An idempotent retry can fail while the original capture remains live.
+        // Transfer preparation ownership so its eventual stop still cleans up.
+        talkPttOwnership.set(TalkPttOwnership(captureId = captureId, epoch = ownershipEpoch))
+        return
+      }
+    }
+    finishTalkCaptureIfIdle(ownershipEpoch)
   }
 
-  private fun finishTalkCaptureIfIdle() {
+  private suspend fun finishTalkCaptureIfIdleAfterPreparation(captureId: String) {
+    withContext(NonCancellable) {
+      voiceCapturePreparationMutex.withLock {
+        val ownership = talkPttOwnership.get()
+        if (ownership?.captureId != captureId || !talkPttOwnership.compareAndSet(ownership, null)) {
+          return@withLock
+        }
+        finishTalkCaptureIfIdle(ownership.epoch)
+      }
+    }
+  }
+
+  private fun finishTalkCaptureIfIdle(ownershipEpoch: Long) {
+    if (ownershipEpoch == 0L || voiceCaptureOwnershipEpoch.get() != ownershipEpoch) return
     if (!talkMode.isEnabled.value && !talkMode.isListening.value && !talkMode.isSpeaking.value) {
       talkMode.ttsOnAllResponses = false
       NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
@@ -1778,6 +1881,7 @@ class NodeRuntime private constructor(
 
   private fun finishTalkModeAfterRelayClose() {
     if (_voiceCaptureMode.value != VoiceCaptureMode.TalkMode) return
+    voiceCaptureOwnershipEpoch.incrementAndGet()
     _voiceCaptureMode.value = VoiceCaptureMode.Off
     talkMode.ttsOnAllResponses = false
     NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
@@ -1910,12 +2014,14 @@ class NodeRuntime private constructor(
     persistManualMic: Boolean = true,
   ) {
     if (mode.requiresMicrophonePermission && !hasRecordAudioPermission()) {
+      voiceCaptureOwnershipEpoch.incrementAndGet()
       _voiceCaptureMode.value = VoiceCaptureMode.Off
       prefs.setVoiceMicEnabled(false)
       externalAudioCaptureActive.value = false
       return
     }
     if (_voiceCaptureMode.value == mode) return
+    voiceCaptureOwnershipEpoch.incrementAndGet()
     _voiceCaptureMode.value = mode
     when (mode) {
       VoiceCaptureMode.Off -> {
@@ -1965,6 +2071,8 @@ class NodeRuntime private constructor(
   }
 
   private fun stopActiveVoiceSession() {
+    voiceCaptureOwnershipEpoch.incrementAndGet()
+    talkPttOwnership.set(null)
     talkMode.ttsOnAllResponses = false
     talkMode.stopAllCapture()
     stopVoicePlayback()

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -60,6 +60,7 @@ import ai.openclaw.app.protocol.OpenClawCanvasA2UIAction
 import ai.openclaw.app.voice.MicCaptureManager
 import ai.openclaw.app.voice.TalkModeManager
 import ai.openclaw.app.voice.TalkPttOnceStart
+import ai.openclaw.app.voice.TalkPttStopPayload
 import ai.openclaw.app.voice.VoiceConversationEntry
 import ai.openclaw.app.voice.VoiceConversationRole
 import android.Manifest
@@ -710,6 +711,7 @@ class NodeRuntime private constructor(
 
   private val voiceLifecycleEpoch = AtomicLong()
   private val voiceCaptureOwnershipEpoch = AtomicLong()
+  private val talkPttCommandEpoch = AtomicLong()
   private val talkPttOwnership = AtomicReference<TalkPttOwnership?>()
   private val voiceCapturePreparationMutex = Mutex()
 
@@ -1717,18 +1719,20 @@ class NodeRuntime private constructor(
   private suspend fun handleTalkPttStart(): GatewaySession.InvokeResult =
     runTalkPttCommand {
       val lifecycleEpoch = voiceLifecycleEpoch.get()
+      val commandEpoch = talkPttCommandEpoch.get()
       if (!_isForeground.value) {
         val payload = talkMode.beginPushToTalk(allowNewCapture = false)
         return@runTalkPttCommand GatewaySession.InvokeResult.ok(payload.toJson())
       }
       val payload =
-        withPreparedTalkPttCommand(lifecycleEpoch) { ownershipEpoch ->
+        withPreparedTalkPttCommand(lifecycleEpoch, commandEpoch) { ownershipEpoch ->
           val started =
             talkMode.beginPushToTalk(
               allowNewCapture = true,
               canStartCapture = {
                 _isForeground.value &&
                   voiceLifecycleEpoch.get() == lifecycleEpoch &&
+                  talkPttCommandEpoch.get() == commandEpoch &&
                   voiceCaptureOwnershipEpoch.get() == ownershipEpoch
               },
             )
@@ -1740,28 +1744,28 @@ class NodeRuntime private constructor(
 
   private suspend fun handleTalkPttStop(): GatewaySession.InvokeResult =
     runTalkPttCommand {
-      val payload = talkMode.endPushToTalk()
-      finishTalkCaptureIfIdleAfterPreparation(payload.captureId)
+      val payload = stopPreparedTalkPttCapture { talkMode.endPushToTalk() }
       GatewaySession.InvokeResult.ok(payload.toJson())
     }
 
   private suspend fun handleTalkPttCancel(): GatewaySession.InvokeResult =
     runTalkPttCommand {
-      val payload = talkMode.cancelPushToTalk()
-      finishTalkCaptureIfIdleAfterPreparation(payload.captureId)
+      val payload = stopPreparedTalkPttCapture { talkMode.cancelPushToTalk() }
       GatewaySession.InvokeResult.ok(payload.toJson())
     }
 
   private suspend fun handleTalkPttOnce(): GatewaySession.InvokeResult =
     runTalkPttCommand {
       val lifecycleEpoch = voiceLifecycleEpoch.get()
+      val commandEpoch = talkPttCommandEpoch.get()
       val start =
-        withPreparedTalkPttCommand(lifecycleEpoch) { ownershipEpoch ->
+        withPreparedTalkPttCommand(lifecycleEpoch, commandEpoch) { ownershipEpoch ->
           val started =
             talkMode.beginPushToTalkOnce(
               canStartCapture = {
                 _isForeground.value &&
                   voiceLifecycleEpoch.get() == lifecycleEpoch &&
+                  talkPttCommandEpoch.get() == commandEpoch &&
                   voiceCaptureOwnershipEpoch.get() == ownershipEpoch
               },
             )
@@ -1786,16 +1790,25 @@ class NodeRuntime private constructor(
 
   private suspend fun <T> withPreparedTalkPttCommand(
     lifecycleEpoch: Long,
+    commandEpoch: Long,
     block: suspend (ownershipEpoch: Long) -> T,
   ): T =
     voiceCapturePreparationMutex.withLock {
       // Preparation suspends while gateway config loads. Serialize ownership so
       // a stale command cannot clean up a newer command before capture starts.
-      val ownershipEpoch = prepareTalkCapture()
+      if (
+        !_isForeground.value ||
+        voiceLifecycleEpoch.get() != lifecycleEpoch ||
+        talkPttCommandEpoch.get() != commandEpoch
+      ) {
+        throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+      }
+      val ownershipEpoch = prepareTalkCapture(lifecycleEpoch, commandEpoch)
       try {
         if (
           !_isForeground.value ||
           voiceLifecycleEpoch.get() != lifecycleEpoch ||
+          talkPttCommandEpoch.get() != commandEpoch ||
           voiceCaptureOwnershipEpoch.get() != ownershipEpoch
         ) {
           throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
@@ -1815,12 +1828,19 @@ class NodeRuntime private constructor(
       GatewaySession.InvokeResult.error(code = code, message = message)
     }
 
-  private suspend fun prepareTalkCapture(): Long {
+  private suspend fun prepareTalkCapture(
+    lifecycleEpoch: Long,
+    commandEpoch: Long,
+  ): Long {
     // Publish preparation on Main with lifecycle shutdown. After this block
     // yields, preparation must not write capture state that backgrounding cleared.
     val ownershipEpoch =
       withContext(Dispatchers.Main) {
-        if (!_isForeground.value) {
+        if (
+          !_isForeground.value ||
+          voiceLifecycleEpoch.get() != lifecycleEpoch ||
+          talkPttCommandEpoch.get() != commandEpoch
+        ) {
           throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
         }
         if (!hasRecordAudioPermission()) {
@@ -1861,13 +1881,29 @@ class NodeRuntime private constructor(
   private suspend fun finishTalkCaptureIfIdleAfterPreparation(captureId: String) {
     withContext(NonCancellable) {
       voiceCapturePreparationMutex.withLock {
-        val ownership = talkPttOwnership.get()
-        if (ownership?.captureId != captureId || !talkPttOwnership.compareAndSet(ownership, null)) {
-          return@withLock
-        }
-        finishTalkCaptureIfIdle(ownership.epoch)
+        finishTalkCaptureIfIdleLocked(captureId)
       }
     }
+  }
+
+  private suspend fun stopPreparedTalkPttCapture(
+    stopCapture: suspend () -> TalkPttStopPayload,
+  ): TalkPttStopPayload =
+    withContext(NonCancellable) {
+      voiceCapturePreparationMutex.withLock {
+        // Invalidation and capture stop share the preparation lock. A later start
+        // must observe the new epoch only after this stop releases the lock.
+        talkPttCommandEpoch.incrementAndGet()
+        val payload = stopCapture()
+        finishTalkCaptureIfIdleLocked(payload.captureId)
+        payload
+      }
+    }
+
+  private fun finishTalkCaptureIfIdleLocked(captureId: String) {
+    val ownership = talkPttOwnership.get()
+    if (ownership?.captureId != captureId || !talkPttOwnership.compareAndSet(ownership, null)) return
+    finishTalkCaptureIfIdle(ownership.epoch)
   }
 
   private fun finishTalkCaptureIfIdle(ownershipEpoch: Long) {
@@ -1881,6 +1917,7 @@ class NodeRuntime private constructor(
 
   private fun finishTalkModeAfterRelayClose() {
     if (_voiceCaptureMode.value != VoiceCaptureMode.TalkMode) return
+    talkPttCommandEpoch.incrementAndGet()
     voiceCaptureOwnershipEpoch.incrementAndGet()
     _voiceCaptureMode.value = VoiceCaptureMode.Off
     talkMode.ttsOnAllResponses = false
@@ -2013,20 +2050,21 @@ class NodeRuntime private constructor(
     mode: VoiceCaptureMode,
     persistManualMic: Boolean = true,
   ) {
+    talkPttCommandEpoch.incrementAndGet()
+    voiceCaptureOwnershipEpoch.incrementAndGet()
     if (mode.requiresMicrophonePermission && !hasRecordAudioPermission()) {
-      voiceCaptureOwnershipEpoch.incrementAndGet()
       _voiceCaptureMode.value = VoiceCaptureMode.Off
       prefs.setVoiceMicEnabled(false)
       externalAudioCaptureActive.value = false
       return
     }
-    if (_voiceCaptureMode.value == mode) return
-    voiceCaptureOwnershipEpoch.incrementAndGet()
+    if (_voiceCaptureMode.value == mode && isVoiceCaptureModeActive(mode)) return
+    talkPttOwnership.set(null)
     _voiceCaptureMode.value = mode
     when (mode) {
       VoiceCaptureMode.Off -> {
         talkMode.ttsOnAllResponses = false
-        talkMode.setEnabled(false)
+        talkMode.stopAllCapture()
         stopVoicePlayback()
         micCapture.setMicEnabled(false)
         if (persistManualMic) {
@@ -2038,7 +2076,7 @@ class NodeRuntime private constructor(
 
       VoiceCaptureMode.ManualMic -> {
         talkMode.ttsOnAllResponses = false
-        talkMode.setEnabled(false)
+        talkMode.stopAllCapture()
         NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.ManualMic)
         if (persistManualMic) {
           prefs.setVoiceMicEnabled(true)
@@ -2059,6 +2097,7 @@ class NodeRuntime private constructor(
         talkMode.ttsOnAllResponses = true
         talkMode.setPlaybackEnabled(speakerEnabled.value)
         scope.launch { talkMode.refreshConfig() }
+        talkMode.stopAllCapture()
         talkMode.setEnabled(true)
         externalAudioCaptureActive.value = true
       }
@@ -2071,6 +2110,7 @@ class NodeRuntime private constructor(
   }
 
   private fun stopActiveVoiceSession() {
+    talkPttCommandEpoch.incrementAndGet()
     voiceCaptureOwnershipEpoch.incrementAndGet()
     talkPttOwnership.set(null)
     talkMode.ttsOnAllResponses = false
@@ -2092,6 +2132,25 @@ class NodeRuntime private constructor(
 
   private val VoiceCaptureMode.requiresMicrophonePermission: Boolean
     get() = this == VoiceCaptureMode.ManualMic || this == VoiceCaptureMode.TalkMode
+
+  private fun isVoiceCaptureModeActive(mode: VoiceCaptureMode): Boolean =
+    when (mode) {
+      VoiceCaptureMode.Off ->
+        !externalAudioCaptureActive.value &&
+          !micCapture.micEnabled.value &&
+          !talkMode.isEnabled.value &&
+          talkMode.activePushToTalkCaptureId == null
+      VoiceCaptureMode.ManualMic ->
+        externalAudioCaptureActive.value &&
+          micCapture.micEnabled.value &&
+          !talkMode.isEnabled.value &&
+          talkMode.activePushToTalkCaptureId == null
+      VoiceCaptureMode.TalkMode ->
+        externalAudioCaptureActive.value &&
+          !micCapture.micEnabled.value &&
+          talkMode.isEnabled.value &&
+          talkMode.activePushToTalkCaptureId == null
+    }
 
   fun refreshGatewayConnection() {
     val endpoint = connectedEndpoint

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1906,17 +1906,18 @@ class NodeRuntime private constructor(
 
   private suspend fun stopPreparedTalkPttCapture(
     stopCapture: suspend () -> TalkPttStopPayload,
-  ): TalkPttStopPayload =
-    withContext(NonCancellable) {
+  ): TalkPttStopPayload {
+    // Preparation can suspend on gateway config. Invalidate it before waiting,
+    // while later starts queue behind this stop with the new command epoch.
+    talkPttCommandEpoch.incrementAndGet()
+    return withContext(NonCancellable) {
       voiceCapturePreparationMutex.withLock {
-        // Invalidation and capture stop share the preparation lock. A later start
-        // must observe the new epoch only after this stop releases the lock.
-        talkPttCommandEpoch.incrementAndGet()
         val payload = stopCapture()
         finishTalkCaptureIfIdleLocked(payload.captureId)
         payload
       }
     }
+  }
 
   private fun finishTalkCaptureIfIdleLocked(captureId: String) {
     synchronized(voiceCaptureOwnershipLock) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2081,16 +2081,13 @@ class NodeRuntime private constructor(
     synchronized(voiceCaptureOwnershipLock) {
       talkPttCommandEpoch.incrementAndGet()
       voiceCaptureOwnershipEpoch.incrementAndGet()
-      if (mode.requiresMicrophonePermission && !hasRecordAudioPermission()) {
-        _voiceCaptureMode.value = VoiceCaptureMode.Off
-        prefs.setVoiceMicEnabled(false)
-        externalAudioCaptureActive.value = false
-        return
-      }
-      if (_voiceCaptureMode.value == mode && isVoiceCaptureModeActive(mode)) return
+      val permissionDenied = mode.requiresMicrophonePermission && !hasRecordAudioPermission()
+      val captureMode = if (permissionDenied) VoiceCaptureMode.Off else mode
+      if (permissionDenied) prefs.setVoiceMicEnabled(false)
+      if (_voiceCaptureMode.value == captureMode && isVoiceCaptureModeActive(captureMode)) return
       talkPttOwnership.set(null)
-      _voiceCaptureMode.value = mode
-      when (mode) {
+      _voiceCaptureMode.value = captureMode
+      when (captureMode) {
         VoiceCaptureMode.Off -> {
           talkMode.ttsOnAllResponses = false
           talkMode.stopAllCapture()

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -81,6 +81,17 @@ data class TalkPttStopPayload(
     }.toString()
 }
 
+internal sealed interface TalkPttOnceStart {
+  data class Busy(
+    val payload: TalkPttStopPayload,
+  ) : TalkPttOnceStart
+
+  data class Started(
+    val captureId: String,
+    val completion: CompletableDeferred<TalkPttStopPayload>,
+  ) : TalkPttOnceStart
+}
+
 internal data class RealtimeToolRun(
   val callId: String,
   val relaySessionId: String,
@@ -105,7 +116,9 @@ private sealed interface RealtimeToolRegistration {
 
   data object AwaitingCompletion : RealtimeToolRegistration
 
-  data class Completed(val dispatch: RealtimeToolCompletionDispatch) : RealtimeToolRegistration
+  data class Completed(
+    val dispatch: RealtimeToolCompletionDispatch,
+  ) : RealtimeToolRegistration
 }
 
 private sealed interface RealtimeToolCompletionDecision {
@@ -113,7 +126,9 @@ private sealed interface RealtimeToolCompletionDecision {
 
   data object Consumed : RealtimeToolCompletionDecision
 
-  data class Dispatch(val completion: RealtimeToolCompletionDispatch) : RealtimeToolCompletionDecision
+  data class Dispatch(
+    val completion: RealtimeToolCompletionDispatch,
+  ) : RealtimeToolCompletionDecision
 }
 
 class TalkModeManager internal constructor(
@@ -269,33 +284,58 @@ class TalkModeManager internal constructor(
     stop()
   }
 
+  internal val activePushToTalkCaptureId: String?
+    get() = activePttCaptureId
+
   /** Starts a push-to-talk capture session for gateway node.invoke callers. */
-  suspend fun beginPushToTalk(allowNewCapture: Boolean): TalkPttStartPayload {
+  suspend fun beginPushToTalk(
+    allowNewCapture: Boolean,
+    canStartCapture: () -> Boolean = { true },
+  ): TalkPttStartPayload =
+    startPushToTalk(
+      allowNewCapture = allowNewCapture,
+      canStartCapture = canStartCapture,
+      completion = null,
+    ).payload
+
+  private sealed interface PushToTalkStartResult {
+    val payload: TalkPttStartPayload
+
+    data class Started(
+      override val payload: TalkPttStartPayload,
+    ) : PushToTalkStartResult
+
+    data class Existing(
+      override val payload: TalkPttStartPayload,
+    ) : PushToTalkStartResult
+  }
+
+  private data class ClearedPushToTalkCapture(
+    val transcript: String,
+    val completion: CompletableDeferred<TalkPttStopPayload>?,
+  )
+
+  private suspend fun startPushToTalk(
+    allowNewCapture: Boolean,
+    canStartCapture: () -> Boolean,
+    completion: CompletableDeferred<TalkPttStopPayload>?,
+    autoStopAfterMs: Long? = null,
+  ): PushToTalkStartResult {
     if (!allowNewCapture) {
       // A background retry may reconcile an existing capture, but must never create one.
       return activePttCaptureId
         ?.let(::TalkPttStartPayload)
+        ?.let { PushToTalkStartResult.Existing(it) }
         ?: throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+    }
+    // PTT begin is idempotent so gateway retries don't start multiple recognizers.
+    activePttCaptureId?.let {
+      return PushToTalkStartResult.Existing(TalkPttStartPayload(captureId = it))
     }
     if (!isConnected()) {
       _statusText.value = "Gateway not connected"
       throw IllegalStateException("UNAVAILABLE: Gateway not connected")
     }
-    // PTT begin is idempotent so gateway retries don't start multiple recognizers.
-    activePttCaptureId?.let { return TalkPttStartPayload(captureId = it) }
-
-    stopSpeaking(resetInterrupt = false)
-    pttTimeoutJob?.cancel()
-    pttTimeoutJob = null
-    pttAutoStopEnabled = false
-    pttCompletion = null
-    silenceJob?.cancel()
-    silenceJob = null
-    listeningMode = false
-    finalizeInFlight = false
-    stopRequested = false
-    lastTranscript = ""
-    lastHeardAtMs = null
 
     val micOk =
       ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
@@ -310,97 +350,194 @@ class TalkModeManager internal constructor(
     }
 
     val captureId = UUID.randomUUID().toString()
-    activePttCaptureId = captureId
-    withContext(Dispatchers.Main) {
-      recognizer?.cancel()
-      recognizer?.destroy()
-      recognizer = SpeechRecognizer.createSpeechRecognizer(context).also { it.setRecognitionListener(listener) }
-      startListeningInternal(markListening = true)
+    val captureGeneration = startGeneration.get()
+    return try {
+      withContext(Dispatchers.Main) {
+        activePttCaptureId?.let {
+          return@withContext PushToTalkStartResult.Existing(TalkPttStartPayload(captureId = it))
+        }
+        if (captureGeneration != startGeneration.get() || !canStartCapture()) {
+          throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
+        }
+        stopSpeaking(resetInterrupt = false)
+        pttTimeoutJob?.cancel()
+        pttTimeoutJob = null
+        pttAutoStopEnabled = false
+        silenceJob?.cancel()
+        silenceJob = null
+        listeningMode = false
+        finalizeInFlight = false
+        stopRequested = false
+        lastTranscript = ""
+        lastHeardAtMs = null
+        activePttCaptureId = captureId
+        pttCompletion = completion
+        try {
+          recognizer?.cancel()
+          recognizer?.destroy()
+          recognizer = SpeechRecognizer.createSpeechRecognizer(context).also { it.setRecognitionListener(listener) }
+          startListeningInternal(markListening = true)
+        } catch (err: Throwable) {
+          runCatching { recognizer?.cancel() }
+          runCatching { recognizer?.destroy() }
+          recognizer = null
+          _isListening.value = false
+          listeningMode = false
+          clearListenWatchdog()
+          activePttCaptureId = null
+          pttCompletion = null
+          completion?.cancel()
+          _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
+          if (_isEnabled.value) {
+            start()
+          }
+          throw err
+        }
+        _statusText.value = "Listening (PTT)"
+        if (autoStopAfterMs != null) {
+          pttAutoStopEnabled = true
+          // Install one-shot jobs before yielding to lifecycle changes. Otherwise a
+          // background stop can run between capture startup and job registration.
+          startSilenceMonitor(captureId)
+          pttTimeoutJob =
+            scope.launch {
+              delay(autoStopAfterMs)
+              if (pttAutoStopEnabled) {
+                endPushToTalk(captureId)
+              }
+            }
+        }
+        PushToTalkStartResult.Started(TalkPttStartPayload(captureId = captureId))
+      }
+    } catch (err: Throwable) {
+      withContext(NonCancellable) {
+        cancelPushToTalk(captureId)
+      }
+      throw err
     }
-    _statusText.value = "Listening (PTT)"
-    return TalkPttStartPayload(captureId = captureId)
   }
 
   /** Stops push-to-talk capture and queues the transcript for gateway chat. */
   suspend fun endPushToTalk(): TalkPttStopPayload {
     val captureId = activePttCaptureId ?: UUID.randomUUID().toString()
-    if (activePttCaptureId == null) {
-      return finishPushToTalk(TalkPttStopPayload(captureId = captureId, transcript = null, status = "idle"))
-    }
-
-    clearPushToTalkRecognition()
-    val transcript = lastTranscript.trim()
-    lastTranscript = ""
-    lastHeardAtMs = null
-
-    if (transcript.isEmpty()) {
-      _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
-      if (_isEnabled.value) {
-        start()
-      }
-      return finishPushToTalk(TalkPttStopPayload(captureId = captureId, transcript = null, status = "empty"))
-    }
-
-    if (!isConnected()) {
-      _statusText.value = "Gateway not connected"
-      if (_isEnabled.value) {
-        start()
-      }
-      return finishPushToTalk(TalkPttStopPayload(captureId = captureId, transcript = transcript, status = "offline"))
-    }
-
-    _statusText.value = "Thinking…"
-    scope.launch {
-      finalizeTranscript(transcript)
-    }
-    return finishPushToTalk(TalkPttStopPayload(captureId = captureId, transcript = transcript, status = "queued"))
+    return endPushToTalk(captureId)
   }
+
+  internal suspend fun endPushToTalk(captureId: String): TalkPttStopPayload =
+    withContext(Dispatchers.Main) {
+      val cleared =
+        clearPushToTalkRecognition(captureId)
+          ?: return@withContext TalkPttStopPayload(captureId = captureId, transcript = null, status = "idle")
+      val transcript = cleared.transcript
+
+      if (transcript.isEmpty()) {
+        _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
+        if (_isEnabled.value) {
+          start()
+        }
+        return@withContext finishPushToTalk(
+          TalkPttStopPayload(captureId = captureId, transcript = null, status = "empty"),
+          cleared.completion,
+        )
+      }
+
+      if (!isConnected()) {
+        _statusText.value = "Gateway not connected"
+        if (_isEnabled.value) {
+          start()
+        }
+        return@withContext finishPushToTalk(
+          TalkPttStopPayload(captureId = captureId, transcript = transcript, status = "offline"),
+          cleared.completion,
+        )
+      }
+
+      _statusText.value = "Thinking…"
+      scope.launch {
+        finalizeTranscript(transcript)
+      }
+      finishPushToTalk(
+        TalkPttStopPayload(captureId = captureId, transcript = transcript, status = "queued"),
+        cleared.completion,
+      )
+    }
 
   /** Cancels push-to-talk capture without sending the current transcript. */
   suspend fun cancelPushToTalk(): TalkPttStopPayload {
     val captureId = activePttCaptureId ?: UUID.randomUUID().toString()
-    if (activePttCaptureId == null) {
-      return finishPushToTalk(TalkPttStopPayload(captureId = captureId, transcript = null, status = "idle"))
-    }
-
-    clearPushToTalkRecognition()
-    lastTranscript = ""
-    lastHeardAtMs = null
-    _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
-    if (_isEnabled.value) {
-      start()
-    }
-    return finishPushToTalk(TalkPttStopPayload(captureId = captureId, transcript = null, status = "cancelled"))
+    return cancelPushToTalk(captureId)
   }
 
-  /** Runs a bounded one-shot PTT turn that auto-stops on silence or timeout. */
-  suspend fun runPushToTalkOnce(maxDurationMs: Long = 12_000L): TalkPttStopPayload {
-    if (pttCompletion != null) {
-      cancelPushToTalk()
-    }
-    if (activePttCaptureId != null) {
-      return TalkPttStopPayload(
-        captureId = activePttCaptureId ?: UUID.randomUUID().toString(),
-        transcript = null,
-        status = "busy",
+  internal suspend fun cancelPushToTalk(captureId: String): TalkPttStopPayload =
+    withContext(Dispatchers.Main) {
+      val cleared =
+        clearPushToTalkRecognition(captureId)
+          ?: return@withContext TalkPttStopPayload(captureId = captureId, transcript = null, status = "idle")
+      _statusText.value = if (_isEnabled.value) "Listening" else "Ready"
+      if (_isEnabled.value) {
+        start()
+      }
+      finishPushToTalk(
+        TalkPttStopPayload(captureId = captureId, transcript = null, status = "cancelled"),
+        cleared.completion,
       )
     }
 
-    beginPushToTalk(allowNewCapture = true)
+  /** Starts a bounded one-shot PTT turn that auto-stops on silence or timeout. */
+  internal suspend fun beginPushToTalkOnce(
+    maxDurationMs: Long = 12_000L,
+    canStartCapture: () -> Boolean = { true },
+  ): TalkPttOnceStart {
+    if (activePttCaptureId != null) {
+      return TalkPttOnceStart.Busy(
+        TalkPttStopPayload(
+          captureId = activePttCaptureId ?: UUID.randomUUID().toString(),
+          transcript = null,
+          status = "busy",
+        ),
+      )
+    }
+
     val completion = CompletableDeferred<TalkPttStopPayload>()
-    pttCompletion = completion
-    pttAutoStopEnabled = true
-    // One-shot PTT auto-stops on silence or timeout; manual PTT waits for an explicit stop call.
-    startSilenceMonitor()
-    pttTimeoutJob =
-      scope.launch {
-        delay(maxDurationMs)
-        if (pttAutoStopEnabled && activePttCaptureId != null) {
-          endPushToTalk()
-        }
-      }
-    return completion.await()
+    return when (
+      val start =
+        startPushToTalk(
+          allowNewCapture = true,
+          canStartCapture = canStartCapture,
+          completion = completion,
+          autoStopAfterMs = maxDurationMs,
+        )
+    ) {
+      is PushToTalkStartResult.Existing ->
+        TalkPttOnceStart.Busy(
+          TalkPttStopPayload(
+            captureId = start.payload.captureId,
+            transcript = null,
+            status = "busy",
+          ),
+        )
+      is PushToTalkStartResult.Started ->
+        TalkPttOnceStart.Started(
+          captureId = start.payload.captureId,
+          completion = completion,
+        )
+    }
   }
+
+  /** Waits for a started one-shot turn without keeping NodeRuntime preparation locked. */
+  internal suspend fun awaitPushToTalkOnce(start: TalkPttOnceStart): TalkPttStopPayload =
+    when (start) {
+      is TalkPttOnceStart.Busy -> start.payload
+      is TalkPttOnceStart.Started ->
+        try {
+          start.completion.await()
+        } catch (err: Throwable) {
+          withContext(NonCancellable) {
+            cancelPushToTalk(start.captureId)
+          }
+          throw err
+        }
+    }
 
   /**
    * Speak a wake-word command through TalkMode's full pipeline:
@@ -1604,18 +1741,18 @@ class TalkModeManager internal constructor(
     }
   }
 
-  private fun startSilenceMonitor() {
+  private fun startSilenceMonitor(captureId: String) {
     silenceJob?.cancel()
     silenceJob =
       scope.launch {
         while (_isEnabled.value || pttAutoStopEnabled) {
           delay(200)
-          checkSilence()
+          checkSilence(captureId)
         }
       }
   }
 
-  private fun checkSilence() {
+  private fun checkSilence(captureId: String) {
     if (!_isListening.value) return
     val transcript = lastTranscript.trim()
     if (transcript.isEmpty()) return
@@ -1624,7 +1761,7 @@ class TalkModeManager internal constructor(
     if (elapsed < silenceWindowMs) return
     if (activePttCaptureId != null) {
       if (pttAutoStopEnabled) {
-        scope.launch { endPushToTalk() }
+        scope.launch { endPushToTalk(captureId) }
       }
       return
     }
@@ -1714,24 +1851,31 @@ class TalkModeManager internal constructor(
     }
   }
 
-  private suspend fun clearPushToTalkRecognition() {
+  private fun clearPushToTalkRecognition(captureId: String): ClearedPushToTalkCapture? {
+    if (activePttCaptureId != captureId) return null
+    val transcript = lastTranscript.trim()
+    val completion = pttCompletion
     pttTimeoutJob?.cancel()
     pttTimeoutJob = null
     pttAutoStopEnabled = false
+    pttCompletion = null
     activePttCaptureId = null
     _isListening.value = false
     listeningMode = false
     clearListenWatchdog()
-    withContext(Dispatchers.Main) {
-      recognizer?.cancel()
-      recognizer?.destroy()
-      recognizer = null
-    }
+    recognizer?.cancel()
+    recognizer?.destroy()
+    recognizer = null
+    lastTranscript = ""
+    lastHeardAtMs = null
+    return ClearedPushToTalkCapture(transcript = transcript, completion = completion)
   }
 
-  private fun finishPushToTalk(payload: TalkPttStopPayload): TalkPttStopPayload {
-    pttCompletion?.complete(payload)
-    pttCompletion = null
+  private fun finishPushToTalk(
+    payload: TalkPttStopPayload,
+    completion: CompletableDeferred<TalkPttStopPayload>?,
+  ): TalkPttStopPayload {
+    completion?.complete(payload)
     return payload
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -17,10 +17,12 @@ import ai.openclaw.app.gateway.GatewayTlsProbeResult
 import ai.openclaw.app.node.ConnectionManager
 import ai.openclaw.app.node.InvokeDispatcher
 import ai.openclaw.app.protocol.OpenClawTalkCommand
+import ai.openclaw.app.voice.MicCaptureManager
 import ai.openclaw.app.voice.TalkModeManager
 import android.Manifest
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
@@ -28,6 +30,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -978,6 +981,71 @@ class GatewayBootstrapAuthTest {
       assertNull(cancel.error)
       assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
     }
+
+  @Test
+  fun pttStartQueuedAfterCancelIsInvalidatedBeforePreparation() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+      val runtime = NodeRuntime(app)
+      val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
+      val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
+      preparationMutex.lock()
+
+      val cancel =
+        async(start = CoroutineStart.UNDISPATCHED) {
+          dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null)
+        }
+      val start =
+        async(start = CoroutineStart.UNDISPATCHED) {
+          dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null)
+        }
+      preparationMutex.unlock()
+
+      assertEquals("NODE_BACKGROUND_UNAVAILABLE", start.await().error?.code)
+      assertNull(cancel.await().error)
+      val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+      assertNull(talkMode.activePushToTalkCaptureId)
+      assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+    }
+
+  @Test
+  fun sameManualMicModeReassertsCaptureAndInvalidatesPendingPtt() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+    val runtime = NodeRuntime(app)
+    runtime.setMicEnabled(true)
+    val commandEpoch = readField<AtomicLong>(runtime, "talkPttCommandEpoch")
+    val epochBeforeReassertion = commandEpoch.get()
+    val micCapture = readField<Lazy<MicCaptureManager>>(runtime, "micCapture\$delegate").value
+    val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+    micCapture.setMicEnabled(false)
+    writeField(talkMode, "activePttCaptureId", "capture-stale")
+
+    runtime.setMicEnabled(true)
+
+    assertTrue(runtime.micEnabled.value)
+    assertNull(talkMode.activePushToTalkCaptureId)
+    assertTrue(commandEpoch.get() > epochBeforeReassertion)
+    assertEquals(VoiceCaptureMode.ManualMic, runtime.voiceCaptureMode.value)
+  }
+
+  @Test
+  fun sameTalkModeReassertionStopsManualMicCapture() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+    val runtime = NodeRuntime(app)
+    runtime.setTalkModeEnabled(true)
+    val micCapture = readField<Lazy<MicCaptureManager>>(runtime, "micCapture\$delegate").value
+    micCapture.setMicEnabled(true)
+
+    runtime.setTalkModeEnabled(true)
+
+    assertFalse(runtime.micEnabled.value)
+    assertEquals(VoiceCaptureMode.TalkMode, runtime.voiceCaptureMode.value)
+    val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+    assertTrue(talkMode.isEnabled.value)
+  }
 
   @Test
   fun backgroundingStopsTalkModeCapture() {

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -22,7 +22,8 @@ import ai.openclaw.app.voice.TalkModeManager
 import android.Manifest
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
@@ -31,8 +32,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -984,31 +989,33 @@ class GatewayBootstrapAuthTest {
     }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun pttStartQueuedAfterCancelIsInvalidatedBeforePreparation() =
-    runBlocking {
+    runTest {
+      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
       val runtime = NodeRuntime(app)
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
       val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
-      preparationMutex.lock()
+      try {
+        preparationMutex.lock()
+        val cancel = async { dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null) }
+        runCurrent()
+        val start = async { dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null) }
+        runCurrent()
+        preparationMutex.unlock()
+        runCurrent()
 
-      val cancel =
-        async(start = CoroutineStart.UNDISPATCHED) {
-          dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null)
-        }
-      yield()
-      val start =
-        async(start = CoroutineStart.UNDISPATCHED) {
-          dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null)
-        }
-      preparationMutex.unlock()
-
-      assertNull(withTimeout(5_000) { cancel.await() }.error)
-      assertEquals("NODE_BACKGROUND_UNAVAILABLE", withTimeout(5_000) { start.await() }.error?.code)
-      val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
-      assertNull(talkMode.activePushToTalkCaptureId)
-      assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+        assertNull(withTimeout(5_000) { cancel.await() }.error)
+        assertEquals("NODE_BACKGROUND_UNAVAILABLE", withTimeout(5_000) { start.await() }.error?.code)
+        val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+        assertNull(talkMode.activePushToTalkCaptureId)
+        assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+      } finally {
+        if (preparationMutex.isLocked) preparationMutex.unlock()
+        Dispatchers.resetMain()
+      }
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -917,6 +917,26 @@ class GatewayBootstrapAuthTest {
   }
 
   @Test
+  fun revokedRecordAudioPermissionStopsGatewayPttBeforeMicStart() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+    val runtime = createTestRuntime(app)
+    val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+    writeField(talkMode, "activePttCaptureId", "capture-1")
+    talkMode.ttsOnAllResponses = true
+    readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value = true
+    shadowOf(app).denyPermissions(Manifest.permission.RECORD_AUDIO)
+
+    runtime.setMicEnabled(true)
+
+    assertEquals(VoiceCaptureMode.Off, runtime.voiceCaptureMode.value)
+    assertNull(talkMode.activePushToTalkCaptureId)
+    assertFalse(talkMode.ttsOnAllResponses)
+    assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+    assertFalse(runtime.prefs.voiceMicEnabled.value)
+  }
+
+  @Test
   @OptIn(ExperimentalCoroutinesApi::class)
   fun talkPttStart_cleansPreparedCaptureWhenBeginFails() =
     runBlocking {

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -1046,6 +1046,35 @@ class GatewayBootstrapAuthTest {
     }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun pttStartWaitingForPreparationIsInvalidatedByCancel() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+      val runtime = createTestRuntime(app)
+      val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
+      val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
+      Dispatchers.setMain(Dispatchers.Unconfined)
+      preparationMutex.lock()
+      try {
+        val start = async { dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null) }
+        yield()
+        val cancel = async { dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null) }
+        yield()
+        preparationMutex.unlock()
+
+        assertEquals("NODE_BACKGROUND_UNAVAILABLE", withTimeout(5_000) { start.await() }.error?.code)
+        assertNull(withTimeout(5_000) { cancel.await() }.error)
+        val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+        assertNull(talkMode.activePushToTalkCaptureId)
+        assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+      } finally {
+        if (preparationMutex.isLocked) preparationMutex.unlock()
+        Dispatchers.resetMain()
+      }
+    }
+
+  @Test
   fun sameManualMicModeReassertsCaptureAndInvalidatesPendingPtt() {
     val app = RuntimeEnvironment.getApplication()
     shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -996,14 +997,15 @@ class GatewayBootstrapAuthTest {
         async(start = CoroutineStart.UNDISPATCHED) {
           dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null)
         }
+      yield()
       val start =
         async(start = CoroutineStart.UNDISPATCHED) {
           dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null)
         }
       preparationMutex.unlock()
 
-      assertEquals("NODE_BACKGROUND_UNAVAILABLE", start.await().error?.code)
-      assertNull(cancel.await().error)
+      assertNull(withTimeout(5_000) { cancel.await() }.error)
+      assertEquals("NODE_BACKGROUND_UNAVAILABLE", withTimeout(5_000) { start.await() }.error?.code)
       val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
       assertNull(talkMode.activePushToTalkCaptureId)
       assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -32,12 +32,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runCurrent
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -921,12 +919,12 @@ class GatewayBootstrapAuthTest {
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
   fun talkPttStart_cleansPreparedCaptureWhenBeginFails() =
-    runTest {
+    runBlocking {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
       val runtime = createTestRuntime(app)
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
-      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      Dispatchers.setMain(Dispatchers.Unconfined)
       try {
         val result = dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null)
 
@@ -977,14 +975,14 @@ class GatewayBootstrapAuthTest {
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
   fun talkPttOnceRetryPreservesCaptureCleanupOwnership() =
-    runTest {
+    runBlocking {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
       val runtime = createTestRuntime(app)
       val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
       writeField(talkMode, "activePttCaptureId", "capture-1")
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
-      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      Dispatchers.setMain(Dispatchers.Unconfined)
       try {
         val retry = dispatcher.handleInvoke(OpenClawTalkCommand.PttOnce.rawValue, null)
         assertNull(retry.error)
@@ -1001,21 +999,20 @@ class GatewayBootstrapAuthTest {
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
   fun pttStartQueuedAfterCancelIsInvalidatedBeforePreparation() =
-    runTest {
+    runBlocking {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
       val runtime = createTestRuntime(app)
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
       val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
-      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      Dispatchers.setMain(Dispatchers.Unconfined)
       try {
         preparationMutex.lock()
         val cancel = async { dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null) }
-        runCurrent()
+        yield()
         val start = async { dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null) }
-        runCurrent()
+        yield()
         preparationMutex.unlock()
-        runCurrent()
 
         assertNull(withTimeout(5_000) { cancel.await() }.error)
         assertEquals("NODE_BACKGROUND_UNAVAILABLE", withTimeout(5_000) { start.await() }.error?.code)

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -993,8 +993,7 @@ class GatewayBootstrapAuthTest {
   }
 
   @Test
-  @OptIn(ExperimentalCoroutinesApi::class)
-  fun talkPttOnceRetryPreservesCaptureCleanupOwnership() =
+  fun talkPttOnceRetryReturnsBusyWithoutPreparingCapture() =
     runBlocking {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
@@ -1002,17 +1001,17 @@ class GatewayBootstrapAuthTest {
       val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
       writeField(talkMode, "activePttCaptureId", "capture-1")
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
-      Dispatchers.setMain(Dispatchers.Unconfined)
+      val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
+      preparationMutex.lock()
       try {
-        val retry = dispatcher.handleInvoke(OpenClawTalkCommand.PttOnce.rawValue, null)
+        val retry =
+          withTimeout(1_000) { dispatcher.handleInvoke(OpenClawTalkCommand.PttOnce.rawValue, null) }
         assertNull(retry.error)
-        assertTrue(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
-
-        val cancel = dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null)
-        assertNull(cancel.error)
+        assertEquals("""{"captureId":"capture-1","status":"busy"}""", retry.payloadJson)
+        assertEquals("capture-1", talkMode.activePushToTalkCaptureId)
         assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
       } finally {
-        Dispatchers.resetMain()
+        preparationMutex.unlock()
       }
     }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -992,12 +992,17 @@ class GatewayBootstrapAuthTest {
   @OptIn(ExperimentalCoroutinesApi::class)
   fun pttStartQueuedAfterCancelIsInvalidatedBeforePreparation() =
     runTest {
-      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = NodeRuntime(app)
+      val securePrefs =
+        app.getSharedPreferences(
+          "openclaw.node.secure.test.${UUID.randomUUID()}",
+          android.content.Context.MODE_PRIVATE,
+        )
+      val runtime = NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs))
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
       val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
+      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
       try {
         preparationMutex.lock()
         val cancel = async { dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null) }

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -1018,7 +1018,7 @@ class GatewayBootstrapAuthTest {
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
-  fun pttStartQueuedAfterCancelIsInvalidatedBeforePreparation() =
+  fun pttStartQueuedAfterCancelUsesNewCommandEpoch() =
     runBlocking {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
@@ -1035,7 +1035,7 @@ class GatewayBootstrapAuthTest {
         preparationMutex.unlock()
 
         assertNull(withTimeout(5_000) { cancel.await() }.error)
-        assertEquals("NODE_BACKGROUND_UNAVAILABLE", withTimeout(5_000) { start.await() }.error?.code)
+        assertEquals("UNAVAILABLE", withTimeout(5_000) { start.await() }.error?.code)
         val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
         assertNull(talkMode.activePushToTalkCaptureId)
         assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -919,20 +919,25 @@ class GatewayBootstrapAuthTest {
   }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun talkPttStart_cleansPreparedCaptureWhenBeginFails() =
-    runBlocking {
+    runTest {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = NodeRuntime(app)
+      val runtime = createTestRuntime(app)
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
+      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      try {
+        val result = dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null)
 
-      val result = dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null)
-
-      assertEquals("UNAVAILABLE", result.error?.code)
-      assertEquals(VoiceCaptureMode.Off, runtime.voiceCaptureMode.value)
-      assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
-      val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
-      assertFalse(talkMode.ttsOnAllResponses)
+        assertEquals("UNAVAILABLE", result.error?.code)
+        assertEquals(VoiceCaptureMode.Off, runtime.voiceCaptureMode.value)
+        assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+        val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+        assertFalse(talkMode.ttsOnAllResponses)
+      } finally {
+        Dispatchers.resetMain()
+      }
     }
 
   @Test
@@ -940,7 +945,7 @@ class GatewayBootstrapAuthTest {
     runBlocking {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = NodeRuntime(app)
+      val runtime = createTestRuntime(app)
       runtime.setForeground(false)
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
 
@@ -956,7 +961,7 @@ class GatewayBootstrapAuthTest {
   fun staleTalkPttCleanupPreservesNewerManualMicOwnership() {
     val app = RuntimeEnvironment.getApplication()
     shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-    val runtime = NodeRuntime(app)
+    val runtime = createTestRuntime(app)
     val ownershipEpoch = readField<AtomicLong>(runtime, "voiceCaptureOwnershipEpoch")
     ownershipEpoch.set(41L)
 
@@ -970,22 +975,27 @@ class GatewayBootstrapAuthTest {
   }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun talkPttOnceRetryPreservesCaptureCleanupOwnership() =
-    runBlocking {
+    runTest {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val runtime = NodeRuntime(app)
+      val runtime = createTestRuntime(app)
       val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
       writeField(talkMode, "activePttCaptureId", "capture-1")
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
+      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      try {
+        val retry = dispatcher.handleInvoke(OpenClawTalkCommand.PttOnce.rawValue, null)
+        assertNull(retry.error)
+        assertTrue(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
 
-      val retry = dispatcher.handleInvoke(OpenClawTalkCommand.PttOnce.rawValue, null)
-      assertNull(retry.error)
-      assertTrue(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
-
-      val cancel = dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null)
-      assertNull(cancel.error)
-      assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+        val cancel = dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null)
+        assertNull(cancel.error)
+        assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+      } finally {
+        Dispatchers.resetMain()
+      }
     }
 
   @Test
@@ -994,12 +1004,7 @@ class GatewayBootstrapAuthTest {
     runTest {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val runtime = NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs))
+      val runtime = createTestRuntime(app)
       val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
       val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
       Dispatchers.setMain(StandardTestDispatcher(testScheduler))
@@ -1027,7 +1032,7 @@ class GatewayBootstrapAuthTest {
   fun sameManualMicModeReassertsCaptureAndInvalidatesPendingPtt() {
     val app = RuntimeEnvironment.getApplication()
     shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-    val runtime = NodeRuntime(app)
+    val runtime = createTestRuntime(app)
     runtime.setMicEnabled(true)
     val commandEpoch = readField<AtomicLong>(runtime, "talkPttCommandEpoch")
     val epochBeforeReassertion = commandEpoch.get()
@@ -1048,7 +1053,7 @@ class GatewayBootstrapAuthTest {
   fun sameTalkModeReassertionStopsManualMicCapture() {
     val app = RuntimeEnvironment.getApplication()
     shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-    val runtime = NodeRuntime(app)
+    val runtime = createTestRuntime(app)
     runtime.setTalkModeEnabled(true)
     val micCapture = readField<Lazy<MicCaptureManager>>(runtime, "micCapture\$delegate").value
     micCapture.setMicEnabled(true)
@@ -1064,7 +1069,7 @@ class GatewayBootstrapAuthTest {
   @Test
   fun backgroundingStopsTalkModeCapture() {
     val app = RuntimeEnvironment.getApplication()
-    val runtime = NodeRuntime(app)
+    val runtime = createTestRuntime(app)
     val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
     readField<MutableStateFlow<VoiceCaptureMode>>(runtime, "_voiceCaptureMode").value = VoiceCaptureMode.TalkMode
     readField<MutableStateFlow<Boolean>>(talkMode, "_isEnabled").value = true
@@ -1087,7 +1092,7 @@ class GatewayBootstrapAuthTest {
   fun backgroundingStopsGatewayPttWhenVoiceModeIsOff() {
     val app = RuntimeEnvironment.getApplication()
     shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-    val runtime = NodeRuntime(app)
+    val runtime = createTestRuntime(app)
     val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
     writeField(talkMode, "activePttCaptureId", "capture-1")
     readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value = true
@@ -1107,6 +1112,15 @@ class GatewayBootstrapAuthTest {
       Thread.sleep(10)
     }
     error("Expected pending gateway trust prompt")
+  }
+
+  private fun createTestRuntime(app: android.app.Application): NodeRuntime {
+    val securePrefs =
+      app.getSharedPreferences(
+        "openclaw.node.secure.test.${UUID.randomUUID()}",
+        android.content.Context.MODE_PRIVATE,
+      )
+    return NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs))
   }
 
   private fun waitForStatusText(runtime: NodeRuntime): String {

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -944,6 +944,42 @@ class GatewayBootstrapAuthTest {
     }
 
   @Test
+  fun staleTalkPttCleanupPreservesNewerManualMicOwnership() {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+    val runtime = NodeRuntime(app)
+    val ownershipEpoch = readField<AtomicLong>(runtime, "voiceCaptureOwnershipEpoch")
+    ownershipEpoch.set(41L)
+
+    runtime.setMicEnabled(true)
+    val cleanup = runtime.javaClass.getDeclaredMethod("finishTalkCaptureIfIdle", Long::class.javaPrimitiveType)
+    cleanup.isAccessible = true
+    cleanup.invoke(runtime, 41L)
+
+    assertEquals(VoiceCaptureMode.ManualMic, runtime.voiceCaptureMode.value)
+    assertTrue(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+  }
+
+  @Test
+  fun talkPttOnceRetryPreservesCaptureCleanupOwnership() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+      val runtime = NodeRuntime(app)
+      val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+      writeField(talkMode, "activePttCaptureId", "capture-1")
+      val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
+
+      val retry = dispatcher.handleInvoke(OpenClawTalkCommand.PttOnce.rawValue, null)
+      assertNull(retry.error)
+      assertTrue(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+
+      val cancel = dispatcher.handleInvoke(OpenClawTalkCommand.PttCancel.rawValue, null)
+      assertNull(cancel.error)
+      assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+    }
+
+  @Test
   fun backgroundingStopsTalkModeCapture() {
     val app = RuntimeEnvironment.getApplication()
     val runtime = NodeRuntime(app)

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -1051,6 +1051,7 @@ class GatewayBootstrapAuthTest {
     val app = RuntimeEnvironment.getApplication()
     shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
     val runtime = createTestRuntime(app)
+    readField<CoroutineScope>(runtime, "scope").coroutineContext[Job]?.cancel()
     runtime.setTalkModeEnabled(true)
     val micCapture = readField<Lazy<MicCaptureManager>>(runtime, "micCapture\$delegate").value
     micCapture.setMicEnabled(true)

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -5,8 +5,9 @@ import ai.openclaw.app.gateway.DeviceAuthTokenStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewaySession
 import android.Manifest
+import android.content.ComponentName
 import android.content.Intent
-import android.content.pm.ResolveInfo
+import android.content.IntentFilter
 import android.os.SystemClock
 import android.speech.RecognitionService
 import kotlinx.coroutines.CompletableDeferred
@@ -98,8 +99,10 @@ class TalkModeManagerTest {
     runTest {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
-      shadowOf(app.packageManager)
-        .setResolveInfosForIntent(Intent(RecognitionService.SERVICE_INTERFACE), listOf(ResolveInfo()))
+      val packageManager = shadowOf(app.packageManager)
+      val speechService = ComponentName(app, "TestSpeechRecognitionService")
+      packageManager.addServiceIfNotPresent(speechService)
+      packageManager.addIntentFilterForService(speechService, IntentFilter(RecognitionService.SERVICE_INTERFACE))
       val manager = createManager()
       Dispatchers.setMain(StandardTestDispatcher(testScheduler))
       try {

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.gateway.DeviceAuthEntry
 import ai.openclaw.app.gateway.DeviceAuthTokenStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewaySession
+import android.Manifest
 import android.os.SystemClock
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -11,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -24,6 +26,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
@@ -84,6 +87,26 @@ class TalkModeManagerTest {
     }
 
   @Test
+  fun beginPushToTalkRejectsInvalidatedCaptureBeforeStarting() =
+    runTest {
+      val app = RuntimeEnvironment.getApplication()
+      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+      val manager = createManager()
+
+      val error =
+        runCatching {
+          manager.beginPushToTalk(
+            allowNewCapture = true,
+            canStartCapture = { false },
+          )
+        }.exceptionOrNull()
+
+      assertEquals("NODE_BACKGROUND_UNAVAILABLE: command requires foreground", error?.message)
+      assertNull(readPrivateField(manager, "activePttCaptureId"))
+      assertFalse(manager.isListening.value)
+    }
+
+  @Test
   fun stopAllCaptureClearsPttWhenContinuousModeIsDisabled() {
     val manager = createManager()
     setPrivateField(manager, "activePttCaptureId", "capture-1")
@@ -96,6 +119,75 @@ class TalkModeManagerTest {
     assertFalse(manager.isListening.value)
     assertEquals("Off", manager.statusText.value)
   }
+
+  @Test
+  fun staleCancellationDoesNotStopNewerPushToTalkCapture() =
+    runTest {
+      val manager = createManager()
+      val completion = CompletableDeferred<TalkPttStopPayload>()
+      setPrivateField(manager, "activePttCaptureId", "capture-new")
+      setPrivateField(manager, "pttCompletion", completion)
+
+      val payload = manager.cancelPushToTalk("capture-old")
+
+      assertEquals("idle", payload.status)
+      assertEquals("capture-new", readPrivateField(manager, "activePttCaptureId"))
+      assertFalse(completion.isCompleted)
+    }
+
+  @Test
+  fun oneShotRetryDoesNotReplaceActivePushToTalkCapture() =
+    runTest {
+      val manager = createManager()
+      val completion = CompletableDeferred<TalkPttStopPayload>()
+      setPrivateField(manager, "activePttCaptureId", "capture-active")
+      setPrivateField(manager, "pttCompletion", completion)
+
+      val start = manager.beginPushToTalkOnce()
+      val payload = manager.awaitPushToTalkOnce(start)
+
+      assertEquals("busy", payload.status)
+      assertEquals("capture-active", payload.captureId)
+      assertEquals("capture-active", readPrivateField(manager, "activePttCaptureId"))
+      assertFalse(completion.isCompleted)
+    }
+
+  @Test
+  fun cancelledOneShotWaitCleansItsCapture() =
+    runTest {
+      val manager = createManager()
+      val completion = CompletableDeferred<TalkPttStopPayload>()
+      setPrivateField(manager, "activePttCaptureId", "capture-1")
+      setPrivateField(manager, "pttCompletion", completion)
+      setMutableStateFlow(manager, "_isListening", true)
+      val start = TalkPttOnceStart.Started(captureId = "capture-1", completion = completion)
+
+      val wait = launch { manager.awaitPushToTalkOnce(start) }
+      advanceUntilIdle()
+      wait.cancelAndJoin()
+
+      assertNull(readPrivateField(manager, "activePttCaptureId"))
+      assertNull(readPrivateField(manager, "pttCompletion"))
+      assertFalse(manager.isListening.value)
+      assertTrue(completion.isCompleted)
+    }
+
+  @Test
+  fun staleStopDoesNotSubmitNewerPushToTalkCapture() =
+    runTest {
+      val manager = createManager()
+      val completion = CompletableDeferred<TalkPttStopPayload>()
+      setPrivateField(manager, "activePttCaptureId", "capture-new")
+      setPrivateField(manager, "pttCompletion", completion)
+      setPrivateField(manager, "lastTranscript", "new partial transcript")
+
+      val payload = manager.endPushToTalk("capture-old")
+
+      assertEquals("idle", payload.status)
+      assertEquals("capture-new", readPrivateField(manager, "activePttCaptureId"))
+      assertEquals("new partial transcript", readPrivateField(manager, "lastTranscript"))
+      assertFalse(completion.isCompleted)
+    }
 
   @Test
   fun duplicateFinalForPendingTalkRunDoesNotStartAllResponseTts() {

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -5,19 +5,25 @@ import ai.openclaw.app.gateway.DeviceAuthTokenStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewaySession
 import android.Manifest
+import android.content.Intent
+import android.content.pm.ResolveInfo
 import android.os.SystemClock
+import android.speech.RecognitionService
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -87,23 +93,30 @@ class TalkModeManagerTest {
     }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun beginPushToTalkRejectsInvalidatedCaptureBeforeStarting() =
     runTest {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+      shadowOf(app.packageManager)
+        .addResolveInfoForIntent(Intent(RecognitionService.SERVICE_INTERFACE), ResolveInfo())
       val manager = createManager()
+      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      try {
+        val error =
+          runCatching {
+            manager.beginPushToTalk(
+              allowNewCapture = true,
+              canStartCapture = { false },
+            )
+          }.exceptionOrNull()
 
-      val error =
-        runCatching {
-          manager.beginPushToTalk(
-            allowNewCapture = true,
-            canStartCapture = { false },
-          )
-        }.exceptionOrNull()
-
-      assertEquals("NODE_BACKGROUND_UNAVAILABLE: command requires foreground", error?.message)
-      assertNull(readPrivateField(manager, "activePttCaptureId"))
-      assertFalse(manager.isListening.value)
+        assertEquals("NODE_BACKGROUND_UNAVAILABLE: command requires foreground", error?.message)
+        assertNull(readPrivateField(manager, "activePttCaptureId"))
+        assertFalse(manager.isListening.value)
+      } finally {
+        Dispatchers.resetMain()
+      }
     }
 
   @Test
@@ -162,15 +175,21 @@ class TalkModeManagerTest {
       setPrivateField(manager, "pttCompletion", completion)
       setMutableStateFlow(manager, "_isListening", true)
       val start = TalkPttOnceStart.Started(captureId = "capture-1", completion = completion)
+      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      try {
+        val wait = launch { manager.awaitPushToTalkOnce(start) }
+        advanceUntilIdle()
+        wait.cancel()
+        runCurrent()
+        wait.join()
 
-      val wait = launch { manager.awaitPushToTalkOnce(start) }
-      advanceUntilIdle()
-      wait.cancelAndJoin()
-
-      assertNull(readPrivateField(manager, "activePttCaptureId"))
-      assertNull(readPrivateField(manager, "pttCompletion"))
-      assertFalse(manager.isListening.value)
-      assertTrue(completion.isCompleted)
+        assertNull(readPrivateField(manager, "activePttCaptureId"))
+        assertNull(readPrivateField(manager, "pttCompletion"))
+        assertFalse(manager.isListening.value)
+        assertTrue(completion.isCompleted)
+      } finally {
+        Dispatchers.resetMain()
+      }
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -99,7 +99,7 @@ class TalkModeManagerTest {
       val app = RuntimeEnvironment.getApplication()
       shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
       shadowOf(app.packageManager)
-        .addResolveInfoForIntent(Intent(RecognitionService.SERVICE_INTERFACE), ResolveInfo())
+        .setResolveInfosForIntent(Intent(RecognitionService.SERVICE_INTERFACE), listOf(ResolveInfo()))
       val manager = createManager()
       Dispatchers.setMain(StandardTestDispatcher(testScheduler))
       try {

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -137,18 +137,23 @@ class TalkModeManagerTest {
   }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun staleCancellationDoesNotStopNewerPushToTalkCapture() =
     runTest {
       val manager = createManager()
       val completion = CompletableDeferred<TalkPttStopPayload>()
       setPrivateField(manager, "activePttCaptureId", "capture-new")
       setPrivateField(manager, "pttCompletion", completion)
+      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      try {
+        val payload = manager.cancelPushToTalk("capture-old")
 
-      val payload = manager.cancelPushToTalk("capture-old")
-
-      assertEquals("idle", payload.status)
-      assertEquals("capture-new", readPrivateField(manager, "activePttCaptureId"))
-      assertFalse(completion.isCompleted)
+        assertEquals("idle", payload.status)
+        assertEquals("capture-new", readPrivateField(manager, "activePttCaptureId"))
+        assertFalse(completion.isCompleted)
+      } finally {
+        Dispatchers.resetMain()
+      }
     }
 
   @Test
@@ -196,6 +201,7 @@ class TalkModeManagerTest {
     }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun staleStopDoesNotSubmitNewerPushToTalkCapture() =
     runTest {
       val manager = createManager()
@@ -203,13 +209,17 @@ class TalkModeManagerTest {
       setPrivateField(manager, "activePttCaptureId", "capture-new")
       setPrivateField(manager, "pttCompletion", completion)
       setPrivateField(manager, "lastTranscript", "new partial transcript")
+      Dispatchers.setMain(StandardTestDispatcher(testScheduler))
+      try {
+        val payload = manager.endPushToTalk("capture-old")
 
-      val payload = manager.endPushToTalk("capture-old")
-
-      assertEquals("idle", payload.status)
-      assertEquals("capture-new", readPrivateField(manager, "activePttCaptureId"))
-      assertEquals("new partial transcript", readPrivateField(manager, "lastTranscript"))
-      assertFalse(completion.isCompleted)
+        assertEquals("idle", payload.status)
+        assertEquals("capture-new", readPrivateField(manager, "activePttCaptureId"))
+        assertEquals("new partial transcript", readPrivateField(manager, "lastTranscript"))
+        assertFalse(completion.isCompleted)
+      } finally {
+        Dispatchers.resetMain()
+      }
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -153,6 +153,7 @@ class TalkModeManagerTest {
     }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun cancelledOneShotWaitCleansItsCapture() =
     runTest {
       val manager = createManager()


### PR DESCRIPTION
Related: #99840
Follow-up to #100483

## What Problem This Solves

Fixes an issue where Android gateway push-to-talk could restart microphone capture after the app backgrounded, or let a stale stop/cancel tear down a newer Manual Mic or push-to-talk session when preparation, retries, and lifecycle changes overlapped.

## Why This Change Was Made

The initial background-stop fix landed from #99840 in #100483, but its check occurred before suspended configuration work and its cleanup was not capture-scoped. This follow-up gives each capture explicit ownership, performs lifecycle-sensitive preparation on Main, serializes preparation and cleanup, and rejects stale work again at the recognizer-start boundary.

## User Impact

Android no longer leaves Talk foreground-service state active after a cancelled, permission-revoked, or backgrounded gateway PTT request, and delayed work cannot replace or stop a newer microphone session. Cancellation invalidates preparation before waiting, while later starts retain their new command epoch. Idempotent one-shot retries return the active capture as busy without opening a second recognizer.

## Evidence

- Exact head: `2dbd12f4fd2e85d2c5cb5ed9c182c3e8ac4ad4aa`, rebased onto `89f911f322c90c3e7e3ec51120686256de19b4b1`.
- Added regression coverage for lifecycle-invalidated starts, cancellation ordering, stale stop/cancel callbacks, cancelled one-shot waits, permission loss, busy retries, Manual Mic ownership, and foreground cleanup.
- Sanitized AWS Crabbox run [`run_8168a951e06e`](https://crabbox.openclaw.ai/portal/runs/run_8168a951e06e) passed the complete `TalkModeManagerTest` and `GatewayBootstrapAuthTest` classes on both Play and third-party Android flavors (65 Gradle tasks) for the identical pre-rebase patch.
- `pnpm native:i18n:check` passed with 2,583 entries and no drift; `git diff --check origin/main...HEAD` passed.
- Fresh post-overlap autoreview reported no accepted/actionable findings (correctness 0.90); `git range-diff` showed the production patch unchanged apart from regenerated i18n line metadata.
- Exact-head GitHub CI is rerunning after the clean rebase; the prior exact-head Android Play and third-party unit lanes passed.
