### PR TITLE
feat(ios): per-gateway custom headers for gateways behind authenticating proxies

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -12323,7 +12323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3312,
+      "line": 3315,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -12331,7 +12331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3312,
+      "line": 3315,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -12339,7 +12339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3316,
+      "line": 3319,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -12347,7 +12347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3316,
+      "line": 3319,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -12355,7 +12355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3604,
+      "line": 3610,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -12363,7 +12363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3604,
+      "line": 3610,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -10019,7 +10019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 858,
+      "line": 871,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Configured",
       "surface": "apple",
@@ -10027,7 +10027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 858,
+      "line": 871,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Not configured",
       "surface": "apple",
@@ -10035,7 +10035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 923,
+      "line": 936,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -10043,7 +10043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 923,
+      "line": 936,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Gateway requests will appear here.",
       "surface": "apple",
@@ -10051,7 +10051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 970,
+      "line": 983,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "High",
       "surface": "apple",
@@ -10059,7 +10059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 970,
+      "line": 983,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Resolving",
       "surface": "apple",
@@ -10067,7 +10067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 975,
+      "line": 988,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "One-time approval",
       "surface": "apple",
@@ -10075,7 +10075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 975,
+      "line": 988,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Permission can be saved",
       "surface": "apple",
@@ -10083,7 +10083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 977,
+      "line": 990,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Medium",
       "surface": "apple",
@@ -10091,7 +10091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 977,
+      "line": 990,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Review",
       "surface": "apple",
@@ -10099,7 +10099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 998,
+      "line": 1011,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "\\(diagnosticsIssueCount)",
       "surface": "apple",
@@ -10107,7 +10107,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1009,
+      "line": 1022,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location off",
       "surface": "apple",
@@ -10115,7 +10115,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1011,
+      "line": 1024,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location While Using",
       "surface": "apple",
@@ -10123,7 +10123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1013,
+      "line": 1026,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location While Using, effective Off",
       "surface": "apple",
@@ -10131,7 +10131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1015,
+      "line": 1028,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location While Using, effective Always",
       "surface": "apple",
@@ -10139,7 +10139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1017,
+      "line": 1030,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location Always",
       "surface": "apple",
@@ -10147,7 +10147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1019,
+      "line": 1032,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location Always, effective While Using",
       "surface": "apple",
@@ -10155,7 +10155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1021,
+      "line": 1034,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Location Always, effective Off",
       "surface": "apple",
@@ -10163,7 +10163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1049,
+      "line": 1062,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Checking iOS notification permission.",
       "surface": "apple",
@@ -10171,7 +10171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1051,
+      "line": 1064,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw can show approval prompts and event alerts when the app is not active.",
       "surface": "apple",
@@ -10179,7 +10179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1053,
+      "line": 1066,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Notifications have been denied. Enable them in iOS Settings.",
       "surface": "apple",
@@ -10187,7 +10187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1055,
+      "line": 1068,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "Enable notifications to receive approval prompts and event alerts outside the app.",
       "surface": "apple",
@@ -10195,7 +10195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1057,
+      "line": 1070,
       "path": "apps/ios/Sources/Design/SettingsProTabActions.swift",
       "source": "OpenClaw cannot determine the current notification permission state.",
       "surface": "apple",
