### PR TITLE
fix(tui): preserve balanced parentheses in markdown link URL extraction (#100661)

### DIFF
--- a/src/tui/osc8-hyperlinks.test.ts
+++ b/src/tui/osc8-hyperlinks.test.ts
@@ -47,6 +47,21 @@ describe("extractUrls", () => {
     const urls = extractUrls("https://example.com/path?q=1&r=2#section");
     expect(urls).toEqual(["https://example.com/path?q=1&r=2#section"]);
   });
+
+  it("extracts markdown link hrefs with parentheses in the URL", () => {
+    const url = "https://en.wikipedia.org/wiki/URL_(disambiguation)";
+    expect(extractUrls(`[Wikipedia](${url})`)).toEqual([url]);
+  });
+
+  it("handles bare URLs with trailing closing paren as punctuation", () => {
+    const urls = extractUrls("(see https://example.com/path)");
+    expect(urls).toEqual(["https://example.com/path"]);
+  });
+
+  it("handles markdown link with angle brackets and parenthetical URL", () => {
+    const url = "https://en.wikipedia.org/wiki/Special_(film)";
+    expect(extractUrls(`[link](<${url}>)`)).toEqual([url]);
+  });
 });
 
 describe("addOsc8Hyperlinks", () => {
@@ -124,6 +139,13 @@ describe("addOsc8Hyperlinks", () => {
     const fragment = "https://example.com/api/v2/u";
     const result = addOsc8Hyperlinks([fragment], [short, long]);
     expect(result[0]).toContain(`\x1b]8;;${long}\x07${fragment}\x1b]8;;\x07`);
+  });
+
+  it("wraps URLs with parentheses in markdown rendered text", () => {
+    const url = "https://en.wikipedia.org/wiki/URL_(disambiguation)";
+    const line = `Wikipedia (${url})`;
+    const result = addOsc8Hyperlinks([line], [url]);
+    expect(result[0]).toBe(`Wikipedia (\x1b]8;;${url}\x07${url}\x1b]8;;\x07)`);
   });
 
   it("handles URL split across three lines", () => {

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -6,6 +6,37 @@ const ANSI_RE = new RegExp(`${SGR_PATTERN}|${OSC8_PATTERN}`, "g");
 const SGR_START_RE = new RegExp(`^${SGR_PATTERN}`);
 const OSC8_START_RE = new RegExp(`^${OSC8_PATTERN}`);
 
+/** Allow one level of balanced parentheses inside a URL so markdown link
+ *  targets like `https://en.wikipedia.org/wiki/URL_(disambiguation)` are
+ *  fully captured instead of truncated at the first `)`. */
+const URL_PATH_WITH_PARENS = /https?:\/\/[^()\s<>]*(?:\([^()\s<>]*\)[^()\s<>]*)*/g;
+
+/** Strip trailing `)` characters that don't have a matching `(` in the URL.
+ *  Bare URLs in prose can pick up a trailing `)` that belongs to surrounding
+ *  punctuation, e.g. `(see https://example.com/path)` — the `)` after `path`
+ *  is sentence punctuation, not part of the URL. */
+function trimUnbalancedTrailingParens(url: string): string {
+  let open = 0;
+  for (const ch of url) {
+    if (ch === "(") {
+      open++;
+    } else if (ch === ")") {
+      open--;
+    }
+  }
+  // If close parens outnumber open parens, the trailing ones are not
+  // part of the URL — strip them.
+  if (open >= 0) {
+    return url;
+  }
+  let trimmed = url;
+  while (trimmed.endsWith(")") && open < 0) {
+    trimmed = trimmed.slice(0, -1);
+    open++;
+  }
+  return trimmed;
+}
+
 /**
  * Extract all unique URLs from raw markdown text.
  * Finds both bare URLs and markdown link hrefs [text](url).
@@ -14,20 +45,20 @@ export function extractUrls(markdown: string): string[] {
   const urls = new Set<string>();
 
   // Markdown link hrefs: [text](url), with optional <...> and optional title.
-  const mdLinkRe = /\[(?:[^\]]*)\]\(\s*<?(https?:\/\/[^)\s>]+)>?(?:\s+["'][^"']*["'])?\s*\)/g;
+  const mdLinkRe = new RegExp(
+    `\\[(?:[^\\]]*)\\]\\(\\s*<?(${URL_PATH_WITH_PARENS.source})>?(?:\\s+["'][^"']*["'])?\\s*\\)`,
+    "g",
+  );
   let m: RegExpExecArray | null;
   while ((m = mdLinkRe.exec(markdown)) !== null) {
     urls.add(m[1]);
   }
 
   // Bare URLs (remove markdown links first to avoid double-matching)
-  const stripped = markdown.replace(
-    /\[(?:[^\]]*)\]\(\s*<?https?:\/\/[^)\s>]+>?(?:\s+["'][^"']*["'])?\s*\)/g,
-    "",
-  );
-  const bareRe = /https?:\/\/[^\s)\]>]+/g;
+  const stripped = markdown.replace(mdLinkRe, "");
+  const bareRe = /https?:\/\/[^\s\]>]+/g;
   while ((m = bareRe.exec(stripped)) !== null) {
-    urls.add(m[0]);
+    urls.add(trimUnbalancedTrailingParens(m[0]));
   }
 
   return [...urls];
@@ -86,12 +117,12 @@ function findUrlRanges(
   }
 
   // Find new URL starts in visible text
-  const urlRe = /https?:\/\/[^\s)\]>]+/g;
+  const urlRe = /https?:\/\/[^\s\]>]+/g;
   urlRe.lastIndex = searchFrom;
   let match: RegExpExecArray | null;
 
   while ((match = urlRe.exec(visibleText)) !== null) {
-    const fragment = match[0];
+    const fragment = trimUnbalancedTrailingParens(match[0]);
     const start = match.index;
 
     // Resolve fragment to a known URL (exact > prefix > superstring)


### PR DESCRIPTION
Fixes #100661

## What Problem This Solves

`extractUrls` in `src/tui/osc8-hyperlinks.ts` used `[^)\s>]+` to capture markdown link hrefs. When a URL contained balanced parentheses — e.g. `https://en.wikipedia.org/wiki/URL_(disambiguation)` — the regex stopped at the first `)`, producing a truncated URL that breaks the rendered hyperlink.

## Why This Change Was Made

Three changes in one file:

1. **`URL_PATH_WITH_PARENS`** — new shared regex pattern `https?:\/\/[^()\s<>]*(?:\([^()\s<>]*\)[^()\s<>]*)*` that captures one level of balanced parentheses inside URL paths. Replaces the old `[^)\s>]+` class.

2. **`trimUnbalancedTrailingParens(url)`** — strips trailing `)` characters when close-paren count exceeds open-paren count. Bare URLs in prose (`(see https://example.com/path)`) can pick up a trailing `)` that is sentence punctuation, not part of the URL.

3. **Apply both everywhere**: `mdLinkRe` (markdown link extraction), `bareRe` (plain-text URL extraction), and `urlRe` (visible-text URL matching in `findUrlRanges`).

## User Impact

TUI hyperlinks with parenthetical URLs (Wikipedia, spec links, etc.) now render correctly instead of being silently broken.

## Evidence

### Proof — Production function call (`node --import tsx`):

```
=== #100661 Proof: URLs with parentheses ===

  PASS: [1] markdown link with parens preserved
  PASS: [2] bare URL trailing paren stripped
  PASS: [3] normal markdown link
  PASS: [4] OSC8 wraps paren URL
  PASS: [5] multiple paren groups
  PASS: [6] angle brackets + paren URL
  PASS: [7] query params + parens
  PASS: [8] regression: bare URL

=== ALL PASS (8p 0f) ===
```

### Tests — Project runner:

```
node scripts/run-vitest.mjs src/tui/osc8-hyperlinks.test.ts --run
  Test Files  1 passed (1) / Tests  21 passed (21)
```

New tests:
- `extracts markdown link hrefs with parentheses in the URL`
- `handles bare URLs with trailing closing paren as punctuation`
- `handles markdown link with angle brackets and parenthetical URL`
- `wraps URLs with parentheses in markdown rendered text`

### Pre-submit:

```
oxfmt --check → clean
git diff --check → clean
```
