### PR TITLE
docs(changelog): credit recent contributor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Apple chat run recovery:** restore active responses from canonical Gateway history after reconnects, foreground resumes, and event gaps, while preserving gateway user-turn identity across Codex and Copilot transcript mirrors to prevent duplicate rows. (#100277)
+- **Claude CLI streamed replies:** preserve assistant text already received from Claude CLI when its terminal result envelope is empty, preventing false empty-response failover after a complete streamed answer. (#90450) Thanks @totobusnello.
+- **Phone identity normalization:** canonicalize stray plus signs, preserve non-phone iMessage handles, and reject digit-free Signal identities across shared channel routing. (#100467) Thanks @morluto.
+- **Tlon scry response bounds:** cap successful Urbit scry JSON reads and cancel oversized streams instead of buffering unbounded peer responses. (#100376) Thanks @hugenshen.
 - **Source build portability:** keep tsdown configuration self-contained so builds do not depend on resolving the tsdown package from unrun's temporary module directory.
 - **Agent tool-call decoding:** preserve surrogate-range numeric HTML entities as literal text while still decoding valid supplementary-plane values, preventing malformed model output from injecting lone UTF-16 surrogates into tool arguments. (#99564) Thanks @mikasa0818.
 - **Gateway event dispatch:** catch and log lazy subscriber setup and handler failures instead of leaking unhandled promise rejections. (#100401) Thanks @cxbAsDev.


### PR DESCRIPTION
## What Problem This Solves

Three contributor-authored fixes landed after their implementation branches had to stay runtime-only to avoid repeated changelog conflicts. Their release notes and contributor credit are therefore missing from `Unreleased`.

## Why This Change Was Made

Add one concise changelog entry for each landed fix in a single maintainer-owned pass:

- #90450 preserves streamed Claude CLI replies when the terminal envelope is empty;
- #100467 canonicalizes phone identities without corrupting non-phone iMessage handles;
- #100376 bounds successful Tlon Urbit scry JSON responses.

This keeps contributor branches focused while preserving the repository's contributor-credit policy.

## User Impact

Release notes now accurately describe the three fixes and thank `@totobusnello`, `@morluto`, and `@hugenshen`.

## Evidence

- Changelog-only diff: three one-line entries under `Unreleased` → `Fixes`.
- `git diff --check` passes.
- Canonical landed implementations: #90450, #100467, and #100376.

## AI-assisted disclosure

- [x] Maintainer-authored changelog closeout
- [x] No runtime or generated files changed
