### PR TITLE
fix(link-understanding): honor global or largest model timeout for link fetches

### DIFF
--- a/src/link-understanding/runner.test.ts
+++ b/src/link-understanding/runner.test.ts
@@ -144,4 +144,59 @@ describe("runLinkUnderstanding", () => {
     expect(result.outputs).toEqual([]);
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
   });
+
+  it("uses the global link-tools timeout for fetches when configured", async () => {
+    mockGuardedFetch("page body", "https://example.com/final");
+    mockCommand("summarized page");
+
+    await runLinkUnderstanding({
+      cfg: {
+        tools: {
+          links: {
+            enabled: true,
+            timeoutSeconds: 15,
+            models: [
+              { type: "cli", command: "summarize-fast", timeoutSeconds: 1 },
+              { type: "cli", command: "summarize-slow", timeoutSeconds: 9 },
+            ],
+          },
+        },
+      } as OpenClawConfig,
+      ctx: ctx("see https://example.com/page"),
+    });
+
+    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 15000,
+        url: "https://example.com/page",
+      }),
+    );
+  });
+
+  it("falls back to the largest model timeout for fetches when no global timeout is set", async () => {
+    mockGuardedFetch("page body", "https://example.com/final");
+    mockCommand("summarized page");
+
+    await runLinkUnderstanding({
+      cfg: {
+        tools: {
+          links: {
+            enabled: true,
+            models: [
+              { type: "cli", command: "summarize-fast", timeoutSeconds: 1 },
+              { type: "cli", command: "summarize-slow", timeoutSeconds: 9 },
+            ],
+          },
+        },
+      } as OpenClawConfig,
+      ctx: ctx("see https://example.com/page"),
+    });
+
+    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 9000,
+        url: "https://example.com/page",
+      }),
+    );
+  });
 });

--- a/src/link-understanding/runner.ts
+++ b/src/link-understanding/runner.ts
@@ -41,6 +41,21 @@ function resolveTimeoutMsFromConfig(params: {
   return resolveTimeoutMs(configured, DEFAULT_LINK_TIMEOUT_SECONDS);
 }
 
+function resolveFetchTimeoutMsFromConfig(params: {
+  config?: LinkToolsConfig;
+  entries: LinkModelConfig[];
+}): number {
+  // The HTTP fetch phase is independent of any single CLI execution, so honor
+  // an explicit global link-tools timeout first. Otherwise use the largest
+  // per-entry timeout so slower entries are not capped by the first entry.
+  if (params.config?.timeoutSeconds != null) {
+    return resolveTimeoutMs(params.config.timeoutSeconds, DEFAULT_LINK_TIMEOUT_SECONDS);
+  }
+  return Math.max(
+    ...params.entries.map((entry) => resolveTimeoutMsFromConfig({ config: params.config, entry })),
+  );
+}
+
 function isLinkUrlTemplate(value: string): boolean {
   return value.includes("LinkUrl") || value.includes("LinkFinalUrl");
 }
@@ -220,8 +235,8 @@ export async function runLinkUnderstanding(params: {
   }
 
   const outputs: string[] = [];
+  const timeoutMs = resolveFetchTimeoutMsFromConfig({ config, entries });
   for (const url of links) {
-    const timeoutMs = resolveTimeoutMsFromConfig({ config, entry: entries[0] });
     let fetched: Awaited<ReturnType<typeof fetchLinkContent>>;
     try {
       fetched = await fetchLinkContent({ url, timeoutMs });


### PR DESCRIPTION
## What Problem This Solves

Fixes #100660.

In `runLinkUnderstanding()` (`src/link-understanding/runner.ts`), the HTTP fetch timeout for every link was resolved from `entries[0]` only. If later model entries had larger `timeoutSeconds`, the fetch could still time out using the first entry's shorter window. The fetch phase is independent of any single CLI execution, so it should use either an explicit global link-tools timeout or the largest configured model timeout.

## Why This Change Was Made

Introduced `resolveFetchTimeoutMsFromConfig()` which:

1. Honors `tools.links.timeoutSeconds` when it is explicitly configured.
2. Falls back to `Math.max(...)` across all configured model timeouts so slower entries are not capped by the first one.

The timeout is now computed once per call instead of once per URL.

## User Impact

Link-understanding fetches no longer fail prematurely when the first configured model has a shorter timeout than later models. Users who set a global `tools.links.timeoutSeconds` get predictable fetch timeouts independent of model ordering.

## Evidence

Added two regression tests in `src/link-understanding/runner.test.ts` that both fail on current `main`:

- **Global timeout test:** with `tools.links.timeoutSeconds: 15` and model timeouts `1` and `9`, the fetch must use `15000` ms. On `main` it uses `1000` ms.
- **Fallback test:** with no global timeout and model timeouts `1` and `9`, the fetch must use `9000` ms. On `main` it uses `1000` ms.

```
pnpm test src/link-understanding/runner.test.ts -- --run
```

All six tests in the file pass.
