### PR TITLE
fix(tasks): reconcile CLI subagent cancellation

### DIFF
--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -239,6 +239,7 @@ openclaw tasks notify <lookup> state_changes
     accepts 1-10 task lookups. Retry preserves the canonical result and starts a
     new fenced queue generation; dismiss keeps the task blocked and records that
     the operator intentionally stopped delivery.
+
   </Accordion>
   <Accordion title="tasks notify">
     ```bash

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -226,7 +226,7 @@ openclaw tasks notify <lookup> state_changes
     openclaw tasks cancel <lookup>
     ```
 
-    For ACP and subagent tasks, this kills the child session; ACP and automation cancellations route through the running Gateway (`tasks.cancel`). For CLI-tracked tasks, cancellation is recorded in the task registry (there is no separate child runtime handle). Status transitions to `cancelled` and a delivery notification is sent when applicable.
+    For ACP and subagent tasks, this kills the child session; ACP and automation cancellations route through the running Gateway (`tasks.cancel`). Direct CLI-tracked tasks are registry-only because they have no separate child runtime handle. CLI rows backed by a `:subagent:` child session are the exception: cancellation first stops that backing subagent, then records the terminal task state. Status transitions to `cancelled` and a delivery notification is sent when applicable.
 
   </Accordion>
   <Accordion title="tasks retry | dismiss">
@@ -239,7 +239,6 @@ openclaw tasks notify <lookup> state_changes
     accepts 1-10 task lookups. Retry preserves the canonical result and starts a
     new fenced queue generation; dismiss keeps the task blocked and records that
     the operator intentionally stopped delivery.
