### PR TITLE
fix(ios): harden Apple Watch pairing activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **iOS Apple Watch pairing:** react immediately to Watch pairing and companion-install changes, and wait for asynchronous WatchConnectivity activation before sending, preventing stale unavailable state and cold-launch delivery races.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
 - **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.

--- a/apps/ios/CHANGELOG.md
+++ b/apps/ios/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed Apple Watch connection setup so pairing and companion-install changes refresh immediately and cold launches wait for WatchConnectivity activation before sending.
 - Redesigned the Settings About screen with the animated mascot, app tagline, and Website/Docs/GitHub/Discord links.
 - Fixed startup aborts caused by inactive Voice Wake initializing the simulator audio pipeline.
 - Debug builds now use separate app, extension, widget, and Watch identifiers plus a distinct debug icon, so they can remain installed beside release builds.

--- a/apps/ios/Sources/Services/WatchConnectivityTransport.swift
+++ b/apps/ios/Sources/Services/WatchConnectivityTransport.swift
@@ -31,6 +31,7 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
     private nonisolated static let logger = Logger(subsystem: "ai.openclawfoundation.app", category: "watch.messaging")
 
     private let session: WCSession?
+    private let activationGate = WatchSessionActivationGate()
     private let callbacksLock = NSLock()
     private let snapshotContextLock = NSLock()
     private var callbacks = WatchConnectivityTransportCallbacks()
@@ -44,7 +45,7 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
         super.init()
         if let session = self.session {
             session.delegate = self
-            session.activate()
+            self.beginActivation(session)
         }
     }
 
@@ -65,7 +66,7 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
     }
 
     func status() async -> WatchMessagingStatus {
-        await self.ensureActivated()
+        try? await self.ensureActivated()
         return self.currentStatusSnapshot()
     }
 
