### PR TITLE
fix(qqbot): bound gateway websocket payloads

### DIFF
--- a/extensions/qqbot/src/engine/gateway/ws-client.test.ts
+++ b/extensions/qqbot/src/engine/gateway/ws-client.test.ts
@@ -77,6 +77,7 @@ describe("createQQWSClient", () => {
       "wss://qq.example.test/ws",
       {
         headers: { "User-Agent": "openclaw-qqbot-test" },
+        maxPayload: 16 * 1024 * 1024,
       },
     ]);
   });
@@ -96,6 +97,7 @@ describe("createQQWSClient", () => {
       {
         agent: { proxied: true },
         headers: { "User-Agent": "openclaw-qqbot-test" },
+        maxPayload: 16 * 1024 * 1024,
       },
     ]);
   });
@@ -115,6 +117,7 @@ describe("createQQWSClient", () => {
       {
         agent: { proxied: true },
         headers: { "User-Agent": "openclaw-qqbot-test" },
+        maxPayload: 16 * 1024 * 1024,
       },
     ]);
   });
@@ -134,6 +137,7 @@ describe("createQQWSClient", () => {
       {
         agent: { proxied: true },
         headers: { "User-Agent": "openclaw-qqbot-test" },
+        maxPayload: 16 * 1024 * 1024,
       },
     ]);
   });

--- a/extensions/qqbot/src/engine/gateway/ws-client.ts
+++ b/extensions/qqbot/src/engine/gateway/ws-client.ts
@@ -3,6 +3,8 @@ import type { Agent } from "node:http";
 import { resolveAmbientNodeProxyAgent } from "openclaw/plugin-sdk/extension-shared";
 import WebSocket from "ws";
 
+const QQBOT_WS_MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
+
 export interface QQWSClientOptions {
   gatewayUrl: string;
   userAgent: string;
@@ -12,6 +14,7 @@ export async function createQQWSClient(options: QQWSClientOptions): Promise<WebS
   const wsAgent = await resolveAmbientNodeProxyAgent<Agent>();
   return new WebSocket(options.gatewayUrl, {
     headers: { "User-Agent": options.userAgent },
+    maxPayload: QQBOT_WS_MAX_PAYLOAD_BYTES,
     ...(wsAgent ? { agent: wsAgent } : {}),
   });
 }


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where the QQ Bot WebSocket gateway connection has no inbound frame size limit (`maxPayload`), allowing an unbounded attacker-controlled or faulty gateway server to send arbitrarily large WebSocket frames that can cause an out-of-memory (OOM) crash.

Identical protections already landed for Discord (#99998) and Signal (#99992) gateway WebSocket connections. The QQ Bot channel was missed and remains the only channel WebSocket connection without a payload cap.

## Why This Change Was Made
The `ws` library defaults to 100 MiB per frame, which is sufficient for a memory exhaustion attack vector. A 16 MiB cap matches the limit used by Discord and OpenAI voice WebSocket connections, providing a consistent defense-in-depth bound without restricting legitimate gateway payloads (message events, heartbeats, reconnect directives).

## User Impact
No user-visible impact. Legitimate QQ Bot gateway frames (message dispatch, heartbeat ACKs, session lifecycle events) are orders of magnitude smaller than 16 MiB. The cap only activates against malformed or malicious frames that would otherwise exhaust the process heap.

## Evidence

### Test proof (vitest)
All 4 existing ws-client tests updated to assert `maxPayload: 16 * 1024 * 1024` is passed to the WebSocket constructor. Full QQ Bot gateway test suite (14 files, 129 tests) passes with no regressions.

```
 Test Files  14 passed (14)
      Tests  129 passed (129)
```

### Negative control
Before this change, `createQQWSClient()` constructs the WebSocket without `maxPayload`:
```ts
// src/engine/gateway/ws-client.ts (before fix)
return new WebSocket(options.gatewayUrl, {
  headers: { "User-Agent": options.userAgent },
  ...(wsAgent ? { agent: wsAgent } : {}),
});  // ← no maxPayload — unbounded inbound frames
```

After fix:
```ts
return new WebSocket(options.gatewayUrl, {
  headers: { "User-Agent": options.userAgent },
  maxPayload: QQBOT_WS_MAX_PAYLOAD_BYTES,  // ← 16 MiB cap
  ...(wsAgent ? { agent: wsAgent } : {}),
});
```

### Pattern alignment
| Channel | PR | Limit |
|---------|-----|-------|
| Discord gateway WS | #99998 | 16 MiB |
| Signal receive WS | #99992 | 1 MiB |
| OpenAI voice WS | #99450 | 16 MiB |
| **QQ Bot gateway WS** | **this PR** | **16 MiB** |