### PR TITLE
fix(acp): close shared state database on gateway shutdown (#100637)

### DIFF
--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -36,9 +36,16 @@ const mockState = vi.hoisted(() => ({
   agentSideConnectionCtor: vi.fn(),
   agentHandleGatewayEvent: vi.fn(async (_evt: unknown) => {}),
   agentStart: vi.fn(),
+  agentShutdown: vi.fn(),
   routeLogsToStderr: vi.fn(),
   startProxy: vi.fn(async (_configForTest: unknown) => null as unknown),
   stopProxy: vi.fn(async (_handle: unknown) => {}),
+  closeOpenClawStateDatabase: vi.fn(),
+  migrateEventLedger: vi.fn(async () => ({ importedSessions: 0, importedEvents: 0 })),
+  gatewayStopDeferred: null as {
+    resolve: () => void;
+    promise: Promise<void>;
+  } | null,
   resolveGatewayClientBootstrap: vi.fn<ResolveGatewayClientBootstrap>(async (_params) => ({
     url: "ws://127.0.0.1:18789",
     urlSource: "local loopback",
@@ -65,6 +72,13 @@ class MockGatewayClient {
     this.callbacks.onClose?.(1000, "gateway stopped");
   }
 
+  async stopAndWait(): Promise<void> {
+    if (mockState.gatewayStopDeferred) {
+      await mockState.gatewayStopDeferred.promise;
+    }
+    this.stop();
+  }
+
   emitHello(): void {
     this.callbacks.onHelloOk?.();
   }
@@ -72,7 +86,6 @@ class MockGatewayClient {
   emitConnectError(message: string): void {
     this.callbacks.onConnectError?.(new Error(message));
   }
-
   emitEvent(event: { event: string; payload?: unknown }): void {
     this.callbacks.onEvent?.(event);
   }
@@ -162,6 +175,16 @@ vi.mock("../logging/console.js", () => ({
   routeLogsToStderr: () => mockState.routeLogsToStderr(),
 }));
 
+vi.mock("../state/openclaw-state-db.js", () => ({
+  closeOpenClawStateDatabase: () => mockState.closeOpenClawStateDatabase(),
+}));
+
+vi.mock("./event-ledger.js", () => ({
+  createSqliteAcpEventLedger: vi.fn(() => ({})),
+  migrateFileAcpEventLedgerToSqlite: () => mockState.migrateEventLedger(),
+  resolveDefaultAcpEventLedgerPath: vi.fn(() => "/tmp/acp-events.json"),
+}));
+
 vi.mock("../infra/net/proxy/proxy-lifecycle.js", () => ({
   startProxy: (config: unknown) => mockState.startProxy(config),
   stopProxy: (handle: unknown) => mockState.stopProxy(handle),
@@ -171,6 +194,10 @@ vi.mock("./translator.js", () => ({
   AcpGatewayAgent: class {
     start(): void {
       mockState.agentStart();
+    }
+
+    shutdown(): void {
+      mockState.agentShutdown();
     }
 
     handleGatewayReconnect(): void {}
@@ -293,9 +320,14 @@ describe("serveAcpGateway startup", () => {
     mockState.agentSideConnectionCtor.mockReset();
     mockState.agentHandleGatewayEvent.mockReset();
     mockState.agentStart.mockReset();
+    mockState.agentShutdown.mockReset();
     mockState.routeLogsToStderr.mockReset();
     mockState.startProxy.mockReset();
     mockState.stopProxy.mockReset();
+    mockState.closeOpenClawStateDatabase.mockReset();
+    mockState.migrateEventLedger.mockReset();
+    mockState.migrateEventLedger.mockResolvedValue({ importedSessions: 0, importedEvents: 0 });
+    mockState.gatewayStopDeferred = null;
     mockState.startProxy.mockResolvedValue(null);
     mockState.stopProxy.mockResolvedValue(undefined);
     mockState.resolveGatewayClientBootstrap.mockReset();
@@ -509,6 +541,158 @@ describe("serveAcpGateway startup", () => {
       await stopServeWithSigint(signalHandlers, servePromise);
       expect(mockState.stopProxy).not.toHaveBeenCalled();
     } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("closes the shared state database on shutdown", async () => {
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+    expect(mockState.closeOpenClawStateDatabase).not.toHaveBeenCalled();
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await emitHelloAndWaitForAgentSideConnection();
+      await stopServeWithSigint(signalHandlers, servePromise);
+      expect(mockState.agentShutdown).toHaveBeenCalledOnce();
+      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledOnce();
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("waits for Gateway transport teardown before closing the shared state database", async () => {
+    let resolveStop!: () => void;
+    const stopPromise = new Promise<void>((resolve) => {
+      resolveStop = resolve;
+    });
+    mockState.gatewayStopDeferred = { resolve: resolveStop, promise: stopPromise };
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await emitHelloAndWaitForAgentSideConnection();
+      signalHandlers.get("SIGTERM")?.();
+      await vi.waitFor(() => {
+        expect(mockState.agentShutdown).toHaveBeenCalledOnce();
+      });
+      expect(mockState.closeOpenClawStateDatabase).not.toHaveBeenCalled();
+
+      resolveStop();
+      await servePromise;
+      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledOnce();
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("waits for both ledger migration and Gateway teardown before closing", async () => {
+    let resolveMigration!: () => void;
+    const migrationPromise = new Promise<{ importedSessions: number; importedEvents: number }>(
+      (resolve) => {
+        resolveMigration = () => resolve({ importedSessions: 1, importedEvents: 1 });
+      },
+    );
+    mockState.migrateEventLedger.mockImplementation(async () => await migrationPromise);
+    let resolveStop!: () => void;
+    const stopPromise = new Promise<void>((resolve) => {
+      resolveStop = resolve;
+    });
+    mockState.gatewayStopDeferred = { resolve: resolveStop, promise: stopPromise };
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await vi.waitFor(() => {
+        expect(mockState.gateways).toHaveLength(1);
+      });
+      getMockGateway().emitHello();
+      await vi.waitFor(() => {
+        expect(mockState.migrateEventLedger).toHaveBeenCalledOnce();
+      });
+
+      signalHandlers.get("SIGTERM")?.();
+      await Promise.resolve();
+      expect(mockState.closeOpenClawStateDatabase).not.toHaveBeenCalled();
+
+      resolveMigration();
+      await Promise.resolve();
+      expect(mockState.closeOpenClawStateDatabase).not.toHaveBeenCalled();
+
+      resolveStop();
+      await servePromise;
+
+      expect(mockState.agentSideConnectionCtor).not.toHaveBeenCalled();
+      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledOnce();
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("closes after a pending ledger migration rejects during shutdown", async () => {
+    let rejectMigration!: (err: Error) => void;
+    const migrationPromise = new Promise<{ importedSessions: number; importedEvents: number }>(
+      (_resolve, reject) => {
+        rejectMigration = reject;
+      },
+    );
+    mockState.migrateEventLedger.mockImplementation(async () => await migrationPromise);
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await vi.waitFor(() => {
+        expect(mockState.gateways).toHaveLength(1);
+      });
+      getMockGateway().emitHello();
+      await vi.waitFor(() => {
+        expect(mockState.migrateEventLedger).toHaveBeenCalledOnce();
+      });
+
+      signalHandlers.get("SIGTERM")?.();
+      await Promise.resolve();
+      expect(mockState.closeOpenClawStateDatabase).not.toHaveBeenCalled();
+
+      rejectMigration(new Error("sqlite busy"));
+      await expect(servePromise).resolves.toBeUndefined();
+
+      expect(mockState.agentSideConnectionCtor).not.toHaveBeenCalled();
+      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledOnce();
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("closes a real node:sqlite DatabaseSync handle through serveAcpGateway shutdown", async () => {
+    // Use the real state-db module to open and verify a DatabaseSync handle —
+    // this proves the full serveAcpGateway → shutdown → close path, not just
+    // the closeOpenClawStateDatabase helper in isolation.
+    const actualStateDb = await vi.importActual<typeof import("../state/openclaw-state-db.js")>(
+      "../state/openclaw-state-db.js",
+    );
+
+    const realDb = actualStateDb.openOpenClawStateDatabase();
+    expect(realDb.db.isOpen).toBe(true);
+    expect(actualStateDb.isOpenClawStateDatabaseOpen()).toBe(true);
+
+    // Wire the test mock so serveAcpGateway's shutdown handler calls the
+    // real closeOpenClawStateDatabase, which closes the handle we opened above.
+    mockState.closeOpenClawStateDatabase.mockImplementation(() => {
+      actualStateDb.closeOpenClawStateDatabase();
+    });
+
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+    try {
+      const servePromise = serveAcpGateway({});
+      await emitHelloAndWaitForAgentSideConnection();
+      await stopServeWithSigint(signalHandlers, servePromise);
+
+      // After serveAcpGateway shutdown completes, the real DatabaseSync
+      // handle must be closed — proving the ACP shutdown fix works
+      // end-to-end, not just in the helper function.
+      expect(realDb.db.isOpen).toBe(false);
+      expect(actualStateDb.isOpenClawStateDatabaseOpen()).toBe(false);
+    } finally {
+      actualStateDb.closeOpenClawStateDatabase();
       onceSpy.mockRestore();
     }
   });

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -21,6 +21,7 @@ import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-re
 import { GatewayClient } from "../gateway/client.js";
 import { isMainModule } from "../infra/is-main.js";
 import { routeLogsToStderr } from "../logging/console.js";
+import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
   createSqliteAcpEventLedger,
   migrateFileAcpEventLedgerToSqlite,
@@ -58,6 +59,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     onClosed = resolve;
   });
   let stopped = false;
+  let startupWork: Promise<unknown> | null = null;
   let onGatewayReadyResolve!: () => void;
   let onGatewayReadyReject!: (err: Error) => void;
   let gatewayReadySettled = false;
@@ -79,6 +81,13 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     gatewayReadySettled = true;
     onGatewayReadyReject(err instanceof Error ? err : new Error(String(err)));
   };
+  const closeStateDatabase = () => {
+    try {
+      closeOpenClawStateDatabase();
+    } catch (err) {
+      console.warn(`acp: state database close failed during shutdown: ${String(err)}`);
+    }
+  };
 
   const gateway = new GatewayClient({
     url: bootstrap.url,
@@ -91,6 +100,9 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     mode: GATEWAY_CLIENT_MODES.CLI,
     caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
     onEvent: (evt) => {
+      if (stopped) {
+        return;
+      }
       // Gateway delivery stays non-blocking, but translator failures must not
       // escape this callback as unhandled process rejections.
       void agent?.handleGatewayEvent(evt).catch((err: unknown) => {
@@ -108,33 +120,42 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
       rejectGatewayReady(err);
     },
     onClose: (code, reason) => {
-      if (!stopped) {
-        rejectGatewayReady(new Error(`gateway closed before ready (${code}): ${reason}`));
-      }
-      agent?.handleGatewayDisconnect(`${code}: ${reason}`);
-      // Resolve only on intentional shutdown (gateway.stop() sets closed
-      // which skips scheduleReconnect, then fires onClose).  Transient
-      // disconnects are followed by automatic reconnect attempts.
       if (stopped) {
-        onClosed();
+        return;
       }
+      rejectGatewayReady(new Error(`gateway closed before ready (${code}): ${reason}`));
+      agent?.handleGatewayDisconnect(`${code}: ${reason}`);
     },
   });
 
-  const shutdown = () => {
+  const shutdown = async () => {
     if (stopped) {
       return;
     }
     stopped = true;
     resolveGatewayReady();
-    gateway.stop();
-    // If no WebSocket is active (e.g. between reconnect attempts),
-    // gateway.stop() won't trigger onClose, so resolve directly.
+    // Revoke ledger access before transport teardown. ACP requests and Gateway
+    // events can both resume asynchronously, and must not reopen the shared DB.
+    const activeAgent = agent;
+    agent = null;
+    activeAgent?.shutdown();
+    const startupSettlement = startupWork?.catch(() => {}) ?? Promise.resolve();
+    const gatewayStop = gateway.stopAndWait().catch((err: unknown) => {
+      console.warn(`acp: gateway stop failed during shutdown: ${String(err)}`);
+    });
+    // Migration and transport teardown are independent. Close only after both
+    // settle so neither can touch or reopen the process-owned SQLite handle.
+    await Promise.all([startupSettlement, gatewayStop]);
+    closeStateDatabase();
     onClosed();
   };
 
-  process.once("SIGINT", shutdown);
-  process.once("SIGTERM", shutdown);
+  process.once("SIGINT", () => {
+    void shutdown();
+  });
+  process.once("SIGTERM", () => {
+    void shutdown();
+  });
 
   // Start gateway first and wait for hello before accepting ACP requests.
   const readiness = await startGatewayClientWhenEventLoopReady(gateway, {
@@ -143,8 +164,8 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   if (!readiness.ready) {
     rejectGatewayReady(new Error("gateway event loop readiness timeout"));
   }
-  await gatewayReady.catch((err: unknown) => {
-    shutdown();
+  await gatewayReady.catch(async (err: unknown) => {
+    await shutdown();
     throw err;
   });
   if (stopped) {
@@ -161,10 +182,24 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
       },
     }),
   );
-  await migrateFileAcpEventLedgerToSqlite({
+  startupWork = migrateFileAcpEventLedgerToSqlite({
     filePath: resolveDefaultAcpEventLedgerPath(process.env),
     archiveSource: true,
   });
+  try {
+    await startupWork;
+  } catch (err) {
+    if (stopped) {
+      return closed;
+    }
+    await shutdown();
+    throw err;
+  } finally {
+    startupWork = null;
+  }
+  if (stopped) {
+    return closed;
+  }
   const eventLedger = createSqliteAcpEventLedger();
 
   void new AgentSideConnection(

--- a/src/acp/translator.session-updates.test.ts
+++ b/src/acp/translator.session-updates.test.ts
@@ -1,0 +1,104 @@
+import type { AgentSideConnection, SessionUpdate } from "@agentclientprotocol/sdk";
+import { describe, expect, it, vi } from "vitest";
+import type { AcpEventLedger } from "./event-ledger.js";
+import { AcpTranslatorSessionUpdates } from "./translator.session-updates.js";
+
+function createLedger(): AcpEventLedger {
+  return {
+    startSession: vi.fn(async () => {}),
+    recordUserPrompt: vi.fn(async () => {}),
+    recordUpdate: vi.fn(async () => {}),
+    markIncomplete: vi.fn(async () => {}),
+    readReplay: vi.fn(async () => ({ complete: true, events: [] })),
+    readReplayBySessionId: vi.fn(async () => ({ complete: true, events: [] })),
+    readReplayBySessionKey: vi.fn(async () => ({ complete: true, events: [] })),
+  };
+}
+
+function createUpdates(params: {
+  ledger: AcpEventLedger;
+  sessionUpdate?: AgentSideConnection["sessionUpdate"];
+}) {
+  return new AcpTranslatorSessionUpdates({
+    connection: {
+      sessionUpdate: params.sessionUpdate ?? vi.fn(async () => {}),
+    },
+    eventLedger: params.ledger,
+    getAvailableCommands: async () => [],
+    log: () => {},
+  });
+}
+
+const update: SessionUpdate = {
+  sessionUpdate: "available_commands_update",
+  availableCommands: [],
+};
+
+describe("AcpTranslatorSessionUpdates shutdown", () => {
+  it("blocks ledger reads and writes after shutdown starts", async () => {
+    const ledger = createLedger();
+    const sessionUpdate = vi.fn(async () => {});
+    const updates = createUpdates({ ledger, sessionUpdate });
+    updates.stop();
+
+    await updates.startLedgerSession(
+      { sessionId: "session-1", sessionKey: "agent:main:session-1", cwd: "/tmp" },
+      { complete: true },
+    );
+    await updates.recordUserPrompt(
+      { sessionId: "session-1", sessionKey: "agent:main:session-1" },
+      "run-1",
+      [],
+    );
+    await updates.emit({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      record: true,
+      update,
+    });
+
+    await expect(
+      updates.readLedgerReplay({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+      }),
+    ).resolves.toEqual({ complete: false, events: [] });
+    await expect(updates.readLedgerReplayBySessionId("session-1")).resolves.toEqual({
+      complete: false,
+      events: [],
+    });
+    await expect(updates.readLedgerReplayBySessionKey("agent:main:session-1")).resolves.toEqual({
+      complete: false,
+      events: [],
+    });
+
+    expect(sessionUpdate).not.toHaveBeenCalled();
+    for (const method of Object.values(ledger)) {
+      expect(method).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not record an update that resumes after shutdown starts", async () => {
+    let resolveSessionUpdate!: () => void;
+    const pendingSessionUpdate = new Promise<void>((resolve) => {
+      resolveSessionUpdate = resolve;
+    });
+    const ledger = createLedger();
+    const updates = createUpdates({
+      ledger,
+      sessionUpdate: vi.fn(async () => await pendingSessionUpdate),
+    });
+
+    const emitPromise = updates.emit({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      record: true,
+      update,
+    });
+    updates.stop();
+    resolveSessionUpdate();
+    await emitPromise;
+
+    expect(ledger.recordUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/acp/translator.session-updates.ts
+++ b/src/acp/translator.session-updates.ts
@@ -32,12 +32,21 @@ function resolveLedgerSessionId(session: { sessionId: string; ledgerSessionId?: 
 
 /** Helper that keeps ACP client updates and replay ledger writes in sync. */
 export class AcpTranslatorSessionUpdates {
+  private stopped = false;
+
   constructor(private options: AcpTranslatorSessionUpdatesOptions) {}
+
+  stop(): void {
+    this.stopped = true;
+  }
 
   async startLedgerSession(
     session: AcpTranslatorLedgerSessionRef,
     options: { complete: boolean; reset?: boolean },
   ): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
     try {
       await this.options.eventLedger.startSession({
         sessionId: resolveLedgerSessionId(session),
@@ -57,6 +66,9 @@ export class AcpTranslatorSessionUpdates {
     sessionId: string;
     sessionKey: string;
   }): Promise<AcpEventLedgerReplay> {
+    if (this.stopped) {
+      return { complete: false, events: [] };
+    }
     try {
       return await this.options.eventLedger.readReplay(params);
     } catch (err) {
@@ -66,6 +78,9 @@ export class AcpTranslatorSessionUpdates {
   }
 
   async readLedgerReplayBySessionId(sessionId: string): Promise<AcpEventLedgerReplay> {
+    if (this.stopped) {
+      return { complete: false, events: [] };
+    }
     try {
       return await this.options.eventLedger.readReplayBySessionId({ sessionId });
     } catch (err) {
@@ -75,6 +90,9 @@ export class AcpTranslatorSessionUpdates {
   }
 
   async readLedgerReplayBySessionKey(sessionKey: string): Promise<AcpEventLedgerReplay> {
+    if (this.stopped) {
+      return { complete: false, events: [] };
+    }
     try {
       return await this.options.eventLedger.readReplayBySessionKey({ sessionKey });
     } catch (err) {
@@ -90,6 +108,9 @@ export class AcpTranslatorSessionUpdates {
     runId: string,
     prompt: PromptRequest["prompt"],
   ): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
     try {
       await this.options.eventLedger.recordUserPrompt({
         sessionId: resolveLedgerSessionId(session),
@@ -113,6 +134,9 @@ export class AcpTranslatorSessionUpdates {
     update: SessionUpdate;
     record?: boolean;
   }): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
     await this.options.connection.sessionUpdate({
       sessionId: params.sessionId,
       update: params.update,
@@ -151,6 +175,9 @@ export class AcpTranslatorSessionUpdates {
     runId?: string;
     update: SessionUpdate;
   }): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
     try {
       await this.options.eventLedger.recordUpdate({
         sessionId: params.ledgerSessionId ?? params.sessionId,
@@ -169,6 +196,9 @@ export class AcpTranslatorSessionUpdates {
   }
 
   private async markLedgerIncomplete(session: AcpTranslatorSessionRef): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
     try {
       await this.options.eventLedger.markIncomplete({
         sessionId: resolveLedgerSessionId(session),

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -309,6 +309,12 @@ export class AcpGatewayAgent implements Agent {
     this.log("ready");
   }
 
+  shutdown(): void {
+    this.sessionUpdates.stop();
+    this.activeDisconnectContext = null;
+    this.clearDisconnectTimer();
+  }
+
   supportsClientReadTextFile(): boolean {
     return this.clientCapabilities.readTextFile;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes #100637. The standalone ACP process opens the shared SQLite event-ledger database, but its shutdown path did not own closing that process-wide handle. A direct close is not sufficient: startup migration, Gateway transport callbacks, or delayed session updates can still resume during shutdown and reopen or write the database.

## Why This Change Was Made

The rewrite puts shutdown state at the existing lifecycle owners instead of wrapping seven ledger methods or tracking a parallel set of event promises:

- `AcpTranslatorSessionUpdates.stop()` gates all later ledger reads, ledger writes, and ACP session updates.
- `AcpGatewayAgent.shutdown()` stops session updates, clears reconnect state, and cancels its reconnect timer.
- `serveAcpGateway()` stops the agent, settles any startup migration, drains the Gateway transport, then closes the shared state database once.
- Gateway event rejections stay non-blocking but are caught so shutdown cannot create an unhandled rejection.

This removes the proposed arbitrary two-second drain timeout and makes the process owner responsible for ordering all work that can touch the shared database.

## User Impact

ACP clients now exit cleanly without leaving a shared SQLite handle behind. Restart and hot-reload paths can reopen and write the state database immediately, while delayed callbacks after shutdown are suppressed instead of reviving stale session state.

No CLI, protocol, configuration, or visual behavior changes. Screenshots do not apply.

## Evidence

Exact landing head: `afa2d7ad970c5bb53e898490c46a8b7b06ab936e`

- Sanitized public-network AWS Crabbox focused proof: `pnpm test src/acp/server.startup.test.ts src/acp/translator.session-updates.test.ts src/acp/translator.event-ledger.test.ts` — 24/24 passed, run `run_ea04d080c829`.
- Real Gateway/ACP/SQLite proof: production CLI connected and exited twice through `openclaw acp client` against a real unauthenticated loopback Gateway; each ACP child exited; the same `state/openclaw.sqlite` file then reopened, accepted `BEGIN IMMEDIATE; COMMIT;`, and closed — run `run_3d90096ca7e1`.
- Fresh Codex autoreview after the final code changes: no accepted/actionable findings; correctness confidence 0.90.
- Hosted CI/Testbox: exact-head relevant build, lint, type, test, QA, security, dependency, and real-behavior checks green in [CI run 28807625053](https://github.com/openclaw/openclaw/actions/runs/28807625053).

Diff scope: five ACP files, +377/-18. Production growth is the lifecycle stop gate and shutdown ordering; the majority of the diff is startup, migration-race, delayed-update, and real `DatabaseSync` regression coverage.

## Compatibility / Migration

- Backward compatible: yes
- Config or environment changes: none
- Migration: none

The root changelog is release-owned; release-note context and contributor credit are preserved here and in the commit.
