### PR TITLE
feat(android): per-gateway custom headers for gateways behind authenticating proxies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Android gateway proxy headers:** store per-gateway custom WebSocket upgrade headers in encrypted preferences, expose a masked manual-connection editor, and enforce TLS-only delivery with reserved-header and cross-gateway isolation. (#100765)
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Android gateway proxy headers:** store per-gateway custom WebSocket upgrade headers in encrypted preferences, expose a masked manual-connection editor, and enforce TLS-only delivery with reserved-header and cross-gateway isolation. (#100765)
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -387,7 +387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1229,
+      "line": 1239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -395,7 +395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1229,
+      "line": 1239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 329,
+      "line": 334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Last gateway error",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 329,
+      "line": 334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Pairing required",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 340,
+      "line": 345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "OpenClaw Android ${openClawAndroidVersionLabel()}",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 381,
+      "line": 386,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Setup code, endpoint, TLS, token, password, onboarding.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 385,
+      "line": 390,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Collapse advanced controls",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 385,
+      "line": 390,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Expand advanced controls",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 416,
+      "line": 421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Run these on the gateway host:",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 419,
+      "line": 424,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "For Tailscale or public hosts, use wss:// or Tailscale Serve. Private LAN ws:// remains supported.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 448,
+      "line": 453,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Android Emulator",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 457,
+      "line": 462,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Localhost",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 484,
+      "line": 489,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Port",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 484,
+      "line": 489,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Port (optional, defaults to 443)",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 510,
+      "line": 515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Turn this on for Tailscale or public hosts. Private LAN ws:// remains supported.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 536,
+      "line": 541,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Leave blank to keep saved token",
       "surface": "android",
@@ -1123,11 +1123,19 @@
     },
     {
       "kind": "ui-call",
-      "line": 545,
+      "line": 550,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Password (optional)",
       "surface": "android",
       "id": "native.android.8123f2cfbe415437"
+    },
+    {
+      "kind": "ui-call",
+      "line": 660,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
+      "source": "CF-Access-Client-Id",
+      "surface": "android",
+      "id": "native.android.4ddaa88cd4939df2"
     },
     {
       "kind": "ui-named-argument",
@@ -6708,6 +6716,54 @@
     {
       "kind": "resource-string",
       "line": 24,
+      "path": "apps/android/app/src/main/res/values/strings.xml",
+      "source": "Custom headers (optional)",
+      "surface": "android",
+      "id": "native.android.43900769f2cf0458"
+    },
+    {
+      "kind": "resource-string",
+      "line": 24,
+      "path": "apps/android/app/src/main/res/values/strings.xml",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "surface": "android",
+      "id": "native.android.6d42cb48a4a32331"
+    },
+    {
+      "kind": "resource-string",
+      "line": 25,
+      "path": "apps/android/app/src/main/res/values/strings.xml",
+      "source": "Header value",
+      "surface": "android",
+      "id": "native.android.c4d4f0299965fe55"
+    },
+    {
+      "kind": "resource-string",
+      "line": 26,
+      "path": "apps/android/app/src/main/res/values/strings.xml",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "surface": "android",
+      "id": "native.android.123e497273b8586e"
+    },
+    {
+      "kind": "resource-string",
+      "line": 27,
+      "path": "apps/android/app/src/main/res/values/strings.xml",
+      "source": "Add header",
+      "surface": "android",
+      "id": "native.android.94f0633a1fb099bc"
+    },
+    {
+      "kind": "resource-string",
+      "line": 28,
+      "path": "apps/android/app/src/main/res/values/strings.xml",
+      "source": "Remove %1$s",
+      "surface": "android",
+      "id": "native.android.ff4c8c3b56827d8e"
+    },
+    {
+      "kind": "resource-string",
+      "line": 29,
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Run onboarding again",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -387,7 +387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1239,
+      "line": 1234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -395,7 +395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1239,
+      "line": 1234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 334,
+      "line": 335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Last gateway error",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 334,
+      "line": 335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Pairing required",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 345,
+      "line": 346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "OpenClaw Android ${openClawAndroidVersionLabel()}",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 386,
+      "line": 387,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Setup code, endpoint, TLS, token, password, onboarding.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 390,
+      "line": 391,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Collapse advanced controls",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 390,
+      "line": 391,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Expand advanced controls",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 421,
+      "line": 422,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Run these on the gateway host:",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 424,
+      "line": 425,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "For Tailscale or public hosts, use wss:// or Tailscale Serve. Private LAN ws:// remains supported.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 453,
+      "line": 454,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Android Emulator",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 462,
+      "line": 463,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Localhost",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 489,
+      "line": 490,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Port",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 489,
+      "line": 490,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Port (optional, defaults to 443)",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 515,
+      "line": 516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Turn this on for Tailscale or public hosts. Private LAN ws:// remains supported.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 541,
+      "line": 542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Leave blank to keep saved token",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 550,
+      "line": 551,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Password (optional)",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 660,
+      "line": 653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "CF-Access-Client-Id",
       "surface": "android",
@@ -6723,7 +6723,7 @@
     },
     {
       "kind": "resource-string",
-      "line": 24,
+      "line": 25,
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
       "surface": "android",
@@ -6731,7 +6731,7 @@
     },
     {
       "kind": "resource-string",
-      "line": 25,
+      "line": 26,
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Header value",
       "surface": "android",
@@ -6739,7 +6739,7 @@
     },
     {
       "kind": "resource-string",
-      "line": 26,
+      "line": 27,
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "This header is managed by the connection and cannot be overridden.",
       "surface": "android",
@@ -6747,7 +6747,7 @@
     },
     {
       "kind": "resource-string",
-      "line": 27,
+      "line": 28,
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Add header",
       "surface": "android",
@@ -6755,7 +6755,7 @@
     },
     {
       "kind": "resource-string",
-      "line": 28,
+      "line": 29,
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Remove %1$s",
       "surface": "android",
@@ -6763,7 +6763,7 @@
     },
     {
       "kind": "resource-string",
-      "line": 29,
+      "line": 30,
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Run onboarding again",
       "surface": "android",
@@ -6771,7 +6771,7 @@
     },
     {
       "kind": "resource-string",
-      "line": 25,
+      "line": 31,
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Resolved endpoint",
       "surface": "android",
@@ -6779,7 +6779,7 @@
     },
     {
       "kind": "resource-string",
-      "line": 26,
+      "line": 32,
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "Verify the certificate fingerprint before trusting this gateway.\n\n%1$s",
       "surface": "android",
@@ -6787,7 +6787,7 @@
     },
     {
       "kind": "resource-string",
-      "line": 27,
+      "line": 33,
       "path": "apps/android/app/src/main/res/values/strings.xml",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2470,
+      "line": 2472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2472,
+      "line": 2474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2474,
+      "line": 2476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -709,6 +709,11 @@
       "translated": "كلمة المرور (اختياري)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "يحلم"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "كلمة المرور"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "رؤوس مخصصة (اختياري)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "تُرسل مع كل اتصال بهذا الـ gateway، على سبيل المثال رؤوس رمز خدمة Cloudflare Access. تُخزَّن مشفّرة وتُطبَّق عند إعادة الاتصال التالية."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "قيمة الرأس"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "تتم إدارة هذا الرأس بواسطة الاتصال ولا يمكن تجاوزه."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "إضافة رأس"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "إزالة %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -709,6 +709,11 @@
       "translated": "Passwort (optional)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Träumen"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Passwort"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Benutzerdefinierte Header (optional)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Wird bei jeder Verbindung zu diesem Gateway gesendet, zum Beispiel Cloudflare Access-Diensttoken-Header. Wird verschlüsselt gespeichert und beim nächsten erneuten Verbindungsaufbau angewendet."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Header-Wert"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Dieser Header wird von der Verbindung verwaltet und kann nicht überschrieben werden."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Header hinzufügen"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "%1$s entfernen"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -709,6 +709,11 @@
       "translated": "Contraseña (opcional)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Soñando"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Contraseña"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Encabezados personalizados (opcional)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Se envía con cada conexión a este Gateway, por ejemplo, encabezados de token de servicio de Cloudflare Access. Se almacena cifrado y se aplica en la próxima reconexión."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Valor del encabezado"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Este encabezado lo gestiona la conexión y no se puede sobrescribir."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Añadir encabezado"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "Eliminar %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -709,6 +709,11 @@
       "translated": "گذرواژه (اختیاری)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "در حال رؤیاپردازی"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "رمز عبور"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "هدرهای سفارشی (اختیاری)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "با هر اتصال به این gateway ارسال می‌شود، برای مثال هدرهای توکن سرویس Cloudflare Access. به‌صورت رمزگذاری‌شده ذخیره می‌شود و در اتصال مجدد بعدی اعمال می‌شود."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "مقدار هدر"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "این هدر توسط اتصال مدیریت می‌شود و قابل بازنویسی نیست."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "افزودن هدر"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "حذف %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -709,6 +709,11 @@
       "translated": "Mot de passe (facultatif)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Rêve"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Mot de passe"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "En-têtes personnalisés (facultatif)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Envoyés à chaque connexion à cette Gateway, par exemple les en-têtes de jeton de service Cloudflare Access. Stockés de manière chiffrée et appliqués lors de la prochaine reconnexion."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Valeur de l’en-tête"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Cet en-tête est géré par la connexion et ne peut pas être remplacé."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Ajouter un en-tête"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "Supprimer %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -709,6 +709,11 @@
       "translated": "पासवर्ड (वैकल्पिक)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Dreaming"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "पासवर्ड"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "कस्टम हेडर (वैकल्पिक)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "इस gateway से हर कनेक्शन के साथ भेजा जाता है, उदाहरण के लिए Cloudflare Access service token headers. एन्क्रिप्ट करके संग्रहीत किया जाता है और अगले reconnect पर लागू किया जाता है।"
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "हेडर मान"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "यह हेडर कनेक्शन द्वारा प्रबंधित है और इसे ओवरराइड नहीं किया जा सकता।"
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "हेडर जोड़ें"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "%1$s हटाएँ"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -709,6 +709,11 @@
       "translated": "Kata sandi (opsional)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Bermimpi"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Kata sandi"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Header kustom (opsional)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Dikirim dengan setiap koneksi ke gateway ini, misalnya header token layanan Cloudflare Access. Disimpan secara terenkripsi dan diterapkan pada koneksi ulang berikutnya."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Nilai header"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Header ini dikelola oleh koneksi dan tidak dapat ditimpa."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Tambahkan header"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "Hapus %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -709,6 +709,11 @@
       "translated": "Password (facoltativa)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Sognando"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Password"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Intestazioni personalizzate (facoltativo)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Inviate con ogni connessione a questo gateway, ad esempio le intestazioni dei token del servizio Cloudflare Access. Archiviate crittografate e applicate alla prossima riconnessione."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Valore dell'intestazione"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Questa intestazione è gestita dalla connessione e non può essere sovrascritta."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Aggiungi intestazione"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "Rimuovi %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -709,6 +709,11 @@
       "translated": "パスワード (省略可)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Dreaming"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "パスワード"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "カスタムヘッダー（任意）"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "このゲートウェイへのすべての接続で送信されます。たとえば、Cloudflare Access サービス トークン ヘッダーなどです。暗号化して保存され、次回の再接続時に適用されます。"
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "ヘッダー値"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "このヘッダーは接続によって管理されており、上書きできません。"
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "ヘッダーを追加"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "%1$s を削除"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -709,6 +709,11 @@
       "translated": "비밀번호(선택 사항)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Dreaming"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "비밀번호"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "사용자 지정 헤더(선택 사항)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "이 Gateway에 연결할 때마다 전송됩니다. 예: Cloudflare Access 서비스 토큰 헤더. 암호화되어 저장되며 다음 재연결 시 적용됩니다."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "헤더 값"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "이 헤더는 연결에서 관리되며 재정의할 수 없습니다."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "헤더 추가"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "%1$s 제거"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -709,6 +709,11 @@
       "translated": "Wachtwoord (optioneel)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Dromen"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Wachtwoord"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Aangepaste headers (optioneel)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Meegestuurd met elke verbinding met deze Gateway, bijvoorbeeld headers voor Cloudflare Access-servicetokens. Versleuteld opgeslagen en toegepast bij de volgende herverbinding."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Headerwaarde"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Deze header wordt beheerd door de verbinding en kan niet worden overschreven."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Header toevoegen"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "%1$s verwijderen"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -709,6 +709,11 @@
       "translated": "Hasło (opcjonalnie)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Śnienie"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Hasło"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Niestandardowe nagłówki (opcjonalnie)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Wysyłane przy każdym połączeniu z tym gateway, na przykład nagłówki tokena usługi Cloudflare Access. Przechowywane w postaci zaszyfrowanej i stosowane przy następnym ponownym połączeniu."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Wartość nagłówka"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Ten nagłówek jest zarządzany przez połączenie i nie można go zastąpić."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Dodaj nagłówek"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "Usuń %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -709,6 +709,11 @@
       "translated": "Senha (opcional)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Sonhando"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Senha"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Cabeçalhos personalizados (opcional)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Enviados com todas as conexões a este gateway, por exemplo, cabeçalhos de token de serviço do Cloudflare Access. Armazenados criptografados e aplicados na próxima reconexão."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Valor do cabeçalho"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Este cabeçalho é gerenciado pela conexão e não pode ser substituído."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Adicionar cabeçalho"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "Remover %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -709,6 +709,11 @@
       "translated": "Пароль (необязательно)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "В мечтах"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Пароль"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Пользовательские заголовки (необязательно)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Отправляются при каждом подключении к этому gateway, например заголовки токена службы Cloudflare Access. Хранятся в зашифрованном виде и применяются при следующем переподключении."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Значение заголовка"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Этот заголовок управляется подключением и не может быть переопределен."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Добавить заголовок"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "Удалить %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -709,6 +709,11 @@
       "translated": "Lösenord (valfritt)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Drömmer"
@@ -4194,6 +4199,36 @@
       "translated": "Lösenord"
     },
     {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Anpassade headers (valfritt)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Skickas med varje anslutning till denna gateway, till exempel Cloudflare Access service token headers. Lagras krypterat och tillämpas vid nästa återanslutning."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Headervärde"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Denna header hanteras av anslutningen och kan inte åsidosättas."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Lägg till header"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "Ta bort %1$s"
+    },
+    {
       "id": "native.android.a43f43c1338a6960",
       "source": "Run onboarding again",
       "translated": "Kör introduktionen igen"
@@ -6871,7 +6906,7 @@
     {
       "id": "native.apple.8584babe715b1133",
       "source": "Discovery Logs",
-      "translated": "Upptäcktsloggar"
+      "translated": "Identifieringsloggar"
     },
     {
       "id": "native.apple.f0a16e985312895b",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -709,6 +709,11 @@
       "translated": "รหัสผ่าน (ไม่บังคับ)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "กำลังฝัน"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "รหัสผ่าน"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "ส่วนหัวที่กำหนดเอง (ไม่บังคับ)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "ส่งไปพร้อมกับทุกการเชื่อมต่อไปยัง gateway นี้ เช่น ส่วนหัวโทเค็นบริการ Cloudflare Access จัดเก็บแบบเข้ารหัสและจะนำไปใช้ในการเชื่อมต่อใหม่ครั้งถัดไป"
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "ค่าส่วนหัว"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "ส่วนหัวนี้ถูกจัดการโดยการเชื่อมต่อและไม่สามารถเขียนทับได้"
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "เพิ่มส่วนหัว"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "ลบ %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -709,6 +709,11 @@
       "translated": "Parola (isteğe bağlı)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Hayal kuruyor"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Parola"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Özel üst bilgiler (isteğe bağlı)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Bu gateway'e yapılan her bağlantıyla birlikte gönderilir; örneğin Cloudflare Access hizmet belirteci üst bilgileri. Şifrelenmiş olarak saklanır ve bir sonraki yeniden bağlantıda uygulanır."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Üst bilgi değeri"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Bu üst bilgi bağlantı tarafından yönetilir ve geçersiz kılınamaz."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Üst bilgi ekle"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "%1$s kaldır"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -709,6 +709,11 @@
       "translated": "Пароль (необов’язково)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Мріяння"
@@ -4194,6 +4199,36 @@
       "translated": "Пароль"
     },
     {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Користувацькі заголовки (необов’язково)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Надсилається з кожним підключенням до цього gateway, наприклад заголовки токена сервісу Cloudflare Access. Зберігається в зашифрованому вигляді та застосовується під час наступного повторного підключення."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Значення заголовка"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Цей заголовок керується підключенням і не може бути перевизначений."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Додати заголовок"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "Видалити %1$s"
+    },
+    {
       "id": "native.android.a43f43c1338a6960",
       "source": "Run onboarding again",
       "translated": "Запустити онбординг знову"
@@ -6796,7 +6831,7 @@
     {
       "id": "native.apple.1604352fea16d495",
       "source": "Wake Words",
-      "translated": "Слова активації"
+      "translated": "Слова пробудження"
     },
     {
       "id": "native.apple.698d47c5569f8d3b",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -709,6 +709,11 @@
       "translated": "Mật khẩu (không bắt buộc)"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Đang mơ"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "Mật khẩu"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "Tiêu đề tùy chỉnh (không bắt buộc)"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "Được gửi cùng mọi kết nối đến gateway này, ví dụ như các tiêu đề mã thông báo dịch vụ Cloudflare Access. Được lưu trữ ở dạng mã hóa và áp dụng trong lần kết nối lại tiếp theo."
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "Giá trị tiêu đề"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "Tiêu đề này do kết nối quản lý và không thể bị ghi đè."
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "Thêm tiêu đề"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "Xóa %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -709,6 +709,11 @@
       "translated": "密码（可选）"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "做梦中"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "密码"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "自定义标头（可选）"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "随每次连接到此 Gateway 一起发送，例如 Cloudflare Access 服务令牌标头。将加密存储，并在下次重新连接时应用。"
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "标头值"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "此标头由连接管理，无法覆盖。"
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "添加标头"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "移除 %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -709,6 +709,11 @@
       "translated": "密碼（選填）"
     },
     {
+      "id": "native.android.4ddaa88cd4939df2",
+      "source": "CF-Access-Client-Id",
+      "translated": "CF-Access-Client-Id"
+    },
+    {
       "id": "native.android.b735fb6c7d284ecf",
       "source": "Dreaming",
       "translated": "Dreaming"
@@ -4192,6 +4197,36 @@
       "id": "native.android.005e23b33d333f6a",
       "source": "Password",
       "translated": "密碼"
+    },
+    {
+      "id": "native.android.43900769f2cf0458",
+      "source": "Custom headers (optional)",
+      "translated": "自訂標頭（選填）"
+    },
+    {
+      "id": "native.android.6d42cb48a4a32331",
+      "source": "Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.",
+      "translated": "會隨每次連線傳送至此 gateway，例如 Cloudflare Access 服務權杖標頭。已加密儲存，並會在下次重新連線時套用。"
+    },
+    {
+      "id": "native.android.c4d4f0299965fe55",
+      "source": "Header value",
+      "translated": "標頭值"
+    },
+    {
+      "id": "native.android.123e497273b8586e",
+      "source": "This header is managed by the connection and cannot be overridden.",
+      "translated": "此標頭由連線管理，無法覆寫。"
+    },
+    {
+      "id": "native.android.94f0633a1fb099bc",
+      "source": "Add header",
+      "translated": "新增標頭"
+    },
+    {
+      "id": "native.android.ff4c8c3b56827d8e",
+      "source": "Remove %1$s",
+      "translated": "移除 %1$s"
     },
     {
       "id": "native.android.a43f43c1338a6960",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -377,6 +377,9 @@ class MainViewModel(
   fun pairNewGateway() {
     viewModelScope.launch(Dispatchers.Default) {
       if (!resetGatewaySetupAuth()) return@launch
+      // Sign out is the explicit forget boundary for proxy credentials. Ordinary same-gateway
+      // auth replacement keeps these per-endpoint values so reconnects do not require re-entry.
+      prefs.clearGatewayCustomHeaders()
       prefs.setOnboardingCompleted(false)
       _startOnboardingAtGatewaySetup.value = true
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -355,6 +355,16 @@ class MainViewModel(
     }
   }
 
+  /** Per-gateway proxy credential headers; values are secrets and must never be logged. */
+  fun gatewayCustomHeaders(stableId: String): Map<String, String> = prefs.loadGatewayCustomHeaders(stableId)
+
+  fun setGatewayCustomHeaders(
+    stableId: String,
+    headers: Map<String, String>,
+  ) {
+    prefs.saveGatewayCustomHeaders(stableId, headers)
+  }
+
   /** Marks onboarding complete and starts the runtime before UI observes connected-state flows. */
   fun setOnboardingCompleted(value: Boolean) {
     if (value) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -809,6 +809,7 @@ class NodeRuntime private constructor(
       onEvent = { event, payloadJson ->
         handleGatewayEvent(event, payloadJson)
       },
+      customHeadersProvider = prefs::loadGatewayCustomHeaders,
     )
 
   private suspend fun subscribeOperatorSessionEvents() {
@@ -873,6 +874,7 @@ class NodeRuntime private constructor(
       onTlsFingerprint = { stableId, fingerprint ->
         prefs.saveGatewayTlsFingerprint(stableId, fingerprint)
       },
+      customHeadersProvider = prefs::loadGatewayCustomHeaders,
     )
 
   /**

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -2,6 +2,7 @@
 
 package ai.openclaw.app
 
+import ai.openclaw.app.gateway.GatewayCustomHeaders
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
@@ -9,6 +10,7 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
@@ -450,6 +452,33 @@ class SecurePrefs(
     _gatewayToken.value = ""
     _gatewayBootstrapToken.value = ""
   }
+
+  /**
+   * Custom proxy headers are per-gateway credentials (Cloudflare Access-style service tokens).
+   * They live in the encrypted store like the other gateway secrets and are read at connect
+   * time; never log their values.
+   */
+  fun loadGatewayCustomHeaders(stableId: String): Map<String, String> {
+    val raw = securePrefs.getString(gatewayCustomHeadersKey(stableId), null) ?: return emptyMap()
+    val stored =
+      runCatching { json.decodeFromString<Map<String, String>>(raw) }.getOrElse { return emptyMap() }
+    return GatewayCustomHeaders.sanitized(stored)
+  }
+
+  fun saveGatewayCustomHeaders(
+    stableId: String,
+    headers: Map<String, String>,
+  ) {
+    val key = gatewayCustomHeadersKey(stableId)
+    val sanitized = GatewayCustomHeaders.sanitized(headers)
+    if (sanitized.isEmpty()) {
+      securePrefs.edit { remove(key) }
+      return
+    }
+    securePrefs.edit { putString(key, json.encodeToString(sanitized)) }
+  }
+
+  private fun gatewayCustomHeadersKey(stableId: String) = "gateway.customHeaders.${stableId.trim()}"
 
   /** Loads the pinned gateway TLS fingerprint for a discovered/manual stable endpoint id. */
   fun loadGatewayTlsFingerprint(stableId: String): String? {

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -49,6 +49,7 @@ class SecurePrefs(
     private const val chatModelFavoritesKey = "chat.modelFavorites"
     private const val chatModelRecentsKey = "chat.modelRecents"
     private const val maxChatModelRecents = 5
+    private const val gatewayCustomHeadersKeyPrefix = "gateway.customHeaders."
   }
 
   private val appContext = context.applicationContext
@@ -478,7 +479,16 @@ class SecurePrefs(
     securePrefs.edit { putString(key, json.encodeToString(sanitized)) }
   }
 
-  private fun gatewayCustomHeadersKey(stableId: String) = "gateway.customHeaders.${stableId.trim()}"
+  /** Forgets every gateway's proxy credentials during an explicit sign-out/re-pair action. */
+  fun clearGatewayCustomHeaders() {
+    val keys = securePrefs.all.keys.filter { it.startsWith(gatewayCustomHeadersKeyPrefix) }
+    if (keys.isEmpty()) return
+    securePrefs.edit {
+      for (key in keys) remove(key)
+    }
+  }
+
+  private fun gatewayCustomHeadersKey(stableId: String) = "$gatewayCustomHeadersKeyPrefix${stableId.trim()}"
 
   /** Loads the pinned gateway TLS fingerprint for a discovered/manual stable endpoint id. */
   fun loadGatewayTlsFingerprint(stableId: String): String? {

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayCustomHeaders.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayCustomHeaders.kt
@@ -11,6 +11,7 @@ object GatewayCustomHeaders {
   private val reservedNames =
     setOf("connection", "content-length", "host", "proxy-connection", "upgrade")
   private const val RESERVED_PREFIX = "sec-websocket-"
+  private const val TOKEN_PUNCTUATION = "!#$%&'*+-.^_`|~"
 
   fun isReservedName(name: String): Boolean {
     val normalized = name.trim().lowercase()
@@ -18,19 +19,25 @@ object GatewayCustomHeaders {
   }
 
   /**
-   * Drops entries that cannot travel as a single well-formed header: empty or reserved names,
-   * and names/values outside printable ASCII. OkHttp throws IllegalArgumentException on such
-   * characters, so dropping here keeps one bad stored entry from wedging every reconnect.
+   * Drops entries that cannot travel as a single well-formed header: empty, reserved, or
+   * non-token names, and values outside printable ASCII. Dropping invalid entries keeps one bad
+   * stored value from wedging every reconnect or being interpreted differently by a proxy.
    */
   fun sanitized(headers: Map<String, String>): Map<String, String> {
     val result = LinkedHashMap<String, String>()
     for ((rawName, value) in headers) {
       val name = rawName.trim()
       if (name.isEmpty() || isReservedName(name)) continue
-      if (!name.all { it in '!'..'~' }) continue
+      if (!name.all(::isTokenCharacter)) continue
       if (!value.all { it in ' '..'~' }) continue
       result[name] = value
     }
     return result
   }
+
+  private fun isTokenCharacter(character: Char): Boolean =
+    character in '0'..'9' ||
+      character in 'A'..'Z' ||
+      character in 'a'..'z' ||
+      character in TOKEN_PUNCTUATION
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayCustomHeaders.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayCustomHeaders.kt
@@ -1,0 +1,36 @@
+package ai.openclaw.app.gateway
+
+/**
+ * Operator-defined HTTP headers attached to gateway connections so gateways fronted by
+ * authenticating reverse proxies (Cloudflare Access-style service tokens) stay reachable.
+ * Header values are credentials: persist them only in SecurePrefs and never log them.
+ */
+object GatewayCustomHeaders {
+  // Connection-management headers the WebSocket upgrade owns. Operator overrides here would
+  // corrupt the handshake or duplicate fields OkHttp sets itself.
+  private val reservedNames =
+    setOf("connection", "content-length", "host", "proxy-connection", "upgrade")
+  private const val RESERVED_PREFIX = "sec-websocket-"
+
+  fun isReservedName(name: String): Boolean {
+    val normalized = name.trim().lowercase()
+    return normalized in reservedNames || normalized.startsWith(RESERVED_PREFIX)
+  }
+
+  /**
+   * Drops entries that cannot travel as a single well-formed header: empty or reserved names,
+   * and names/values outside printable ASCII. OkHttp throws IllegalArgumentException on such
+   * characters, so dropping here keeps one bad stored entry from wedging every reconnect.
+   */
+  fun sanitized(headers: Map<String, String>): Map<String, String> {
+    val result = LinkedHashMap<String, String>()
+    for ((rawName, value) in headers) {
+      val name = rawName.trim()
+      if (name.isEmpty() || isReservedName(name)) continue
+      if (!name.all { it in '!'..'~' }) continue
+      if (!value.all { it in ' '..'~' }) continue
+      result[name] = value
+    }
+    return result
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -165,6 +165,7 @@ class GatewaySession(
   private val onEvent: (event: String, payloadJson: String?) -> Unit,
   private val onInvoke: (suspend (InvokeRequest) -> InvokeResult)? = null,
   private val onTlsFingerprint: ((stableId: String, fingerprint: String) -> Unit)? = null,
+  private val customHeadersProvider: ((stableId: String) -> Map<String, String>)? = null,
 ) {
   private companion object {
     // Keep connect timeout above observed gateway unauthorized close on lower-end devices.
@@ -530,8 +531,17 @@ class GatewaySession(
 
     suspend fun connect(): ConnectedGateway {
       val url = buildGatewayWebSocketUrl(endpoint.host, endpoint.port, tls != null)
-      val request = Request.Builder().url(url).build()
-      socket = client.newWebSocket(request, listener)
+      val builder = Request.Builder().url(url)
+      // Operator-supplied proxy credentials (Cloudflare Access-style) ride on the upgrade
+      // request. Read from the provider at connect time so edits apply on the next reconnect
+      // without re-pairing. Values are credentials: never log them.
+      val headers = customHeadersProvider?.invoke(tls?.stableId ?: endpoint.stableId)
+      if (headers != null) {
+        for ((name, value) in GatewayCustomHeaders.sanitized(headers)) {
+          builder.addHeader(name, value)
+        }
+      }
+      socket = client.newWebSocket(builder.build(), listener)
       return connectDeferred.await()
     }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -530,18 +530,13 @@ class GatewaySession(
     val remoteAddress: String = formatGatewayAuthority(endpoint.host, endpoint.port)
 
     suspend fun connect(): ConnectedGateway {
-      val url = buildGatewayWebSocketUrl(endpoint.host, endpoint.port, tls != null)
-      val builder = Request.Builder().url(url)
-      // Operator-supplied proxy credentials (Cloudflare Access-style) ride on the upgrade
-      // request. Read from the provider at connect time so edits apply on the next reconnect
-      // without re-pairing. Values are credentials: never log them.
-      val headers = customHeadersProvider?.invoke(tls?.stableId ?: endpoint.stableId)
-      if (headers != null) {
-        for ((name, value) in GatewayCustomHeaders.sanitized(headers)) {
-          builder.addHeader(name, value)
-        }
-      }
-      socket = client.newWebSocket(builder.build(), listener)
+      val request =
+        buildGatewayWebSocketUpgradeRequest(
+          endpoint = endpoint,
+          tls = tls,
+          customHeadersProvider = customHeadersProvider,
+        )
+      socket = client.newWebSocket(request, listener)
       return connectDeferred.await()
     }
 
@@ -1543,6 +1538,23 @@ internal fun buildGatewayWebSocketUrl(
 ): String {
   val scheme = if (useTls) "wss" else "ws"
   return "$scheme://${formatGatewayAuthority(host, port)}"
+}
+
+/** Builds one gateway upgrade request without exposing proxy credentials to cleartext routes. */
+internal fun buildGatewayWebSocketUpgradeRequest(
+  endpoint: GatewayEndpoint,
+  tls: GatewayTlsParams?,
+  customHeadersProvider: ((stableId: String) -> Map<String, String>)?,
+): Request {
+  val request = Request.Builder().url(buildGatewayWebSocketUrl(endpoint.host, endpoint.port, tls != null))
+  if (tls == null) return request.build()
+
+  // Read at connect time so edits apply on the next reconnect. Headers may contain service tokens
+  // or Authorization values, so the cleartext branch above must never invoke the provider.
+  for ((name, value) in GatewayCustomHeaders.sanitized(customHeadersProvider?.invoke(tls.stableId).orEmpty())) {
+    request.addHeader(name, value)
+  }
+  return request.build()
 }
 
 /** Formats host/port for gateway URLs, including IPv6 bracket wrapping. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -146,10 +146,11 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
   }
 
   val setupResolvedEndpoint = remember(setupCode) { decodeGatewaySetupCode(setupCode)?.url?.let { parseGatewayEndpoint(it)?.displayUrl } }
-  val manualResolvedEndpoint =
+  val manualEndpointConfig =
     remember(manualHostInput, manualPortInput, manualTlsInput) {
-      composeGatewayManualUrl(manualHostInput, manualPortInput, manualTlsInput)?.let { parseGatewayEndpoint(it)?.displayUrl }
+      composeGatewayManualUrl(manualHostInput, manualPortInput, manualTlsInput)?.let(::parseGatewayEndpoint)
     }
+  val manualResolvedEndpoint = manualEndpointConfig?.displayUrl
 
   val activeEndpoint =
     remember(isConnected, remoteAddress, setupResolvedEndpoint, manualResolvedEndpoint, inputMode) {
@@ -568,12 +569,14 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
               EndpointPreview(endpoint = manualResolvedEndpoint)
             }
 
-            ManualGatewayCustomHeadersEditor(
-              viewModel = viewModel,
-              manualHostInput = manualHostInput,
-              manualPortInput = manualPortInput,
-              manualTlsInput = manualTlsInput,
-            )
+            // Proxy credentials are unavailable on cleartext ws:// routes, including pasted URLs
+            // whose explicit scheme overrides the TLS toggle. The transport enforces this too.
+            manualEndpointConfig?.takeIf { it.tls }?.let { endpoint ->
+              ManualGatewayCustomHeadersEditor(
+                viewModel = viewModel,
+                stableId = GatewayEndpoint.manual(host = endpoint.host, port = endpoint.port).stableId,
+              )
+            }
           }
 
           HorizontalDivider(color = mobileBorder)
@@ -599,22 +602,12 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
 @Composable
 private fun ManualGatewayCustomHeadersEditor(
   viewModel: MainViewModel,
-  manualHostInput: String,
-  manualPortInput: String,
-  manualTlsInput: Boolean,
+  stableId: String,
 ) {
-  val stableId =
-    remember(manualHostInput, manualPortInput, manualTlsInput) {
-      composeGatewayManualUrl(manualHostInput, manualPortInput, manualTlsInput)
-        ?.let { parseGatewayEndpoint(it) }
-        ?.let { GatewayEndpoint.manual(host = it.host, port = it.port).stableId }
-    }
-  if (stableId == null) return
-
   var headers by remember(stableId) { mutableStateOf(viewModel.gatewayCustomHeaders(stableId)) }
-  var nameInput by rememberSaveable { mutableStateOf("") }
+  var nameInput by rememberSaveable(stableId) { mutableStateOf("") }
   // Not rememberSaveable: header values are credentials and must not land in saved instance state.
-  var valueInput by remember { mutableStateOf("") }
+  var valueInput by remember(stableId) { mutableStateOf("") }
 
   val trimmedName = nameInput.trim()
   val nameIsReserved = GatewayCustomHeaders.isReservedName(trimmedName)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -3,6 +3,8 @@ package ai.openclaw.app.ui
 import ai.openclaw.app.GatewayConnectionProblem
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.R
+import ai.openclaw.app.gateway.GatewayCustomHeaders
+import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.ui.mobileCardSurface
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
@@ -23,6 +25,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.ExpandLess
@@ -34,6 +37,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
@@ -56,6 +60,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 
 private enum class ConnectInputMode {
@@ -562,6 +567,13 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
             if (!manualResolvedEndpoint.isNullOrBlank()) {
               EndpointPreview(endpoint = manualResolvedEndpoint)
             }
+
+            ManualGatewayCustomHeadersEditor(
+              viewModel = viewModel,
+              manualHostInput = manualHostInput,
+              manualPortInput = manualPortInput,
+              manualTlsInput = manualTlsInput,
+            )
           }
 
           HorizontalDivider(color = mobileBorder)
@@ -575,6 +587,117 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
 
     if (!validationText.isNullOrBlank()) {
       Text(validationText!!, style = mobileCaption1, color = mobileWarning)
+    }
+  }
+}
+
+/**
+ * Per-gateway proxy credential headers for the manual endpoint (Cloudflare Access-style
+ * service tokens). Values are secrets: masked while typing, hidden once saved, stored
+ * encrypted, and applied on the next reconnect.
+ */
+@Composable
+private fun ManualGatewayCustomHeadersEditor(
+  viewModel: MainViewModel,
+  manualHostInput: String,
+  manualPortInput: String,
+  manualTlsInput: Boolean,
+) {
+  val stableId =
+    remember(manualHostInput, manualPortInput, manualTlsInput) {
+      composeGatewayManualUrl(manualHostInput, manualPortInput, manualTlsInput)
+        ?.let { parseGatewayEndpoint(it) }
+        ?.let { GatewayEndpoint.manual(host = it.host, port = it.port).stableId }
+    }
+  if (stableId == null) return
+
+  var headers by remember(stableId) { mutableStateOf(viewModel.gatewayCustomHeaders(stableId)) }
+  var nameInput by rememberSaveable { mutableStateOf("") }
+  // Not rememberSaveable: header values are credentials and must not land in saved instance state.
+  var valueInput by remember { mutableStateOf("") }
+
+  val trimmedName = nameInput.trim()
+  val nameIsReserved = GatewayCustomHeaders.isReservedName(trimmedName)
+  val nameIsDuplicate = headers.keys.any { it.equals(trimmedName, ignoreCase = true) }
+
+  fun persist(updated: Map<String, String>) {
+    viewModel.setGatewayCustomHeaders(stableId, updated)
+    headers = viewModel.gatewayCustomHeaders(stableId)
+  }
+
+  Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Text(
+      stringResource(R.string.custom_headers_optional),
+      style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+      color = mobileTextSecondary,
+    )
+    Text(
+      stringResource(R.string.custom_headers_explainer),
+      style = mobileCaption1,
+      color = mobileTextSecondary,
+    )
+
+    for (name in headers.keys.sorted()) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+      ) {
+        Text(name, style = mobileBody.copy(fontFamily = FontFamily.Monospace), color = mobileText)
+        IconButton(onClick = { persist(headers - name) }) {
+          Icon(
+            Icons.Default.Close,
+            contentDescription = stringResource(R.string.remove_custom_header, name),
+            tint = mobileTextSecondary,
+          )
+        }
+      }
+    }
+
+    OutlinedTextField(
+      value = nameInput,
+      onValueChange = { nameInput = it },
+      placeholder = { Text("CF-Access-Client-Id", style = mobileBody, color = mobileTextTertiary) },
+      modifier = Modifier.fillMaxWidth(),
+      singleLine = true,
+      keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
+      textStyle = mobileBody.copy(fontFamily = FontFamily.Monospace, color = mobileText),
+      shape = RoundedCornerShape(14.dp),
+      colors = outlinedColors(),
+    )
+    OutlinedTextField(
+      value = valueInput,
+      onValueChange = { valueInput = it },
+      placeholder = { Text(stringResource(R.string.custom_header_value), style = mobileBody, color = mobileTextTertiary) },
+      modifier = Modifier.fillMaxWidth(),
+      singleLine = true,
+      visualTransformation = PasswordVisualTransformation(),
+      keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+      textStyle = mobileBody.copy(color = mobileText),
+      shape = RoundedCornerShape(14.dp),
+      colors = outlinedColors(),
+    )
+    if (nameIsReserved) {
+      Text(stringResource(R.string.custom_header_reserved), style = mobileCaption1, color = mobileWarning)
+    }
+    Button(
+      onClick = {
+        persist(headers + (trimmedName to valueInput))
+        nameInput = ""
+        valueInput = ""
+      },
+      enabled = trimmedName.isNotEmpty() && !nameIsReserved && !nameIsDuplicate,
+      modifier = Modifier.height(40.dp),
+      shape = RoundedCornerShape(12.dp),
+      contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+      colors =
+        ButtonDefaults.buttonColors(
+          containerColor = mobileSurface,
+          contentColor = mobileText,
+        ),
+      border = BorderStroke(1.dp, mobileBorderStrong),
+    ) {
+      Text(stringResource(R.string.add_custom_header), style = mobileCaption1.copy(fontWeight = FontWeight.Bold))
     }
   }
 }

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">استخدام TLS</string>
     <string name="token_optional">الرمز المميز (اختياري)</string>
     <string name="password">كلمة المرور</string>
+    <string name="custom_headers_optional">رؤوس مخصصة (اختياري)</string>
+    <string name="custom_headers_explainer">تُرسل مع كل اتصال بهذا الـ gateway، على سبيل المثال رؤوس رمز خدمة Cloudflare Access. تُخزَّن مشفّرة وتُطبَّق عند إعادة الاتصال التالية.</string>
+    <string name="custom_header_value">قيمة الرأس</string>
+    <string name="custom_header_reserved">تتم إدارة هذا الرأس بواسطة الاتصال ولا يمكن تجاوزه.</string>
+    <string name="add_custom_header">إضافة رأس</string>
+    <string name="remove_custom_header">إزالة %1$s</string>
     <string name="run_onboarding_again">تشغيل الإعداد الأولي مرة أخرى</string>
     <string name="resolved_endpoint">نقطة النهاية التي تم حلها</string>
     <string name="gateway_trust_first_seen">تحقق من بصمة الشهادة قبل الوثوق بهذه البوابة.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">TLS verwenden</string>
     <string name="token_optional">Token (optional)</string>
     <string name="password">Passwort</string>
+    <string name="custom_headers_optional">Benutzerdefinierte Header (optional)</string>
+    <string name="custom_headers_explainer">Wird bei jeder Verbindung zu diesem Gateway gesendet, zum Beispiel Cloudflare Access-Diensttoken-Header. Wird verschlüsselt gespeichert und beim nächsten erneuten Verbindungsaufbau angewendet.</string>
+    <string name="custom_header_value">Header-Wert</string>
+    <string name="custom_header_reserved">Dieser Header wird von der Verbindung verwaltet und kann nicht überschrieben werden.</string>
+    <string name="add_custom_header">Header hinzufügen</string>
+    <string name="remove_custom_header">%1$s entfernen</string>
     <string name="run_onboarding_again">Onboarding erneut ausführen</string>
     <string name="resolved_endpoint">Aufgelöster Endpunkt</string>
     <string name="gateway_trust_first_seen">Überprüfen Sie den Zertifikatfingerabdruck, bevor Sie diesem Gateway vertrauen.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Usar TLS</string>
     <string name="token_optional">Token (opcional)</string>
     <string name="password">Contraseña</string>
+    <string name="custom_headers_optional">Encabezados personalizados (opcional)</string>
+    <string name="custom_headers_explainer">Se envía con cada conexión a este Gateway, por ejemplo, encabezados de token de servicio de Cloudflare Access. Se almacena cifrado y se aplica en la próxima reconexión.</string>
+    <string name="custom_header_value">Valor del encabezado</string>
+    <string name="custom_header_reserved">Este encabezado lo gestiona la conexión y no se puede sobrescribir.</string>
+    <string name="add_custom_header">Añadir encabezado</string>
+    <string name="remove_custom_header">Eliminar %1$s</string>
     <string name="run_onboarding_again">Ejecutar la incorporación de nuevo</string>
     <string name="resolved_endpoint">Endpoint resuelto</string>
     <string name="gateway_trust_first_seen">Verifica la huella digital del certificado antes de confiar en este gateway.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-fa/strings.xml
+++ b/apps/android/app/src/main/res/values-fa/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">استفاده از TLS</string>
     <string name="token_optional">توکن (اختیاری)</string>
     <string name="password">رمز عبور</string>
+    <string name="custom_headers_optional">هدرهای سفارشی (اختیاری)</string>
+    <string name="custom_headers_explainer">با هر اتصال به این gateway ارسال می‌شود، برای مثال هدرهای توکن سرویس Cloudflare Access. به‌صورت رمزگذاری‌شده ذخیره می‌شود و در اتصال مجدد بعدی اعمال می‌شود.</string>
+    <string name="custom_header_value">مقدار هدر</string>
+    <string name="custom_header_reserved">این هدر توسط اتصال مدیریت می‌شود و قابل بازنویسی نیست.</string>
+    <string name="add_custom_header">افزودن هدر</string>
+    <string name="remove_custom_header">حذف %1$s</string>
     <string name="run_onboarding_again">اجرای دوباره فرایند شروع به کار</string>
     <string name="resolved_endpoint">نقطه پایانی حل‌شده</string>
     <string name="gateway_trust_first_seen">پیش از اعتماد به این دروازه، اثر انگشت گواهی را تأیید کنید.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Utiliser TLS</string>
     <string name="token_optional">Jeton (facultatif)</string>
     <string name="password">Mot de passe</string>
+    <string name="custom_headers_optional">En-têtes personnalisés (facultatif)</string>
+    <string name="custom_headers_explainer">Envoyés à chaque connexion à cette Gateway, par exemple les en-têtes de jeton de service Cloudflare Access. Stockés de manière chiffrée et appliqués lors de la prochaine reconnexion.</string>
+    <string name="custom_header_value">Valeur de l’en-tête</string>
+    <string name="custom_header_reserved">Cet en-tête est géré par la connexion et ne peut pas être remplacé.</string>
+    <string name="add_custom_header">Ajouter un en-tête</string>
+    <string name="remove_custom_header">Supprimer %1$s</string>
     <string name="run_onboarding_again">Relancer l’intégration</string>
     <string name="resolved_endpoint">Point de terminaison résolu</string>
     <string name="gateway_trust_first_seen">Vérifiez l’empreinte du certificat avant d’accorder votre confiance à cette passerelle.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-hi/strings.xml
+++ b/apps/android/app/src/main/res/values-hi/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">TLS का उपयोग करें</string>
     <string name="token_optional">टोकन (वैकल्पिक)</string>
     <string name="password">पासवर्ड</string>
+    <string name="custom_headers_optional">कस्टम हेडर (वैकल्पिक)</string>
+    <string name="custom_headers_explainer">इस gateway से हर कनेक्शन के साथ भेजा जाता है, उदाहरण के लिए Cloudflare Access service token headers. एन्क्रिप्ट करके संग्रहीत किया जाता है और अगले reconnect पर लागू किया जाता है।</string>
+    <string name="custom_header_value">हेडर मान</string>
+    <string name="custom_header_reserved">यह हेडर कनेक्शन द्वारा प्रबंधित है और इसे ओवरराइड नहीं किया जा सकता।</string>
+    <string name="add_custom_header">हेडर जोड़ें</string>
+    <string name="remove_custom_header">%1$s हटाएँ</string>
     <string name="run_onboarding_again">ऑनबोर्डिंग फिर से चलाएँ</string>
     <string name="resolved_endpoint">रिज़ॉल्व किया गया एंडपॉइंट</string>
     <string name="gateway_trust_first_seen">इस गेटवे पर भरोसा करने से पहले प्रमाणपत्र फ़िंगरप्रिंट सत्यापित करें।\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-in/strings.xml
+++ b/apps/android/app/src/main/res/values-in/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Gunakan TLS</string>
     <string name="token_optional">Token (opsional)</string>
     <string name="password">Kata sandi</string>
+    <string name="custom_headers_optional">Header kustom (opsional)</string>
+    <string name="custom_headers_explainer">Dikirim dengan setiap koneksi ke gateway ini, misalnya header token layanan Cloudflare Access. Disimpan secara terenkripsi dan diterapkan pada koneksi ulang berikutnya.</string>
+    <string name="custom_header_value">Nilai header</string>
+    <string name="custom_header_reserved">Header ini dikelola oleh koneksi dan tidak dapat ditimpa.</string>
+    <string name="add_custom_header">Tambahkan header</string>
+    <string name="remove_custom_header">Hapus %1$s</string>
     <string name="run_onboarding_again">Jalankan onboarding lagi</string>
     <string name="resolved_endpoint">Endpoint yang diselesaikan</string>
     <string name="gateway_trust_first_seen">Verifikasi sidik jari sertifikat sebelum memercayai gateway ini.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-it/strings.xml
+++ b/apps/android/app/src/main/res/values-it/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Usa TLS</string>
     <string name="token_optional">Token (opzionale)</string>
     <string name="password">Password</string>
+    <string name="custom_headers_optional">Intestazioni personalizzate (facoltativo)</string>
+    <string name="custom_headers_explainer">Inviate con ogni connessione a questo gateway, ad esempio le intestazioni dei token del servizio Cloudflare Access. Archiviate crittografate e applicate alla prossima riconnessione.</string>
+    <string name="custom_header_value">Valore dell\'intestazione</string>
+    <string name="custom_header_reserved">Questa intestazione è gestita dalla connessione e non può essere sovrascritta.</string>
+    <string name="add_custom_header">Aggiungi intestazione</string>
+    <string name="remove_custom_header">Rimuovi %1$s</string>
     <string name="run_onboarding_again">Esegui di nuovo l’onboarding</string>
     <string name="resolved_endpoint">Endpoint risolto</string>
     <string name="gateway_trust_first_seen">Verifica l’impronta digitale del certificato prima di considerare attendibile questo gateway.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">TLS を使用</string>
     <string name="token_optional">トークン（任意）</string>
     <string name="password">パスワード</string>
+    <string name="custom_headers_optional">カスタムヘッダー（任意）</string>
+    <string name="custom_headers_explainer">このゲートウェイへのすべての接続で送信されます。たとえば、Cloudflare Access サービス トークン ヘッダーなどです。暗号化して保存され、次回の再接続時に適用されます。</string>
+    <string name="custom_header_value">ヘッダー値</string>
+    <string name="custom_header_reserved">このヘッダーは接続によって管理されており、上書きできません。</string>
+    <string name="add_custom_header">ヘッダーを追加</string>
+    <string name="remove_custom_header">%1$s を削除</string>
     <string name="run_onboarding_again">オンボーディングを再実行</string>
     <string name="resolved_endpoint">解決済みエンドポイント</string>
     <string name="gateway_trust_first_seen">このゲートウェイを信頼する前に、証明書のフィンガープリントを確認してください。\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">TLS 사용</string>
     <string name="token_optional">토큰(선택 사항)</string>
     <string name="password">비밀번호</string>
+    <string name="custom_headers_optional">사용자 지정 헤더(선택 사항)</string>
+    <string name="custom_headers_explainer">이 Gateway에 연결할 때마다 전송됩니다. 예: Cloudflare Access 서비스 토큰 헤더. 암호화되어 저장되며 다음 재연결 시 적용됩니다.</string>
+    <string name="custom_header_value">헤더 값</string>
+    <string name="custom_header_reserved">이 헤더는 연결에서 관리되며 재정의할 수 없습니다.</string>
+    <string name="add_custom_header">헤더 추가</string>
+    <string name="remove_custom_header">%1$s 제거</string>
     <string name="run_onboarding_again">온보딩 다시 실행</string>
     <string name="resolved_endpoint">확인된 엔드포인트</string>
     <string name="gateway_trust_first_seen">이 게이트웨이를 신뢰하기 전에 인증서 지문을 확인하세요.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-nl/strings.xml
+++ b/apps/android/app/src/main/res/values-nl/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">TLS gebruiken</string>
     <string name="token_optional">Token (optioneel)</string>
     <string name="password">Wachtwoord</string>
+    <string name="custom_headers_optional">Aangepaste headers (optioneel)</string>
+    <string name="custom_headers_explainer">Meegestuurd met elke verbinding met deze Gateway, bijvoorbeeld headers voor Cloudflare Access-servicetokens. Versleuteld opgeslagen en toegepast bij de volgende herverbinding.</string>
+    <string name="custom_header_value">Headerwaarde</string>
+    <string name="custom_header_reserved">Deze header wordt beheerd door de verbinding en kan niet worden overschreven.</string>
+    <string name="add_custom_header">Header toevoegen</string>
+    <string name="remove_custom_header">%1$s verwijderen</string>
     <string name="run_onboarding_again">Onboarding opnieuw uitvoeren</string>
     <string name="resolved_endpoint">Opgelost endpoint</string>
     <string name="gateway_trust_first_seen">Controleer de certificaatvingerafdruk voordat je deze gateway vertrouwt.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-pl/strings.xml
+++ b/apps/android/app/src/main/res/values-pl/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Użyj TLS</string>
     <string name="token_optional">Token (opcjonalnie)</string>
     <string name="password">Hasło</string>
+    <string name="custom_headers_optional">Niestandardowe nagłówki (opcjonalnie)</string>
+    <string name="custom_headers_explainer">Wysyłane przy każdym połączeniu z tym gateway, na przykład nagłówki tokena usługi Cloudflare Access. Przechowywane w postaci zaszyfrowanej i stosowane przy następnym ponownym połączeniu.</string>
+    <string name="custom_header_value">Wartość nagłówka</string>
+    <string name="custom_header_reserved">Ten nagłówek jest zarządzany przez połączenie i nie można go zastąpić.</string>
+    <string name="add_custom_header">Dodaj nagłówek</string>
+    <string name="remove_custom_header">Usuń %1$s</string>
     <string name="run_onboarding_again">Uruchom ponownie wdrażanie</string>
     <string name="resolved_endpoint">Rozpoznany punkt końcowy</string>
     <string name="gateway_trust_first_seen">Sprawdź odcisk certyfikatu, zanim zaufasz tej bramie.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Usar TLS</string>
     <string name="token_optional">Token (opcional)</string>
     <string name="password">Senha</string>
+    <string name="custom_headers_optional">Cabeçalhos personalizados (opcional)</string>
+    <string name="custom_headers_explainer">Enviados com todas as conexões a este gateway, por exemplo, cabeçalhos de token de serviço do Cloudflare Access. Armazenados criptografados e aplicados na próxima reconexão.</string>
+    <string name="custom_header_value">Valor do cabeçalho</string>
+    <string name="custom_header_reserved">Este cabeçalho é gerenciado pela conexão e não pode ser substituído.</string>
+    <string name="add_custom_header">Adicionar cabeçalho</string>
+    <string name="remove_custom_header">Remover %1$s</string>
     <string name="run_onboarding_again">Executar integração novamente</string>
     <string name="resolved_endpoint">Endpoint resolvido</string>
     <string name="gateway_trust_first_seen">Verifique a impressão digital do certificado antes de confiar neste gateway.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Использовать TLS</string>
     <string name="token_optional">Токен (необязательно)</string>
     <string name="password">Пароль</string>
+    <string name="custom_headers_optional">Пользовательские заголовки (необязательно)</string>
+    <string name="custom_headers_explainer">Отправляются при каждом подключении к этому gateway, например заголовки токена службы Cloudflare Access. Хранятся в зашифрованном виде и применяются при следующем переподключении.</string>
+    <string name="custom_header_value">Значение заголовка</string>
+    <string name="custom_header_reserved">Этот заголовок управляется подключением и не может быть переопределен.</string>
+    <string name="add_custom_header">Добавить заголовок</string>
+    <string name="remove_custom_header">Удалить %1$s</string>
     <string name="run_onboarding_again">Запустить настройку заново</string>
     <string name="resolved_endpoint">Разрешенная конечная точка</string>
     <string name="gateway_trust_first_seen">Проверьте отпечаток сертификата, прежде чем доверять этому шлюзу.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Använd TLS</string>
     <string name="token_optional">Token (valfritt)</string>
     <string name="password">Lösenord</string>
+    <string name="custom_headers_optional">Anpassade headers (valfritt)</string>
+    <string name="custom_headers_explainer">Skickas med varje anslutning till denna gateway, till exempel Cloudflare Access service token headers. Lagras krypterat och tillämpas vid nästa återanslutning.</string>
+    <string name="custom_header_value">Headervärde</string>
+    <string name="custom_header_reserved">Denna header hanteras av anslutningen och kan inte åsidosättas.</string>
+    <string name="add_custom_header">Lägg till header</string>
+    <string name="remove_custom_header">Ta bort %1$s</string>
     <string name="run_onboarding_again">Kör introduktionen igen</string>
     <string name="resolved_endpoint">Löst slutpunkt</string>
     <string name="gateway_trust_first_seen">Verifiera certifikatets fingeravtryck innan du litar på denna gateway.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">ใช้ TLS</string>
     <string name="token_optional">โทเค็น (ไม่บังคับ)</string>
     <string name="password">รหัสผ่าน</string>
+    <string name="custom_headers_optional">ส่วนหัวที่กำหนดเอง (ไม่บังคับ)</string>
+    <string name="custom_headers_explainer">ส่งไปพร้อมกับทุกการเชื่อมต่อไปยัง gateway นี้ เช่น ส่วนหัวโทเค็นบริการ Cloudflare Access จัดเก็บแบบเข้ารหัสและจะนำไปใช้ในการเชื่อมต่อใหม่ครั้งถัดไป</string>
+    <string name="custom_header_value">ค่าส่วนหัว</string>
+    <string name="custom_header_reserved">ส่วนหัวนี้ถูกจัดการโดยการเชื่อมต่อและไม่สามารถเขียนทับได้</string>
+    <string name="add_custom_header">เพิ่มส่วนหัว</string>
+    <string name="remove_custom_header">ลบ %1$s</string>
     <string name="run_onboarding_again">เรียกใช้การเริ่มต้นใช้งานอีกครั้ง</string>
     <string name="resolved_endpoint">เอนด์พอยต์ที่แก้ไขแล้ว</string>
     <string name="gateway_trust_first_seen">ตรวจสอบลายนิ้วมือของใบรับรองก่อนเชื่อถือเกตเวย์นี้\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">TLS kullan</string>
     <string name="token_optional">Token (isteğe bağlı)</string>
     <string name="password">Parola</string>
+    <string name="custom_headers_optional">Özel üst bilgiler (isteğe bağlı)</string>
+    <string name="custom_headers_explainer">Bu gateway\'e yapılan her bağlantıyla birlikte gönderilir; örneğin Cloudflare Access hizmet belirteci üst bilgileri. Şifrelenmiş olarak saklanır ve bir sonraki yeniden bağlantıda uygulanır.</string>
+    <string name="custom_header_value">Üst bilgi değeri</string>
+    <string name="custom_header_reserved">Bu üst bilgi bağlantı tarafından yönetilir ve geçersiz kılınamaz.</string>
+    <string name="add_custom_header">Üst bilgi ekle</string>
+    <string name="remove_custom_header">%1$s kaldır</string>
     <string name="run_onboarding_again">Başlangıç sürecini tekrar çalıştır</string>
     <string name="resolved_endpoint">Çözümlenen uç nokta</string>
     <string name="gateway_trust_first_seen">Bu ağ geçidine güvenmeden önce sertifika parmak izini doğrulayın.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-uk/strings.xml
+++ b/apps/android/app/src/main/res/values-uk/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Використовувати TLS</string>
     <string name="token_optional">Токен (необов’язково)</string>
     <string name="password">Пароль</string>
+    <string name="custom_headers_optional">Користувацькі заголовки (необов’язково)</string>
+    <string name="custom_headers_explainer">Надсилається з кожним підключенням до цього gateway, наприклад заголовки токена сервісу Cloudflare Access. Зберігається в зашифрованому вигляді та застосовується під час наступного повторного підключення.</string>
+    <string name="custom_header_value">Значення заголовка</string>
+    <string name="custom_header_reserved">Цей заголовок керується підключенням і не може бути перевизначений.</string>
+    <string name="add_custom_header">Додати заголовок</string>
+    <string name="remove_custom_header">Видалити %1$s</string>
     <string name="run_onboarding_again">Запустити адаптацію знову</string>
     <string name="resolved_endpoint">Визначена кінцева точка</string>
     <string name="gateway_trust_first_seen">Перевірте відбиток сертифіката, перш ніж довіряти цьому шлюзу.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-vi/strings.xml
+++ b/apps/android/app/src/main/res/values-vi/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Sử dụng TLS</string>
     <string name="token_optional">Token (tùy chọn)</string>
     <string name="password">Mật khẩu</string>
+    <string name="custom_headers_optional">Tiêu đề tùy chỉnh (không bắt buộc)</string>
+    <string name="custom_headers_explainer">Được gửi cùng mọi kết nối đến gateway này, ví dụ như các tiêu đề mã thông báo dịch vụ Cloudflare Access. Được lưu trữ ở dạng mã hóa và áp dụng trong lần kết nối lại tiếp theo.</string>
+    <string name="custom_header_value">Giá trị tiêu đề</string>
+    <string name="custom_header_reserved">Tiêu đề này do kết nối quản lý và không thể bị ghi đè.</string>
+    <string name="add_custom_header">Thêm tiêu đề</string>
+    <string name="remove_custom_header">Xóa %1$s</string>
     <string name="run_onboarding_again">Chạy hướng dẫn thiết lập lại</string>
     <string name="resolved_endpoint">Điểm cuối đã phân giải</string>
     <string name="gateway_trust_first_seen">Xác minh dấu vân tay chứng chỉ trước khi tin cậy cổng này.\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">使用 TLS</string>
     <string name="token_optional">令牌（可选）</string>
     <string name="password">密码</string>
+    <string name="custom_headers_optional">自定义标头（可选）</string>
+    <string name="custom_headers_explainer">随每次连接到此 Gateway 一起发送，例如 Cloudflare Access 服务令牌标头。将加密存储，并在下次重新连接时应用。</string>
+    <string name="custom_header_value">标头值</string>
+    <string name="custom_header_reserved">此标头由连接管理，无法覆盖。</string>
+    <string name="add_custom_header">添加标头</string>
+    <string name="remove_custom_header">移除 %1$s</string>
     <string name="run_onboarding_again">再次运行引导流程</string>
     <string name="resolved_endpoint">已解析的端点</string>
     <string name="gateway_trust_first_seen">验证证书指纹后再信任此网关。\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">使用 TLS</string>
     <string name="token_optional">權杖（選填）</string>
     <string name="password">密碼</string>
+    <string name="custom_headers_optional">自訂標頭（選填）</string>
+    <string name="custom_headers_explainer">會隨每次連線傳送至此 gateway，例如 Cloudflare Access 服務權杖標頭。已加密儲存，並會在下次重新連線時套用。</string>
+    <string name="custom_header_value">標頭值</string>
+    <string name="custom_header_reserved">此標頭由連線管理，無法覆寫。</string>
+    <string name="add_custom_header">新增標頭</string>
+    <string name="remove_custom_header">移除 %1$s</string>
     <string name="run_onboarding_again">再次執行新手導覽</string>
     <string name="resolved_endpoint">已解析的端點</string>
     <string name="gateway_trust_first_seen">請先驗證憑證指紋，再信任此閘道。\n\n%1$s</string>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -21,6 +21,12 @@
     <string name="use_tls">Use TLS</string>
     <string name="token_optional">Token (optional)</string>
     <string name="password">Password</string>
+    <string name="custom_headers_optional">Custom headers (optional)</string>
+    <string name="custom_headers_explainer">Sent with every connection to this gateway, for example Cloudflare Access service token headers. Stored encrypted and applied on the next reconnect.</string>
+    <string name="custom_header_value">Header value</string>
+    <string name="custom_header_reserved">This header is managed by the connection and cannot be overridden.</string>
+    <string name="add_custom_header">Add header</string>
+    <string name="remove_custom_header">Remove %1$s</string>
     <string name="run_onboarding_again">Run onboarding again</string>
     <string name="resolved_endpoint">Resolved endpoint</string>
     <string name="gateway_trust_first_seen">Verify the certificate fingerprint before trusting this gateway.\n\n%1$s</string>

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -123,7 +123,6 @@ class GatewayBootstrapAuthTest {
     val runtime = app.ensureRuntime()
     writeField(runtime, "connectedEndpoint", GatewayEndpoint.manual("old-gateway.example", 18789))
     val viewModel = MainViewModel(app)
-
     viewModel.pairNewGateway()
     runBlocking {
       withTimeout(5_000) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -274,4 +274,21 @@ class SecurePrefsTest {
     )
     assertEquals(mapOf("X-Allowed" to "yes"), prefs.loadGatewayCustomHeaders(stableId))
   }
+
+  @Test
+  fun gatewayCustomHeaders_explicitClearRemovesOnlyCustomHeaderCredentials() {
+    val context = RuntimeEnvironment.getApplication()
+    val securePrefs = context.getSharedPreferences("openclaw.node.secure.test.headers3", Context.MODE_PRIVATE)
+    securePrefs.edit().clear().commit()
+    val prefs = SecurePrefs(context, securePrefsOverride = securePrefs)
+    prefs.saveGatewayCustomHeaders("manual|one.example|443", mapOf("X-One" to "secret-one"))
+    prefs.saveGatewayCustomHeaders("manual|two.example|443", mapOf("X-Two" to "secret-two"))
+    prefs.putString("unrelated.secret", "keep")
+
+    prefs.clearGatewayCustomHeaders()
+
+    assertTrue(prefs.loadGatewayCustomHeaders("manual|one.example|443").isEmpty())
+    assertTrue(prefs.loadGatewayCustomHeaders("manual|two.example|443").isEmpty())
+    assertEquals("keep", prefs.getString("unrelated.secret"))
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -268,6 +268,9 @@ class SecurePrefsTest {
       mapOf(
         "Host" to "smuggled.example",
         "Sec-WebSocket-Protocol" to "override",
+        "X Bad" to "space",
+        "X:Bad" to "colon",
+        "X-Bad-é" to "unicode",
         "X-Split" to "a\r\nEvil: b",
         "X-Allowed" to "yes",
       ),

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -229,4 +229,49 @@ class SecurePrefsTest {
     )
     assertEquals(prefs.modelRecents.value, SecurePrefs(context).modelRecents.value)
   }
+
+  @Test
+  fun gatewayCustomHeaders_roundTripStaysScopedPerGateway() {
+    val context = RuntimeEnvironment.getApplication()
+    val securePrefs = context.getSharedPreferences("openclaw.node.secure.test.headers", Context.MODE_PRIVATE)
+    securePrefs.edit().clear().commit()
+    val prefs = SecurePrefs(context, securePrefsOverride = securePrefs)
+    val stableId = "manual|gw.example.com|443"
+
+    assertTrue(prefs.loadGatewayCustomHeaders(stableId).isEmpty())
+    prefs.saveGatewayCustomHeaders(
+      stableId,
+      mapOf("CF-Access-Client-Id" to "client-id", "CF-Access-Client-Secret" to "client-secret"),
+    )
+    assertEquals(
+      mapOf("CF-Access-Client-Id" to "client-id", "CF-Access-Client-Secret" to "client-secret"),
+      prefs.loadGatewayCustomHeaders(stableId),
+    )
+    // Headers are per-gateway credentials; another endpoint never observes them.
+    assertTrue(prefs.loadGatewayCustomHeaders("manual|other.example.com|443").isEmpty())
+
+    prefs.saveGatewayCustomHeaders(stableId, emptyMap())
+    assertTrue(prefs.loadGatewayCustomHeaders(stableId).isEmpty())
+    assertFalse(securePrefs.contains("gateway.customHeaders.$stableId"))
+  }
+
+  @Test
+  fun gatewayCustomHeaders_dropsReservedAndUnsafeEntries() {
+    val context = RuntimeEnvironment.getApplication()
+    val securePrefs = context.getSharedPreferences("openclaw.node.secure.test.headers2", Context.MODE_PRIVATE)
+    securePrefs.edit().clear().commit()
+    val prefs = SecurePrefs(context, securePrefsOverride = securePrefs)
+    val stableId = "manual|gw.example.com|443"
+
+    prefs.saveGatewayCustomHeaders(
+      stableId,
+      mapOf(
+        "Host" to "smuggled.example",
+        "Sec-WebSocket-Protocol" to "override",
+        "X-Split" to "a\r\nEvil: b",
+        "X-Allowed" to "yes",
+      ),
+    )
+    assertEquals(mapOf("X-Allowed" to "yes"), prefs.loadGatewayCustomHeaders(stableId))
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
@@ -21,12 +21,14 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 private const val TEST_TIMEOUT_MS = 8_000L
@@ -56,7 +58,37 @@ private class NoopDeviceAuthStore : DeviceAuthTokenStore {
 @Config(sdk = [34])
 class GatewaySessionCustomHeadersTest {
   @Test
-  fun upgradeRequest_carriesOnlyThisGatewaysSanitizedHeaders() =
+  fun tlsUpgradeRequest_carriesLatestSanitizedHeadersForOnlyThisGateway() {
+    val app = RuntimeEnvironment.getApplication()
+    val securePrefsBacking =
+      app.getSharedPreferences("openclaw.node.secure.test.${UUID.randomUUID()}", Context.MODE_PRIVATE)
+    val prefs = SecurePrefs(app, securePrefsOverride = securePrefsBacking)
+    val stableId = "manual|gateway.example|443"
+    val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 443)
+    val tls = GatewayTlsParams(required = true, expectedFingerprint = "aa", allowTOFU = false, stableId = stableId)
+
+    prefs.saveGatewayCustomHeaders(stableId, mapOf("CF-Access-Client-Id" to "client-id"))
+    securePrefsBacking
+      .edit()
+      .putString(
+        "gateway.customHeaders.$stableId",
+        """{"CF-Access-Client-Id":"client-id","Host":"smuggled.example"}""",
+      ).commit()
+    prefs.saveGatewayCustomHeaders("manual|other.example|443", mapOf("X-Other-Gateway" to "leak"))
+
+    val first = buildGatewayWebSocketUpgradeRequest(endpoint, tls, prefs::loadGatewayCustomHeaders)
+    assertTrue(first.url.isHttps)
+    assertEquals("client-id", first.header("CF-Access-Client-Id"))
+    assertNull(first.header("Host"))
+    assertNull(first.header("X-Other-Gateway"))
+
+    prefs.saveGatewayCustomHeaders(stableId, mapOf("CF-Access-Client-Id" to "updated-id"))
+    val reconnected = buildGatewayWebSocketUpgradeRequest(endpoint, tls, prefs::loadGatewayCustomHeaders)
+    assertEquals("updated-id", reconnected.header("CF-Access-Client-Id"))
+  }
+
+  @Test
+  fun cleartextUpgrade_neverReadsOrSendsStoredCustomHeaders() =
     runBlocking {
       val app = RuntimeEnvironment.getApplication()
       val securePrefsBacking =
@@ -66,19 +98,11 @@ class GatewaySessionCustomHeadersTest {
       val handshake = AtomicReference<RecordedRequest?>(null)
       val server = startCapturingGatewayServer { request -> handshake.compareAndSet(null, request) }
       val stableId = "manual|127.0.0.1|${server.port}"
-      // Reserved names must be dropped at the transport even if a stale store still has them.
       prefs.saveGatewayCustomHeaders(
         stableId,
         mapOf("CF-Access-Client-Id" to "client-id", "CF-Access-Client-Secret" to "client-secret"),
       )
-      securePrefsBacking
-        .edit()
-        .putString(
-          "gateway.customHeaders.$stableId",
-          """{"CF-Access-Client-Id":"client-id","CF-Access-Client-Secret":"client-secret","Host":"smuggled.example"}""",
-        ).commit()
-      // A different gateway's credentials must never ride this endpoint's upgrade.
-      prefs.saveGatewayCustomHeaders("manual|other.example.com|443", mapOf("X-Other-Gateway" to "leak"))
+      val providerRead = AtomicBoolean(false)
 
       val sessionJob = SupervisorJob()
       val scope = CoroutineScope(sessionJob + Dispatchers.Default)
@@ -91,7 +115,10 @@ class GatewaySessionCustomHeadersTest {
           onConnected = { if (!connected.isCompleted) connected.complete(Unit) },
           onDisconnected = {},
           onEvent = { _, _ -> },
-          customHeadersProvider = prefs::loadGatewayCustomHeaders,
+          customHeadersProvider = { id ->
+            providerRead.set(true)
+            prefs.loadGatewayCustomHeaders(id)
+          },
         )
 
       try {
@@ -131,10 +158,10 @@ class GatewaySessionCustomHeadersTest {
         withTimeout(TEST_TIMEOUT_MS) { connected.await() }
 
         val request = requireNotNull(handshake.get()) { "no websocket upgrade recorded" }
-        assertEquals("client-id", request.getHeader("CF-Access-Client-Id"))
-        assertEquals("client-secret", request.getHeader("CF-Access-Client-Secret"))
+        assertEquals(false, providerRead.get())
+        assertNull(request.getHeader("CF-Access-Client-Id"))
+        assertNull(request.getHeader("CF-Access-Client-Secret"))
         assertEquals("127.0.0.1:${server.port}", request.getHeader("Host"))
-        assertNull(request.getHeader("X-Other-Gateway"))
       } finally {
         session.disconnectAndJoin()
         scope.cancel()

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
@@ -1,0 +1,180 @@
+package ai.openclaw.app.gateway
+
+import ai.openclaw.app.SecurePrefs
+import android.content.Context
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicReference
+
+private const val TEST_TIMEOUT_MS = 8_000L
+private const val CONNECT_CHALLENGE_FRAME =
+  """{"type":"event","event":"connect.challenge","payload":{"nonce":"android-test-nonce"}}"""
+
+private class NoopDeviceAuthStore : DeviceAuthTokenStore {
+  override fun loadEntry(
+    deviceId: String,
+    role: String,
+  ): DeviceAuthEntry? = null
+
+  override fun saveToken(
+    deviceId: String,
+    role: String,
+    token: String,
+    scopes: List<String>,
+  ) = Unit
+
+  override fun clearToken(
+    deviceId: String,
+    role: String,
+  ) = Unit
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class GatewaySessionCustomHeadersTest {
+  @Test
+  fun upgradeRequest_carriesOnlyThisGatewaysSanitizedHeaders() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      val securePrefsBacking =
+        app.getSharedPreferences("openclaw.node.secure.test.${UUID.randomUUID()}", Context.MODE_PRIVATE)
+      val prefs = SecurePrefs(app, securePrefsOverride = securePrefsBacking)
+
+      val handshake = AtomicReference<RecordedRequest?>(null)
+      val server = startCapturingGatewayServer { request -> handshake.compareAndSet(null, request) }
+      val stableId = "manual|127.0.0.1|${server.port}"
+      // Reserved names must be dropped at the transport even if a stale store still has them.
+      prefs.saveGatewayCustomHeaders(
+        stableId,
+        mapOf("CF-Access-Client-Id" to "client-id", "CF-Access-Client-Secret" to "client-secret"),
+      )
+      securePrefsBacking
+        .edit()
+        .putString(
+          "gateway.customHeaders.$stableId",
+          """{"CF-Access-Client-Id":"client-id","CF-Access-Client-Secret":"client-secret","Host":"smuggled.example"}""",
+        ).commit()
+      // A different gateway's credentials must never ride this endpoint's upgrade.
+      prefs.saveGatewayCustomHeaders("manual|other.example.com|443", mapOf("X-Other-Gateway" to "leak"))
+
+      val sessionJob = SupervisorJob()
+      val scope = CoroutineScope(sessionJob + Dispatchers.Default)
+      val connected = CompletableDeferred<Unit>()
+      val session =
+        GatewaySession(
+          scope = scope,
+          identityStore = DeviceIdentityStore(app),
+          deviceAuthStore = NoopDeviceAuthStore(),
+          onConnected = { if (!connected.isCompleted) connected.complete(Unit) },
+          onDisconnected = {},
+          onEvent = { _, _ -> },
+          customHeadersProvider = prefs::loadGatewayCustomHeaders,
+        )
+
+      try {
+        session.connect(
+          endpoint =
+            GatewayEndpoint(
+              stableId = stableId,
+              name = "test",
+              host = "127.0.0.1",
+              port = server.port,
+              tlsEnabled = false,
+            ),
+          token = "test-token",
+          bootstrapToken = null,
+          password = null,
+          options =
+            GatewayConnectOptions(
+              role = "node",
+              scopes = emptyList(),
+              caps = emptyList(),
+              commands = emptyList(),
+              permissions = emptyMap(),
+              client =
+                GatewayClientInfo(
+                  id = "openclaw-android-test",
+                  displayName = "Android Test",
+                  version = "1.0.0-test",
+                  platform = "android",
+                  mode = "node",
+                  instanceId = "android-test-instance",
+                  deviceFamily = "android",
+                  modelIdentifier = "test",
+                ),
+            ),
+          tls = null,
+        )
+        withTimeout(TEST_TIMEOUT_MS) { connected.await() }
+
+        val request = requireNotNull(handshake.get()) { "no websocket upgrade recorded" }
+        assertEquals("client-id", request.getHeader("CF-Access-Client-Id"))
+        assertEquals("client-secret", request.getHeader("CF-Access-Client-Secret"))
+        assertEquals("127.0.0.1:${server.port}", request.getHeader("Host"))
+        assertNull(request.getHeader("X-Other-Gateway"))
+      } finally {
+        session.disconnectAndJoin()
+        scope.cancel()
+        server.shutdown()
+      }
+    }
+
+  private fun startCapturingGatewayServer(onHandshake: (RecordedRequest) -> Unit): MockWebServer {
+    val json = Json { ignoreUnknownKeys = true }
+    return MockWebServer().apply {
+      dispatcher =
+        object : Dispatcher() {
+          override fun dispatch(request: RecordedRequest): MockResponse {
+            onHandshake(request)
+            return MockResponse().withWebSocketUpgrade(
+              object : WebSocketListener() {
+                override fun onOpen(
+                  webSocket: WebSocket,
+                  response: Response,
+                ) {
+                  webSocket.send(CONNECT_CHALLENGE_FRAME)
+                }
+
+                override fun onMessage(
+                  webSocket: WebSocket,
+                  text: String,
+                ) {
+                  val frame = json.parseToJsonElement(text).jsonObject
+                  if (frame["type"]?.jsonPrimitive?.content != "req") return
+                  val id = frame["id"]?.jsonPrimitive?.content ?: return
+                  if (frame["method"]?.jsonPrimitive?.content != "connect") return
+                  webSocket.send(
+                    """{"type":"res","id":"$id","ok":true,"payload":{"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}""",
+                  )
+                }
+              },
+            )
+          }
+        }
+      start()
+    }
+  }
+}


### PR DESCRIPTION
Related: #100698

## What Problem This Solves

Resolves a problem where the Android app cannot connect to a gateway fronted by an authenticating reverse proxy (Cloudflare Access-style service tokens): the proxy rejects the WebSocket upgrade before it reaches the gateway, and the app has no way to attach the proxy's credential headers. Operators with that deployment shape are locked out of mobile entirely; a tunnel sidecar is not an option on Android.

## Why This Change Was Made

Adds per-gateway custom request headers, injected on the gateway WebSocket upgrade and nowhere else (the gateway WebSocket is the Android app's only HTTP contact — there are no other OkHttp call sites in app code). Design boundaries:

- Headers are credentials: stored in `EncryptedSharedPreferences` alongside the other gateway secrets (`SecurePrefs`, scoped by endpoint `stableId`), values masked while typing and hidden once saved, never logged.
- `GatewaySession` reads the headers through an injected provider at connect time, so edits apply on the next reconnect without re-pairing. Both runtime sessions (operator + node) share the same `SecurePrefs`-backed provider.
- TLS fingerprint pinning (`GatewayTls`) and the pairing/trust flows are untouched — headers are HTTP-level and ride the `Request`, pinning stays on the trust manager.
- Credential headers are TLS-only: cleartext `ws://` routes neither read the provider nor attach stored values, and the editor is hidden for cleartext manual targets.
- A sanitizer (`GatewayCustomHeaders`) drops reserved handshake headers (`Host`, `Connection`, `Upgrade`, `Sec-WebSocket-*`, `Content-Length`, `Proxy-Connection`), invalid HTTP-token names, and non-printable values. This protects the upgrade, prevents proxy/parser ambiguity, and keeps one bad stored entry from wedging every reconnect.
- UI is gated behind the existing Advanced controls → Manual connection surface, scoped to the parsed effective endpoint's `stableId` (the same identity the TLS pin and credentials use). Editor state resets when that endpoint changes.
- Explicit Pair New Gateway clears the stored custom-header credentials together with the other pairing credentials; ordinary reconnects preserve them.

Non-goals: macOS parity (noted follow-up).

## User Impact

Operators can now put their gateway behind Cloudflare Access (or any header-authenticating proxy) and still use the Android app: add the service-token headers once under Advanced controls → Manual. Existing setups are unaffected; with no headers configured the upgrade request is unchanged.

## Evidence

- `GatewaySessionCustomHeadersTest` (Robolectric + MockWebServer): the recorded secure WebSocket upgrade carries this gateway's sanitized headers, a smuggled `Host` stored for the same gateway is dropped (real host preserved), and headers stored for a *different* gateway never appear. A cleartext test proves the provider is not read and credentials are not attached.
- `SecurePrefsTest`: encrypted round-trip, per-gateway scoping, delete-on-empty, explicit reset cleanup, and reserved/invalid-name/control-character rejection.
- Focused suites run green on both flavors (`:app:testPlayDebugUnitTest` and `:app:testThirdPartyDebugUnitTest`); `GatewayTls` is untouched.
- `pnpm android:i18n:check` and `pnpm native:i18n:check` pass with the six new strings translated across all 21 locales.
- Codex autoreview of the branch: clean, no accepted/actionable findings.

## Review

This touches the auth/connection surface. Requesting owner + security review from @openclaw/openclaw-secops before merge (security-sensitive per repo policy); please look specifically at the secure-store scoping, the reserved-header sanitizer, and the non-gateway isolation guarantees.