@@ -13330,16 +13330,16 @@
       "id": "native.apple.acc5936e406af08c"
     },
     {
-      "kind": "ui-call",
+      "kind": "ui-call-concatenated",
       "line": 37,
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
-      "source": "Sent with every connection to this gateway. Changes apply on the next reconnect.",
+      "source": "Sent with foreground app connections to this gateway. Changes apply on the next reconnect; Share extension delivery is not yet supported.",
       "surface": "apple",
-      "id": "native.apple.9fb142062b3a3398"
+      "id": "native.apple.8896386269ac4882"
     },
     {
       "kind": "ui-call",
-      "line": 44,
+      "line": 45,
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Header name",
       "surface": "apple",
@@ -13347,7 +13347,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 50,
+      "line": 51,
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Header value",
       "surface": "apple",
@@ -13355,7 +13355,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 63,
+      "line": 64,
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Add Header",
       "surface": "apple",
@@ -13363,7 +13363,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 70,
+      "line": 71,
       "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
       "source": "Custom Headers",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -10819,7 +10819,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 896,
+      "line": 897,
+      "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
+      "source": "Custom Headers",
+      "surface": "apple",
+      "id": "native.apple.438ae7e5b8544548"
+    },
+    {
+      "kind": "ui-call",
+      "line": 904,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Reset Onboarding",
       "surface": "apple",
@@ -10827,7 +10835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 923,
+      "line": 931,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Wake",
       "surface": "apple",
@@ -10835,7 +10843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 926,
+      "line": 934,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Talk Mode",
       "surface": "apple",
@@ -10843,7 +10851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 934,
+      "line": 942,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speech Language",
       "surface": "apple",
@@ -10851,7 +10859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 941,
+      "line": 949,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Speakerphone",
       "surface": "apple",
@@ -10859,7 +10867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 945,
+      "line": 953,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Wake Words",
       "surface": "apple",
@@ -10867,7 +10875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 966,
+      "line": 974,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice",
       "surface": "apple",
@@ -10875,7 +10883,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 967,
+      "line": 975,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Provider",
       "surface": "apple",
@@ -10883,7 +10891,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 974,
+      "line": 982,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Realtime Voice",
       "surface": "apple",
@@ -10891,7 +10899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 975,
+      "line": 983,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Gateway Default",
       "surface": "apple",
@@ -10899,7 +10907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 982,
+      "line": 990,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Voice Mode",
       "surface": "apple",
@@ -10907,7 +10915,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 983,
+      "line": 991,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Active Voice",
       "surface": "apple",
@@ -10915,7 +10923,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 985,
+      "line": 993,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Last Voice Issue",
       "surface": "apple",
@@ -10923,7 +10931,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 987,
+      "line": 995,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Transport",
       "surface": "apple",
@@ -10931,7 +10939,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 988,
+      "line": 996,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "API Key",
       "surface": "apple",
@@ -10939,7 +10947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 996,
+      "line": 1004,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Show Talk Control",
       "surface": "apple",
@@ -10947,7 +10955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 999,
+      "line": 1007,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Default Share Instruction",
       "surface": "apple",
@@ -10955,7 +10963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1006,
+      "line": 1014,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Run Share Self-Test",
       "surface": "apple",
@@ -10963,7 +10971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1023,
+      "line": 1031,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Debug Logs",
       "surface": "apple",
@@ -10971,7 +10979,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1026,
+      "line": 1034,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Debug Screen Status",
       "surface": "apple",
@@ -10979,7 +10987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1030,
+      "line": 1038,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Discovery Logs",
       "surface": "apple",
@@ -10987,7 +10995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1036,
+      "line": 1044,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device",
       "surface": "apple",
@@ -10995,7 +11003,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1037,
+      "line": 1045,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Device Name",
       "surface": "apple",
@@ -11003,7 +11011,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1039,
+      "line": 1047,
       "path": "apps/ios/Sources/Design/SettingsProTabSections.swift",
       "source": "Instance ID",
       "surface": "apple",
@@ -13304,6 +13312,62 @@
       "source": "Connection",
       "surface": "apple",
       "id": "native.apple.e69088f1f2dcbd99"
+    },
+    {
+      "kind": "ui-call",
+      "line": 29,
+      "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
+      "source": "Value",
+      "surface": "apple",
+      "id": "native.apple.41e812a22a1b042d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 34,
+      "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
+      "source": "Headers",
+      "surface": "apple",
+      "id": "native.apple.acc5936e406af08c"
+    },
+    {
+      "kind": "ui-call",
+      "line": 37,
+      "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
+      "source": "Sent with every connection to this gateway. Changes apply on the next reconnect.",
+      "surface": "apple",
+      "id": "native.apple.9fb142062b3a3398"
+    },
+    {
+      "kind": "ui-call",
+      "line": 44,
+      "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
+      "source": "Header name",
+      "surface": "apple",
+      "id": "native.apple.319594454c1ff701"
+    },
+    {
+      "kind": "ui-call",
+      "line": 50,
+      "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
+      "source": "Header value",
+      "surface": "apple",
+      "id": "native.apple.7c4ff27cd7fa2c96"
+    },
+    {
+      "kind": "ui-call",
+      "line": 63,
+      "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
+      "source": "Add Header",
+      "surface": "apple",
+      "id": "native.apple.a1368ad2d29a1152"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 70,
+      "path": "apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift",
+      "source": "Custom Headers",
+      "surface": "apple",
+      "id": "native.apple.19fba912c31023b5"
     },
     {
       "kind": "ui-named-argument",

--- a/apps/ios/Sources/Design/SettingsProTabActions.swift
+++ b/apps/ios/Sources/Design/SettingsProTabActions.swift
@@ -616,6 +616,19 @@ extension SettingsProTab {
         self.gatewayCredentialFieldStableID ?? self.currentManualGatewayStableID
     }
 
+    var gatewayCustomHeadersTargetStableID: String? {
+        guard let stableID = self.gatewayCredentialTargetStableID else { return nil }
+        if self.currentManualGatewayStableID == stableID {
+            return self.manualGatewayTLS ? stableID : nil
+        }
+        if let active = self.appModel.activeGatewayConnectConfig,
+           active.effectiveStableID == stableID
+        {
+            return active.url.scheme?.lowercased() == "wss" ? stableID : nil
+        }
+        return nil
+    }
+
     var manualGatewayEnabledBinding: Binding<Bool> {
         Binding(
             get: { self.manualGatewayEnabled },

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -890,7 +890,7 @@ extension SettingsProTab {
             }
             self.gatewaySecureField("Gateway Auth Token", text: self.gatewayTokenBinding)
             self.gatewaySecureField("Gateway Password", text: self.gatewayPasswordBinding)
-            if let headersStableID = self.gatewayCredentialTargetStableID {
+            if let headersStableID = self.gatewayCustomHeadersTargetStableID {
                 NavigationLink {
                     GatewayCustomHeadersSettingsView(gatewayStableID: headersStableID)
                 } label: {

--- a/apps/ios/Sources/Design/SettingsProTabSections.swift
+++ b/apps/ios/Sources/Design/SettingsProTabSections.swift
@@ -890,6 +890,14 @@ extension SettingsProTab {
             }
             self.gatewaySecureField("Gateway Auth Token", text: self.gatewayTokenBinding)
             self.gatewaySecureField("Gateway Password", text: self.gatewayPasswordBinding)
+            if let headersStableID = self.gatewayCredentialTargetStableID {
+                NavigationLink {
+                    GatewayCustomHeadersSettingsView(gatewayStableID: headersStableID)
+                } label: {
+                    Text("Custom Headers")
+                        .font(OpenClawType.body)
+                }
+            }
             Button(role: .destructive) {
                 self.showResetOnboardingAlert = true
             } label: {

--- a/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
+++ b/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
@@ -22,6 +22,7 @@ enum GatewaySettingsStore {
     private static let preferredGatewayStableIDAccount = "preferredStableID"
     private static let lastDiscoveredGatewayStableIDAccount = "lastDiscoveredStableID"
     private static let lastGatewayConnectionAccount = "lastConnection"
+    private static let gatewayCustomHeadersService = "ai.openclawfoundation.app.gateway.custom-headers"
     private static let talkProviderApiKeyAccountPrefix = "provider.apiKey." // pragma: allowlist secret
 
     struct GatewayCredentialMetadata: Codable, Equatable {
@@ -257,10 +258,17 @@ enum GatewaySettingsStore {
     /// tokens). They live in the Keychain like the other gateway secrets and are read at
     /// connect time; never log their values.
     static func loadGatewayCustomHeaders(gatewayStableID: String) -> [String: String] {
+        self.loadGatewayCustomHeaders(gatewayStableID: gatewayStableID, service: self.gatewayCustomHeadersService)
+    }
+
+    static func loadGatewayCustomHeaders(
+        gatewayStableID: String,
+        service: String) -> [String: String]
+    {
         let stableID = self.authenticationOwnerID(routeStableID: gatewayStableID)
         guard !stableID.isEmpty,
               let json = KeychainStore.loadString(
-                  service: self.gatewayService,
+                  service: service,
                   account: self.customHeadersAccount(stableID: stableID)),
               let data = json.data(using: .utf8),
               let headers = try? JSONDecoder().decode([String: String].self, from: data)
@@ -270,19 +278,41 @@ enum GatewaySettingsStore {
 
     @discardableResult
     static func saveGatewayCustomHeaders(_ headers: [String: String], gatewayStableID: String) -> Bool {
+        self.saveGatewayCustomHeaders(
+            headers,
+            gatewayStableID: gatewayStableID,
+            service: self.gatewayCustomHeadersService)
+    }
+
+    @discardableResult
+    static func saveGatewayCustomHeaders(
+        _ headers: [String: String],
+        gatewayStableID: String,
+        service: String) -> Bool
+    {
         let stableID = self.authenticationOwnerID(routeStableID: gatewayStableID)
         guard !stableID.isEmpty else { return false }
         let account = self.customHeadersAccount(stableID: stableID)
         let sanitized = GatewayCustomHeaders.sanitized(headers)
         guard !sanitized.isEmpty else {
-            let deleted = KeychainStore.delete(service: self.gatewayService, account: account)
-            return deleted
-                || KeychainStore.loadString(service: self.gatewayService, account: account) == nil
+            let deleted = KeychainStore.delete(service: service, account: account)
+            return deleted || KeychainStore.loadString(service: service, account: account) == nil
         }
         guard let data = try? JSONEncoder().encode(sanitized),
               let json = String(data: data, encoding: .utf8)
         else { return false }
-        return KeychainStore.saveString(json, service: self.gatewayService, account: account)
+        return KeychainStore.saveString(json, service: service, account: account)
+    }
+
+    /// Full onboarding reset is the explicit forget boundary for every gateway's proxy secrets.
+    @discardableResult
+    static func clearGatewayCustomHeaders() -> Bool {
+        self.clearGatewayCustomHeaders(service: self.gatewayCustomHeadersService)
+    }
+
+    @discardableResult
+    static func clearGatewayCustomHeaders(service: String) -> Bool {
+        KeychainStore.deleteAll(service: service)
     }
 
     private static func customHeadersAccount(stableID: String) -> String {

--- a/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
+++ b/apps/ios/Sources/Gateway/GatewaySettingsStore.swift
@@ -253,6 +253,42 @@ enum GatewaySettingsStore {
         routeStableID.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Custom proxy headers are per-gateway credentials (Cloudflare Access-style service
+    /// tokens). They live in the Keychain like the other gateway secrets and are read at
+    /// connect time; never log their values.
+    static func loadGatewayCustomHeaders(gatewayStableID: String) -> [String: String] {
+        let stableID = self.authenticationOwnerID(routeStableID: gatewayStableID)
+        guard !stableID.isEmpty,
+              let json = KeychainStore.loadString(
+                  service: self.gatewayService,
+                  account: self.customHeadersAccount(stableID: stableID)),
+              let data = json.data(using: .utf8),
+              let headers = try? JSONDecoder().decode([String: String].self, from: data)
+        else { return [:] }
+        return GatewayCustomHeaders.sanitized(headers)
+    }
+
+    @discardableResult
+    static func saveGatewayCustomHeaders(_ headers: [String: String], gatewayStableID: String) -> Bool {
+        let stableID = self.authenticationOwnerID(routeStableID: gatewayStableID)
+        guard !stableID.isEmpty else { return false }
+        let account = self.customHeadersAccount(stableID: stableID)
+        let sanitized = GatewayCustomHeaders.sanitized(headers)
+        guard !sanitized.isEmpty else {
+            let deleted = KeychainStore.delete(service: self.gatewayService, account: account)
+            return deleted
+                || KeychainStore.loadString(service: self.gatewayService, account: account) == nil
+        }
+        guard let data = try? JSONEncoder().encode(sanitized),
+              let json = String(data: data, encoding: .utf8)
+        else { return false }
+        return KeychainStore.saveString(json, service: self.gatewayService, account: account)
+    }
+
+    private static func customHeadersAccount(stableID: String) -> String {
+        "customHeaders.\(stableID)"
+    }
+
     @discardableResult
     static func migrateProvenRelayCredentials(
         instanceId: String,

--- a/apps/ios/Sources/Gateway/KeychainStore.swift
+++ b/apps/ios/Sources/Gateway/KeychainStore.swift
@@ -13,4 +13,8 @@ enum KeychainStore {
     static func delete(service: String, account: String) -> Bool {
         GenericPasswordKeychainStore.delete(service: service, account: account)
     }
+
+    static func deleteAll(service: String) -> Bool {
+        GenericPasswordKeychainStore.deleteAll(service: service)
+    }
 }

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -3191,6 +3191,9 @@ extension NodeAppModel {
                         password: reconnectAuth.password,
                         connectOptions: operatorOptions,
                         sessionBox: sessionBox,
+                        extraHeadersProvider: {
+                            GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: stableID)
+                        },
                         onConnected: { [weak self] in
                             await self?.handleOperatorGatewayConnected(
                                 url: url,
@@ -3333,6 +3336,9 @@ extension NodeAppModel {
                         password: reconnectAuth.password,
                         connectOptions: connectedOptions,
                         sessionBox: sessionBox,
+                        extraHeadersProvider: {
+                            GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: stableID)
+                        },
                         onConnected: { [weak self] in
                             await self?.handleNodeGatewayConnected(
                                 url: url,

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingReset.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingReset.swift
@@ -111,6 +111,7 @@ enum GatewayOnboardingReset {
             DeviceAuthStore.clearToken(deviceId: deviceId, role: "operator")
             DeviceAuthStore.clearAll(profile: .shareExtension)
             GatewayTLSStore.clearAllFingerprints()
+            GatewaySettingsStore.clearGatewayCustomHeaders()
         }
 
         GatewaySettingsStore.clearLastGatewayConnection(defaults: defaults)

--- a/apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift
+++ b/apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift
@@ -1,0 +1,155 @@
+import OpenClawKit
+import SwiftUI
+
+/// Per-gateway custom header editor for gateways behind authenticating reverse proxies
+/// (Cloudflare Access-style service tokens). Header values are credentials: they render
+/// masked, persist in the Keychain, and must never appear in logs or diagnostics.
+struct GatewayCustomHeadersSettingsView: View {
+    let gatewayStableID: String
+
+    @State private var entries: [HeaderEntry] = []
+    @State private var newName = ""
+    @State private var newValue = ""
+    @State private var loaded = false
+
+    private struct HeaderEntry: Identifiable, Equatable {
+        let id = UUID()
+        var name: String
+        var value: String
+    }
+
+    var body: some View {
+        Form {
+            if !self.entries.isEmpty {
+                Section {
+                    ForEach(self.$entries) { $entry in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(entry.name)
+                                .font(OpenClawType.subheadSemiBold)
+                            self.headerValueField("Value", text: $entry.value)
+                        }
+                    }
+                    .onDelete(perform: self.removeEntries)
+                } header: {
+                    Text("Headers")
+                        .font(OpenClawType.captionSemiBold)
+                } footer: {
+                    Text("Sent with every connection to this gateway. Changes apply on the next reconnect.")
+                        .font(OpenClawType.caption)
+                }
+            }
+
+            Section {
+                TextField(text: self.$newName, prompt: Text("Header name").font(OpenClawType.subhead)) {
+                    Text("Header name")
+                        .font(OpenClawType.subhead)
+                }
+                .font(OpenClawType.subhead)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                self.headerValueField("Header value", text: self.$newValue)
+                Button {
+                    self.addEntry()
+                } label: {
+                    Label {
+                        Text("Add Header")
+                            .font(OpenClawType.subheadSemiBold)
+                    } icon: {
+                        Image(systemName: "plus")
+                    }
+                }
+                .disabled(!self.canAddEntry)
+            } header: {
+                Text("Add Header")
+                    .font(OpenClawType.captionSemiBold)
+            } footer: {
+                Text(self.addFooterText)
+                    .font(OpenClawType.caption)
+            }
+        }
+        .navigationTitle("Custom Headers")
+        .toolbar {
+            EditButton()
+                .font(OpenClawType.subheadSemiBold)
+        }
+        .onAppear(perform: self.loadOnce)
+        .onChange(of: self.entries) { _, _ in
+            guard self.loaded else { return }
+            self.persist()
+        }
+    }
+
+    private var trimmedNewName: String {
+        self.newName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var newNameIsReserved: Bool {
+        GatewayCustomHeaders.isReservedName(self.trimmedNewName)
+    }
+
+    private var newNameIsDuplicate: Bool {
+        let name = self.trimmedNewName
+        return self.entries.contains { $0.name.caseInsensitiveCompare(name) == .orderedSame }
+    }
+
+    private var canAddEntry: Bool {
+        !self.trimmedNewName.isEmpty && !self.newNameIsReserved && !self.newNameIsDuplicate
+    }
+
+    private var addFooterText: String {
+        if self.newNameIsReserved {
+            return "This header is managed by the connection and cannot be overridden."
+        }
+        if self.newNameIsDuplicate {
+            return "A header with this name already exists."
+        }
+        return "For gateways behind an authenticating proxy, for example Cloudflare Access "
+            + "service token headers. Values are stored securely and sent only to this gateway."
+    }
+
+    private func headerValueField(_ placeholder: String, text: Binding<String>) -> some View {
+        ZStack(alignment: .leading) {
+            SecureField("", text: text)
+                .font(OpenClawType.subhead)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .accessibilityLabel(placeholder)
+            if text.wrappedValue.isEmpty {
+                Text(placeholder)
+                    .font(OpenClawType.subhead)
+                    .foregroundStyle(.tertiary)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+            }
+        }
+    }
+
+    private func loadOnce() {
+        guard !self.loaded else { return }
+        self.entries = GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: self.gatewayStableID)
+            .sorted { $0.key.localizedCaseInsensitiveCompare($1.key) == .orderedAscending }
+            .map { HeaderEntry(name: $0.key, value: $0.value) }
+        self.loaded = true
+    }
+
+    private func addEntry() {
+        guard self.canAddEntry else { return }
+        self.entries.append(HeaderEntry(name: self.trimmedNewName, value: self.newValue))
+        self.newName = ""
+        self.newValue = ""
+    }
+
+    private func removeEntries(at offsets: IndexSet) {
+        self.entries.remove(atOffsets: offsets)
+    }
+
+    private func persist() {
+        var headers: [String: String] = [:]
+        for entry in self.entries {
+            let name = entry.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty else { continue }
+            headers[name] = entry.value
+        }
+        GatewaySettingsStore.saveGatewayCustomHeaders(headers, gatewayStableID: self.gatewayStableID)
+    }
+}

--- a/apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift
+++ b/apps/ios/Sources/Settings/GatewayCustomHeadersSettingsView.swift
@@ -34,7 +34,8 @@ struct GatewayCustomHeadersSettingsView: View {
                     Text("Headers")
                         .font(OpenClawType.captionSemiBold)
                 } footer: {
-                    Text("Sent with every connection to this gateway. Changes apply on the next reconnect.")
+                    Text("Sent with foreground app connections to this gateway. "
+                        + "Changes apply on the next reconnect; Share extension delivery is not yet supported.")
                         .font(OpenClawType.caption)
                 }
             }
@@ -103,8 +104,8 @@ struct GatewayCustomHeadersSettingsView: View {
         if self.newNameIsDuplicate {
             return "A header with this name already exists."
         }
-        return "For gateways behind an authenticating proxy, for example Cloudflare Access "
-            + "service token headers. Values are stored securely and sent only to this gateway."
+        return "For secure gateways behind an authenticating proxy, for example Cloudflare Access "
+            + "service token headers. Values are stored securely and sent only over TLS to this gateway."
     }
 
     private func headerValueField(_ placeholder: String, text: Binding<String>) -> some View {

--- a/apps/ios/Tests/GatewaySettingsStoreTests.swift
+++ b/apps/ios/Tests/GatewaySettingsStoreTests.swift
@@ -95,6 +95,36 @@ private func withLastGatewaySnapshot(_ body: () -> Void) {
 }
 
 @Suite(.serialized) struct GatewaySettingsStoreTests {
+    @Test func `custom headers round trip per gateway`() {
+        let gatewayID = "manual|headers.example.com|443|\(UUID().uuidString)"
+        let otherGatewayID = "manual|other.example.com|443|\(UUID().uuidString)"
+        defer { GatewaySettingsStore.saveGatewayCustomHeaders([:], gatewayStableID: gatewayID) }
+
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID).isEmpty)
+        #expect(GatewaySettingsStore.saveGatewayCustomHeaders(
+            ["CF-Access-Client-Id": "client-id", "CF-Access-Client-Secret": "client-secret"],
+            gatewayStableID: gatewayID))
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID) == [
+            "CF-Access-Client-Id": "client-id",
+            "CF-Access-Client-Secret": "client-secret",
+        ])
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: otherGatewayID).isEmpty)
+
+        #expect(GatewaySettingsStore.saveGatewayCustomHeaders([:], gatewayStableID: gatewayID))
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID).isEmpty)
+    }
+
+    @Test func `custom header storage drops reserved names`() {
+        let gatewayID = "manual|reserved.example.com|443|\(UUID().uuidString)"
+        defer { GatewaySettingsStore.saveGatewayCustomHeaders([:], gatewayStableID: gatewayID) }
+
+        #expect(GatewaySettingsStore.saveGatewayCustomHeaders(
+            ["Host": "smuggled.example", "X-Allowed": "yes"],
+            gatewayStableID: gatewayID))
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID)
+            == ["X-Allowed": "yes"])
+    }
+
     @Test func `credentials stay bound to their gateway`() {
         let instanceID = "credential-owner-\(UUID().uuidString)"
         defer { GatewaySettingsStore.deleteGatewayCredentials(instanceId: instanceID) }

--- a/apps/ios/Tests/GatewaySettingsStoreTests.swift
+++ b/apps/ios/Tests/GatewaySettingsStoreTests.swift
@@ -96,33 +96,79 @@ private func withLastGatewaySnapshot(_ body: () -> Void) {
 
 @Suite(.serialized) struct GatewaySettingsStoreTests {
     @Test func `custom headers round trip per gateway`() {
+        let service = "\(gatewayService).custom-headers-test.\(UUID().uuidString)"
         let gatewayID = "manual|headers.example.com|443|\(UUID().uuidString)"
         let otherGatewayID = "manual|other.example.com|443|\(UUID().uuidString)"
-        defer { GatewaySettingsStore.saveGatewayCustomHeaders([:], gatewayStableID: gatewayID) }
+        defer { GatewaySettingsStore.clearGatewayCustomHeaders(service: service) }
 
-        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID).isEmpty)
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID, service: service).isEmpty)
         #expect(GatewaySettingsStore.saveGatewayCustomHeaders(
             ["CF-Access-Client-Id": "client-id", "CF-Access-Client-Secret": "client-secret"],
-            gatewayStableID: gatewayID))
-        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID) == [
+            gatewayStableID: gatewayID,
+            service: service))
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID, service: service) == [
             "CF-Access-Client-Id": "client-id",
             "CF-Access-Client-Secret": "client-secret",
         ])
