### PR TITLE
docs(changelog): credit five Control UI and TUI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI coalesced updates:** show a clear queued-restart completion banner when an update joins an already-running Gateway restart. (#93082) Thanks @goutamadwant.
+- **Control UI connection errors:** preserve structured pairing and authentication failures for pending RPC callers while keeping generic disconnect behavior unchanged. (#54758) Thanks @ruanrrn.
+- **TUI startup status:** show `starting up` during post-connect initialization without overwriting active-run or reconnect state. (#93999) Thanks @ml12580.
+- **Control UI restart recovery:** recover stale bundle pages through a bounded whole-document refresh after Gateway updates or restarts. (#99111) Thanks @ZengWen-DT.
+- **TUI active Gateway ports:** follow the verified active local Gateway port when no explicit URL, port, or remote target is configured. (#73338, #42461) Thanks @haishmg and @vincentkoc.
 - **Apple chat run recovery:** restore active responses from canonical Gateway history after reconnects, foreground resumes, and event gaps, while preserving gateway user-turn identity across Codex and Copilot transcript mirrors to prevent duplicate rows. (#100277)
 - **Claude CLI streamed replies:** preserve assistant text already received from Claude CLI when its terminal result envelope is empty, preventing false empty-response failover after a complete streamed answer. (#90450) Thanks @totobusnello.
 - **Phone identity normalization:** canonicalize stray plus signs, preserve non-phone iMessage handles, and reject digit-free Signal identities across shared channel routing. (#100467) Thanks @morluto.


### PR DESCRIPTION
## What Problem This Solves

Five contributor fixes for the Control UI and TUI landed without maintainer-owned release-note entries.

## Why This Change Was Made

Add one focused attribution batch after the contributor code PRs landed, matching the repository policy that maintainers—not contributor branches—own changelog updates.

## User Impact

The Unreleased changelog now documents coalesced update feedback, structured Control UI connection errors, TUI startup status, stale bundle recovery, and active custom Gateway port discovery, with contributor credit.

## Evidence

- Landed fixes: #93082, #54758, #93999, #99111, #73338
- Linked issues closed: #78481, #74385, #99092, #42461
- `git diff --check`
- Docs/changelog-only change; no runtime or generated surface changed
