### PR TITLE
test(plugins): register Workboard typed hook contract

### DIFF
--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -23,6 +23,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
   "extensions/memory-core/src/dreaming.ts",
   "extensions/memory-lancedb/index.ts",
   "extensions/thread-ownership/index.ts",
+  "extensions/workboard/index.ts",
 ] as const;
 const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/acpx/index.ts": ["reply_dispatch"],
@@ -35,6 +36,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start", "gateway_stop"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/thread-ownership/index.ts": ["message_received", "message_sending"],
+  "extensions/workboard/index.ts": ["subagent_ended"],
 } as const satisfies Record<
   (typeof BUNDLED_TYPED_HOOK_REGISTRATION_FILES)[number],
   readonly string[]


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where current `main` fails the bundled-plugin contract suite after Workboard added its subagent cleanup hook.

## Why This Change Was Made

Registers Workboard’s existing typed `subagent_ended` hook in both explicit boundary allowlists. This preserves the contract test’s fail-closed inventory without changing plugin runtime behavior.

## User Impact

No product behavior change. Plugin contract CI correctly recognizes the Workboard cleanup hook while continuing to reject unreviewed hook registrations or hook names.

## Evidence

- Before on current `main`: `boundary-invariants.test.ts` reports `extensions/workboard/index.ts` as an unexpected typed-hook registration.
- The runtime registration is `api.on("subagent_ended", ...)` in `extensions/workboard/index.ts`.
- Fresh structured autoreview: clean, confidence 0.92.
- `git diff --check` passes.
- Focused Testbox proof and exact-head CI recorded before merge.
