### PR TITLE
feat(crestodian): AI-only conversation with model-judged approvals

### DIFF
--- a/docs/cli/crestodian.md
+++ b/docs/cli/crestodian.md
@@ -85,9 +85,11 @@ quit
 
 Crestodian uses typed operations instead of editing config ad hoc.
 
-Read-only, run immediately: show overview, list agents, list installed plugins, search ClawHub plugins, show model/backend status, run status/health checks, check Gateway reachability, run doctor without interactive fixes, validate config, show the audit-log path.
+Read-only, run immediately: show overview, list agents, list installed plugins, search ClawHub plugins, show model/backend status, run status/health checks, check Gateway reachability, run doctor without interactive fixes, validate config, show the audit-log path. Starting the guided channel setup (`connect telegram`) also runs immediately — the wizard itself collects explicit answers and commits only at the end.
 
 Persistent, require conversational approval (or `--yes` for a direct command): write config, `config set`, `config set-ref`, setup/onboarding bootstrap, change the default model, start/stop/restart the Gateway, create agents, install or uninstall plugins, run doctor repairs that rewrite config or state.
+
+Approval is given in your own words: unambiguous replies ("yes", "sure", "go ahead", "not now") resolve from a closed deterministic list, and anything else is judged by a separate host-run model call that sees only your message and the pending proposal — never by the conversation model itself, which cannot self-approve. Ambiguous replies keep the proposal pending and the conversation asks again. When no model is usable, only the closed deterministic list applies.
 
 Applied writes are recorded in `~/.openclaw/audit/crestodian.jsonl`. Discovery is not audited; only applied operations and writes are.
 
@@ -119,14 +121,17 @@ If none are available, setup still writes the default workspace and leaves the m
 
 The macOS app drives the same ladder through the `crestodian.setup.detect` and `crestodian.setup.activate` gateway methods: detect lists every reusable backend it finds, activate live-tests one candidate (a real "reply with OK" completion) and only persists the model, workspace, and gateway defaults after the test passes. A failing candidate never changes config; the app automatically walks down the ladder and finally offers a manual API-key step (Anthropic, OpenAI, or Google) that is verified the same way before it is saved.
 
-## Model-assisted planner
+## AI conversation
 
-Interactive Crestodian is AI-first. Exact typed commands run instantly and deterministically. Every other message runs through the same embedded agent loop as regular OpenClaw agents, restricted to one ring-zero `crestodian` tool that wraps the typed operations: read actions run freely, mutations require your conversational yes for that exact operation, and every applied write is audited and re-validated. The agent session persists, so the custodian has real multi-turn memory. It first uses the configured OpenClaw model; with no usable model it falls back to a local runtime already present on the machine:
+Interactive Crestodian is AI-only: every message — including ones that look like typed commands — runs through the same embedded agent loop as regular OpenClaw agents, restricted to one ring-zero `crestodian` tool that wraps the typed operations. Read actions run freely, mutations require your conversational approval for that exact operation (see Operations and approval), and every applied write is audited and re-validated. The agent session persists, so the custodian has real multi-turn memory. It first uses the configured OpenClaw model; with no usable model it falls back to a local runtime already present on the machine, in setup-ladder order:
 
 - Claude Code CLI: `claude-cli/claude-opus-4-8` (agent loop; the ring-zero tool is served over MCP, see the trust model below)
 - Codex app-server harness: `openai/gpt-5.5` (agent loop with an enforced single-tool allow-list)
+- Gemini CLI: `google-gemini-cli/gemini-3.1-pro-preview` (agent loop; ring-zero tool over MCP)
 
-When the agent loop is unavailable, Crestodian degrades to a bounded single-turn planner, and without any model to deterministic typed commands. The planner cannot mutate config directly; it must translate the request into one of Crestodian's typed commands, and normal approval/audit rules apply. Crestodian prints the model it used and the interpreted command before running anything. Fallback planner turns are temporary, tool-disabled where the runtime supports it, and use a temporary workspace/session.
+When the agent loop is unavailable, Crestodian degrades to a bounded single-turn planner, and only without any usable model at all to deterministic typed commands. The planner cannot mutate config directly; it must translate the request into one of Crestodian's typed commands, and normal approval/audit rules apply. Crestodian prints the model it used and the interpreted command before running anything. Fallback planner turns are temporary, tool-disabled where the runtime supports it, and use a temporary workspace/session.
+
+The typed command grammar is anchored: a message either matches a command exactly or it is conversation. Questions and natural phrasing ("why did my gateway stop?") never trigger operations — they are answered by the AI.
 
 Message-channel rescue mode never uses the model-assisted planner. Remote rescue stays deterministic so a broken or compromised normal agent path cannot be used as a config editor.
 
@@ -181,7 +186,7 @@ switch to main agent
 
 Message rescue mode is the message-channel entrypoint for Crestodian: use it when your normal agent is dead but a trusted channel (for example WhatsApp) still receives commands.
 
