### PR TITLE
fix(codex): ignore late item/started for completed blocker items

### DIFF
--- a/extensions/codex/src/app-server/attempt-notification-state.ts
+++ b/extensions/codex/src/app-server/attempt-notification-state.ts
@@ -94,6 +94,7 @@ export function applyCodexTurnNotificationState(params: {
   turnWatches: CodexAttemptTurnWatchController;
   activeTurnItemIds: Set<string>;
   activeCompletionBlockerItemIds: Set<string>;
+  completedCompletionBlockerItemIds: Set<string>;
   activeAppServerTurnRequests: number;
   pendingOpenClawDynamicToolCompletionIds: Set<string>;
   turnCrossedToolHandoff: boolean;
@@ -123,7 +124,11 @@ export function applyCodexTurnNotificationState(params: {
     });
     params.onReportExecutionNotification(notification);
     updateActiveTurnItemIds(notification, params.activeTurnItemIds);
-    updateActiveCompletionBlockerItemIds(notification, params.activeCompletionBlockerItemIds);
+    updateActiveCompletionBlockerItemIds(
+      notification,
+      params.activeCompletionBlockerItemIds,
+      params.completedCompletionBlockerItemIds,
+    );
     if (notification.method === "item/completed" && params.activeTurnItemIds.size === 0) {
       params.onScheduleTerminalDynamicToolReleaseCheck();
     }

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -66,6 +66,7 @@ export function updateActiveTurnItemIds(
 export function updateActiveCompletionBlockerItemIds(
   notification: CodexServerNotification,
   activeItemIds: Set<string>,
+  completedItemIds?: Set<string>,
 ): void {
   if (notification.method !== "item/started" && notification.method !== "item/completed") {
     return;
@@ -76,6 +77,14 @@ export function updateActiveCompletionBlockerItemIds(
   }
   if (notification.method === "item/completed") {
     activeItemIds.delete(itemId);
+    // Remember completed ids so an out-of-order item/started (correlation is
+    // plain string equality with no sequence numbers) cannot resurrect an
+    // already-completed item as a phantom blocker for the rest of the turn.
+    completedItemIds?.add(itemId);
+    return;
+  }
+  // Ignore a late item/started for an item we already saw complete.
+  if (completedItemIds?.has(itemId)) {
     return;
   }
   const item = readCodexNotificationItem(notification.params);

--- a/extensions/codex/src/app-server/attempt-turn-watches.test.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.test.ts
@@ -323,4 +323,47 @@ describe("Codex completion blocker item tracking", () => {
       expect(activeItemIds).toEqual(new Set());
     },
   );
+
+  it("ignores a late item/started for an already-completed item", () => {
+    const activeItemIds = new Set<string>();
+    const completedItemIds = new Set<string>();
+
+    // item/completed arrives before its item/started (ordering inversion).
+    updateActiveCompletionBlockerItemIds(
+      { method: "item/completed", params: { item: { id: "item-1", type: "commandExecution" } } },
+      activeItemIds,
+      completedItemIds,
+    );
+    expect(activeItemIds).toEqual(new Set());
+    expect(completedItemIds).toEqual(new Set(["item-1"]));
+
+    // The late item/started must not resurrect the completed item as a phantom
+    // blocker that would suppress the completion/terminal watches for the turn.
+    updateActiveCompletionBlockerItemIds(
+      { method: "item/started", params: { item: { id: "item-1", type: "commandExecution" } } },
+      activeItemIds,
+      completedItemIds,
+    );
+    expect(activeItemIds).toEqual(new Set());
+  });
+
+  it("still tracks a normal started->completed pair when completed ids are provided", () => {
+    const activeItemIds = new Set<string>();
+    const completedItemIds = new Set<string>();
+
+    updateActiveCompletionBlockerItemIds(
+      { method: "item/started", params: { item: { id: "item-1", type: "mcpToolCall" } } },
+      activeItemIds,
+      completedItemIds,
+    );
+    expect(activeItemIds).toEqual(new Set(["item-1"]));
+
+    updateActiveCompletionBlockerItemIds(
+      { method: "item/completed", params: { item: { id: "item-1", type: "mcpToolCall" } } },
+      activeItemIds,
+      completedItemIds,
+    );
+    expect(activeItemIds).toEqual(new Set());
+    expect(completedItemIds).toEqual(new Set(["item-1"]));
+  });
 });

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1681,6 +1681,7 @@ export async function runCodexAppServerAttempt(
   const pendingOpenClawDynamicToolCompletionIds = new Set<string>();
   const activeTurnItemIds = new Set<string>();
   const activeCompletionBlockerItemIds = new Set<string>();
+  const completedCompletionBlockerItemIds = new Set<string>();
   const activeFinalizationHookRunIds = new Set<string>();
   const finalizationHookBatchStatuses = new Map<string, string | undefined>();
   let unsettledFinalizationHookCount = 0;
@@ -2011,6 +2012,7 @@ export async function runCodexAppServerAttempt(
       turnWatches,
       activeTurnItemIds,
       activeCompletionBlockerItemIds,
+      completedCompletionBlockerItemIds,
       activeAppServerTurnRequests,
       pendingOpenClawDynamicToolCompletionIds,
       turnCrossedToolHandoff,


### PR DESCRIPTION
## Summary

- Track completed Codex blocker item ids so an out-of-order `item/started` can no longer re-add an already-completed item to the active completion-blocker set.
- Prevents a phantom blocker from permanently suppressing the completion and terminal watches for the rest of a turn.

## Motivation

Refs #99272 (the "out-of-order blocker hazard" bullet).

`updateActiveCompletionBlockerItemIds` in `extensions/codex/src/app-server/attempt-notifications.ts` deletes an id on `item/completed` and adds it on `item/started`. Correlation is plain string equality with no sequence numbers (`notification-correlation.ts`), so if `item/completed` arrives before its `item/started` (an ordering inversion), the late `item/started` re-adds the id and nothing ever removes it. That phantom blocker keeps `getActiveCompletionBlockerItemCount() > 0`, which defers the completion and terminal idle watches (`attempt-turn-watches.ts:128/196/326`) for the rest of the turn — a wedged turn never terminates cleanly at the harness level.

The fix threads a `completedCompletionBlockerItemIds` set through the notification state path and ignores a late `item/started` for any id already observed complete. This is the focused, atomic piece of #99272; the wall-clock ceiling and progress-method scoping in that issue are left for separate changes.

## Verification

- `npx vitest run extensions/codex/src/app-server/attempt-turn-watches.test.ts` — 27 passed (includes 2 new tests: late `item/started` after `item/completed` does not resurrect the blocker; a normal started→completed pair still tracks correctly).
- `npx vitest run extensions/codex/src/app-server/run-attempt.turn-watches.test.ts` — 96 passed.
- `tsc --noEmit` on the codex extension produces the same pre-existing SDK build-order errors with and without this change (0 new type errors); the touched files are error-free.
- Did NOT change: the guard predicate is additive — the `completedItemIds` argument is optional, so existing callers of `updateActiveCompletionBlockerItemIds` are unaffected.
