### PR TITLE
Record stale foreground final suppression in transcripts

### DIFF
--- a/src/auto-reply/dispatch.freshness.test.ts
+++ b/src/auto-reply/dispatch.freshness.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { OutboundDeliveryError } from "../infra/outbound/deliver-types.js";
 import { resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { getReplyPayloadMetadata } from "./reply-payload.js";
 import type { ReplyDispatchBeforeDeliver } from "./reply/reply-dispatcher.js";
 import { buildTestCtx } from "./reply/test-ctx.js";
 import type { FinalizedMsgContext, MsgContext } from "./templating.js";
@@ -64,6 +65,7 @@ function dispatchWithDeliveries(
   dispatcherOptions: {
     beforeDeliver?: ReplyDispatchBeforeDeliver;
     deliver?: (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => Promise<object | void>;
+    onBeforeDeliverCancelled?: (payload: ReplyPayload, info: { kind: Delivery["kind"] }) => void;
     onSettled?: () => object | void | Promise<object | void>;
     onFreshSettledDelivery?: () => object | void | Promise<object | void>;
   } = {},
@@ -94,6 +96,7 @@ describe("foreground reply freshness", () => {
 
   it("suppresses an older foreground final after a newer inbound event starts for the same session target", async () => {
     const deliveries: Delivery[] = [];
+    const cancellationReasons: Array<string | undefined> = [];
     const olderStarted = createDeferred<void>();
     const releaseOlderFinal = createDeferred<void>();
 
@@ -116,6 +119,13 @@ describe("foreground reply freshness", () => {
     const olderDispatch = dispatchWithDeliveries(
       buildForegroundCtx({ MessageSid: "old-message" }),
       deliveries,
+      {
+        onBeforeDeliverCancelled: (payload) => {
+          cancellationReasons.push(
+            getReplyPayloadMetadata(payload)?.foregroundDeliverySuppression?.reason,
+          );
+        },
+      },
     );
     await olderStarted.promise;
 
@@ -136,6 +146,35 @@ describe("foreground reply freshness", () => {
       counts: { tool: 0, block: 0, final: 0 },
     });
     expect(deliveries).toEqual([{ kind: "final", text: "new final" }]);
+    expect(cancellationReasons).toEqual(["stale-foreground"]);
+  });
+
+  it("leaves configured beforeDeliver cancellations untagged", async () => {
+    const deliveries: Delivery[] = [];
+    const cancellationReasons: Array<string | undefined> = [];
+
+    hoisted.dispatchReplyFromConfigMock.mockImplementation(
+      async (params: DispatchReplyFromConfigParams) => {
+        params.dispatcher.sendFinalReply({ text: "policy-blocked final" });
+        return queuedFinalResult();
+      },
+    );
+
+    const result = await dispatchWithDeliveries(buildForegroundCtx(), deliveries, {
+      beforeDeliver: () => null,
+      onBeforeDeliverCancelled: (payload) => {
+        cancellationReasons.push(
+          getReplyPayloadMetadata(payload)?.foregroundDeliverySuppression?.reason,
+        );
+      },
+    });
+
+    expect(result).toEqual({
+      queuedFinal: false,
+      counts: { tool: 0, block: 0, final: 0 },
+    });
+    expect(deliveries).toEqual([]);
+    expect(cancellationReasons).toEqual([undefined]);
   });
 
   it("keeps an older foreground final when a newer inbound has no visible delivery while beforeDeliver is pending", async () => {

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -20,7 +20,7 @@ import {
   resolveCommandTurnTargetSessionKey,
 } from "./command-turn-context.js";
 import { withReplyDispatcher } from "./dispatch-dispatcher.js";
-import { copyReplyPayloadMetadata } from "./reply-payload.js";
+import { copyReplyPayloadMetadata, setReplyPayloadMetadata } from "./reply-payload.js";
 import type { CommandSessionMetadataChange } from "./reply/command-session-metadata.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.types.js";
@@ -615,15 +615,23 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
       ? async (payload, info) => {
           // Check both before and after hooks because hooks can await while newer replies finish.
           if (await shouldCancelForegroundReplyDelivery(foregroundReplyFence)) {
+            // Only the foreground fence proves "not shown because stale"; hook
+            // cancellations may be intentional policy and must stay untagged.
+            setReplyPayloadMetadata(payload, {
+              foregroundDeliverySuppression: { reason: "stale-foreground" },
+            });
             return null;
           }
           const deliverPayload = configuredBeforeDeliver
             ? await configuredBeforeDeliver(payload, info)
             : payload;
-          if (
-            !deliverPayload ||
-            (await shouldCancelForegroundReplyDelivery(foregroundReplyFence))
-          ) {
+          if (!deliverPayload) {
+            return null;
+          }
+          if (await shouldCancelForegroundReplyDelivery(foregroundReplyFence)) {
+            setReplyPayloadMetadata(payload, {
+              foregroundDeliverySuppression: { reason: "stale-foreground" },
+            });
             return null;
           }
           return deliverPayload;

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -215,6 +215,12 @@ export type ReplyPayloadMetadata = {
   assistantMessageIndex?: number;
   /** The runtime owns the transcript decision for this assistant payload. */
   assistantTranscriptOwned?: boolean;
+  /** Foreground freshness prevented a visible final after transcript persistence. */
+  foregroundDeliverySuppression?: {
+    reason: "stale-foreground";
+  };
+  /** Opaque owner for one final-delivery transcript capture on a shared dispatcher. */
+  finalDeliveryCapture?: object;
   /** replyToId existed before reply threading could inject an implicit target. */
   replyToIdExplicit?: boolean;
   /** Canonical reply policy used by both message-tool dedupe and final delivery routing. */

--- a/src/auto-reply/reply/before-deliver.test.ts
+++ b/src/auto-reply/reply/before-deliver.test.ts
@@ -2,7 +2,10 @@
 import { describe, expect, it } from "vitest";
 import { getReplyPayloadMetadata, setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
-import { createReplyDispatcher } from "./reply-dispatcher.js";
+import {
+  appendReplyDispatcherBeforeDeliverCancelled,
+  createReplyDispatcher,
+} from "./reply-dispatcher.js";
 
 describe("beforeDeliver in reply dispatcher", () => {
   it("cancels delivery before queueing when transformReplyPayload returns null", async () => {
@@ -58,6 +61,49 @@ describe("beforeDeliver in reply dispatcher", () => {
     expect(cancelled).toEqual(["blocked reply"]);
     expect(dispatcher.getQueuedCounts()).toEqual({ tool: 0, block: 0, final: 2 });
     expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+  });
+
+  it("notifies appended cancellation observers when beforeDeliver returns null", async () => {
+    const delivered: string[] = [];
+    const cancelled: string[] = [];
+    const errors: string[] = [];
+
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload.text ?? "");
+      },
+      beforeDeliver: () => null,
+      onBeforeDeliverCancelled: (payload) => {
+        cancelled.push(`constructed:${payload.text ?? ""}`);
+      },
+      onError: (err) => {
+        errors.push(err instanceof Error ? err.message : String(err));
+      },
+    });
+    appendReplyDispatcherBeforeDeliverCancelled(dispatcher, (payload) => {
+      cancelled.push(`appended-a:${payload.text ?? ""}`);
+    });
+    appendReplyDispatcherBeforeDeliverCancelled(dispatcher, () => {
+      throw new Error("observer failed");
+    });
+    appendReplyDispatcherBeforeDeliverCancelled(dispatcher, (payload) => {
+      cancelled.push(`appended-b:${payload.text ?? ""}`);
+    });
+
+    dispatcher.sendFinalReply({ text: "blocked reply" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+
+    expect(delivered).toEqual([]);
+    expect(cancelled).toEqual([
+      "constructed:blocked reply",
+      "appended-a:blocked reply",
+      "appended-b:blocked reply",
+    ]);
+    expect(errors).toEqual(["observer failed"]);
+    expect(dispatcher.getQueuedCounts()).toEqual({ tool: 0, block: 0, final: 1 });
+    expect(dispatcher.getCancelledCounts?.()).toEqual({ tool: 0, block: 0, final: 1 });
+    expect(dispatcher.getFailedCounts?.()).toEqual({ tool: 0, block: 0, final: 0 });
   });
 
   it("notifies cancellation when beforeDeliver throws before delivery", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -40,7 +40,7 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
 import { settleReplyDispatcher } from "../dispatch-dispatcher.js";
-import { getReplyPayloadMetadata } from "../reply-payload.js";
+import { copyReplyPayloadMetadata, getReplyPayloadMetadata } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
 import { setReplyPayloadMetadata, type GetReplyOptions, type ReplyPayload } from "../types.js";
 import { markCommandSessionMetadataChanged } from "./command-session-metadata.js";
@@ -717,7 +717,9 @@ function createDispatcher(): ReplyDispatcher {
       beforeDeliver = previousBeforeDeliver
         ? async (payload, info) => {
             const previousPayload = await previousBeforeDeliver(payload, info);
-            return previousPayload ? hook(previousPayload, info) : null;
+            return previousPayload
+              ? hook(copyReplyPayloadMetadata(payload, previousPayload), info)
+              : null;
           }
         : hook;
     }),
@@ -1489,6 +1491,76 @@ describe("dispatchReplyFromConfig", () => {
 
     expect(result.queuedFinal).toBe(true);
     expect(transcriptMocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
+  });
+
+  it("records stale-foreground suppressed CLI-owned finals without duplicating answer text", async () => {
+    setNoAbort();
+    const dispatcher = createReplyDispatcher({
+      deliver: vi.fn(async () => undefined),
+      beforeDeliver: (payload, info) => {
+        if (info.kind !== "final") {
+          return payload;
+        }
+        setReplyPayloadMetadata(payload, {
+          foregroundDeliverySuppression: { reason: "stale-foreground" },
+        });
+        return null;
+      },
+    });
+    transcriptMocks.appendAssistantMessageToSessionTranscript.mockClear();
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        Provider: "slack",
+        Surface: "slack",
+        OriginatingChannel: "slack",
+        OriginatingTo: "channel:C123",
+        SessionKey: "agent:main:slack:channel:C123",
+        MessageSid: "slack-message-cli",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async (_ctx, opts) => {
+        (
+          opts as GetReplyOptions & {
+            onSessionPrepared?: (binding: {
+              sessionKey?: string;
+              sessionId: string;
+              storePath?: string;
+            }) => void;
+          }
+        ).onSessionPrepared?.({
+          sessionKey: "agent:main:slack:channel:c123",
+          sessionId: "prepared-session",
+          storePath: "/tmp/prepared-sessions.json",
+        });
+        return setReplyPayloadMetadata(
+          { text: "The CLI answer already lives in the transcript." },
+          { assistantTranscriptOwned: true },
+        );
+      },
+    });
+    await settleReplyDispatcher({ dispatcher });
+
+    expect(result.queuedFinal).toBe(true);
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledTimes(1);
+    expect(transcriptMocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
+      sessionKey: "agent:main:slack:channel:C123",
+      agentId: "main",
+      expectedSessionId: "prepared-session",
+      text: "Channel final suppressed before delivery: stale foreground",
+      mediaUrls: undefined,
+      idempotencyKey: "channel-final-suppressed:slack-message-cli:0",
+      deliveryMirror: {
+        kind: "channel-final-suppressed",
+        reason: "stale-foreground",
+        sourceMessageId: "slack-message-cli",
+      },
+      storePath: "/tmp/prepared-sessions.json",
+      updateMode: "inline",
+      config: emptyConfig,
+      beforeMessageWrite: expect.any(Function),
+    });
   });
 
   it("disables routed delivery mirrors for CLI-owned finals", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -123,6 +123,7 @@ import {
   getReplyPayloadMetadata,
   isReplyPayloadStatusNotice,
   markReplyPayloadAsTtsSupplement,
+  setReplyPayloadMetadata,
   type ReplyPayload,
 } from "../reply-payload.js";
 import type { FinalizedMsgContext } from "../templating.js";
@@ -152,7 +153,10 @@ import type { ReplySessionBinding } from "./get-reply.types.js";
 import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
 import { hasInboundAudio } from "./inbound-media.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
-import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
+import {
+  appendReplyDispatcherBeforeDeliverCancelled,
+  waitForReplyDispatcherIdle,
+} from "./reply-dispatcher.js";
 import type {
   DispatcherOutcomeCountsView,
   ReplyDispatchKind,
@@ -195,6 +199,7 @@ type TranscriptMirror = SourceReplyTranscriptMirror & {
   storePath?: string;
   preferText?: boolean;
   deliveryMirror?: SessionTranscriptDeliveryMirror;
+  transcriptOwner?: boolean;
 };
 type InternalReplyResolverOptions = {
   onSessionMetadataChanges?: (changes: CommandSessionMetadataChange[]) => void;
@@ -866,42 +871,107 @@ function transcriptMirrorForDeliveredPayload(
   };
 }
 
+const STALE_FOREGROUND_SUPPRESSED_FINAL_TEXT =
+  "Channel final suppressed before delivery: stale foreground";
+
+function captureSuppressedTranscriptMirror(params: {
+  metadata: TranscriptMirror;
+  payload: ReplyPayload;
+  deliveryId?: string | number;
+}): TranscriptMirror | undefined {
+  const payloadMetadata = getReplyPayloadMetadata(params.payload);
+  if (
+    !params.metadata.transcriptOwner ||
+    payloadMetadata?.foregroundDeliverySuppression?.reason !== "stale-foreground"
+  ) {
+    return undefined;
+  }
+  const sourceMessageId = normalizeOptionalString(params.metadata.deliveryMirror?.sourceMessageId);
+  if (!sourceMessageId) {
+    return undefined;
+  }
+  const { transcriptOwner: _transcriptOwner, ...metadata } = params.metadata;
+  return {
+    ...metadata,
+    // The transcript owner already persisted the answer; this row records only delivery state.
+    text: STALE_FOREGROUND_SUPPRESSED_FINAL_TEXT,
+    mediaUrls: undefined,
+    preferText: true,
+    idempotencyKey: `channel-final-suppressed:${sourceMessageId}:${params.deliveryId ?? "single"}`,
+    deliveryMirror: {
+      kind: "channel-final-suppressed",
+      reason: "stale-foreground",
+      sourceMessageId,
+    },
+  };
+}
+
 function captureDeliveredTranscriptMirror(params: {
   dispatcher: ReplyDispatcher;
   metadata?: TranscriptMirror;
+  deliveryId?: string | number;
+  captureToken?: object;
 }): () => TranscriptMirror | undefined {
   if (!params.metadata || !params.dispatcher.appendBeforeDeliver) {
-    return () => params.metadata;
+    return () => (params.metadata?.transcriptOwner ? undefined : params.metadata);
   }
   const metadata = params.metadata;
   let deliveredMetadata: TranscriptMirror | undefined;
+  let suppressedMetadata: TranscriptMirror | undefined;
   let observedFinal = false;
   const { idempotencyKey, sessionKey } = metadata;
   params.dispatcher.appendBeforeDeliver((payload, info) => {
     if (info.kind !== "final") {
       return payload;
     }
+    if (getReplyPayloadMetadata(payload)?.finalDeliveryCapture !== params.captureToken) {
+      return payload;
+    }
     observedFinal = true;
-    const payloadMetadata = getReplyPayloadMetadata(payload)?.sourceReplyTranscriptMirror;
+    const payloadMetadata = getReplyPayloadMetadata(payload);
+    const payloadMirror = payloadMetadata?.sourceReplyTranscriptMirror;
     if (
-      payloadMetadata &&
-      payloadMetadata.idempotencyKey === idempotencyKey &&
-      payloadMetadata.sessionKey === sessionKey
+      payloadMirror &&
+      payloadMirror.idempotencyKey === idempotencyKey &&
+      payloadMirror.sessionKey === sessionKey
     ) {
       deliveredMetadata = transcriptMirrorForDeliveredPayload(
         {
-          ...payloadMetadata,
+          ...payloadMirror,
           ...(metadata.expectedSessionId ? { expectedSessionId: metadata.expectedSessionId } : {}),
           storePath: metadata.storePath,
         },
         payload,
       );
-    } else if (!payloadMetadata && (!idempotencyKey || metadata.deliveryMirror)) {
+    } else if (
+      !payloadMirror &&
+      !metadata.transcriptOwner &&
+      (!idempotencyKey || metadata.deliveryMirror)
+    ) {
       deliveredMetadata = transcriptMirrorForDeliveredPayload(metadata, payload);
     }
     return payload;
   });
-  return () => (observedFinal ? deliveredMetadata : metadata);
+  appendReplyDispatcherBeforeDeliverCancelled(params.dispatcher, (payload, info) => {
+    if (info.kind !== "final") {
+      return;
+    }
+    if (getReplyPayloadMetadata(payload)?.finalDeliveryCapture !== params.captureToken) {
+      return;
+    }
+    observedFinal = true;
+    suppressedMetadata = captureSuppressedTranscriptMirror({
+      metadata,
+      payload,
+      deliveryId: params.deliveryId,
+    });
+  });
+  return () =>
+    observedFinal
+      ? (suppressedMetadata ?? deliveredMetadata)
+      : metadata.transcriptOwner
+        ? undefined
+        : metadata;
 }
 
 async function mirrorTranscriptAfterDispatcherSettled(params: {
@@ -911,11 +981,15 @@ async function mirrorTranscriptAfterDispatcherSettled(params: {
   cfg: OpenClawConfig;
 }): Promise<void> {
   const after = getDispatcherFinalOutcomeCounts(params.dispatcher);
-  if (after.cancelled > params.before.cancelled || after.failed > params.before.failed) {
-    return;
-  }
   const metadata = params.metadata();
   if (!metadata) {
+    return;
+  }
+  const suppressedFinal = metadata.deliveryMirror?.kind === "channel-final-suppressed";
+  if (
+    !suppressedFinal &&
+    (after.cancelled > params.before.cancelled || after.failed > params.before.failed)
+  ) {
     return;
   }
   await mirrorDeliveredReplyToTranscript({
@@ -2728,8 +2802,7 @@ export async function dispatchReplyFromConfig(
       );
       const transcriptMirror =
         sourceReplyTranscriptMirror ??
-        (!hasTranscriptOwner &&
-        normalizedCurrentSurface === "slack" &&
+        (normalizedCurrentSurface === "slack" &&
         hasVisibleFinalContent &&
         transcriptMirrorSessionKey
           ? transcriptMirrorForDeliveredPayload(
@@ -2741,6 +2814,7 @@ export async function dispatchReplyFromConfig(
                   : {}),
                 storePath: transcriptMirrorSessionBinding?.storePath ?? sessionStoreEntry.storePath,
                 preferText: true,
+                ...(hasTranscriptOwner ? { transcriptOwner: true } : {}),
                 idempotencyKey: transcriptMirrorSourceId
                   ? `channel-final:${transcriptMirrorSourceId}:${options.deliveryId ?? "single"}`
                   : undefined,
@@ -2758,9 +2832,18 @@ export async function dispatchReplyFromConfig(
       const finalOutcomeBefore = transcriptMirror
         ? getDispatcherFinalOutcomeCounts(dispatcher)
         : undefined;
+      const finalDeliveryCapture = transcriptMirror ? {} : undefined;
       const deliveredTranscriptMirror = transcriptMirror
-        ? captureDeliveredTranscriptMirror({ dispatcher, metadata: transcriptMirror })
+        ? captureDeliveredTranscriptMirror({
+            dispatcher,
+            metadata: transcriptMirror,
+            deliveryId: options.deliveryId,
+            captureToken: finalDeliveryCapture,
+          })
         : undefined;
+      if (finalDeliveryCapture) {
+        setReplyPayloadMetadata(normalizedPayload, { finalDeliveryCapture });
+      }
       const queuedFinal = dispatcher.sendFinalReply(normalizedPayload);
       if (queuedFinal && deliveredTranscriptMirror && finalOutcomeBefore) {
         // The common settle owner runs this after successful delivery or

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -48,6 +48,20 @@ export type { ReplyDispatchBeforeDeliver };
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
 const silentReplyLogger = createSubsystemLogger("silent-reply/dispatcher");
+const beforeDeliverCancelledHooks = new WeakMap<ReplyDispatcher, ReplyDispatchCancelHandler[]>();
+
+/** Adds a core-internal cancellation observer without expanding the plugin-facing dispatcher. */
+export function appendReplyDispatcherBeforeDeliverCancelled(
+  dispatcher: ReplyDispatcher,
+  hook: ReplyDispatchCancelHandler,
+): boolean {
+  const hooks = beforeDeliverCancelledHooks.get(dispatcher);
+  if (!hooks) {
+    return false;
+  }
+  hooks.push(hook);
+  return true;
+}
 
 function buildReplyDispatchRuntimeInfo(
   payload: ReplyPayload,
@@ -168,6 +182,7 @@ function normalizeReplyPayloadInternal(
 
 export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDispatcher {
   let beforeDeliver = options.beforeDeliver;
+  const appendedBeforeDeliverCancelledHooks: ReplyDispatchCancelHandler[] = [];
   let sendChain: Promise<void> = Promise.resolve();
   // Track in-flight deliveries so we can emit a reliable "idle" signal.
   // Start with pending=1 as a "reservation" to prevent premature gateway restart.
@@ -198,6 +213,27 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     pending: () => pending,
     waitForIdle: () => sendChain,
   });
+
+  const reportObserverError = (err: unknown, info: ReplyDispatchRuntimeInfo) => {
+    void Promise.resolve(options.onError?.(err, info)).catch(() => undefined);
+  };
+
+  const notifyBeforeDeliverCancelled = async (
+    payload: ReplyPayload,
+    info: ReplyDispatchRuntimeInfo,
+  ) => {
+    const observers = [
+      ...(options.onBeforeDeliverCancelled ? [options.onBeforeDeliverCancelled] : []),
+      ...appendedBeforeDeliverCancelledHooks,
+    ];
+    for (const observer of observers) {
+      try {
+        await observer(payload, info);
+      } catch (err: unknown) {
+        reportObserverError(err, info);
+      }
+    }
+  };
 
   const enqueue = (kind: ReplyDispatchKind, payload: ReplyPayload) => {
     const originalWasExactSilent = isSilentReplyText(payload.text, SILENT_REPLY_TOKEN);
@@ -247,20 +283,12 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
           try {
             deliverPayload = await beforeDeliver(normalized, dispatchInfo);
           } catch (err: unknown) {
-            try {
-              await options.onBeforeDeliverCancelled?.(normalized, dispatchInfo);
-            } catch (cancelErr: unknown) {
-              void options.onError?.(cancelErr, dispatchInfo);
-            }
+            await notifyBeforeDeliverCancelled(normalized, dispatchInfo);
             throw err;
           }
           if (!deliverPayload) {
             cancelledCounts[kind] += 1;
-            try {
-              await options.onBeforeDeliverCancelled?.(normalized, dispatchInfo);
-            } catch (err: unknown) {
-              void options.onError?.(err, dispatchInfo);
-            }
+            await notifyBeforeDeliverCancelled(normalized, dispatchInfo);
             return;
           }
           deliverPayload = copyReplyPayloadMetadata(normalized, deliverPayload);
@@ -276,7 +304,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         try {
           options.onDeliverySettled?.(dispatchInfo);
         } catch (err: unknown) {
-          void options.onError?.(err, dispatchInfo);
+          reportObserverError(err, dispatchInfo);
         }
         pending -= 1;
         // Clear reservation if:
@@ -315,7 +343,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     });
   };
 
-  return {
+  const dispatcher: ReplyDispatcher = {
     sendToolResult: (payload) => enqueue("tool", payload),
     sendBlockReply: (payload) => enqueue("block", payload),
     sendFinalReply: (payload) => enqueue("final", payload),
@@ -345,6 +373,8 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             })
         : undefined,
   };
+  beforeDeliverCancelledHooks.set(dispatcher, appendedBeforeDeliverCancelledHooks);
+  return dispatcher;
 }
 
 export async function waitForReplyDispatcherIdle(

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -6,7 +6,11 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import { repairToolUseResultPairing } from "../../agents/session-transcript-repair.js";
 import * as transcriptEvents from "../../sessions/transcript-events.js";
 import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.js";
-import { OPENCLAW_TRANSCRIPT_ARTIFACT_API } from "../../shared/transcript-only-openclaw-assistant.js";
+import {
+  OPENCLAW_DELIVERY_MIRROR_MODEL,
+  OPENCLAW_TRANSCRIPT_ARTIFACT_API,
+  OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER,
+} from "../../shared/transcript-only-openclaw-assistant.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { resolveSessionTranscriptPathInDir } from "./paths.js";
 import { updateSessionStoreEntry } from "./store.js";
@@ -623,6 +627,90 @@ describe("appendAssistantMessageToSessionTranscript", () => {
         kind: "channel-final",
         sourceMessageId: "message-1",
       });
+    }
+  });
+
+  it("idempotently appends suppressed channel finals by key while preserving source ids", async () => {
+    writeTranscriptStore();
+
+    const text = "Channel final suppressed before delivery: stale foreground";
+    const first = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text,
+      storePath: fixture.storePath(),
+      idempotencyKey: "channel-final-suppressed:message-1:0",
+      deliveryMirror: {
+        kind: "channel-final-suppressed",
+        reason: "stale-foreground",
+        sourceMessageId: "message-1",
+      },
+    });
+    const replay = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text,
+      storePath: fixture.storePath(),
+      idempotencyKey: "channel-final-suppressed:message-1:0",
+      deliveryMirror: {
+        kind: "channel-final-suppressed",
+        reason: "stale-foreground",
+        sourceMessageId: "message-1",
+      },
+    });
+    const nextTurn = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text,
+      storePath: fixture.storePath(),
+      idempotencyKey: "channel-final-suppressed:message-2:0",
+      deliveryMirror: {
+        kind: "channel-final-suppressed",
+        reason: "stale-foreground",
+        sourceMessageId: "message-2",
+      },
+    });
+
+    expect(first.ok).toBe(true);
+    expect(replay.ok).toBe(true);
+    expect(nextTurn.ok).toBe(true);
+    if (first.ok && replay.ok && nextTurn.ok) {
+      expect(replay.messageId).toBe(first.messageId);
+      expect(nextTurn.messageId).not.toBe(first.messageId);
+      const lines = fs.readFileSync(first.sessionFile, "utf-8").trim().split("\n");
+      expect(lines).toHaveLength(3);
+      const firstMirror = JSON.parse(lines[1]).message;
+      const secondMirror = JSON.parse(lines[2]).message;
+      expect(firstMirror).toMatchObject({
+        api: OPENCLAW_TRANSCRIPT_ARTIFACT_API,
+        provider: OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER,
+        model: OPENCLAW_DELIVERY_MIRROR_MODEL,
+        openclawDeliveryMirror: {
+          kind: "channel-final-suppressed",
+          reason: "stale-foreground",
+          sourceMessageId: "message-1",
+        },
+      });
+      expect(secondMirror.openclawDeliveryMirror).toEqual({
+        kind: "channel-final-suppressed",
+        reason: "stale-foreground",
+        sourceMessageId: "message-2",
+      });
+      await appendSessionTranscriptMessage({
+        transcriptPath: first.sessionFile,
+        message: {
+          role: "user",
+          content: "next user turn",
+          timestamp: Date.now(),
+        },
+      });
+      await expect(
+        readRecentUserAssistantTextFromSessionTranscript(first.sessionFile, { limit: 10 }),
+      ).resolves.toEqual([
+        {
+          id: expect.any(String),
+          role: "user",
+          text: "next user turn",
+          timestamp: expect.any(Number),
+        },
+      ]);
     }
   });
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -36,10 +36,16 @@ export type SessionTranscriptAppendResult =
     };
 
 export type SessionTranscriptUpdateMode = "inline" | "file-only" | "none";
-export type SessionTranscriptDeliveryMirror = {
-  kind: "channel-final";
-  sourceMessageId?: string;
-};
+export type SessionTranscriptDeliveryMirror =
+  | {
+      kind: "channel-final";
+      sourceMessageId?: string;
+    }
+  | {
+      kind: "channel-final-suppressed";
+      reason: "stale-foreground";
+      sourceMessageId?: string;
+    };
 
 export type SessionTranscriptAssistantMessage = Parameters<SessionManager["appendMessage"]>[0] & {
   role: "assistant";
@@ -468,11 +474,11 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
         reason: "blocked by before_message_write",
       };
     }
-    const identifiedChannelFinal =
-      Boolean(explicitIdempotencyKey) && isChannelFinalDeliveryMirror(params.message);
+    const identifiedDeliveryMirror =
+      Boolean(explicitIdempotencyKey) && isIdentifiedDeliveryMirror(params.message);
     let latestEquivalentAssistantId: string | undefined;
-    // Unidentified delivery mirrors dedupe by latest text. Identified channel finals use their
-    // idempotency key so repeated replies on separate user turns remain distinct.
+    // Identified delivery mirrors, including suppressed finals, dedupe only by
+    // key so same-text markers from different source ids remain separate rows.
     const turn = await persistSessionTranscriptTurn(
       {
         sessionId: currentEntry.sessionId,
@@ -508,7 +514,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
               : {}),
             shouldAppend: async (target) => {
               latestEquivalentAssistantId =
-                isRedundantDeliveryMirror(params.message) && !identifiedChannelFinal
+                isRedundantDeliveryMirror(params.message) && !identifiedDeliveryMirror
                   ? await findLatestEquivalentAssistantMessageId(
                       target.sessionFile,
                       preparedUnkeyedMessage as SessionTranscriptAssistantMessage,
@@ -577,10 +583,13 @@ function isRedundantDeliveryMirror(message: SessionTranscriptAssistantMessage): 
   );
 }
 
-function isChannelFinalDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {
+function isIdentifiedDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {
   const marker = (message as { openclawDeliveryMirror?: SessionTranscriptDeliveryMirror })
     .openclawDeliveryMirror;
-  return isRedundantDeliveryMirror(message) && marker?.kind === "channel-final";
+  return (
+    isRedundantDeliveryMirror(message) &&
+    (marker?.kind === "channel-final" || marker?.kind === "channel-final-suppressed")
+  );
 }
 
 function extractAssistantMessageText(message: SessionTranscriptAssistantMessage): string | null {


### PR DESCRIPTION
## What Problem This Solves

Fixes #95490. Reported by @bek91.

Stale foreground delivery cancellation could leave transcript state ambiguous: CLI-owned or embedded-owned assistant turns were already persisted, but when the visible channel final was suppressed by a newer foreground turn, the transcript had no durable marker explaining that the channel send did not happen. Source-mirror finals also needed the same transcript-truth marker without changing CLI persistence or the foreground freshness fence.

## Why This Change Was Made

This records intentional stale-foreground final suppression as a transcript-only delivery mirror.

The change:
- adds an appendable before-deliver cancellation observer to `ReplyDispatcher`
- tags stale foreground cancellations at the freshness fence
- records `channel-final-suppressed` transcript-only delivery mirror rows for stale-cancelled transcript-owned finals and source mirrors
- scopes delivered/suppressed mirror capture to the exact final payload with an opaque capture token
- preserves hook-redacted payload text/media when building suppressed excerpts, and writes marker-only rows when hooks did not produce a delivery payload
- keeps suppressed delivery-mirror rows idempotent by source/delivery key and out of prompt context

## User Impact

Users and future replay/debugging see transcript truth: when a persisted assistant turn was not visibly delivered because a newer foreground turn superseded it, the transcript records a small marker instead of silently appearing incomplete. Successful CLI-owned and embedded-owned finals still avoid duplicate answer rows.

## Evidence

AI-assisted PR.

Validation:
- `git diff --check`
- `./node_modules/.bin/tsgo --noEmit --pretty false --project tsconfig.json 2>&1 | rg "dispatch-from-config\.ts\(90[0-9]|dispatch-from-config\.ts\(91[0-9]|dispatch-from-config\.ts\(92[0-9]|dispatch-from-config\.test\.ts\(1606|TS18048|TS2339" -C 2 || true`
  - no matching branch-introduced `dispatch-from-config` type errors after the fix
  - full project typecheck still reports unrelated existing `frsize` fixture errors in `extensions/workboard/src/store.test.ts`, `src/cli/update-cli.test.ts`, and `src/infra/disk-space.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/dispatch.freshness.test.ts src/auto-reply/reply/before-deliver.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/config/sessions/transcript.test.ts -- --reporter=dot`
- `codex review --base origin/main`

### Known residuals / proof gaps

- Suppressed markers for transcript-owned (CLI/embedded) finals are recorded where final delivery mirror metadata is prepared, which today is the Slack surface path (`src/auto-reply/reply/dispatch-from-config.ts:2865`); source-mirror finals get markers on all surfaces. Extending owned-final suppressed markers to other channels is a follow-up candidate.
- Pre-hook stale cancellations intentionally write marker-only rows with no content excerpt: configured before-deliver hooks never ran for that payload, so its redaction status is unknown and the conservative choice is bookkeeping text only. Post-hook cancellations excerpt from the hook-transformed payload.
- No live Slack reproduction of the original race has been run yet (the linked issue carries `clawsweeper:needs-live-repro`); current proof is source-level analysis plus the focused Vitest suites above.
- Full `pnpm tsgo*`/lint lanes are deferred to hosted CI on this PR; only the narrow local tsgo probe above was run locally.
