### PR TITLE
fix(agents): MiniMax VLM can consume oversized success responses

### DIFF
--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -243,6 +243,51 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
     expect(error.message.length).toBeLessThan(520);
     expect(canceled).toBe(true);
   });
+
+  it("bounds large successful response bodies before parsing JSON", async () => {
+    let canceled = false;
+    let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            JSON.stringify({
+              base_resp: { status_code: 0, status_msg: "ok" },
+              content: "x".repeat(300_000),
+            }),
+          ),
+        );
+        closeTimer = setTimeout(() => controller.close(), 0);
+      },
+      cancel() {
+        canceled = true;
+        if (closeTimer) {
+          clearTimeout(closeTimer);
+        }
+      },
+    });
+    const fetchSpy = vi.fn(async () => {
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "application/json", "Trace-Id": "trace-success" },
+      });
+    });
+    global.fetch = withFetchPreconnect(fetchSpy);
+
+    const error = await minimaxUnderstandImage({
+      apiKey: "minimax-test-key",
+      prompt: "hi",
+      imageDataUrl: "data:image/png;base64,AAAA",
+      apiHost: "https://api.minimax.io",
+    }).catch((caught: unknown) => caught);
+
+    if (!(error instanceof Error)) {
+      throw new Error("expected MiniMax VLM request to reject oversized successful JSON");
+    }
+    expect(error.message).toContain("MiniMax VLM response body exceeded");
+    expect(error.message).toContain("Trace-Id: trace-success");
+    expect(canceled).toBe(true);
+  });
 });
 
 describe("isMinimaxVlmModel", () => {

--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -246,24 +246,14 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
 
   it("bounds large successful response bodies before parsing JSON", async () => {
     let canceled = false;
-    let closeTimer: ReturnType<typeof setTimeout> | undefined;
+    let pullCount = 0;
     const body = new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(
-          new TextEncoder().encode(
-            JSON.stringify({
-              base_resp: { status_code: 0, status_msg: "ok" },
-              content: "x".repeat(300_000),
-            }),
-          ),
-        );
-        closeTimer = setTimeout(() => controller.close(), 0);
+      pull(controller) {
+        pullCount += 1;
+        controller.enqueue(new Uint8Array(1024 * 1024));
       },
       cancel() {
         canceled = true;
-        if (closeTimer) {
-          clearTimeout(closeTimer);
-        }
       },
     });
     const fetchSpy = vi.fn(async () => {
@@ -284,8 +274,10 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
     if (!(error instanceof Error)) {
       throw new Error("expected MiniMax VLM request to reject oversized successful JSON");
     }
-    expect(error.message).toContain("MiniMax VLM response body exceeded");
-    expect(error.message).toContain("Trace-Id: trace-success");
+    expect(error.message).toBe(
+      "MiniMax VLM response [Trace-Id=trace-success]: JSON response exceeds 16777216 bytes",
+    );
+    expect(pullCount).toBe(17);
     expect(canceled).toBe(true);
   });
 });

