### PR TITLE
fix: silence heartbeat notify=false fallback replies

### DIFF
--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -40,6 +40,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     modelRuntimeId?: string;
     model?: string;
     target?: "telegram" | "last";
+    showOk?: boolean;
   }): OpenClawConfig {
     return {
       agents: {
@@ -67,7 +68,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
         telegram: {
           token: "test-token",
           allowFrom: ["*"],
-          heartbeat: { showOk: false },
+          heartbeat: { showOk: params.showOk ?? false },
         },
       },
       session: { store: params.storePath },
@@ -157,9 +158,9 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
     });
   }
 
-  async function runPlainFallbackReply(text: string) {
+  async function runPlainFallbackReply(text: string, options: { showOk?: boolean } = {}) {
     return await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
-      const cfg = createConfig({ tmpDir, storePath });
+      const cfg = createConfig({ tmpDir, storePath, showOk: options.showOk });
       await seedMainSessionStore(storePath, cfg, {
         lastChannel: "telegram",
         lastProvider: "telegram",
@@ -281,7 +282,9 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
   );
 
   it("suppresses marker-only notify=false fallback replies", async () => {
-    const { result, sendTelegram } = await runPlainFallbackReply("notify=false\r\n");
+    const { result, sendTelegram } = await runPlainFallbackReply("notify=false\r\n", {
+      showOk: true,
+    });
 
     expect(result.status).toBe("ran");
     expect(sendTelegram).not.toHaveBeenCalled();

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -88,7 +88,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
 
   function expectTelegramSend(
     sendTelegram: ReturnType<typeof vi.fn>,
-    params: { text: string; cfg: OpenClawConfig },
+    params: { text: string; cfg: OpenClawConfig; silent?: boolean },
   ) {
     expect(sendTelegram).toHaveBeenCalledTimes(1);
     expect(sendTelegram.mock.calls).toEqual([
@@ -99,6 +99,7 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
           verbose: false,
           cfg: params.cfg,
           accountId: undefined,
+          ...(params.silent !== undefined ? { silent: params.silent } : {}),
         },
       ],
     ]);
@@ -145,6 +146,26 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
         lastTo: TELEGRAM_GROUP,
       });
       replySpy.mockResolvedValue(createHeartbeatToolResponsePayload(response));
+      const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: createDeps({ sendTelegram, getReplyFromConfig: replySpy }),
+      });
+
+      return { result, sendTelegram, replySpy, cfg };
+    });
+  }
+
+  async function runPlainFallbackReply(text: string) {
+    return await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = createConfig({ tmpDir, storePath });
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      replySpy.mockResolvedValue({ text });
       const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1" });
 
       const result = await runHeartbeatOnce({
@@ -233,6 +254,52 @@ describe("runHeartbeatOnce heartbeat response tool", () => {
 
     expectTelegramSend(sendTelegram, {
       text: "Build is blocked on missing credentials.",
+      cfg,
+    });
+  });
+
+  it.each(["", "\n", "\r\n"])(
+    "converts trailing notify=false fallback text into silent Telegram delivery with suffix %j",
+    async (suffix) => {
+      const { result, sendTelegram, cfg } = await runPlainFallbackReply(
+        `No interruption needed.\n\nnotify=false${suffix}`,
+      );
+
+      expect(result.status).toBe("ran");
+      expectTelegramSend(sendTelegram, {
+        text: "No interruption needed.",
+        cfg,
+        silent: true,
+      });
+      expect(getLastHeartbeatEvent()).toMatchObject({
+        status: "sent",
+        preview: "No interruption needed.",
+        channel: "telegram",
+        silent: true,
+      });
+    },
+  );
+
+  it("suppresses marker-only notify=false fallback replies", async () => {
+    const { result, sendTelegram } = await runPlainFallbackReply("notify=false\r\n");
+
+    expect(result.status).toBe("ran");
+    expect(sendTelegram).not.toHaveBeenCalled();
+    expect(getLastHeartbeatEvent()).toMatchObject({
+      status: "ok-token",
+      channel: "telegram",
+      silent: true,
+    });
+  });
+
+  it("preserves inline notify=false fallback text", async () => {
+    const { result, sendTelegram, cfg } = await runPlainFallbackReply(
+      "The literal notify=false flag is documented.",
+    );
+
+    expect(result.status).toBe("ran");
+    expectTelegramSend(sendTelegram, {
+      text: "The literal notify=false flag is documented.",
       cfg,
     });
   });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -845,6 +845,7 @@ type NormalizedHeartbeatDelivery = {
   text: string;
   hasMedia: boolean;
   isInternalPlaceholderOnly: boolean;
+  silent?: boolean;
 };
 
 function isStreamErrorFallbackPlaceholderOnly(text: string): boolean {
@@ -859,6 +860,16 @@ function isStreamErrorFallbackPlaceholderOnly(text: string): boolean {
   return remaining.length === 0;
 }
 
+const TRAILING_HEARTBEAT_NOTIFY_FALSE_RE = /(?:^|[\r\n])[ \t]*notify=false[ \t]*(?:\r?\n[ \t]*)*$/i;
+
+function stripTrailingHeartbeatNotifyFalse(text: string): { text: string; silent: boolean } {
+  const match = TRAILING_HEARTBEAT_NOTIFY_FALSE_RE.exec(text);
+  if (!match) {
+    return { text, silent: false };
+  }
+  return { text: text.slice(0, match.index).trimEnd(), silent: true };
+}
+
 function normalizeHeartbeatReply(
   payload: ReplyPayload,
   responsePrefix: string | undefined,
@@ -871,20 +882,29 @@ function normalizeHeartbeatReply(
     maxAckChars: ackMaxChars,
   });
   const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
-  const isInternalPlaceholderOnly = isStreamErrorFallbackPlaceholderOnly(stripped.text);
+  const notifyFalse = stripTrailingHeartbeatNotifyFalse(stripped.text);
+  const isInternalPlaceholderOnly = isStreamErrorFallbackPlaceholderOnly(notifyFalse.text);
   if ((stripped.shouldSkip || isInternalPlaceholderOnly) && !hasMedia) {
     return {
       shouldSkip: true,
       text: "",
       hasMedia,
       isInternalPlaceholderOnly,
+      ...(notifyFalse.silent ? { silent: true } : {}),
     };
   }
-  let finalText = isInternalPlaceholderOnly ? "" : stripped.text;
+  let finalText = isInternalPlaceholderOnly ? "" : notifyFalse.text;
   if (responsePrefix && finalText && !finalText.startsWith(responsePrefix)) {
     finalText = `${responsePrefix} ${finalText}`;
   }
-  return { shouldSkip: false, text: finalText, hasMedia, isInternalPlaceholderOnly };
+  const shouldSkip = !hasMedia && finalText.trim().length === 0;
+  return {
+    shouldSkip,
+    text: finalText,
+    hasMedia,
+    isInternalPlaceholderOnly,
+    ...(notifyFalse.silent ? { silent: true } : {}),
+  };
 }
 
 function normalizeHeartbeatToolNotification(
@@ -2059,8 +2079,12 @@ export async function runHeartbeatOnce(opts: {
         ? replyPayload.text.trim()
         : null;
     if (execFallbackText) {
-      normalized.text = execFallbackText;
-      normalized.shouldSkip = false;
+      const execNotifyFalse = stripTrailingHeartbeatNotifyFalse(execFallbackText);
+      normalized.text = execNotifyFalse.text;
+      normalized.shouldSkip = !normalized.hasMedia && !normalized.text.trim();
+      if (execNotifyFalse.silent) {
+        normalized.silent = true;
+      }
     }
     const replacement = !heartbeatToolResponse
       ? replaceGenericExternalRunFailureText(normalized.text)
@@ -2238,6 +2262,7 @@ export async function runHeartbeatOnce(opts: {
             ]),
       ],
       deps: opts.deps,
+      silent: normalized.silent,
     });
     if (send.status === "failed" || send.status === "partial_failed") {
       throw send.error;
@@ -2292,6 +2317,7 @@ export async function runHeartbeatOnce(opts: {
       hasMedia: mediaUrls.length > 0,
       channel: delivery.channel,
       accountId: delivery.accountId,
+      ...(normalized.silent === true ? { silent: true } : {}),
       indicatorType: visibility.useIndicator ? resolveIndicatorType(eventStatus) : undefined,
     });
     await updateTaskTimestamps();

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -2105,7 +2105,7 @@ export async function runHeartbeatOnce(opts: {
         updatedAt: previousUpdatedAt,
       });
 
-      const okSent = await maybeSendHeartbeatOk();
+      const okSent = normalized.silent ? false : await maybeSendHeartbeatOk();
       emitHeartbeatEvent({
         status: "ok-token",
         reason: opts.reason,

--- a/test/helpers/infra/heartbeat-runner-channel-plugins.ts
+++ b/test/helpers/infra/heartbeat-runner-channel-plugins.ts
@@ -40,6 +40,7 @@ function createHeartbeatOutboundAdapter(channelId: HeartbeatSendChannelId): Chan
               ...baseOptions,
               ...(typeof threadId === "number" ? { messageThreadId: threadId } : {}),
               ...(typeof replyToId === "string" ? { replyToMessageId: Number(replyToId) } : {}),
+              ...(opts.silent !== undefined ? { silent: opts.silent } : {}),
             }
           : {
               ...baseOptions,


### PR DESCRIPTION
Closes #80569

## What Problem This Solves

Fixes an issue where Telegram heartbeat fallback replies could expose a trailing standalone `notify=false` control marker as user-visible message text and still deliver the message as a normal notification.

## Why This Change Was Made

This keeps the fix at the heartbeat fallback boundary instead of parsing Telegram transport text. Plain fallback replies now consume only a final standalone `notify=false` line, forward the existing durable-send `silent` metadata, suppress marker-only replies, and preserve inline `notify=false` text.

## User Impact

Users no longer see `notify=false` appended to Telegram heartbeat fallback replies. When a fallback reply includes that final control marker, OpenClaw sends the remaining message silently through the existing Telegram `disable_notification` path.

## Evidence

- Mantis native Telegram Desktop proof passed for head `496436a93b18cfa540e38adbcb53e1445306dc4e`: https://github.com/openclaw/openclaw/actions/runs/28779391086
  - Artifact: https://github.com/openclaw/openclaw/actions/runs/28779391086/artifacts/8105380192
  - Published before/after screenshots, GIFs, MP4 clips, and raw QA manifest: https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-100735/run-28779391086-1/index.json
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.tool-response.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts src/infra/heartbeat-events-filter.test.ts extensions/telegram/src/outbound-adapter.test.ts src/channels/message/send.test.ts`  
  Passed: 4 Vitest shards, 130 tests.
- `node scripts/run-vitest.mjs src/infra/outbound/payloads.test.ts extensions/telegram/src/bot/delivery.test.ts`  
  Passed: 2 Vitest shards, 102 tests.
- `node scripts/run-vitest.mjs src/infra/heartbeat-runner.tool-response.test.ts`  
  Passed after formatting: 1 Vitest shard, 21 tests.
- `node_modules/.bin/oxfmt --check --threads=1 src/infra/heartbeat-runner.ts src/infra/heartbeat-runner.tool-response.test.ts test/helpers/infra/heartbeat-runner-channel-plugins.ts` passed.
- `git diff --check` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed clean: no accepted/actionable findings.

Earlier remote/Testbox local-launch gap is now covered by the Mantis native Telegram Desktop proof above. The local Crabbox wrapper in this checkout still fails basic version/help sanity checks before project code, but the required Telegram-visible behavior proof exists in the hosted Mantis run.
