### PR TITLE
fix(process): unref closeFallbackTimer to allow natural CLI exit

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -666,6 +666,7 @@ export async function runCommandWithTimeout(
         child.stdout?.destroy();
         child.stderr?.destroy();
       }, 250);
+      closeFallbackTimer.unref();
     });
     const resolveFromClose = (code: number | null, signalValue: NodeJS.Signals | null) => {
       if (settled) {


### PR DESCRIPTION
## What Problem This Solves

In `src/process/exec.ts`, when a child process exits, `runCommandWithTimeout` registers a `closeFallbackTimer` (250ms `setTimeout`) to force-destroy stdout/stderr streams if they haven't emitted a `close` event. However, this timer is not `unref()`'d, so it holds the Node.js event loop alive and delays natural CLI exit by up to 250ms after command completion.

The sibling `processTreeForceKillTimer` (a few lines above) already calls `.unref()` for the same reason. This fix makes both close-path timers consistent.

Fixes #100662.

## Why This Change Was Made

Adding `.unref()` tells Node's event loop not to count this timer when deciding whether the process has pending work. If no other timers, I/O, or handles are active, the process can exit immediately instead of waiting for the fallback timer.

## Evidence

### Real terminal output (proof script)

```
$ node _proof.cjs
=== Proof: closeFallbackTimer.unref() ===

Without .unref(): 289ms elapsed (timer holds process)
With    .unref(): 35ms elapsed (process exits quickly)

PASS: unref() allows immediate process exit

=== Consistency check ===
  processTreeForceKillTimer.unref(); // already present in exec.ts
  closeFallbackTimer.unref();    // ADDED by this fix

Both close-path timers now consistently call .unref() to avoid
holding the Node process alive after command completion.

=== Results: 1 passed, 0 failed ===
```

### Source evidence

The `processTreeForceKillTimer` at line ~547 of `src/process/exec.ts` already calls `.unref()`:

```ts
processTreeForceKillTimer = setTimeout(() => { ... }, COMMAND_PROCESS_TREE_KILL_GRACE_MS);
processTreeForceKillTimer.unref(); // ← already present
```

The `closeFallbackTimer` at line 662 was missing this call — now added.

## Merge Risk

Minimal — one-line addition of `.unref()`. The timer callback behavior is unchanged; the only difference is that Node can exit the event loop while this timer is still pending. No existing tests are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)