### PR TITLE
fix(state): close shared database during shutdown

### DIFF
--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -37,6 +37,7 @@ const mockState = vi.hoisted(() => ({
   routeLogsToStderr: vi.fn(),
   startProxy: vi.fn(async (_configForTest: unknown) => null as unknown),
   stopProxy: vi.fn(async (_handle: unknown) => {}),
+  closeOpenClawStateDatabase: vi.fn(),
   resolveGatewayClientBootstrap: vi.fn<ResolveGatewayClientBootstrap>(async (_params) => ({
     url: "ws://127.0.0.1:18789",
     urlSource: "local loopback",
@@ -154,6 +155,13 @@ vi.mock("../infra/is-main.js", () => ({
 
 vi.mock("../logging/console.js", () => ({
   routeLogsToStderr: () => mockState.routeLogsToStderr(),
+}));
+
+vi.mock("../state/openclaw-state-db.js", async () => ({
+  ...(await vi.importActual<typeof import("../state/openclaw-state-db.js")>(
+    "../state/openclaw-state-db.js",
+  )),
+  closeOpenClawStateDatabase: () => mockState.closeOpenClawStateDatabase(),
 }));
 
 vi.mock("../infra/net/proxy/proxy-lifecycle.js", () => ({
@@ -287,6 +295,7 @@ describe("serveAcpGateway startup", () => {
     mockState.routeLogsToStderr.mockReset();
     mockState.startProxy.mockReset();
     mockState.stopProxy.mockReset();
+    mockState.closeOpenClawStateDatabase.mockReset();
     mockState.startProxy.mockResolvedValue(null);
     mockState.stopProxy.mockResolvedValue(undefined);
     mockState.resolveGatewayClientBootstrap.mockReset();
@@ -310,6 +319,21 @@ describe("serveAcpGateway startup", () => {
       expect(mockState.agentSideConnectionCtor).not.toHaveBeenCalled();
       await emitHelloAndWaitForAgentSideConnection();
       await stopServeWithSigint(signalHandlers, servePromise);
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("closes the shared state database on signal shutdown", async () => {
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await emitHelloAndWaitForAgentSideConnection();
+
+      await stopServeWithSigint(signalHandlers, servePromise);
+
+      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledTimes(1);
     } finally {
       onceSpy.mockRestore();
     }

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -21,6 +21,7 @@ import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-re
 import { GatewayClient } from "../gateway/client.js";
 import { isMainModule } from "../infra/is-main.js";
 import { routeLogsToStderr } from "../logging/console.js";
+import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
   createSqliteAcpEventLedger,
   migrateFileAcpEventLedgerToSqlite,
@@ -121,6 +122,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     stopped = true;
     resolveGatewayReady();
     gateway.stop();
+    closeOpenClawStateDatabase();
     // If no WebSocket is active (e.g. between reconnect attempts),
     // gateway.stop() won't trigger onClose, so resolve directly.
     onClosed();

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -15,6 +15,8 @@ const mocks = {
   disposeAllSessionMcpRuntimes: vi.fn(async () => undefined),
   triggerInternalHook: vi.fn<TriggerInternalHookMock>(async (_eventValue) => undefined),
   disposeAllBundleLspRuntimes: vi.fn(async () => undefined),
+  closePluginStateDatabase: vi.fn(() => undefined),
+  closeOpenClawStateDatabase: vi.fn(() => undefined),
 };
 const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
 const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
@@ -67,6 +69,17 @@ vi.mock("../logging/subsystem.js", () => ({
     info: mocks.logInfo,
     warn: mocks.logWarn,
   })),
+}));
+
+vi.mock("../plugin-state/plugin-state-store.js", () => ({
+  closePluginStateDatabase: mocks.closePluginStateDatabase,
+}));
+
+vi.mock("../state/openclaw-state-db.js", async () => ({
+  ...(await vi.importActual<typeof import("../state/openclaw-state-db.js")>(
+    "../state/openclaw-state-db.js",
+  )),
+  closeOpenClawStateDatabase: mocks.closeOpenClawStateDatabase,
 }));
 
 const { createGatewayCloseHandler } = await import("./server-close.js");
@@ -158,6 +171,8 @@ describe("createGatewayCloseHandler", () => {
     mocks.triggerInternalHook.mockResolvedValue(undefined);
     mocks.disposeAllBundleLspRuntimes.mockClear();
     mocks.disposeAllBundleLspRuntimes.mockResolvedValue(undefined);
+    mocks.closePluginStateDatabase.mockClear();
+    mocks.closeOpenClawStateDatabase.mockClear();
   });
 
   afterEach(() => {
@@ -181,6 +196,8 @@ describe("createGatewayCloseHandler", () => {
     expect(deps.cron.stop).toHaveBeenCalledTimes(1);
     expect(deps.heartbeatRunner.stop).toHaveBeenCalledTimes(1);
     expect(deps.chatRunState.clear).toHaveBeenCalledTimes(1);
+    expect(mocks.closePluginStateDatabase).toHaveBeenCalledTimes(1);
+    expect(mocks.closeOpenClawStateDatabase).toHaveBeenCalledTimes(1);
   });
 
   it("stops plugin services before channel runtimes", async () => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -12,6 +12,7 @@ import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { closePluginStateDatabase } from "../plugin-state/plugin-state-store.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
+import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
   abortTrackedChatRunById,
   type ChatAbortControllerEntry,
@@ -866,6 +867,7 @@ export function createGatewayCloseHandler(
         ]);
       });
       await shutdownStep("plugin-state-store", () => closePluginStateDatabase(), warnings);
+      await shutdownStep("state-db", () => closeOpenClawStateDatabase(), warnings);
       await measureCloseStep("config-reloader", () =>
         shutdownStep("config-reloader", () => params.configReloader.stop(), warnings),
       );


### PR DESCRIPTION
Closes #100637.

## What Problem This Solves
ACP and gateway shutdown should release the shared SQLite state database through its existing lifecycle owner so hot-reload and shutdown paths do not leave state handles behind.

## Evidence
Adds shutdown coverage for the standalone ACP server signal path and the gateway close handler state database cleanup step.