-Supported command: `/crestodian <request>`.
+Supported command: `/crestodian <request>`. Rescue accepts the exact typed command grammar only — natural language is rejected with a hint, never guessed into an operation, and no model is ever consulted.
 
 ```text
 You, in a trusted owner DM: /crestodian status

--- a/docs/cli/crestodian.md
+++ b/docs/cli/crestodian.md
@@ -133,6 +133,8 @@ When the agent loop is unavailable, Crestodian degrades to a bounded single-turn
 
 The typed command grammar is anchored: a message either matches a command exactly or it is conversation. Questions and natural phrasing ("why did my gateway stop?") never trigger operations — they are answered by the AI.
 
+One secret-hygiene exception: an exact `config set` on a sensitive path (tokens, keys, passwords) never reaches a model. It runs on the deterministic path with a redacted proposal, and the value is masked in the AI-visible history. Prefer `config set-ref <path> env <ENV_VAR>` for secrets.
+
 Message-channel rescue mode never uses the model-assisted planner. Remote rescue stays deterministic so a broken or compromised normal agent path cannot be used as a config editor.
 
 ### CLI harness trust model

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1368,7 +1368,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Examples
   - H2: Operations and approval
   - H2: Setup bootstrap
-  - H2: Model-assisted planner
+  - H2: AI conversation
   - H3: CLI harness trust model
   - H2: Switching to an agent
   - H2: Message rescue mode

--- a/src/agents/tools/crestodian-tool.test.ts
+++ b/src/agents/tools/crestodian-tool.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createCrestodianTool,
   hashCrestodianOperation,
+  resolveCrestodianDirectiveTransition,
   resolveCrestodianProposalTransition,
+  type CrestodianToolDirective,
 } from "./crestodian-tool.js";
 
 const mocks = vi.hoisted(() => ({
@@ -223,6 +225,47 @@ describe("crestodian tool", () => {
   it("rejects unknown or underspecified actions as input errors", async () => {
     const tool = createCrestodianTool({ surface: "cli" });
     await expect(tool.execute("t5", { action: "config_get" })).rejects.toThrow(/path/);
+  });
+
+  it("records interactive directives for the host without executing operations", async () => {
+    const directiveRef: { current?: CrestodianToolDirective } = {};
+    const tool = createCrestodianTool({ surface: "cli", directiveRef });
+
+    const connect = await tool.execute("t5", { action: "connect_channel", channel: "Telegram" });
+    expect(toolText(connect)).toContain("directive:");
+    expect(directiveRef.current).toEqual({ kind: "channel-setup", channel: "telegram" });
+
+    const open = await tool.execute("t6", { action: "open_agent", agentId: "work" });
+    expect(toolText(open)).toContain("directive:");
+    expect(directiveRef.current).toEqual({ kind: "open-tui", agentId: "work" });
+
+    // Directives are host handoffs, never operation executions.
+    expect(mocks.executeCrestodianOperation).not.toHaveBeenCalled();
+  });
+
+  it("mirrors directive transitions for out-of-process (CLI MCP) hosts", () => {
+    expect(
+      resolveCrestodianDirectiveTransition({
+        args: { action: "connect_channel", channel: "telegram" },
+        resultText: "directive: the host chat now starts the guided telegram setup.",
+      }),
+    ).toEqual({ kind: "channel-setup", channel: "telegram" });
+    expect(
+      resolveCrestodianDirectiveTransition({
+        args: { action: "open_agent" },
+        resultText: "directive: the host now hands the user over.",
+      }),
+    ).toEqual({ kind: "open-tui" });
+    // Non-directive results and other actions never mirror.
+    expect(
+      resolveCrestodianDirectiveTransition({ args: { action: "status" }, resultText: "ok" }),
+    ).toBeNull();
+    expect(
+      resolveCrestodianDirectiveTransition({
+        args: { action: "connect_channel", channel: "telegram" },
+        resultText: "error: boom",
+      }),
+    ).toBeNull();
   });
 
   it("mirrors proposal transitions for out-of-process (CLI MCP) hosts", () => {

--- a/src/agents/tools/crestodian-tool.ts
+++ b/src/agents/tools/crestodian-tool.ts
@@ -322,6 +322,7 @@ export function createCrestodianTool(options: CrestodianToolOptions): AnyAgentTo
           directive.kind === "channel-setup"
             ? `${CRESTODIAN_DIRECTIVE_PREFIX} the host chat now starts the guided ${directive.channel} setup with the user. Tell the user the setup questions come next; do not describe steps yourself.`
             : `${CRESTODIAN_DIRECTIVE_PREFIX} the host now hands the user over to their normal agent. Say goodbye briefly.`,
+          {},
         );
       }
       const persistent = isPersistentCrestodianOperation(operation);

--- a/src/agents/tools/crestodian-tool.ts
+++ b/src/agents/tools/crestodian-tool.ts
@@ -18,9 +18,10 @@ export type CrestodianToolOptions = {
   /** Where setup side effects run; the gateway surface never manages its own daemon. */
   surface: "cli" | "gateway";
   /**
-   * Host-verified consent for THIS turn: true only when the user's actual
-   * message was an explicit approval. The model-supplied `approved` argument
-   * alone must never authorize a mutation (prompt injection, model error).
+   * Host-verified consent for THIS turn: true only when the host judged the
+   * user's actual message to be an explicit approval. The model-supplied
+   * `approved` argument alone must never authorize a mutation (prompt
+   * injection, model error).
    */
   approvalArmed?: boolean;
   /**
@@ -29,7 +30,18 @@ export type CrestodianToolOptions = {
    * may execute only a call matching that hash. Cleared after use.
    */
   proposalRef?: { current?: string };
+  /**
+   * Host handoff channel for actions the tool cannot perform itself
+   * (interactive channel-setup wizard, opening the agent TUI). The engine
+   * reads it after the turn; CLI MCP hosts mirror it from tool events.
+   */
+  directiveRef?: { current?: CrestodianToolDirective };
 };
+
+/** Interactive handoffs the hosting chat engine executes after the turn. */
+export type CrestodianToolDirective =
+  | { kind: "channel-setup"; channel: string }
+  | { kind: "open-tui"; agentId?: string; workspace?: string };
 
 /** Canonical operation fingerprint used to bind "yes" to one exact mutation. */
 export function hashCrestodianOperation(operation: CrestodianOperation): string {
@@ -39,6 +51,40 @@ export function hashCrestodianOperation(operation: CrestodianOperation): string 
 /** Result markers shared with out-of-process hosts (CLI MCP runs). */
 export const CRESTODIAN_NEEDS_APPROVAL_PREFIX = "needs-approval:";
 export const CRESTODIAN_APPROVAL_MISMATCH_PREFIX = "approval-mismatch:";
+export const CRESTODIAN_DIRECTIVE_PREFIX = "directive:";
+
+/**
+ * Reconstruct a host directive from an out-of-process tool result. Directive
+ * actions run inside the MCP subprocess on CLI-harness runs, so the host
+ * replays them from harness tool events the same way proposals are mirrored.
+ */
+export function resolveCrestodianDirectiveTransition(params: {
+  args: Record<string, unknown>;
+  resultText: string;
+}): CrestodianToolDirective | null {
+  if (!params.resultText.startsWith(CRESTODIAN_DIRECTIVE_PREFIX)) {
+    return null;
+  }
+  try {
+    return directiveForOperation(operationForAction(params.args));
+  } catch {
+    return null;
+  }
+}
+
+function directiveForOperation(operation: CrestodianOperation): CrestodianToolDirective | null {
+  if (operation.kind === "channel-setup") {
+    return { kind: "channel-setup", channel: operation.channel };
+  }
+  if (operation.kind === "open-tui") {
+    return {
+      kind: "open-tui",
+      ...(operation.agentId ? { agentId: operation.agentId } : {}),
+      ...(operation.workspace ? { workspace: operation.workspace } : {}),
+    };
+  }
+  return null;
+}
 
 /**
  * Mirror a proposalRef transition from an out-of-process tool result. CLI MCP
@@ -81,6 +127,9 @@ const CRESTODIAN_TOOL_ACTIONS = [
   "config_schema",
   "gateway_status",
   "plugin_search",
+  // Interactive handoffs executed by the hosting chat after this turn.
+  "connect_channel",
+  "open_agent",
   // Mutating actions below require approved=true.
   "setup",
   "set_default_model",
@@ -102,7 +151,10 @@ const CrestodianToolSchema = Type.Object({
   envVar: Type.Optional(Type.String({ description: "Env var name for config_set_ref" })),
   model: Type.Optional(Type.String({ description: "provider/model ref" })),
   workspace: Type.Optional(Type.String({ description: "Workspace directory" })),
-  agentId: Type.Optional(Type.String({ description: "Agent id for create_agent" })),
+  agentId: Type.Optional(Type.String({ description: "Agent id for create_agent/open_agent" })),
+  channel: Type.Optional(
+    Type.String({ description: "Channel id for connect_channel (e.g. telegram)" }),
+  ),
   query: Type.Optional(Type.String({ description: "Search query for plugin_search" })),
   spec: Type.Optional(Type.String({ description: "npm/clawhub spec for plugin_install" })),
   pluginId: Type.Optional(Type.String({ description: "Plugin id for plugin_uninstall" })),
@@ -161,6 +213,17 @@ function operationForAction(params: Record<string, unknown>): CrestodianOperatio
     }
     case "gateway_status":
       return { kind: "gateway-status" };
+    case "connect_channel":
+      return { kind: "channel-setup", channel: requireParam(params, "channel").toLowerCase() };
+    case "open_agent": {
+      const agentId = readStringParam(params, "agentId")?.trim();
+      const workspace = readStringParam(params, "workspace")?.trim();
+      return {
+        kind: "open-tui",
+        ...(agentId ? { agentId } : {}),
+        ...(workspace ? { workspace } : {}),
+      };
+    }
     case "gateway_start":
       return { kind: "gateway-start" };
     case "gateway_stop":
@@ -239,7 +302,8 @@ export function createCrestodianTool(options: CrestodianToolOptions): AnyAgentTo
     label: "Crestodian",
     description: [
       "Ring-zero OpenClaw setup and repair. Read actions (status/models/agents/channels/config_get/config_schema/gateway_status/plugin_search/validate_config/doctor/audit) run immediately.",
-      "Mutating actions (setup/set_default_model/config_set/config_set_ref/create_agent/gateway_*/plugin_install/plugin_uninstall/doctor_fix) REQUIRE approved=true, which you may only set after the user explicitly said yes to that exact change in this conversation.",
+      "connect_channel(channel) starts the guided channel setup in this chat; open_agent hands the user to their normal agent. Both run immediately.",
+      "Mutating actions (setup/set_default_model/config_set/config_set_ref/create_agent/gateway_*/plugin_install/plugin_uninstall/doctor_fix) REQUIRE approved=true, which you may only set after the user clearly agreed to that exact change in this conversation.",
       "Before writing an unfamiliar config path, call config_schema for it — the schema is the source of truth. Secrets go through config_set_ref (env var), never plaintext echoes.",
       "Every applied write is validated; if the result reports CONFIG INVALID, fix it immediately. All writes are audited.",
     ].join(" "),
@@ -247,6 +311,19 @@ export function createCrestodianTool(options: CrestodianToolOptions): AnyAgentTo
     execute: async (_toolCallId, args) => {
       const params = (args ?? {}) as Record<string, unknown>;
       const operation = operationForAction(params);
+      const directive = directiveForOperation(operation);
+      if (directive) {
+        // Not a write: the host chat performs the interactive handoff after
+        // this turn (the wizard itself collects explicit user answers).
+        if (options.directiveRef) {
+          options.directiveRef.current = directive;
+        }
+        return textResult(
+          directive.kind === "channel-setup"
+            ? `${CRESTODIAN_DIRECTIVE_PREFIX} the host chat now starts the guided ${directive.channel} setup with the user. Tell the user the setup questions come next; do not describe steps yourself.`
+            : `${CRESTODIAN_DIRECTIVE_PREFIX} the host now hands the user over to their normal agent. Say goodbye briefly.`,
+        );
+      }
       const persistent = isPersistentCrestodianOperation(operation);
       if (persistent) {
         const operationHash = hashCrestodianOperation(operation);

--- a/src/crestodian/agent-turn.ts
+++ b/src/crestodian/agent-turn.ts
@@ -22,6 +22,16 @@ export const CRESTODIAN_AGENT_ID = "crestodian";
 
 const AGENT_TURN_TIMEOUT_MS = 120_000;
 
+export type CrestodianAgentTurnDirective =
+  import("../agents/tools/crestodian-tool.js").CrestodianToolDirective;
+
+export type CrestodianAgentTurnReply = {
+  text: string;
+  modelLabel?: string;
+  /** Interactive handoff the tool requested; the host chat executes it. */
+  directive?: CrestodianAgentTurnDirective;
+};
+
 export type CrestodianAgentTurnRunner = (params: {
   input: string;
   overview: CrestodianOverview;
@@ -29,7 +39,7 @@ export type CrestodianAgentTurnRunner = (params: {
   /** Host-verified: the user's current message is an explicit approval. */
   approvalArmed: boolean;
   session: CrestodianAgentSession;
-}) => Promise<{ text: string; modelLabel?: string } | null>;
+}) => Promise<CrestodianAgentTurnReply | null>;
 
 export type CrestodianAgentSession = {
   sessionId: string;
@@ -153,21 +163,26 @@ async function planCrestodianAgentTurn(
 
 /**
  * CLI harnesses run the crestodian tool in a stdio MCP subprocess, so the
- * in-process proposalRef cannot be shared with the host. Mirror the tool's
- * proposal transitions from the harness tool events instead: a denial
- * registers the exact-operation hash, a mismatch voids it, and an executed
- * mutation consumes it — same lifecycle as crestodian-tool.ts enforces.
+ * in-process proposalRef/directiveRef cannot be shared with the host. Mirror
+ * the tool's transitions from the harness tool events instead: a denial
+ * registers the exact-operation hash, a mismatch voids it, an executed
+ * mutation consumes it, and directive actions replay the interactive handoff —
+ * same lifecycle as crestodian-tool.ts enforces.
  */
-async function mirrorCrestodianProposalFromToolEvents(params: {
+async function mirrorCrestodianToolStateFromEvents(params: {
   runId: string;
   proposalRef: { current?: string };
+  directiveRef: { current?: CrestodianAgentTurnDirective };
 }): Promise<() => void> {
-  const [{ onAgentEvent }, { extractToolResultText }, { resolveCrestodianProposalTransition }] =
-    await Promise.all([
-      import("../infra/agent-events.js"),
-      import("../agents/embedded-agent-subscribe.tools.js"),
-      import("../agents/tools/crestodian-tool.js"),
-    ]);
+  const [
+    { onAgentEvent },
+    { extractToolResultText },
+    { resolveCrestodianProposalTransition, resolveCrestodianDirectiveTransition },
+  ] = await Promise.all([
+    import("../infra/agent-events.js"),
+    import("../agents/embedded-agent-subscribe.tools.js"),
+    import("../agents/tools/crestodian-tool.js"),
+  ]);
   return onAgentEvent((evt) => {
     if (evt.runId !== params.runId || evt.stream !== "tool" || evt.data.phase !== "result") {
       return;
@@ -181,12 +196,14 @@ async function mirrorCrestodianProposalFromToolEvents(params: {
       typeof evt.data.args === "object" && evt.data.args !== null
         ? (evt.data.args as Record<string, unknown>)
         : {};
-    const transition = resolveCrestodianProposalTransition({
-      args,
-      resultText: extractToolResultText(evt.data.result) ?? "",
-    });
+    const resultText = extractToolResultText(evt.data.result) ?? "";
+    const transition = resolveCrestodianProposalTransition({ args, resultText });
     if (transition) {
       params.proposalRef.current = transition.proposal;
+    }
+    const directive = resolveCrestodianDirectiveTransition({ args, resultText });
+    if (directive) {
+      params.directiveRef.current = directive;
     }
   });
 }
@@ -199,7 +216,7 @@ async function mirrorCrestodianProposalFromToolEvents(params: {
 export async function runCrestodianAgentTurnWithDeps(
   params: CrestodianAgentTurnParams,
   deps: CrestodianAgentTurnDeps = {},
-): Promise<{ text: string; modelLabel?: string } | null> {
+): Promise<CrestodianAgentTurnReply | null> {
   const { workspaceDir, sessionFile } = await ensureCrestodianDirs(params.session.sessionId);
   const plan = await planCrestodianAgentTurn(params, deps, workspaceDir);
   if (!plan) {
@@ -221,19 +238,24 @@ export async function runCrestodianAgentTurnWithDeps(
     messageChannel: "crestodian",
     messageProvider: "crestodian",
   };
+  // Directives are per-turn: the tool records at most one interactive handoff
+  // and the engine executes it after the reply.
+  const directiveRef: { current?: CrestodianAgentTurnDirective } = {};
   const crestodianTool = {
     surface: params.surface,
     approvalArmed: params.approvalArmed,
     proposalRef: params.session.proposalRef,
+    directiveRef,
   };
 
   try {
     let result: EmbeddedRunResult;
     if (plan.runner === "cli") {
       const runCli = deps.runCliAgent ?? (await import("../agents/cli-runner.js")).runCliAgent;
-      const stopProposalMirror = await mirrorCrestodianProposalFromToolEvents({
+      const stopToolStateMirror = await mirrorCrestodianToolStateFromEvents({
         runId,
         proposalRef: params.session.proposalRef,
+        directiveRef,
       });
       try {
         result = (await runCli({
@@ -247,7 +269,7 @@ export async function runCrestodianAgentTurnWithDeps(
           cleanupCliLiveSessionOnRunEnd: true,
         })) as EmbeddedRunResult;
       } finally {
-        stopProposalMirror();
+        stopToolStateMirror();
       }
       // Thread the harness's own session forward so the next turn resumes the
       // native CLI transcript instead of reseeding from scratch.
@@ -277,7 +299,11 @@ export async function runCrestodianAgentTurnWithDeps(
     if (!text) {
       return null;
     }
-    return { text, modelLabel: plan.modelLabel };
+    return {
+      text,
+      modelLabel: plan.modelLabel,
+      ...(directiveRef.current ? { directive: directiveRef.current } : {}),
+    };
   } catch {
     // Loop unavailable for this backend (missing CLI, auth failure, timeout):
     // the conversation must keep working, so degrade to the planner path.

--- a/src/crestodian/approval-intent.test.ts
+++ b/src/crestodian/approval-intent.test.ts
@@ -1,0 +1,89 @@
+// Approval-intent tests: closed-list fast path plus model-judged classification.
+import { describe, expect, it, vi } from "vitest";
+import {
+  classifyCrestodianApprovalIntent,
+  classifyCrestodianApprovalText,
+} from "./approval-intent.js";
+
+const validSnapshot = {
+  exists: true,
+  valid: true,
+  path: "/tmp/openclaw.json",
+  hash: "h",
+  config: {},
+  sourceConfig: {},
+  runtimeConfig: {},
+  issues: [],
+} as never;
+
+function completionDeps(replyText: string) {
+  return {
+    readConfigFileSnapshot: vi.fn(async () => validSnapshot),
+    prepareSimpleCompletionModelForAgent: vi.fn(async () => ({
+      model: {},
+      auth: {},
+      selection: { provider: "openai", modelId: "gpt-5.5" },
+    })) as never,
+    completeWithPreparedSimpleCompletionModel: vi.fn(async () => ({
+      content: [{ type: "text", text: replyText }],
+    })) as never,
+  };
+}
+
+describe("classifyCrestodianApprovalText", () => {
+  it("accepts natural affirmatives regardless of case and punctuation", () => {
+    for (const text of ["yes", "Yes.", "sure", "ok!", "Okay,", "go ahead", "yes please", "do it"]) {
+      expect(classifyCrestodianApprovalText(text)).toBe("approve");
+    }
+  });
+
+  it("treats clear rejections as declines", () => {
+    for (const text of ["no", "no thanks", "not now", "cancel", "don't", "nah, later"]) {
+      expect(classifyCrestodianApprovalText(text)).toBe("decline");
+    }
+  });
+
+  it("keeps everything ambiguous as other", () => {
+    for (const text of ["maybe", "what does that change?", "yes but use gpt instead", ""]) {
+      expect(classifyCrestodianApprovalText(text)).toBe("other");
+    }
+  });
+});
+
+describe("classifyCrestodianApprovalIntent", () => {
+  it("short-circuits closed-list answers without a model call", async () => {
+    const deps = completionDeps("approve");
+    await expect(classifyCrestodianApprovalIntent({ message: "yes" }, deps)).resolves.toBe(
+      "approve",
+    );
+    expect(deps.completeWithPreparedSimpleCompletionModel).not.toHaveBeenCalled();
+  });
+
+  it("asks the model for ambiguous messages and trusts a clear verdict", async () => {
+    const deps = completionDeps("approve");
+    await expect(
+      classifyCrestodianApprovalIntent(
+        { message: "alright, ship that change", proposal: "set config gateway.port to 19001" },
+        deps,
+      ),
+    ).resolves.toBe("approve");
+    expect(deps.completeWithPreparedSimpleCompletionModel).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed to other on unexpected model output", async () => {
+    const deps = completionDeps("I think the user probably agrees");
+    await expect(
+      classifyCrestodianApprovalIntent({ message: "hmm alright I guess?" }, deps),
+    ).resolves.toBe("other");
+  });
+
+  it("fails closed to other when no model is usable", async () => {
+    const deps = {
+      ...completionDeps("approve"),
+      prepareSimpleCompletionModelForAgent: vi.fn(async () => ({ error: "no model" })) as never,
+    };
+    await expect(classifyCrestodianApprovalIntent({ message: "alright then" }, deps)).resolves.toBe(
+      "other",
+    );
+  });
+});

--- a/src/crestodian/approval-intent.ts
+++ b/src/crestodian/approval-intent.ts
@@ -1,0 +1,147 @@
+// Classifies whether a user's chat message approves a pending Crestodian proposal.
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { extractAssistantText } from "../agents/embedded-agent-utils.js";
+import {
+  completeWithPreparedSimpleCompletionModel,
+  prepareSimpleCompletionModelForAgent,
+} from "../agents/simple-completion-runtime.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+
+/**
+ * Approval detection for pending mutations. The host — not the conversation
+ * model — decides whether a turn is armed, so the agent loop can never
+ * self-approve (see crestodian-tool.ts). Users approve in their own words:
+ * unambiguous replies resolve instantly from a closed list, everything else is
+ * judged by a separate single-shot model call that sees only the user's
+ * message and the proposal description, never tool output. When no completion
+ * model is usable the closed list is the whole decision — "other" (the safe
+ * default) keeps the proposal pending and the conversation re-asks.
+ */
+export type CrestodianApprovalIntent = "approve" | "decline" | "other";
+
+export type CrestodianApprovalClassifier = (params: {
+  message: string;
+  /** Human-readable proposal description when the host knows it. */
+  proposal?: string;
+}) => Promise<CrestodianApprovalIntent>;
+
+const APPROVAL_INTENT_TIMEOUT_MS = 10_000;
+const APPROVAL_INTENT_MAX_TOKENS = 8;
+
+// Approvals arm a mutation, so the deterministic list is whole-message only;
+// declines merely drop a proposal, so a leading match ("no thanks") suffices.
+const APPROVE_RE =
+  /^(?:y|yes|yeah|yep|yup|sure|ok|okay|approve|approved|apply|confirm|confirmed|do it|go ahead|sounds good|yes please|please do)$/i;
+const DECLINE_RE = /^(?:n|no|nope|nah|skip|not now|cancel|stop|abort|later|decline|don'?t)\b/i;
+
+function normalizeApprovalText(message: string): string {
+  return message
+    .trim()
+    .replace(/[.!?,\s]+$/u, "")
+    .toLowerCase();
+}
+
+/** Closed-list classification: exact affirmatives, prefix declines. */
+export function classifyCrestodianApprovalText(message: string): CrestodianApprovalIntent {
+  const normalized = normalizeApprovalText(message);
+  if (!normalized) {
+    return "other";
+  }
+  if (APPROVE_RE.test(normalized)) {
+    return "approve";
+  }
+  if (DECLINE_RE.test(normalized)) {
+    return "decline";
+  }
+  return "other";
+}
+
+const APPROVAL_INTENT_SYSTEM_PROMPT = [
+  "You classify one chat message from a user who was just asked to approve a pending configuration change.",
+  "Reply with exactly one word:",
+  "approve — the message clearly consents to applying the pending change now.",
+  "decline — the message clearly rejects or postpones the pending change.",
+  "other — anything else: questions, new requests, partial or conditional agreement, or unclear intent.",
+  "Only classify consent for the pending change itself. A message asking to change the proposal is not approval.",
+].join("\n");
+
+export type CrestodianApprovalIntentDeps = {
+  readConfigFileSnapshot?: typeof readConfigFileSnapshot;
+  prepareSimpleCompletionModelForAgent?: typeof prepareSimpleCompletionModelForAgent;
+  completeWithPreparedSimpleCompletionModel?: typeof completeWithPreparedSimpleCompletionModel;
+};
+
+/**
+ * Judge whether a message approves the pending proposal. Deterministic
+ * closed-list answers short-circuit (a literal "yes" needs no model and must
+ * keep working on configless machines); ambiguous messages go to the
+ * configured completion model. CLI-harness-only hosts get no model judgment —
+ * spawning a full harness per approval check is too slow — so their ambiguous
+ * replies stay "other" and the conversation asks for a clear yes.
+ */
+export async function classifyCrestodianApprovalIntent(
+  params: {
+    message: string;
+    proposal?: string;
+  },
+  deps: CrestodianApprovalIntentDeps = {},
+): Promise<CrestodianApprovalIntent> {
+  const textIntent = classifyCrestodianApprovalText(params.message);
+  if (textIntent !== "other") {
+    return textIntent;
+  }
+  try {
+    const snapshot = await (deps.readConfigFileSnapshot ?? readConfigFileSnapshot)();
+    if (!snapshot.exists || !snapshot.valid) {
+      return "other";
+    }
+    const cfg = snapshot.runtimeConfig ?? snapshot.config;
+    const prepared = await (
+      deps.prepareSimpleCompletionModelForAgent ?? prepareSimpleCompletionModelForAgent
+    )({
+      cfg,
+      agentId: resolveDefaultAgentId(cfg),
+      allowMissingApiKeyModes: ["aws-sdk"],
+    });
+    if ("error" in prepared) {
+      return "other";
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), APPROVAL_INTENT_TIMEOUT_MS);
+    try {
+      const response = await (
+        deps.completeWithPreparedSimpleCompletionModel ?? completeWithPreparedSimpleCompletionModel
+      )({
+        model: prepared.model,
+        auth: prepared.auth,
+        context: {
+          systemPrompt: APPROVAL_INTENT_SYSTEM_PROMPT,
+          messages: [
+            {
+              role: "user",
+              content: [
+                `Pending change: ${params.proposal ?? "a configuration change proposed in this conversation"}`,
+                `User message: ${params.message}`,
+              ].join("\n"),
+              timestamp: Date.now(),
+            },
+          ],
+        },
+        options: {
+          maxTokens: APPROVAL_INTENT_MAX_TOKENS,
+          signal: controller.signal,
+        },
+      });
+      const verdict = extractAssistantText(response)?.trim().toLowerCase().split(/\s+/)[0];
+      if (verdict === "approve" || verdict === "decline") {
+        return verdict;
+      }
+      return "other";
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    // Approval must fail closed: an unreachable model means no arming.
+    return "other";
+  }
+}

--- a/src/crestodian/assistant-backends.ts
+++ b/src/crestodian/assistant-backends.ts
@@ -1,18 +1,21 @@
 // Crestodian planner backends choose safe local model runners available on this host.
+import {
+  CLAUDE_CLI_DEFAULT_MODEL_REF,
+  CODEX_APP_SERVER_DEFAULT_MODEL_REF,
+  GEMINI_CLI_DEFAULT_MODEL_REF,
+} from "../commands/onboard-inference.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { CrestodianOverview } from "./overview.js";
 
 /**
- * Local planner backend selection for Crestodian assistant mode.
+ * Local planner/agent-loop backend selection for Crestodian.
  *
- * Crestodian only offers planners backed by tools present on the host, and the
- * returned backend config is scoped to the workspace being repaired.
+ * Crestodian only offers backends backed by tools present on the host, in the
+ * same order the setup ladder detects them (Claude Code, Codex, Gemini), and
+ * the returned backend config is scoped to the workspace being repaired.
  */
-const CRESTODIAN_CLAUDE_CLI_MODEL = "claude-opus-4-8";
-const CRESTODIAN_CODEX_MODEL = "gpt-5.5";
-
 type CrestodianLocalPlannerBackend = {
-  kind: "claude-cli" | "codex-app-server";
+  kind: "claude-cli" | "codex-app-server" | "gemini-cli";
   label: string;
   runner: "cli" | "embedded";
   provider: string;
@@ -20,23 +23,33 @@ type CrestodianLocalPlannerBackend = {
   buildConfig: (workspaceDir: string) => OpenClawConfig;
 };
 
+function splitModelRef(modelRef: string): { provider: string; model: string } {
+  const slash = modelRef.indexOf("/");
+  return { provider: modelRef.slice(0, slash), model: modelRef.slice(slash + 1) };
+}
+
 const CLAUDE_CLI_BACKEND: CrestodianLocalPlannerBackend = {
   kind: "claude-cli",
-  label: `claude-cli/${CRESTODIAN_CLAUDE_CLI_MODEL}`,
+  label: CLAUDE_CLI_DEFAULT_MODEL_REF,
   runner: "cli",
-  provider: "claude-cli",
-  model: CRESTODIAN_CLAUDE_CLI_MODEL,
-  buildConfig: (workspaceDir) =>
-    buildCliPlannerConfig(workspaceDir, `claude-cli/${CRESTODIAN_CLAUDE_CLI_MODEL}`),
+  ...splitModelRef(CLAUDE_CLI_DEFAULT_MODEL_REF),
+  buildConfig: (workspaceDir) => buildCliPlannerConfig(workspaceDir, CLAUDE_CLI_DEFAULT_MODEL_REF),
 };
 
 const CODEX_APP_SERVER_BACKEND: CrestodianLocalPlannerBackend = {
   kind: "codex-app-server",
-  label: `openai/${CRESTODIAN_CODEX_MODEL} via codex`,
+  label: `${CODEX_APP_SERVER_DEFAULT_MODEL_REF} via codex`,
   runner: "embedded",
-  provider: "openai",
-  model: CRESTODIAN_CODEX_MODEL,
+  ...splitModelRef(CODEX_APP_SERVER_DEFAULT_MODEL_REF),
   buildConfig: buildCodexAppServerPlannerConfig,
+};
+
+const GEMINI_CLI_BACKEND: CrestodianLocalPlannerBackend = {
+  kind: "gemini-cli",
+  label: GEMINI_CLI_DEFAULT_MODEL_REF,
+  runner: "cli",
+  ...splitModelRef(GEMINI_CLI_DEFAULT_MODEL_REF),
+  buildConfig: (workspaceDir) => buildCliPlannerConfig(workspaceDir, GEMINI_CLI_DEFAULT_MODEL_REF),
 };
 
 /** Select local assistant planner backends available for the current overview. */
@@ -49,6 +62,9 @@ export function selectCrestodianLocalPlannerBackends(
   }
   if (overview.tools.codex.found) {
     backends.push(CODEX_APP_SERVER_BACKEND);
+  }
+  if (overview.tools.gemini.found) {
+    backends.push(GEMINI_CLI_BACKEND);
   }
   return backends;
 }
@@ -71,7 +87,7 @@ export function buildCodexAppServerPlannerConfig(workspaceDir: string): OpenClaw
     agents: {
       defaults: {
         workspace: workspaceDir,
-        model: { primary: `openai/${CRESTODIAN_CODEX_MODEL}` },
+        model: { primary: CODEX_APP_SERVER_DEFAULT_MODEL_REF },
       },
     },
     plugins: {

--- a/src/crestodian/assistant-prompts.ts
+++ b/src/crestodian/assistant-prompts.ts
@@ -17,7 +17,7 @@ export const CRESTODIAN_ASSISTANT_MAX_TOKENS = 700;
 export const CRESTODIAN_ASSISTANT_SYSTEM_PROMPT = [
   "You are Crestodian, OpenClaw's setup custodian: a small, tidy hermit crab that lives in the config shell.",
   "Personality: warm, competent, concise. Dry humor in small doses. Never corporate. You configure things so the user does not have to.",
-  "You are talking to someone setting up or repairing OpenClaw. Your goals, in order: working inference (reuse a detected Claude Code/Codex login or API key), a workspace, a running gateway, then channels (Discord, Slack, Telegram, WhatsApp, ...) and handing off to their agent (`talk to agent`).",
+  "You are talking to someone setting up or repairing OpenClaw. Your goals, in order: working inference (reuse a detected Claude Code/Codex/Gemini login or API key), a workspace, a running gateway, then channels (Discord, Slack, Telegram, WhatsApp, ...) and handing off to their agent (`talk to agent`).",
   'Return only compact JSON: {"reply": string, "command"?: string}.',
   "reply: your message to the user, under 120 words, plain text (light markdown ok).",
   "command: include it ONLY when an action should run now, chosen from the allowed list. Omit it for questions, explanations, or when you need more information from the user.",
@@ -72,12 +72,12 @@ export const CRESTODIAN_ASSISTANT_SYSTEM_PROMPT = [
 export const CRESTODIAN_AGENT_SYSTEM_PROMPT = [
   "You are Crestodian, OpenClaw's setup custodian: a small, tidy hermit crab that lives in the config shell.",
   "Personality: warm, competent, concise. Dry humor in small doses. Never corporate. You configure things so the user does not have to.",
-  "You are talking to someone setting up or repairing OpenClaw. Goals, in order: working inference (reuse a detected Claude Code/Codex login or API key), a workspace, a running gateway, then channels (Discord, Slack, Telegram, WhatsApp, ...) and handing off to their agent.",
+  "You are talking to someone setting up or repairing OpenClaw. Goals, in order: working inference (reuse a detected Claude Code/Codex/Gemini login or API key), a workspace, a running gateway, then channels (Discord, Slack, Telegram, WhatsApp, ...) and handing off to their agent.",
   "You act ONLY through the `crestodian` tool. Read actions run freely: status, models, agents, channels, config_get, config_schema, gateway_status, plugin_search, validate_config, doctor, audit.",
-  "Mutating actions (setup, set_default_model, config_set, config_set_ref, create_agent, gateway_start/stop/restart, plugin_install, plugin_uninstall, doctor_fix) change the user's machine. Protocol: when you decide a mutation is needed, call the tool with the exact action right away (without approved) — it is safely denied and registers the proposal — then describe the change and ask for the user's yes. After their yes, retry the identical call with approved=true. Never set approved=true without their explicit yes.",
+  "Mutating actions (setup, set_default_model, config_set, config_set_ref, create_agent, gateway_start/stop/restart, plugin_install, plugin_uninstall, doctor_fix) change the user's machine. Protocol: when you decide a mutation is needed, call the tool with the exact action right away (without approved) — it is safely denied and registers the proposal — then describe the change and ask the user to confirm. Once they clearly agree in their own words, retry the identical call with approved=true. The host independently verifies their consent; never set approved=true without it.",
   "The config file is ~/.openclaw/openclaw.json (JSON5). Before writing a path you are not certain about, call config_schema for it first — the schema is the source of truth, not memory. Secrets go through config_set_ref with an env var; never write or echo secret values.",
   "If a tool result reports CONFIG INVALID, fix it immediately before anything else.",
-  "To connect a chat channel, tell the user to type `connect <channel>` (for example `connect telegram`) — that starts the guided channel setup. To hand off to their agent, tell them to say `talk to agent`.",
+  "To connect a chat channel, call connect_channel with the channel id (for example telegram) — the guided setup then runs right here in the chat. To hand the user off to their normal agent, call open_agent.",
   "Keep replies under 120 words. Ask one question at a time. Never claim something was done unless the tool result confirms it.",
 ].join("\n");
 
@@ -147,6 +147,7 @@ export function buildCrestodianAssistantUserPrompt(params: {
     `Gateway reachable: ${params.overview.gateway.reachable}`,
     `Codex binary: ${params.overview.tools.codex.found ? "found" : "not found"}`,
     `Claude Code CLI: ${params.overview.tools.claude.found ? "found" : "not found"}`,
+    `Gemini CLI: ${params.overview.tools.gemini.found ? "found" : "not found"}`,
     `OpenAI API key: ${params.overview.tools.apiKeys.openai ? "found" : "not found"}`,
     `Anthropic API key: ${params.overview.tools.apiKeys.anthropic ? "found" : "not found"}`,
     `OpenClaw docs: ${params.overview.references.docsPath ?? params.overview.references.docsUrl}`,
@@ -198,11 +199,38 @@ export function parseCrestodianAssistantPlanText(
 }
 
 function extractFirstJsonObject(text: string): string | null {
-  // Planner output must be JSON, but this tolerates model wrappers before re-validating fields.
+  // Planner output must be JSON, but this tolerates model wrappers before
+  // re-validating fields. A balanced scan (string-aware) keeps a trailing
+  // prose "}" or a second JSON object from corrupting the first.
   const start = text.indexOf("{");
-  const end = text.lastIndexOf("}");
-  if (start < 0 || end <= start) {
+  if (start < 0) {
     return null;
   }
-  return text.slice(start, end + 1);
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i += 1) {
+    const char = text[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      inString = true;
+    } else if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+  return null;
 }

--- a/src/crestodian/assistant.configured.test.ts
+++ b/src/crestodian/assistant.configured.test.ts
@@ -36,6 +36,7 @@ describe("Crestodian configured-model planner", () => {
           tools: {
             codex: { command: "codex", found: false },
             claude: { command: "claude", found: false },
+            gemini: { command: "gemini", found: false },
             apiKeys: { openai: false, anthropic: false },
           },
           gateway: {

--- a/src/crestodian/assistant.test.ts
+++ b/src/crestodian/assistant.test.ts
@@ -25,6 +25,7 @@ function overview(overrides: Partial<CrestodianOverview["tools"]> = {}): Crestod
     tools: {
       codex: { command: "codex", found: false },
       claude: { command: "claude", found: false },
+      gemini: { command: "gemini", found: false },
       apiKeys: { openai: false, anthropic: false },
       ...overrides,
     },
@@ -172,6 +173,17 @@ describe("Crestodian assistant", () => {
         }),
       ).map((backend) => backend.kind),
     ).toEqual(["claude-cli", "codex-app-server"]);
+
+    // Setup-ladder order: Claude Code, Codex, Gemini.
+    expect(
+      selectCrestodianLocalPlannerBackends(
+        overview({
+          claude: { command: "claude", found: true },
+          codex: { command: "codex", found: true },
+          gemini: { command: "gemini", found: true },
+        }),
+      ).map((backend) => backend.kind),
+    ).toEqual(["claude-cli", "codex-app-server", "gemini-cli"]);
 
     const [codexAppServer] = selectCrestodianLocalPlannerBackends(
       overview({

--- a/src/crestodian/chat-engine.channel-hooks.test.ts
+++ b/src/crestodian/chat-engine.channel-hooks.test.ts
@@ -53,7 +53,35 @@ vi.mock("../config/config.js", async (importOriginal) => ({
 
 describe("Crestodian chat channel setup", () => {
   it("runs collected channel hooks after writing config", async () => {
-    const engine = new CrestodianChatEngine({ yes: true });
+    const engine = new CrestodianChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: {
+        loadOverview: async () =>
+          ({
+            config: {
+              path: "/tmp/openclaw.json",
+              exists: true,
+              valid: true,
+              issues: [],
+              hash: "h",
+            },
+            agents: [],
+            defaultAgentId: "main",
+            tools: {
+              codex: { command: "codex", found: false },
+              claude: { command: "claude", found: false },
+              gemini: { command: "gemini", found: false },
+              apiKeys: { openai: false, anthropic: false },
+            },
+            gateway: { url: "ws://127.0.0.1:18789", source: "local", reachable: false },
+            references: {
+              docsUrl: "https://docs.openclaw.ai",
+              sourceUrl: "https://github.com/openclaw/openclaw",
+            },
+          }) as never,
+      },
+    });
 
     const reply = await engine.handle("connect matrix");
 

--- a/src/crestodian/chat-engine.test.ts
+++ b/src/crestodian/chat-engine.test.ts
@@ -78,29 +78,41 @@ describe("CrestodianChatEngine", () => {
     expect(engine.hasPendingProposal()).toBe(false);
   });
 
-  it("drops an agent-loop proposal when the user declines", async () => {
+  it("voids an agent-loop proposal on decline and lets the AI acknowledge", async () => {
+    let observedProposalOnSecondTurn: string | undefined = "sentinel";
     const runAgentTurn = vi.fn(
       async (params: { session: { proposalRef: { current?: string } } }) => {
-        params.session.proposalRef.current = "registered-operation";
-        return { text: "I can change that after your approval." };
+        if (runAgentTurn.mock.calls.length === 1) {
+          params.session.proposalRef.current = "registered-operation";
+          return { text: "I can change that after your approval." };
+        }
+        observedProposalOnSecondTurn = params.session.proposalRef.current;
+        return { text: "Okay, leaving it as is." };
       },
     );
     const engine = new CrestodianChatEngine({
       runAgentTurn: runAgentTurn as never,
+      classifyApproval: async () => "other",
       deps: { loadOverview: fakeOverviewLoader() },
     });
 
     await engine.handle("change the model");
     const declined = await engine.handle("no thanks");
 
-    expect(declined.text).toContain("Skipped");
-    expect(runAgentTurn).toHaveBeenCalledOnce();
+    // The decline voids the registered hash before the AI turn, so a later
+    // generic approval can never arm the stale mutation.
+    expect(observedProposalOnSecondTurn).toBeUndefined();
+    expect(declined.text).toContain("leaving it as is");
+    expect(runAgentTurn).toHaveBeenCalledTimes(2);
   });
 
-  it("hosts a channel setup wizard as chat turns after approval", async () => {
+  it("hosts a channel setup wizard as chat turns", async () => {
     useTempStateDir();
     const wizardRuns: string[] = [];
     const engine = new CrestodianChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
       runChannelSetupWizard: async (channel: string, prompter: WizardPrompter) => {
         wizardRuns.push(channel);
         const token = await prompter.text({ message: "Bot token" });
@@ -116,10 +128,8 @@ describe("CrestodianChatEngine", () => {
       },
     });
 
-    const plan = await engine.handle("connect telegram");
-    expect(plan.text).toContain("walk through connecting the telegram channel");
-
-    const tokenStep = await engine.handle("yes");
+    // Starting the wizard is not a write: it begins immediately, no approval step.
+    const tokenStep = await engine.handle("connect telegram");
     expect(tokenStep.text).toContain("Bot token");
 
     const modeStep = await engine.handle("123:abc");
@@ -133,8 +143,10 @@ describe("CrestodianChatEngine", () => {
   it("marks sensitive hosted-wizard replies and auto-advances notes", async () => {
     useTempStateDir();
     const engine = new CrestodianChatEngine({
-      yes: true,
       surface: "gateway",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
       runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
         await prompter.note("Before entering the token, open the provider console.");
         await prompter.text({ message: "Bot token", sensitive: true });
@@ -151,8 +163,10 @@ describe("CrestodianChatEngine", () => {
   it("routes sensitive CLI wizard prompts to the masked channel setup flow", async () => {
     useTempStateDir();
     const engine = new CrestodianChatEngine({
-      yes: true,
       surface: "cli",
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
       runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
         await prompter.text({ message: "Bot token", sensitive: true });
       },
@@ -168,7 +182,9 @@ describe("CrestodianChatEngine", () => {
   it("keeps hosted-wizard validation errors on the current prompt", async () => {
     useTempStateDir();
     const engine = new CrestodianChatEngine({
-      yes: true,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
       runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
         await prompter.text({
           message: "Port",
@@ -189,7 +205,9 @@ describe("CrestodianChatEngine", () => {
   it("cancels a hosted wizard mid-flight", async () => {
     useTempStateDir();
     const engine = new CrestodianChatEngine({
-      yes: true,
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
       runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
         await prompter.text({ message: "Bot token" });
       },
@@ -202,11 +220,104 @@ describe("CrestodianChatEngine", () => {
     expect(cancelled.text).toContain("cancelled");
   });
 
-  it("signals the agent handoff for talk to agent", async () => {
-    const engine = new CrestodianChatEngine({});
+  it("signals the agent handoff for talk to agent in deterministic mode", async () => {
+    const engine = new CrestodianChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: async () => null,
+      deps: { loadOverview: fakeOverviewLoader() },
+    });
     const reply = await engine.handle("talk to agent");
     expect(reply.action).toBe("open-tui");
     expect(reply.handoff?.kind).toBe("open-tui");
+  });
+
+  it("executes an open-tui directive from the agent loop", async () => {
+    const engine = new CrestodianChatEngine({
+      runAgentTurn: async () => ({
+        text: "Handing you over. *waves claw*",
+        directive: { kind: "open-tui" as const, agentId: "work" },
+      }),
+      deps: { loadOverview: fakeOverviewLoader() },
+    });
+    const reply = await engine.handle("I want to talk to my work agent now");
+    expect(reply.action).toBe("open-tui");
+    expect(reply.handoff).toMatchObject({ kind: "open-tui", agentId: "work" });
+    expect(reply.text).toContain("Handing you over");
+  });
+
+  it("starts the channel wizard from an agent-loop directive", async () => {
+    useTempStateDir();
+    const engine = new CrestodianChatEngine({
+      runAgentTurn: async () => ({
+        text: "Telegram it is — setup questions follow.",
+        directive: { kind: "channel-setup" as const, channel: "telegram" },
+      }),
+      deps: { loadOverview: fakeOverviewLoader() },
+      runChannelSetupWizard: async (_channel: string, prompter: WizardPrompter) => {
+        await prompter.text({ message: "Bot token" });
+      },
+    });
+    const reply = await engine.handle("hook me up with telegram please");
+    expect(reply.text).toContain("Telegram it is");
+    expect(reply.text).toContain("Bot token");
+  });
+
+  it("arms an agent turn when the classifier approves in the user's own words", async () => {
+    const armedFlags: boolean[] = [];
+    const runAgentTurn = vi.fn(
+      async (params: {
+        approvalArmed: boolean;
+        session: { proposalRef: { current?: string } };
+      }) => {
+        armedFlags.push(params.approvalArmed);
+        params.session.proposalRef.current = "op-hash";
+        return { text: "ok" };
+      },
+    );
+    const engine = new CrestodianChatEngine({
+      runAgentTurn: runAgentTurn as never,
+      classifyApproval: async ({ message }) =>
+        message.includes("sounds great") ? "approve" : "other",
+      deps: { loadOverview: fakeOverviewLoader() },
+    });
+
+    await engine.handle("switch me to gpt");
+    await engine.handle("that sounds great, please");
+
+    expect(armedFlags).toEqual([false, true]);
+  });
+
+  it("clears a stale host proposal once the agent loop owns the conversation", async () => {
+    const engine = new CrestodianChatEngine({
+      runAgentTurn: async () => ({ text: "loop reply" }),
+      classifyApproval: async () => "other",
+      deps: { loadOverview: fakeOverviewLoader() },
+    });
+    engine.propose({ kind: "config-set", path: "gateway.port", value: "19001" });
+
+    await engine.handle("actually, tell me about workspaces first");
+
+    // A later approval must arm the loop's own proposal, not the stale one.
+    expect(engine.hasPendingProposal()).toBe(false);
+  });
+
+  it("redacts sensitive config-set values from the AI-visible history", async () => {
+    const planner = vi.fn(async (_params: { history?: Array<{ role: string; text: string }> }) => ({
+      reply: "noted",
+    }));
+    const engine = new CrestodianChatEngine({
+      runAgentTurn: async () => null,
+      planWithAssistant: planner as never,
+      deps: { loadOverview: fakeOverviewLoader() },
+    });
+
+    await engine.handle("config set channels.telegram.botToken 123:very-secret");
+    await engine.handle("did that work?");
+
+    const history = planner.mock.calls.at(-1)?.[0]?.history ?? [];
+    const userTurns = history.filter((turn) => turn.role === "user").map((turn) => turn.text);
+    expect(userTurns.some((text) => text.includes("very-secret"))).toBe(false);
+    expect(userTurns.some((text) => text.includes("<redacted secret>"))).toBe(true);
   });
 
   it("prefers the real agent loop for fuzzy messages", async () => {
@@ -295,6 +406,7 @@ describe("CrestodianChatEngine", () => {
     const engine = new CrestodianChatEngine({
       runAgentTurn: async () => null,
       planWithAssistant: planner,
+      classifyApproval: async () => "other",
       deps: { loadOverview: fakeOverviewLoader() },
     });
     engine.propose({ kind: "config-set", path: "gateway.port", value: "19001" });
@@ -424,7 +536,12 @@ describe("Crestodian agent loop backends", () => {
     const call = runCliAgent.mock.calls[0][0];
     expect(call.provider).toBe("claude-cli");
     expect(call.model).toBe("claude-opus-4-8");
-    expect(call.crestodianTool).toEqual({ surface: "cli", approvalArmed: false, proposalRef: {} });
+    expect(call.crestodianTool).toEqual({
+      surface: "cli",
+      approvalArmed: false,
+      proposalRef: {},
+      directiveRef: {},
+    });
     // CLI harnesses reject toolsAllow; the restriction rides on the MCP config.
     expect(call.toolsAllow).toBeUndefined();
     expect(call.cliSessionId).toBeUndefined();
@@ -454,7 +571,12 @@ describe("Crestodian agent loop backends", () => {
     const call = runCliAgent.mock.calls[0][0];
     expect(call.provider).toBe("claude-cli");
     expect(call.model).toBe("claude-opus-4-8");
-    expect(call.crestodianTool).toEqual({ surface: "cli", approvalArmed: false, proposalRef: {} });
+    expect(call.crestodianTool).toEqual({
+      surface: "cli",
+      approvalArmed: false,
+      proposalRef: {},
+      directiveRef: {},
+    });
     const config = call.config as {
       agents?: { defaults?: { model?: { primary?: string } } };
     };
@@ -498,7 +620,12 @@ describe("Crestodian agent loop backends", () => {
     const call = runEmbeddedAgent.mock.calls[0][0];
     expect(call.toolsAllow).toEqual(["crestodian"]);
     expect(call.agentHarnessId).toBe("codex");
-    expect(call.crestodianTool).toEqual({ surface: "cli", approvalArmed: false, proposalRef: {} });
+    expect(call.crestodianTool).toEqual({
+      surface: "cli",
+      approvalArmed: false,
+      proposalRef: {},
+      directiveRef: {},
+    });
   });
 });
 
@@ -514,6 +641,7 @@ function fakeOverviewLoader(
       tools: {
         codex: { command: "codex", found: overrides.codexFound ?? false },
         claude: { command: "claude", found: overrides.claudeFound ?? false },
+        gemini: { command: "gemini", found: false },
         apiKeys: { openai: false, anthropic: false },
       },
       gateway: { url: "ws://127.0.0.1:18789", source: "local", reachable: false },

--- a/src/crestodian/chat-engine.test.ts
+++ b/src/crestodian/chat-engine.test.ts
@@ -302,6 +302,30 @@ describe("CrestodianChatEngine", () => {
     expect(engine.hasPendingProposal()).toBe(false);
   });
 
+  it("keeps an exact sensitive config set away from every model path", async () => {
+    useTempStateDir();
+    const runAgentTurn = vi.fn(async () => ({ text: "should never run" }));
+    const planner = vi.fn(async () => ({ reply: "should never run" }));
+    const runConfigSet = vi.fn(async () => {});
+    const engine = new CrestodianChatEngine({
+      runAgentTurn: runAgentTurn as never,
+      planWithAssistant: planner as never,
+      deps: { runConfigSet, loadOverview: fakeOverviewLoader() },
+    });
+
+    const proposed = await engine.handle("config set channels.telegram.botToken 123:very-secret");
+
+    expect(runAgentTurn).not.toHaveBeenCalled();
+    expect(planner).not.toHaveBeenCalled();
+    expect(proposed.text).toContain("<redacted>");
+    expect(proposed.text).not.toContain("very-secret");
+    expect(engine.hasPendingProposal()).toBe(true);
+
+    const applied = await engine.handle("yes");
+    expect(runConfigSet).toHaveBeenCalledOnce();
+    expect(applied.text).toContain("[crestodian] done: config.set");
+  });
+
   it("redacts sensitive config-set values from the AI-visible history", async () => {
     const planner = vi.fn(async (_params: { history?: Array<{ role: string; text: string }> }) => ({
       reply: "noted",
@@ -309,6 +333,7 @@ describe("CrestodianChatEngine", () => {
     const engine = new CrestodianChatEngine({
       runAgentTurn: async () => null,
       planWithAssistant: planner as never,
+      classifyApproval: async () => "other",
       deps: { loadOverview: fakeOverviewLoader() },
     });
 

--- a/src/crestodian/chat-engine.test.ts
+++ b/src/crestodian/chat-engine.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { runCrestodianAgentTurnWithDeps } from "./agent-turn.js";
+import { classifyCrestodianApprovalText } from "./approval-intent.js";
 import { CrestodianChatEngine } from "./chat-engine.js";
 
 const mocks = vi.hoisted(() => ({
@@ -92,7 +93,7 @@ describe("CrestodianChatEngine", () => {
     );
     const engine = new CrestodianChatEngine({
       runAgentTurn: runAgentTurn as never,
-      classifyApproval: async () => "other",
+      classifyApproval: async ({ message }) => classifyCrestodianApprovalText(message),
       deps: { loadOverview: fakeOverviewLoader() },
     });
 

--- a/src/crestodian/chat-engine.ts
+++ b/src/crestodian/chat-engine.ts
@@ -507,7 +507,7 @@ export class CrestodianChatEngine {
       return {
         text: loopReply.text,
         action: "open-tui",
-        handoff: { kind: "open-tui", ...loopReply.directive },
+        handoff: loopReply.directive,
       };
     }
     return { text: loopReply.text, action: "none" };

--- a/src/crestodian/chat-engine.ts
+++ b/src/crestodian/chat-engine.ts
@@ -1,4 +1,5 @@
 // Crestodian chat engine: transport-agnostic conversation over typed operations.
+import { isSensitiveConfigPath } from "../config/sensitive-paths.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { WizardSession, type WizardStep } from "../wizard/session.js";
 import {
@@ -8,8 +9,13 @@ import {
   type CrestodianAgentSession,
   type CrestodianAgentTurnRunner,
 } from "./agent-turn.js";
+import {
+  classifyCrestodianApprovalText,
+  type CrestodianApprovalClassifier,
+  type CrestodianApprovalIntent,
+} from "./approval-intent.js";
 import type { CrestodianAssistantPlanner, CrestodianAssistantTurn } from "./assistant.js";
-import { approvalQuestion, isYes } from "./dialogue.js";
+import { approvalQuestion } from "./dialogue.js";
 import {
   describeCrestodianPersistentOperation,
   executeCrestodianOperation,
@@ -25,13 +31,15 @@ import { loadCrestodianOverview, type CrestodianOverview } from "./overview.js";
  * and the gateway `crestodian.chat` RPC both drive this engine, so onboarding
  * behaves the same in a terminal and in the macOS app.
  *
- * Every free-form message is an AI turn: the custodian persona replies and may
- * propose exactly one typed command. The model never mutates anything — its
- * command re-parses through the same closed operation union, and persistent
- * operations still wait for the user's conversational "yes". Exact typed
- * commands, approvals, and hosted wizards resolve deterministically so the
- * conversation keeps working when no model is usable yet (fresh machine,
- * logged-out CLIs, broken config).
+ * The conversation is AI-only: every message is an AI turn (agent loop first,
+ * single-turn planner as fallback), and approval of pending mutations is
+ * judged from the user's own words by a host-run classifier — never by the
+ * conversation model itself, which cannot self-approve (see
+ * crestodian-tool.ts). The anchored typed-command grammar is not a chat
+ * feature: it only takes over when no model is usable at all (fresh machine,
+ * logged-out CLIs, broken config), so repair keeps working configless.
+ * Hosted wizards resolve deterministically because they are structured forms,
+ * not conversation.
  */
 export type CrestodianChatEngineOptions = {
   yes?: boolean;
@@ -39,6 +47,8 @@ export type CrestodianChatEngineOptions = {
   planWithAssistant?: CrestodianAssistantPlanner;
   /** Test seam for the embedded agent-loop turn runner. */
   runAgentTurn?: CrestodianAgentTurnRunner;
+  /** Test seam for the approval-intent classifier. */
+  classifyApproval?: CrestodianApprovalClassifier;
   /** Where side effects run; the gateway surface never manages its own daemon. */
   surface?: "cli" | "gateway";
   /** Test seam for the channel-setup wizard hosted by the chat bridge. */
@@ -164,10 +174,13 @@ function renderWizardStep(step: WizardStep): string {
 function parseWizardAnswer(step: WizardStep, text: string): { value: unknown } | null {
   const trimmed = text.trim();
   if (step.type === "confirm") {
-    if (isYes(trimmed)) {
+    // Wizard confirms are structured form fields, so the closed-list
+    // classifier decides; ambiguous answers re-render the prompt.
+    const intent = classifyCrestodianApprovalText(trimmed);
+    if (intent === "approve") {
       return { value: true };
     }
-    if (/^(n|no|nope|skip)$/i.test(trimmed)) {
+    if (intent === "decline") {
       return { value: false };
     }
     return null;
@@ -214,11 +227,22 @@ function parseWizardAnswer(step: WizardStep, text: string): { value: unknown } |
   return { value: step.type === "action" ? true : undefined };
 }
 
-const DECLINE_RE = /^(n|no|nope|skip|not now|cancel|later)\b/i;
-
 function formatOperationError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return `That did not go through: ${message}`;
+}
+
+/**
+ * A typed `config set` against a sensitive path carries a raw secret; the
+ * stored history feeds future planner prompts (and CLI-harness transcripts),
+ * so the value is masked the same way hosted-wizard secrets are.
+ */
+function redactSensitiveCommandText(text: string): string {
+  const operation = parseCrestodianOperation(text);
+  if (operation.kind === "config-set" && isSensitiveConfigPath(operation.path)) {
+    return `config set ${operation.path} <redacted secret>`;
+  }
+  return text;
 }
 
 /**
@@ -248,12 +272,15 @@ export class CrestodianChatEngine {
   private wizardBridge: ActiveWizardBridge | null = null;
   private readonly history: CrestodianAssistantTurn[] = [];
   private readonly agentSession: CrestodianAgentSession = createCrestodianAgentSession();
+  /** Turns run strictly one at a time; interleaved handles corrupt wizard/pending state. */
+  private turnQueue: Promise<unknown> = Promise.resolve();
 
   constructor(private readonly opts: CrestodianChatEngineOptions = {}) {}
 
   /**
-   * Seed a proposed operation that a bare "yes" will apply. Used by first-run
-   * onboarding: the welcome message states the plan, the user just agrees.
+   * Seed a proposed operation that the user's next approval will apply. Used
+   * by first-run onboarding: the welcome message states the plan, the user
+   * just agrees.
    */
   propose(operation: CrestodianOperation): string {
     this.clearPendingProposals();
@@ -277,11 +304,21 @@ export class CrestodianChatEngine {
   }
 
   async handle(text: string): Promise<CrestodianChatReply> {
+    const turn = this.turnQueue.then(() => this.handleSerialized(text));
+    // The queue must survive a failed turn or every later message would reject.
+    this.turnQueue = turn.catch(() => undefined);
+    return await turn;
+  }
+
+  private async handleSerialized(text: string): Promise<CrestodianChatReply> {
     // Snapshot before resolving: wizard answers to sensitive steps (tokens,
     // passwords) must never enter the AI-visible history.
     const sensitiveTurn = this.wizardBridge?.step?.sensitive === true;
     const reply = await this.resolveTurn(text);
-    this.history.push({ role: "user", text: sensitiveTurn ? "<redacted secret>" : text });
+    this.history.push({
+      role: "user",
+      text: sensitiveTurn ? "<redacted secret>" : redactSensitiveCommandText(text),
+    });
     if (reply.text) {
       this.history.push({ role: "assistant", text: reply.text });
     }
@@ -296,67 +333,93 @@ export class CrestodianChatEngine {
       // A hosted wizard consumes every reply until it finishes or is cancelled.
       return { text: await this.resolveWizardBridgeReply(text), action: "none" };
     }
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return {
+        text: "Tiny claw tap: tell me what you want — setup, repair, channels, anything config.",
+        action: "none",
+      };
+    }
+    if (/^(quit|exit)$/i.test(trimmed)) {
+      // Leaving the process is a host action, not a conversation the AI owns.
+      return { text: "Crestodian retracts into shell. Bye.", action: "exit" };
+    }
+
+    // Approval is judged from the user's own words, host-side. The classifier
+    // only runs while a proposal is pending, and "other" (questions, new
+    // requests) keeps the proposal pending and lets the AI carry on.
+    const intent = await this.classifyApprovalIntent(text);
     if (this.pending) {
-      // Approval is deterministic: "yes" applies, a clear "no" drops the
-      // proposal. Anything else goes to the AI with the proposal kept pending,
-      // so questions ("what's a workspace?") don't silently cancel setup.
-      if (isYes(text)) {
-        const pending = this.pending;
-        this.clearPendingProposals();
-        if (pending.kind === "channel-setup") {
-          return { text: await this.startChannelSetupWizard(pending.channel), action: "none" };
-        }
-        const capture = createCaptureRuntime();
-        let applied = false;
-        try {
-          const result = await executeCrestodianOperation(pending, capture, {
-            approved: true,
-            deps: this.commandDeps(),
-          });
-          applied = result.applied;
-        } catch (error) {
-          capture.error(formatOperationError(error));
-        }
-        const verify = applied ? await this.verifyConfigAfterWrite() : null;
-        return {
-          text: [capture.read() || "Applied. Audit entry written.", verify]
-            .filter(Boolean)
-            .join("\n\n"),
-          action: "none",
-        };
+      if (intent === "approve") {
+        return await this.applyPendingProposal();
       }
-      if (DECLINE_RE.test(text.trim())) {
+      if (intent === "decline") {
         this.clearPendingProposals();
         return { text: "Skipped. No barnacles on config today.", action: "none" };
       }
     }
-
-    if (DECLINE_RE.test(text.trim()) && this.agentSession.proposalRef.current) {
-      this.clearPendingProposals();
-      return { text: "Skipped. No barnacles on config today.", action: "none" };
+    if (intent === "decline") {
+      // A declined agent-loop proposal must never stay armable: void the
+      // registered hash now and let the AI acknowledge conversationally.
+      this.agentSession.proposalRef.current = undefined;
     }
 
-    // Exact typed commands run deterministically (instant, no model); strict
-    // grammar keeps anything conversational flowing to the AI custodian.
-    const direct = parseCrestodianOperation(text, { strict: true });
-    if (direct.kind !== "none") {
-      return await this.runOperation(direct, undefined);
-    }
-    if (!text.trim()) {
-      return { text: direct.message, action: "none" };
-    }
-    if (/^(quit|exit)$/i.test(text.trim())) {
-      return { text: "Crestodian retracts into shell. Bye.", action: "exit" };
-    }
+    return await this.resolveAssistantTurn(text, intent === "approve");
+  }
 
-    return await this.resolveAssistantTurn(text);
+  private async classifyApprovalIntent(text: string): Promise<CrestodianApprovalIntent> {
+    const hasProposal =
+      this.pending !== null || this.agentSession.proposalRef.current !== undefined;
+    if (!hasProposal) {
+      return "other";
+    }
+    const classify =
+      this.opts.classifyApproval ??
+      (await import("./approval-intent.js")).classifyCrestodianApprovalIntent;
+    return await classify({
+      message: text,
+      ...(this.pending ? { proposal: describeCrestodianPersistentOperation(this.pending) } : {}),
+    });
+  }
+
+  private async applyPendingProposal(): Promise<CrestodianChatReply> {
+    const pending = this.pending;
+    this.clearPendingProposals();
+    if (!pending) {
+      return { text: "", action: "none" };
+    }
+    if (pending.kind === "channel-setup") {
+      return { text: await this.startChannelSetupWizard(pending.channel), action: "none" };
+    }
+    const capture = createCaptureRuntime();
+    let applied = false;
+    try {
+      const result = await executeCrestodianOperation(pending, capture, {
+        approved: true,
+        deps: this.commandDeps(),
+      });
+      applied = result.applied;
+    } catch (error) {
+      capture.error(formatOperationError(error));
+    }
+    const verify = applied ? await this.verifyConfigAfterWrite() : null;
+    return {
+      text: [capture.read() || "Applied. Audit entry written.", verify]
+        .filter(Boolean)
+        .join("\n\n"),
+      action: "none",
+    };
   }
 
   /**
-   * AI turn: the custodian persona answers and may propose one typed command.
-   * Falls back to deterministic guidance when no model backend is usable.
+   * AI turn: the custodian persona answers and acts through the ring-zero
+   * tool. Falls back to the single-turn planner, then to the anchored typed
+   * grammar when no model backend is usable at all.
    */
-  private async resolveAssistantTurn(text: string): Promise<CrestodianChatReply> {
+  private async resolveAssistantTurn(
+    text: string,
+    approvalArmed: boolean,
+  ): Promise<CrestodianChatReply> {
     const overview = await this.loadOverview();
 
     // Preferred path: the real agent loop (embedded runtime, ring-zero tool,
@@ -366,19 +429,27 @@ export class CrestodianChatEngine {
     try {
       const loopReply = await withDeadline(
         agentTurn({
-          input: text,
+          input: this.pending
+            ? // Hand a host-seeded proposal (onboarding welcome) to the loop so
+              // the conversation can reshape it through the tool handshake.
+              `[pending-proposal] Awaiting the user's approval: ${describeCrestodianPersistentOperation(this.pending)}. If they want it (or a variant), drive it through the crestodian tool yourself.\n${text}`
+            : text,
           overview,
           surface: this.opts.surface ?? "cli",
