### PR TITLE
fix(ci): restore gateway architecture and lint gates

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -115,7 +115,7 @@ export async function runGatewayLoop(params: {
   if (process.title === "openclaw") {
     process.title = "openclaw-gateway";
   }
-  let startupStartedAt = Date.now();
+  let startupStartedAt: number;
   // Eagerly resolve the lifecycle runtime module before installing signal
   // listeners. Without this, every subsequent lifecycle path (SIGUSR1,
   // SIGTERM-with-intent, restart iteration hook, stability bundle writer)

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -25,7 +25,6 @@ import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.
 import type { refreshLatestUpdateRestartSentinel } from "./server-restart-sentinel.js";
 import type { logGatewayStartup } from "./server-startup-log.js";
 import type { startGatewayTailscaleExposure } from "./server-tailscale.js";
-import type { GatewaySidecarStartupMode } from "./server.impl.js";
 
 const ACP_BACKEND_READY_TIMEOUT_MS = 5_000;
 const ACP_BACKEND_READY_POLL_MS = 50;
@@ -71,6 +70,8 @@ const loadGatewayRestartSentinelModule = createLazyRuntimeModule(
 export type GatewayPostReadySidecarHandle = {
   stop: () => Awaitable<void>;
 };
+
+export type GatewaySidecarStartupMode = "start" | "defer";
 
 /** Stop sidecars immediately when shutdown has already started before they are reported. */
 export function stopPostReadySidecarsAfterCloseStarted(params: {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -108,6 +108,7 @@ import {
   getRequiredSharedGatewaySessionGeneration,
   type SharedGatewaySessionGenerationState,
 } from "./server-shared-auth-generation.js";
+import type { GatewaySidecarStartupMode } from "./server-startup-post-attach.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
 import { createGatewayEventLoopHealthMonitor } from "./server/event-loop-health.js";
 import {
@@ -454,8 +455,6 @@ export type GatewayCloseOptions = {
 export type GatewayServer = {
   close: (opts?: GatewayCloseOptions) => Promise<void>;
 };
-
-export type GatewaySidecarStartupMode = "start" | "defer";
 
 export type GatewayServerOptions = {
   /**

--- a/src/infra/gateway-boot-lifecycle.ts
+++ b/src/infra/gateway-boot-lifecycle.ts
@@ -114,7 +114,7 @@ export function inspectGatewayCrashLoopBreaker(
         .limit(1),
     );
     return buildGatewayCrashLoopBreakerDecision({
-      uncleanBoots: Number(uncleanRow?.count ?? 0),
+      uncleanBoots: uncleanRow?.count ?? 0,
       latestBreakerStartedAtMs: latestBreaker?.startedAtMs,
       latestRecoveryStartedAtMs: latestRecovery?.startedAtMs,
     });

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -499,7 +499,7 @@ export interface FlowRuns {
 export interface GatewayBootLifecycle {
   boot_id: string;
   completed_at_ms: number | null;
-  outcome: "clean_stop" | "forced_stop" | "planned_restart" | "startup_failed" | null;
+  outcome: string | null;
   pid: number;
   reason: string | null;
   started_at_ms: number;


### PR DESCRIPTION
## What Problem This Solves

Current `main` fails two required CI lanes: Madge reports a Gateway type-dependency cycle, core oxlint reports two errors in the newly landed crash-loop lifecycle code, and the architecture lane detects a stale generated Kysely declaration. The failures reproduce unchanged on unrelated PR heads and block the native landing workflow.

## Why This Change Was Made

The sidecar startup mode now belongs to `server-startup-post-attach.ts`, its only policy consumer. `server.impl.ts` imports that leaf type instead of making the startup module depend back on the full server implementation, breaking the cycle without adding a compatibility layer.

The two lint fixes remove an unnecessary numeric conversion from an already-number-typed Kysely count and declare the startup timestamp without an immediately overwritten initializer.

The Kysely declaration is regenerated from the canonical SQLite schema; no handwritten schema policy is retained in generated output.

## User Impact

No runtime behavior change. This restores the architecture and lint gates required to land unrelated fixes safely.

## Evidence

- Blacksmith Testbox `tbx_01kwv0vw0yy55xenj6evvanps7` (`coral-krill`): targeted `oxfmt` — 4/4 files clean.
- Same Testbox run: targeted oxlint — 0 errors, 0 warnings.
- Same Testbox run: `pnpm check:madge-import-cycles` — 0 cycles.
- Hosted exact-head architecture reached the Kysely verifier after passing both import-cycle guards; the generator now reproduces the committed declaration byte-for-byte.
- Fresh Blacksmith Testbox `tbx_01kwv41smppwgrwmnc9fztm3py` (`jade-crab`): full architecture, generated Kysely verification, database guards, 5-file format, and targeted lint all passed; 0 cycles and 0 lint errors/warnings.
- Fresh AutoReview after the generated update: clean, confidence 0.86.
- `git diff --check`: passed; production LOC is net zero.
