### PR TITLE
docs(changelog): add GitHub preview entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.
 - **Control UI Talk controls:** keep voice, model, and sensitivity in the composer while moving provider, transport, VAD timing, and reasoning defaults to Settings → Communications → Talk.
+- **Control UI GitHub previews:** show issue and pull request state, title, author, activity, comments, and change statistics in hover and keyboard-focus cards. (#100434)
 - **Logbook work journal:** add a disabled-by-default bundled plugin that turns paired-node screen snapshots into a private timeline, daily standup, and timeline-grounded Q&A in a plugin-contributed Control UI tab. (#99930)
 - **Control UI message context:** reveal per-message token, context, and model details from the timestamp on hover or activation instead of showing a separate Context button.
 - **Control UI session titles:** reveal truncated recent-session names with a reduced-motion-safe hover animation.


### PR DESCRIPTION
## What Problem This Solves

The GitHub issue and pull request hover-card feature landed in #100434 without its changelog entry so unrelated high-frequency changelog updates would not repeatedly invalidate the exact-head feature proof.

## Why This Change Was Made

This follow-up records the shipped Control UI behavior in the current Unreleased section after the feature merge.

## User Impact

Release notes now describe the GitHub issue and pull request hover and keyboard-focus previews.

## Evidence

- Changelog-only diff against current `main`.
- `git diff --check` — passed.
- Feature implementation and full validation: #100434.
- Tracking issue: #100412.

AI-assisted with Codex. I understand and reviewed the change. Agent transcript omitted; no transcript attachment was requested.
