### PR TITLE
test(channels): fix bundled shape guard lint

### DIFF
--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -946,7 +946,7 @@ describe("bundled channel entry shape guards", () => {
     const pluginDir = path.join(root, "extensions", "alpha");
     const escapedPluginDir = path.join(outsideRoot, "escape");
     const testGlobal = globalThis as typeof globalThis & {
-      __escapedBundledSourceLoaded?: boolean;
+      escapedBundledSourceLoaded?: boolean;
     };
     fs.mkdirSync(pluginsDir, { recursive: true });
     fs.mkdirSync(pluginDir, { recursive: true });
@@ -984,7 +984,7 @@ describe("bundled channel entry shape guards", () => {
     fs.writeFileSync(
       path.join(escapedPluginDir, "index.js"),
       [
-        "globalThis.__escapedBundledSourceLoaded = true;",
+        "globalThis.escapedBundledSourceLoaded = true;",
         "export default {",
         "  kind: 'bundled-channel-entry',",
         "  id: 'escape',",
@@ -1030,12 +1030,12 @@ describe("bundled channel entry shape guards", () => {
       expect(bundled.getBundledChannelPlugin("alpha")?.meta.label).toBe("Source Alpha");
       expect(bundled.getBundledChannelSetupPlugin("alpha")?.meta.label).toBe("Setup Alpha");
       expect(bundled.getBundledChannelPlugin("escape")).toBeUndefined();
-      expect(testGlobal.__escapedBundledSourceLoaded).toBeUndefined();
+      expect(testGlobal.escapedBundledSourceLoaded).toBeUndefined();
     } finally {
       restoreBundledPluginsDir(previousBundledPluginsDir);
       fs.rmSync(root, { recursive: true, force: true });
       fs.rmSync(outsideRoot, { recursive: true, force: true });
-      delete testGlobal.__escapedBundledSourceLoaded;
+      delete testGlobal.escapedBundledSourceLoaded;
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

The source-only bundled-channel regression test added by #100737 uses a test-global property with leading and trailing underscores. The repository lint rule rejects those two property accesses, so every current-main CI run fails `check-lint` even when the PR does not touch channels.

## Why This Change Was Made

Rename the test-only sentinel consistently in its type, generated fixture, assertion, and cleanup. This fixes the lint error without adding a suppression or changing the production bundled-channel behavior.

## User Impact

No runtime change. Current-main CI and dependent PRs can complete their lint gate again.

## Evidence

- Blacksmith Testbox `tbx_01kwv87ycea0nz6rxfdktqnzb3`: `src/channels/plugins/bundled.shape-guard.test.ts` — 25 passed.
- Targeted repository oxlint for the file passed after the rename; before the change it reported `no-underscore-dangle` at lines 1033 and 1038.
- `git diff --check` passed.
