### PR TITLE
docs(android): credit landed app improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Android cron job details:** add a read-only Settings detail view with schedule, payload, delivery state, job ID copy, refresh, and nested back navigation. (#95107) Thanks @Tosko4.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.
@@ -21,6 +22,10 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Android Canvas navigation:** block device-local loopback and unspecified main-frame web targets across direct, user, JavaScript, and redirect navigation while preserving remote, LAN, emulator-host, and bundled canvases. (#99874) Thanks @ly85206559.
+- **Android network recovery:** reconnect Gateway sessions immediately when Android regains a validated network instead of waiting for the current reconnect backoff. (#100347) Thanks @ly85206559.
+- **Android Voice layout:** keep Voice settings controls within their intended width so nested cards do not overflow or clip on constrained screens. (#100491) Thanks @IWhatsskill.
+- **Android camera logging:** remove release-path camera clip diagnostics that exposed temporary file details and added noisy invoke logs. (#99484) Thanks @NianJiuZst.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
 - **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -8,6 +8,12 @@ Adds read-only Cron Job details in Settings, including schedule, payload and del
 
 Gateway sessions now retry immediately when Android regains a validated network, without waiting for the current reconnect backoff.
 
+Canvas main-frame navigation now blocks device-local loopback and unspecified web targets while preserving remote, LAN, emulator-host, and bundled canvases.
+
+Voice settings now stay within their intended width instead of overflowing or clipping on constrained screens.
+
+Camera clip capture no longer emits release-path diagnostics containing temporary file details.
+
 ## 2026.6.11 - 2026-07-01
 
 Improves Android gateway setup with localized onboarding, QR pairing fixes, and support for local mDNS gateway hosts.

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -9493,6 +9493,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Proposal content
   - H2: Support files
   - H2: Agent tool
+  - H2: Suggested skills
   - H2: Approval and autonomy
   - H2: Gateway methods
   - H2: Storage


### PR DESCRIPTION
Related: #95107, #100347, #99874, #100491, #99484

## What Problem This Solves

The five landed Android improvements were not all represented in the root and app changelogs, leaving user-visible behavior and contributor credit incomplete.

## Why This Change Was Made

Adds concise Unreleased entries for Cron Job details, validated-network reconnects, Canvas navigation hardening, Voice layout sizing, and camera clip log cleanup. The root changelog credits each contributor; the Android changelog keeps the app-specific summary readable.

## User Impact

Release notes now accurately describe the landed Android behavior and preserve contributor attribution. Runtime behavior is unchanged.

## Evidence

- `git diff --check`
- `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=/tmp/openclaw-clawhub-docs-100702 pnpm docs:map:gen`
- Documentation-only diff: 11 changelog lines plus one generated ClawHub map heading
- Landed PRs: #95107, #100347, #99874, #100491, #99484
