### PR TITLE
fix(update): guard Windows task autostart during package updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - **Compaction participant deduplication:** include canonical sender identity in duplicate long-message keys so identical turns from different participants remain in compacted transcripts. (#98310, #98336) Thanks @SunnyShu0925.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
+- **Windows package-update task guard:** temporarily disable only an enabled managed Scheduled Task while replacing the package tree, then restore it before recovery or restart so legacy repeated triggers cannot relaunch the Gateway mid-update. (#88292, #87993) Thanks @vincentkoc.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Detail-less provider failures:** keep opaque upstream failures from cooling API-key auth profiles while preserving WHAM-backed OpenAI OAuth health checks and configured model fallback. (#100600, #100617) Thanks @fengjikui.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -11,6 +11,7 @@ import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 import { getGatewayRunRuntimeHooks } from "./gateway-cli/runtime-hooks.js";
 import type { RootHelpRenderOptions } from "./program/root-help.js";
 import { runCli, shouldStartProxyForCli } from "./run-main.js";
+import { registerSignalExitBarrier } from "./signal-exit-barrier.js";
 
 type ConfigSnapshotStub = {
   exists: boolean;
@@ -2455,6 +2456,13 @@ describe("runCli exit behavior", () => {
       void code;
       return undefined as never;
     }) as typeof process.exit);
+    let finishCompanionCleanup: (() => void) | undefined;
+    const unregisterCompanionCleanup = registerSignalExitBarrier(
+      () =>
+        new Promise<void>((resolve) => {
+          finishCompanionCleanup = resolve;
+        }),
+    );
 
     try {
       const runPromise = runCli(["node", "openclaw", "plugins", "marketplace", "list"]);
@@ -2475,6 +2483,11 @@ describe("runCli exit behavior", () => {
       await vi.waitFor(() => {
         expect(stopProxyMock).toHaveBeenCalledWith(handle);
       });
+      expect(exitSpy).not.toHaveBeenCalled();
+      if (!finishCompanionCleanup) {
+        throw new Error("companion signal cleanup did not start");
+      }
+      finishCompanionCleanup();
       await vi.waitFor(() => {
         expect(exitSpy).toHaveBeenCalledWith(130);
       });
@@ -2483,6 +2496,7 @@ describe("runCli exit behavior", () => {
       await runPromise;
       expect(stopProxyMock).toHaveBeenCalledTimes(1);
     } finally {
+      unregisterCompanionCleanup();
       exitSpy.mockRestore();
       processOnceSpy.mockRestore();
     }

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -52,6 +52,7 @@ import {
   shouldUseSecretsHelpFastPath,
   shouldUseSetupOnboardConfigureHelpFastPath,
 } from "./run-main-policy.js";
+import { registerSignalExitBarrier, waitForSignalExitBarriers } from "./signal-exit-barrier.js";
 import { createGatewayStartupTrace } from "./startup-trace.js";
 import { normalizeWindowsArgv } from "./windows-argv.js";
 
@@ -905,6 +906,7 @@ export async function runCli(argv: string[] = process.argv) {
   let onSigterm: (() => void) | null = null;
   let onSigint: (() => void) | null = null;
   let onExit: (() => void) | null = null;
+  let unregisterProxySignalExitBarrier: (() => void) | null = null;
   let bestEffortConfigPromise: Promise<OpenClawConfig> | null = null;
   const isolateProxyConfigEnv = isGatewayRunInvocation;
   const readBestEffortCliConfig = async (): Promise<OpenClawConfig> => {
@@ -932,6 +934,8 @@ export async function runCli(argv: string[] = process.argv) {
     }
   };
   const stopStartedProxy = async () => {
+    unregisterProxySignalExitBarrier?.();
+    unregisterProxySignalExitBarrier = null;
     uninstallProxySignalHandlers();
     const handle = proxyHandle;
     proxyHandle = null;
@@ -949,8 +953,9 @@ export async function runCli(argv: string[] = process.argv) {
     if (!proxyHandle || onSigterm || onSigint || onExit) {
       return;
     }
+    unregisterProxySignalExitBarrier = registerSignalExitBarrier(stopStartedProxy);
     const shutdown = (exitCode: number) => {
-      void stopStartedProxy().finally(() => {
+      void waitForSignalExitBarriers().finally(() => {
         process.exit(exitCode);
       });
     };

--- a/src/cli/signal-exit-barrier.ts
+++ b/src/cli/signal-exit-barrier.ts
@@ -1,0 +1,27 @@
+type SignalExitBarrier = () => Promise<void>;
+
+// Gates let bounded mutations finish before signal cleanup begins; barriers
+// then prevent one cleanup from exiting while another still owns state.
+const activeBarriers = new Set<SignalExitBarrier>();
+const activeGates = new Set<Promise<void>>();
+
+export function registerSignalExitGate(gate: Promise<void>): () => void {
+  activeGates.add(gate);
+  return () => activeGates.delete(gate);
+}
+
+export function registerSignalExitBarrier(barrier: SignalExitBarrier): () => void {
+  activeBarriers.add(barrier);
+  return () => activeBarriers.delete(barrier);
+}
+
+export async function waitForSignalExitBarriers(): Promise<void> {
+  const gateResults = await Promise.allSettled(activeGates);
+  const barrierResults = await Promise.allSettled([...activeBarriers].map((barrier) => barrier()));
+  const failures = [...gateResults, ...barrierResults]
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "Signal exit cleanup failed");
+  }
+}

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -3773,6 +3773,48 @@ describe("update-cli", () => {
     );
   });
 
+  it("preserves both the update and Scheduled Task recovery failures", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    mockPackageInstallStatus(createCaseDir("openclaw-update-recovery-failure"));
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["openclaw", "gateway", "run"],
+      environment: {
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      },
+    });
+    serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+    suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv) => {
+      if (argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g") {
+        throw new Error("update invariant broke");
+      }
+      return {
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+    resumeScheduledTaskAutoStartAfterUpdate.mockRejectedValueOnce(new Error("task restore failed"));
+
+    try {
+      await expect(updateCommand({ yes: true, restart: false })).rejects.toEqual(
+        expect.objectContaining({
+          errors: [
+            expect.objectContaining({ message: "update invariant broke" }),
+            expect.objectContaining({ message: "task restore failed" }),
+          ],
+        }),
+      );
+      expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledTimes(1);
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
   it.each(["SIGINT", "SIGBREAK"] as const)(
     "restores Windows Scheduled Task autostart on %s during suspension",
     async (signal) => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -42,6 +42,8 @@ const resolveGlobalManager = vi.fn();
 const serviceLoaded = vi.fn();
 const serviceStop = vi.fn();
 const serviceRestart = vi.fn();
+const suspendScheduledTaskAutoStartForUpdate = vi.fn();
+const resumeScheduledTaskAutoStartAfterUpdate = vi.fn();
 const prepareRestartScript = vi.fn();
 const runRestartScript = vi.fn();
 const mockedRunDaemonInstall = vi.fn();
@@ -326,6 +328,13 @@ vi.mock("../daemon/launchd.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../daemon/launchd.js")>()),
   disableCurrentOpenClawUpdateLaunchdJob:
     launchdUpdateCleanupMocks.disableCurrentOpenClawUpdateLaunchdJob,
+}));
+
+vi.mock("../daemon/schtasks.js", () => ({
+  suspendScheduledTaskAutoStartForUpdate: (...args: unknown[]) =>
+    suspendScheduledTaskAutoStartForUpdate(...args),
+  resumeScheduledTaskAutoStartAfterUpdate: (...args: unknown[]) =>
+    resumeScheduledTaskAutoStartAfterUpdate(...args),
 }));
 
 vi.mock("../infra/ports.js", () => ({
@@ -887,6 +896,8 @@ describe("update-cli", () => {
     resolveGlobalManager.mockResolvedValue("npm");
     serviceStop.mockResolvedValue(undefined);
     serviceRestart.mockResolvedValue({ outcome: "completed" });
+    suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(false);
+    resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(false);
     serviceLoaded.mockResolvedValue(false);
     serviceReadCommand.mockImplementation(async () =>
       (await serviceLoaded()) ? { programArguments: ["openclaw", "gateway", "run"] } : null,
@@ -1115,6 +1126,9 @@ describe("update-cli", () => {
   });
 
   it("does not restart a stopped managed gateway after post-core plugin errors", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
+    resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
     const root = createCaseDir("openclaw-update");
     const entryPath = path.join(root, "dist", "index.js");
     mockPackageInstallStatus(root);
@@ -1172,11 +1186,20 @@ describe("update-cli", () => {
     });
 
     await updateCommand({ yes: true });
+    platformSpy.mockRestore();
 
     expect(serviceStop).toHaveBeenCalled();
     expect(serviceRestart).not.toHaveBeenCalled();
     expect(runDaemonRestart).not.toHaveBeenCalled();
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(
+      requireValue(spawn.mock.invocationCallOrder[0], "post-core update process order"),
+    ).toBeLessThan(
+      requireValue(
+        resumeScheduledTaskAutoStartAfterUpdate.mock.invocationCallOrder[0],
+        "Scheduled Task resume order",
+      ),
+    );
   });
 
   it("does not carry gateway service markers into the post-core update process", async () => {
@@ -3583,6 +3606,11 @@ describe("update-cli", () => {
   });
 
   it("stops a running managed gateway before package replacement", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const processOnSpy = vi.spyOn(process, "on");
+    const processOffSpy = vi.spyOn(process, "off");
+    suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
+    resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
     const tempDir = await createTrackedTempDir("openclaw-update-stop-service-");
     const nodeModules = path.join(tempDir, "node_modules");
     const pkgRoot = path.join(nodeModules, "openclaw");
@@ -3647,6 +3675,7 @@ describe("update-cli", () => {
         await updateCommand({ yes: true });
       },
     );
+    platformSpy.mockRestore();
 
     const npmInstallCallIndex = vi
       .mocked(runCommandWithTimeout)
@@ -3666,8 +3695,171 @@ describe("update-cli", () => {
       "service stop call order",
     );
     const requiredNpmInstallCallOrder = requireValue(npmInstallCallOrder, "npm install call order");
+    const suspendOrder = requireValue(
+      suspendScheduledTaskAutoStartForUpdate.mock.invocationCallOrder[0],
+      "Scheduled Task suspend order",
+    );
+    const resumeOrder = requireValue(
+      resumeScheduledTaskAutoStartAfterUpdate.mock.invocationCallOrder[0],
+      "Scheduled Task resume order",
+    );
+    const sigintListenerIndex = processOnSpy.mock.calls.findIndex(([event]) => event === "SIGINT");
+    const sigintListenerOrder = requireValue(
+      processOnSpy.mock.invocationCallOrder[sigintListenerIndex],
+      "SIGINT recovery listener order",
+    );
+    expect(suspendScheduledTaskAutoStartForUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      }),
+    );
+    expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      }),
+    );
+    expect(sigintListenerOrder).toBeLessThan(suspendOrder);
+    expect(suspendOrder).toBeLessThan(requiredServiceStopCallOrder);
     expect(requiredServiceStopCallOrder).toBeLessThan(requiredNpmInstallCallOrder);
+    expect(requiredNpmInstallCallOrder).toBeLessThan(resumeOrder);
+    expect(processOnSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+    expect(processOnSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+    expect(processOffSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+    expect(processOffSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+    processOnSpy.mockRestore();
+    processOffSpy.mockRestore();
   });
+
+  it("restores Windows Scheduled Task autostart when service stop fails", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    mockPackageInstallStatus(createCaseDir("openclaw-update-stop-failure"));
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["openclaw", "gateway", "run"],
+      environment: {
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      },
+    });
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 4242,
+      state: "running",
+    });
+    suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
+    serviceStop.mockRejectedValueOnce(new Error("stop failed"));
+    resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
+
+    await updateCommand({ yes: true });
+    platformSpy.mockRestore();
+
+    expect(suspendScheduledTaskAutoStartForUpdate).toHaveBeenCalledTimes(1);
+    expect(serviceStop).toHaveBeenCalledTimes(1);
+    expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledTimes(1);
+    expect(packageInstallCommandCall()).toBeUndefined();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    const suspendOrder = suspendScheduledTaskAutoStartForUpdate.mock.invocationCallOrder[0];
+    const stopOrder = serviceStop.mock.invocationCallOrder[0];
+    const resumeOrder = resumeScheduledTaskAutoStartAfterUpdate.mock.invocationCallOrder[0];
+    expect(requireValue(suspendOrder, "Scheduled Task suspend order")).toBeLessThan(
+      requireValue(stopOrder, "service stop order"),
+    );
+    expect(requireValue(stopOrder, "service stop order")).toBeLessThan(
+      requireValue(resumeOrder, "Scheduled Task resume order"),
+    );
+  });
+
+  it("restores Windows Scheduled Task autostart when interrupted during suspension", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    const processOnSpy = vi.spyOn(process, "on");
+    const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    let finishSuspension: ((suspended: boolean) => void) | undefined;
+    suspendScheduledTaskAutoStartForUpdate.mockImplementationOnce(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishSuspension = resolve;
+        }),
+    );
+    resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
+    mockPackageInstallStatus(createCaseDir("openclaw-update-suspension-signal"));
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["openclaw", "gateway", "run"],
+      environment: {
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_KIND: "gateway",
+      },
+    });
+    serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+
+    const updatePromise = updateCommand({ yes: true, restart: false });
+    await vi.waitFor(() => expect(suspendScheduledTaskAutoStartForUpdate).toHaveBeenCalledOnce());
+    const sigintListener = processOnSpy.mock.calls.find(([event]) => event === "SIGINT")?.[1];
+    if (typeof sigintListener !== "function" || !finishSuspension) {
+      throw new Error("expected armed SIGINT recovery and pending task suspension");
+    }
+    sigintListener();
+    sigintListener();
+    expect(resumeScheduledTaskAutoStartAfterUpdate).not.toHaveBeenCalled();
+    finishSuspension(true);
+
+    await updatePromise;
+    expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledTimes(1);
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(packageInstallCommandCall()).toBeUndefined();
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    await vi.waitFor(() => {
+      expect(processExitSpy).toHaveBeenCalledTimes(2);
+      expect(processExitSpy).toHaveBeenCalledWith(130);
+    });
+    platformSpy.mockRestore();
+    processOnSpy.mockRestore();
+    processExitSpy.mockRestore();
+  });
+
+  it.each(["running", "stopped"] as const)(
+    "guards a %s Windows Scheduled Task during a no-restart package update",
+    async (runtimeStatus) => {
+      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      mockPackageInstallStatus(createCaseDir("openclaw-update-stopped-task"));
+      serviceReadCommand.mockResolvedValue({
+        programArguments: ["openclaw", "gateway", "run"],
+        environment: {
+          OPENCLAW_SERVICE_MARKER: "openclaw",
+          OPENCLAW_SERVICE_KIND: "gateway",
+        },
+      });
+      serviceReadRuntime.mockResolvedValue(
+        runtimeStatus === "running"
+          ? { status: "running", state: "running", pid: 4242 }
+          : { status: "stopped", state: "stopped" },
+      );
+      suspendScheduledTaskAutoStartForUpdate.mockResolvedValue(true);
+      resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
+
+      await updateCommand({ yes: true, restart: false });
+      platformSpy.mockRestore();
+
+      expect(serviceStop).not.toHaveBeenCalled();
+      expect(packageInstallCommandCall()).toBeDefined();
+      const suspendOrder = suspendScheduledTaskAutoStartForUpdate.mock.invocationCallOrder[0];
+      const installCallIndex = vi
+        .mocked(runCommandWithTimeout)
+        .mock.calls.findIndex(
+          (call) => Array.isArray(call[0]) && call[0][0] === "npm" && call[0][1] === "i",
+        );
+      const installOrder =
+        vi.mocked(runCommandWithTimeout).mock.invocationCallOrder[installCallIndex];
+      const resumeOrder = resumeScheduledTaskAutoStartAfterUpdate.mock.invocationCallOrder[0];
+      expect(requireValue(suspendOrder, "Scheduled Task suspend order")).toBeLessThan(
+        requireValue(installOrder, "package install order"),
+      );
+      expect(requireValue(installOrder, "package install order")).toBeLessThan(
+        requireValue(resumeOrder, "Scheduled Task resume order"),
+      );
+    },
+  );
 
   it("stops a running managed gateway when git checkout rebuild starts", async () => {
     const serviceEntrypoint = path.join(process.cwd(), "dist", "index.js");

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -3807,6 +3807,7 @@ describe("update-cli", () => {
             expect.objectContaining({ message: "update invariant broke" }),
             expect.objectContaining({ message: "task restore failed" }),
           ],
+          cause: expect.objectContaining({ message: "update invariant broke" }),
         }),
       );
       expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledTimes(1);

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -3726,8 +3726,10 @@ describe("update-cli", () => {
     expect(requiredNpmInstallCallOrder).toBeLessThan(resumeOrder);
     expect(processOnSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
     expect(processOnSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+    expect(processOnSpy).toHaveBeenCalledWith("SIGBREAK", expect.any(Function));
     expect(processOffSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
     expect(processOffSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+    expect(processOffSpy).toHaveBeenCalledWith("SIGBREAK", expect.any(Function));
     processOnSpy.mockRestore();
     processOffSpy.mockRestore();
   });
@@ -3771,52 +3773,55 @@ describe("update-cli", () => {
     );
   });
 
-  it("restores Windows Scheduled Task autostart when interrupted during suspension", async () => {
-    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    const processOnSpy = vi.spyOn(process, "on");
-    const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-    let finishSuspension: ((suspended: boolean) => void) | undefined;
-    suspendScheduledTaskAutoStartForUpdate.mockImplementationOnce(
-      () =>
-        new Promise<boolean>((resolve) => {
-          finishSuspension = resolve;
-        }),
-    );
-    resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
-    mockPackageInstallStatus(createCaseDir("openclaw-update-suspension-signal"));
-    serviceReadCommand.mockResolvedValue({
-      programArguments: ["openclaw", "gateway", "run"],
-      environment: {
-        OPENCLAW_SERVICE_MARKER: "openclaw",
-        OPENCLAW_SERVICE_KIND: "gateway",
-      },
-    });
-    serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+  it.each(["SIGINT", "SIGBREAK"] as const)(
+    "restores Windows Scheduled Task autostart on %s during suspension",
+    async (signal) => {
+      const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      const processOnSpy = vi.spyOn(process, "on");
+      const processExitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+      let finishSuspension: ((suspended: boolean) => void) | undefined;
+      suspendScheduledTaskAutoStartForUpdate.mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            finishSuspension = resolve;
+          }),
+      );
+      resumeScheduledTaskAutoStartAfterUpdate.mockResolvedValue(true);
+      mockPackageInstallStatus(createCaseDir("openclaw-update-suspension-signal"));
+      serviceReadCommand.mockResolvedValue({
+        programArguments: ["openclaw", "gateway", "run"],
+        environment: {
+          OPENCLAW_SERVICE_MARKER: "openclaw",
+          OPENCLAW_SERVICE_KIND: "gateway",
+        },
+      });
+      serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
 
-    const updatePromise = updateCommand({ yes: true, restart: false });
-    await vi.waitFor(() => expect(suspendScheduledTaskAutoStartForUpdate).toHaveBeenCalledOnce());
-    const sigintListener = processOnSpy.mock.calls.find(([event]) => event === "SIGINT")?.[1];
-    if (typeof sigintListener !== "function" || !finishSuspension) {
-      throw new Error("expected armed SIGINT recovery and pending task suspension");
-    }
-    sigintListener();
-    sigintListener();
-    expect(resumeScheduledTaskAutoStartAfterUpdate).not.toHaveBeenCalled();
-    finishSuspension(true);
+      const updatePromise = updateCommand({ yes: true, restart: false });
+      await vi.waitFor(() => expect(suspendScheduledTaskAutoStartForUpdate).toHaveBeenCalledOnce());
+      const signalListener = processOnSpy.mock.calls.find(([event]) => event === signal)?.[1];
+      if (typeof signalListener !== "function" || !finishSuspension) {
+        throw new Error(`expected armed ${signal} recovery and pending task suspension`);
+      }
+      signalListener();
+      signalListener();
+      expect(resumeScheduledTaskAutoStartAfterUpdate).not.toHaveBeenCalled();
+      finishSuspension(true);
 
-    await updatePromise;
-    expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledTimes(1);
-    expect(serviceStop).not.toHaveBeenCalled();
-    expect(packageInstallCommandCall()).toBeUndefined();
-    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
-    await vi.waitFor(() => {
-      expect(processExitSpy).toHaveBeenCalledTimes(2);
-      expect(processExitSpy).toHaveBeenCalledWith(130);
-    });
-    platformSpy.mockRestore();
-    processOnSpy.mockRestore();
-    processExitSpy.mockRestore();
-  });
+      await updatePromise;
+      expect(resumeScheduledTaskAutoStartAfterUpdate).toHaveBeenCalledTimes(1);
+      expect(serviceStop).not.toHaveBeenCalled();
+      expect(packageInstallCommandCall()).toBeUndefined();
+      expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+      await vi.waitFor(() => {
+        expect(processExitSpy).toHaveBeenCalledTimes(2);
+        expect(processExitSpy).toHaveBeenCalledWith(130);
+      });
+      platformSpy.mockRestore();
+      processOnSpy.mockRestore();
+      processExitSpy.mockRestore();
+    },
+  );
 
   it.each(["running", "stopped"] as const)(
     "guards a %s Windows Scheduled Task during a no-restart package update",

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1252,7 +1252,7 @@ async function maybeStopManagedServiceBeforeMutableUpdate(params: {
         throw new AggregateError(
           [err, resumeErr],
           `Failed to stop the managed gateway (${String(err)}) and restore Windows Scheduled Task autostart (${String(resumeErr)})`,
-          { cause: err },
+          { cause: resumeErr },
         );
       } finally {
         windowsTaskAutoStartRecovery.complete();
@@ -4211,7 +4211,7 @@ async function updateCommandInternal(
       throw new AggregateError(
         [err, resumeErr],
         `Update failed (${String(err)}) and Windows Scheduled Task autostart could not be restored (${String(resumeErr)})`,
-        { cause: err },
+        { cause: resumeErr },
       );
     }
     await maybeRestartServiceAfterFailedMutableUpdate({

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -4211,6 +4211,8 @@ async function updateCommandInternal(
     try {
       await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(preManagedServiceStop);
     } catch (resumeErr) {
+      recoveryState.windowsTaskAutoStartRecovery?.complete();
+      recoveryState.windowsTaskAutoStartRecovery = undefined;
       // oxlint-disable-next-line eslint/preserve-caught-error -- Both caught errors remain inspectable as aggregate members.
       throw new AggregateError(
         [err, resumeErr],

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -982,7 +982,6 @@ function serviceControlStdoutForMode(jsonMode: boolean): NodeJS.WritableStream {
 function armWindowsTaskAutoStartRecovery(
   serviceEnv: NodeJS.ProcessEnv,
 ): WindowsTaskAutoStartRecovery {
-  let suspensionPromise: Promise<boolean>;
   let restorePromise: Promise<void> | undefined;
   let unregisterSignalExitBarrier = () => {};
   let finishUpdate: (() => void) | undefined;
@@ -996,7 +995,7 @@ function armWindowsTaskAutoStartRecovery(
   const onSignal = (exitCode: number) => {
     interrupted = true;
     void waitForSignalExitBarriers()
-      .catch((err) => {
+      .catch((err: unknown) => {
         defaultRuntime.error(`Failed to complete update shutdown cleanup: ${String(err)}`);
       })
       .finally(() => {
@@ -1030,7 +1029,7 @@ function armWindowsTaskAutoStartRecovery(
   unregisterSignalExitBarrier = registerSignalExitBarrier(restore);
   // Arm recovery before starting the persistent state change. A signal arriving
   // while schtasks is still returning waits for that result before restoring.
-  suspensionPromise = suspendScheduledTaskAutoStartForUpdate(serviceEnv);
+  const suspensionPromise = suspendScheduledTaskAutoStartForUpdate(serviceEnv);
   return { suspended: suspensionPromise, restore, complete, interrupted: () => interrupted };
 }
 
@@ -1253,6 +1252,7 @@ async function maybeStopManagedServiceBeforeMutableUpdate(params: {
         throw new AggregateError(
           [err, resumeErr],
           `Failed to stop the managed gateway (${String(err)}) and restore Windows Scheduled Task autostart (${String(resumeErr)})`,
+          { cause: err },
         );
       } finally {
         windowsTaskAutoStartRecovery.complete();
@@ -4211,6 +4211,7 @@ async function updateCommandInternal(
       throw new AggregateError(
         [err, resumeErr],
         `Update failed (${String(err)}) and Windows Scheduled Task autostart could not be restored (${String(resumeErr)})`,
+        { cause: err },
       );
     }
     await maybeRestartServiceAfterFailedMutableUpdate({

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1252,10 +1252,10 @@ async function maybeStopManagedServiceBeforeMutableUpdate(params: {
       try {
         await windowsTaskAutoStartRecovery.restore();
       } catch (resumeErr) {
-        // oxlint-disable-next-line eslint/preserve-caught-error -- Both caught errors remain inspectable as aggregate members.
         throw new AggregateError(
           [err, resumeErr],
           `Failed to stop the managed gateway (${String(err)}) and restore Windows Scheduled Task autostart (${String(resumeErr)})`,
+          { cause: err },
         );
       } finally {
         windowsTaskAutoStartRecovery.complete();
@@ -4213,10 +4213,10 @@ async function updateCommandInternal(
     } catch (resumeErr) {
       recoveryState.windowsTaskAutoStartRecovery?.complete();
       recoveryState.windowsTaskAutoStartRecovery = undefined;
-      // oxlint-disable-next-line eslint/preserve-caught-error -- Both caught errors remain inspectable as aggregate members.
       throw new AggregateError(
         [err, resumeErr],
         `Update failed (${String(err)}) and Windows Scheduled Task autostart could not be restored (${String(resumeErr)})`,
+        { cause: err },
       );
     }
     await maybeRestartServiceAfterFailedMutableUpdate({

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1252,10 +1252,10 @@ async function maybeStopManagedServiceBeforeMutableUpdate(params: {
       try {
         await windowsTaskAutoStartRecovery.restore();
       } catch (resumeErr) {
+        // oxlint-disable-next-line eslint/preserve-caught-error -- Both caught errors remain inspectable as aggregate members.
         throw new AggregateError(
           [err, resumeErr],
           `Failed to stop the managed gateway (${String(err)}) and restore Windows Scheduled Task autostart (${String(resumeErr)})`,
-          { cause: resumeErr },
         );
       } finally {
         windowsTaskAutoStartRecovery.complete();
@@ -4211,10 +4211,10 @@ async function updateCommandInternal(
     try {
       await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(preManagedServiceStop);
     } catch (resumeErr) {
+      // oxlint-disable-next-line eslint/preserve-caught-error -- Both caught errors remain inspectable as aggregate members.
       throw new AggregateError(
         [err, resumeErr],
         `Update failed (${String(err)}) and Windows Scheduled Task autostart could not be restored (${String(resumeErr)})`,
-        { cause: resumeErr },
       );
     }
     await maybeRestartServiceAfterFailedMutableUpdate({

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -44,6 +44,10 @@ import {
 import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
 import { disableCurrentOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import { resolveGatewayRestartLogPath } from "../../daemon/restart-logs.js";
+import {
+  resumeScheduledTaskAutoStartAfterUpdate,
+  suspendScheduledTaskAutoStartForUpdate,
+} from "../../daemon/schtasks.js";
 import { summarizeGatewayServiceLayout } from "../../daemon/service-layout.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
 import {
@@ -144,6 +148,11 @@ import {
 import { commitPluginInstallRecordsWithConfig } from "../plugins-install-record-commit.js";
 import { listPersistedBundledPluginLocationBridges } from "../plugins-location-bridges.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../plugins-registry-refresh.js";
+import {
+  registerSignalExitBarrier,
+  registerSignalExitGate,
+  waitForSignalExitBarriers,
+} from "../signal-exit-barrier.js";
 import {
   hasNativePackageInstallPayload,
   resolveBundleInstallRecordPayload,
@@ -894,6 +903,18 @@ type PreManagedServiceStop = {
   running: boolean;
   blockMessage?: string;
   serviceEnv?: NodeJS.ProcessEnv;
+  windowsTaskAutoStartRecovery?: WindowsTaskAutoStartRecovery;
+};
+
+type WindowsTaskAutoStartRecovery = {
+  suspended: Promise<boolean>;
+  restore: () => Promise<void>;
+  complete: () => void;
+  interrupted: () => boolean;
+};
+
+type UpdateCommandRecoveryState = {
+  windowsTaskAutoStartRecovery?: WindowsTaskAutoStartRecovery;
 };
 
 class UpdateCommandAbort extends Error {
@@ -958,6 +979,134 @@ function serviceControlStdoutForMode(jsonMode: boolean): NodeJS.WritableStream {
   return jsonMode ? JSON_MODE_SERVICE_STDOUT : process.stdout;
 }
 
+function armWindowsTaskAutoStartRecovery(
+  serviceEnv: NodeJS.ProcessEnv,
+): WindowsTaskAutoStartRecovery {
+  let suspensionPromise: Promise<boolean>;
+  let restorePromise: Promise<void> | undefined;
+  let unregisterSignalExitBarrier = () => {};
+  let finishUpdate: (() => void) | undefined;
+  let interrupted = false;
+  const updateFinished = new Promise<void>((resolve) => {
+    finishUpdate = resolve;
+  });
+  const unregisterSignalExitGate = registerSignalExitGate(updateFinished);
+  // Task Scheduler persists the disabled bit beyond this process, so recover it
+  // before normal signal exits as well as from the update's ordinary paths.
+  const onSignal = (exitCode: number) => {
+    interrupted = true;
+    void waitForSignalExitBarriers()
+      .catch((err) => {
+        defaultRuntime.error(`Failed to complete update shutdown cleanup: ${String(err)}`);
+      })
+      .finally(() => {
+        process.exit(exitCode);
+      });
+  };
+  const onSigint = () => onSignal(130);
+  const onSigterm = () => onSignal(143);
+  const removeSignalHandlers = () => {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+    unregisterSignalExitBarrier();
+  };
+  const complete = () => {
+    finishUpdate?.();
+    finishUpdate = undefined;
+    unregisterSignalExitGate();
+  };
+  const restore = () => {
+    restorePromise ??= suspensionPromise
+      .then(async (suspended) => {
+        if (suspended) {
+          await resumeScheduledTaskAutoStartAfterUpdate(serviceEnv);
+        }
+      })
+      .finally(removeSignalHandlers);
+    return restorePromise;
+  };
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+  unregisterSignalExitBarrier = registerSignalExitBarrier(restore);
+  // Arm recovery before starting the persistent state change. A signal arriving
+  // while schtasks is still returning waits for that result before restoring.
+  suspensionPromise = suspendScheduledTaskAutoStartForUpdate(serviceEnv);
+  return { suspended: suspensionPromise, restore, complete, interrupted: () => interrupted };
+}
+
+async function abortWindowsTaskUpdateIfInterrupted(
+  recovery: WindowsTaskAutoStartRecovery,
+): Promise<void> {
+  if (!recovery.interrupted()) {
+    return;
+  }
+  try {
+    await recovery.restore();
+  } finally {
+    recovery.complete();
+  }
+  throw new UpdateCommandAbort();
+}
+
+async function maybeSuspendWindowsTaskAutoStartForPackageUpdate(params: {
+  updateInstallKind: "git" | "package";
+  serviceEnv: NodeJS.ProcessEnv | undefined;
+}): Promise<WindowsTaskAutoStartRecovery | undefined> {
+  if (
+    params.updateInstallKind !== "package" ||
+    process.platform !== "win32" ||
+    !params.serviceEnv
+  ) {
+    return undefined;
+  }
+  const recovery = armWindowsTaskAutoStartRecovery(params.serviceEnv);
+  let suspended: boolean;
+  try {
+    suspended = await recovery.suspended;
+  } catch (err) {
+    await recovery.restore().catch(() => undefined);
+    recovery.complete();
+    throw err;
+  }
+  await abortWindowsTaskUpdateIfInterrupted(recovery);
+  if (!suspended) {
+    try {
+      await recovery.restore();
+    } finally {
+      recovery.complete();
+    }
+    return undefined;
+  }
+  return recovery;
+}
+
+async function maybeResumeWindowsTaskAutoStartAfterPackageUpdate(
+  stopState: PreManagedServiceStop | undefined,
+): Promise<void> {
+  if (!stopState?.windowsTaskAutoStartRecovery) {
+    return;
+  }
+  // The recovery exists only when this update disabled an enabled task. Clear it
+  // after use so later failure paths cannot repeat the state change.
+  await stopState.windowsTaskAutoStartRecovery.restore();
+  stopState.windowsTaskAutoStartRecovery = undefined;
+}
+
+async function restoreWindowsTaskAutoStartOrExit(
+  stopState: PreManagedServiceStop | undefined,
+): Promise<boolean> {
+  try {
+    await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(stopState);
+    return true;
+  } catch (err) {
+    defaultRuntime.error(
+      `Failed to restore Windows Scheduled Task autostart after package update: ${String(err)}`,
+    );
+    defaultRuntime.exit(1);
+    return false;
+  }
+}
+
 async function maybeStopManagedServiceBeforeMutableUpdate(params: {
   updateInstallKind: "git" | "package";
   root: string;
@@ -993,32 +1142,53 @@ async function maybeStopManagedServiceBeforeMutableUpdate(params: {
         ),
       );
     }
+    const windowsTaskAutoStartRecovery = isRunningInsideGatewayService()
+      ? undefined
+      : await maybeSuspendWindowsTaskAutoStartForPackageUpdate({
+          updateInstallKind: params.updateInstallKind,
+          serviceEnv: serviceState.env,
+        });
     return {
       stopped: false,
       inspected: true,
       runtimeInspected,
       running: serviceState.running,
       serviceEnv: serviceState.env,
+      ...(windowsTaskAutoStartRecovery ? { windowsTaskAutoStartRecovery } : {}),
     };
   }
 
   if (!runtimeInspected) {
+    // An inherited gateway process cannot safely update and will be rejected below.
+    // Do not leave its task disabled while returning that rejection.
+    const windowsTaskAutoStartRecovery = isRunningInsideGatewayService()
+      ? undefined
+      : await maybeSuspendWindowsTaskAutoStartForPackageUpdate({
+          updateInstallKind: params.updateInstallKind,
+          serviceEnv: serviceState.env,
+        });
     return {
       stopped: false,
       inspected: true,
       runtimeInspected: false,
       running: false,
       serviceEnv: serviceState.env,
+      ...(windowsTaskAutoStartRecovery ? { windowsTaskAutoStartRecovery } : {}),
     };
   }
 
   if (!serviceState.running) {
+    const windowsTaskAutoStartRecovery = await maybeSuspendWindowsTaskAutoStartForPackageUpdate({
+      updateInstallKind: params.updateInstallKind,
+      serviceEnv: serviceState.env,
+    });
     return {
       stopped: false,
       inspected: true,
       runtimeInspected: true,
       running: false,
       serviceEnv: serviceState.env,
+      ...(windowsTaskAutoStartRecovery ? { windowsTaskAutoStartRecovery } : {}),
     };
   }
 
@@ -1060,16 +1230,46 @@ async function maybeStopManagedServiceBeforeMutableUpdate(params: {
       theme.muted(`Stopping managed gateway service before ${params.updateInstallKind} update...`),
     );
   }
-  await service.stop({
-    env: serviceState.env,
-    stdout: serviceControlStdoutForMode(params.jsonMode),
+  const windowsTaskAutoStartRecovery = await maybeSuspendWindowsTaskAutoStartForPackageUpdate({
+    updateInstallKind: params.updateInstallKind,
+    serviceEnv: serviceState.env,
   });
+  try {
+    await service.stop({
+      env: serviceState.env,
+      stdout: serviceControlStdoutForMode(params.jsonMode),
+    });
+    if (windowsTaskAutoStartRecovery) {
+      await abortWindowsTaskUpdateIfInterrupted(windowsTaskAutoStartRecovery);
+    }
+  } catch (err) {
+    if (err instanceof UpdateCommandAbort) {
+      throw err;
+    }
+    if (windowsTaskAutoStartRecovery) {
+      try {
+        await windowsTaskAutoStartRecovery.restore();
+      } catch (resumeErr) {
+        throw new AggregateError(
+          [err, resumeErr],
+          `Failed to stop the managed gateway (${String(err)}) and restore Windows Scheduled Task autostart (${String(resumeErr)})`,
+        );
+      } finally {
+        windowsTaskAutoStartRecovery.complete();
+      }
+      if (windowsTaskAutoStartRecovery.interrupted()) {
+        throw new UpdateCommandAbort();
+      }
+    }
+    throw err;
+  }
   return {
     stopped: true,
     inspected: true,
     runtimeInspected: true,
     running: true,
     serviceEnv: serviceState.env,
+    ...(windowsTaskAutoStartRecovery ? { windowsTaskAutoStartRecovery } : {}),
   };
 }
 
@@ -3169,7 +3369,11 @@ async function continuePostCoreUpdateInFreshProcess(params: {
   preUpdateConfig?: PreUpdateConfigRestoreInput;
   updateStartedAtMs: number;
   nodeRunner?: string;
-}): Promise<{ resumed: boolean; pluginUpdate?: PostCorePluginUpdateResult }> {
+}): Promise<{
+  resumed: boolean;
+  pluginUpdate?: PostCorePluginUpdateResult;
+  exitCode?: number;
+}> {
   const entryPath = await resolveGatewayInstallEntrypoint(params.root);
   if (!entryPath) {
     return { resumed: false };
@@ -3295,8 +3499,7 @@ async function continuePostCoreUpdateInFreshProcess(params: {
       if (pluginUpdate) {
         return { resumed: true, pluginUpdate };
       }
-      defaultRuntime.exit(exitCode);
-      throw new Error(`post-update process exited with code ${exitCode}`);
+      return { resumed: false, exitCode };
     }
     return { resumed: true, ...(pluginUpdate ? { pluginUpdate } : {}) };
   } finally {
@@ -3383,12 +3586,24 @@ async function withUpdateInProgressEnv<T>(run: () => Promise<T>): Promise<T> {
 }
 
 export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
+  const recoveryState: UpdateCommandRecoveryState = {};
   return await withUpdateInProgressEnv(async () => {
-    await updateCommandInternal(opts);
+    try {
+      await updateCommandInternal(opts, recoveryState);
+    } finally {
+      try {
+        await recoveryState.windowsTaskAutoStartRecovery?.restore();
+      } finally {
+        recoveryState.windowsTaskAutoStartRecovery?.complete();
+      }
+    }
   });
 }
 
-async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> {
+async function updateCommandInternal(
+  opts: UpdateCommandOptions,
+  recoveryState: UpdateCommandRecoveryState,
+): Promise<void> {
   suppressDeprecations();
   await cleanupStaleManagedServiceUpdateHandoffs().catch(() => undefined);
   const invocationCwd = tryResolveInvocationCwd();
@@ -3888,6 +4103,10 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
           shouldRestart,
           jsonMode: Boolean(opts.json),
         });
+        if (preManagedServiceStop.windowsTaskAutoStartRecovery) {
+          recoveryState.windowsTaskAutoStartRecovery =
+            preManagedServiceStop.windowsTaskAutoStartRecovery;
+        }
         if (
           preManagedServiceStop.stopped ||
           preManagedServiceStop.blockMessage ||
@@ -3900,6 +4119,9 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
         }
       }
     } catch (err) {
+      if (err instanceof UpdateCommandAbort) {
+        throw err;
+      }
       stop();
       defaultRuntime.error(`Failed to stop managed gateway service before update: ${String(err)}`);
       defaultRuntime.exit(1);
@@ -3983,6 +4205,14 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
     if (err instanceof UpdateCommandAbort) {
       return;
     }
+    try {
+      await maybeResumeWindowsTaskAutoStartAfterPackageUpdate(preManagedServiceStop);
+    } catch (resumeErr) {
+      throw new AggregateError(
+        [err, resumeErr],
+        `Update failed (${String(err)}) and Windows Scheduled Task autostart could not be restored (${String(resumeErr)})`,
+      );
+    }
     await maybeRestartServiceAfterFailedMutableUpdate({
       preManagedServiceStop,
       jsonMode: Boolean(opts.json),
@@ -3996,6 +4226,9 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   }
 
   if (result.status === "error") {
+    if (!(await restoreWindowsTaskAutoStartOrExit(preManagedServiceStop))) {
+      return;
+    }
     await writeControlPlaneUpdateRestartSentinelBestEffort({
       meta: controlPlaneUpdateSentinelMeta,
       result,
@@ -4010,6 +4243,9 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   }
 
   if (result.status === "skipped") {
+    if (!(await restoreWindowsTaskAutoStartOrExit(preManagedServiceStop))) {
+      return;
+    }
     await writeControlPlaneUpdateRestartSentinelBestEffort({
       meta: controlPlaneUpdateSentinelMeta,
       result,
@@ -4104,6 +4340,13 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
           }
         : undefined,
     });
+    if (freshProcessResult.exitCode !== undefined) {
+      if (!(await restoreWindowsTaskAutoStartOrExit(preManagedServiceStop))) {
+        return;
+      }
+      defaultRuntime.exit(freshProcessResult.exitCode);
+      throw new Error(`post-update process exited with code ${freshProcessResult.exitCode}`);
+    }
     pluginsUpdatedInFreshProcess = freshProcessResult.resumed;
     postCorePluginUpdate = freshProcessResult.pluginUpdate;
   }
@@ -4176,6 +4419,9 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
     : result;
 
   if (postCorePluginUpdate?.status === "error") {
+    if (!(await restoreWindowsTaskAutoStartOrExit(preManagedServiceStop))) {
+      return;
+    }
     await writeControlPlaneUpdateRestartSentinelBestEffort({
       meta: controlPlaneUpdateSentinelMeta,
       result: resultWithPostUpdate,
@@ -4255,6 +4501,9 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
     jsonMode: Boolean(opts.json),
   });
 
+  if (!(await restoreWindowsTaskAutoStartOrExit(preManagedServiceStop))) {
+    return;
+  }
   const restartOk = await maybeRestartService({
     shouldRestart,
     result: resultWithPostUpdate,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1004,9 +1004,11 @@ function armWindowsTaskAutoStartRecovery(
   };
   const onSigint = () => onSignal(130);
   const onSigterm = () => onSignal(143);
+  const onSigbreak = () => onSignal(130);
   const removeSignalHandlers = () => {
     process.off("SIGINT", onSigint);
     process.off("SIGTERM", onSigterm);
+    process.off("SIGBREAK", onSigbreak);
     unregisterSignalExitBarrier();
   };
   const complete = () => {
@@ -1026,6 +1028,7 @@ function armWindowsTaskAutoStartRecovery(
   };
   process.on("SIGINT", onSigint);
   process.on("SIGTERM", onSigterm);
+  process.on("SIGBREAK", onSigbreak);
   unregisterSignalExitBarrier = registerSignalExitBarrier(restore);
   // Arm recovery before starting the persistent state change. A signal arriving
   // while schtasks is still returning waits for that result before restoring.

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -924,6 +924,14 @@ class UpdateCommandAbort extends Error {
   }
 }
 
+function createAggregateErrorWithCause(
+  errors: unknown[],
+  message: string,
+  cause: unknown,
+): AggregateError {
+  return new AggregateError(errors, message, { cause });
+}
+
 type ManagedServiceRootRedirect = {
   root: string;
   previousRoot: string;
@@ -1252,10 +1260,10 @@ async function maybeStopManagedServiceBeforeMutableUpdate(params: {
       try {
         await windowsTaskAutoStartRecovery.restore();
       } catch (resumeErr) {
-        throw new AggregateError(
+        throw createAggregateErrorWithCause(
           [err, resumeErr],
           `Failed to stop the managed gateway (${String(err)}) and restore Windows Scheduled Task autostart (${String(resumeErr)})`,
-          { cause: err },
+          err,
         );
       } finally {
         windowsTaskAutoStartRecovery.complete();
@@ -4213,10 +4221,10 @@ async function updateCommandInternal(
     } catch (resumeErr) {
       recoveryState.windowsTaskAutoStartRecovery?.complete();
       recoveryState.windowsTaskAutoStartRecovery = undefined;
-      throw new AggregateError(
+      throw createAggregateErrorWithCause(
         [err, resumeErr],
         `Update failed (${String(err)}) and Windows Scheduled Task autostart could not be restored (${String(resumeErr)})`,
-        { cause: err },
+        err,
       );
     }
     await maybeRestartServiceAfterFailedMutableUpdate({

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -173,7 +173,7 @@ describe("Scheduled Task stop/restart cleanup", () => {
     });
   });
 
-  it("fails closed when the task XML cannot be read", async () => {
+  it("fails closed when task absence cannot be confirmed", async () => {
     await withPreparedGatewayTask(async ({ env }) => {
       schtasksResponses.push({
         code: 1,
@@ -186,6 +186,30 @@ describe("Scheduled Task stop/restart cleanup", () => {
       );
 
       expect(schtasksCalls).toEqual([["/Query", "/TN", "OpenClaw Gateway", "/XML"]]);
+      expect(spawnSync).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("ignores a stale task script when COM proves the task is absent", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push({
+        code: 1,
+        stdout: "",
+        stderr: "FEHLER: Die angegebene Datei wurde nicht gefunden.",
+      });
+      spawnSync.mockReturnValueOnce({
+        pid: 0,
+        output: [null, "-2147024894", ""],
+        stdout: "-2147024894",
+        stderr: "",
+        status: 1,
+        signal: null,
+      });
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(false);
+
+      expect(schtasksCalls).toEqual([["/Query", "/TN", "OpenClaw Gateway", "/XML"]]);
+      expect(spawnSync).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/daemon/schtasks.stop.test.ts
+++ b/src/daemon/schtasks.stop.test.ts
@@ -1,4 +1,6 @@
 // Windows schtasks stop tests cover stopping scheduled task services.
+import fs from "node:fs/promises";
+import path from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-helpers/schtasks-base-mocks.js";
@@ -20,6 +22,21 @@ const sleepMock = vi.hoisted(() =>
     timeState.now += ms;
   }),
 );
+const spawnSync = vi.hoisted(() =>
+  vi.fn(() => ({
+    pid: 0,
+    output: [null, "-2147024891", ""],
+    stdout: "-2147024891",
+    stderr: "",
+    status: 1,
+    signal: null,
+  })),
+);
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, spawnSync };
+});
 
 vi.mock("../infra/gateway-processes.js", () => ({
   findVerifiedGatewayListenerPidsOnPortSync: (port: number) =>
@@ -33,7 +50,12 @@ vi.mock("../utils.js", async () => {
   };
 });
 
-const { restartScheduledTask, stopScheduledTask } = await import("./schtasks.js");
+const {
+  restartScheduledTask,
+  resumeScheduledTaskAutoStartAfterUpdate,
+  stopScheduledTask,
+  suspendScheduledTaskAutoStartForUpdate,
+} = await import("./schtasks.js");
 const GATEWAY_PORT = 18789;
 const SUCCESS_RESPONSE = { code: 0, stdout: "", stderr: "" } as const;
 
@@ -101,6 +123,15 @@ beforeEach(() => {
   sleepMock.mockImplementation(async (ms: number) => {
     timeState.now += ms;
   });
+  spawnSync.mockReset();
+  spawnSync.mockReturnValue({
+    pid: 0,
+    output: [null, "-2147024891", ""],
+    stdout: "-2147024891",
+    stderr: "",
+    status: 1,
+    signal: null,
+  });
   inspectPortUsage.mockResolvedValue(freePortUsage());
 });
 
@@ -109,6 +140,176 @@ afterEach(() => {
 });
 
 describe("Scheduled Task stop/restart cleanup", () => {
+  it("suspends a task whose Settings.Enabled value uses the default", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push(
+        {
+          ...SUCCESS_RESPONSE,
+          stdout: "<Task><Settings><StartWhenAvailable>true</StartWhenAvailable></Settings></Task>",
+        },
+        { ...SUCCESS_RESPONSE },
+      );
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(true);
+
+      expect(schtasksCalls).toEqual([
+        ["/Query", "/TN", "OpenClaw Gateway", "/XML"],
+        ["/Change", "/TN", "OpenClaw Gateway", "/DISABLE"],
+      ]);
+    });
+  });
+
+  it("preserves an already-disabled task", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push({
+        ...SUCCESS_RESPONSE,
+        stdout:
+          "<Task><Triggers><LogonTrigger><Enabled>true</Enabled></LogonTrigger></Triggers><Settings><Enabled>false</Enabled></Settings></Task>",
+      });
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(false);
+
+      expect(schtasksCalls).toEqual([["/Query", "/TN", "OpenClaw Gateway", "/XML"]]);
+    });
+  });
+
+  it("fails closed when the task XML cannot be read", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push({
+        code: 1,
+        stdout: "",
+        stderr: "ERROR: The system cannot find the file specified.",
+      });
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).rejects.toThrow(
+        "schtasks XML query failed: ERROR: The system cannot find the file specified.",
+      );
+
+      expect(schtasksCalls).toEqual([["/Query", "/TN", "OpenClaw Gateway", "/XML"]]);
+    });
+  });
+
+  it("fails closed when the task enabled state is missing", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push({ ...SUCCESS_RESPONSE, stdout: "<Task><Triggers /></Task>" });
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).rejects.toThrow(
+        "schtasks XML query did not expose the task enabled state",
+      );
+    });
+  });
+
+  it("restores an enabled task after an ambiguous disable failure", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push(
+        {
+          ...SUCCESS_RESPONSE,
+          stdout: "<Task><Settings><Enabled>true</Enabled></Settings></Task>",
+        },
+        { code: 124, stdout: "", stderr: "schtasks timed out after 15000ms" },
+        { ...SUCCESS_RESPONSE },
+      );
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).rejects.toThrow(
+        "schtasks disable failed: schtasks timed out after 15000ms",
+      );
+
+      expect(schtasksCalls).toEqual([
+        ["/Query", "/TN", "OpenClaw Gateway", "/XML"],
+        ["/Change", "/TN", "OpenClaw Gateway", "/DISABLE"],
+        ["/Change", "/TN", "OpenClaw Gateway", "/ENABLE"],
+      ]);
+    });
+  });
+
+  it("leaves startup-folder fallback installs unchanged when the task is absent", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      const startupEntry = path.join(
+        env.APPDATA,
+        "Microsoft",
+        "Windows",
+        "Start Menu",
+        "Programs",
+        "Startup",
+        "OpenClaw Gateway.cmd",
+      );
+      await fs.mkdir(path.dirname(startupEntry), { recursive: true });
+      await fs.writeFile(startupEntry, "@echo off\r\n", "utf8");
+      schtasksResponses.push({
+        code: 1,
+        stdout: "",
+        stderr: "FEHLER: Die angegebene Datei wurde nicht gefunden.",
+      });
+      spawnSync.mockReturnValueOnce({
+        pid: 0,
+        output: [null, "-2147024894", ""],
+        stdout: "-2147024894",
+        stderr: "",
+        status: 1,
+        signal: null,
+      });
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(false);
+
+      expect(schtasksCalls).toEqual([["/Query", "/TN", "OpenClaw Gateway", "/XML"]]);
+      expect(spawnSync).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("fails closed on an ambiguous task query even when a startup entry exists", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      const startupEntry = path.join(
+        env.APPDATA,
+        "Microsoft",
+        "Windows",
+        "Start Menu",
+        "Programs",
+        "Startup",
+        "OpenClaw Gateway.cmd",
+      );
+      await fs.mkdir(path.dirname(startupEntry), { recursive: true });
+      await fs.writeFile(startupEntry, "@echo off\r\n", "utf8");
+      schtasksResponses.push({ code: 1, stdout: "", stderr: "ERROR: Access is denied." });
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).rejects.toThrow(
+        "schtasks XML query failed: ERROR: Access is denied.",
+      );
+      expect(spawnSync).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("reads NUL-separated Scheduled Task XML", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      const xml = "<Task><Settings><Enabled>true</Enabled></Settings></Task>";
+      schtasksResponses.push(
+        { ...SUCCESS_RESPONSE, stdout: `\uFEFF${xml.split("").join("\u0000")}` },
+        { ...SUCCESS_RESPONSE },
+      );
+
+      await expect(suspendScheduledTaskAutoStartForUpdate(env)).resolves.toBe(true);
+    });
+  });
+
+  it("reenables a task after the update window", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push({ ...SUCCESS_RESPONSE });
+
+      await expect(resumeScheduledTaskAutoStartAfterUpdate(env)).resolves.toBe(true);
+
+      expect(schtasksCalls).toEqual([["/Change", "/TN", "OpenClaw Gateway", "/ENABLE"]]);
+    });
+  });
+
+  it("surfaces a failed task reenable", async () => {
+    await withPreparedGatewayTask(async ({ env }) => {
+      schtasksResponses.push({ code: 1, stdout: "", stderr: "ERROR: Access is denied." });
+
+      await expect(resumeScheduledTaskAutoStartAfterUpdate(env)).rejects.toThrow(
+        "schtasks enable failed: ERROR: Access is denied.",
+      );
+    });
+  });
+
   it("kills lingering verified gateway listeners after schtasks stop", async () => {
     await withPreparedGatewayTask(async ({ env, stdout }) => {
       pushSuccessfulSchtasksResponses(3);

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1391,6 +1391,108 @@ function isTaskNotRunning(res: { stdout: string; stderr: string; code: number })
   return detail.includes("not running");
 }
 
+function parseScheduledTaskXmlEnabled(output: string): boolean | null {
+  const normalized = output.replace(/^\uFEFF/u, "").replaceAll(String.fromCharCode(0), "");
+  const settings = /<Settings(?:\s[^>]*)?>([\s\S]*?)<\/Settings>/iu.exec(normalized)?.[1];
+  if (settings === undefined) {
+    return null;
+  }
+  const enabled = /<Enabled>\s*(true|false)\s*<\/Enabled>/iu.exec(settings)?.[1];
+  // Task Scheduler's schema defaults a missing Settings.Enabled value to true.
+  return enabled === undefined ? true : enabled.toLowerCase() === "true";
+}
+
+function probeScheduledTaskExists(taskName: string): boolean | null {
+  const encodedTaskName = Buffer.from(taskName, "utf8").toString("base64");
+  const script = [
+    "$ErrorActionPreference='Stop'",
+    `$taskName=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encodedTaskName}'))`,
+    "try { $service=New-Object -ComObject 'Schedule.Service'; $service.Connect(); $null=$service.GetFolder('\\').GetTask($taskName); exit 0 } catch { $exception=$_.Exception; while($null -ne $exception.InnerException){$exception=$exception.InnerException}; [Console]::Out.Write($exception.HResult); exit 1 }",
+  ].join("; ");
+  const probe = spawnSync(
+    getWindowsPowerShellExePath(),
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-EncodedCommand",
+      Buffer.from(script, "utf16le").toString("base64"),
+    ],
+    { encoding: "utf8", timeout: 5_000, windowsHide: true },
+  );
+  if (probe.error) {
+    return null;
+  }
+  if (probe.status === 0) {
+    return true;
+  }
+  const hresult = Number.parseInt(probe.stdout.trim(), 10);
+  // Task Scheduler COM reports missing task and missing task-folder paths as
+  // locale-independent HRESULT_FROM_WIN32 values. Every other failure stays fatal.
+  return hresult === -2147024894 || hresult === -2147024893 ? false : null;
+}
+
+async function changeScheduledTaskEnabledState(params: {
+  env: GatewayServiceEnv;
+  enabled: boolean;
+}): Promise<boolean> {
+  const taskName = resolveTaskName(params.env);
+  if (!params.enabled) {
+    const query = await execSchtasks(["/Query", "/TN", taskName, "/XML"]);
+    if (query.code !== 0) {
+      if (await isStartupEntryInstalled(params.env)) {
+        const taskExists = probeScheduledTaskExists(taskName);
+        if (taskExists === false) {
+          return false;
+        }
+      }
+      const detail = (query.stderr || query.stdout).trim() || "unknown error";
+      throw new Error(`schtasks XML query failed: ${detail}`);
+    }
+    const enabled = parseScheduledTaskXmlEnabled(query.stdout);
+    if (enabled === null) {
+      throw new Error("schtasks XML query did not expose the task enabled state");
+    }
+    if (!enabled) {
+      return false;
+    }
+  }
+
+  const action = params.enabled ? "/ENABLE" : "/DISABLE";
+  const result = await execSchtasks(["/Change", "/TN", taskName, action]);
+  if (result.code !== 0) {
+    const detail = (result.stderr || result.stdout).trim() || "unknown error";
+    const changeError = new Error(
+      `schtasks ${params.enabled ? "enable" : "disable"} failed: ${detail}`,
+    );
+    if (!params.enabled) {
+      // The task was proven enabled before /DISABLE. A timeout or non-zero exit
+      // can still follow a committed change, so restore that known prior state.
+      const restore = await execSchtasks(["/Change", "/TN", taskName, "/ENABLE"]);
+      if (restore.code !== 0) {
+        const restoreDetail = (restore.stderr || restore.stdout).trim() || "unknown error";
+        throw new AggregateError(
+          [changeError, new Error(`schtasks enable failed: ${restoreDetail}`)],
+          "Scheduled Task disable failed and its enabled state could not be restored",
+        );
+      }
+    }
+    throw changeError;
+  }
+  return true;
+}
+
+export async function suspendScheduledTaskAutoStartForUpdate(
+  env: GatewayServiceEnv = process.env as GatewayServiceEnv,
+): Promise<boolean> {
+  return await changeScheduledTaskEnabledState({ env, enabled: false });
+}
+
+export async function resumeScheduledTaskAutoStartAfterUpdate(
+  env: GatewayServiceEnv = process.env as GatewayServiceEnv,
+): Promise<boolean> {
+  return await changeScheduledTaskEnabledState({ env, enabled: true });
+}
+
 export async function stopScheduledTask({ stdout, env }: GatewayServiceControlArgs): Promise<void> {
   const effectiveEnv = env ?? (process.env as GatewayServiceEnv);
   try {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1439,11 +1439,9 @@ async function changeScheduledTaskEnabledState(params: {
   if (!params.enabled) {
     const query = await execSchtasks(["/Query", "/TN", taskName, "/XML"]);
     if (query.code !== 0) {
-      if (await isStartupEntryInstalled(params.env)) {
-        const taskExists = probeScheduledTaskExists(taskName);
-        if (taskExists === false) {
-          return false;
-        }
+      const taskExists = probeScheduledTaskExists(taskName);
+      if (taskExists === false) {
+        return false;
       }
       const detail = (query.stderr || query.stdout).trim() || "unknown error";
       throw new Error(`schtasks XML query failed: ${detail}`);


### PR DESCRIPTION
## What Problem This Solves

Legacy Windows Gateway Scheduled Tasks can contain a `PT3M` repetition trigger. During a package update, stopping the running Gateway does not prevent that trigger from relaunching it while npm is replacing the package tree.

Fixes #87993. Replays and supersedes #88292 while preserving @vincentkoc's authorship.

## Why This Change Was Made

Package updates now suspend only an enabled managed Scheduled Task before service or package mutation, retain that state through post-core work, and restore the original enabled state before restart, recovery, error return, or signal exit. Already-disabled tasks stay disabled; deleted tasks are treated as absent through a locale-independent Task Scheduler COM result; ambiguous query or mutation failures fail closed.

The replay also coordinates task restoration with the CLI's existing signal cleanup so Ctrl+C, Ctrl+Break, and proxy shutdown cannot race package mutation or lose the original failure. Git update behavior and non-Windows platforms remain unchanged.

## User Impact

Windows package updates no longer risk a repeated Scheduled Task relaunching the Gateway against a partially replaced installation. Existing operator-disabled tasks are preserved, and stale gateway scripts without a Scheduled Task no longer block updates.

## Evidence

- Native Windows disable/enable scenario: https://crabbox.openclaw.ai/portal/runs/run_bc9acf23d798
- Native Windows Task Scheduler COM missing-task proof: https://crabbox.openclaw.ai/portal/runs/run_765b0254db6a
- Testbox focused proof: 18 daemon tests, 181 updater tests, and 141 CLI exit tests passed.
- Testbox changed gates passed: core and core-test typechecks, lint, import-cycle, database-first, runtime-sidecar, webhook, and pairing guards.
- Full Testbox build passed, including tsdown, runtime postbuild, plugin SDK export checks, and Control UI build.
- Fresh branch autoreview: no accepted or actionable findings; overall correctness 0.90.
- Final rebase touched only `CHANGELOG.md`; the seven code commits range-diff identically, followed by a second green focused suite and changed-gate run.
