### PR TITLE
fix(agents): use per-attempt replay metadata for silent provider-error retry gating (#97877)

### DIFF
--- a/src/agents/agent-tool-handler-state.test-helpers.ts
+++ b/src/agents/agent-tool-handler-state.test-helpers.ts
@@ -9,6 +9,7 @@ import { createEmbeddedRunReplayState } from "./embedded-agent-runner/replay-sta
 export function createBaseToolHandlerState() {
   return {
     replayState: createEmbeddedRunReplayState(),
+    currentAttemptReplayState: createEmbeddedRunReplayState(),
     toolMetaById: new Map<string, unknown>(),
     toolMetas: [] as Array<{ toolName?: string; meta?: string; asyncStarted?: boolean }>,
     acceptedSessionSpawns: [],

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -138,35 +138,55 @@ describe("runEmbeddedAgent silent-error retry", () => {
     expect(result.payloads).toBeUndefined();
   });
 
-  it.each([
-    ["timeout", "LLM request timed out."],
-    ["server_error", "Internal server error"],
-  ] as const)("does not intercept recognized %s failover errors", async (reason, errorMessage) => {
-    mockedClassifyAssistantFailoverReason.mockReturnValue(reason);
+  it.each([["timeout", "LLM request timed out."]] as const)(
+    "does not intercept recognized %s failover errors",
+    async (reason, errorMessage) => {
+      mockedClassifyAssistantFailoverReason.mockReturnValue(reason);
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+        emptyErrorAttempt(
+          "anthropic",
+          "claude-opus-4-8",
+          1120,
+          [
+            {
+              type: "thinking",
+              thinking: "internal reasoning before provider error",
+              thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
+            },
+          ],
+          errorMessage,
+        ),
+      );
+
+      await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+        runId: `run-empty-error-retry-${reason}`,
+      });
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("retries empty server_error failover errors (#97877)", async () => {
+    mockedClassifyFailoverReason.mockReturnValue("server_error");
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      emptyErrorAttempt(
-        "anthropic",
-        "claude-opus-4-8",
-        1120,
-        [
-          {
-            type: "thinking",
-            thinking: "internal reasoning before provider error",
-            thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
-          },
-        ],
-        errorMessage,
-      ),
+      emptyErrorAttempt("openrouter", "minimax/minimax-m3", 0, [], "Internal Server Error"),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      successAttempt("openrouter", "minimax/minimax-m3"),
     );
 
-    await runEmbeddedAgent({
+    const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
-      provider: "anthropic",
-      model: "claude-opus-4-8",
-      runId: `run-empty-error-retry-${reason}`,
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      runId: "run-empty-error-retry-server-error",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
   });
 
   it("does not intercept concrete non-transient failover errors", async () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2787,6 +2787,94 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
+  it("retries clean provider errors when cumulative metadata is dirty from prior turns (#97877)", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    // Cumulative metadata is dirty (prior-turn tools), but per-attempt
+    // metadata is clean — the failed provider call itself had no side
+    // effects, so it should be retried.
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          currentAttemptReplayMetadata: {
+            hadPotentialSideEffects: false,
+            replaySafe: true,
+          },
+          lastAssistant: assistant,
+        }),
+        assistant,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not retry when per-attempt metadata is dirty from same-attempt tools", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    // Both cumulative and per-attempt metadata agree: current attempt
+    // produced side effects (tools/messaging/spawns), so retry is unsafe.
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          currentAttemptReplayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          lastAssistant: assistant,
+        }),
+        assistant,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back conservatively when per-attempt metadata is missing (legacy harness)", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    // Legacy harnesses don't emit currentAttemptReplayMetadata — fall
+    // back to cumulative replayMetadata (conservative: no retry).
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          // No currentAttemptReplayMetadata — legacy fallback
+          lastAssistant: assistant,
+        }),
+        assistant,
+      }),
+    ).toBe(false);
+  });
+
   it("detects empty openai-compatible stop turns with non-zero output usage", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({
       provider: "llamacpp",

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3397,6 +3397,7 @@ async function runEmbeddedAgentInternal(
             genericUnknownReasoningError ||
             assistantFailoverReason === "no_error_details" ||
             assistantFailoverReason === "unclassified" ||
+            assistantFailoverReason === "server_error" ||
             assistantFailoverReason === "unknown";
           // Retry replay-safe non-visible provider errors before assistant
           // failover surfaces them as terminal provider failures.

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -128,6 +128,10 @@ function createSubscriptionMock(): SubscriptionMock {
       replayInvalid: false,
       hadPotentialSideEffects: false,
     }),
+    getCurrentAttemptReplayState: () => ({
+      replayInvalid: false,
+      hadPotentialSideEffects: false,
+    }),
     didSendViaMessagingTool: () => false,
     didSendDeterministicApprovalPrompt: () => false,
     getLastToolError: () => undefined,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3667,6 +3667,7 @@ export async function runEmbeddedAttempt(
         getVisibleBlockReplyCount,
         getSuccessfulCronAdds,
         getReplayState,
+        getCurrentAttemptReplayState,
         didSendViaMessagingTool,
         didSendDeterministicApprovalPrompt,
         getLastToolError,
@@ -5544,6 +5545,12 @@ export async function runEmbeddedAttempt(
       const replayMetadata = replayMetadataFromState(
         observeReplayMetadata(getReplayState(), observedReplayMetadata),
       );
+      // Per-attempt metadata for silent-error retry gating: starts clean
+      // for every attempt and only reflects the current attempt's side
+      // effects (tools, messaging, spawns, cron), not prior-turn history.
+      const currentAttemptReplayMetadata = replayMetadataFromState(
+        observeReplayMetadata(getCurrentAttemptReplayState(), observedReplayMetadata),
+      );
       const completedClientToolCalls = clientToolCallSlots.flatMap((slot) =>
         slot.completed && slot.params
           ? [
@@ -5717,6 +5724,7 @@ export async function runEmbeddedAttempt(
 
       return {
         replayMetadata,
+        currentAttemptReplayMetadata,
         itemLifecycle: getItemLifecycle(),
         setTerminalLifecycleMeta,
         aborted,

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -536,6 +536,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     | "didDeliverSourceReplyViaMessageTool"
     | "messagingToolSourceReplyPayloads"
     | "replayMetadata"
+    | "currentAttemptReplayMetadata"
   >;
   assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
 }): boolean {
@@ -545,7 +546,14 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
   if (hasAttemptTerminalState(params.attempt)) {
     return false;
   }
-  if (resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects) {
+  // Prefer per-attempt metadata when available so prior-turn tool side
+  // effects don't permanently block retry of a transient provider error.
+  // Fall back to cumulative replayMetadata for legacy harnesses that
+  // haven't started returning currentAttemptReplayMetadata yet
+  // (conservative: treat absent per-attempt metadata as unsafe).
+  const attemptReplayMeta =
+    params.attempt.currentAttemptReplayMetadata ?? params.attempt.replayMetadata;
+  if (resolveAttemptReplayMetadata({ replayMetadata: attemptReplayMeta }).hadPotentialSideEffects) {
     return false;
   }
 

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -240,6 +240,13 @@ export type EmbeddedRunAttemptResult = {
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
   replayMetadata: EmbeddedRunReplayMetadata;
+  /** Per-attempt replay metadata that reflects side effects from the current
+   *  attempt only, independent of prior-turn accumulated replay state. Used
+   *  to gate silent provider-error retries so a transient 5xx after earlier
+   *  tool calls is still retryable when the failed attempt itself produced no
+   *  side effects. Absent for legacy harnesses — callers fall back to
+   *  `replayMetadata` (conservative). */
+  currentAttemptReplayMetadata?: EmbeddedRunReplayMetadata;
   itemLifecycle: {
     startedCount: number;
     completedCount: number;

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -47,6 +47,7 @@ function createContext(
       pendingToolTrustedLocalMedia: false,
       deferredBlockReplies: [],
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
+      currentAttemptReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
       blockState: {
         thinking: true,
         final: true,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -26,6 +26,7 @@ function createMockContext(overrides?: {
     },
     state: {
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
+      currentAttemptReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
       toolMetaById: new Map(),
       toolMetas: [],
       toolSummaryById: new Set(),

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -85,6 +85,7 @@ function createTestContext(): {
       pendingToolTrustedLocalMedia: false,
       deterministicApprovalPromptPending: false,
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
+      currentAttemptReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
       messagingToolSentTexts: [],
       messagingToolSentTextsNormalized: [],
       messagingToolSentMediaUrls: [],

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1272,6 +1272,13 @@ export async function handleToolExecutionEnd(
       replayInvalid: true,
       hadPotentialSideEffects: true,
     });
+    ctx.state.currentAttemptReplayState = mergeEmbeddedRunReplayState(
+      ctx.state.currentAttemptReplayState,
+      {
+        replayInvalid: true,
+        hadPotentialSideEffects: true,
+      },
+    );
   }
 
   // Commit messaging tool evidence on success, discard on error.

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -149,6 +149,12 @@ export type EmbeddedAgentSubscribeState = {
   compactionRetryPromise: Promise<void> | null;
   unsubscribed: boolean;
   replayState: EmbeddedRunReplayState;
+  /** Per-attempt replay state that starts clean for every attempt, tracking
+   *  only the current attempt's side effects independently of prior-turn
+   *  accumulated history. Used to gate silent provider-error retries so a
+   *  transient 5xx after prior tool calls is still retryable when the failed
+   *  attempt itself did not produce side effects. */
+  currentAttemptReplayState: EmbeddedRunReplayState;
   livenessState?: EmbeddedRunLivenessState;
   terminalStopReason?: string;
   yielded?: boolean;
@@ -319,6 +325,7 @@ type ToolHandlerState = Pick<
   | "deterministicApprovalPromptPending"
   | "hadDeterministicSideEffect"
   | "replayState"
+  | "currentAttemptReplayState"
   | "messagingToolSentTexts"
   | "messagingToolSentTextsNormalized"
   | "messagingToolSentMediaUrls"

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -1256,7 +1256,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.lastDeliveredBlockReplyText = undefined;
     state.toolExecutionSinceLastBlockReply = false;
     state.replayState = mergeEmbeddedRunReplayState(state.replayState, params.initialReplayState);
-    state.currentAttemptReplayState = createEmbeddedRunReplayState();
+    // currentAttemptReplayState must survive compaction retries so side
+    // effects from before compaction remain tracked within the same attempt.
+    // It starts clean at subscription init and is never reset mid-attempt.
     state.livenessState = "working";
     resetAssistantMessageState(0);
   };

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -220,6 +220,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     compactionRetryPromise: null,
     unsubscribed: false,
     replayState: createEmbeddedRunReplayState(params.initialReplayState),
+    currentAttemptReplayState: createEmbeddedRunReplayState(),
     livenessState: "working",
     hadDeterministicSideEffect: false,
     pendingEventChain: null,
@@ -1255,6 +1256,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.lastDeliveredBlockReplyText = undefined;
     state.toolExecutionSinceLastBlockReply = false;
     state.replayState = mergeEmbeddedRunReplayState(state.replayState, params.initialReplayState);
+    state.currentAttemptReplayState = createEmbeddedRunReplayState();
     state.livenessState = "working";
     resetAssistantMessageState(0);
   };
@@ -1437,6 +1439,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     getVisibleBlockReplyCount: () => state.visibleBlockReplyCount,
     getSuccessfulCronAdds: () => state.successfulCronAdds,
     getReplayState: () => ({ ...state.replayState }),
+    getCurrentAttemptReplayState: () => ({ ...state.currentAttemptReplayState }),
     // Returns true if any messaging tool successfully sent a message.
     // Used to suppress agent's confirmation text (e.g., "Respondi no Telegram!")
     // which is generated AFTER the tool sends the actual answer.


### PR DESCRIPTION
Fixes #97877

## What Problem This Solves

The [empty-error-retry] path in shouldRetrySilentErrorAssistantTurn is gated by cumulative hadPotentialSideEffects, which stays dirty for the session lifetime after any prior-turn tool call. A transient provider 5xx on a clean later turn was incorrectly blocked.

## Why This Change Was Made

Six changes across three layers:

Layer 1 — Per-attempt replay state (core fix):
- currentAttemptReplayState starts clean for every attempt
- Tool handlers update both cumulative and current-attempt replay state
- Exposed via getCurrentAttemptReplayState()

Layer 2 — Per-attempt metadata on result:
- Added optional currentAttemptReplayMetadata to EmbeddedRunAttemptResult
- Computed at result assembly from current-attempt state + observed metadata

Layer 3 — Retry gate:
- shouldRetrySilentErrorAssistantTurn prefers currentAttemptReplayMetadata, falling back to cumulative replayMetadata for legacy harnesses (conservative)

Bonus: server_error added to silentErrorRetryReason.

## User Impact

Agents recover from transient provider 5xx on any turn, even after prior tool calls. Retry blocked only when the same attempt had side effects.

## Evidence

### Proof 1 — Production function call:

```
[1] prior tools + per-attempt clean → retry = true PASS
[2] same-attempt tools → no retry = false PASS
[3] legacy (no per-attempt) → no retry = false PASS
```

### Proof 2 — Focused tests:

```
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.incomplete-turn.test.ts --run
  114 passed (3 new regression tests)

node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.empty-error-retry.test.ts --run
  22 passed (new server_error retry test)
```

### Proof 3 — Full related suite:

```
7 files, 379 tests passed
```

### Proof 4 — Formatting:

oxfmt --check and git diff --check both clean.
