### PR TITLE
test(plugins): register workboard typed hook contract

### DIFF
--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -23,6 +23,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
   "extensions/memory-core/src/dreaming.ts",
   "extensions/memory-lancedb/index.ts",
   "extensions/thread-ownership/index.ts",
+  "extensions/workboard/index.ts",
 ] as const;
 const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/acpx/index.ts": ["reply_dispatch"],
@@ -35,6 +36,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/memory-core/src/dreaming.ts": ["before_agent_reply", "gateway_start", "gateway_stop"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/thread-ownership/index.ts": ["message_received", "message_sending"],
+  "extensions/workboard/index.ts": ["subagent_ended"],
 } as const satisfies Record<
   (typeof BUNDLED_TYPED_HOOK_REGISTRATION_FILES)[number],
   readonly string[]


### PR DESCRIPTION
Closes #100613

## What Problem This Solves

Fixes the remaining managed-worktrees merge regression where the Workboard plugin's new `subagent_ended` hook is rejected by the explicit typed-hook contract inventory, keeping current-main CI and rebased pull requests red.

## Why This Change Was Made

Adds the existing Workboard registration file and its exact hook name to the canonical inventory. The Control UI navigation half of #100613 was independently fixed by `55a0012c44b52af2f22982cc85568e6e5d0df5c7`, so this branch deliberately drops its superseded UI rewrite.

## User Impact

No runtime behavior changes. Repository contract checks now recognize the managed-worktree cleanup hook that already runs in Workboard.

## Evidence

- Exact current-main base: `d5371395218c0f88318656502a2c471aab21b596`.
- Blacksmith Testbox `tbx_01kwtwyv7y2f25b1b8hkynew9g` (`jade-crab`), run https://github.com/openclaw/openclaw/actions/runs/28769016840: `pnpm test src/plugins/contracts/boundary-invariants.test.ts` passed all 14 tests.
- `git diff --check` and targeted `oxfmt --check`: passed.
- Fresh Codex autoreview: no accepted/actionable findings; patch correctness 0.99.
