### PR TITLE
fix: reuse successful terminal main sessions

### DIFF
--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -213,7 +213,9 @@ export function resolveTerminalMainSessionTranscriptRegistryCheck(
   if (!hasTerminalLifecycle) {
     return undefined;
   }
-  if (params.entry.status === "failed") {
+  if (params.entry.status === "done" || params.entry.status === "failed") {
+    // Successful rows can receive managed transcript writes after registry bookkeeping.
+    // Only interrupted terminal rows need the mtime recovery guard.
     // Failed rows with a present transcript stay reusable for retry/recovery.
     // Callers already rotate failed rows when the transcript is missing.
     return undefined;

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1286,7 +1286,7 @@ describe("gateway agent handler", () => {
   });
 
   it.each([
-    { name: "status terminal row", status: "done" as const },
+    { name: "timeout terminal row", status: "timeout" as const },
     { name: "endedAt-only terminal row" },
   ])(
     "rotates a terminal main session from a $name when its transcript is newer",


### PR DESCRIPTION
Closes #99964

## What Problem This Solves

Fixes an issue where successful main-agent sessions could roll over into a new session and archive the previous transcript as `.jsonl.reset` when the transcript file mtime was newer than `sessions.json.updatedAt`.

## Why This Change Was Made

Successful `status: "done"` terminal-main rows now skip the transcript-mtime recovery guard, matching the expected reuse behavior after normal managed transcript writes. Interrupted terminal states such as `timeout` still use the recovery guard.

## User Impact

Main sessions that completed successfully can continue on the next user message instead of unexpectedly rotating to a new session ID and making a normal transcript look like a reset.

## Evidence

- Claim proved: successful terminal main rows are reusable while interrupted terminal rows still rotate when transcript mtime is newer than registry state.
- Head SHA: 4d224864af5114e8d10c47fb2cd1fa4db6eb37bb
- Commands / artifacts:
  - `git diff --check`
  - `git diff --check HEAD~1..HEAD`
  - `node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts -- -t "terminal main"`
- Observed result:
  - diff whitespace checks passed.
  - focused Vitest passed: 2 files passed, 12 tests passed, 364 skipped.
- Not tested / proof gaps:
  - Broad typecheck/full suite not run per scoped-check instruction.
  - Autoreview was attempted but did not complete: the first run hit local Windows config encoding, and the UTF-8 retry failed after the Codex review engine used an invalid API key and built an over-broad origin/main bundle. I treated this as local review-environment failure, not product proof.