### PR TITLE
fix(control-ui): preserve assistant download filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Docs: https://docs.openclaw.ai
 - **iOS Watch replies:** persist queued quick replies in the gateway-scoped chat outbox and submit them through idempotent chat delivery, preventing losses, duplicates, and cross-gateway sends after reconnects. (#100031) Thanks @NianJiuZst.
 - **iOS Gateway auth retry:** restrict stored device-token retry to parsed loopback hosts and reject wildcard bind addresses, preventing remote lookalike hostnames from receiving trusted retry credentials. (#99859) Thanks @ly85206559.
 - **Bedrock Mantle discovery:** bound model-catalog fetch time and response size, and release rejected response bodies so stalled, oversized, or failed provider responses fall back safely. (#99961) Thanks @zhangguiping-xydt.
+- **Control UI attachment filenames:** preserve original Unicode filenames for document downloads while keeping image, audio, and video responses previewable inline. (#87528, #74274, #96545) Thanks @LPtrichor.
 
 ## 2026.7.1
 

--- a/src/gateway/control-ui-assistant-media.e2e.test.ts
+++ b/src/gateway/control-ui-assistant-media.e2e.test.ts
@@ -18,7 +18,7 @@ describe("Control UI assistant media e2e", () => {
 
     const mediaDir = path.join(stateDir, "media", "control-ui-assistant-media-e2e");
     await fs.mkdir(mediaDir, { recursive: true });
-    const filePath = path.join(mediaDir, "ticketed-preview.txt");
+    const filePath = path.join(mediaDir, "测试 ticketed (final).txt");
     await fs.writeFile(filePath, "ticketed control ui media\n", "utf8");
 
     await withGatewayServer(
@@ -46,6 +46,9 @@ describe("Control UI assistant media e2e", () => {
           `${route}?source=${sourceParam}&mediaTicket=${encodeURIComponent(payload.mediaTicket ?? "")}`,
         );
         expect(ticketed.status).toBe(200);
+        expect(ticketed.headers.get("content-disposition")).toBe(
+          `attachment; filename="__ ticketed (final).txt"; filename*=UTF-8''%E6%B5%8B%E8%AF%95%20ticketed%20%28final%29.txt`,
+        );
         expect(await ticketed.text()).toBe("ticketed control ui media\n");
 
         const otherFilePath = path.join(mediaDir, "other-preview.txt");

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -432,6 +432,58 @@ describe("handleControlUiHttpRequest", () => {
         });
         expect(handled).toBe(true);
         expect(res.statusCode).toBe(200);
+        expect(res["setHeader"]).toHaveBeenCalledWith(
+          "Content-Disposition",
+          `inline; filename="photo.png"; filename*=UTF-8''photo.png`,
+        );
+      },
+    });
+  });
+
+  it.each([
+    { filename: "voice.ogg", disposition: "inline" },
+    { filename: "clip.mp4", disposition: "inline" },
+    { filename: "report.pdf", disposition: "attachment" },
+    { filename: "archive.bin", disposition: "attachment" },
+  ])("serves $filename with $disposition disposition", async ({ filename, disposition }) => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-disposition-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, filename);
+        await fs.writeFile(filePath, Buffer.from("fixture"));
+        const { res, handled } = await runAssistantMediaRequest({
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+          method: "GET",
+          auth: { mode: "token", token: "test-token", allowTailscale: false },
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res["setHeader"]).toHaveBeenCalledWith(
+          "Content-Disposition",
+          `${disposition}; filename="${filename}"; filename*=UTF-8''${filename}`,
+        );
+      },
+    });
+  });
+
+  it("encodes Unicode and RFC 8187 delimiter characters in assistant media filenames", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-filename-",
+      fn: async (tmpRoot) => {
+        const filename = `测试 100% 'draft' (1).pdf`;
+        const filePath = path.join(tmpRoot, filename);
+        await fs.writeFile(filePath, Buffer.from("fixture"));
+        const { res, handled } = await runAssistantMediaRequest({
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+          method: "GET",
+          auth: { mode: "token", token: "test-token", allowTailscale: false },
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res["setHeader"]).toHaveBeenCalledWith(
+          "Content-Disposition",
+          `attachment; filename="__ 100_ 'draft' (1).pdf"; filename*=UTF-8''%E6%B5%8B%E8%AF%95%20100%25%20%27draft%27%20%281%29.pdf`,
+        );
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -4,7 +4,7 @@ import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
-import { detectMime } from "@openclaw/media-core/mime";
+import { detectMime, kindFromMime } from "@openclaw/media-core/mime";
 import {
   asDateTimestampMs,
   resolveTimestampMsToIsoString,
@@ -71,6 +71,18 @@ const CONTROL_UI_ASSETS_MISSING_MESSAGE =
 const CONTROL_UI_OPERATOR_READ_SCOPE = "operator.read";
 const CONTROL_UI_OPERATOR_ROLE = "operator";
 const controlUiAssistantMediaTicketSecret = randomBytes(32);
+
+function buildAssistantMediaContentDisposition(filename: string, mime?: string): string {
+  // Keep the RFC 6266 fallback ASCII; filename* carries the exact UTF-8 name.
+  const fallback = filename.replace(/[^\x20-\x7e]|[%"\\]/g, "_") || "download";
+  const extended = encodeURIComponent(filename).replace(
+    /[\x27()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  const kind = kindFromMime(mime);
+  const inline = kind === "image" || kind === "audio" || kind === "video";
+  return `${inline ? "inline" : "attachment"}; filename="${fallback}"; filename*=UTF-8''${extended}`;
+}
 
 type ControlUiRequestOptions = {
   basePath?: string;
@@ -630,11 +642,12 @@ export async function handleControlUiAssistantMediaRequest(
       buffer: sniffBuffer?.subarray(0, bytesRead),
       filePath: localPath,
     });
-    if (mime) {
-      res.setHeader("Content-Type", mime);
-    } else {
-      res.setHeader("Content-Type", "application/octet-stream");
-    }
+    const contentType = mime ?? "application/octet-stream";
+    res.setHeader("Content-Type", contentType);
+    res.setHeader(
+      "Content-Disposition",
+      buildAssistantMediaContentDisposition(path.basename(localPath), contentType),
+    );
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Content-Length", String(opened.stat.size));
     const stream = opened.handle.createReadStream({ start: 0, autoClose: false });

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -252,6 +252,64 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("downloads an assistant document with the server-provided Unicode filename", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const source = "/tmp/openclaw/测试 report.pdf";
+    const mediaUrl = `/__openclaw__/assistant-media?source=${encodeURIComponent(source)}&mediaTicket=ticket-download`;
+    const requestedUrls: URL[] = [];
+    // The document opens in a new tab, so intercept at the context boundary.
+    await context.route("**/__openclaw__/assistant-media?**", async (route) => {
+      const url = new URL(route.request().url());
+      requestedUrls.push(url);
+      await route.fulfill({
+        body: "%PDF-1.4\n",
+        contentType: "application/pdf",
+        headers: {
+          "Content-Disposition": `attachment; filename="__ report.pdf"; filename*=UTF-8''%E6%B5%8B%E8%AF%95%20report.pdf`,
+        },
+      });
+    });
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "Your report is ready." },
+            {
+              type: "attachment",
+              attachment: {
+                kind: "document",
+                label: "测试 report.pdf",
+                mimeType: "application/pdf",
+                url: mediaUrl,
+              },
+            },
+          ],
+          timestamp: Date.now(),
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const link = page.getByRole("link", { name: "测试 report.pdf" });
+      await link.waitFor({ state: "visible", timeout: 10_000 });
+      const [download] = await Promise.all([page.waitForEvent("download"), link.click()]);
+
+      expect(download.suggestedFilename()).toBe("测试 report.pdf");
+      expect(requestedUrls).toHaveLength(1);
+      expect(requestedUrls[0]?.searchParams.get("source")).toBe(source);
+      expect(requestedUrls[0]?.searchParams.get("mediaTicket")).toBe("ticket-download");
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("renders a direct tool-result image from Gateway history", async () => {
     const context = await newBrowserContext({
       locale: "en-US",


### PR DESCRIPTION
## What Problem This Solves

Assistant documents served through the Control UI media route lose their original filename and can open inline instead of downloading. This fixes #96545, salvages the valid intent from #87528, and supersedes the narrower #74274 approach.

## Why This Change Was Made

Generate a standards-compliant `Content-Disposition` at the existing authenticated media owner. Image, audio, and video responses remain inline; documents and unknown binary files download. Every response carries a conservative ASCII `filename` fallback plus a UTF-8 RFC 8187 `filename*`, so Unicode and delimiter-heavy names survive without introducing a second media path or client-side filename policy.

## User Impact

WebChat document links download with their server-provided filename, including Unicode names. Existing image, audio, and video previews keep their inline behavior.

## Evidence

- Blacksmith Testbox `tbx_01kwv3e6wmqvd6m1bsh7x9jcgz`: Gateway route tests passed with 256 assertions plus the real HTTP assistant-media flow.
- Same Testbox: focused Chromium download check passed and all 25 mocked-Gateway Chromium chat flows passed; Chromium used the UTF-8 server filename for the downloaded PDF.
- Added coverage for PNG, OGG, MP4, PDF, unknown binaries, Unicode names, percent signs, quotes, parentheses, and the real HTTP response header.
- Fresh Codex autoreview: clean, confidence 0.88.
- `git diff --check` passed.

Co-authored-by: Rovy <xiaxia@rovy.dev>
