### PR TITLE
fix(agents): suppress unhandled stdout/stderr stream errors in sandbox SSH commands

### DIFF
--- a/src/agents/sandbox/ssh.stream-errors.test.ts
+++ b/src/agents/sandbox/ssh.stream-errors.test.ts
@@ -1,0 +1,104 @@
+// SSH sandbox stream-error handling tests
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+type MockChildProcess = EventEmitter & {
+  stdin: PassThrough;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+function createMockChildProcess(): MockChildProcess {
+  const child = new EventEmitter() as MockChildProcess;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = vi.fn();
+  return child;
+}
+
+vi.mock("node:child_process", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:child_process")>(
+      "node:child_process",
+    );
+  return { ...actual, spawn: spawnMock };
+});
+
+describe("ssh sandbox stream error handling", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("runSshSandboxCommand registers error listeners on stdout and stderr", async () => {
+    const child = createMockChildProcess();
+    const stdoutOn = vi.spyOn(child.stdout, "on");
+    const stderrOn = vi.spyOn(child.stderr, "on");
+
+    spawnMock.mockImplementationOnce(
+      (_cmd: string, _args: readonly string[], _opts: SpawnOptions): ChildProcess => {
+        process.nextTick(() => child.emit("close", 1));
+        return child as unknown as ChildProcess;
+      },
+    );
+
+    const { runSshSandboxCommand } = await import("./ssh.js");
+
+    try {
+      await runSshSandboxCommand({
+        command: "echo test",
+        target: { host: "localhost", username: "test", connectTimeoutMs: 100 },
+        allowFailure: true,
+      });
+    } catch {
+      // Expected — we mocked a failing close
+    }
+
+    expect(stdoutOn).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(stderrOn).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+
+  it("uploadDirectoryToSshTarget registers error listeners on tar and ssh streams", async () => {
+    const tarChild = createMockChildProcess();
+    const sshChild = createMockChildProcess();
+    const tarStderrOn = vi.spyOn(tarChild.stderr, "on");
+    const sshStdoutOn = vi.spyOn(sshChild.stdout, "on");
+    const sshStderrOn = vi.spyOn(sshChild.stderr, "on");
+
+    spawnMock
+      .mockImplementationOnce(
+        (_cmd: string, _args: readonly string[], _opts: SpawnOptions): ChildProcess => {
+          process.nextTick(() => tarChild.emit("close", 0));
+          return tarChild as unknown as ChildProcess;
+        },
+      )
+      .mockImplementationOnce(
+        (_cmd: string, _args: readonly string[], _opts: SpawnOptions): ChildProcess => {
+          process.nextTick(() => sshChild.emit("close", 0));
+          return sshChild as unknown as ChildProcess;
+        },
+      );
+
+    const { uploadDirectoryToSshTarget } = await import("./ssh.js");
+
+    try {
+      await uploadDirectoryToSshTarget({
+        localPath: "/tmp/test",
+        remotePath: "/tmp/test",
+        target: { host: "localhost", username: "test", connectTimeoutMs: 100 },
+      });
+    } catch {
+      // Expected
+    }
+
+    expect(tarStderrOn).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(sshStdoutOn).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(sshStderrOn).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+});

--- a/src/agents/sandbox/ssh.ts
+++ b/src/agents/sandbox/ssh.ts
@@ -683,7 +683,9 @@ export async function runSshSandboxCommand(
     const stderrChunks: Buffer[] = [];
 
     child.stdout.on("data", (chunk) => stdoutChunks.push(Buffer.from(chunk)));
+    child.stdout.on("error", () => {});
     child.stderr.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
+    child.stderr.on("error", () => {});
     child.on("error", reject);
     child.on("close", (code) => {
       const stdout = Buffer.concat(stdoutChunks);
@@ -792,8 +794,11 @@ export async function uploadDirectoryToSshTarget(params: {
     let sshCode = 0;
 
     tar.stderr.on("data", (chunk) => tarStderr.push(Buffer.from(chunk)));
+    tar.stderr.on("error", () => {});
     ssh.stdout.on("data", (chunk) => sshStdout.push(Buffer.from(chunk)));
+    ssh.stdout.on("error", () => {});
     ssh.stderr.on("data", (chunk) => sshStderr.push(Buffer.from(chunk)));
+    ssh.stderr.on("error", () => {});
 
     const fail = (error: unknown) => {
       tar.kill("SIGKILL");


### PR DESCRIPTION
## What Problem This Solves

`runSshCommand` and the tar-over-SSH pipe transfer in sandbox/ssh.ts attach `data` listeners to child process stdout/stderr streams, but do not attach `error` listeners. If any stream emits an `error` event, the unhandled error can crash the OpenClaw process.

## Why This Change Was Made

Add no-op `error` handlers to all child stdout/stderr streams that have data listeners. Stream read errors are treated as non-fatal because the child process `error`/`close` handlers already report the real outcome.

## Changes

- **`src/agents/sandbox/ssh.ts`** — add `child.stdout.on("error", () => {})` and `child.stderr.on("error", () => {})` in `runSshCommand` (2 lines) + `tar.stderr`/`ssh.stdout`/`ssh.stderr` error handlers in the pipe transfer path (3 lines)

## Evidence

```bash
node --import tsx/esm scripts/proof/ssh-stream-errors.mts
```

```
==============================================================
Proof: stream error handlers in sandbox/ssh.ts
==============================================================

Test 1: stdout and stderr stream errors do not crash
  exit code: 1
  stdout: "SSH output"
  stderr: "SSH stderr"
  ✅ PASS: Process did not crash on stream errors

Test 2: Multiple child streams (tar + ssh pipe pattern)
  tar stderr: 0 bytes
  ssh stdout: 11 bytes
  ssh stderr: 0 bytes
  ✅ PASS: Multi-stream pipe pattern handles errors safely

==============================================================
✅ PROOF PASSED
==============================================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)