### PR TITLE
fix(anthropic): Fable 5 skips context1m setup when enabled

### DIFF
--- a/extensions/anthropic/stream-wrappers.test.ts
+++ b/extensions/anthropic/stream-wrappers.test.ts
@@ -46,16 +46,16 @@ function createPayloadCapturingBaseStream(captured: {
   };
 }
 
-function runComposedAnthropicProviderStream(apiKey: string) {
+function runComposedAnthropicProviderStream(apiKey: string, modelId = "claude-sonnet-4-6") {
   const captured: { headers?: Record<string, string>; payload?: Record<string, unknown> } = {};
   const wrapped = wrapAnthropicProviderStream({
     streamFn: createPayloadCapturingBaseStream(captured),
-    modelId: "claude-sonnet-4-6",
+    modelId,
     extraParams: { context1m: true, serviceTier: "auto" },
   } as never);
 
   void wrapped?.(
-    { provider: "anthropic", api: "anthropic-messages", id: "claude-sonnet-4-6" } as never,
+    { provider: "anthropic", api: "anthropic-messages", id: modelId } as never,
     {} as never,
     { apiKey } as never,
   );
@@ -154,6 +154,17 @@ describe("anthropic stream wrappers", () => {
 
     expect(captured.headers?.["anthropic-beta"]).toContain(OAUTH_BETA);
     expect(captured.headers?.["anthropic-beta"]).not.toContain(CONTEXT_1M_BETA);
+  });
+
+  it("uses Fable 5 identity boundaries for context1m beta wrapper activation", () => {
+    const fable5 = runComposedAnthropicProviderStream("sk-ant-oat01-oauth-token", "claude-fable-5");
+    const fable50 = runComposedAnthropicProviderStream(
+      "sk-ant-oat01-oauth-token",
+      "claude-fable-50",
+    );
+
+    expect(fable5.headers?.["anthropic-beta"]).toBe(OAUTH_BETA_HEADER);
+    expect(fable50.headers?.["anthropic-beta"]).toBeUndefined();
   });
 
   it("preserves OAuth-required betas when legacy context-1m is the only configured beta", () => {

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -5,6 +5,7 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { streamSimple } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { resolveClaudeFable5ModelIdentity } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   applyAnthropicPayloadPolicyToParams,
   composeProviderStreamWrappers,
@@ -46,6 +47,9 @@ type AnthropicServiceTier = "auto" | "standard_only";
 type DynamicFastMode = boolean | (() => boolean | undefined);
 
 function isAnthropic1MModel(modelId: string): boolean {
+  if (resolveClaudeFable5ModelIdentity({ id: modelId }) !== undefined) {
+    return true;
+  }
   const normalized = normalizeLowercaseStringOrEmpty(modelId);
   return ANTHROPIC_GA_1M_MODEL_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Anthropic users selecting Claude Fable 5 with `context1m` enabled would not get the same stream wrapper behavior as other 1M-context Claude models, even though Fable 5 is registered with a 1,000,000-token context window.

## Why This Change Was Made

The Anthropic stream wrapper now treats Fable 5 as a 1M-context model by reusing the shared Fable 5 model identity helper. This keeps the wrapper predicate aligned with provider model registration while preserving the identity boundary so `claude-fable-50` is not matched as Fable 5.

## User Impact

Claude Fable 5 now follows the expected `context1m` provider-wrapper path. Other Anthropic 1M model prefix handling is unchanged, and non-Fable lookalike model ids remain outside this Fable-specific path.

## Evidence

- Real wrapper/provider-path proof: imported the Anthropic stream wrapper and ran it with `context1m: true` before any network call. Fable 5 receives the provider beta wrapper headers while the lookalike `claude-fable-50` does not:

  ```text
  [
    {
      "modelId": "claude-fable-5",
      "context1m": true,
      "anthropicBeta": "fine-grained-tool-streaming-2025-05-14,interleaved-thinking-2025-05-14",
      "serviceTier": "auto"
    },
    {
      "modelId": "claude-fable-50",
      "context1m": true,
      "anthropicBeta": null,
      "serviceTier": "auto"
    }
  ]
  ```

- Focused regression tests:

  ```text
  node scripts/run-vitest.mjs run extensions/anthropic/stream-wrappers.test.ts extensions/anthropic/provider-policy-api.test.ts

  Test Files  2 passed (2)
       Tests  32 passed (32)
  ```
