### PR TITLE
fix(telegram): extract canonical rich block text

### DIFF
--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -165,6 +165,80 @@ describe("resolveTelegramInboundBody", () => {
     expect(htmlResult?.rawBody).toBe("Forwarded html");
   });
 
+  it("extracts visible text from canonical rich-message block fields", async () => {
+    const result = await resolveTelegramBody({
+      msg: {
+        message_id: 0,
+        date: 1_700_000_000,
+        chat: { id: 42, type: "private", first_name: "Pat" },
+        from: { id: 42, first_name: "Pat" },
+        rich_message: {
+          blocks: [
+            {
+              type: "details",
+              summary: "Run summary",
+              blocks: [
+                {
+                  type: "list",
+                  items: [
+                    {
+                      label: "1.",
+                      blocks: [
+                        {
+                          type: "paragraph",
+                          text: "CI clean",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "mathematical_expression",
+              expression: "a^2+b^2=c^2",
+            },
+            {
+              type: "photo",
+              caption: {
+                text: "Chart",
+                credit: "OpenClaw",
+              },
+            },
+          ],
+        },
+      } as never,
+    });
+
+    expect(result?.rawBody).toBe("Run summary\n1.\nCI clean\na^2+b^2=c^2\nChart\nOpenClaw");
+    expect(result?.bodyText).toBe("Run summary\n1.\nCI clean\na^2+b^2=c^2\nChart\nOpenClaw");
+  });
+
+  it("keeps rich-message table caption spans inline", async () => {
+    const result = await resolveTelegramBody({
+      msg: {
+        message_id: 0,
+        date: 1_700_000_000,
+        chat: { id: 42, type: "private", first_name: "Pat" },
+        from: { id: 42, first_name: "Pat" },
+        rich_message: {
+          blocks: [
+            {
+              type: "table",
+              caption: [
+                { type: "plain", text: "Total " },
+                { type: "bold", text: "Q1" },
+              ],
+            },
+          ],
+        },
+      } as never,
+    });
+
+    expect(result?.rawBody).toBe("Total Q1");
+    expect(result?.bodyText).toBe("Total Q1");
+  });
+
   it("keeps rich-message placeholders quiet in requireMention groups", async () => {
     const logger = { info: vi.fn() };
     const result = await resolveTelegramBody({

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -154,8 +154,29 @@ function renderRichBlocks(value: unknown): string {
     return telegramHtmlToPlainTextFallback(value.html);
   }
   const parts: string[] = [];
-  for (const key of ["text", "title", "subtitle", "caption", "credit"] as const) {
+  for (const key of [
+    "text",
+    "summary",
+    "label",
+    "title",
+    "subtitle",
+    "credit",
+    "expression",
+  ] as const) {
     parts.push(renderRichInlineText(value[key]));
+  }
+  if (value.caption !== undefined) {
+    const caption = value.caption;
+    if (isRecord(caption) && caption.credit !== undefined) {
+      parts.push(
+        joinRichText(
+          [renderRichInlineText(caption.text), renderRichInlineText(caption.credit)],
+          "\n",
+        ),
+      );
+    } else {
+      parts.push(renderRichInlineText(caption));
+    }
   }
   for (const key of ["blocks", "items", "rows", "cells", "headers", "children"] as const) {
     parts.push(renderRichBlocks(value[key]));

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -550,6 +550,50 @@ describe("describeReplyTarget", () => {
     expect(result?.quoteSourceText).toBeUndefined();
   });
 
+  it("describes rich-message-only reply targets with canonical block text", () => {
+    const result = describeReplyTarget({
+      message_id: 2,
+      date: 1000,
+      chat: { id: 1, type: "private" },
+      reply_to_message: {
+        message_id: 1,
+        date: 900,
+        chat: { id: 1, type: "private" },
+        rich_message: {
+          blocks: [
+            {
+              type: "details",
+              summary: "Run summary",
+              blocks: [
+                {
+                  type: "list",
+                  items: [
+                    {
+                      label: "1.",
+                      blocks: [{ type: "paragraph", text: "CI clean" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "mathematical_expression",
+              expression: "a^2+b^2=c^2",
+            },
+            {
+              type: "photo",
+              caption: { text: "Chart", credit: "OpenClaw" },
+            },
+          ],
+        },
+        from: { id: 42, first_name: "Alice", is_bot: false },
+      },
+    } as never);
+
+    expect(result?.body).toBe("Run summary\n1.\nCI clean\na^2+b^2=c^2\nChart\nOpenClaw");
+    expect(result?.quoteSourceText).toBeUndefined();
+  });
+
   it("drops binary reply captions with no safe fallback", () => {
     const result = describeReplyTarget({
       message_id: 2,


### PR DESCRIPTION
Refs #99471

## What Problem This Solves

Telegram Bot API 10.1 rich-message reply/forward echoes can carry visible text only in canonical rich block fields. Current `main` already extracts markdown, html, and basic rich block text, but it misses several visible fields that appear in real rich-message block payloads: details `summary`, list item `label`, block-level `expression`, and caption objects with nested `text` / `credit`.

When those fields are the only visible content in the echoed `rich_message`, OpenClaw can still collapse the reply/forward context to `[unsupported Telegram rich_message received]`, so the agent loses the message being replied to or forwarded.

This PR only addresses the rich-message block extraction addendum from #99471. It does not close the broader issue and does not attempt to fix the typing breaker or empty rich payload send behavior tracked there.

## What Changed

- Broaden Telegram inbound rich-message text extraction to include canonical visible block fields that can appear in Bot API 10.1 reply/forward echoes:
  - `summary` for details/collapsible blocks
  - `label` for list items
  - block-level `expression` for mathematical expression blocks
  - caption objects with `text` and `credit`
- Keep RichText caption spans inline so table captions such as `Total ` + bold `Q1` render as `Total Q1`, not as separate lines.
- Preserve the existing placeholder fallback for empty or unrenderable rich messages.

## Evidence

- Source-level reproduction: current `main` rich-message block flattening does not read the canonical `summary`, `label`, block-level `expression`, or caption-object `credit` fields this PR targets.
- Shared extraction point: inbound message body, reply-target descriptions, and message-cache contexts already consume the same rich-message body helper, so the change covers the direct inbound and reply/forward context paths without adding separate parsers.
- Regression tests passed locally:
  - `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.body.test.ts extensions/telegram/src/bot/helpers.test.ts extensions/telegram/src/message-cache.test.ts` — 3 files, 133 tests passed
  - `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot/body-helpers.ts extensions/telegram/src/bot-message-context.body.test.ts extensions/telegram/src/bot/helpers.test.ts`
  - `git diff --check`
- Oracle second-model review:
  - First review found a valid table-caption inline-span regression risk.
  - Fixed that issue and added regression coverage.
  - Follow-up Oracle review reported no remaining actionable findings.
- ClawSweeper source review agreed this is the narrow shared owner boundary and rated patch quality as strong, while requesting real Telegram/Mantis proof before merge.

## Real Behavior Proof Status

Manual Telegram live proof captured on 2026-07-06 15:44 Asia/Shanghai using the PR candidate Gateway from commit `094dbd153e2a66077ce0dc28169e5f0acafc05ca`.

Proof flow:

1. Temporarily ran the Gateway from the PR worktree with `channels.telegram.richMessages=true`.
2. Sent a Bot API 10.1 rich seed message into a private Telegram forum topic. The seed included:
   - `<details><summary>OC_RICH_SUMMARY_100570</summary>...`
   - `<ol><li>OC_RICH_LIST_100570</li></ol>`
   - `<tg-math-block>OC_RICH_EXPR_100570</tg-math-block>`
   - `<figcaption>OC_RICH_CAPTION_100570<cite>OC_RICH_CREDIT_100570</cite></figcaption>`
3. Replied to that rich seed from a Telegram client.
4. The agent received the reply target as visible text, not as the unsupported placeholder:

```text
[Replying to: "OC_RICH_SUMMARY_100570 OC_RICH_BODY_100570 • OC_RICH_LIST_100570 OC_RICH_EXPR_100570OC_RICH_CAPTION_100570OC_RICH_CREDIT_100570"]
canary reply
```

Result: the reply context preserved the targeted `summary`, list label/body text, math expression, caption text, and caption credit tokens, and did not render `[unsupported Telegram rich_message received]` for the reply target.

No chat id, token, screenshot, or private transcript is included here; only the synthetic canary tokens and the sanitized received text are recorded.