### PR TITLE
fix(link-understanding): honor slowest fetch timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Link understanding timeouts:** honor the configured per-link fetch budget before model-specific CLI overrides, and otherwise size the shared fetch timeout for the slowest fallback. (#100682, #100660) Thanks @TurboTheTurtle.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
 - **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.

--- a/src/link-understanding/runner.test.ts
+++ b/src/link-understanding/runner.test.ts
@@ -127,6 +127,34 @@ describe("runLinkUnderstanding", () => {
     );
   });
 
+  it("uses the configured per-link budget before model timeouts", async () => {
+    mockGuardedFetch("page body", "https://example.com/final");
+    mockCommand("summarized page");
+
+    await runLinkUnderstanding({
+      cfg: {
+        tools: {
+          links: {
+            enabled: true,
+            timeoutSeconds: 3,
+            models: [
+              { type: "cli", command: "summarize-fast", timeoutSeconds: 1 },
+              { type: "cli", command: "summarize-slow", timeoutSeconds: 9 },
+            ],
+          },
+        },
+      } as OpenClawConfig,
+      ctx: ctx("see https://example.com/page"),
+    });
+
+    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 3000,
+        url: "https://example.com/page",
+      }),
+    );
+  });
+
   it("does not run configured curl fetchers against attacker-controlled URLs", async () => {
     mockGuardedFetch("guarded page body");
 

--- a/src/link-understanding/runner.test.ts
+++ b/src/link-understanding/runner.test.ts
@@ -100,6 +100,33 @@ describe("runLinkUnderstanding", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it("fetches with the largest configured model timeout", async () => {
+    mockGuardedFetch("page body", "https://example.com/final");
+    mockCommand("summarized page");
+
+    await runLinkUnderstanding({
+      cfg: {
+        tools: {
+          links: {
+            enabled: true,
+            models: [
+              { type: "cli", command: "summarize-fast", timeoutSeconds: 1 },
+              { type: "cli", command: "summarize-slow", timeoutSeconds: 9 },
+            ],
+          },
+        },
+      } as OpenClawConfig,
+      ctx: ctx("see https://example.com/page"),
+    });
+
+    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 9000,
+        url: "https://example.com/page",
+      }),
+    );
+  });
+
   it("does not run configured curl fetchers against attacker-controlled URLs", async () => {
     mockGuardedFetch("guarded page body");
 

--- a/src/link-understanding/runner.ts
+++ b/src/link-understanding/runner.ts
@@ -41,6 +41,15 @@ function resolveTimeoutMsFromConfig(params: {
   return resolveTimeoutMs(configured, DEFAULT_LINK_TIMEOUT_SECONDS);
 }
 
+function resolveFetchTimeoutMsFromConfig(params: {
+  config?: LinkToolsConfig;
+  entries: LinkModelConfig[];
+}): number {
+  return Math.max(
+    ...params.entries.map((entry) => resolveTimeoutMsFromConfig({ config: params.config, entry })),
+  );
+}
+
 function isLinkUrlTemplate(value: string): boolean {
   return value.includes("LinkUrl") || value.includes("LinkFinalUrl");
 }
@@ -220,8 +229,8 @@ export async function runLinkUnderstanding(params: {
   }
 
   const outputs: string[] = [];
+  const timeoutMs = resolveFetchTimeoutMsFromConfig({ config, entries });
   for (const url of links) {
-    const timeoutMs = resolveTimeoutMsFromConfig({ config, entry: entries[0] });
     let fetched: Awaited<ReturnType<typeof fetchLinkContent>>;
     try {
       fetched = await fetchLinkContent({ url, timeoutMs });

--- a/src/link-understanding/runner.ts
+++ b/src/link-understanding/runner.ts
@@ -45,8 +45,13 @@ function resolveFetchTimeoutMsFromConfig(params: {
   config?: LinkToolsConfig;
   entries: LinkModelConfig[];
 }): number {
+  if (params.config?.timeoutSeconds !== undefined) {
+    return resolveTimeoutMs(params.config.timeoutSeconds, DEFAULT_LINK_TIMEOUT_SECONDS);
+  }
   return Math.max(
-    ...params.entries.map((entry) => resolveTimeoutMsFromConfig({ config: params.config, entry })),
+    ...params.entries.map((entry) =>
+      resolveTimeoutMs(entry.timeoutSeconds, DEFAULT_LINK_TIMEOUT_SECONDS),
+    ),
   );
 }
 


### PR DESCRIPTION
Closes #100660.

## What Problem This Solves
Link understanding fetched page content with only the first configured model timeout, so later entries with longer timeouts could still inherit the first entry's shorter fetch cap.

## Evidence
Adds regression coverage proving guarded fetch uses the largest effective timeout across configured link models.