### PR TITLE
fix(agents): Anthropic-compatible streams hang on oversized partial responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
-- **Anthropic-compatible stream hardening:** bound incomplete SSE frames in the native Messages parser so malformed or hostile streams fail cleanly instead of growing memory without limit. (#100686) Thanks @zhangguiping-xydt.
-
 ### Changes
 
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+- **Anthropic-compatible stream hardening:** bound incomplete SSE frames in the native Messages parser so malformed or hostile streams fail cleanly instead of growing memory without limit. (#100686) Thanks @zhangguiping-xydt.
+
 ### Changes
 
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -882,6 +882,47 @@ describe("anthropic transport stream", () => {
     expect((cancelReason as Error).message).toBe(result.errorMessage);
   });
 
+  it("rejects oversized Anthropic SSE frames before buffering without bound", async () => {
+    const controller = new AbortController();
+    const encoder = new TextEncoder();
+    let cancelCalled = false;
+    guardedFetchMock.mockResolvedValueOnce(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(streamController) {
+            streamController.enqueue(encoder.encode("x".repeat(16 * 1024 * 1024 + 1)));
+          },
+          cancel() {
+            cancelCalled = true;
+          },
+        }),
+        { status: 200, headers: { "content-type": "text/event-stream" } },
+      ),
+    );
+
+    const resultPromise = runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+      } as AnthropicStreamContext,
+      { apiKey: "sk-ant-api", signal: controller.signal } as AnthropicStreamOptions,
+    );
+
+    const timedOut = Symbol("timed out");
+    const result = await Promise.race([resultPromise, delay(1_000, timedOut)]);
+    if (result === timedOut) {
+      controller.abort(new Error("oversized Anthropic SSE frame did not trip buffer cap"));
+      await resultPromise;
+      throw new Error("Anthropic SSE stream did not reject oversized pending buffer within 1000ms");
+    }
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe(
+      "Anthropic Messages SSE response exceeded max pending buffer size (16777216 chars) without event boundary",
+    );
+    expect(cancelCalled).toBe(true);
+  });
+
   it("honors ANTHROPIC_BASE_URL when model base URL is blank", async () => {
     vi.stubEnv("ANTHROPIC_BASE_URL", " https://anthropic-proxy.example/v1 ");
 

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -85,6 +85,8 @@ const CLAUDE_CODE_VERSION = "2.1.75";
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_CHARS = 400;
 const ANTHROPIC_MESSAGES_ERROR_BODY_READ_IDLE_TIMEOUT_MS = 10_000;
+// Mirror the fetch sanitizer cap here because compatible routes such as Kimi
+// bypass that layer; without a parser-local guard, partial frames grow forever.
 const ANTHROPIC_MESSAGES_SSE_PENDING_BUFFER_MAX_CHARS = 16 * 1024 * 1024;
 const CLAUDE_CODE_TOOLS = [
   "Read",

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -85,6 +85,7 @@ const CLAUDE_CODE_VERSION = "2.1.75";
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const ANTHROPIC_MESSAGES_ERROR_BODY_MAX_CHARS = 400;
 const ANTHROPIC_MESSAGES_ERROR_BODY_READ_IDLE_TIMEOUT_MS = 10_000;
+const ANTHROPIC_MESSAGES_SSE_PENDING_BUFFER_MAX_CHARS = 16 * 1024 * 1024;
 const CLAUDE_CODE_TOOLS = [
   "Read",
   "Write",
@@ -718,6 +719,15 @@ function parseAnthropicSseEventData(data: string): Record<string, unknown> {
   }
 }
 
+function assertAnthropicSsePendingBufferWithinLimit(pendingChars: number): void {
+  if (pendingChars <= ANTHROPIC_MESSAGES_SSE_PENDING_BUFFER_MAX_CHARS) {
+    return;
+  }
+  throw new Error(
+    `Anthropic Messages SSE response exceeded max pending buffer size (${ANTHROPIC_MESSAGES_SSE_PENDING_BUFFER_MAX_CHARS} chars) without event boundary`,
+  );
+}
+
 async function* parseAnthropicSseBody(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
@@ -736,6 +746,7 @@ async function* parseAnthropicSseBody(
       buffer = `${buffer}${decoder.decode(value, { stream: true })}`.replaceAll("\r\n", "\n");
       let frameEnd = buffer.indexOf("\n\n");
       while (frameEnd >= 0) {
+        assertAnthropicSsePendingBufferWithinLimit(frameEnd);
         const frame = buffer.slice(0, frameEnd);
         buffer = buffer.slice(frameEnd + 2);
         const data = frame
@@ -748,8 +759,11 @@ async function* parseAnthropicSseBody(
         }
         frameEnd = buffer.indexOf("\n\n");
       }
+      assertAnthropicSsePendingBufferWithinLimit(buffer.length);
     }
-    const tail = `${buffer}${decoder.decode()}`.replaceAll("\r\n", "\n").trim();
+    const tailBuffer = `${buffer}${decoder.decode()}`.replaceAll("\r\n", "\n");
+    assertAnthropicSsePendingBufferWithinLimit(tailBuffer.length);
+    const tail = tailBuffer.trim();
     if (tail) {
       const data = tail
         .split("\n")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Anthropic-compatible streaming requests could keep accumulating an incomplete SSE frame when the upstream response never sent an event boundary. A malformed or hostile stream could make the transport hang while growing the pending frame buffer instead of failing with a bounded error.

## Why This Change Was Made

The Anthropic Messages SSE parser now enforces a 16 MiB cap on each pending SSE frame/tail before it continues buffering. Complete event boundaries are drained before checking the remaining pending buffer, so large chunks containing bounded frames are not rejected just because they arrived together.

This does not change provider configuration, request payloads, schema, or normal completed SSE frame handling.

## User Impact

Anthropic-compatible streaming calls now fail fast with a stable transport error when an upstream response sends an oversized incomplete SSE frame. Normal Anthropic streaming responses continue to parse as before.

## Evidence

Before the fix, the new regression test timed out because the stream never rejected the oversized pending frame:

```text
FAIL  |agents| src/agents/anthropic-transport-stream.test.ts > anthropic transport stream > rejects oversized Anthropic SSE frames before buffering without bound
Error: Anthropic SSE stream did not reject oversized pending buffer within 1000ms
```

After the fix:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/anthropic-transport-stream.test.ts

Test Files  1 passed (1)
Tests  94 passed (94)
```

TypeScript validation:

```text
pnpm tsgo:test:src
exit_code=0
```
