### PR TITLE
fix(cron): allow null model and fallbacks in cron update patch payload

### DIFF
--- a/src/config/zod-schema.agent-model.ts
+++ b/src/config/zod-schema.agent-model.ts
@@ -7,7 +7,7 @@ export const AgentModelSchema = z.union([
   z
     .object({
       primary: z.string().optional(),
-      fallbacks: z.array(z.string()).optional(),
+      fallbacks: z.array(z.string()).nullable().optional(),
     })
     .strict(),
 ]);
@@ -17,7 +17,7 @@ export const AgentToolModelSchema = z.union([
   z
     .object({
       primary: z.string().optional(),
-      fallbacks: z.array(z.string()).optional(),
+      fallbacks: z.array(z.string()).nullable().optional(),
       timeoutMs: z.number().int().positive().optional(),
     })
     .strict(),

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -80,3 +80,50 @@ describe("ModelsConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 });
+
+import { AgentModelSchema, AgentToolModelSchema } from "./zod-schema.agent-model.js";
+
+describe("AgentModelSchema nullable fallbacks", () => {
+  it("accepts null fallbacks (clear-to-inherit)", () => {
+    const result = AgentModelSchema.safeParse({ primary: "openai/gpt-5", fallbacks: null });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.fallbacks).toBeNull();
+  });
+  it("accepts fallbacks as array", () => {
+    const result = AgentModelSchema.safeParse({
+      primary: "openai/gpt-5",
+      fallbacks: ["anthropic/claude-haiku-3-5"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.fallbacks).toEqual(["anthropic/claude-haiku-3-5"]);
+  });
+  it("rejects non-array non-null fallbacks", () => {
+    const result = AgentModelSchema.safeParse({
+      primary: "openai/gpt-5",
+      fallbacks: "not-an-array",
+    });
+    expect(result.success).toBe(false);
+  });
+  it("accepts string-only model (no fallbacks field)", () => {
+    const result = AgentModelSchema.safeParse("openai/gpt-5");
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe("openai/gpt-5");
+  });
+});
+
+describe("AgentToolModelSchema nullable fallbacks", () => {
+  it("accepts null fallbacks", () => {
+    const result = AgentToolModelSchema.safeParse({ primary: "openai/gpt-5", fallbacks: null });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.fallbacks).toBeNull();
+  });
+  it("accepts fallbacks as array", () => {
+    const result = AgentToolModelSchema.safeParse({
+      primary: "openai/gpt-5",
+      fallbacks: ["anthropic/claude-haiku-3-5"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.fallbacks).toEqual(["anthropic/claude-haiku-3-5"]);
+  });
+});
+

--- a/src/config/zod-schema.models.test.ts
+++ b/src/config/zod-schema.models.test.ts
@@ -87,7 +87,9 @@ describe("AgentModelSchema nullable fallbacks", () => {
   it("accepts null fallbacks (clear-to-inherit)", () => {
     const result = AgentModelSchema.safeParse({ primary: "openai/gpt-5", fallbacks: null });
     expect(result.success).toBe(true);
-    if (result.success) expect(result.data.fallbacks).toBeNull();
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).fallbacks).toBeNull();
+    }
   });
   it("accepts fallbacks as array", () => {
     const result = AgentModelSchema.safeParse({
@@ -95,7 +97,9 @@ describe("AgentModelSchema nullable fallbacks", () => {
       fallbacks: ["anthropic/claude-haiku-3-5"],
     });
     expect(result.success).toBe(true);
-    if (result.success) expect(result.data.fallbacks).toEqual(["anthropic/claude-haiku-3-5"]);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).fallbacks).toEqual(["anthropic/claude-haiku-3-5"]);
+    }
   });
   it("rejects non-array non-null fallbacks", () => {
     const result = AgentModelSchema.safeParse({
@@ -107,7 +111,9 @@ describe("AgentModelSchema nullable fallbacks", () => {
   it("accepts string-only model (no fallbacks field)", () => {
     const result = AgentModelSchema.safeParse("openai/gpt-5");
     expect(result.success).toBe(true);
-    if (result.success) expect(result.data).toBe("openai/gpt-5");
+    if (result.success) {
+      expect(result.data).toBe("openai/gpt-5");
+    }
   });
 });
 
@@ -115,7 +121,9 @@ describe("AgentToolModelSchema nullable fallbacks", () => {
   it("accepts null fallbacks", () => {
     const result = AgentToolModelSchema.safeParse({ primary: "openai/gpt-5", fallbacks: null });
     expect(result.success).toBe(true);
-    if (result.success) expect(result.data.fallbacks).toBeNull();
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).fallbacks).toBeNull();
+    }
   });
   it("accepts fallbacks as array", () => {
     const result = AgentToolModelSchema.safeParse({
@@ -123,7 +131,9 @@ describe("AgentToolModelSchema nullable fallbacks", () => {
       fallbacks: ["anthropic/claude-haiku-3-5"],
     });
     expect(result.success).toBe(true);
-    if (result.success) expect(result.data.fallbacks).toEqual(["anthropic/claude-haiku-3-5"]);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>).fallbacks).toEqual(["anthropic/claude-haiku-3-5"]);
+    }
   });
 });
 

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -858,7 +858,7 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         backend: z.string().optional(),
-        fallbacks: z.array(z.string()).optional(),
+        fallbacks: z.array(z.string()).nullable().optional(),
         defaultAgent: z.string().optional(),
         allowedAgents: z.array(z.string()).optional(),
         maxConcurrentSessions: z.number().int().positive().optional(),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users would see `must be array` when clearing cron per-job overrides with `cron update --patch '{"payload":{"fallbacks":null}}'`.

Fixes #100707

## Why This Change Was Made

`AgentModelSchema` and `AgentToolModelSchema` used `z.array(z.string()).optional()` — optional but not nullable. Adding `.nullable()` lets null clears reach the Gateway service layer, which already deletes stored override keys on null input.

## User Impact

Users can clear per-job fallback overrides via `cron update --patch` with `null` values to restore global agent defaults.

## Evidence

- `pnpm test -- --run -t "nullable fallback" src/config/zod-schema.models.test.ts`: 6 passed, 0 failed, Duration 1.11s

```text
[test] starting test/vitest/vitest.runtime-config.config.ts

 RUN  v4.1.9 …/openclaw

 Test Files  1 passed (1)
      Tests  6 passed | 18 skipped (24)
   Start at  15:42:06
   Duration  1.11s
```

Focused tests cover null acceptance (both schemas), array acceptance, and negative control (non-array non-null rejected).

AI-assisted: built with Codex