### PR TITLE
fix: warn when active transcript byte guard is inactive

### DIFF
--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -9,7 +9,11 @@ import {
 import { readConfigFileSnapshot } from "./config.js";
 import { findLegacyConfigIssues } from "./legacy.js";
 import { buildWebSearchProviderConfig, withTempHome, writeOpenClawConfig } from "./test-helpers.js";
-import { validateConfigObject, validateConfigObjectRaw } from "./validation.js";
+import {
+  validateConfigObject,
+  validateConfigObjectRaw,
+  validateConfigObjectWithPlugins,
+} from "./validation.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 const nonBooleanConfigCases = [
@@ -1432,6 +1436,28 @@ describe("config strict validation", () => {
           process.env.OPENCLAW_BIND = prev;
         }
       }
+    });
+  });
+
+  it("warns when maxActiveTranscriptBytes cannot run without transcript rotation", () => {
+    const result = validateConfigObjectWithPlugins(
+      {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: "10b",
+            },
+          },
+        },
+      },
+      { pluginValidation: "skip" },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toContainEqual({
+      path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+      message:
+        "maxActiveTranscriptBytes is inactive unless agents.defaults.compaction.truncateAfterCompaction is true",
     });
   });
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -48,6 +48,7 @@ import { isRecord, resolveUserPath } from "../utils.js";
 import { findDuplicateAgentDirs, formatDuplicateAgentDirError } from "./agent-dirs.js";
 import { appendAllowedValuesHint, summarizeAllowedValues } from "./allowed-values.js";
 import { GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA } from "./bundled-channel-config-metadata.generated.js";
+import { parseNonNegativeByteSize } from "./byte-size.js";
 import {
   collectChannelDmPolicyMetadata,
   collectChannelSchemaMetadataWithOwnership,
@@ -1034,6 +1035,25 @@ function validateGatewayTailscaleAuth(config: OpenClawConfig): ConfigValidationI
   ];
 }
 
