### PR TITLE
fix(pdf): PDF analysis fails for plugin-provided and bundled-catalog models

### DIFF
--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -1053,6 +1053,35 @@ describe("resolveModel", () => {
     });
   });
 
+  it("resolves provider-prefixed registry model ids from the short local id", async () => {
+    // Registries can store custom model ids provider-prefixed (e.g. "custom/vision-1")
+    // while callers pass the short local id, so the registry lookup must retry the
+    // prefixed form. Regression guard for the removed resolveModelFromRegistry retry.
+    mockDiscoveredModel(discoverModels, {
+      provider: "custom",
+      modelId: "custom/vision-1",
+      templateModel: {
+        id: "custom/vision-1",
+        name: "Custom Vision 1",
+        provider: "custom",
+        api: "openai-responses",
+        baseUrl: "https://models.example.com/v1",
+        reasoning: false,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 1024,
+      },
+    });
+
+    const result = await resolveModelAsyncForTest("custom", "vision-1", "/tmp/agent");
+
+    expectRecordFields(expectResolvedModel(result), {
+      provider: "custom",
+      id: "custom/vision-1",
+    });
+  });
+
   it("does not use bundled static catalog rows unless the caller opts in", async () => {
     const result = await resolveModelAsync(
       "mistral",

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -963,7 +963,13 @@ function resolveExplicitModelWithRegistry(params: {
   ) {
     return { kind: "suppressed" };
   }
-  const model = modelRegistry.find(provider, modelId) as Model | null;
+  // Registries can store custom model ids provider-prefixed (e.g. "kimchi/vision-1")
+  // while callers pass the short local id; retry the prefixed form so those models
+  // stay resolvable, matching the removed resolveModelFromRegistry helper.
+  let model = modelRegistry.find(provider, modelId) as Model | null;
+  if (!model && !modelId.includes("/")) {
+    model = modelRegistry.find(provider, `${provider}/${modelId}`) as Model | null;
+  }
 
   if (model) {
     const configuredBaseUrl =

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -1,5 +1,5 @@
-// Shared media tool tests cover root separation, provider availability, and
-// model-registry normalization for generation/understanding tools.
+// Shared media tool tests cover root separation and provider availability for
+// generation/understanding tools.
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
@@ -12,7 +12,6 @@ import {
   resolveMediaToolInboundRoots,
   resolveCapabilityModelConfigForTool,
   resolveMediaToolLocalRoots,
-  resolveModelFromRegistry,
 } from "./media-tool-shared.js";
 
 // Keep media-tool-shared tests focused on root separation; channel-inbound
@@ -42,22 +41,6 @@ vi.mock("../../media/channel-inbound-roots.js", () => ({
 
 function normalizeHostPath(value: string): string {
   return path.normalize(path.resolve(value));
-}
-
-function createModelRegistryStub(resolve: (provider: string, modelId: string) => unknown): {
-  calls: Array<[string, string]>;
-  registry: { find: (provider: string, modelId: string) => unknown };
-} {
-  const calls: Array<[string, string]> = [];
-  return {
-    calls,
-    registry: {
-      find(provider, modelId) {
-        calls.push([provider, modelId]);
-        return resolve(provider, modelId);
-      },
-    },
-  };
 }
 
 describe("readBooleanToolParam", () => {
@@ -130,55 +113,6 @@ describe("resolveMediaToolLocalRoots", () => {
       }),
     ).toEqual([accountRoot, sharedRoot, "/Users/*/Library/Messages/Attachments"]);
   });
-});
-
-describe("resolveModelFromRegistry", () => {
-  it("normalizes provider and model refs before registry lookup", () => {
-    const foundModel = { provider: "ollama", id: "qwen3.5:397b-cloud" };
-    const { calls, registry } = createModelRegistryStub(() => foundModel);
-
-    const result = resolveModelFromRegistry({
-      modelRegistry: registry,
-      provider: " OLLAMA ",
-      modelId: " qwen3.5:397b-cloud ",
-    });
-
-    expect(calls).toEqual([["ollama", "qwen3.5:397b-cloud"]]);
-    expect(result).toBe(foundModel);
-  });
-
-  it("reports the normalized ref when the registry lookup misses", () => {
-    const { registry } = createModelRegistryStub(() => null);
-
-    expect(() =>
-      resolveModelFromRegistry({
-        modelRegistry: registry,
-        provider: " OLLAMA ",
-        modelId: " qwen3.5:397b-cloud ",
-      }),
-    ).toThrow("Unknown model: ollama/qwen3.5:397b-cloud");
-  });
-
-  it("falls back to provider-prefixed custom model IDs", () => {
-    // Custom providers can store ids with provider prefixes; try both forms so
-    // callers can pass the short local model id.
-    const foundModel = { provider: "kimchi", id: "kimchi/claude-opus-4-6" };
-    const { calls, registry } = createModelRegistryStub((_, modelId) =>
-      modelId === "kimchi/claude-opus-4-6" ? foundModel : null,
-    );
-
-    const result = resolveModelFromRegistry({
-      modelRegistry: registry,
-      provider: "kimchi",
-      modelId: "claude-opus-4-6",
-    });
-
-    expect(calls).toEqual([
-      ["kimchi", "claude-opus-4-6"],
-      ["kimchi", "kimchi/claude-opus-4-6"],
-    ]);
-    expect(result).toBe(foundModel);
-  }, 180_000);
 });
 
 describe("hasGenerationToolAvailability", () => {

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -25,7 +25,6 @@ import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { loadCapabilityManifestSnapshot } from "../../plugins/capability-provider-runtime.js";
 import { listAvailableManifestContractValues } from "../../plugins/manifest-contract-eligibility.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
-import { normalizeModelRef } from "../model-selection.js";
 import {
   ToolInputError,
   readPositiveIntegerParam,
@@ -631,30 +630,6 @@ export function buildTextToolResult(
       attempts: result.attempts,
     },
   };
-}
-
-/**
- * Resolves a catalog model while supporting registries that index model ids with provider prefixes.
- */
-export function resolveModelFromRegistry(params: {
-  modelRegistry: { find: (provider: string, modelId: string) => unknown };
-  provider: string;
-  modelId: string;
-}): Model {
-  const resolvedRef = normalizeModelRef(params.provider, params.modelId, {
-    allowPluginNormalization: false,
-  });
-  let model = params.modelRegistry.find(resolvedRef.provider, resolvedRef.model) as Model | null;
-  if (!model && !resolvedRef.model.includes("/")) {
-    model = params.modelRegistry.find(
-      resolvedRef.provider,
-      `${resolvedRef.provider}/${resolvedRef.model}`,
-    ) as Model | null;
-  }
-  if (!model) {
-    throw new Error(`Unknown model: ${resolvedRef.provider}/${resolvedRef.model}`);
-  }
-  return model;
 }
 
 /**

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -8,8 +8,8 @@ import type { OpenClawConfig } from "../../config/config.js";
 import * as pdfExtractModule from "../../media/pdf-extract.js";
 import * as webMedia from "../../media/web-media.js";
 import { withEnvAsync } from "../../test-utils/env.js";
-import * as modelDiscovery from "../agent-model-discovery.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
+import * as model from "../embedded-agent-runner/model.js";
 import * as modelAuth from "../model-auth.js";
 import * as modelsConfig from "../models-config.js";
 import * as pdfNativeProviders from "./pdf-native-providers.js";
@@ -116,36 +116,33 @@ async function stubPdfToolInfra(
     provider?: string;
     input?: string[];
     api?: string;
-    modelFound?: boolean;
   },
 ) {
-  // Keep PDF tool tests focused on orchestration; provider discovery, auth, and
+  // Keep PDF tool tests focused on orchestration; model resolution, auth, and
   // remote media loading are replaced with narrow spies at the module boundary.
+  // resolveModelAsync is the same resolver the image tool and main loop use, so
+  // stubbing it keeps provider-runtime/static-catalog resolution out of scope.
   const loadSpy = vi.spyOn(webMedia, "loadWebMediaRaw");
   if (params?.mockLoad !== false) {
     loadSpy.mockResolvedValue(FAKE_PDF_MEDIA as never);
   }
 
-  vi.spyOn(modelDiscovery, "discoverAuthStorage").mockReturnValue({
-    setRuntimeApiKey: vi.fn(),
-  } as never);
-  const find =
-    params?.modelFound === false
-      ? () => null
-      : () =>
-          ({
-            provider: params?.provider ?? "anthropic",
-            api:
-              params?.api ??
-              (params?.provider === "openai"
-                ? "openai-chatgpt-responses"
-                : params?.provider === "openai"
-                  ? "openai-responses"
-                  : "anthropic-messages"),
-            maxTokens: 8192,
-            input: params?.input ?? ["text", "document"],
-          }) as never;
-  vi.spyOn(modelDiscovery, "discoverModels").mockReturnValue({ find } as never);
+  const provider = params?.provider ?? "anthropic";
+  const api = params?.api ?? (provider === "openai" ? "openai-responses" : "anthropic-messages");
+  vi.spyOn(model, "resolveModelAsync").mockImplementation(async (resolvedProvider, modelId) => {
+    return {
+      model: {
+        provider: resolvedProvider,
+        id: modelId,
+        name: modelId,
+        api,
+        maxTokens: 8192,
+        input: params?.input ?? ["text", "document"],
+      },
+      authStorage: { setRuntimeApiKey: vi.fn() },
+      modelRegistry: {},
+    } as never;
+  });
 
   vi.spyOn(modelsConfig, "ensureOpenClawModelsJson").mockResolvedValue({
     agentDir,
@@ -520,9 +517,13 @@ describe("createPdfTool", () => {
       );
       expect(modelsAgentDir).toBe(agentDir);
       expect(modelsOptions).toEqual({ workspaceDir });
-      expect(modelDiscovery.discoverModels).toHaveBeenCalledWith(expect.anything(), agentDir, {
-        workspaceDir,
-      });
+      expect(model.resolveModelAsync).toHaveBeenCalledWith(
+        "anthropic",
+        "claude-opus-4-6",
+        agentDir,
+        expect.anything(),
+        expect.objectContaining({ allowBundledStaticCatalogFallback: true, workspaceDir }),
+      );
       expect(extractSpy).not.toHaveBeenCalled();
       expect(result.content).toEqual([{ type: "text", text: "native summary" }]);
       expectFields(result.details, {
@@ -648,7 +649,42 @@ describe("createPdfTool", () => {
         native: false,
         model: OPENAI_PDF_MODEL,
       });
+      // Non-native fallback candidates resolve through the shared resolver too,
+      // so plugin-provided/catalog-native providers stay usable for extraction.
+      expect(model.resolveModelAsync).toHaveBeenCalledWith(
+        "openai",
+        "gpt-5.4-mini",
+        agentDir,
+        expect.anything(),
+        expect.objectContaining({ allowBundledStaticCatalogFallback: true }),
+      );
       expect(firstCompletionContext()?.systemPrompt).toBeUndefined();
+    });
+  });
+
+  it("surfaces the resolver error when model resolution fails", async () => {
+    // resolveModelAsync reports a rich diagnostic in `error` when a candidate
+    // cannot be resolved; the pdf tool must surface that instead of a generic
+    // "Unknown model" string. Failure-path coverage suggested by @STiFLeR7.
+    await withTempPdfAgentDir(async (agentDir) => {
+      vi.spyOn(webMedia, "loadWebMediaRaw").mockResolvedValue(FAKE_PDF_MEDIA as never);
+      vi.spyOn(modelsConfig, "ensureOpenClawModelsJson").mockResolvedValue({
+        agentDir,
+        wrote: false,
+      });
+      const resolverError = "Custom model resolution failed: API key missing or invalid.";
+      vi.spyOn(model, "resolveModelAsync").mockResolvedValue({
+        model: undefined,
+        error: resolverError,
+        authStorage: { setRuntimeApiKey: vi.fn() },
+        modelRegistry: {},
+      } as never);
+      const cfg = withPdfModel(ANTHROPIC_PDF_MODEL);
+      const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", { prompt: "summarize", pdf: "/tmp/doc.pdf" }),
+      ).rejects.toThrow(resolverError);
     });
   });
 

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -19,6 +19,7 @@ import { extractPdfContent, type PdfExtractedContent } from "../../media/pdf-ext
 import { loadWebMediaRaw } from "../../media/web-media.js";
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
+import { resolveModelAsync } from "../embedded-agent-runner/model.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
 import { optionalFiniteNumberSchema } from "../schema/typebox.js";
 import { readFiniteNumberParam, ToolInputError } from "./common.js";
@@ -27,7 +28,6 @@ import {
   applyImageModelConfigDefaults,
   buildTextToolResult,
   REMOTE_MEDIA_READ_IDLE_TIMEOUT_MS,
-  resolveModelFromRegistry,
   resolveMediaToolLocalRoots,
   resolveModelRuntimeApiKey,
   resolvePromptAndModelOverride,
@@ -46,8 +46,6 @@ import {
 import { resolvePdfModelConfigForTool } from "./pdf-tool.model-config.js";
 import {
   createSandboxBridgeReadFile,
-  discoverAuthStorage,
-  discoverModels,
   ensureOpenClawModelsJson,
   resolveSandboxedBridgeMediaPath,
   runWithImageModelFallback,
@@ -161,8 +159,6 @@ async function runPdfPrompt(params: {
 
   const modelsOptions = params.workspaceDir ? { workspaceDir: params.workspaceDir } : undefined;
   await ensureOpenClawModelsJson(effectiveCfg, params.agentDir, modelsOptions);
-  const authStorage = discoverAuthStorage(params.agentDir);
-  const modelRegistry = discoverModels(authStorage, params.agentDir, modelsOptions);
 
   let extractionCache: PdfExtractedContent[] | null = null;
   const getExtractions = async (): Promise<PdfExtractedContent[]> => {
@@ -176,7 +172,22 @@ async function runPdfPrompt(params: {
     cfg: effectiveCfg,
     modelOverride: params.modelOverride,
     run: async (provider, modelId) => {
-      const model = resolveModelFromRegistry({ modelRegistry, provider, modelId });
+      // Resolve each fallback candidate through resolveModelAsync (not
+      // discoverModels/registry.find) so plugin-provided providers and bundled
+      // static-catalog models resolve like the image tool and main agent loop.
+      const { model, error, authStorage } = await resolveModelAsync(
+        provider,
+        modelId,
+        params.agentDir,
+        effectiveCfg,
+        {
+          allowBundledStaticCatalogFallback: true,
+          ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+        },
+      );
+      if (!model) {
+        throw new Error(error ?? `Unknown model: ${provider}/${modelId}`);
+      }
       const apiKey = await resolveModelRuntimeApiKey({
         model,
         cfg: effectiveCfg,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the `pdf` tool fails with "Unknown model" and refuses to analyze a document whenever its selected or fallback PDF model comes from a plugin-provided provider or a bundled-catalog model that has not been materialized into the agent's `models.json`. Users who point PDF analysis at a plugin vision/image provider, or at a catalog-native model, get an error instead of a described PDF even though the exact same provider and model already work for the `image` tool and for normal agent turns.

## Why This Change Was Made

The PDF tool resolved its fallback candidates through a narrow `discoverModels` + registry `find()` lookup, which only sees entries written to `models.json`; it never ran provider runtime hooks and never fell back to the bundled static catalog, so plugin-provided and catalog-native models were invisible to it. This change routes PDF model resolution through the shared `resolveModelAsync(..., { allowBundledStaticCatalogFallback: true })` resolver, the same path the `image` tool (`src/media-understanding/image.ts`) and the main agent loop already use, so PDF resolution now behaves consistently with the rest of the product. The shared resolver also gained the provider-prefixed registry fallback that the removed `resolveModelFromRegistry` helper used to perform, so custom providers that store their model ids as `provider/model` in `models.json` keep resolving when the short local id is requested. The now-unused `resolveModelFromRegistry` helper and its unit test were removed.

## User Impact

The `pdf` tool can now analyze documents with plugin-provided providers and bundled-catalog models, matching the behavior users already get from the `image` tool, so configured PDF/vision providers that previously produced "Unknown model" now resolve and run. When a model genuinely cannot be resolved, the failure now carries the richer diagnostics from the shared resolver instead of a bare "Unknown model" string. No configuration changes are required, and there is no behavior change for setups whose PDF model was already present in `models.json`.

## Evidence

Real behavior proof against a live plugin provider (Xiaomi MiMo — a bundled plugin provider that ships a static model catalog and is exactly the "plugin-provided model" case above). The transcript below drives the pdf tool's real production resolution + analysis pipeline (the same `resolveModelAsync` → `resolveModelRuntimeApiKey` → `extractPdfContent` → `complete()` calls `runPdfPrompt` makes), against the live `api.xiaomimimo.com` endpoint. No mocks; API key redacted:

```
[before] discoverModels().find(xiaomi, mimo-v2-flash)  = MISS  ->  old pdf path throws "Unknown model: xiaomi/mimo-v2-flash"
[after]  resolveModelAsync(xiaomi, mimo-v2-flash, { allowBundledStaticCatalogFallback: true })  = RESOLVED xiaomi/mimo-v2-flash
[analyze] resolved model + api key ok; extracted PDF text chars: 262
[analyze] live MiMo response: "This document is a positive quarterly report for OpenClaw, highlighting twenty percent revenue growth, the integration of the Xiaomi MiMo model into its PDF analysis tool, and sustained high customer satisfaction above ninety percent."
```

So the same plugin-catalog model that the old registry-only path reports as "Unknown model" is resolved by the shared resolver on this branch, and a real end-to-end PDF analysis then completes. (The end-to-end analysis call uses `mimo-v2.5-pro`, which is what the live `api.xiaomimimo.com` key serves today; the bundled `xiaomi` catalog still ships the older `mimo-v2-*` ids, so refreshing that catalog is a separate follow-up unrelated to this resolver fix.)

Focused unit tests: `pnpm test src/agents/tools/pdf-tool.test.ts` passes; the suite asserts that the native-provider and text-extraction paths each resolve candidates through `resolveModelAsync` with `allowBundledStaticCatalogFallback: true`, and that the tool surfaces the resolver-provided error when a model cannot be resolved. `src/agents/embedded-agent-runner/model.test.ts` adds a regression test that a provider-prefixed registry id (for example `custom/vision-1`) resolves from the short local id.

This is a convergence onto already-shipped behavior rather than a new resolution path: `src/media-understanding/image.ts` runs `ensureOpenClawModelsJson` and then `resolveModelAsync(..., { allowBundledStaticCatalogFallback: true })`, and `src/agents/embedded-agent-runner/compact.ts` consumes the same `{ model, error, authStorage }` result shape, so the PDF tool now matches the resolver contract those paths rely on.
