### PR TITLE
fix(plugins): fall back to runtime registry when manifest pre-filter cannot match tool allowlist

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -410,6 +410,46 @@ describe("resolveEmbeddedAttemptToolConstructionPlan", () => {
     );
   });
 
+  it("materializes only plugin candidates for external plugin tool names (e.g. lcm_*)", () => {
+    expectConstructionPlan(
+      resolveEmbeddedAttemptToolConstructionPlan({
+        toolsAllow: ["lcm_grep", "lcm_describe", "lcm_expand_query"],
+      }),
+      {
+        constructTools: true,
+        includeCoreTools: false,
+        runtimeToolAllowlist: ["lcm_grep", "lcm_describe", "lcm_expand_query"],
+        coding: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: true,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      },
+    );
+  });
+
+  it("materializes only plugin candidates for unknown tool names not in core factory sets", () => {
+    expectConstructionPlan(
+      resolveEmbeddedAttemptToolConstructionPlan({
+        toolsAllow: ["my_custom_memory_tool"],
+      }),
+      {
+        constructTools: true,
+        includeCoreTools: false,
+        runtimeToolAllowlist: ["my_custom_memory_tool"],
+        coding: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: true,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      },
+    );
+  });
+
   it("skips local construction when only bundled tool runtimes can match", () => {
     expectConstructionPlan(
       resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: ["strict__strict_probe"] }),

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -2965,6 +2965,63 @@ describe("resolvePluginTools optional tools", () => {
 
     expectResolvedToolNames(tools, ["optional_tool"]);
   });
+
+  it("falls back to runtime registry when manifest contracts.tools cannot match allowlist entries", () => {
+    // Regression test for the active-memory Lossless Claw tool visibility bug
+    // (issue #100537, PR #100675). When the allowlist contains plugin tool
+    // names that are NOT declared in any plugin's manifest contracts.tools,
+    // the manifest-based pre-filter (resolvePluginToolRuntimePluginIds)
+    // produces an empty onlyPluginIds list, and the runtime registry must be
+    // consulted instead of returning early with zero tools.
+    const context = {
+      ...createContext(),
+      config: {
+        ...createContext().config,
+        plugins: {
+          ...createContext().config.plugins,
+          entries: {
+            "optional-demo": { enabled: true },
+          },
+        },
+      },
+    };
+    const config = context.config;
+    // Manifest declares only "optional_tool" in contracts.tools.
+    installToolManifestSnapshot({
+      config,
+      plugin: {
+        id: "optional-demo",
+        origin: "bundled",
+        enabledByDefault: true,
+        channels: [],
+        providers: [],
+        contracts: {
+          tools: ["optional_tool"],
+        },
+      },
+    });
+    // Runtime registry registers an external-style tool name (e.g. lcm_grep)
+    // that is NOT listed in the manifest contracts.tools.
+    const entry: MockRegistryToolEntry = {
+      pluginId: "optional-demo",
+      optional: false,
+      source: "/tmp/optional-demo.js",
+      names: ["lcm_grep"],
+      factory: () => makeTool("lcm_grep"),
+    };
+    const registry = createToolRegistry([entry]);
+    loadOpenClawPluginsMock.mockReturnValue(registry);
+
+    const tools = resolvePluginTools(
+      createResolveToolsParams({
+        context,
+        toolAllowlist: ["lcm_grep"],
+      }),
+    );
+
+    expectResolvedToolNames(tools, ["lcm_grep"]);
+    expectLoaderSelectedOnlyPluginIds(["optional-demo"]);
+  });
 });
 
 describe("buildPluginToolMetadataKey", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -630,6 +630,37 @@ function resolvePluginToolRuntimePluginIds(params: {
       pluginIds.add(plugin.id);
     }
   }
+  // When the manifest contracts.tools pre-filter cannot match any allowlist
+  // entry, fall back to all enabled plugins that declare tool contracts so
+  // the runtime registry (which may hold tools registered via registerTool()
+  // but not declared in the manifest contracts.tools) gets a chance to match.
+  if (pluginIds.size === 0 && allowlist.size > 0) {
+    for (const plugin of snapshot.plugins) {
+      if (
+        !isManifestPluginAvailableForControlPlane({
+          snapshot,
+          plugin,
+          config: params.config,
+        })
+      ) {
+        continue;
+      }
+      if (
+        normalizedPlugins.entries[plugin.id]?.enabled === false ||
+        normalizedPlugins.deny.includes(plugin.id)
+      ) {
+        continue;
+      }
+      if (denylistBlocksPlugin({ pluginId: plugin.id, denylist })) {
+        continue;
+      }
+      const toolNames = plugin.contracts?.tools ?? [];
+      if (toolNames.length === 0) {
+        continue;
+      }
+      pluginIds.add(plugin.id);
+    }
+  }
   return [...pluginIds].toSorted((left, right) => left.localeCompare(right));
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #100537 — When `active-memory` is configured with external plugin tools (like `lcm_grep`, `lcm_describe`, `lcm_expand_query` from `lossless-claw`), the embedded sub-agent run fails with:

```
No callable tools remain after resolving explicit tool allowlist
(runtime toolsAllow: lcm_grep, lcm_describe, lcm_expand_query);
no registered tools matched.
```

## Root Cause

In `resolvePluginTools` (`src/plugins/tools.ts`), the `resolvePluginToolRuntimePluginIds` function pre-filters which plugin IDs to load based on manifest `contracts.tools`. It only selects a plugin when at least one manifest-declared tool name matches the allowlist.

When the allowlist contains tool names that are registered at runtime via `registerTool()` but are **not** declared in any plugin's manifest `contracts.tools`, the manifest pre-filter produces an empty `onlyPluginIds` list. The function then returned early at line 1125 with zero tools, **never consulting the runtime registry** where the tools are actually available.

## Fix

Added a fallback in `resolvePluginToolRuntimePluginIds`: when the manifest `contracts.tools` pre-filter cannot match any allowlist entry but the allowlist is non-empty, include all enabled plugins that declare tool contracts. This lets the runtime registry perform the actual tool name matching via `pluginToolNamesMatchAllowlist`.

**Safety**: The runtime registry iteration still applies `pluginToolNamesMatchAllowlist` as a second filtering layer, so only tools whose names match the allowlist are returned. The fallback only activates in the failure case (empty pre-filter + non-empty allowlist).

## Changes

- `src/plugins/tools.ts` — Add fallback in `resolvePluginToolRuntimePluginIds` when manifest pre-filter produces empty results with a non-empty allowlist
- `src/plugins/tools.optional.test.ts` — Add regression test verifying the fallback loads the runtime registry

## Evidence

| Test suite | Result |
|---|---|
| `tools.optional.test.ts` | 69/69 passed (1 new regression test) |
| `attempt-tool-construction-plan.test.ts` | 23/23 passed |
| `agent-tools.create-openclaw-coding-tools.test.ts` | 68/68 passed |
| `active-memory/index.test.ts` | 156/156 passed |

**Regression proof**: Temporarily removing the fallback block caused the new test to fail (`expected ["lcm_grep"]` but received `[]`), confirming the test detects the bug on current `main` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)