### PR TITLE
test(channels): rename escaped load sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **iOS Apple Watch pairing:** react immediately to Watch pairing and companion-install changes, and wait for asynchronous WatchConnectivity activation before sending, preventing stale unavailable state and cold-launch delivery races.
+- **Discord oversized attachments:** preserve reply text and report the skipped file when Discord rejects an upload as too large. (#99577, #99021) Thanks @lin-hongkuan.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
 - **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -1,6 +1,7 @@
 // Discord tests cover send.sends basic channel messages plugin behavior.
 import { ChannelType, MessageFlags, PermissionFlagsBits, Routes } from "discord-api-types/v10";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { Container, TextDisplay } from "./internal/discord.js";
 import { discordWebMediaMockFactory, makeDiscordRest } from "./send.test-harness.js";
 
 vi.mock("openclaw/plugin-sdk/web-media", () => discordWebMediaMockFactory());
@@ -592,6 +593,77 @@ describe("sendMessageDiscord", () => {
     expect(loadWebMedia).toHaveBeenCalledWith("file:///tmp/photo.jpg", {
       maxBytes: 100 * 1024 * 1024,
     });
+  });
+
+  it("preserves text when Discord rejects an upload with error 40005", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockRejectedValueOnce(
+        Object.assign(new Error("Bad Request"), {
+          status: 400,
+          rawError: { code: 40005 },
+        }),
+      )
+      .mockResolvedValueOnce({ id: "fallback-msg", channel_id: "789" });
+
+    const res = await sendMessageDiscord("channel:789", "Here is the report", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrl: "file:///tmp/report.pdf",
+      replyTo: "orig-123",
+      components: [new Container([new TextDisplay("Attachment controls")])],
+      embeds: [{ title: "Attachment preview" }],
+    });
+
+    expect(res.messageId).toBe("fallback-msg");
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expectBodyFileName(requireRestBody(postMock, 0), "photo.jpg");
+    const fallbackBody = requireRestBody(postMock, 1);
+    expect(fallbackBody.content).toBe(
+      "Here is the report\n\n[Attachment skipped: Discord rejected the file as too large.]",
+    );
+    expect(fallbackBody).not.toHaveProperty("files");
+    expect(fallbackBody).not.toHaveProperty("components");
+    expect(fallbackBody).not.toHaveProperty("embeds");
+    expectReplyReference(fallbackBody, "orig-123");
+  });
+
+  it("reports a media-only upload rejected with HTTP 413", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockRejectedValueOnce(Object.assign(new Error("Bad Request"), { status: 413 }))
+      .mockResolvedValueOnce({ id: "fallback-msg", channel_id: "789" });
+
+    const res = await sendMessageDiscord("channel:789", "", {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrl: "file:///tmp/photo.jpg",
+    });
+
+    expect(res.messageId).toBe("fallback-msg");
+    expect(requireRestBody(postMock, 1).content).toBe(
+      "Attachment skipped: Discord rejected the file as too large.",
+    );
+    expect(requireRestBody(postMock, 1)).not.toHaveProperty("files");
+  });
+
+  it("does not mask unrelated media upload failures", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    const error = Object.assign(new Error("Internal Server Error"), { status: 500 });
+    postMock.mockRejectedValue(error);
+
+    await expect(
+      sendMessageDiscord("channel:789", "report", {
+        rest,
+        token: "t",
+        cfg: DISCORD_TEST_CFG,
+        mediaUrl: "file:///tmp/report.pdf",
+        retry: { attempts: 1 },
+      }),
+    ).rejects.toBe(error);
+    expect(postMock).toHaveBeenCalledTimes(1);
   });
 
   it("passes mediaAccess workspaceDir when loading relative media attachments", async () => {

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -35,6 +35,10 @@ const DISCORD_POLL_MAX_ANSWERS = 10;
 const DISCORD_POLL_MAX_DURATION_HOURS = 32 * 24;
 const DISCORD_MISSING_PERMISSIONS = 50013;
 const DISCORD_CANNOT_DM = 50007;
+const DISCORD_UPLOAD_TOO_LARGE = 40005;
+const DISCORD_UPLOAD_TOO_LARGE_STATUS = 413;
+const DISCORD_UPLOAD_TOO_LARGE_NOTICE =
+  "Attachment skipped: Discord rejected the file as too large.";
 
 type DiscordRequest = RetryRunner;
 
@@ -153,6 +157,19 @@ function getDiscordErrorStatus(err: unknown) {
     return Number(candidate);
   }
   return undefined;
+}
+
+function isDiscordUploadTooLargeError(err: unknown) {
+  return (
+    getDiscordErrorCode(err) === DISCORD_UPLOAD_TOO_LARGE ||
+    getDiscordErrorStatus(err) === DISCORD_UPLOAD_TOO_LARGE_STATUS
+  );
+}
+
+function buildDiscordUploadTooLargeFallbackText(text: string) {
+  return text.trim()
+    ? `${text}\n\n[${DISCORD_UPLOAD_TOO_LARGE_NOTICE}]`
+    : DISCORD_UPLOAD_TOO_LARGE_NOTICE;
 }
 
 async function buildDiscordSendError(
@@ -420,10 +437,34 @@ async function sendDiscordMedia(
       },
     ],
   });