-        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: otherGatewayID).isEmpty)
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(
+            gatewayStableID: otherGatewayID,
+            service: service).isEmpty)
+        #expect(GatewaySettingsStore.saveGatewayCustomHeaders(
+            ["X-Other": "other-value"],
+            gatewayStableID: otherGatewayID,
+            service: service))
 
-        #expect(GatewaySettingsStore.saveGatewayCustomHeaders([:], gatewayStableID: gatewayID))
-        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID).isEmpty)
+        #expect(GatewaySettingsStore.saveGatewayCustomHeaders(
+            [:],
+            gatewayStableID: gatewayID,
+            service: service))
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(
+            gatewayStableID: gatewayID,
+            service: service).isEmpty)
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(
+            gatewayStableID: otherGatewayID,
+            service: service) == ["X-Other": "other-value"])
     }
 
     @Test func `custom header storage drops reserved names`() {
+        let service = "\(gatewayService).custom-headers-test.\(UUID().uuidString)"
         let gatewayID = "manual|reserved.example.com|443|\(UUID().uuidString)"
-        defer { GatewaySettingsStore.saveGatewayCustomHeaders([:], gatewayStableID: gatewayID) }
+        defer { GatewaySettingsStore.clearGatewayCustomHeaders(service: service) }
 
         #expect(GatewaySettingsStore.saveGatewayCustomHeaders(
             ["Host": "smuggled.example", "X-Allowed": "yes"],
-            gatewayStableID: gatewayID))
-        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID)
+            gatewayStableID: gatewayID,
+            service: service))
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(gatewayStableID: gatewayID, service: service)
             == ["X-Allowed": "yes"])
