### PR TITLE
improve(ui): declutter the Cron Jobs page into compact scannable rows

### DIFF
--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -256,7 +256,7 @@ describeControlUiE2e("Control UI cron mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}cron`);
       await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
       const existingCard = page.locator(".cron-job", { hasText: existingJob.name });
-      expect(await existingCard.locator(".cron-job-chips").textContent()).toContain(
+      expect(await existingCard.locator(".cron-job-meta-line").textContent()).toContain(
         `Model: ${configuredModel}`,
       );
       const details = await existingCard

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -487,6 +487,10 @@ describe("cron view", () => {
       container,
     );
 
+    const summary = getElement(container, ".cron-job-details__summary", HTMLElement);
+    expect(summary.querySelector(".cron-job-detail-label")?.textContent?.trim()).toBe("Prompt");
+    expect(summary.querySelector(".cron-job-details__preview")?.textContent?.trim()).toBe("do it");
+
     const details = Array.from(container.querySelectorAll(".cron-job-detail-section")).map(
       (section) => ({
         label: section.querySelector(".cron-job-detail-label")?.textContent?.trim(),
@@ -494,15 +498,9 @@ describe("cron view", () => {
       }),
     );
     expect(details).toEqual([
-      { label: "Prompt", value: "do it" },
       { label: "Model", value: "Default" },
       { label: "Delivery", value: "webhook (https://example.invalid/cron)" },
     ]);
-    expect(
-      Array.from(container.querySelectorAll(".cron-job-chips .chip")).map((chip) =>
-        chip.textContent?.trim(),
-      ),
-    ).toContain("Model: Default");
   });
 
   it("shows configured cron job models in job details", () => {
@@ -523,9 +521,7 @@ describe("cron view", () => {
     );
     expect(details).toContainEqual({ label: "Model", value: "openai/gpt-5.2" });
     expect(
-      Array.from(container.querySelectorAll(".cron-job-chips .chip")).map((chip) =>
-        chip.textContent?.trim(),
-      ),
+      getElement(container, ".cron-job-meta-line", HTMLElement).textContent?.replace(/\s+/g, " "),
     ).toContain("Model: openai/gpt-5.2");
   });
 
@@ -918,8 +914,12 @@ describe("cron view", () => {
       container,
     );
 
+    const menu = getElement(container, ".cron-job-menu", HTMLDetailsElement);
+    menu.setAttribute("open", "");
+
     const cloneButton = getButtonByText(container, "Clone");
     cloneButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(menu.hasAttribute("open")).toBe(false);
 
     const enableButton = getButtonByText(container, "Disable");
     enableButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -1,8 +1,15 @@
 // Control UI view renders cron screen content.
 import { html, nothing } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
+import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import type { ChannelUiMetaEntry, CronJob, CronRunLogEntry, CronStatus } from "../../api/types.ts";
+import type {
+  ChannelUiMetaEntry,
+  CronDelivery,
+  CronJob,
+  CronRunLogEntry,
+  CronStatus,
+} from "../../api/types.ts";
 import type {
   CronDeliveryStatus,
   CronJobsEnabledFilter,
@@ -13,6 +20,7 @@ import type {
   CronSortDir,
 } from "../../api/types.ts";
 import { pathForRoute } from "../../app-route-paths.ts";
+import { icon } from "../../components/icons.ts";
 import { toSanitizedMarkdownHtml } from "../../components/markdown.ts";
 import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
@@ -440,7 +448,7 @@ export function renderCron(props: CronProps) {
           <div class="cron-summary-label">${t("cron.summary.jobs")}</div>
           <div class="cron-summary-value">${props.status?.jobs ?? t("common.na")}</div>
         </div>
-        <div class="cron-summary-item cron-summary-item--wide">
+        <div class="cron-summary-item">
           <div class="cron-summary-label">${t("cron.summary.nextWake")}</div>
           <div class="cron-summary-value">${formatNextRun(props.status?.nextWakeAtMs ?? null)}</div>
         </div>
@@ -613,7 +621,11 @@ export function renderCron(props: CronProps) {
               `
             : html`
                 <div class="list" style="margin-top: 12px;">
-                  ${props.jobs.map((job) => renderJob(job, props))}
+                  ${repeat(
+                    props.jobs,
+                    (job) => job.id,
+                    (job) => renderJob(job, props),
+                  )}
                 </div>
               `}
           ${props.jobsHasMore
@@ -1609,122 +1621,142 @@ function renderFieldError(message?: string, id?: string) {
 
 function renderJob(job: CronJob, props: CronProps) {
   const isSelected = props.runsJobId === job.id;
-  const itemClass = `list-item list-item-clickable cron-job${isSelected ? " list-item-selected" : ""}`;
-  const modelLabel = getCronJobModelLabel(job);
+  const itemClass = [
+    "list-item",
+    "list-item-clickable",
+    "cron-job",
+    isSelected ? "list-item-selected" : "",
+    job.enabled ? "" : "cron-job--disabled",
+  ]
+    .filter(Boolean)
+    .join(" ");
   const selectAnd = (action: () => void) => {
     props.onLoadRuns(job.id);
     action();
   };
+  const scrollToRunHistory = () => {
+    requestAnimationFrame(() => {
+      const runHistory = document.querySelector("[data-run-history]");
+      if (runHistory instanceof HTMLElement && typeof runHistory.scrollIntoView === "function") {
+        runHistory.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+    });
+  };
+  const menuItem = (label: string, action: () => void, options?: { danger?: boolean }) => html`
+    <button
+      class=${options?.danger ? "cron-job-menu__item danger" : "cron-job-menu__item"}
+      role="menuitem"
+      ?disabled=${props.busy}
+      @click=${(event: Event) => {
+        // Close the details-based menu before acting so it does not linger open.
+        (event.currentTarget as HTMLElement).closest("details")?.removeAttribute("open");
+        selectAnd(action);
+      }}
+    >
+      ${label}
+    </button>
+  `;
   return html`
     <div class=${itemClass} @click=${() => props.onLoadRuns(job.id)}>
-      <div class="cron-job-header">
-        <div class="list-main">
-          <div class="list-title">${job.name}</div>
-          <div class="list-sub">${formatCronSchedule(job)}</div>
-          ${job.agentId
-            ? html`<div class="muted cron-job-agent">
-                ${t("cron.jobDetail.agent")}: ${job.agentId}
-              </div>`
-            : nothing}
+      <div class="cron-job-row">
+        <div class="cron-job-main">
+          <div class="cron-job-title-line">
+            <span class="list-title">${job.name}</span>
+            ${renderJobStatusPill(job)}
+            ${job.enabled ? nothing : html`<span class="chip">${t("cron.jobList.disabled")}</span>`}
+          </div>
+          <div class="cron-job-meta-line">${renderJobMeta(job)}</div>
         </div>
-        <div class="list-meta">${renderJobState(job)}</div>
-      </div>
-      ${renderJobPayload(job)}
-      <div class="cron-job-footer">
-        <div class="chip-row cron-job-chips">
-          <span class=${`chip ${job.enabled ? "chip-ok" : "chip-danger"}`}>
-            ${job.enabled ? t("cron.jobList.enabled") : t("cron.jobList.disabled")}
-          </span>
-          <span class="chip">${job.sessionTarget}</span>
-          <span class="chip">${job.wakeMode}</span>
-          ${modelLabel
-            ? html`<span class="chip">${t("cron.form.model")}: ${modelLabel}</span>`
-            : nothing}
-        </div>
-        <div class="row cron-job-actions">
+        <div class="cron-job-actions" @click=${(event: Event) => event.stopPropagation()}>
           <button
-            class="btn"
+            class="btn btn--sm"
             ?disabled=${props.busy}
-            @click=${(event: Event) => {
-              event.stopPropagation();
-              selectAnd(() => props.onEdit(job));
-            }}
-          >
-            ${t("cron.jobList.edit")}
-          </button>
-          <button
-            class="btn"
-            ?disabled=${props.busy}
-            @click=${(event: Event) => {
-              event.stopPropagation();
-              selectAnd(() => props.onClone(job));
-            }}
-          >
-            ${t("cron.jobList.clone")}
-          </button>
-          <button
-            class="btn"
-            ?disabled=${props.busy}
-            @click=${(event: Event) => {
-              event.stopPropagation();
-              selectAnd(() => props.onToggle(job, !job.enabled));
-            }}
-          >
-            ${job.enabled ? t("cron.jobList.disable") : t("cron.jobList.enable")}
-          </button>
-          <button
-            class="btn"
-            ?disabled=${props.busy}
-            @click=${(event: Event) => {
-              event.stopPropagation();
-              selectAnd(() => props.onRun(job, "force"));
-            }}
+            @click=${() => selectAnd(() => props.onRun(job, "force"))}
           >
             ${t("cron.jobList.run")}
           </button>
           <button
-            class="btn"
+            class="btn btn--sm"
             ?disabled=${props.busy}
-            @click=${(event: Event) => {
-              event.stopPropagation();
-              selectAnd(() => props.onRun(job, "due"));
-            }}
+            @click=${() => selectAnd(() => props.onEdit(job))}
           >
-            Run if due
+            ${t("cron.jobList.edit")}
           </button>
-          <button
-            class="btn"
-            ?disabled=${props.busy}
-            @click=${(event: Event) => {
-              event.stopPropagation();
-              props.onLoadRuns(job.id);
-              requestAnimationFrame(() => {
-                const runHistory = document.querySelector("[data-run-history]");
-                if (
-                  runHistory instanceof HTMLElement &&
-                  typeof runHistory.scrollIntoView === "function"
-                ) {
-                  runHistory.scrollIntoView({ behavior: "smooth", block: "start" });
-                }
-              });
-            }}
-          >
-            ${t("cron.jobList.history")}
-          </button>
-          <button
-            class="btn danger"
-            ?disabled=${props.busy}
-            @click=${(event: Event) => {
-              event.stopPropagation();
-              selectAnd(() => props.onRemove(job));
-            }}
-          >
-            ${t("cron.jobList.remove")}
-          </button>
+          <details class="cron-job-menu">
+            <summary
+              class="btn btn--sm cron-job-menu__trigger"
+              role="button"
+              aria-haspopup="menu"
+              aria-label="More actions"
+              title="More actions"
+            >
+              ${icon("moreHorizontal")}
+            </summary>
+            <div class="cron-job-menu__panel" role="menu">
+              ${menuItem("Run if due", () => props.onRun(job, "due"))}
+              ${menuItem(job.enabled ? t("cron.jobList.disable") : t("cron.jobList.enable"), () =>
+                props.onToggle(job, !job.enabled),
+              )}
+              ${menuItem(t("cron.jobList.clone"), () => props.onClone(job))}
+              ${menuItem(t("cron.jobList.history"), scrollToRunHistory)}
+              ${menuItem(t("cron.jobList.remove"), () => props.onRemove(job), { danger: true })}
+            </div>
+          </details>
         </div>
       </div>
+      ${renderJobDetails(job)}
     </div>
   `;
+}
+
+function renderJobMeta(job: CronJob) {
+  const nextRunAtMs = job.state?.nextRunAtMs;
+  const lastRunAtMs = job.state?.lastRunAtMs;
+  const payload = getCronJobPayload(job);
+  const configuredModel = payload?.kind === "agentTurn" ? payload.model?.trim() : undefined;
+  const segments = [html`<span>${formatCronSchedule(job)}</span>`];
+  if (job.agentId) {
+    segments.push(html`<span>${t("cron.jobDetail.agent")}: ${job.agentId}</span>`);
+  }
+  // Surface explicit model overrides at a glance; default-model jobs stay quiet here.
+  if (configuredModel) {
+    segments.push(html`<span>${t("cron.form.model")}: ${configuredModel}</span>`);
+  }
+  if (typeof nextRunAtMs === "number" && Number.isFinite(nextRunAtMs)) {
+    segments.push(
+      html`<span title=${formatMs(nextRunAtMs)}>
+        ${t("cron.jobState.next")} ${formatRelativeTimestamp(nextRunAtMs)}
+      </span>`,
+    );
+  }
+  if (typeof lastRunAtMs === "number" && Number.isFinite(lastRunAtMs)) {
+    segments.push(
+      html`<span title=${formatMs(lastRunAtMs)}>
+        ${t("cron.jobState.last")} ${formatRelativeTimestamp(lastRunAtMs)}
+      </span>`,
+    );
+  }
+  return segments;
+}
+
+function renderJobStatusPill(job: CronJob) {
+  const rawStatus = resolveCronJobLastRunStatus(job);
+  if (rawStatus !== "ok" && rawStatus !== "error" && rawStatus !== "skipped") {
+    return nothing;
+  }
+  const statusClass =
+    rawStatus === "ok"
+      ? "cron-job-status-ok"
+      : rawStatus === "error"
+        ? "cron-job-status-error"
+        : "cron-job-status-skipped";
+  const statusLabel =
+    rawStatus === "ok"
+      ? t("cron.runs.runStatusOk")
+      : rawStatus === "error"
+        ? t("cron.runs.runStatusError")
+        : t("cron.runs.runStatusSkipped");
+  return html`<span class=${`cron-job-status-pill ${statusClass}`}>${statusLabel}</span>`;
 }
 
 function getCronJobModelLabel(job: CronJob) {
@@ -1735,133 +1767,95 @@ function getCronJobModelLabel(job: CronJob) {
   return payload.model?.trim() || t("agents.default");
 }
 
-function renderJobPayload(job: CronJob) {
+function formatDeliveryTarget(delivery: CronDelivery) {
+  if (delivery.mode === "webhook") {
+    return delivery.to ? ` (${delivery.to})` : "";
+  }
+  if (delivery.channel || delivery.to) {
+    return ` (${delivery.channel ?? "last"}${delivery.to ? ` -> ${delivery.to}` : ""})`;
+  }
+  return "";
+}
+
+function renderJobDetails(job: CronJob) {
   const payload = getCronJobPayload(job);
   if (!payload) {
-    return html``;
+    return nothing;
   }
-  if (payload.kind === "systemEvent") {
-    return html`<div class="cron-job-detail">
-      <span class="cron-job-detail-label">${t("cron.jobDetail.system")}</span>
-      <span class="muted cron-job-detail-value">${payload.text}</span>
-    </div>`;
-  }
-
-  const delivery = job.delivery;
-  const deliveryTarget =
-    delivery?.mode === "webhook"
-      ? delivery.to
-        ? ` (${delivery.to})`
-        : ""
-      : delivery?.channel || delivery?.to
-        ? ` (${delivery.channel ?? "last"}${delivery.to ? ` -> ${delivery.to}` : ""})`
-        : "";
-
-  if (payload.kind === "command") {
-    return html`
-      <div class="cron-job-detail">
-        <div class="cron-job-detail-section">
-          <span class="cron-job-detail-label">${t("cron.jobDetail.command")}</span>
-          <code class="muted cron-job-detail-value">${payload.argv.join(" ")}</code>
-        </div>
-        ${payload.cwd
-          ? html`<div class="cron-job-detail-section">
-              <span class="cron-job-detail-label">${t("cron.jobDetail.cwd")}</span>
-              <span class="muted cron-job-detail-value">${payload.cwd}</span>
-            </div>`
-          : nothing}
-        ${delivery
-          ? html`<div class="cron-job-detail-section">
-              <span class="cron-job-detail-label">${t("cron.jobDetail.delivery")}</span>
-              <span class="muted cron-job-detail-value">${delivery.mode}${deliveryTarget}</span>
-            </div>`
-          : nothing}
-      </div>
-    `;
-  }
-
+  const label =
+    payload.kind === "systemEvent"
+      ? t("cron.jobDetail.system")
+      : payload.kind === "command"
+        ? t("cron.jobDetail.command")
+        : t("cron.jobDetail.prompt");
+  const preview =
+    payload.kind === "systemEvent"
+      ? payload.text
+      : payload.kind === "command"
+        ? payload.argv.join(" ")
+        : payload.message;
+  // Expanding/reading details must not re-route the run-history selection.
   return html`
-    <div class="cron-job-detail">
-      <div class="cron-job-detail-section">
-        <span class="cron-job-detail-label">${t("cron.jobDetail.prompt")}</span>
-        <div class="muted cron-job-detail-value chat-text" @click=${stopPropagationForInteractive}>
-          ${unsafeHTML(toSanitizedMarkdownHtml(payload.message))}
-        </div>
-      </div>
-      <div class="cron-job-detail-section">
-        <span class="cron-job-detail-label">${t("cron.form.model")}</span>
-        <span class="muted cron-job-detail-value">${getCronJobModelLabel(job)}</span>
-      </div>
-      ${delivery
-        ? html`<div class="cron-job-detail-section">
-            <span class="cron-job-detail-label">${t("cron.jobDetail.delivery")}</span>
-            <span class="muted cron-job-detail-value">${delivery.mode}${deliveryTarget}</span>
-          </div>`
-        : nothing}
-    </div>
+    <details class="cron-job-details" @click=${(event: Event) => event.stopPropagation()}>
+      <summary class="cron-job-details__summary">
+        ${icon("chevronRight")}
+        <span class="cron-job-detail-label">${label}</span>
+        <span class="cron-job-details__preview muted">${preview}</span>
+      </summary>
+      <div class="cron-job-detail">${renderJobPayloadBody(job, payload)}</div>
+    </details>
   `;
 }
 
-function stopPropagationForInteractive(event: MouseEvent) {
-  const target = event.target as HTMLElement | null;
-  if (target?.closest("a,button,input,textarea,select,summary,[role='button'],[role='link']")) {
-    event.stopPropagation();
+function renderJobPayloadBody(
+  job: CronJob,
+  payload: NonNullable<ReturnType<typeof getCronJobPayload>>,
+) {
+  const delivery = job.delivery;
+  const deliverySection = delivery
+    ? html`<div class="cron-job-detail-section">
+        <span class="cron-job-detail-label">${t("cron.jobDetail.delivery")}</span>
+        <span class="muted cron-job-detail-value">
+          ${delivery.mode}${formatDeliveryTarget(delivery)}
+        </span>
+      </div>`
+    : nothing;
+  const chips = html`
+    <div class="chip-row cron-job-detail-chips">
+      <span class="chip">${job.sessionTarget}</span>
+      <span class="chip">${job.wakeMode}</span>
+    </div>
+  `;
+  if (payload.kind === "systemEvent") {
+    return html`<span class="muted cron-job-detail-value">${payload.text}</span>${chips}`;
   }
-}
-
-function formatStateRelative(ms?: number) {
-  if (typeof ms !== "number" || !Number.isFinite(ms)) {
-    return t("common.na");
+  if (payload.kind === "command") {
+    return html`
+      <code class="muted cron-job-detail-value">${payload.argv.join(" ")}</code>
+      ${payload.cwd
+        ? html`<div class="cron-job-detail-section">
+            <span class="cron-job-detail-label">${t("cron.jobDetail.cwd")}</span>
+            <span class="muted cron-job-detail-value">${payload.cwd}</span>
+          </div>`
+        : nothing}
+      ${deliverySection}${chips}
+    `;
   }
-  return formatRelativeTimestamp(ms);
+  return html`
+    <div class="muted cron-job-detail-value chat-text">
+      ${unsafeHTML(toSanitizedMarkdownHtml(payload.message))}
+    </div>
+    <div class="cron-job-detail-section">
+      <span class="cron-job-detail-label">${t("cron.form.model")}</span>
+      <span class="muted cron-job-detail-value">${getCronJobModelLabel(job)}</span>
+    </div>
+    ${deliverySection}${chips}
+  `;
 }
 
 function formatRunNextLabel(nextRunAtMs: number, nowMs = Date.now()) {
   const rel = formatRelativeTimestamp(nextRunAtMs);
   return nextRunAtMs > nowMs ? t("cron.runEntry.next", { rel }) : t("cron.runEntry.due", { rel });
-}
-
-function renderJobState(job: CronJob) {
-  const rawStatus = resolveCronJobLastRunStatus(job);
-  const statusClass =
-    rawStatus === "ok"
-      ? "cron-job-status-ok"
-      : rawStatus === "error"
-        ? "cron-job-status-error"
-        : rawStatus === "skipped"
-          ? "cron-job-status-skipped"
-          : "cron-job-status-na";
-  const statusLabel =
-    rawStatus === "ok"
-      ? t("cron.runs.runStatusOk")
-      : rawStatus === "error"
-        ? t("cron.runs.runStatusError")
-        : rawStatus === "skipped"
-          ? t("cron.runs.runStatusSkipped")
-          : t("cron.runs.runStatusUnknown");
-  const nextRunAtMs = job.state?.nextRunAtMs;
-  const lastRunAtMs = job.state?.lastRunAtMs;
-
-  return html`
-    <div class="cron-job-state">
-      <div class="cron-job-state-row">
-        <span class="cron-job-state-key">${t("cron.jobState.status")}</span>
-        <span class=${`cron-job-status-pill ${statusClass}`}>${statusLabel}</span>
-      </div>
-      <div class="cron-job-state-row">
-        <span class="cron-job-state-key">${t("cron.jobState.next")}</span>
-        <span class="cron-job-state-value" title=${formatMs(nextRunAtMs)}>
-          ${formatStateRelative(nextRunAtMs)}
-        </span>
-      </div>
-      <div class="cron-job-state-row">
-        <span class="cron-job-state-key">${t("cron.jobState.last")}</span>
-        <span class="cron-job-state-value" title=${formatMs(lastRunAtMs)}>
-          ${formatStateRelative(lastRunAtMs)}
-        </span>
-      </div>
-    </div>
-  `;
 }
 
 function runStatusLabel(value: string): string {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1287,36 +1287,29 @@
 .cron-summary-strip {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: 12px 18px;
-  padding: 14px 16px;
+  padding: 12px 16px;
 }
 
 .cron-summary-strip__left {
-  display: grid;
-  gap: 8px 14px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 24px;
   flex: 1 1 auto;
   min-width: 0;
 }
 
 .cron-summary-item {
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--bg-elevated);
-  padding: 10px 12px;
-  min-height: 62px;
-  display: grid;
-  gap: 6px;
-}
-
-.cron-summary-item--wide {
-  grid-column: span 1;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
 }
 
 .cron-summary-label {
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: 11px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -1324,12 +1317,13 @@
 
 .cron-summary-value {
   color: var(--text-strong);
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   line-height: 1.3;
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
 }
 
 .cron-summary-strip__actions {
@@ -1812,46 +1806,19 @@
 }
 
 @media (max-width: 1100px) {
-  .cron-job.list-item {
-    display: flex;
-    flex-direction: column;
-    padding: 0;
-    overflow: hidden;
-    max-width: 100%;
-  }
-
-  .cron-job .cron-job-header {
-    display: flex;
+  .cron-job-row {
     flex-direction: column;
     gap: 8px;
-    border-radius: var(--radius-md) var(--radius-md) 0 0;
-    width: 100%;
-  }
-
-  .cron-job .list-meta {
-    min-width: 0;
-  }
-
-  .cron-job .cron-job-header .cron-job-state {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 4px 16px;
-  }
-
-  .cron-job .cron-job-detail,
-  .cron-job .cron-job-footer {
-    width: 100%;
-    box-sizing: border-box;
   }
 
   .cron-summary-strip {
     flex-direction: column;
+    align-items: flex-start;
   }
 
   .cron-summary-strip__left {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
     width: 100%;
+    gap: 6px 18px;
   }
 
   .cron-summary-strip__actions {
@@ -2660,14 +2627,7 @@
   max-width: 100%;
 }
 
-/* Cron jobs: allow long payload/state text and keep action buttons inside the card. */
-.cron-job-payload,
-.cron-job-agent,
-.cron-job-state {
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-
+/* Cron jobs: compact single-column rows with on-demand details. */
 .cron-job .list-title {
   font-weight: 600;
   font-size: 15px;
@@ -2676,66 +2636,108 @@
 }
 
 .cron-job {
-  grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);
-  grid-template-areas:
-    "header header"
-    "payload payload"
-    "footer footer";
-  row-gap: 0;
-  padding: 0;
-  overflow: hidden;
-}
-
-.cron-job .cron-job-header {
-  grid-area: header;
-  display: flex;
-  flex-direction: column;
-  align-items: baseline;
+  grid-template-columns: minmax(0, 1fr);
   gap: 8px;
-  padding: 12px;
-  background: var(--secondary);
-  border-radius: var(--radius-md) var(--radius-md) 0 0;
-  border-bottom: 1px solid var(--border);
+  padding: 12px 14px;
 }
 
-@media (min-width: 1101px) {
-  .cron-job .cron-job-header {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(240px, 300px);
-    gap: 16px;
-    align-items: start;
-  }
+.cron-job--disabled .cron-job-main {
+  opacity: 0.6;
 }
 
-:root[data-theme-mode="light"] .cron-job .cron-job-header {
-  background: var(--bg-muted);
-}
-
-.cron-job .list-meta {
-  min-width: 240px;
-  gap: 8px;
-}
-
-.cron-job-footer {
-  grid-area: footer;
+.cron-job-row {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 12px;
-  border-top: none;
-  padding: 4px 12px 12px;
+  min-width: 0;
 }
 
-.cron-job-chips {
+.cron-job-main {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
   flex: 1 1 auto;
 }
 
-.cron-job-detail {
-  grid-area: payload;
-  display: grid;
+.cron-job-title-line {
+  display: flex;
+  align-items: center;
   gap: 8px;
-  margin-top: 2px;
-  padding: 8px 12px 12px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.cron-job-meta-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 6px;
+  color: var(--muted);
+  font-size: 12px;
+  min-width: 0;
+}
+
+.cron-job-meta-line > span {
+  overflow-wrap: anywhere;
+}
+
+.cron-job-meta-line > span + span::before {
+  content: "·";
+  margin-right: 6px;
+}
+
+.cron-job-details {
+  min-width: 0;
+}
+
+.cron-job-details__summary {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  cursor: pointer;
+  list-style: none;
+  min-width: 0;
+}
+
+.cron-job-details__summary::-webkit-details-marker {
+  display: none;
+}
+
+.cron-job-details__summary svg {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  align-self: center;
+  stroke: var(--muted);
+  fill: none;
+  stroke-width: 2px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.cron-job-details[open] > .cron-job-details__summary svg {
+  transform: rotate(90deg);
+}
+
+.cron-job-details__preview {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Expanded body repeats the full payload, so hide the one-line preview. */
+.cron-job-details[open] .cron-job-details__preview {
+  visibility: hidden;
+}
+
+.cron-job-detail {
+  display: grid;
+  gap: 10px;
+  padding: 8px 0 2px 18px;
   overflow: hidden;
 }
 
@@ -2747,51 +2749,21 @@
 
 .cron-job-detail-label {
   color: var(--muted);
-  font-size: 12px; /* was 11px */
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  padding: 4px 8px;
-  background: var(--secondary);
-  border-radius: var(--radius-sm);
-  display: inline-block;
-  width: fit-content;
-}
-
-.cron-job-detail-value {
-  font-size: 13px;
-  line-height: 1.35;
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-.cron-job-state {
-  display: grid;
-  gap: 4px;
-}
-
-.cron-job-state-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 10px;
-}
-
-.cron-job-state-key {
-  color: var(--muted);
-  font-size: 12px; /* was 10px */
+  font-size: 11px;
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
 
-.cron-job-state-value {
-  color: var(--text);
-  font-size: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.cron-job-detail-value {
+  font-size: 13px;
+  line-height: 1.4;
   min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.cron-job-detail-chips {
+  margin-top: 2px;
 }
 
 .cron-job-status-pill {
@@ -2821,18 +2793,67 @@
   background: var(--warn-subtle);
 }
 
-.cron-job-status-na {
-  color: var(--muted);
-}
-
 .cron-job-actions {
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  margin-top: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
 }
 
-.cron-job-actions .btn {
-  flex: 0 0 auto;
+.cron-job-menu {
+  position: relative;
+}
+
+.cron-job-menu__trigger {
+  list-style: none;
+}
+
+.cron-job-menu__trigger::-webkit-details-marker {
+  display: none;
+}
+
+/* Invisible full-viewport hit area so clicking anywhere outside closes the menu. */
+.cron-job-menu[open] > .cron-job-menu__trigger::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  cursor: default;
+}
+
+.cron-job-menu__panel {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 30;
+  min-width: 150px;
+  display: grid;
+  padding: 4px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+}
+
+.cron-job-menu__item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.cron-job-menu__item:hover {
+  background: var(--bg-hover);
+}
+
+.cron-job-menu__item.danger {
+  color: var(--danger);
 }
 
 @container (max-width: 560px) {
@@ -2845,21 +2866,13 @@
     text-align: left;
   }
 
+  .cron-job-row {
+    flex-direction: column;
+    gap: 8px;
+  }
+
   .cron-job-actions {
     justify-content: flex-start;
-  }
-
-  .cron-job {
-    grid-template-columns: 1fr;
-    grid-template-areas:
-      "header"
-      "payload"
-      "footer";
-  }
-
-  .cron-job-footer {
-    flex-direction: column;
-    align-items: stretch;
   }
 }
 
@@ -4324,17 +4337,8 @@ td.data-table-key-col {
 }
 
 @media (max-width: 600px) {
-  .cron-job .cron-job-header {
-    padding: 10px;
-    gap: 6px;
-  }
-
-  .cron-job .cron-job-header .cron-job-state {
-    gap: 4px 12px;
-  }
-
   .cron-job .cron-job-detail {
-    padding: 10px;
+    padding-left: 10px;
   }
 
   .cron-job .cron-job-detail-value {
@@ -4352,24 +4356,6 @@ td.data-table-key-col {
   .cron-job .cron-job-detail-value pre {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
-  }
-
-  .cron-job .cron-job-footer {
-    padding: 8px 10px 10px;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    flex-wrap: nowrap;
-    gap: 8px;
-  }
-
-  .cron-job .cron-job-footer .chip-row,
-  .cron-job .cron-job-footer .cron-job-actions {
-    flex-wrap: nowrap;
-    flex-shrink: 0;
-  }
-
-  .cron-job .cron-job-footer .cron-job-actions {
-    gap: 6px;
   }
 }
 


### PR DESCRIPTION
Closes #100633

## What Problem This Solves

The Cron Jobs page rendered every job as a tall card: full prompt markdown, boxed `PROMPT`/`DELIVERY` labels, a three-row status block, a chips row, and seven always-visible action buttons per job. With a handful of jobs the list took several screens to scan and the run history card was pushed far below the fold. The summary strip used three large boxed tiles for three small facts.

## Why This Change Was Made

Jobs are now compact rows built for scanning: title + last-run status pill (+ `disabled` chip when off), a single metadata line (schedule · agent · model override · next · last, with absolute timestamps on hover), and a one-line prompt preview that expands in place (native `<details>`) to the full markdown prompt, model, delivery target, and session/wake chips. `Run` and `Edit` stay as primary buttons; `Run if due`, `Enable/Disable`, `Clone`, `History`, and `Remove` move into a per-row overflow menu that closes after acting or when clicking anywhere outside. The summary strip is now one inline stat line. Rows are keyed with `repeat()` so expanded/menu state stays with the right job across refreshes.

The model visibility from #95341 is preserved and improved: explicitly configured models now show in the always-visible metadata line (default-model jobs stay quiet there), and the expanded details keep the `Model` section (`Default` when unset). No gateway API, config, or i18n key changes; the run history card and the job form are untouched.

## User Impact

Operators can scan many cron jobs at a glance, see health (status/next/last) and model overrides per row without reading a status table, expand a row only when they need the full prompt or delivery details, and reach destructive actions (`Remove`) deliberately via the overflow menu instead of a seventh inline button.

## Evidence

- Testbox (Blacksmith) full `ui` Vitest project (pre-rebase run): 130 files / 2066 tests passed — https://github.com/openclaw/openclaw/actions/runs/28770191939
- `pnpm check:changed` (oxlint + tsgo lanes + import cycles) delegated to Testbox: green — https://github.com/openclaw/openclaw/actions/runs/28770284322
- Post-rebase cron-scoped Vitest rerun on Testbox after integrating #95341's model display into the new layout: link added in comments.
- Autoreview (Codex, gpt-5.5): clean on the pre-rebase diff and re-run clean on the rebased branch.
- Screenshots (default, expanded details, open overflow menu, dark mode) attached in the PR comment below via the Crabbox artifact bundle. The mock-gateway harness (`ui/src/test-helpers/control-ui-e2e.ts`) was used to render the page with representative jobs, including a disabled job and a model-override job.
