### PR TITLE
docs(changelog): credit Vincent replay fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
+- **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.
+- **Config size-drop guard:** compare writes against canonical bytes for parseable object configs instead of raw BOM and indentation overhead, while preserving raw audit telemetry and the conservative malformed-input fallback. (#100591, #71865) Thanks @vincentkoc.
 - **Control UI coalesced updates:** show a clear queued-restart completion banner when an update joins an already-running Gateway restart. (#93082) Thanks @goutamadwant.
 - **Control UI connection errors:** preserve structured pairing and authentication failures for pending RPC callers while keeping generic disconnect behavior unchanged. (#54758) Thanks @ruanrrn.
 - **TUI startup status:** show `starting up` during post-connect initialization without overwriting active-run or reconnect state. (#93999) Thanks @ml12580.


### PR DESCRIPTION
## What Problem This Solves

Records three user-visible Vincent replay fixes that landed without changelog edits to avoid conflicts while `CHANGELOG.md` was moving rapidly:

- #100554: clearer plugin-install fallback diagnostics
- #100569: deduplicated config-validation warnings
- #100591: canonical config size-drop baselines

## Why This Change Was Made

Adds one focused changelog-only follow-up after all three implementation PRs landed, preserving contributor credit without rebasing or conflicting each runtime fix.

## User Impact

Release notes accurately describe the fixes and thank @vincentkoc.

## Evidence

- `git diff --check`
- Manual verification against the merged PR titles, bodies, and commit behavior