-          // Mutations unlock only on an explicit user approval in this exact
-          // message; the model cannot self-approve (see crestodian-tool.ts).
-          approvalArmed: isYes(text),
+          // Mutations unlock only on host-verified approval of THIS message;
+          // the model cannot self-approve (see crestodian-tool.ts).
+          approvalArmed,
           session: this.agentSession,
         }).catch(() => null),
         null,
         AGENT_TURN_DEADLINE_MS,
       );
       if (loopReply?.text) {
-        return { text: loopReply.text, action: "none" };
+        // The loop owns the conversation now. A stale engine-side proposal
+        // must not survive it, or a later approval could apply an operation
+        // the user was no longer looking at.
+        this.pending = null;
+        return await this.applyAgentTurnReply(loopReply);
       }
     } catch {
       // Fall through to the single-turn planner.
@@ -399,13 +470,7 @@ export class CrestodianChatEngine {
       ASSISTANT_TURN_DEADLINE_MS,
     ).catch(() => null);
     if (!plan) {
-      return {
-        text: [
-          "I could not reach a model for that (deterministic mode).",
-          "I can run doctor/status/health, check or restart Gateway, list agents/models, set default model, connect channels (`connect telegram`), show audit, or switch to your agent TUI.",
-        ].join("\n"),
-        action: "none",
-      };
+      return this.resolveDeterministicTurn(text);
     }
 
     const replyText = plan.reply ?? "";
@@ -418,12 +483,52 @@ export class CrestodianChatEngine {
       return { text: replyText || "…", action: "none" };
     }
     // Security contract: surface the interpreted command and model before
-    // anything runs (docs/cli/crestodian.md, Model-Assisted Planner).
+    // anything runs (docs/cli/crestodian.md, AI conversation).
     const provenance = `(${plan.modelLabel ?? "model"} → \`${plan.command}\`)`;
     const executed = await this.runOperation(operation, provenance);
     return {
       ...executed,
       text: [replyText, executed.text].filter(Boolean).join("\n\n"),
+    };
+  }
+
+  private async applyAgentTurnReply(loopReply: {
+    text: string;
+    directive?: import("./agent-turn.js").CrestodianAgentTurnDirective;
+  }): Promise<CrestodianChatReply> {
+    if (loopReply.directive?.kind === "channel-setup") {
+      const wizardIntro = await this.startChannelSetupWizard(loopReply.directive.channel);
+      return {
+        text: [loopReply.text, wizardIntro].filter(Boolean).join("\n\n"),
+        action: "none",
+      };
+    }
+    if (loopReply.directive?.kind === "open-tui") {
+      return {
+        text: loopReply.text,
+        action: "open-tui",
+        handoff: { kind: "open-tui", ...loopReply.directive },
+      };
+    }
+    return { text: loopReply.text, action: "none" };
+  }
+
+  /**
+   * Last resort with zero usable models: the anchored typed grammar keeps
+   * setup/repair working on a fresh or broken machine (docs/cli/crestodian.md,
+   * configless contract). This is never reached while any model answers.
+   */
+  private async resolveDeterministicTurn(text: string): Promise<CrestodianChatReply> {
+    const direct = parseCrestodianOperation(text);
+    if (direct.kind !== "none") {
+      return await this.runOperation(direct, undefined);
+    }
+    return {
+      text: [
+        "I could not reach a model for that (deterministic mode).",
+        "I can run doctor/status/health, check or restart Gateway, list agents/models, set default model, connect channels (`connect telegram`), show audit, or switch to your agent TUI.",
+      ].join("\n"),
+      action: "none",
     };
   }
 
