### PR TITLE
docs(changelog): note Apple chat run recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Apple chat run recovery:** restore active responses from canonical Gateway history after reconnects, foreground resumes, and event gaps, while preserving gateway user-turn identity across Codex and Copilot transcript mirrors to prevent duplicate rows. (#100277)
 - **Source build portability:** keep tsdown configuration self-contained so builds do not depend on resolving the tsdown package from unrun's temporary module directory.
 - **Agent tool-call decoding:** preserve surrogate-range numeric HTML entities as literal text while still decoding valid supplementary-plane values, preventing malformed model output from injecting lone UTF-16 surrogates into tool arguments. (#99564) Thanks @mikasa0818.
 - **Gateway event dispatch:** catch and log lazy subscriber setup and handler failures instead of leaking unhandled promise rejections. (#100401) Thanks @cxbAsDev.


### PR DESCRIPTION
Related: #100277
Related: #100197

## What Problem This Solves

The landed Apple chat reconnect recovery was missing from the Unreleased changelog, so the user-visible behavior would not appear in release notes.

## Why This Change Was Made

Adds one Fixes entry describing active-response restoration and duplicate-row prevention across iOS/macOS chat and provider transcript mirrors.

## User Impact

Users and operators can see the reconnect/foreground recovery improvement in the next release notes.

## Evidence

- `git diff --check`
- The entry references landed PR #100277; its exact-head CI run 28763343519 passed before merge.
