### PR TITLE
fix(crestodian): suppress unhandled stdout/stderr stream errors in probeLocalCommand

### DIFF
--- a/src/crestodian/probes.stream-errors.test.ts
+++ b/src/crestodian/probes.stream-errors.test.ts
@@ -1,0 +1,62 @@
+// Crestodian probe stream-error handling tests.
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+type MockChildProcess = EventEmitter & {
+  stdin: PassThrough;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+function createMockChildProcess(): MockChildProcess {
+  const child = new EventEmitter() as MockChildProcess;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = vi.fn();
+  return child;
+}
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process",
+    );
+  return { ...actual, spawn: spawnMock };
+});
+
+describe("probeLocalCommand stream error handling", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers error listeners on stdout and stderr", async () => {
+    const child = createMockChildProcess();
+    const stdoutOn = vi.spyOn(child.stdout, "on");
+    const stderrOn = vi.spyOn(child.stderr, "on");
+
+    spawnMock.mockImplementationOnce(
+      (_cmd: string, _args: readonly string[], _opts: SpawnOptions): ChildProcess => {
+        process.nextTick(() => child.emit("close", 0));
+        return child as unknown as ChildProcess;
+      },
+    );
+
+    const { probeLocalCommand } = await import("./probes.js");
+
+    await probeLocalCommand("echo", ["test"], { timeoutMs: 1000 });
+
+    expect(stdoutOn).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(stderrOn).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+});

--- a/src/crestodian/probes.stream-errors.test.ts
+++ b/src/crestodian/probes.stream-errors.test.ts
@@ -2,7 +2,7 @@
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -23,10 +23,7 @@ function createMockChildProcess(): MockChildProcess {
 }
 
 vi.mock("node:child_process", async () => {
-  const actual =
-    await vi.importActual<typeof import("node:child_process")>(
-      "node:child_process",
-    );
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
   return { ...actual, spawn: spawnMock };
 });
 
@@ -36,27 +33,27 @@ describe("probeLocalCommand stream error handling", () => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("registers error listeners on stdout and stderr", async () => {
+  it("keeps child close authoritative when stdout and stderr emit errors", async () => {
     const child = createMockChildProcess();
-    const stdoutOn = vi.spyOn(child.stdout, "on");
-    const stderrOn = vi.spyOn(child.stderr, "on");
 
     spawnMock.mockImplementationOnce(
       (_cmd: string, _args: readonly string[], _opts: SpawnOptions): ChildProcess => {
-        process.nextTick(() => child.emit("close", 0));
+        process.nextTick(() => {
+          child.stdout.emit("error", new Error("stdout closed"));
+          child.stderr.emit("error", new Error("stderr closed"));
+          child.emit("close", 0);
+        });
         return child as unknown as ChildProcess;
       },
     );
 
     const { probeLocalCommand } = await import("./probes.js");
 
-    await probeLocalCommand("echo", ["test"], { timeoutMs: 1000 });
-
-    expect(stdoutOn).toHaveBeenCalledWith("error", expect.any(Function));
-    expect(stderrOn).toHaveBeenCalledWith("error", expect.any(Function));
+    await expect(probeLocalCommand("echo", ["test"], { timeoutMs: 1000 })).resolves.toEqual({
+      command: "echo",
+      found: true,
+      version: undefined,
+      error: undefined,
+    });
   });
 });

--- a/src/crestodian/probes.ts
+++ b/src/crestodian/probes.ts
@@ -79,9 +79,11 @@ export async function probeLocalCommand(
     child.stdout.on("data", (chunk) => {
       stdout = appendBounded(stdout, String(chunk), outputLimit);
     });
+    child.stdout.on("error", () => {});
     child.stderr.on("data", (chunk) => {
       stderr = appendBounded(stderr, String(chunk), outputLimit);
     });
+    child.stderr.on("error", () => {});
     child.on("error", (err: NodeJS.ErrnoException) => {
       finish({
         command,

--- a/src/crestodian/probes.ts
+++ b/src/crestodian/probes.ts
@@ -19,6 +19,9 @@ export type LocalCommandProbe = {
 const LOCAL_COMMAND_PROBE_OUTPUT_MAX_CHARS = 16 * 1024;
 const LOCAL_COMMAND_PROBE_KILL_GRACE_MS = 500;
 
+// The child close/error events own the probe result; pipe errors must not escape and crash setup.
+const ignoreOutputStreamError = () => {};
+
 function appendBounded(previous: string, chunk: string, limit: number): string {
   const next = previous + chunk;
   return next.length > limit ? next.slice(-limit) : next;
@@ -79,11 +82,11 @@ export async function probeLocalCommand(
     child.stdout.on("data", (chunk) => {
       stdout = appendBounded(stdout, String(chunk), outputLimit);
     });
-    child.stdout.on("error", () => {});
+    child.stdout.on("error", ignoreOutputStreamError);
     child.stderr.on("data", (chunk) => {
       stderr = appendBounded(stderr, String(chunk), outputLimit);
     });
-    child.stderr.on("error", () => {});
+    child.stderr.on("error", ignoreOutputStreamError);
     child.on("error", (err: NodeJS.ErrnoException) => {
       finish({
         command,


### PR DESCRIPTION
## What Problem This Solves

`probeLocalCommand` attaches `data` listeners to `child.stdout` and `child.stderr`, but does not attach `error` listeners. If either stream emits an `error` event, the unhandled error can crash the OpenClaw process.

## Why This Change Was Made

Add no-op `error` handlers to both stdout and stderr streams after the data handlers. Stream read errors are treated as non-fatal because the child process `error`/`close` handlers already report the real outcome.

## Changes

- **`src/crestodian/probes.ts`** — share a documented no-op output-stream error handler across stdout and stderr while leaving child close/error authoritative.
- **`src/crestodian/probes.stream-errors.test.ts`** — emit errors from both real `PassThrough` streams and assert the successful child close still determines the result.

## Evidence

Exact head: `d311f9d1575a75230dc85eb0f11a0d2a40a8faa3`

- Behavioral regression: emits controlled stdout and stderr errors through the production `probeLocalCommand`, then closes the child successfully; the probe resolves from close rather than crashing.
- Source-blind CLI proof: ran `openclaw crestodian --json` through the real CLI entry with controlled local-tool probe failures in three modes: stdout only, stderr only, and both streams. All three exited zero, returned parseable JSON, and preserved successful tool-probe results.
- Fresh Codex autoreview: clean; no accepted/actionable findings.
- Exact-head CI: [run 28810451498](https://github.com/openclaw/openclaw/actions/runs/28810451498) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