+    }
+
+    @Test func `custom header reset clears every gateway but preserves unrelated credentials`() {
+        let service = "\(gatewayService).custom-headers-test.\(UUID().uuidString)"
+        let firstGatewayID = "manual|first-reset.example.com|443|\(UUID().uuidString)"
+        let secondGatewayID = "manual|second-reset.example.com|443|\(UUID().uuidString)"
+        let unrelatedAccount = "unrelated-reset-secret.\(UUID().uuidString)"
+        defer { _ = KeychainStore.delete(service: gatewayService, account: unrelatedAccount) }
+
+        #expect(GatewaySettingsStore.saveGatewayCustomHeaders(
+            ["X-Proxy-Token": "first"],
+            gatewayStableID: firstGatewayID,
+            service: service))
+        #expect(GatewaySettingsStore.saveGatewayCustomHeaders(
+            ["X-Proxy-Token": "second"],
+            gatewayStableID: secondGatewayID,
+            service: service))
+        #expect(KeychainStore.saveString("keep", service: gatewayService, account: unrelatedAccount))
+
+        #expect(GatewaySettingsStore.clearGatewayCustomHeaders(service: service))
+
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(
+            gatewayStableID: firstGatewayID,
+            service: service).isEmpty)
+        #expect(GatewaySettingsStore.loadGatewayCustomHeaders(
+            gatewayStableID: secondGatewayID,
+            service: service).isEmpty)
+        #expect(KeychainStore.loadString(service: gatewayService, account: unrelatedAccount) == "keep")
     }
 
     @Test func `credentials stay bound to their gateway`() {

--- a/apps/ios/Tests/PushRelayHeaderIsolationTests.swift
+++ b/apps/ios/Tests/PushRelayHeaderIsolationTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+/// Gateway custom headers are proxy credentials scoped to one gateway. They ride only the
+/// gateway WebSocket upgrade; the push relay is a different trust domain and must never
+/// observe them, even while they sit in the store.
+private final class CapturingURLProtocol: URLProtocol {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var requests: [URLRequest] = []
+
+    static func drain() -> [URLRequest] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        let drained = self.requests
+        self.requests = []
+        return drained
+    }
+
+    private static func record(_ request: URLRequest) {
+        self.lock.lock()
+        self.requests.append(request)
+        self.lock.unlock()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.record(self.request)
+        guard let url = self.request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: 503,
+                  httpVersion: nil,
+                  headerFields: ["Content-Type": "application/json"])
+        else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        self.client?.urlProtocol(self, didLoad: Data("{}".utf8))
+        self.client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+struct PushRelayHeaderIsolationTests {
+    @Test func `push relay requests never carry gateway custom headers`() async throws {
+        let gatewayID = "manual|proxied.example.com|443|\(UUID().uuidString)"
+        defer { GatewaySettingsStore.saveGatewayCustomHeaders([:], gatewayStableID: gatewayID) }
+        #expect(GatewaySettingsStore.saveGatewayCustomHeaders(
+            ["CF-Access-Client-Id": "client-id", "CF-Access-Client-Secret": "client-secret"],
+            gatewayStableID: gatewayID))
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CapturingURLProtocol.self]
+        let client = try PushRelayClient(
+            baseURL: #require(URL(string: "https://relay.example.invalid")),
+            session: URLSession(configuration: configuration))
+        let input = PushRelayRegistrationInput(
+            installationId: "test-install",
+            bundleId: "ai.openclaw.tests",
+            appVersion: "1.0",
+            environment: .sandbox,
+            relayProfile: .deviceSandbox,
+            proofPolicy: .appleDevelopment,
+            distribution: .local,
+            apnsTokenHex: "00",
+            gatewayIdentity: PushRelayGatewayIdentity(deviceId: "device", publicKey: "key"))
+
+        // Registration fails at the stubbed challenge; the captured request is what matters.
+        _ = try? await client.register(input)
+
+        let requests = CapturingURLProtocol.drain()
+        #expect(!requests.isEmpty)
+        for request in requests {
+            #expect(request.value(forHTTPHeaderField: "CF-Access-Client-Id") == nil)
+            #expect(request.value(forHTTPHeaderField: "CF-Access-Client-Secret") == nil)
+        }
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
@@ -50,6 +50,10 @@ struct GatewayChannelConnectTests {
             self.failure = failure
         }
 
