### PR TITLE
fix(memory): fork local embedding worker with stable node

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings-worker-stable-node.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker-stable-node.test.ts
@@ -1,0 +1,104 @@
+// Covers stable Node executable selection for the local embedding worker.
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const childProcessMocks = vi.hoisted(() => ({
+  fork: vi.fn(),
+}));
+
+const fsMocks = vi.hoisted(() => ({
+  access: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    fork: childProcessMocks.fork,
+  };
+});
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      access: fsMocks.access,
+    },
+    access: fsMocks.access,
+  };
+});
+
+import { createLocalEmbeddingWorkerProvider } from "./embeddings-worker.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockWorkerChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    connected: boolean;
+    killed: boolean;
+    disconnect: () => void;
+    kill: () => void;
+    send: (message: { id: number }, callback?: (err: Error | null) => void) => void;
+  };
+  child.connected = true;
+  child.killed = false;
+  child.disconnect = vi.fn(() => {
+    child.connected = false;
+  });
+  child.kill = vi.fn(() => {
+    child.killed = true;
+  });
+  child.send = vi.fn((message: { id: number }, callback?: (err: Error | null) => void) => {
+    callback?.(null);
+    queueMicrotask(() => child.emit("message", { id: message.id, ok: true }));
+  });
+  childProcessMocks.fork.mockReturnValue(child);
+  return child;
+}
+
+describe("local embedding worker stable Node path", () => {
+  it("forks Homebrew Cellar parents through the stable opt symlink", async () => {
+    const originalExecPath = process.execPath;
+    const staleNode = "/opt/homebrew/Cellar/node/26.3.0/bin/node";
+    const stableNode = "/opt/homebrew/opt/node/bin/node";
+    Object.defineProperty(process, "execPath", {
+      configurable: true,
+      value: staleNode,
+    });
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === stableNode) {
+        return;
+      }
+      throw new Error("missing");
+    });
+    mockWorkerChild();
+
+    try {
+      const provider = await createLocalEmbeddingWorkerProvider(
+        {
+          config: {} as never,
+          provider: "local",
+          model: "",
+          fallback: "none",
+        },
+        { workerScriptPath: "/tmp/openclaw-local-embedding-worker.cjs" },
+      );
+      await provider.close?.();
+    } finally {
+      Object.defineProperty(process, "execPath", {
+        configurable: true,
+        value: originalExecPath,
+      });
+    }
+
+    expect(childProcessMocks.fork).toHaveBeenCalledWith(
+      "/tmp/openclaw-local-embedding-worker.cjs",
+      [],
+      expect.objectContaining({ execPath: stableNode }),
+    );
+  });
+});

--- a/packages/memory-host-sdk/src/host/embeddings-worker.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-worker.ts
@@ -1,5 +1,6 @@
 // Memory Host SDK module implements embeddings worker behavior.
 import { fork, type ChildProcess } from "node:child_process";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { DEFAULT_LOCAL_MODEL } from "./embedding-defaults.js";
@@ -145,6 +146,36 @@ const WORKER_UNSAFE_EXEC_ARGV_OPTION_PREFIXES = [
 
 const WORKER_CLOSE_GRACE_MS = 250;
 
+/** Resolve Homebrew Cellar Node paths to stable symlinks before forking workers. */
+async function resolveStableWorkerNodePath(nodePath: string): Promise<string> {
+  const cellarMatch = nodePath.match(
+    /^(.+?)[\\/]Cellar[\\/]([^\\/]+)[\\/][^\\/]+[\\/]bin[\\/]node$/,
+  );
+  if (!cellarMatch) {
+    return nodePath;
+  }
+  const prefix = cellarMatch[1];
+  const formula = cellarMatch[2];
+  const pathModule = nodePath.includes("\\") ? path.win32 : path.posix;
+  const optPath = pathModule.join(prefix, "opt", formula, "bin", "node");
+  try {
+    await fs.access(optPath);
+    return optPath;
+  } catch {
+    // fall through
+  }
+  if (formula === "node") {
+    const binPath = pathModule.join(prefix, "bin", "node");
+    try {
+      await fs.access(binPath);
+      return binPath;
+    } catch {
+      // fall through
+    }
+  }
+  return nodePath;
+}
+
 /** Drop execArgv flags that would make forked workers debug/eval stateful or unsafe. */
 function resolveWorkerExecArgv(): string[] {
   const args: string[] = [];
@@ -175,7 +206,10 @@ class LocalEmbeddingWorkerClient {
   private nextRequestId = 1;
   private pending = new Map<number, PendingRequest>();
 
-  constructor(private readonly scriptPath: string) {}
+  constructor(
+    private readonly scriptPath: string,
+    private readonly execPath: string,
+  ) {}
 
   /** Start or reuse the child worker and initialize its provider. */
   async initialize(options: EmbeddingProviderOptions): Promise<void> {
@@ -234,6 +268,7 @@ class LocalEmbeddingWorkerClient {
     }
 
     const child = fork(this.scriptPath, [], {
+      execPath: this.execPath,
       execArgv: resolveWorkerExecArgv(),
       serialization: "json",
       stdio: ["ignore", "ignore", "ignore", "ipc"],
@@ -359,8 +394,10 @@ export async function createLocalEmbeddingWorkerProvider(
 ): Promise<EmbeddingProvider> {
   const modelPath = normalizeOptionalString(options.local?.modelPath) || DEFAULT_LOCAL_MODEL;
   const workerOptions = serializeLocalEmbeddingOptions(options, runtimeOptions);
+  const workerExecPath = await resolveStableWorkerNodePath(process.execPath);
   const client = new LocalEmbeddingWorkerClient(
     runtimeOptions?.workerScriptPath ?? resolveDefaultWorkerScriptPath(),
+    workerExecPath,
   );
   try {
     await client.initialize(workerOptions);


### PR DESCRIPTION
Closes #99183

## What Problem This Solves

Fixes an issue where the local embedding worker could fail to start with `ENOENT` after a Homebrew Node upgrade when the parent process was launched from an old Cellar `process.execPath` that no longer exists.

## Why This Change Was Made

The embedding worker now resolves Homebrew Cellar Node paths to the stable `opt/<formula>/bin/node` symlink before forking the worker process, with a `bin/node` fallback for the `node` formula. Non-Cellar paths keep the existing behavior.

## User Impact

Users who upgrade Homebrew Node can continue using the local embedding worker without restarting from a deleted Node binary path.

## Evidence

- Claim proved: local embedding worker forks no longer inherit a stale Homebrew Cellar `process.execPath`; the worker fork resolves that parent path to a stable Homebrew executable before passing it as `fork({ execPath })`.
- Head SHA: 48df1c522038400efa3d98b9d5abb39955eb27c9
- Commands / artifacts:
  - `git diff --check`
  - `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/embeddings-worker-stable-node.test.ts packages/memory-host-sdk/src/host/embeddings.test.ts`
- Observed result:
  - Vitest passed: 2 files, 19 tests.
  - `git diff --check` passed.
- Related PRs checked:
  - #100518, #99222, #99318, and #99563 are open related PRs. None had `proof: sufficient` or `ready for maintainer look` when checked; #100518 and #99563 still carried needs-proof/context/availability-risk signals.
- Not tested / proof gaps:
  - Did not run a live macOS Homebrew upgrade reproduction.
  - Did not run broad changed checks or full typecheck per scoped-check instruction.