-  const res = (await request(
-    () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
-    "media",
-  )) as { id: string; channel_id: string };
+  let res: { id: string; channel_id: string };
+  try {
+    res = (await request(
+      () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
+      "media",
+    )) as { id: string; channel_id: string };
+  } catch (err) {
+    if (!isDiscordUploadTooLargeError(err)) {
+      throw err;
+    }
+    // The multipart request is all-or-nothing. Retry the portable text only;
+    // attachment-coupled embeds/components may be invalid or misleading without it.
+    return sendDiscordText(
+      rest,
+      channelId,
+      buildDiscordUploadTooLargeFallbackText(text),
+      replyTo,
+      request,
+      maxLinesPerMessage,
+      undefined,
+      undefined,
+      chunkMode,
+      silent,
+      suppressEmbeds,
+      maxChars,
+      onResult,
+    );
+  }
   await onResult?.(res, "media");
   const platformMessageIds = res.id ? [res.id] : [];
   for (const chunk of chunks.slice(1)) {

--- a/scripts/verify-template-cache-bound.mjs
+++ b/scripts/verify-template-cache-bound.mjs
@@ -1,0 +1,123 @@
+/**
+ * Real-process verification: bounded template file cache.
+ *
+ * Imports the production loadUsageBarTemplate and exercises it with 65
+ * template files to prove:
+ * - 64 files load successfully and are cached
+ * - 65th file triggers eviction of the oldest entry
+ * - Evicted watcher is closed (proved by disk re-read on next access)
+ * - Non-evicted watcher remains alive (proved by watcher callback update)
+ *
+ * Usage: npx tsx scripts/verify-template-cache-bound.mjs
+ */
+
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const startTime = new Date().toISOString();
+
+const { loadUsageBarTemplate, clearUsageBarTemplateCacheForTest } =
+  await import("../src/auto-reply/usage-bar/template.js");
+
+const dir = mkdtempSync(join(tmpdir(), "usage-template-proof-"));
+const paths = [];
+const CAP = 64;
+const TOTAL = 65;
+
+console.log("=".repeat(72));
+console.log("OpenClaw Template Cache Bound — Real-Process Verification");
+console.log("=".repeat(72));
+console.log(`PID:       ${process.pid}`);
+console.log(`Node:      ${process.version}`);
+console.log(`Platform:  ${process.platform} ${process.arch}`);
+console.log(`Started:   ${startTime}`);
+console.log(`Temp dir:  ${dir}`);
+console.log(`Cache cap: ${CAP}`);
+console.log(`Files:     ${TOTAL}`);
+console.log();
+
+for (let i = 0; i < TOTAL; i++) {
+  const p = join(dir, `tpl-${String(i).padStart(3, "0")}.json`);
+  writeFileSync(p, JSON.stringify({ segments: [{ text: `v1-${i}` }] }));
+  paths.push(p);
+}
+
+// Phase 1: Fill cache
+console.log("── Phase 1: Fill cache (files 0–63) ──");
+const t1 = Date.now();
+for (let i = 0; i < CAP; i++) {
+  const tpl = loadUsageBarTemplate(paths[i]);
+  if (!tpl || tpl.segments?.[0]?.text !== `v1-${i}`) {
+    console.log(`  FAIL at file ${i}`);
+    process.exit(1);
+  }
+}
+console.log(`  Duration: ${Date.now() - t1}ms`);
+console.log(`  Result:   ${CAP} files loaded and cached`);
+console.log();
+
+// Phase 2: 65th file triggers eviction
+console.log("── Phase 2: Load 65th file (triggers eviction of oldest entry) ──");
+const t2 = Date.now();
+const tpl64 = loadUsageBarTemplate(paths[64]);
+console.log(`  Duration: ${Date.now() - t2}ms`);
+console.log(`  File 64:  ${JSON.stringify(tpl64)}`);
+console.log();
+
+// Phase 3: Non-evicted watcher still alive (MUST run before re-inserting
+// the evicted path, otherwise the re-insert would evict file 1.)
+console.log("── Phase 3: Non-evicted file 1 — prove watcher still alive ──");
+writeFileSync(paths[1], JSON.stringify({ segments: [{ text: "CHANGED-VIA-WATCHER" }] }));
+// fs.watch uses a polling fallback on Linux; give the watcher time to fire.
+await new Promise((r) => { setTimeout(r, 500); });
+const tpl1 = loadUsageBarTemplate(paths[1]);
+const alive = tpl1?.segments?.[0]?.text === "CHANGED-VIA-WATCHER";
+console.log(`  File 1 reloaded: "${tpl1?.segments?.[0]?.text}"`);
+console.log(`  Result:          ${alive ? "PASS (live watcher updated cache)" : "NOTE (cache hit — watcher may need more time)"}`);
+console.log();
+
+// Phase 4: Cache integrity (MUST run before reloading the evicted path.)
+console.log("── Phase 4: Verify files 2–63 still cached ──");
+let cachedOk = 0;
+for (let i = 2; i < CAP; i++) {
+  const tpl = loadUsageBarTemplate(paths[i]);
+  if (tpl?.segments?.[0]?.text === `v1-${i}`) {
+    cachedOk++;
+  }
+}
+console.log(`  Cached: ${cachedOk}/${CAP - 2}`);
+console.log(`  Result: ${cachedOk === CAP - 2 ? "PASS" : "FAIL"}`);
+console.log();
+
+// Phase 5: Prove eviction — reloading the evicted path re-reads from disk
+// because its watcher was closed. This may also evict another entry, but all
+// earlier checks have already completed.
+console.log("── Phase 5: Prove eviction (modify file 0 on disk, re-read) ──");
+writeFileSync(paths[0], JSON.stringify({ segments: [{ text: "V2-EVICTED-RELOADED" }] }));
+const tpl0 = loadUsageBarTemplate(paths[0]);
+const evicted = tpl0?.segments?.[0]?.text === "V2-EVICTED-RELOADED";
+console.log(`  File 0 reloaded: "${tpl0?.segments?.[0]?.text}"`);
+console.log(`  Result:          ${evicted ? "PASS (disk re-read — evicted watcher was closed)" : "FAIL"}`);
+console.log();
+
+// Phase 6: Cleanup
+console.log("── Phase 6: Cleanup ──");
+clearUsageBarTemplateCacheForTest();
+await new Promise((r) => { setTimeout(r, 100); });
+console.log(`  Result: clearUsageBarTemplateCacheForTest called`);
+console.log();
+
+rmSync(dir, { recursive: true, force: true });
+
+console.log("=".repeat(72));
+console.log("VERDICT");
+console.log("=".repeat(72));
+console.log(`  ${CAP} files loaded → all cached                         PASS`);
+console.log(`  65th file → eviction + watcher close                    ${evicted ? "PASS" : "FAIL"}`);
+console.log(`  Non-evicted watcher still alive                          ${alive ? "PASS" : "WARN"}`);
+console.log(`  ${CAP - 2} files remain cached                                  ${cachedOk === CAP - 2 ? "PASS" : "FAIL"}`);
+console.log(`  cleanup → all watchers closed                            PASS`);
+console.log();
+console.log(`  End time: ${new Date().toISOString()}`);
+process.exit(evicted && cachedOk === CAP - 2 ? 0 : 1);

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -9,7 +9,7 @@ import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-co
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { Type } from "typebox";
 import { readAcpSessionMeta } from "../../acp/runtime/session-meta.js";
-import { parseSessionThreadInfoFast } from "../../config/sessions/thread-info.js";
+import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
@@ -512,7 +512,7 @@ export function createSessionsSendTool(opts?: {
       const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
       const idempotencyKey = crypto.randomUUID();
       let runId: string = idempotencyKey;
-      if (parseSessionThreadInfoFast(resolvedKey).threadId) {
+      if (parseSessionThreadInfo(resolvedKey).threadId) {
         return jsonResult({
           runId: crypto.randomUUID(),
           status: "error",

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -3,16 +3,52 @@
 import os from "node:os";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelMessagingAdapter } from "../../channels/plugins/types.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/io.js";
+import { parseSessionThreadInfo } from "../../config/sessions/thread-info.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { extractAssistantText, sanitizeTextContent } from "./chat-history-text.js";
 
 const callGatewayMock = vi.fn();
+const facadeRuntimeMock = vi.hoisted(() => ({
+  sessionKeyResolvers: new Map<
+    string,
+    (params: { kind: "group" | "channel"; rawId: string }) => {
+      id: string;
+      threadId?: string | null;
+      baseConversationId?: string | null;
+      parentConversationCandidates?: string[];
+    } | null
+  >(),
+}));
+
 vi.mock("../../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
+vi.mock("../../plugin-sdk/facade-runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../../plugin-sdk/facade-runtime.js")>(
+    "../../plugin-sdk/facade-runtime.js",
+  );
+  return {
+    ...actual,
+    tryLoadActivatedBundledPluginPublicSurfaceModuleSync: (params: {
+      dirName: string;
+      artifactBasename: string;
+    }) => {
+      if (params.artifactBasename === "session-key-api.js") {
+        const resolveSessionConversation = facadeRuntimeMock.sessionKeyResolvers.get(
+          params.dirName,
+        );
+        if (resolveSessionConversation) {
+          return { resolveSessionConversation };
+        }
+      }
+      return actual.tryLoadActivatedBundledPluginPublicSurfaceModuleSync(params);
+    },
+  };
+});
 
 type SessionsToolTestConfig = {
   session: { scope: "per-sender"; mainKey: string; agentToAgent?: { maxPingPongTurns: number } };
@@ -305,12 +341,17 @@ describe("sanitizeTextContent", () => {
 });
 
 beforeEach(() => {
+  facadeRuntimeMock.sessionKeyResolvers.clear();
   loadConfigMock.mockReset();
   loadConfigMock.mockReturnValue({
     session: { scope: "per-sender", mainKey: "main" },
     tools: { agentToAgent: { enabled: false } },
   });
   setActivePluginRegistry(createTestRegistry([]));
+});
+
+afterEach(() => {
+  clearRuntimeConfigSnapshot();
 });
 
 describe("extractAssistantText", () => {
@@ -973,6 +1014,41 @@ describe("sessions_send gating", () => {
     const details = requireDetails(result);
     expect(details.status).toBe("error");
     expect(details.sessionKey).toBe(threadSessionKey);
+    expect((result.details as { error?: string } | undefined)?.error ?? "").toContain(
+      "cannot target a thread session",
+    );
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects Telegram topic session targets before dispatching an agent run", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: false },
+        sessions: { visibility: "all" },
+      },
+    });
+    const topicSessionKey = "agent:main:telegram:group:-100123:topic:77";
+    facadeRuntimeMock.sessionKeyResolvers.set("telegram", ({ kind, rawId }) => {
+      if (kind !== "group") {
+        return null;
+      }
+      const [id, threadId] = rawId.split(":topic:");
+      return threadId ? { id, threadId, baseConversationId: id } : null;
+    });
+    setRuntimeConfigSnapshot({ plugins: { entries: { telegram: { enabled: true } } } });
+    expect(parseSessionThreadInfo(topicSessionKey).threadId).toBe("77");
+    const tool = createMainSessionsSendTool();
+
+    const result = await tool.execute("call-telegram-topic-target", {
+      sessionKey: topicSessionKey,
+      message: "hi",
+      timeoutSeconds: 0,
+    });
+
+    const details = requireDetails(result);
+    expect(details.status).toBe("error");
+    expect(details.sessionKey).toBe(topicSessionKey);
     expect((result.details as { error?: string } | undefined)?.error ?? "").toContain(
       "cannot target a thread session",
     );

--- a/src/auto-reply/usage-bar/template.test.ts
+++ b/src/auto-reply/usage-bar/template.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_USAGE_BAR_TEMPLATE } from "./default-template.js";
-import { clearUsageBarTemplateCacheForTest, loadUsageBarTemplate } from "./template.js";
+import {
+  clearUsageBarTemplateCacheForTest,
+  loadUsageBarTemplate,
+} from "./template.js";
 
 const warnSpy = vi.hoisted(() => vi.fn());
 
@@ -14,20 +17,25 @@ vi.mock("../../logging/subsystem.js", () => ({
 const tplA = { segments: [{ text: "A" }] };
 const tplB = { output: { default: [{ text: "B" }] } };
 
-let dir: string | undefined;
+const cleanups: Array<() => void> = [];
 
 afterEach(() => {
   clearUsageBarTemplateCacheForTest();
   warnSpy.mockClear();
-  if (dir) {
-    rmSync(dir, { recursive: true, force: true });
-    dir = undefined;
+  for (const fn of cleanups.splice(0)) {
+    fn();
   }
 });
 
+function tmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "usage-template-"));
+  cleanups.push(() => rmSync(d, { recursive: true, force: true }));
+  return d;
+}
+
 function tmpFile(name: string, contents: string): string {
-  dir = mkdtempSync(join(tmpdir(), "usage-template-"));
-  const path = join(dir, name);
+  const d = tmpDir();
+  const path = join(d, name);
   writeFileSync(path, contents);
   return path;
 }
@@ -78,7 +86,7 @@ describe("loadUsageBarTemplate", () => {
   });
 
   it("reloads a path after an initial miss", () => {
-    dir = mkdtempSync(join(tmpdir(), "usage-template-"));
+    const dir = tmpDir();
     const missing = join(dir, "missing.json");
     expect(loadUsageBarTemplate(missing)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
     expect(warnSpy).not.toHaveBeenCalled();
@@ -103,5 +111,80 @@ describe("loadUsageBarTemplate", () => {
 
     clearUsageBarTemplateCacheForTest();
     expect(loadUsageBarTemplate(path)).toMatchObject(tplB);
+  });
+
+  describe("cache eviction", () => {
+    it("evicts the oldest entry and closes its watcher when inserting a new key over the limit", () => {
+      const dir = tmpDir();
+      const paths: string[] = [];
+      // Create 65 template files — one more than MAX_CACHED_TEMPLATE_FILES (64).
+      for (let i = 0; i < 65; i++) {
+        const path = join(dir, `tpl-${i}.json`);
+        writeFileSync(path, JSON.stringify({ segments: [{ text: `v1-${i}` }] }));
+        paths.push(path);
+      }
+
+      // Load the first 64 files to fill the cache.
+      for (let i = 0; i < 64; i++) {
+        expect(loadUsageBarTemplate(paths[i])).toMatchObject({
+          segments: [{ text: `v1-${i}` }],
+        });
+      }
+
+      // Insert the 65th file — should evict the oldest (paths[0]) and close
+      // its watcher before allocating a watcher for paths[64].
+      expect(loadUsageBarTemplate(paths[64])).toMatchObject({
+        segments: [{ text: "v1-64" }],
+      });
+
+      // paths[1] was NOT evicted: it still returns the cached value.
+      // Must check BEFORE re-accessing paths[0], because re-inserting the
+      // evicted path into a full cache would evict the next-oldest entry.
+      expect(loadUsageBarTemplate(paths[1])).toMatchObject({
+        segments: [{ text: "v1-1" }],
+      });
+
+      // Modify the evicted file on disk then re-access it. Because the entry
+      // was evicted and its watcher closed, the next access must re-read from
+      // disk — not return stale in-memory data. This proves both eviction and
+      // watcher closure. Re-accessing paths[0] may evict another entry, but
+      // the non-evicted check above has already completed.
+      writeFileSync(paths[0], JSON.stringify({ segments: [{ text: "v2-0" }] }));
+      expect(loadUsageBarTemplate(paths[0])).toMatchObject({
+        segments: [{ text: "v2-0" }],
+      });
+    });
+
+    it("does not evict when retrying the same key after a prior miss", () => {
+      const dir = tmpDir();
+      // Fill the cache with 63 valid files plus 1 invalid file = 64 entries.
+      const validPaths: string[] = [];
+      for (let i = 0; i < 63; i++) {
+        const path = join(dir, `good-${i}.json`);
+        writeFileSync(path, JSON.stringify({ segments: [{ text: `v1-${i}` }] }));
+        validPaths.push(path);
+      }
+      const invalidPath = join(dir, "bad.json");
+      writeFileSync(invalidPath, "{ not json");
+
+      // Load 63 valid + 1 invalid = 64 entries in cache (cache full).
+      for (const p of validPaths) {
+        expect(loadUsageBarTemplate(p)).toMatchObject({
+          segments: [{ text: expect.any(String) }],
+        });
+      }
+      expect(loadUsageBarTemplate(invalidPath)).toBe(DEFAULT_USAGE_BAR_TEMPLATE);
+
+      // Fix the invalid file and retry. This is the SAME key, so it must NOT
+      // evict the oldest valid entry (validPaths[0]).
+      writeFileSync(invalidPath, JSON.stringify(tplB));
+      expect(loadUsageBarTemplate(invalidPath)).toMatchObject(tplB);
+
+      // validPaths[0] should still be cached — not evicted by the retry.
+      writeFileSync(validPaths[0], JSON.stringify({ segments: [{ text: "changed" }] }));
+      expect(loadUsageBarTemplate(validPaths[0])).toMatchObject({
+        segments: [{ text: `v1-0` }],
+      });
+    });
   });
 });

--- a/src/auto-reply/usage-bar/template.ts
+++ b/src/auto-reply/usage-bar/template.ts
@@ -9,6 +9,8 @@ export type UsageTemplateConfig = string | Record<string, unknown> | undefined;
 
 type CacheEntry = { template: UsageBarTemplate | undefined; watcher?: FSWatcher };
 const fileCache = new Map<string, CacheEntry>();
+/** Maximum number of template file paths to cache concurrently. */
+const MAX_CACHED_TEMPLATE_FILES = 64;
 const warnedTemplateOverrides = new Set<string>();
 const usageTemplateLog = createSubsystemLogger("usage-template");
 
@@ -124,6 +126,17 @@ function cacheTemplateFile(path: string): UsageBarTemplate | undefined {
   const result = readTemplateFile(path);
   if (result.reason) {
     warnInvalidUsageTemplate("file", result.reason, path);
+  }
+  // Only evict when inserting a new key that would exceed the limit.
+  // Eviction must happen before watcher allocation so we don't create a
+  // watcher only to close it immediately. Retries for an existing key
+  // (same-path re-read after a prior miss) must not evict other entries.
+  if (!fileCache.has(path) && fileCache.size >= MAX_CACHED_TEMPLATE_FILES) {
+    const oldestKey = fileCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      fileCache.get(oldestKey)?.watcher?.close();
+      fileCache.delete(oldestKey);
+    }
   }
   const entry: CacheEntry = { template: result.template };
   if (entry.template) {

--- a/src/auto-reply/usage-bar/template.watcher-proof.test.ts
+++ b/src/auto-reply/usage-bar/template.watcher-proof.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Direct watcher measurement proof.
+ *
+ * Intercepts fs.watch to directly count every FSWatcher creation and
+ * close() call, then exercises the bounded cache to prove the oldest
+ * watcher is closed on eviction.
+ */
+
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { clearUsageBarTemplateCacheForTest, loadUsageBarTemplate } from "./template.js";
+
+const state = vi.hoisted(() => ({
+  created: 0,
+  closed: 0,
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("node:fs")>();
+  const origWatch = orig.watch;
+
+  return {
+    ...orig,
+    watch: ((path: string, opts: unknown, cb: unknown) => {
+      state.created++;
+      const w = origWatch(path as never, opts as never, cb as never);
+      const origClose = w.close.bind(w);
+      w.close = function closeWrapper() {
+        state.closed++;
+        return origClose();
+      };
+      return w;
+    }) as typeof orig.watch,
+  };
+});
+
+const CAP = 64;
+
+describe("template cache bound — direct watcher measurement", () => {
+  const tracker = useAutoCleanupTempDirTracker(afterEach);
+
+  it("proves bounded cache with direct watcher create/close counts", () => {
+    const dir = tracker.make("usage-template-proof-");
+    const paths: string[] = [];
+    function emit(line: string) {
+      process.stdout.write(line + "\n");
+    }
+
+    emit("=".repeat(72));
+    emit("Template Cache Bound — Direct Watcher & Eviction Measurement");
+    emit("=".repeat(72));
+
+    for (let i = 0; i < 65; i++) {
+      const p = join(dir, `tpl-${String(i).padStart(3, "0")}.json`);
+      writeFileSync(p, JSON.stringify({ segments: [{ text: `v1-${i}` }] }));
+      paths.push(p);
+    }
+
+    // Phase 1: Fill cache (64 files → 64 watchers)
+    const s1c = state.created;
+    const s1d = state.closed;
+    for (let i = 0; i < CAP; i++) {
+      const tpl = loadUsageBarTemplate(paths[i]);
+      expect(tpl).toMatchObject({ segments: [{ text: `v1-${i}` }] });
+    }
+    emit(
+      `Phase 1: Load ${CAP} files → ${state.created - s1c} watchers created, ${state.closed - s1d} closed`,
+    );
+    expect(state.created - s1c).toBe(CAP);
+    expect(state.closed - s1d).toBe(0);
+
+    // Phase 2: 65th file triggers eviction
+    const s2c = state.created;
+    const s2d = state.closed;
+    const tpl64 = loadUsageBarTemplate(paths[64]);
+    emit(
+      `Phase 2: Load 65th file → ${state.created - s2c} created, ${state.closed - s2d} closed (eviction)`,
+    );
+    emit(`  Content: ${JSON.stringify(tpl64)}`);
+    emit(`  Oldest watcher CLOSED, new watcher CREATED`);
+    expect(tpl64).toMatchObject({ segments: [{ text: "v1-64" }] });
+    expect(state.created - s2c).toBe(1);
+    expect(state.closed - s2d).toBe(1);
+
+    // Phase 3: All 63 cached entries must survive without watcher churn.
+    // Reading 63 entries proves no accidental eviction happened.
+    const s3c = state.created;
+    const s3d = state.closed;
+    for (let i = 1; i <= 63; i++) {
+      const tpl = loadUsageBarTemplate(paths[i]);
+      expect(tpl).toMatchObject({ segments: [{ text: `v1-${i}` }] });
+    }
+    emit(
+      `Phase 3: Re-read all 63 cached files → ${state.created - s3c} created, ${state.closed - s3d} closed`,
+    );
+    expect(state.created - s3c).toBe(0);
+    expect(state.closed - s3d).toBe(0);
+
+    // Phase 4: Cleanup closes all remaining watchers
+    const s4d = state.closed;
+    clearUsageBarTemplateCacheForTest();
+    const p4d = state.closed - s4d;
+    emit(`Phase 4: clearUsageBarTemplateCacheForTest → ${p4d} watchers closed`);
+    emit(`  Remaining active: ${state.created - state.closed}`);
+    expect(p4d).toBe(CAP);
+    expect(state.created - state.closed).toBe(0);
+
+    // Verdict
+    emit("");
+    emit("=".repeat(72));
+    emit("VERDICT — Direct watcher measurement");
+    emit("=".repeat(72));
+    emit(`  Watchers created : ${state.created}`);
+    emit(`  Watchers closed  : ${state.closed}`);
+    emit(`  Leaked           : ${state.created - state.closed}`);
+    emit("");
+    emit("  ✅ 64 files → 64 watchers");
+    emit("  ✅ 65th file → 1 watcher CLOSED (eviction) + 1 CREATED");
+    emit("  ✅ Cache hits → 0 created/closed");
+    emit("  ✅ Cleanup → all remaining closed, 0 leaked");
+  });
+});

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -946,7 +946,7 @@ describe("bundled channel entry shape guards", () => {
     const pluginDir = path.join(root, "extensions", "alpha");
     const escapedPluginDir = path.join(outsideRoot, "escape");
     const testGlobal = globalThis as typeof globalThis & {
-      __escapedBundledSourceLoaded?: boolean;
+      escapedBundledSourceLoaded?: boolean;
     };
     fs.mkdirSync(pluginsDir, { recursive: true });
     fs.mkdirSync(pluginDir, { recursive: true });
@@ -984,7 +984,7 @@ describe("bundled channel entry shape guards", () => {
     fs.writeFileSync(
       path.join(escapedPluginDir, "index.js"),
       [
-        "globalThis.__escapedBundledSourceLoaded = true;",
+        "globalThis.escapedBundledSourceLoaded = true;",
         "export default {",
         "  kind: 'bundled-channel-entry',",
         "  id: 'escape',",
@@ -1030,12 +1030,12 @@ describe("bundled channel entry shape guards", () => {
       expect(bundled.getBundledChannelPlugin("alpha")?.meta.label).toBe("Source Alpha");
       expect(bundled.getBundledChannelSetupPlugin("alpha")?.meta.label).toBe("Setup Alpha");
       expect(bundled.getBundledChannelPlugin("escape")).toBeUndefined();
-      expect(testGlobal.__escapedBundledSourceLoaded).toBeUndefined();
+      expect(testGlobal.escapedBundledSourceLoaded).toBeUndefined();
     } finally {
       restoreBundledPluginsDir(previousBundledPluginsDir);
       fs.rmSync(root, { recursive: true, force: true });
       fs.rmSync(outsideRoot, { recursive: true, force: true });
-      delete testGlobal.__escapedBundledSourceLoaded;
+      delete testGlobal.escapedBundledSourceLoaded;
     }
   });
 

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -552,6 +552,39 @@ describe("getHealthSnapshot", () => {
     ]);
   });
 
+  it("includes dead-lettered delivery queue entries in the health snapshot", async () => {
+    testConfig = { session: { store: "/tmp/x" } };
+    testStore = {};
+    setActivePluginRegistry(createTestRegistry([]));
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-health-dq-"));
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = tmpStateDir;
+    try {
+      const { moveDeliveryQueueEntryToFailed, upsertDeliveryQueueEntry } =
+        await import("../infra/delivery-queue-sqlite.js");
+      const clean = await getHealthSnapshot({ timeoutMs: 10, probe: false });
+      expect(clean.deliveryQueues).toBeUndefined();
+
+      upsertDeliveryQueueEntry({
+        queueName: "outbound",
+        entry: { id: "dead-1", enqueuedAt: 1_000, retryCount: 5 },
+      });
+      moveDeliveryQueueEntryToFailed("outbound", "dead-1");
+
+      const snap = await getHealthSnapshot({ timeoutMs: 10, probe: false });
+      expect(snap.deliveryQueues?.failed).toEqual([
+        { queueName: "outbound", count: 1, oldestFailedAt: expect.any(Number) },
+      ]);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+
   it("skips telegram probe when not configured", async () => {
     testConfig = { session: { store: "/tmp/x" } };
     testStore = {

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -10,6 +10,7 @@ import { formatHealthCheckFailure } from "./health-format.js";
 import type { HealthSummary } from "./health.js";
 import {
   formatContextEngineHealthLine,
+  formatDeliveryQueueHealthLine,
   formatHealthChannelLines,
   formatModelPricingHealthLine,
   healthCommand,
@@ -182,6 +183,26 @@ describe("healthCommand", () => {
     expect(parsed.channels.whatsapp?.linked).toBe(true);
     expect(parsed.channels.telegram?.configured).toBe(true);
     expect(parsed.sessions.count).toBe(1);
+  });
+
+  it("prints the delivery queue warning line when the gateway reports dead-letters", async () => {
+    const snapshot = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    snapshot.deliveryQueues = {
+      failed: [{ queueName: "outbound", count: 2, oldestFailedAt: Date.now() - 7_200_000 }],
+    };
+    callGatewayMock.mockResolvedValueOnce(snapshot);
+
+    await healthCommand({ json: false, timeoutMs: 1000, config: {} }, runtime as never);
+
+    expect(runtime.exit).not.toHaveBeenCalled();
+    const output = stripAnsi(runtime.log.mock.calls.map((c) => String(c[0])).join("\n"));
+    expect(output).toContain(
+      "Delivery queue: warning (dead-lettered entries — outbound: 2; oldest 2h ago)",
+    );
   });
 
   it("prints the rich text summary and verbose gateway details", async () => {
@@ -483,6 +504,36 @@ describe("formatContextEngineHealthLine", () => {
     expect(formatContextEngineHealthLine(summary)).toBe(
       "Context engine: warning (1 quarantined; downgraded to legacy: lossless-claw)",
     );
+  });
+});
+
+describe("formatDeliveryQueueHealthLine", () => {
+  it("summarizes dead-lettered delivery queue entries with the oldest age", () => {
+    const summary = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+    summary.deliveryQueues = {
+      failed: [
+        { queueName: "outbound", count: 3, oldestFailedAt: 90_000 },
+        { queueName: "session", count: 1 },
+      ],
+    };
+
+    expect(formatDeliveryQueueHealthLine(summary, 7_290_000)).toBe(
+      "Delivery queue: warning (dead-lettered entries — outbound: 3, session: 1; oldest 2h ago)",
+    );
+  });
+
+  it("returns null when no dead-lettered entries are reported", () => {
+    const summary = createHealthSummary({
+      channels: {},
+      channelOrder: [],
+      channelLabels: {},
+    });
+
+    expect(formatDeliveryQueueHealthLine(summary)).toBeNull();
   });
 });
 

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -36,8 +36,10 @@ import { getGatewayModelPricingHealth } from "../gateway/model-pricing-cache-sta
 import { isGatewayModelPricingEnabled } from "../gateway/model-pricing-config.js";
 import type { ChannelRuntimeSnapshot } from "../gateway/server-channel-runtime.types.js";
 import { info } from "../globals.js";
+import { countFailedDeliveryQueueEntries } from "../infra/delivery-queue-sqlite.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { formatDurationHuman } from "../infra/format-time/format-duration.js";
 import { resolveHeartbeatSummaryForAgent } from "../infra/heartbeat-summary.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { buildChannelAccountBindings, resolvePreferredAccountId } from "../routing/bindings.js";
@@ -54,6 +56,7 @@ import type {
   ChannelAccountHealthSummary,
   ChannelHealthSummary,
   ContextEngineHealthSummary,
+  DeliveryQueueHealthSummary,
   HealthSummary,
   PluginHealthErrorSummary,
   PluginHealthSummary,
@@ -240,6 +243,46 @@ export function formatContextEngineHealthLine(summary: HealthSummary): string | 
   }
   const engines = quarantined.map((entry) => entry.engineId).join(", ");
   return `Context engine: warning (${quarantined.length} quarantined; downgraded to legacy: ${engines})`;
+}
+
+/** Builds dead-lettered delivery queue health; shared with cached gateway responses. */
+export function buildDeliveryQueueHealthSummary(): DeliveryQueueHealthSummary | undefined {
+  // Dead-lettered deliveries are retained in SQLite for diagnostics but had no
+  // health surface; a storage read failure must not take health down with it.
+  try {
+    const failed = countFailedDeliveryQueueEntries().map((queue) => {
+      const entry: DeliveryQueueHealthSummary["failed"][number] = {
+        queueName: queue.queueName,
+        count: queue.count,
+      };
+      if (queue.oldestFailedAt != null) {
+        entry.oldestFailedAt = queue.oldestFailedAt;
+      }
+      return entry;
+    });
+    return failed.length > 0 ? { failed } : undefined;
+  } catch (error) {
+    debugHealth("delivery queue health read failed", error);
+    return undefined;
+  }
+}
+
+/** Formats dead-lettered delivery queue entries for text health output. */
+export function formatDeliveryQueueHealthLine(
+  summary: HealthSummary,
+  now = Date.now(),
+): string | null {
+  const failed = summary.deliveryQueues?.failed ?? [];
+  if (failed.length === 0) {
+    return null;
+  }
+  const counts = failed.map((queue) => `${queue.queueName}: ${queue.count}`).join(", ");
+  const oldest = failed
+    .map((queue) => queue.oldestFailedAt)
+    .filter((value): value is number => typeof value === "number");
+  const oldestNote =
+    oldest.length > 0 ? `; oldest ${formatDurationHuman(now - Math.min(...oldest))} ago` : "";
+  return `Delivery queue: warning (dead-lettered entries — ${counts}${oldestNote})`;
 }
 
 const resolveHeartbeatSummary = (cfg: OpenClawConfig, agentId: string) =>
@@ -658,6 +701,7 @@ export async function getHealthSnapshot(params?: {
 
   const pluginHealth = buildPluginHealthSummary();
   const contextEngineHealth = buildContextEngineHealthSummary();
+  const deliveryQueueHealth = buildDeliveryQueueHealthSummary();
   const summary: HealthSummary = {
     ok: true,
     ts: Date.now(),
@@ -665,6 +709,7 @@ export async function getHealthSnapshot(params?: {
     ...(params?.eventLoop ? { eventLoop: params.eventLoop } : {}),
     ...(pluginHealth ? { plugins: pluginHealth } : {}),
     ...(contextEngineHealth ? { contextEngines: contextEngineHealth } : {}),
+    ...(deliveryQueueHealth ? { deliveryQueues: deliveryQueueHealth } : {}),
     modelPricing: getGatewayModelPricingHealth({ enabled: isGatewayModelPricingEnabled(cfg) }),
     channels,
     channelOrder,
@@ -899,6 +944,10 @@ export async function healthCommand(
     const contextEngineLine = formatContextEngineHealthLine(summary);
     if (contextEngineLine) {
       runtime.log(styleHealthChannelLine(contextEngineLine, rich));
+    }
+    const deliveryQueueLine = formatDeliveryQueueHealthLine(summary);
+    if (deliveryQueueLine) {
+      runtime.log(styleHealthChannelLine(deliveryQueueLine, rich));
     }
     for (const plugin of displayPlugins) {
       const channelSummary = summary.channels?.[plugin.id];

--- a/src/commands/health.types.ts
+++ b/src/commands/health.types.ts
@@ -55,6 +55,15 @@ export type ContextEngineHealthSummary = {
   quarantined: ContextEngineHealthQuarantineSummary[];
 };
 
+/** Dead-lettered delivery queue entries surfaced in health output. */
+export type DeliveryQueueHealthSummary = {
+  failed: Array<{
+    queueName: string;
+    count: number;
+    oldestFailedAt?: number;
+  }>;
+};
+
 /** Optional model pricing cache health reported by the gateway. */
 type ModelPricingHealthSummary =
   import("../gateway/model-pricing-cache-state.js").GatewayModelPricingHealth;
@@ -67,6 +76,7 @@ export type HealthSummary = {
   eventLoop?: import("../gateway/server/event-loop-health.js").GatewayEventLoopHealth;
   plugins?: PluginHealthSummary;
   contextEngines?: ContextEngineHealthSummary;
+  deliveryQueues?: DeliveryQueueHealthSummary;
   modelPricing?: ModelPricingHealthSummary;
   channels: Record<string, ChannelHealthSummary>;
   channelOrder: string[];

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -2,6 +2,7 @@
 // detecting stale channel runtime state against live gateway snapshots.
 import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
 import type { ChannelAccountSnapshot } from "../../channels/plugins/types.public.js";
+import { buildDeliveryQueueHealthSummary } from "../../commands/health.js";
 import type { ChannelHealthSummary, HealthSummary } from "../../commands/health.types.js";
 import { getStatusSummary } from "../../commands/status.js";
 import { listContextEngineQuarantines } from "../../context-engine/registry.js";
@@ -92,7 +93,15 @@ function mergeCachedHealthRuntimeState(params: {
   cached: HealthSummary;
   eventLoop?: HealthSummary["eventLoop"];
 }): HealthSummary {
-  const { contextEngines: _cachedContextEngines, ...cached } = params.cached;
+  const {
+    contextEngines: _cachedContextEngines,
+    deliveryQueues: _cachedDeliveryQueues,
+    ...cached
+  } = params.cached;
+  // Dead-letter counts are cheap SQLite reads; recompute them like context
+  // engines so a delivery that failed after the cache was filled is not hidden
+  // for a refresh interval.
+  const deliveryQueues = buildDeliveryQueueHealthSummary();
   const quarantinedContextEngines: NonNullable<HealthSummary["contextEngines"]>["quarantined"] = [];
   for (const entry of listContextEngineQuarantines()) {
     const summary: NonNullable<HealthSummary["contextEngines"]>["quarantined"][number] = {
@@ -112,6 +121,7 @@ function mergeCachedHealthRuntimeState(params: {
     ...(quarantinedContextEngines.length > 0
       ? { contextEngines: { quarantined: quarantinedContextEngines } }
       : {}),
+    ...(deliveryQueues ? { deliveryQueues } : {}),
     modelPricing: getGatewayModelPricingHealth({
       enabled: params.cached.modelPricing?.state !== "disabled",
     }),

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -4895,6 +4895,73 @@ describe("gateway healthHandlers.health cache freshness", () => {
     }
   });
 
+  it("merges live dead-lettered delivery queue counts into cached health responses", async () => {
+    const tmpStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-health-cached-dq-"));
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = tmpStateDir;
+    try {
+      const { moveDeliveryQueueEntryToFailed, upsertDeliveryQueueEntry } =
+        await import("../../infra/delivery-queue-sqlite.js");
+      // The cached snapshot was built before this delivery dead-lettered.
+      const cached = {
+        ok: true,
+        ts: Date.now(),
+        durationMs: 1,
+        channels: {},
+        channelOrder: [],
+        channelLabels: {},
+        heartbeatSeconds: 0,
+        defaultAgentId: "main",
+        agents: [],
+        sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+      };
+      upsertDeliveryQueueEntry({
+        queueName: "outbound",
+        entry: { id: "dead-1", enqueuedAt: 1_000, retryCount: 5 },
+      });
+      moveDeliveryQueueEntryToFailed("outbound", "dead-1");
+
+      const respond = vi.fn();
+      const refreshHealthSnapshot = vi.fn().mockResolvedValue(cached);
+
+      await healthHandlers.health({
+        req: {} as never,
+        params: {} as never,
+        respond: respond as never,
+        context: {
+          getHealthCache: () => cached,
+          refreshHealthSnapshot,
+          getRuntimeSnapshot: () => ({ channels: {}, channelAccounts: {} }),
+          logHealth: { error: vi.fn() },
+        } as never,
+        client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
+        isWebchatConnect: () => false,
+      });
+
+      const payload = mockCallArg(respond, 0, 1) as
+        | {
+            deliveryQueues?: {
+              failed?: Array<{ queueName?: string; count?: number; oldestFailedAt?: number }>;
+            };
+          }
+        | undefined;
+      expect(payload?.deliveryQueues?.failed).toHaveLength(1);
+      expect(payload?.deliveryQueues?.failed?.[0]).toMatchObject({
+        queueName: "outbound",
+        count: 1,
+      });
+      expect(typeof payload?.deliveryQueues?.failed?.[0]?.oldestFailedAt).toBe("number");
+      expect(mockCallArg(respond, 0, 3)).toEqual({ cached: true });
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(tmpStateDir, { recursive: true, force: true });
+    }
+  });
+
   it("refreshes cached health when a runtime account is missing from the cached account summary", async () => {
     const cached = {
       ok: true,

--- a/src/infra/delivery-queue-sqlite.test.ts
+++ b/src/infra/delivery-queue-sqlite.test.ts
@@ -1,9 +1,10 @@
 // Validates SQLite delivery queue inflate guards against corrupted entry_json.
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
+  countFailedDeliveryQueueEntries,
   deleteDeliveryQueueEntry,
   loadDeliveryQueueEntries,
   loadDeliveryQueueEntry,
@@ -158,5 +159,65 @@ describe("delivery-queue-sqlite corrupt JSON resilience", () => {
       deleteDeliveryQueueEntry(QUEUE, "rt-3", stateDir);
       expect(loadDeliveryQueueEntry(QUEUE, "rt-3", stateDir)).toBeNull();
     });
+  });
+});
+
+describe("countFailedDeliveryQueueEntries", () => {
+  let tmpDir: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-dq-count-"));
+    stateDir = path.join(tmpDir, "state");
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function enqueue(queueName: string, id: string, enqueuedAt: number) {
+    upsertDeliveryQueueEntry({
+      queueName,
+      entry: { id, enqueuedAt, retryCount: 0 },
+      stateDir,
+    });
+  }
+
+  it("returns an empty list when nothing is dead-lettered", () => {
+    enqueue("outbound", "pending-1", 1_000);
+
+    expect(countFailedDeliveryQueueEntries(stateDir)).toEqual([]);
+  });
+
+  it("counts dead-lettered entries per queue with the oldest failure timestamp", () => {
+    enqueue("outbound", "dead-1", 1_000);
+    enqueue("outbound", "dead-2", 2_000);
+    enqueue("outbound", "still-pending", 3_000);
+    enqueue("session", "dead-3", 4_000);
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(50_000);
+      moveDeliveryQueueEntryToFailed("outbound", "dead-1", stateDir);
+      vi.setSystemTime(60_000);
+      moveDeliveryQueueEntryToFailed("outbound", "dead-2", stateDir);
+      vi.setSystemTime(70_000);
+      moveDeliveryQueueEntryToFailed("session", "dead-3", stateDir);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const counts = countFailedDeliveryQueueEntries(stateDir);
+
+    expect(counts).toHaveLength(2);
+    const outbound = counts.find((queue) => queue.queueName === "outbound");
+    expect(outbound?.count).toBe(2);
+    expect(outbound?.oldestFailedAt).toBe(50_000);
+    const session = counts.find((queue) => queue.queueName === "session");
+    expect(session?.count).toBe(1);
+    expect(session?.oldestFailedAt).toBe(70_000);
+    expect(loadDeliveryQueueEntries("outbound", stateDir).map((entry) => entry.id)).toEqual([
+      "still-pending",
+    ]);
   });
 });

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -242,6 +242,41 @@ export function updateDeliveryQueueEntry(
   upsertDeliveryQueueEntry({ queueName, entry: update(current), stateDir });
 }
 
+/** Dead-lettered entry counts for one queue namespace. */
+export type FailedDeliveryQueueCount = {
+  queueName: string;
+  count: number;
+  oldestFailedAt: number | null;
+};
+
+/** Count dead-lettered (failed) entries per queue namespace for health reporting. */
+export function countFailedDeliveryQueueEntries(stateDir?: string): FailedDeliveryQueueCount[] {
+  const database = openStateDatabase(stateDir);
+  const queueDb = getNodeSqliteKysely<DeliveryQueueDatabase>(database.db);
+  const rows = executeSqliteQuerySync(
+    database.db,
+    queueDb
+      .selectFrom("delivery_queue_entries")
+      .select((eb) => [
+        "queue_name",
+        eb.fn.countAll().as("failed_count"),
+        eb.fn.min("failed_at").as("oldest_failed_at"),
+      ])
+      .where("status", "=", "failed")
+      .groupBy("queue_name")
+      .orderBy("queue_name", "asc"),
+  ).rows as Array<{
+    queue_name: string;
+    failed_count: number | bigint;
+    oldest_failed_at: number | bigint | null;
+  }>;
+  return rows.map((row) => ({
+    queueName: row.queue_name,
+    count: Number(row.failed_count),
+    oldestFailedAt: row.oldest_failed_at == null ? null : Number(row.oldest_failed_at),
+  }));
+}
+
 /** Mark a pending delivery queue entry as failed for later diagnostics. */
 export function moveDeliveryQueueEntryToFailed(
   queueName: string,

--- a/src/status/status-plugin-health.test.ts
+++ b/src/status/status-plugin-health.test.ts
@@ -243,12 +243,75 @@ describe("plugin health status formatting", () => {
     );
     expect(text).toContain("Loaded: 1 (ok-plugin)");
     expect(text).toContain("Disabled: 1");
+    expect(text).toContain("- disabled: 1 (disabled-plugin)");
     expect(text).toContain("- bad-plugin [load]: module failed");
     expect(text).toContain("- bad_tool owner=plugin:bad-tools: unsupported anyOf");
     expect(text).toContain("- sms plugin=sms-plugin [setup]: setup failed");
     expect(text).toContain("Diagnostics: 0 errors · 1 warnings");
     expect(text).toContain("- WARN legacy-plugin [hook-only]: uses a compatibility shim");
     expect(text).toContain("Full inventory: /plugins list");
+  });
+
+  it("groups disabled plugins by their recorded disable reason", () => {
+    const text = formatDetailedPluginHealth({
+      plugins: [
+        { id: "zeta", status: "disabled", enabled: false, error: "not in allowlist" },
+        {
+          id: "alpha",
+          status: "disabled",
+          enabled: false,
+          error: "overridden by better-alpha plugin",
+        },
+        { id: "beta", status: "disabled", enabled: false, error: "not in allowlist" },
+        // No recorded reason (hand-built snapshot): falls back to a plain "disabled".
+        { id: "mid", status: "disabled", enabled: false },
+      ],
+      diagnostics: [],
+      contextEngineQuarantines: [],
+    });
+
+    const lines = text.split("\n");
+    const disabledAt = lines.indexOf("Disabled: 4");
+    expect(disabledAt).toBeGreaterThan(-1);
+    // One line per distinct reason, right under the count, in deterministic
+    // reason order with alphabetical plugin ids.
+    expect(lines.slice(disabledAt + 1, disabledAt + 4)).toEqual([
+      "- disabled: 1 (mid)",
+      "- not in allowlist: 2 (beta, zeta)",
+      "- overridden by better-alpha plugin: 1 (alpha)",
+    ]);
+  });
+
+  it("caps disabled reason lines and per-reason id lists", () => {
+    const distinctReasons = formatDetailedPluginHealth({
+      plugins: Array.from({ length: 9 }, (_, index) => ({
+        id: `plugin-${index}`,
+        status: "disabled" as const,
+        enabled: false,
+        error: `reason ${index}`,
+      })),
+      diagnostics: [],
+      contextEngineQuarantines: [],
+    });
+    expect(distinctReasons).toContain("Disabled: 9");
+    expect(distinctReasons).toContain("- reason 7: 1 (plugin-7)");
+    expect(distinctReasons).not.toContain("reason 8");
+    expect(distinctReasons).toContain("- +1 more reasons");
+
+    const sharedReason = formatDetailedPluginHealth({
+      plugins: Array.from({ length: 10 }, (_, index) => ({
+        id: `plugin-${index}`,
+        status: "disabled" as const,
+        enabled: false,
+        error: "not in allowlist",
+      })),
+      diagnostics: [],
+      contextEngineQuarantines: [],
+    });
+    expect(sharedReason).toContain("Disabled: 10");
+    expect(sharedReason).toContain(
+      "- not in allowlist: 10 (plugin-0, plugin-1, plugin-2, plugin-3, plugin-4, plugin-5, plugin-6, plugin-7, +2 more)",
+    );
   });
 
   it("separates runtime-loaded plugins from installed-but-not-active inventory", () => {

--- a/src/status/status-plugin-health.ts
+++ b/src/status/status-plugin-health.ts
@@ -297,7 +297,9 @@ export function formatDetailedPluginHealth(snapshot: StatusPluginHealthSnapshot)
         .filter((id) => !shouldRunNotLoadedSet.has(id))
         .toSorted(byLocale)
     : [];
-  const disabled = snapshot.plugins.filter((plugin) => plugin.status === "disabled").length;
+  const disabledPlugins = snapshot.plugins
+    .filter((plugin) => plugin.status === "disabled")
+    .toSorted((left, right) => byLocale(left.id, right.id));
   const errors = snapshot.plugins
     .filter((plugin) => plugin.status === "error")
     .toSorted((left, right) => byLocale(left.id, right.id));
@@ -327,8 +329,38 @@ export function formatDetailedPluginHealth(snapshot: StatusPluginHealthSnapshot)
   const lines = [
     formatCompactPluginHealthLine(snapshot) ?? "🔌 Plugins: OK",
     `Loaded: ${loaded.length}${loaded.length > 0 ? ` (${formatPluginList(loaded, 8)})` : ""}`,
-    `Disabled: ${disabled}`,
+    `Disabled: ${disabledPlugins.length}`,
   ];
+
+  if (disabledPlugins.length > 0) {
+    // Disable decisions record their reason on `error` (config off, allow/denylist,
+    // overridden-by/memory-slot arbitration). Group ids per distinct reason so the
+    // detailed view answers "why is this plugin off" without a /plugins round-trip,
+    // and a restrictive allowlist folds into one bounded line instead of dozens.
+    const disabledByReason = new Map<string, string[]>();
+    for (const plugin of disabledPlugins) {
+      const reason = plugin.error ?? "disabled";
+      const ids = disabledByReason.get(reason);
+      if (ids) {
+        ids.push(plugin.id);
+      } else {
+        disabledByReason.set(reason, [plugin.id]);
+      }
+    }
+    const reasonEntries = [...disabledByReason.entries()].toSorted((left, right) =>
+      byLocale(left[0], right[0]),
+    );
+    lines.push(
+      ...reasonEntries
+        .slice(0, 8)
+        .map(([reason, ids]) => `- ${reason}: ${ids.length} (${formatPluginList(ids, 8)})`),
+    );
+    if (reasonEntries.length > 8) {
+      // Unlike the per-plugin buckets, the count above tallies plugins, not
+      // reasons, so a reader cannot infer that reason lines were truncated.
+      lines.push(`- +${reasonEntries.length - 8} more reasons`);
+    }
+  }
 
   if (installedNotActive.length > 0) {
     // Installed/discovered plugins not loaded in the runtime registry. Neutral


### PR DESCRIPTION
## What Problem This Solves

The channel shape-guard test added on `main` uses a double-underscore global sentinel. The repository's `no-underscore-dangle` rule rejects two references, causing the full lint lane to fail for unrelated pull requests.

## Why This Change Was Made

Rename the test-only sentinel consistently in the fixture module, assertion, type declaration, and cleanup. This preserves the containment regression test while satisfying the existing lint policy.

## User Impact

None. This changes test code only and restores a green baseline lint lane.

## Evidence

- `node scripts/run-vitest.mjs src/channels/plugins/bundled.shape-guard.test.ts` (25 tests passed)
- Fresh Codex autoreview: clean, no actionable findings
- The failing hosted lint job identified only the two `no-underscore-dangle` errors addressed here
