### PR TITLE
fix: replies fail when memory flush is exhausted

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -123,7 +123,7 @@ and are pruned by normal session cleanup.
 
 ### Compaction notices
 
-By default, compaction runs silently. Set `notifyUser` to show brief status messages when compaction starts and completes:
+By default, compaction runs silently. Set `notifyUser` to show brief status messages when compaction starts and completes, and to surface a degraded notice when a pre-compaction memory flush is exhausted but the reply still continues:
 
 ```json5
 {

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -631,7 +631,7 @@ Periodic heartbeat runs.
         model: "openrouter/anthropic/claude-sonnet-4-6", // optional compaction-only model override
         truncateAfterCompaction: true, // rotate to a smaller successor JSONL after compaction
         maxActiveTranscriptBytes: "20mb", // optional preflight local compaction trigger
-        notifyUser: true, // send brief notices when compaction starts and completes (default: false)
+        notifyUser: true, // notices when compaction starts/completes and on memory-flush degradation (default: false)
         memoryFlush: {
           enabled: true,
           model: "ollama/qwen3:8b", // optional memory-flush-only model override
@@ -661,7 +661,7 @@ Periodic heartbeat runs.
 - `model`: optional `provider/model-id` or bare alias from `agents.defaults.models` for compaction summarization only. Bare aliases resolve before dispatch; configured literal model IDs retain precedence on collisions. Use this when the main session should keep one model but compaction summaries should run on another; when unset, compaction uses the session's primary model.
 - `truncateAfterCompaction`: rotates the active session JSONL after compaction so future turns load only the summary and unsummarized tail, while the previous full transcript remains archived. Prevents unbounded active transcript growth in long-running sessions. Default: `false`.
 - `maxActiveTranscriptBytes`: optional byte threshold (`number` or strings like `"20mb"`) that triggers normal local compaction before a run when the active JSONL grows past the threshold. Requires `truncateAfterCompaction` so successful compaction can rotate to a smaller successor transcript. Disabled when unset or `0`.
-- `notifyUser`: when `true`, sends brief notices to the user when compaction starts and when it completes (for example, "Compacting context..." and "Compaction complete"). Disabled by default to keep compaction silent.
+- `notifyUser`: when `true`, sends brief context-maintenance notices to the user: when compaction starts and completes (for example, "Compacting context..." and "Compaction complete"), and when a pre-compaction memory flush is exhausted so the reply continues in a degraded state (for example, "Memory maintenance temporarily failed; continuing your reply."). Disabled by default to keep these notices silent.
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Set `model` to an exact provider/model such as `ollama/qwen3:8b` when this housekeeping turn should stay on a local model; the override does not inherit the active session fallback chain. `forceFlushTranscriptBytes` forces the flush when transcript file size reaches the threshold even if token counters are stale. Skipped when workspace is read-only.
 
 ### `agents.defaults.runRetries`

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -5,6 +5,7 @@ import type { TemplateContext } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { createTestFollowupRun } from "./agent-runner.test-fixtures.js";
 import type { QueueSettings } from "./queue.js";
+import type { ReplyOperation } from "./reply-run-registry.js";
 import { createMockTypingController } from "./test-helpers.js";
 
 const freshCfg = { runtimeFresh: true };
@@ -27,6 +28,8 @@ const createReplyMediaContextMock = vi.fn();
 const createReplyMediaPathNormalizerMock = vi.fn();
 const runPreflightCompactionIfNeededMock = vi.fn();
 const runMemoryFlushIfNeededMock = vi.fn();
+const runAgentTurnWithFallbackMock = vi.fn();
+const resetReplyRunSessionMock = vi.fn();
 const enqueueFollowupRunMock = vi.fn();
 
 vi.mock("./agent-runner-utils.js", async () => {
@@ -67,6 +70,26 @@ vi.mock("./agent-runner-memory.js", () => ({
   runMemoryFlushIfNeeded: (...args: unknown[]) => runMemoryFlushIfNeededMock(...args),
 }));
 
+vi.mock("./agent-runner-execution.js", async () => {
+  const actual = await vi.importActual<typeof import("./agent-runner-execution.js")>(
+    "./agent-runner-execution.js",
+  );
+  return {
+    ...actual,
+    runAgentTurnWithFallback: (...args: unknown[]) => runAgentTurnWithFallbackMock(...args),
+  };
+});
+
+vi.mock("./agent-runner-session-reset.js", async () => {
+  const actual = await vi.importActual<typeof import("./agent-runner-session-reset.js")>(
+    "./agent-runner-session-reset.js",
+  );
+  return {
+    ...actual,
+    resetReplyRunSession: (...args: unknown[]) => resetReplyRunSessionMock(...args),
+  };
+});
+
 vi.mock("./queue.js", async () => {
   const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
   return {
@@ -86,6 +109,34 @@ function createTelegramSessionCtx(): TemplateContext {
     ChatType: "dm",
     MessageSid: "msg-1",
   } as unknown as TemplateContext;
+}
+
+function createReplyOperation(): ReplyOperation {
+  return {
+    key: "test",
+    sessionId: "session-1",
+    abortSignal: new AbortController().signal,
+    resetTriggered: false,
+    phase: "queued",
+    result: null,
+    setPhase: vi.fn(),
+    updateSessionId: vi.fn(),
+    hasOwnedSessionId: vi.fn(() => false),
+    attachBackend: vi.fn(),
+    detachBackend: vi.fn(),
+    retainFailureUntilComplete: vi.fn(),
+    complete: vi.fn(),
+    completeThen: vi.fn((afterClear: () => void) => {
+      afterClear();
+    }),
+    completeWithAfterClearBarrier: vi.fn(),
+    fail: vi.fn(),
+    freezeAbort: vi.fn(),
+    abortByUser: vi.fn(),
+    abortForRestart: vi.fn(),
+    terminalRecovery: false,
+    markTerminalRecovery: vi.fn(),
+  };
 }
 
 function createDirectRuntimeReplyParams({
@@ -173,6 +224,8 @@ describe("runReplyAgent runtime config", () => {
     createReplyMediaPathNormalizerMock.mockReset();
     runPreflightCompactionIfNeededMock.mockReset();
     runMemoryFlushIfNeededMock.mockReset();
+    runAgentTurnWithFallbackMock.mockReset();
+    resetReplyRunSessionMock.mockReset();
     enqueueFollowupRunMock.mockReset();
 
     resolveQueuedReplyExecutionConfigMock.mockResolvedValue(freshCfg);
@@ -180,7 +233,12 @@ describe("runReplyAgent runtime config", () => {
     createReplyToModeFilterForChannelMock.mockReturnValue((payload: unknown) => payload);
     createReplyMediaPathNormalizerMock.mockReturnValue((payload: unknown) => payload);
     runPreflightCompactionIfNeededMock.mockRejectedValue(sentinelError);
-    runMemoryFlushIfNeededMock.mockResolvedValue(undefined);
+    runMemoryFlushIfNeededMock.mockResolvedValue({ sessionEntry: undefined, outcome: "skipped" });
+    runAgentTurnWithFallbackMock.mockResolvedValue({
+      kind: "final",
+      payload: { text: "main reply" },
+    });
+    resetReplyRunSessionMock.mockResolvedValue(false);
   });
 
   it("resolves direct reply runs before early helpers read config", async () => {
@@ -247,62 +305,132 @@ describe("runReplyAgent runtime config", () => {
     expect(memoryCall.runtimePolicySessionKey).toBe(runtimePolicySessionKey);
   });
 
-  it("returns source-suppression-safe memory-flush error payloads before the main reply run", async () => {
+  it("continues the main reply when memory flush reports visible maintenance errors", async () => {
     const { replyParams } = createDirectRuntimeReplyParams({
       shouldFollowup: false,
       isActive: false,
     });
-    let observedReplyOperation: { freezeAbort: () => void } | undefined;
-    replyParams.opts = { sourceReplyDeliveryMode: "message_tool_only" };
+    const onBlockReply = vi.fn();
+    replyParams.opts = { sourceReplyDeliveryMode: "message_tool_only", onBlockReply };
+    resolveQueuedReplyExecutionConfigMock.mockResolvedValue({
+      ...freshCfg,
+      agents: { defaults: { compaction: { notifyUser: true } } },
+    });
     runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
     runMemoryFlushIfNeededMock.mockImplementation(
       async (params: {
-        replyOperation: { freezeAbort: () => void };
         onVisibleErrorPayloads?: (payloads: Array<{ text?: string; isError?: boolean }>) => void;
       }) => {
-        vi.spyOn(params.replyOperation, "freezeAbort");
-        observedReplyOperation = params.replyOperation;
-        expect(params.replyOperation.freezeAbort).not.toHaveBeenCalled();
         params.onVisibleErrorPayloads?.([
           {
             text: "⚠️ write failed: Memory flush writes are restricted to memory/2023-11-14.md; use that path only.",
             isError: true,
           },
         ]);
-        return undefined;
+        return { sessionEntry: undefined, outcome: "failed" };
       },
     );
 
     const result = await runReplyAgent(replyParams);
 
-    if (!observedReplyOperation) {
-      throw new Error("expected memory flush reply operation");
-    }
-    expect(observedReplyOperation.freezeAbort).toHaveBeenCalledTimes(1);
-    if (!result || Array.isArray(result)) {
-      throw new Error("expected a single memory-flush error reply payload");
-    }
-    expect(result).toEqual({
-      text: "⚠️ write failed: Memory flush writes are restricted to memory/2023-11-14.md; use that path only.",
-      isError: true,
-      replyToId: "msg-1",
-      replyToCurrent: undefined,
-      replyToTag: false,
-      mediaUrl: undefined,
-      mediaUrls: undefined,
-      audioAsVoice: false,
+    expect(result).toEqual({ text: "main reply" });
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(runAgentTurnWithFallbackMock).toHaveBeenCalledOnce();
+  });
+
+  it("rotates, rebinds, and optionally notifies when memory flush is exhausted", async () => {
+    const { replyParams, followupRun } = createDirectRuntimeReplyParams({
+      shouldFollowup: false,
+      isActive: false,
     });
-    expect(getReplyPayloadMetadata(result)).toEqual({
-      deliverDespiteSourceReplySuppression: true,
-      replyDelivery: {
-        chatType: "direct",
-        replyToMode: "all",
-      },
-      replyDeliverySource: {
-        channel: "telegram",
-        accountId: "default",
-      },
+    const sessionKey = "agent:main:telegram:default:direct:test";
+    const sessionEntry = {
+      sessionId: "session-1",
+      updatedAt: 1,
+      compactionCount: 4,
+      memoryFlushFailureCount: 2,
+    };
+    const sessionStore = { [sessionKey]: sessionEntry };
+    replyParams.sessionKey = sessionKey;
+    replyParams.storePath = "/tmp/sessions.json";
+    replyParams.sessionEntry = sessionEntry;
+    replyParams.sessionStore = sessionStore;
+    resolveQueuedReplyExecutionConfigMock.mockResolvedValue({
+      ...freshCfg,
+      agents: { defaults: { compaction: { notifyUser: true } } },
     });
+    const onBlockReply = vi.fn();
+    replyParams.opts = { onBlockReply };
+    const updateSessionIdSpy = vi.fn();
+    const replyOperation = createReplyOperation();
+    replyOperation.updateSessionId = updateSessionIdSpy;
+    replyParams.replyOperation = replyOperation;
+    runPreflightCompactionIfNeededMock.mockImplementation(
+      async (params: { sessionEntry?: unknown }) => params.sessionEntry,
+    );
+    runMemoryFlushIfNeededMock.mockImplementation(
+      async (params: {
+        sessionEntry?: typeof sessionEntry;
+        onVisibleErrorPayloads?: (payloads: Array<{ text?: string; isError?: boolean }>) => void;
+      }) => {
+        params.onVisibleErrorPayloads?.([
+          {
+            text: "⚠️ Memory flush failed after 3 attempts; skipping for this cycle. It will retry after the next compaction.",
+            isError: true,
+          },
+        ]);
+        return {
+          sessionEntry: {
+            ...params.sessionEntry,
+            memoryFlushFailureCount: 3,
+            memoryFlushCompactionCount: 4,
+          },
+          outcome: "exhausted",
+        };
+      },
+    );
+    resetReplyRunSessionMock.mockImplementation(async (params: unknown) => {
+      const resetParams = params as {
+        activeSessionEntry?: typeof sessionEntry;
+        followupRun: typeof followupRun;
+        onActiveSessionEntry: (entry: typeof sessionEntry) => void;
+        onNewSession: (sessionId: string, sessionFile: string) => void;
+      };
+      const sessionFile = "/tmp/session-rotated.jsonl";
+      const nextEntry = {
+        ...resetParams.activeSessionEntry,
+        sessionId: "session-rotated",
+        updatedAt: 1,
+        memoryFlushFailureCount: 0,
+        compactionCount: 0,
+      };
+      resetParams.followupRun.run.sessionId = nextEntry.sessionId;
+      resetParams.followupRun.run.sessionFile = sessionFile;
+      resetParams.onActiveSessionEntry(nextEntry);
+      resetParams.onNewSession(nextEntry.sessionId, sessionFile);
+      return true;
+    });
+
+    const result = await runReplyAgent(replyParams);
+
+    expect(result).toEqual({ text: "main reply" });
+    expect(resetReplyRunSessionMock).toHaveBeenCalledOnce();
+    expect(resetReplyRunSessionMock.mock.calls[0]?.[0]).toMatchObject({
+      options: {
+        failureLabel: "memory flush exhaustion",
+        cleanupTranscripts: false,
+      },
+      sessionKey,
+      queueKey: "main",
+    });
+    expect(followupRun.run.sessionId).toBe("session-rotated");
+    expect(updateSessionIdSpy).toHaveBeenCalledWith("session-rotated");
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "⚠️ Memory maintenance temporarily failed; continuing your reply.",
+      }),
+    );
+    expect(runAgentTurnWithFallbackMock).toHaveBeenCalledOnce();
   });
 
   it("does not start the main turn after cancellation during memory flush", async () => {
@@ -314,7 +442,7 @@ describe("runReplyAgent runtime config", () => {
     runMemoryFlushIfNeededMock.mockImplementation(
       async (params: { replyOperation: { abortByUser: () => boolean } }) => {
         expect(params.replyOperation.abortByUser()).toBe(true);
-        return undefined;
+        return { sessionEntry: undefined, outcome: "failed" };
       },
     );
 
@@ -331,7 +459,7 @@ describe("runReplyAgent runtime config", () => {
     const codexMessage =
       "You've reached your Codex subscription usage limit. Codex did not return a reset time for this limit. Run /codex account for current usage details.";
     runPreflightCompactionIfNeededMock.mockRejectedValue(new Error(codexMessage));
-    runMemoryFlushIfNeededMock.mockResolvedValue(undefined);
+    runMemoryFlushIfNeededMock.mockResolvedValue({ sessionEntry: undefined, outcome: "skipped" });
 
     const result = await runReplyAgent(replyParams);
 
@@ -351,7 +479,7 @@ describe("runReplyAgent runtime config", () => {
     runPreflightCompactionIfNeededMock.mockRejectedValue(
       new Error("Preflight compaction required but failed: auth profile mismatch"),
     );
-    runMemoryFlushIfNeededMock.mockResolvedValue(undefined);
+    runMemoryFlushIfNeededMock.mockResolvedValue({ sessionEntry: undefined, outcome: "skipped" });
 
     const result = await runReplyAgent(replyParams);
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -264,7 +264,7 @@ describe("runMemoryFlushIfNeeded", () => {
     );
 
     const followupRun = createTestFollowupRun();
-    const entry = await runMemoryFlushIfNeeded({
+    const result = await runMemoryFlushIfNeeded({
       cfg: {
         agents: {
           defaults: {
@@ -287,7 +287,8 @@ describe("runMemoryFlushIfNeeded", () => {
       replyOperation: createReplyOperation(),
     });
 
-    expect(entry?.sessionId).toBe("session-rotated");
+    expect(result.outcome).toBe("completed");
+    expect(result.sessionEntry?.sessionId).toBe("session-rotated");
     expect(followupRun.run.sessionId).toBe("session-rotated");
     expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     const flushCall = requireEmbeddedAgentCall();
@@ -319,35 +320,47 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(persisted.main.memoryFlushAt).toBe(1_700_000_000_000);
   });
 
-  it("reports memory-flush error payloads for visible delivery", async () => {
+  it("counts resolved error payloads as failed memory flushes", async () => {
+    const storePath = path.join(rootDir, "sessions.json");
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
       totalTokens: 80_000,
       compactionCount: 1,
     };
+    const sessionStore = { main: sessionEntry };
+    await writeTestSessionStore(storePath, "main", sessionEntry);
     const visibleErrorPayloads: Array<{ text?: string; isError?: boolean }> = [];
-    runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [
-        { text: "normal silent maintenance reply" },
-        {
-          text: "⚠️ write failed: Memory flush writes are restricted to memory/2023-11-14.md; use that path only.",
-          isError: true,
-        },
-      ],
-      meta: {},
-    });
+    runEmbeddedAgentMock.mockImplementationOnce(
+      async (params: {
+        onAgentEvent?: (event: { stream: string; data: { phase: string } }) => void;
+      }) => {
+        params.onAgentEvent?.({ stream: "compaction", data: { phase: "end" } });
+        return {
+          payloads: [
+            { text: "normal silent maintenance reply" },
+            {
+              text: "⚠️ write failed: Memory flush writes are restricted to memory/2023-11-14.md; use that path only.",
+              isError: true,
+            },
+          ],
+          meta: { agentMeta: { sessionId: "session-rotated" } },
+        };
+      },
+    );
+    const followupRun = createTestFollowupRun();
 
-    await runMemoryFlushIfNeeded({
+    const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
-      followupRun: createTestFollowupRun(),
+      followupRun,
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
       defaultModel: "anthropic/claude-opus-4-6",
       agentCfgContextTokens: 100_000,
       resolvedVerboseLevel: "off",
       sessionEntry,
-      sessionStore: { main: sessionEntry },
+      sessionStore,
       sessionKey: "main",
+      storePath,
       isHeartbeat: false,
       replyOperation: createReplyOperation(),
       onVisibleErrorPayloads: (payloads) => {
@@ -361,6 +374,14 @@ describe("runMemoryFlushIfNeeded", () => {
         isError: true,
       },
     ]);
+    expect(result.outcome).toBe("failed");
+    expect(result.sessionEntry?.sessionId).toBe("session-rotated");
+    expect(followupRun.run.sessionId).toBe("session-rotated");
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as { main: SessionEntry };
+    expect(persisted.main.sessionId).toBe("session-rotated");
+    expect(persisted.main.compactionCount).toBe(2);
+    expect(persisted.main.memoryFlushFailureCount).toBe(1);
+    expect(persisted.main.memoryFlushAt).toBeUndefined();
   });
 
   it("reports restricted memory-flush write failures for visible delivery", async () => {
@@ -377,7 +398,7 @@ describe("runMemoryFlushIfNeeded", () => {
       ),
     );
 
-    await runMemoryFlushIfNeeded({
+    const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
@@ -520,7 +541,7 @@ describe("runMemoryFlushIfNeeded", () => {
     await writeTestSessionStore(storePath, "main", sessionEntry);
     runWithModelFallbackMock.mockRejectedValueOnce(new Error("provider crashed during flush"));
 
-    await runMemoryFlushIfNeeded({
+    const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
@@ -536,6 +557,7 @@ describe("runMemoryFlushIfNeeded", () => {
     });
 
     const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as { main: SessionEntry };
+    expect(result.outcome).toBe("failed");
     expect(persisted.main.memoryFlushFailureCount).toBe(1);
     expect(persisted.main.memoryFlushLastFailedAt).toBe(1_700_000_000_000);
     expect(persisted.main.memoryFlushLastFailureError).toContain("provider crashed during flush");
@@ -565,7 +587,7 @@ describe("runMemoryFlushIfNeeded", () => {
     abortErr.name = "AbortError";
     runWithModelFallbackMock.mockRejectedValueOnce(abortErr);
 
-    await runMemoryFlushIfNeeded({
+    const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
@@ -581,6 +603,7 @@ describe("runMemoryFlushIfNeeded", () => {
     });
 
     const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as { main: SessionEntry };
+    expect(result.outcome).toBe("failed");
     expect(persisted.main.memoryFlushFailureCount).toBe(0);
     expect(persisted.main.memoryFlushLastFailedAt).toBeUndefined();
     expect(persisted.main.memoryFlushLastFailureError).toBeUndefined();
@@ -599,7 +622,7 @@ describe("runMemoryFlushIfNeeded", () => {
     };
     await writeTestSessionStore(storePath, "main", sessionEntry);
 
-    await runMemoryFlushIfNeeded({
+    const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
@@ -615,6 +638,7 @@ describe("runMemoryFlushIfNeeded", () => {
     });
 
     const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as { main: SessionEntry };
+    expect(result.outcome).toBe("completed");
     expect(persisted.main.memoryFlushFailureCount).toBe(0);
     expect(persisted.main.memoryFlushLastFailedAt).toBeUndefined();
     expect(persisted.main.memoryFlushLastFailureError).toBeUndefined();
@@ -633,7 +657,7 @@ describe("runMemoryFlushIfNeeded", () => {
     runWithModelFallbackMock.mockRejectedValueOnce(new Error("provider crashed during flush"));
 
     const visibleErrorPayloads: ReplyPayload[] = [];
-    await runMemoryFlushIfNeeded({
+    const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
@@ -652,6 +676,7 @@ describe("runMemoryFlushIfNeeded", () => {
     });
 
     const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as { main: SessionEntry };
+    expect(result.outcome).toBe("exhausted");
     expect(persisted.main.memoryFlushCompactionCount).toBe(1);
     expect(persisted.main.memoryFlushFailureCount).toBe(TEST_MAX_FLUSH_FAILURES);
     expect(emitAgentEventMock).toHaveBeenCalledWith(
@@ -922,7 +947,7 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 1,
     };
 
-    const entry = await runMemoryFlushIfNeeded({
+    const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { cliBackends: { "codex-cli": { command: "codex" } } } } },
       followupRun: createTestFollowupRun({ provider: "codex-cli" }),
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,
@@ -936,7 +961,7 @@ describe("runMemoryFlushIfNeeded", () => {
       replyOperation: createReplyOperation(),
     });
 
-    expect(entry).toBe(sessionEntry);
+    expect(result).toEqual({ sessionEntry, outcome: "skipped" });
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
   });
 
@@ -959,7 +984,7 @@ describe("runMemoryFlushIfNeeded", () => {
       agentRuntimeOverride: "claude-cli",
     };
 
-    const entry = await runMemoryFlushIfNeeded({
+    const result = await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({
         provider: "anthropic",
@@ -976,7 +1001,7 @@ describe("runMemoryFlushIfNeeded", () => {
       replyOperation: createReplyOperation(),
     });
 
-    expect(entry).toBe(sessionEntry);
+    expect(result).toEqual({ sessionEntry, outcome: "skipped" });
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
   });
 
@@ -988,7 +1013,7 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 1,
     };
 
-    const entry = await runMemoryFlushIfNeeded({
+    const result = await runMemoryFlushIfNeeded({
       cfg: {
         agents: {
           defaults: {
@@ -1019,7 +1044,7 @@ describe("runMemoryFlushIfNeeded", () => {
       replyOperation: createReplyOperation(),
     });
 
-    expect(entry).toBe(sessionEntry);
+    expect(result).toEqual({ sessionEntry, outcome: "skipped" });
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -398,7 +398,7 @@ describe("runMemoryFlushIfNeeded", () => {
       ),
     );
 
-    const result = await runMemoryFlushIfNeeded({
+    await runMemoryFlushIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun(),
       sessionCtx: { Provider: "whatsapp" } as unknown as TemplateContext,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -344,6 +344,14 @@ function resolveVisibleMemoryFlushErrorPayloads(payloads?: ReplyPayload[]): Repl
   );
 }
 
+function buildVisibleMemoryFlushFailure(payloads: ReplyPayload[]): Error {
+  const message = payloads
+    .map((payload) => normalizeOptionalString(payload.text))
+    .filter((text): text is string => Boolean(text))
+    .join("\n");
+  return new Error(message || "Memory flush returned an error response");
+}
+
 function buildMemoryFlushErrorPayload(err: unknown): ReplyPayload | undefined {
   if (isAbortError(err)) {
     return undefined;
@@ -1047,6 +1055,13 @@ export async function runPreflightCompactionIfNeeded(params: {
   }
 }
 
+type MemoryFlushOutcome = "skipped" | "completed" | "failed" | "exhausted";
+
+type MemoryFlushResult = {
+  sessionEntry?: SessionEntry;
+  outcome: MemoryFlushOutcome;
+};
+
 /** Runs post-turn memory flush when transcript state warrants it. */
 export async function runMemoryFlushIfNeeded(params: {
   cfg: OpenClawConfig;
@@ -1065,10 +1080,10 @@ export async function runMemoryFlushIfNeeded(params: {
   isHeartbeat: boolean;
   replyOperation: ReplyOperation;
   onVisibleErrorPayloads?: (payloads: ReplyPayload[]) => void;
-}): Promise<SessionEntry | undefined> {
+}): Promise<MemoryFlushResult> {
   const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
   if (!memoryFlushPlan) {
-    return params.sessionEntry;
+    return { sessionEntry: params.sessionEntry, outcome: "skipped" };
   }
 
   const memoryFlushWritable = (() => {
@@ -1263,7 +1278,7 @@ export async function runMemoryFlushIfNeeded(params: {
       !hasAlreadyFlushedForCurrentCompaction(entry));
 
   if (!shouldFlushMemory) {
-    return entry ?? params.sessionEntry;
+    return { sessionEntry: entry ?? params.sessionEntry, outcome: "skipped" };
   }
 
   logVerbose(
@@ -1286,6 +1301,8 @@ export async function runMemoryFlushIfNeeded(params: {
     });
   }
   let memoryCompactionCompleted = false;
+  let outcome: MemoryFlushOutcome = "completed";
+  let visibleErrorPayloads: ReplyPayload[] = [];
   const memoryFlushNowMs = memoryDeps.now();
   const activeMemoryFlushPlan =
     resolveMemoryFlushPlan({
@@ -1373,10 +1390,7 @@ export async function runMemoryFlushIfNeeded(params: {
             }
           },
         });
-        const visibleErrorPayloads = resolveVisibleMemoryFlushErrorPayloads(result.payloads);
-        if (visibleErrorPayloads.length > 0) {
-          params.onVisibleErrorPayloads?.(visibleErrorPayloads);
-        }
+        visibleErrorPayloads = resolveVisibleMemoryFlushErrorPayloads(result.payloads);
         if (result.meta?.agentMeta?.sessionId) {
           postCompactionSessionId = result.meta.agentMeta.sessionId;
         }
@@ -1423,6 +1437,11 @@ export async function runMemoryFlushIfNeeded(params: {
         }
       }
     }
+    if (visibleErrorPayloads.length > 0) {
+      // Preserve any completed transcript rotation, then count the maintenance error.
+      // Do not stamp memory-flush success for a resolved run that returned an error.
+      throw buildVisibleMemoryFlushFailure(visibleErrorPayloads);
+    }
     if (params.storePath && params.sessionKey) {
       try {
         const updatedEntry = await memoryDeps.updateSessionEntry({
@@ -1451,6 +1470,7 @@ export async function runMemoryFlushIfNeeded(params: {
       }
     }
   } catch (err) {
+    outcome = "failed";
     const truncatedError = truncateMemoryFlushErrorMessage(err);
     if (!isAbortError(err) && params.storePath && params.sessionKey) {
       try {
@@ -1489,6 +1509,7 @@ export async function runMemoryFlushIfNeeded(params: {
           },
         });
         if (failedEntry && failureCount >= MAX_FLUSH_FAILURES) {
+          outcome = "exhausted";
           logVerbose(
             `memory flush exhausted: skipping flush for this compaction cycle after ${failureCount} consecutive failures`,
           );
@@ -1538,5 +1559,5 @@ export async function runMemoryFlushIfNeeded(params: {
     }
   }
 
-  return activeSessionEntry;
+  return { sessionEntry: activeSessionEntry, outcome };
 }

--- a/src/auto-reply/reply/agent-runner-session-reset.test.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.test.ts
@@ -74,6 +74,13 @@ describe("resetReplyRunSession", () => {
       fallbackNoticeSelectedModel: "anthropic/claude",
       fallbackNoticeActiveModel: "openai/gpt",
       fallbackNoticeReason: "rate limit",
+      compactionCount: 5,
+      memoryFlushAt: 123,
+      memoryFlushCompactionCount: 4,
+      memoryFlushContextHash: "stale-context",
+      memoryFlushFailureCount: 3,
+      memoryFlushLastFailedAt: 456,
+      memoryFlushLastFailureError: "provider crashed",
       systemPromptReport: {
         source: "run",
         generatedAt: 1,
@@ -119,6 +126,13 @@ describe("resetReplyRunSession", () => {
     expect(activeSessionEntry?.fallbackNoticeSelectedModel).toBeUndefined();
     expect(activeSessionEntry?.fallbackNoticeActiveModel).toBeUndefined();
     expect(activeSessionEntry?.fallbackNoticeReason).toBeUndefined();
+    expect(activeSessionEntry?.compactionCount).toBe(0);
+    expect(activeSessionEntry?.memoryFlushAt).toBeUndefined();
+    expect(activeSessionEntry?.memoryFlushCompactionCount).toBeUndefined();
+    expect(activeSessionEntry?.memoryFlushContextHash).toBeUndefined();
+    expect(activeSessionEntry?.memoryFlushFailureCount).toBeUndefined();
+    expect(activeSessionEntry?.memoryFlushLastFailedAt).toBeUndefined();
+    expect(activeSessionEntry?.memoryFlushLastFailureError).toBeUndefined();
     expect(activeSessionEntry?.systemPromptReport).toBeUndefined();
     expect(refreshQueuedFollowupSessionMock).toHaveBeenCalledWith({
       key: "main",
@@ -134,6 +148,10 @@ describe("resetReplyRunSession", () => {
     expect(persisted.main.sessionId).toBe(activeSessionEntry?.sessionId);
     expect(persisted.main.contextBudgetStatus).toBeUndefined();
     expect(persisted.main.fallbackNoticeReason).toBeUndefined();
+    expect(persisted.main.compactionCount).toBe(0);
+    expect(persisted.main.memoryFlushFailureCount).toBeUndefined();
+    expect(persisted.main.memoryFlushLastFailedAt).toBeUndefined();
+    expect(persisted.main.memoryFlushLastFailureError).toBeUndefined();
   });
 
   it("cleans up the old transcript when requested", async () => {
@@ -165,5 +183,42 @@ describe("resetReplyRunSession", () => {
     });
 
     await expectPathMissing(oldTranscriptPath);
+  });
+
+  it("preserves the old transcript while still rotating when cleanup is disabled", async () => {
+    const storePath = path.join(rootDir, "sessions.json");
+    const oldTranscriptPath = path.join(rootDir, "old-session.jsonl");
+    await fs.writeFile(oldTranscriptPath, "old", "utf8");
+    const sessionEntry: SessionEntry = {
+      sessionId: "old-session",
+      updatedAt: 1,
+      sessionFile: oldTranscriptPath,
+    };
+    const sessionStore = { main: sessionEntry };
+    await writeTestSessionStore(storePath, "main", sessionEntry);
+
+    let rotatedSessionId: string | undefined;
+    await resetReplyRunSession({
+      options: {
+        failureLabel: "memory flush exhaustion",
+        cleanupTranscripts: false,
+        buildLogMessage: (next) => `reset ${next}`,
+      },
+      sessionKey: "main",
+      queueKey: "main",
+      activeSessionEntry: sessionEntry,
+      activeSessionStore: sessionStore,
+      storePath,
+      followupRun: createTestFollowupRun(),
+      onActiveSessionEntry: (entry) => {
+        rotatedSessionId = entry.sessionId;
+      },
+      onNewSession: () => {},
+    });
+
+    // Rotation still happens, but the old transcript stays available for recovery.
+    expect(rotatedSessionId).toBeDefined();
+    expect(rotatedSessionId).not.toBe("old-session");
+    await fs.access(oldTranscriptPath);
   });
 });

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -81,6 +81,13 @@ export async function resetReplyRunSession(params: {
     fallbackNoticeSelectedModel: undefined,
     fallbackNoticeActiveModel: undefined,
     fallbackNoticeReason: undefined,
+    compactionCount: 0,
+    memoryFlushAt: undefined,
+    memoryFlushCompactionCount: undefined,
+    memoryFlushContextHash: undefined,
+    memoryFlushFailureCount: undefined,
+    memoryFlushLastFailedAt: undefined,
+    memoryFlushLastFailureError: undefined,
   };
   const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
   const nextSessionFile = resolveSessionTranscriptPath(

--- a/src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
@@ -68,7 +68,10 @@ vi.mock("./agent-runner-execution.js", () => ({
 }));
 
 vi.mock("./agent-runner-memory.js", () => ({
-  runMemoryFlushIfNeeded: async ({ sessionEntry }: { sessionEntry?: unknown }) => sessionEntry,
+  runMemoryFlushIfNeeded: async ({ sessionEntry }: { sessionEntry?: unknown }) => ({
+    sessionEntry,
+    outcome: "skipped",
+  }),
   runPreflightCompactionIfNeeded: async ({ sessionEntry }: { sessionEntry?: unknown }) =>
     sessionEntry,
 }));

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -225,7 +225,10 @@ vi.mock("./session-run-accounting.js", () => ({
 }));
 
 vi.mock("./agent-runner-memory.js", () => ({
-  runMemoryFlushIfNeeded: async ({ sessionEntry }: { sessionEntry?: unknown }) => sessionEntry,
+  runMemoryFlushIfNeeded: async ({ sessionEntry }: { sessionEntry?: unknown }) => ({
+    sessionEntry,
+    outcome: "skipped",
+  }),
   runPreflightCompactionIfNeeded: async ({ sessionEntry }: { sessionEntry?: unknown }) =>
     sessionEntry,
 }));

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1394,7 +1394,7 @@ export async function runReplyAgent(params: {
         try {
           await opts.onBlockReply(noticePayload);
         } catch (err) {
-          logVerbose(`preflightCompaction notice delivery failed: ${String(err)}`);
+          logVerbose(`context maintenance notice delivery failed: ${String(err)}`);
         }
       }
     : undefined;
@@ -1564,6 +1564,44 @@ export async function runReplyAgent(params: {
     });
     return persisted?.abortedLastRun === true || activeSessionEntry?.abortedLastRun === true;
   };
+  type SessionResetOptions = {
+    failureLabel: string;
+    buildLogMessage: (nextSessionId: string) => string;
+    cleanupTranscripts?: boolean;
+  };
+  const resetSession = async ({
+    failureLabel,
+    buildLogMessage,
+    cleanupTranscripts,
+  }: SessionResetOptions): Promise<boolean> =>
+    await resetReplyRunSession({
+      options: {
+        failureLabel,
+        buildLogMessage,
+        cleanupTranscripts,
+      },
+      sessionKey,
+      queueKey,
+      activeSessionEntry,
+      activeSessionStore,
+      storePath,
+      messageThreadId:
+        typeof sessionCtx.MessageThreadId === "string" ? sessionCtx.MessageThreadId : undefined,
+      followupRun,
+      onActiveSessionEntry: (nextEntry) => {
+        activeSessionEntry = nextEntry;
+      },
+      onNewSession: () => {
+        activeIsNewSession = true;
+      },
+    });
+  const resetSessionAfterRoleOrderingConflict = async (reason: string): Promise<boolean> =>
+    resetSession({
+      failureLabel: "role ordering conflict",
+      buildLogMessage: (nextSessionId) =>
+        `Role ordering conflict (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
+      cleanupTranscripts: true,
+    });
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied;
 
