### PR TITLE
fix(acp): close SQLite ledger handles on shutdown (#100637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **ACP server shutdown:** close the SQLite-backed ACP event ledger during shutdown so hot reloads and restarts do not leave state database handles locked. (#100637) Thanks @aniruddhaadak80.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
 - **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.

--- a/src/acp/event-ledger.test.ts
+++ b/src/acp/event-ledger.test.ts
@@ -2,7 +2,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  isOpenClawStateDatabaseOpen,
+} from "../state/openclaw-state-db.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
   createInMemoryAcpEventLedger,
@@ -136,19 +139,50 @@ describe("ACP event ledger", () => {
         },
       });
 
-      closeOpenClawStateDatabaseForTest();
+      first.close();
       const second = createSqliteAcpEventLedger({ path: databasePath });
-      const replay = await second.readReplay({
+      try {
+        const replay = await second.readReplay({
+          sessionId: "session-1",
+          sessionKey: "agent:main:work",
+        });
+
+        expect(replay.complete).toBe(true);
+        expect(replay.events).toHaveLength(1);
+        expect(replay.events[0]?.update).toEqual({
+          sessionUpdate: "agent_thought_chunk",
+          content: { type: "text", text: "Thinking" },
+        });
+      } finally {
+        second.close();
+      }
+    });
+  });
+
+  it("closes the SQLite-backed state database handle through the ledger lifecycle", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      const databasePath = path.join(dir, "openclaw.sqlite");
+      const ledger = createSqliteAcpEventLedger({ path: databasePath, now: () => 1000 });
+      await ledger.startSession({
         sessionId: "session-1",
         sessionKey: "agent:main:work",
+        cwd: "/work",
+        complete: true,
       });
 
-      expect(replay.complete).toBe(true);
-      expect(replay.events).toHaveLength(1);
-      expect(replay.events[0]?.update).toEqual({
-        sessionUpdate: "agent_thought_chunk",
-        content: { type: "text", text: "Thinking" },
+      expect(isOpenClawStateDatabaseOpen()).toBe(true);
+      ledger.close();
+      expect(isOpenClawStateDatabaseOpen()).toBe(false);
+
+      const reopened = createSqliteAcpEventLedger({ path: databasePath });
+      await expect(
+        reopened.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
+      ).resolves.toMatchObject({
+        complete: true,
+        events: [],
       });
+      reopened.close();
+      expect(isOpenClawStateDatabaseOpen()).toBe(false);
     });
   });
 
@@ -195,22 +229,26 @@ describe("ACP event ledger", () => {
         archiveSource: true,
       });
       const sqlite = createSqliteAcpEventLedger({ path: databasePath });
-      const replay = await sqlite.readReplay({
-        sessionId: "session-1",
-        sessionKey: "agent:main:work",
-      });
+      try {
+        const replay = await sqlite.readReplay({
+          sessionId: "session-1",
+          sessionKey: "agent:main:work",
+        });
 
-      expect(migrated).toEqual({
-        importedSessions: 1,
-        importedEvents: 1,
-        archived: true,
-      });
-      expect(replay.complete).toBe(true);
-      expect(replay.events[0]?.update).toEqual({
-        sessionUpdate: "agent_message_chunk",
-        content: { type: "text", text: "Answer" },
-      });
-      await expect(fs.stat(`${filePath}.migrated`)).resolves.toBeTruthy();
+        expect(migrated).toEqual({
+          importedSessions: 1,
+          importedEvents: 1,
+          archived: true,
+        });
+        expect(replay.complete).toBe(true);
+        expect(replay.events[0]?.update).toEqual({
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Answer" },
+        });
+        await expect(fs.stat(`${filePath}.migrated`)).resolves.toBeTruthy();
+      } finally {
+        sqlite.close();
+      }
     });
   });
 
@@ -243,9 +281,13 @@ describe("ACP event ledger", () => {
         },
       });
 
-      await expect(
-        ledger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
-      ).resolves.toEqual({ complete: false, events: [] });
+      try {
+        await expect(
+          ledger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
+        ).resolves.toEqual({ complete: false, events: [] });
+      } finally {
+        ledger.close();
+      }
     });
   });
 
@@ -427,5 +469,4 @@ describe("ACP event ledger", () => {
       ledger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
     ).resolves.toEqual({ complete: false, events: [] });
   });
