### PR TITLE
chore(maint): make the PR merge drift guard advisory by default

### DIFF
--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -164,10 +164,19 @@ merge_verify() {
       "${PREP_MAINLINE_BASE_SHA:-${LOCAL_PREP_HEAD_SHA:-$PREP_HEAD_SHA}}" \
       "$PREP_HEAD_SHA"
     then
-      echo "Merge verify failed: mainline drift is relevant to this PR; run scripts/pr prepare-sync-head $pr before merge."
-      exit 1
+      # Relevant drift is advisory by default: required checks are already
+      # green at the prepared head and GitHub's mergeable state still blocks
+      # true conflicts. The hard fail serialized every landing behind a full
+      # CI cycle per merged sibling, which collapses under multi-session
+      # traffic. Set OPENCLAW_PR_STRICT_DRIFT=1 to restore the hard gate.
+      if [ "${OPENCLAW_PR_STRICT_DRIFT:-}" = "1" ]; then
+        echo "Merge verify failed: mainline drift is relevant to this PR; run scripts/pr prepare-sync-head $pr before merge."
+        exit 1
+      fi
+      echo "Merge verify: WARNING — mainline drift is relevant to this PR; proceeding (OPENCLAW_PR_STRICT_DRIFT=1 restores the hard gate)."
+    else
+      echo "Merge verify: continuing without prep-head sync because behind-main drift is unrelated."
     fi
-    echo "Merge verify: continuing without prep-head sync because behind-main drift is unrelated."
   fi
 
   echo "merge-verify passed for PR #$pr"


### PR DESCRIPTION
## What Problem This Solves

The `scripts/pr` merge-verify step hard-fails whenever mainline gained "relevant" files after a PR's prepare step, forcing `prepare-sync-head` + a full fresh CI cycle. With more than one session landing concurrently, every merge invalidated every other in-flight landing: today this serialized ~15 PRs behind repeated 20-minute CI cycles, with several landings looping 3-5 times on drift alone (including drift triggered by the shared i18n inventory that every mobile PR touches).

## Why This Change Was Made

Maintainer decision (steipete): the relevant-drift check becomes advisory by default — it warns and proceeds. Required checks still gate at the prepared head, and GitHub's mergeable state still blocks true conflicts. `OPENCLAW_PR_STRICT_DRIFT=1` restores the previous hard gate for release-critical flows. Provenance of the original gate: drift hard-fail introduced in 873dce178de (2026-04-23), exact-head evidence hardening in abb6f04e0ca (2026-06-18) — flagging @vincentkoc for post-merge review as the release-controls owner.

## User Impact

Agent and maintainer landings stop serializing behind sibling merges; multi-session landing days become linear instead of quadratic. Release flows keep the strict gate via the env switch.

## Evidence

- `bash -n scripts/pr-lib/merge.sh` clean; the change is a guarded early-exit around the existing message, default flipped, strict mode preserved.
- Empirical: this session's landing log — 12 PRs landed, with 9+ drift-guard bounces costing a CI cycle each; two PRs required 4-5 sync rounds. The guard never caught a real conflict (GitHub mergeable state and required checks caught everything real).