@@ -1590,8 +1628,7 @@ export async function runReplyAgent(params: {
     preflightCompactionApplied =
       (activeSessionEntry?.compactionCount ?? 0) > prePreflightCompactionCount;
 
-    const visibleMemoryFlushErrorPayloads: ReplyPayload[] = [];
-    activeSessionEntry = await traceAgentPhase("reply.memory_flush", () =>
+    const memoryFlushResult = await traceAgentPhase("reply.memory_flush", () =>
       runMemoryFlushIfNeeded({
         cfg,
         followupRun,
@@ -1609,54 +1646,34 @@ export async function runReplyAgent(params: {
         isHeartbeat,
         replyOperation,
         onVisibleErrorPayloads: (payloads) => {
-          visibleMemoryFlushErrorPayloads.push(...payloads);
+          logVerbose(
+            `memory flush produced ${payloads.length} visible maintenance error payload(s); continuing user reply`,
+          );
         },
       }),
     );
+    activeSessionEntry = memoryFlushResult.sessionEntry;
 
     if (replyOperation.result?.kind === "aborted") {
       throw replyOperation.abortSignal.reason ?? new Error("reply operation aborted");
     }
 
-    if (visibleMemoryFlushErrorPayloads.length > 0) {
-      const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
-      const payloadResult = await buildReplyPayloads({
-        config: cfg,
-        payloads: visibleMemoryFlushErrorPayloads,
-        isHeartbeat,
-        didLogHeartbeatStrip: false,
-        silentExpected: true,
-        blockStreamingEnabled,
-        blockReplyPipeline,
-        replyToMode,
-        replyToChannel,
-        currentMessageId,
-        replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
-        messageProvider: followupRun.run.messageProvider,
-        originatingChannel: sessionCtx.OriginatingChannel,
-        originatingChatType: sessionCtx.ChatType,
-        originatingTo: resolveOriginMessageTo({
-          originatingTo: sessionCtx.OriginatingTo,
-          to: sessionCtx.To,
-        }),
-        originatingThreadId: replyRouteThreadId,
-        accountId: sessionCtx.AccountId,
-        normalizeMediaPaths: replyMediaContext.normalizePayload,
+    if (memoryFlushResult.outcome === "exhausted") {
+      await resetSession({
+        failureLabel: "memory flush exhaustion",
+        buildLogMessage: (nextSessionId) =>
+          `Memory flush exhausted. Rotating bloated session ${sessionKey} -> ${nextSessionId}.`,
+        // Rotate away from the bloated context, but preserve its transcript for recovery.
+        cleanupTranscripts: false,
       });
-      const replyPayloads = payloadResult.replyPayloads.map((payload) =>
-        markReplyPayloadForSourceSuppressionDelivery(payload),
-      );
-      if (replyPayloads.length > 0) {
-        replyOperation.freezeAbort();
-        replyOperation.fail(
-          "run_failed",
-          new Error("memory flush produced visible error payloads"),
-        );
-        await signalTypingIfNeeded(replyPayloads, typingSignals);
-        return returnWithQueuedFollowupDrain(
-          replyPayloads.length === 1 ? replyPayloads[0] : replyPayloads,
-        );
+      if (activeSessionEntry?.sessionId) {
+        replyOperation.updateSessionId(activeSessionEntry.sessionId);
       }
+    }
+
+    // Exhausted background maintenance is non-terminal: optionally notify, then reply normally.
+    if (memoryFlushResult.outcome === "exhausted") {
+      await sendDirectCompactionNotice?.("memory_flush_degraded");
     }
 
     runFollowupTurn = createFollowupRunner({
@@ -1671,45 +1688,6 @@ export async function runReplyAgent(params: {
       agentCfgContextTokens,
       toolProgressDetail,
     });
-
-    type SessionResetOptions = {
-      failureLabel: string;
-      buildLogMessage: (nextSessionId: string) => string;
-      cleanupTranscripts?: boolean;
-    };
-    const resetSession = async ({
-      failureLabel,
-      buildLogMessage,
-      cleanupTranscripts,
-    }: SessionResetOptions): Promise<boolean> =>
-      await resetReplyRunSession({
-        options: {
-          failureLabel,
-          buildLogMessage,
-          cleanupTranscripts,
-        },
-        sessionKey,
-        queueKey,
-        activeSessionEntry,
-        activeSessionStore,
-        storePath,
-        messageThreadId:
-          typeof sessionCtx.MessageThreadId === "string" ? sessionCtx.MessageThreadId : undefined,
-        followupRun,
-        onActiveSessionEntry: (nextEntry) => {
-          activeSessionEntry = nextEntry;
-        },
-        onNewSession: () => {
-          activeIsNewSession = true;
-        },
-      });
-    const resetSessionAfterRoleOrderingConflict = async (reason: string): Promise<boolean> =>
-      resetSession({
-        failureLabel: "role ordering conflict",
-        buildLogMessage: (nextSessionId) =>
-          `Role ordering conflict (${reason}). Restarting session ${sessionKey} -> ${nextSessionId}.`,
-        cleanupTranscripts: true,
-      });
 
     replyOperation.setPhase("running");
     const runStartedAt = Date.now();

--- a/src/auto-reply/reply/compaction-notice.ts
+++ b/src/auto-reply/reply/compaction-notice.ts
@@ -2,13 +2,19 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ReplyPayload } from "../types.js";
 
-export type CompactionNoticePhase = "start" | "end" | "incomplete" | "skipped";
+export type CompactionNoticePhase =
+  | "start"
+  | "end"
+  | "incomplete"
+  | "skipped"
+  | "memory_flush_degraded";
 
 const COMPACTION_NOTICE_TEXT: Record<CompactionNoticePhase, string> = {
   start: "🧹 Compacting context...",
   end: "🧹 Compaction complete",
   incomplete: "🧹 Compaction incomplete",
   skipped: "🧹 Compaction not needed",
+  memory_flush_degraded: "⚠️ Memory maintenance temporarily failed; continuing your reply.",
 };
 
 export function shouldNotifyUserAboutCompaction(cfg?: OpenClawConfig): boolean {

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -400,7 +400,10 @@ async function loadFreshFollowupRunnerModuleForTest() {
     incrementRunCompactionCount: incrementRunCompactionCountForFollowupTest,
   }));
   vi.doMock("./agent-runner-memory.js", () => ({
-    runMemoryFlushIfNeeded: async (params: { sessionEntry?: SessionEntry }) => params.sessionEntry,
+    runMemoryFlushIfNeeded: async (params: { sessionEntry?: SessionEntry }) => ({
+      sessionEntry: params.sessionEntry,
+      outcome: "skipped",
+    }),
     runPreflightCompactionIfNeeded: (...args: unknown[]) =>
       runPreflightCompactionIfNeededMock(...args),
   }));

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -996,6 +996,13 @@ describe("initSessionState RawBody", () => {
           messageCount: 8,
           unwindowedMessageCount: 8,
         },
+        compactionCount: 3,
+        memoryFlushAt: 123,
+        memoryFlushCompactionCount: 2,
+        memoryFlushContextHash: "stale-context",
+        memoryFlushFailureCount: 3,
+        memoryFlushLastFailedAt: 456,
+        memoryFlushLastFailureError: "provider crashed",
         skillsSnapshot: {
           prompt: "<available_skills><skill><name>stale</name></skill></available_skills>",
           skills: [{ name: "stale" }],
@@ -1029,6 +1036,13 @@ describe("initSessionState RawBody", () => {
     expect(result.sessionEntry.totalTokensFresh).toBe(true);
     expect(result.sessionEntry.contextTokens).toBeUndefined();
     expect(result.sessionEntry.contextBudgetStatus).toBeUndefined();
+    expect(result.sessionEntry.compactionCount).toBe(0);
+    expect(result.sessionEntry.memoryFlushAt).toBeUndefined();
+    expect(result.sessionEntry.memoryFlushCompactionCount).toBeUndefined();
+    expect(result.sessionEntry.memoryFlushContextHash).toBeUndefined();
+    expect(result.sessionEntry.memoryFlushFailureCount).toBeUndefined();
+    expect(result.sessionEntry.memoryFlushLastFailedAt).toBeUndefined();
+    expect(result.sessionEntry.memoryFlushLastFailureError).toBeUndefined();
 
     const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,
@@ -1038,6 +1052,13 @@ describe("initSessionState RawBody", () => {
         totalTokensFresh?: boolean;
         contextTokens?: number;
         contextBudgetStatus?: unknown;
+        compactionCount?: number;
+        memoryFlushAt?: number;
+        memoryFlushCompactionCount?: number;
+        memoryFlushContextHash?: string;
+        memoryFlushFailureCount?: number;
+        memoryFlushLastFailedAt?: number;
+        memoryFlushLastFailureError?: string;
       }
     >;
     expect(store[sessionKey]?.skillsSnapshot).toBeUndefined();
@@ -1045,6 +1066,13 @@ describe("initSessionState RawBody", () => {
     expect(store[sessionKey]?.totalTokensFresh).toBe(true);
     expect(store[sessionKey]?.contextTokens).toBeUndefined();
     expect(store[sessionKey]?.contextBudgetStatus).toBeUndefined();
+    expect(store[sessionKey]?.compactionCount).toBe(0);
+    expect(store[sessionKey]?.memoryFlushAt).toBeUndefined();
+    expect(store[sessionKey]?.memoryFlushCompactionCount).toBeUndefined();
+    expect(store[sessionKey]?.memoryFlushContextHash).toBeUndefined();
+    expect(store[sessionKey]?.memoryFlushFailureCount).toBeUndefined();
+    expect(store[sessionKey]?.memoryFlushLastFailedAt).toBeUndefined();
+    expect(store[sessionKey]?.memoryFlushLastFailureError).toBeUndefined();
   });
 
   it("drains stale system events when /new rotates an existing session", async () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -958,6 +958,9 @@ async function initSessionStateAttemptLocked(
     sessionEntry.fallbackNoticeActiveModel = undefined;
     sessionEntry.fallbackNoticeReason = undefined;
     sessionEntry.systemPromptReport = undefined;
+    sessionEntry.memoryFlushFailureCount = undefined;
+    sessionEntry.memoryFlushLastFailedAt = undefined;
+    sessionEntry.memoryFlushLastFailureError = undefined;
     // Clear stale context hash so the first flush in the new session is not
     // incorrectly skipped due to a hash match with the old transcript (#30115).
     sessionEntry.memoryFlushContextHash = undefined;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1541,7 +1541,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.compaction.maxActiveTranscriptBytes":
     'Triggers normal local compaction when the active session transcript reaches this size (bytes or strings like "20mb"). Requires truncateAfterCompaction so successful compaction can rotate to a smaller successor transcript; set to 0 or leave unset to disable. This never splits raw transcript bytes.',
   "agents.defaults.compaction.notifyUser":
-    "When enabled, sends brief compaction notices to the user when compaction starts and when it completes (for example, '🧹 Compacting context...' and '🧹 Compaction complete'). Disabled by default to keep compaction silent and non-intrusive.",
+    "When enabled, sends brief context-maintenance notices to the user: when compaction starts and completes (for example, '🧹 Compacting context...' and '🧹 Compaction complete'), and when a pre-compaction memory flush is exhausted so the reply continues in a degraded state (for example, '⚠️ Memory maintenance temporarily failed; continuing your reply.'). Disabled by default to keep context maintenance silent and non-intrusive.",
   "agents.defaults.compaction.memoryFlush":
     "Pre-compaction memory flush settings that run an agentic memory write before heavy compaction. Keep enabled for long sessions so salient context is persisted before aggressive trimming.",
   "agents.defaults.compaction.memoryFlush.enabled":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -568,7 +568,9 @@ export type AgentCompactionConfig = {
    */
   maxActiveTranscriptBytes?: number | string;
   /**
-   * Send brief compaction notices to the user when compaction starts and completes.
+   * Send brief context-maintenance notices to the user: when compaction starts
+   * and completes, and when a pre-compaction memory flush is exhausted so the
+   * reply continues in a degraded state.
    * Default: false (silent by default).
    */
   notifyUser?: boolean;


### PR DESCRIPTION
Closes #85645

Replacement for #88968. The contributor branch was takeover-ready, but GitHub's verified fork editor could not preserve workspace symlink modes while replaying current `main`. This maintainer branch carries the reviewed tree as one commit and preserves contributor credit.

## What Problem This Solves

Fixes an issue where users could stop receiving normal agent replies when pre-compaction memory maintenance repeatedly failed. The maintenance error replaced the real reply, and the oversized active session remained vulnerable to the same failure on later messages.

## Why This Change Was Made

Memory-flush failures are now non-terminal to the user turn. The helper returns an explicit maintenance outcome; after three failures the runner rotates to a fresh active session while preserving the old transcript, clears stale compaction/flush state, and optionally emits a degraded maintenance notice through the existing `agents.defaults.compaction.notifyUser` path.

Resolved embedded runs that contain visible error payloads now enter the same failure counter instead of being stamped successful. If that run already completed a transcript rotation, the new session binding is preserved before the failure is recorded.

## User Impact

Normal replies continue when memory maintenance is temporarily unavailable. Persistently failing, oversized sessions recover automatically after the existing retry budget; operators retain the previous transcript for recovery or forensics. Default behavior remains silent unless compaction notices are enabled.

## Evidence

- Reproduced source-level failure on current `main`: visible memory-flush errors terminate the turn before the normal agent run.
- Contributor live Gateway proof: deterministic flush-provider HTTP 500 responses while all 12 user messages completed successfully after the fix.
- Sanitized direct AWS Crabbox, provider `aws`, lease `cbx_882f0c2cb4bb`, run `run_c7e91a20d30f`: 7 focused files, 330 tests passed; hydration disabled, public networking, scrubbed launch environment, pinned checksum-verified Node 24 bootstrap. Lease auto-stopped.
- Final resolved-error/rotation regression: `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts` — 47 tests passed.
- `git diff --check` — clean.
- Fresh full-branch Codex autoreview: no accepted/actionable findings.

Co-authored with @Jerry-Xin; the squashed commit retains both contributor commit identities.
