### PR TITLE
fix: honor open-ended usage date ranges

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -89,6 +89,20 @@ describe("gateway usage helpers", () => {
     return result.value;
   }
 
+  function withTimeZone<T>(timeZone: string, run: () => T): T {
+    const previous = process.env.TZ;
+    process.env.TZ = timeZone;
+    try {
+      return run();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = previous;
+      }
+    }
+  }
+
   beforeEach(() => {
     testApi.costUsageCache.clear();
     vi.useRealTimers();
@@ -191,6 +205,36 @@ describe("gateway usage helpers", () => {
       endDate: "2026-02-02",
     });
     expectUtcDateRange(result, "2026-02-01", "2026-02-02");
+  });
+
+  it("resolveDateRange honors a startDate-only range through today", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-05T12:34:56.000Z"));
+    expectUtcDateRange(
+      testApi.resolveDateRange({ startDate: "2026-02-03" }),
+      "2026-02-03",
+      "2026-02-05",
+    );
+  });
+
+  it("resolveDateRange honors an endDate-only range ending on that day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-05T12:34:56.000Z"));
+    expectUtcDateRange(
+      testApi.resolveDateRange({ endDate: "2026-02-05" }),
+      "2026-01-07",
+      "2026-02-05",
+    );
+  });
+
+  it("resolveDateRange keeps endDate-only gateway ranges on calendar days across DST", () => {
+    withTimeZone("America/New_York", () => {
+      const range = expectDateRange(
+        testApi.resolveDateRange({ endDate: "2026-03-10", mode: "gateway" }),
+      );
+      expect(range.startMs).toBe(new Date(2026, 1, 9).getTime());
+      expect(range.endMs).toBe(new Date(2026, 2, 11).getTime() - 1);
+    });
   });
 
   it("resolveDateRange uses explicit UTC mode", () => {

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -74,6 +74,7 @@ type DateRangeResolution = { ok: true; value: DateRange } | { ok: false; error: 
 type DateInterpretation =
   | { mode: "utc" | "gateway" }
   | { mode: "specific"; utcOffsetMinutes: number };
+type DateParts = { year: number; monthIndex: number; day: number };
 
 type CostUsageCacheEntry = {
   summary?: CostUsageSummary;
@@ -139,9 +140,7 @@ function resolveSessionUsageFileOrRespond(
   return { config, entry, agentId, sessionId, sessionFile };
 }
 
-const parseDateParts = (
-  raw: unknown,
-): { year: number; monthIndex: number; day: number } | undefined => {
+const parseDateParts = (raw: unknown): DateParts | undefined => {
   if (typeof raw !== "string" || !raw.trim()) {
     return undefined;
   }
@@ -168,6 +167,34 @@ const parseDateParts = (
     return undefined;
   }
   return { year, monthIndex, day };
+};
+
+const shiftDateParts = (parts: DateParts, days: number): DateParts => {
+  const shifted = new Date(Date.UTC(parts.year, parts.monthIndex, parts.day + days));
+  return {
+    year: shifted.getUTCFullYear(),
+    monthIndex: shifted.getUTCMonth(),
+    day: shifted.getUTCDate(),
+  };
+};
+
+const getDatePartsForDate = (date: Date, interpretation: DateInterpretation): DateParts => {
+  if (interpretation.mode === "gateway") {
+    return { year: date.getFullYear(), monthIndex: date.getMonth(), day: date.getDate() };
+  }
+  if (interpretation.mode === "specific") {
+    const shifted = new Date(date.getTime() + interpretation.utcOffsetMinutes * 60 * 1000);
+    return {
+      year: shifted.getUTCFullYear(),
+      monthIndex: shifted.getUTCMonth(),
+      day: shifted.getUTCDate(),
+    };
+  }
+  return {
+    year: date.getUTCFullYear(),
+    monthIndex: date.getUTCMonth(),
+    day: date.getUTCDate(),
+  };
 };
 
 // usage.cost / sessions.usage accept optional startDate/endDate. parseDateParts returns
@@ -255,31 +282,29 @@ const parseDateToMs = (
   if (!parts) {
     return undefined;
   }
+  return datePartsToMs(parts, interpretation);
+};
+
+const datePartsToMs = (
+  parts: DateParts,
+  interpretation: DateInterpretation = { mode: "utc" },
+): number => {
   const { year, monthIndex, day } = parts;
   if (interpretation.mode === "gateway") {
-    const ms = new Date(year, monthIndex, day).getTime();
-    return Number.isNaN(ms) ? undefined : ms;
+    return new Date(year, monthIndex, day).getTime();
   }
   if (interpretation.mode === "specific") {
-    const ms = Date.UTC(year, monthIndex, day) - interpretation.utcOffsetMinutes * 60 * 1000;
-    return Number.isNaN(ms) ? undefined : ms;
+    return Date.UTC(year, monthIndex, day) - interpretation.utcOffsetMinutes * 60 * 1000;
   }
-  const ms = Date.UTC(year, monthIndex, day);
-  return Number.isNaN(ms) ? undefined : ms;
+  return Date.UTC(year, monthIndex, day);
 };
 
 const getTodayStartMs = (now: Date, interpretation: DateInterpretation): number => {
-  if (interpretation.mode === "gateway") {
-    return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-  }
-  if (interpretation.mode === "specific") {
-    const shifted = new Date(now.getTime() + interpretation.utcOffsetMinutes * 60 * 1000);
-    return (
-      Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate()) -
-      interpretation.utcOffsetMinutes * 60 * 1000
-    );
-  }
-  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return datePartsToMs(getDatePartsForDate(now, interpretation), interpretation);
+};
+
+const getDayEndMs = (parts: DateParts, interpretation: DateInterpretation): number => {
+  return datePartsToMs(shiftDateParts(parts, 1), interpretation) - 1;
 };
 
 const parseDays = (raw: unknown): number | undefined => {
@@ -336,18 +361,50 @@ const resolveDateRange = (params: {
 
   const now = new Date();
   const interpretation = resolveDateInterpretation(params);
+  const todayDateParts = getDatePartsForDate(now, interpretation);
   const todayStartMs = getTodayStartMs(now, interpretation);
-  const todayEndMs = todayStartMs + DAY_MS - 1;
+  const todayEndMs = getDayEndMs(todayDateParts, interpretation);
 
   const startMs = parseDateToMs(params.startDate, interpretation);
   const endMs = parseDateToMs(params.endDate, interpretation);
 
   if (startMs !== undefined && endMs !== undefined) {
-    if (startMs > endMs) {
+    const resolvedStartMs = startMs;
+    const resolvedEndMs = endMs;
+    if (resolvedStartMs > resolvedEndMs) {
       return { ok: false, error: "startDate must not be after endDate" };
     }
-    // endMs should be end of day
-    return { ok: true, value: { startMs, endMs: endMs + DAY_MS - 1 } };
+    const endDateParts = parseDateParts(params.endDate);
+    if (!endDateParts) {
+      return {
+        ok: false,
+        error: "invalid endDate: expected a valid YYYY-MM-DD calendar date",
+      };
+    }
+    return {
+      ok: true,
+      value: { startMs: resolvedStartMs, endMs: getDayEndMs(endDateParts, interpretation) },
+    };
+  }
+  if (startMs !== undefined) {
+    if (startMs > todayStartMs) {
+      return { ok: false, error: "startDate must not be after endDate" };
+    }
+    return { ok: true, value: { startMs, endMs: todayEndMs } };
+  }
+  if (endMs !== undefined) {
+    const endDateParts = parseDateParts(params.endDate);
+    if (!endDateParts) {
+      return {
+        ok: false,
+        error: "invalid endDate: expected a valid YYYY-MM-DD calendar date",
+      };
+    }
+    const resolvedStartMs = datePartsToMs(shiftDateParts(endDateParts, -29), interpretation);
+    return {
+      ok: true,
+      value: { startMs: resolvedStartMs, endMs: getDayEndMs(endDateParts, interpretation) },
+    };
   }
 
   const rangeDays = resolveRangeDays(params.range);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users or API clients that supplied only `startDate` or only `endDate` to usage range queries would receive an unrelated default recent window instead of a range anchored to the requested date.

AI-assisted.

## Why This Change Was Made

The gateway now treats either explicit date as authoritative before falling back to preset or default ranges. A start-date-only request resolves from that day through today, while an end-date-only request resolves to the 30-day window ending on that day. Date boundaries are resolved by calendar day for the selected interpretation so gateway-local DST transitions do not shift the window by an hour.

## User Impact

Usage clients can request open-ended date ranges without silently getting the wrong usage totals. Existing explicit start/end ranges, invalid-date validation, preset ranges, and default ranges continue to work.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/usage.test.ts` passed: 2 files, 62 tests.
- `node_modules/.bin/oxfmt --check --threads=1 src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings after fixing the DST review finding.
- Attempted `pnpm changed:lanes --json`, but pnpm began dependency reconciliation and hit registry metadata/download retries; I interrupted it before completion and did not count it as validation.
