### PR TITLE
fix(gateway): commit runtime snapshot on noop config reloads

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -698,6 +698,9 @@ function createReloaderHarness(
   const onConfigApplied = vi.fn(
     async (_plan: GatewayReloadPlan, _nextConfig: OpenClawConfig) => {},
   );
+  const onNoopConfigCommit = vi.fn(
+    async (_plan: GatewayReloadPlan, _nextConfig: OpenClawConfig) => {},
+  );
   const onHotReload = vi.fn(async (_plan: GatewayReloadPlan, _nextConfig: OpenClawConfig) => {});
   const onRestart = vi.fn((_plan: GatewayReloadPlan, _nextConfig: OpenClawConfig) => {});
   let writeListener: ((event: ConfigWriteNotification) => void) | null = null;
@@ -726,6 +729,7 @@ function createReloaderHarness(
     subscribeToWrites,
     onConfigChange,
     onConfigApplied,
+    onNoopConfigCommit,
     onHotReload,
     onRestart,
     log,
@@ -735,6 +739,7 @@ function createReloaderHarness(
     watcher,
     onConfigChange,
     onConfigApplied,
+    onNoopConfigCommit,
     onHotReload,
     onRestart,
     log,
@@ -809,6 +814,39 @@ describe("startGatewayConfigReloader", () => {
     expect(harness.onConfigApplied).toHaveBeenCalledTimes(1);
     expect(harness.onHotReload).not.toHaveBeenCalled();
     expect(harness.onRestart).not.toHaveBeenCalled();
+    await harness.reloader.stop();
+  });
+
+  it("commits runtime snapshot changes for no-op visible reply reloads", async () => {
+    const initialConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      messages: { visibleReplies: "automatic" },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      messages: { visibleReplies: "message_tool" },
+    };
+    const readSnapshot = vi.fn(async () =>
+      makeSnapshot({ config: nextConfig, hash: "visible-replies" }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialConfig });
+
+    harness.watcher.emit("change");
+    await vi.runAllTimersAsync();
+
+    expect(harness.onNoopConfigCommit).toHaveBeenCalledTimes(1);
+    expect(harness.onNoopConfigCommit.mock.calls[0]?.[0].noopPaths).toContain(
+      "messages.visibleReplies",
+    );
+    expect(harness.onNoopConfigCommit.mock.calls[0]?.[1]).toBe(nextConfig);
+    expect(harness.onHotReload).not.toHaveBeenCalled();
+    expect(harness.onRestart).not.toHaveBeenCalled();
+    expect(harness.onConfigChange.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.onNoopConfigCommit.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(harness.onNoopConfigCommit.mock.invocationCallOrder[0]).toBeLessThan(
+      harness.onConfigApplied.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     await harness.reloader.stop();
   });
 
@@ -1774,6 +1812,7 @@ describe("startGatewayConfigReloader watcher error recovery", () => {
       readSnapshot: vi.fn(async () => makeSnapshot()),
       initialPluginInstallRecords: {},
       readPluginInstallRecords: async () => ({}),
+      onNoopConfigCommit: vi.fn(async () => {}),
       onHotReload: vi.fn(async () => {}),
       onRestart: vi.fn(),
       log,

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -117,6 +117,7 @@ export function startGatewayConfigReloader(opts: {
   readSnapshot: () => Promise<ConfigFileSnapshot>;
   onConfigChange?: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
   onConfigApplied?: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
+  onNoopConfigCommit: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => Promise<void>;
   onHotReload: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => Promise<void>;
   onRestart: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
   promoteSnapshot?: (snapshot: ConfigFileSnapshot, reason: string) => Promise<boolean>;
@@ -287,6 +288,9 @@ export function startGatewayConfigReloader(opts: {
     }
     if (isNoopReloadPlan(plan) && !followUp.requiresRestart) {
       await opts.onConfigChange?.(plan, nextConfig);
+      // No-op plans still change the runtime config snapshot. Commit before
+      // marking applied so getRuntimeConfig() readers do not stay stale until restart.
+      await opts.onNoopConfigCommit(plan, nextConfig);
       await opts.onConfigApplied?.(plan, nextConfig);
       return;
     }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1269,6 +1269,117 @@ describe("gateway Gmail hot reload handlers", () => {
     expect(clearGmailRestartAbortController).toHaveBeenCalledWith(abortController);
   });
 
+  it("commits runtime secrets for managed no-op config reloads", async () => {
+    vi.useFakeTimers();
+    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
+      current: null,
+    };
+    const initialConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      messages: { visibleReplies: "automatic" },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      messages: { visibleReplies: "message_tool" },
+    };
+    const activateRuntimeSecrets = vi.fn(async (config: OpenClawConfig) => ({
+      sourceConfig: config,
+      config,
+      authStores: [],
+      warnings: [],
+      webTools: {},
+    }));
+    const heartbeatRunner = { stop: vi.fn(), updateConfig: vi.fn() };
+    const reloader = startManagedGatewayConfigReloader({
+      minimalTestGateway: false,
+      initialConfig,
+      initialCompareConfig: initialConfig,
+      initialInternalWriteHash: null,
+      watchPath: "/tmp/openclaw.json",
+      readSnapshot: vi.fn(async () => ({
+        path: "/tmp/openclaw.json",
+        exists: true,
+        raw: "{}",
+        parsed: {},
+        sourceConfig: nextConfig,
+        resolved: nextConfig,
+        valid: true,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+        hash: "hash-next",
+      })) as never,
+      promoteSnapshot: vi.fn(async () => true) as never,
+      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
+        writeListenerRef.current = listener;
+        return () => {
+          if (writeListenerRef.current === listener) {
+            writeListenerRef.current = null;
+          }
+        };
+      }) as never,
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: heartbeatRunner as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState: vi.fn(),
+      startChannel: vi.fn(async () => {}),
+      stopChannel: vi.fn(async () => {}),
+      reloadPlugins: vi.fn(
+        async (): Promise<GatewayPluginReloadResult> => ({
+          restartChannels: new Set(),
+          activeChannels: new Set(),
+        }),
+      ),
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      channelManager: {} as never,
+      activateRuntimeSecrets: activateRuntimeSecrets as never,
+      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
+      sharedGatewaySessionGenerationState: { current: undefined, required: null },
+      clients: [],
+      reconcileTerminalSessions: vi.fn(),
+      commitTerminalConfig: vi.fn(),
+    });
+    const registeredWriteListener = writeListenerRef.current;
+    if (!registeredWriteListener) {
+      throw new Error("Expected config write listener to be registered");
+    }
+
+    registeredWriteListener({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: nextConfig,
+      runtimeConfig: nextConfig,
+      persistedHash: "hash-next",
+      revision: 1,
+      fingerprint: "runtime-hash-next",
+      sourceFingerprint: "source-hash-next",
+      writtenAtMs: Date.now(),
+    });
+    await vi.runAllTimersAsync();
+
+    expect(activateRuntimeSecrets).toHaveBeenCalledTimes(1);
+    expect(activateRuntimeSecrets).toHaveBeenCalledWith(nextConfig, {
+      reason: "reload",
+      activate: true,
+    });
+    expect(heartbeatRunner.updateConfig).not.toHaveBeenCalled();
+    await reloader.stop();
+  });
+
   it("aborts an in-flight managed Gmail restart when the reloader stops", async () => {
     const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
       current: null,

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -740,6 +740,12 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
     subscribeToWrites: params.subscribeToWrites,
     onConfigChange: (plan, nextConfig) => params.reconcileTerminalSessions(plan, nextConfig),
     onConfigApplied: () => params.commitTerminalConfig(),
+    onNoopConfigCommit: async (_plan, nextConfig) => {
+      await params.activateRuntimeSecrets(nextConfig, {
+        reason: "reload",
+        activate: true,
+      });
+    },
     onHotReload: async (plan, nextConfig) => {
       const previousSharedGatewaySessionGeneration =
         params.sharedGatewaySessionGenerationState.current;

--- a/src/gateway/server-runtime-services.ts
+++ b/src/gateway/server-runtime-services.ts
@@ -1,5 +1,6 @@
 // Gateway post-ready runtime services.
 // Starts delayed maintenance, cron, heartbeat, recovery, and pricing refresh work.
+import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isVitestRuntimeEnv } from "../infra/env.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
@@ -228,7 +229,10 @@ export function activateGatewayScheduledServices(params: {
     // production starts without launching background loops.
     return { heartbeatRunner: createNoopHeartbeatRunner(), stopModelPricingRefresh: () => {} };
   }
-  const heartbeatRunner = startHeartbeatRunner({ cfg: params.cfgAtStart });
+  const heartbeatRunner = startHeartbeatRunner({
+    cfg: params.cfgAtStart,
+    readCurrentConfig: getRuntimeConfig,
+  });
   if (params.startCron !== false) {
     startGatewayCronWithLogging({
       cron: params.cron,

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -1,6 +1,11 @@
 // Tests heartbeat runner scheduling and timer cleanup.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig } from "../config/config.js";
+import {
+  getRuntimeConfig,
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+  type OpenClawConfig,
+} from "../config/config.js";
 import { startHeartbeatRunner } from "./heartbeat-runner.js";
 import { computeNextHeartbeatPhaseDueMs, resolveHeartbeatPhaseMs } from "./heartbeat-schedule.js";
 import {
@@ -165,6 +170,7 @@ describe("startHeartbeatRunner", () => {
 
   afterEach(() => {
     resetHeartbeatWakeStateForTests();
+    resetConfigRuntimeState();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
@@ -215,6 +221,37 @@ describe("startHeartbeatRunner", () => {
       startIndex: 1,
     });
 
+    runner.stop();
+  });
+
+  it("reads the latest runtime config for heartbeat wakes after no-op reload commits", async () => {
+    useFakeHeartbeatTime();
+
+    const initialConfig: OpenClawConfig = {
+      ...heartbeatConfig(),
+      messages: { visibleReplies: "automatic" },
+    };
+    const nextConfig: OpenClawConfig = {
+      ...heartbeatConfig(),
+      messages: { visibleReplies: "message_tool" },
+    };
+    setRuntimeConfigSnapshot(initialConfig, initialConfig);
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: initialConfig,
+      readCurrentConfig: getRuntimeConfig,
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    setRuntimeConfigSnapshot(nextConfig, nextConfig);
+    requestHeartbeat(wake("manual", { coalesceMs: 0 }));
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    const options = getRunCall(runSpy, 0);
+    expect((options.cfg as OpenClawConfig).messages?.visibleReplies).toBe("message_tool");
+    expect((options.heartbeat as { every?: string }).every).toBe("30m");
     runner.stop();
   });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -2316,6 +2316,7 @@ export async function runHeartbeatOnce(opts: {
 
 export function startHeartbeatRunner(opts: {
   cfg?: OpenClawConfig;
+  readCurrentConfig?: () => OpenClawConfig;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   runOnce?: typeof runHeartbeatOnce;
@@ -2331,6 +2332,7 @@ export function startHeartbeatRunner(opts: {
     timer: null as NodeJS.Timeout | null,
     stopped: false,
   };
+  const readCurrentConfig = opts.readCurrentConfig ?? (() => state.cfg);
   let initialized = false;
   let heartbeatTimeoutOverflowWarned = false;
 
@@ -2570,6 +2572,7 @@ export function startHeartbeatRunner(opts: {
     const isInterval = reason === "interval";
     const startedAt = Date.now();
     const now = startedAt;
+    const wakeConfig = readCurrentConfig();
     let ran = false;
     // Track retryable busy skips so we can skip re-arm in finally — the wake
     // layer handles retry for this case (DEFAULT_RETRY_MS = 1 s).
@@ -2589,10 +2592,10 @@ export function startHeartbeatRunner(opts: {
         }
         try {
           const res = await runOnce({
-            cfg: state.cfg,
+            cfg: wakeConfig,
             agentId: targetAgent.agentId,
             heartbeat: resolveHeartbeatForWake({
-              cfg: state.cfg,
+              cfg: wakeConfig,
               agentId: targetAgent.agentId,
               configuredHeartbeat: targetAgent.heartbeat,
               requestedHeartbeat,
@@ -2654,7 +2657,7 @@ export function startHeartbeatRunner(opts: {
         let res: HeartbeatRunResult;
         try {
           res = await runOnce({
-            cfg: state.cfg,
+            cfg: wakeConfig,
             agentId: agent.agentId,
             heartbeat: agent.heartbeat,
             source: params.source,
@@ -2687,13 +2690,13 @@ export function startHeartbeatRunner(opts: {
         let agentRan = res.status === "ran";
 
         const defaultSessionKey = resolveHeartbeatSession(
-          state.cfg,
+          wakeConfig,
           agent.agentId,
           agent.heartbeat,
         ).sessionKey;
         const dueSessionKeys = canHeartbeatDeliverCommitments(agent.heartbeat)
           ? await listDueCommitmentSessionKeys({
-              cfg: state.cfg,
+              cfg: wakeConfig,
               agentId: agent.agentId,
               nowMs: now,
               limit: 10,
@@ -2706,7 +2709,7 @@ export function startHeartbeatRunner(opts: {
           let commitmentRes: HeartbeatRunResult;
           try {
             commitmentRes = await runOnce({
-              cfg: state.cfg,
+              cfg: wakeConfig,
               agentId: agent.agentId,
               heartbeat: agent.heartbeat,
               runScope: "commitment-only",


### PR DESCRIPTION
## Summary

Fixes stale runtime config on the Gateway for every `kind: "none"` reload-classified key, including `messages.visibleReplies` / `messages.groupChat.visibleReplies` — the bug reported in #100321 (thanks @Sedrak-Hovhannisyan for the report and initial patch).

Root cause: when the config watcher classified all changed paths as no-op, `startGatewayConfigReloader.applySnapshot` early-returned before `onHotReload`, and the process-global runtime snapshot (`setRuntimeConfigSnapshot`) was only ever committed inside the hot-reload path. Every "none" key whose consumers read `getRuntimeConfig()` per turn (`messages.visibleReplies`, `messages.responsePrefix`, `messages.ackReaction`, `diagnostics.stuckSessionWarnMs/AbortMs`, …) stayed stale until a full Gateway restart, while the CLI printed "No gateway restart needed."

Fix:
- New required `onNoopConfigCommit` callback on `startGatewayConfigReloader`; the managed Gateway wires it to the same `activateRuntimeSecrets(nextConfig, { reason: "reload", activate: true })` primitive the hot path uses, so noop plans commit the runtime/secrets/web-tool snapshot without the heavyweight `applyHotReload` machinery (no prepared-model reset, no directory-cache reset, no channel work).
- Heartbeat wakes now read the current runtime config (`readCurrentConfig: getRuntimeConfig` injected at the Gateway seam) instead of the `state.cfg` captured at start, so heartbeat-driven turns also observe applied config changes; schedule recalculation stays owned by `updateConfig`/`restart-heartbeat`.
- The CLI "No gateway restart needed." hint for none-classified keys is now truthful; no per-key hot rules added.

Supersedes #100321, which reclassified only the two visibleReplies keys as actionless `kind: "hot"` — that left every sibling "none" key stale, missed heartbeat-driven turns entirely, and ran the full hot-reload machinery per toggle.

## Verification

- `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts src/gateway/server-reload-handlers.test.ts src/cli/config-cli.test.ts src/infra/heartbeat-runner.scheduler.test.ts` — 3 shards, 537 tests, all green (run twice: once by implementer, once independently).
- New behavior tests: noop plan commits snapshot before `onConfigApplied` and without `onHotReload`/`onRestart` (`config-reload.test.ts`); managed Gateway wires the commit to `activateRuntimeSecrets` without touching the heartbeat (`server-reload-handlers.test.ts`); heartbeat wake after a snapshot commit sees the new `messages.visibleReplies` value (`heartbeat-runner.scheduler.test.ts`).
- `pnpm tsgo` — passed.
- `pnpm build` — passed, no `[INEFFECTIVE_DYNAMIC_IMPORT]`.
- autoreview (local mode) — clean, no actionable findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
