### PR TITLE
improve(ui): pin sidebar nav above a scrollable session list

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -845,7 +845,6 @@ export class AppSidebar extends LitElement {
       <aside class="sidebar ${this.collapsed ? "sidebar--collapsed" : ""}">
         <div class="sidebar-shell">
           <div class="sidebar-shell__body">
-            ${this.renderSessions()}
             <nav class="sidebar-nav" @contextmenu=${this.openCustomizeMenuFromContext}>
               ${this.collapsed ? this.renderRoute("chat") : nothing}
               <div class="nav-section__items">
@@ -853,6 +852,7 @@ export class AppSidebar extends LitElement {
               </div>
               ${this.renderMoreSection()}
             </nav>
+            ${this.renderSessions()}
           </div>
           <div class="sidebar-shell__footer">
             <div class="sidebar-footer-bar">

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -474,7 +474,10 @@
 }
 
 .sidebar-nav {
-  flex: 1;
+  /* Nav stays pinned above the session list; the cap keeps sessions reachable
+     when an expanded More section outgrows a short window (nav then scrolls). */
+  flex: 0 0 auto;
+  max-height: 60%;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 0;
@@ -482,11 +485,14 @@
 }
 
 .sidebar-sessions {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 8px;
-  flex-shrink: 0;
+  /* Sessions own the leftover height below the pinned nav and scroll inside. */
+  flex: 1 1 auto;
+  min-height: 0;
   padding: 0 8px;
-  margin-bottom: 10px;
+  margin-top: 10px;
 }
 
 .sidebar-new-session {
@@ -543,15 +549,21 @@
   stroke-linejoin: round;
 }
 
+/* min-height: 0 down this chain lets the recent list shrink and scroll instead
+   of pushing the sidebar footer out of view. */
 .sidebar-recent-sessions {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 10px;
   margin: 0 -8px;
+  min-height: 0;
 }
 
 .sidebar-recent-sessions__group {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 2px;
+  min-height: 0;
 }
 
 /* Anchors the session-picker popover to the full header width. */
@@ -647,8 +659,7 @@
 .sidebar-recent-sessions__list {
   display: grid;
   gap: 2px;
-  /* Bounded so short viewports keep the nav below reachable. */
-  max-height: min(42vh, 400px);
+  min-height: 0;
   overflow-y: auto;
   scrollbar-width: thin;
 }
@@ -1046,9 +1057,9 @@
 }
 
 .sidebar--collapsed .sidebar-sessions {
-  justify-items: center;
+  align-items: center;
   padding: 0;
-  margin-bottom: 14px;
+  margin-top: 14px;
 }
 
 .sidebar--collapsed .sidebar-new-session {

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -175,7 +175,10 @@
 
   .sidebar-nav,
   .sidebar--collapsed .sidebar-nav {
-    flex: 1 1 auto;
+    /* Match the desktop pinned-nav layout so the session list keeps the
+       remaining drawer height. */
+    flex: 0 0 auto;
+    max-height: 60%;
     display: block;
     padding: 0;
     overflow-x: hidden;


### PR DESCRIPTION
## What Problem This Solves

In the Control UI web sidebar, the session list rendered above the navigation items (Overview, Workboard, Agents, More), and the navigation was the scrolling region below it. With a long session list the primary navigation sat below the fold, and the sessions area was capped to a fixed height (`min(42vh, 400px)`) instead of using the available sidebar height.

## Why This Change Was Made

The sidebar now renders navigation first and keeps it pinned (non-scrolling) at the top, while the session list owns the remaining sidebar height and scrolls internally. The recent-session list's fixed height cap is removed since the flex layout now bounds it naturally, and the mobile drawer uses the same pinned-nav layout. A 60% height cap on the nav keeps sessions reachable if an expanded More section outgrows a short window.

## User Impact

Navigation items (Overview, Workboard, Agents, More) are always visible at the top of the sidebar. Sessions get the rest of the sidebar height and scroll on their own, so tall windows show more sessions instead of stopping at 400px.

## Evidence

Control UI e2e (mock gateway) on Blacksmith Testbox: `pnpm test ui/src/e2e/sidebar-customization.e2e.test.ts ui/src/e2e/session-management.e2e.test.ts` — 2 files, 3 tests passed. Path-scoped `pnpm check:changed` gates on the same box passed (format/lint/guards, exit 0). Codex autoreview: clean, no actionable findings.

Before (sessions above nav, nav scrolled away) → after (nav pinned, sessions scrollable below):

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-nav-first/before-sessions-on-top.png) | ![after](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-nav-first/after-nav-pinned.png) |

Default pinned state (Overview only) after the change:

![after default](https://raw.githubusercontent.com/steipete/openclaw-pr-assets/main/sidebar-nav-first/after-default-overview.png)
