### PR TITLE
perf(acp): use PRAGMA page_count for O(1) ledger byte estimate

### DIFF
--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -682,16 +682,13 @@ function upsertSqliteSession(
 }
 
 function estimateSqliteLedgerBytes(db: DatabaseSync): number {
-  const row = db
-    .prepare(
-      `SELECT
-         COALESCE(SUM(length(session_id) + length(session_key) + length(cwd) + 32), 0) AS sessions,
-         (SELECT COALESCE(SUM(length(session_id) + length(session_key) + length(update_json) + COALESCE(length(run_id), 0) + 32), 0)
-            FROM acp_replay_events) AS events
-       FROM acp_replay_sessions`,
-    )
-    .get() as { sessions?: number | bigint; events?: number | bigint } | undefined;
-  return normalizeSqliteInteger(row?.sessions ?? 0) + normalizeSqliteInteger(row?.events ?? 0);
+  // Use SQLite page-count metadata for an O(1) file-size estimate instead
+  // of SUM(length(...)) which scans every row on each call. This function
+  // runs on every event append and inside trim loops, so the old table
+  // scan caused noticeable degradation with large histories.
+  const pc = db.prepare("PRAGMA page_count").get() as { page_count: number } | undefined;
+  const ps = db.prepare("PRAGMA page_size").get() as { page_size: number } | undefined;
+  return (pc?.page_count ?? 0) * (ps?.page_size ?? 0);
 }
 
 function trimSqliteLedger(


### PR DESCRIPTION
## What Problem This Solves

Fixes #100622: `estimateSqliteLedgerBytes` ran expensive `SUM(length(...))` subqueries against `acp_replay_sessions` and `acp_replay_events` on every event append and inside trim loops. This caused full table scans that degraded performance with large event histories.

## Why This Change Was Made

Replaced the table-scanning `SUM(length(...))` query with `PRAGMA page_count * page_size`, which SQLite serves from the database header in O(1) time without touching any table rows. The function is called on every event write (hot path) and repeatedly inside trim loops.

## User Impact

- Event ledger writes no longer degrade with growing history
- Trim loops that call `estimateSqliteLedgerBytes` repeatedly complete faster
- The estimate is file-level rather than ledger-specific, which is sufficient for the trim threshold check

## Evidence

- [x] Source analysis confirms `estimateSqliteLedgerBytes` at `src/acp/event-ledger.ts:684` as the hot-path function
- [x] `pnpm test src/acp/translator.event-ledger.test.ts` — 3 tests pass
- [x] `oxlint` passes on changed file
- [x] `normalizeSqliteInteger` still used by 10 other call sites, no dead code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
