### PR TITLE
fix(ai/mistral): forward reasoning options even when model manifest disables reasoning

### DIFF
--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -231,6 +231,44 @@ describe("Mistral provider", () => {
     });
   });
 
+  it("forwards reasoning options even when the model manifest disables reasoning", async () => {
+    const stream = streamSimpleMistral(makeMistralModel(), context, {
+      apiKey: "sk-mistral-provider",
+      reasoning: "low",
+    });
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const payload = mistralMockState.payloads[0] as {
+      promptMode?: string;
+      reasoningEffort?: string;
+    };
+    expect(payload.promptMode).toBe("reasoning");
+    expect(payload.reasoningEffort).toBeUndefined();
+  });
+
+  it("forwards reasoningEffort for models that use effort-based reasoning", async () => {
+    const stream = streamSimpleMistral(
+      { ...makeMistralModel(), id: "mistral-small-latest" },
+      context,
+      {
+        apiKey: "sk-mistral-provider",
+        reasoning: "low",
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const payload = mistralMockState.payloads[0] as {
+      promptMode?: string;
+      reasoningEffort?: string;
+    };
+    expect(payload.promptMode).toBeUndefined();
+    expect(payload.reasoningEffort).toBeDefined();
+  });
+
   it("strips the internal cache boundary marker from the system message", async () => {
     const stream = streamSimpleMistral(
       makeMistralModel(),

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -195,11 +195,15 @@ export const streamSimpleMistral: StreamFunction<"mistral-conversations", Simple
   }
 
   const base = buildBaseOptions(model, options, apiKey);
-  const clampedReasoning = options?.reasoning
-    ? clampThinkingLevel(model, options.reasoning)
+  const requestedReasoning = options?.reasoning;
+  const clampedReasoning = requestedReasoning
+    ? clampThinkingLevel(model, requestedReasoning)
     : undefined;
-  const reasoning = clampedReasoning === "off" ? undefined : clampedReasoning;
-  const shouldUseReasoning = model.reasoning && reasoning !== undefined;
+  // Honor explicitly-requested reasoning options even when the static model
+  // manifest does not declare reasoning support. Manifests can lag behind
+  // newly-released model capabilities, and the user request should win.
+  const reasoning = clampedReasoning === "off" ? requestedReasoning : clampedReasoning;
+  const shouldUseReasoning = reasoning !== undefined;
 
   return streamMistral(model, context, {
     ...base,
@@ -765,7 +769,7 @@ function usesReasoningEffort(model: Model<"mistral-conversations">): boolean {
 }
 
 function usesPromptModeReasoning(model: Model<"mistral-conversations">): boolean {
-  return model.reasoning && !usesReasoningEffort(model);
+  return !usesReasoningEffort(model);
 }
 
 function mapReasoningEffort(

--- a/scripts/proof/mistral-reasoning-options.mts
+++ b/scripts/proof/mistral-reasoning-options.mts
@@ -1,0 +1,80 @@
+// Real behavior proof: Mistral provider forwards reasoning options even when
+// the static model manifest marks reasoning as disabled.
+//
+// The proof calls streamSimpleMistral with a model whose manifest has
+// reasoning: false, intercepts the outgoing HTTP request via a custom fetch,
+// and verifies that prompt_mode/reasoning_effort are still included when the
+// caller explicitly requests reasoning.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+let capturedBody: Record<string, unknown> | undefined;
+const originalFetch = globalThis.fetch;
+// @ts-expect-error proof-only fetch replacement
+globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const request = input instanceof Request ? input : new Request(input, init);
+  try {
+    const text = await request.clone().text();
+    capturedBody = text ? (JSON.parse(text) as Record<string, unknown>) : undefined;
+  } catch {
+    // ignore parse errors
+  }
+  // Return a minimal SSE stream so the SDK parser terminates cleanly.
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode('data: {"object":"chat.completion.chunk"}\n\n'),
+        );
+        controller.close();
+      },
+    }),
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  );
+};
+
+const { streamSimpleMistral } = await import(
+  path.join(repoRoot, "packages/ai/src/providers/mistral.js")
+);
+
+const model = {
+  id: "mistral-large-latest",
+  name: "Mistral Large",
+  api: "mistral-conversations",
+  provider: "mistral",
+  baseUrl: "https://api.mistral.ai",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 8192,
+} as const;
+
+const context = {
+  messages: [{ role: "user", content: "hello", timestamp: 0 }],
+};
+
+console.log("=== Proof: Mistral reasoning options forwarded despite reasoning: false ===\n");
+
+const stream = streamSimpleMistral(model as never, context, {
+  apiKey: "sk-proof",
+  reasoning: "low",
+});
+await stream.result();
+
+globalThis.fetch = originalFetch;
+
+console.log(`Payload prompt_mode: ${capturedBody?.prompt_mode ?? "<undefined>"}`);
+console.log(`Payload reasoning_effort: ${capturedBody?.reasoning_effort ?? "<undefined>"}`);
+
+if (capturedBody?.prompt_mode === "reasoning") {
+  console.log(
+    "\nPASS: reasoning option was forwarded as prompt_mode despite model.reasoning=false.",
+  );
+} else {
+  console.log("\nFAIL: reasoning option was stripped.");
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Fixes #100664.

## What Problem This Solves

In `packages/ai/src/providers/mistral.ts`, `streamSimpleMistral` derives Mistral-specific `promptMode` / `reasoningEffort` from the provider-agnostic `options.reasoning`. The derivation first clamps the level through `clampThinkingLevel`, which returns `"off"` when the model manifest has `reasoning: false`. `"off"` is then treated as "no reasoning", so user-requested reasoning parameters are silently stripped from the API payload even when the caller explicitly requested them.

## Why This Change Was Made

Model capability manifests can lag behind newly released model capabilities. When a caller explicitly requests reasoning, the provider should honor that request and let the upstream API decide whether the model supports it, rather than discarding the parameters based on a stale static flag.

The change:
- Preserves the originally requested reasoning level when clamping downgrades it to `"off"`.
- Removes the `model.reasoning` gate from `usesPromptModeReasoning` so the decision is based on the model's known reasoning mode (prompt-mode vs effort-based) rather than whether the manifest declares reasoning support.
- Keeps `shouldUseReasoning` true whenever the caller explicitly requested reasoning.

## User Impact

Users who configure `reasoning` for a Mistral model whose manifest does not yet mark `reasoning: true` will now see the `promptMode` / `reasoningEffort` parameters forwarded to Mistral, instead of having them silently dropped.

## Evidence

Regression test:

```bash
node scripts/run-vitest.mjs packages/ai/src/providers/mistral.test.ts
```

```
Test Files  1 passed (1)
     Tests  10 passed (10)
```

Real behavior proof:

```bash
node_modules/.bin/tsx scripts/proof/mistral-reasoning-options.mts
```

The proof calls `streamSimpleMistral` with a real model object whose manifest has `reasoning: false`, intercepts the outgoing HTTP request with a custom `fetch`, and verifies the serialized payload still contains `prompt_mode: "reasoning"`:

```
=== Proof: Mistral reasoning options forwarded despite reasoning: false ===

Payload prompt_mode: reasoning
Payload reasoning_effort: <undefined>

PASS: reasoning option was forwarded as prompt_mode despite model.reasoning=false.
```
