### PR TITLE
fix(android): finish onboarding after permission reapproval

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1707,7 +1707,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 665,
+      "line": 686,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Trust",
       "surface": "android",
@@ -1715,7 +1715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 670,
+      "line": 691,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Cancel",
       "surface": "android",
@@ -1723,7 +1723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 867,
+      "line": 888,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1731,7 +1731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 893,
+      "line": 914,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -1739,7 +1739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 949,
+      "line": 970,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect to your Gateway",
       "surface": "android",
@@ -1747,7 +1747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 950,
+      "line": 971,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose device permissions",
       "surface": "android",
@@ -1755,7 +1755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 951,
+      "line": 972,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use OpenClaw from your phone",
       "surface": "android",
@@ -1763,7 +1763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 973,
+      "line": 994,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Security notice",
       "surface": "android",
@@ -1771,7 +1771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 975,
+      "line": 996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The connected OpenClaw agent can use device capabilities you enable. Continue only if you trust the Gateway and agent you connect to.",
       "surface": "android",
@@ -1779,7 +1779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1016,
+      "line": 1037,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -1787,7 +1787,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1026,
+      "line": 1047,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not open setup guide.",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1034,
+      "line": 1055,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR or setup code",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1040,
+      "line": 1061,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Set up manually",
       "surface": "android",
@@ -1811,7 +1811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1062,
+      "line": 1083,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Before you start",
       "surface": "android",
@@ -1819,7 +1819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1068,
+      "line": 1089,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Access to the Gateway device",
       "surface": "android",
@@ -1827,7 +1827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1072,
+      "line": 1093,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Phone can reach the Gateway",
       "surface": "android",
@@ -1835,7 +1835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1079,
+      "line": 1100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Android setup guide",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1122,
+      "line": 1143,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup Gateway",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1128,
+      "line": 1149,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Start your Gateway.",
       "surface": "android",
@@ -1859,7 +1859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1134,
+      "line": 1155,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Generate a QR code.",
       "surface": "android",
@@ -1867,7 +1867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1155,
+      "line": 1176,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose from gallery",
       "surface": "android",
@@ -1875,7 +1875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1209,
+      "line": 1230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "QR code not accepted",
       "surface": "android",
@@ -1883,7 +1883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1224,
+      "line": 1245,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose another image",
       "surface": "android",
@@ -1891,7 +1891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1277,
+      "line": 1298,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR code",
       "surface": "android",
@@ -1899,7 +1899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1279,
+      "line": 1300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open the camera and frame the code from openclaw qr.",
       "surface": "android",
@@ -1907,7 +1907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1313,
+      "line": 1334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Align the QR code inside the square.",
       "surface": "android",
@@ -1915,7 +1915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1331,
+      "line": 1352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Camera access is needed to scan the setup QR.",
       "surface": "android",
@@ -1923,7 +1923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1336,
+      "line": 1357,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow camera",
       "surface": "android",
@@ -1931,7 +1931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1357,
+      "line": 1378,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close scanner",
       "surface": "android",
@@ -1939,7 +1939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1519,
+      "line": 1540,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enter setup code",
       "surface": "android",
@@ -1947,7 +1947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1520,
+      "line": 1541,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
@@ -1955,7 +1955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1524,
+      "line": 1545,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste setup code",
       "surface": "android",
@@ -1963,7 +1963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1528,
+      "line": 1549,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code was not accepted",
       "surface": "android",
@@ -1971,7 +1971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1532,
+      "line": 1553,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use setup code",
       "surface": "android",
@@ -1979,7 +1979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1563,
+      "line": 1584,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Manual setup",
       "surface": "android",
@@ -1987,7 +1987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1566,
+      "line": 1587,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway URL",
       "surface": "android",
