### PR TITLE
fix: replay Gemini latest alias thought signatures

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1547,6 +1547,27 @@ describe("google transport stream", () => {
     });
   });
 
+  it("adds the Gemini thought-signature fallback for unsigned Flash latest alias tool calls", () => {
+    const model = buildGeminiModel({
+      id: "gemini-flash-latest",
+      name: "Gemini Flash Latest",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [googleToolCallAssistantTurn({ model: "gemini-flash-latest" })],
+    } as never);
+
+    expect(params.contents[0]).toEqual({
+      role: "model",
+      parts: [
+        {
+          thoughtSignature: "skip_thought_signature_validator",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
   it("re-attaches replayed Gemini thought signatures when a later tool call is missing one", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -160,7 +160,7 @@ function requiresToolCallId(modelId: string): boolean {
 }
 
 function requiresToolCallThoughtSignature(modelId: string): boolean {
-  return normalizeLowercaseStringOrEmpty(modelId).includes("gemini-3");
+  return isGoogleGemini3ProModel(modelId) || isGoogleGemini3FlashModel(modelId);
 }
 
 function supportsMultimodalFunctionResponse(modelId: string): boolean {
@@ -532,7 +532,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
     routeModel,
     (id) => (requiresToolCallId(model.id) ? normalizeToolCallId(id) : id),
     {
-      preserveCrossModelToolCallThoughtSignature: requiresToolCallThoughtSignature(model.id),
+      preserveCrossModelToolCallThoughtSignature: shouldReplayToolCallThoughtSignature,
     },
   );
   // Parallel calls need one immediate function-response turn. Gemini < 3 images cannot


### PR DESCRIPTION
Closes #100566

## What Problem This Solves

Fixes an issue where users routing tool-calling requests to `google/gemini-flash-latest` could hit a Google API 400 because replayed tool calls were not given the Gemini thought-signature fallback required by the current Gemini Flash family.

## Why This Change Was Made

The Google transport now uses the same Gemini 3 Pro/Flash family predicates that already understand latest aliases when deciding whether tool-call thought signatures must be replayed. This keeps the repair inside the Google provider transport and avoids adding config or broader provider behavior.

## User Impact

Users can continue tool-calling sessions on `google/gemini-flash-latest` without the alias missing the thought-signature replay fallback used for Gemini 3 Flash-family models.

## Evidence

- Head SHA: `ee1baf286621ac40e52fd5f306c1a6c4c0e37ed1`
- Claim proved: the Google payload builder adds the Gemini thought-signature fallback for unsigned `gemini-flash-latest` tool calls, and a real Gemini API replay payload containing that fallback is accepted without the missing-thought-signature 400.
- Commands / artifacts:
  - `git diff --check` passed.
  - `git diff --check origin/main...HEAD` passed.
  - `node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts extensions/google/provider-models.test.ts` passed: 2 files, 102 tests.
  - User-assisted live Gemini proof on 2026-07-06 via PowerShell script: `powershell -ExecutionPolicy Bypass -File $env:TEMP\gemini-replay-proof.ps1 -ProxyUrl "http://127.0.0.1:7897"`.
- Observed result:
  - Focused regression test emits `skip_thought_signature_validator` for `gemini-flash-latest` tool-call replay.
  - Redacted live Gemini API proof returned `model: "gemini-flash-latest"`, `status: 200`, `ok: true`, `missingThoughtSignature400: false`, `errorSnippet: ""`, and `keyPrinted: false` for a replay payload whose model turn included `thoughtSignature: "skip_thought_signature_validator"` and a `lookup` function call.
- Not tested / proof gaps: this live proof directly exercised the Gemini `generateContent` API with the repaired replay payload shape; it was not a full OpenClaw CLI/Gateway end-to-end run.