### PR TITLE
fix(telegram): keep live retryable failures unacknowledged

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -214,7 +214,7 @@ export function createTelegramBotCore(
         if (isTelegramSpooledReplayUpdate(ctx.update)) {
           throw new TelegramSpooledReplayProcessingError(result.error);
         }
-        updateTracker.finishUpdate(begin.update, { completed: true });
+        updateTracker.finishUpdate(begin.update, { completed: false });
         return;
       }
       updateTracker.finishUpdate(begin.update, { completed: true });

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -2708,7 +2708,7 @@ describe("createTelegramBot", () => {
     expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([202]);
   });
 
-  it("persists recorded dispatch failures during normal polling", async () => {
+  it("keeps recorded dispatch failures retryable during normal polling", async () => {
     sequentializeSpy.mockImplementationOnce(
       () => async (_ctx: unknown, next: () => Promise<void>) => {
         await next();
@@ -2762,11 +2762,20 @@ describe("createTelegramBot", () => {
       });
     });
     await flushTelegramTestMicrotasks();
-    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([501]);
+    expect(onUpdateId).not.toHaveBeenCalled();
 
     await runMiddlewareChain({ update: { update_id: 502 } }, async () => {});
     await flushTelegramTestMicrotasks();
-    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([501, 502]);
+    expect(onUpdateId).not.toHaveBeenCalled();
+
+    const retryHandler = vi.fn();
+    await runMiddlewareChain({ update: { update_id: 501 } }, async () => {
+      retryHandler();
+    });
+    await flushTelegramTestMicrotasks();
+
+    expect(retryHandler).toHaveBeenCalledTimes(1);
+    expect(onUpdateId.mock.calls.map((call) => Number(call[0]))).toEqual([502]);
   });
 
   it("rejects recorded dispatch failures during isolated spool replay", async () => {


### PR DESCRIPTION
## What Problem This Solves

Normal live Telegram polling could acknowledge an inbound update even when provider/model dispatch failed before any final response existed. Spooled replay already kept retryable failures pending, but the non-spooled live path marked `failed-retryable` results as completed, advancing the update watermark and making the user message unreplayable after a provider outage.

## Summary

- Treat normal live `failed-retryable` Telegram processing results as incomplete in the update tracker.
- Preserve isolated spooled replay behavior, including throwing `TelegramSpooledReplayProcessingError` for spooled replay failures.
- Update the normal polling regression so retryable dispatch failures do not persist the failed update or a newer update until the failed update is retried successfully.

## Upstream Search

Checked current `upstream/main`, open/closed PRs, issues, and the named adjacent fixes before implementing. No exact existing fix covered the normal live pre-final failure path.

- `#92281` / `9921825e179` is already in the release branch and fixes the spooled replay version of this class.
- `#96095` confirms generated final delivery after a final exists, but does not address pre-final provider/model dispatch failure.
- `#97270` hardens Telegram Bot API 5xx polling recovery and outbound provider-send timeouts, but does not change live update completion after `failed-retryable` processing.
- `upstream/main` still had the same `bot-core.ts` branch and the normal-polling test that persisted recorded dispatch failures.

## Evidence

- 2026-07-05 11:49:16 EDT: all configured model routes failed before a Telegram reply existed in Alex DM lane.
- OpenAI path hit the subscription limit; `llm.mittell.ai/qwen3.6-27b` hit the 120s idle timeout; `kebab-rtx6000/qwen3.6-27b` terminated or timed out.
- Later RTX attempts showed `ETIMEDOUT`, `EHOSTUNREACH`, and `EHOSTDOWN`.
- Code proof on the running `upgrade-v2026.6.11` branch showed `extensions/telegram/src/bot-message.ts` only enabled dispatch retry/fallback suppression for `spooledReplay`, while `extensions/telegram/src/bot-core.ts` completed normal live `failed-retryable` updates.
- Existing coverage in `extensions/telegram/src/bot.create-telegram-bot.test.ts` encoded the bad behavior by expecting a normal polling dispatch failure to advance the offset.

## Validation

Run in the hydrated `upgrade-v2026.6.11` checkout after applying the same patch:

```text
node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/bot-message.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/polling-session.test.ts
Test Files  4 passed (4)
Tests       325 passed (325)

pnpm tsgo:extensions:test
pass

./node_modules/.bin/oxfmt --check extensions/telegram/src/bot-core.ts extensions/telegram/src/bot.create-telegram-bot.test.ts
All matched files use the correct format.

git diff --check
pass
```

The PR worktree is based on `upstream/main`; the cherry-pick applied cleanly and `git diff --check upstream/main...HEAD` plus oxfmt using the hydrated checkout binary passed there. The separate PR worktree did not have its own `node_modules`, so Vitest was not rerun from that path.
