### PR TITLE
improve: skill auto-capture catches reactive corrections and routes them to existing skills

### DIFF
--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -204,11 +204,11 @@ agent session or the CLI.
 
 ## Suggested skills
 
-OpenClaw detects durable instructions such as “next time” and “remember to” after successful
-interactive turns. On the next turn, the agent offers to save the detected workflow through
-`skill_workshop`; the user decides whether to create a proposal. This built-in suggestion does not
-create or change a skill by itself. Enable `skills.workshop.autonomous.enabled` to create pending
-proposals directly instead.
+OpenClaw detects durable instructions such as “next time,” “remember to,” and reactive corrections
+when an interactive turn ends, including failed turns. On the next turn, the agent offers to save
+the most recent detected workflow through `skill_workshop`; the user decides whether to create a
+proposal. This built-in suggestion does not create or change a skill by itself. Enable
+`skills.workshop.autonomous.enabled` to create pending proposals directly instead.
 
 ## Approval and autonomy
 
@@ -230,11 +230,16 @@ proposals directly instead.
 
 | Setting                    | Default     | Effect                                                                                                                                                                 |
 | -------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `autonomous.enabled`       | `false`     | Lets OpenClaw create pending proposals from durable conversation signals after a successful turn.                                                                      |
+| `autonomous.enabled`       | `false`     | Creates pending proposals directly instead of offering the most recent detected workflow on the next turn.                                                             |
 | `allowSymlinkTargetWrites` | `false`     | Lets apply write through workspace skill symlinks whose real target is listed in `skills.load.allowSymlinkTargets`.                                                    |
 | `approvalPolicy`           | `"pending"` | `"pending"` requires an approval prompt before agent-initiated `apply`, `reject`, or `quarantine`. `"auto"` skips the prompt (the agent still has to call the action). |
 | `maxPending`               | `50`        | Caps pending and quarantined proposals per workspace (1-200).                                                                                                          |
 | `maxSkillBytes`            | `40000`     | Caps proposal body size in bytes (1024-200000).                                                                                                                        |
+
+Autonomous capture recognizes prospective rules (for example, “from now on”) and reactive
+corrections (for example, “that’s not what I asked”). It groups new instructions by topic into up
+to three proposals per turn, routes vocabulary matches to existing writable workspace skills, and
+revises its own pending proposal when another correction targets the same skill.
 
 Proposal descriptions are always capped at 160 bytes, independent of
 `maxSkillBytes`.

--- a/src/config/sessions/skill-suggestions.ts
+++ b/src/config/sessions/skill-suggestions.ts
@@ -1,6 +1,12 @@
 // Session skill suggestions are one-shot hints consumed by the next interactive turn.
-import { patchSessionEntry, type SessionAccessScope } from "./session-accessor.js";
+import {
+  loadSessionEntry,
+  patchSessionEntry,
+  type SessionAccessScope,
+} from "./session-accessor.js";
 import type { PendingSkillSuggestion, SessionEntry } from "./types.js";
+
+const MAX_SKILL_CAPTURE_SIGNAL_HASHES = 32;
 
 type SessionSkillSuggestionScope = Pick<
   SessionAccessScope,
@@ -12,11 +18,109 @@ type SessionSkillSuggestionConsumption = {
   suggestion?: PendingSkillSuggestion;
 };
 