+        func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
+            self.makeWebSocketTask(request: URLRequest(url: url))
+        }
+
         func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
             _ = request
             let task = GatewayTestWebSocketTask(receiveHook: { _, receiveIndex in

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
@@ -50,8 +50,8 @@ struct GatewayChannelConnectTests {
             self.failure = failure
         }
 
-        func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
-            _ = url
+        func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
+            _ = request
             let task = GatewayTestWebSocketTask(receiveHook: { _, receiveIndex in
                 if receiveIndex == 0 {
                     return .data(GatewayWebSocketTestSupport.connectChallengeData())

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelDeviceTokenRetryTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelDeviceTokenRetryTests.swift
@@ -63,8 +63,8 @@ private final class TrustedDeviceRetryGatewaySession: WebSocketSessioning, Gatew
         self.allowsDeviceTokenRetryAuth = allowsDeviceTokenRetryAuth
     }
 
-    func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
-        _ = url
+    func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
+        _ = request
         let attemptIndex = self.lock.withDeviceRetryLock { () -> Int in
             let current = self.makeCount
             self.makeCount += 1

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelDeviceTokenRetryTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelDeviceTokenRetryTests.swift
@@ -63,6 +63,10 @@ private final class TrustedDeviceRetryGatewaySession: WebSocketSessioning, Gatew
         self.allowsDeviceTokenRetryAuth = allowsDeviceTokenRetryAuth
     }
 
+    func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
+        self.makeWebSocketTask(request: URLRequest(url: url))
+    }
+
     func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
         _ = request
         let attemptIndex = self.lock.withDeviceRetryLock { () -> Int in

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -75,6 +75,10 @@ private final class FakeWebSocketTask: WebSocketTasking, @unchecked Sendable {
 private final class FakeWebSocketSession: WebSocketSessioning, @unchecked Sendable {
     let task = FakeWebSocketTask()
 
+    func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
+        self.makeWebSocketTask(request: URLRequest(url: url))
+    }
+
     func makeWebSocketTask(request _: URLRequest) -> WebSocketTaskBox {
         WebSocketTaskBox(task: self.task)
     }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayConnectionControlTests.swift
@@ -75,7 +75,7 @@ private final class FakeWebSocketTask: WebSocketTasking, @unchecked Sendable {
 private final class FakeWebSocketSession: WebSocketSessioning, @unchecked Sendable {
     let task = FakeWebSocketTask()
 
-    func makeWebSocketTask(url _: URL) -> WebSocketTaskBox {
+    func makeWebSocketTask(request _: URLRequest) -> WebSocketTaskBox {
         WebSocketTaskBox(task: self.task)
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -266,8 +266,8 @@ final class GatewayTestWebSocketSession: WebSocketSessioning, @unchecked Sendabl
         self.lock.withLock { self.tasks.last }
     }
 
-    func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
-        _ = url
+    func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
+        _ = request
         let task = self.taskFactory()
         self.lock.withLock {
             self.makeCount += 1

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -266,6 +266,10 @@ final class GatewayTestWebSocketSession: WebSocketSessioning, @unchecked Sendabl
         self.lock.withLock { self.tasks.last }
     }
 
+    func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
+        self.makeWebSocketTask(request: URLRequest(url: url))
+    }
+
     func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
         _ = request
         let task = self.taskFactory()

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -77,12 +77,12 @@ public struct WebSocketTaskBox: @unchecked Sendable {
 }
 
 public protocol WebSocketSessioning: AnyObject {
-    func makeWebSocketTask(url: URL) -> WebSocketTaskBox
+    func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox
 }
 
 extension URLSession: WebSocketSessioning {
-    public func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
-        let task = self.webSocketTask(with: url)
+    public func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
+        let task = self.webSocketTask(with: request)
         // Avoid "Message too long" receive errors for large snapshots / history payloads.
         task.maximumMessageSize = 16 * 1024 * 1024 // 16 MB
         return WebSocketTaskBox(task: task)
@@ -275,6 +275,7 @@ public actor GatewayChannelActor {
     private var issuedDeviceAuthRoles = Set<String>()
     private var reconnectPausedForAuthFailure = false
     private let defaultRequestTimeoutMs: Double = 15000
+    private let extraHeadersProvider: (@Sendable () -> [String: String])?
     private let pushHandler: (@Sendable (GatewayPush) async -> Void)?
     private var connectOptions: GatewayConnectOptions?
     private let disconnectHandler: (@Sendable (String) async -> Void)?
@@ -287,12 +288,14 @@ public actor GatewayChannelActor {
         session: WebSocketSessionBox? = nil,
         pushHandler: (@Sendable (GatewayPush) async -> Void)? = nil,
         connectOptions: GatewayConnectOptions? = nil,
-        disconnectHandler: (@Sendable (String) async -> Void)? = nil)
+        disconnectHandler: (@Sendable (String) async -> Void)? = nil,
+        extraHeadersProvider: (@Sendable () -> [String: String])? = nil)
     {
         self.url = url
         self.token = token
         self.bootstrapToken = bootstrapToken
         self.password = password
+        self.extraHeadersProvider = extraHeadersProvider
         self.session = session?.session ?? URLSession(configuration: .default)
         self.pushHandler = pushHandler
         self.connectOptions = connectOptions
@@ -367,6 +370,18 @@ public actor GatewayChannelActor {
         }
     }
 
+    /// Operator-supplied proxy credentials (Cloudflare Access-style) ride on the upgrade
+    /// request. Read from the provider at connect time so edits apply on the next reconnect
+    /// without re-pairing. Values are credentials: never log them.
+    private func makeUpgradeRequest() -> URLRequest {
+        var request = URLRequest(url: self.url)
+        guard let headers = self.extraHeadersProvider?(), !headers.isEmpty else { return request }
+        for (name, value) in GatewayCustomHeaders.sanitized(headers) {
+            request.setValue(value, forHTTPHeaderField: name)
+        }
+        return request
+    }
+
     public func connect() async throws {
         if self.connected, self.task?.state == .running { return }
         if self.isConnecting {
@@ -379,7 +394,7 @@ public actor GatewayChannelActor {
         defer { self.isConnecting = false }
 
         self.task?.cancel(with: .goingAway, reason: nil)
-        self.task = self.session.makeWebSocketTask(url: self.url)
+        self.task = self.session.makeWebSocketTask(request: self.makeUpgradeRequest())
         self.task?.resume()
         do {
             try await AsyncTimeout.withTimeout(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -77,10 +77,24 @@ public struct WebSocketTaskBox: @unchecked Sendable {
 }
 
 public protocol WebSocketSessioning: AnyObject {
+    func makeWebSocketTask(url: URL) -> WebSocketTaskBox
     func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox
 }
 
+extension WebSocketSessioning {
+    /// Compatibility path for existing session conformers. URLSession and pinning sessions
+    /// override this requirement so operator headers remain attached to the upgrade request.
+    public func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
+        guard let url = request.url else { preconditionFailure("WebSocket request URL is required") }
+        return self.makeWebSocketTask(url: url)
+    }
+}
+
 extension URLSession: WebSocketSessioning {
+    public func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
+        self.makeWebSocketTask(request: URLRequest(url: url))
+    }
+
     public func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
         let task = self.webSocketTask(with: request)
         // Avoid "Message too long" receive errors for large snapshots / history payloads.
@@ -375,6 +389,9 @@ public actor GatewayChannelActor {
     /// without re-pairing. Values are credentials: never log them.
     private func makeUpgradeRequest() -> URLRequest {
         var request = URLRequest(url: self.url)
+        // Custom headers can contain service tokens or Authorization values. Do not even read
+        // the provider for cleartext routes, where credentials would be exposed in transit.
+        guard self.url.scheme?.lowercased() == "wss" else { return request }
         guard let headers = self.extraHeadersProvider?(), !headers.isEmpty else { return request }
         for (name, value) in GatewayCustomHeaders.sanitized(headers) {
             request.setValue(value, forHTTPHeaderField: name)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayCustomHeaders.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayCustomHeaders.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Operator-defined HTTP headers attached to every gateway-bound request so gateways fronted
+/// by authenticating reverse proxies (Cloudflare Access-style service tokens) stay reachable.
+/// Header values are credentials: persist them in the platform secure store and never log them.
+public enum GatewayCustomHeaders {
+    /// Connection-management headers the WebSocket upgrade owns. Operator overrides here would
+    /// corrupt the handshake or smuggle conflicting transport state past URLSession.
+    private static let reservedNames: Set<String> = [
+        "connection", "content-length", "host", "proxy-connection", "upgrade",
+    ]
+    private static let reservedPrefix = "sec-websocket-"
+
+    public static func isReservedName(_ name: String) -> Bool {
+        let normalized = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return self.reservedNames.contains(normalized) || normalized.hasPrefix(self.reservedPrefix)
+    }
+
+    /// Drops entries that cannot travel as a single well-formed header: empty or reserved
+    /// names, and names/values with control characters (request-splitting guard).
+    public static func sanitized(_ headers: [String: String]) -> [String: String] {
+        var result: [String: String] = [:]
+        for (name, value) in headers {
+            let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedName.isEmpty,
+                  !self.isReservedName(trimmedName),
+                  !self.containsControlCharacters(trimmedName),
+                  !self.containsControlCharacters(value)
+            else { continue }
+            result[trimmedName] = value
+        }
+        return result
+    }
+
+    private static func containsControlCharacters(_ text: String) -> Bool {
+        text.unicodeScalars.contains { $0.properties.generalCategory == .control }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayCustomHeaders.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayCustomHeaders.swift
@@ -10,26 +10,38 @@ public enum GatewayCustomHeaders {
         "connection", "content-length", "host", "proxy-connection", "upgrade",
     ]
     private static let reservedPrefix = "sec-websocket-"
+    private static let tokenPunctuation = Set("!#$%&'*+-.^_`|~".utf8)
 
     public static func isReservedName(_ name: String) -> Bool {
         let normalized = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return self.reservedNames.contains(normalized) || normalized.hasPrefix(self.reservedPrefix)
     }
 
-    /// Drops entries that cannot travel as a single well-formed header: empty or reserved
-    /// names, and names/values with control characters (request-splitting guard).
+    /// Drops entries that cannot travel as a single well-formed header: empty, reserved, or
+    /// non-token names, and values with control characters (request-splitting guard).
     public static func sanitized(_ headers: [String: String]) -> [String: String] {
         var result: [String: String] = [:]
         for (name, value) in headers {
             let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmedName.isEmpty,
                   !self.isReservedName(trimmedName),
-                  !self.containsControlCharacters(trimmedName),
+                  self.isValidName(trimmedName),
                   !self.containsControlCharacters(value)
             else { continue }
             result[trimmedName] = value
         }
         return result
+    }
+
+    private static func isValidName(_ name: String) -> Bool {
+        name.utf8.allSatisfy { byte in
+            switch byte {
+            case 48...57, 65...90, 97...122:
+                true
+            default:
+                self.tokenPunctuation.contains(byte)
+            }
+        }
     }
 
     private static func containsControlCharacters(_ text: String) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -205,6 +205,7 @@ public actor GatewayNodeSession {
         password: String?,
         connectOptions: GatewayConnectOptions,
         sessionBox: WebSocketSessionBox?,
+        extraHeadersProvider: (@Sendable () -> [String: String])? = nil,
         onConnected: @escaping @Sendable () async -> Void,
         onDisconnected: @escaping @Sendable (String) async -> Void,
         onInvoke: @escaping @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse) async throws
@@ -250,7 +251,11 @@ public actor GatewayNodeSession {
                 connectOptions: connectOptions,
                 disconnectHandler: { [weak self] reason in
                     await self?.handleChannelDisconnected(reason, channelGeneration: channelGeneration)
-                })
+                },
+                // Intentionally outside the shouldReconnect identity key: the channel re-reads
+                // the provider on every upgrade, so header edits ride the next reconnect
+                // without forcing a new channel.
+                extraHeadersProvider: extraHeadersProvider)
             self.channel = channel
             self.activeURL = url
             self.activeToken = token

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
@@ -205,6 +205,10 @@ GatewayTLSFailureProviding, GatewayDeviceTokenRetryTrustProviding, @unchecked Se
         self.failureLock.unlock()
     }
 
+    public func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
+        self.makeWebSocketTask(request: URLRequest(url: url))
+    }
+
     public func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
         let task = self.session.webSocketTask(with: request)
         task.maximumMessageSize = 16 * 1024 * 1024

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayTLSPinning.swift
@@ -205,8 +205,8 @@ GatewayTLSFailureProviding, GatewayDeviceTokenRetryTrustProviding, @unchecked Se
         self.failureLock.unlock()
     }
 
-    public func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
-        let task = self.session.webSocketTask(with: url)
+    public func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
+        let task = self.session.webSocketTask(with: request)
         task.maximumMessageSize = 16 * 1024 * 1024
         return WebSocketTaskBox(task: task)
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GenericPasswordKeychainStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GenericPasswordKeychainStore.swift
@@ -24,6 +24,16 @@ public enum GenericPasswordKeychainStore {
         return status == errSecSuccess || status == errSecItemNotFound
     }
 
+    @discardableResult
+    public static func deleteAll(service: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+
     private static func loadData(service: String, account: String) -> Data? {
         var query = self.baseQuery(service: service, account: account)
         query[kSecReturnData as String] = true

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayCustomHeadersTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayCustomHeadersTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import OpenClawKit
+
+struct GatewayCustomHeadersTests {
+    @Test func `sanitized keeps operator proxy credential headers`() {
+        let headers = GatewayCustomHeaders.sanitized([
+            "CF-Access-Client-Id": "client-id",
+            "CF-Access-Client-Secret": "client-secret",
+            "Authorization": "Basic dXNlcjpwYXNz",
+        ])
+        #expect(headers == [
+            "CF-Access-Client-Id": "client-id",
+            "CF-Access-Client-Secret": "client-secret",
+            "Authorization": "Basic dXNlcjpwYXNz",
+        ])
+    }
+
+    @Test func `sanitized drops reserved handshake header names`() {
+        let headers = GatewayCustomHeaders.sanitized([
+            "Host": "evil.example",
+            "connection": "close",
+            "Upgrade": "h2c",
+            "Sec-WebSocket-Protocol": "override",
+            "sec-websocket-key": "override",
+            "Content-Length": "0",
+            "Proxy-Connection": "keep-alive",
+            "X-Allowed": "yes",
+        ])
+        #expect(headers == ["X-Allowed": "yes"])
+    }
+
+    @Test func `sanitized drops empty names and control characters`() {
+        let headers = GatewayCustomHeaders.sanitized([
+            "": "value",
+            "   ": "value",
+            "X-Split\r\nEvil": "value",
+            "X-Value-Split": "a\r\nEvil: b",
+            "X-Tab-Value": "a\tb",
+            "X-Fine": "value",
+        ])
+        #expect(headers == ["X-Fine": "value"])
+    }
+
+    @Test func `reserved name check is case and whitespace insensitive`() {
+        #expect(GatewayCustomHeaders.isReservedName(" HOST "))
+        #expect(GatewayCustomHeaders.isReservedName("Sec-WebSocket-Extensions"))
+        #expect(!GatewayCustomHeaders.isReservedName("CF-Access-Client-Id"))
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayCustomHeadersTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayCustomHeadersTests.swift
@@ -30,10 +30,13 @@ struct GatewayCustomHeadersTests {
         #expect(headers == ["X-Allowed": "yes"])
     }
 
-    @Test func `sanitized drops empty names and control characters`() {
+    @Test func `sanitized drops invalid names and control characters`() {
         let headers = GatewayCustomHeaders.sanitized([
             "": "value",
             "   ": "value",
+            "X Bad": "value",
+            "X:Bad": "value",
+            "X-Bad-é": "value",
             "X-Split\r\nEvil": "value",
             "X-Value-Split": "a\r\nEvil: b",
             "X-Tab-Value": "a\tb",

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -326,6 +326,7 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
     private let connectError: [String: Any]?
     private let cancelGate: FirstCancelGate?
     private var tasks: [FakeGatewayWebSocketTask] = []
+    private var requests: [URLRequest] = []
     private var makeCount = 0
 
     init(
@@ -346,10 +347,14 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
         self.lock.withLock { self.tasks.last }
     }
 
-    func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
-        _ = url
-        return self.lock.withLock {
+    func latestRequest() -> URLRequest? {
+        self.lock.withLock { self.requests.last }
+    }
+
+    func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
+        self.lock.withLock {
             self.makeCount += 1
+            self.requests.append(request)
             let task = FakeGatewayWebSocketTask(
                 helloAuth: self.helloAuth,
                 connectError: self.connectError,
@@ -357,6 +362,23 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
             self.tasks.append(task)
             return WebSocketTaskBox(task: task)
         }
+    }
+}
+
+private final class MutableHeaderValue: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: String
+
+    init(value: String) {
+        self.value = value
+    }
+
+    func get() -> String {
+        self.lock.withLock { self.value }
+    }
+
+    func set(_ value: String) {
+        self.lock.withLock { self.value = value }
     }
 }
 
@@ -453,6 +475,62 @@ struct GatewayNodeSessionTests {
         }
         let finalDisconnects = await disconnects.values()
         #expect(finalDisconnects.isEmpty)
+    }
+
+    @Test
+    func `upgrade request carries sanitized custom headers read per connect`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let secret = MutableHeaderValue(value: "first-secret")
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "node",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: false)
+        let url = try #require(URL(string: "ws://gateway.example.invalid"))
+        let provider: @Sendable () -> [String: String] = {
+            [
+                "CF-Access-Client-Id": "client-id",
+                "CF-Access-Client-Secret": secret.get(),
+                "Host": "smuggled.example.invalid",
+            ]
+        }
+        let connectOnce: () async throws -> Void = {
+            try await gateway.connect(
+                url: url,
+                token: nil,
+                bootstrapToken: nil,
+                password: nil,
+                connectOptions: options,
+                sessionBox: WebSocketSessionBox(session: session),
+                extraHeadersProvider: provider,
+                onConnected: {},
+                onDisconnected: { _ in },
+                onInvoke: { req in
+                    BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+                })
+        }
+
+        try await connectOnce()
+        let request = try #require(session.latestRequest())
+        #expect(request.url == url)
+        #expect(request.value(forHTTPHeaderField: "CF-Access-Client-Id") == "client-id")
+        #expect(request.value(forHTTPHeaderField: "CF-Access-Client-Secret") == "first-secret")
+        #expect(request.value(forHTTPHeaderField: "Host") == nil)
+
+        // Header edits must ride the next upgrade without re-pairing or a new channel identity.
+        secret.set("second-secret")
+        await gateway.disconnect()
+        try await connectOnce()
+        let reconnectRequest = try #require(session.latestRequest())
+        #expect(reconnectRequest.value(forHTTPHeaderField: "CF-Access-Client-Secret") == "second-secret")
+
+        await gateway.disconnect()
     }
 
     @Test

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -351,6 +351,10 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
         self.lock.withLock { self.requests.last }
     }
 
+    func makeWebSocketTask(url: URL) -> WebSocketTaskBox {
+        self.makeWebSocketTask(request: URLRequest(url: url))
+    }
+
     func makeWebSocketTask(request: URLRequest) -> WebSocketTaskBox {
         self.lock.withLock {
             self.makeCount += 1
@@ -368,17 +372,25 @@ private final class FakeGatewayWebSocketSession: WebSocketSessioning, @unchecked
 private final class MutableHeaderValue: @unchecked Sendable {
     private let lock = NSLock()
     private var value: String
+    private var reads = 0
 
     init(value: String) {
         self.value = value
     }
 
     func get() -> String {
-        self.lock.withLock { self.value }
+        self.lock.withLock {
+            self.reads += 1
+            return self.value
+        }
     }
 
     func set(_ value: String) {
         self.lock.withLock { self.value = value }
+    }
+
+    func readCount() -> Int {
+        self.lock.withLock { self.reads }
     }
 }
 
@@ -492,7 +504,7 @@ struct GatewayNodeSessionTests {
             clientMode: "node",
             clientDisplayName: "iOS Test",
             includeDeviceIdentity: false)
-        let url = try #require(URL(string: "ws://gateway.example.invalid"))
+        let url = try #require(URL(string: "wss://gateway.example.invalid"))
         let provider: @Sendable () -> [String: String] = {
             [
                 "CF-Access-Client-Id": "client-id",
@@ -530,6 +542,42 @@ struct GatewayNodeSessionTests {
         let reconnectRequest = try #require(session.latestRequest())
         #expect(reconnectRequest.value(forHTTPHeaderField: "CF-Access-Client-Secret") == "second-secret")
 
+        await gateway.disconnect()
+    }
+
+    @Test
+    func `cleartext upgrade never reads or attaches custom headers`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let secret = MutableHeaderValue(value: "must-not-be-read")
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: [],
+            commands: [],
+            permissions: [:],
+            clientId: "openclaw-ios-test",
+            clientMode: "node",
+            clientDisplayName: "iOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://gateway.example.invalid")),
+            token: nil,
+            bootstrapToken: nil,
+            password: nil,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            extraHeadersProvider: { [secret] in ["Authorization": secret.get()] },
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { req in
+                BridgeInvokeResponse(id: req.id, ok: true, payloadJSON: nil, error: nil)
+            })
+
+        let request = try #require(session.latestRequest())
+        #expect(secret.readCount() == 0)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
         await gateway.disconnect()
     }
 


### PR DESCRIPTION
Related: #100698

## What Problem This Solves

Resolves a problem where the iOS app cannot connect to a gateway fronted by an authenticating reverse proxy (Cloudflare Access-style service tokens): the proxy rejects the WebSocket upgrade before it reaches the gateway, and the app has no way to attach the proxy's credential headers. Operators with that deployment shape are locked out of mobile entirely; a tunnel sidecar is not an option on iOS.

## Why This Change Was Made

Adds per-gateway custom request headers, injected on the gateway WebSocket upgrade and nowhere else. Design boundaries:

- Headers are credentials: stored in the Keychain alongside the other per-gateway secrets (`GatewaySettingsStore`, scoped by gateway `stableID`), values masked in the UI, never logged, never included in diagnostics.
- The channel reads the headers through a provider at connect time, so edits apply on the next reconnect without re-pairing and without changing the channel identity key.
- `WebSocketSessioning` now accepts a `URLRequest` additively while preserving the shipped URL-based requirement for downstream conformers. URLSession and `GatewayTLSPinningSession` keep the full request; TLS fingerprint pinning and pairing/trust flows remain unchanged.
- A shared sanitizer (`GatewayCustomHeaders`) drops reserved handshake headers (`Host`, `Connection`, `Upgrade`, `Sec-WebSocket-*`, `Content-Length`, `Proxy-Connection`), invalid HTTP-token names, and control characters, so a stored entry can neither corrupt the upgrade, split requests, nor be parsed differently by an intermediary.
- Headers never reach non-gateway destinations. The push relay client and the OpenAI voice path build their own requests on separate sessions; a regression test pins that isolation.
- Credential headers are TLS-only: cleartext `ws://` routes neither read the provider nor attach stored values, and the editor is hidden for cleartext manual targets.
- Full Reset Onboarding deletes the dedicated custom-header Keychain service while targeted re-pairing preserves the proxy credentials needed to reach that gateway.
- UI is gated behind the existing advanced connection surface (Settings → Gateway → Custom Headers), scoped to the same gateway the auth token/password fields target.

Non-goals: macOS parity (noted follow-up), WebView surfaces (Terminal/Canvas WKWebViews follow browser SSO flows, not service-token headers), and Share extension delivery. The Share extension cannot safely read the app's Keychain records without a separate shared-Keychain entitlement/storage design; the settings UI discloses this limit.

## User Impact

Operators can now put their gateway behind Cloudflare Access (or any header-authenticating proxy) and still use the iOS app: add the service-token headers once per gateway in Settings → Gateway → Custom Headers. Existing setups are unaffected; with no headers configured the upgrade request is byte-identical to before.

## Evidence

- `OpenClawKit` focused transport proof (`swift test --package-path apps/shared/OpenClawKit --filter 'Gateway(CustomHeaders|NodeSession)Tests'`, 33/33 green): sanitized request-time injection, provider re-read on reconnect, reserved/invalid-name/control-character filtering, and cleartext provider non-invocation.
- Focused iOS app proof (`xcodebuild test`, Xcode 26.5, iPhone 17 simulator): `GatewaySettingsStoreTests` 18/18 — dedicated-Keychain round-trip, per-gateway scoping, delete-on-empty, full-reset deletion, unrelated-secret preservation, and reserved-name rejection.
- The first platform-remote attempt used AWS Crabbox `mac2.metal` lease `cbx_f74f6afeeadd`, but that image had no Xcode and only Swift 6.0.3 while OpenClawKit requires Swift 6.2. The focused local Xcode 26.5 fallback above is the resulting platform proof; exact-head hosted CI remains the merge gate.
- App compiles clean via `xcodebuild build-for-testing` (SwiftFormat/SwiftLint phases included).
- TLS pinning untouched: no changes to challenge handling; header injection rides the upgrade `URLRequest`, pinning stays on the session delegate.
- Codex autoreview of the change: clean, no accepted/actionable findings.

## Review

This touches the auth/connection surface. Requesting owner + security review from @openclaw/openclaw-secops before merge (security-sensitive per repo policy); please look specifically at the secure-store scoping, the reserved-header sanitizer, and the non-gateway isolation guarantees.
