### PR TITLE
fix(channels): canonicalize bundled module boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Android PTT microphone ownership:** pause realtime relay capture while push-to-talk owns the microphone, then resume only for the same completed capture. (#99986) Thanks @NianJiuZst.
+- **Bundled channel loading:** resolve source-only bundled channel entries from their current registry root and canonicalize active-release aliases before enforcing module boundaries, avoiding false setup-entry warnings in mixed source/dist deployments without admitting paths outside the active package boundary.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.
 - **Config validation diagnostics:** emit each unchanged sanitized validation-warning payload once per config path, reset deduplication after a clean validation, and preserve the warning fingerprint across transient invalid reads and failed refreshes. (#100569, #25574) Thanks @vincentkoc.

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -1039,6 +1039,57 @@ describe("bundled channel entry shape guards", () => {
     }
   });
 
+  it("accepts canonical built entries through the active package symlink", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-alias-boundary-"));
+    const previousBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+    const releaseRoot = path.join(root, "releases", "release-sha");
+    const currentRoot = path.join(root, "current");
+    const pluginDir = path.join(releaseRoot, "dist", "extensions", "alpha");
+    const setupEntryPath = path.join(pluginDir, "setup-entry.cjs");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.symlinkSync(releaseRoot, currentRoot, process.platform === "win32" ? "junction" : "dir");
+    fs.writeFileSync(
+      setupEntryPath,
+      [
+        "module.exports = {",
+        "  kind: 'bundled-channel-setup-entry',",
+        "  loadSetupPlugin() {",
+        "    return { id: 'alpha', meta: { label: 'Aliased Alpha' }, capabilities: {}, config: {} };",
+        "  },",
+        "};",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    vi.doMock("../../plugins/bundled-channel-runtime.js", () => ({
+      listBundledChannelPluginMetadata: () => [
+        {
+          ...alphaChannelMetadata({ includeSetup: true }),
+          rootDir: pluginDir,
+          setupSource: {
+            source: setupEntryPath,
+            built: setupEntryPath,
+          },
+        },
+      ],
+      resolveBundledChannelGeneratedPath: () => null,
+    }));
+
+    try {
+      process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = path.join(currentRoot, "dist", "extensions");
+      const bundled = await importFreshModule<typeof import("./bundled.js")>(
+        import.meta.url,
+        "./bundled.js?scope=bundled-alias-boundary",
+      );
+
+      expect(bundled.getBundledChannelSetupPlugin("alpha")?.meta.label).toBe("Aliased Alpha");
+    } finally {
+      restoreBundledPluginsDir(previousBundledPluginsDir);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("caches undefined bundled plugin loads as unavailable", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-null-load-"));
     const previousBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -112,6 +112,21 @@ function isSourceModulePath(modulePath: string): boolean {
   return /\.(?:c|m)?tsx?$/iu.test(modulePath);
 }
 
+function resolveCanonicalPathOrAbsolute(targetPath: string): string {
+  try {
+    return fs.realpathSync.native(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
+}
+
+function isPathInsideCanonicalRoot(rootPath: string, targetPath: string): boolean {
+  return isPathInside(
+    resolveCanonicalPathOrAbsolute(rootPath),
+    resolveCanonicalPathOrAbsolute(targetPath),
+  );
+}
+
 function isPackageLocalBundledDistModulePath(params: {
   rootScope: BundledChannelRootScope;
   metadata: BundledChannelPluginMetadata;
@@ -123,7 +138,7 @@ function isPackageLocalBundledDistModulePath(params: {
       : []),
     path.join(params.rootScope.packageRoot, "extensions", params.metadata.dirName, "dist"),
   ];
-  return distRoots.some((root) => isPathInside(root, params.modulePath));
+  return distRoots.some((root) => isPathInsideCanonicalRoot(root, params.modulePath));
 }
 
 function resolveChannelPluginModuleEntry(
@@ -191,13 +206,18 @@ function resolveBundledChannelBoundaryRoot(params: {
     bundledChannelBoundaryRoots.set(cacheKey, cached);
     return cached;
   }
-  const isModuleUnderRoot = (root: string) => isPathInside(path.resolve(root), params.modulePath);
+  const canonicalModulePath = resolveCanonicalPathOrAbsolute(params.modulePath);
+  const resolveMatchingRoot = (root: string): string | null => {
+    const canonicalRoot = resolveCanonicalPathOrAbsolute(root);
+    return isPathInside(canonicalRoot, canonicalModulePath) ? canonicalRoot : null;
+  };
   const overrideRoot = params.pluginsDir
     ? path.resolve(params.pluginsDir, params.metadata.dirName)
     : null;
   let boundaryRoot: string;
-  if (overrideRoot && isModuleUnderRoot(overrideRoot)) {
-    boundaryRoot = overrideRoot;
+  const overrideBoundaryRoot = overrideRoot ? resolveMatchingRoot(overrideRoot) : null;
+  if (overrideBoundaryRoot) {
+    boundaryRoot = overrideBoundaryRoot;
   } else {
     const distRoot = path.resolve(
       params.packageRoot,
@@ -205,8 +225,9 @@ function resolveBundledChannelBoundaryRoot(params: {
       "extensions",
       params.metadata.dirName,
     );
-    if (isModuleUnderRoot(distRoot)) {
-      boundaryRoot = distRoot;
+    const distBoundaryRoot = resolveMatchingRoot(distRoot);
+    if (distBoundaryRoot) {
+      boundaryRoot = distBoundaryRoot;
     } else {
       const distRuntimeRoot = path.resolve(
         params.packageRoot,
@@ -214,9 +235,11 @@ function resolveBundledChannelBoundaryRoot(params: {
         "extensions",
         params.metadata.dirName,
       );
-      boundaryRoot = isModuleUnderRoot(distRuntimeRoot)
-        ? distRuntimeRoot
-        : path.resolve(params.packageRoot, "extensions", params.metadata.dirName);
+      boundaryRoot =
+        resolveMatchingRoot(distRuntimeRoot) ??
+        resolveCanonicalPathOrAbsolute(
+          path.resolve(params.packageRoot, "extensions", params.metadata.dirName),
+        );
     }
   }
   bundledChannelBoundaryRoots.set(cacheKey, boundaryRoot);


### PR DESCRIPTION
## Summary

- canonicalize bundled module and boundary paths before containment checks
- handle `current` symlink paths and canonical SHA release paths as the same trusted plugin root
- preserve the existing root-scoped file-open guard and package boundary
- add a regression test for the exact active-release symlink layout

## Root cause

The managed runner starts through the `current` symlink, while derived plugin metadata uses canonical SHA release paths. Lexical boundary selection treated those aliases as different trees and selected the source boundary for valid built setup entries.

## Proof

- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/channels/plugins/bundled.ts src/channels/plugins/bundled.shape-guard.test.ts` — passed
- `pnpm exec vitest run src/channels/plugins/bundled.shape-guard.test.ts` — 26 passed
- `pnpm build` — passed
- Blacksmith Testbox via Crabbox: `tbx_01kwv8dkdtp26p0q2mmfzn6pmr`
- autoreview: clean, no accepted/actionable findings