-
 });

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -8,6 +8,7 @@ import { resolveStateDir } from "../config/paths.js";
 import { withFileLock } from "../infra/file-lock.js";
 import { readJsonFile } from "../infra/json-files.js";
 import {
+  closeOpenClawStateDatabase,
   openOpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
   runOpenClawStateWriteTransaction,
@@ -70,6 +71,7 @@ export type AcpEventLedger = {
   readReplay: (params: { sessionId: string; sessionKey: string }) => Promise<AcpEventLedgerReplay>;
   readReplayBySessionId: (params: { sessionId: string }) => Promise<AcpEventLedgerReplay>;
   readReplayBySessionKey: (params: { sessionKey: string }) => Promise<AcpEventLedgerReplay>;
+  close: () => void;
 };
 
 type LedgerSession = {
@@ -352,6 +354,8 @@ function createLedgerApi(params: {
   });
 
   return {
+    close() {},
+
     async startSession(sessionParams) {
       await params.mutate(() => {
         getOrCreateSession(params.state, sessionParams);
@@ -849,6 +853,10 @@ export function createSqliteAcpEventLedger(
   const read = <T>(fn: (db: DatabaseSync) => T): T => fn(openOpenClawStateDatabase(dbOptions).db);
 
   return {
+    close() {
+      closeOpenClawStateDatabase();
+    },
+
     async startSession(sessionParams) {
       mutate((db) => {
         upsertSqliteSession(db, state, sessionParams);

--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -34,9 +34,15 @@ const mockState = vi.hoisted(() => ({
   gatewayOptions: [] as GatewayClientOptions[],
   agentSideConnectionCtor: vi.fn(),
   agentStart: vi.fn(),
+  eventLedgerClose: vi.fn(),
   routeLogsToStderr: vi.fn(),
   startProxy: vi.fn(async (_configForTest: unknown) => null as unknown),
   stopProxy: vi.fn(async (_handle: unknown) => {}),
+  migrateFileAcpEventLedgerToSqlite: vi.fn(async (_params: unknown) => ({
+    importedSessions: 0,
+    importedEvents: 0,
+    archived: false,
+  })),
   resolveGatewayClientBootstrap: vi.fn<ResolveGatewayClientBootstrap>(async (_params) => ({
     url: "ws://127.0.0.1:18789",
     urlSource: "local loopback",
@@ -154,6 +160,22 @@ vi.mock("../infra/is-main.js", () => ({
 
 vi.mock("../logging/console.js", () => ({
   routeLogsToStderr: () => mockState.routeLogsToStderr(),
+}));
+
+vi.mock("./event-ledger.js", () => ({
+  createSqliteAcpEventLedger: () => ({
+    close: () => mockState.eventLedgerClose(),
+    markIncomplete: vi.fn(async () => {}),
+    readReplay: vi.fn(async () => ({ complete: false, events: [] })),
+    readReplayBySessionId: vi.fn(async () => ({ complete: false, events: [] })),
+    readReplayBySessionKey: vi.fn(async () => ({ complete: false, events: [] })),
+    recordUpdate: vi.fn(async () => {}),
+    recordUserPrompt: vi.fn(async () => {}),
+    startSession: vi.fn(async () => {}),
+  }),
+  migrateFileAcpEventLedgerToSqlite: (params: unknown) =>
+    mockState.migrateFileAcpEventLedgerToSqlite(params),
+  resolveDefaultAcpEventLedgerPath: () => "legacy-acp-event-ledger.json",
 }));
 
 vi.mock("../infra/net/proxy/proxy-lifecycle.js", () => ({
@@ -284,9 +306,16 @@ describe("serveAcpGateway startup", () => {
     mockState.gatewayOptions.length = 0;
     mockState.agentSideConnectionCtor.mockReset();
     mockState.agentStart.mockReset();
+    mockState.eventLedgerClose.mockReset();
     mockState.routeLogsToStderr.mockReset();
     mockState.startProxy.mockReset();
     mockState.stopProxy.mockReset();
+    mockState.migrateFileAcpEventLedgerToSqlite.mockReset();
+    mockState.migrateFileAcpEventLedgerToSqlite.mockResolvedValue({
+      importedSessions: 0,
+      importedEvents: 0,
+      archived: false,
+    });
     mockState.startProxy.mockResolvedValue(null);
     mockState.stopProxy.mockResolvedValue(undefined);
     mockState.resolveGatewayClientBootstrap.mockReset();
@@ -458,6 +487,24 @@ describe("serveAcpGateway startup", () => {
       await emitHelloAndWaitForAgentSideConnection();
       await stopServeWithSigint(signalHandlers, servePromise);
       expect(mockState.stopProxy).not.toHaveBeenCalled();
+    } finally {
+      onceSpy.mockRestore();
+    }
+  });
+
+  it("closes the ACP event ledger when a shutdown signal stops the server", async () => {
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await emitHelloAndWaitForAgentSideConnection();
+
+      expect(mockState.eventLedgerClose).not.toHaveBeenCalled();
+      await stopServeWithSigint(signalHandlers, servePromise);
+      expect(mockState.eventLedgerClose).toHaveBeenCalledTimes(1);
+
+      signalHandlers.get("SIGINT")?.();
+      expect(mockState.eventLedgerClose).toHaveBeenCalledTimes(1);
     } finally {
       onceSpy.mockRestore();
     }

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -25,6 +25,7 @@ import {
   createSqliteAcpEventLedger,
   migrateFileAcpEventLedgerToSqlite,
   resolveDefaultAcpEventLedgerPath,
+  type AcpEventLedger,
 } from "./event-ledger.js";
 import { readSecretFromFile } from "./secret-file.js";
 import { AcpGatewayAgent } from "./translator.js";
@@ -53,6 +54,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
   });
 
   let agent: AcpGatewayAgent | null = null;
+  let eventLedger: AcpEventLedger | undefined;
   let onClosed!: () => void;
   const closed = new Promise<void>((resolve) => {
     onClosed = resolve;
@@ -121,6 +123,8 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     stopped = true;
     resolveGatewayReady();
     gateway.stop();
+    eventLedger?.close();
+    eventLedger = undefined;
     // If no WebSocket is active (e.g. between reconnect attempts),
     // gateway.stop() won't trigger onClose, so resolve directly.
     onClosed();
@@ -158,7 +162,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     filePath: resolveDefaultAcpEventLedgerPath(process.env),
     archiveSource: true,
   });
-  const eventLedger = createSqliteAcpEventLedger();
+  eventLedger = createSqliteAcpEventLedger();
 
   void new AgentSideConnection(
     (conn: AgentSideConnection) => {


### PR DESCRIPTION
Fixes #100637.

## What Problem This Solves
The ACP stdio server creates a SQLite-backed ACP event ledger from the shared OpenClaw state database, but shutdown/hot-reload paths did not close that ledger. On Windows, the remaining open `openclaw.sqlite` / WAL handles can keep temporary state directories locked and make restart cleanup fail with `EBUSY`.

Affected surface: `src/acp/server.ts` (`serveAcpGateway` signal shutdown) and `src/acp/event-ledger.ts` (`createSqliteAcpEventLedger`).

## Summary
- add an `AcpEventLedger.close()` lifecycle hook, with SQLite-backed ledgers closing the shared state database cache
- close the ACP event ledger exactly once from `serveAcpGateway` shutdown
- update SQLite ledger tests to close handles before temp-dir cleanup and add a Windows file-lock regression

## Evidence
Red proof before the fix:
- `npx -y node@22.19.0 scripts/test-projects.mjs "src/acp/event-ledger.test.ts" -t "closes the SQLite-backed state database handle through the ledger lifecycle" --reporter verbose` failed with `EBUSY: resource busy or locked, unlink ... openclaw.sqlite`
- `npx -y node@22.19.0 scripts/test-projects.mjs "src/acp/server.startup.test.ts" -t "closes the ACP event ledger when a shutdown signal stops the server" --reporter verbose` failed because `eventLedgerClose` was called 0 times

Green proof after the fix:
- `npx -y node@22.19.0 scripts/test-projects.mjs "src/acp/event-ledger.test.ts" "src/acp/server.startup.test.ts" --reporter verbose` passed 2 shards: server 13 tests, event ledger 13 tests
- `pnpm tsgo:core` passed
- `pnpm tsgo:core:test` passed
- `pnpm exec oxfmt --check --threads=1 src/acp/event-ledger.ts src/acp/event-ledger.test.ts src/acp/server.ts src/acp/server.startup.test.ts` passed
- LSP diagnostics: no diagnostics on changed TS files
- `git diff --check upstream/main` passed

## Not run
- `pnpm check:changed`: Blacksmith/Testbox is unavailable on this host, and local `changed:lanes` compares against the fork stale `origin/main` instead of current upstream, selecting unrelated all-repo lanes.