+function collectActiveTranscriptByteGuardWarnings(config: OpenClawConfig): ConfigValidationIssue[] {
+  const compaction = config.agents?.defaults?.compaction;
+  const maxActiveTranscriptBytes = parseNonNegativeByteSize(compaction?.maxActiveTranscriptBytes);
+  if (
+    maxActiveTranscriptBytes === null ||
+    maxActiveTranscriptBytes <= 0 ||
+    compaction?.truncateAfterCompaction === true
+  ) {
+    return [];
+  }
+  return [
+    {
+      path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+      message:
+        "maxActiveTranscriptBytes is inactive unless agents.defaults.compaction.truncateAfterCompaction is true",
+    },
+  ];
+}
+
 /**
  * Validates config without applying runtime defaults.
  * Use this when you need the raw validated config (e.g., for writing back to file).
@@ -1202,16 +1222,17 @@ function validateConfigObjectWithPluginsBase(
         manifestRegistry: registryInfo?.registry,
       })
     : base.config;
+  const configWarnings = collectActiveTranscriptByteGuardWarnings(config);
   if (opts.pluginValidation === "skip") {
     return {
       ok: true,
       config,
-      warnings: [],
+      warnings: configWarnings,
     };
   }
 
   const issues: ConfigValidationIssue[] = [];
-  const warnings: ConfigValidationIssue[] = [];
+  const warnings: ConfigValidationIssue[] = [...configWarnings];
   const hasExplicitPluginsConfig = isRecord(raw) && Object.hasOwn(raw, "plugins");
   const explicitPluginReferences = collectExplicitPluginReferences(raw);
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1694,6 +1694,47 @@ describe("doctor health contributions", () => {
     });
   });
 
+  it("reports inactive active-transcript byte guards in lint mode", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const byteGuardCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/active-transcript-byte-guard",
+    );
+    expect(byteGuardCheck).toBeDefined();
+
+    await expect(
+      runDoctorLintChecks(
+        {
+          cfg: {
+            agents: {
+              defaults: {
+                compaction: {
+                  maxActiveTranscriptBytes: "10b",
+                },
+              },
+            },
+          },
+          mode: "lint" as const,
+          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+        },
+        {
+          checks: [byteGuardCheck!],
+          onlyIds: ["core/doctor/active-transcript-byte-guard"],
+        },
+      ),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      checksSkipped: 0,
+      findings: [
+        expect.objectContaining({
+          checkId: "core/doctor/active-transcript-byte-guard",
+          severity: "warning",
+          path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+          requirement: "truncate-after-compaction-required",
+        }),
+      ],
+    });
+  });
+
   it("keeps legacy plugin dependency lint opt-in and read-only", async () => {
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     const tempDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "openclaw-legacy-plugin-deps-lint-"));

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -7,6 +7,7 @@ import {
   isLegacyParentWritableUpdateDoctorPass,
   UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
 } from "../commands/doctor/shared/update-phase.js";
+import { parseNonNegativeByteSize } from "../config/byte-size.js";
 import { resolveIsNixMode } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
@@ -795,6 +796,33 @@ type ToolResultCapTarget = {
   scopeLabel: string;
   target?: string;
 };
+
+const ACTIVE_TRANSCRIPT_BYTE_GUARD_CHECK_ID = "core/doctor/active-transcript-byte-guard";
+
+function collectActiveTranscriptByteGuardFindings(cfg: OpenClawConfig): readonly HealthFinding[] {
+  const compaction = cfg.agents?.defaults?.compaction;
+  const maxActiveTranscriptBytes = parseNonNegativeByteSize(compaction?.maxActiveTranscriptBytes);
+  if (
+    maxActiveTranscriptBytes === null ||
+    maxActiveTranscriptBytes <= 0 ||
+    compaction?.truncateAfterCompaction === true
+  ) {
+    return [];
+  }
+  return [
+    {
+      checkId: ACTIVE_TRANSCRIPT_BYTE_GUARD_CHECK_ID,
+      severity: "warning",
+      message:
+        "agents.defaults.compaction.maxActiveTranscriptBytes is set but inactive because truncateAfterCompaction is not true.",
+      path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+      target: "agents.defaults.compaction.truncateAfterCompaction",
+      requirement: "truncate-after-compaction-required",
+      fixHint:
+        "Set agents.defaults.compaction.truncateAfterCompaction to true, or remove maxActiveTranscriptBytes.",
+    },
+  ];
+}
 
 async function collectToolResultCapFindings(
   cfg: OpenClawConfig,
@@ -1980,6 +2008,16 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
         detect: async (ctx) => collectToolResultCapFindings(ctx.cfg),
       },
       run: runToolResultCapHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:active-transcript-byte-guard",
+      label: "Active transcript byte guard",
+      healthChecks: {
+        id: ACTIVE_TRANSCRIPT_BYTE_GUARD_CHECK_ID,
+        description:
+          "Detect maxActiveTranscriptBytes settings that cannot run without transcript rotation.",
+        detect: async (ctx) => collectActiveTranscriptByteGuardFindings(ctx.cfg),
+      },
     }),
     createDoctorHealthContribution({
       id: "doctor:provider-catalog-projection",


### PR DESCRIPTION
﻿Closes #100529

## What Problem This Solves

Fixes an issue where users could set `agents.defaults.compaction.maxActiveTranscriptBytes` and reasonably expect active transcript byte pruning to run, but the setting stayed inactive unless `agents.defaults.compaction.truncateAfterCompaction` was also true.

## Why This Change Was Made

The runtime already treats `maxActiveTranscriptBytes` as inactive without transcript rotation. This change exposes that contract in the two user-visible diagnostic paths that already carry config warnings: config validation warnings during load, and a structured `openclaw doctor lint` health finding.

The check stays narrow: unset, invalid, or zero byte limits remain quiet; positive numeric or byte-string limits warn only when `truncateAfterCompaction` is not explicitly true.

## User Impact

Users and operators now get an actionable warning instead of silently carrying a no-op byte guard. The fix tells them to either enable `agents.defaults.compaction.truncateAfterCompaction` or remove `maxActiveTranscriptBytes`.

## Evidence

Focused proof:

- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts -t "inactive active-transcript"`
  - 1 passed, 81 skipped.
- `OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs src/config/config-misc.test.ts -t "maxActiveTranscriptBytes"`
  - 1 passed, 91 skipped.
- `git diff --check`
  - passed.
- `$autoreview` local mode through `.agents/skills/autoreview/scripts/autoreview`
  - clean: no accepted/actionable findings reported, overall patch is correct (0.86).

Remote proof gap:

- `node scripts/crabbox-wrapper.mjs warmup --provider blacksmith-testbox --keep --timing-json`
  - failed before running tests because the local `crabbox` binary failed basic `--version`/`--help` sanity checks.
  - The focused tests above were run through the repo's narrow local fallback.