@@ -1995,7 +1995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1568,
+      "line": 1589,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
@@ -2003,7 +2003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1569,
+      "line": 1590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
@@ -2011,7 +2011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1572,
+      "line": 1593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the Gateway computer's LAN address or secure remote hostname.",
       "surface": "android",
@@ -2019,7 +2019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1579,
+      "line": 1600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token",
       "surface": "android",
@@ -2027,7 +2027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1580,
+      "line": 1601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste token",
       "surface": "android",
@@ -2035,7 +2035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1582,
+      "line": 1603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste a shared Gateway token or operator-issued token.",
       "surface": "android",
@@ -2043,7 +2043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1589,
+      "line": 1610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password",
       "surface": "android",
@@ -2051,7 +2051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1590,
+      "line": 1611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
@@ -2059,7 +2059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1594,
+      "line": 1615,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection type",
       "surface": "android",
@@ -2067,7 +2067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1596,
+      "line": 1617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Local network",
       "surface": "android",
@@ -2075,7 +2075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1597,
+      "line": 1618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Secure remote",
       "surface": "android",
@@ -2083,7 +2083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1600,
+      "line": 1621,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Local works for LAN or emulator hosts. Secure remote is for wss:// or Tailscale Serve/Funnel.",
       "surface": "android",
@@ -2091,7 +2091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1608,
+      "line": 1629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not test connection",
       "surface": "android",
@@ -2099,7 +2099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1613,
+      "line": 1634,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Test connection",
       "surface": "android",
@@ -2107,7 +2107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1791,
+      "line": 1812,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "View details",
       "surface": "android",
@@ -2115,7 +2115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1824,
+      "line": 1845,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection details",
       "surface": "android",
@@ -2123,7 +2123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1836,
+      "line": 1857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy",
       "surface": "android",
@@ -2131,7 +2131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1841,
+      "line": 1862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close",
       "surface": "android",
@@ -2139,7 +2139,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1853,
+      "line": 1874,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Details copied",
       "surface": "android",
@@ -2147,7 +2147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1938,
+      "line": 1959,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approve node access",
       "surface": "android",
@@ -2155,7 +2155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1945,
+      "line": 1966,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway pairing is complete. Approve this phone as a node so OpenClaw can use the device capabilities you enable.",
       "surface": "android",
@@ -2163,7 +2163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1953,
+      "line": 1974,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "On the Gateway computer, run:",
       "surface": "android",
@@ -2171,7 +2171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1962,
+      "line": 1983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the requestId from the pending command in the approve command.",
       "surface": "android",
@@ -2179,7 +2179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1973,
+      "line": 1994,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "I have approved",
       "surface": "android",
@@ -2187,7 +2187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1986,
+      "line": 2007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still waiting for approval",
       "surface": "android",
@@ -2195,7 +2195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1989,
+      "line": 2010,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Run the approve command on the Gateway computer, then check again.",
       "surface": "android",
@@ -2203,7 +2203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1996,
+      "line": 2017,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OK",
       "surface": "android",
@@ -2211,7 +2211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2146,
+      "line": 2167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
@@ -2219,7 +2219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2172,
+      "line": 2193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Only enable access you are comfortable letting OpenClaw use while this phone is connected. You can change these later in Android Settings.",
       "surface": "android",
@@ -2227,7 +2227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2184,
+      "line": 2205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
@@ -2235,7 +2235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2211,
+      "line": 2232,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
@@ -2243,7 +2243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2258,
+      "line": 2279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permissions",
       "surface": "android",
@@ -2251,7 +2251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2583,
+      "line": 2604,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The code may have expired or been generated for another Gateway.",
       "surface": "android",
@@ -2259,7 +2259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2587,
+      "line": 2608,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -2267,7 +2267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2588,
+      "line": 2609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
@@ -2275,7 +2275,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2589,
+      "line": 2610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -2283,7 +2283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2591,
+      "line": 2612,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -2291,7 +2291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2595,
+      "line": 2616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -2299,7 +2299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2596,
+      "line": 2617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
@@ -2307,7 +2307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2597,
+      "line": 2618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
@@ -2315,7 +2315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2614,
+      "line": 2635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "$summary $it",
       "surface": "android",
