### PR TITLE
fix: preserve parenthesized URLs in TUI markdown links

### DIFF
--- a/src/tui/osc8-hyperlinks.test.ts
+++ b/src/tui/osc8-hyperlinks.test.ts
@@ -25,6 +25,18 @@ describe("extractUrls", () => {
     expect(urls).toEqual(["https://example.com/path"]);
   });
 
+  it("extracts markdown link hrefs with balanced parentheses", () => {
+    const urls = extractUrls("[Wikipedia](https://en.wikipedia.org/wiki/URL_(disambiguation))");
+    expect(urls).toEqual(["https://en.wikipedia.org/wiki/URL_(disambiguation)"]);
+  });
+
+  it("extracts angle-bracket markdown hrefs with balanced parentheses", () => {
+    const urls = extractUrls(
+      '[Wikipedia](<https://en.wikipedia.org/wiki/URL_(disambiguation)> "URL")',
+    );
+    expect(urls).toEqual(["https://en.wikipedia.org/wiki/URL_(disambiguation)"]);
+  });
+
   it("extracts both bare URLs and markdown links", () => {
     const md = "See [docs](https://docs.example.com) and https://api.example.com";
     const urls = extractUrls(md);
@@ -98,6 +110,14 @@ describe("addOsc8Hyperlinks", () => {
 
     // The URL part should be wrapped with OSC 8
     expect(result[0]).toContain(`\x1b]8;;${url}\x07`);
+  });
+
+  it("uses the full known URL target when rendered text contains balanced parentheses", () => {
+    const url = "https://en.wikipedia.org/wiki/URL_(disambiguation)";
+    const line = `Wikipedia (${url})`;
+    const result = addOsc8Hyperlinks([line], [url]);
+
+    expect(result[0]).toBe(`Wikipedia (\x1b]8;;${url}\x07${url}\x1b]8;;\x07)`);
   });
 
   it("handles multiple URLs on the same line", () => {

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -6,6 +6,18 @@ const ANSI_RE = new RegExp(`${SGR_PATTERN}|${OSC8_PATTERN}`, "g");
 const SGR_START_RE = new RegExp(`^${SGR_PATTERN}`);
 const OSC8_START_RE = new RegExp(`^${OSC8_PATTERN}`);
 
+const MD_LINK_HREF_PATTERN = String.raw`https?:\/\/(?:[^\s()>]+|\([^\s()]*\))+`;
+
+function createMarkdownLinkRe(captureHref: boolean): RegExp {
+  const hrefPattern = captureHref ? `(${MD_LINK_HREF_PATTERN})` : MD_LINK_HREF_PATTERN;
+  // The href pattern accepts balanced parenthesized URL segments while the
+  // final unmatched ")" still terminates the markdown link.
+  return new RegExp(
+    String.raw`\[(?:[^\]]*)\]\(\s*<?${hrefPattern}>?(?:\s+["'][^"']*["'])?\s*\)`,
+    "g",
+  );
+}
+
 /**
  * Extract all unique URLs from raw markdown text.
  * Finds both bare URLs and markdown link hrefs [text](url).
@@ -14,17 +26,14 @@ export function extractUrls(markdown: string): string[] {
   const urls = new Set<string>();
 
   // Markdown link hrefs: [text](url), with optional <...> and optional title.
-  const mdLinkRe = /\[(?:[^\]]*)\]\(\s*<?(https?:\/\/[^)\s>]+)>?(?:\s+["'][^"']*["'])?\s*\)/g;
+  const mdLinkRe = createMarkdownLinkRe(true);
   let m: RegExpExecArray | null;
   while ((m = mdLinkRe.exec(markdown)) !== null) {
     urls.add(m[1]);
   }
 
   // Bare URLs (remove markdown links first to avoid double-matching)
-  const stripped = markdown.replace(
-    /\[(?:[^\]]*)\]\(\s*<?https?:\/\/[^)\s>]+>?(?:\s+["'][^"']*["'])?\s*\)/g,
-    "",
-  );
+  const stripped = markdown.replace(createMarkdownLinkRe(false), "");
   const bareRe = /https?:\/\/[^\s)\]>]+/g;
   while ((m = bareRe.exec(stripped)) !== null) {
     urls.add(m[0]);
@@ -125,11 +134,17 @@ function findUrlRanges(
       }
     }
 
-    ranges.push({ start, end: start + fragment.length, url: resolvedUrl });
+    let visibleMatchLength = fragment.length;
+    if (resolvedUrl.length > fragment.length && visibleText.startsWith(resolvedUrl, start)) {
+      visibleMatchLength = resolvedUrl.length;
+      urlRe.lastIndex = start + visibleMatchLength;
+    }
+
+    ranges.push({ start, end: start + visibleMatchLength, url: resolvedUrl });
 
     // If fragment is a strict prefix of the resolved URL, it may be split
-    if (resolvedUrl.length > fragment.length && resolvedUrl.startsWith(fragment)) {
-      newPending = { url: resolvedUrl, consumed: fragment.length };
+    if (resolvedUrl.length > visibleMatchLength && resolvedUrl.startsWith(fragment)) {
+      newPending = { url: resolvedUrl, consumed: visibleMatchLength };
     }
   }
 


### PR DESCRIPTION
Closes #100661

## What Problem This Solves

Fixes an issue where users viewing markdown links in the TUI would get broken OSC8 hyperlink targets when the markdown href contained a balanced parenthesized URL segment, such as Wikipedia-style URLs ending in `(disambiguation)`.

AI-assisted: yes. I used Codex for the implementation and review pass, and I understand the change.

## Why This Change Was Made

The markdown-link href matcher now uses one shared URL pattern for both extraction and markdown-link stripping, and that pattern accepts balanced parenthesized URL segments before the final unmatched markdown `)` terminator. This keeps markdown href extraction and bare-URL de-duplication aligned without changing the existing bare URL matcher behavior.

## User Impact

TUI-rendered markdown links that point to common parenthesized URLs now preserve the full clickable target instead of dropping the closing parenthesis from the URL.

## Evidence

- `node scripts/run-vitest.mjs src/tui/osc8-hyperlinks.test.ts src/tui/components/hyperlink-markdown.test.ts` passed: 2 files, 22 tests.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts` passed: 1 file, 18 tests.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings.
- Attempted `pnpm check:changed -- src/tui/osc8-hyperlinks.ts src/tui/osc8-hyperlinks.test.ts`, but this local checkout cannot run the delegated Testbox gate because the Crabbox binary is not installed (`selected binary failed basic --version/--help sanity checks`).
