### PR TITLE
docs: refresh generated docs map

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2354,6 +2354,18 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Full list
   - H2: Related
 
+## concepts/managed-worktrees.md
+
+- Route: /concepts/managed-worktrees
+- Headings:
+  - H2: Layout and names
+  - H2: Provision ignored files
+  - H2: Run repository setup
+  - H2: Snapshots, cleanup, and restore
+  - H2: CLI
+  - H2: Gateway methods
+  - H2: Workboard workspaces
+
 ## concepts/mantis-slack-desktop-runbook.md
 
 - Route: /concepts/mantis-slack-desktop-runbook


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the generated documentation map omitted the new managed-worktrees page, causing `check-docs` to fail on current `main` and on unrelated pull requests.

## Why This Change Was Made

Regenerated `docs/docs_map.md` from the current English documentation sources using the repository-owned generator. No authored documentation content changed.

## User Impact

No product behavior changes. Documentation CI can validate the current source tree again, and the managed-worktrees page is discoverable through the generated map.

## Evidence

- Before: `node scripts/generate-docs-map.mjs --check` reported `docs/docs_map.md is out of date` on current `main`.
- Generated with `node scripts/generate-docs-map.mjs`.
- After: `node scripts/generate-docs-map.mjs --check` reports the map is up to date.
- `git diff --check` passes.
