### PR TITLE
fix(gateway): restore boot lifecycle quality gates

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -115,7 +115,7 @@ export async function runGatewayLoop(params: {
   if (process.title === "openclaw") {
     process.title = "openclaw-gateway";
   }
-  let startupStartedAt = Date.now();
+  let startupStartedAt: number;
   // Eagerly resolve the lifecycle runtime module before installing signal
   // listeners. Without this, every subsequent lifecycle path (SIGUSR1,
   // SIGTERM-with-intent, restart iteration hook, stability bundle writer)

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -30,7 +30,7 @@ import {
   type ChatRunEntry,
   type ChatRunState,
 } from "./server-chat-state.js";
-import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
+import type { GatewayPostReadySidecarHandle } from "./server-startup-types.js";
 
 const shutdownLog = createSubsystemLogger("gateway/shutdown");
 const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 5_000;

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -3,7 +3,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
-import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
+import type { GatewayPostReadySidecarHandle } from "./server-startup-types.js";
 
 // Mutable server handles track timers, sidecars, subscriptions, and service
 // cleanup hooks that shutdown/reload code must stop exactly once.

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -24,8 +24,11 @@ import {
 import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.js";
 import type { refreshLatestUpdateRestartSentinel } from "./server-restart-sentinel.js";
 import type { logGatewayStartup } from "./server-startup-log.js";
+import type {
+  GatewayPostReadySidecarHandle,
+  GatewaySidecarStartupMode,
+} from "./server-startup-types.js";
 import type { startGatewayTailscaleExposure } from "./server-tailscale.js";
-import type { GatewaySidecarStartupMode } from "./server.impl.js";
 
 const ACP_BACKEND_READY_TIMEOUT_MS = 5_000;
 const ACP_BACKEND_READY_POLL_MS = 50;
@@ -67,10 +70,6 @@ const loadInternalHooksModule = createLazyRuntimeModule(() => import("../hooks/i
 const loadGatewayRestartSentinelModule = createLazyRuntimeModule(
   () => import("./server-restart-sentinel.js"),
 );
-
-export type GatewayPostReadySidecarHandle = {
-  stop: () => Awaitable<void>;
-};
 
 /** Stop sidecars immediately when shutdown has already started before they are reported. */
 export function stopPostReadySidecarsAfterCloseStarted(params: {

--- a/src/gateway/server-startup-types.ts
+++ b/src/gateway/server-startup-types.ts
@@ -1,0 +1,5 @@
+export type GatewayPostReadySidecarHandle = {
+  stop: () => void | Promise<void>;
+};
+
+export type GatewaySidecarStartupMode = "start" | "defer";

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -108,6 +108,7 @@ import {
   getRequiredSharedGatewaySessionGeneration,
   type SharedGatewaySessionGenerationState,
 } from "./server-shared-auth-generation.js";
+import type { GatewaySidecarStartupMode } from "./server-startup-types.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
 import { createGatewayEventLoopHealthMonitor } from "./server/event-loop-health.js";
 import {
@@ -454,8 +455,6 @@ export type GatewayCloseOptions = {
 export type GatewayServer = {
   close: (opts?: GatewayCloseOptions) => Promise<void>;
 };
-
-export type GatewaySidecarStartupMode = "start" | "defer";
 
 export type GatewayServerOptions = {
   /**

--- a/src/infra/gateway-boot-lifecycle.ts
+++ b/src/infra/gateway-boot-lifecycle.ts
@@ -114,7 +114,7 @@ export function inspectGatewayCrashLoopBreaker(
         .limit(1),
     );
     return buildGatewayCrashLoopBreakerDecision({
-      uncleanBoots: Number(uncleanRow?.count ?? 0),
+      uncleanBoots: uncleanRow?.count ?? 0,
       latestBreakerStartedAtMs: latestBreaker?.startedAtMs,
       latestRecoveryStartedAtMs: latestRecovery?.startedAtMs,
     });

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -499,7 +499,7 @@ export interface FlowRuns {
 export interface GatewayBootLifecycle {
   boot_id: string;
   completed_at_ms: number | null;
-  outcome: "clean_stop" | "forced_stop" | "planned_restart" | "startup_failed" | null;
+  outcome: string | null;
   pid: number;
   reason: string | null;
   started_at_ms: number;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where pull requests based on the new gateway crash-loop lifecycle change could not pass the repository lint and architecture gates. The affected `main` revision introduced an unused startup timestamp assignment, a redundant numeric conversion, an import cycle through the gateway startup implementation, and a checked-in Kysely type that did not match the schema generator.

## Why This Change Was Made

The shared sidecar handle and startup-mode contracts now live in a dependency-free startup types module, so mutable runtime state no longer imports the post-attach implementation and that implementation no longer imports `server.impl.ts`. The two lint failures are removed with declarations that preserve the existing runtime behavior and inferred database type, and the generated database declaration is aligned with the unconstrained nullable SQLite `TEXT` column.

## User Impact

No intended runtime behavior change. Gateway startup ownership is clearer, and downstream pull requests can again pass the affected lint and architecture gates.

## Evidence

- Fresh structured autoreview after the generated-type correction: clean, 0.99 confidence.
- Blacksmith Testbox full architecture gate: https://github.com/openclaw/openclaw/actions/runs/28774082594
  - `check:import-cycles`: 0 runtime value cycles.
  - `check:madge-import-cycles`: 0 cycles.
  - Generated Kysely verification and guardrails: passed.
  - Database-first legacy-store guard: passed.
- `node scripts/run-oxlint.mjs` on all seven touched files: passed.
- `git diff --check`: passed.
