### PR TITLE
fix(process): unref closeFallbackTimer in runCommandWithTimeout

### DIFF
--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -334,6 +334,47 @@ describe("runCommandWithTimeout", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "unrefs the close fallback timer so it does not keep the process alive",
+    async () => {
+      const originalSetTimeout = globalThis.setTimeout;
+      const unref = vi.fn();
+      vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+        callback: () => void,
+        timeout?: number,
+      ) => {
+        const timer = originalSetTimeout(callback, timeout);
+        Object.defineProperty(timer, "unref", {
+          value: () => {
+            unref();
+            return timer;
+          },
+          writable: true,
+          configurable: true,
+        });
+        return timer;
+      }) as typeof setTimeout);
+
+      const child = createKilledChild();
+      spawnMock.mockReturnValue(child);
+      await loadExecModules({ mockSpawn: true });
+
+      const resultPromise = runCommandWithTimeout(createSilentIdleArgv(), {
+        timeoutMs: 2_000,
+      });
+
+      child.emit("exit", 0, null);
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(unref).toHaveBeenCalledOnce();
+
+      child.emit("close", 0, null);
+      const result = await resultPromise;
+      expect(result.termination).toBe("exit");
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "swallows stdin EPIPE when child exits before input is consumed (#75438)",
     { timeout: 5_000 },
     async () => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -666,6 +666,7 @@ export async function runCommandWithTimeout(
         child.stdout?.destroy();
         child.stderr?.destroy();
       }, 250);
+      closeFallbackTimer.unref();
     });
     const resolveFromClose = (code: number | null, signalValue: NodeJS.Signals | null) => {
       if (settled) {


### PR DESCRIPTION
Fixes #100662.

## What Problem This Solves

In `src/process/exec.ts`, `runCommandWithTimeout` arms a 250 ms `closeFallbackTimer` after a child process exits, to force-destroy `stdout`/`stderr` if they have not emitted `close`. This timer was not `unref()`'d, so it kept the Node event loop alive and delayed natural CLI termination even when the command had already completed.

## Why This Change Was Made

Calling `.unref()` on the fallback timer lets Node exit as soon as the command promise resolves and there is no other work, matching the behavior of the other timers in the same function (e.g. `processTreeForceKillTimer.unref()`).

## User Impact

CLI users will no longer experience an extra ~250 ms hang after spawned commands finish.

## Evidence

Added a regression test in `src/process/exec.test.ts` that intercepts `setTimeout`, arms the close fallback timer by emitting `exit` on a mocked child, and asserts `.unref()` is called exactly once.

```bash
node_modules/.bin/vitest run --project=process src/process/exec.test.ts
```

Result:
```
Test Files  1 passed (1)
     Tests  20 passed (20)
```

Full process shard also passes:
```bash
node_modules/.bin/vitest run --project=process
```

Result:
```
Test Files  11 passed (11)
     Tests  136 passed (136)
```

Formatting and linting on the changed files pass:
```bash
node_modules/.bin/oxfmt --check src/process/exec.ts src/process/exec.test.ts
node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.json src/process/exec.ts src/process/exec.test.ts
```
