### PR TITLE
fix(process): unref close fallback timer

### DIFF
--- a/src/process/exec.no-output-timer.test.ts
+++ b/src/process/exec.no-output-timer.test.ts
@@ -121,6 +121,35 @@ describe("runCommandWithTimeout no-output timer", () => {
     expect(result.termination).toBe("exit");
   });
 
+  it("unrefs the close fallback timer while waiting for close after exit", async () => {
+    const fake = createFakeSpawnedChild();
+    spawnMock.mockReturnValue(fake.child);
+    const originalSetTimeout = globalThis.setTimeout;
+    const closeFallbackUnref = vi.fn();
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      ...args: Parameters<typeof setTimeout>
+    ) => {
+      const timer = originalSetTimeout(...args);
+      if (args[1] === 250) {
+        const timeoutHandle = timer as NodeJS.Timeout;
+        const originalUnref = timeoutHandle.unref.bind(timeoutHandle);
+        timeoutHandle.unref = vi.fn(() => {
+          closeFallbackUnref();
+          return originalUnref();
+        }) as NodeJS.Timeout["unref"];
+      }
+      return timer;
+    }) as typeof setTimeout);
+
+    const runPromise = runCommandWithTimeout(["node", "-e", "ignored"], { timeoutMs: 1_000 });
+    fake.child.emit("exit", 0, null);
+
+    expect(closeFallbackUnref).toHaveBeenCalledTimes(1);
+
+    fake.child.emit("close", 0, null);
+    await expect(runPromise).resolves.toMatchObject({ termination: "exit" });
+  });
+
   it("marks no-output timeout when the spawned child goes silent", async () => {
     vi.useFakeTimers();
     const fake = createFakeSpawnedChild();

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -666,6 +666,7 @@ export async function runCommandWithTimeout(
         child.stdout?.destroy();
         child.stderr?.destroy();
       }, 250);
+      closeFallbackTimer.unref();
     });
     const resolveFromClose = (code: number | null, signalValue: NodeJS.Signals | null) => {
       if (settled) {


### PR DESCRIPTION
Closes #100662.

## What Problem This Solves
After child process exit, the close fallback timer kept a referenced 250ms handle alive while waiting for `close`, delaying natural CLI exit.

## Evidence
Adds regression coverage that observes the close fallback timer and verifies it is unrefed while the command still resolves normally.