### PR TITLE
fix(openai): image generation unavailable when openai provider set via config apiKey + custom baseUrl

### DIFF
--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -409,6 +409,32 @@ describe("openai image generation provider", () => {
     ).toBe(false);
   });
 
+  it("reports configured from a config apiKey (gateway-routed openai) with no env/profile creds", () => {
+    const provider = buildOpenAIImageGenerationProvider();
+
+    // Config-only auth: a provider apiKey in config, with no env var and no
+    // auth profile.
+    isProviderApiKeyConfiguredMock.mockReturnValue(false);
+    ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
+
+    expect(
+      provider.isConfigured?.({
+        agentDir: "/tmp/agent",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://gateway.example.test/openai/v1",
+                apiKey: "gateway-token",
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("reports ChatGPT OAuth image auth as configured for ChatGPT routes", () => {
     const provider = buildOpenAIImageGenerationProvider();
 

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -435,6 +435,32 @@ describe("openai image generation provider", () => {
     ).toBe(true);
   });
 
+  it("treats an empty config apiKey as not configured", () => {
+    const provider = buildOpenAIImageGenerationProvider();
+
+    // An empty-string placeholder resolves to no usable credential in the
+    // generate path, so readiness must not count it either.
+    isProviderApiKeyConfiguredMock.mockReturnValue(false);
+    ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
+
+    expect(
+      provider.isConfigured?.({
+        agentDir: "/tmp/agent",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://gateway.example.test/openai/v1",
+                apiKey: "",
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
   it("reports ChatGPT OAuth image auth as configured for ChatGPT routes", () => {
     const provider = buildOpenAIImageGenerationProvider();
 

--- a/extensions/openai/image-generation-provider.test.ts
+++ b/extensions/openai/image-generation-provider.test.ts
@@ -50,7 +50,8 @@ const {
   logInfoMock: vi.fn(),
 }));
 
-vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>()),
   ensureAuthProfileStore: ensureAuthProfileStoreMock,
   isProviderApiKeyConfigured: isProviderApiKeyConfiguredMock,
   listProfilesForProvider: listProfilesForProviderMock,
@@ -435,11 +436,14 @@ describe("openai image generation provider", () => {
     ).toBe(true);
   });
 
-  it("treats an empty config apiKey as not configured", () => {
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])("treats a %s config apiKey as not configured", (_label, apiKey) => {
     const provider = buildOpenAIImageGenerationProvider();
 
-    // An empty-string placeholder resolves to no usable credential in the
-    // generate path, so readiness must not count it either.
+    // Blank placeholders resolve to no usable credential in the generate
+    // path, so readiness must not count them either.
     isProviderApiKeyConfiguredMock.mockReturnValue(false);
     ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
 
@@ -451,7 +455,7 @@ describe("openai image generation provider", () => {
             providers: {
               openai: {
                 baseUrl: "https://gateway.example.test/openai/v1",
-                apiKey: "",
+                apiKey,
                 models: [],
               },
             },

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -829,6 +829,11 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
     id: "openai",
     label: "OpenAI",
     isConfigured: ({ cfg, agentDir }) => {
+      // generateImage already authenticates from a config apiKey; count it as
+      // configured here too, so image gen works from config alone, like chat.
+      if (cfg?.models?.providers?.openai?.apiKey !== undefined) {
+        return true;
+      }
       const configuredBaseUrl = resolveConfiguredOpenAIBaseUrl(cfg);
       const hasPublicOpenAIBaseUrl = isPublicOpenAIImageBaseUrl(configuredBaseUrl);
       const hasChatGPTRouteConfig = hasChatGPTImageRouteConfig(cfg);

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -829,9 +829,10 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
     id: "openai",
     label: "OpenAI",
     isConfigured: ({ cfg, agentDir }) => {
-      // generateImage already authenticates from a config apiKey; count it as
-      // configured here too, so image gen works from config alone, like chat.
-      if (cfg?.models?.providers?.openai?.apiKey !== undefined) {
+      // generateImage already authenticates from a config apiKey; count a
+      // non-empty one as configured here too, so image gen works from config
+      // alone, like chat.
+      if (cfg?.models?.providers?.openai?.apiKey) {
         return true;
       }
       const configuredBaseUrl = resolveConfiguredOpenAIBaseUrl(cfg);

--- a/extensions/openai/image-generation-provider.ts
+++ b/extensions/openai/image-generation-provider.ts
@@ -17,6 +17,7 @@ import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
 import { MAX_IMAGE_BYTES } from "openclaw/plugin-sdk/media-runtime";
 import {
   ensureAuthProfileStore,
+  hasConfiguredSecretInput,
   isProviderApiKeyConfigured,
   listProfilesForProvider,
   type AuthProfileStore,
@@ -830,9 +831,9 @@ export function buildOpenAIImageGenerationProvider(): ImageGenerationProvider {
     label: "OpenAI",
     isConfigured: ({ cfg, agentDir }) => {
       // generateImage already authenticates from a config apiKey; count a
-      // non-empty one as configured here too, so image gen works from config
-      // alone, like chat.
-      if (cfg?.models?.providers?.openai?.apiKey) {
+      // usable one (non-blank literal or secret ref) as configured here too,
+      // so image gen works from config alone, like chat.
+      if (hasConfiguredSecretInput(cfg?.models?.providers?.openai?.apiKey)) {
         return true;
       }
       const configuredBaseUrl = resolveConfiguredOpenAIBaseUrl(cfg);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where image generation reports "not configured" — and is skipped
by capability availability/auto-selection and shown as unavailable in
`image_generate`'s provider `list` — when the OpenAI provider is configured
entirely through config: `models.providers.openai.apiKey` plus a custom
`baseUrl` (for example an OpenAI-compatible proxy/gateway), with no
`OPENAI_API_KEY` environment variable and no auth profile.

Chat models configured the same way authenticate and appear available, but image
generation did not — even though generating with that same config actually
works. So operators who wire the OpenAI provider purely via config saw image
generation as broken/unconfigured.

## Why This Change Was Made

The `openai` image provider's `isConfigured` only consulted environment
variables / auth profiles (`isProviderApiKeyConfigured`) and considered a config
`apiKey` only *inside* that env/profile-gated branch. Meanwhile the generate
path already resolves a config `apiKey` via `resolveApiKeyForProvider` and honors
the config `baseUrl` via `resolveConfiguredOpenAIBaseUrl`. Readiness was
therefore stricter than generation, and inconsistent with chat providers, which
authenticate purely from provider config.

This change makes `isConfigured` recognize a usable configured provider
`apiKey` as a complete direct-auth credential (an early return), so readiness
matches what the generate path can actually do. "Usable" is decided by
`hasConfiguredSecretInput` — the same secret-presence contract runtime auth
uses — so a non-blank literal or a secret ref counts, while empty or
whitespace-only placeholders (which the generate path normalizes away and then
fails on) do not. Same semantics as #100779 for the Google image provider. The
env/profile, public-OpenAI, and Codex/ChatGPT-OAuth branches are unchanged.

## User Impact

Operators can enable image generation purely via `models.providers.openai`
(`apiKey` + `baseUrl`) — e.g. pointing at an OpenAI-compatible gateway — without
setting `OPENAI_API_KEY` or adding an auth profile. The provider now reports
configured, is eligible for capability auto-selection, and appears in
`image_generate`'s provider `list`. No change for setups that use an
environment variable, an auth profile, the public OpenAI endpoint, or
Codex/ChatGPT OAuth.

## Evidence

- Added a focused regression test in
  `extensions/openai/image-generation-provider.test.ts`: a custom `baseUrl` plus
  a config `apiKey`, with no env var and no auth profile, now reports
  `isConfigured: true` (previously `false`); the existing "custom endpoint with
  no creds → not configured" case still holds.
- Guard tests: empty (`""`) and whitespace-only (`"   "`) config `apiKey`
  values still report not configured (fail under a bare `!== undefined` or
  truthiness check, pass with `hasConfiguredSecretInput`). Addresses the
  ClawSweeper P1 (whitespace false positive) and P2 (whitespace regression
  coverage) findings.
- `oxfmt --check` clean on the changed files.
- Behavior trace: `generateImage` already resolves the config `apiKey`
  (`resolveApiKeyForProvider`) and honors the config `baseUrl`
  (`resolveConfiguredOpenAIBaseUrl`); only `isConfigured` lagged. Full
  vitest/tsgo run in CI.

