### PR TITLE
fix: reject fractional PDF page numbers

### DIFF
--- a/src/agents/tools/pdf-tool.helpers.test.ts
+++ b/src/agents/tools/pdf-tool.helpers.test.ts
@@ -82,6 +82,10 @@ describe("parsePageRange", () => {
     expect(() => parsePageRange("0", 20)).toThrow("Invalid page number");
   });
 
+  it("throws on fractional page number", () => {
+    expect(() => parsePageRange("1.5", 20)).toThrow('Invalid page number: "1.5"');
+  });
+
   it("throws on negative page number", () => {
     expect(() => parsePageRange("-1", 20)).toThrow("Invalid page number");
   });

--- a/src/agents/tools/pdf-tool.helpers.ts
+++ b/src/agents/tools/pdf-tool.helpers.ts
@@ -66,7 +66,7 @@ export function parsePageRange(range: string, maxPages: number): number[] {
       }
     } else {
       const num = Number(part);
-      if (!Number.isFinite(num) || num < 1) {
+      if (!Number.isFinite(num) || !Number.isInteger(num) || num < 1) {
         throw new Error(`Invalid page number: "${part}"`);
       }
       if (num <= maxPages) {

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -309,6 +309,26 @@ describe("createPdfTool", () => {
     });
   });
 
+  it("rejects fractional page numbers before native PDF analysis", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, { provider: "anthropic", input: ["text", "document"] });
+      const nativeSpy = vi
+        .spyOn(pdfNativeProviders, "anthropicAnalyzePdf")
+        .mockResolvedValue("native summary");
+      const cfg = withPdfModel(ANTHROPIC_PDF_MODEL);
+      const tool = requirePdfTool((await loadCreatePdfTool())({ config: cfg, agentDir }));
+
+      await expect(
+        tool.execute("t1", {
+          prompt: "summarize",
+          pdf: "/tmp/doc.pdf",
+          pages: "1.5",
+        }),
+      ).rejects.toThrow('Invalid page number: "1.5"');
+      expect(nativeSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it("passes validated maxBytesMb to PDF loading", async () => {
     await withTempPdfAgentDir(async (agentDir) => {
       const { loadSpy } = await stubPdfToolInfra(agentDir, {


### PR DESCRIPTION
﻿Closes #99393

## What Problem This Solves

Fixes an issue where the PDF tool accepted fractional `pages` values such as `1.5`, allowing invalid page selections to reach later extraction paths where non-integer pages could be dropped.

## Why This Change Was Made

The PDF page parser now rejects non-integer single-page tokens at the public `pages` parsing boundary using the existing invalid page-number error path. The fix preserves existing integer page, range, clamp, sort, and dedupe behavior.

## User Impact

Users who pass fractional PDF page numbers now receive a clear input error instead of a misleading PDF analysis path that may omit the requested content.

## Evidence

- Head SHA: `c18f5e2d6d8d7c6d1dc18fc65f3dd825e37eb8c9`
- Claim proved: fractional PDF page tokens are rejected by the parser and by the tool before native PDF analysis starts.
- Commands / artifacts:
  - `git diff --check` passed.
  - `git diff upstream/main...HEAD --check` passed.
  - `node scripts/run-vitest.mjs src/agents/tools/pdf-tool.helpers.test.ts` passed: 23 tests.
  - `node scripts/run-vitest.mjs src/agents/tools/pdf-tool.test.ts` passed: 27 tests.
- Observed result: `parsePageRange("1.5", 20)` now throws `Invalid page number: "1.5"`, and the PDF tool rejects `pages: "1.5"` before native provider analysis.
- Not tested / proof gaps: no broad typecheck/lint was run by request.
