### PR TITLE
docs(changelog): credit Control UI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
+- **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
 - **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.


### PR DESCRIPTION
## What Problem This Solves

The clean landing branches for #100719 and #100725 intentionally exclude `CHANGELOG.md` so their already-proven runtime patches do not repeatedly conflict with OpenClaw's high-traffic release-notes hunk. Their user-visible fixes and contributor credit still need release-note coverage.

## Why This Change Was Made

Keep the two code PRs as one focused runtime commit each, then own their changelog entries in this maintainer-only closeout. This preserves release notes and contributor attribution without coupling exact-head UI CI to unrelated concurrent changelog edits.

## User Impact

No runtime change. The next release notes describe the corrected per-agent default-model label and canonical inbound-image preview behavior.

## Evidence

- Entries match the final reviewed behavior and link the replacement PRs, original contributor PRs, and canonical issues.
- Contributor thanks remain attached to the relevant fix.
- `git diff --check` passed.
