### PR TITLE
fix(process): unref closeFallbackTimer to avoid delaying CLI exit

### DIFF
--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -334,6 +334,46 @@ describe("runCommandWithTimeout", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "unrefs the close fallback timer so it does not delay process exit",
+    { timeout: 5_000 },
+    async () => {
+      await loadExecModules({ mockSpawn: true });
+      const child = createKilledChild();
+      spawnMock.mockReturnValue(child);
+
+      const unref = vi.fn();
+      const fakeFallbackTimer = { unref } as unknown as NodeJS.Timeout;
+      const originalSetTimeout = globalThis.setTimeout.bind(globalThis);
+      const timeoutSpy = vi
+        .spyOn(globalThis, "setTimeout")
+        .mockImplementation((callback, delay) => {
+          if (delay === 250) {
+            return fakeFallbackTimer;
+          }
+          return originalSetTimeout(callback as TimerHandler, delay as number);
+        });
+
+      try {
+        const resultPromise = runCommandWithTimeout(createSilentIdleArgv(), {
+          timeoutMs: 2_000,
+        });
+
+        child.emit("exit", 0, null);
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 10);
+        });
+        expect(unref).toHaveBeenCalledOnce();
+
+        child.emit("close", 0, null);
+        const result = await resultPromise;
+        expect(result.termination).toBe("exit");
+      } finally {
+        timeoutSpy.mockRestore();
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "swallows stdin EPIPE when child exits before input is consumed (#75438)",
     { timeout: 5_000 },
     async () => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -666,6 +666,7 @@ export async function runCommandWithTimeout(
         child.stdout?.destroy();
         child.stderr?.destroy();
       }, 250);
+      closeFallbackTimer.unref();
     });
     const resolveFromClose = (code: number | null, signalValue: NodeJS.Signals | null) => {
       if (settled) {


### PR DESCRIPTION
## What Problem This Solves

Fixes #100662.

In `runCommandWithTimeout()` (`src/process/exec.ts`), when a child process exits, a 250 ms `closeFallbackTimer` is armed to destroy `stdout`/`stderr` if the streams do not emit `close`. That timer was never `unref()`'d, so it keeps the Node.js event loop alive and delays natural CLI exit by up to 250 ms after the command has already completed.

## Why This Change Was Made

Added `closeFallbackTimer.unref()` immediately after creating the timer, matching the pattern already used for `processTreeForceKillTimer` in the same function. The fallback still runs if the process stays alive for other reasons, but it no longer prevents the CLI from exiting when no other work remains.

## User Impact

CLI commands that use `runCommandWithTimeout` no longer experience an unnecessary ~250 ms exit delay. In loops that spawn many short-lived commands, the cumulative delay is removed.

## Evidence

Added a regression test in `src/process/exec.test.ts` that fails on current `main`:

- It intercepts `setTimeout` and returns a fake timer for the 250 ms fallback window.
- After the child emits `exit`, it asserts that `unref()` was called on the fallback timer.
- On `main` the assertion fails (`unref()` was never called); with this change it passes.

```
pnpm test src/process/exec.test.ts -- --run -t "unrefs the close fallback timer"
```

Also verified the full `src/process/exec.test.ts` suite remains green.
