### PR TITLE
fix(lmstudio): respect embedding preload context limits

### DIFF
--- a/extensions/lmstudio/src/embedding-provider.test.ts
+++ b/extensions/lmstudio/src/embedding-provider.test.ts
@@ -1,0 +1,115 @@
+// LM Studio embedding provider tests cover preload context-length precedence.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/plugin-entry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createLmstudioEmbeddingProvider } from "./embedding-provider.js";
+
+const ensureLmstudioModelLoadedMock = vi.hoisted(() =>
+  vi.fn(
+    async (_params?: { requestedContextLength?: number }) => "text-embedding-nomic-embed-text-v1.5",
+  ),
+);
+const resolveLmstudioProviderHeadersMock = vi.hoisted(() =>
+  vi.fn(async (_params?: unknown) => undefined),
+);
+const resolveLmstudioRuntimeApiKeyMock = vi.hoisted(() =>
+  vi.fn(async (_params?: unknown) => undefined),
+);
+
+vi.mock("./models.fetch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./models.fetch.js")>();
+  return {
+    ...actual,
+    ensureLmstudioModelLoaded: (params: { requestedContextLength?: number }) =>
+      ensureLmstudioModelLoadedMock(params),
+  };
+});
+
+vi.mock("./runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./runtime.js")>();
+  return {
+    ...actual,
+    resolveLmstudioProviderHeaders: (params: unknown) => resolveLmstudioProviderHeadersMock(params),
+    resolveLmstudioRuntimeApiKey: (params: unknown) => resolveLmstudioRuntimeApiKeyMock(params),
+  };
+});
+
+const EMBEDDING_MODEL = "text-embedding-nomic-embed-text-v1.5";
+
+function buildConfig(params: {
+  model?: Record<string, unknown>;
+  provider?: Record<string, unknown>;
+}): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        lmstudio: {
+          baseUrl: "http://localhost:1234/v1",
+          models: [{ id: EMBEDDING_MODEL, ...params.model }],
+          ...params.provider,
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+async function readRequestedContextLength(config: OpenClawConfig): Promise<unknown> {
+  await createLmstudioEmbeddingProvider({
+    config,
+    provider: "lmstudio",
+    model: EMBEDDING_MODEL,
+    fallback: "none",
+  });
+  expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+  return ensureLmstudioModelLoadedMock.mock.calls[0]?.[0]?.requestedContextLength;
+}
+
+describe("createLmstudioEmbeddingProvider preload context length", () => {
+  beforeEach(() => {
+    ensureLmstudioModelLoadedMock.mockClear();
+  });
+
+  it.each([
+    {
+      name: "model contextTokens before every fallback",
+      model: { contextTokens: 4096, contextWindow: 8192 },
+      provider: { contextTokens: 2048, contextWindow: 16384 },
+      expected: 4096,
+    },
+    {
+      name: "provider contextTokens as the model's effective cap",
+      model: { contextWindow: 8192 },
+      provider: { contextTokens: 4096, contextWindow: 16384 },
+      expected: 4096,
+    },
+    {
+      name: "model contextWindow when below the provider cap",
+      model: { contextWindow: 8192 },
+      provider: { contextTokens: 16384, contextWindow: 32768 },
+      expected: 8192,
+    },
+    {
+      name: "provider contextTokens when the model has no context fields",
+      provider: { contextTokens: 4096, contextWindow: 16384 },
+      expected: 4096,
+    },
+    {
+      name: "model contextWindow before provider contextWindow",
+      model: { contextWindow: 8192 },
+      provider: { contextWindow: 16384 },
+      expected: 8192,
+    },
+    {
+      name: "provider contextWindow as the final configured fallback",
+      provider: { contextWindow: 16384 },
+      expected: 16384,
+    },
+    {
+      name: "the loader default when no context is configured",
+      expected: undefined,
+    },
+  ])("uses $name", async ({ model, provider, expected }) => {
+    await expect(readRequestedContextLength(buildConfig({ model, provider }))).resolves.toBe(
+      expected,
+    );
+  });
+});

--- a/extensions/lmstudio/src/embedding-provider.ts
+++ b/extensions/lmstudio/src/embedding-provider.ts
@@ -9,9 +9,13 @@ import {
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { resolveMemorySecretInputString } from "openclaw/plugin-sdk/memory-core-host-secret";
 import { formatErrorMessage, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { LMSTUDIO_DEFAULT_EMBEDDING_MODEL, LMSTUDIO_PROVIDER_ID } from "./defaults.js";
 import { ensureLmstudioModelLoaded } from "./models.fetch.js";
-import { resolveLmstudioInferenceBase } from "./models.js";
+import {
+  normalizeLmstudioConfiguredCatalogEntries,
+  resolveLmstudioInferenceBase,
+} from "./models.js";
 import {
   buildLmstudioAuthHeaders,
   resolveLmstudioProviderHeaders,
@@ -63,6 +67,31 @@ async function resolveLmstudioApiKey(
     }
     throw error;
   }
+}
+
+function resolveEmbeddingPreloadContextLength(params: {
+  model: string;
+  models: unknown;
+  providerContextTokens: unknown;
+  providerContextWindow: unknown;
+}): number | undefined {
+  const configuredModel = normalizeLmstudioConfiguredCatalogEntries(params.models).find(
+    (entry) => normalizeLmstudioModel(entry.id) === params.model,
+  );
+  if (configuredModel?.contextTokens !== undefined) {
+    return configuredModel.contextTokens;
+  }
+  // Provider contextTokens is the model default, so it caps an explicit model
+  // window only when that model did not declare its own effective token cap.
+  const providerContextTokens = asPositiveSafeInteger(params.providerContextTokens);
+  if (configuredModel?.contextWindow !== undefined && providerContextTokens !== undefined) {
+    return Math.min(configuredModel.contextWindow, providerContextTokens);
+  }
+  return (
+    providerContextTokens ??
+    configuredModel?.contextWindow ??
+    asPositiveSafeInteger(params.providerContextWindow)
+  );
 }
 
 /** Creates the LM Studio embedding provider client and preloads the target model before return. */
@@ -119,6 +148,12 @@ export async function createLmstudioEmbeddingProvider(
     headers,
     ssrfPolicy,
   };
+  const requestedContextLength = resolveEmbeddingPreloadContextLength({
+    model,
+    models: providerConfig?.models,
+    providerContextTokens: providerConfig?.contextTokens,
+    providerContextWindow: providerConfig?.contextWindow,
+  });
 
   try {
     await ensureLmstudioModelLoaded({
@@ -127,6 +162,7 @@ export async function createLmstudioEmbeddingProvider(
       headers: headerOverrides,
       ssrfPolicy,
       modelKey: model,
+      requestedContextLength,
       timeoutMs: 120_000,
     });
   } catch (error) {


### PR DESCRIPTION
Closes #97016

Supersedes #99613 and #97033 while preserving both contributors' commit credit.

## What Problem This Solves

Fixes an issue where LM Studio memory embeddings could preload at the model's default or maximum context length even when users configured a smaller model- or provider-level context. On constrained GPUs this could trigger CUDA out-of-memory failures before memory search ran.

## Why This Change Was Made

The LM Studio embedding adapter now resolves the effective preload context at its provider-owned boundary: an explicit model `contextTokens` wins; otherwise provider `contextTokens` caps a model window; then model or provider `contextWindow` supplies the fallback. The existing load helper still clamps that request to LM Studio's advertised model limit.

This replaces the narrower #99613 patch, which handled only model fields, and incorporates the provider-default coverage identified in #97033 without changing config or public plugin APIs.

## User Impact

LM Studio memory-search users can constrain embedding-model preload context through their existing `contextTokens` and `contextWindow` configuration. Configurations without either field keep the existing loader default.

Credit to @zak-li for #99613, @ZOOWH for #97033, and @hxz398 for the production reproduction in #97016.

## Evidence

- Exact prepared head: `6882deab2c5db61d4733705a35d2371a7306cb50` ([exact-head CI](https://github.com/openclaw/openclaw/actions/runs/28809661632)).
- Blacksmith Testbox `tbx_01kww6r6n6adx8ranfm2194pr4`: 50 focused LM Studio assertions passed across the embedding adapter, loader, and inference sibling.
- Same Testbox: scoped `check:changed` passed extension production/test typechecking, lint, guards, and import-cycle checks.
- Live headless LM Studio `llmster 0.0.18-1`: `openclaw memory status --deep --json` returned `embeddingProbe.ok = true`; `/api/v1/models` reported the real Nomic embedding model loaded with `context_length: 1024` from a provider cap over a 2048 model window.
- Official LM Studio contract checked: [`POST /api/v1/models/load`](https://lmstudio.ai/docs/developer/rest/load) accepts `context_length` for embedding models.
- Fresh whole-branch AutoReview: no accepted/actionable findings; patch correct, confidence 0.85.