-
   </Accordion>
   <Accordion title="tasks notify">
     ```bash

--- a/src/tasks/task-registry-cancel.ts
+++ b/src/tasks/task-registry-cancel.ts
@@ -162,14 +162,26 @@ function handleSubagentKillResultForTask(params: {
       },
     };
   }
-  if ((!params.result.found || !params.result.killed) && !isProvisionalSubagentKill) {
+  if (params.result.found && !params.result.killed && params.result.error) {
     return {
       handled: true,
       isProvisionalSubagentKill,
       result: {
         found: true,
         cancelled: false,
-        reason: params.result.found ? "Subagent was not running." : "Subagent task not found.",
+        reason: formatErrorMessage(params.result.error),
+        task: cloneTaskRecord(current ?? params.task),
+      },
+    };
+  }
+  if (!params.result.found && !isProvisionalSubagentKill) {
+    return {
+      handled: true,
+      isProvisionalSubagentKill,
+      result: {
+        found: true,
+        cancelled: false,
+        reason: "Subagent task not found.",
         task: cloneTaskRecord(current ?? params.task),
       },
     };

--- a/src/tasks/task-registry-cancel.ts
+++ b/src/tasks/task-registry-cancel.ts
@@ -7,6 +7,7 @@ import { isHarnessOwnedSubagentTask } from "./harness-owned-subagent-task.js";
 import { isProvisionalSubagentKillTask } from "./task-cancellation-state.js";
 import { isTerminalTaskStatus } from "./task-executor-policy.js";
 import { ensureLinkedTaskFlowRegistryReady } from "./task-registry-common.js";
+import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
 import { maybeDeliverTaskTerminalUpdate } from "./task-registry-delivery.js";
 import { updateTask } from "./task-registry-mutation.js";
 import { finalizeTaskRecordByRunId, updateTaskStateByRunId } from "./task-registry-record-api.js";
@@ -17,7 +18,25 @@ import {
   loadTaskRegistryControlRuntime,
   tasks,
 } from "./task-registry-state.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import type { TaskRecord, TaskRuntime } from "./task-registry.types.js";
+
+type CancelTaskByIdResult = {
+  found: boolean;
+  cancelled: boolean;
+  reason?: string;
+  task?: TaskRecord;
+};
+
+type SubagentKillResultHandling =
+  | {
+      handled: true;
+      isProvisionalSubagentKill: boolean;
+      result: CancelTaskByIdResult;
+    }
+  | {
+      handled: false;
+      isProvisionalSubagentKill: boolean;
+    };
 
 function ensureTaskCancellationReady(task: TaskRecord): void {
   const runId = task.runId?.trim();
@@ -34,11 +53,137 @@ function ensureTaskCancellationReady(task: TaskRecord): void {
   }
 }
 
+function handleSubagentKillResultForTask(params: {
+  task: TaskRecord;
+  childSessionKey: string;
+  runtime: Extract<TaskRuntime, "cli" | "subagent">;
+  isProvisionalSubagentKill: boolean;
+  result: Awaited<ReturnType<TaskRegistryControlRuntime["killSubagentRunAdmin"]>>;
+}): SubagentKillResultHandling {
+  let isProvisionalSubagentKill = params.isProvisionalSubagentKill;
+  const current = tasks.get(params.task.taskId);
+  if (current?.status === "cancelled" && current.error === SUBAGENT_KILL_TASK_ERROR) {
+    isProvisionalSubagentKill = true;
+  }
+  if (current?.status === "succeeded") {
+    return {
+      handled: true,
+      isProvisionalSubagentKill,
+      result: {
+        found: true,
+        cancelled: false,
+        reason: "Subagent completed while cancellation was in progress.",
+        task: cloneTaskRecord(current),
+      },
+    };
+  }
+  if (current && isTerminalTaskStatus(current.status) && current.status !== "cancelled") {
+    return {
+      handled: true,
+      isProvisionalSubagentKill,
+      result: {
+        found: true,
+        cancelled: false,
+        reason: `Subagent became ${current.status} while cancellation was in progress.`,
+        task: cloneTaskRecord(current),
+      },
+    };
+  }
+  if (current?.status === "cancelled" && !isProvisionalSubagentKill) {
+    return {
+      handled: true,
+      isProvisionalSubagentKill,
+      result: {
+        found: true,
+        cancelled: false,
+        reason: "Subagent was cancelled while cancellation was in progress.",
+        task: cloneTaskRecord(current),
+      },
+    };
+  }
+  if (params.result.found && params.result.targetState?.state === "terminal") {
+    // A subagent run becomes terminal before its task projection settles.
+    // Reconcile the original task scope: steer/orphan recovery may have
+    // replaced the registry run ID without remapping durable task rows.
+    const taskRunId = params.task.runId?.trim() || params.result.runId;
+    const reconciledTasks = finalizeTaskRecordByRunId({
+      runId: taskRunId,
+      runtime: params.runtime,
+      sessionKey: params.childSessionKey,
+      ...params.result.targetState.task,
+    });
+    const reconciled = reconciledTasks.find((candidate) => candidate.taskId === params.task.taskId);
+    if (!reconciled) {
+      return {
+        handled: true,
+        isProvisionalSubagentKill,
+        result: {
+          found: true,
+          cancelled: false,
+          reason: "Subagent became terminal, but task state reconciliation failed to persist.",
+          task: cloneTaskRecord(tasks.get(params.task.taskId) ?? params.task),
+        },
+      };
+    }
+    if (
+      params.result.targetState.task.status === "cancelled" &&
+      params.result.targetState.task.error === SUBAGENT_KILL_TASK_ERROR
+    ) {
+      return {
+        handled: false,
+        isProvisionalSubagentKill: true,
+      };
+    }
+    const reason =
+      params.result.targetState.task.status === "succeeded"
+        ? "Subagent completed while cancellation was in progress."
+        : `Subagent became ${params.result.targetState.task.status} while cancellation was in progress.`;
+    return {
+      handled: true,
+      isProvisionalSubagentKill,
+      result: {
+        found: true,
+        cancelled: false,
+        reason,
+        task: cloneTaskRecord(reconciled),
+      },
+    };
+  }
+  if (params.result.found && params.result.targetState?.state === "finalizing") {
+    return {
+      handled: true,
+      isProvisionalSubagentKill,
+      result: {
+        found: true,
+        cancelled: false,
+        reason: "Subagent completion is still being finalized.",
+        task: cloneTaskRecord(current ?? params.task),
+      },
+    };
+  }
+  if ((!params.result.found || !params.result.killed) && !isProvisionalSubagentKill) {
+    return {
+      handled: true,
+      isProvisionalSubagentKill,
+      result: {
+        found: true,
+        cancelled: false,
+        reason: params.result.found ? "Subagent was not running." : "Subagent task not found.",
+        task: cloneTaskRecord(current ?? params.task),
+      },
+    };
+  }
+  return {
+    handled: false,
+    isProvisionalSubagentKill,
+  };
+}
+
 export async function cancelTaskById(params: {
   cfg: OpenClawConfig;
   taskId: string;
   reason?: string;
-}): Promise<{ found: boolean; cancelled: boolean; reason?: string; task?: TaskRecord }> {
+}): Promise<CancelTaskByIdResult> {
   ensureTaskRegistryReady();
   const task = tasks.get(params.taskId.trim());
   if (!task) {
@@ -71,6 +216,24 @@ export async function cancelTaskById(params: {
   const childSessionKey = task.childSessionKey?.trim();
   try {
     ensureTaskCancellationReady(task);
+    if (task.runtime === "cli" && childSessionKey?.includes(":subagent:")) {
+      const { killSubagentRunAdmin } = await loadTaskRegistryControlRuntime();
+      const result = await killSubagentRunAdmin({
+        cfg: params.cfg,
+        sessionKey: childSessionKey,
+      });
+      const handling = handleSubagentKillResultForTask({
+        task,
+        childSessionKey,
+        runtime: "cli",
+        isProvisionalSubagentKill,
+        result,
+      });
+      isProvisionalSubagentKill = handling.isProvisionalSubagentKill;
+      if (handling.handled) {
+        return handling.result;
+      }
+    }
     // A direct kill is only a provisional terminal projection. Re-read the
     // owning subagent run before promotion so its canonical completion can win.
     if (isBackgroundExecTask(task)) {
@@ -133,87 +296,16 @@ export async function cancelTaskById(params: {
           cfg: params.cfg,
           sessionKey: childSessionKey,
         });
-        const current = tasks.get(task.taskId);
-        if (current?.status === "cancelled" && current.error === SUBAGENT_KILL_TASK_ERROR) {
-          isProvisionalSubagentKill = true;
-        }
-        if (current?.status === "succeeded") {
-          return {
-            found: true,
-            cancelled: false,
-            reason: "Subagent completed while cancellation was in progress.",
-            task: cloneTaskRecord(current),
-          };
-        }
-        if (current && isTerminalTaskStatus(current.status) && current.status !== "cancelled") {
-          return {
-            found: true,
-            cancelled: false,
-            reason: `Subagent became ${current.status} while cancellation was in progress.`,
-            task: cloneTaskRecord(current),
-          };
-        }
-        if (current?.status === "cancelled" && !isProvisionalSubagentKill) {
-          return {
-            found: true,
-            cancelled: false,
-            reason: "Subagent was cancelled while cancellation was in progress.",
-            task: cloneTaskRecord(current),
-          };
-        }
-        if (result.found && result.targetState?.state === "terminal") {
-          // A subagent run becomes terminal before its task projection settles.
-          // Reconcile the original task scope: steer/orphan recovery may have
-          // replaced the registry run ID without remapping durable task rows.
-          const taskRunId = task.runId?.trim() || result.runId;
-          const reconciledTasks = finalizeTaskRecordByRunId({
-            runId: taskRunId,
-            runtime: "subagent",
-            sessionKey: childSessionKey,
-            ...result.targetState.task,
-          });
-          const reconciled = reconciledTasks.find((candidate) => candidate.taskId === task.taskId);
-          if (!reconciled) {
-            return {
-              found: true,
-              cancelled: false,
-              reason: "Subagent became terminal, but task state reconciliation failed to persist.",
-              task: cloneTaskRecord(tasks.get(task.taskId) ?? task),
-            };
-          }
-          if (
-            result.targetState.task.status === "cancelled" &&
-            result.targetState.task.error === SUBAGENT_KILL_TASK_ERROR
-          ) {
-            isProvisionalSubagentKill = true;
-          } else {
-            const reason =
-              result.targetState.task.status === "succeeded"
-                ? "Subagent completed while cancellation was in progress."
-                : `Subagent became ${result.targetState.task.status} while cancellation was in progress.`;
-            return {
-              found: true,
-              cancelled: false,
-              reason,
-              task: cloneTaskRecord(reconciled),
-            };
-          }
-        }
-        if (result.found && result.targetState?.state === "finalizing") {
-          return {
-            found: true,
-            cancelled: false,
-            reason: "Subagent completion is still being finalized.",
-            task: cloneTaskRecord(current ?? task),
-          };
-        }
-        if ((!result.found || !result.killed) && !isProvisionalSubagentKill) {
-          return {
-            found: true,
-            cancelled: false,
-            reason: result.found ? "Subagent was not running." : "Subagent task not found.",
-            task: cloneTaskRecord(current ?? task),
-          };
+        const handling = handleSubagentKillResultForTask({
+          task,
+          childSessionKey,
+          runtime: "subagent",
+          isProvisionalSubagentKill,
+          result,
+        });
+        isProvisionalSubagentKill = handling.isProvisionalSubagentKill;
+        if (handling.handled) {
+          return handling.result;
         }
       } else {
         return {

--- a/src/tasks/task-registry-cancel.ts
+++ b/src/tasks/task-registry-cancel.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { isBackgroundExecTask } from "./background-exec-task-contract.js";
 import { CRON_TASK_KIND } from "./cron-task-contract.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
@@ -216,7 +217,11 @@ export async function cancelTaskById(params: {
   const childSessionKey = task.childSessionKey?.trim();
   try {
     ensureTaskCancellationReady(task);
-    if (task.runtime === "cli" && childSessionKey?.includes(":subagent:")) {
+    if (
+      task.runtime === "cli" &&
+      typeof childSessionKey === "string" &&
+      isSubagentSessionKey(childSessionKey)
+    ) {
       const { killSubagentRunAdmin } = await loadTaskRegistryControlRuntime();
       const result = await killSubagentRunAdmin({
         cfg: params.cfg,

--- a/src/tasks/task-registry-control.types.ts
+++ b/src/tasks/task-registry-control.types.ts
@@ -23,6 +23,7 @@ type KillSubagentRunAdminResult =
       sessionKey: string;
       cascadeKilled: number;
       cascadeLabels?: string[];
+      error?: unknown;
     };
 
 type KillSubagentRunAdmin = (params: {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -5061,6 +5061,45 @@ describe("task-registry", () => {
     });
   });
 
+  it("preserves CLI-tracked subagent rows when backing child kill fails", async () => {
+    await withTaskRegistryTempDir(async () => {
+      hoisted.cancelSessionMock.mockClear();
+      hoisted.killSubagentRunAdminMock.mockClear();
+
+      const task = createTaskFixture("cli", {
+        childSessionKey: "agent:mirror:subagent:kill-error-child",
+        runId: "run-cli-subagent-kill-error-child",
+        task: "Cancel child-backed CLI task after kill error",
+        deliveryStatus: "not_applicable",
+      });
+      hoisted.killSubagentRunAdminMock.mockResolvedValueOnce({
+        found: true,
+        killed: false,
+        runId: task.runId!,
+        sessionKey: task.childSessionKey!,
+        cascadeKilled: 0,
+        error: new Error("backing child is still active"),
+      });
+
+      const result = await cancelTask(task.taskId);
+
+      expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
+      expect(hoisted.killSubagentRunAdminMock).toHaveBeenCalledWith({
+        cfg: {},
+        sessionKey: "agent:mirror:subagent:kill-error-child",
+      });
+      expectRecordFields(result, {
+        found: true,
+        cancelled: false,
+        reason: "backing child is still active",
+      });
+      expectRecordFields(getTaskById(task.taskId), {
+        status: "running",
+        error: undefined,
+      });
+    });
+  });
+
   it("does not cancel CLI-tracked subagent rows when the backing subagent is missing", async () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.cancelSessionMock.mockClear();

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -4906,6 +4906,169 @@ describe("task-registry", () => {
     },
   );
 
+  it("kills CLI-tracked subagent child sessions before cancelling the registry row", async () => {
+    await withTaskRegistryTempDir(async () => {
+      hoisted.cancelSessionMock.mockClear();
+      hoisted.killSubagentRunAdminMock.mockClear();
+      hoisted.killSubagentRunAdminMock.mockResolvedValueOnce({
+        found: true,
+        killed: true,
+      });
+
+      const task = createTaskFixture("cli", {
+        childSessionKey: "agent:mirror:subagent:child",
+        runId: "run-cancel-cli-subagent-child",
+        task: "Cancel child-backed CLI task",
+        deliveryStatus: "not_applicable",
+      });
+
+      const result = await cancelTask(task.taskId);
+
+      expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
+      expect(hoisted.killSubagentRunAdminMock).toHaveBeenCalledWith({
+        cfg: {},
+        sessionKey: "agent:mirror:subagent:child",
+      });
+      expectRecordFields(result, {
+        found: true,
+        cancelled: true,
+      });
+      expectRecordFields(getTaskById(task.taskId), {
+        status: "cancelled",
+        error: "Cancelled by operator.",
+      });
+    });
+  });
+
+  it("preserves CLI-tracked subagent success that wins during cancellation", async () => {
+    await withTaskRegistryTempDir(async () => {
+      hoisted.cancelSessionMock.mockClear();
+      hoisted.killSubagentRunAdminMock.mockClear();
+
+      const task = createTaskFixture("cli", {
+        childSessionKey: "agent:mirror:subagent:completed-child",
+        runId: "run-cli-subagent-completed-child",
+        task: "Cancel completed child-backed CLI task",
+        deliveryStatus: "not_applicable",
+      });
+      hoisted.killSubagentRunAdminMock.mockResolvedValueOnce({
+        found: true,
+        killed: false,
+        runId: task.runId!,
+        sessionKey: task.childSessionKey!,
+        cascadeKilled: 0,
+        targetState: {
+          state: "terminal",
+          task: {
+            status: "succeeded",
+            endedAt: 200,
+            terminalSummary: "child completed",
+          },
+        },
+      });
+
+      const result = await cancelTask(task.taskId);
+
+      expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
+      expect(hoisted.killSubagentRunAdminMock).toHaveBeenCalledWith({
+        cfg: {},
+        sessionKey: "agent:mirror:subagent:completed-child",
+      });
+      expectRecordFields(result, {
+        found: true,
+        cancelled: false,
+        reason: "Subagent completed while cancellation was in progress.",
+      });
+      expectRecordFields(result.task, {
+        taskId: task.taskId,
+        status: "succeeded",
+        endedAt: 200,
+        error: undefined,
+        terminalSummary: "child completed",
+      });
+      expectRecordFields(getTaskById(task.taskId), {
+        status: "succeeded",
+        endedAt: 200,
+        error: undefined,
+        terminalSummary: "child completed",
+      });
+    });
+  });
+
+  it("defers CLI-tracked subagent cancellation while completion is finalizing", async () => {
+    await withTaskRegistryTempDir(async () => {
+      hoisted.cancelSessionMock.mockClear();
+      hoisted.killSubagentRunAdminMock.mockClear();
+
+      const task = createTaskFixture("cli", {
+        childSessionKey: "agent:mirror:subagent:finalizing-child",
+        runId: "run-cli-subagent-finalizing-child",
+        task: "Cancel finalizing child-backed CLI task",
+        deliveryStatus: "not_applicable",
+      });
+      hoisted.killSubagentRunAdminMock.mockResolvedValueOnce({
+        found: true,
+        killed: false,
+        runId: task.runId!,
+        sessionKey: task.childSessionKey!,
+        cascadeKilled: 0,
+        targetState: { state: "finalizing" },
+      });
+
+      const result = await cancelTask(task.taskId);
+
+      expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
+      expect(hoisted.killSubagentRunAdminMock).toHaveBeenCalledWith({
+        cfg: {},
+        sessionKey: "agent:mirror:subagent:finalizing-child",
+      });
+      expectRecordFields(result, {
+        found: true,
+        cancelled: false,
+        reason: "Subagent completion is still being finalized.",
+      });
+      expectRecordFields(getTaskById(task.taskId), {
+        status: "running",
+        error: undefined,
+      });
+    });
+  });
+
+  it("does not cancel CLI-tracked subagent rows when the backing subagent is missing", async () => {
+    await withTaskRegistryTempDir(async () => {
+      hoisted.cancelSessionMock.mockClear();
+      hoisted.killSubagentRunAdminMock.mockClear();
+
+      const task = createTaskFixture("cli", {
+        childSessionKey: "agent:mirror:subagent:missing-child",
+        runId: "run-cli-subagent-missing-child",
+        task: "Cancel missing child-backed CLI task",
+        deliveryStatus: "not_applicable",
+      });
+      hoisted.killSubagentRunAdminMock.mockResolvedValueOnce({
+        found: false,
+        killed: false,
+      });
+
+      const result = await cancelTask(task.taskId);
+
+      expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
+      expect(hoisted.killSubagentRunAdminMock).toHaveBeenCalledWith({
+        cfg: {},
+        sessionKey: "agent:mirror:subagent:missing-child",
+      });
+      expectRecordFields(result, {
+        found: true,
+        cancelled: false,
+        reason: "Subagent task not found.",
+      });
+      expectRecordFields(getTaskById(task.taskId), {
+        status: "running",
+        error: undefined,
+      });
+    });
+  });
+
   it("cancels active cron tasks through the cron runtime abort handle", async () => {
     await withTaskRegistryTempDir(async () => {
       const abortController = new AbortController();

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -4940,6 +4940,33 @@ describe("task-registry", () => {
     });
   });
 
+  it("keeps opaque CLI child-session keys containing a subagent marker registry-only", async () => {
+    await withTaskRegistryTempDir(async () => {
+      hoisted.cancelSessionMock.mockClear();
+      hoisted.killSubagentRunAdminMock.mockClear();
+
+      const task = createTaskFixture("cli", {
+        childSessionKey: "agent:main:matrix:group:!opaque:subagent:example.org",
+        runId: "run-cli-opaque-child-key",
+        task: "Cancel opaque CLI child-key task",
+        deliveryStatus: "not_applicable",
+      });
+
+      const result = await cancelTask(task.taskId);
+
+      expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
+      expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
+      expectRecordFields(result, {
+        found: true,
+        cancelled: true,
+      });
+      expectRecordFields(getTaskById(task.taskId), {
+        status: "cancelled",
+        error: "Cancelled by operator.",
+      });
+    });
+  });
+
   it("preserves CLI-tracked subagent success that wins during cancellation", async () => {
     await withTaskRegistryTempDir(async () => {
       hoisted.cancelSessionMock.mockClear();


### PR DESCRIPTION
## What Problem This Solves

This is a narrow cancellation-path follow-up for TaskFlow rows that already have a tracked child relationship but do not get fully reconciled today.

In local upgrade-replay incidents, operator cancellation could fail to clear active task state or could clear only the registry row while leaving a backing child session alive:

- stale subagent wrapper rows could return `Subagent was not running.` and stay non-terminal, blocking flow cancellation with `One or more child tasks are still active.`
- `runtime=cli` task rows whose `childSessionKey` points at a `:subagent:` child could be marked cancelled without killing the backing child session, allowing the child to continue appending events or reappear after restart

This PR keeps the fix at the operator cancellation entrypoint. It does not replace #90505, which is a broader maintenance-side reconciliation fix for killed subagent task rows and carries a separate session-state transition/docs tradeoff.

## Summary

- cancel CLI-tracked tasks with `childSessionKey` pointing at a `:subagent:` child by killing the backing subagent session before marking the registry row cancelled
- preserve backing subagent terminal/finalizing outcomes before cancelling CLI mirror rows, so a late `succeeded`/`failed`/finalizing state is not overwritten by operator cancellation
- keep direct/main CLI follow-up rows registry-only so cancelling them does not kill the user's main session
- allow found-but-not-running subagent wrappers to fall through to registry cancellation instead of returning `Subagent was not running.`
- keep childless ACP `context_engine_turn_maintenance` rows non-cancellable without an owner handoff, because active deferred maintenance rows need an owner-aware cancellation path

## Relationship to existing work

Related issue: #90444.

This is a narrow follow-up to the uncovered operator-facing cancellation cases described in #90444. It intentionally does not change the broader maintenance reconciliation model covered by #90505.

#90505 remains the larger active/candidate fix for killed subagent task-row finalization. This PR only addresses cancellation entrypoints that can otherwise leave TaskFlow rows or backing child sessions inconsistent even when an operator explicitly tries to repair the state with `tasks cancel` / `tasks flow cancel`.

## Evidence

Local production/operator evidence, sanitized:

- `openclaw tasks cancel` returned `Subagent was not running.` for a found-but-stopped subagent wrapper, but the task row stayed non-terminal and continued blocking flow cancellation.
- A `runtime=cli` task with a `:subagent:` child session was marked cancelled in the task registry without stopping the backing child session; after restart/restore, the child could continue producing events and the task could effectively reappear as running.
- After applying the CLI/subagent cancellation-path behavior locally, restarting the gateway, and replaying the affected cleanup, `running=0`, `queued=0`, and task audit no longer reported stale running/queued/cancel-stuck rows for these cases.

Focused validation on this branch:

- `node scripts/test-projects.mjs src/tasks/task-registry.test.ts src/agents/embedded-agent-runner/context-engine-maintenance.test.ts`
  - `src/tasks/task-registry.test.ts`: `Tests 113 passed (113)`
  - `src/agents/embedded-agent-runner/context-engine-maintenance.test.ts`: `Tests 21 passed (21)`
- `git diff --check`
- `pnpm exec oxfmt --check src/tasks/task-registry.ts src/tasks/task-registry.test.ts src/agents/embedded-agent-runner/context-engine-maintenance.ts src/agents/embedded-agent-runner/context-engine-maintenance.test.ts`

## Negative Boundaries

- Does not change the `lost -> succeeded` maintenance reconciliation rule discussed in #90505.
- Does not attempt to solve the larger session write-lock / session-state design line.
- Does not kill direct/main CLI child sessions; those remain registry-only cancellation to avoid terminating the user's main conversation.
- Does not overwrite backing subagent terminal/finalizing outcomes when a CLI mirror row cancellation races with completion.
- Does not mark childless `acp/context_engine_turn_maintenance` rows cancelled without an owner-aware cancellation handoff; stale maintenance cleanup should be handled by a separate owner-aware follow-up.
