### PR TITLE
fix: avoid repeated ACP ledger byte scans during writes

### DIFF
--- a/src/acp/event-ledger.test.ts
+++ b/src/acp/event-ledger.test.ts
@@ -609,6 +609,99 @@ describe("ACP event ledger", () => {
     });
   });
 
+  it("invalidates SQLite byte estimate cache after the shared database handle reopens", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      type SqlitePrepare = DatabaseSync["prepare"];
+      type SqliteStatement = ReturnType<SqlitePrepare>;
+      const prepareDescriptor = Object.getOwnPropertyDescriptor(DatabaseSync.prototype, "prepare");
+      if (typeof prepareDescriptor?.value !== "function") {
+        throw new Error("Expected DatabaseSync.prototype.prepare to be patchable");
+      }
+      const originalPrepare = prepareDescriptor.value as SqlitePrepare;
+      let byteEstimateQueries = 0;
+      Object.defineProperty(DatabaseSync.prototype, "prepare", {
+        ...prepareDescriptor,
+        value: function prepareWithStableDataVersion(this: DatabaseSync, sql: string) {
+          const statement = Reflect.apply(originalPrepare, this, [sql]) as SqliteStatement;
+          if (sql.includes("COALESCE(SUM(length(session_id)")) {
+            byteEstimateQueries++;
+          }
+          if (sql !== "PRAGMA data_version") {
+            return statement;
+          }
+          return new Proxy(statement, {
+            get(target, property, receiver) {
+              if (property !== "get") {
+                return Reflect.get(target, property, receiver) as unknown;
+              }
+              return () => ({ data_version: 1 });
+            },
+          });
+        },
+      });
+      try {
+        const databasePath = path.join(dir, "openclaw.sqlite");
+        const ledger = createSqliteAcpEventLedger({
+          path: databasePath,
+          maxSerializedBytes: 1024,
+        });
+        await ledger.startSession({
+          sessionId: "session-1",
+          sessionKey: "agent:main:work",
+          cwd: "/work",
+          complete: true,
+        });
+        expect(byteEstimateQueries).toBe(1);
+
+        closeOpenClawStateDatabaseForTest();
+        const externalDb = new DatabaseSync(databasePath);
+        try {
+          externalDb
+            .prepare(
+              `INSERT INTO acp_replay_events (session_id, seq, at, session_key, run_id, update_json)
+               VALUES (?, ?, ?, ?, ?, ?)`,
+            )
+            .run(
+              "session-1",
+              1,
+              1001,
+              "agent:main:work",
+              null,
+              JSON.stringify({
+                sessionUpdate: "tool_call_update",
+                toolCallId: "tool-1",
+                status: "completed",
+                rawOutput: { content: "x".repeat(5_000) },
+              }),
+            );
+          externalDb
+            .prepare(
+              "UPDATE acp_replay_sessions SET updated_at = ?, next_seq = ? WHERE session_id = ?",
+            )
+            .run(1001, 2, "session-1");
+        } finally {
+          externalDb.close();
+        }
+
+        await ledger.recordUpdate({
+          sessionId: "session-1",
+          sessionKey: "agent:main:work",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "Answer" },
+          },
+        });
+
+        expect(byteEstimateQueries).toBe(2);
+        await expect(
+          ledger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
+        ).resolves.toEqual({ complete: false, events: [] });
+      } finally {
+        Object.defineProperty(DatabaseSync.prototype, "prepare", prepareDescriptor);
+      }
+    });
+  });
+
   it("does not publish SQLite byte estimate deltas from failed writes", async () => {
     await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
       type SqlitePrepare = DatabaseSync["prepare"];

--- a/src/acp/event-ledger.test.ts
+++ b/src/acp/event-ledger.test.ts
@@ -1,6 +1,7 @@
 /** Tests ACP event ledger recording, replay, retention, and SQLite migration. */
 import fs from "node:fs/promises";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
@@ -428,4 +429,272 @@ describe("ACP event ledger", () => {
     ).resolves.toEqual({ complete: false, events: [] });
   });
 
+  it("marks SQLite-backed replay incomplete when serialized byte retention trims payloads", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      const ledger = createSqliteAcpEventLedger({
+        path: path.join(dir, "openclaw.sqlite"),
+        maxSerializedBytes: 1024,
+      });
+      await ledger.startSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        cwd: "/work",
+        complete: true,
+      });
+      await ledger.recordUpdate({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tool-1",
+          status: "completed",
+          rawOutput: { content: "x".repeat(5_000) },
+        },
+      });
+
+      await expect(
+        ledger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
+      ).resolves.toEqual({ complete: false, events: [] });
+    });
+  });
+
+  it("does not rescan replay table byte totals for each SQLite-backed update", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      type SqlitePrepare = DatabaseSync["prepare"];
+      const prepareDescriptor = Object.getOwnPropertyDescriptor(DatabaseSync.prototype, "prepare");
+      if (typeof prepareDescriptor?.value !== "function") {
+        throw new Error("Expected DatabaseSync.prototype.prepare to be patchable");
+      }
+      const originalPrepare = prepareDescriptor.value as SqlitePrepare;
+      let byteEstimateQueries = 0;
+      Object.defineProperty(DatabaseSync.prototype, "prepare", {
+        ...prepareDescriptor,
+        value: function prepareWithQueryCount(this: DatabaseSync, sql: string) {
+          if (sql.includes("COALESCE(SUM(length(session_id)")) {
+            byteEstimateQueries++;
+          }
+          return Reflect.apply(originalPrepare, this, [sql]) as ReturnType<SqlitePrepare>;
+        },
+      });
+      try {
+        const ledger = createSqliteAcpEventLedger({
+          path: path.join(dir, "openclaw.sqlite"),
+          maxSerializedBytes: 1024 * 1024,
+        });
+        await ledger.startSession({
+          sessionId: "session-1",
+          sessionKey: "agent:main:work",
+          cwd: "/work",
+          complete: true,
+        });
+        expect(byteEstimateQueries).toBe(1);
+
+        for (let index = 0; index < 5; index++) {
+          await ledger.recordUpdate({
+            sessionId: "session-1",
+            sessionKey: "agent:main:work",
+            update: {
+              sessionUpdate: "agent_message_chunk",
+              content: { type: "text", text: `Answer ${index}` },
+            },
+          });
+        }
+
+        expect(byteEstimateQueries).toBe(1);
+      } finally {
+        Object.defineProperty(DatabaseSync.prototype, "prepare", prepareDescriptor);
+      }
+    });
+  });
+
+  it("shares SQLite byte estimate cache across ledger instances for one database", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      const databasePath = path.join(dir, "openclaw.sqlite");
+      const trimmingLedger = createSqliteAcpEventLedger({
+        path: databasePath,
+        maxSerializedBytes: 1024,
+      });
+      await trimmingLedger.startSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        cwd: "/work",
+        complete: true,
+      });
+
+      const permissiveLedger = createSqliteAcpEventLedger({
+        path: databasePath,
+        maxSerializedBytes: 1024 * 1024,
+      });
+      await permissiveLedger.recordUpdate({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tool-1",
+          status: "completed",
+          rawOutput: { content: "x".repeat(5_000) },
+        },
+      });
+
+      await trimmingLedger.recordUpdate({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Answer" },
+        },
+      });
+
+      await expect(
+        trimmingLedger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
+      ).resolves.toEqual({ complete: false, events: [] });
+    });
+  });
+
+  it("invalidates SQLite byte estimate cache after another connection writes", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      const databasePath = path.join(dir, "openclaw.sqlite");
+      const ledger = createSqliteAcpEventLedger({
+        path: databasePath,
+        maxSerializedBytes: 1024,
+      });
+      await ledger.startSession({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        cwd: "/work",
+        complete: true,
+      });
+
+      const externalDb = new DatabaseSync(databasePath);
+      try {
+        externalDb
+          .prepare(
+            `INSERT INTO acp_replay_events (session_id, seq, at, session_key, run_id, update_json)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          )
+          .run(
+            "session-1",
+            1,
+            1001,
+            "agent:main:work",
+            null,
+            JSON.stringify({
+              sessionUpdate: "tool_call_update",
+              toolCallId: "tool-1",
+              status: "completed",
+              rawOutput: { content: "x".repeat(5_000) },
+            }),
+          );
+        externalDb
+          .prepare(
+            "UPDATE acp_replay_sessions SET updated_at = ?, next_seq = ? WHERE session_id = ?",
+          )
+          .run(1001, 2, "session-1");
+      } finally {
+        externalDb.close();
+      }
+
+      await ledger.recordUpdate({
+        sessionId: "session-1",
+        sessionKey: "agent:main:work",
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Answer" },
+        },
+      });
+
+      await expect(
+        ledger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
+      ).resolves.toEqual({ complete: false, events: [] });
+    });
+  });
+
+  it("does not publish SQLite byte estimate deltas from failed writes", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      type SqlitePrepare = DatabaseSync["prepare"];
+      type SqliteStatement = ReturnType<SqlitePrepare>;
+      const prepareDescriptor = Object.getOwnPropertyDescriptor(DatabaseSync.prototype, "prepare");
+      if (typeof prepareDescriptor?.value !== "function") {
+        throw new Error("Expected DatabaseSync.prototype.prepare to be patchable");
+      }
+      const originalPrepare = prepareDescriptor.value as SqlitePrepare;
+      let failNextSessionAdvance = false;
+      Object.defineProperty(DatabaseSync.prototype, "prepare", {
+        ...prepareDescriptor,
+        value: function prepareWithSessionAdvanceFailure(this: DatabaseSync, sql: string) {
+          const statement = Reflect.apply(originalPrepare, this, [sql]) as SqliteStatement;
+          if (!sql.includes("UPDATE acp_replay_sessions") || !sql.includes("next_seq = ?")) {
+            return statement;
+          }
+          return new Proxy(statement, {
+            get(target, property, receiver) {
+              if (property !== "run") {
+                return Reflect.get(target, property, receiver) as unknown;
+              }
+              return (...args: Parameters<SqliteStatement["run"]>) => {
+                if (failNextSessionAdvance) {
+                  failNextSessionAdvance = false;
+                  throw new Error("injected session advance failure");
+                }
+                const run = Reflect.get(target, "run", target) as SqliteStatement["run"];
+                return Reflect.apply(run, target, args) as ReturnType<SqliteStatement["run"]>;
+              };
+            },
+          });
+        },
+      });
+      try {
+        const ledger = createSqliteAcpEventLedger({
+          path: path.join(dir, "openclaw.sqlite"),
+          maxSerializedBytes: 1024,
+        });
+        await ledger.startSession({
+          sessionId: "session-1",
+          sessionKey: "agent:main:work",
+          cwd: "/work",
+          complete: true,
+        });
+
+        failNextSessionAdvance = true;
+        await expect(
+          ledger.recordUpdate({
+            sessionId: "session-1",
+            sessionKey: "agent:main:work",
+            update: {
+              sessionUpdate: "tool_call_update",
+              toolCallId: "tool-1",
+              status: "completed",
+              rawOutput: { content: "x".repeat(5_000) },
+            },
+          }),
+        ).rejects.toThrow("injected session advance failure");
+
+        await ledger.recordUpdate({
+          sessionId: "session-1",
+          sessionKey: "agent:main:work",
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: "Answer" },
+          },
+        });
+
+        await expect(
+          ledger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
+        ).resolves.toMatchObject({
+          complete: true,
+          events: [
+            {
+              seq: 1,
+              update: {
+                sessionUpdate: "agent_message_chunk",
+                content: { type: "text", text: "Answer" },
+              },
+            },
+          ],
+        });
+      } finally {
+        Object.defineProperty(DatabaseSync.prototype, "prepare", prepareDescriptor);
+      }
+    });
+  });
 });

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -12,6 +12,7 @@ import {
   type OpenClawStateDatabaseOptions,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { isRecord } from "../utils.js";
 
 const LEDGER_VERSION = 1;
@@ -102,6 +103,17 @@ type MutableLedgerState = {
   maxSerializedBytes: number;
   now: () => number;
 };
+
+type SqliteLedgerByteCache = {
+  dataVersion?: number;
+  serializedBytes?: number;
+};
+
+type SqliteLedgerState = Omit<MutableLedgerState, "store"> & {
+  byteCache: SqliteLedgerByteCache;
+};
+
+const sqliteLedgerByteCaches = new Map<string, SqliteLedgerByteCache>();
 
 function createEmptyStore(): LedgerStore {
   return {
@@ -556,6 +568,101 @@ type AcpReplayEventRow = {
   update_json: string;
 };
 
+const SQLITE_LEDGER_ROW_OVERHEAD = 32;
+
+function getSqliteTextLength(value: string | null | undefined): number {
+  if (!value) {
+    return 0;
+  }
+  // SQLite length(TEXT) counts code points before NUL; mirror the old SQL estimate.
+  return Array.from(value.split("\0", 1)[0] ?? "").length;
+}
+
+function estimateSqliteSessionRowBytes(
+  row: Pick<AcpReplaySessionRow, "session_id" | "session_key" | "cwd">,
+): number {
+  return (
+    getSqliteTextLength(row.session_id) +
+    getSqliteTextLength(row.session_key) +
+    getSqliteTextLength(row.cwd) +
+    SQLITE_LEDGER_ROW_OVERHEAD
+  );
+}
+
+function estimateSqliteEventRowBytes(
+  row: Pick<AcpReplayEventRow, "session_id" | "session_key" | "run_id" | "update_json">,
+): number {
+  return (
+    getSqliteTextLength(row.session_id) +
+    getSqliteTextLength(row.session_key) +
+    getSqliteTextLength(row.update_json) +
+    getSqliteTextLength(row.run_id) +
+    SQLITE_LEDGER_ROW_OVERHEAD
+  );
+}
+
+function readSqliteEventRowsForSession(db: DatabaseSync, sessionId: string): AcpReplayEventRow[] {
+  return db
+    .prepare(
+      `SELECT session_id, seq, at, session_key, run_id, update_json
+         FROM acp_replay_events
+        WHERE session_id = ?`,
+    )
+    .all(sessionId) as AcpReplayEventRow[];
+}
+
+function estimateSqliteSessionTreeBytes(db: DatabaseSync, session: AcpReplaySessionRow): number {
+  return (
+    estimateSqliteSessionRowBytes(session) +
+    readSqliteEventRowsForSession(db, session.session_id).reduce(
+      (total, event) => total + estimateSqliteEventRowBytes(event),
+      0,
+    )
+  );
+}
+
+function applySqliteLedgerBytesDelta(
+  state: { byteCache: SqliteLedgerByteCache },
+  delta: number,
+): void {
+  if (state.byteCache.serializedBytes === undefined || delta === 0) {
+    return;
+  }
+  state.byteCache.serializedBytes = Math.max(0, state.byteCache.serializedBytes + delta);
+}
+
+function readSqliteDataVersion(db: DatabaseSync): number | undefined {
+  const row = db.prepare("PRAGMA data_version").get() as
+    | Record<string, number | bigint | undefined>
+    | undefined;
+  const value = row ? Object.values(row)[0] : undefined;
+  return value === undefined ? undefined : normalizeSqliteInteger(value);
+}
+
+function syncSqliteLedgerByteCache(db: DatabaseSync, state: { byteCache: SqliteLedgerByteCache }) {
+  const dataVersion = readSqliteDataVersion(db);
+  if (dataVersion === undefined) {
+    state.byteCache.serializedBytes = undefined;
+    return;
+  }
+  if (
+    state.byteCache.serializedBytes !== undefined &&
+    state.byteCache.dataVersion !== undefined &&
+    state.byteCache.dataVersion !== dataVersion
+  ) {
+    state.byteCache.serializedBytes = undefined;
+  }
+  state.byteCache.dataVersion = dataVersion;
+}
+
+function getSqliteLedgerBytes(
+  db: DatabaseSync,
+  state: { byteCache: SqliteLedgerByteCache },
+): number {
+  state.byteCache.serializedBytes ??= estimateSqliteLedgerBytes(db);
+  return state.byteCache.serializedBytes;
+}
+
 function sqliteRowToLedgerSession(db: DatabaseSync, row: AcpReplaySessionRow): LedgerSession {
   const events = db
     .prepare(
@@ -598,14 +705,21 @@ function sqliteRowToLedgerEvent(row: AcpReplayEventRow): AcpEventLedgerEntry | u
   });
 }
 
-function readSqliteSessionById(db: DatabaseSync, sessionId: string): LedgerSession | undefined {
-  const row = db
+function readSqliteSessionMetadataById(
+  db: DatabaseSync,
+  sessionId: string,
+): AcpReplaySessionRow | undefined {
+  return db
     .prepare(
       `SELECT session_id, session_key, cwd, complete, created_at, updated_at, next_seq
          FROM acp_replay_sessions
         WHERE session_id = ?`,
     )
     .get(sessionId) as AcpReplaySessionRow | undefined;
+}
+
+function readSqliteSessionById(db: DatabaseSync, sessionId: string): LedgerSession | undefined {
+  const row = readSqliteSessionMetadataById(db, sessionId);
   return row ? sqliteRowToLedgerSession(db, row) : undefined;
 }
 
@@ -627,7 +741,7 @@ function readLatestCompleteSqliteSessionByKey(
 
 function upsertSqliteSession(
   db: DatabaseSync,
-  state: Pick<MutableLedgerState, "now">,
+  state: Pick<SqliteLedgerState, "now" | "byteCache">,
   params: {
     sessionId: string;
     sessionKey: string;
@@ -637,27 +751,49 @@ function upsertSqliteSession(
   },
 ): LedgerSession {
   const now = state.now();
-  const existing = readSqliteSessionById(db, params.sessionId);
+  const existing = readSqliteSessionMetadataById(db, params.sessionId);
   if (!params.reset && existing) {
     const cwd = params.cwd || existing.cwd;
     const complete = existing.complete || params.complete ? 1 : 0;
+    const nextRow = {
+      ...existing,
+      session_key: params.sessionKey,
+      cwd,
+    };
     db.prepare(
       `UPDATE acp_replay_sessions
           SET session_key = ?, cwd = ?, complete = ?, updated_at = ?
         WHERE session_id = ?`,
     ).run(params.sessionKey, cwd, complete, now, params.sessionId);
+    applySqliteLedgerBytesDelta(
+      state,
+      estimateSqliteSessionRowBytes(nextRow) - estimateSqliteSessionRowBytes(existing),
+    );
     return {
-      ...existing,
+      sessionId: existing.session_id,
       sessionKey: params.sessionKey,
       cwd,
       complete: complete === 1,
+      createdAt: normalizeSqliteInteger(existing.created_at),
       updatedAt: now,
+      nextSeq: normalizeSqliteInteger(existing.next_seq),
+      events: [],
     };
   }
 
   if (params.reset) {
+    const removedEventBytes = readSqliteEventRowsForSession(db, params.sessionId).reduce(
+      (total, row) => total + estimateSqliteEventRowBytes(row),
+      0,
+    );
     db.prepare("DELETE FROM acp_replay_events WHERE session_id = ?").run(params.sessionId);
+    applySqliteLedgerBytesDelta(state, -removedEventBytes);
   }
+  const nextRow = {
+    session_id: params.sessionId,
+    session_key: params.sessionKey,
+    cwd: params.cwd,
+  };
   db.prepare(
     `INSERT INTO acp_replay_sessions (
        session_id, session_key, cwd, complete, created_at, updated_at, next_seq
@@ -669,12 +805,17 @@ function upsertSqliteSession(
        updated_at = excluded.updated_at,
        next_seq = excluded.next_seq`,
   ).run(params.sessionId, params.sessionKey, params.cwd, params.complete ? 1 : 0, now, now);
+  applySqliteLedgerBytesDelta(
+    state,
+    estimateSqliteSessionRowBytes(nextRow) -
+      (existing ? estimateSqliteSessionRowBytes(existing) : 0),
+  );
   return {
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
     cwd: params.cwd,
     complete: params.complete,
-    createdAt: existing?.createdAt ?? now,
+    createdAt: existing ? normalizeSqliteInteger(existing.created_at) : now,
     updatedAt: now,
     nextSeq: 1,
     events: [],
@@ -696,7 +837,10 @@ function estimateSqliteLedgerBytes(db: DatabaseSync): number {
 
 function trimSqliteLedger(
   db: DatabaseSync,
-  state: Pick<MutableLedgerState, "maxEventsPerSession" | "maxSessions" | "maxSerializedBytes">,
+  state: Pick<
+    SqliteLedgerState,
+    "maxEventsPerSession" | "maxSessions" | "maxSerializedBytes" | "byteCache"
+  >,
 ): void {
   const sessionsWithCounts = db
     .prepare(
@@ -713,18 +857,19 @@ function trimSqliteLedger(
     }
     const oldEvents = db
       .prepare(
-        `SELECT seq
+        `SELECT session_id, seq, at, session_key, run_id, update_json
            FROM acp_replay_events
           WHERE session_id = ?
           ORDER BY seq ASC
           LIMIT ?`,
       )
-      .all(row.session_id, overage) as Array<{ seq: number | bigint }>;
+      .all(row.session_id, overage) as AcpReplayEventRow[];
     const deleteEvent = db.prepare(
       "DELETE FROM acp_replay_events WHERE session_id = ? AND seq = ?",
     );
     for (const event of oldEvents) {
       deleteEvent.run(row.session_id, normalizeSqliteInteger(event.seq));
+      applySqliteLedgerBytesDelta(state, -estimateSqliteEventRowBytes(event));
     }
     db.prepare("UPDATE acp_replay_sessions SET complete = 0 WHERE session_id = ?").run(
       row.session_id,
@@ -733,27 +878,34 @@ function trimSqliteLedger(
 
   const oldSessions = db
     .prepare(
-      `SELECT session_id
+      `SELECT session_id, session_key, cwd, complete, created_at, updated_at, next_seq
          FROM acp_replay_sessions
         ORDER BY updated_at DESC, session_id ASC
         LIMIT -1 OFFSET ?`,
     )
-    .all(state.maxSessions) as Array<{ session_id: string }>;
+    .all(state.maxSessions) as AcpReplaySessionRow[];
   for (const session of oldSessions) {
+    const removedBytes = estimateSqliteSessionTreeBytes(db, session);
     db.prepare("DELETE FROM acp_replay_sessions WHERE session_id = ?").run(session.session_id);
+    applySqliteLedgerBytesDelta(state, -removedBytes);
   }
 
-  let serializedBytes = estimateSqliteLedgerBytes(db);
+  let serializedBytes = getSqliteLedgerBytes(db, state);
   while (serializedBytes > state.maxSerializedBytes) {
     const event = db
       .prepare(
-        `SELECT e.session_id AS session_id, e.seq AS seq
+        `SELECT e.session_id AS session_id,
+                e.seq AS seq,
+                e.at AS at,
+                e.session_key AS session_key,
+                e.run_id AS run_id,
+                e.update_json AS update_json
            FROM acp_replay_events e
            JOIN acp_replay_sessions s ON s.session_id = e.session_id
           ORDER BY s.updated_at ASC, e.seq ASC
           LIMIT 1`,
       )
-      .get() as { session_id: string; seq: number | bigint } | undefined;
+      .get() as AcpReplayEventRow | undefined;
     if (!event) {
       break;
     }
@@ -761,35 +913,35 @@ function trimSqliteLedger(
       event.session_id,
       normalizeSqliteInteger(event.seq),
     );
+    applySqliteLedgerBytesDelta(state, -estimateSqliteEventRowBytes(event));
     db.prepare("UPDATE acp_replay_sessions SET complete = 0 WHERE session_id = ?").run(
       event.session_id,
     );
-    serializedBytes = estimateSqliteLedgerBytes(db);
+    serializedBytes = getSqliteLedgerBytes(db, state);
   }
 
   while (serializedBytes > state.maxSerializedBytes) {
     const session = db
       .prepare(
-        `SELECT session_id
+        `SELECT session_id, session_key, cwd, complete, created_at, updated_at, next_seq
            FROM acp_replay_sessions
           ORDER BY updated_at ASC, session_id ASC
           LIMIT 1`,
       )
-      .get() as { session_id: string } | undefined;
+      .get() as AcpReplaySessionRow | undefined;
     if (!session) {
       break;
     }
+    const removedBytes = estimateSqliteSessionTreeBytes(db, session);
     db.prepare("DELETE FROM acp_replay_sessions WHERE session_id = ?").run(session.session_id);
-    serializedBytes = estimateSqliteLedgerBytes(db);
+    applySqliteLedgerBytesDelta(state, -removedBytes);
+    serializedBytes = getSqliteLedgerBytes(db, state);
   }
 }
 
 function appendSqliteUpdate(
   db: DatabaseSync,
-  state: Pick<
-    MutableLedgerState,
-    "now" | "maxEventsPerSession" | "maxSessions" | "maxSerializedBytes"
-  >,
+  state: SqliteLedgerState,
   params: {
     sessionId: string;
     sessionKey: string;
@@ -804,6 +956,7 @@ function appendSqliteUpdate(
     complete: false,
   });
   const now = state.now();
+  const updateJson = JSON.stringify(cloneJsonValue(params.update));
   db.prepare(
     `INSERT INTO acp_replay_events (session_id, seq, at, session_key, run_id, update_json)
      VALUES (?, ?, ?, ?, ?, ?)`,
@@ -813,7 +966,16 @@ function appendSqliteUpdate(
     now,
     params.sessionKey,
     params.runId ?? null,
-    JSON.stringify(cloneJsonValue(params.update)),
+    updateJson,
+  );
+  applySqliteLedgerBytesDelta(
+    state,
+    estimateSqliteEventRowBytes({
+      session_id: params.sessionId,
+      session_key: params.sessionKey,
+      run_id: params.runId ?? null,
+      update_json: updateJson,
+    }),
   );
   db.prepare(
     `UPDATE acp_replay_sessions
@@ -835,31 +997,55 @@ function buildSqliteReplay(session: LedgerSession | undefined): AcpEventLedgerRe
   };
 }
 
+function getSqliteLedgerByteCache(options: OpenClawStateDatabaseOptions): SqliteLedgerByteCache {
+  const cacheKey = path.resolve(
+    options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
+  );
+  let cache = sqliteLedgerByteCaches.get(cacheKey);
+  if (!cache) {
+    cache = {};
+    sqliteLedgerByteCaches.set(cacheKey, cache);
+  }
+  return cache;
+}
+
 /** Creates the SQLite-backed ACP event ledger used by the state database. */
 export function createSqliteAcpEventLedger(
   params: OpenClawStateDatabaseOptions & LedgerOptions = {},
 ): AcpEventLedger {
   const normalized = normalizeLedgerOptions(params);
   const dbOptions = { env: params.env, path: params.path };
-  const state = {
+  const byteCache = getSqliteLedgerByteCache(dbOptions);
+  const state: SqliteLedgerState = {
     ...normalized,
+    byteCache,
   };
-  const mutate = (fn: (db: DatabaseSync) => void) =>
-    runOpenClawStateWriteTransaction((database) => fn(database.db), dbOptions);
+  const mutate = (fn: (db: DatabaseSync, transactionState: SqliteLedgerState) => void) => {
+    const transactionState = {
+      ...state,
+      byteCache: { ...state.byteCache },
+    };
+    runOpenClawStateWriteTransaction((database) => {
+      syncSqliteLedgerByteCache(database.db, transactionState);
+      fn(database.db, transactionState);
+    }, dbOptions);
+    state.byteCache.serializedBytes = transactionState.byteCache.serializedBytes;
+    state.byteCache.dataVersion = transactionState.byteCache.dataVersion;
+  };
   const read = <T>(fn: (db: DatabaseSync) => T): T => fn(openOpenClawStateDatabase(dbOptions).db);
 
   return {
     async startSession(sessionParams) {
-      mutate((db) => {
-        upsertSqliteSession(db, state, sessionParams);
-        trimSqliteLedger(db, state);
+      mutate((db, transactionState) => {
+        upsertSqliteSession(db, transactionState, sessionParams);
+        trimSqliteLedger(db, transactionState);
       });
     },
 
     async recordUserPrompt(promptParams) {
-      mutate((db) => {
+      mutate((db, transactionState) => {
         for (const update of createUserPromptUpdates(promptParams.prompt)) {
-          appendSqliteUpdate(db, state, {
+          appendSqliteUpdate(db, transactionState, {
             sessionId: promptParams.sessionId,
             sessionKey: promptParams.sessionKey,
             runId: promptParams.runId,
@@ -870,8 +1056,8 @@ export function createSqliteAcpEventLedger(
     },
 
     async recordUpdate(updateParams) {
-      mutate((db) => {
-        appendSqliteUpdate(db, state, updateParams);
+      mutate((db, transactionState) => {
+        appendSqliteUpdate(db, transactionState, updateParams);
       });
     },
 

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -105,6 +105,7 @@ type MutableLedgerState = {
 };
 
 type SqliteLedgerByteCache = {
+  db?: DatabaseSync;
   dataVersion?: number;
   serializedBytes?: number;
 };
@@ -640,12 +641,20 @@ function readSqliteDataVersion(db: DatabaseSync): number | undefined {
 }
 
 function syncSqliteLedgerByteCache(db: DatabaseSync, state: { byteCache: SqliteLedgerByteCache }) {
+  const connectionChanged = state.byteCache.db !== db;
+  if (connectionChanged) {
+    state.byteCache.serializedBytes = undefined;
+    state.byteCache.dataVersion = undefined;
+    state.byteCache.db = db;
+  }
   const dataVersion = readSqliteDataVersion(db);
   if (dataVersion === undefined) {
     state.byteCache.serializedBytes = undefined;
+    state.byteCache.dataVersion = undefined;
     return;
   }
   if (
+    !connectionChanged &&
     state.byteCache.serializedBytes !== undefined &&
     state.byteCache.dataVersion !== undefined &&
     state.byteCache.dataVersion !== dataVersion
@@ -1031,6 +1040,7 @@ export function createSqliteAcpEventLedger(
     }, dbOptions);
     state.byteCache.serializedBytes = transactionState.byteCache.serializedBytes;
     state.byteCache.dataVersion = transactionState.byteCache.dataVersion;
+    state.byteCache.db = transactionState.byteCache.db;
   };
   const read = <T>(fn: (db: DatabaseSync) => T): T => fn(openOpenClawStateDatabase(dbOptions).db);
 


### PR DESCRIPTION
Closes #100622

## What Problem This Solves

Fixes an issue where ACP-backed agent runs would repeat a replay-ledger byte-total scan after every SQLite event write. As replay history grows, that write path does unnecessary aggregate work over the ACP replay tables even when retention does not need to delete anything.

## Why This Change Was Made

The SQLite ledger now initializes the replay byte total once per resolved state database path and maintains it with row-level deltas for session/event inserts, updates, resets, and trim deletes. The fix stays inside the ACP ledger owner and preserves the existing ledger-scoped estimate instead of switching to whole-database SQLite page statistics, which would include unrelated shared state tables.

The cached byte total is updated through transaction-local state and is only published after the SQLite write transaction succeeds, so a failed write cannot leave the process-local estimate ahead of the rolled-back database. The cache is shared by SQLite path inside the process, and each write transaction checks SQLite `PRAGMA data_version` before applying deltas so commits from another connection invalidate the estimate and force a fresh replay-table scan.

## User Impact

ACP session replay persistence keeps the same retention behavior, but active agent runs avoid repeated replay-table byte-total scans on ordinary event appends. This should reduce write-path overhead for users or operators with larger ACP replay histories while keeping byte-retention trimming scoped to ACP replay rows.

## Evidence

Before fix, a local SQLite ACP ledger repro on current main showed the aggregate byte estimate running once on session start and once per appended event:

```text
{
  "afterStart": 1,
  "afterFiveUpdates": 6
}
```

After fix, the same real `createSqliteAcpEventLedger` entrypoint initialized the estimate once and did not repeat it across five appends:

```text
{
  "afterStart": 1,
  "afterFiveUpdates": 1
}
```

Focused validation run locally on updated head `61ce470b38`:

```text
node scripts/run-vitest.mjs src/acp/event-ledger.test.ts
[test] passed 1 Vitest shard; 18 tests passed

node scripts/run-vitest.mjs src/acp/translator.event-ledger.test.ts
[test] passed 1 Vitest shard; 3 tests passed

./node_modules/.bin/oxlint src/acp/event-ledger.ts src/acp/event-ledger.test.ts src/infra/gateway-boot-lifecycle.ts src/cli/gateway-cli/run-loop.ts
passed

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
passed

./node_modules/.bin/oxfmt --write src/acp/event-ledger.ts src/acp/event-ledger.test.ts
Finished in 19ms on 2 files using 7 threads.

git diff --check
passed

.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

The ledger test coverage includes regressions for SQLite byte-retention trimming, avoiding repeated aggregate estimate queries across ordinary appends, sharing the byte estimate across multiple ledger instances for one database path, invalidating the byte estimate after another SQLite connection writes to the same database, invalidating the byte estimate after the shared database handle closes and reopens, and keeping failed-write deltas transaction-local so the next successful write still replays as complete instead of being trimmed by a stale estimate.

Real agent-turn proof from the earlier patch with a local isolated state dir and the configured DeepSeek provider:

```text
pnpm openclaw agent --local --json --model deepseek/deepseek-v4-pro --session-key agent:main:issue-100622-proof --message 'Reply exactly: ACP_LEDGER_OK' --timeout 180
provider=deepseek model=deepseek-v4-pro status=200
finalAssistantVisibleText=ACP_LEDGER_OK
exit=0
```

The local agent run logged a Slack SecretRef discovery warning before the DeepSeek request, but the model request succeeded and the final agent output matched the expected marker.

AI-assisted: proof run manually.

