### PR TITLE
fix(auto-reply): force-clear stale active reply operation on session reset (#99082)

### DIFF
--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -1,10 +1,10 @@
 // Tracks active reply runs so stop, queue, and status commands can coordinate.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { createAbortError } from "../../infra/abort-signal.js";
 import {
   createAgentRunRestartAbortError,
   isAgentRunRestartAbortReason,
 } from "../../agents/run-termination.js";
+import { createAbortError } from "../../infra/abort-signal.js";
 import {
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
@@ -856,6 +856,24 @@ export function forceClearReplyRunBySessionId(sessionId: string, cause?: unknown
   operation.fail("run_failed", cause);
   operation.complete();
   return true;
+}
+
+/** Release an active reply operation owned by the archived session id during
+ *  session reset/rotation. Queued reservations are intentionally left alone so
+ *  session init can rebind them to the new session id via `updateSessionId`.
+ *  Only non-queued (running/compacting) operations are cleared — these are
+ *  stale work from the old session that would otherwise block the new session's
+ *  reply delivery for the full stuck-session recovery window. (#99082) */
+export function forceClearReplyRunForResetBySessionId(sessionId: string, cause?: unknown): boolean {
+  const operation = resolveReplyRunForCurrentSessionId(sessionId);
+  if (!operation || operation.phase === "queued") {
+    return false;
+  }
+  operation.abortForRestart();
+  if (!resolveReplyRunForCurrentSessionId(sessionId)) {
+    return true;
+  }
+  return forceClearReplyRunBySessionId(sessionId, cause);
 }
 
 export function waitForReplyRunEndBySessionId(

--- a/src/auto-reply/reply/session-reset-cleanup.test.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.test.ts
@@ -1,13 +1,19 @@
 // Tests session reset cleanup for stale files and persisted state.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   enqueueSystemEvent,
   peekSystemEvents,
   resetSystemEventsForTest,
 } from "../../infra/system-events.js";
+import {
+  createReplyOperation,
+  replyRunRegistry,
+  testing as replyRunTesting,
+} from "./reply-run-registry.js";
 import { clearSessionResetRuntimeState } from "./session-reset-cleanup.js";
 
 afterEach(() => {
+  replyRunTesting.resetReplyRunRegistry();
   resetSystemEventsForTest();
 });
 
@@ -24,5 +30,60 @@ describe("clearSessionResetRuntimeState", () => {
     expect(peekSystemEvents("alpha")).toStrictEqual([]);
     expect(peekSystemEvents("beta")).toStrictEqual([]);
     expect(peekSystemEvents("gamma")).toEqual(["fresh gamma"]);
+  });
+
+  it("releases an active reply operation owned by the archived reset session id", () => {
+    const cancel = vi.fn();
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:room:1",
+      sessionId: "old-session",
+      resetTriggered: false,
+    });
+    operation.attachBackend({
+      kind: "embedded",
+      cancel,
+      isStreaming: () => false,
+    });
+    operation.setPhase("running");
+
+    const result = clearSessionResetRuntimeState(["agent:main:room:1", "old-session"], {
+      activeReplySessionIds: ["old-session"],
+    });
+
+    expect(result.activeReplyRunsCleared).toBe(1);
+    expect(cancel).toHaveBeenCalledWith("restart");
+    expect(replyRunRegistry.isActive("agent:main:room:1")).toBe(false);
+  });
+
+  it("leaves queued reservations so session init can rebind them", () => {
+    createReplyOperation({
+      sessionKey: "agent:main:room:1",
+      sessionId: "old-session",
+      resetTriggered: false,
+    });
+    // default phase is "queued"
+
+    const result = clearSessionResetRuntimeState(["agent:main:room:1", "old-session"], {
+      activeReplySessionIds: ["old-session"],
+    });
+
+    expect(result.activeReplyRunsCleared).toBe(0);
+    expect(replyRunRegistry.get("agent:main:room:1")?.phase).toBe("queued");
+  });
+
+  it("does not clear a fresh active reply whose sessionId does not match the archived id", () => {
+    const operation = createReplyOperation({
+      sessionKey: "agent:main:room:1",
+      sessionId: "new-session",
+      resetTriggered: false,
+    });
+    operation.setPhase("running");
+
+    const result = clearSessionResetRuntimeState(["agent:main:room:1", "old-session"], {
+      activeReplySessionIds: ["old-session"],
+    });
+
+    expect(result.activeReplyRunsCleared).toBe(0);
+    expect(replyRunRegistry.get("agent:main:room:1")).toBe(operation);
   });
 });

--- a/src/auto-reply/reply/session-reset-cleanup.ts
+++ b/src/auto-reply/reply/session-reset-cleanup.ts
@@ -1,25 +1,45 @@
 /** Clears reset-related queues and system events for session keys. */
 import { drainSystemEventEntries } from "../../infra/system-events.js";
 import { clearSessionQueues, type ClearSessionQueueResult } from "./queue/cleanup.js";
+import { forceClearReplyRunForResetBySessionId } from "./reply-run-registry.js";
 
 /** Runtime cleanup result for reset-related queues and system events. */
 type ClearSessionResetRuntimeStateResult = ClearSessionQueueResult & {
   systemEventsCleared: number;
+  activeReplyRunsCleared: number;
 };
 
