### PR TITLE
fix(control-ui): restore staged media filenames

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -1,6 +1,6 @@
 // Control UI HTTP tests cover static asset serving, bootstrap config, avatar and
 // assistant media routes, pairing helpers, and session-generation metadata.
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
@@ -444,6 +444,10 @@ describe("handleControlUiHttpRequest", () => {
     { filename: "voice.ogg", disposition: "inline" },
     { filename: "clip.mp4", disposition: "inline" },
     { filename: "report.pdf", disposition: "attachment" },
+    {
+      filename: "invoice---123e4567-e89b-12d3-a456-426614174000.pdf",
+      disposition: "attachment",
+    },
     { filename: "archive.bin", disposition: "attachment" },
   ])("serves $filename with $disposition disposition", async ({ filename, disposition }) => {
     await withAllowedAssistantMediaRoot({
@@ -490,7 +494,7 @@ describe("handleControlUiHttpRequest", () => {
 
   it("serves assistant media from canonical inbound media refs", async () => {
     const stateDir = resolveStateDir();
-    const id = `ui-media-ref-${Date.now()}-${Math.random().toString(36).slice(2)}.png`;
+    const id = `report---${randomUUID()}.pdf`;
     const filePath = path.join(stateDir, "media", "inbound", id);
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, Buffer.from("not-a-real-png"));
@@ -503,6 +507,10 @@ describe("handleControlUiHttpRequest", () => {
       });
       expect(handled).toBe(true);
       expect(res.statusCode).toBe(200);
+      expect(res["setHeader"]).toHaveBeenCalledWith(
+        "Content-Disposition",
+        `attachment; filename="report.pdf"; filename*=UTF-8''report.pdf`,
+      );
     } finally {
       await fs.rm(filePath, { force: true });
     }

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -23,8 +23,11 @@ import { verifyPairingToken } from "../infra/pairing-token.js";
 import { isWithinDir } from "../infra/path-safety.js";
 import { assertLocalMediaAllowed, getDefaultLocalRoots } from "../media/local-media-access.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
-import { resolveMediaReferenceLocalPath } from "../media/media-reference.js";
-import { extractOriginalFilename, getMediaDir } from "../media/store.js";
+import {
+  resolveMediaReferenceLocalPath,
+  resolveMediaReferenceLocalPathInfo,
+} from "../media/media-reference.js";
+import { extractOriginalFilename } from "../media/store.js";
 import { AVATAR_MAX_BYTES } from "../shared/avatar-policy.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
@@ -630,7 +633,8 @@ export async function handleControlUiAssistantMediaRequest(
     await opened.handle.close().catch(() => {});
   };
   try {
-    localPath = await resolveMediaReferenceLocalPath(source);
+    const resolvedReference = await resolveMediaReferenceLocalPathInfo(source);
+    localPath = resolvedReference.path;
     await assertLocalMediaAllowed(localPath, localRoots);
     opened = await openLocalFileSafely({ filePath: localPath });
     const sniffLength = Math.min(opened.stat.size, 8192);
@@ -644,10 +648,10 @@ export async function handleControlUiAssistantMediaRequest(
       filePath: localPath,
     });
     const contentType = mime ?? "application/octet-stream";
-    const isInboundStorePath = isWithinDir(path.join(getMediaDir(), "inbound"), localPath);
-    const filename = isInboundStorePath
-      ? extractOriginalFilename(localPath)
-      : path.basename(localPath);
+    const filename =
+      resolvedReference.kind === "inbound"
+        ? extractOriginalFilename(localPath)
+        : path.basename(localPath);
     res.setHeader("Content-Type", contentType);
     res.setHeader(
       "Content-Disposition",

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -24,6 +24,7 @@ import { isWithinDir } from "../infra/path-safety.js";
 import { assertLocalMediaAllowed, getDefaultLocalRoots } from "../media/local-media-access.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 import { resolveMediaReferenceLocalPath } from "../media/media-reference.js";
+import { extractOriginalFilename, getMediaDir } from "../media/store.js";
 import { AVATAR_MAX_BYTES } from "../shared/avatar-policy.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
@@ -643,10 +644,14 @@ export async function handleControlUiAssistantMediaRequest(
       filePath: localPath,
     });
     const contentType = mime ?? "application/octet-stream";
+    const isInboundStorePath = isWithinDir(path.join(getMediaDir(), "inbound"), localPath);
+    const filename = isInboundStorePath
+      ? extractOriginalFilename(localPath)
+      : path.basename(localPath);
     res.setHeader("Content-Type", contentType);
     res.setHeader(
       "Content-Disposition",
-      buildAssistantMediaContentDisposition(path.basename(localPath), contentType),
+      buildAssistantMediaContentDisposition(filename, contentType),
     );
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Content-Length", String(opened.stat.size));

--- a/src/media/media-reference.test.ts
+++ b/src/media/media-reference.test.ts
@@ -10,6 +10,7 @@ import {
   parseInboundMediaUri,
   resolveInboundMediaReference,
   resolveMediaReferenceLocalPath,
+  resolveMediaReferenceLocalPathInfo,
   resolveMediaReferenceSandboxPath,
 } from "./media-reference.js";
 
@@ -133,7 +134,13 @@ describe("media reference helpers", () => {
       await expect(resolveMediaReferenceLocalPath(`media://inbound/${id}`)).resolves.toBe(
         realFilePath,
       );
+      await expect(
+        resolveMediaReferenceLocalPathInfo(`media://inbound/${id}`),
+      ).resolves.toStrictEqual({ kind: "inbound", path: realFilePath });
       await expect(resolveMediaReferenceLocalPath("  MEDIA: ./out.png")).resolves.toBe("./out.png");
+      await expect(resolveMediaReferenceLocalPathInfo("  MEDIA: ./out.png")).resolves.toStrictEqual(
+        { kind: "local", path: "./out.png" },
+      );
     } finally {
       await fs.rm(filePath, { force: true });
     }

--- a/src/media/media-reference.ts
+++ b/src/media/media-reference.ts
@@ -228,10 +228,18 @@ export async function resolveInboundMediaReference(
   };
 }
 
+/** Resolves a media reference while preserving whether it belongs to the inbound store. */
+export async function resolveMediaReferenceLocalPathInfo(source: string) {
+  const normalizedSource = normalizeMediaReferenceSource(source);
+  const inboundReference = await resolveInboundMediaReference(normalizedSource);
+  return inboundReference
+    ? { kind: "inbound" as const, path: inboundReference.physicalPath }
+    : { kind: "local" as const, path: normalizedSource };
+}
+
 /** Converts inbound media references for callers that need a direct local file path. */
 export async function resolveMediaReferenceLocalPath(source: string): Promise<string> {
-  const normalizedSource = normalizeMediaReferenceSource(source);
-  return (await resolveInboundMediaReference(normalizedSource))?.physicalPath ?? normalizedSource;
+  return (await resolveMediaReferenceLocalPathInfo(source)).path;
 }
 
 async function resolveInboundMediaPath(id: string, source: string): Promise<string> {


### PR DESCRIPTION
Follow-up to #100728

## What Problem This Solves

Fixes an issue where assistant documents stored under canonical `media://inbound` references would download with the media store's UUID-suffixed staging name instead of the original filename.

## Why This Change Was Made

The authenticated assistant-media route now restores the caller-facing name only for files inside the inbound media-store root. Ordinary allowed local files continue to use their exact basename, even when that name legitimately ends in a UUID-like suffix.

## User Impact

Control UI downloads preserve original staged attachment names without renaming unrelated local files.

## Evidence

- Blacksmith Testbox `tbx_01kwv3cxf387yceenrhrmk7rr5` (`jade-shrimp`): formatting check passed.
- Gateway HTTP matrix: 260 tests passed, including staged-name restoration and the inverse ordinary-local-file case.
- Assistant media HTTP E2E: 1 test passed.
- Control UI chat-flow E2E: 25 tests passed, including browser download filename behavior.
- Fresh whole-branch autoreview: clean after constraining restoration to the inbound store root.
