### PR TITLE
fix(google): resolve thought_signature gate for Gemini latest aliases

### DIFF
--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1993,6 +1993,35 @@ describe("google transport stream", () => {
     });
   });
 
+  it.each([
+    ["gemini-pro-latest", "Gemini Pro Latest"],
+    ["gemini-flash-latest", "Gemini Flash Latest"],
+    ["gemini-flash-lite-latest", "Gemini Flash Lite Latest"],
+  ])(
+    "adds skip-validator fallback to first-turn unsigned Gemini 3 tool calls for %s",
+    (modelId, modelName) => {
+      const model = buildGeminiModel({ id: modelId, name: modelName });
+      const params = buildGoogleGenerativeAiParams(model, {
+        messages: [
+          googleToolCallAssistantTurn({ model: modelId }),
+          toolResultTurn(),
+          googleToolCallAssistantTurn({ timestamp: 2, model: modelId }),
+        ],
+      } as never);
+
+      const modelTurns = params.contents.filter(isModelTurnWithParts);
+      expect(modelTurns).toHaveLength(2);
+      expect(modelTurns[0]).toMatchObject({
+        parts: [
+          {
+            thoughtSignature: "skip_thought_signature_validator",
+            functionCall: { name: "lookup", args: { q: "hello" } },
+          },
+        ],
+      });
+    },
+  );
+
   it("does not trust cross-provider tool-call thought signatures for non-Gemini-3 models", () => {
     const model = buildGeminiModel({
       id: "gemini-2.5-pro",

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -160,7 +160,7 @@ function requiresToolCallId(modelId: string): boolean {
 }
 
 function requiresToolCallThoughtSignature(modelId: string): boolean {
-  return normalizeLowercaseStringOrEmpty(modelId).includes("gemini-3");
+  return isGoogleGemini3ProModel(modelId) || isGoogleGemini3FlashModel(modelId);
 }
 
 function supportsMultimodalFunctionResponse(modelId: string): boolean {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -8748,6 +8748,50 @@ describe("openai transport stream", () => {
         | undefined;
       expect(assistant?.tool_calls?.[0]?.extra_content).toBeUndefined();
     });
+
+    it.each([
+      ["gemini-pro-latest", "Gemini Pro Latest"],
+      ["gemini-flash-latest", "Gemini Flash Latest"],
+      ["gemini-flash-lite-latest", "Gemini Flash Lite Latest"],
+    ])(
+      "uses the Gemini skip-validator signature for unsigned tool calls on %s",
+      (modelId, modelName) => {
+        const latestModel = { ...geminiModel, id: modelId, name: modelName };
+        const params = buildOpenAICompletionsParams(
+          latestModel,
+          {
+            messages: [
+              {
+                role: "assistant",
+                api: latestModel.api,
+                provider: latestModel.provider,
+                model: latestModel.id,
+                usage: {
+                  input: 0,
+                  output: 0,
+                  cacheRead: 0,
+                  cacheWrite: 0,
+                  totalTokens: 0,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+                },
+                stopReason: "toolUse",
+                timestamp: 1,
+                content: [{ type: "toolCall", id: "call_abc", name: "echo_value", arguments: {} }],
+              },
+            ],
+            tools: [],
+          } as never,
+          undefined,
+        ) as { messages: Array<Record<string, unknown>> };
+
+        const assistant = params.messages.find((message) => message.role === "assistant") as
+          | { tool_calls?: Array<{ extra_content?: { google?: { thought_signature?: string } } }> }
+          | undefined;
+        expect(assistant?.tool_calls?.[0]?.extra_content?.google?.thought_signature).toBe(
+          "skip_thought_signature_validator",
+        );
+      },
+    );
   });
 
   it("uses Mistral compat defaults for direct Mistral completions providers", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -67,6 +67,10 @@ import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js"
 import { redactIdentifier } from "../logging/redact-identifier.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  isGoogleGemini3FlashModel,
+  isGoogleGemini3ProModel,
+} from "../plugin-sdk/provider-stream-shared.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { resolveProviderTransportTurnStateWithPlugin } from "../plugins/provider-runtime.js";
 import { CHARS_PER_TOKEN_ESTIMATE, estimateStringChars } from "../utils/cjk-chars.js";
@@ -3972,7 +3976,7 @@ function isGoogleOpenAICompatModel(model: OpenAIModeModel): boolean {
 }
 
 function requiresGoogleCompatToolCallThoughtSignature(model: OpenAIModeModel): boolean {
-  return model.id.toLowerCase().includes("gemini-3");
+  return isGoogleGemini3ProModel(model.id) || isGoogleGemini3FlashModel(model.id);
 }
 
 const GOOGLE_COMPAT_THOUGHT_SIGNATURE_ELLIPSIS_RE = /[\u2026]|\.\.\./;


### PR DESCRIPTION
Fixes #100566.

AI-assisted: yes. Maintainer rewrite reviewed the native Google transport, Google OpenAI-compatible sibling, canonical model-family helpers, installed `@google/genai` types/serializer, and Google's current thought-signature contract.

## What Problem This Solves

Google's floating `gemini-pro-latest`, `gemini-flash-latest`, and `gemini-flash-lite-latest` aliases can resolve to Gemini 3 models without containing the literal string `gemini-3`. Both Google tool-history transports used that literal substring as the gate for required thought-signature replay, so unsigned tool calls could reach Google and fail with HTTP 400.

## Why This Change Was Made

The final implementation replaces both literal gates with OpenClaw's existing canonical `isGoogleGemini3ProModel` and `isGoogleGemini3FlashModel` classifiers. Those helpers already own explicit Gemini 3 ids and the three floating aliases, so native GenerateContent and Google OpenAI-compatible replay now share one model-family decision.

The unrelated runtime tool-allowlist commit previously stacked on this branch was removed.

Google's official contract requires Gemini 3 function-call signatures to be replayed and documents `skip_thought_signature_validator` as the last-resort marker for synthetic calls: [Google AI documentation](https://ai.google.dev/gemini-api/docs/generate-content/thought-signatures).

## User Impact

Agents using Google's `*-latest` aliases can continue after tool calls instead of failing with `Function call is missing a thought_signature`.

## Evidence

Final reviewed head: `5715cde2f5d5eb30675863692e44869cae133231`.

- [Sanitized public-network AWS Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_95e868b79a4a), no IAM role, no Tailscale, no hydrated credentials: 289 OpenAI transport and 83 native Google transport assertions passed.
- The focused run used predecessor head `49190247bad0204cb1003a58a451d259e19adfdd`; stable patch-id comparison confirms the complete four-file patch is byte-equivalent after the final main rebase.
- Live `gemini-flash-latest` API matrix with a real key: model-generated signature replay returned 200; removing the signature reproduced the pre-fix 400; adding the exact sentinel emitted by this patch returned 200.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- Installed `@google/genai` 2.10.0 directly inspected: `Part.thoughtSignature` is typed and serialized into outbound GenerateContent parts.
- `git diff --check`: pass.

No screenshot is useful for this provider payload bug; the live status matrix is the direct before/after proof.
