### PR TITLE
improve: skill-workshop prompt banks reactive corrections without a save command

### DIFF
--- a/src/agents/skill-workshop-prompt.ts
+++ b/src/agents/skill-workshop-prompt.ts
@@ -10,6 +10,8 @@ export function buildSkillWorkshopPromptSection(): string[] {
     "## Skill Workshop",
     "Use `skill_workshop` when the user wants to create, update, revise, list, inspect, apply, reject, or quarantine a reusable skill, Skill Workshop proposal, playbook, workflow, procedure, or durable instruction.",
     "Treat a request as durable when it should be saved, repeated, proposed, installed later, shared as a skill, or used as a standing workflow instead of answered once in chat.",
+    'Corrections and standing preferences are durable even when phrased reactively ("that\'s not what I asked", "stop doing X", "you\'re still doing Y", "I don\'t want to repeat myself") — not only when the user explicitly says to save something. When the user corrects how an existing skill\'s work should be done, propose the fix into that skill with `action=update` in the same turn; do not wait for a follow-up like "save that to the skill".',
+    "After proposing a captured correction, tell the user which skill proposal it landed in so the capture is verifiable rather than a promise.",
     "Do not create or change skill proposal files manually with `write`, `edit`, `exec`, shell commands, or direct filesystem operations. The final proposal artifact must go through `skill_workshop`.",
     "Use `action=create` for a new skill, `action=update` for an existing approved/live skill, and `action=revise` for an existing pending proposal; keep `description` under 160 bytes and `proposal_content` within the configured body limit.",
     "For `action=update`, pass a concise `description` when the existing live skill description should be shortened in the proposal listing.",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -755,6 +755,12 @@ describe("buildAgentSystemPrompt", () => {
       "Treat a request as durable when it should be saved, repeated, proposed, installed later, shared as a skill, or used as a standing workflow instead of answered once in chat.",
     );
     expect(withTool).toContain(
+      "Corrections and standing preferences are durable even when phrased reactively",
+    );
+    expect(withTool).toContain(
+      "propose the fix into that skill with `action=update` in the same turn",
+    );
+    expect(withTool).toContain(
       "Do not create or change skill proposal files manually with `write`, `edit`, `exec`, shell commands, or direct filesystem operations.",
     );
     expect(withTool).toContain("keep `description` under 160 bytes");


### PR DESCRIPTION
## What Problem This Solves
The Skill Workshop prompt section frames the tool as something to reach for "when the user wants to create, update, revise… a skill". Users don't talk like that: they correct reactively ("that's not what I asked", "you're still using X", "I don't want to repeat myself"). Field evidence from a live two-day agent deployment: a session's corrections only reached skills when the user happened to say "update all the skills and memory now please" / "save everything to skills" — and on the day nobody said the magic phrase, the corrections (including the session's most important one) were lost to the context window.

## Why This Change Was Made
Three lines added to `buildSkillWorkshopPromptSection()`: reactively-phrased corrections and standing preferences are durable signals; a correction about how an existing skill's work should be done becomes an `action=update` proposal in the same turn without waiting for a save request; and the agent reports which proposal the correction landed in so capture is verifiable rather than a promise. Lifecycle safety is untouched — proposals stay pending behind scan + explicit human approval.

Companion to #100576 (autonomous auto-capture for the same signals at the harness level); this covers the interactive path where the agent itself should act on the correction.

## User Impact
Users stop needing a magic phrase for feedback to stick: correcting the agent in plain reactive language now produces a pending skill-update proposal the same turn, with an explicit pointer to where it landed.

## Evidence
- `node scripts/run-vitest.mjs src/agents/system-prompt.test.ts` → 91 passed, including two new assertions locking the added guidance into the prompt when `skill_workshop` is available.
- `autoreview --mode branch --base origin/main` (codex/gpt-5.5): **clean — overall: patch is correct (0.9)**.