### PR TITLE
fix(ui): stop repeating tool names in expanded activity

### DIFF
--- a/src/gateway/server-startup-log.test.ts
+++ b/src/gateway/server-startup-log.test.ts
@@ -1,11 +1,14 @@
 // Startup log tests cover security warnings, model detail formatting, plugin
 // summaries, bind URLs, ANSI output, and dangerous config reporting.
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { formatAgentModelStartupDetails, logGatewayStartup } from "./server-startup-log.js";
 
 const pluginRegistryMocks = vi.hoisted(() => ({
   loadPluginManifestRegistryForPluginRegistry: vi.fn(),
+}));
+const modelMocks = vi.hoisted(() => ({
+  resolveThinkingDefault: vi.fn(() => "medium" as const),
 }));
 
 vi.mock("../plugins/plugin-registry.js", async (importOriginal) => ({
@@ -14,26 +17,16 @@ vi.mock("../plugins/plugin-registry.js", async (importOriginal) => ({
     pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry,
 }));
 
-describe("gateway startup log", () => {
-  beforeAll(() => {
-    formatAgentModelStartupDetails({
-      cfg: {
-        models: {
-          providers: {
-            google: {
-              api: "google-generative-ai",
-              baseUrl: "https://generativelanguage.googleapis.com/v1beta",
-              models: [],
-            },
-          },
-        },
-      },
-      provider: "google",
-      model: "gemma-4-26b-a4b-it",
-    });
-  });
+// Provider thinking owns a dedicated suite. Startup logging only needs its
+// fixture-level default while proving precedence and banner composition.
+vi.mock("../agents/model-thinking-default.js", () => ({
+  resolveThinkingDefault: modelMocks.resolveThinkingDefault,
+}));
 
+describe("gateway startup log", () => {
   beforeEach(() => {
+    modelMocks.resolveThinkingDefault.mockClear();
+    modelMocks.resolveThinkingDefault.mockReturnValue("medium");
     pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReset();
     pluginRegistryMocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
       plugins: [],
@@ -281,6 +274,7 @@ describe("gateway startup log", () => {
         model: "gpt-5.5",
       }),
     ).toBe("thinking=medium, fast=on");
+    expect(modelMocks.resolveThinkingDefault).toHaveBeenCalledTimes(1);
   });
 
   it("preserves explicit startup thinking off", () => {
@@ -299,6 +293,7 @@ describe("gateway startup log", () => {
         model: "gpt-5.5",
       }),
     ).toBe("thinking=off, fast=on");
+    expect(modelMocks.resolveThinkingDefault).not.toHaveBeenCalled();
   });
 
   it("shows thinking off for configured provider models with reasoning disabled", () => {
@@ -329,6 +324,7 @@ describe("gateway startup log", () => {
         model: "gemma-4-26b-a4b-it",
       }),
     ).toBe("thinking=off, fast=off");
+    expect(modelMocks.resolveThinkingDefault).not.toHaveBeenCalled();
   });
 
   it("uses default agent mode overrides in the startup model details", () => {

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -136,7 +136,6 @@ export function formatAgentModelStartupDetails(params: {
   provider: string;
   model: string;
 }): string {
-  const configuredCatalog = buildConfiguredModelCatalog({ cfg: params.cfg });
   const defaultAgentId = resolveDefaultAgentId(params.cfg);
   const defaultAgentConfig = resolveAgentConfig(params.cfg, defaultAgentId);
   const explicitThinking = resolveExplicitStartupThinking({
@@ -145,25 +144,29 @@ export function formatAgentModelStartupDetails(params: {
     model: params.model,
     defaultAgentThinking: defaultAgentConfig?.thinkingDefault,
   });
-  const resolvedThinking =
-    explicitThinking ??
-    resolveThinkingDefault({
-      cfg: params.cfg,
-      provider: params.provider,
-      model: params.model,
-      catalog: configuredCatalog,
-    });
-  const thinking =
-    explicitThinking ??
-    (isConfiguredReasoningDisabled({
-      catalog: configuredCatalog,
-      provider: params.provider,
-      model: params.model,
-    })
-      ? "off"
-      : resolvedThinking === "off"
-        ? "medium"
-        : resolvedThinking);
+  let thinking = explicitThinking;
+  if (thinking === undefined) {
+    const configuredCatalog = buildConfiguredModelCatalog({ cfg: params.cfg });
+    // Catalog reasoning=false is authoritative; avoid loading provider policy artifacts
+    // only to discard their default below.
+    if (
+      isConfiguredReasoningDisabled({
+        catalog: configuredCatalog,
+        provider: params.provider,
+        model: params.model,
+      })
+    ) {
+      thinking = "off";
+    } else {
+      const resolvedThinking = resolveThinkingDefault({
+        cfg: params.cfg,
+        provider: params.provider,
+        model: params.model,
+        catalog: configuredCatalog,
+      });
+      thinking = resolvedThinking === "off" ? "medium" : resolvedThinking;
+    }
+  }
   const fast = resolveFastModeState({
     cfg: params.cfg,
     provider: params.provider,

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -23,6 +23,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
   "extensions/memory-core/src/dreaming.ts",
   "extensions/memory-lancedb/index.ts",
   "extensions/thread-ownership/index.ts",
+  "extensions/workboard/index.ts",
 ] as const;
 const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/acpx/index.ts": ["reply_dispatch"],
@@ -35,6 +36,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start", "gateway_stop"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/thread-ownership/index.ts": ["message_received", "message_sending"],
+  "extensions/workboard/index.ts": ["subagent_ended"],
 } as const satisfies Record<
   (typeof BUNDLED_TYPED_HOOK_REGISTRATION_FILES)[number],
   readonly string[]

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1532,6 +1532,9 @@ describe("grouped chat rendering", () => {
     });
 
     expect(container.querySelector(".chat-tool-msg-summary__label")?.textContent?.trim()).toBe(
+      "presentation_create",
+    );
+    expect(container.querySelector(".chat-tool-msg-summary__names")?.textContent?.trim()).toBe(
       "Example Deck",
     );
     expect(container.querySelector(".chat-tool-msg-summary")?.textContent).not.toContain(
@@ -1542,6 +1545,9 @@ describe("grouped chat rendering", () => {
       isToolMessageExpanded: () => true,
     });
 
+    expect(container.querySelector(".chat-tool-msg-body")?.textContent).not.toContain(
+      "presentation_create",
+    );
     expect(container.querySelector(".chat-tool-card__block code")?.textContent).toBe(
       "with Example Deck",
     );

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -1977,20 +1977,20 @@ function renderGroupedMessage(
         ? toolNames.join(", ")
         : `${toolNames.slice(0, 2).join(", ")} +${toolNames.length - 2} more`
     : singleToolDisplayDetail
-      ? singleToolCard?.outputText?.trim()
-        ? "output"
-        : undefined
+      ? !markdown && !hasImages
+        ? singleToolDisplayDetail
+        : singleToolCard?.outputText?.trim()
+          ? "output"
+          : undefined
       : toolNames.length <= 3
         ? toolNames.join(", ")
         : `${toolNames.slice(0, 2).join(", ")} +${toolNames.length - 2} more`;
   const toolPreview = markdown ? (formatCollapsedToolPreviewText(markdown) ?? "") : "";
   const toolMessageLabelRaw = toolMessageHasError
     ? "Tool error"
-    : singleToolDisplayDetail && !markdown && !hasImages
-      ? singleToolDisplayDetail
-      : singleToolDisplay && !markdown && !hasImages
-        ? singleToolDisplay.label
-        : "Tool output";
+    : singleToolDisplay && !markdown && !hasImages
+      ? singleToolDisplay.label
+      : "Tool output";
   const toolMessageLabel =
     formatCollapsedToolSummaryText(toolMessageLabelRaw) ?? toolMessageLabelRaw;
   const toolSummaryLabel = formatDistinctCollapsedToolSummaryText(

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -121,6 +121,36 @@ describe("tool-cards", () => {
     ]);
   });
 
+  it("does not repeat the tool identity in expanded details", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:4a:call-4a",
+          name: "skill_workshop",
+          args: { action: "create" },
+          inputText: '{\n  "action": "create"\n}',
+          outputText: "Proposal created",
+        },
+        {
+          expanded: true,
+          onOpenSidebar: vi.fn(),
+          onToggleExpanded: vi.fn(),
+        },
+      ),
+      container,
+    );
+
+    expect(container.textContent?.match(/Skill Workshop/g)).toHaveLength(1);
+    expect(container.querySelector(".chat-tool-msg-body")?.textContent).not.toContain(
+      "Skill Workshop",
+    );
+    expect(container.querySelector(".chat-tool-card__detail")?.textContent).toContain("create");
+    expect(container.querySelector(".chat-tool-card__action-btn")).toBeInstanceOf(
+      HTMLButtonElement,
+    );
+  });
+
   it("renders expanded tool calls without an inline output block when no output is present", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -423,29 +423,29 @@ export function renderExpandedToolCardContent(
 
   return html`
     <div class="chat-tool-card ${isError ? "chat-tool-card--error" : ""}">
-      <div class="chat-tool-card__header">
-        <div class="chat-tool-card__title">
-          <span class="chat-tool-card__icon">${renderToolIcon(display.icon)}</span>
-          <span>${display.label}</span>
-        </div>
-        ${canOpenSidebar
-          ? html`
-              <div class="chat-tool-card__actions">
-                <openclaw-tooltip content="Open in the side panel">
-                  <button
-                    class="chat-tool-card__action-btn"
-                    type="button"
-                    @click=${() => onOpenSidebar?.(sidebarActionContent)}
-                    aria-label="Open tool details in side panel"
-                  >
-                    <span class="chat-tool-card__action-icon">${icons.panelRightOpen}</span>
-                  </button>
-                </openclaw-tooltip>
-              </div>
-            `
-          : nothing}
-      </div>
-      ${detail ? html`<div class="chat-tool-card__detail">${detail}</div>` : nothing}
+      ${detail || canOpenSidebar
+        ? html`
+            <div class="chat-tool-card__header">
+              ${detail ? html`<div class="chat-tool-card__detail">${detail}</div>` : nothing}
+              ${canOpenSidebar
+                ? html`
+                    <div class="chat-tool-card__actions">
+                      <openclaw-tooltip content="Open in the side panel">
+                        <button
+                          class="chat-tool-card__action-btn"
+                          type="button"
+                          @click=${() => onOpenSidebar?.(sidebarActionContent)}
+                          aria-label="Open tool details in side panel"
+                        >
+                          <span class="chat-tool-card__action-icon">${icons.panelRightOpen}</span>
+                        </button>
+                      </openclaw-tooltip>
+                    </div>
+                  `
+                : nothing}
+            </div>
+          `
+        : nothing}
       ${hasInput
         ? renderToolDataBlock({
             label: "Tool input",

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -151,42 +151,9 @@
 .chat-tool-card__header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   min-width: 0;
-}
-
-.chat-tool-card__title {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  flex: 1 1 auto;
-  font-weight: 600;
-  font-size: var(--control-ui-text-sm);
-  line-height: 1.2;
-  min-width: 0;
-  max-width: 100%;
-  overflow-wrap: anywhere;
-}
-
-.chat-tool-card__icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 16px;
-  height: 16px;
-  color: var(--muted);
-  flex-shrink: 0;
-}
-
-.chat-tool-card__icon svg {
-  width: 14px;
-  height: 14px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.5px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 
 .chat-tool-card__actions {
@@ -194,6 +161,7 @@
   align-items: center;
   gap: 6px;
   justify-content: flex-end;
+  margin-left: auto;
 }
 
 .chat-tool-card__action-btn {
@@ -236,14 +204,11 @@
   stroke-linejoin: round;
 }
 
-.chat-tool-card--error .chat-tool-card__icon {
-  color: var(--destructive, var(--danger, #c0392b));
-}
-
 .chat-tool-card__detail {
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: var(--control-ui-text-sm);
   color: var(--muted);
-  margin-top: 4px;
 }
 
 .chat-tool-card__block {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where expanding a Control UI tool call repeated the tool icon and name inside the detail body even though the disclosure row already identified the tool.

## Why This Change Was Made

Makes the collapsed disclosure the canonical place for tool identity across inline and standalone tool rows. Expanded content now starts with the useful command/detail and keeps the side-panel action, input, and result blocks without a duplicate heading.

## User Impact

Expanded tool activity is shorter and easier to scan. Tool names remain visible in the disclosure row, including detail-first standalone calls, while the expanded body focuses on inputs and results.

## Evidence

| Before | After |
| --- | --- |
| ![Expanded tool call before](https://github.com/user-attachments/assets/7b956a1a-ee60-4f46-a82d-0723c38d27f4) | ![Expanded tool call after](https://github.com/user-attachments/assets/6eed1bfc-4591-47a8-9470-30dc5d0e2fb7) |

- Screenshots captured from the same deterministic dark-mode mocked Gateway flow on Blacksmith Testbox.
- `pnpm test ui/src/pages/chat/components/chat-tool-cards.test.ts ui/src/pages/chat/components/chat-message.test.ts` — 100 tests passed on Testbox `tbx_01kwtthdytwjcatn7gpfwxhpvw`.
- Focused real-browser Control UI E2E — passed on Testbox `tbx_01kwtvjw00dqmdeej61sg9tgwb` ([Actions run](https://github.com/openclaw/openclaw/actions/runs/28768214085)).
- `pnpm check:changed` — typecheck, lint, and repository guards passed on Testbox `tbx_01kwtthdytwjcatn7gpfwxhpvw`.
- Codex autoreview — clean after addressing the standalone-row identity path.
