### PR TITLE
fix(agents): include gemini latest aliases in thought_signature replay

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -8603,6 +8603,55 @@ describe("openai transport stream", () => {
       );
     });
 
+    it("injects thought_signature for gemini-flash-latest (dynamic alias resolved to Gemini 3.x)", () => {
+      const flashLatestModel = {
+        ...geminiModel,
+        id: "google/gemini-flash-latest",
+        name: "Gemini Flash Latest",
+      };
+      const params = buildOpenAICompletionsParams(
+        flashLatestModel,
+        {
+          messages: [
+            {
+              role: "assistant",
+              api: flashLatestModel.api,
+              provider: flashLatestModel.provider,
+              model: flashLatestModel.id,
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "toolUse",
+              timestamp: 1,
+              content: [
+                {
+                  type: "toolCall",
+                  id: "call_xyz",
+                  name: "echo_value",
+                  arguments: { value: "repro" },
+                  thoughtSignature: "SIG-LATEST-123==",
+                },
+              ],
+            },
+          ],
+          tools: [],
+        } as never,
+        undefined,
+      ) as { messages: Array<Record<string, unknown>> };
+
+      const assistant = params.messages.find((message) => message.role === "assistant") as
+        | { tool_calls?: Array<{ extra_content?: { google?: { thought_signature?: string } } }> }
+        | undefined;
+      expect(assistant?.tool_calls?.[0]?.extra_content?.google?.thought_signature).toBe(
+        "SIG-LATEST-123==",
+      );
+    });
+
     it("falls back to skip_thought_signature_validator when a captured same-route Gemini 3 signature is truncated", () => {
       // Compaction-truncated sig: 109 chars, length mod 4 == 1.
       // Same-route assistant tool-call whose captured thoughtSignature is truncated.

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3972,7 +3972,12 @@ function isGoogleOpenAICompatModel(model: OpenAIModeModel): boolean {
 }
 
 function requiresGoogleCompatToolCallThoughtSignature(model: OpenAIModeModel): boolean {
-  return model.id.toLowerCase().includes("gemini-3");
+  const id = model.id.toLowerCase();
+  // Gemini 3.x models need thought_signature replay.
+  // Dynamic "latest" aliases (e.g. gemini-flash-latest) resolve to
+  // Gemini 3.x templates but carry the alias as model.id, not the
+  // resolved template id, so check those explicitly too.
+  return id.includes("gemini-3") || (id.includes("gemini-") && id.includes("-latest"));
 }
 
 const GOOGLE_COMPAT_THOUGHT_SIGNATURE_ELLIPSIS_RE = /[\u2026]|\.\.\./;


### PR DESCRIPTION
## What Problem This Solves

Fixes #100566. `google/gemini-flash-latest` (and similar dynamic aliases) cause a 400 error when tool calls are used: "Function call is missing a thought_signature." This is a regression in 2026.6.11.

## Root Cause / Fix

`requiresGoogleCompatToolCallThoughtSignature` only matched model IDs containing `"gemini-3"`. But dynamic aliases like `gemini-flash-latest` resolve to Gemini 3.x templates while carrying the alias — not the resolved template ID — as `model.id`. The check returned `false`, so `fallbackSig` was `undefined`, and thought_signature injection was skipped entirely for those models.

**Fix** (2 lines): Expand the check to also cover any Gemini model ID containing `"-latest"`:

```typescript
return id.includes("gemini-3") || (id.includes("gemini-") && id.includes("-latest"));
```

Blast radius: only `gemini-*-latest` aliases (gemini-flash-latest, gemini-pro-latest, gemini-flash-lite-latest). `gemini-2.5-pro` and other non-Gemini-3 models are unchanged.

## Evidence

### Test suite
```
$ node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts -t "thought_signature"

Test Files  1 passed (1)   Tests  16 passed (16)
```

Added a focused test for `google/gemini-flash-latest` → thought_signature injected correctly.

### Before/After

| Model ID | Before | After |
|----------|--------|-------|
| `gemini-3-flash-preview` | thought_signature ✅ | thought_signature ✅ (unchanged) |
| `google/gemini-flash-latest` | thought_signature ❌ (400 error) | thought_signature ✅ |
| `gemini-2.5-pro` | no thought_signature | no thought_signature (unchanged) |

### Pre-submit
oxlint clean | git diff --check clean | autoreview 0.95 (zero findings) | 16 tests passed

## Change Type

Bug fix (regression) | agents/transport | 2 files, +55/-1, XS
