### PR TITLE
test(release): match pinned Claude CLI setup

### DIFF
--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1096,7 +1096,7 @@ describe("package artifact reuse", () => {
       'echo "timeout command not found; cannot bound live ACP bind setup after ${timeout_value}"',
     );
     expect(readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8")).toContain(
-      "run_setup_command npm install -g @anthropic-ai/claude-code",
+      'run_setup_command npm install -g "@anthropic-ai/claude-code@$claude_code_version"',
     );
     expect(readFileSync("scripts/test-live-acp-bind-docker.sh", "utf8")).toContain(
       "run_setup_command bash -lc 'curl -fsSL https://app.factory.ai/cli | sh'",


### PR DESCRIPTION
## What Problem This Solves

Current `main` pins the Docker ACP bind Claude CLI to the version declared by the installed Claude Agent SDK, but the package-acceptance test still expects the retired unversioned install command. This breaks the compact tooling CI shard.

## Why This Change Was Made

Update the assertion to match the existing version-pinned command. Production behavior is unchanged.

## User Impact

None. This repairs current-main test coverage and unblocks unrelated pull requests from the baseline CI failure.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts`
- `./node_modules/.bin/oxfmt --check test/scripts/package-acceptance-workflow.test.ts`
- `git diff --check`
- Codex autoreview: clean, zero findings
