### PR TITLE
fix: warn when transcript byte guard is inactive

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1693,6 +1693,85 @@ describe("doctor health contributions", () => {
     });
   });
 
+  it("warns when maxActiveTranscriptBytes is set without transcript rotation", async () => {
+    const contributionChecks = await resolveDoctorContributionHealthChecks();
+    const toolResultCapCheck = contributionChecks.find(
+      (check) => check.id === "core/doctor/tool-result-cap",
+    );
+    expect(toolResultCapCheck).toBeDefined();
+
+    const baseCtx = {
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              maxActiveTranscriptBytes: "10mb",
+            },
+          },
+        },
+      },
+      mode: "lint" as const,
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+    };
+
+    await expect(
+      runDoctorLintChecks(baseCtx, {
+        checks: [toolResultCapCheck!],
+        onlyIds: ["core/doctor/tool-result-cap"],
+      }),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      findings: [
+        expect.objectContaining({
+          checkId: "core/doctor/tool-result-cap",
+          path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+          requirement: "truncateAfterCompaction-required",
+        }),
+      ],
+    });
+
+    const contribution = requireDoctorContribution("doctor:tool-result-cap");
+    await contribution.run({
+      ...baseCtx,
+      configResult: { cfg: baseCtx.cfg },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      options: {},
+      cfgForPersistence: baseCtx.cfg,
+      configPath: "/tmp/fake-openclaw.json",
+      env: {},
+    });
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("active transcript byte guard is inactive"),
+      "Tool result cap",
+    );
+
+    await expect(
+      runDoctorLintChecks(
+        {
+          ...baseCtx,
+          cfg: {
+            agents: {
+              defaults: {
+                compaction: {
+                  truncateAfterCompaction: true,
+                  maxActiveTranscriptBytes: "10mb",
+                },
+              },
+            },
+          },
+        },
+        {
+          checks: [toolResultCapCheck!],
+          onlyIds: ["core/doctor/tool-result-cap"],
+        },
+      ),
+    ).resolves.toMatchObject({
+      checksRun: 1,
+      findings: [],
+    });
+  });
+
   it("keeps legacy plugin dependency lint opt-in and read-only", async () => {
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     const tempDir = fs.mkdtempSync(nodePath.join(os.tmpdir(), "openclaw-legacy-plugin-deps-lint-"));

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -6,6 +6,7 @@ import {
   isLegacyParentWritableUpdateDoctorPass,
   UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
 } from "../commands/doctor/shared/update-phase.js";
+import { parseNonNegativeByteSize } from "../config/byte-size.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
 import type { UpdatePostInstallDoctorResult } from "../infra/update-doctor-result.js";
@@ -794,6 +795,33 @@ type ToolResultCapTarget = {
   target?: string;
 };
 
+function collectInactiveMaxActiveTranscriptByteGuardFinding(
+  cfg: OpenClawConfig,
+): HealthFinding[] {
+  const compaction = cfg.agents?.defaults?.compaction;
+  const parsed = parseNonNegativeByteSize(compaction?.maxActiveTranscriptBytes);
+  if (
+    typeof parsed !== "number" ||
+    parsed <= 0 ||
+    compaction?.truncateAfterCompaction === true
+  ) {
+    return [];
+  }
+  return [
+    {
+      checkId: "core/doctor/tool-result-cap",
+      severity: "warning",
+      message:
+        "agents.defaults.compaction.maxActiveTranscriptBytes is set, but the active transcript byte guard is inactive until truncateAfterCompaction is true.",
+      path: "agents.defaults.compaction.maxActiveTranscriptBytes",
+      target: "agents.defaults.compaction",
+      requirement: "truncateAfterCompaction-required",
+      fixHint:
+        "Set agents.defaults.compaction.truncateAfterCompaction to true, or unset maxActiveTranscriptBytes.",
+    },
+  ];
+}
+
 async function collectToolResultCapFindings(
   cfg: OpenClawConfig,
 ): Promise<readonly HealthFinding[]> {
@@ -828,14 +856,15 @@ async function collectToolResultCapFindings(
       target: `agents.list.${normalizedAgentId}`,
     });
   }
+  const byteGuardFindings = collectInactiveMaxActiveTranscriptByteGuardFinding(cfg);
   if (targets.length === 0) {
-    return [];
+    return byteGuardFindings;
   }
 
   const { collectToolResultCapDoctorIssues, toolResultCapDoctorIssueToHealthFinding } =
     await import("./doctor-tool-result-cap-advice.js");
 
-  return collectToolResultCapTargetAdvice({
+  const toolResultFindings = await collectToolResultCapTargetAdvice({
     cfg,
     readOnlyCatalog: true,
     targets,
@@ -844,6 +873,7 @@ async function collectToolResultCapFindings(
       collectToolResultCapDoctorIssues(entry).map(toolResultCapDoctorIssueToHealthFinding),
     ),
   );
+  return [...byteGuardFindings, ...toolResultFindings];
 }
 
 async function collectToolResultCapTargetAdvice(params: {
@@ -925,22 +955,29 @@ async function runToolResultCapHealth(ctx: DoctorHealthFlowContext): Promise<voi
       scopeLabel: `agent "${normalizedAgentId}"`,
     });
   }
-  if (targets.length === 0) {
+  const byteGuardFindings = collectInactiveMaxActiveTranscriptByteGuardFinding(ctx.cfg);
+  if (targets.length === 0 && byteGuardFindings.length === 0) {
     return;
   }
 
-  const { buildToolResultCapDoctorAdvice } = await import("./doctor-tool-result-cap-advice.js");
   const { note } = await loadNoteModule();
-  const entries = await collectToolResultCapTargetAdvice({
-    cfg: ctx.cfg,
-    targets,
-  });
-  const lines = entries.flatMap((entry) =>
-    buildToolResultCapDoctorAdvice({
-      ...entry,
-      deep: ctx.options.deep === true,
-    }),
-  );
+  const { buildToolResultCapDoctorAdvice } = await import("./doctor-tool-result-cap-advice.js");
+  const entries =
+    targets.length > 0
+      ? await collectToolResultCapTargetAdvice({
+          cfg: ctx.cfg,
+          targets,
+        })
+      : [];
+  const lines = [
+    ...entries.flatMap((entry) =>
+      buildToolResultCapDoctorAdvice({
+        ...entry,
+        deep: ctx.options.deep === true,
+      }),
+    ),
+    ...byteGuardFindings.map((entry) => `- ${entry.message}`),
+  ];
   if (lines.length > 0) {
     note(lines.join("\n"), "Tool result cap");
   }


### PR DESCRIPTION
Closes #100529

## What Problem This Solves

Fixes an issue where operators could configure `agents.defaults.compaction.maxActiveTranscriptBytes` and believe the active transcript byte guard was enabled even though it remains inactive unless `truncateAfterCompaction` is true.

## Why This Change Was Made

Doctor now reports a warning for the inactive byte-guard configuration through the existing tool-result-cap health contribution. The change is diagnostic only: it does not change compaction policy, schema, runtime defaults, or existing config behavior.

## User Impact

Operators get an actionable Doctor warning that explains why the configured transcript byte guard is inactive and how to enable or remove it, instead of discovering the no-op behavior from long-running sessions.

## Evidence

- Head SHA: `af6aff325891b09b01018c45cab731a236334117`
- Claim proved: Doctor lint and normal Doctor output surface a warning when `maxActiveTranscriptBytes` is positive and `truncateAfterCompaction` is not true, and the warning disappears when transcript rotation is enabled.
- Commands / artifacts:
  - `git diff --check` passed.
  - `node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts src/auto-reply/reply/agent-runner-memory.test.ts src/config/schema.help.quality.test.ts` passed: 73 + 23 + 47 tests.
- Observed result: focused Doctor regression coverage reports `truncateAfterCompaction-required` for the inactive guard and no finding when `truncateAfterCompaction: true` is configured.
- Not tested / proof gaps: no broad typecheck/lint was run by request. A targeted oxlint attempt was blocked by local worktree tool setup (`prepare-extension-package-boundary-artifacts` could not find a path), not by a lint finding.