### PR TITLE
feat(skills): suggest saving detected reusable workflows by default

### DIFF
--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -202,6 +202,14 @@ Skill Workshop tool, so run proposal review actions from a normal host-side
 agent session or the CLI.
 </Note>
 
+## Suggested skills
+
+OpenClaw detects durable instructions such as “next time” and “remember to” after successful
+interactive turns. On the next turn, the agent offers to save the detected workflow through
+`skill_workshop`; the user decides whether to create a proposal. This built-in suggestion does not
+create or change a skill by itself. Enable `skills.workshop.autonomous.enabled` to create pending
+proposals directly instead.
+
 ## Approval and autonomy
 
 ```json5

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -40,6 +40,7 @@ const storeRuntimeLoads = vi.hoisted(() => vi.fn());
 const updateSessionStore = vi.hoisted(() => vi.fn());
 const loadSessionEntryMock = vi.hoisted(() => vi.fn());
 const updateAmbientTranscriptWatermarkMock = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+const consumeSessionSkillSuggestionMock = vi.hoisted(() => vi.fn());
 
 vi.mock(import("../../config/sessions/session-accessor.js"), async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../config/sessions/session-accessor.js")>();
@@ -51,6 +52,10 @@ vi.mock(import("../../config/sessions/session-accessor.js"), async (importOrigin
 
 vi.mock("../../config/sessions/ambient-transcript-watermark.js", () => ({
   updateAmbientTranscriptWatermark: updateAmbientTranscriptWatermarkMock,
+}));
+
+vi.mock("../../config/sessions/skill-suggestions.js", () => ({
+  consumeSessionSkillSuggestion: consumeSessionSkillSuggestionMock,
 }));
 
 vi.mock("../../config/sessions/store.runtime.js", () => {
@@ -318,12 +323,13 @@ describe("runPreparedReply media-only handling", () => {
     storeRuntimeLoads.mockClear();
     updateSessionStore.mockReset();
     loadSessionEntryMock.mockReset();
+    consumeSessionSkillSuggestionMock.mockReset();
     updateAmbientTranscriptWatermarkMock.mockClear();
     vi.clearAllMocks();
     vi.mocked(buildDirectChatContext).mockReturnValue("");
     vi.mocked(buildGroupIntro).mockReturnValue("");
     vi.mocked(buildGroupChatContext).mockReturnValue("");
-    vi.mocked(buildInboundUserContextPrefix).mockReturnValue("");
+    vi.mocked(buildInboundUserContextPrefix).mockReset().mockReturnValue("");
     vi.mocked(resolveInboundUserContextPromptJoiner).mockReturnValue(undefined);
     replyRunTesting.resetReplyRunRegistry();
   });
@@ -1534,10 +1540,15 @@ describe("runPreparedReply media-only handling", () => {
         tokensUsed: 0,
         continuationTurns: 0,
       },
+      pendingSkillSuggestion: {
+        skillName: "github-pr-workflow",
+        detectedAt: 1,
+      },
     };
     const completeEntry: SessionEntry = {
       ...activeEntry,
       goal: { ...activeEntry.goal!, status: "complete" },
+      pendingSkillSuggestion: undefined,
     };
     vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({ mode: "interrupt" });
     vi.mocked(inboundMeta.formatActiveGoalContext).mockImplementation((entry) =>
@@ -1545,8 +1556,19 @@ describe("runPreparedReply media-only handling", () => {
     );
     vi.mocked(inboundMeta.buildInboundUserContextPrefix).mockImplementation(
       (_ctx, _envelope, entry) =>
-        entry?.goal?.status === "active" ? "Active goal: Finish the interrupted work" : "",
+        [
+          entry?.goal?.status === "active" ? "Active goal: Finish the interrupted work" : undefined,
+          entry?.pendingSkillSuggestion
+            ? 'A reusable workflow ("github-pr-workflow") was detected last turn — offer to save it as a skill via skill_workshop if the user agrees.'
+            : undefined,
+        ]
+          .filter(Boolean)
+          .join("\n\n"),
     );
+    consumeSessionSkillSuggestionMock.mockResolvedValueOnce({
+      entry: { ...activeEntry, pendingSkillSuggestion: undefined },
+      suggestion: activeEntry.pendingSkillSuggestion,
+    });
     loadSessionEntryMock.mockReturnValue(completeEntry);
     const activeRun = createReplyOperation({
       sessionId: "session-goal-interrupt",
@@ -1579,6 +1601,61 @@ describe("runPreparedReply media-only handling", () => {
     });
     const call = requireLastRunReplyAgentCall();
     expect(call.followupRun.currentInboundContext?.text ?? "").not.toContain("Active goal:");
+    expect(call.followupRun.currentInboundContext?.text).toContain(
+      'A reusable workflow ("github-pr-workflow") was detected last turn',
+    );
+  });
+
+  it("consumes a skill suggestion once for the next interactive turn", async () => {
+    const suggestion = { skillName: "github-pr-workflow", detectedAt: 1 };
+    const sessionEntry: SessionEntry = {
+      sessionId: "skill-suggestion-session",
+      updatedAt: 1,
+      pendingSkillSuggestion: suggestion,
+    };
+    const clearedEntry: SessionEntry = {
+      ...sessionEntry,
+      pendingSkillSuggestion: undefined,
+    };
+    const sessionStore = { "session-key": sessionEntry };
+    consumeSessionSkillSuggestionMock.mockResolvedValueOnce({
+      entry: clearedEntry,
+      suggestion,
+    });
+    vi.mocked(buildInboundUserContextPrefix).mockImplementation((_ctx, _envelope, entry) =>
+      entry?.pendingSkillSuggestion
+        ? 'A reusable workflow ("github-pr-workflow") was detected last turn — offer to save it as a skill via skill_workshop if the user agrees.'
+        : "",
+    );
+
+    await runPreparedReply(
+      baseParams({
+        isNewSession: false,
+        sessionEntry,
+        sessionStore,
+        storePath: "/tmp/openclaw-session-store.json",
+      }),
+    );
+
+    expect(consumeSessionSkillSuggestionMock).toHaveBeenCalledOnce();
+    expect(sessionStore["session-key"].pendingSkillSuggestion).toBeUndefined();
+    expect(requireLastRunReplyAgentCall().followupRun.currentInboundContext?.text).toContain(
+      'A reusable workflow ("github-pr-workflow") was detected last turn',
+    );
+
+    await runPreparedReply(
+      baseParams({
+        isNewSession: false,
+        sessionEntry,
+        sessionStore,
+        storePath: "/tmp/openclaw-session-store.json",
+      }),
+    );
+
+    expect(consumeSessionSkillSuggestionMock).toHaveBeenCalledOnce();
+    expect(
+      requireLastRunReplyAgentCall().followupRun.currentInboundContext?.text ?? "",
+    ).not.toContain("A reusable workflow");
   });
   it("treats reset-triggered followup mode as interrupt when the session lane is empty", async () => {
     const queueSettings = await import("./queue/settings-runtime.js");
@@ -2676,6 +2753,10 @@ describe("runPreparedReply media-only handling", () => {
         tokensUsed: 0,
         continuationTurns: 0,
       },
+      pendingSkillSuggestion: {
+        skillName: "github-pr-workflow",
+        detectedAt: 1,
+      },
     };
 
     await runPreparedReply(
@@ -2691,6 +2772,8 @@ describe("runPreparedReply media-only handling", () => {
       expect.anything(),
       undefined,
     );
+    expect(consumeSessionSkillSuggestionMock).not.toHaveBeenCalled();
+    expect(sessionEntry.pendingSkillSuggestion).toBeDefined();
   });
 
   it("uses persisted Discord chat metadata for system-event CLI static prompt identity", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -27,8 +27,9 @@ import {
   resolveSessionFilePathOptions,
 } from "../../config/sessions/paths.js";
 import { loadSessionEntry } from "../../config/sessions/session-accessor.js";
+import { consumeSessionSkillSuggestion } from "../../config/sessions/skill-suggestions.js";
 import { resolveSessionStoreEntry } from "../../config/sessions/store.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import type { PendingSkillSuggestion, SessionEntry } from "../../config/sessions/types.js";
 import { resolveSilentReplySettings } from "../../config/silent-reply.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
@@ -48,6 +49,7 @@ import {
 } from "../../sessions/user-turn-transcript.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
+import { resolveSkillWorkshopConfig } from "../../skills/workshop/config.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { hasControlCommand } from "../command-detection.js";
 import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
@@ -173,6 +175,24 @@ function normalizeMessageTimestampMs(value: unknown): number | undefined {
   const timestampMs =
     timestamp < EPOCH_MILLISECONDS_THRESHOLD ? Math.trunc(timestamp * 1000) : timestamp;
   return asDateTimestampMs(timestampMs);
+}
+
+function projectSkillSuggestionForTurn(
+  entry: SessionEntry | undefined,
+  suggestion: PendingSkillSuggestion | undefined,
+): SessionEntry | undefined {
+  if (!entry) {
+    return undefined;
+  }
+  if (suggestion) {
+    return { ...entry, pendingSkillSuggestion: suggestion };
+  }
+  if (!entry.pendingSkillSuggestion) {
+    return entry;
+  }
+  const projected = { ...entry };
+  delete projected.pendingSkillSuggestion;
+  return projected;
 }
 
 async function updateRoomEventAmbientTranscriptWatermark(params: {
@@ -755,40 +775,6 @@ export async function runPreparedReply(
   const baseBodyFinal = isBareSessionReset
     ? (bareResetPromptState?.prompt ?? "")
     : stripPromptThinkingDirectives(baseBody);
-  const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
-  const inboundUserContextSessionCtx = isNewSession
-    ? {
-        ...sessionCtx,
-        ...(normalizeOptionalString(sessionCtx.ThreadHistoryBody)
-          ? { InboundHistory: undefined, ThreadStarterBody: undefined }
-          : {}),
-      }
-    : { ...sessionCtx, ThreadStarterBody: undefined };
-  let goalContextSessionEntry = isHeartbeat
-    ? undefined
-    : (sessionStore?.[sessionKey] ?? sessionEntryHandle?.getCurrent() ?? sessionEntry);
-  let activeGoalContext = formatActiveGoalContext(goalContextSessionEntry);
-  let inboundUserContext = buildInboundUserContextPrefix(
-    inboundUserContextSessionCtx,
-    envelopeOptions,
-    goalContextSessionEntry,
-  );
-  const refreshGoalContextAfterAdmissionWait = () => {
-    if (isHeartbeat) {
-      return;
-    }
-    goalContextSessionEntry =
-      storePath && sessionKey
-        ? loadSessionEntry({ storePath, sessionKey, readConsistency: "latest" })
-        : (sessionEntryHandle?.getCurrent() ?? sessionStore?.[sessionKey] ?? sessionEntry);
-    activeGoalContext = formatActiveGoalContext(goalContextSessionEntry);
-    inboundUserContext = buildInboundUserContextPrefix(
-      inboundUserContextSessionCtx,
-      envelopeOptions,
-      goalContextSessionEntry,
-    );
-  };
-  const inboundUserContextPromptJoiner = resolveInboundUserContextPromptJoiner(sessionCtx);
   const hasUserBody =
     baseBodyFinal.trim().length > 0 ||
     softResetTail.length > 0 ||
@@ -808,6 +794,72 @@ export async function runPreparedReply(
       text: "I didn't receive any text in your message. Please resend or add a caption.",
     };
   }
+  const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
+  const skillSuggestionEnabled = !resolveSkillWorkshopConfig(cfg).autonomous.enabled;
+  const inboundUserContextSessionCtx = isNewSession
+    ? {
+        ...sessionCtx,
+        ...(normalizeOptionalString(sessionCtx.ThreadHistoryBody)
+          ? { InboundHistory: undefined, ThreadStarterBody: undefined }
+          : {}),
+      }
+    : { ...sessionCtx, ThreadStarterBody: undefined };
+  let consumedSkillSuggestion: PendingSkillSuggestion | undefined;
+  const resolveContextSessionEntry = async (
+    entry: SessionEntry | undefined,
+  ): Promise<SessionEntry | undefined> => {
+    if (isHeartbeat) {
+      return undefined;
+    }
+    let currentEntry = entry;
+    if (!consumedSkillSuggestion && currentEntry?.pendingSkillSuggestion) {
+      try {
+        const consumed = await consumeSessionSkillSuggestion({
+          agentId,
+          sessionKey,
+          storePath,
+        });
+        if (consumed) {
+          currentEntry = consumed.entry;
+          consumedSkillSuggestion = skillSuggestionEnabled ? consumed.suggestion : undefined;
+          sessionEntry = consumed.entry;
+          sessionEntryHandle?.replaceCurrent(consumed.entry);
+          if (sessionStore) {
+            sessionStore[sessionKey] = consumed.entry;
+          }
+        }
+      } catch (error) {
+        logVerbose(`Skill suggestion consume failed: ${String(error)}`);
+      }
+    }
+    return projectSkillSuggestionForTurn(currentEntry, consumedSkillSuggestion);
+  };
+  let inboundContextSessionEntry = await resolveContextSessionEntry(
+    sessionStore?.[sessionKey] ?? sessionEntryHandle?.getCurrent() ?? sessionEntry,
+  );
+  let activeGoalContext = formatActiveGoalContext(inboundContextSessionEntry);
+  let inboundUserContext = buildInboundUserContextPrefix(
+    inboundUserContextSessionCtx,
+    envelopeOptions,
+    inboundContextSessionEntry,
+  );
+  const refreshInboundContextAfterAdmissionWait = async () => {
+    if (isHeartbeat) {
+      return;
+    }
+    const latestSessionEntry =
+      storePath && sessionKey
+        ? loadSessionEntry({ storePath, sessionKey, readConsistency: "latest" })
+        : (sessionEntryHandle?.getCurrent() ?? sessionStore?.[sessionKey] ?? sessionEntry);
+    inboundContextSessionEntry = await resolveContextSessionEntry(latestSessionEntry);
+    activeGoalContext = formatActiveGoalContext(inboundContextSessionEntry);
+    inboundUserContext = buildInboundUserContextPrefix(
+      inboundUserContextSessionCtx,
+      envelopeOptions,
+      inboundContextSessionEntry,
+    );
+  };
+  const inboundUserContextPromptJoiner = resolveInboundUserContextPromptJoiner(sessionCtx);
   const promptEnvelopeBase = buildReplyPromptEnvelopeBase({
     ctx,
     sessionCtx,
@@ -1248,8 +1300,8 @@ export async function runPreparedReply(
         preparedSessionState = resolvePreparedSessionState();
         ({ authProfileId, authProfileIdSource } = await resolveRuntimeAuthProfile());
         preparedSessionState = resolvePreparedSessionState();
-        // The interrupted run may have stopped or started a goal while admission waited.
-        refreshGoalContextAfterAdmissionWait();
+        // The interrupted run may have changed goal or suggestion state while admission waited.
+        await refreshInboundContextAfterAdmissionWait();
         ({
           prefixedCommandBody,
           queuedBody,

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -294,6 +294,24 @@ describe("buildInboundMetaSystemPrompt", () => {
 });
 
 describe("buildInboundUserContextPrefix", () => {
+  it("injects a pending skill suggestion into the current user-role context", () => {
+    const entry: SessionEntry = {
+      sessionId: "skill-suggestion-session",
+      updatedAt: 1,
+      pendingSkillSuggestion: {
+        skillName: "github-pr-workflow",
+        detectedAt: 1,
+      },
+    };
+
+    const text = buildInboundUserContextPrefix({} as TemplateContext, undefined, entry);
+
+    expect(text).toBe(
+      'A reusable workflow ("github-pr-workflow") was detected last turn — offer to save it as a skill via skill_workshop if the user agrees.',
+    );
+    expect(text.split("\n")).toHaveLength(1);
+  });
+
   it("injects an active goal into the current user-role context", () => {
     const text = buildInboundUserContextPrefix(
       {} as TemplateContext,

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -18,6 +18,7 @@ const MAX_UNTRUSTED_JSON_STRING_CHARS = 2_000;
 const MAX_UNTRUSTED_HISTORY_ENTRIES = 20;
 const MAX_UNTRUSTED_TRANSCRIPT_FIELD_CHARS = 500;
 const MAX_ACTIVE_GOAL_OBJECTIVE_CHARS = 200;
+const MAX_SKILL_SUGGESTION_NAME_CHARS = 120;
 const ACTIVE_GOAL_CONTEXT_PREFIX = "Active goal: ";
 const ACTIVE_GOAL_CONTEXT_SUFFIX = " — advance it or update its status (get_goal/update_goal).";
 const INBOUND_SOURCE_MODALITIES = new Set(["text", "voice", "audio", "image", "video", "document"]);
@@ -33,6 +34,18 @@ export function formatActiveGoalContext(sessionEntry?: SessionEntry): string | u
       ? objective
       : `${truncateUtf16Safe(objective, MAX_ACTIVE_GOAL_OBJECTIVE_CHARS - 1).trimEnd()}…`;
   return `${ACTIVE_GOAL_CONTEXT_PREFIX}${boundedObjective}${ACTIVE_GOAL_CONTEXT_SUFFIX}`;
+}
+
+export function formatPendingSkillSuggestionContext(
+  sessionEntry?: SessionEntry,
+): string | undefined {
+  const rawSkillName = normalizeOptionalString(sessionEntry?.pendingSkillSuggestion?.skillName);
+  if (!rawSkillName) {
+    return undefined;
+  }
+  const normalizedSkillName = rawSkillName.replace(/\s+/gu, " ").replaceAll('"', "'");
+  const skillName = truncateUtf16Safe(normalizedSkillName, MAX_SKILL_SUGGESTION_NAME_CHARS);
+  return `A reusable workflow ("${skillName}") was detected last turn — offer to save it as a skill via skill_workshop if the user agrees.`;
 }
 
 function isQueuedGoalOnlyBlock(block: string, injectedGoals: ReadonlySet<string>): boolean {
@@ -819,6 +832,11 @@ export function buildInboundUserContextPrefix(
   const activeGoalContext = formatActiveGoalContext(sessionEntry);
   if (activeGoalContext) {
     blocks.push(activeGoalContext);
+  }
+
+  const pendingSkillSuggestionContext = formatPendingSkillSuggestionContext(sessionEntry);
+  if (pendingSkillSuggestionContext) {
+    blocks.push(pendingSkillSuggestionContext);
   }
 
   if (currentMessageContext) {

--- a/src/config/sessions/skill-suggestions.ts
+++ b/src/config/sessions/skill-suggestions.ts
@@ -1,0 +1,74 @@
+// Session skill suggestions are one-shot hints consumed by the next interactive turn.
+import { patchSessionEntry, type SessionAccessScope } from "./session-accessor.js";
+import type { PendingSkillSuggestion, SessionEntry } from "./types.js";
+
+type SessionSkillSuggestionScope = Pick<
+  SessionAccessScope,
+  "agentId" | "env" | "sessionKey" | "storePath"
+>;
+
+type SessionSkillSuggestionConsumption = {
+  entry: SessionEntry;
+  suggestion?: PendingSkillSuggestion;
+};
+
+/** Records one suggestion without replacing an earlier unconsumed suggestion. */
+export async function recordSessionSkillSuggestion(
+  options: SessionSkillSuggestionScope & {
+    skillName: string;
+    signalHash: string;
+    detectedAt?: number;
+  },
+): Promise<boolean> {
+  const skillName = options.skillName.trim();
+  const signalHash = options.signalHash.trim();
+  if (!skillName || !signalHash) {
+    return false;
+  }
+  let recorded = false;
+  const result = await patchSessionEntry(
+    {
+      agentId: options.agentId,
+      env: options.env,
+      sessionKey: options.sessionKey,
+      storePath: options.storePath,
+    },
+    (entry) => {
+      if (entry.pendingSkillSuggestion || entry.lastSkillSuggestionSignalHash === signalHash) {
+        return null;
+      }
+      recorded = true;
+      return {
+        pendingSkillSuggestion: {
+          skillName,
+          detectedAt: options.detectedAt ?? Date.now(),
+        },
+        lastSkillSuggestionSignalHash: signalHash,
+      };
+    },
+    { preserveActivity: true },
+  );
+  return Boolean(result && recorded);
+}
+
+/** Atomically clears and returns the suggestion owned by this interactive turn. */
+export async function consumeSessionSkillSuggestion(
+  options: SessionSkillSuggestionScope,
+): Promise<SessionSkillSuggestionConsumption | undefined> {
+  let currentEntry: SessionEntry | undefined;
+  let suggestion: PendingSkillSuggestion | undefined;
+  const result = await patchSessionEntry(
+    options,
+    (entry) => {
+      currentEntry = entry;
+      if (!entry.pendingSkillSuggestion) {
+        return null;
+      }
+      suggestion = { ...entry.pendingSkillSuggestion };
+      return { pendingSkillSuggestion: undefined };
+    },
+    { preserveActivity: true },
+  );
+  const entry = result ?? currentEntry;
+  return entry ? { entry, suggestion } : undefined;
+}

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -218,6 +218,11 @@ export type SessionGoal = {
   budgetLimitedAt?: number;
 };
 
+export type PendingSkillSuggestion = {
+  skillName: string;
+  detectedAt: number;
+};
+
 export type RestartRecoveryRun = {
   runId: string;
   lifecycleGeneration: string;
@@ -291,6 +296,10 @@ export type SessionEntry = {
   quotaSuspension?: QuotaSuspension;
   /** Core-owned durable goal state for this thread/session. */
   goal?: SessionGoal;
+  /** Durable one-shot Skill Workshop suggestion for the next interactive turn. */
+  pendingSkillSuggestion?: PendingSkillSuggestion;
+  /** Fingerprint of the last signal queued as a skill suggestion. */
+  lastSkillSuggestionSignalHash?: string;
   /** Timestamp (ms) when the current sessionId first became active. */
   sessionStartedAt?: number;
   /** Stable usage lineage key for transcript-backed rollups across sessionId rotations. */

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -34,6 +34,8 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "abortedLastRun",
   "restartRecoveryRuns",
   "goal",
+  "pendingSkillSuggestion",
+  "lastSkillSuggestionSignalHash",
   "sessionStartedAt",
   "ambientTranscriptWatermarks",
   "lastInteractionAt",

--- a/src/skills/research/autocapture.test.ts
+++ b/src/skills/research/autocapture.test.ts
@@ -2,6 +2,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadSessionEntry, upsertSessionEntry } from "../../config/sessions/session-accessor.js";
+import { consumeSessionSkillSuggestion } from "../../config/sessions/skill-suggestions.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -16,6 +18,7 @@ import { runSkillResearchAutoCapture } from "./autocapture.js";
 
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
+const SESSION_KEY = "agent:main:main";
 
 beforeEach(async () => {
   testState = await createOpenClawTestState({
@@ -33,9 +36,21 @@ async function makeWorkspace(): Promise<string> {
   return await tempDirs.make("openclaw-skill-workshop-");
 }
 
+async function seedSession(sessionKey = SESSION_KEY): Promise<void> {
+  await upsertSessionEntry(
+    { agentId: "main", sessionKey },
+    { sessionId: `session-${sessionKey}`, updatedAt: 1 },
+  );
+}
+
+function readSession(sessionKey = SESSION_KEY) {
+  return loadSessionEntry({ agentId: "main", sessionKey, readConsistency: "latest" });
+}
+
 describe("skill research auto-capture", () => {
   it("queues a pending proposal from durable user correction", async () => {
     const workspaceDir = await makeWorkspace();
+    await seedSession();
 
     await runSkillResearchAutoCapture({
       event: {
@@ -48,7 +63,7 @@ describe("skill research auto-capture", () => {
           },
         ],
       },
-      ctx: { workspaceDir, agentId: "main" },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
       config: {
         skills: {
           workshop: {
@@ -71,10 +86,12 @@ describe("skill research auto-capture", () => {
     const proposal = await inspectSkillProposal(proposals.proposals[0].id, { workspaceDir });
     expect(proposal?.content).toContain("status: proposal");
     expect(proposal?.content).toContain("always check CI before final response");
+    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
   });
 
-  it("stays inert when auto-capture is disabled", async () => {
+  it("records and one-shot consumes a suggestion with default config", async () => {
     const workspaceDir = await makeWorkspace();
+    await seedSession();
 
     await runSkillResearchAutoCapture({
       event: {
@@ -86,19 +103,103 @@ describe("skill research auto-capture", () => {
           },
         ],
       },
-      ctx: { workspaceDir },
-      config: {
-        skills: {
-          workshop: {
-            autonomous: {
-              enabled: false,
-            },
-          },
-        },
-      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
     });
 
     expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+    expect(readSession()?.pendingSkillSuggestion).toMatchObject({
+      skillName: "screenshot-asset-workflow",
+    });
+
+    const first = await consumeSessionSkillSuggestion({
+      agentId: "main",
+      sessionKey: SESSION_KEY,
+    });
+    expect(first?.suggestion).toMatchObject({ skillName: "screenshot-asset-workflow" });
+    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
+
+    const second = await consumeSessionSkillSuggestion({
+      agentId: "main",
+      sessionKey: SESSION_KEY,
+    });
+    expect(second?.suggestion).toBeUndefined();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content: "Remember to always verify generated screenshots before replying.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+    });
+    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
+  });
+
+  it("does not record a suggestion when no durable signal is present", async () => {
+    const workspaceDir = await makeWorkspace();
+    await seedSession();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [{ role: "user", content: "Please review this pull request." }],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+    });
+
+    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
+  });
+
+  it("does not record a suggestion after a failed turn", async () => {
+    const workspaceDir = await makeWorkspace();
+    await seedSession();
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: false,
+        messages: [
+          {
+            role: "user",
+            content: "Remember to always verify generated screenshots before replying.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+    });
+
+    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
+  });
+
+  it("does not record a suggestion while a matching proposal is pending", async () => {
+    const workspaceDir = await makeWorkspace();
+    await seedSession();
+    const event = {
+      success: true,
+      messages: [
+        {
+          role: "user",
+          content:
+            "From now on, when working on GitHub PRs, always check CI before final response.",
+        },
+      ],
+    };
+
+    await runSkillResearchAutoCapture({
+      event,
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+      config: { skills: { workshop: { autonomous: { enabled: true } } } },
+    });
+    await runSkillResearchAutoCapture({
+      event,
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+    });
+
+    expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(1);
+    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
   });
 
   it.each([
@@ -136,6 +237,8 @@ describe("skill research auto-capture", () => {
     },
   ])("skips $name before queuing proposals", async ({ ctx }) => {
     const workspaceDir = await makeWorkspace();
+    const sessionKey = ctx.sessionKey ?? SESSION_KEY;
+    await seedSession(sessionKey);
 
     await runSkillResearchAutoCapture({
       event: {
@@ -149,22 +252,15 @@ describe("skill research auto-capture", () => {
         ],
       },
       ctx: { workspaceDir, agentId: "main", ...ctx },
-      config: {
-        skills: {
-          workshop: {
-            autonomous: {
-              enabled: true,
-            },
-          },
-        },
-      },
     });
 
     expect((await listSkillProposals({ workspaceDir })).proposals).toHaveLength(0);
+    expect(readSession(sessionKey)?.pendingSkillSuggestion).toBeUndefined();
   });
 
   it("preserves existing skill content when auto-capturing an update", async () => {
     const workspaceDir = await makeWorkspace();
+    await seedSession();
     const skillFile = path.join(workspaceDir, "skills", "github-pr-workflow", "SKILL.md");
     await fs.mkdir(path.dirname(skillFile), { recursive: true });
     await fs.writeFile(
@@ -194,7 +290,7 @@ describe("skill research auto-capture", () => {
           },
         ],
       },
-      ctx: { workspaceDir, agentId: "main" },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
       config: {
         skills: {
           workshop: {
@@ -218,5 +314,20 @@ describe("skill research auto-capture", () => {
     const updatedSkill = await fs.readFile(skillFile, "utf8");
     expect(updatedSkill).toContain("Preserve this original review checklist.");
     expect(updatedSkill).toContain("always check CI before final response");
+
+    await runSkillResearchAutoCapture({
+      event: {
+        success: true,
+        messages: [
+          {
+            role: "user",
+            content:
+              "From now on, when working on GitHub PRs, always check CI before final response.",
+          },
+        ],
+      },
+      ctx: { workspaceDir, agentId: "main", sessionKey: SESSION_KEY },
+    });
+    expect(readSession()?.pendingSkillSuggestion).toBeUndefined();
   });
 });

--- a/src/skills/research/autocapture.ts
+++ b/src/skills/research/autocapture.ts
@@ -1,5 +1,8 @@
 // Research autocapture helpers decide when skill research signals should be captured.
+import { resolveStorePath } from "../../config/sessions/paths.js";
+import { recordSessionSkillSuggestion } from "../../config/sessions/skill-suggestions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { sha256Hex } from "../../infra/crypto-digest.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { readWorkspaceSkillFile } from "../lifecycle/workspace-skill-write.js";
 import { resolveSkillWorkshopConfig } from "../workshop/config.js";
@@ -49,16 +52,13 @@ function isSkillResearchAutoCaptureEligible(ctx: SkillResearchAgentContext): boo
     .some((segment) => AUTO_CAPTURE_BLOCKED_SESSION_SEGMENTS.has(segment));
 }
 
-/** Captures durable skill research signals from a session transcript when enabled. */
+/** Captures or suggests durable skill research signals from a completed session turn. */
 export async function runSkillResearchAutoCapture(params: {
   event: SkillResearchAgentEndEvent;
   ctx: SkillResearchAgentContext;
   config?: OpenClawConfig;
 }): Promise<void> {
   const workshopConfig = resolveSkillWorkshopConfig(params.config);
-  if (!workshopConfig.autonomous.enabled) {
-    return;
-  }
   if (params.event.success === false) {
     return;
   }
@@ -83,6 +83,37 @@ export async function runSkillResearchAutoCapture(params: {
         entry.skillKey === proposal.skillName,
     )
   ) {
+    return;
+  }
+
+  if (!workshopConfig.autonomous.enabled) {
+    const sessionKey = params.ctx.sessionKey?.trim();
+    if (!sessionKey) {
+      return;
+    }
+    try {
+      const target = resolveSkillProposalTarget({
+        workspaceDir,
+        skillName: proposal.skillName,
+      });
+      if ((await readWorkspaceSkillFile(target.skillFile)) !== null) {
+        return;
+      }
+      const recorded = await recordSessionSkillSuggestion({
+        agentId: params.ctx.agentId,
+        sessionKey,
+        storePath: resolveStorePath(params.config?.session?.store, {
+          agentId: params.ctx.agentId,
+        }),
+        skillName: target.skillKey,
+        signalHash: sha256Hex(proposal.evidence),
+      });
+      if (recorded) {
+        log.info(`skill research queued suggestion ${target.skillKey}`);
+      }
+    } catch (error) {
+      log.warn(`skill research suggestion skipped: ${String(error)}`);
+    }
     return;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Skill capture had two modes with nothing in between: off (the default — durable-instruction signals detected at agent-end were silently dropped) and `skills.workshop.autonomous.enabled` (proposals filed directly). Users repeatedly ask for the agent to get better at repeated tasks, but full autonomous capture stays opt-in for good reasons. The detection machinery already existed and did nothing for the default configuration.

Closes #95477 (scoped: suggestion tier; full post-task self-reflection remains future work).

## Why This Change Was Made

**Default-on suggest tier** between off and autonomous, reusing existing seams end to end:

- `runSkillResearchAutoCapture` (`src/skills/research/autocapture.ts`): when autonomy is off, the same signal extraction now records a one-shot `pendingSkillSuggestion` on the session entry instead of returning early. Same eligibility gates (success only; no cron/heartbeat/subagent/active-memory sessions), same pending-proposal dedupe, plus a live-skill guard (existing skills don't get "save this as a skill" suggestions).
- **Replay-proof by construction**: a `lastSkillSuggestionSignalHash` fingerprint (sha256 of the signal evidence) is stored alongside, so the same correction re-extracted from transcript history on later turns never re-suggests — the invariant the coordinated capture design (#100576 review) requires, landed here first.
- **One-shot consumption** (`src/config/sessions/skill-suggestions.ts`): atomic record/consume via `patchSessionEntry` — an unconsumed suggestion is never replaced, the next non-heartbeat interactive turn atomically clears the flag and injects exactly one user-role context line (`inbound-meta.ts`, same seam and conventions as the active-goal line from #100468, quote-sanitized and length-bounded):
  `A reusable workflow ("<skillName>") was detected last turn — offer to save it as a skill via skill_workshop if the user agrees.`
  Competing/queued turns see cleared state; heartbeats neither inject nor consume.
- **The agent offers; the user decides.** The line instructs the agent to offer — the proposal (if the user agrees) goes through the normal `skill_workshop` pending/approval flow. `autonomous.enabled` behavior is unchanged (direct proposals, no suggestion line).
- No new config keys. Session store is the only state owner (`pendingSkillSuggestion` + fingerprint registered as reserved session-entry slot keys). System prompt and prior transcript bytes untouched.

## User Impact

Out of the box, OpenClaw now notices "from now on…"-style durable instructions and offers — once, on the next turn — to save them as a reviewable skill. Saying yes produces a normal pending Skill Workshop proposal; ignoring it costs nothing further. Operators who enabled autonomous capture see no change. Docs: "Suggested skills" section in [skill-workshop](https://docs.openclaw.ai/tools/skill-workshop).

## Evidence

- Focused Testbox suites green on the final tree: `src/skills/research/autocapture.test.ts` (suggest recorded on default config; not recorded when autonomous/signal absent/pending proposal/live skill/blocked trigger; fingerprint replay guard), `src/auto-reply/reply/inbound-meta.test.ts` (line format, sanitization, absence), `src/auto-reply/reply/get-reply-run.media-only.test.ts` (one-shot consume, heartbeat exclusion, queued-turn behavior).
- Structured second-model review (Codex, gpt-5.5) of the diff: clean.
- `git diff --check`, formatting, docs formatting clean.
- Release-note context: user-facing `feat` — the Skill Workshop now suggests saving detected reusable workflows by default; the agent offers, the user decides, approval flow unchanged.