@@ -439,7 +544,9 @@ export class CrestodianChatEngine {
       };
     }
 
-    if (operation.kind === "channel-setup" && this.opts.yes) {
+    if (operation.kind === "channel-setup") {
+      // Starting the wizard is not a write; the wizard collects explicit
+      // answers and commits only at the end.
       return { text: await this.startChannelSetupWizard(operation.channel), action: "none" };
     }
 
@@ -509,6 +616,7 @@ export class CrestodianChatEngine {
     const notice = `⚠ openclaw.json failed validation after that write:\n${issuesText}`;
     const recovery = await this.resolveAssistantTurn(
       `[config-verify] The config file is now invalid:\n${issuesText}\nPropose one corrective command from the allowed list.`,
+      false,
     );
     if (!recovery.text || recovery.text.includes("deterministic mode")) {
       return `${notice}\nSay \`doctor fix\` to repair it, or \`config schema <path>\` to check the expected shape.`;

--- a/src/crestodian/chat-engine.ts
+++ b/src/crestodian/chat-engine.ts
@@ -345,6 +345,14 @@ export class CrestodianChatEngine {
       return { text: "Crestodian retracts into shell. Bye.", action: "exit" };
     }
 
+    // Secret hygiene: an exact `config set` on a sensitive path carries a raw
+    // token and must never reach a model. It runs on the deterministic path
+    // (redacted proposal + approval), matching the wizard's masked-input rules.
+    const typed = parseCrestodianOperation(text);
+    if (typed.kind === "config-set" && isSensitiveConfigPath(typed.path)) {
+      return await this.runOperation(typed, undefined);
+    }
+
     // Approval is judged from the user's own words, host-side. The classifier
     // only runs while a proposal is pending, and "other" (questions, new
     // requests) keeps the proposal pending and lets the AI carry on.

--- a/src/crestodian/crestodian.test.ts
+++ b/src/crestodian/crestodian.test.ts
@@ -12,6 +12,7 @@ const overview: CrestodianOverview = {
   tools: {
     codex: { command: "codex", found: false, error: "not found" },
     claude: { command: "claude", found: false, error: "not found" },
+    gemini: { command: "gemini", found: false, error: "not found" },
     apiKeys: { openai: true, anthropic: false },
   },
   gateway: {

--- a/src/crestodian/dialogue.ts
+++ b/src/crestodian/dialogue.ts
@@ -24,11 +24,6 @@ export function approvalQuestion(operation: CrestodianOperation): string {
   return `Apply this operation: ${describeCrestodianPersistentOperation(operation)}?`;
 }
 
-/** Parse affirmative approval text accepted by the interactive dialogue. */
-export function isYes(input: string): boolean {
-  return /^(y|yes|apply|do it|approved?)$/i.test(input.trim());
-}
-
 /** Resolve user input to a Crestodian operation, optionally using the assistant planner. */
 export async function resolveCrestodianOperation(
   input: string,

--- a/src/crestodian/operations.test.ts
+++ b/src/crestodian/operations.test.ts
@@ -154,6 +154,7 @@ vi.mock("./overview.js", () => ({
     tools: {
       codex: { command: "codex", found: false, error: "not found" },
       claude: { command: "claude", found: false, error: "not found" },
+      gemini: { command: "gemini", found: false, error: "not found" },
       apiKeys: { openai: true, anthropic: false },
     },
     gateway: {
@@ -238,8 +239,14 @@ describe("parseCrestodianOperation", () => {
     });
   });
 
-  it("keeps ambiguous model requests read-only", () => {
-    expect(parseCrestodianOperation("models please")).toEqual({ kind: "models" });
+  it("routes ambiguous model requests to the AI instead of guessing", () => {
+    expect(parseCrestodianOperation("models please").kind).toBe("none");
+    expect(parseCrestodianOperation("why did my gateway stop").kind).toBe("none");
+    expect(parseCrestodianOperation("should I talk to my agent about this?").kind).toBe("none");
+    expect(parseCrestodianOperation("set me up with telegram").kind).toBe("none");
+    expect(parseCrestodianOperation("can I set the default model gpt-5.5 later?").kind).toBe(
+      "none",
+    );
   });
 
   it("parses gateway lifecycle operations", () => {
@@ -350,9 +357,9 @@ describe("parseCrestodianOperation", () => {
       kind: "channel-setup",
       channel: "discord",
     });
-    // Channel setup is persistent: it writes channel config after the wizard.
+    // Starting the wizard is not a write; the wizard collects explicit answers.
     expect(isPersistentCrestodianOperation({ kind: "channel-setup", channel: "telegram" })).toBe(
-      true,
+      false,
     );
     expect(isPersistentCrestodianOperation({ kind: "channel-list" })).toBe(false);
   });
@@ -518,7 +525,6 @@ describe("parseCrestodianOperation", () => {
     expect(runPluginsSearch).toHaveBeenCalledWith("calendar", runtime);
     expect(lines.join("\n")).toContain("plugin rows");
     expect(lines.join("\n")).toContain("search rows: calendar");
-    expect(lines.join("\n")).toContain("[crestodian] done: plugins.search");
   });
 
   it("installs plugins only after approval and audits the write", async () => {

--- a/src/crestodian/operations.ts
+++ b/src/crestodian/operations.ts
@@ -17,6 +17,12 @@ import type { CrestodianOverview } from "./overview.js";
 /**
  * Crestodian command parser and operation executor.
  *
+ * The grammar is a single anchored command language: every pattern must match
+ * the whole input. Natural language never parses into an operation — it flows
+ * to the AI custodian instead (chat) or to the planner (one-shot). This is a
+ * security property, not a convenience: unanchored keyword matching used to
+ * turn questions like "why did my gateway stop" into mutation proposals.
+ *
  * Persistent operations require explicit approval, write audit records, and
  * lazy-load heavy CLI modules only when the selected operation needs them.
  */
@@ -27,9 +33,6 @@ type CrestodianOverviewFormatter = (overview: CrestodianOverview) => string;
 
 const loadConfigModule = async () => await import("../config/config.js");
 const loadOverviewModule = async () => await import("./overview.js");
-const loadModelsSharedModule = async () => await import("../commands/models/shared.js");
-const loadConfigCliModule = async () => await import("../cli/config-cli.js");
-const loadDoctorModule = async () => await import("../commands/doctor.js");
 
 /** Parsed Crestodian operation before approval/execution. */
 export type CrestodianOperation =
@@ -116,32 +119,56 @@ export type CrestodianCommandDeps = {
   applySetup?: typeof import("./setup-apply.js").applyCrestodianSetup;
 };
 
-const SET_MODEL_RE = /(?:set|configure|use)\s+(?:the\s+)?(?:default\s+)?model\s+(.+)/i;
-const CONFIGURE_MODELS_RE = /(?:set|configure|use)\s+models?\s+(?<model>\S+)/i;
-const CREATE_AGENT_RE =
-  /(?:create|add|setup|set\s+up)\s+(?:(?:an?|new|my)\s+)?agent\s+(?<agent>[a-z0-9_-]+)/i;
-const TALK_AGENT_RE =
-  /(?:talk\s+to|switch\s+to|open|enter)\s+(?:(?:my|the)\s+)?(?:(?<agent>[a-z0-9_-]+)\s+)?agent/i;
-const WORKSPACE_RE = /(?:workspace|workdir|cwd|for|in)\s+(?<workspace>"[^"]+"|'[^']+'|\S+)/i;
-const MODEL_RE = /\bmodel\s+(?<model>\S+)/i;
-const CONFIG_SET_RE =
-  /^(?:config\s+set|set\s+config)\s+(?<path>[A-Za-z0-9_.[\]-]+)\s+(?<value>.+)$/i;
-const CONFIG_GET_RE = /^config\s+get\s+(?<path>[A-Za-z0-9_.[\]-]+)$/i;
-const CONFIG_SCHEMA_RE = /^config\s+schema(?:\s+(?<path>[A-Za-z0-9_.[\]-]+))?$/i;
-const CONFIG_SET_REF_RE =
-  /^(?:config\s+set-ref|set\s+secretref|set\s+secret\s+ref)\s+(?<path>[A-Za-z0-9_.[\]-]+)\s+(?:(?<source>env|file|exec)\s+)?(?<id>\S+)(?:\s+provider\s+(?<provider>[A-Za-z0-9_-]+))?$/i;
-const SETUP_RE =
-  /^(?:setup(?!\s+agent\b)|set\s+me\s+up|set\s+up\s+openclaw|onboard|onboard\s+me|bootstrap|first\s+run)(?:\b|$)/i;
-const PLUGIN_LIST_RE = /^(?:plugins?|clawhub)\s+list$|^list\s+plugins?$/i;
+// Grammar tokens. Workspace/path tokens accept quoted strings so paths with
+// spaces survive; model refs and ids stay single tokens.
+const TOKEN = String.raw`(?:"[^"]+"|'[^']+'|\S+)`;
+const CONFIG_PATH = String.raw`[A-Za-z0-9_.[\]-]+`;
+
+// Every command pattern is anchored to the whole input. Optional clauses use a
+// fixed order (workspace before model) so filler words never become values.
+const CONFIG_SET_RE = new RegExp(
+  String.raw`^(?:config\s+set|set\s+config)\s+(?<path>${CONFIG_PATH})\s+(?<value>.+)$`,
+  "i",
+);
+const CONFIG_GET_RE = new RegExp(String.raw`^config\s+get\s+(?<path>${CONFIG_PATH})$`, "i");
+const CONFIG_SCHEMA_RE = new RegExp(
+  String.raw`^config\s+schema(?:\s+(?<path>${CONFIG_PATH}))?$`,
+  "i",
+);
+const CONFIG_SET_REF_RE = new RegExp(
+  String.raw`^(?:config\s+set-ref|set\s+secretref|set\s+secret\s+ref)\s+(?<path>${CONFIG_PATH})\s+(?:(?<source>env|file|exec)\s+)?(?<id>\S+)(?:\s+provider\s+(?<provider>[A-Za-z0-9_-]+))?$`,
+  "i",
+);
+const SETUP_RE = new RegExp(
+  String.raw`^(?:setup|set\s+me\s+up|set\s+up\s+openclaw|onboard(?:\s+me)?|bootstrap|first\s+run)(?:\s+workspace\s+(?<workspace>${TOKEN}))?(?:\s+model\s+(?<model>\S+))?$`,
+  "i",
+);
+const CREATE_AGENT_RE = new RegExp(
+  String.raw`^(?:create|add|set\s*up|new)\s+(?:(?:an?|new|my)\s+)?agent\s+(?<agent>[a-z0-9_-]+)(?:\s+workspace\s+(?<workspace>${TOKEN}))?(?:\s+model\s+(?<model>\S+))?$`,
+  "i",
+);
+// "talk to agent for ~/Projects/work" is a documented selector; "for|in" are
+// only valid here, after the literal word "agent", never as generic fillers.
+const TALK_AGENT_RE = new RegExp(
+  String.raw`^(?:talk\s+to|switch\s+to|open|enter)\s+(?:(?:my|the)\s+)?(?:(?<agent>[a-z0-9_-]+)\s+)?agent(?:\s+(?:for|in|workspace)\s+(?<workspace>${TOKEN}))?$`,
+  "i",
+);
+const SET_MODEL_RE = /^(?:set|configure|use)\s+(?:the\s+)?(?:default\s+)?models?\s+(?<model>\S+)$/i;
+const GATEWAY_RE =
+  /^(?:gateway\s+(?<sub>status|start|stop|restart)|(?<verb>start|stop|restart)\s+(?:the\s+)?gateway)$/i;
+const PLUGIN_LIST_RE = /^(?:(?:plugins?|clawhub)\s+list|list\s+plugins?)$/i;
 const PLUGIN_SEARCH_RE =
   /^(?:(?:plugins?|clawhub)\s+search|search\s+plugins?(?:\s+for)?)\s+(?<query>.+)$/i;
 const PLUGIN_INSTALL_RE =
-  /^(?:(?:plugins?)\s+install|install\s+(?:(?<source>npm|clawhub)\s+)?plugins?)\s+(?<spec>\S+)$/i;
+  /^(?:plugins?\s+install|install\s+(?:(?<source>npm|clawhub)\s+)?plugins?)\s+(?<spec>\S+)$/i;
 const PLUGIN_UNINSTALL_RE =
-  /^(?:(?:plugins?)\s+(?:uninstall|remove)|(?:uninstall|remove)\s+plugins?)\s+(?<pluginId>[A-Za-z0-9_.@/-]+)$/i;
+  /^(?:plugins?\s+(?:uninstall|remove)|(?:uninstall|remove)\s+plugins?)\s+(?<pluginId>[A-Za-z0-9_.@/-]+)$/i;
 const CHANNEL_LIST_RE = /^(?:channels|list\s+channels|show\s+channels)$/i;
 const CHANNEL_CONNECT_RE =
   /^(?:connect|link)\s+(?:channel\s+)?(?:to\s+)?(?<channel>[a-z0-9_-]+)(?:\s+channel)?$/i;
+
+const NO_MATCH_MESSAGE =
+  "I can run doctor/status/health, check or restart Gateway, list agents/models, set default model, connect channels (`connect telegram`), show audit, or switch to your agent TUI.";
 
 /** Audit/source labels for detected inference backends (docs-visible contract). */
 const INFERENCE_SOURCE_LABELS: Record<InferenceBackendKind, string> = {
@@ -154,17 +181,11 @@ const INFERENCE_SOURCE_LABELS: Record<InferenceBackendKind, string> = {
 };
 
 /**
- * Parse one user command into Crestodian's closed operation union.
- *
- * strict mode (AI-first chat) only matches exact command grammar so natural
- * language flows to the assistant; loose mode (one-shot CLI, rescue) keeps the
- * forgiving keyword heuristics.
+ * Parse one user command into Crestodian's closed operation union. Anything
+ * that does not match the anchored grammar exactly returns kind "none" so the
+ * caller can route it to the AI custodian (or show guidance).
  */
-export function parseCrestodianOperation(
-  input: string,
-  opts: { strict?: boolean } = {},
-): CrestodianOperation {
-  const strict = opts.strict === true;
+export function parseCrestodianOperation(input: string): CrestodianOperation {
   const trimmed = input.trim();
   const lower = trimmed.toLowerCase();
   if (!trimmed) {
@@ -176,8 +197,38 @@ export function parseCrestodianOperation(
   if (["help", "?", "overview", "system"].includes(lower)) {
     return { kind: "overview" };
   }
-  if (lower === "audit" || (!strict && lower.includes("audit log"))) {
-    return { kind: "audit" };
+  switch (lower) {
+    case "audit":
+    case "audit log":
+    case "show audit":
+      return { kind: "audit" };
+    case "status":
+      return { kind: "status" };
+    case "health":
+      return { kind: "health" };
+    case "doctor":
+      return { kind: "doctor" };
+    case "doctor fix":
+    case "doctor repair":
+      return { kind: "doctor-fix" };
+    case "config validate":
+    case "validate config":
+      return { kind: "config-validate" };
+    case "agents":
+    case "list agents":
+      return { kind: "agents" };
+    case "models":
+    case "list models":
+      return { kind: "models" };
+    case "tui":
+    case "open tui":
+    case "chat":
+      return { kind: "open-tui" };
+    case "quit":
+    case "exit":
+      return { kind: "none", message: "Crestodian retracts into shell. Bye." };
+    default:
+      break;
   }
   const configSetRefMatch = trimmed.match(CONFIG_SET_REF_RE);
   if (configSetRefMatch?.groups?.path && configSetRefMatch.groups.id?.trim()) {
@@ -208,13 +259,6 @@ export function parseCrestodianOperation(
     const path = configSchemaMatch.groups?.path?.trim();
     return { kind: "config-schema", ...(path ? { path } : {}) };
   }
-  if (
-    lower === "config validate" ||
-    lower === "validate config" ||
-    lower.includes("validate config")
-  ) {
-    return { kind: "config-validate" };
-  }
   if (PLUGIN_LIST_RE.test(trimmed)) {
     return { kind: "plugin-list" };
   }
@@ -243,97 +287,55 @@ export function parseCrestodianOperation(
   if (channelConnectMatch?.groups?.channel) {
     return { kind: "channel-setup", channel: channelConnectMatch.groups.channel.toLowerCase() };
   }
-  if (SETUP_RE.test(lower)) {
-    const workspace = trimShellishToken(trimmed.match(WORKSPACE_RE)?.groups?.workspace);
-    const model = trimmed.match(MODEL_RE)?.groups?.model;
+  const setupMatch = trimmed.match(SETUP_RE);
+  if (setupMatch) {
+    const workspace = trimShellishToken(setupMatch.groups?.workspace);
+    const model = setupMatch.groups?.model;
     return {
       kind: "setup",
       ...(workspace ? { workspace } : {}),
       ...(model ? { model } : {}),
     };
   }
-  if (strict ? lower === "doctor" || lower === "doctor fix" : lower.includes("doctor")) {
-    if (lower.includes("fix") || lower.includes("repair")) {
-      return { kind: "doctor-fix" };
-    }
-    return { kind: "doctor" };
-  }
-  if (strict ? lower === "health" : lower.includes("health")) {
-    return { kind: "health" };
-  }
-  if (
-    strict
-      ? /^(?:gateway\s+(?:status|start|stop|restart)|(?:start|stop|restart)\s+(?:the\s+)?gateway)$/.test(
-          lower,
-        )
-      : lower.includes("gateway")
-  ) {
-    if (lower.includes("restart")) {
-      return { kind: "gateway-restart" };
-    }
-    if (lower.includes("start")) {
+  const gatewayMatch = trimmed.match(GATEWAY_RE);
+  if (gatewayMatch) {
+    const action = (gatewayMatch.groups?.sub ?? gatewayMatch.groups?.verb ?? "").toLowerCase();
+    if (action === "start") {
       return { kind: "gateway-start" };
     }
-    if (lower.includes("stop")) {
+    if (action === "stop") {
       return { kind: "gateway-stop" };
+    }
+    if (action === "restart") {
+      return { kind: "gateway-restart" };
     }
     return { kind: "gateway-status" };
   }
-  if (strict ? lower === "status" : lower.includes("status")) {
-    return { kind: "status" };
+  const createMatch = trimmed.match(CREATE_AGENT_RE);
+  if (createMatch?.groups?.agent) {
+    const workspace = trimShellishToken(createMatch.groups.workspace);
+    const model = createMatch.groups.model;
+    return {
+      kind: "create-agent",
+      agentId: normalizeAgentId(createMatch.groups.agent),
+      ...(workspace ? { workspace } : {}),
+      ...(model ? { model } : {}),
+    };
   }
-  if (
-    strict
-      ? lower === "agents" || CREATE_AGENT_RE.test(trimmed) || TALK_AGENT_RE.test(trimmed)
-      : lower.includes("agent")
-  ) {
-    // Creation is checked before "talk to agent" because setup phrasing can contain both words.
-    const createMatch = trimmed.match(CREATE_AGENT_RE);
-    if (createMatch?.groups?.agent) {
-      const workspace = trimShellishToken(trimmed.match(WORKSPACE_RE)?.groups?.workspace);
-      const model = trimmed.match(MODEL_RE)?.groups?.model;
-      return {
-        kind: "create-agent",
-        agentId: normalizeAgentId(createMatch.groups.agent),
-        ...(workspace ? { workspace } : {}),
-        ...(model ? { model } : {}),
-      };
-    }
-    const talkMatch = trimmed.match(TALK_AGENT_RE);
-    if (talkMatch) {
-      const workspace = trimShellishToken(trimmed.match(WORKSPACE_RE)?.groups?.workspace);
-      return {
-        kind: "open-tui",
-        agentId: talkMatch.groups?.agent,
-        ...(workspace ? { workspace } : {}),
-      };
-    }
-    return { kind: "agents" };
+  const talkMatch = trimmed.match(TALK_AGENT_RE);
+  if (talkMatch) {
+    const workspace = trimShellishToken(talkMatch.groups?.workspace);
+    return {
+      kind: "open-tui",
+      ...(talkMatch.groups?.agent ? { agentId: talkMatch.groups.agent } : {}),
+      ...(workspace ? { workspace } : {}),
+    };
   }
-  if (strict ? lower === "models" || SET_MODEL_RE.test(trimmed) : lower.includes("model")) {
-    const match = trimmed.match(SET_MODEL_RE);
-    const pluralMatch = trimmed.match(CONFIGURE_MODELS_RE);
-    const model = match?.[1]?.trim() ?? pluralMatch?.groups?.model?.trim();
-    if (model) {
-      return { kind: "set-default-model", model };
-    }
-    return { kind: "models" };
+  const setModelMatch = trimmed.match(SET_MODEL_RE);
+  if (setModelMatch?.groups?.model) {
+    return { kind: "set-default-model", model: setModelMatch.groups.model };
   }
-  if (
-    strict
-      ? lower === "tui" || lower === "open tui"
-      : lower === "tui" || lower.includes("open tui") || lower.includes("chat")
-  ) {
-    return { kind: "open-tui" };
-  }
-  if (lower === "quit" || lower === "exit") {
-    return { kind: "none", message: "Crestodian retracts into shell. Bye." };
-  }
-  return {
-    kind: "none",
-    message:
-      "I can run doctor/status/health, check or restart Gateway, list agents/models, set default model, connect channels (`connect telegram`), show audit, or switch to your agent TUI.",
-  };
+  return { kind: "none", message: NO_MATCH_MESSAGE };
 }
 
 function trimShellishToken(value: string | undefined): string | undefined {
@@ -377,14 +379,17 @@ function validateCrestodianPluginInstallSpec(spec: string): string | null {
   return null;
 }
 
-/** Return whether an operation can change local state or process lifecycle. */
+/**
+ * Return whether an operation can change local state or process lifecycle.
+ * channel-setup is intentionally absent: starting the guided wizard is not a
+ * write — the wizard itself collects explicit answers and commits at the end.
+ */
 export function isPersistentCrestodianOperation(operation: CrestodianOperation): boolean {
   return (
     operation.kind === "set-default-model" ||
     operation.kind === "config-set" ||
     operation.kind === "config-set-ref" ||
     operation.kind === "setup" ||
-    operation.kind === "channel-setup" ||
     operation.kind === "doctor-fix" ||
     operation.kind === "plugin-install" ||
     operation.kind === "plugin-uninstall" ||
@@ -406,8 +411,6 @@ export function describeCrestodianPersistentOperation(operation: CrestodianOpera
       return `set config ${operation.path} to ${operation.source} SecretRef ${operation.source === "env" ? operation.id : "<redacted>"}`;
     case "setup":
       return formatSetupPlanDescription(operation);
-    case "channel-setup":
-      return `walk through connecting the ${operation.channel} channel`;
     case "doctor-fix":
       return "run doctor repairs";
     case "plugin-install":
@@ -520,11 +523,6 @@ async function chooseSetupModel(params: {
   return { model: detected.modelRef, source: INFERENCE_SOURCE_LABELS[detected.kind] };
 }
 
-function logQueued(runtime: RuntimeEnv, operation: string): void {
-  runtime.log(`[crestodian] queued: ${operation}`);
-  runtime.log(`[crestodian] running: ${operation}`);
-}
-
 function formatGatewayStatusLine(overview: CrestodianOverview): string {
   return [
     `Gateway: ${overview.gateway.reachable ? "reachable" : "not reachable"}`,
@@ -562,25 +560,6 @@ async function loadOverviewForOperation(
   }
   const { loadCrestodianOverview } = await loadOverviewModule();
   return await loadCrestodianOverview();
-}
-
-async function formatOverviewForOperation(
-  overview: CrestodianOverview,
-  deps: CrestodianCommandDeps | undefined,
-): Promise<string> {
-  if (deps?.formatOverview) {
-    return deps.formatOverview(overview);
-  }
-  const { formatCrestodianOverview } = await loadOverviewModule();
-  return formatCrestodianOverview(overview);
-}
-
-async function loadConfigFileMutationHelpers(): Promise<{
-  mutateConfigFile: ConfigModule["mutateConfigFile"];
-  readConfigFileSnapshot: ConfigModule["readConfigFileSnapshot"];
-}> {
-  const { mutateConfigFile, readConfigFileSnapshot } = await loadConfigModule();
-  return { mutateConfigFile, readConfigFileSnapshot };
 }
 
 function formatConfigValidationLine(snapshot: ConfigFileSnapshot): string {
@@ -638,621 +617,608 @@ async function resolveTuiAgentId(params: {
   return match?.id ?? requested;
 }
 
-/** Execute a parsed Crestodian operation after applying approval gates and audit logging. */
-export async function executeCrestodianOperation(
-  operation: CrestodianOperation,
-  runtime: RuntimeEnv,
-  opts: {
-    approved?: boolean;
-    deps?: CrestodianCommandDeps;
-    auditDetails?: Record<string, unknown>;
-  } = {},
-): Promise<CrestodianOperationResult> {
-  if (operation.kind === "none") {
-    runtime.log(operation.message);
-    return { applied: false, exitsInteractive: operation.message.includes("Bye.") };
+type ExecuteOptions = {
+  approved?: boolean;
+  deps?: CrestodianCommandDeps;
+  auditDetails?: Record<string, unknown>;
+};
+
+/**
+ * One persistent operation = one audited apply. The shared wrapper owns the
+ * approval gate, before/after config hashes, the audit record, and the
+ * `[crestodian] running/done` markers the e2e lanes assert on; each spec only
+ * describes what to run and what to record.
+ */
+type PersistentApplyContext = {
+  runtime: RuntimeEnv;
+  deps?: CrestodianCommandDeps;
+};
+
+type PersistentApplyOutcome = {
+  summary: string;
+  details?: Record<string, unknown>;
+  /** Overrides the after-snapshot config path in the audit record. */
+  configPath?: string;
+};
+
+async function applyPersistentOperation(params: {
+  auditOperation: string;
+  operation: CrestodianOperation;
+  runtime: RuntimeEnv;
+  opts: ExecuteOptions;
+  run: (ctx: PersistentApplyContext) => Promise<PersistentApplyOutcome>;
+}): Promise<CrestodianOperationResult> {
+  const { auditOperation, runtime, opts } = params;
+  if (!opts.approved) {
+    const message = formatCrestodianPersistentPlan(params.operation);
+    runtime.log(message);
+    return { applied: false, message };
   }
-  if (operation.kind === "overview") {
-    const overview = await loadOverviewForOperation(opts.deps);
-    runtime.log(await formatOverviewForOperation(overview, opts.deps));
-    return { applied: false };
-  }
-  if (operation.kind === "agents") {
-    const overview = await loadOverviewForOperation(opts.deps);
-    runtime.log(
-      [
-        "Agents:",
-        ...overview.agents.map((agent) => {
-          const bits = [
-            agent.id,
-            agent.isDefault ? "default" : undefined,
-            agent.name ? `name=${agent.name}` : undefined,
-            agent.workspace
-              ? `workspace=${shortenHomePath(resolveUserPath(agent.workspace))}`
-              : undefined,
-          ].filter(Boolean);
-          return `  - ${bits.join(" | ")}`;
-        }),
-      ].join("\n"),
-    );
-    return { applied: false };
-  }
-  if (operation.kind === "models") {
-    const overview = await loadOverviewForOperation(opts.deps);
-    runtime.log(
-      [
-        `Default model: ${overview.defaultModel ?? "not configured"}`,
-        `Codex: ${overview.tools.codex.found ? "found" : "not found"}`,
-        `Claude Code: ${overview.tools.claude.found ? "found" : "not found"}`,
-        `OpenAI key: ${overview.tools.apiKeys.openai ? "found" : "not found"}`,
-        `Anthropic key: ${overview.tools.apiKeys.anthropic ? "found" : "not found"}`,
-      ].join("\n"),
-    );
-    return { applied: false };
-  }
-  if (operation.kind === "plugin-list") {
-    logQueued(runtime, "plugins.list");
-    const runPluginsList =
-      opts.deps?.runPluginsList ??
-      (async (pluginRuntime: RuntimeEnv) => {
-        const { runPluginsListCommand } = await import("../cli/plugins-list-command.js");
-        await runPluginsListCommand({}, pluginRuntime);
+  runtime.log(`[crestodian] running: ${auditOperation}`);
+  const { readConfigFileSnapshot } = await loadConfigModule();
+  const before = await readConfigFileSnapshot();
+  const outcome = await params.run({ runtime, deps: opts.deps });
+  const after = await readConfigFileSnapshot();
+  await appendCrestodianAuditEntry({
+    operation: auditOperation,
+    summary: outcome.summary,
+    configPath: outcome.configPath ?? after.path ?? before.path ?? undefined,
+    configHashBefore: before.hash ?? null,
+    configHashAfter: after.hash ?? null,
+    details: { ...opts.auditDetails, ...outcome.details },
+  });
+  runtime.log(`[crestodian] done: ${auditOperation}`);
+  return { applied: true };
+}
+
+async function runConfigSetOperation(params: {
+  operation: Extract<CrestodianOperation, { kind: "config-set" | "config-set-ref" }>;
+  ctx: PersistentApplyContext;
+}): Promise<void> {
+  const { operation, ctx } = params;
+  const runConfigSet =
+    ctx.deps?.runConfigSet ??
+    (async (setOpts: { path?: string; value?: string; cliOptions: ConfigSetOptions }) => {
+      const { runConfigSet: importedRunConfigSet } = await import("../cli/config-cli.js");
+      await importedRunConfigSet({
+        ...setOpts,
+        runtime: createNoExitRuntime(ctx.runtime),
       });
-    await runPluginsList(runtime);
-    runtime.log("[crestodian] done: plugins.list");
-    return { applied: false };
-  }
-  if (operation.kind === "plugin-search") {
-    logQueued(runtime, "plugins.search");
-    const runPluginsSearch =
-      opts.deps?.runPluginsSearch ??
-      (async (query: string, pluginRuntime: RuntimeEnv) => {
-        const { runPluginsSearchCommand } = await import("../cli/plugins-search-command.js");
-        await runPluginsSearchCommand(query, {}, pluginRuntime);
-      });
-    await runPluginsSearch(operation.query, runtime);
-    runtime.log("[crestodian] done: plugins.search");
-    return { applied: false };
-  }
-  if (operation.kind === "audit") {
-    runtime.log(`Audit log: ${resolveCrestodianAuditPath()}`);
-    runtime.log("Only applied writes/actions are recorded; discovery stays quiet.");
-    return { applied: false };
-  }
-  if (operation.kind === "config-validate") {
-    const snapshot = await readConfigFileSnapshotLazy();
-    runtime.log(formatConfigValidationLine(snapshot));
-    return { applied: false };
-  }
-  if (operation.kind === "config-get") {
-    const snapshot = await readConfigFileSnapshotLazy();
-    if (!snapshot.exists) {
-      runtime.log(`Config missing: ${shortenHomePath(snapshot.path)}`);
-      return { applied: false };
-    }
-    const cfg = snapshot.valid ? (snapshot.sourceConfig ?? snapshot.config) : snapshot.sourceConfig;
-    const lookup = readConfigValueAtPath(cfg ?? {}, operation.path);
-    if (!lookup.found) {
-      runtime.log(
-        `${operation.path}: not set. Use \`config schema ${operation.path}\` to see what is allowed.`,
-      );
-      return { applied: false };
-    }
-    const redacted = redactConfigValue(lookup.value, operation.path);
-    const rendered = JSON.stringify(redacted, null, 2) ?? "null";
-    runtime.log(
-      rendered.length > CONFIG_GET_OUTPUT_MAX_CHARS
-        ? `${operation.path} = ${rendered.slice(0, CONFIG_GET_OUTPUT_MAX_CHARS)}\n… (truncated)`
-        : `${operation.path} = ${rendered}`,
-    );
-    return { applied: false };
-  }
-  if (operation.kind === "config-schema") {
-    const { buildConfigSchema, lookupConfigSchema } = await import("../config/schema.js");
-    const response = buildConfigSchema();
-    const path = operation.path ?? ".";
-    const result = lookupConfigSchema(response, path);
-    if (!result) {
-      runtime.log(`No config schema at "${path}". Try \`config schema .\` for the root keys.`);
-      return { applied: false };
-    }
-    const schema = result.schema as {
-      type?: string | string[];
-      description?: string;
-      enum?: unknown[];
-      default?: unknown;
-    };
-    const childLines = result.children.slice(0, CONFIG_SCHEMA_CHILDREN_MAX).map((child) => {
-      const type = Array.isArray(child.type) ? child.type.join("|") : (child.type ?? "object");
-      const bits = [
-        type,
-        child.required ? "required" : undefined,
-        child.hasChildren ? "…" : undefined,
-      ]
-        .filter(Boolean)
-        .join(", ");
-      return `  - ${child.path} (${bits})`;
     });
-    runtime.log(
-      [
-        `Schema for ${result.path === "" ? "." : result.path}:`,
-        schema.type
-          ? `type: ${Array.isArray(schema.type) ? schema.type.join("|") : schema.type}`
-          : undefined,
-        schema.description ? `description: ${schema.description}` : undefined,
-        schema.enum
-          ? `allowed values: ${schema.enum.map((v) => JSON.stringify(v)).join(", ")}`
-          : undefined,
-        schema.default !== undefined ? `default: ${JSON.stringify(schema.default)}` : undefined,
-        ...(childLines.length > 0 ? ["keys:", ...childLines] : []),
-        result.children.length > CONFIG_SCHEMA_CHILDREN_MAX
-          ? `… +${result.children.length - CONFIG_SCHEMA_CHILDREN_MAX} more keys`
-          : undefined,
-      ]
-        .filter((line): line is string => line !== undefined)
-        .join("\n"),
-    );
-    return { applied: false };
-  }
-  if (operation.kind === "channel-list") {
-    // Use the same discovery as channel setup (bundled plugins + trusted
-    // catalog), so the listing matches what `connect <channel>` can configure
-    // even before any plugin registry is active.
-    const [{ listChannelSetupPlugins }, { resolveChannelSetupEntries, shouldShowChannelInSetup }] =
-      await Promise.all([
-        import("../channels/plugins/setup-registry.js"),
-        import("../commands/channel-setup/discovery.js"),
-      ]);
-    const snapshot = await readConfigFileSnapshotLazy();
-    const cfg = snapshot.valid ? (snapshot.runtimeConfig ?? snapshot.config) : {};
-    const resolved = resolveChannelSetupEntries({
-      cfg,
-      installedPlugins: listChannelSetupPlugins(),
-    });
-    const entries = resolved.entries
-      .filter((entry) => shouldShowChannelInSetup(entry.meta))
-      .toSorted((a, b) => a.id.localeCompare(b.id));
-    runtime.log(
-      [
-        "Channels:",
-        ...entries.map(
-          (entry) => `  - ${entry.id}${entry.meta.label ? ` (${entry.meta.label})` : ""}`,
-        ),
-        "",
-        "Say `connect <channel>` to walk through setup (for example `connect telegram`).",
-      ].join("\n"),
-    );
-    return { applied: false };
-  }
-  if (operation.kind === "channel-setup") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    // Channel setup is a multi-step wizard; only interactive Crestodian (TUI
-    // chat bridge) can host it. One-shot mode points at the guided paths.
-    runtime.log(
-      [
-        `Connecting ${operation.channel} needs an interactive session.`,
-        "Run `openclaw crestodian` and say `connect " + operation.channel + "`,",
-        "or run `openclaw channels add` for the terminal wizard.",
-      ].join("\n"),
-    );
-    return { applied: false };
-  }
-  if (operation.kind === "setup") {
-    const overview = await loadOverviewForOperation(opts.deps);
-    const setupModel = await chooseSetupModel({
-      overview,
-      requestedModel: operation.model,
-      deps: opts.deps,
-    });
-    if (!opts.approved) {
-      const message = [
-        formatCrestodianPersistentPlan(operation),
-        setupModel.model
-          ? `Model choice: ${setupModel.model} (${setupModel.source}).`
-          : setupModel.source === "existing default model"
-            ? `Model choice: keep existing default ${overview.defaultModel}.`
-            : "Model choice: none found yet. I will only set the workspace; install/login Codex or Claude Code, or set OPENAI_API_KEY/ANTHROPIC_API_KEY, then run setup again.",
-      ].join("\n");
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    logQueued(runtime, "crestodian.setup");
-    const { readConfigFileSnapshot } = await loadConfigModule();
-    const before = await readConfigFileSnapshot();
-    const workspace = resolveUserPath(operation.workspace ?? process.cwd());
-    const applySetup =
-      opts.deps?.applySetup ?? (await import("./setup-apply.js")).applyCrestodianSetup;
-    const applied = await applySetup({
-      workspace,
-      ...(setupModel.model ? { model: setupModel.model } : {}),
-      surface: opts.deps?.setupSurface ?? "cli",
-      runtime,
-    });
-    const after = await readConfigFileSnapshot();
-    await appendCrestodianAuditEntry({
-      operation: "crestodian.setup",
-      summary: setupModel.model
-        ? `Bootstrapped setup with ${setupModel.model}`
-        : "Bootstrapped setup workspace",
-      configPath: after.path || applied.configPath || undefined,
-      configHashBefore: before.hash ?? null,
-      configHashAfter: after.hash ?? null,
-      details: {
-        ...opts.auditDetails,
-        workspace,
-        modelSource: setupModel.source,
-        ...(setupModel.model ? { model: setupModel.model } : {}),
-      },
-    });
-    runtime.log(`Updated ${after.path || applied.configPath}`);
-    for (const line of applied.lines) {
-      runtime.log(line);
-    }
-    if (!setupModel.model && overview.defaultModel) {
-      runtime.log(`Default model: ${overview.defaultModel} (kept)`);
-    } else if (!setupModel.model) {
-      runtime.log("Default model: not configured yet");
-    }
-    runtime.log("[crestodian] done: crestodian.setup");
-    return { applied: true };
-  }
   if (operation.kind === "config-set") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    logQueued(runtime, "config.set");
-    const { readConfigFileSnapshot } = await loadConfigModule();
-    const before = await readConfigFileSnapshot();
-    const runConfigSet =
-      opts.deps?.runConfigSet ??
-      (async (setOpts: { path?: string; value?: string; cliOptions: ConfigSetOptions }) => {
-        const { runConfigSet: importedRunConfigSet } = await loadConfigCliModule();
-        await importedRunConfigSet({
-          ...setOpts,
-          runtime: createNoExitRuntime(runtime),
-        });
-      });
-    await runConfigSet({
-      path: operation.path,
-      value: operation.value,
-      cliOptions: {},
-    });
-    const after = await readConfigFileSnapshot();
-    await appendCrestodianAuditEntry({
-      operation: "config.set",
-      summary: `Set config ${operation.path}`,
-      configPath: after.path || before.path || undefined,
-      configHashBefore: before.hash ?? null,
-      configHashAfter: after.hash ?? null,
-      details: {
-        ...opts.auditDetails,
-        path: operation.path,
-      },
-    });
-    runtime.log("[crestodian] done: config.set");
-    return { applied: true };
+    await runConfigSet({ path: operation.path, value: operation.value, cliOptions: {} });
+    return;
   }
-  if (operation.kind === "config-set-ref") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    logQueued(runtime, "config.setRef");
-    const { readConfigFileSnapshot } = await loadConfigModule();
-    const before = await readConfigFileSnapshot();
-    const runConfigSet =
-      opts.deps?.runConfigSet ??
-      (async (setOpts: { path?: string; value?: string; cliOptions: ConfigSetOptions }) => {
-        const { runConfigSet: importedRunConfigSet } = await loadConfigCliModule();
-        await importedRunConfigSet({
-          ...setOpts,
-          runtime: createNoExitRuntime(runtime),
-        });
-      });
-    await runConfigSet({
-      path: operation.path,
-      cliOptions: {
-        refProvider: operation.provider ?? "default",
-        refSource: operation.source,
-        refId: operation.id,
-      },
-    });
-    const after = await readConfigFileSnapshot();
-    await appendCrestodianAuditEntry({
-      operation: "config.setRef",
-      summary: `Set config ${operation.path} SecretRef`,
-      configPath: after.path || before.path || undefined,
-      configHashBefore: before.hash ?? null,
-      configHashAfter: after.hash ?? null,
-      details: {
-        ...opts.auditDetails,
-        path: operation.path,
-        source: operation.source,
-        provider: operation.provider ?? "default",
-      },
-    });
-    runtime.log("[crestodian] done: config.setRef");
-    return { applied: true };
+  await runConfigSet({
+    path: operation.path,
+    cliOptions: {
+      refProvider: operation.provider ?? "default",
+      refSource: operation.source,
+      refId: operation.id,
+    },
+  });
+}
+
+async function executeSetup(
+  operation: Extract<CrestodianOperation, { kind: "setup" }>,
+  runtime: RuntimeEnv,
+  opts: ExecuteOptions,
+): Promise<CrestodianOperationResult> {
+  const overview = await loadOverviewForOperation(opts.deps);
+  const setupModel = await chooseSetupModel({
+    overview,
+    requestedModel: operation.model,
+    deps: opts.deps,
+  });
+  if (!opts.approved) {
+    const message = [
+      formatCrestodianPersistentPlan(operation),
+      setupModel.model
+        ? `Model choice: ${setupModel.model} (${setupModel.source}).`
+        : setupModel.source === "existing default model"
+          ? `Model choice: keep existing default ${overview.defaultModel}.`
+          : "Model choice: none found yet. I will only set the workspace; install/login Codex or Claude Code, or set OPENAI_API_KEY/ANTHROPIC_API_KEY, then run setup again.",
+    ].join("\n");
+    runtime.log(message);
+    return { applied: false, message };
   }
-  if (operation.kind === "plugin-install") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
+  const workspace = resolveUserPath(operation.workspace ?? process.cwd());
+  return await applyPersistentOperation({
+    auditOperation: "crestodian.setup",
+    operation,
+    runtime,
+    opts,
+    run: async (ctx) => {
+      const applySetup =
+        ctx.deps?.applySetup ?? (await import("./setup-apply.js")).applyCrestodianSetup;
+      const applied = await applySetup({
+        workspace,
+        ...(setupModel.model ? { model: setupModel.model } : {}),
+        surface: ctx.deps?.setupSurface ?? "cli",
+        runtime: ctx.runtime,
+      });
+      const after = await readConfigFileSnapshotLazy();
+      ctx.runtime.log(`Updated ${after.path || applied.configPath}`);
+      for (const line of applied.lines) {
+        ctx.runtime.log(line);
+      }
+      if (!setupModel.model && overview.defaultModel) {
+        ctx.runtime.log(`Default model: ${overview.defaultModel} (kept)`);
+      } else if (!setupModel.model) {
+        ctx.runtime.log("Default model: not configured yet");
+      }
+      return {
+        summary: setupModel.model
+          ? `Bootstrapped setup with ${setupModel.model}`
+          : "Bootstrapped setup workspace",
+        configPath: after.path || applied.configPath,
+        details: {
+          workspace,
+          modelSource: setupModel.source,
+          ...(setupModel.model ? { model: setupModel.model } : {}),
+        },
+      };
+    },
+  });
+}
+
+async function executeSetDefaultModel(
+  operation: Extract<CrestodianOperation, { kind: "set-default-model" }>,
+  runtime: RuntimeEnv,
+  opts: ExecuteOptions,
+): Promise<CrestodianOperationResult> {
+  return await applyPersistentOperation({
+    auditOperation: "config.setDefaultModel",
+    operation,
+    runtime,
+    opts,
+    run: async (ctx) => {
+      const { mutateConfigFile } = await loadConfigModule();
+      const { applyDefaultModelPrimaryUpdate } = await import("../commands/models/shared.js");
+      const result = await mutateConfigFile({
+        base: "source",
+        mutate: (cfg) => {
+          const next = applyDefaultModelPrimaryUpdate({
+            cfg,
+            modelRaw: operation.model,
+            field: "model",
+          });
+          Object.assign(cfg, next);
+        },
+      });
+      const { resolveAgentModelPrimaryValue } = await import("../config/model-input.js");
+      const effectiveModel = resolveAgentModelPrimaryValue(
+        result.nextConfig.agents?.defaults?.model,
+      );
+      ctx.runtime.log(`Updated ${result.path}`);
+      ctx.runtime.log(`Default model: ${effectiveModel ?? operation.model}`);
+      return {
+        summary: `Set default model to ${operation.model}`,
+        configPath: result.path,
+        details: { requestedModel: operation.model, effectiveModel },
+      };
+    },
+  });
+}
+
+async function executePluginInstall(
+  operation: Extract<CrestodianOperation, { kind: "plugin-install" }>,
+  runtime: RuntimeEnv,
+  opts: ExecuteOptions,
+): Promise<CrestodianOperationResult> {
+  if (opts.approved) {
     const validationError = validateCrestodianPluginInstallSpec(operation.spec);
     if (validationError) {
       runtime.error(validationError);
       runtime.exit(1);
       return { applied: false };
     }
-    logQueued(runtime, "plugin.install");
-    const before = await readConfigFileSnapshotLazy();
-    const runPluginInstall =
-      opts.deps?.runPluginInstall ??
-      (async (spec: string, pluginRuntime: RuntimeEnv) => {
-        const { runPluginInstallCommand } = await import("../cli/plugins-install-command.js");
-        await runPluginInstallCommand({ raw: spec, opts: {}, runtime: pluginRuntime });
-      });
-    await runPluginInstall(operation.spec, createNoExitRuntime(runtime));
-    const after = await readConfigFileSnapshotLazy();
-    await appendCrestodianAuditEntry({
-      operation: "plugin.install",
-      summary: `Installed plugin ${operation.spec}`,
-      configPath: after.path || before.path || undefined,
-      configHashBefore: before.hash ?? null,
-      configHashAfter: after.hash ?? null,
-      details: {
-        ...opts.auditDetails,
-        spec: operation.spec,
-      },
-    });
-    runtime.log("[crestodian] done: plugin.install");
-    runtime.log("Restart the Gateway to apply installed plugin changes.");
-    return { applied: true };
   }
-  if (operation.kind === "plugin-uninstall") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    logQueued(runtime, "plugin.uninstall");
-    const before = await readConfigFileSnapshotLazy();
-    const runPluginUninstall =
-      opts.deps?.runPluginUninstall ??
-      (async (pluginId: string, pluginRuntime: RuntimeEnv) => {
-        const { runPluginUninstallCommand } = await import("../cli/plugins-uninstall-command.js");
-        await runPluginUninstallCommand(pluginId, { force: true }, pluginRuntime);
-      });
-    await runPluginUninstall(operation.pluginId, createNoExitRuntime(runtime));
-    const after = await readConfigFileSnapshotLazy();
-    await appendCrestodianAuditEntry({
-      operation: "plugin.uninstall",
-      summary: `Uninstalled plugin ${operation.pluginId}`,
-      configPath: after.path || before.path || undefined,
-      configHashBefore: before.hash ?? null,
-      configHashAfter: after.hash ?? null,
-      details: {
-        ...opts.auditDetails,
-        pluginId: operation.pluginId,
-      },
-    });
-    runtime.log("[crestodian] done: plugin.uninstall");
-    runtime.log("Restart the Gateway to apply plugin changes.");
-    return { applied: true };
-  }
-  if (operation.kind === "create-agent") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    logQueued(runtime, "agents.create");
-    const { readConfigFileSnapshot } = await loadConfigModule();
-    const before = await readConfigFileSnapshot();
-    const workspace = resolveUserPath(operation.workspace ?? process.cwd());
-    const runAgentsAdd =
-      opts.deps?.runAgentsAdd ??
-      (await import("../commands/agents.commands.add.js")).agentsAddCommand;
-    await runAgentsAdd(
-      {
-        name: operation.agentId,
-        workspace,
-        ...(operation.model ? { model: operation.model } : {}),
-        nonInteractive: true,
-      },
-      runtime,
-      { hasFlags: true },
-    );
-    const after = await readConfigFileSnapshot();
-    await appendCrestodianAuditEntry({
-      operation: "agents.create",
-      summary: `Created agent ${operation.agentId}`,
-      configPath: after.path || before.path || undefined,
-      configHashBefore: before.hash ?? null,
-      configHashAfter: after.hash ?? null,
-      details: {
-        ...opts.auditDetails,
-        agentId: operation.agentId,
-        workspace,
-        ...(operation.model ? { model: operation.model } : {}),
-      },
-    });
-    runtime.log("[crestodian] done: agents.create");
-    return { applied: true };
-  }
-  if (operation.kind === "doctor") {
-    logQueued(runtime, "doctor");
-    const runDoctor = opts.deps?.runDoctor ?? (await loadDoctorModule()).doctorCommand;
-    await runDoctor(runtime, { nonInteractive: true });
-    runtime.log("[crestodian] done: doctor");
-    return { applied: false };
-  }
-  if (operation.kind === "doctor-fix") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    logQueued(runtime, "doctor.fix");
-    const { readConfigFileSnapshot } = await loadConfigModule();
-    const before = await readConfigFileSnapshot();
-    const runDoctor = opts.deps?.runDoctor ?? (await loadDoctorModule()).doctorCommand;
-    await runDoctor(runtime, { nonInteractive: true, repair: true, yes: true });
-    const after = await readConfigFileSnapshot();
-    await appendCrestodianAuditEntry({
-      operation: "doctor.fix",
-      summary: "Ran doctor repairs",
-      configPath: after.path || before.path || undefined,
-      configHashBefore: before.hash ?? null,
-      configHashAfter: after.hash ?? null,
-      details: opts.auditDetails,
-    });
-    runtime.log("[crestodian] done: doctor.fix");
-    return { applied: true };
-  }
-  if (operation.kind === "status") {
-    logQueued(runtime, "status.check");
-    const { statusCommand } = await import("../commands/status.command.js");
-    await statusCommand({ timeoutMs: 10_000 }, runtime);
-    runtime.log("[crestodian] done: status.check");
-    return { applied: false };
-  }
-  if (operation.kind === "health") {
-    logQueued(runtime, "health.check");
-    const { healthCommand } = await import("../commands/health.js");
-    await healthCommand({ timeoutMs: 10_000 }, runtime);
-    runtime.log("[crestodian] done: health.check");
-    return { applied: false };
-  }
-  if (operation.kind === "gateway-status") {
-    const overview = await loadOverviewForOperation(opts.deps);
-    runtime.log(formatGatewayStatusLine(overview));
-    return { applied: false };
-  }
-  if (operation.kind === "gateway-start") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    logQueued(runtime, "gateway.start");
-    const runGatewayStart = opts.deps?.runGatewayStart ?? (() => runGatewayLifecycle("start"));
-    await runGatewayStart();
-    await appendCrestodianAuditEntry({
-      operation: "gateway.start",
-      summary: "Started Gateway",
-      details: opts.auditDetails,
-    });
-    runtime.log("[crestodian] done: gateway.start");
-    return { applied: true };
-  }
-  if (operation.kind === "gateway-stop") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    logQueued(runtime, "gateway.stop");
-    const runGatewayStop = opts.deps?.runGatewayStop ?? (() => runGatewayLifecycle("stop"));
-    await runGatewayStop();
-    await appendCrestodianAuditEntry({
-      operation: "gateway.stop",
-      summary: "Stopped Gateway",
-      details: opts.auditDetails,
-    });
-    runtime.log("[crestodian] done: gateway.stop");
-    return { applied: true };
-  }
-  if (operation.kind === "gateway-restart") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    logQueued(runtime, "gateway.restart");
-    const runGatewayRestart =
-      opts.deps?.runGatewayRestart ?? (() => runGatewayLifecycle("restart"));
-    await runGatewayRestart();
-    await appendCrestodianAuditEntry({
-      operation: "gateway.restart",
-      summary: "Restarted Gateway",
-      details: opts.auditDetails,
-    });
-    runtime.log("[crestodian] done: gateway.restart");
-    return { applied: true };
-  }
-  if (operation.kind === "open-tui") {
-    logQueued(runtime, "tui.open");
-    const agentId = await resolveTuiAgentId({
-      requestedAgentId: operation.agentId,
-      requestedWorkspace: operation.workspace,
-      deps: opts.deps,
-    });
-    const session = agentId ? buildAgentMainSessionKey({ agentId }) : undefined;
-    const runTui = opts.deps?.runTui ?? (await import("../tui/tui.js")).runTui;
-    const result = await runTui({ local: true, session, deliver: false, historyLimit: 200 });
-    if (result?.exitReason === "return-to-crestodian") {
-      runtime.log(
-        result.crestodianMessage
-          ? `[crestodian] returned from agent with request: ${result.crestodianMessage}`
-          : "[crestodian] returned from agent",
-      );
-      return {
-        applied: false,
-        nextInput: result.crestodianMessage,
-      };
-    }
-    return { applied: false, exitsInteractive: true };
-  }
-  if (operation.kind === "set-default-model") {
-    if (!opts.approved) {
-      const message = formatCrestodianPersistentPlan(operation);
-      runtime.log(message);
-      return { applied: false, message };
-    }
-    logQueued(runtime, "config.setDefaultModel");
-    const { mutateConfigFile, readConfigFileSnapshot } = await loadConfigFileMutationHelpers();
-    const before = await readConfigFileSnapshot();
-    const { applyDefaultModelPrimaryUpdate } = await loadModelsSharedModule();
-    const result = await mutateConfigFile({
-      base: "source",
-      mutate: (cfg) => {
-        const next = applyDefaultModelPrimaryUpdate({
-          cfg,
-          modelRaw: operation.model,
-          field: "model",
+  const result = await applyPersistentOperation({
+    auditOperation: "plugin.install",
+    operation,
+    runtime,
+    opts,
+    run: async (ctx) => {
+      const runPluginInstall =
+        ctx.deps?.runPluginInstall ??
+        (async (spec: string, pluginRuntime: RuntimeEnv) => {
+          const { runPluginInstallCommand } = await import("../cli/plugins-install-command.js");
+          await runPluginInstallCommand({ raw: spec, opts: {}, runtime: pluginRuntime });
         });
-        Object.assign(cfg, next);
-      },
-    });
-    const after = await readConfigFileSnapshot();
-    const { resolveAgentModelPrimaryValue } = await import("../config/model-input.js");
-    const effectiveModel = resolveAgentModelPrimaryValue(result.nextConfig.agents?.defaults?.model);
-    await appendCrestodianAuditEntry({
-      operation: "config.setDefaultModel",
-      summary: `Set default model to ${operation.model}`,
-      configPath: result.path,
-      configHashBefore: before.hash ?? result.previousHash,
-      configHashAfter: after.hash ?? null,
-      details: {
-        ...opts.auditDetails,
-        requestedModel: operation.model,
-        effectiveModel,
-      },
-    });
-    runtime.log(`Updated ${result.path}`);
-    runtime.log(`Default model: ${effectiveModel ?? operation.model}`);
-    runtime.log("[crestodian] done: config.setDefaultModel");
-    return { applied: true };
+      await runPluginInstall(operation.spec, createNoExitRuntime(ctx.runtime));
+      return { summary: `Installed plugin ${operation.spec}`, details: { spec: operation.spec } };
+    },
+  });
+  if (result.applied) {
+    runtime.log("Restart the Gateway to apply installed plugin changes.");
   }
-  return { applied: false };
+  return result;
+}
+
+/** Execute a parsed Crestodian operation after applying approval gates and audit logging. */
+export async function executeCrestodianOperation(
+  operation: CrestodianOperation,
+  runtime: RuntimeEnv,
+  opts: ExecuteOptions = {},
+): Promise<CrestodianOperationResult> {
+  switch (operation.kind) {
+    case "none":
+      runtime.log(operation.message);
+      return { applied: false, exitsInteractive: operation.message.includes("Bye.") };
+    case "overview": {
+      const overview = await loadOverviewForOperation(opts.deps);
+      if (opts.deps?.formatOverview) {
+        runtime.log(opts.deps.formatOverview(overview));
+      } else {
+        const { formatCrestodianOverview } = await loadOverviewModule();
+        runtime.log(formatCrestodianOverview(overview));
+      }
+      return { applied: false };
+    }
+    case "agents": {
+      const overview = await loadOverviewForOperation(opts.deps);
+      runtime.log(
+        [
+          "Agents:",
+          ...overview.agents.map((agent) => {
+            const bits = [
+              agent.id,
+              agent.isDefault ? "default" : undefined,
+              agent.name ? `name=${agent.name}` : undefined,
+              agent.workspace
+                ? `workspace=${shortenHomePath(resolveUserPath(agent.workspace))}`
+                : undefined,
+            ].filter(Boolean);
+            return `  - ${bits.join(" | ")}`;
+          }),
+        ].join("\n"),
+      );
+      return { applied: false };
+    }
+    case "models": {
+      const overview = await loadOverviewForOperation(opts.deps);
+      runtime.log(
+        [
+          `Default model: ${overview.defaultModel ?? "not configured"}`,
+          `Codex: ${overview.tools.codex.found ? "found" : "not found"}`,
+          `Claude Code: ${overview.tools.claude.found ? "found" : "not found"}`,
+          `Gemini CLI: ${overview.tools.gemini.found ? "found" : "not found"}`,
+          `OpenAI key: ${overview.tools.apiKeys.openai ? "found" : "not found"}`,
+          `Anthropic key: ${overview.tools.apiKeys.anthropic ? "found" : "not found"}`,
+        ].join("\n"),
+      );
+      return { applied: false };
+    }
+    case "plugin-list": {
+      const runPluginsList =
+        opts.deps?.runPluginsList ??
+        (async (pluginRuntime: RuntimeEnv) => {
+          const { runPluginsListCommand } = await import("../cli/plugins-list-command.js");
+          await runPluginsListCommand({}, pluginRuntime);
+        });
+      await runPluginsList(runtime);
+      return { applied: false };
+    }
+    case "plugin-search": {
+      const runPluginsSearch =
+        opts.deps?.runPluginsSearch ??
+        (async (query: string, pluginRuntime: RuntimeEnv) => {
+          const { runPluginsSearchCommand } = await import("../cli/plugins-search-command.js");
+          await runPluginsSearchCommand(query, {}, pluginRuntime);
+        });
+      await runPluginsSearch(operation.query, runtime);
+      return { applied: false };
+    }
+    case "audit":
+      runtime.log(`Audit log: ${resolveCrestodianAuditPath()}`);
+      runtime.log("Only applied writes/actions are recorded; discovery stays quiet.");
+      return { applied: false };
+    case "config-validate": {
+      const snapshot = await readConfigFileSnapshotLazy();
+      runtime.log(formatConfigValidationLine(snapshot));
+      return { applied: false };
+    }
+    case "config-get": {
+      const snapshot = await readConfigFileSnapshotLazy();
+      if (!snapshot.exists) {
+        runtime.log(`Config missing: ${shortenHomePath(snapshot.path)}`);
+        return { applied: false };
+      }
+      const cfg = snapshot.valid
+        ? (snapshot.sourceConfig ?? snapshot.config)
+        : snapshot.sourceConfig;
+      const lookup = readConfigValueAtPath(cfg ?? {}, operation.path);
+      if (!lookup.found) {
+        runtime.log(
+          `${operation.path}: not set. Use \`config schema ${operation.path}\` to see what is allowed.`,
+        );
+        return { applied: false };
+      }
+      const redacted = redactConfigValue(lookup.value, operation.path);
+      const rendered = JSON.stringify(redacted, null, 2) ?? "null";
+      runtime.log(
+        rendered.length > CONFIG_GET_OUTPUT_MAX_CHARS
+          ? `${operation.path} = ${rendered.slice(0, CONFIG_GET_OUTPUT_MAX_CHARS)}\n… (truncated)`
+          : `${operation.path} = ${rendered}`,
+      );
+      return { applied: false };
+    }
+    case "config-schema": {
+      const { buildConfigSchema, lookupConfigSchema } = await import("../config/schema.js");
+      const response = buildConfigSchema();
+      const path = operation.path ?? ".";
+      const result = lookupConfigSchema(response, path);
+      if (!result) {
+        runtime.log(`No config schema at "${path}". Try \`config schema .\` for the root keys.`);
+        return { applied: false };
+      }
+      const schema = result.schema as {
+        type?: string | string[];
+        description?: string;
+        enum?: unknown[];
+        default?: unknown;
+      };
+      const childLines = result.children.slice(0, CONFIG_SCHEMA_CHILDREN_MAX).map((child) => {
+        const type = Array.isArray(child.type) ? child.type.join("|") : (child.type ?? "object");
+        const bits = [
+          type,
+          child.required ? "required" : undefined,
+          child.hasChildren ? "…" : undefined,
+        ]
+          .filter(Boolean)
+          .join(", ");
+        return `  - ${child.path} (${bits})`;
+      });
+      runtime.log(
+        [
+          `Schema for ${result.path === "" ? "." : result.path}:`,
+          schema.type
+            ? `type: ${Array.isArray(schema.type) ? schema.type.join("|") : schema.type}`
+            : undefined,
+          schema.description ? `description: ${schema.description}` : undefined,
+          schema.enum
+            ? `allowed values: ${schema.enum.map((v) => JSON.stringify(v)).join(", ")}`
+            : undefined,
+          schema.default !== undefined ? `default: ${JSON.stringify(schema.default)}` : undefined,
+          ...(childLines.length > 0 ? ["keys:", ...childLines] : []),
+          result.children.length > CONFIG_SCHEMA_CHILDREN_MAX
+            ? `… +${result.children.length - CONFIG_SCHEMA_CHILDREN_MAX} more keys`
+            : undefined,
+        ]
+          .filter((line): line is string => line !== undefined)
+          .join("\n"),
+      );
+      return { applied: false };
+    }
+    case "channel-list": {
+      // Use the same discovery as channel setup (bundled plugins + trusted
+      // catalog), so the listing matches what `connect <channel>` can configure
+      // even before any plugin registry is active.
+      const [
+        { listChannelSetupPlugins },
+        { resolveChannelSetupEntries, shouldShowChannelInSetup },
+      ] = await Promise.all([
+        import("../channels/plugins/setup-registry.js"),
+        import("../commands/channel-setup/discovery.js"),
+      ]);
+      const snapshot = await readConfigFileSnapshotLazy();
+      const cfg = snapshot.valid ? (snapshot.runtimeConfig ?? snapshot.config) : {};
+      const resolved = resolveChannelSetupEntries({
+        cfg,
+        installedPlugins: listChannelSetupPlugins(),
+      });
+      const entries = resolved.entries
+        .filter((entry) => shouldShowChannelInSetup(entry.meta))
+        .toSorted((a, b) => a.id.localeCompare(b.id));
+      runtime.log(
+        [
+          "Channels:",
+          ...entries.map(
+            (entry) => `  - ${entry.id}${entry.meta.label ? ` (${entry.meta.label})` : ""}`,
+          ),
+          "",
+          "Say `connect <channel>` to walk through setup (for example `connect telegram`).",
+        ].join("\n"),
+      );
+      return { applied: false };
+    }
+    case "channel-setup":
+      // Channel setup is a multi-step wizard; only interactive Crestodian (TUI
+      // chat bridge or the gateway chat) can host it. One-shot mode points at
+      // the guided paths.
+      runtime.log(
+        [
+          `Connecting ${operation.channel} needs an interactive session.`,
+          "Run `openclaw crestodian` and say `connect " + operation.channel + "`,",
+          "or run `openclaw channels add` for the terminal wizard.",
+        ].join("\n"),
+      );
+      return { applied: false };
+    case "setup":
+      return await executeSetup(operation, runtime, opts);
+    case "config-set":
+      return await applyPersistentOperation({
+        auditOperation: "config.set",
+        operation,
+        runtime,
+        opts,
+        run: async (ctx) => {
+          await runConfigSetOperation({ operation, ctx });
+          return { summary: `Set config ${operation.path}`, details: { path: operation.path } };
+        },
+      });
+    case "config-set-ref":
+      return await applyPersistentOperation({
+        auditOperation: "config.setRef",
+        operation,
+        runtime,
+        opts,
+        run: async (ctx) => {
+          await runConfigSetOperation({ operation, ctx });
+          return {
+            summary: `Set config ${operation.path} SecretRef`,
+            details: {
+              path: operation.path,
+              source: operation.source,
+              provider: operation.provider ?? "default",
+            },
+          };
+        },
+      });
+    case "plugin-install":
+      return await executePluginInstall(operation, runtime, opts);
+    case "plugin-uninstall": {
+      const result = await applyPersistentOperation({
+        auditOperation: "plugin.uninstall",
+        operation,
+        runtime,
+        opts,
+        run: async (ctx) => {
+          const runPluginUninstall =
+            ctx.deps?.runPluginUninstall ??
+            (async (pluginId: string, pluginRuntime: RuntimeEnv) => {
+              const { runPluginUninstallCommand } =
+                await import("../cli/plugins-uninstall-command.js");
+              await runPluginUninstallCommand(pluginId, { force: true }, pluginRuntime);
+            });
+          await runPluginUninstall(operation.pluginId, createNoExitRuntime(ctx.runtime));
+          return {
+            summary: `Uninstalled plugin ${operation.pluginId}`,
+            details: { pluginId: operation.pluginId },
+          };
+        },
+      });
+      if (result.applied) {
+        runtime.log("Restart the Gateway to apply plugin changes.");
+      }
+      return result;
+    }
+    case "create-agent": {
+      const workspace = resolveUserPath(operation.workspace ?? process.cwd());
+      return await applyPersistentOperation({
+        auditOperation: "agents.create",
+        operation,
+        runtime,
+        opts,
+        run: async (ctx) => {
+          const runAgentsAdd =
+            ctx.deps?.runAgentsAdd ??
+            (await import("../commands/agents.commands.add.js")).agentsAddCommand;
+          await runAgentsAdd(
+            {
+              name: operation.agentId,
+              workspace,
+              ...(operation.model ? { model: operation.model } : {}),
+              nonInteractive: true,
+            },
+            ctx.runtime,
+            { hasFlags: true },
+          );
+          return {
+            summary: `Created agent ${operation.agentId}`,
+            details: {
+              agentId: operation.agentId,
+              workspace,
+              ...(operation.model ? { model: operation.model } : {}),
+            },
+          };
+        },
+      });
+    }
+    case "doctor": {
+      const runDoctor =
+        opts.deps?.runDoctor ?? (await import("../commands/doctor.js")).doctorCommand;
+      await runDoctor(runtime, { nonInteractive: true });
+      return { applied: false };
+    }
+    case "doctor-fix":
+      return await applyPersistentOperation({
+        auditOperation: "doctor.fix",
+        operation,
+        runtime,
+        opts,
+        run: async (ctx) => {
+          const runDoctor =
+            ctx.deps?.runDoctor ?? (await import("../commands/doctor.js")).doctorCommand;
+          await runDoctor(ctx.runtime, { nonInteractive: true, repair: true, yes: true });
+          return { summary: "Ran doctor repairs" };
+        },
+      });
+    case "status": {
+      const { statusCommand } = await import("../commands/status.command.js");
+      await statusCommand({ timeoutMs: 10_000 }, runtime);
+      return { applied: false };
+    }
+    case "health": {
+      const { healthCommand } = await import("../commands/health.js");
+      await healthCommand({ timeoutMs: 10_000 }, runtime);
+      return { applied: false };
+    }
+    case "gateway-status": {
+      const overview = await loadOverviewForOperation(opts.deps);
+      runtime.log(formatGatewayStatusLine(overview));
+      return { applied: false };
+    }
+    case "gateway-start":
+      return await applyPersistentOperation({
+        auditOperation: "gateway.start",
+        operation,
+        runtime,
+        opts,
+        run: async (ctx) => {
+          const runGatewayStart = ctx.deps?.runGatewayStart ?? (() => runGatewayLifecycle("start"));
+          await runGatewayStart();
+          return { summary: "Started Gateway" };
+        },
+      });
+    case "gateway-stop":
+      return await applyPersistentOperation({
+        auditOperation: "gateway.stop",
+        operation,
+        runtime,
+        opts,
+        run: async (ctx) => {
+          const runGatewayStop = ctx.deps?.runGatewayStop ?? (() => runGatewayLifecycle("stop"));
+          await runGatewayStop();
+          return { summary: "Stopped Gateway" };
+        },
+      });
+    case "gateway-restart":
+      return await applyPersistentOperation({
+        auditOperation: "gateway.restart",
+        operation,
+        runtime,
+        opts,
+        run: async (ctx) => {
+          const runGatewayRestart =
+            ctx.deps?.runGatewayRestart ?? (() => runGatewayLifecycle("restart"));
+          await runGatewayRestart();
+          return { summary: "Restarted Gateway" };
+        },
+      });
+    case "open-tui": {
+      const agentId = await resolveTuiAgentId({
+        requestedAgentId: operation.agentId,
+        requestedWorkspace: operation.workspace,
+        deps: opts.deps,
+      });
+      const session = agentId ? buildAgentMainSessionKey({ agentId }) : undefined;
+      const runTui = opts.deps?.runTui ?? (await import("../tui/tui.js")).runTui;
+      const result = await runTui({ local: true, session, deliver: false, historyLimit: 200 });
+      if (result?.exitReason === "return-to-crestodian") {
+        runtime.log(
+          result.crestodianMessage
+            ? `[crestodian] returned from agent with request: ${result.crestodianMessage}`
+            : "[crestodian] returned from agent",
+        );
+        return { applied: false, nextInput: result.crestodianMessage };
+      }
+      return { applied: false, exitsInteractive: true };
+    }
+    case "set-default-model":
+      return await executeSetDefaultModel(operation, runtime, opts);
+    default:
+      return { applied: false };
+  }
 }

--- a/src/crestodian/overview.test.ts
+++ b/src/crestodian/overview.test.ts
@@ -60,6 +60,7 @@ describe("loadCrestodianOverview", () => {
     expect(overview.agents.map((agent) => agent.id)).toEqual(["main", "work"]);
     expect(overview.tools.codex.found).toBe(true);
     expect(overview.tools.claude.found).toBe(false);
+    expect(overview.tools.gemini.found).toBe(false);
     expect(overview.gateway.url).toBe("ws://127.0.0.1:19001");
     expect(overview.gateway.reachable).toBe(false);
     expect(overview.references.docsPath).toMatch(/docs$/);

--- a/src/crestodian/overview.ts
+++ b/src/crestodian/overview.ts
@@ -42,6 +42,7 @@ export type CrestodianOverview = {
   tools: {
     codex: LocalCommandProbe;
     claude: LocalCommandProbe;
+    gemini: LocalCommandProbe;
     apiKeys: {
       openai: boolean;
       anthropic: boolean;
@@ -169,10 +170,11 @@ export async function loadCrestodianOverview(
   }
   const resolveReferences = deps.resolveOpenClawReferencePaths ?? resolveOpenClawReferencePaths;
   const commandProbe = deps.probeLocalCommand ?? probeLocalCommand;
-  const [codex, claude, gateway, references] = await Promise.all([
+  const [codex, claude, gemini, gateway, references] = await Promise.all([
     // Probes run in parallel; each individual probe is timeout-bounded in probes.ts.
     commandProbe("codex"),
     commandProbe("claude"),
+    commandProbe("gemini"),
     (deps.probeGatewayUrl ?? probeGatewayUrl)(gatewayUrl),
     resolveFastTestReferences(env) ??
       resolveReferences({
@@ -195,6 +197,7 @@ export async function loadCrestodianOverview(
     tools: {
       codex,
       claude,
+      gemini,
       apiKeys: {
         openai: Boolean(env.OPENAI_API_KEY?.trim()),
         anthropic: Boolean(env.ANTHROPIC_API_KEY?.trim()),
@@ -256,13 +259,14 @@ export function formatCrestodianOverview(overview: CrestodianOverview): string {
     ...agentLines,
     `Codex: ${formatCommandProbe(overview.tools.codex)}`,
     `Claude Code: ${formatCommandProbe(overview.tools.claude)}`,
+    `Gemini CLI: ${formatCommandProbe(overview.tools.gemini)}`,
     `API keys: OpenAI ${overview.tools.apiKeys.openai ? "found" : "not found"}, Anthropic ${
       overview.tools.apiKeys.anthropic ? "found" : "not found"
     }`,
-    `Planner: ${
+    `AI: ${
       overview.defaultModel
-        ? `model-assisted via ${overview.defaultModel} for fuzzy local commands`
-        : "deterministic only until a model is configured"
+        ? `conversation runs on ${overview.defaultModel}`
+        : "no model configured; local Claude Code/Codex/Gemini logins are reused when present"
     }`,
     `Docs: ${overview.references.docsPath ?? overview.references.docsUrl}`,
     overview.references.sourcePath
@@ -302,9 +306,9 @@ function formatStartupConfigStatus(overview: CrestodianOverview): string {
 
 function formatStartupUse(overview: CrestodianOverview): string {
   if (overview.defaultModel) {
-    return `Using: ${overview.defaultModel} for fuzzy local planning.`;
+    return `Using: ${overview.defaultModel} — just tell me what you want.`;
   }
-  return "Using: deterministic typed commands until we configure a model.";
+  return "Using: any local Claude Code/Codex/Gemini login I can find; typed commands as last resort.";
 }
 
 function formatStartupGatewayStatus(overview: CrestodianOverview): string {

--- a/src/crestodian/rescue-message.test.ts
+++ b/src/crestodian/rescue-message.test.ts
@@ -207,6 +207,50 @@ describe("Crestodian rescue message", () => {
     expect(deps.runTui).not.toHaveBeenCalled();
   });
 
+  it("rejects natural language instead of guessing an operation", async () => {
+    const cfg: OpenClawConfig = { crestodian: { rescue: { enabled: true } } };
+    const deps = {
+      runGatewayStop: vi.fn(async () => {}),
+      runGatewayRestart: vi.fn(async () => {}),
+    };
+
+    // Questions must never become mutation plans (previously "why did my
+    // gateway stop" keyword-matched into a gateway-stop proposal).
+    await expect(
+      runRescue("/crestodian why did my gateway stop", cfg, commandContext(), deps),
+    ).resolves.toContain("I can run doctor/status/health");
+    await expect(
+      runRescue("/crestodian explain how restart gateway works", cfg, commandContext(), deps),
+    ).resolves.toContain("I can run doctor/status/health");
+    expect(deps.runGatewayStop).not.toHaveBeenCalled();
+    expect(deps.runGatewayRestart).not.toHaveBeenCalled();
+  });
+
+  it("refuses channel setup from remote rescue with a local pointer", async () => {
+    const cfg: OpenClawConfig = { crestodian: { rescue: { enabled: true } } };
+    await expect(runRescue("/crestodian connect telegram", cfg)).resolves.toContain(
+      "cannot host the interactive channel setup",
+    );
+  });
+
+  it("drops a pending rescue change on decline", async () => {
+    await withRescueStateDir("decline-", async () => {
+      const cfg: OpenClawConfig = { crestodian: { rescue: { enabled: true } } };
+      const deps = { runGatewayRestart: vi.fn(async () => {}) };
+
+      await expect(
+        runRescue("/crestodian restart gateway", cfg, commandContext(), deps),
+      ).resolves.toContain("Reply /crestodian yes to apply");
+      await expect(runRescue("/crestodian no", cfg, commandContext(), deps)).resolves.toContain(
+        "Dropped the pending Crestodian rescue change",
+      );
+      await expect(runRescue("/crestodian yes", cfg, commandContext(), deps)).resolves.toBe(
+        "No pending Crestodian rescue change is waiting for approval.",
+      );
+      expect(deps.runGatewayRestart).not.toHaveBeenCalled();
+    });
+  });
+
   it("refuses plugin install from remote rescue", async () => {
     const cfg: OpenClawConfig = { crestodian: { rescue: { enabled: true } } };
     const deps = {

--- a/src/crestodian/rescue-message.ts
+++ b/src/crestodian/rescue-message.ts
@@ -11,6 +11,7 @@ import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { tryReadJson, writeJson } from "../infra/json-files.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { classifyCrestodianApprovalText } from "./approval-intent.js";
 import {
   executeCrestodianOperation,
   formatCrestodianPersistentPlan,
@@ -48,7 +49,6 @@ export type CrestodianRescueMessageInput = {
 };
 
 const CRESTODIAN_COMMAND = "/crestodian";
-const APPROVAL_RE = /^(yes|y|apply|approve|approved|do it)$/i;
 
 function createCaptureRuntime(): { runtime: RuntimeEnv; read: () => string } {
   const lines: string[] = [];
@@ -146,6 +146,12 @@ function formatUnsupportedRemoteOperation(operation: CrestodianOperation): strin
       "Use local `openclaw` for agent handoff, or ask for status, doctor, config, gateway, agents, or models.",
     ].join(" ");
   }
+  if (operation.kind === "channel-setup") {
+    return [
+      "Crestodian rescue cannot host the interactive channel setup from a message channel.",
+      "Run `openclaw crestodian` locally and say `connect " + operation.channel + "` instead.",
+    ].join(" ");
+  }
   if (operation.kind === "plugin-install") {
     return [
       "Crestodian rescue cannot install plugins from a message channel by default because plugin install downloads executable code.",
@@ -174,7 +180,9 @@ export async function runCrestodianRescueMessage(
   }
 
   const pendingPath = resolvePendingPath(input);
-  if (APPROVAL_RE.test(rescueMessage)) {
+  // Remote rescue never consults a model (a broken/compromised agent path must
+  // not become a config editor); approval stays on the closed deterministic list.
+  if (classifyCrestodianApprovalText(rescueMessage) === "approve") {
     const pending = await readPending(pendingPath);
     if (!pending) {
       return "No pending Crestodian rescue change is waiting for approval.";
@@ -192,6 +200,14 @@ export async function runCrestodianRescueMessage(
     });
     await fs.rm(pendingPath, { force: true });
     return capture.read() || "Crestodian rescue change applied.";
+  }
+
+  if (classifyCrestodianApprovalText(rescueMessage) === "decline") {
+    const pending = await readPending(pendingPath);
+    await fs.rm(pendingPath, { force: true });
+    return pending
+      ? "Dropped the pending Crestodian rescue change."
+      : "No pending Crestodian rescue change is waiting for approval.";
   }
 
   const operation = parseCrestodianOperation(rescueMessage);

--- a/src/crestodian/tui-backend.test.ts
+++ b/src/crestodian/tui-backend.test.ts
@@ -12,6 +12,7 @@ const overview: CrestodianOverview = {
   tools: {
     codex: { command: "codex", found: false, error: "not found" },
     claude: { command: "claude", found: false, error: "not found" },
+    gemini: { command: "gemini", found: false, error: "not found" },
     apiKeys: { openai: true, anthropic: false },
   },
   gateway: {


### PR DESCRIPTION
## What Problem This Solves

Crestodian is documented as AI-first, but keyword heuristics front-ran the AI and turned natural language into operations, and approvals only accepted a hardcoded regex. All reproduced against `main` (#100604):

- `should I talk to my agent about this?` parsed as `open-tui` and immediately exited Crestodian into the agent TUI.
- `set me up with telegram` proposed a full `setup` bootstrap; `setup for my team` extracted workspace `"my"`; `can I set the default model gpt-5.5 later?` proposed the garbage model ref `gpt-5.5 later?`.
- Rescue/one-shot loose mode: `/crestodian why did my gateway stop` proposed **stopping the gateway**; `openclaw crestodian --message "explain how restart gateway works" --yes` **restarted it**.
- `isYes` accepted only `y|yes|apply|do it|approved` — even `Yes.` (trailing period) bounced, and "sure"/"ok"/"go ahead" looped back to a re-ask.

## Why This Change Was Made

The conversation layer should be AI-only: the model owns interpretation and dialogue, the host owns consent verification, and the typed grammar exists only where no model can run (configless fallback, rescue, one-shot).

- **AI-only chat.** Every message routes to the agent loop (planner as fallback). The typed grammar is now a single anchored command language used solely as the no-model deterministic fallback and the rescue/one-shot command surface — questions can never execute operations.
- **Model-judged approvals.** New `approval-intent.ts`: a host-run classifier judges approve/decline from the user's own words (closed-list fast path for unambiguous replies, single-shot model judgment for the rest, fail-closed to "other"). The conversation model still cannot self-approve — the three-gate handshake in `crestodian-tool.ts` (model assertion + host-verified consent + exact-operation hash) is unchanged; only the host's consent source got smarter. Remote rescue stays deterministic-only by design.
- **Tool-driven navigation.** New ring-zero `connect_channel`/`open_agent` directive actions: the AI starts the hosted channel wizard or agent handoff itself (in-process ref for embedded runs, event mirror for CLI MCP runs), replacing "tell the user to type `connect telegram`". Starting a wizard is no longer approval-gated — the wizard itself collects explicit answers.
- **Engine hardening.** Chat turns are serialized (interleaved handles corrupted wizard/pending state); a stale host-side proposal is cleared once the agent loop owns the conversation (a later "yes" could previously apply an operation the user was no longer looking at); a declined agent-loop proposal is voided so it can never be armed later; sensitive `config set` values are redacted from AI-visible history.
- **Refactor.** `operations.ts` executor is table-driven: one `applyPersistentOperation` wrapper owns the approval gate, before/after config hashes, audit record, and `[crestodian] running/done` markers (net −36 LOC in that file despite the new grammar comments).
- **Gemini parity.** Gemini CLI joins the overview probes, `models` output, prompts, and the local backend ladder (setup-ladder order), with model refs single-sourced from `onboard-inference.ts`.

## User Impact

Talking to Crestodian works like talking to an agent: questions get answers, "sure, go ahead" counts as approval, `connect telegram` in any phrasing starts the guided setup, and nothing mutates without host-verified consent bound to the exact operation. Configless machines keep the full deterministic command surface. Docs updated (`docs/cli/crestodian.md`: AI conversation, approvals, rescue grammar, Gemini fallback).

## Evidence

- Parser regression matrix verified live: all eight NL misfires now return `none` (routed to AI) while every documented command (`setup workspace … model …`, `config set-ref … env …`, `talk to agent for …`, `/crestodian restart gateway`, …) parses identically, and the e2e contract markers (`[crestodian] done: <op>`, audit op ids) are unchanged.
- New/updated tests: `approval-intent.test.ts` (closed-list + model judgment + fail-closed), `chat-engine.test.ts` (armed turns via classifier, directive execution, stale-proposal clearing, decline voiding, history redaction, wizard-without-ceremony), `crestodian-tool.test.ts` (directive recording + CLI MCP mirroring), `rescue-message.test.ts` (NL rejection, channel-setup refusal, decline drop), `operations.test.ts` (anchored grammar).
- Focused suites green: 16 files / 104 tests across `src/crestodian`, `src/agents/tools/crestodian-tool.test.ts`, `src/gateway/server-methods/crestodian.test.ts` (raw `vitest run` with isolated module cache; Testbox leases were shutting down mid-hydration at the time, hosted CI covers the full gate).
- `tsgo -p tsconfig.core.json` clean for all touched files.
- Structured Codex review (gpt-5.5) of the branch diff: one P1 accepted and fixed (exact sensitive `config set` commands previously reached the AI turn; they now run deterministically and never touch a model), rerun clean with no actionable findings.

One extra hardening beyond the review: a typed sensitive `config set` is masked in AI-visible history, and its plan/audit output was already redacted.

Follow-up (out of scope here): streaming progress for long agent turns, and moving rescue pending-approval files into the SQLite state store.

Fixes #100604
