### PR TITLE
fix(gateway): format usage dates in range timezone

### DIFF
--- a/src/gateway/server-methods/usage.cost-usage-cache.test.ts
+++ b/src/gateway/server-methods/usage.cost-usage-cache.test.ts
@@ -1,7 +1,7 @@
 // Regression: costUsageCache (usage.ts:65) has no production delete/prune/evict
 // path. The TTL at L310 is read-only — on a miss after expiry, set() overwrites
-// the same key but never removes stale keys. parseDateRange derives cacheKey
-// from getTodayStartMs so cacheKey rolls at every UTC 00:00, and additional
+// the same key but never removes stale keys. resolveDateRange derives cacheKey
+// from the current calendar day so cacheKey rolls at every UTC 00:00, and additional
 // axes (days, startDate, endDate, utcOffset) multiply cardinality.
 //
 // The same file has three sibling caches that implement MAX + FIFO eviction

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -344,6 +344,39 @@ describe("sessions.usage", () => {
     );
   });
 
+  it("formats response date labels in the requested timezone offset", async () => {
+    const respond = await runSessionsUsage({
+      ...BASE_USAGE_RANGE,
+      startDate: "2026-07-06",
+      endDate: "2026-07-06",
+      mode: "specific",
+      utcOffset: "UTC+8",
+    });
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(mockArg(respond, 0, 0)).toBe(true);
+    const result = mockArg(respond, 0, 1) as { startDate: string; endDate: string };
+    expect(result.startDate).toBe("2026-07-06");
+    expect(result.endDate).toBe("2026-07-06");
+  });
+
+  it("keeps explicit gateway response date labels on DST-short days", async () => {
+    await withEnvAsync({ TZ: "America/New_York" }, async () => {
+      const respond = await runSessionsUsage({
+        ...BASE_USAGE_RANGE,
+        startDate: "2026-03-08",
+        endDate: "2026-03-08",
+        mode: "gateway",
+      });
+
+      expect(respond).toHaveBeenCalledTimes(1);
+      expect(mockArg(respond, 0, 0)).toBe(true);
+      const result = mockArg(respond, 0, 1) as { startDate: string; endDate: string };
+      expect(result.startDate).toBe("2026-03-08");
+      expect(result.endDate).toBe("2026-03-08");
+    });
+  });
+
   it("discovers usage for requested disk-only agents not listed in config", async () => {
     const respond = await runSessionsUsage({ ...BASE_USAGE_RANGE, agentId: "codex" });
 

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -89,6 +89,20 @@ describe("gateway usage helpers", () => {
     return result.value;
   }
 
+  function withTimeZone<T>(timeZone: string, run: () => T): T {
+    const previous = process.env.TZ;
+    process.env.TZ = timeZone;
+    try {
+      return run();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = previous;
+      }
+    }
+  }
+
   beforeEach(() => {
     testApi.costUsageCache.clear();
     vi.useRealTimers();
@@ -260,6 +274,20 @@ describe("gateway usage helpers", () => {
     const expectedStart = new Date(2026, 1, 5).getTime();
     expect(range.startMs).toBe(expectedStart);
     expect(range.endMs).toBe(expectedStart + dayMs - 1);
+  });
+
+  it("resolveDateRange uses gateway calendar end boundaries for explicit DST-short days", () => {
+    withTimeZone("America/New_York", () => {
+      const range = expectDateRange(
+        testApi.resolveDateRange({
+          startDate: "2026-03-08",
+          endDate: "2026-03-08",
+          mode: "gateway",
+        }),
+      );
+      expect(range.startMs).toBe(new Date(2026, 2, 8).getTime());
+      expect(range.endMs).toBe(new Date(2026, 2, 9).getTime() - 1);
+    });
   });
 
   it("resolveDateRange clamps days to at least 1 and defaults to 30 days", () => {

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -290,6 +290,21 @@ describe("gateway usage helpers", () => {
     });
   });
 
+  it("resolveDateRange keeps trailing gateway ranges on calendar days across DST", () => {
+    withTimeZone("America/New_York", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-03-09T12:00:00.000Z"));
+      const range = expectDateRange(
+        testApi.resolveDateRange({
+          days: 2,
+          mode: "gateway",
+        }),
+      );
+      expect(range.startMs).toBe(new Date(2026, 2, 8).getTime());
+      expect(range.endMs).toBe(new Date(2026, 2, 10).getTime() - 1);
+    });
+  });
+
   it("resolveDateRange clamps days to at least 1 and defaults to 30 days", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-05T12:34:56.000Z"));

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -74,6 +74,7 @@ type DateRangeResolution = { ok: true; value: DateRange } | { ok: false; error: 
 type DateInterpretation =
   | { mode: "utc" | "gateway" }
   | { mode: "specific"; utcOffsetMinutes: number };
+type DateParts = { year: number; monthIndex: number; day: number };
 
 type CostUsageCacheEntry = {
   summary?: CostUsageSummary;
@@ -139,9 +140,7 @@ function resolveSessionUsageFileOrRespond(
   return { config, entry, agentId, sessionId, sessionFile };
 }
 
-const parseDateParts = (
-  raw: unknown,
-): { year: number; monthIndex: number; day: number } | undefined => {
+const parseDateParts = (raw: unknown): DateParts | undefined => {
   if (typeof raw !== "string" || !raw.trim()) {
     return undefined;
   }
@@ -168,6 +167,22 @@ const parseDateParts = (
     return undefined;
   }
   return { year, monthIndex, day };
+};
+
+const datePartsToEndMs = (parts: DateParts, interpretation: DateInterpretation): number => {
+  const { year, monthIndex, day } = parts;
+  if (interpretation.mode === "gateway") {
+    return new Date(year, monthIndex, day + 1).getTime() - 1;
+  }
+  if (interpretation.mode === "specific") {
+    return Date.UTC(year, monthIndex, day + 1) - interpretation.utcOffsetMinutes * 60 * 1000 - 1;
+  }
+  return Date.UTC(year, monthIndex, day + 1) - 1;
+};
+
+const parseDateEndToMs = (raw: unknown, interpretation: DateInterpretation): number | undefined => {
+  const parts = parseDateParts(raw);
+  return parts ? datePartsToEndMs(parts, interpretation) : undefined;
 };
 
 // usage.cost / sessions.usage accept optional startDate/endDate. parseDateParts returns
@@ -282,6 +297,26 @@ const getTodayStartMs = (now: Date, interpretation: DateInterpretation): number 
   return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
 };
 
+const formatDateLabel = (ms: number, interpretation: DateInterpretation): string => {
+  const date = new Date(ms);
+  if (interpretation.mode === "gateway") {
+    return formatDateParts(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+  if (interpretation.mode === "specific") {
+    const shifted = new Date(ms + interpretation.utcOffsetMinutes * 60 * 1000);
+    return formatDateParts(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate());
+  }
+  return formatDateParts(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+};
+
+const formatDateParts = (year: number, monthIndex: number, day: number): string =>
+  `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+
+const formatExplicitDateLabel = (raw: unknown): string | undefined => {
+  const parts = parseDateParts(raw);
+  return parts ? formatDateParts(parts.year, parts.monthIndex, parts.day) : undefined;
+};
+
 const parseDays = (raw: unknown): number | undefined => {
   if (typeof raw === "number" && Number.isFinite(raw)) {
     return Math.floor(raw);
@@ -346,8 +381,14 @@ const resolveDateRange = (params: {
     if (startMs > endMs) {
       return { ok: false, error: "startDate must not be after endDate" };
     }
-    // endMs should be end of day
-    return { ok: true, value: { startMs, endMs: endMs + DAY_MS - 1 } };
+    const endOfDayMs = parseDateEndToMs(params.endDate, interpretation);
+    if (endOfDayMs === undefined) {
+      return {
+        ok: false,
+        error: "invalid endDate: expected a valid YYYY-MM-DD calendar date",
+      };
+    }
+    return { ok: true, value: { startMs, endMs: endOfDayMs } };
   }
 
   const rangeDays = resolveRangeDays(params.range);
@@ -978,9 +1019,8 @@ export const usageHandlers: GatewayRequestHandlers = {
     }
     const config = context.getRuntimeConfig();
     const { startMs, endMs } = dateRange.value;
-    const dailyUtcOffsetMinutes = resolveDayBucketUtcOffsetMinutes(
-      resolveDateInterpretation({ mode: p.mode, utcOffset: p.utcOffset }),
-    );
+    const dateInterpretation = resolveDateInterpretation({ mode: p.mode, utcOffset: p.utcOffset });
+    const dailyUtcOffsetMinutes = resolveDayBucketUtcOffsetMinutes(dateInterpretation);
     const limit = typeof p.limit === "number" && Number.isFinite(p.limit) ? p.limit : 50;
     const includeContextWeight = p.includeContextWeight ?? false;
     const specificKey = normalizeOptionalString(p.key) ?? null;
@@ -1426,12 +1466,6 @@ export const usageHandlers: GatewayRequestHandlers = {
       }
     }
 
-    // Format dates back to YYYY-MM-DD strings
-    const formatDateStr = (ms: number) => {
-      const d = new Date(ms);
-      return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-${String(d.getUTCDate()).padStart(2, "0")}`;
-    };
-
     const tail = buildUsageAggregateTail({
       byChannelMap,
       latencyTotals,
@@ -1469,10 +1503,19 @@ export const usageHandlers: GatewayRequestHandlers = {
       ...tail,
     };
 
+    const explicitStartDate = formatExplicitDateLabel(p.startDate);
+    const explicitEndDate = formatExplicitDateLabel(p.endDate);
+    let responseStartDate = formatDateLabel(startMs, dateInterpretation);
+    let responseEndDate = formatDateLabel(endMs, dateInterpretation);
+    if (explicitStartDate !== undefined && explicitEndDate !== undefined) {
+      responseStartDate = explicitStartDate;
+      responseEndDate = explicitEndDate;
+    }
+
     const result: SessionsUsageResult = {
       updatedAt: now,
-      startDate: formatDateStr(startMs),
-      endDate: formatDateStr(endMs),
+      startDate: responseStartDate,
+      endDate: responseEndDate,
       sessions,
       totals: aggregateTotals,
       aggregates,

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -65,7 +65,6 @@ import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 const COST_USAGE_CACHE_TTL_MS = 30_000;
 const COST_USAGE_CACHE_MAX = 256;
 const SESSIONS_USAGE_AGENT_LOAD_CONCURRENCY = 12;
-const DAY_MS = 24 * 60 * 60 * 1000;
 
 type DateRange = { startMs: number; endMs: number };
 // Keep validation and parsed timestamps in one result so handlers cannot forward
@@ -169,21 +168,28 @@ const parseDateParts = (raw: unknown): DateParts | undefined => {
   return { year, monthIndex, day };
 };
 
-const datePartsToEndMs = (parts: DateParts, interpretation: DateInterpretation): number => {
-  const { year, monthIndex, day } = parts;
-  if (interpretation.mode === "gateway") {
-    return new Date(year, monthIndex, day + 1).getTime() - 1;
-  }
-  if (interpretation.mode === "specific") {
-    return Date.UTC(year, monthIndex, day + 1) - interpretation.utcOffsetMinutes * 60 * 1000 - 1;
-  }
-  return Date.UTC(year, monthIndex, day + 1) - 1;
+const shiftDateParts = (parts: DateParts, days: number): DateParts => {
+  const shifted = new Date(Date.UTC(parts.year, parts.monthIndex, parts.day + days));
+  return {
+    year: shifted.getUTCFullYear(),
+    monthIndex: shifted.getUTCMonth(),
+    day: shifted.getUTCDate(),
+  };
 };
 
-const parseDateEndToMs = (raw: unknown, interpretation: DateInterpretation): number | undefined => {
-  const parts = parseDateParts(raw);
-  return parts ? datePartsToEndMs(parts, interpretation) : undefined;
+const datePartsToStartMs = (parts: DateParts, interpretation: DateInterpretation): number => {
+  const { year, monthIndex, day } = parts;
+  if (interpretation.mode === "gateway") {
+    return new Date(year, monthIndex, day).getTime();
+  }
+  if (interpretation.mode === "specific") {
+    return Date.UTC(year, monthIndex, day) - interpretation.utcOffsetMinutes * 60 * 1000;
+  }
+  return Date.UTC(year, monthIndex, day);
 };
+
+const datePartsToEndMs = (parts: DateParts, interpretation: DateInterpretation): number =>
+  datePartsToStartMs(shiftDateParts(parts, 1), interpretation) - 1;
 
 // usage.cost / sessions.usage accept optional startDate/endDate. parseDateParts returns
 // undefined for both absent and invalid input, so an explicitly supplied but unparseable
@@ -258,6 +264,25 @@ const resolveDayBucketUtcOffsetMinutes = (interpretation: DateInterpretation) =>
       ? interpretation.utcOffsetMinutes
       : 0;
 
+const getDateParts = (date: Date, interpretation: DateInterpretation): DateParts => {
+  if (interpretation.mode === "gateway") {
+    return { year: date.getFullYear(), monthIndex: date.getMonth(), day: date.getDate() };
+  }
+  if (interpretation.mode === "specific") {
+    const shifted = new Date(date.getTime() + interpretation.utcOffsetMinutes * 60 * 1000);
+    return {
+      year: shifted.getUTCFullYear(),
+      monthIndex: shifted.getUTCMonth(),
+      day: shifted.getUTCDate(),
+    };
+  }
+  return {
+    year: date.getUTCFullYear(),
+    monthIndex: date.getUTCMonth(),
+    day: date.getUTCDate(),
+  };
+};
+
 /**
  * Parse a date string (YYYY-MM-DD) to start-of-day timestamp based on interpretation mode.
  * Returns undefined if invalid.
@@ -270,52 +295,16 @@ const parseDateToMs = (
   if (!parts) {
     return undefined;
   }
-  const { year, monthIndex, day } = parts;
-  if (interpretation.mode === "gateway") {
-    const ms = new Date(year, monthIndex, day).getTime();
-    return Number.isNaN(ms) ? undefined : ms;
-  }
-  if (interpretation.mode === "specific") {
-    const ms = Date.UTC(year, monthIndex, day) - interpretation.utcOffsetMinutes * 60 * 1000;
-    return Number.isNaN(ms) ? undefined : ms;
-  }
-  const ms = Date.UTC(year, monthIndex, day);
-  return Number.isNaN(ms) ? undefined : ms;
-};
-
-const getTodayStartMs = (now: Date, interpretation: DateInterpretation): number => {
-  if (interpretation.mode === "gateway") {
-    return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-  }
-  if (interpretation.mode === "specific") {
-    const shifted = new Date(now.getTime() + interpretation.utcOffsetMinutes * 60 * 1000);
-    return (
-      Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate()) -
-      interpretation.utcOffsetMinutes * 60 * 1000
-    );
-  }
-  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return datePartsToStartMs(parts, interpretation);
 };
 
 const formatDateLabel = (ms: number, interpretation: DateInterpretation): string => {
-  const date = new Date(ms);
-  if (interpretation.mode === "gateway") {
-    return formatDateParts(date.getFullYear(), date.getMonth(), date.getDate());
-  }
-  if (interpretation.mode === "specific") {
-    const shifted = new Date(ms + interpretation.utcOffsetMinutes * 60 * 1000);
-    return formatDateParts(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate());
-  }
-  return formatDateParts(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  const parts = getDateParts(new Date(ms), interpretation);
+  return formatDateParts(parts.year, parts.monthIndex, parts.day);
 };
 
 const formatDateParts = (year: number, monthIndex: number, day: number): string =>
   `${year}-${String(monthIndex + 1).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
-
-const formatExplicitDateLabel = (raw: unknown): string | undefined => {
-  const parts = parseDateParts(raw);
-  return parts ? formatDateParts(parts.year, parts.monthIndex, parts.day) : undefined;
-};
 
 const parseDays = (raw: unknown): number | undefined => {
   if (typeof raw === "number" && Number.isFinite(raw)) {
@@ -349,6 +338,15 @@ const resolveRangeDays = (raw: unknown): number | "all" | undefined => {
   return undefined;
 };
 
+const resolveTrailingDays = (
+  endDateParts: DateParts,
+  days: number,
+  interpretation: DateInterpretation,
+): DateRange => ({
+  startMs: datePartsToStartMs(shiftDateParts(endDateParts, -(days - 1)), interpretation),
+  endMs: datePartsToEndMs(endDateParts, interpretation),
+});
+
 /**
  * Get date range from params (startDate/endDate or days).
  * Falls back to last 30 days if not provided.
@@ -371,24 +369,19 @@ const resolveDateRange = (params: {
 
   const now = new Date();
   const interpretation = resolveDateInterpretation(params);
-  const todayStartMs = getTodayStartMs(now, interpretation);
-  const todayEndMs = todayStartMs + DAY_MS - 1;
+  const todayDateParts = getDateParts(now, interpretation);
+  const todayEndMs = datePartsToEndMs(todayDateParts, interpretation);
 
-  const startMs = parseDateToMs(params.startDate, interpretation);
-  const endMs = parseDateToMs(params.endDate, interpretation);
+  const startDateParts = parseDateParts(params.startDate);
+  const endDateParts = parseDateParts(params.endDate);
 
-  if (startMs !== undefined && endMs !== undefined) {
-    if (startMs > endMs) {
+  if (startDateParts && endDateParts) {
+    const startMs = datePartsToStartMs(startDateParts, interpretation);
+    const endStartMs = datePartsToStartMs(endDateParts, interpretation);
+    if (startMs > endStartMs) {
       return { ok: false, error: "startDate must not be after endDate" };
     }
-    const endOfDayMs = parseDateEndToMs(params.endDate, interpretation);
-    if (endOfDayMs === undefined) {
-      return {
-        ok: false,
-        error: "invalid endDate: expected a valid YYYY-MM-DD calendar date",
-      };
-    }
-    return { ok: true, value: { startMs, endMs: endOfDayMs } };
+    return { ok: true, value: { startMs, endMs: datePartsToEndMs(endDateParts, interpretation) } };
   }
 
   const rangeDays = resolveRangeDays(params.range);
@@ -396,20 +389,17 @@ const resolveDateRange = (params: {
     return { ok: true, value: { startMs: 0, endMs: todayEndMs } };
   }
   if (rangeDays !== undefined) {
-    const start = todayStartMs - (rangeDays - 1) * DAY_MS;
-    return { ok: true, value: { startMs: start, endMs: todayEndMs } };
+    return { ok: true, value: resolveTrailingDays(todayDateParts, rangeDays, interpretation) };
   }
 
   const days = parseDays(params.days);
   if (days !== undefined) {
     const clampedDays = Math.max(1, days);
-    const start = todayStartMs - (clampedDays - 1) * DAY_MS;
-    return { ok: true, value: { startMs: start, endMs: todayEndMs } };
+    return { ok: true, value: resolveTrailingDays(todayDateParts, clampedDays, interpretation) };
   }
 
   // Default to last 30 days
-  const defaultStartMs = todayStartMs - 29 * DAY_MS;
-  return { ok: true, value: { startMs: defaultStartMs, endMs: todayEndMs } };
+  return { ok: true, value: resolveTrailingDays(todayDateParts, 30, interpretation) };
 };
 
 type DiscoveredSessionWithAgent = DiscoveredSession & { agentId: string };
@@ -945,7 +935,6 @@ export const testApi = {
   parseUtcOffsetToMinutes,
   resolveDateInterpretation,
   parseDateToMs,
-  getTodayStartMs,
   parseDays,
   resolveDateRange,
   discoverAllSessionsForUsage,
@@ -1503,19 +1492,10 @@ export const usageHandlers: GatewayRequestHandlers = {
       ...tail,
     };
 
-    const explicitStartDate = formatExplicitDateLabel(p.startDate);
-    const explicitEndDate = formatExplicitDateLabel(p.endDate);
-    let responseStartDate = formatDateLabel(startMs, dateInterpretation);
-    let responseEndDate = formatDateLabel(endMs, dateInterpretation);
-    if (explicitStartDate !== undefined && explicitEndDate !== undefined) {
-      responseStartDate = explicitStartDate;
-      responseEndDate = explicitEndDate;
-    }
-
     const result: SessionsUsageResult = {
       updatedAt: now,
-      startDate: responseStartDate,
-      endDate: responseEndDate,
+      startDate: formatDateLabel(startMs, dateInterpretation),
+      endDate: formatDateLabel(endMs, dateInterpretation),
       sessions,
       totals: aggregateTotals,
       aggregates,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `sessions.usage` responses could report `startDate` / `endDate` labels using UTC calendar days even when the request interpreted the range in a specific UTC offset or gateway-local time.

AI-assisted.

## Why This Change Was Made

The response date labels now use the same date interpretation as range resolution. When callers provide both explicit dates, the response preserves those calendar labels; otherwise it formats the computed range timestamps through the selected interpretation. This also updates explicit end-date resolution to use calendar day ends for the selected interpretation so gateway-local DST transition days do not query data outside the labelled range.

## User Impact

Usage clients in non-UTC offsets can trust that `sessions.usage.startDate` and `sessions.usage.endDate` describe the requested local day instead of an adjacent UTC day. Gateway-local explicit ranges on DST-short days also avoid including data from the next local day.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/usage.sessions-usage.test.ts src/gateway/server-methods/usage.test.ts` passed: 4 files, 100 tests.
- `node_modules/.bin/oxfmt --check --threads=1 src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings after addressing the gateway DST boundary review finding.
