### PR TITLE
fix(google): replay thought signatures for Gemini latest aliases

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1800,6 +1800,30 @@ describe("google transport stream", () => {
     });
   });
 
+  it.each(["gemini-pro-latest", "gemini-flash-latest", "gemini-flash-lite-latest"] as const)(
+    "adds skip-validator fallback for unsigned %s tool-call replay",
+    (id) => {
+      const model = buildGeminiModel({
+        id,
+        name: "Gemini Latest",
+      });
+
+      const params = buildGoogleGenerativeAiParams(model, {
+        messages: [googleToolCallAssistantTurn({ model: id })],
+      } as never);
+
+      expect(params.contents[0]).toMatchObject({
+        role: "model",
+        parts: [
+          {
+            thoughtSignature: "skip_thought_signature_validator",
+            functionCall: { name: "lookup", args: { q: "hello" } },
+          },
+        ],
+      });
+    },
+  );
+
   it("does not re-attach replayed Gemini thought signatures to a different tool-call part", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -160,7 +160,7 @@ function requiresToolCallId(modelId: string): boolean {
 }
 
 function requiresToolCallThoughtSignature(modelId: string): boolean {
-  return normalizeLowercaseStringOrEmpty(modelId).includes("gemini-3");
+  return isGoogleGemini3ProModel(modelId) || isGoogleGemini3FlashModel(modelId);
 }
 
 function supportsMultimodalFunctionResponse(modelId: string): boolean {


### PR DESCRIPTION
Closes #100566

## What Problem This Solves

Fixes an issue where users running `google/gemini-flash-latest` with tool calls could hit a Google Generative AI 400 error about a missing `thought_signature` during tool-call replay. This affected Gemini latest aliases even though they resolve to Gemini 3 Flash-family behavior.

## Why This Change Was Made

The Google transport now uses the existing Gemini 3 Pro/Flash family classifiers when deciding whether tool-call history needs thought-signature replay fallback. That keeps the policy aligned with the model-resolution/thinking code that already treats `gemini-pro-latest`, `gemini-flash-latest`, and `gemini-flash-lite-latest` as Gemini 3 models, without adding new config or broad fallback behavior.

Google's current Gemini 3 generateContent docs say function-calling requests must return thought signatures and can otherwise receive 400 validation errors, including for Gemini 3 Flash with minimal thinking: https://ai.google.dev/gemini-api/docs/generate-content/gemini-3

## User Impact

Users can keep using Gemini latest aliases with tool-using agents without OpenClaw dropping the Gemini 3 thought-signature fallback path. Stored unsigned tool-call history for those aliases now gets the same skip-validator fallback already used for explicit Gemini 3 model ids.

## Evidence

- `node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts extensions/google/thinking.test.ts` - 2 files passed, 110 tests passed.
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts` - passed.
- `git diff --check` - passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings.


