### PR TITLE
fix(tui): preserve markdown URL parentheses

### DIFF
--- a/src/tui/osc8-hyperlinks.test.ts
+++ b/src/tui/osc8-hyperlinks.test.ts
@@ -20,6 +20,11 @@ describe("extractUrls", () => {
     expect(urls).toEqual(["https://example.com/path"]);
   });
 
+  it("extracts markdown link hrefs with balanced parentheses", () => {
+    const url = "https://en.wikipedia.org/wiki/URL_(disambiguation)";
+    expect(extractUrls(`[Wikipedia](${url})`)).toEqual([url]);
+  });
+
   it("extracts markdown links with angle brackets and title text", () => {
     const urls = extractUrls('[Click here](<https://example.com/path> "Example Title")');
     expect(urls).toEqual(["https://example.com/path"]);
@@ -98,6 +103,14 @@ describe("addOsc8Hyperlinks", () => {
 
     // The URL part should be wrapped with OSC 8
     expect(result[0]).toContain(`\x1b]8;;${url}\x07`);
+  });
+
+  it("wraps rendered markdown URLs with balanced parentheses", () => {
+    const url = "https://en.wikipedia.org/wiki/URL_(disambiguation)";
+    const line = `Wikipedia (${url})`;
+    const result = addOsc8Hyperlinks([line], [url]);
+
+    expect(result[0]).toBe(`Wikipedia (\x1b]8;;${url}\x07${url}\x1b]8;;\x07)`);
   });
 
   it("handles multiple URLs on the same line", () => {

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -5,6 +5,27 @@ const OSC8_PATTERN = "\\x1b\\]8;;.*?(?:\\x07|\\x1b\\\\)";
 const ANSI_RE = new RegExp(`${SGR_PATTERN}|${OSC8_PATTERN}`, "g");
 const SGR_START_RE = new RegExp(`^${SGR_PATTERN}`);
 const OSC8_START_RE = new RegExp(`^${OSC8_PATTERN}`);
+const MARKDOWN_LINK_RE =
+  /\[(?:[^\]]*)\]\(\s*<?(https?:\/\/(?:[^\s<>()[\]]+|\([^()\s<>]*\))+)>?(?:\s+["'][^"']*["'])?\s*\)/g;
+
+function trimUnbalancedTrailingParens(url: string): string {
+  let openParens = 0;
+  let closeParens = 0;
+  for (const ch of url) {
+    if (ch === "(") {
+      openParens++;
+    } else if (ch === ")") {
+      closeParens++;
+    }
+  }
+
+  let trimmed = url;
+  while (trimmed.endsWith(")") && closeParens > openParens) {
+    trimmed = trimmed.slice(0, -1);
+    closeParens--;
+  }
+  return trimmed;
+}
 
 /**
  * Extract all unique URLs from raw markdown text.
@@ -14,20 +35,18 @@ export function extractUrls(markdown: string): string[] {
   const urls = new Set<string>();
 
   // Markdown link hrefs: [text](url), with optional <...> and optional title.
-  const mdLinkRe = /\[(?:[^\]]*)\]\(\s*<?(https?:\/\/[^)\s>]+)>?(?:\s+["'][^"']*["'])?\s*\)/g;
   let m: RegExpExecArray | null;
-  while ((m = mdLinkRe.exec(markdown)) !== null) {
+  MARKDOWN_LINK_RE.lastIndex = 0;
+  while ((m = MARKDOWN_LINK_RE.exec(markdown)) !== null) {
     urls.add(m[1]);
   }
 
   // Bare URLs (remove markdown links first to avoid double-matching)
-  const stripped = markdown.replace(
-    /\[(?:[^\]]*)\]\(\s*<?https?:\/\/[^)\s>]+>?(?:\s+["'][^"']*["'])?\s*\)/g,
-    "",
-  );
-  const bareRe = /https?:\/\/[^\s)\]>]+/g;
+  MARKDOWN_LINK_RE.lastIndex = 0;
+  const stripped = markdown.replace(MARKDOWN_LINK_RE, "");
+  const bareRe = /https?:\/\/[^\s\]>]+/g;
   while ((m = bareRe.exec(stripped)) !== null) {
-    urls.add(m[0]);
+    urls.add(trimUnbalancedTrailingParens(m[0]));
   }
 
   return [...urls];
@@ -86,12 +105,12 @@ function findUrlRanges(
   }
 
   // Find new URL starts in visible text
-  const urlRe = /https?:\/\/[^\s)\]>]+/g;
+  const urlRe = /https?:\/\/[^\s\]>]+/g;
   urlRe.lastIndex = searchFrom;
   let match: RegExpExecArray | null;
 
   while ((match = urlRe.exec(visibleText)) !== null) {
-    const fragment = match[0];
+    const fragment = trimUnbalancedTrailingParens(match[0]);
     const start = match.index;
 
     // Resolve fragment to a known URL (exact > prefix > superstring)


### PR DESCRIPTION
Closes #100661.

## What Problem This Solves
Markdown link destinations can contain balanced parentheses, but the TUI URL extractor stopped at the first `)`, so OSC8 links used truncated hrefs.

## Evidence
Adds regression coverage for extracting and wrapping rendered markdown URLs with balanced parentheses.

Copied live TUI output from the PR branch, exercising `HyperlinkMarkdown.render(width=120)`:

```text
branch: fix-100661-url-parentheses
component: HyperlinkMarkdown.render(width=120)
markdown: [Wikipedia](https://en.wikipedia.org/wiki/URL_(disambiguation))
rendered-lines: 1
visible-line: Wikipedia (https://en.wikipedia.org/wiki/URL_(disambiguation))
osc8-target: https://en.wikipedia.org/wiki/URL_(disambiguation)
target-complete: true
rendered-line-json: "Wikipedia (\u001b]8;;https://en.wikipedia.org/wiki/URL_(disambiguation)\u0007https://en.wikipedia.org/wiki/URL_(disambiguation)\u001b]8;;\u0007)                                                          "
```

The copied output shows the rendered TUI line uses the complete parenthesized URL as the OSC8 target.