--- a/src/agents/minimax-vlm.normalizes-api-key.test.ts
+++ b/src/agents/minimax-vlm.normalizes-api-key.test.ts
@@ -277,7 +277,9 @@ describe("minimaxUnderstandImage apiKey normalization", () => {
     expect(error.message).toBe(
       "MiniMax VLM response [Trace-Id=trace-success]: JSON response exceeds 16777216 bytes",
     );
-    expect(pullCount).toBe(17);
+    // WHATWG streams may pre-pull one chunk beyond the bytes consumed by the reader.
+    expect(pullCount).toBeGreaterThanOrEqual(17);
+    expect(pullCount).toBeLessThanOrEqual(18);
     expect(canceled).toBe(true);
   });
 });

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -1,3 +1,4 @@
+import { readResponseWithLimit } from "../infra/http-body.js";
 import { readResponseBodySnippet } from "../infra/http-error-body.js";
 /**
  * Adapts MiniMax VLM image-understanding requests for agent image inputs.
@@ -14,6 +15,7 @@ type MinimaxBaseResp = {
 
 const MINIMAX_VLM_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const MINIMAX_VLM_ERROR_BODY_MAX_CHARS = 400;
+const MINIMAX_VLM_SUCCESS_BODY_MAX_BYTES = 256 * 1024;
 const DEFAULT_MINIMAX_VLM_TIMEOUT_MS = 60_000;
 
 export function isMinimaxVlmProvider(provider: string): boolean {
@@ -142,7 +144,19 @@ export async function minimaxUnderstandImage(params: {
     );
   }
 
-  const json = (await res.json().catch(() => null)) as unknown;
+  const body = await readResponseWithLimit(res, MINIMAX_VLM_SUCCESS_BODY_MAX_BYTES, {
+    onOverflow: ({ maxBytes }) => {
+      const trace = traceId ? ` Trace-Id: ${traceId}` : "";
+      return new Error(`MiniMax VLM response body exceeded ${maxBytes} bytes.${trace}`);
+    },
+  });
+  const json = (() => {
+    try {
+      return JSON.parse(body.toString("utf8")) as unknown;
+    } catch {
+      return null;
+    }
+  })();
   if (!isRecord(json)) {
     const trace = traceId ? ` Trace-Id: ${traceId}` : "";
     throw new Error(`MiniMax VLM response was not JSON.${trace}`);

--- a/src/agents/minimax-vlm.ts
+++ b/src/agents/minimax-vlm.ts
@@ -1,4 +1,3 @@
-import { readResponseWithLimit } from "../infra/http-body.js";
 import { readResponseBodySnippet } from "../infra/http-error-body.js";
 /**
  * Adapts MiniMax VLM image-understanding requests for agent image inputs.
@@ -7,6 +6,7 @@ import { ensureGlobalUndiciEnvProxyDispatcher } from "../infra/net/undici-global
 import { resolvePositiveTimerTimeoutMs } from "../shared/number-coercion.js";
 import { isRecord } from "../utils.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
+import { readProviderJsonResponse } from "./provider-http-errors.js";
 
 type MinimaxBaseResp = {
   status_code?: number;
@@ -15,7 +15,6 @@ type MinimaxBaseResp = {
 
 const MINIMAX_VLM_ERROR_BODY_MAX_BYTES = 8 * 1024;
 const MINIMAX_VLM_ERROR_BODY_MAX_CHARS = 400;
-const MINIMAX_VLM_SUCCESS_BODY_MAX_BYTES = 256 * 1024;
 const DEFAULT_MINIMAX_VLM_TIMEOUT_MS = 60_000;
 
 export function isMinimaxVlmProvider(provider: string): boolean {
@@ -144,19 +143,10 @@ export async function minimaxUnderstandImage(params: {
     );
   }
 
-  const body = await readResponseWithLimit(res, MINIMAX_VLM_SUCCESS_BODY_MAX_BYTES, {
-    onOverflow: ({ maxBytes }) => {
-      const trace = traceId ? ` Trace-Id: ${traceId}` : "";
-      return new Error(`MiniMax VLM response body exceeded ${maxBytes} bytes.${trace}`);
-    },
-  });
-  const json = (() => {
-    try {
-      return JSON.parse(body.toString("utf8")) as unknown;
-    } catch {
-      return null;
-    }
-  })();
+  const responseLabel = traceId
+    ? `MiniMax VLM response [Trace-Id=${traceId}]`
+    : "MiniMax VLM response";
+  const json = await readProviderJsonResponse<unknown>(res, responseLabel);
   if (!isRecord(json)) {
     const trace = traceId ? ` Trace-Id: ${traceId}` : "";
     throw new Error(`MiniMax VLM response was not JSON.${trace}`);

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -447,32 +447,24 @@ function registerImageToolEnvReset(priorFetch: typeof global.fetch, keys: string
 }
 
 function stubMinimaxOkFetch() {
-  const fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    statusText: "OK",
-    headers: new Headers(),
-    json: async () => ({
+  const fetch = vi.fn().mockResolvedValue(
+    Response.json({
       content: "ok",
       base_resp: { status_code: 0, status_msg: "" },
     }),
-  });
+  );
   global.fetch = withFetchPreconnect(fetch);
   vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
   return fetch;
 }
 
 function stubMinimaxFetch(baseResp: { status_code: number; status_msg: string }, content = "ok") {
-  const fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    status: 200,
-    statusText: "OK",
-    headers: new Headers(),
-    json: async () => ({
+  const fetch = vi.fn().mockResolvedValue(
+    Response.json({
       content,
       base_resp: baseResp,
     }),
-  });
+  );
   global.fetch = withFetchPreconnect(fetch);
   return fetch;
 }

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -447,7 +447,7 @@ function registerImageToolEnvReset(priorFetch: typeof global.fetch, keys: string
 }
 
 function stubMinimaxOkFetch() {
-  const fetch = vi.fn().mockResolvedValue(
+  const fetch = vi.fn().mockImplementation(async () =>
     Response.json({
       content: "ok",
       base_resp: { status_code: 0, status_msg: "" },
@@ -459,7 +459,7 @@ function stubMinimaxOkFetch() {
 }
 
 function stubMinimaxFetch(baseResp: { status_code: number; status_msg: string }, content = "ok") {
-  const fetch = vi.fn().mockResolvedValue(
+  const fetch = vi.fn().mockImplementation(async () =>
     Response.json({
       content,
       base_resp: baseResp,

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -150,17 +150,12 @@ describe("describeImageWithModel", () => {
     vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", path.join(process.cwd(), "extensions"));
     vi.stubGlobal("fetch", fetchMock);
     vi.clearAllMocks();
-    fetchMock.mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: "OK",
-      headers: { get: vi.fn(() => null) },
-      json: vi.fn(async () => ({
+    fetchMock.mockResolvedValue(
+      Response.json({
         base_resp: { status_code: 0 },
         content: "portal ok",
-      })),
-      text: vi.fn(async () => ""),
-    });
+      }),
+    );
     discoverModelsMock.mockReturnValue({
       find: vi.fn(() => ({
         provider: "minimax-portal",

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -150,7 +150,7 @@ describe("describeImageWithModel", () => {
     vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", path.join(process.cwd(), "extensions"));
     vi.stubGlobal("fetch", fetchMock);
     vi.clearAllMocks();
-    fetchMock.mockResolvedValue(
+    fetchMock.mockImplementation(async () =>
       Response.json({
         base_resp: { status_code: 0 },
         content: "portal ok",


### PR DESCRIPTION
## What Problem This Solves

MiniMax VLM image understanding previously parsed successful `200 OK` responses with `Response.json()`, so a malformed or hostile provider response could be consumed without a body-size bound. Non-OK responses were already read through a bounded diagnostic path.

## Why This Change Was Made

Successful MiniMax VLM responses now use the existing shared `readProviderJsonResponse` owner. That gives the route the same 16 MiB JSON limit, stream cancellation, and parse-error behavior as other provider HTTP consumers while preserving MiniMax Trace-Id context in the error label. The earlier PR-local 256 KiB reader was deleted; one canonical response reader is simpler and avoids a provider-specific limit and duplicate stream code.

Tests now use real WHATWG `Response` objects so they exercise the production body reader. The regression feeds an unbounded successful stream, verifies rejection at 16 MiB, and proves the stream is cancelled without draining indefinitely.

## User Impact

Normal MiniMax VLM responses are unchanged. Oversized or malformed successful JSON responses now fail with a bounded diagnostic instead of allowing unbounded response consumption. No config, request payload, provider routing, timeout, or public API changes.

## Evidence

- Exact rewritten head: `5eec0663b6cdcfc197340b5df4aa1171efd8aa30` on repaired `main` `8ce620f3e675b25111dcbed6d1e124fedd4756a3`.
- Focused MiniMax VLM regression passed: 13 tests, including bounded read and stream cancellation.
- Shared provider-response reader tests and the real-`Response` image-tool/media-understanding callers were reviewed.
- Fresh final-patch autoreview: clean (0.98).
- Hosted exact-head CI: [run 28785857324](https://github.com/openclaw/openclaw/actions/runs/28785857324) passed the full repository matrix.

Contributor report and original implementation credited to @zhangguiping-xydt. Release notes are deferred to the repository's release-owned changelog flow.
