### PR TITLE
fix(auto-reply): force-clear stale active reply operation on session reset (#99082)

### DIFF
--- a/src/agents/agent-tool-handler-state.test-helpers.ts
+++ b/src/agents/agent-tool-handler-state.test-helpers.ts
@@ -9,6 +9,7 @@ import { createEmbeddedRunReplayState } from "./embedded-agent-runner/replay-sta
 export function createBaseToolHandlerState() {
   return {
     replayState: createEmbeddedRunReplayState(),
+    currentAttemptReplayState: createEmbeddedRunReplayState(),
     toolMetaById: new Map<string, unknown>(),
     toolMetas: [] as Array<{ toolName?: string; meta?: string; asyncStarted?: boolean }>,
     acceptedSessionSpawns: [],

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.test.ts
@@ -138,35 +138,55 @@ describe("runEmbeddedAgent silent-error retry", () => {
     expect(result.payloads).toBeUndefined();
   });
 
-  it.each([
-    ["timeout", "LLM request timed out."],
-    ["server_error", "Internal server error"],
-  ] as const)("does not intercept recognized %s failover errors", async (reason, errorMessage) => {
-    mockedClassifyAssistantFailoverReason.mockReturnValue(reason);
+  it.each([["timeout", "LLM request timed out."]] as const)(
+    "does not intercept recognized %s failover errors",
+    async (reason, errorMessage) => {
+      mockedClassifyAssistantFailoverReason.mockReturnValue(reason);
+      mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+        emptyErrorAttempt(
+          "anthropic",
+          "claude-opus-4-8",
+          1120,
+          [
+            {
+              type: "thinking",
+              thinking: "internal reasoning before provider error",
+              thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
+            },
+          ],
+          errorMessage,
+        ),
+      );
+
+      await runEmbeddedAgent({
+        ...overflowBaseRunParams,
+        provider: "anthropic",
+        model: "claude-opus-4-8",
+        runId: `run-empty-error-retry-${reason}`,
+      });
+
+      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("retries empty server_error failover errors (#97877)", async () => {
+    mockedClassifyFailoverReason.mockReturnValue("server_error");
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
-      emptyErrorAttempt(
-        "anthropic",
-        "claude-opus-4-8",
-        1120,
-        [
-          {
-            type: "thinking",
-            thinking: "internal reasoning before provider error",
-            thinkingSignature: JSON.stringify({ id: "rs_error", type: "reasoning" }),
-          },
-        ],
-        errorMessage,
-      ),
+      emptyErrorAttempt("openrouter", "minimax/minimax-m3", 0, [], "Internal Server Error"),
+    );
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      successAttempt("openrouter", "minimax/minimax-m3"),
     );
 
-    await runEmbeddedAgent({
+    const result = await runEmbeddedAgent({
       ...overflowBaseRunParams,
-      provider: "anthropic",
-      model: "claude-opus-4-8",
-      runId: `run-empty-error-retry-${reason}`,
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      runId: "run-empty-error-retry-server-error",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads).toBeUndefined();
   });
 
   it("does not intercept concrete non-transient failover errors", async () => {

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -2787,6 +2787,94 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     ).toBe(false);
   });
 
+  it("retries clean provider errors when cumulative metadata is dirty from prior turns (#97877)", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    // Cumulative metadata is dirty (prior-turn tools), but per-attempt
+    // metadata is clean — the failed provider call itself had no side
+    // effects, so it should be retried.
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          currentAttemptReplayMetadata: {
+            hadPotentialSideEffects: false,
+            replaySafe: true,
+          },
+          lastAssistant: assistant,
+        }),
+        assistant,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not retry when per-attempt metadata is dirty from same-attempt tools", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    // Both cumulative and per-attempt metadata agree: current attempt
+    // produced side effects (tools/messaging/spawns), so retry is unsafe.
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          currentAttemptReplayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          lastAssistant: assistant,
+        }),
+        assistant,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back conservatively when per-attempt metadata is missing (legacy harness)", () => {
+    const assistant = {
+      role: "assistant",
+      stopReason: "error",
+      provider: "openrouter",
+      model: "minimax/minimax-m3",
+      content: [],
+      usage: { input: 100, output: 0, totalTokens: 100 },
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    // Legacy harnesses don't emit currentAttemptReplayMetadata — fall
+    // back to cumulative replayMetadata (conservative: no retry).
+    expect(
+      shouldRetrySilentErrorAssistantTurn({
+        attempt: makeAttemptResult({
+          assistantTexts: [],
+          replayMetadata: {
+            hadPotentialSideEffects: true,
+            replaySafe: false,
+          },
+          // No currentAttemptReplayMetadata — legacy fallback
+          lastAssistant: assistant,
+        }),
+        assistant,
+      }),
+    ).toBe(false);
+  });
+
   it("detects empty openai-compatible stop turns with non-zero output usage", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({
       provider: "llamacpp",

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -3397,6 +3397,7 @@ async function runEmbeddedAgentInternal(
             genericUnknownReasoningError ||
             assistantFailoverReason === "no_error_details" ||
             assistantFailoverReason === "unclassified" ||
+            assistantFailoverReason === "server_error" ||
             assistantFailoverReason === "unknown";
           // Retry replay-safe non-visible provider errors before assistant
           // failover surfaces them as terminal provider failures.

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.test-support.ts
@@ -128,6 +128,10 @@ function createSubscriptionMock(): SubscriptionMock {
       replayInvalid: false,
       hadPotentialSideEffects: false,
     }),
+    getCurrentAttemptReplayState: () => ({
+      replayInvalid: false,
+      hadPotentialSideEffects: false,
+    }),
     didSendViaMessagingTool: () => false,
     didSendDeterministicApprovalPrompt: () => false,
     getLastToolError: () => undefined,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3667,6 +3667,7 @@ export async function runEmbeddedAttempt(
         getVisibleBlockReplyCount,
         getSuccessfulCronAdds,
         getReplayState,
+        getCurrentAttemptReplayState,
         didSendViaMessagingTool,
         didSendDeterministicApprovalPrompt,
         getLastToolError,
@@ -5544,6 +5545,12 @@ export async function runEmbeddedAttempt(
       const replayMetadata = replayMetadataFromState(
         observeReplayMetadata(getReplayState(), observedReplayMetadata),
       );
+      // Per-attempt metadata for silent-error retry gating: starts clean
+      // for every attempt and only reflects the current attempt's side
+      // effects (tools, messaging, spawns, cron), not prior-turn history.
+      const currentAttemptReplayMetadata = replayMetadataFromState(
+        observeReplayMetadata(getCurrentAttemptReplayState(), observedReplayMetadata),
+      );
       const completedClientToolCalls = clientToolCallSlots.flatMap((slot) =>
         slot.completed && slot.params
           ? [
@@ -5717,6 +5724,7 @@ export async function runEmbeddedAttempt(
 
       return {
         replayMetadata,
+        currentAttemptReplayMetadata,
         itemLifecycle: getItemLifecycle(),
         setTerminalLifecycleMeta,
         aborted,

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -536,6 +536,7 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
     | "didDeliverSourceReplyViaMessageTool"
     | "messagingToolSourceReplyPayloads"
     | "replayMetadata"
+    | "currentAttemptReplayMetadata"
   >;
   assistant: EmbeddedRunAttemptResult["lastAssistant"] | null | undefined;
 }): boolean {
@@ -545,7 +546,14 @@ export function shouldRetrySilentErrorAssistantTurn(params: {
   if (hasAttemptTerminalState(params.attempt)) {
     return false;
   }
-  if (resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects) {
+  // Prefer per-attempt metadata when available so prior-turn tool side
+  // effects don't permanently block retry of a transient provider error.
+  // Fall back to cumulative replayMetadata for legacy harnesses that
+  // haven't started returning currentAttemptReplayMetadata yet
+  // (conservative: treat absent per-attempt metadata as unsafe).
+  const attemptReplayMeta =
+    params.attempt.currentAttemptReplayMetadata ?? params.attempt.replayMetadata;
+  if (resolveAttemptReplayMetadata({ replayMetadata: attemptReplayMeta }).hadPotentialSideEffects) {
     return false;
   }
 

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -240,6 +240,13 @@ export type EmbeddedRunAttemptResult = {
   /** True when sessions_yield tool was called during this attempt. */
   yieldDetected?: boolean;
   replayMetadata: EmbeddedRunReplayMetadata;
+  /** Per-attempt replay metadata that reflects side effects from the current
+   *  attempt only, independent of prior-turn accumulated replay state. Used
+   *  to gate silent provider-error retries so a transient 5xx after earlier
+   *  tool calls is still retryable when the failed attempt itself produced no
+   *  side effects. Absent for legacy harnesses — callers fall back to
+   *  `replayMetadata` (conservative). */
+  currentAttemptReplayMetadata?: EmbeddedRunReplayMetadata;
   itemLifecycle: {
     startedCount: number;
     completedCount: number;

--- a/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.lifecycle.test.ts
@@ -47,6 +47,7 @@ function createContext(
       pendingToolTrustedLocalMedia: false,
       deferredBlockReplies: [],
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
+      currentAttemptReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
       blockState: {
         thinking: true,
         final: true,

--- a/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.media.test.ts
@@ -26,6 +26,7 @@ function createMockContext(overrides?: {
     },
     state: {
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
+      currentAttemptReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
       toolMetaById: new Map(),
       toolMetas: [],
       toolSummaryById: new Set(),

--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -85,6 +85,7 @@ function createTestContext(): {
       pendingToolTrustedLocalMedia: false,
       deterministicApprovalPromptPending: false,
       replayState: { replayInvalid: false, hadPotentialSideEffects: false },
+      currentAttemptReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
       messagingToolSentTexts: [],
       messagingToolSentTextsNormalized: [],
       messagingToolSentMediaUrls: [],

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -1272,6 +1272,13 @@ export async function handleToolExecutionEnd(
       replayInvalid: true,
       hadPotentialSideEffects: true,
     });
+    ctx.state.currentAttemptReplayState = mergeEmbeddedRunReplayState(
+      ctx.state.currentAttemptReplayState,
+      {
+        replayInvalid: true,
+        hadPotentialSideEffects: true,
+      },
+    );
   }
 
   // Commit messaging tool evidence on success, discard on error.

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -149,6 +149,12 @@ export type EmbeddedAgentSubscribeState = {
   compactionRetryPromise: Promise<void> | null;
   unsubscribed: boolean;
   replayState: EmbeddedRunReplayState;
+  /** Per-attempt replay state that starts clean for every attempt, tracking
+   *  only the current attempt's side effects independently of prior-turn
+   *  accumulated history. Used to gate silent provider-error retries so a
+   *  transient 5xx after prior tool calls is still retryable when the failed
+   *  attempt itself did not produce side effects. */
+  currentAttemptReplayState: EmbeddedRunReplayState;
   livenessState?: EmbeddedRunLivenessState;
   terminalStopReason?: string;
   yielded?: boolean;
@@ -319,6 +325,7 @@ type ToolHandlerState = Pick<
   | "deterministicApprovalPromptPending"
   | "hadDeterministicSideEffect"
   | "replayState"
+  | "currentAttemptReplayState"
   | "messagingToolSentTexts"
   | "messagingToolSentTextsNormalized"
   | "messagingToolSentMediaUrls"

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -220,6 +220,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     compactionRetryPromise: null,
     unsubscribed: false,
     replayState: createEmbeddedRunReplayState(params.initialReplayState),
+    currentAttemptReplayState: createEmbeddedRunReplayState(),
     livenessState: "working",
     hadDeterministicSideEffect: false,
     pendingEventChain: null,
@@ -1255,6 +1256,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.lastDeliveredBlockReplyText = undefined;
     state.toolExecutionSinceLastBlockReply = false;
     state.replayState = mergeEmbeddedRunReplayState(state.replayState, params.initialReplayState);
+    state.currentAttemptReplayState = createEmbeddedRunReplayState();
     state.livenessState = "working";
     resetAssistantMessageState(0);
   };
@@ -1437,6 +1439,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     getVisibleBlockReplyCount: () => state.visibleBlockReplyCount,
     getSuccessfulCronAdds: () => state.successfulCronAdds,
     getReplayState: () => ({ ...state.replayState }),
+    getCurrentAttemptReplayState: () => ({ ...state.currentAttemptReplayState }),
     // Returns true if any messaging tool successfully sent a message.
     // Used to suppress agent's confirmation text (e.g., "Respondi no Telegram!")
     // which is generated AFTER the tool sends the actual answer.

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -1,10 +1,10 @@
 // Tracks active reply runs so stop, queue, and status commands can coordinate.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { createAbortError } from "../../infra/abort-signal.js";
 import {
   createAgentRunRestartAbortError,
   isAgentRunRestartAbortReason,
 } from "../../agents/run-termination.js";
+import { createAbortError } from "../../infra/abort-signal.js";
 import {
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
@@ -856,6 +856,24 @@ export function forceClearReplyRunBySessionId(sessionId: string, cause?: unknown
   operation.fail("run_failed", cause);
   operation.complete();
   return true;
+}
+
+/** Release an active reply operation owned by the archived session id during
+ *  session reset/rotation. Queued reservations are intentionally left alone so
+ *  session init can rebind them to the new session id via `updateSessionId`.
+ *  Only non-queued (running/compacting) operations are cleared — these are
+ *  stale work from the old session that would otherwise block the new session's
+ *  reply delivery for the full stuck-session recovery window. (#99082) */
+export function forceClearReplyRunForResetBySessionId(sessionId: string, cause?: unknown): boolean {
+  const operation = resolveReplyRunForCurrentSessionId(sessionId);
+  if (!operation || operation.phase === "queued") {
+    return false;
+  }
+  operation.abortForRestart();
+  if (!resolveReplyRunForCurrentSessionId(sessionId)) {
+    return true;
+  }
+  return forceClearReplyRunBySessionId(sessionId, cause);
 }
 
 export function waitForReplyRunEndBySessionId(

--- a/src/auto-reply/reply/session-reset-cleanup.test.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.test.ts
@@ -1,13 +1,19 @@
 // Tests session reset cleanup for stale files and persisted state.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   enqueueSystemEvent,
   peekSystemEvents,
   resetSystemEventsForTest,
 } from "../../infra/system-events.js";
+import {
+  createReplyOperation,
+  replyRunRegistry,
+  testing as replyRunTesting,
+} from "./reply-run-registry.js";
 import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 
 afterEach(() => {
+  replyRunTesting.resetReplyRunRegistry();
   resetSystemEventsForTest();
 });
 
@@ -24,5 +30,60 @@ describe("clearSessionResetRuntimeState", () => {
     expect(peekSystemEvents("alpha")).toStrictEqual([]);
     expect(peekSystemEvents("beta")).toStrictEqual([]);
     expect(peekSystemEvents("gamma")).toEqual(["fresh gamma"]);
+  });
+
+  it("releases an active reply operation owned by the archived reset session id", () => {
+    const cancel = vi.fn();
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:room:1",
+      sessionId: "old-session",
+      resetTriggered: false,
+    });
+    operation.attachBackend({
+      kind: "embedded",
+      cancel,
+      isStreaming: () => false,
+    });
+    operation.setPhase("running");
+
+    const result = clearSessionResetRuntimeState(["agent:main:room:1", "old-session"], {
+      activeReplySessionIds: ["old-session"],
+    });
+
+    expect(result.activeReplyRunsCleared).toBe(1);
+    expect(cancel).toHaveBeenCalledWith("restart");
+    expect(replyRunRegistry.isActive("agent:main:room:1")).toBe(false);
+  });
+
+  it("leaves queued reservations so session init can rebind them", () => {
+    createReplyOperation({
+      sessionKey: "agent:main:room:1",
+      sessionId: "old-session",
+      resetTriggered: false,
+    });
+    // default phase is "queued"
+
+    const result = clearSessionResetRuntimeState(["agent:main:room:1", "old-session"], {
+      activeReplySessionIds: ["old-session"],
+    });
+
+    expect(result.activeReplyRunsCleared).toBe(0);
+    expect(replyRunRegistry.get("agent:main:room:1")?.phase).toBe("queued");
+  });
+
+  it("does not clear a fresh active reply whose sessionId does not match the archived id", () => {
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:room:1",
+      sessionId: "new-session",
+      resetTriggered: false,
+    });
+    operation.setPhase("running");
+
+    const result = clearSessionResetRuntimeState(["agent:main:room:1", "old-session"], {
+      activeReplySessionIds: ["old-session"],
+    });
+
+    expect(result.activeReplyRunsCleared).toBe(0);
+    expect(replyRunRegistry.get("agent:main:room:1")).toBe(operation);
   });
 });

--- a/src/auto-reply/reply/session-reset-cleanup.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.ts
@@ -1,25 +1,45 @@
 /** Clears reset-related queues and system events for session keys. */
 import { drainSystemEventEntries } from "../../infra/system-events.js";
 import { clearSessionQueues, type ClearSessionQueueResult } from "./queue/cleanup.js";
+import { forceClearReplyRunForResetBySessionId } from "./reply-run-registry.js";
 
 /** Runtime cleanup result for reset-related queues and system events. */
 type ClearSessionResetRuntimeStateResult = ClearSessionQueueResult & {
   systemEventsCleared: number;
+  activeReplyRunsCleared: number;
 };
 
-/** Clears queued follow-ups and pending system events for reset session keys. */
+/** Clears queued follow-ups, pending system events, and stale active reply
+ *  operations for reset session keys. Archived session ids passed via
+ *  `activeReplySessionIds` are force-cleared from the reply-run registry,
+ *  unblocking the post-reset session's visible reply delivery. (#99082) */
 export function clearSessionResetRuntimeState(
   keys: Array<string | undefined>,
+  opts?: { activeReplySessionIds?: Array<string | undefined> },
 ): ClearSessionResetRuntimeStateResult {
   const cleared = clearSessionQueues(keys);
   let systemEventsCleared = 0;
+  let activeReplyRunsCleared = 0;
 
   for (const key of cleared.keys) {
     systemEventsCleared += drainSystemEventEntries(key).length;
   }
 
+  for (const sessionId of opts?.activeReplySessionIds ?? []) {
+    if (
+      sessionId &&
+      forceClearReplyRunForResetBySessionId(
+        sessionId,
+        new Error("clearing active reply operation for reset session"),
+      )
+    ) {
+      activeReplyRunsCleared += 1;
+    }
+  }
+
   return {
     ...cleared,
     systemEventsCleared,
+    activeReplyRunsCleared,
   };
 }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -684,7 +684,9 @@ async function initSessionStateAttemptLocked(
     previousSessionId: previousSessionEntry?.sessionId,
   });
   if (previousSessionEntry) {
-    clearSessionResetRuntimeState([sessionKey, previousSessionEntry.sessionId]);
+    clearSessionResetRuntimeState([sessionKey, previousSessionEntry.sessionId], {
+      activeReplySessionIds: [previousSessionEntry.sessionId],
+    });
   }
 
   const recoveredTerminalEntry =

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -401,7 +401,9 @@ async function ensureSessionRuntimeCleanup(params: {
   if (params.sessionId) {
     queueKeys.add(params.sessionId);
   }
-  clearSessionResetRuntimeState([...queueKeys]);
+  clearSessionResetRuntimeState([...queueKeys], {
+    activeReplySessionIds: [params.sessionId],
+  });
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
     params.assertCurrent?.();


### PR DESCRIPTION
Fixes #99082

## What Problem This Solves

When `/reset` is issued in a multi-agent room, the session rotates: the old session is archived and a new one is created. But the reply-run registry is keyed by the stable **session key**, not the session id. A running reply operation owned by the archived session id survives the reset — blocking the new session's first visible reply (including the "Session reset." acknowledgement) for the full stuck-session recovery window (default ~6 minutes).

This reliably wedges all but one agent per room after reset: the first agent to finish resetting delivers its ack, but every other agent's stale reply operation under the archived session id keeps the slot latched, queuing all inbound messages behind it.

## Why This Change Was Made

Two changes across two layers:

**Layer 1 — Registry-level helper:**
- **`reply-run-registry.ts`**: Added `forceClearReplyRunForResetBySessionId(sessionId)` — releases non-queued (running/compacting) reply operations owned by the given session id. Queued reservations are intentionally preserved so `get-reply-run.ts` can rebind them to the new session id via `updateSessionId`.

**Layer 2 — Reset cleanup integration:**
- **`session-reset-cleanup.ts`**: Added optional `activeReplySessionIds` parameter to `clearSessionResetRuntimeState`. When provided, each archived session id is force-cleared from the reply registry.
- **`session-reset-service.ts`** + **`session.ts`**: Pass the archived session id as `activeReplySessionIds` during reset cleanup.

## User Impact

`/reset` in multi-agent rooms now unblocks all agents promptly instead of wedging all but one for ~6 minutes. The reset acknowledgement and queued messages can proceed once the old session is rotated.

Queued reply reservations (the default initial phase) survive the cleanup — session init can still rebind them to the new session id, so no legitimate in-flight replies are dropped.

## Evidence

### Proof 1 — Production function call (`node --import tsx`):

```
=== #99082 Proof: Reset clears stale active reply operation ===

[1] Active running operation from archived session is force-cleared
  PASS: force-clear returned true
  PASS: registry slot is free
[2] Queued reservation from archived session survives reset
  PASS: force-clear returned false (queued preserved)
  PASS: queued op still exists
[3] Fresh session's active operation is untouched
  PASS: force-clear returned false (wrong sessionId)
  PASS: fresh op still active
[4] Full reset cleanup clears active reply + queues
  PASS: activeReplyRunsCleared=1
  PASS: registry slot freed
  PASS: new session can register reply op
[5] Full reset cleanup preserves queued reservations
  PASS: activeReplyRunsCleared=0 (queued preserved)
  PASS: queued op survives

=== ALL PASS (11 passed, 0 failed) ===
```

The proof script calls the exact production functions (`createReplyOperation`, `forceClearReplyRunForResetBySessionId`, `clearSessionResetRuntimeState`) with the same session-key/session-id shapes used in the reset flow.

### Proof 2 — Focused tests:

```
node scripts/run-vitest.mjs src/auto-reply/reply/session-reset-cleanup.test.ts --run
  Test Files  1 passed (1) / Tests  4 passed (4)
```

New regression tests:
- `releases an active reply operation owned by the archived reset session id`
- `leaves queued reservations so session init can rebind them`
- `does not clear a fresh active reply whose sessionId does not match the archived id`

### Proof 3 — Formatting:
```
pnpm exec oxfmt --check <all changed files> → clean (after auto-fix)
git diff --check → clean
```
