### PR TITLE
fix(ui): open embedded terminal before login gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - **Config size-drop guard:** compare writes against canonical bytes for parseable object configs instead of raw BOM and indentation overhead, while preserving raw audit telemetry and the conservative malformed-input fallback. (#100591, #71865) Thanks @vincentkoc.
 - **Control UI coalesced updates:** show a clear queued-restart completion banner when an update joins an already-running Gateway restart. (#93082) Thanks @goutamadwant.
 - **Control UI connection errors:** preserve structured pairing and authentication failures for pending RPC callers while keeping generic disconnect behavior unchanged. (#54758) Thanks @ruanrrn.
+- **iOS embedded terminal:** open the terminal-only Control surface directly while native Gateway authentication connects instead of exposing the Web UI login screen.
 - **TUI startup status:** show `starting up` during post-connect initialization without overwriting active-run or reconnect state. (#93999) Thanks @ml12580.
 - **Control UI restart recovery:** recover stale bundle pages through a bounded whole-document refresh after Gateway updates or restarts. (#99111) Thanks @ZengWen-DT.
 - **TUI active Gateway ports:** follow the verified active local Gateway port when no explicit URL, port, or remote target is configured. (#73338, #42461) Thanks @haishmg and @vincentkoc.

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -240,6 +240,21 @@ export class OpenClawApp extends LitElement {
           ></openclaw-gateway-url-confirmation>
         `
       : nothing;
+    // Embedded mobile terminals own the whole document. Keep the generic login
+    // gate out of this path or a connecting native session exposes Web UI chrome.
+    if (this.terminalOnly) {
+      return html`
+        <openclaw-terminal-panel
+          .client=${this.terminalClient}
+          .available=${this.terminalAvailable}
+          .themeMode=${resolveTerminalThemeMode()}
+          fullscreen
+        ></openclaw-terminal-panel>
+        ${!this.terminalAvailable && (this.gatewayConnected || this.gatewayLastError)
+          ? html`<div class="terminal-view-unavailable">${t("terminal.unavailable")}</div>`
+          : nothing}
+      `;
+    }
     // Transport drops after an established session keep the shell mounted
     // (offline banner + client auto-retry); the login gate is reserved for
     // first connects, credential rejections, and manual gate submissions.
@@ -288,21 +303,6 @@ export class OpenClawApp extends LitElement {
           ></openclaw-login-gate>
           ${gatewayUrlConfirmation}
         </openclaw-tooltip-provider>
-      `;
-    }
-    // Terminal-only document (`?view=terminal`): the mobile apps embed this as
-    // a full-screen WebView page, so render just the terminal — no shell chrome.
-    if (this.terminalOnly) {
-      return html`
-        <openclaw-terminal-panel
-          .client=${this.terminalClient}
-          .available=${this.terminalAvailable}
-          .themeMode=${resolveTerminalThemeMode()}
-          fullscreen
-        ></openclaw-terminal-panel>
-        ${this.terminalAvailable
-          ? nothing
-          : html`<div class="terminal-view-unavailable">${t("terminal.unavailable")}</div>`}
       `;
     }
     return html`

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -1,0 +1,88 @@
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+
+let browser: Browser;
+let server: ControlUiE2eServer;
+
+describeControlUiE2e("embedded terminal document", () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(
+        `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+      );
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("renders only the terminal while native authentication connects", async () => {
+    const context = await browser.newContext({ serviceWorkers: "block" });
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      (
+        window as Window & {
+          ["__OPENCLAW_NATIVE_CONTROL_AUTH__"]?: {
+            gatewayUrl: string;
+            token: string;
+          };
+        }
+      )["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = {
+        gatewayUrl: "ws://gateway.example.test",
+        token: "native-terminal-token",
+      };
+    });
+    const gateway = await installMockGateway(page, {
+      deferredMethods: ["connect"],
+      featureMethods: ["terminal.open"],
+      methodResponses: {
+        "terminal.list": { sessions: [] },
+        "terminal.open": {
+          agentId: "main",
+          confined: false,
+          cwd: "/workspace",
+          sessionId: "terminal-e2e",
+          shell: "/bin/bash",
+        },
+      },
+      terminalEnabled: true,
+    });
+
+    try {
+      const response = await page.goto(`${server.baseUrl}?view=terminal`);
+      expect(response?.status()).toBe(200);
+      const connect = await gateway.waitForRequest("connect");
+
+      expect(connect.params).toMatchObject({ auth: { token: "native-terminal-token" } });
+      expect(await page.locator("openclaw-login-gate").count()).toBe(0);
+      expect(await page.locator("openclaw-terminal-panel").count()).toBe(1);
+
+      await gateway.resolveDeferred("connect");
+      const terminalOpen = await gateway.waitForRequest("terminal.open");
+      expect(terminalOpen.params).toMatchObject({
+        cols: expect.any(Number),
+        rows: expect.any(Number),
+      });
+      expect(await page.locator("openclaw-login-gate").count()).toBe(0);
+      expect(await page.locator("openclaw-terminal-panel").count()).toBe(1);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -54,10 +54,12 @@ export type ControlUiMockGatewayScenario = {
   }>;
   defaultAgentId?: string;
   deferredMethods?: string[];
+  featureMethods?: string[];
   historyMessages?: unknown[];
   methodResponses?: Record<string, unknown>;
   models?: Array<{ id: string; name: string; provider: string }>;
   sessionKey?: string;
+  terminalEnabled?: boolean;
 };
 
 type NormalizedControlUiMockGatewayScenario = Required<ControlUiMockGatewayScenario>;
@@ -210,10 +212,12 @@ function normalizeScenario(
     controlUiTabs: scenario.controlUiTabs ?? [],
     defaultAgentId,
     deferredMethods: scenario.deferredMethods ?? [],
+    featureMethods: scenario.featureMethods ?? ["chat.metadata", "chat.startup"],
     historyMessages: scenario.historyMessages ?? [],
     methodResponses: scenario.methodResponses ?? {},
     models: scenario.models ?? [{ id: "gpt-5.5", name: "gpt-5.5", provider: "openai" }],
     sessionKey,
+    terminalEnabled: scenario.terminalEnabled ?? false,
   };
 }
 
@@ -228,6 +232,7 @@ export function createControlUiMockBootstrapConfig(scenario: ControlUiMockGatewa
     embedSandbox: "scripts",
     localMediaPreviewRoots: [],
     serverVersion: "e2e",
+    terminalEnabled: normalizedScenario.terminalEnabled,
   };
 }
 
@@ -394,7 +399,7 @@ function installControlUiMockGateway(input: {
               "operator.pairing",
             ],
           },
-          features: { events: [], methods: ["chat.metadata", "chat.startup"] },
+          features: { events: [], methods: scenario.featureMethods },
           controlUiTabs: scenario.controlUiTabs,
           protocol: protocolVersion,
           server: { connId: "control-ui-e2e", version: "e2e" },


### PR DESCRIPTION
## What Problem This Solves

Opening Control → Terminal in the iOS app could expose the generic Web UI login screen while the app's injected native Gateway authentication was still connecting. The embedded terminal is a dedicated document and should never render Web UI chrome.

## Why This Change Was Made

Render terminal-only mode before the generic login gate, while preserving the terminal panel during connection and showing the unavailable state only after a connection result exists. Add a browser regression test that injects the same native authentication payload as iOS, pauses the Gateway handshake, and proves the login gate never mounts before or after `terminal.open`.

## User Impact

iOS users opening Control → Terminal now land directly in the terminal. Native Gateway authentication remains invisible, and unavailable messaging still appears when the connected Gateway cannot provide terminal access.

## Evidence

- Regression proof before the fix: the new E2E test found one `openclaw-login-gate` while native authentication was pending.
- Focused Testbox proof: 6 tests passed across the embedded terminal E2E, Control UI E2E helpers, and terminal panel.
- Testbox changed gate: core/core-test type checks, lint, and guards passed.
- Testbox Control UI production build passed.
- Fresh GPT-5.5 autoreview: no accepted or actionable findings; patch judged correct (0.82 confidence).
- Live iOS proof: installed OpenClaw app on an iPhone 17 simulator, connected to an isolated real Gateway serving the patched Control UI, opened Control → Terminal, and ran `printf 'IOS_TERMINAL_LIVE_OK\\n'`; output appeared and the shell prompt returned without a Web UI login screen.
- Hosted validation environment: Blacksmith Testbox `tbx_01kwv4y4aebd59fqgf9ccpccnf` (`coral-crayfish`).

AI-assisted implementation and validation.
