### PR TITLE
fix(agents): remove internal reasoning placeholder from model-visible context to prevent channel reply leaks

### DIFF
--- a/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
@@ -23,7 +23,6 @@ import {
   TEST_SESSION_ID,
 } from "./embedded-agent-runner.sanitize-session-history.test-harness.js";
 import { validateReplayTurns } from "./embedded-agent-runner/replay-history.js";
-import { OMITTED_ASSISTANT_REASONING_TEXT } from "./embedded-agent-runner/thinking.js";
 import { castAgentMessage, castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
 import { extractToolCallsFromAssistant } from "./tool-call-id.js";
 import type { TranscriptPolicy } from "./transcript-policy.js";
@@ -1774,9 +1773,7 @@ describe("sanitizeSessionHistory", () => {
       modelId: "claude-3-7-sonnet-20250219",
     });
 
-    expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
-      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
-    ]);
+    expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([]);
     expect((result[3] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
       {
         type: "thinking",
@@ -1823,9 +1820,7 @@ describe("sanitizeSessionHistory", () => {
         modelId: "claude-3-7-sonnet-20250219",
       });
 
-      expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
-        { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
-      ]);
+      expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([]);
       expect((result[3] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
         { type: "text", text: "latest visible answer" },
       ]);
@@ -1855,9 +1850,7 @@ describe("sanitizeSessionHistory", () => {
       modelId: "claude-sonnet-4-6",
     });
 
-    expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
-      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
-    ]);
+    expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([]);
   });
 
   it.each([
@@ -2036,9 +2029,7 @@ describe("sanitizeSessionHistory", () => {
         modelId: "claude-sonnet-4-6",
       });
 
-      expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
-        { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
-      ]);
+      expect((result[1] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([]);
       expect((result[3] as Extract<AgentMessage, { role: "assistant" }>).content).toEqual([
         { type: "thinking", thinking: "latest blank", thinkingSignature: "" },
       ]);

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -317,6 +317,7 @@ import {
 import { applySystemPromptToSession } from "../system-prompt.js";
 import { repairRejectedThinkingReplayInSessionManager } from "../thinking-replay-repair.js";
 import {
+  compactAssistantMessages,
   dropReasoningFromHistory,
   dropThinkingBlocks,
   wrapAnthropicStreamWithRecovery,
@@ -2950,9 +2951,10 @@ export async function runEmbeddedAttempt(
             const reasoningSanitized = transcriptPolicy.dropReasoningFromHistory
               ? dropReasoningFromHistory(messages)
               : messages;
-            return transcriptPolicy.dropThinkingBlocks
+            const noThinking = transcriptPolicy.dropThinkingBlocks
               ? dropThinkingBlocks(reasoningSanitized)
               : reasoningSanitized;
+            return compactAssistantMessages(noThinking);
           },
         );
       }

--- a/src/agents/embedded-agent-runner/thinking-replay-repair.test.ts
+++ b/src/agents/embedded-agent-runner/thinking-replay-repair.test.ts
@@ -71,9 +71,7 @@ describe("repairRejectedThinkingReplayInSessionManager", () => {
     const result = repairRejectedThinkingReplayInSessionManager({ sessionManager });
 
     expect(result).toMatchObject({ repaired: true, repairedCount: 1 });
-    expect(branchAssistantContents(sessionManager)).toEqual([
-      [{ type: "text", text: "[assistant reasoning omitted]" }],
-    ]);
+    expect(branchAssistantContents(sessionManager)).toEqual([[]]);
   });
 
   it("preserves downstream branch suffix entries after rewriting the first repaired assistant", () => {

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -7,6 +7,7 @@ import { castAgentMessage, castAgentMessages } from "../test-helpers/agent-messa
 import {
   OMITTED_ASSISTANT_REASONING_TEXT,
   assessLastAssistantMessage,
+  compactAssistantMessages,
   dropReasoningFromHistory,
   dropThinkingBlocks,
   isAssistantMessageWithContent,
@@ -149,9 +150,7 @@ describe("dropThinkingBlocks", () => {
     const latestAssistant = result[3] as Extract<AgentMessage, { role: "assistant" }>;
     const originalLatestAssistant = messages[3] as Extract<AgentMessage, { role: "assistant" }>;
 
-    expect(oldAssistant.content).toEqual([
-      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
-    ]);
+    expect(oldAssistant.content).toEqual([]);
     expect(latestAssistant.content).toEqual(originalLatestAssistant.content);
   });
 
@@ -172,9 +171,7 @@ describe("dropThinkingBlocks", () => {
     const result = dropThinkingBlocks(messages);
     const oldAssistant = result[1] as Extract<AgentMessage, { role: "assistant" }>;
 
-    expect(oldAssistant.content).toEqual([
-      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
-    ]);
+    expect(oldAssistant.content).toEqual([]);
   });
 });
 
@@ -212,7 +209,7 @@ describe("dropReasoningFromHistory", () => {
     const result = dropReasoningFromHistory(messages);
     const assistant = result[1] as AssistantMessage;
 
-    expect(assistant.content).toEqual([{ type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT }]);
+    expect(assistant.content).toEqual([]);
   });
 
   it("preserves reasoning for the active tool-call continuation after the latest user turn", () => {
@@ -377,7 +374,7 @@ describe("stripInvalidThinkingSignatures", () => {
     const result = stripInvalidThinkingSignatures(messages);
     const assistant = result[0] as Extract<AgentMessage, { role: "assistant" }>;
 
-    expect(assistant.content).toEqual([{ type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT }]);
+    expect(assistant.content).toEqual([]);
   });
 
   it("strips redacted thinking blocks with invalid opaque signatures from older assistant messages", () => {
@@ -512,9 +509,7 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     if (!retryMessage || retryMessage.role !== "assistant") {
       throw new Error("Expected Anthropic recovery retry to start with an assistant message");
     }
-    expect(retryMessage.content).toEqual([
-      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
-    ]);
+    expect(retryMessage.content).toEqual([]);
   });
 
   it("retries with visible assistant text when stripping thinking leaves content", async () => {
@@ -832,9 +827,7 @@ describe("wrapAnthropicStreamWithRecovery", () => {
     if (!retryMessage || retryMessage.role !== "assistant") {
       throw new Error("Expected Anthropic recovery retry to start with an assistant message");
     }
-    expect(retryMessage.content).toEqual([
-      { type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT },
-    ]);
+    expect(retryMessage.content).toEqual([]);
   });
 
   it("does not retry non-thinking terminal stream-error events", async () => {
@@ -1291,5 +1284,45 @@ describe("stripStaleThinkingSignaturesForCompactionReplay", () => {
     const result = stripStaleThinkingSignaturesForCompactionReplay(messages);
     // Same millisecond as compaction: treated as post-compaction; signature preserved
     expect(result).toBe(messages);
+  });
+});
+
+describe("compactAssistantMessages", () => {
+  it("removes assistant messages that carry only the old persisted placeholder sentinel", () => {
+    const result = compactAssistantMessages([
+      castAgentMessage({ role: "user", content: "first" }),
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT }],
+      }),
+      castAgentMessage({ role: "user", content: "second" }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.role).toBe("user");
+    expect(JSON.stringify(result)).not.toContain(OMITTED_ASSISTANT_REASONING_TEXT);
+  });
+
+  it("removes empty-content assistant messages", () => {
+    const result = compactAssistantMessages([
+      castAgentMessage({ role: "user", content: "first" }),
+      castAgentMessage({ role: "assistant", content: [] }),
+      castAgentMessage({ role: "user", content: "second" }),
+    ]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("preserves assistant messages with real text content", () => {
+    const result = compactAssistantMessages([
+      castAgentMessage({ role: "user", content: "first" }),
+      castAgentMessage({ role: "assistant", content: [{ type: "text", text: "hello" }] }),
+      castAgentMessage({ role: "user", content: "second" }),
+    ]);
+    expect(result).toHaveLength(3);
+    expect(result[1]?.role).toBe("assistant");
+  });
+
+  it("returns original reference when unchanged", () => {
+    const input = [castAgentMessage({ role: "user", content: "hi" })];
+    expect(compactAssistantMessages(input)).toBe(input);
   });
 });

--- a/src/agents/embedded-agent-runner/thinking.ts
+++ b/src/agents/embedded-agent-runner/thinking.ts
@@ -4,6 +4,7 @@
 import { collectErrorGraphCandidates, formatErrorMessage } from "../../infra/errors.js";
 import type { AssistantMessageEvent } from "../../llm/types.js";
 import { createAssistantMessageEventStream } from "../../llm/utils/event-stream.js";
+import { mergeConsecutiveUserTurns } from "../embedded-agent-helpers.js";
 import type { AgentMessage, StreamFn } from "../runtime/index.js";
 import { log } from "./logger.js";
 
@@ -90,8 +91,11 @@ function hasMeaningfulText(block: AssistantContentBlock): boolean {
 }
 
 function buildOmittedAssistantReasoningContent(): AssistantContentBlock[] {
-  // Provider converters drop blank text blocks; keep this neutral text non-empty so the assistant turn survives replay.
-  return [{ type: "text", text: OMITTED_ASSISTANT_REASONING_TEXT } as AssistantContentBlock];
+  // Return empty content so downstream filters (compactAssistantMessages) can
+  // detect and strip these messages generically without string-matching the
+  // placeholder text. Provider converters handle empty assistant messages by
+  // skipping them; alternation is repaired by compactAssistantMessages.
+  return [];
 }
 
 function parseTimestampMs(value: unknown): number | null {
@@ -487,6 +491,62 @@ export function dropReasoningFromHistory(messages: AgentMessage[]): AgentMessage
       ...message,
       content: nextContent.length > 0 ? nextContent : buildOmittedAssistantReasoningContent(),
     });
+  }
+  return touched ? out : messages;
+}
+
+/**
+ * Removes assistant messages with no meaningful visible content (e.g. messages
+ * that became empty or placeholder-only after reasoning/thinking sanitization)
+ * and merges resulting consecutive user messages to maintain provider-required
+ * message alternation. This prevents internal placeholder text from entering
+ * model-visible context where it can leak into channel replies.
+ *
+ * Handles both new empty message content (content: []) and the old persisted
+ * [assistant reasoning omitted] placeholder sentinel from existing transcripts.
+ *
+ * @returns A new message array, or the original if unchanged.
+ */
+export function compactAssistantMessages(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  const out: AgentMessage[] = [];
+
+  for (const msg of messages) {
+    // Skip assistant messages that carry no visible content
+    if (msg.role === "assistant") {
+      const content = Array.isArray(msg.content) ? msg.content : [];
+      const hasVisible = content.some((block) => {
+        const type = (block as { type?: unknown }).type;
+        if (type === "thinking" || type === "redacted_thinking") {
+          return false;
+        }
+        if (type === "toolCall" || type === "tool_use" || type === "function_call") {
+          return true;
+        }
+        if (type === "text") {
+          const text = (block as { text?: string }).text?.trim();
+          if (text && text !== OMITTED_ASSISTANT_REASONING_TEXT) {
+            return true;
+          }
+          return false;
+        }
+        return true;
+      });
+      if (!hasVisible) {
+        touched = true;
+        continue;
+      }
+    }
+    const last = out.at(-1);
+    if (msg.role === "user" && last?.role === "user") {
+      out[out.length - 1] = mergeConsecutiveUserTurns(
+        last as Extract<AgentMessage, { role: "user" }>,
+        msg as Extract<AgentMessage, { role: "user" }>,
+      );
+      touched = true;
+      continue;
+    }
+    out.push(msg);
   }
   return touched ? out : messages;
 }


### PR DESCRIPTION
## What Problem This Solves

When a model responds with only reasoning/thinking blocks (no visible text), `dropReasoningFromHistory` replaces the assistant message with `[assistant reasoning omitted]` placeholder text in model-visible context. The model treats this placeholder as dialogue text and may incorporate it into subsequent visible replies, which then leak into channel output as broken-looking messages.

- **Problem**: Internal placeholder text enters model-visible context as assistant dialogue, leaking into channel replies
- **Solution**: Make `buildOmittedAssistantReasoningContent` return empty content instead of placeholder text, and add a generic `compactAssistantMessages` filter that removes empty-content assistant messages (merging consecutive users) from model-visible context
- **What changed**: `src/agents/embedded-agent-runner/thinking.ts` (3 changes: empty content, new `compactAssistantMessages`, import), `src/agents/embedded-agent-runner/run/attempt.ts` (apply compact in streamFn transform), test assertions in 3 test files
- **What did NOT change**: Feishu channel, Anthropic provider converter, other placeholder sources in extensions, transcript persistence, `dropReasoningFromHistory` interface

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to #99725
- [ ] This PR fixes a bug or regression

## Motivation

The previous PR (#99936) attempted to fix this at the Feishu channel level by falling back to raw content when `normalizeMentions` produced empty text. This was rejected by maintainer because `normalizeMentions` intentionally strips bot mentions — feeding the transport placeholder `@_bot_1` to the model is wrong.

The maintainer directed: "fix the boundary that actually writes assistant placeholder text into user context." The boundary is `buildOmittedAssistantReasoningContent()` in `thinking.ts`, which is called from `dropReasoningFromHistory` when thinking-only messages are sanitized.

## Evidence

- Behavior addressed: Internal `[assistant reasoning omitted]` placeholder text no longer enters model-visible context where it can leak into channel replies
- Real environment tested: Linux, Node 22, branch `fix/compact-omitted-reasoning-99725` off main
- Exact steps or command run after this patch:

```bash
pnpm test src/agents/embedded-agent-runner/thinking.test.ts
pnpm test src/agents/embedded-agent-runner.sanitize-session-history.test.ts
pnpm test src/agents/embedded-agent-runner/thinking-replay-repair.test.ts
```

- Evidence after fix:

```console
$ pnpm test src/agents/embedded-agent-runner/thinking.test.ts
 Test Files  1 passed (1)
      Tests  52 passed (52)

$ pnpm test src/agents/embedded-agent-runner.sanitize-session-history.test.ts
 Test Files  1 passed (1)
      Tests  76 passed (76)

$ pnpm test src/agents/embedded-agent-runner/thinking-replay-repair.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

End-to-end proof (simulating `attempt.ts` transform — runs before provider call, no API key needed):

```console
$ node --import tsx -e "
import { dropReasoningFromHistory, compactAssistantMessages } from './src/agents/...';
const result = compactAssistantMessages(dropReasoningFromHistory([
  {role:'user', content:[{type:'text',text:'hi'}]},
  {role:'assistant', content:[{type:'thinking',thinking:'ok'}]},
  {role:'user', content:[{type:'text',text:'next'}]},
]));
console.log(result.length, 'msg(s), roles:', result.map(m=>m.role));
console.log('Has placeholder:', JSON.stringify(result).includes('assistant reasoning omitted'));
"
1 msg(s), roles: [ 'user' ]
Has placeholder: false
```

Full behavior matrix (5 scenarios verified via `node --import tsx`):

| Scenario | Input | Output | Result |
|---|---|---|---|
| Bug leak path | `[user, thinking-only, user]` | `[user(merged)]` — no placeholder | ✅ |
| Normal conversation | `[user, visible-text, user]` | `[user, assistant, user]` | ✅ |
| Tool calls | `[user, tool_use, toolResult, user]` | `[user, tool_use, toolResult, user]` | ✅ |
| Multi-turn thinking | `[user, thinking, user, thinking, user]` | `[user(merged)]` | ✅ |
| Identity preservation | `[user]` unchanged | Same reference | ✅ |

- Observed result after fix:
  1. `buildOmittedAssistantReasoningContent` returns `[]` instead of `[{type:"text", text:"[assistant reasoning omitted]"}]`
  2. Empty assistant messages are removed from model-visible context by `compactAssistantMessages`
  3. Consecutive user messages resulting from removal are merged via existing `mergeConsecutiveUserTurns`
  4. All 132 existing tests pass across 3 test files
  5. No placeholder text enters model-visible context

- What was not tested: Live E2E test with Feishu + minimax (requires credentials), Anthropic thinking replay live test (requires API key)

## Root Cause

The placeholder text `[assistant reasoning omitted]` is produced by `buildOmittedAssistantReasoningContent()` in `src/agents/embedded-agent-runner/thinking.ts:92-95`, called from `dropReasoningFromHistory` (line 489) when all assistant message content was thinking-only blocks. The placeholder served to keep the assistant turn non-empty (providers drop blank assistant messages), but entered model-visible context where it could be incorporated into subsequent replies.

## Regression Test Plan

- `thinking.test.ts` 52 tests cover `dropReasoningFromHistory`, `compactAssistantMessages`, `dropThinkingBlocks`, `stripInvalidThinkingSignatures`, `wrapAnthropicStreamWithRecovery`
- `sanitize-session-history.test.ts` 76 tests cover the full `sanitizeSessionHistory` pipeline
- `thinking-replay-repair.test.ts` 4 tests cover `repairRejectedThinkingReplayInSessionManager`

## User-visible / Behavior Changes

None directly. The bug fix prevents internal placeholder text from leaking into channel replies. Users should no longer see `[assistant reasoning omitted]` appearing in their chat replies after short messages.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes — only empty-content assistant messages are removed; all existing tests pass
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — fixes the boundary where placeholder text enters model-visible context. The generic `compactAssistantMessages` handles any future placeholder sources without string matching.
- **Refactor needed**: No
- **Alternative considered**: (1) Change placeholder text string — doesn't prevent leakage, model references any dialogue-like text. (2) Filter in reply pipeline — treats symptom not cause. (3) Fix each of 5 placeholder sources individually — more changes, less maintainable.

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

**Highest risk area**: Providers that require strict user→assistant alternation (Anthropic) might receive consecutive user messages after empty assistant removal.

**Mitigation**: `compactAssistantMessages` uses the existing `mergeConsecutiveUserTurns` to merge consecutive user messages, which is already used by `validateAnthropicTurns` and `validateGeminiTurns` for the same purpose in the existing pipeline.

**Compatibility**: No breaking changes. Empty assistant messages were previously `[{type:"text", text:"[assistant reasoning omitted]"}]` and are now `[]`. Provider converters already handle empty assistant messages (Anthropic converter uses `continue` to skip them).

---

Related to #99725