### PR TITLE
fix(codex): return JSON-RPC codes for handler errors

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -481,6 +481,38 @@ describe("CodexAppServerClient", () => {
     });
   });
 
+  it("returns JSON-RPC internal errors when server request handlers throw", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    harness.client.addRequestHandler((request) => {
+      if (request.method === "account/chatgptAuthTokens/refresh") {
+        throw new Error("refresh_token_invalidated: reauthentication required");
+      }
+      return undefined;
+    });
+
+    harness.send({
+      id: "srv-refresh",
+      method: "account/chatgptAuthTokens/refresh",
+      params: { accountId: "acct-1" },
+    });
+    await vi.waitFor(() => expect(harness.writes.length).toBe(1));
+
+    expect(JSON.parse(harness.writes[0] ?? "{}")).toEqual({
+      id: "srv-refresh",
+      error: {
+        code: -32603,
+        message: "refresh_token_invalidated: reauthentication required",
+      },
+    });
+    expect(warn).toHaveBeenCalledWith("codex app-server server request handler failed", {
+      id: "srv-refresh",
+      method: "account/chatgptAuthTokens/refresh",
+      error: expect.any(Error),
+    });
+  });
+
   it("fails closed when a dynamic tool server request handler hangs", async () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -468,10 +468,17 @@ export class CodexAppServerClient {
       }
       this.writeMessage({ id: request.id, result: defaultServerRequestResponse(request) });
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      embeddedAgentLog.warn("codex app-server server request handler failed", {
+        id: request.id,
+        method: request.method,
+        error,
+      });
       this.writeMessage({
         id: request.id,
         error: {
-          message: error instanceof Error ? error.message : String(error),
+          code: -32603,
+          message,
         },
       });
     }


### PR DESCRIPTION
## Summary

Fixes the Codex app-server client so server-initiated request handler exceptions are serialized as valid JSON-RPC error responses with a numeric `error.code` instead of only an error message.

## Issue/Motivation

Fixes #100693.

When the Codex app-server asks OpenClaw to refresh ChatGPT auth tokens and the handler throws, the current response is malformed for JSON-RPC because `error.code` is omitted. Codex then treats the response as invalid and can surface a generic timeout such as `auth refresh request timed out after 10s`, hiding the actionable reauthentication failure.

## Changes

- Add `code: -32603` to server-request handler failure responses.
- Preserve the original handler error message in the JSON-RPC error payload.
- Log the failed server request method/id for OpenClaw diagnostics.
- Add a regression test for a failing `account/chatgptAuthTokens/refresh` server request handler.

## Testing

- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/client.test.ts` — 29 tests passed.
- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/client.test.ts extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/auth-bridge.test.ts` — 110 tests passed.
- `git diff --check` — passed.
- Diff secret scan for token-like patterns — passed.

## What Problem This Solves

Codex app-server JSON-RPC error responses from OpenClaw must include a numeric `error.code`. Without it, auth-refresh handler failures can be rejected as malformed responses and users see a timeout instead of the real reauthentication error.

## Evidence

- Regression test added in `extensions/codex/src/app-server/client.test.ts` verifies handler exceptions serialize as:
  - `error.code: -32603`
  - the original handler error message.
- Targeted Codex app-server tests pass:
  - `extensions/codex/src/app-server/client.test.ts`
  - `extensions/codex/src/app-server/shared-client.test.ts`
  - `extensions/codex/src/app-server/auth-bridge.test.ts`
- `git diff --check` and local diff secret scan passed.
