### PR TITLE
fix(openai): route MP3 TTS through voice delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **OpenAI Realtime Codex auth:** reuse external Codex OAuth profiles for Realtime voice sessions when no explicit OpenAI API key is configured.
+- **OpenAI-compatible TTS voice notes:** route configured MP3 speech output through native voice-message delivery when the channel supports it, while keeping WAV output on the audio-file path. (#83227, #80317) Thanks @HemantSudarshan.
 - **Talk transcription providers:** cold-load explicitly configured Voice Call streaming providers, including runtime aliases, when another provider registry is already active, keeping catalog and session selection aligned. (#97170, #97738) Thanks @solavrc.
 - **Android Canvas navigation:** block device-local loopback and unspecified main-frame web targets across direct, user, JavaScript, and redirect navigation while preserving remote, LAN, emulator-host, and bundled canvases. (#99874) Thanks @ly85206559.
 - **Android network recovery:** reconnect Gateway sessions immediately when Android regains a validated network instead of waiting for the current reconnect backoff. (#100347) Thanks @ly85206559.

--- a/extensions/openai/speech-provider.test.ts
+++ b/extensions/openai/speech-provider.test.ts
@@ -535,28 +535,33 @@ describe("buildOpenAISpeechProvider", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("honors explicit responseFormat overrides and clears voice-note compatibility when not opus", async () => {
-    const provider = buildOpenAISpeechProvider();
-    mockSpeechFetchExpectingFormat("wav");
+  it.each([
+    { responseFormat: "wav" as const, voiceCompatible: false },
+    { responseFormat: "mp3" as const, voiceCompatible: true },
+  ])(
+    "marks configured $responseFormat voice-note compatibility as $voiceCompatible",
+    async ({ responseFormat, voiceCompatible }) => {
+      const provider = buildOpenAISpeechProvider();
+      mockSpeechFetchExpectingFormat(responseFormat);
 
-    const result = await provider.synthesize({
-      text: "hello",
-      cfg: {} as never,
-      providerConfig: {
-        apiKey: "sk-test",
-        baseUrl: "https://proxy.example.com/openai/v1",
-        model: "canopylabs/orpheus-v1-english",
-        voice: "daniel",
-        responseFormat: "wav",
-      },
-      target: "voice-note",
-      timeoutMs: 1_000,
-    });
+      const result = await provider.synthesize({
+        text: "hello",
+        cfg: {} as never,
+        providerConfig: {
+          apiKey: "sk-test",
+          model: "gpt-4o-mini-tts",
+          voice: "alloy",
+          responseFormat,
+        },
+        target: "voice-note",
+        timeoutMs: 1_000,
+      });
 
-    expect(result.outputFormat).toBe("wav");
-    expect(result.fileExtension).toBe(".wav");
-    expect(result.voiceCompatible).toBe(false);
-  });
+      expect(result.outputFormat).toBe(responseFormat);
+      expect(result.fileExtension).toBe(`.${responseFormat}`);
+      expect(result.voiceCompatible).toBe(voiceCompatible);
+    },
+  );
 
   it("passes extra_body config through to OpenAI-compatible speech requests", async () => {
     const provider = buildOpenAISpeechProvider();

--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -1,4 +1,5 @@
 // Openai provider module implements model/runtime integration.
+import { isVoiceMessageCompatibleAudio } from "openclaw/plugin-sdk/media-runtime";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type {
   SpeechDirectiveTokenParseContext,
@@ -364,11 +365,14 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
         timeoutMs: req.timeoutMs,
         maxBytes: resolveGeneratedAudioMaxBytes(req),
       });
+      const fileExtension = responseFormatToFileExtension(responseFormat);
       return {
         audioBuffer,
         outputFormat: responseFormat,
-        fileExtension: responseFormatToFileExtension(responseFormat),
-        voiceCompatible: req.target === "voice-note" && responseFormat === "opus",
+        fileExtension,
+        voiceCompatible:
+          req.target === "voice-note" &&
+          isVoiceMessageCompatibleAudio({ fileName: `speech${fileExtension}` }),
       };
     },
     synthesizeTelephony: async (req) => {


### PR DESCRIPTION
## What Problem This Solves

OpenAI-compatible TTS configured with `responseFormat: "mp3"` reports voice-note output as incompatible. Speech-core then keeps the result on audio-file delivery even though Telegram's native voice-message path and the shared media contract accept MP3.

Closes #80317. Supersedes the conflicting, non-maintainer-editable #83227 while preserving its contributor credit.

## Why This Change Was Made

The OpenAI speech provider now derives compatibility from the existing shared voice-message media policy instead of maintaining an Opus-only provider rule. The produced file extension is computed once and passed to that policy; voice-note MP3 and Opus remain compatible, while WAV remains an audio file.

This keeps format policy at its existing owner boundary. Existing speech-core tests own provider-metadata routing, and existing Telegram tests own MP3 `sendVoice` behavior, so the replacement retains one focused parameterized OpenAI regression instead of duplicating cross-layer tests.

## User Impact

Users of Piper, Kokoro, and other OpenAI-compatible TTS endpoints can configure MP3 output and receive native Telegram voice messages rather than audio attachments. Non-voice targets and WAV output are unchanged.

## Evidence

- Blacksmith Testbox `tbx_01kwv40nw0cbq0f8s7kt1wvps6`: OpenAI provider, speech-core, and Telegram send suites passed, 216/216 tests.
- Same Testbox: `pnpm check:changed` passed extension production/test typechecks, changed-file lint, dependency and package guards, database-first guard, runtime sidecar guard, and import-cycle verification.
- Production provider live proof against a real local OpenAI-compatible HTTP endpoint captured `response_format: "mp3"` and returned `outputFormat: "mp3"`, `fileExtension: ".mp3"`, `voiceCompatible: true`, and six response bytes.
- Fresh autoreview: no actionable findings; overall correctness 0.98.
- Official contracts checked: OpenAI speech supports MP3 output, and Telegram `sendVoice` accepts MP3 voice messages.
- `git diff --check origin/main...HEAD` passed.

Co-authored-by: Hemantsudarshan <hemanthsudarshan2002@gmail.com>
