### PR TITLE
fix(telegram): dedupe visible assistant prompt context

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -48,6 +48,7 @@ import {
   resolveAmbientTranscriptWatermarkKey,
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 import { expandTelegramAllowFromWithAccessGroups } from "./access-groups.js";
 import { resolveTelegramAccount, resolveTelegramMediaRuntimeOptions } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -187,13 +188,17 @@ type TelegramPromptContextMessageForDedupe = {
 function resolvePromptContextTextDedupeKey(
   message: TelegramPromptContextMessageForDedupe,
 ): string | undefined {
-  if (typeof message.body !== "string" || !message.body.trim()) {
+  if (typeof message.body !== "string") {
+    return undefined;
+  }
+  const visibleBody = stripInlineDirectiveTagsForDelivery(message.body).text.trim();
+  if (!visibleBody) {
     return undefined;
   }
   if (typeof message.timestamp_ms !== "number" || !Number.isFinite(message.timestamp_ms)) {
     return undefined;
   }
-  return `${message.timestamp_ms}:${message.body.trim()}`;
+  return `${message.timestamp_ms}:${visibleBody}`;
 }
 
 export const registerTelegramHandlers = ({

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1884,6 +1884,38 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("marks directive-tagged durable finals with the transcript prompt-context timestamp", async () => {
+    const transcriptTimestamp = Date.now() + 1_000;
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    mockDefaultSessionEntry();
+    readLatestAssistantTextByIdentity.mockResolvedValue({
+      text: "[[reply_to_current]]Final answer",
+      timestamp: transcriptTimestamp,
+    });
+    deliverInboundReplyWithMessageSendContext.mockResolvedValue({
+      status: "handled_visible",
+      delivery: {
+        messageIds: ["2001"],
+        visibleReplySent: true,
+      },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context, streamMode: "off" });
+
+    const outbound = expectRecordFields(mockCallArg(deliverInboundReplyWithMessageSendContext), {
+      payload: expect.objectContaining({ text: "Final answer" }),
+    });
+    expectRecordFields(expectRecordFields(outbound.payload, {}).channelData, {
+      telegram: { promptContextTimestampMs: transcriptTimestamp },
+    });
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("keeps the Telegram edit cap for non-block previews regardless of chunk config", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -54,6 +54,7 @@ import {
   appendAssistantMirrorMessageByIdentity,
   readLatestAssistantTextByIdentity,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-chunking";
 import { resolveTelegramConfigReasoningDefault } from "./agent-config.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -1580,9 +1581,14 @@ export const dispatchTelegramMessage = async ({
   };
   const resolveCurrentTurnTranscriptFinalText = async (): Promise<string | undefined> =>
     (await resolveCurrentTurnTranscriptFinal())?.text;
+  const normalizePromptContextTimestampText = (text: string): string =>
+    stripInlineDirectiveTagsForDelivery(text).text.trim();
   const resolvePromptContextTimestampMs = async (text: string): Promise<number | undefined> => {
     const final = await resolveCurrentTurnTranscriptFinal();
-    if (final?.text.trim() !== text.trim()) {
+    if (
+      !final ||
+      normalizePromptContextTimestampText(final.text) !== normalizePromptContextTimestampText(text)
+    ) {
       return undefined;
     }
     return final.timestamp;

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -153,6 +153,7 @@ async function writeDirectTelegramTranscriptContext(params: {
   cfg: OpenClawConfig;
   storePath: string;
   chatId: number;
+  role?: "assistant" | "user";
   senderId: number;
   sessionId: string;
   text: string;
@@ -188,10 +189,10 @@ async function writeDirectTelegramTranscriptContext(params: {
     [
       JSON.stringify({ type: "session", id: params.sessionId }),
       JSON.stringify({
-        id: "transcript-user-1",
+        id: params.role === "assistant" ? "transcript-assistant-1" : "transcript-user-1",
         type: "message",
         message: {
-          role: "user",
+          role: params.role ?? "user",
           content: params.text,
           timestamp: params.timestamp,
         },
@@ -2426,6 +2427,102 @@ describe("createTelegramBot", () => {
       expect(photoMessage?.media_ref).toBe("telegram:file/reference-photo-1");
     } finally {
       await rm(storePath, { force: true });
+    }
+  });
+
+  it("dedupes direct assistant transcript context against cached Telegram replies after stripping directives", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+
+    const storePath = `/tmp/openclaw-telegram-dm-visible-dedupe-${process.pid}-${Date.now()}.json`;
+    const config = {
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+      session: {
+        store: storePath,
+      },
+    } satisfies NonNullable<Parameters<typeof createTelegramBot>[0]["config"]>;
+
+    await rm(storePath, { force: true });
+    await rm(`${storePath}.telegram-messages.json`, { force: true });
+    try {
+      loadConfig.mockReturnValue(config);
+      createTelegramBot({ token: "tok", config });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      const baseCtx = {
+        me: { id: 999, username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      };
+      const chatId = 7773;
+      const senderId = 202;
+      const visibleReply = "Yep - I'm here now.";
+      const replyTimestampMs = 1_778_474_700_000;
+
+      await writeDirectTelegramTranscriptContext({
+        cfg: config,
+        storePath,
+        chatId,
+        role: "assistant",
+        senderId,
+        sessionId: "telegram-dm-assistant-visible-dedupe-session",
+        text: `[[reply_to_current]]${visibleReply}`,
+        timestamp: replyTimestampMs,
+      });
+      await handler({
+        ...baseCtx,
+        message: {
+          chat: { id: chatId, type: "private" },
+          text: "still there?",
+          date: 1_778_474_850,
+          message_id: 741,
+          from: { id: senderId, is_bot: false, first_name: "Kesava" },
+          reply_to_message: {
+            chat: { id: chatId, type: "private" },
+            date: Math.floor(replyTimestampMs / 1000),
+            from: { id: 999, is_bot: true, first_name: "OpenClaw" },
+            message_id: 736,
+            text: visibleReply,
+          },
+        },
+      });
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = mockMsgContextArg(
+        replySpy as unknown as MockCallSource,
+        0,
+        0,
+        "replySpy call",
+      );
+      const [conversationContext] = requireArray(
+        payload.UntrustedStructuredContext,
+        "structured context",
+      );
+      const contextRecord = requireRecord(conversationContext, "conversation context");
+      const contextPayload = requireRecord(contextRecord.payload, "conversation context payload");
+      const messages = requireArray(contextPayload.messages, "conversation context messages").map(
+        (message, index) => requireRecord(message, `conversation context message ${index + 1}`),
+      );
+
+      expect(messages).toEqual([
+        expect.objectContaining({
+          body: visibleReply,
+          is_reply_target: true,
+          message_id: "736",
+          sender: "OpenClaw",
+        }),
+      ]);
+      expect(messages.filter((message) => message.body === visibleReply)).toHaveLength(1);
+      expect(JSON.stringify(messages)).not.toContain("[[reply_to_current]]");
+      expect(messages.some((message) => String(message.message_id).startsWith("session:"))).toBe(
+        false,
+      );
+    } finally {
+      await rm(storePath, { force: true });
+      await rm(`${storePath}.telegram-messages.json`, { force: true });
     }
   });
 

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2461,6 +2461,7 @@ describe("createTelegramBot", () => {
       const senderId = 202;
       const visibleReply = "Yep - I'm here now.";
       const replyTimestampMs = 1_778_474_700_000;
+      const telegramReplyDate = Math.floor((replyTimestampMs + 5_000) / 1000);
 
       await writeDirectTelegramTranscriptContext({
         cfg: config,
@@ -2482,9 +2483,10 @@ describe("createTelegramBot", () => {
           from: { id: senderId, is_bot: false, first_name: "Kesava" },
           reply_to_message: {
             chat: { id: chatId, type: "private" },
-            date: Math.floor(replyTimestampMs / 1000),
+            date: telegramReplyDate,
             from: { id: 999, is_bot: true, first_name: "OpenClaw" },
             message_id: 736,
+            openclaw_prompt_context_timestamp_ms: replyTimestampMs,
             text: visibleReply,
           },
         },


### PR DESCRIPTION
Fixes #99117.
Alternative to #100571 with a narrower dedupe key and handler/dispatch regression coverage.
AI-assisted: yes

## What Problem This Solves

Fixes an issue where Telegram DM follow-up prompts could include the same assistant reply twice when the session transcript retained inline reply directives but the Telegram message cache contained the visible delivered text. The duplicated context made the assistant see both a synthetic `session:` transcript row and the real Telegram cache row for the same reply.

## Why This Change Was Made

The shipped change keeps the existing timestamp-aligned dedupe boundary and normalizes body text through the same inline directive stripping used for delivery. The follow-up commit also applies the same delivery-visible comparison when copying the transcript timestamp into outbound Telegram prompt-context cache entries, so replies like `[[reply_to_current]]Final answer` still get the transcript timestamp even though Telegram receives only `Final answer`.

That lets the Telegram cache row win over the transcript-only row for the same delivered reply without merging repeated assistant messages that happen to have the same visible text at different times.

## User Impact

Telegram DM follow-up prompts no longer repeat assistant replies just because transcript text still contains tags such as `[[reply_to_current]]`. Prompt context stays closer to what the user actually saw in Telegram, while preserving distinct replies sent at different timestamps.

## Evidence

- Mantis Telegram Desktop proof on the previous head `8a3b4c254911b47c97cf232bf633f2a54e6d615b` failed and showed the candidate still duplicated the hidden assistant context marker: https://github.com/openclaw/openclaw/pull/100573#issuecomment-4889191820
- Follow-up commit `5c4cc7245e` fixes the missing directive-aware timestamp handoff from transcript final text into outbound Telegram prompt-context cache rows.
- Current-head Mantis Telegram Desktop proof run https://github.com/openclaw/openclaw/actions/runs/28773461514 completed successfully for `5c4cc7245ef0ea1bee514d41b48bc1aa0f44bf6a`; manifest reports `pass: true` and candidate `fixed: true`. Mantis did not generate before/after GIFs because this PR changes hidden Telegram conversation context rather than visible chat UI: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-100573/run-28773461514-1/index.json
- Current-head hidden prompt-context terminal proof on `5c4cc7245ef0ea1bee514d41b48bc1aa0f44bf6a` used the current source `stripInlineDirectiveTagsForDelivery` helper and the same directive-tagged assistant/cache inputs. It shows the directive-tagged session row and Telegram cache row produce the same timestamp-preserving key, the session-only duplicate is dropped, and the final hidden prompt context has exactly one visible assistant row:

```text
head=5c4cc7245ef0ea1bee514d41b48bc1aa0f44bf6a
session.body=[[reply_to_current]]Yep - I'm here now.
cache.body=Yep - I'm here now.
session.key=1778474700000:Yep - I'm here now.
cache.key=1778474700000:Yep - I'm here now.
session.rows.retained.after.cache.dedupe=0
final.prompt.messages=[{"role":"assistant","body":"Yep - I'm here now.","timestamp_ms":1778474700000,"source":"telegram-message-cache"}]
visible.assistant.context.rows=1
PASS hidden prompt-context dedupe: one visible assistant row remains
```

- `node scripts/run-vitest.mjs run extensions/telegram/src/bot.test.ts extensions/telegram/src/bot-message-dispatch.test.ts -t 'dedupes direct assistant transcript context|marks directive-tagged durable finals'` - passed, 2 tests; 258 skipped
- `pnpm lint:extensions:telegram-grammy-types` - passed
- `git diff --check` - passed
- Earlier full Telegram-focused runs also passed:
  - `node scripts/run-vitest.mjs run extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot.test.ts -t "prompt-context timestamp|stripping directives"` - passed
  - `node scripts/run-vitest.mjs run extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot.test.ts` - passed, 260 tests
  - `pnpm tsgo:test:extensions` - passed