+function normalizeSignalHashes(signalHashes: readonly string[]): string[] {
+  const normalized: string[] = [];
+  for (const value of signalHashes) {
+    const hash = value.trim();
+    if (hash && !normalized.includes(hash)) {
+      normalized.push(hash);
+    }
+  }
+  return normalized;
+}
+
+function appendSignalHashes(entry: SessionEntry, signalHashes: readonly string[]): string[] {
+  const hashes = [...(entry.skillCaptureSignalHashes ?? [])];
+  for (const hash of signalHashes) {
+    const previousIndex = hashes.indexOf(hash);
+    if (previousIndex >= 0) {
+      hashes.splice(previousIndex, 1);
+    }
+    hashes.push(hash);
+  }
+  return hashes.slice(-MAX_SKILL_CAPTURE_SIGNAL_HASHES);
+}
+
+/** Reads recent durable-instruction fingerprints, oldest first. */
+export function readSessionSkillCaptureSignalHashes(
+  options: SessionSkillSuggestionScope,
+): string[] | undefined {
+  const entry = loadSessionEntry({ ...options, readConsistency: "latest" });
+  return entry ? [...(entry.skillCaptureSignalHashes ?? [])] : undefined;
+}
+
+/** Records processed durable-instruction fingerprints in a bounded newest-last ring. */
+export async function recordSessionSkillCaptureSignals(
+  options: SessionSkillSuggestionScope & { signalHashes: readonly string[] },
+): Promise<boolean> {
+  const signalHashes = normalizeSignalHashes(options.signalHashes);
+  if (signalHashes.length === 0) {
+    return false;
+  }
+  const result = await patchSessionEntry(
+    options,
+    (entry) => ({ skillCaptureSignalHashes: appendSignalHashes(entry, signalHashes) }),
+    { preserveActivity: true },
+  );
+  return Boolean(result);
+}
+
+/** Atomically claims one instruction group and returns only the hashes added by this claim. */
+export async function claimSessionSkillCaptureSignals(
+  options: SessionSkillSuggestionScope & {
+    signalHash: string;
+    signalHashes: readonly string[];
+  },
+): Promise<string[] | undefined> {
+  const signalHash = options.signalHash.trim();
+  const signalHashes = normalizeSignalHashes(options.signalHashes);
+  if (!signalHash || signalHashes.length === 0) {
+    return undefined;
+  }
+  let claimedSignalHashes: string[] | undefined;
+  const result = await patchSessionEntry(
+    options,
+    (entry) => {
+      if (entry.skillCaptureSignalHashes?.includes(signalHash)) {
+        return null;
+      }
+      claimedSignalHashes = signalHashes.filter(
+        (hash) => !entry.skillCaptureSignalHashes?.includes(hash),
+      );
+      return {
+        skillCaptureSignalHashes: appendSignalHashes(entry, signalHashes),
+      };
+    },
+    { preserveActivity: true },
+  );
+  return result ? claimedSignalHashes : undefined;
+}
+
+/** Releases a failed claim so a later agent-end replay can retry the group. */
+export async function releaseSessionSkillCaptureSignals(
+  options: SessionSkillSuggestionScope & { signalHashes: readonly string[] },
+): Promise<void> {
+  const released = new Set(normalizeSignalHashes(options.signalHashes));
+  if (released.size === 0) {
+    return;
+  }
+  await patchSessionEntry(
+    options,
+    (entry) => ({
+      skillCaptureSignalHashes: entry.skillCaptureSignalHashes?.filter(
+        (hash) => !released.has(hash),
+      ),
+    }),
+    { preserveActivity: true },
+  );
+}
+
 /** Records one suggestion without replacing an earlier unconsumed suggestion. */
 export async function recordSessionSkillSuggestion(
   options: SessionSkillSuggestionScope & {
     skillName: string;
     signalHash: string;
+    relatedSignalHashes?: readonly string[];
     detectedAt?: number;
   },
 ): Promise<boolean> {
@@ -34,16 +138,20 @@ export async function recordSessionSkillSuggestion(
       storePath: options.storePath,
     },
     (entry) => {
-      if (entry.pendingSkillSuggestion || entry.lastSkillSuggestionSignalHash === signalHash) {
+      if (entry.pendingSkillSuggestion || entry.skillCaptureSignalHashes?.includes(signalHash)) {
         return null;
       }
+      const signalHashes = normalizeSignalHashes([
+        ...(options.relatedSignalHashes ?? []),
+        signalHash,
+      ]);
       recorded = true;
       return {
         pendingSkillSuggestion: {
           skillName,
           detectedAt: options.detectedAt ?? Date.now(),
         },
-        lastSkillSuggestionSignalHash: signalHash,
+        skillCaptureSignalHashes: appendSignalHashes(entry, signalHashes),
       };
     },
     { preserveActivity: true },

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -298,8 +298,8 @@ export type SessionEntry = {
   goal?: SessionGoal;
   /** Durable one-shot Skill Workshop suggestion for the next interactive turn. */
   pendingSkillSuggestion?: PendingSkillSuggestion;
-  /** Fingerprint of the last signal queued as a skill suggestion. */
-  lastSkillSuggestionSignalHash?: string;
+  /** Recent durable-instruction fingerprints already processed by Skill Workshop capture. */
+  skillCaptureSignalHashes?: string[];
   /** Timestamp (ms) when the current sessionId first became active. */
   sessionStartedAt?: number;
   /** Stable usage lineage key for transcript-backed rollups across sessionId rotations. */

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -35,7 +35,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "restartRecoveryRuns",
   "goal",
   "pendingSkillSuggestion",
-  "lastSkillSuggestionSignalHash",
+  "skillCaptureSignalHashes",
   "sessionStartedAt",
   "ambientTranscriptWatermarks",
   "lastInteractionAt",

--- a/src/skills/research/autocapture.test.ts
+++ b/src/skills/research/autocapture.test.ts
@@ -1,9 +1,12 @@
 // Research autocapture tests cover capture policy, persistence, and config gating.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
-import { consumeSessionSkillSuggestion } from "../../config/sessions/skill-suggestions.js";
+import {
+  consumeSessionSkillSuggestion,
+  recordSessionSkillCaptureSignals,
+} from "../../config/sessions/skill-suggestions.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -13,28 +16,15 @@ import {
   applySkillProposal,
   inspectSkillProposal,
   listSkillProposals,
+  proposeCreateSkill,
+  rejectSkillProposal,
 } from "../workshop/service.js";
+import * as workshopService from "../workshop/service.js";
 import { runSkillResearchAutoCapture } from "./autocapture.js";
 
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
 const SESSION_KEY = "agent:main:main";
-
-beforeEach(async () => {
-  testState = await createOpenClawTestState({
-    layout: "state-only",
-    prefix: "openclaw-skill-workshop-state-",
-  });
-});
-
-afterEach(async () => {
-  await testState.cleanup();
-  await tempDirs.cleanup();
-});
-
-async function makeWorkspace(): Promise<string> {
-  return await tempDirs.make("openclaw-skill-workshop-");
-}
 
 async function seedSession(sessionKey = SESSION_KEY): Promise<void> {
   await upsertSessionEntry(
@@ -47,10 +37,26 @@ function readSession(sessionKey = SESSION_KEY) {
   return loadSessionEntry({ agentId: "main", sessionKey, readConsistency: "latest" });
 }
 
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-skill-workshop-state-",
+  });
+  await seedSession();
+});
+
+afterEach(async () => {
+  await testState.cleanup();
+  await tempDirs.cleanup();
+});
+
+async function makeWorkspace(): Promise<string> {
+  return await tempDirs.make("openclaw-skill-workshop-");
+}
+
 describe("skill research auto-capture", () => {
   it("queues a pending proposal from durable user correction", async () => {
     const workspaceDir = await makeWorkspace();
-    await seedSession();
 
     await runSkillResearchAutoCapture({
       event: {
@@ -86,97 +92,10 @@ describe("skill research auto-capture", () => {
     const proposal = await inspectSkillProposal(proposals.proposals[0].id, { workspaceDir });
     expect(proposal?.content).toContain("status: proposal");
     expect(proposal?.content).toContain("always check CI before final response");
-    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
   });
 
-  it("records and one-shot consumes a suggestion with default config", async () => {
+  it("records one suggestion for the most recent group when autonomy is disabled", async () => {
     const workspaceDir = await makeWorkspace();
-    await seedSession();
-
-    await runSkillResearchAutoCapture({
-      event: {
-        success: true,
-        messages: [
-          {
-            role: "user",
-            content: "Remember to always verify generated screenshots before replying.",
-          },
-        ],
-      },
-      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
-    });
-
-    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
-    expect(readSession()?.pendingSkillSuggestion).toMatchObject({
-      skillName: "screenshot-asset-workflow",
-    });
-
-    const first = await consumeSessionSkillSuggestion({
-      agentId: "main",
-      sessionKey: SESSION_KEY,
-    });
-    expect(first?.suggestion).toMatchObject({ skillName: "screenshot-asset-workflow" });
-    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
-
-    const second = await consumeSessionSkillSuggestion({
-      agentId: "main",
-      sessionKey: SESSION_KEY,
-    });
-    expect(second?.suggestion).toBeUndefined();
-
-    await runSkillResearchAutoCapture({
-      event: {
-        success: true,
-        messages: [
-          {
-            role: "user",
-            content: "Remember to always verify generated screenshots before replying.",
-          },
-        ],
-      },
-      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
-    });
-    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
-  });
-
-  it("does not record a suggestion when no durable signal is present", async () => {
-    const workspaceDir = await makeWorkspace();
-    await seedSession();
-
-    await runSkillResearchAutoCapture({
-      event: {
-        success: true,
-        messages: [{ role: "user", content: "Please review this pull request." }],
-      },
-      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
-    });
-
-    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
-  });
-
-  it("does not record a suggestion after a failed turn", async () => {
-    const workspaceDir = await makeWorkspace();
-    await seedSession();
-
-    await runSkillResearchAutoCapture({
-      event: {
-        success: false,
-        messages: [
-          {
-            role: "user",
-            content: "Remember to always verify generated screenshots before replying.",
-          },
-        ],
-      },
-      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
-    });
-
-    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
-  });
-
-  it("does not record a suggestion while a matching proposal is pending", async () => {
-    const workspaceDir = await makeWorkspace();
-    await seedSession();
     const event = {
       success: true,
       messages: [
@@ -185,20 +104,37 @@ describe("skill research auto-capture", () => {
           content:
             "From now on, when working on GitHub PRs, always check CI before final response.",
         },
+        {
+          role: "user",
+          content: "Remember to always verify generated screenshots before replying.",
+        },
       ],
+    };
+    const ctx = { workspaceDir, agentId: "main", sessionKey: SESSION_KEY };
+    const config = {
+      skills: {
+        workshop: {
+          autonomous: {
+            enabled: false,
+          },
+        },
+      },
     };
 
     await runSkillResearchAutoCapture({
       event,
-      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
-      config: { skills: { workshop: { autonomous: { enabled: true } } } },
-    });
-    await runSkillResearchAutoCapture({
-      event,
-      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      ctx,
+      config,
     });
 
-    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(1);
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+    expect(readSession()?.pendingSkillSuggestion).toMatchObject({
+      skillName: "screenshot-asset-workflow",
+    });
+    expect(readSession()?.skillCaptureSignalHashes?.length).toBeGreaterThan(0);
+
+    await consumeSessionSkillSuggestion({ agentId: "main", sessionKey: SESSION_KEY });
+    await runSkillResearchAutoCapture({ event, ctx, config });
     expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
   });
 
@@ -237,8 +173,7 @@ describe("skill research auto-capture", () => {
     },
   ])("skips $name before queuing proposals", async ({ ctx }) => {
     const workspaceDir = await makeWorkspace();
-    const sessionKey = ctx.sessionKey ?? SESSION_KEY;
-    await seedSession(sessionKey);
+    await seedSession(ctx.sessionKey);
 
     await runSkillResearchAutoCapture({
       event: {
@@ -252,15 +187,22 @@ describe("skill research auto-capture", () => {
         ],
       },
       ctx: { workspaceDir, agentId: "main", ...ctx },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
     });
 
     expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
-    expect(readSession(sessionKey)?.pendingSkillSuggestion).toBeUndefined();
   });
 
   it("preserves existing skill content when auto-capturing an update", async () => {
     const workspaceDir = await makeWorkspace();
-    await seedSession();
     const skillFile = path.join(workspaceDir, "skills", "github-pr-workflow", "SKILL.md");
     await fs.mkdir(path.dirname(skillFile), { recursive: true });
     await fs.writeFile(
@@ -314,6 +256,628 @@ describe("skill research auto-capture", () => {
     const updatedSkill = await fs.readFile(skillFile, "utf8");
     expect(updatedSkill).toContain("Preserve this original review checklist.");
     expect(updatedSkill).toContain("always check CI before final response");
+  });
+
+  it("queues a proposal from a reactive correction, not just prospective phrasing", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content:
+              "You're still using the transcripts as tone references — they should not be included as voice material at all.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    expect(proposals.proposals).toHaveLength(1);
+    expect(proposals.proposals[0]).toMatchObject({
+      kind: "create",
+      status: "pending",
+      skillKey: "learned-workflows",
+    });
+    const proposal = await inspectSkillProposal(proposals.proposals[0].id, { workspaceDir });
+    expect(proposal?.content).toContain("should not be included as voice material");
+  });
+
+  it("routes a correction to the existing workspace skill it is about", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillFile = path.join(workspaceDir, "skills", "signal-scout", "SKILL.md");
+    await fs.mkdir(path.dirname(skillFile), { recursive: true });
+    await fs.writeFile(
+      skillFile,
+      [
+        "---",
+        'name: "signal-scout"',
+        'description: "Mine the market for signals and validate them before drafting."',
+        "---",
+        "",
+        "# Signal Scout",
+        "",
+        "- Capture first, score later.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content:
+              "I thought we were working on listening — capture real market signals with quoted evidence before scoring anything.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    expect(proposals.proposals).toHaveLength(1);
+    expect(proposals.proposals[0]).toMatchObject({
+      kind: "update",
+      status: "pending",
+      skillKey: "signal-scout",
+    });
+
+    await applySkillProposal({ workspaceDir, proposalId: proposals.proposals[0].id });
+    const updatedSkill = await fs.readFile(skillFile, "utf8");
+    expect(updatedSkill).toContain("Capture first, score later.");
+    expect(updatedSkill).toContain("capture real market signals with quoted evidence");
+  });
+
+  it("routes a correction to a writable project agent skill under .agents/skills", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillFile = path.join(workspaceDir, ".agents", "skills", "signal-scout", "SKILL.md");
+    await fs.mkdir(path.dirname(skillFile), { recursive: true });
+    await fs.writeFile(
+      skillFile,
+      [
+        "---",
+        'name: "signal-scout"',
+        'description: "Mine the market for signals and validate them before drafting."',
+        "---",
+        "",
+        "# Signal Scout",
+        "",
+        "- Capture first, score later.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content:
+              "I thought we were working on listening — capture real market signals with quoted evidence before scoring anything.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    expect(proposals.proposals).toHaveLength(1);
+    expect(proposals.proposals[0]).toMatchObject({
+      kind: "update",
+      status: "pending",
+      skillKey: "signal-scout",
+    });
+
+    await applySkillProposal({ workspaceDir, proposalId: proposals.proposals[0].id });
+    const updatedSkill = await fs.readFile(skillFile, "utf8");
+    expect(updatedSkill).toContain("Capture first, score later.");
+    expect(updatedSkill).toContain("capture real market signals with quoted evidence");
+  });
+
+  it("captures corrections from failed runs", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: false,
+        messages: [
+          {
+            role: "user",
+            content:
+              "From now on, when working on GitHub PRs, always check CI before final response.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    expect(proposals.proposals).toHaveLength(1);
+    expect(proposals.proposals[0]).toMatchObject({
+      kind: "create",
+      status: "pending",
+      skillKey: "github-pr-workflow",
+    });
+  });
+
+  it("queues one proposal per distinct topic when a session has several corrections", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content:
+              "From now on, when working on GitHub PRs, always check CI before final response.",
+          },
+          {
+            role: "user",
+            content: "Remember to always optimize screenshot assets before attaching them.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config: {
+        skills: {
+          workshop: {
+            autonomous: {
+              enabled: true,
+            },
+          },
+        },
+      },
+    });
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    const skillKeys = proposals.proposals.map((entry) => entry.skillKey).toSorted();
+    expect(skillKeys).toEqual(["github-pr-workflow", "screenshot-asset-workflow"]);
+  });
+
+  it("does not replay a topic omitted by the per-turn proposal cap", async () => {
+    const workspaceDir = await makeWorkspace();
+    const event = {
+      success: true,
+      messages: [
+        {
+          role: "user",
+          content: "From now on, always check GitHub pull request CI before final response.",
+        },
+        {
+          role: "user",
+          content: "Remember to always optimize screenshot assets before attaching them.",
+        },
+        {
+          role: "user",
+          content: "Going forward, always write a QA scenario before testing this workflow.",
+        },
+        {
+          role: "user",
+          content: "Next time, always verify animated GIF output before replying.",
+        },
+      ],
+    };
+    const ctx = { workspaceDir, agentId: "main", sessionKey: SESSION_KEY };
+    const config = { skills: { workshop: { autonomous: { enabled: true } } } };
+
+    await runSkillResearchAutoCapture({ event, ctx, config });
+    await runSkillResearchAutoCapture({ event, ctx, config });
+
+    const skillKeys = (await listSkillProposals({ workspaceDir })).proposals
+      .map((entry) => entry.skillKey)
+      .toSorted();
+    expect(skillKeys).toEqual([
+      "animated-gif-workflow",
+      "qa-scenario-workflow",
+      "screenshot-asset-workflow",
+    ]);
+  });
+
+  it("suppresses autocapture when the same run used skill_workshop to create a proposal", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content:
+              "From now on, when working on GitHub PRs, always check CI before final response.",
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call-learn",
+                name: "skill_workshop",
+                arguments: { action: "create", name: "github-pr-workflow" },
+              },
+            ],
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config: { skills: { workshop: { autonomous: { enabled: true } } } },
+    });
+
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+    expect(readSession()?.skillCaptureSignalHashes).toHaveLength(1);
+  });
+
+  it("captures when the same-run skill_workshop mutation explicitly failed", async () => {
+    const workspaceDir = await makeWorkspace();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: false,
+        messages: [
+          {
+            role: "user",
+            content:
+              "From now on, when working on GitHub PRs, always check CI before final response.",
+          },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "call-learn-failed",
+                name: "skill_workshop",
+                arguments: { action: "create", name: "github-pr-workflow" },
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call-learn-failed",
+            toolName: "skill_workshop",
+            content: [{ type: "text", text: "proposal rejected" }],
+            isError: true,
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config: { skills: { workshop: { autonomous: { enabled: true } } } },
+    });
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    expect(proposals.proposals).toHaveLength(1);
+    expect(proposals.proposals[0].skillKey).toBe("github-pr-workflow");
+  });
+
+  it("does not let a historical skill_workshop call suppress a later correction", async () => {
+    const workspaceDir = await makeWorkspace();
+    const learnedTurn = [
+      {
+        role: "user",
+        content: "From now on, always check CI before final response on GitHub pull requests.",
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            name: "skill_workshop",
+            arguments: { action: "create", name: "github-pr-workflow" },
+          },
+        ],
+      },
+    ];
+    const ctx = { workspaceDir, agentId: "main", sessionKey: SESSION_KEY };
+    const config = { skills: { workshop: { autonomous: { enabled: true } } } };
+
+    await runSkillResearchAutoCapture({
+      event: { success: true, messages: learnedTurn },
+      ctx,
+      config,
+    });
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          ...learnedTurn,
+          {
+            role: "user",
+            content: "Remember to always optimize screenshot assets before attaching them.",
+          },
+        ],
+      },
+      ctx,
+      config,
+    });
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    expect(proposals.proposals).toHaveLength(1);
+    expect(proposals.proposals[0].skillKey).toBe("screenshot-asset-workflow");
+  });
+
+  it("revises the pending autocapture proposal with a second correction", async () => {
+    const workspaceDir = await makeWorkspace();
+    const first = {
+      role: "user",
+      content: "From now on, for GitHub pull requests, always check CI before final response.",
+    };
+    const second = {
+      role: "user",
+      content:
+        "You're still ignoring GitHub merge checks — always inspect the exact head before landing.",
+    };
+    const config = { skills: { workshop: { autonomous: { enabled: true } } } };
+
+    await runSkillResearchAutoCapture({
+      event: { success: true, messages: [first] },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config,
+    });
+    await runSkillResearchAutoCapture({
+      event: { success: true, messages: [first, second] },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config,
+    });
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    expect(proposals.proposals).toHaveLength(1);
+    const proposal = await inspectSkillProposal(proposals.proposals[0].id, { workspaceDir });
+    expect(proposal?.record.proposedVersion).toBe("v2");
+    expect(proposal?.content).toContain("inspect the exact head before landing");
+    expect(proposal?.content.match(/check CI before final response/g)).toHaveLength(1);
+  });
+
+  it("serializes concurrent revisions for one session", async () => {
+    const workspaceDir = await makeWorkspace();
+    const first = {
+      role: "user",
+      content: "From now on, for GitHub pull requests, always check CI before final response.",
+    };
+    const exactHead = {
+      role: "user",
+      content: "You're still ignoring GitHub merge checks — always inspect the exact head.",
+    };
+    const comments = {
+      role: "user",
+      content: "Remember to always read GitHub review comments before landing a pull request.",
+    };
+    const ctx = { workspaceDir, agentId: "main", sessionKey: SESSION_KEY };
+    const config = { skills: { workshop: { autonomous: { enabled: true } } } };
+
+    await runSkillResearchAutoCapture({
+      event: { success: true, messages: [first] },
+      ctx,
+      config,
+    });
+    await Promise.all([
+      runSkillResearchAutoCapture({
+        event: { success: true, messages: [first, exactHead] },
+        ctx,
+        config,
+      }),
+      runSkillResearchAutoCapture({
+        event: { success: true, messages: [first, comments] },
+        ctx,
+        config,
+      }),
+    ]);
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    expect(proposals.proposals).toHaveLength(1);
+    const proposal = await inspectSkillProposal(proposals.proposals[0].id, { workspaceDir });
+    expect(proposal?.record.proposedVersion).toBe("v3");
+    expect(proposal?.content).toContain("inspect the exact head");
+    expect(proposal?.content).toContain("read GitHub review comments");
+  });
+
+  it.each(["applied", "rejected"] as const)(
+    "does not replay a %s autocapture proposal from the same transcript",
+    async (status) => {
+      const workspaceDir = await makeWorkspace();
+      const event = {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content:
+              "From now on, when working on GitHub PRs, always check CI before final response.",
+          },
+        ],
+      };
+      const ctx = { workspaceDir, agentId: "main", sessionKey: SESSION_KEY };
+      const config = { skills: { workshop: { autonomous: { enabled: true } } } };
+
+      await runSkillResearchAutoCapture({ event, ctx, config });
+      const proposalId = (await listSkillProposals({ workspaceDir })).proposals[0].id;
+      if (status === "applied") {
+        await applySkillProposal({ workspaceDir, proposalId });
+      } else {
+        await rejectSkillProposal({ workspaceDir, proposalId });
+      }
+      await runSkillResearchAutoCapture({ event, ctx, config });
+
+      const proposals = await listSkillProposals({ workspaceDir });
+      expect(proposals.proposals).toHaveLength(1);
+      expect(proposals.proposals[0].status).toBe(status);
+    },
+  );
+
+  it("captures only new fingerprints after a failed turn", async () => {
+    const workspaceDir = await makeWorkspace();
+    const previous = {
+      role: "user",
+      content: "From now on, for GitHub pull requests, always check CI before final response.",
+    };
+    const newCorrection = {
+      role: "user",
+      content: "Remember to always optimize screenshot assets before attaching them.",
+    };
+    const ctx = { workspaceDir, agentId: "main", sessionKey: SESSION_KEY };
+    const config = { skills: { workshop: { autonomous: { enabled: true } } } };
+
+    await runSkillResearchAutoCapture({
+      event: { success: true, messages: [previous] },
+      ctx,
+      config,
+    });
+    await runSkillResearchAutoCapture({
+      event: { success: false, messages: [previous, newCorrection] },
+      ctx,
+      config,
+    });
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    expect(proposals.proposals).toHaveLength(2);
+    const screenshotEntry = proposals.proposals.find(
+      (entry) => entry.skillKey === "screenshot-asset-workflow",
+    );
+    expect(screenshotEntry).toBeDefined();
+    const screenshot = await inspectSkillProposal(screenshotEntry?.id ?? "", { workspaceDir });
+    expect(screenshot?.content).toContain("optimize screenshot assets");
+    expect(screenshot?.content).not.toContain("check CI before final response");
+  });
+
+  it("performs no workspace skill discovery when the turn has no durable signal", async () => {
+    const workspaceDir = await makeWorkspace();
+    const discovery = vi.spyOn(workshopService, "listWritableWorkspaceSkillSummaries");
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [{ role: "user", content: "Please review this pull request." }],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+    });
+
+    expect(discovery).not.toHaveBeenCalled();
+    discovery.mockRestore();
+  });
+
+  it("suggests saving a correction into an existing routed skill", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillFile = path.join(workspaceDir, "skills", "signal-scout", "SKILL.md");
+    await fs.mkdir(path.dirname(skillFile), { recursive: true });
+    await fs.writeFile(
+      skillFile,
+      [
+        "---",
+        'name: "signal-scout"',
+        'description: "Mine market signals before drafting."',
+        "---",
+        "",
+        "# Signal Scout",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content:
+              "I thought we agreed to capture quoted market signals before drafting anything.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+    });
+
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+    expect(readSession()?.pendingSkillSuggestion).toMatchObject({ skillName: "signal-scout" });
+  });
+
+  it("suggests an inferred topic when its exact skill already exists", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillFile = path.join(workspaceDir, "skills", "github-pr-workflow", "SKILL.md");
+    await fs.mkdir(path.dirname(skillFile), { recursive: true });
+    await fs.writeFile(
+      skillFile,
+      [
+        "---",
+        'name: "github-pr-workflow"',
+        'description: "Release checklist."',
+        "---",
+        "",
+        "# GitHub PR Workflow",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content:
+              "From now on, for pull requests, always inspect the exact head before landing.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+    });
+
+    expect(readSession()?.pendingSkillSuggestion).toMatchObject({
+      skillName: "github-pr-workflow",
+    });
+  });
+
+  it("never revises a manual pending proposal for the same skill", async () => {
+    const workspaceDir = await makeWorkspace();
+    const manual = await proposeCreateSkill({
+      workspaceDir,
+      name: "github-pr-workflow",
+      description: "Manual GitHub workflow proposal.",
+      content: "# GitHub PR Workflow\n\n- Manual draft.\n",
+      createdBy: "cli",
+    });
 
     await runSkillResearchAutoCapture({
       event: {
@@ -327,7 +891,53 @@ describe("skill research auto-capture", () => {
         ],
       },
       ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config: { skills: { workshop: { autonomous: { enabled: true } } } },
     });
+
+    const proposals = await listSkillProposals({ workspaceDir });
+    expect(proposals.proposals).toHaveLength(1);
+    const unchanged = await inspectSkillProposal(manual.record.id, { workspaceDir });
+    expect(unchanged?.record.createdBy).toBe("cli");
+    expect(unchanged?.record.proposedVersion).toBe("v1");
+  });
+
+  it("bounds captured signal fingerprints to the newest 32", async () => {
+    await recordSessionSkillCaptureSignals({
+      agentId: "main",
+      sessionKey: SESSION_KEY,
+      signalHashes: Array.from({ length: 40 }, (_, index) => `hash-${index}`),
+    });
+
+    expect(readSession()?.skillCaptureSignalHashes).toEqual(
+      Array.from({ length: 32 }, (_, index) => `hash-${index + 8}`),
+    );
+  });
+
+  it("does not re-suggest a dismissed fingerprint", async () => {
+    const workspaceDir = await makeWorkspace();
+    const event = {
+      success: true,
+      messages: [
+        {
+          role: "user",
+          content: "Remember to always verify generated screenshots before replying.",
+        },
+      ],
+    };
+    const ctx = { workspaceDir, agentId: "main", sessionKey: SESSION_KEY };
+
+    await runSkillResearchAutoCapture({ event, ctx });
+    expect(
+      (
+        await consumeSessionSkillSuggestion({
+          agentId: "main",
+          sessionKey: SESSION_KEY,
+        })
+      )?.suggestion,
+    ).toBeDefined();
+    await runSkillResearchAutoCapture({ event, ctx });
+
     expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
   });
 });

--- a/src/skills/research/autocapture.ts
+++ b/src/skills/research/autocapture.ts
@@ -1,14 +1,34 @@
-// Research autocapture helpers decide when skill research signals should be captured.
+// Research autocapture helpers coordinate replay-safe capture and suggestion state.
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { resolveStorePath } from "../../config/sessions/paths.js";
-import { recordSessionSkillSuggestion } from "../../config/sessions/skill-suggestions.js";
+import {
+  claimSessionSkillCaptureSignals,
+  readSessionSkillCaptureSignalHashes,
+  recordSessionSkillCaptureSignals,
+  recordSessionSkillSuggestion,
+  releaseSessionSkillCaptureSignals,
+} from "../../config/sessions/skill-suggestions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { readWorkspaceSkillFile } from "../lifecycle/workspace-skill-write.js";
 import { resolveSkillWorkshopConfig } from "../workshop/config.js";
-import { listSkillProposals, proposeCreateSkill, proposeUpdateSkill } from "../workshop/service.js";
+import { stripProposalFrontmatterForSkill } from "../workshop/frontmatter.js";
+import {
+  inspectSkillProposal,
+  listSkillProposals,
+  listWritableWorkspaceSkillSummaries,
+  proposeCreateSkill,
+  proposeUpdateSkill,
+  reviseSkillProposal,
+} from "../workshop/service.js";
 import { resolveSkillProposalTarget } from "../workshop/store.js";
-import { extractDurableInstructionProposal } from "./signals.js";
+import {
+  type DurableInstruction,
+  extractDurableInstructions,
+  groupDurableInstructionProposals,
+} from "./signals.js";
+import { compactWhitespace } from "./text.js";
 
 type SkillResearchAgentEndEvent = {
   messages: unknown[];
@@ -26,6 +46,9 @@ type SkillResearchAgentContext = {
 const log = createSubsystemLogger("skills/research");
 const AUTO_CAPTURE_BLOCKED_TRIGGERS = new Set(["cron", "heartbeat", "memory", "overflow"]);
 const AUTO_CAPTURE_BLOCKED_SESSION_SEGMENTS = new Set(["cron", "hook", "subagent"]);
+const TOOL_CALL_BLOCK_TYPES = new Set(["toolCall", "tool_use", "function_call"]);
+const SKILL_WORKSHOP_MUTATING_ACTIONS = new Set(["create", "update", "revise"]);
+const skillCaptureQueue = new KeyedAsyncQueue();
 
 // Captured updates append below existing skill text so learned context stays auditable.
 function buildAutoCaptureUpdateContent(existingSkill: string, capturedContent: string): string {
@@ -52,16 +75,142 @@ function isSkillResearchAutoCaptureEligible(ctx: SkillResearchAgentContext): boo
     .some((segment) => AUTO_CAPTURE_BLOCKED_SESSION_SEGMENTS.has(segment));
 }
 
-/** Captures or suggests durable skill research signals from a completed session turn. */
+function readToolCallAction(value: unknown): string | undefined {
+  let input = value;
+  if (typeof input === "string") {
+    try {
+      input = JSON.parse(input) as unknown;
+    } catch {
+      return undefined;
+    }
+  }
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return undefined;
+  }
+  const action = (input as { action?: unknown }).action;
+  return typeof action === "string" ? action.trim().toLowerCase() : undefined;
+}
+
+function isSkillWorkshopMutationBlock(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const block = value as {
+    type?: unknown;
+    name?: unknown;
+    arguments?: unknown;
+    input?: unknown;
+    args?: unknown;
+  };
+  if (!TOOL_CALL_BLOCK_TYPES.has(String(block.type))) {
+    return false;
+  }
+  if (typeof block.name !== "string" || block.name.trim().toLowerCase() !== "skill_workshop") {
+    return false;
+  }
+  const action = readToolCallAction(block.arguments ?? block.input ?? block.args);
+  return action ? SKILL_WORKSHOP_MUTATING_ACTIONS.has(action) : false;
+}
+
+function hasUnfailedSkillWorkshopMutationCall(messages: readonly unknown[]): boolean {
+  const callIds = new Set<string>();
+  let hasUnidentifiedCall = false;
+  for (const message of messages) {
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      continue;
+    }
+    const content = (message as { content?: unknown }).content;
+    const blocks = Array.isArray(content) ? content : [content];
+    for (const block of blocks) {
+      if (!isSkillWorkshopMutationBlock(block)) {
+        continue;
+      }
+      const id =
+        block && typeof block === "object" && !Array.isArray(block)
+          ? (block as { id?: unknown }).id
+          : undefined;
+      if (typeof id === "string" && id) {
+        callIds.add(id);
+      } else {
+        hasUnidentifiedCall = true;
+      }
+    }
+  }
+  if (hasUnidentifiedCall) {
+    return true;
+  }
+  for (const message of messages) {
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      continue;
+    }
+    const result = message as { role?: unknown; toolCallId?: unknown; isError?: unknown };
+    if (
+      result.role === "toolResult" &&
+      result.isError === true &&
+      typeof result.toolCallId === "string"
+    ) {
+      callIds.delete(result.toolCallId);
+    }
+  }
+  return callIds.size > 0;
+}
+
+function currentTurnMessages(messages: readonly unknown[]): readonly unknown[] {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (
+      message &&
+      typeof message === "object" &&
+      !Array.isArray(message) &&
+      (message as { role?: unknown }).role === "user"
+    ) {
+      return messages.slice(index);
+    }
+  }
+  return messages;
+}
+
+function fingerprintInstructions(instructions: readonly string[]): string {
+  const normalized = instructions
+    .map((instruction) => compactWhitespace(instruction).toLowerCase())
+    .join("\n");
+  return sha256Hex(normalized);
+}
+
+function proposalSignalHashes(proposal: DurableInstruction): string[] {
+  return [
+    ...new Set([
+      ...proposal.instructions.map((instruction) => fingerprintInstructions([instruction])),
+      fingerprintInstructions(proposal.instructions),
+    ]),
+  ];
+}
+
+function instructionSignalHashes(instructions: readonly string[]): string[] {
+  return [...new Set(instructions.map((instruction) => fingerprintInstructions([instruction])))];
+}
+
+function buildProposalOrigin(ctx: SkillResearchAgentContext) {
+  return {
+    ...(ctx.agentId ? { agentId: ctx.agentId } : {}),
+    ...(ctx.sessionKey ? { sessionKey: ctx.sessionKey } : {}),
+    ...(ctx.runId ? { runId: ctx.runId } : {}),
+  };
+}
+
+/**
+ * Captures or suggests durable skill research signals from a completed session turn.
+ *
+ * Runs regardless of the turn's success flag: the extracted signals are the user's own words,
+ * which stay valid when a run fails — corrections given in a failed or timed-out turn are the
+ * ones most worth keeping.
+ */
 export async function runSkillResearchAutoCapture(params: {
   event: SkillResearchAgentEndEvent;
   ctx: SkillResearchAgentContext;
   config?: OpenClawConfig;
 }): Promise<void> {
   const workshopConfig = resolveSkillWorkshopConfig(params.config);
-  if (params.event.success === false) {
-    return;
-  }
   const workspaceDir = params.ctx.workspaceDir;
   if (!workspaceDir) {
     return;
@@ -69,87 +218,219 @@ export async function runSkillResearchAutoCapture(params: {
   if (!isSkillResearchAutoCaptureEligible(params.ctx)) {
     return;
   }
-
-  const proposal = extractDurableInstructionProposal({ messages: params.event.messages });
-  if (!proposal) {
+  const sessionKey = params.ctx.sessionKey?.trim();
+  if (!sessionKey) {
     return;
   }
-
-  const manifest = await listSkillProposals({ workspaceDir });
-  if (
-    manifest.proposals.some(
-      (entry) =>
-        (entry.status === "pending" || entry.status === "quarantined") &&
-        entry.skillKey === proposal.skillName,
-    )
-  ) {
-    return;
-  }
-
-  if (!workshopConfig.autonomous.enabled) {
-    const sessionKey = params.ctx.sessionKey?.trim();
-    if (!sessionKey) {
+  const sessionScope = {
+    agentId: params.ctx.agentId,
+    sessionKey,
+    storePath: resolveStorePath(params.config?.session?.store, {
+      agentId: params.ctx.agentId,
+    }),
+  };
+  // Proposals are workspace-scoped, so different sessions must not inspect and revise the same
+  // pending draft concurrently from stale content.
+  await skillCaptureQueue.enqueue(workspaceDir, async () => {
+    const turnMessages = currentTurnMessages(params.event.messages);
+    if (hasUnfailedSkillWorkshopMutationCall(turnMessages)) {
+      const signalHashes = extractDurableInstructions([...turnMessages]).map((instruction) =>
+        fingerprintInstructions([instruction]),
+      );
+      await recordSessionSkillCaptureSignals({ ...sessionScope, signalHashes });
       return;
     }
-    try {
-      const target = resolveSkillProposalTarget({
-        workspaceDir,
-        skillName: proposal.skillName,
-      });
-      if ((await readWorkspaceSkillFile(target.skillFile)) !== null) {
+
+    const capturedSignalHashes = readSessionSkillCaptureSignalHashes(sessionScope);
+    if (!capturedSignalHashes) {
+      return;
+    }
+    const capturedSignals = new Set(capturedSignalHashes);
+    const instructions = extractDurableInstructions(params.event.messages).filter(
+      (instruction) => !capturedSignals.has(fingerprintInstructions([instruction])),
+    );
+    if (instructions.length === 0) {
+      return;
+    }
+
+    // Discovery runs only after cheap signal extraction, and uses the same writable status as
+    // proposeUpdateSkill (including .agents/skills project skills).
+    const existingSkills = listWritableWorkspaceSkillSummaries(workspaceDir, {
+      config: params.config,
+      agentId: params.ctx.agentId,
+    });
+    const proposals = groupDurableInstructionProposals({
+      instructions,
+      existingSkills,
+    });
+    if (proposals.length === 0) {
+      return;
+    }
+
+    const manifest = await listSkillProposals({ workspaceDir });
+    const allInstructionSignalHashes = instructionSignalHashes(instructions);
+    if (!workshopConfig.autonomous.enabled) {
+      const proposal = proposals.at(-1);
+      if (!proposal) {
         return;
       }
-      const recorded = await recordSessionSkillSuggestion({
-        agentId: params.ctx.agentId,
-        sessionKey,
-        storePath: resolveStorePath(params.config?.session?.store, {
-          agentId: params.ctx.agentId,
-        }),
-        skillName: target.skillKey,
-        signalHash: sha256Hex(proposal.evidence),
-      });
-      if (recorded) {
-        log.info(`skill research queued suggestion ${target.skillKey}`);
+      const signalHashes = proposalSignalHashes(proposal);
+      const signalHash = signalHashes.at(-1);
+      if (!signalHash || capturedSignals.has(signalHash)) {
+        return;
       }
-    } catch (error) {
-      log.warn(`skill research suggestion skipped: ${String(error)}`);
-    }
-    return;
-  }
-
-  try {
-    const target = resolveSkillProposalTarget({
-      workspaceDir,
-      skillName: proposal.skillName,
-    });
-    const existingSkill = await readWorkspaceSkillFile(target.skillFile);
-    const result =
-      existingSkill === null
-        ? await proposeCreateSkill({
+      if (
+        manifest.proposals.some(
+          (entry) =>
+            (entry.status === "pending" || entry.status === "quarantined") &&
+            entry.skillKey === proposal.skillName,
+        )
+      ) {
+        await recordSessionSkillCaptureSignals({
+          ...sessionScope,
+          signalHashes: [...allInstructionSignalHashes, ...signalHashes],
+        });
+        return;
+      }
+      try {
+        if (!proposal.existingSkill) {
+          const target = resolveSkillProposalTarget({
             workspaceDir,
-            config: params.config,
-            name: proposal.skillName,
-            description: proposal.description,
-            content: proposal.content,
-            createdBy: "skill-workshop",
-            goal: proposal.goal,
-            evidence: proposal.evidence,
-          })
-        : await proposeUpdateSkill({
-            workspaceDir,
-            config: params.config,
-            agentId: params.ctx.agentId,
             skillName: proposal.skillName,
-            description: proposal.description,
-            content: buildAutoCaptureUpdateContent(existingSkill, proposal.content),
-            createdBy: "skill-workshop",
-            goal: proposal.goal,
-            evidence: proposal.evidence,
           });
-    log.info(
-      `skill research auto-capture queued workshop proposal ${result.record.target.skillKey}`,
+          if ((await readWorkspaceSkillFile(target.skillFile)) !== null) {
+            await recordSessionSkillCaptureSignals({
+              ...sessionScope,
+              signalHashes: [...allInstructionSignalHashes, ...signalHashes],
+            });
+            return;
+          }
+        }
+        const recorded = await recordSessionSkillSuggestion({
+          ...sessionScope,
+          skillName: proposal.skillName,
+          signalHash,
+          relatedSignalHashes: [...allInstructionSignalHashes, ...signalHashes.slice(0, -1)],
+        });
+        if (recorded) {
+          log.info(`skill research queued suggestion ${proposal.skillName}`);
+        }
+      } catch (error) {
+        log.warn(`skill research suggestion skipped: ${String(error)}`);
+      }
+      return;
+    }
+
+    const selectedInstructionHashes = new Set(
+      proposals.flatMap((proposal) => instructionSignalHashes(proposal.instructions)),
     );
-  } catch (error) {
-    log.warn(`skill research auto-capture skipped: ${String(error)}`);
-  }
+    await recordSessionSkillCaptureSignals({
+      ...sessionScope,
+      signalHashes: allInstructionSignalHashes.filter(
+        (hash) => !selectedInstructionHashes.has(hash),
+      ),
+    });
+
+    for (const proposal of proposals) {
+      const signalHashes = proposalSignalHashes(proposal);
+      const signalHash = signalHashes.at(-1);
+      if (!signalHash || capturedSignals.has(signalHash)) {
+        continue;
+      }
+
+      const claimedSignalHashes = await claimSessionSkillCaptureSignals({
+        ...sessionScope,
+        signalHash,
+        signalHashes,
+      });
+      if (!claimedSignalHashes) {
+        continue;
+      }
+      for (const hash of claimedSignalHashes) {
+        capturedSignals.add(hash);
+      }
+
+      try {
+        const sameSkillEntries = manifest.proposals.filter(
+          (entry) => entry.skillKey === proposal.skillName,
+        );
+        if (sameSkillEntries.some((entry) => entry.status === "quarantined")) {
+          await recordSessionSkillCaptureSignals({ ...sessionScope, signalHashes });
+          continue;
+        }
+        const pendingEntries = sameSkillEntries.filter((entry) => entry.status === "pending");
+        let autocapturePending:
+          | NonNullable<Awaited<ReturnType<typeof inspectSkillProposal>>>
+          | undefined;
+        for (const entry of pendingEntries) {
+          const inspected = await inspectSkillProposal(entry.id, { workspaceDir });
+          if (inspected?.record.createdBy === "skill-workshop") {
+            autocapturePending = inspected;
+            break;
+          }
+        }
+        if (pendingEntries.length > 0 && !autocapturePending) {
+          await recordSessionSkillCaptureSignals({ ...sessionScope, signalHashes });
+          continue;
+        }
+
+        // A routed proposal matches a writable skill summary; its filePath is the live SKILL.md.
+        // Inferred-topic proposals fall back to the flat layout the workshop uses for creates.
+        const matched = existingSkills.find((entry) => entry.name === proposal.skillName);
+        const skillFile =
+          matched?.filePath ??
+          resolveSkillProposalTarget({ workspaceDir, skillName: proposal.skillName }).skillFile;
+        const existingSkill = await readWorkspaceSkillFile(skillFile);
+        const result = autocapturePending
+          ? await reviseSkillProposal({
+              workspaceDir,
+              config: params.config,
+              proposalId: autocapturePending.record.id,
+              content: buildAutoCaptureUpdateContent(
+                stripProposalFrontmatterForSkill(autocapturePending.content),
+                proposal.content,
+              ),
+              evidence: [autocapturePending.record.evidence, proposal.evidence]
+                .filter((value): value is string => Boolean(value))
+                .join("\n"),
+            })
+          : existingSkill === null
+            ? await proposeCreateSkill({
+                workspaceDir,
+                config: params.config,
+                name: proposal.skillName,
+                description: proposal.description,
+                content: proposal.content,
+                createdBy: "skill-workshop",
+                origin: buildProposalOrigin(params.ctx),
+                goal: proposal.goal,
+                evidence: proposal.evidence,
+              })
+            : await proposeUpdateSkill({
+                workspaceDir,
+                config: params.config,
+                agentId: params.ctx.agentId,
+                skillName: proposal.skillName,
+                description: proposal.description,
+                content: buildAutoCaptureUpdateContent(existingSkill, proposal.content),
+                createdBy: "skill-workshop",
+                origin: buildProposalOrigin(params.ctx),
+                goal: proposal.goal,
+                evidence: proposal.evidence,
+              });
+        log.info(
+          `skill research auto-capture queued workshop proposal ${result.record.target.skillKey}`,
+        );
+      } catch (error) {
+        await releaseSessionSkillCaptureSignals({
+          ...sessionScope,
+          signalHashes: claimedSignalHashes,
+        });
+        for (const hash of claimedSignalHashes) {
+          capturedSignals.delete(hash);
+        }
+        log.warn(`skill research auto-capture skipped ${proposal.skillName}: ${String(error)}`);
+      }
+    }
+  });
 }

--- a/src/skills/research/signals.test.ts
+++ b/src/skills/research/signals.test.ts
@@ -1,0 +1,125 @@
+// Signal extraction tests cover reactive/prospective patterns, grouping, and skill routing.
+import { describe, expect, it } from "vitest";
+import { extractDurableInstructionProposals } from "./signals.js";
+
+function userMessage(content: string): { role: string; content: string } {
+  return { role: "user", content };
+}
+
+describe("extractDurableInstructionProposals", () => {
+  it.each([
+    "From now on, when working on GitHub PRs, always check CI before final response.",
+    "Going forward every draft should include the source links at the bottom for me.",
+    "That's not what I asked for — only use the rule banks, never their delivery style.",
+    "You're still using the transcripts as tone references, cut that out of the drafts.",
+    "Stop building scorecards before we have any captured evidence in the ledger first.",
+    "I told you the raw scripts are all coach data, there is no creator data here yet.",
+    "I don't wanna have to repeat myself about the sources block in every new script.",
+    "Those scores should never have been invented without real market evidence behind them.",
+    "I thought we were working on listening, not scoring — capture the signal first.",
+  ])("captures: %s", (content) => {
+    const proposals = extractDurableInstructionProposals({ messages: [userMessage(content)] });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].evidence).toContain(content.slice(20, 40).trim());
+  });
+
+  it.each([
+    "yo this script is bomb",
+    "Can you just go ahead and build it?",
+    "That looks great, thanks so much for the quick turnaround on this one today.",
+    "What is the current state of the trends inbox and the reference library now?",
+  ])("ignores: %s", (content) => {
+    expect(extractDurableInstructionProposals({ messages: [userMessage(content)] })).toHaveLength(
+      0,
+    );
+  });
+
+  it("groups multiple corrections about one topic into a single proposal", () => {
+    const proposals = extractDurableInstructionProposals({
+      messages: [
+        userMessage("From now on, when working on GitHub PRs, always check CI before replying."),
+        userMessage("Next time on a GitHub PR, make sure to link the issue in the description."),
+      ],
+    });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].skillName).toBe("github-pr-workflow");
+    expect(proposals[0].content).toContain("always check CI");
+    expect(proposals[0].content).toContain("link the issue");
+  });
+
+  it("routes corrections to an existing skill by shared vocabulary", () => {
+    const proposals = extractDurableInstructionProposals({
+      messages: [
+        userMessage(
+          "Stop building concept cards before the signal capture has real market evidence.",
+        ),
+      ],
+      existingSkills: [
+        { name: "signal-scout", description: "Mine the market for signals and validate them." },
+        { name: "content-develop", description: "Draft scripts in the persona voice." },
+      ],
+    });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].skillName).toBe("signal-scout");
+  });
+
+  it("falls back to inferred topics when no existing skill matches", () => {
+    const proposals = extractDurableInstructionProposals({
+      messages: [
+        userMessage("Remember to always optimize screenshot assets before attaching them."),
+      ],
+      existingSkills: [
+        { name: "signal-scout", description: "Mine the market for signals and validate them." },
+      ],
+    });
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0].skillName).toBe("screenshot-asset-workflow");
+  });
+
+  it("caps the number of proposals, keeping the most recent topics", () => {
+    const proposals = extractDurableInstructionProposals({
+      messages: [
+        userMessage("From now on, when working on GitHub PRs, always check CI before replying."),
+        userMessage("Remember to always optimize screenshot assets before attaching them."),
+        userMessage("Next time a QA scenario runs, make sure to record the failing seed value."),
+        userMessage("From now on animated GIF exports must always use the two-pass palette."),
+      ],
+      maxProposals: 2,
+    });
+    expect(proposals.map((proposal) => proposal.skillName)).toEqual([
+      "qa-scenario-workflow",
+      "animated-gif-workflow",
+    ]);
+  });
+
+  it("keeps a repeated topic when its latest correction is the most recent", () => {
+    const proposals = extractDurableInstructionProposals({
+      messages: [
+        userMessage("From now on, when working on GitHub PRs, always check CI before replying."),
+        userMessage("Remember to always optimize screenshot assets before attaching them."),
+        userMessage("Next time a QA scenario runs, make sure to record the failing seed value."),
+        userMessage("Next time on a GitHub PR, make sure to link the issue in the description."),
+      ],
+      maxProposals: 2,
+    });
+    expect(proposals.map((proposal) => proposal.skillName)).toEqual([
+      "qa-scenario-workflow",
+      "github-pr-workflow",
+    ]);
+    const github = proposals.find((proposal) => proposal.skillName === "github-pr-workflow");
+    expect(github?.content).toContain("always check CI");
+    expect(github?.content).toContain("link the issue");
+  });
+
+  it("ignores non-user transcript entries", () => {
+    const proposals = extractDurableInstructionProposals({
+      messages: [
+        {
+          role: "assistant",
+          content: "From now on I will always check CI before the final response.",
+        },
+      ],
+    });
+    expect(proposals).toHaveLength(0);
+  });
+});

--- a/src/skills/research/signals.ts
+++ b/src/skills/research/signals.ts
@@ -2,9 +2,14 @@
 import { normalizeSkillIndexName } from "../discovery/skill-index.js";
 import { compactWhitespace, extractTranscriptText } from "./text.js";
 
-const CORRECTION_PATTERNS = [
+// Durable signals arrive in two shapes: prospective rules ("from now on…") and reactive
+// corrections ("that's not what I asked", "you're still using X", "I thought we were…").
+// Reactive phrasing dominates real sessions — users mostly push back on what just happened
+// rather than dictate future policy — so both shapes are captured.
+const PROSPECTIVE_PATTERNS = [
   /\bnext time\b/i,
   /\bfrom now on\b/i,
+  /\bgoing forward\b/i,
   /\bremember to\b/i,
   /\bmake sure to\b/i,
   /\balways\b.{0,80}\b(use|check|verify|record|save|prefer)\b/i,
@@ -12,12 +17,64 @@ const CORRECTION_PATTERNS = [
   /\bwhen asked\b/i,
 ];
 
-type DurableInstruction = {
+const REACTIVE_PATTERNS = [
+  /\b(?:that|this|it)(?:'s| is| was)? (?:wrong|not what i (?:asked|meant|said|wanted))\b/i,
+  /\bdon'?t\b.{0,60}\bagain\b/i,
+  /\bstop (?:using|doing|making|building|adding)\b/i,
+  /\bstill (?:using|doing|making|ignoring)\b/i,
+  /\b(?:i|we) (?:told|asked) you\b/i,
+  /\brepeat myself\b/i,
+  /\bshould (?:not|never) (?:have|be)\b/i,
+  /\bi thought (?:we|you) (?:were|was|would|agreed)\b/i,
+];
+
+const CORRECTION_PATTERNS = [...PROSPECTIVE_PATTERNS, ...REACTIVE_PATTERNS];
+
+// Bound the sweep so a long session can't flood the workshop with proposals.
+const MAX_CAPTURED_INSTRUCTIONS = 8;
+const DEFAULT_MAX_PROPOSALS = 3;
+// An existing skill must share at least this much vocabulary before a correction routes to it.
+const SKILL_MATCH_MIN_SCORE = 2;
+
+const SKILL_MATCH_STOPWORDS = new Set([
+  "and",
+  "are",
+  "before",
+  "but",
+  "for",
+  "from",
+  "have",
+  "into",
+  "not",
+  "should",
+  "that",
+  "the",
+  "them",
+  "then",
+  "they",
+  "this",
+  "was",
+  "were",
+  "what",
+  "when",
+  "with",
+  "you",
+  "your",
+]);
+
+export type WorkspaceSkillSummary = {
+  name: string;
+  description?: string;
+};
+
+export type DurableInstruction = {
   skillName: string;
   description: string;
   content: string;
   goal: string;
   evidence: string;
+  instructions: string[];
+  existingSkill: boolean;
 };
 
 // Topic inference stays conservative so autocapture proposes broad skills, not brittle names.
@@ -40,7 +97,7 @@ function inferTopic(text: string): { skillName: string; title: string; label: st
   if (/\bqa\b|\bscenario\b|\btest plan\b/.test(lower)) {
     return { skillName: "qa-scenario-workflow", title: "QA Scenario Workflow", label: "QA tasks" };
   }
-  if (/\bpr\b|\bpull request\b|\bgithub\b/.test(lower)) {
+  if (/\bpr\b|\bpull requests?\b|\bgithub\b/.test(lower)) {
     return {
       skillName: "github-pr-workflow",
       title: "GitHub PR Workflow",
@@ -61,34 +118,185 @@ function extractInstruction(text: string): string | undefined {
   return trimmed.replace(/^ok[,. ]+/i, "");
 }
 
-/** Extracts a candidate durable instruction from transcript text. */
-export function extractDurableInstructionProposal(params: {
-  messages: unknown[];
-}): DurableInstruction | undefined {
-  const transcript = extractTranscriptText(params.messages);
-  const userTexts = transcript.filter((entry) => entry.role === "user").map((entry) => entry.text);
-  const instruction = userTexts.map(extractInstruction).findLast(Boolean);
-  if (!instruction) {
-    return undefined;
+function tokenizeForSkillMatch(value: string): string[] {
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length >= 3 && !SKILL_MATCH_STOPWORDS.has(token));
+}
+
+// Cheap singular/plural equivalence keeps "coaches" matching a "coach-distiller" skill
+// without pulling in a stemmer.
+function skillTokensMatch(a: string, b: string): boolean {
+  if (a === b) {
+    return true;
   }
-  const topic = inferTopic(instruction);
-  const skillName = normalizeSkillIndexName(topic.skillName);
+  return a === `${b}s` || b === `${a}s` || a === `${b}es` || b === `${a}es`;
+}
+
+// Routes a correction to the existing skill it is most plausibly about. Skill-name vocabulary
+// counts double so "signal" routes to signal-scout even when the description barely overlaps.
+function matchExistingSkill(
+  instruction: string,
+  skills: readonly WorkspaceSkillSummary[],
+): WorkspaceSkillSummary | undefined {
+  let best: WorkspaceSkillSummary | undefined;
+  let bestScore = 0;
+  const instructionTokens = new Set(tokenizeForSkillMatch(instruction));
+  for (const skill of skills) {
+    const nameTokens = tokenizeForSkillMatch(skill.name.replace(/-/g, " "));
+    const descriptionTokens = tokenizeForSkillMatch(skill.description ?? "");
+    let score = 0;
+    for (const token of instructionTokens) {
+      if (nameTokens.some((candidate) => skillTokensMatch(candidate, token))) {
+        score += 2;
+      } else if (descriptionTokens.some((candidate) => skillTokensMatch(candidate, token))) {
+        score += 1;
+      }
+    }
+    if (score > bestScore) {
+      bestScore = score;
+      best = skill;
+    }
+  }
+  return bestScore >= SKILL_MATCH_MIN_SCORE ? best : undefined;
+}
+
+function titleFromSkillName(skillName: string): string {
+  return skillName
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function buildInstructionGroup(params: {
+  skillName: string;
+  title: string;
+  label: string;
+  instructions: string[];
+  existingSkill: boolean;
+}): DurableInstruction | undefined {
+  const skillName = normalizeSkillIndexName(params.skillName);
   if (!skillName) {
     return undefined;
   }
   return {
     skillName,
-    description: `Reusable workflow notes for ${topic.label}.`,
-    goal: `Capture durable user correction for ${topic.label}.`,
-    evidence: instruction,
+    description: `Reusable workflow notes for ${params.label}.`,
+    goal: `Capture durable user corrections for ${params.label}.`,
+    evidence: params.instructions.join("\n"),
+    instructions: [...params.instructions],
+    existingSkill: params.existingSkill,
     content: [
-      `# ${topic.title}`,
+      `# ${params.title}`,
       "",
       "## Workflow",
       "",
-      `- ${instruction}`,
+      ...params.instructions.map((instruction) => `- ${instruction}`),
       "- Verify the result before final reply.",
       "- Record durable pitfalls as short bullets; avoid copying transcript noise.",
     ].join("\n"),
   };
+}
+
+/**
+ * Cheaply extracts candidate durable instructions from transcript text, newest last.
+ */
+export function extractDurableInstructions(messages: unknown[]): string[] {
+  const transcript = extractTranscriptText(messages);
+  const userTexts = transcript.filter((entry) => entry.role === "user").map((entry) => entry.text);
+  const instructions: string[] = [];
+  for (const text of userTexts) {
+    const instruction = extractInstruction(text);
+    if (instruction && !instructions.includes(instruction)) {
+      instructions.push(instruction);
+    }
+  }
+  return instructions.slice(-MAX_CAPTURED_INSTRUCTIONS);
+}
+
+/**
+ * Routes and groups already-extracted instructions into one proposal per target skill.
+ */
+export function groupDurableInstructionProposals(params: {
+  instructions: readonly string[];
+  existingSkills?: readonly WorkspaceSkillSummary[];
+  maxProposals?: number;
+}): DurableInstruction[] {
+  if (params.instructions.length === 0) {
+    return [];
+  }
+
+  const groups = new Map<
+    string,
+    { title: string; label: string; instructions: string[]; existingSkill: boolean }
+  >();
+  for (const instruction of params.instructions) {
+    const inferred = inferTopic(instruction);
+    const existingSkills = params.existingSkills ?? [];
+    const existing =
+      matchExistingSkill(instruction, existingSkills) ??
+      existingSkills.find((skill) => normalizeSkillIndexName(skill.name) === inferred.skillName);
+    const topic = existing
+      ? {
+          skillName: existing.name,
+          title: titleFromSkillName(existing.name),
+          label: `the ${existing.name} skill`,
+        }
+      : inferred;
+    const group = groups.get(topic.skillName);
+    if (group) {
+      group.instructions.push(instruction);
+      // Re-insert so the recency cap ranks topics by their LATEST correction, not their first.
+      groups.delete(topic.skillName);
+      groups.set(topic.skillName, group);
+    } else {
+      groups.set(topic.skillName, {
+        title: topic.title,
+        label: topic.label,
+        instructions: [instruction],
+        existingSkill: Boolean(existing),
+      });
+    }
+  }
+
+  const maxProposals = params.maxProposals ?? DEFAULT_MAX_PROPOSALS;
+  const proposals: DurableInstruction[] = [];
+  // Most recent groups win when the cap bites — later corrections carry the freshest intent.
+  for (const [skillName, group] of [...groups.entries()].slice(-maxProposals)) {
+    const proposal = buildInstructionGroup({
+      skillName,
+      title: group.title,
+      label: group.label,
+      instructions: group.instructions,
+      existingSkill: group.existingSkill,
+    });
+    if (proposal) {
+      proposals.push(proposal);
+    }
+  }
+  return proposals;
+}
+
+/**
+ * Extracts, routes, and groups durable instructions. Runtime capture uses the two phase helpers
+ * above so signal-free turns can return before workspace skill discovery.
+ */
+export function extractDurableInstructionProposals(params: {
+  messages: unknown[];
+  existingSkills?: readonly WorkspaceSkillSummary[];
+  maxProposals?: number;
+}): DurableInstruction[] {
+  return groupDurableInstructionProposals({
+    instructions: extractDurableInstructions(params.messages),
+    existingSkills: params.existingSkills,
+    maxProposals: params.maxProposals,
+  });
+}
+
+/** Extracts a single candidate durable instruction; kept for callers that want one proposal. */
+export function extractDurableInstructionProposal(params: {
+  messages: unknown[];
+}): DurableInstruction | undefined {
+  return extractDurableInstructionProposals({ ...params, maxProposals: 1 }).at(-1);
 }

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -304,6 +304,40 @@ export async function proposeCreateSkill(
   return { record, content: proposalContent };
 }
 
+/** Summary of a workspace skill the workshop is allowed to write. */
+export type WritableWorkspaceSkillSummary = {
+  name: string;
+  description?: string;
+  filePath: string;
+};
+
+/**
+ * Lists the workspace skills the workshop can target with update proposals, using the same
+ * status discovery as `proposeUpdateSkill` so callers that route corrections to existing
+ * skills stay in lockstep with what an update can actually write.
+ */
+export function listWritableWorkspaceSkillSummaries(
+  workspaceDir: string,
+  opts?: { config?: OpenClawConfig; agentId?: string },
+): WritableWorkspaceSkillSummary[] {
+  const status = buildWorkspaceSkillStatus(workspaceDir, {
+    config: opts?.config,
+    agentId: opts?.agentId,
+  });
+  const summaries: WritableWorkspaceSkillSummary[] = [];
+  for (const skill of status.skills) {
+    if (!WRITABLE_WORKSPACE_SOURCES.has(skill.source)) {
+      continue;
+    }
+    summaries.push(
+      skill.description
+        ? { name: skill.skillKey, description: skill.description, filePath: skill.filePath }
+        : { name: skill.skillKey, filePath: skill.filePath },
+    );
+  }
+  return summaries;
+}
+
 export async function proposeUpdateSkill(
   input: SkillProposalUpdateInput & SkillWorkshopWorkspaceOptions,
 ): Promise<SkillProposalReadResult> {


### PR DESCRIPTION
## What Problem This Solves

Skill auto-capture missed reactive corrections, could route tied matches to an arbitrary skill, overwrote existing skill descriptions, replayed historical transcript signals, and could double-capture explicit `/learn` requests. Current `main` also has a default suggestion tier, so suggestion and autonomous capture need one coordinated signal and provenance path.

## Why This Change Was Made

- Detect prospective instructions and conservative reactive corrections, grouped by topic.
- Pass the exact current-turn user messages from CLI, embedded, Codex app-server, and Copilot runners. Existing SDK/native callers retain the previous event-message fallback.
- Route only unique matches to writable workspace skills, including `.agents/skills`, while preserving existing skill descriptions.
- Revise only pending proposals created by auto-capture; manual workshop proposals remain untouched.
- Suppress same-run `/learn` duplication in both suggestion and autonomous modes.
- Keep suggestions success-only. Autonomous mode can retain a user correction from a failed turn.
- Skip skill discovery on signal-free turns and avoid replaying applied or rejected historical feedback.
- Preserve callers without `runId`; use it only when available for same-run provenance and deduplication.
- Keep the compact Skill Workshop prompt contract unchanged. The default suggestion tier on current `main` supersedes the always-rendered prompt approach from #100578.

## User Impact

Users get pending skill improvements from the correction they just made, targeted only when one writable skill is the clear match. Existing metadata and manual proposals are preserved, explicit `/learn` remains authoritative, and old transcript corrections do not get captured again.

## Evidence

- Blacksmith Testbox through Crabbox: `tbx_01kwv5ewt8fz6mw1r050y6rt7s` (`blacksmith-testbox`), validating local head `f811a19cb015d1b5c99075ac58744d97ea4f3346`.
- Focused Testbox coverage: signal extraction/routing, workshop proposal ownership, gateway schema, end-of-run orchestration, CLI current-turn capture, and embedded compaction-safe current-turn capture.
- Testbox `pnpm check:changed -- <18 changed paths>`: clean.
- Fresh `autoreview --mode branch --base origin/main`: no accepted/actionable findings; overall patch-correct confidence `0.78`.
- Rebase verification: final head `609b97d3d6b1d19de619d17bb974b8ea40dc923c` has the same stable patch ID as the Testbox-validated and autoreviewed content after rebasing onto `7b68306949d9a268cb2b3d6ddc635073b5ddcff6`.
- Codex contract checked directly in `codex-rs/app-server-protocol/src/protocol/v2/turn.rs` and `codex-rs/app-server/src/request_processors/turn_processor.rs`: turn input is the current `Vec<UserInput>` validated before turn start.
