### PR TITLE
fix(discord): bound gateway metadata response size

### DIFF
--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -17,6 +17,7 @@ const DEFAULT_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 30_000;
 const MAX_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 120_000;
 const DISCORD_GATEWAY_INFO_TIMEOUT_ENV = "OPENCLAW_DISCORD_GATEWAY_INFO_TIMEOUT_MS";
 const DISCORD_GATEWAY_METADATA_FALLBACK_LOG_INTERVAL_MS = 60_000;
+const MAX_DISCORD_GATEWAY_METADATA_BYTES = 1 * 1024 * 1024;
 
 type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text">;
 export type DiscordGatewayFetchInit = Record<string, unknown> & {
@@ -32,6 +33,23 @@ export type DiscordGatewayMetadataFetchOptions = {
 };
 
 type DiscordGatewayMetadataError = Error & { transient?: boolean };
+
+function checkDiscordGatewayContentLength(raw: string | null): void {
+  if (!raw) return;
+  if (!/^\d+$/.test(raw)) {
+    throw createGatewayMetadataError({
+      detail: "Discord API /gateway/bot response has invalid content-length",
+      transient: false,
+    });
+  }
+  const size = Number(raw);
+  if (!Number.isSafeInteger(size) || size > MAX_DISCORD_GATEWAY_METADATA_BYTES) {
+    throw createGatewayMetadataError({
+      detail: `Discord API /gateway/bot response exceeds size limit (${size} bytes)`,
+      transient: false,
+    });
+  }
+}
 
 const discordGatewayBotInfoSchema = Type.Object({
   url: Type.String({ minLength: 1 }),
@@ -186,8 +204,15 @@ export async function fetchDiscordGatewayInfo(params: {
   }
 
   let body: string;
+  checkDiscordGatewayContentLength(response.headers.get("content-length"));
   try {
     body = await response.text();
+    if (new TextEncoder().encode(body).byteLength > MAX_DISCORD_GATEWAY_METADATA_BYTES) {
+      throw createGatewayMetadataError({
+        detail: "Discord API /gateway/bot response exceeds size limit after reading",
+        transient: false,
+      });
+    }
   } catch (error) {
     throw createGatewayMetadataError({
       detail: formatErrorMessage(error),

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -19,7 +19,7 @@ const DISCORD_GATEWAY_INFO_TIMEOUT_ENV = "OPENCLAW_DISCORD_GATEWAY_INFO_TIMEOUT_
 const DISCORD_GATEWAY_METADATA_FALLBACK_LOG_INTERVAL_MS = 60_000;
 const MAX_DISCORD_GATEWAY_METADATA_BYTES = 1 * 1024 * 1024;
 
-type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text">;
+type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text" | "headers">;
 export type DiscordGatewayFetchInit = Record<string, unknown> & {
   headers?: Record<string, string>;
 };
@@ -35,7 +35,7 @@ export type DiscordGatewayMetadataFetchOptions = {
 type DiscordGatewayMetadataError = Error & { transient?: boolean };
 
 function checkDiscordGatewayContentLength(raw: string | null): void {
-  if (!raw) return;
+  if (!raw) { return; }
   if (!/^\d+$/.test(raw)) {
     throw createGatewayMetadataError({
       detail: "Discord API /gateway/bot response has invalid content-length",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Discord gateway /gateway/bot metadata endpoint response is read via `response.text()` without any size limit, which could allow unbounded memory allocation if Discord returns a large response body.

## Why This Change Was Made

The gateway metadata fetch now checks the `content-length` header (if present) against a 1 MB limit before reading, and validates the actual byte length after reading. This follows the same bounded-read pattern already established in the hosted external plugin catalog (`readHostedCatalogResponseText`).

## User Impact

Discord gateway metadata fetching is now resilient to oversized responses — users with very large guild sets or transient API edge cases get a clear error instead of unbounded memory growth.

## Evidence

- Pattern: bounded read mirrors `readHostedCatalogResponseText` in `src/plugins/official-external-plugin-catalog.ts`
- CI will run `pnpm test extensions/discord/src/monitor/gateway-metadata.test.ts`

---

## Suggestion: Prevent Similar Issues

Several recent PRs fix similar unbounded read / response size limit issues (signal WebSocket maxPayload, MCP HTTP fetch fallback, and this Discord gateway metadata PR). Consider adding broader guardrails:

1. Require a bounded-read pattern (check `content-length` + `byteLength` cap) for all external HTTP fetches under `extensions/`
2. Add a review reminder or lint rule for `response.text()` / `response.json()` calls in production code to ensure a size bound exists
3. Extract shared `MAX_*_BYTES` constants or a reusable bounded-read helper so each plugin does not reinvent this pattern

AI-assisted: built with Codex