-/** Clears queued follow-ups and pending system events for reset session keys. */
+/** Clears queued follow-ups, pending system events, and stale active reply
+ *  operations for reset session keys. Archived session ids passed via
+ *  `activeReplySessionIds` are force-cleared from the reply-run registry,
+ *  unblocking the post-reset session's visible reply delivery. (#99082) */
 export function clearSessionResetRuntimeState(
   keys: Array<string | undefined>,
+  opts?: { activeReplySessionIds?: Array<string | undefined> },
 ): ClearSessionResetRuntimeStateResult {
   const cleared = clearSessionQueues(keys);
   let systemEventsCleared = 0;
+  let activeReplyRunsCleared = 0;
 
   for (const key of cleared.keys) {
     systemEventsCleared += drainSystemEventEntries(key).length;
   }
 
+  for (const sessionId of opts?.activeReplySessionIds ?? []) {
+    if (
+      sessionId &&
+      forceClearReplyRunForResetBySessionId(
+        sessionId,
+        new Error("clearing active reply operation for reset session"),
+      )
+    ) {
+      activeReplyRunsCleared += 1;
+    }
+  }
+
   return {
     ...cleared,
     systemEventsCleared,
+    activeReplyRunsCleared,
   };
 }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -684,7 +684,9 @@ async function initSessionStateAttemptLocked(
     previousSessionId: previousSessionEntry?.sessionId,
   });
   if (previousSessionEntry) {
-    clearSessionResetRuntimeState([sessionKey, previousSessionEntry.sessionId]);
+    clearSessionResetRuntimeState([sessionKey, previousSessionEntry.sessionId], {
+      activeReplySessionIds: [previousSessionEntry.sessionId],
+    });
   }
 
   const recoveredTerminalEntry =

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -401,7 +401,9 @@ async function ensureSessionRuntimeCleanup(params: {
   if (params.sessionId) {
     queueKeys.add(params.sessionId);
   }
-  clearSessionResetRuntimeState([...queueKeys]);
+  clearSessionResetRuntimeState([...queueKeys], {
+    activeReplySessionIds: [params.sessionId],
+  });
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
     params.assertCurrent?.();


### PR DESCRIPTION
Fixes #99082

## What Problem This Solves

When `/reset` is issued in a multi-agent room, the session rotates: the old session is archived and a new one is created. But the reply-run registry is keyed by the stable **session key**, not the session id. A running reply operation owned by the archived session id survives the reset — blocking the new session's first visible reply (including the "Session reset." acknowledgement) for the full stuck-session recovery window (default ~6 minutes).

This reliably wedges all but one agent per room after reset: the first agent to finish resetting delivers its ack, but every other agent's stale reply operation under the archived session id keeps the slot latched, queuing all inbound messages behind it.

## Why This Change Was Made

Two changes across two layers:

**Layer 1 — Registry-level helper:**
- **`reply-run-registry.ts`**: Added `forceClearReplyRunForResetBySessionId(sessionId)` — releases non-queued (running/compacting) reply operations owned by the given session id. Queued reservations are intentionally preserved so `get-reply-run.ts` can rebind them to the new session id via `updateSessionId`.

**Layer 2 — Reset cleanup integration:**
- **`session-reset-cleanup.ts`**: Added optional `activeReplySessionIds` parameter to `clearSessionResetRuntimeState`. When provided, each archived session id is force-cleared from the reply registry.
- **`session-reset-service.ts`** + **`session.ts`**: Pass the archived session id as `activeReplySessionIds` during reset cleanup.

## User Impact

`/reset` in multi-agent rooms now unblocks all agents promptly instead of wedging all but one for ~6 minutes. The reset acknowledgement and queued messages can proceed once the old session is rotated.

Queued reply reservations (the default initial phase) survive the cleanup — session init can rebind them to the new session id.

## Evidence

### Proof — Production function call (`node --import tsx`):

```
=== #99082 Proof: Reset clears stale active reply operation ===

[1] Active running operation from archived session is force-cleared
  PASS: force-clear returned true
  PASS: registry slot is free
[2] Queued reservation from archived session survives reset
  PASS: force-clear returned false (queued preserved)
  PASS: queued op still exists
[3] Fresh session's active operation is untouched
  PASS: force-clear returned false (wrong sessionId)
  PASS: fresh op still active
[4] Full reset cleanup clears active reply + queues
  PASS: activeReplyRunsCleared=1
  PASS: registry slot freed
  PASS: new session can register reply op
[5] Full reset cleanup preserves queued reservations
  PASS: activeReplyRunsCleared=0 (queued preserved)
  PASS: queued op survives

=== ALL PASS (11 passed, 0 failed) ===
```

### Tests — Project runner:

```
node scripts/run-vitest.mjs src/auto-reply/reply/session-reset-cleanup.test.ts --run
  Test Files  1 passed (1) / Tests  4 passed (4)
```

New regression tests:
- `releases an active reply operation owned by the archived reset session id`
- `leaves queued reservations so session init can rebind them`
- `does not clear a fresh active reply whose sessionId does not match the archived id`

### Pre-submit:

```
oxfmt --check → clean
git diff --check → clean
autoreview → patch is correct
```
