### PR TITLE
feat(android): add Listen action speaking assistant messages via gateway TTS

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -139,7 +139,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 113,
+      "line": 114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -147,7 +147,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 204,
+      "line": 205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -155,7 +155,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 214,
+      "line": 215,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 579,
+      "line": 584,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2472,
+      "line": 2492,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2474,
+      "line": 2494,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2476,
+      "line": 2496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -5811,15 +5811,31 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 70,
+      "line": 72,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Message actions",
       "surface": "android",
       "id": "native.android.7bf61a1da504c271"
     },
     {
+      "kind": "conditional-branch",
+      "line": 81,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Listen",
+      "surface": "android",
+      "id": "native.android.9b4d58eb6f2eb2af"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 81,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Stop",
+      "surface": "android",
+      "id": "native.android.dc64ec935e5d0de4"
+    },
+    {
       "kind": "ui-named-argument",
-      "line": 78,
+      "line": 86,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Copy",
       "surface": "android",
@@ -5827,7 +5843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 82,
+      "line": 90,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Select text",
       "surface": "android",
@@ -5835,7 +5851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 86,
+      "line": 94,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Share",
       "surface": "android",
@@ -5843,7 +5859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 90,
+      "line": 98,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Reply",
       "surface": "android",
@@ -5851,7 +5867,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 116,
+      "line": 124,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Done",
       "surface": "android",
@@ -5859,7 +5875,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 137,
+      "line": 145,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Message copied",
       "surface": "android",
@@ -5867,7 +5883,7 @@
     },
     {
       "kind": "ui-chooser",
-      "line": 148,
+      "line": 156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "Share message",
       "surface": "android",
@@ -5875,7 +5891,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 152,
+      "line": 160,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
       "source": "No app can share this message",
       "surface": "android",
@@ -5883,7 +5899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 122,
+      "line": 127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5891,7 +5907,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 143,
+      "line": 148,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5899,15 +5915,31 @@
     },
     {
       "kind": "ui-call",
-      "line": 163,
+      "line": 168,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "No messages yet",
       "surface": "android",
       "id": "native.android.a7d32e86ce4c0a17"
     },
     {
+      "kind": "conditional-branch",
+      "line": 154,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Preparing audio…",
+      "surface": "android",
+      "id": "native.android.9ab1dd78954fc3c2"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 154,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Speaking…",
+      "surface": "android",
+      "id": "native.android.0ee4d153c4e592d3"
+    },
+    {
       "kind": "ui-named-argument",
-      "line": 202,
+      "line": 260,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Preview · $domain",
       "surface": "android",
@@ -5915,7 +5947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 211,
+      "line": 269,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Expand link preview",
       "surface": "android",
@@ -5923,7 +5955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 235,
+      "line": 293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Loading preview…",
       "surface": "android",
@@ -5931,7 +5963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 236,
+      "line": 294,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "No preview available",
       "surface": "android",
@@ -5939,7 +5971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 281,
+      "line": 339,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Thinking...",
       "surface": "android",
@@ -5947,7 +5979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 297,
+      "line": 355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Tools",
       "surface": "android",
@@ -5955,7 +5987,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 300,
+      "line": 358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Running tools...",
       "surface": "android",
@@ -5963,7 +5995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 303,
+      "line": 361,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "${display.emoji} ${display.label}",
       "surface": "android",
@@ -5971,7 +6003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 321,
+      "line": 379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "... +${toolCalls.size - 6} more",
       "surface": "android",
@@ -5979,7 +6011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 352,
+      "line": 410,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "You",
       "surface": "android",
@@ -5987,7 +6019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 366,
+      "line": 424,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Retry",
       "surface": "android",
@@ -5995,7 +6027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 369,
+      "line": 427,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Delete",
       "surface": "android",
@@ -6003,7 +6035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 401,
+      "line": 459,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -6011,7 +6043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 438,
+      "line": 496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "System",
       "surface": "android",
@@ -6019,7 +6051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 439,
+      "line": 497,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -6027,7 +6059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 465,
+      "line": 523,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",
@@ -6035,7 +6067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 266,
+      "line": 276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -6043,7 +6075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 424,
+      "line": 436,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -6051,7 +6083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 482,
+      "line": 494,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -6059,7 +6091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 503,
+      "line": 515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -6067,7 +6099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 508,
+      "line": 520,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "More new chat options",
       "surface": "android",
@@ -6075,7 +6107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 523,
+      "line": 535,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -6083,7 +6115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 526,
+      "line": 538,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -6091,7 +6123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 668,
+      "line": 686,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -6099,7 +6131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 695,
+      "line": 713,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -6107,7 +6139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 721,
+      "line": 739,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -6115,7 +6147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 752,
+      "line": 770,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -6123,15 +6155,31 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 753,
+      "line": 771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
       "id": "native.android.579c05816c7dfa79"
     },
     {
+      "kind": "conditional-branch",
+      "line": 955,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Preparing audio…",
+      "surface": "android",
+      "id": "native.android.5aafbef3744d86f3"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 955,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Speaking…",
+      "surface": "android",
+      "id": "native.android.d7919c440a82f426"
+    },
+    {
       "kind": "ui-named-argument",
-      "line": 904,
+      "line": 976,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -6139,7 +6187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 906,
+      "line": 978,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -6147,7 +6195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 909,
+      "line": 981,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -6155,7 +6203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 919,
+      "line": 991,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -6163,7 +6211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 920,
+      "line": 992,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -6171,7 +6219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1054,
+      "line": 1126,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -6179,7 +6227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1120,
+      "line": 1192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -6187,7 +6235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1186,
+      "line": 1258,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -6195,7 +6243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1186,
+      "line": 1258,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -6203,7 +6251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1203,
+      "line": 1275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -6211,7 +6259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1265,
+      "line": 1337,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -6219,7 +6267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1355,
+      "line": 1427,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -6227,7 +6275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1370,
+      "line": 1442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -6235,7 +6283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1385,
+      "line": 1457,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -6243,7 +6291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1423,
+      "line": 1495,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -6251,7 +6299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1444,
+      "line": 1516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -6259,7 +6307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1500,
+      "line": 1572,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -6267,7 +6315,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1539,
+      "line": 1611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -6275,7 +6323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 273,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt",
       "source": "CHAT ERROR",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Assistant messages now offer a long-press Listen action with gateway TTS playback, on-device fallback, and tap-to-stop status.
+
 The Settings About screen now shows the animated mascot with the app tagline plus Website, Docs, GitHub, and Discord links.
 
 Adds a read-only Files browser for agent workspaces with directory navigation, text and image previews, and system share export.

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -5,6 +5,7 @@ import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewayUpdateAvailableSummary
@@ -230,6 +231,8 @@ class MainViewModel(
   val pendingRunCount: StateFlow<Int> = runtimeState(initial = 0) { it.pendingRunCount }
   val chatCommands: StateFlow<List<ChatCommandEntry>> = runtimeState(initial = emptyList<ChatCommandEntry>()) { it.chatCommands }
   val chatOutboxItems: StateFlow<List<ChatOutboxItem>> = runtimeState(initial = emptyList()) { it.chatOutboxItems }
+  internal val chatMessageSpeech: StateFlow<MessageSpeechState?> =
+    runtimeState(initial = null) { it.messageSpeechState }
   val execApprovals: StateFlow<List<GatewayExecApprovalSummary>> = runtimeState(initial = emptyList()) { it.execApprovals }
   val execApprovalsRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.execApprovalsRefreshing }
   val execApprovalsErrorText: StateFlow<String?> = runtimeState(initial = null) { it.execApprovalsErrorText }
@@ -699,6 +702,17 @@ class MainViewModel(
 
   fun toggleModelFavorite(ref: String) {
     prefs.toggleModelFavorite(ref)
+  }
+
+  fun toggleChatMessageSpeech(
+    messageId: String,
+    text: String,
+  ) {
+    ensureRuntime().toggleMessageSpeech(messageId = messageId, text = text)
+  }
+
+  fun stopChatMessageSpeech() {
+    runtimeRef.value?.stopMessageSpeech()
   }
 
   fun switchChatSession(sessionKey: String) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -10,9 +10,13 @@ import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatTranscriptCache
+import ai.openclaw.app.chat.MessageSpeechClient
+import ai.openclaw.app.chat.MessageSpeechController
+import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.chat.RoomChatCommandOutbox
 import ai.openclaw.app.chat.RoomChatTranscriptCache
+import ai.openclaw.app.chat.SystemSpeechSpeaker
 import ai.openclaw.app.gateway.DeviceAuthEntry
 import ai.openclaw.app.gateway.DeviceAuthStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
@@ -59,6 +63,7 @@ import ai.openclaw.app.node.invokeErrorFromThrowable
 import ai.openclaw.app.node.parseHexColorArgb
 import ai.openclaw.app.protocol.OpenClawCanvasA2UIAction
 import ai.openclaw.app.voice.MicCaptureManager
+import ai.openclaw.app.voice.TalkAudioPlayer
 import ai.openclaw.app.voice.TalkModeManager
 import ai.openclaw.app.voice.TalkPttOnceStart
 import ai.openclaw.app.voice.TalkPttStopPayload
@@ -948,6 +953,20 @@ class NodeRuntime private constructor(
       it.applyMainSessionKey(_mainSessionKey.value)
     }
 
+  private val messageSpeechControllerLazy =
+    lazy {
+      MessageSpeechController(
+        scope = scope,
+        synthesizer = MessageSpeechClient(session = operatorSession, json = json),
+        player = TalkAudioPlayer(appContext),
+        localSpeech = SystemSpeechSpeaker(appContext),
+      )
+    }
+  private val messageSpeechController: MessageSpeechController
+    get() = messageSpeechControllerLazy.value
+  internal val messageSpeechState: StateFlow<MessageSpeechState?>
+    get() = messageSpeechController.state
+
   /**
    * Stable per-gateway scope for the offline chat cache; resolved per call so cached transcripts
    * never leak across gateways. Null (nothing paired/configured) disables cache reads and writes.
@@ -1510,6 +1529,7 @@ class NodeRuntime private constructor(
         refreshExecApprovalsFromGateway()
       }
     } else {
+      stopMessageSpeech()
       stopActiveVoiceSession()
       publishNodePresenceAliveBeacon(NodePresenceAliveBeacon.Trigger.Background, throttleRecentSuccess = true)
     }
@@ -2553,6 +2573,7 @@ class NodeRuntime private constructor(
     notificationOutbox.clear()
     connectAttemptSeq.incrementAndGet()
     chat.onGatewayScopeChanging()
+    stopMessageSpeech()
     stopActiveVoiceSession()
     connectedEndpoint = null
     _gatewayControlPage.value = null
@@ -2705,6 +2726,7 @@ class NodeRuntime private constructor(
   }
 
   fun switchChatSession(sessionKey: String) {
+    stopMessageSpeech()
     chat.switchSession(sessionKey)
   }
 
@@ -2713,7 +2735,19 @@ class NodeRuntime private constructor(
   }
 
   fun startNewChat(worktree: Boolean = false) {
+    stopMessageSpeech()
     chat.startNewChat(worktree = worktree)
+  }
+
+  fun toggleMessageSpeech(
+    messageId: String,
+    text: String,
+  ) {
+    messageSpeechController.toggle(messageId = messageId, text = text)
+  }
+
+  fun stopMessageSpeech() {
+    if (messageSpeechControllerLazy.isInitialized()) messageSpeechController.stop()
   }
 
   fun sendChat(

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/MessageSpeechController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/MessageSpeechController.kt
@@ -1,0 +1,303 @@
+package ai.openclaw.app.chat
+
+import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.voice.TalkAudioPlaying
+import ai.openclaw.app.voice.TalkSpeakAudio
+import android.content.Context
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import android.util.Log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.util.concurrent.atomic.AtomicLong
+
+private const val TAG = "MessageSpeech"
+
+internal enum class MessageSpeechPhase {
+  Preparing,
+  Speaking,
+}
+
+/** Playback state for the chat Listen action; null when idle. */
+internal data class MessageSpeechState(
+  val messageId: String,
+  val phase: MessageSpeechPhase,
+)
+
+/** Renders message text to an audio clip; null means fall back to local TTS. */
+internal fun interface MessageSpeechSynthesizing {
+  suspend fun synthesize(text: String): TalkSpeakAudio?
+}
+
+/** Speaks text with the on-device engine when the gateway cannot render audio. */
+internal interface LocalSpeechSpeaking {
+  suspend fun speak(text: String)
+
+  fun stop()
+}
+
+/** Gateway tts.speak client using the general configured TTS provider chain. */
+internal class MessageSpeechClient(
+  private val session: GatewaySession? = null,
+  private val json: Json = Json { ignoreUnknownKeys = true },
+  private val requestDetailed: (suspend (String, String, Long) -> GatewaySession.RpcResult)? = null,
+) : MessageSpeechSynthesizing {
+  override suspend fun synthesize(text: String): TalkSpeakAudio? {
+    val response =
+      try {
+        performRequest(
+          method = "tts.speak",
+          paramsJson = json.encodeToString(TtsSpeakRequest(text = text)),
+          timeoutMs = 60_000,
+        )
+      } catch (err: CancellationException) {
+        throw err
+      } catch (err: Throwable) {
+        Log.d(TAG, "tts.speak request failed: ${err.message ?: err::class.simpleName}")
+        return null
+      }
+    if (!response.ok) {
+      // Provider/config absence and older gateways both degrade to the on-device voice.
+      Log.d(TAG, "tts.speak unavailable: ${response.error?.message ?: "unknown error"}")
+      return null
+    }
+    val payload =
+      try {
+        json.decodeFromString<TtsSpeakResponse>(response.payloadJson ?: "")
+      } catch (err: Throwable) {
+        Log.d(TAG, "tts.speak payload invalid: ${err.message ?: err::class.simpleName}")
+        return null
+      }
+    val bytes =
+      try {
+        android.util.Base64.decode(payload.audioBase64, android.util.Base64.DEFAULT)
+      } catch (err: Throwable) {
+        Log.d(TAG, "tts.speak audio decode failed: ${err.message ?: err::class.simpleName}")
+        return null
+      }
+    if (bytes.isEmpty()) return null
+    return TalkSpeakAudio(
+      bytes = bytes,
+      provider = payload.provider,
+      outputFormat = payload.outputFormat,
+      voiceCompatible = null,
+      mimeType = payload.mimeType,
+      fileExtension = payload.fileExtension,
+    )
+  }
+
+  private suspend fun performRequest(
+    method: String,
+    paramsJson: String,
+    timeoutMs: Long,
+  ): GatewaySession.RpcResult {
+    requestDetailed?.let { return it(method, paramsJson, timeoutMs) }
+    val activeSession = session ?: throw IllegalStateException("session missing")
+    return activeSession.requestDetailed(method = method, paramsJson = paramsJson, timeoutMs = timeoutMs)
+  }
+}
+
+@Serializable
+internal data class TtsSpeakRequest(
+  val text: String,
+)
+
+@Serializable
+private data class TtsSpeakResponse(
+  val audioBase64: String,
+  val provider: String,
+  val outputFormat: String? = null,
+  val mimeType: String? = null,
+  val fileExtension: String? = null,
+)
+
+/** Drives one active chat Listen request, preferring gateway audio over local TTS. */
+internal class MessageSpeechController(
+  private val scope: CoroutineScope,
+  private val synthesizer: MessageSpeechSynthesizing,
+  private val player: TalkAudioPlaying,
+  private val localSpeech: LocalSpeechSpeaking,
+) {
+  private val _state = MutableStateFlow<MessageSpeechState?>(null)
+  val state: StateFlow<MessageSpeechState?> = _state.asStateFlow()
+
+  // A superseded playback's completion must not clear state owned by the next request.
+  private val generation = AtomicLong(0)
+  private var job: Job? = null
+
+  fun toggle(
+    messageId: String,
+    text: String,
+  ) {
+    if (_state.value?.messageId == messageId) {
+      stop()
+      return
+    }
+    start(messageId = messageId, text = text)
+  }
+
+  fun stop() {
+    generation.incrementAndGet()
+    job?.cancel()
+    job = null
+    player.stop()
+    localSpeech.stop()
+    _state.value = null
+  }
+
+  private fun start(
+    messageId: String,
+    text: String,
+  ) {
+    stop()
+    val spoken = text.trim()
+    if (spoken.isEmpty()) return
+    val token = generation.incrementAndGet()
+    _state.value = MessageSpeechState(messageId = messageId, phase = MessageSpeechPhase.Preparing)
+    job =
+      scope.launch {
+        try {
+          val clip = synthesizer.synthesize(spoken)
+          if (generation.get() != token) return@launch
+          _state.value = MessageSpeechState(messageId = messageId, phase = MessageSpeechPhase.Speaking)
+          if (!playClip(clip) && generation.get() == token) {
+            localSpeech.speak(spoken)
+          }
+        } finally {
+          if (generation.get() == token) _state.value = null
+        }
+      }
+  }
+
+  private suspend fun playClip(clip: TalkSpeakAudio?): Boolean {
+    if (clip == null) return false
+    return try {
+      player.play(clip)
+      true
+    } catch (err: CancellationException) {
+      throw err
+    } catch (err: Throwable) {
+      Log.w(TAG, "clip playback failed: ${err.message ?: err::class.simpleName}")
+      false
+    }
+  }
+}
+
+/** Minimal on-device TTS wrapper for the chat Listen fallback voice. */
+internal class SystemSpeechSpeaker(
+  private val context: Context,
+) : LocalSpeechSpeaking {
+  private val lock = Any()
+  private var engine: TextToSpeech? = null
+  private var ready: CompletableDeferred<Boolean>? = null
+  private var active: CompletableDeferred<Unit>? = null
+
+  override suspend fun speak(text: String) {
+    val engine = ensureEngine() ?: return
+    val utteranceId = "chat-listen-${System.nanoTime()}"
+    val done = CompletableDeferred<Unit>()
+    synchronized(lock) {
+      active?.cancel()
+      active = done
+    }
+    withContext(Dispatchers.Main.immediate) {
+      engine.setOnUtteranceProgressListener(
+        object : UtteranceProgressListener() {
+          override fun onStart(id: String?) {}
+
+          override fun onDone(id: String?) {
+            if (id == utteranceId) done.complete(Unit)
+          }
+
+          @Deprecated("Deprecated in Java")
+          override fun onError(id: String?) {
+            if (id == utteranceId) done.complete(Unit)
+          }
+
+          override fun onError(
+            id: String?,
+            errorCode: Int,
+          ) {
+            if (id == utteranceId) done.complete(Unit)
+          }
+        },
+      )
+      if (engine.speak(text, TextToSpeech.QUEUE_FLUSH, null, utteranceId) != TextToSpeech.SUCCESS) {
+        done.complete(Unit)
+      }
+    }
+    try {
+      done.await()
+    } finally {
+      synchronized(lock) {
+        if (active === done) active = null
+      }
+    }
+  }
+
+  override fun stop() {
+    synchronized(lock) {
+      active?.cancel()
+      active = null
+    }
+    engine?.stop()
+  }
+
+  private suspend fun ensureEngine(): TextToSpeech? {
+    val current = synchronized(lock) { ready }
+    val pending = current ?: createEngine()
+    if (pending.await()) return synchronized(lock) { engine }
+
+    // A failed Android TTS service can recover later; do not cache its failed initialization.
+    val failedEngine =
+      synchronized(lock) {
+        if (ready !== pending) return null
+        ready = null
+        engine.also { engine = null }
+      }
+    withContext(Dispatchers.Main.immediate) { failedEngine?.shutdown() }
+    return null
+  }
+
+  private suspend fun createEngine(): CompletableDeferred<Boolean> {
+    val pending = CompletableDeferred<Boolean>()
+    val ownsInitialization =
+      synchronized(lock) {
+        if (ready != null) {
+          false
+        } else {
+          ready = pending
+          true
+        }
+      }
+    if (!ownsInitialization) return synchronized(lock) { checkNotNull(ready) }
+
+    val created =
+      try {
+        // Finish publishing the constructed engine even if the Listen job is stopped mid-init.
+        withContext(NonCancellable + Dispatchers.Main.immediate) {
+          TextToSpeech(context) { status -> pending.complete(status == TextToSpeech.SUCCESS) }
+        }
+      } catch (err: Throwable) {
+        Log.d(TAG, "system TTS initialization failed: ${err.message ?: err::class.simpleName}")
+        pending.complete(false)
+        null
+      }
+    synchronized(lock) {
+      if (ready === pending) engine = created else created?.shutdown()
+    }
+    return pending
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt
@@ -51,6 +51,8 @@ internal fun ChatMessageActionHost(
   onReply: (String) -> Unit,
   modifier: Modifier = Modifier,
   enabled: Boolean = true,
+  listenActive: Boolean = false,
+  onToggleListen: (() -> Unit)? = null,
   content: @Composable () -> Unit,
 ) {
   if (!enabled || text.isBlank()) {
@@ -75,6 +77,12 @@ internal fun ChatMessageActionHost(
       expanded = menuExpanded,
       onDismissRequest = { menuExpanded = false },
     ) {
+      onToggleListen?.let { toggleListen ->
+        MessageActionItem(label = if (listenActive) "Stop" else "Listen") {
+          toggleListen()
+          menuExpanded = false
+        }
+      }
       MessageActionItem(label = "Copy") {
         copyChatMessage(context, text)
         menuExpanded = false

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app.ui.chat
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
+import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.ui.mobileBorder
 import ai.openclaw.app.ui.mobileCallout
 import ai.openclaw.app.ui.mobileCardSurface
@@ -34,7 +35,7 @@ import androidx.compose.ui.unit.dp
 
 /** Renders chat history newest-first while preserving stable scroll behavior during streaming. */
 @Composable
-fun ChatMessageListCard(
+internal fun ChatMessageListCard(
   sessionKey: String,
   messages: List<ChatMessage>,
   historyLoading: Boolean,
@@ -48,6 +49,8 @@ fun ChatMessageListCard(
   onRetryOutbox: (String) -> Unit = {},
   onDeleteOutbox: (String) -> Unit = {},
   onReplyMessage: (String) -> Unit = {},
+  speechState: MessageSpeechState? = null,
+  onToggleListen: ((String, String) -> Unit)? = null,
 ) {
   val timeline =
     remember(messages, pendingRunCount, pendingToolCalls, streamingAssistantText, outboxItems) {
@@ -82,6 +85,8 @@ fun ChatMessageListCard(
             ChatMessageBubble(
               message = item.message,
               onReplyMessage = onReplyMessage,
+              speechState = speechState,
+              onToggleListen = onToggleListen,
             )
           is ChatTimelineItem.OutboxCommand ->
             ChatOutboxBubble(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -5,6 +5,8 @@ import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatOutboxStatus
 import ai.openclaw.app.chat.ChatPendingToolCall
+import ai.openclaw.app.chat.MessageSpeechPhase
+import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.normalizeVisibleChatMessageRole
 import ai.openclaw.app.tools.ToolDisplayRegistry
 import ai.openclaw.app.ui.MobileColorsAccessor
@@ -35,7 +37,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -69,9 +74,11 @@ private data class ChatBubbleStyle(
 
 /** Renders one persisted chat message as text and image parts. */
 @Composable
-fun ChatMessageBubble(
+internal fun ChatMessageBubble(
   message: ChatMessage,
   onReplyMessage: (String) -> Unit = {},
+  speechState: MessageSpeechState? = null,
+  onToggleListen: ((String, String) -> Unit)? = null,
 ) {
   val role = normalizeVisibleChatMessageRole(message.role) ?: return
   val style = bubbleStyle(role)
@@ -89,14 +96,65 @@ fun ChatMessageBubble(
   if (displayableContent.isEmpty()) return
 
   val messageText = chatMessagePlainText(displayableContent)
+  val messageSpeech = speechState?.takeIf { it.messageId == message.id }
+  val canListen = role == "assistant" && messageText.isNotBlank() && onToggleListen != null
+  val toggleListen: (() -> Unit)? =
+    if (canListen) {
+      { checkNotNull(onToggleListen).invoke(message.id, messageText) }
+    } else {
+      null
+    }
   ChatMessageActionHost(
     text = messageText,
     onReply = onReplyMessage,
+    listenActive = messageSpeech != null,
+    onToggleListen = toggleListen,
     modifier = Modifier.fillMaxWidth(),
   ) {
     ChatBubbleContainer(style = style, roleLabel = roleLabel(role)) {
       ChatMessageBody(content = displayableContent, textColor = mobileText)
       ChatMessageLinkPreview(messageId = message.id, role = role, content = displayableContent)
+      messageSpeech?.let { speech ->
+        MessageSpeechIndicator(
+          phase = speech.phase,
+          onStop = { checkNotNull(onToggleListen).invoke(message.id, messageText) },
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun MessageSpeechIndicator(
+  phase: MessageSpeechPhase,
+  onStop: () -> Unit,
+) {
+  Surface(
+    onClick = onStop,
+    shape = RoundedCornerShape(999.dp),
+    color = mobileAccentSoft,
+  ) {
+    Row(
+      modifier = Modifier.padding(horizontal = 9.dp, vertical = 5.dp),
+      horizontalArrangement = Arrangement.spacedBy(6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Icon(
+        imageVector =
+          if (phase == MessageSpeechPhase.Preparing) {
+            Icons.Default.HourglassEmpty
+          } else {
+            Icons.AutoMirrored.Filled.VolumeUp
+          },
+        contentDescription = null,
+        modifier = Modifier.size(14.dp),
+        tint = mobileTextSecondary,
+      )
+      Text(
+        text = if (phase == MessageSpeechPhase.Preparing) "Preparing audio…" else "Speaking…",
+        style = mobileCaption1,
+        color = mobileTextSecondary,
+      )
     }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -9,6 +9,8 @@ import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
+import ai.openclaw.app.chat.MessageSpeechPhase
+import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.resolveAgentIdFromMainSessionKey
 import ai.openclaw.app.ui.copyGatewayDiagnosticsReport
@@ -49,12 +51,14 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.AttachFile
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.HourglassEmpty
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Refresh
@@ -70,6 +74,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -126,6 +131,7 @@ fun ChatScreen(
   val assistantAutoSendInFlight by viewModel.assistantAutoSendInFlight.collectAsState()
   val remoteAddress by viewModel.remoteAddress.collectAsState()
   val outboxItems by viewModel.chatOutboxItems.collectAsState()
+  val messageSpeechState by viewModel.chatMessageSpeech.collectAsState()
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
@@ -145,6 +151,10 @@ fun ChatScreen(
   val scope = rememberCoroutineScope()
   val attachments = remember { mutableStateListOf<PendingImageAttachment>() }
   var showModelPicker by rememberSaveable { mutableStateOf(false) }
+
+  DisposableEffect(viewModel) {
+    onDispose(viewModel::stopChatMessageSpeech)
+  }
   val modelSections =
     remember(modelCatalog, modelFavorites, modelRecents) {
       chatModelPickerSections(
@@ -287,6 +297,8 @@ fun ChatScreen(
       onDeleteOutbox = viewModel::deleteChatOutboxCommand,
       onStarterPrompt = { prompt -> input = prompt },
       onReplyMessage = viewModel::setChatReplyDraft,
+      speechState = messageSpeechState,
+      onToggleListen = viewModel::toggleChatMessageSpeech,
       modifier = Modifier.weight(1f),
     )
 
@@ -604,6 +616,8 @@ private fun ChatMessageList(
   onDeleteOutbox: (String) -> Unit,
   onStarterPrompt: (String) -> Unit,
   onReplyMessage: (String) -> Unit,
+  speechState: MessageSpeechState?,
+  onToggleListen: (String, String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val timeline =
@@ -641,6 +655,8 @@ private fun ChatMessageList(
               content = item.message.content,
               timestampMs = item.message.timestampMs,
               onReplyMessage = onReplyMessage,
+              speechState = speechState,
+              onToggleListen = onToggleListen,
             )
           is ChatTimelineItem.OutboxCommand ->
             ChatOutboxBubble(
@@ -657,6 +673,8 @@ private fun ChatMessageList(
               content = listOf(ChatMessageContent(text = item.text)),
               timestampMs = null,
               onReplyMessage = onReplyMessage,
+              speechState = null,
+              onToggleListen = onToggleListen,
             )
           ChatTimelineItem.Thinking -> ChatThinkingBubble()
         }
@@ -819,6 +837,8 @@ private fun ChatBubble(
   content: List<ChatMessageContent>,
   timestampMs: Long?,
   onReplyMessage: (String) -> Unit,
+  speechState: MessageSpeechState?,
+  onToggleListen: (String, String) -> Unit,
 ) {
   val normalizedRole = role.trim().lowercase(Locale.US)
   val isUser = normalizedRole == "user"
@@ -832,15 +852,26 @@ private fun ChatBubble(
     }
   if (displayableContent.isEmpty()) return
 
+  val messageText = chatMessagePlainText(displayableContent)
+  val messageSpeech = speechState?.takeIf { it.messageId == messageId }
+  val canListen = !live && messageId != null && normalizedRole == "assistant" && messageText.isNotBlank()
+  val toggleListen: (() -> Unit)? =
+    if (canListen) {
+      { onToggleListen(checkNotNull(messageId), messageText) }
+    } else {
+      null
+    }
+
   Row(
     modifier = Modifier.fillMaxWidth(),
     horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
   ) {
-    val messageText = chatMessagePlainText(displayableContent)
     ChatMessageActionHost(
       text = messageText,
       onReply = onReplyMessage,
       enabled = !live,
+      listenActive = messageSpeech != null,
+      onToggleListen = toggleListen,
       modifier = Modifier.fillMaxWidth(if (isUser) 0.84f else 0.94f),
     ) {
       Surface(
@@ -874,6 +905,12 @@ private fun ChatBubble(
           if (messageId != null) {
             ChatMessageLinkPreview(messageId = messageId, role = normalizedRole, content = displayableContent)
           }
+          messageSpeech?.let { speech ->
+            FullChatSpeechIndicator(
+              phase = speech.phase,
+              onStop = { onToggleListen(checkNotNull(messageId), messageText) },
+            )
+          }
           timestampMs?.let {
             Text(
               text = formatChatTimestamp(it),
@@ -884,6 +921,41 @@ private fun ChatBubble(
           }
         }
       }
+    }
+  }
+}
+
+@Composable
+private fun FullChatSpeechIndicator(
+  phase: MessageSpeechPhase,
+  onStop: () -> Unit,
+) {
+  Surface(
+    onClick = onStop,
+    shape = RoundedCornerShape(999.dp),
+    color = ClawTheme.colors.surfacePressed,
+  ) {
+    Row(
+      modifier = Modifier.padding(horizontal = 9.dp, vertical = 5.dp),
+      horizontalArrangement = Arrangement.spacedBy(6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Icon(
+        imageVector =
+          if (phase == MessageSpeechPhase.Preparing) {
+            Icons.Default.HourglassEmpty
+          } else {
+            Icons.AutoMirrored.Filled.VolumeUp
+          },
+        contentDescription = null,
+        modifier = Modifier.size(14.dp),
+        tint = ClawTheme.colors.textMuted,
+      )
+      Text(
+        text = if (phase == MessageSpeechPhase.Preparing) "Preparing audio…" else "Speaking…",
+        style = ClawTheme.type.caption,
+        color = ClawTheme.colors.textMuted,
+      )
     }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -87,8 +88,13 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   val pendingAssistantAutoSend by viewModel.pendingAssistantAutoSend.collectAsState()
   val assistantAutoSendInFlight by viewModel.assistantAutoSendInFlight.collectAsState()
   val outboxItems by viewModel.chatOutboxItems.collectAsState()
+  val messageSpeechState by viewModel.chatMessageSpeech.collectAsState()
   val gatewayConnectionDisplay by viewModel.gatewayConnectionDisplay.collectAsState()
   val gatewayOffline = !gatewayConnectionDisplay.isConnected
+
+  DisposableEffect(viewModel) {
+    onDispose(viewModel::stopChatMessageSpeech)
+  }
 
   LaunchedEffect(Unit) {
     val loadSessionKey = resolveInitialChatLoadSessionKey(sessionKey, mainSessionKey)
@@ -177,6 +183,8 @@ fun ChatSheetContent(viewModel: MainViewModel) {
       onRetryOutbox = viewModel::retryChatOutboxCommand,
       onDeleteOutbox = viewModel::deleteChatOutboxCommand,
       onReplyMessage = viewModel::setChatReplyDraft,
+      speechState = messageSpeechState,
+      onToggleListen = viewModel::toggleChatMessageSpeech,
     )
 
     Row(modifier = Modifier.fillMaxWidth().imePadding()) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/MessageSpeechControllerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/MessageSpeechControllerTest.kt
@@ -1,0 +1,222 @@
+package ai.openclaw.app.chat
+
+import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.voice.TalkAudioPlaying
+import ai.openclaw.app.voice.TalkSpeakAudio
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+private fun speechClip(bytes: ByteArray = byteArrayOf(1, 2, 3)): TalkSpeakAudio =
+  TalkSpeakAudio(
+    bytes = bytes,
+    provider = "openai",
+    outputFormat = "mp3",
+    voiceCompatible = null,
+    mimeType = "audio/mpeg",
+    fileExtension = ".mp3",
+  )
+
+private class FakePlayer : TalkAudioPlaying {
+  val played = mutableListOf<TalkSpeakAudio>()
+  var stopCount = 0
+  var gate: CompletableDeferred<Unit>? = null
+  var failure: Throwable? = null
+  private var activeGate: CompletableDeferred<Unit>? = null
+
+  override suspend fun play(audio: TalkSpeakAudio) {
+    played += audio
+    failure?.let { throw it }
+    val currentGate = gate
+    activeGate = currentGate
+    currentGate?.await()
+  }
+
+  override fun stop() {
+    stopCount += 1
+    activeGate?.cancel()
+    activeGate = null
+  }
+}
+
+private class FakeLocalSpeech : LocalSpeechSpeaking {
+  val spoken = mutableListOf<String>()
+  var stopCount = 0
+
+  override suspend fun speak(text: String) {
+    spoken += text
+  }
+
+  override fun stop() {
+    stopCount += 1
+  }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class MessageSpeechControllerTest {
+  @Test
+  fun clientRequestsTtsSpeakAndPreservesPlaybackMetadata() =
+    runTest {
+      var method = ""
+      var params = ""
+      var timeoutMs = 0L
+      val client =
+        MessageSpeechClient(
+          requestDetailed = { requestMethod, requestParams, requestTimeoutMs ->
+            method = requestMethod
+            params = requestParams
+            timeoutMs = requestTimeoutMs
+            GatewaySession.RpcResult(
+              ok = true,
+              payloadJson =
+                """{"audioBase64":"AQID","provider":"openai","outputFormat":"mp3","mimeType":"audio/mpeg","fileExtension":".mp3"}""",
+              error = null,
+            )
+          },
+        )
+
+      val audio = checkNotNull(client.synthesize("Hello"))
+
+      assertEquals("tts.speak", method)
+      assertEquals("""{"text":"Hello"}""", params)
+      assertEquals(60_000L, timeoutMs)
+      assertArrayEquals(byteArrayOf(1, 2, 3), audio.bytes)
+      assertEquals("openai", audio.provider)
+      assertEquals("mp3", audio.outputFormat)
+      assertEquals("audio/mpeg", audio.mimeType)
+      assertEquals(".mp3", audio.fileExtension)
+    }
+
+  @Test
+  fun playsGatewayClipAndClearsState() =
+    runTest {
+      val player = FakePlayer().also { it.gate = CompletableDeferred() }
+      val local = FakeLocalSpeech()
+      val controller = controller(player = player, local = local)
+
+      controller.toggle(messageId = "m1", text = "Hello there.")
+      assertEquals(
+        MessageSpeechState(messageId = "m1", phase = MessageSpeechPhase.Preparing),
+        controller.state.value,
+      )
+
+      runCurrent()
+      assertEquals(
+        MessageSpeechState(messageId = "m1", phase = MessageSpeechPhase.Speaking),
+        controller.state.value,
+      )
+      assertEquals(1, player.played.size)
+
+      player.gate?.complete(Unit)
+      advanceUntilIdle()
+      assertNull(controller.state.value)
+      assertTrue(local.spoken.isEmpty())
+    }
+
+  @Test
+  fun fallsBackToLocalSpeechWhenGatewayCannotRender() =
+    runTest {
+      val player = FakePlayer()
+      val local = FakeLocalSpeech()
+      val controller = controller(player = player, local = local, synthesizer = { null })
+
+      controller.toggle(messageId = "m1", text = "Read me aloud")
+      advanceUntilIdle()
+
+      assertEquals(listOf("Read me aloud"), local.spoken)
+      assertTrue(player.played.isEmpty())
+      assertNull(controller.state.value)
+    }
+
+  @Test
+  fun fallsBackToLocalSpeechWhenClipPlaybackFails() =
+    runTest {
+      val player = FakePlayer().also { it.failure = IllegalStateException("Unsupported talk audio format") }
+      val local = FakeLocalSpeech()
+      val controller = controller(player = player, local = local)
+
+      controller.toggle(messageId = "m1", text = "Broken clip")
+      advanceUntilIdle()
+
+      assertEquals(listOf("Broken clip"), local.spoken)
+      assertNull(controller.state.value)
+    }
+
+  @Test
+  fun toggleWhileActiveStopsWithoutFallback() =
+    runTest {
+      val player = FakePlayer().also { it.gate = CompletableDeferred() }
+      val local = FakeLocalSpeech()
+      val controller = controller(player = player, local = local)
+
+      controller.toggle(messageId = "m1", text = "Long reply")
+      runCurrent()
+      controller.toggle(messageId = "m1", text = "Long reply")
+
+      assertNull(controller.state.value)
+      assertTrue(player.stopCount > 0)
+      advanceUntilIdle()
+      assertTrue(local.spoken.isEmpty())
+      assertNull(controller.state.value)
+    }
+
+  @Test
+  fun startingAnotherMessageSupersedesTheFirst() =
+    runTest {
+      val player = FakePlayer().also { it.gate = CompletableDeferred() }
+      val local = FakeLocalSpeech()
+      val controller = controller(player = player, local = local)
+
+      controller.toggle(messageId = "m1", text = "First message")
+      runCurrent()
+      player.gate = CompletableDeferred()
+      controller.toggle(messageId = "m2", text = "Second message")
+      runCurrent()
+
+      assertEquals(
+        MessageSpeechState(messageId = "m2", phase = MessageSpeechPhase.Speaking),
+        controller.state.value,
+      )
+      player.gate?.complete(Unit)
+      advanceUntilIdle()
+      assertNull(controller.state.value)
+      assertTrue(local.spoken.isEmpty())
+    }
+
+  @Test
+  fun blankTextStaysIdle() =
+    runTest {
+      val player = FakePlayer()
+      val local = FakeLocalSpeech()
+      val controller = controller(player = player, local = local)
+
+      controller.toggle(messageId = "m1", text = "   \n ")
+      advanceUntilIdle()
+
+      assertNull(controller.state.value)
+      assertTrue(player.played.isEmpty())
+      assertTrue(local.spoken.isEmpty())
+    }
+
+  private fun kotlinx.coroutines.test.TestScope.controller(
+    player: FakePlayer,
+    local: FakeLocalSpeech,
+    synthesizer: MessageSpeechSynthesizing = MessageSpeechSynthesizing { speechClip() },
+  ): MessageSpeechController =
+    MessageSpeechController(
+      scope = this,
+      synthesizer = synthesizer,
+      player = player,
+      localSpeech = local,
+    )
+}

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -242,6 +242,7 @@ The Android Chat tab supports session selection (default `main`, plus other exis
 - History: `chat.history` (display-normalized — inline directive tags, plain-text tool-call XML payloads (`<tool_call>`, `<function_call>`, `<tool_calls>`, `<function_calls>`, and truncated variants), and leaked ASCII/full-width model control tokens are stripped; silent-token assistant rows such as exact `NO_REPLY` / `no_reply` are omitted; oversized rows can be replaced with placeholders)
 - Send: `chat.send`
 - Push updates (best-effort): `chat.subscribe` -> `event:"chat"`
+- Listen: long-press an assistant message and choose **Listen** to hear it; audio renders via gateway `tts.speak` with the configured TTS provider chain, and on-device system TTS is used when the gateway cannot render audio. Playback stops on session switch.
 
 ### 7. Canvas + camera
 

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -242,7 +242,7 @@ The Android Chat tab supports session selection (default `main`, plus other exis
 - History: `chat.history` (display-normalized — inline directive tags, plain-text tool-call XML payloads (`<tool_call>`, `<function_call>`, `<tool_calls>`, `<function_calls>`, and truncated variants), and leaked ASCII/full-width model control tokens are stripped; silent-token assistant rows such as exact `NO_REPLY` / `no_reply` are omitted; oversized rows can be replaced with placeholders)
 - Send: `chat.send`
 - Push updates (best-effort): `chat.subscribe` -> `event:"chat"`
-- Listen: long-press an assistant message and choose **Listen** to hear it; audio renders via gateway `tts.speak` with the configured TTS provider chain, and on-device system TTS is used when the gateway cannot render audio. Playback stops on session switch.
+- Listen: long-press an assistant message and choose **Listen** to hear it; audio renders via gateway `tts.speak` with the configured TTS provider chain, and on-device system TTS is used when the gateway cannot render audio. Playback stops on session switch, new chat, app backgrounding, or chat close.
 
 ### 7. Canvas + camera
 


### PR DESCRIPTION
## What Problem This Solves

Android users cannot hear an assistant reply from the chat transcript (tracking issue: #100708). Gateway support landed in #100770; the iOS client landed in #100771.

## Why This Change Was Made

- **Shared Listen action**: the existing long-press message menu now offers **Listen** or **Stop** for persisted assistant messages with visible text. Both the full Chat tab and compact chat sheet use the same action host; user, tool-only, image-only, blank, and streaming rows do not expose a dead action.
- **One playback owner**: `MessageSpeechController` calls gateway `tts.speak`, passes the full format/MIME/extension metadata through the existing `TalkAudioPlayer`, and falls back to Android `TextToSpeech` when synthesis or clip playback is unavailable. A generation token prevents superseded completions from clearing newer playback state.
- **Transcript-exact speech**: Listen reuses `chatMessagePlainText`, the same visible-text projection already used by Copy, Share, and Reply.
- **Lifecycle cleanup**: playback stops on session switch, New Chat, app backgrounding, and disposal of either chat surface. Failed Android TTS initialization is discarded so the next Listen attempt retries instead of caching a dead engine.
- **Inline state**: assistant bubbles show tappable **Preparing audio…** and **Speaking…** status pills that stop playback.

## User Impact

Long-press an assistant reply and choose **Listen**. OpenClaw uses the configured gateway TTS provider when available and the device voice otherwise, with no new player dependency.

## Evidence

- Blacksmith Testbox `tbx_01kwwbfhfzkzhzj2xt84x4vsy3`: full `:app:testPlayDebugUnitTest`, `:app:ktlintCheck`, and `:app:assemblePlayDebug` — green on the final rebased tree.
- Focused `MessageSpeechControllerTest` plus `ChatMessageActionsTest`: 10/10, including RPC request/metadata preservation, gateway and playback fallbacks, stop/supersede, blank input, and transcript text projection.
- Native i18n inventory: `entries=2764 changed=false`.
- Fresh Codex autoreview: clean on the final rebased branch.
- Exact-head CI: [run 28816900466](https://github.com/openclaw/openclaw/actions/runs/28816900466) passed for `90ea96348683e427bbcf49c7aa28c4b94771bde1`.
- Device gap: the exact proof variant is installed on a connected Pixel 10a, but the locked device still blocks audible gateway/fallback playback capture.