@@ -108,7 +109,7 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
     }
 
     func sendPayload(_ payload: [String: Any]) async throws -> WatchNotificationSendResult {
-        await self.ensureActivated()
+        try await self.ensureActivated()
         let session = try self.requireReadySession()
         if session.isReachable {
             do {
@@ -130,7 +131,7 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
     }
 
     func sendSnapshotPayload(_ payload: [String: Any]) async throws -> WatchNotificationSendResult {
-        await self.ensureActivated()
+        try await self.ensureActivated()
         let session = try self.requireReadySession()
         if session.isReachable {
             do {
@@ -183,6 +184,9 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
         guard let session = self.session else {
             throw WatchMessagingError.unsupported
         }
+        guard session.activationState == .activated else {
+            throw WatchSessionActivationError.failed("session stayed inactive")
+        }
         let snapshot = Self.status(for: session)
         guard snapshot.paired else {
             throw WatchMessagingError.notPaired
@@ -193,18 +197,20 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
         return session
     }
 
-    private func ensureActivated() async {
+    private func beginActivation(_ session: WCSession) {
+        if self.activationGate.beginActivation() {
+            session.activate()
+        }
+    }
+
+    private func ensureActivated() async throws {
         guard let session = self.session else { return }
         if session.activationState == .activated {
+            self.activationGate.complete(activated: true, errorDescription: nil)
             return
         }
-        session.activate()
-        for _ in 0..<8 {
-            if session.activationState == .activated {
-                return
-            }
-            try? await Task.sleep(nanoseconds: 100_000_000)
-        }
+        self.beginActivation(session)
+        try await self.activationGate.waitUntilActivated()
     }
 
     private func emitStatusUpdate(_ snapshot: WatchMessagingStatus) {
@@ -262,12 +268,14 @@ final class WatchConnectivityTransport: NSObject, @unchecked Sendable {
     }
 
     private nonisolated static func status(for session: WCSession) -> WatchMessagingStatus {
-        WatchMessagingStatus(
+        let activationState = session.activationState
+        let isActivated = activationState == .activated
+        return WatchMessagingStatus(
             supported: true,
-            paired: session.isPaired,
-            appInstalled: session.isWatchAppInstalled,
-            reachable: session.isReachable,
-            activationState: self.activationStateLabel(session.activationState))
+            paired: isActivated && session.isPaired,
+            appInstalled: isActivated && session.isWatchAppInstalled,
+            reachable: isActivated && session.isReachable,
+            activationState: self.activationStateLabel(activationState))
     }
 
     private nonisolated static func activationStateLabel(_ state: WCSessionActivationState) -> String {
@@ -290,6 +298,9 @@ extension WatchConnectivityTransport: WCSessionDelegate {
         activationDidCompleteWith activationState: WCSessionActivationState,
         error: (any Error)?)
     {
+        self.activationGate.complete(
+            activated: activationState == .activated,
+            errorDescription: error?.localizedDescription)
         GatewayDiagnostics.log(
             "watch messaging: activation complete "
                 + "state=\(Self.activationStateLabel(activationState)) "
@@ -303,11 +314,22 @@ extension WatchConnectivityTransport: WCSessionDelegate {
         self.emitStatusUpdate(Self.status(for: session))
     }
 
-    func sessionDidBecomeInactive(_: WCSession) {}
+    func sessionDidBecomeInactive(_ session: WCSession) {
+        GatewayDiagnostics.log("watch messaging: session became inactive")
+        self.emitStatusUpdate(Self.status(for: session))
+    }
 
     func sessionDidDeactivate(_ session: WCSession) {
         GatewayDiagnostics.log("watch messaging: session did deactivate; reactivating")
-        session.activate()
+        self.activationGate.reset()
+        self.beginActivation(session)
+        self.emitStatusUpdate(Self.status(for: session))
+    }
+
+    func sessionWatchStateDidChange(_ session: WCSession) {
+        GatewayDiagnostics.log(
+            "watch messaging: watch state changed "
+                + "paired=\(session.isPaired) installed=\(session.isWatchAppInstalled)")
         self.emitStatusUpdate(Self.status(for: session))
     }
 

--- a/apps/ios/Sources/Services/WatchSessionActivationGate.swift
+++ b/apps/ios/Sources/Services/WatchSessionActivationGate.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+enum WatchSessionActivationError: LocalizedError {
+    case failed(String)
+    case timedOut
+
+    var errorDescription: String? {
+        switch self {
+        case let .failed(reason):
+            "WATCH_UNAVAILABLE: Apple Watch session activation failed (\(reason))"
+        case .timedOut:
+            "WATCH_UNAVAILABLE: Apple Watch session activation timed out"
+        }
+    }
+}
+
+/// Joins concurrent sends to one WCSession activation and bounds the wait for its delegate callback.
+/// A failed or timed-out generation remains retryable so a later foreground launch can recover.
+final class WatchSessionActivationGate: @unchecked Sendable {
+    private typealias Waiter = CheckedContinuation<Void, any Error>
+
+    private enum State {
+        case idle
+        case activating(UInt64)
+        case completed(Result<Void, WatchSessionActivationError>)
+    }
+
+    private let lock = NSLock()
+    private let timeoutNanoseconds: UInt64
+    private var generation: UInt64 = 0
+    private var state = State.idle
+    private var waiters: [Waiter] = []
+
+    init(timeoutNanoseconds: UInt64 = 15_000_000_000) {
+        self.timeoutNanoseconds = timeoutNanoseconds
+    }
+
+    @discardableResult
+    func beginActivation() -> Bool {
+        let generationToStart: UInt64? = self.lock.withLock {
+            switch self.state {
+            case .idle:
+                break
+            case .activating:
+                return nil
+            case let .completed(result):
+                if case .success = result {
+                    return nil
+                }
+            }
+
+            self.generation &+= 1
+            self.state = .activating(self.generation)
+            return self.generation
+        }
+
+        guard let generationToStart else { return false }
+        Task { [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: self?.timeoutNanoseconds ?? 0)
+            } catch {
+                return
+            }
+            self?.finish(.failure(.timedOut), generation: generationToStart)
+        }
+        return true
+    }
+
+    func waitUntilActivated() async throws {
+        try await withCheckedThrowingContinuation { (continuation: Waiter) in
+            let completedResult: Result<Void, WatchSessionActivationError>? = self.lock.withLock {
+                switch self.state {
+                case .idle:
+                    return .failure(.failed("activation was not started"))
+                case .activating:
+                    self.waiters.append(continuation)
+                    return nil
+                case let .completed(result):
+                    return result
+                }
+            }
+            if let completedResult {
+                Self.resume(continuation, with: completedResult)
+            }
+        }
+    }
+
+    func complete(activated: Bool, errorDescription: String?) {
+        let result: Result<Void, WatchSessionActivationError>
+        if activated {
+            result = .success(())
+        } else {
+            let reason = errorDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let failureReason = reason.flatMap { $0.isEmpty ? nil : $0 } ?? "session stayed inactive"
+            result = .failure(.failed(failureReason))
+        }
+        self.finish(result, generation: nil)
+    }
+
+    func reset() {
+        let waiters: [Waiter] = self.lock.withLock {
+            self.state = .idle
+            let waiters = self.waiters
+            self.waiters.removeAll()
+            return waiters
+        }
+        let result = Result<Void, WatchSessionActivationError>.failure(
+            .failed("active Apple Watch changed"))
+        for waiter in waiters {
+            Self.resume(waiter, with: result)
+        }
+    }
+
+    private func finish(
+        _ result: Result<Void, WatchSessionActivationError>,
+        generation expectedGeneration: UInt64?)
+    {
+        let waiters: [Waiter]? = self.lock.withLock {
+            if let expectedGeneration {
+                guard case let .activating(activeGeneration) = self.state,
+                      activeGeneration == expectedGeneration
+                else {
+                    return nil
+                }
+            }
+            self.state = .completed(result)
+            let waiters = self.waiters
+            self.waiters.removeAll()
+            return waiters
+        }
+        guard let waiters else { return }
+        for waiter in waiters {
+            Self.resume(waiter, with: result)
+        }
+    }
+
+    private static func resume(
+        _ continuation: Waiter,
+        with result: Result<Void, WatchSessionActivationError>)
+    {
+        switch result {
+        case .success:
+            continuation.resume(returning: ())
+        case let .failure(error):
+            continuation.resume(throwing: error)
+        }
+    }
+}

--- a/apps/ios/Tests/WatchSessionActivationGateTests.swift
+++ b/apps/ios/Tests/WatchSessionActivationGateTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct WatchSessionActivationGateTests {
+    @Test func `iPhone observes watch pairing and install changes`() throws {
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Sources/Services/WatchConnectivityTransport.swift")
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        #expect(source.contains("func sessionWatchStateDidChange(_ session: WCSession)"))
+        #expect(source.contains("paired=\\(session.isPaired) installed=\\(session.isWatchAppInstalled)"))
+    }
+
+    @Test func `concurrent waiters share one activation`() async throws {
+        let gate = WatchSessionActivationGate(timeoutNanoseconds: 1_000_000_000)
+
+        #expect(gate.beginActivation())
+        #expect(!gate.beginActivation())
+        let first = Task { try await gate.waitUntilActivated() }
+        let second = Task { try await gate.waitUntilActivated() }
+
+        gate.complete(activated: true, errorDescription: nil)
+
+        try await first.value
+        try await second.value
+    }
+
+    @Test func `activation timeout remains retryable`() async throws {
+        let gate = WatchSessionActivationGate(timeoutNanoseconds: 1_000_000)
+
+        #expect(gate.beginActivation())
+        await #expect(throws: WatchSessionActivationError.self) {
+            try await gate.waitUntilActivated()
+        }
+
+        #expect(gate.beginActivation())
+        gate.complete(activated: true, errorDescription: nil)
+        try await gate.waitUntilActivated()
+    }
+
+    @Test func `activation errors reach every waiter`() async {
+        let gate = WatchSessionActivationGate(timeoutNanoseconds: 1_000_000_000)
+
+        #expect(gate.beginActivation())
+        let first = Task { try await gate.waitUntilActivated() }
+        let second = Task { try await gate.waitUntilActivated() }
+        gate.complete(activated: false, errorDescription: "not paired")
+
+        await #expect(throws: WatchSessionActivationError.self) { try await first.value }
+        await #expect(throws: WatchSessionActivationError.self) { try await second.value }
+    }
+}

--- a/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
+++ b/apps/ios/WatchApp/Sources/WatchConnectivityReceiver.swift
@@ -24,6 +24,7 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
 
     private let store: WatchInboxStore
     private let session: WCSession?
+    private let activationGate = WatchSessionActivationGate()
 
     init(store: WatchInboxStore) {
         self.store = store
@@ -38,26 +39,33 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
     func activate() {
         guard let session else { return }
         session.delegate = self
-        session.activate()
+        self.beginActivation(session)
     }
 
-    private func ensureActivated() async {
-        guard let session else { return }
+    private func beginActivation(_ session: WCSession) {
+        if self.activationGate.beginActivation() {
+            session.activate()
+        }
+    }
+
+    private func activatedSession() async throws -> WCSession {
+        guard let session else {
+            throw WatchSessionActivationError.failed("session unavailable")
+        }
         if session.activationState == .activated {
-            return
+            self.activationGate.complete(activated: true, errorDescription: nil)
+            return session
         }
-        session.activate()
-        for _ in 0..<8 {
-            if session.activationState == .activated {
-                return
-            }
-            try? await Task.sleep(nanoseconds: 100_000_000)
+        self.beginActivation(session)
+        try await self.activationGate.waitUntilActivated()
+        guard session.activationState == .activated else {
+            throw WatchSessionActivationError.failed("session stayed inactive")
         }
+        return session
     }
 
     func requestExecApprovalSnapshot() async {
-        await self.ensureActivated()
-        guard let session else { return }
+        guard let session = try? await self.activatedSession() else { return }
         let request = WatchExecApprovalSnapshotRequestMessage(
             requestId: UUID().uuidString,
             sentAtMs: Self.nowMs())
@@ -74,13 +82,11 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
     }
 
     func requestAppSnapshot() async -> WatchReplySendResult {
-        await self.ensureActivated()
-        guard let session else {
-            return WatchReplySendResult(
-                deliveredImmediately: false,
-                queuedForDelivery: false,
-                transport: "none",
-                errorMessage: "watch session unavailable")
+        let session: WCSession
+        do {
+            session = try await self.activatedSession()
+        } catch {
+            return Self.unavailableResult(error)
         }
         let request = WatchAppSnapshotRequestMessage(
             requestId: UUID().uuidString,
@@ -90,13 +96,11 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
     }
 
     func sendReply(_ draft: WatchReplyDraft) async -> WatchReplySendResult {
-        await self.ensureActivated()
-        guard let session else {
-            return WatchReplySendResult(
-                deliveredImmediately: false,
-                queuedForDelivery: false,
-                transport: "none",
-                errorMessage: "watch session unavailable")
+        let session: WCSession
+        do {
+            session = try await self.activatedSession()
+        } catch {
+            return Self.unavailableResult(error)
         }
 
         var payload: [String: Any] = [
@@ -133,13 +137,11 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
         gatewayStableID: String?,
         decision: WatchExecApprovalDecision) async -> WatchReplySendResult
     {
-        await self.ensureActivated()
-        guard let session else {
-            return WatchReplySendResult(
-                deliveredImmediately: false,
-                queuedForDelivery: false,
-                transport: "none",
-                errorMessage: "watch session unavailable")
+        let session: WCSession
+        do {
+            session = try await self.activatedSession()
+        } catch {
+            return Self.unavailableResult(error)
         }
 
         let payload = Self.encodeExecApprovalResolvePayload(
@@ -153,13 +155,11 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
     }
 
     func sendAppCommand(_ message: WatchAppCommandMessage) async -> WatchReplySendResult {
-        await self.ensureActivated()
-        guard let session else {
-            return WatchReplySendResult(
-                deliveredImmediately: false,
-                queuedForDelivery: false,
-                transport: "none",
-                errorMessage: "watch session unavailable")
+        let session: WCSession
+        do {
+            session = try await self.activatedSession()
+        } catch {
+            return Self.unavailableResult(error)
         }
         return await self.sendPayload(Self.encodeAppCommandPayload(message), session: session)
     }
@@ -193,6 +193,14 @@ final class WatchConnectivityReceiver: NSObject, @unchecked Sendable {
                 replyHandler: { _ in continuation.resume(returning: ()) },
                 errorHandler: { error in continuation.resume(throwing: error) })
         }
+    }
+
+    private static func unavailableResult(_ error: any Error) -> WatchReplySendResult {
+        WatchReplySendResult(
+            deliveredImmediately: false,
+            queuedForDelivery: false,
+            transport: "none",
+            errorMessage: error.localizedDescription)
     }
 
     private static func nowMs() -> Int {
@@ -587,8 +595,11 @@ extension WatchConnectivityReceiver: WCSessionDelegate {
     func session(
         _ session: WCSession,
         activationDidCompleteWith activationState: WCSessionActivationState,
-        error _: (any Error)?)
+        error: (any Error)?)
     {
+        self.activationGate.complete(
+            activated: activationState == .activated,
+            errorDescription: error?.localizedDescription)
         if activationState == .activated, !session.receivedApplicationContext.isEmpty {
             self.consumeIncomingPayload(
                 session.receivedApplicationContext,

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -311,6 +311,8 @@ targets:
       - path: WatchApp
         excludes:
           - Info.plist
+      - path: Sources/Services/WatchSessionActivationGate.swift
+        group: Sources/Services
       - path: Sources/Fonts
         buildPhase: resources
       - path: Resources/Localizable.xcstrings

--- a/docs/platforms/ios.md
+++ b/docs/platforms/ios.md
@@ -51,6 +51,12 @@ creation has a token or password auth path.
 4. The official app connects automatically. If **Devices** shows a pending
    request, review its role and scopes before approving it.
 
+The Apple Watch companion does not have a separate OpenClaw pairing approval.
+Pair the Watch with the iPhone in Apple's Watch app, install OpenClaw from
+**Watch app -> My Watch -> Available Apps**, then open OpenClaw once on both
+devices. OpenClaw follows Apple Watch pairing and install changes immediately;
+the Gateway's device approval covers the iPhone node.
+
 The Control UI button requires an already paired session with `operator.admin`.
 As a terminal fallback, pick a discovered gateway in the iOS app (or enable
 Manual Host and enter host/port), then approve the request on the Gateway host:
@@ -231,6 +237,12 @@ openclaw nodes invoke --node "iOS Node" --command canvas.snapshot --params '{"ma
 - `NODE_BACKGROUND_UNAVAILABLE`: bring the iOS app to the foreground (canvas/camera/screen commands require it).
 - `A2UI_HOST_UNAVAILABLE`: the bundled A2UI page was not reachable in the app WebView; keep the app foregrounded on the Screen tab and retry.
 - Pairing prompt never appears: run `openclaw devices list` and approve manually.
+- Watch shows no iPhone state: confirm the iPhone reports `watchPaired: true`
+  and `watchAppInstalled: true` in `watch.status`. If pairing is false, pair the
+  Watch in Apple's Watch app. If installation is false, install the companion
+  from **My Watch -> Available Apps**. After either change, open OpenClaw on the
+  Watch once; immediate reachability still requires both apps to be running,
+  while queued updates can arrive later in the background.
 - Reconnect fails after reinstall: the Keychain pairing token was cleared; re-pair the node.
 
 ## Related docs


### PR DESCRIPTION
## What Problem This Solves

The iPhone could keep reporting stale Apple Watch pairing and companion-install state because it did not implement `sessionWatchStateDidChange(_:)`. Both apps also gave asynchronous `WCSession.activate()` only 800 ms before continuing, which made cold-launch sends race activation.

## Why This Change Was Made

- Observe Apple Watch pairing and installation changes on iPhone and publish the new status immediately.
- Replace duplicated fixed polling with one shared, bounded activation gate used by iOS and watchOS.
- Join concurrent activation waiters, propagate activation failures, and keep later retries possible after failures or timeouts.
- Document the Apple system-pairing flow and practical status checks.

## User Impact

Apple Watch pairing and companion installation changes now appear without restarting the iPhone app. Cold-launch requests wait for the WatchConnectivity delegate result instead of racing an arbitrary delay, producing reliable delivery or a clear `WATCH_UNAVAILABLE` error.

## Evidence

- `xcodebuild ... -only-testing:OpenClawTests/WatchSessionActivationGateTests test`: 4 tests passed.
- Full iOS simulator build succeeded with the Watch companion embedded.
- Paired iPhone/Watch simulators logged `sessionWatchStateDidChange`, immediately changing status to `paired=true appInstalled=true activation=activated` and queuing the app snapshot.
- Blacksmith Testbox `tbx_01kwv5n711h9sfgyfw5ep0y6jr`: `pnpm check:changed` passed.
- Autoreview: clean; no accepted/actionable findings.

Physical-device pairing was not available for this validation; the paired simulator exercised the system pairing/install transition and both app targets compiled successfully.