@@ -2323,7 +2323,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 2757,
+      "line": 2786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
@@ -2331,7 +2331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2819,
+      "line": 2848,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
@@ -2339,7 +2339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2819,
+      "line": 2848,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Permission-triggered node reapproval now finishes onboarding instead of returning to Permissions and repeating the approval flow.
+
 The OpenClaw mascot now comes alive across onboarding and the app headers with the same float, blink, antenna-wiggle, and claw-snap animation as openclaw.ai.
 
 Adds read-only Cron Job details in Settings, including schedule, payload and delivery state, job ID copy, refresh, and nested back navigation.

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -158,6 +158,21 @@ internal enum class OnboardingGatewayInputSource {
   Manual,
 }
 
+/**
+ * Tracks approval purpose and the one-shot initial auto-continue.
+ * Reopening Permissions after reapproval or auto-forwarding after Back recreates the loop.
+ */
+internal enum class OnboardingNodeApprovalMode {
+  BeforePermissionsAutoContinue,
+  BeforePermissions,
+  PermissionReapproval,
+}
+
+internal enum class OnboardingNodeApprovalReadyAction {
+  ShowPermissions,
+  FinishOnboarding,
+}
+
 private const val GATEWAY_CONNECT_SETTLING_MS = 2_500L
 private const val GATEWAY_CONNECT_TIMEOUT_MS = 20_000L
 private const val NODE_APPROVAL_REFRESH_OBSERVE_TIMEOUT_MS = 750L
