### PR TITLE
refactor(ui): consolidate sidebar navigation contract

### DIFF
--- a/ui/src/app-navigation-groups.test.ts
+++ b/ui/src/app-navigation-groups.test.ts
@@ -1,47 +1,55 @@
-// Control UI tests cover navigation groups behavior.
+// Control UI tests cover sidebar pinned-route customization behavior.
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_SIDEBAR_PINNED_ROUTES,
   SETTINGS_NAVIGATION_ROUTES,
-  SIDEBAR_SECTIONS,
+  SIDEBAR_NAV_ROUTES,
   isSettingsNavigationRoute,
-  isRouteInSidebarSection,
+  normalizeSidebarPinnedRoutes,
+  sidebarMoreRoutes,
 } from "./app-navigation.ts";
 import { routeIdFromPath } from "./app-routes.ts";
 
-describe("SIDEBAR_SECTIONS", () => {
-  it("collapses detailed settings slices into one sidebar entry", () => {
-    const settings = SIDEBAR_SECTIONS.find((group) => group.label === "settings");
-    expect(settings?.routes).toEqual(["config"]);
+describe("sidebar pinned routes", () => {
+  it("defaults to a small pinned set drawn from the customizable routes", () => {
+    expect(DEFAULT_SIDEBAR_PINNED_ROUTES.length).toBeLessThan(SIDEBAR_NAV_ROUTES.length);
+    for (const routeId of DEFAULT_SIDEBAR_PINNED_ROUTES) {
+      expect(SIDEBAR_NAV_ROUTES).toContain(routeId);
+    }
+  });
+
+  it("keeps managed worktrees in the customizable sidebar", () => {
+    expect(SIDEBAR_NAV_ROUTES).toContain("worktrees");
+  });
+
+  it("keeps channel management and settings slices out of the customizable sidebar", () => {
+    expect(SIDEBAR_NAV_ROUTES).not.toContain("channels");
+    expect(SIDEBAR_NAV_ROUTES).not.toContain("config");
+    expect(SETTINGS_NAVIGATION_ROUTES).toContain("channels");
     expect(SETTINGS_NAVIGATION_ROUTES.every((routeId) => isSettingsNavigationRoute(routeId))).toBe(
       true,
     );
   });
 
-  it("keeps channel management out of the primary control sidebar", () => {
-    const control = SIDEBAR_SECTIONS.find((group) => group.label === "control");
-    expect(control?.routes).toEqual([
-      "overview",
-      "activity",
-      "workboard",
-      "worktrees",
-      "instances",
-      "sessions",
-      "usage",
-      "cron",
-    ]);
-    expect(SETTINGS_NAVIGATION_ROUTES).toContain("channels");
+  it("normalizes persisted pinned routes, dropping unknown and duplicate entries", () => {
+    expect(
+      normalizeSidebarPinnedRoutes(["worktrees", "overview", "worktrees", "bogus", 7]),
+    ).toEqual(["worktrees", "overview"]);
+    expect(normalizeSidebarPinnedRoutes([])).toEqual([]);
   });
 
-  it("keeps the settings group active for nested settings routes", () => {
-    const settings = SIDEBAR_SECTIONS.find((group) => group.label === "settings");
-    if (!settings) {
-      throw new Error("Expected settings group");
-    }
+  it("falls back to null for non-list values so callers use defaults", () => {
+    expect(normalizeSidebarPinnedRoutes(undefined)).toBeNull();
+    expect(normalizeSidebarPinnedRoutes({ overview: true })).toBeNull();
+    expect(normalizeSidebarPinnedRoutes("overview")).toBeNull();
+  });
 
-    expect(isRouteInSidebarSection(settings, "appearance")).toBe(true);
-    expect(isRouteInSidebarSection(settings, "channels")).toBe(true);
-    expect(isRouteInSidebarSection(settings, "debug")).toBe(true);
-    expect(isRouteInSidebarSection(settings, "chat")).toBe(false);
+  it("puts every unpinned nav route into the More section", () => {
+    const pinned = ["overview", "worktrees"] as const;
+    const more = sidebarMoreRoutes(pinned);
+    expect(more).not.toContain("overview");
+    expect(more).not.toContain("worktrees");
+    expect(new Set([...pinned, ...more])).toEqual(new Set(SIDEBAR_NAV_ROUTES));
   });
 
   it("routes every published settings slice", () => {

--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -174,6 +174,7 @@ describe("pathForRoute", () => {
   it("returns correct path without base", () => {
     expect(pathForRoute("chat")).toBe("/chat");
     expect(pathForRoute("overview")).toBe("/overview");
+    expect(pathForRoute("worktrees")).toBe("/worktrees");
   });
 
   it("prepends base path", () => {
@@ -187,6 +188,7 @@ describe("routeIdFromPath", () => {
     expect(routeIdFromPath("/chat")).toBe("chat");
     expect(routeIdFromPath("/overview")).toBe("overview");
     expect(routeIdFromPath("/activity")).toBe("activity");
+    expect(routeIdFromPath("/worktrees")).toBe("worktrees");
     expect(routeIdFromPath("/sessions")).toBe("sessions");
     expect(routeIdFromPath("/dreaming")).toBe("dreams");
     expect(routeIdFromPath("/dreams")).toBe("dreams");

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -62,45 +62,6 @@ export function sidebarMoreRoutes(pinned: readonly SidebarNavRoute[]): SidebarNa
   return SIDEBAR_NAV_ROUTES.filter((routeId) => !pinned.includes(routeId));
 }
 
-type SidebarSectionRouteId = (typeof SIDEBAR_SECTIONS)[number]["routes"][number];
-
-export type SidebarNavRoute = Exclude<SidebarSectionRouteId, "chat" | "config">;
-
-export const SIDEBAR_NAV_ROUTES = SIDEBAR_SECTIONS.flatMap((section) =>
-  section.label === "control" || section.label === "agent" ? section.routes : [],
-) as readonly SidebarNavRoute[];
-
-export const DEFAULT_SIDEBAR_PINNED_ROUTES = [
-  "overview",
-] as const satisfies readonly SidebarNavRoute[];
-
-const SIDEBAR_NAV_ROUTE_SET = new Set<NavigationRouteId>(SIDEBAR_NAV_ROUTES);
-
-function isSidebarNavRoute(value: unknown): value is SidebarNavRoute {
-  return typeof value === "string" && SIDEBAR_NAV_ROUTE_SET.has(value as NavigationRouteId);
-}
-
-export function normalizeSidebarPinnedRoutes(value: unknown): SidebarNavRoute[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  const seen = new Set<SidebarNavRoute>();
-  const routes: SidebarNavRoute[] = [];
-  for (const routeId of value) {
-    if (!isSidebarNavRoute(routeId) || seen.has(routeId)) {
-      continue;
-    }
-    seen.add(routeId);
-    routes.push(routeId);
-  }
-  return routes;
-}
-
-export function sidebarMoreRoutes(pinnedRoutes: readonly SidebarNavRoute[]): SidebarNavRoute[] {
-  const pinned = new Set(pinnedRoutes);
-  return SIDEBAR_NAV_ROUTES.filter((routeId) => !pinned.has(routeId));
-}
-
 export const SETTINGS_NAVIGATION_ROUTES = [
   "config",
   "channels",

--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -5,33 +5,62 @@ import { t } from "./i18n/index.ts";
 
 export type NavigationRouteId = RouteId;
 
-type SidebarSection = {
-  label: string;
-  routes: readonly NavigationRouteId[];
-};
-
 type NavigationItem = {
   [TRouteId in NavigationRouteId]: IconName;
 };
 
-export const SIDEBAR_SECTIONS = [
-  { label: "chat", routes: ["chat"] },
-  {
-    label: "control",
-    routes: [
-      "overview",
-      "activity",
-      "workboard",
-      "worktrees",
-      "instances",
-      "sessions",
-      "usage",
-      "cron",
-    ],
-  },
-  { label: "agent", routes: ["agents", "skills", "skill-workshop", "nodes", "dreams"] },
-  { label: "settings", routes: ["config"] },
-] as const satisfies readonly SidebarSection[];
+// The sidebar shows a small user-customizable pinned set; every other nav route
+// lives in the collapsed "More" section. Chat is reachable through the session
+// list and Settings/Docs live in the sidebar footer, so neither is listed here.
+export const SIDEBAR_NAV_ROUTES = [
+  "overview",
+  "activity",
+  "workboard",
+  "worktrees",
+  "instances",
+  "sessions",
+  "usage",
+  "cron",
+  "agents",
+  "skills",
+  "skill-workshop",
+  "nodes",
+  "dreams",
+] as const satisfies readonly NavigationRouteId[];
+
+export type SidebarNavRoute = (typeof SIDEBAR_NAV_ROUTES)[number];
+
+// Sessions are the sidebar's core content; Overview is the only page pinned by
+// default. Users pin more via the customize menu.
+export const DEFAULT_SIDEBAR_PINNED_ROUTES = [
+  "overview",
+] as const satisfies readonly SidebarNavRoute[];
+
+/**
+ * Normalize a persisted pinned-route list. Returns null when the value is not a
+ * list (caller falls back to defaults); unknown or duplicate entries are dropped
+ * so prefs survive route renames/removals without a migration.
+ */
+export function normalizeSidebarPinnedRoutes(value: unknown): SidebarNavRoute[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const pinned: SidebarNavRoute[] = [];
+  for (const entry of value) {
+    if (
+      typeof entry === "string" &&
+      (SIDEBAR_NAV_ROUTES as readonly string[]).includes(entry) &&
+      !pinned.includes(entry as SidebarNavRoute)
+    ) {
+      pinned.push(entry as SidebarNavRoute);
+    }
+  }
+  return pinned;
+}
+
+export function sidebarMoreRoutes(pinned: readonly SidebarNavRoute[]): SidebarNavRoute[] {
+  return SIDEBAR_NAV_ROUTES.filter((routeId) => !pinned.includes(routeId));
+}
 
 type SidebarSectionRouteId = (typeof SIDEBAR_SECTIONS)[number]["routes"][number];
 
@@ -115,16 +144,6 @@ const NAVIGATION_ICONS: NavigationItem = {
 
 export function isSettingsNavigationRoute(routeId: NavigationRouteId): boolean {
   return (SETTINGS_NAVIGATION_ROUTES as readonly NavigationRouteId[]).includes(routeId);
-}
-
-export function isRouteInSidebarSection(
-  section: SidebarSection,
-  routeId: NavigationRouteId,
-): boolean {
-  if (section.label === "settings") {
-    return isSettingsNavigationRoute(routeId);
-  }
-  return section.routes.includes(routeId);
 }
 
 export function navigationIconForRoute(routeId: NavigationRouteId): IconName {

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -98,15 +98,19 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       const menu = sidebar.getByRole("menu", { name: "Customize sidebar" });
       const overviewItem = menu.getByRole("menuitemcheckbox", { name: "Overview" });
       await expect.poll(() => overviewItem.getAttribute("aria-checked")).toBe("true");
+      const worktreesItem = menu.getByRole("menuitemcheckbox", { name: "Worktrees" });
+      await expect.poll(() => worktreesItem.getAttribute("aria-checked")).toBe("false");
       await expect
         .poll(() => overviewItem.evaluate((element) => element === document.activeElement))
         .toBe(true);
       await captureUiProof(page, "02-customize-menu.png");
 
+      await worktreesItem.click();
+      await expect.poll(() => trimmedTextContents(pinnedItems)).toEqual(["Overview", "Worktrees"]);
       await overviewItem.click();
-      await expect.poll(() => trimmedTextContents(pinnedItems)).toEqual([]);
+      await expect.poll(() => trimmedTextContents(pinnedItems)).toEqual(["Worktrees"]);
       await page.reload();
-      await expect.poll(() => trimmedTextContents(pinnedItems)).toEqual([]);
+      await expect.poll(() => trimmedTextContents(pinnedItems)).toEqual(["Worktrees"]);
       await expect.poll(() => moreButton.getAttribute("aria-expanded")).toBe("true");
       await expect
         .poll(() =>


### PR DESCRIPTION
## What Problem This Solves

Current `main` builds again after the emergency export restoration in `55a0012c44b`, but it now carries two sidebar navigation models: the section API introduced by #100535 and the customizable route contract consumed by the sidebar and settings flows. The section API has no production consumer and duplicates route policy.

## Why This Change Was Made

Keep one canonical customizable-sidebar contract instead of retaining aliases around an unused model. The route list, persisted pin normalization, default pins, and derived More menu share one owner. Worktrees remains a normal pinnable route and is exercised through the existing browser persistence flow.

## User Impact

No new product contract beyond the already-landed sidebar and Worktrees features. Users can pin Worktrees from Customize sidebar and retain that choice across reloads; maintainers have one typed route policy instead of two competing models.

## Evidence

- Provenance: #100535 overwrote #100386’s customizable exports; `55a0012c44b` restored the missing exports and build, leaving the unused section API alongside them.
- Blacksmith Testbox `tbx_01kwtv7wj41ka3fybn46qhbrv7`: 57/57 navigation and settings tests passed.
- Same Testbox: production UI build passed; 998 modules transformed and the Worktrees chunk emitted.
- Same Testbox: 3/3 Chromium E2Es passed, including real Worktrees pin/reload persistence, update coalescing, and stale-module mount recovery.
- Same Testbox: 18/18 PTY scenarios and exact changed-gate passed.
- Fresh branch AutoReview: no accepted/actionable findings.
- Final rebased head `9c8c48868bc40e63c8712d8262a14e3e5b72fcc1`: Blacksmith Testbox `tbx_01kwtxvd6n9vkdjxa2has3g3h8` passed 57/57 navigation/settings tests and the production UI build (998 modules, Worktrees chunk emitted); [run 28769594466](https://github.com/openclaw/openclaw/actions/runs/28769594466).
- Final branch AutoReview: clean, confidence 0.83; focused duplicate-removal AutoReview: clean, confidence 0.89.
