### PR TITLE
fix(errors): classify rate-limit errors before timeout in detectErrorKind

### DIFF
--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -136,6 +136,14 @@ describe("error helpers", () => {
       expected: "rate_limit",
     },
     {
+      value: new Error("Rate limit exceeded, timeout: 30s"),
+      expected: "rate_limit",
+    },
+    {
+      value: Object.assign(new Error("HTTP 429 Too Many Requests"), { code: "ETIMEDOUT" }),
+      expected: "rate_limit",
+    },
+    {
       value: new Error("context_window exceeded with too many tokens"),
       expected: "context_length",
     },

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -164,9 +164,6 @@ export function detectErrorKind(err: unknown): ErrorKind | undefined {
   ) {
     return "refusal";
   }
-  if (message.includes("timeout") || code === "etimedout" || code === "timeout") {
-    return "timeout";
-  }
   if (
     message.includes("rate limit") ||
     message.includes("too many requests") ||
@@ -174,6 +171,9 @@ export function detectErrorKind(err: unknown): ErrorKind | undefined {
     code === "429"
   ) {
     return "rate_limit";
+  }
+  if (message.includes("timeout") || code === "etimedout" || code === "timeout") {
+    return "timeout";
   }
   if (
     message.includes("context length") ||


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where `detectErrorKind` misclassifies rate-limit errors as timeout errors when the error message contains both rate-limit and timeout keywords (e.g., `"Rate limit exceeded, timeout: 30s"`).

Because the `timeout` check runs before the `rate_limit` check, provider error messages that say `"Rate limit exceeded, timeout: 30s"` or `"Too many requests, timeout in 5 seconds"` match `message.includes("timeout")` first and are classified as `timeout` instead of `rate_limit`. This causes the wrong recovery strategy — the agent uses simple retry for `timeout` errors instead of exponential backoff for `rate_limit` errors, which can lead to the provider blocking the agent for hammering during rate limiting.

## Why This Change Was Made
Swapped the order of the `rate_limit` and `timeout` checks so that rate-limit detection takes priority. A rate-limit error that happens to mention "timeout" should be treated as a rate limit, since the primary failure mode is throttling and the correct recovery is backoff. Pure timeout errors (no rate-limit keywords) still fall through to the timeout check unchanged.

## User Impact
Agents encountering provider rate limits that mention timeouts will now correctly back off instead of hammering the provider. This prevents providers from escalating rate-limit responses (e.g., temporary blocks, longer cooldowns) that can occur when the client retries too aggressively.

## Evidence

### Negative control (pre-fix behavior)
```
Rate limit + timeout => timeout ← BUG! should be rate_limit
Too many req + timeout => timeout ← BUG! should be rate_limit
429 + ETIMEDOUT => timeout ← BUG! should be rate_limit
```

### After fix (all assertions pass)
```
  PASS: rate limit error containing timeout => rate_limit
  PASS: too many requests + timeout => rate_limit
  PASS: 429 error with timeout msg => rate_limit
  PASS: ETIMEDOUT code without rate limit => timeout
  PASS: pure rate limit => rate_limit
  PASS: pure timeout code => timeout
  PASS: context_length still works
  PASS: refusal still works
  PASS: unknown error => undefined
ALL: 9 passed, 0 failed
```

### vitest
```
 Test Files  1 passed (1)
      Tests  26 passed (26)
```