### PR TITLE
fix(openai): show current default model in missing-auth hint

### DIFF
--- a/extensions/openai/openai-provider-missing-auth.test.ts
+++ b/extensions/openai/openai-provider-missing-auth.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const FUTURE_DEFAULT_MODEL = "openai/gpt-next-default";
+
+describe("OpenAI missing auth message", () => {
+  afterEach(() => {
+    vi.doUnmock("./default-models.js");
+    vi.resetModules();
+  });
+
+  it("uses the shared OpenAI default model in the ChatGPT/Codex OAuth hint", async () => {
+    vi.resetModules();
+    vi.doMock("./default-models.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("./default-models.js")>();
+      return {
+        ...actual,
+        OPENAI_DEFAULT_MODEL: FUTURE_DEFAULT_MODEL,
+        OPENAI_CODEX_DEFAULT_MODEL: FUTURE_DEFAULT_MODEL,
+      };
+    });
+
+    const { buildOpenAIProvider } = await import("./openai-provider.js");
+    const provider = buildOpenAIProvider();
+
+    const message = provider.buildMissingAuthMessage?.({
+      provider: "openai",
+      listProfileIds: (providerId: string) => (providerId === "openai" ? ["openai:codex"] : []),
+    } as never);
+
+    expect(message).toContain(`Use ${FUTURE_DEFAULT_MODEL} with the ChatGPT/Codex OAuth profile`);
+  });
+});

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -871,7 +871,7 @@ export function buildOpenAIProvider(): ProviderPlugin {
       if (ctx.listProfileIds(PROVIDER_ID).length === 0) {
         return undefined;
       }
-      return 'No API key found for provider "openai". You are authenticated with OpenAI ChatGPT/Codex OAuth. Use openai/gpt-5.5 with the ChatGPT/Codex OAuth profile, or set OPENAI_API_KEY for direct OpenAI API access.';
+      return `No API key found for provider "openai". You are authenticated with OpenAI ChatGPT/Codex OAuth. Use ${OPENAI_DEFAULT_MODEL} with the ChatGPT/Codex OAuth profile, or set OPENAI_API_KEY for direct OpenAI API access.`;
     },
     matchesContextOverflowError: ({ errorMessage }) =>
       /content_filter.*(?:prompt|input).*(?:too long|exceed)/i.test(errorMessage),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who are authenticated with OpenAI ChatGPT/Codex OAuth but try to run an OpenAI model through direct API-key auth would see a missing-auth hint that could drift from the actual OpenAI default model.

## Why This Change Was Made

The OpenAI missing-auth hint now uses the shared OpenAI default model constant instead of hard-coding the model name in the provider message. A regression test mocks a future default model to prove the hint follows the source of truth rather than the current literal value.

## User Impact

Users who hit the OpenAI missing-auth path get guidance that stays aligned with the configured default ChatGPT/Codex-compatible model when the default changes.

## Evidence

- `node scripts/run-vitest.mjs extensions/openai/openai-provider.test.ts extensions/openai/openai-provider-missing-auth.test.ts`
  - 2 test files passed; 46 tests passed.
- `git diff --check origin/main...HEAD`
  - Passed.
- Live CLI proof through the real OpenClaw command surface:
  - Command: `pnpm openclaw infer model run --local --model openai/gpt-5.4 --prompt "hello from live proof" --json`
  - Environment: isolated `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, and `OPENCLAW_WORKSPACE_DIR`; OpenAI OAuth profile present; OpenAI API-key auth intentionally unavailable.
  - Observed output:

```text
Error: Auth lookup failed for provider "openai": No API key found for provider "openai". You are authenticated with OpenAI ChatGPT/Codex OAuth. Use openai/gpt-5.5 with the ChatGPT/Codex OAuth profile, or set OPENAI_API_KEY for direct OpenAI API access.
```