@@ -291,9 +306,9 @@ fun OnboardingFlow(
     var recoveryNowMs by remember { mutableLongStateOf(SystemClock.elapsedRealtime()) }
     var nodeApprovalBackStep by rememberSaveable { mutableStateOf(OnboardingStep.Recovery) }
     var permissionsBackStep by rememberSaveable { mutableStateOf(OnboardingStep.NodeApproval) }
+    var nodeApprovalMode by rememberSaveable { mutableStateOf(OnboardingNodeApprovalMode.BeforePermissions) }
     var nodeApprovalCheckRequested by rememberSaveable { mutableStateOf(false) }
     var nodeApprovalCheckRefreshStarted by rememberSaveable { mutableStateOf(false) }
-    var nodeApprovalAutoContinueEnabled by rememberSaveable { mutableStateOf(false) }
 
     OpenClawSystemBarAppearance(lightAppearance = !onboardingDark)
 
@@ -331,6 +346,19 @@ fun OnboardingFlow(
       inlineQrScannerActive = next.inlineQrScannerActive
       setupCodeEntryOpenedFromScanner = next.setupCodeEntryOpenedFromScanner
       step = next.step
+    }
+
+    fun handleNodeApprovalReady() {
+      nodeApprovalCheckRequested = false
+      nodeApprovalCheckRefreshStarted = false
+      when (nodeApprovalReadyAction(nodeApprovalMode)) {
+        OnboardingNodeApprovalReadyAction.ShowPermissions -> {
+          nodeApprovalMode = OnboardingNodeApprovalMode.BeforePermissions
+          permissionsBackStep = OnboardingStep.NodeApproval
+          step = OnboardingStep.Permissions
+        }
+        OnboardingNodeApprovalReadyAction.FinishOnboarding -> viewModel.setOnboardingCompleted(true)
+      }
     }
 
     BackHandler(
@@ -397,7 +425,7 @@ fun OnboardingFlow(
       }
     }
 
-    LaunchedEffect(step, ready, nodeApprovalCheckRequested, nodeApprovalCheckRefreshStarted, nodesDevicesRefreshing) {
+    LaunchedEffect(step, ready, nodeApprovalMode, nodeApprovalCheckRequested, nodeApprovalCheckRefreshStarted, nodesDevicesRefreshing) {
       if (
         step == OnboardingStep.NodeApproval &&
         nodeApprovalCheckCanContinue(
@@ -407,27 +435,20 @@ fun OnboardingFlow(
           ready = ready,
         )
       ) {
-        nodeApprovalCheckRequested = false
-        nodeApprovalCheckRefreshStarted = false
-        permissionsBackStep = OnboardingStep.NodeApproval
-        step = OnboardingStep.Permissions
+        handleNodeApprovalReady()
       }
     }
 
-    LaunchedEffect(step, ready, nodeCapabilityApproval, nodeApprovalAutoContinueEnabled) {
+    LaunchedEffect(step, ready, nodeCapabilityApproval, nodeApprovalMode) {
       if (
         nodeApprovalShouldAutoContinue(
           step = step,
           ready = ready,
           nodeCapabilityApproval = nodeCapabilityApproval,
-          autoContinueEnabled = nodeApprovalAutoContinueEnabled,
+          mode = nodeApprovalMode,
         )
       ) {
-        nodeApprovalCheckRequested = false
-        nodeApprovalCheckRefreshStarted = false
-        nodeApprovalAutoContinueEnabled = false
-        permissionsBackStep = OnboardingStep.NodeApproval
-        step = OnboardingStep.Permissions
+        handleNodeApprovalReady()
       }
     }
 
@@ -474,7 +495,7 @@ fun OnboardingFlow(
         OnboardingStep.NodeApproval -> {
           nodeApprovalCheckRequested = false
           nodeApprovalCheckRefreshStarted = false
-          nodeApprovalAutoContinueEnabled = true
+          nodeApprovalMode = OnboardingNodeApprovalMode.BeforePermissionsAutoContinue
           nodeApprovalBackStep = OnboardingStep.Recovery
           step = OnboardingStep.NodeApproval
         }
@@ -837,9 +858,9 @@ fun OnboardingFlow(
                 )
               nodeApprovalBackStep = reapprovalBackSteps.nodeApprovalBackStep
               permissionsBackStep = reapprovalBackSteps.permissionsBackStep
+              nodeApprovalMode = OnboardingNodeApprovalMode.PermissionReapproval
               nodeApprovalCheckRequested = false
               nodeApprovalCheckRefreshStarted = false
-              nodeApprovalAutoContinueEnabled = false
               viewModel.refreshNodesDevices()
               viewModel.refreshGatewayConnection()
               step = OnboardingStep.NodeApproval
@@ -2723,14 +2744,22 @@ internal fun nodeApprovalCheckCanContinue(
     !nodesDevicesRefreshing &&
     ready
 
+internal fun nodeApprovalReadyAction(mode: OnboardingNodeApprovalMode): OnboardingNodeApprovalReadyAction =
+  when (mode) {
+    OnboardingNodeApprovalMode.BeforePermissionsAutoContinue,
+    OnboardingNodeApprovalMode.BeforePermissions,
+    -> OnboardingNodeApprovalReadyAction.ShowPermissions
+    OnboardingNodeApprovalMode.PermissionReapproval -> OnboardingNodeApprovalReadyAction.FinishOnboarding
+  }
+
 internal fun nodeApprovalShouldAutoContinue(
   step: OnboardingStep,
   ready: Boolean,
   nodeCapabilityApproval: GatewayNodeCapabilityApproval,
-  autoContinueEnabled: Boolean,
+  mode: OnboardingNodeApprovalMode,
 ): Boolean =
   step == OnboardingStep.NodeApproval &&
-    autoContinueEnabled &&
+    mode == OnboardingNodeApprovalMode.BeforePermissionsAutoContinue &&
     ready &&
     !nodeCapabilityApprovalNeedsUserAction(nodeCapabilityApproval)
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/OnboardingFlowLogicTest.kt
@@ -639,7 +639,7 @@ class OnboardingFlowLogicTest {
         step = OnboardingStep.NodeApproval,
         ready = true,
         nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-        autoContinueEnabled = true,
+        mode = OnboardingNodeApprovalMode.BeforePermissionsAutoContinue,
       ),
     )
     assertFalse(
@@ -647,7 +647,7 @@ class OnboardingFlowLogicTest {
         step = OnboardingStep.NodeApproval,
         ready = true,
         nodeCapabilityApproval = GatewayNodeCapabilityApproval.PendingApproval(null),
-        autoContinueEnabled = true,
+        mode = OnboardingNodeApprovalMode.BeforePermissionsAutoContinue,
       ),
     )
     assertFalse(
@@ -655,7 +655,7 @@ class OnboardingFlowLogicTest {
         step = OnboardingStep.Permissions,
         ready = true,
         nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-        autoContinueEnabled = true,
+        mode = OnboardingNodeApprovalMode.BeforePermissionsAutoContinue,
       ),
     )
     assertFalse(
@@ -663,8 +663,32 @@ class OnboardingFlowLogicTest {
         step = OnboardingStep.NodeApproval,
         ready = true,
         nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
-        autoContinueEnabled = false,
+        mode = OnboardingNodeApprovalMode.BeforePermissions,
       ),
+    )
+    assertFalse(
+      nodeApprovalShouldAutoContinue(
+        step = OnboardingStep.NodeApproval,
+        ready = true,
+        nodeCapabilityApproval = GatewayNodeCapabilityApproval.Approved,
+        mode = OnboardingNodeApprovalMode.PermissionReapproval,
+      ),
+    )
+  }
+
+  @Test
+  fun nodeApprovalReadyActionFinishesPermissionReapprovalWithoutReopeningPermissions() {
+    assertEquals(
+      OnboardingNodeApprovalReadyAction.ShowPermissions,
+      nodeApprovalReadyAction(OnboardingNodeApprovalMode.BeforePermissionsAutoContinue),
+    )
+    assertEquals(
+      OnboardingNodeApprovalReadyAction.ShowPermissions,
+      nodeApprovalReadyAction(OnboardingNodeApprovalMode.BeforePermissions),
+    )
+    assertEquals(
+      OnboardingNodeApprovalReadyAction.FinishOnboarding,
+      nodeApprovalReadyAction(OnboardingNodeApprovalMode.PermissionReapproval),
     )
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users who changed device capabilities during QR onboarding were sent back to Permissions after completing the required node reapproval. That made setup appear to loop between Permissions and Approve node access instead of finishing.

## Why This Change Was Made

The approval screen now records whether it is the initial pre-permissions approval, a manual revisit of that approval, or permission-triggered reapproval. One completion path consumes initial auto-continue exactly once, opens Permissions only for the initial approval, and finishes onboarding directly after permission reapproval.

## User Impact

Android QR onboarding now completes after the final permission-triggered node approval. Back navigation still returns from reapproval to Permissions and then gateway recovery without immediately auto-forwarding again.

AI-assisted: implemented and reviewed with Codex; the author inspected the state transitions and accepted the first review finding before rerunning review.

## Evidence

- Blacksmith Testbox through Crabbox `tbx_01kwv88d1zz3wvdgbg9t9x91h6`: focused `OnboardingFlowLogicTest` passed.
- Same Testbox: full `:app:testPlayDebugUnitTest` passed after rebasing.
- Same Testbox: `pnpm native:i18n:check` reports `changed=false` after regenerating the native inventory.
- Regression coverage asserts initial approval opens Permissions, permission reapproval finishes onboarding, and Back revisits do not re-arm auto-continue.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex --model gpt-5.5 --thinking high` reported no actionable findings.
- `git diff --check origin/main...HEAD` passed.
- Visual evidence is not applicable; this changes navigation state only, with no rendering change.
