### PR TITLE
feat(ios): model picker favorites and recents with working iOS model switching

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -5707,7 +5707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 476,
+      "line": 503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -5715,7 +5715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 476,
+      "line": 503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -5723,7 +5723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 863,
+      "line": 906,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -5731,7 +5731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 864,
+      "line": 907,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
@@ -5739,7 +5739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 865,
+      "line": 908,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
@@ -5747,7 +5747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1812,
+      "line": 1911,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -5755,7 +5755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1812,
+      "line": 1911,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",
@@ -20299,7 +20299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 192,
+      "line": 195,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -20307,7 +20307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 211,
+      "line": 216,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Model",
       "surface": "apple",
@@ -20315,7 +20315,47 @@
     },
     {
       "kind": "ui-call",
-      "line": 234,
+      "line": 233,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Pinned",
+      "surface": "apple",
+      "id": "native.apple.745b004e0b5b6b80"
+    },
+    {
+      "kind": "ui-call",
+      "line": 241,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Recent",
+      "surface": "apple",
+      "id": "native.apple.69381a0a462ccd84"
+    },
+    {
+      "kind": "ui-call",
+      "line": 249,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Models",
+      "surface": "apple",
+      "id": "native.apple.aa321cf4820426ef"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 278,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Pin model",
+      "surface": "apple",
+      "id": "native.apple.75550b03f06d6abc"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 278,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Unpin model",
+      "surface": "apple",
+      "id": "native.apple.af4df27bdbacb5de"
+    },
+    {
+      "kind": "ui-call",
+      "line": 282,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Session",
       "surface": "apple",
@@ -20323,7 +20363,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 298,
+      "line": 346,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Add Image",
       "surface": "apple",
@@ -20331,7 +20371,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 299,
+      "line": 347,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Attachments",
       "surface": "apple",
@@ -20339,7 +20379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 469,
+      "line": 517,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
@@ -20347,7 +20387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 515,
+      "line": 563,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
@@ -20355,7 +20395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 515,
+      "line": 563,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
@@ -20363,7 +20403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 548,
+      "line": 596,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -20371,7 +20411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 548,
+      "line": 596,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -20379,7 +20419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 658,
+      "line": 706,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -20387,7 +20427,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 667,
+      "line": 715,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -20395,7 +20435,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 676,
+      "line": 724,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -20403,7 +20443,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 685,
+      "line": 733,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -20411,7 +20451,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 817,
+      "line": 865,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -20419,7 +20459,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 842,
+      "line": 890,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -20427,7 +20467,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 857,
+      "line": 905,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -20435,7 +20475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 965,
+      "line": 1013,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -20443,7 +20483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 965,
+      "line": 1013,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -35,6 +35,40 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         var agentId: String?
     }
 
+    private struct SessionPatchModelParams: Encodable {
+        var key: String
+        var agentId: String?
+        var model: String?
+
+        enum CodingKeys: String, CodingKey {
+            case key
+            case agentId
+            case model
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(self.key, forKey: .key)
+            try container.encodeIfPresent(self.agentId, forKey: .agentId)
+            if let model {
+                try container.encode(model, forKey: .model)
+            } else {
+                try container.encodeNil(forKey: .model)
+            }
+        }
+    }
+
+    private struct ModelsListResponse: Decodable {
+        var models: [Model]
+
+        struct Model: Decodable {
+            var id: String
+            var name: String
+            var provider: String
+            var contextWindow: Int?
+        }
+    }
+
     private struct ChatSendParams: Codable {
         var sessionKey: String
         var agentId: String?
@@ -138,6 +172,18 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             completed: self.isAgentWaitCompletionStatus(status))
     }
 
+    static func decodeModelChoices(_ data: Data) throws -> [OpenClawChatModelChoice] {
+        let decoded = try JSONDecoder().decode(ModelsListResponse.self, from: data)
+        return decoded.models.map { model in
+            let name = model.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            return OpenClawChatModelChoice(
+                modelID: model.id,
+                name: name.isEmpty ? model.id : model.name,
+                provider: model.provider,
+                contextWindow: model.contextWindow)
+        }
+    }
+
     static func makeCreateSessionParamsJSON(
         key: String,
         agentId: String? = nil,
@@ -162,6 +208,14 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
 
     private static func makeSessionKeyParamsJSON(_ sessionKey: String, agentId: String?) throws -> String {
         try self.encodeParams(SessionKeyParams(key: sessionKey, agentId: agentId))
+    }
+
+    static func makeSessionPatchModelParamsJSON(
+        sessionKey: String,
+        agentId: String? = nil,
+        model: String?) throws -> String
+    {
+        try self.encodeParams(SessionPatchModelParams(key: sessionKey, agentId: agentId, model: model))
     }
 
     private static func makeHistoryParamsJSON(sessionKey: String, agentId: String?) throws -> String {
@@ -219,6 +273,22 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         let json = try Self.makeListSessionsParamsJSON(limit: limit)
         let res = try await self.gateway.request(method: "sessions.list", paramsJSON: json, timeoutSeconds: 15)
         return try JSONDecoder().decode(OpenClawChatSessionsListResponse.self, from: res)
+    }
+
+    func listModels() async throws -> [OpenClawChatModelChoice] {
+        let response = try await self.gateway.request(
+            method: "models.list",
+            paramsJSON: nil,
+            timeoutSeconds: 15)
+        return try Self.decodeModelChoices(response)
+    }
+
+    func setSessionModel(sessionKey: String, model: String?) async throws {
+        let json = try Self.makeSessionPatchModelParamsJSON(
+            sessionKey: sessionKey,
+            agentId: self.selectedGlobalAgentId(for: sessionKey),
+            model: model)
+        _ = try await self.gateway.request(method: "sessions.patch", paramsJSON: json, timeoutSeconds: 15)
     }
 
     func setActiveSessionKey(_ sessionKey: String) async throws {

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -46,6 +46,43 @@ struct IOSGatewayChatTransportTests {
         #expect(params["limit"] as? Int == 12)
     }
 
+    @Test func `session model patch params include model and selected agent`() throws {
+        let params = try self.object(
+            from: IOSGatewayChatTransport.makeSessionPatchModelParamsJSON(
+                sessionKey: "global",
+                agentId: "reviewer",
+                model: "anthropic/claude-opus-4"))
+        #expect(params["key"] as? String == "global")
+        #expect(params["agentId"] as? String == "reviewer")
+        #expect(params["model"] as? String == "anthropic/claude-opus-4")
+    }
+
+    @Test func `session model patch params encode default model as null`() throws {
+        let params = try self.object(
+            from: IOSGatewayChatTransport.makeSessionPatchModelParamsJSON(
+                sessionKey: "agent:main:main",
+                model: nil))
+        #expect(params["key"] as? String == "agent:main:main")
+        #expect(params["agentId"] == nil)
+        #expect(params["model"] is NSNull)
+    }
+
+    @Test func `models list response decodes choices and falls back blank names`() throws {
+        let data = Data(
+            #"{"models":[{"id":"claude-opus-4","name":"Claude Opus 4","provider":"anthropic","contextWindow":200000,"reasoning":true},{"id":"gpt-5","name":"  ","provider":"openai","extra":"ignored"}]}"#.utf8)
+        let choices = try IOSGatewayChatTransport.decodeModelChoices(data)
+
+        #expect(choices.count == 2)
+        #expect(choices[0].modelID == "claude-opus-4")
+        #expect(choices[0].name == "Claude Opus 4")
+        #expect(choices[0].provider == "anthropic")
+        #expect(choices[0].contextWindow == 200_000)
+        #expect(choices[1].modelID == "gpt-5")
+        #expect(choices[1].name == "gpt-5")
+        #expect(choices[1].provider == "openai")
+        #expect(choices[1].contextWindow == nil)
+    }
+
     @Test func `commands list params request text scope with args`() throws {
         let params = try self.object(from: IOSGatewayChatTransport.makeCommandsListParamsJSON())
         #expect(params["scope"] as? String == "text")

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -174,6 +174,9 @@ struct OpenClawChatComposer: View {
                     }
                     if self.viewModel.showsModelPicker {
                         self.modelPicker
+                        if self.viewModel.modelSelectionID != OpenClawChatViewModel.defaultModelSelectionID {
+                            self.modelPinButton
+                        }
                     }
                 }
             }
@@ -208,7 +211,9 @@ struct OpenClawChatComposer: View {
     }
 
     private var modelPicker: some View {
-        Picker(
+        // Sections come from an O(n) recompute over the catalog; bind once per body eval.
+        let sections = self.viewModel.modelPickerSections
+        return Picker(
             "Model",
             selection: Binding(
                 get: { self.viewModel.modelSelectionID },
@@ -217,10 +222,34 @@ struct OpenClawChatComposer: View {
             Text(self.viewModel.defaultModelLabel)
                 .font(OpenClawChatTypography.captionSemiBold)
                 .tag(OpenClawChatViewModel.defaultModelSelectionID)
-            ForEach(self.viewModel.modelChoices) { model in
-                Text(model.displayLabel)
-                    .font(OpenClawChatTypography.captionSemiBold)
-                    .tag(model.selectionID)
+            if sections.pinned.isEmpty, sections.recent.isEmpty {
+                // No pins/recents yet: keep the pre-feature flat list without section chrome.
+                self.modelOptions(sections.remaining)
+            } else {
+                if !sections.pinned.isEmpty {
+                    Section {
+                        self.modelOptions(sections.pinned)
+                    } header: {
+                        Text("Pinned")
+                            .font(OpenClawChatTypography.captionSemiBold)
+                    }
+                }
+                if !sections.recent.isEmpty {
+                    Section {
+                        self.modelOptions(sections.recent)
+                    } header: {
+                        Text("Recent")
+                            .font(OpenClawChatTypography.captionSemiBold)
+                    }
+                }
+                if !sections.remaining.isEmpty {
+                    Section {
+                        self.modelOptions(sections.remaining)
+                    } header: {
+                        Text("Models")
+                            .font(OpenClawChatTypography.captionSemiBold)
+                    }
+                }
             }
         }
         .labelsHidden()
@@ -228,6 +257,25 @@ struct OpenClawChatComposer: View {
         .controlSize(.small)
         .frame(maxWidth: 240, alignment: .leading)
         .help("Model")
+    }
+
+    private func modelOptions(_ models: [OpenClawChatModelChoice]) -> some View {
+        ForEach(models) { model in
+            Text(model.displayLabel)
+                .font(OpenClawChatTypography.captionSemiBold)
+                .tag(model.selectionID)
+        }
+    }
+
+    private var modelPinButton: some View {
+        Button {
+            self.viewModel.toggleSelectedModelPinned()
+        } label: {
+            Image(systemName: self.viewModel.isSelectedModelPinned ? "star.fill" : "star")
+                .font(.system(size: 12, weight: .semibold))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(self.viewModel.isSelectedModelPinned ? "Unpin model" : "Pin model")
     }
 
     private var sessionPicker: some View {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModelPickerStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModelPickerStore.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+public struct ChatModelPickerSections: Sendable, Equatable {
+    public let pinned: [OpenClawChatModelChoice]
+    public let recent: [OpenClawChatModelChoice]
+    public let remaining: [OpenClawChatModelChoice]
+}
+
+@MainActor
+public final class ChatModelPickerStore {
+    private static let favoritesKey = "openclaw.chat.modelFavorites"
+    private static let recentsKey = "openclaw.chat.modelRecents"
+    private static let maxRecents = 5
+
+    private let defaults: UserDefaults
+
+    public private(set) var favorites: [String]
+    public private(set) var recents: [String]
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.favorites = defaults.stringArray(forKey: Self.favoritesKey) ?? []
+        self.recents = defaults.stringArray(forKey: Self.recentsKey) ?? []
+    }
+
+    public func isFavorite(_ selectionID: String) -> Bool {
+        self.favorites.contains(selectionID)
+    }
+
+    public func toggleFavorite(_ selectionID: String) {
+        self.favorites = self.defaults.stringArray(forKey: Self.favoritesKey) ?? []
+        if self.isFavorite(selectionID) {
+            self.favorites.removeAll { $0 == selectionID }
+        } else {
+            self.favorites.append(selectionID)
+        }
+        self.defaults.set(self.favorites, forKey: Self.favoritesKey)
+    }
+
+    public func recordRecent(_ selectionID: String) {
+        guard !selectionID.isEmpty, selectionID != OpenClawChatViewModel.defaultModelSelectionID else { return }
+        self.recents = self.defaults.stringArray(forKey: Self.recentsKey) ?? []
+        self.recents.removeAll { $0 == selectionID }
+        self.recents.insert(selectionID, at: 0)
+        self.recents = Array(self.recents.prefix(Self.maxRecents))
+        self.defaults.set(self.recents, forKey: Self.recentsKey)
+    }
+
+    static func sections(
+        choices: [OpenClawChatModelChoice],
+        favorites: [String],
+        recents: [String]) -> ChatModelPickerSections
+    {
+        var choicesByID: [String: OpenClawChatModelChoice] = [:]
+        for choice in choices where choicesByID[choice.selectionID] == nil {
+            choicesByID[choice.selectionID] = choice
+        }
+
+        var included = Set<String>()
+        let pinned = favorites.compactMap { selectionID -> OpenClawChatModelChoice? in
+            guard included.insert(selectionID).inserted else { return nil }
+            return choicesByID[selectionID]
+        }
+        let recent = recents.compactMap { selectionID -> OpenClawChatModelChoice? in
+            guard included.insert(selectionID).inserted else { return nil }
+            return choicesByID[selectionID]
+        }
+        let remaining = choices.filter { included.insert($0.selectionID).inserted }
+        return ChatModelPickerSections(pinned: pinned, recent: recent, remaining: remaining)
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -9,7 +9,7 @@ private let chatUILogger = Logger(subsystem: "ai.openclaw", category: "OpenClawC
 @Observable
 // swiftlint:disable:next type_body_length
 public final class OpenClawChatViewModel {
-    public static let defaultModelSelectionID = "__default__"
+    public nonisolated static let defaultModelSelectionID = "__default__"
     static let maxAttachmentBytes = 5_000_000
 
     public internal(set) var messages: [OpenClawChatMessage] = []
@@ -20,6 +20,8 @@ public final class OpenClawChatViewModel {
     public internal(set) var thinkingLevelOptions: [OpenClawChatThinkingLevelOption]
     public private(set) var modelSelectionID: String = "__default__"
     public private(set) var modelChoices: [OpenClawChatModelChoice] = []
+    private var modelPickerFavorites: [String]
+    private var modelPickerRecents: [String]
     public private(set) var slashCommands: [OpenClawChatCommandChoice] = []
     public private(set) var isLoadingSlashCommands = false
     public private(set) var slashCommandsErrorText: String?
@@ -63,6 +65,8 @@ public final class OpenClawChatViewModel {
     let haptics: OpenClawChatHaptics
     let transcriptCache: (any OpenClawChatTranscriptCache)?
     let outbox: (any OpenClawChatCommandOutbox)?
+    @ObservationIgnored
+    private let modelPickerStore: ChatModelPickerStore
     /// Per-message outbox display state; rows without an entry are normal
     /// transcript rows. Observable so bubbles update when flush progresses.
     public internal(set) var outboxStatesByMessageID: [UUID: OpenClawChatOutboxMessageState] = [:]
@@ -238,6 +242,7 @@ public final class OpenClawChatViewModel {
         haptics: OpenClawChatHaptics = OpenClawChatHaptics(),
         transcriptCache: (any OpenClawChatTranscriptCache)? = nil,
         outbox: (any OpenClawChatCommandOutbox)? = nil,
+        modelPickerStore: ChatModelPickerStore = ChatModelPickerStore(),
         initialThinkingLevel: String? = nil,
         onSessionChanged: (@MainActor (String) -> Void)? = nil,
         onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)? = nil,
@@ -247,6 +252,9 @@ public final class OpenClawChatViewModel {
         self.transport = transport
         self.haptics = haptics
         self.transcriptCache = transcriptCache
+        self.modelPickerStore = modelPickerStore
+        self.modelPickerFavorites = modelPickerStore.favorites
+        self.modelPickerRecents = modelPickerStore.recents
         let normalizedAgentId = activeAgentId?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         self.activeAgentId = normalizedAgentId?.isEmpty == false ? normalizedAgentId : nil
         self.outbox = outbox
@@ -288,6 +296,24 @@ public final class OpenClawChatViewModel {
 
     public func refresh() {
         self.startBootstrap()
+    }
+
+    public var modelPickerSections: ChatModelPickerSections {
+        ChatModelPickerStore.sections(
+            choices: self.modelChoices,
+            favorites: self.modelPickerFavorites,
+            recents: self.modelPickerRecents)
+    }
+
+    public var isSelectedModelPinned: Bool {
+        self.modelSelectionID != Self.defaultModelSelectionID &&
+            self.modelPickerFavorites.contains(self.modelSelectionID)
+    }
+
+    public func toggleSelectedModelPinned() {
+        guard self.modelSelectionID != Self.defaultModelSelectionID else { return }
+        self.modelPickerStore.toggleFavorite(self.modelSelectionID)
+        self.modelPickerFavorites = self.modelPickerStore.favorites
     }
 
     public func resumeFromForeground() {
@@ -1453,6 +1479,8 @@ public final class OpenClawChatViewModel {
                 self.lastSuccessfulModelSelectionIDsBySession[sessionKey] = next
                 return
             }
+            self.modelPickerStore.recordRecent(next)
+            self.modelPickerRecents = self.modelPickerStore.recents
             self.applySuccessfulModelSelection(next, sessionKey: sessionKey, syncSelection: true)
         } catch {
             guard requestID == self.latestModelSelectionRequestIDsBySession[sessionKey] else { return }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatModelPickerStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatModelPickerStoreTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import OpenClawChatUI
+
+private func pickerModel(_ selectionID: String) -> OpenClawChatModelChoice {
+    let parts = selectionID.split(separator: "/", maxSplits: 1).map(String.init)
+    return OpenClawChatModelChoice(
+        modelID: parts.count == 2 ? parts[1] : selectionID,
+        name: selectionID,
+        provider: parts.count == 2 ? parts[0] : "test",
+        contextWindow: nil)
+}
+
+@MainActor
+private func withPickerStore(_ body: (ChatModelPickerStore, UserDefaults) throws -> Void) throws {
+    let suiteName = "ChatModelPickerStoreTests.\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suiteName))
+    defer { defaults.removePersistentDomain(forName: suiteName) }
+    try body(ChatModelPickerStore(defaults: defaults), defaults)
+}
+
+@MainActor
+@Suite struct ChatModelPickerStoreTests {
+    @Test func `favorites and recents round trip through defaults`() throws {
+        try withPickerStore { store, defaults in
+            store.toggleFavorite("anthropic/opus")
+            store.recordRecent("openai/gpt")
+
+            let reloaded = ChatModelPickerStore(defaults: defaults)
+            #expect(reloaded.favorites == ["anthropic/opus"])
+            #expect(reloaded.recents == ["openai/gpt"])
+        }
+    }
+
+    @Test func `recents dedupe move to front cap and skip invalid ids`() throws {
+        try withPickerStore { store, _ in
+            store.recordRecent("")
+            store.recordRecent(OpenClawChatViewModel.defaultModelSelectionID)
+            for id in ["one", "two", "three", "four", "five", "six"] {
+                store.recordRecent(id)
+            }
+            #expect(store.recents == ["six", "five", "four", "three", "two"])
+
+            store.recordRecent("four")
+            #expect(store.recents == ["four", "six", "five", "three", "two"])
+        }
+    }
+
+    @Test func `favorites preserve pin order and remove unpinned ids`() throws {
+        try withPickerStore { store, _ in
+            store.toggleFavorite("one")
+            store.toggleFavorite("two")
+            store.toggleFavorite("three")
+            #expect(store.favorites == ["one", "two", "three"])
+
+            store.toggleFavorite("two")
+            #expect(store.favorites == ["one", "three"])
+
+            store.toggleFavorite("two")
+            #expect(store.favorites == ["one", "three", "two"])
+        }
+    }
+
+    @Test func `separate stores preserve each others updates`() throws {
+        try withPickerStore { first, defaults in
+            let second = ChatModelPickerStore(defaults: defaults)
+
+            first.toggleFavorite("one")
+            second.toggleFavorite("two")
+            #expect(second.favorites == ["one", "two"])
+
+            first.recordRecent("one")
+            second.recordRecent("two")
+            #expect(second.recents == ["two", "one"])
+        }
+    }
+
+    @Test func `ordering preserves sections and skips missing models`() {
+        let choices = [pickerModel("a/one"), pickerModel("b/two"), pickerModel("c/three"), pickerModel("d/four")]
+        let sections = ChatModelPickerStore.sections(
+            choices: choices,
+            favorites: ["c/three", "missing/model", "a/one"],
+            recents: ["a/one", "d/four", "missing/recent"])
+
+        #expect(sections.pinned.map(\.selectionID) == ["c/three", "a/one"])
+        #expect(sections.recent.map(\.selectionID) == ["d/four"])
+        #expect(sections.remaining.map(\.selectionID) == ["b/two"])
+    }
+
+    @Test func `ordering handles empty inputs`() {
+        let sections = ChatModelPickerStore.sections(choices: [], favorites: [], recents: [])
+        #expect(sections.pinned.isEmpty)
+        #expect(sections.recent.isEmpty)
+        #expect(sections.remaining.isEmpty)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -158,6 +158,7 @@ private func commandChoice(
         acceptsArgs: acceptsArgs)
 }
 
+@MainActor
 private func makeViewModel(
     sessionKey: String = "main",
     activeAgentId: String? = nil,
@@ -178,10 +179,15 @@ private func makeViewModel(
     waitForRunCompletionHook: (@Sendable (String, Int) async -> Bool)? = nil,
     healthResponses: [Bool] = [true],
     initialThinkingLevel: String? = nil,
+    modelPickerStore: ChatModelPickerStore? = nil,
     onSessionChanged: (@MainActor (String) -> Void)? = nil,
     onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)? = nil) async
     -> (TestChatTransport, OpenClawChatViewModel)
 {
+    // Default to a throwaway suite so model selections in unrelated tests never
+    // write favorites/recents into the test host's standard UserDefaults.
+    let pickerStore = modelPickerStore
+        ?? ChatModelPickerStore(defaults: UserDefaults(suiteName: "ChatViewModelTests.\(UUID().uuidString)") ?? .standard)
     let transport = TestChatTransport(
         historyResponses: historyResponses,
         sessionsResponses: sessionsResponses,
@@ -199,15 +205,14 @@ private func makeViewModel(
         sendMessageStatus: sendMessageStatus,
         waitForRunCompletionHook: waitForRunCompletionHook,
         healthResponses: healthResponses)
-    let vm = await MainActor.run {
-        OpenClawChatViewModel(
-            sessionKey: sessionKey,
-            transport: transport,
-            activeAgentId: activeAgentId,
-            initialThinkingLevel: initialThinkingLevel,
-            onSessionChanged: onSessionChanged,
-            onThinkingLevelChanged: onThinkingLevelChanged)
-    }
+    let vm = OpenClawChatViewModel(
+        sessionKey: sessionKey,
+        transport: transport,
+        activeAgentId: activeAgentId,
+        modelPickerStore: pickerStore,
+        initialThinkingLevel: initialThinkingLevel,
+        onSessionChanged: onSessionChanged,
+        onThinkingLevelChanged: onThinkingLevelChanged)
     return (transport, vm)
 }
 
@@ -4697,6 +4702,43 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.modelSelectionID } == OpenClawChatViewModel.defaultModelSelectionID)
     }
 
+    @Test @MainActor func `successful model selection records recent and selected pin updates sections`() async throws {
+        let suiteName = "ChatViewModelTests.modelPicker.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let modelPickerStore = ChatModelPickerStore(defaults: defaults)
+        let now = Date().timeIntervalSince1970 * 1000
+        let selectedID = "openai/gpt-5.4"
+        let models = [
+            modelChoice(id: "gpt-5.4", name: "GPT-5.4", provider: "openai"),
+            modelChoice(id: "claude-opus-4-6", name: "Claude Opus 4.6"),
+        ]
+        let sessions = OpenClawChatSessionsListResponse(
+            ts: now,
+            path: nil,
+            count: 1,
+            defaults: nil,
+            sessions: [sessionEntry(key: "main", updatedAt: now, model: nil)])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            modelPickerStore: modelPickerStore)
+
+        try await loadAndWaitBootstrap(vm: vm)
+        await MainActor.run { vm.selectModel(selectedID) }
+        try await waitUntil("successful model selection recorded as recent") {
+            await MainActor.run { vm.modelPickerSections.recent.map(\.selectionID) == [selectedID] }
+        }
+        #expect(await transport.patchedModels() == [selectedID])
+        #expect(modelPickerStore.recents == [selectedID])
+
+        await MainActor.run { vm.toggleSelectedModelPinned() }
+        #expect(await MainActor.run { vm.isSelectedModelPinned })
+        #expect(await MainActor.run { vm.modelPickerSections.pinned.map(\.selectionID) } == [selectedID])
+        #expect(await MainActor.run { vm.modelPickerSections.recent.isEmpty })
+    }
+
     @Test func `selecting provider qualified model disambiguates duplicate model I ds`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let history = historyPayload()
@@ -4763,7 +4805,11 @@ struct ChatViewModelTests {
         }
     }
 
-    @Test func `stale model patch completions do not overwrite newer selection`() async throws {
+    @Test @MainActor func `stale model patch completions do not overwrite newer selection`() async throws {
+        let suiteName = "ChatViewModelTests.staleModelPicker.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let modelPickerStore = ChatModelPickerStore(defaults: defaults)
         let now = Date().timeIntervalSince1970 * 1000
         let history = historyPayload()
         let sessions = OpenClawChatSessionsListResponse(
@@ -4787,7 +4833,8 @@ struct ChatViewModelTests {
                 if model == "openai/gpt-5.4" {
                     try await Task.sleep(for: .milliseconds(200))
                 }
-            })
+            },
+            modelPickerStore: modelPickerStore)
 
         try await loadAndWaitBootstrap(vm: vm)
 
@@ -4806,6 +4853,7 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.modelSelectionID } == "openai/gpt-5.4-pro")
         #expect(await MainActor.run { vm.sessions.first(where: { $0.key == "main" })?.model } == "gpt-5.4-pro")
         #expect(await MainActor.run { vm.sessions.first(where: { $0.key == "main" })?.modelProvider } == "openai")
+        #expect(modelPickerStore.recents == ["openai/gpt-5.4-pro"])
     }
 
     @Test func `send waits for in flight model patch to finish`() async throws {

--- a/scripts/ios-write-swift-filelist.mjs
+++ b/scripts/ios-write-swift-filelist.mjs
@@ -21,6 +21,7 @@ const sharedSwiftFiles = [
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownPreprocessor.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift",
+  "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatModelPickerStore.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatPayloadDecoding.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift",


### PR DESCRIPTION
Related: #100699

## What Problem This Solves

Fixes an issue where iOS users could not see or switch models in chat at all: the iOS gateway transport never implemented `models.list`/`sessions.patch(model)`, so the shared composer's model picker stayed hidden on iOS (it only worked in the macOS webchat). On top of that, the picker treated all models equally — frequently used models required scanning the full flat catalog list on every switch.

## Why This Change Was Made

Implements the missing `listModels`/`setSessionModel` overrides on the iOS gateway transport (same `sessions.patch` wire format the macOS transport uses), and adds favorites + recents to the shared model picker: pin/unpin the selected model from the composer, with the picker ordered Pinned → Recent → Models. Pins and recents persist per device in `UserDefaults` via a small injectable store; recents (capped at 5) are recorded only when a selection round-trips successfully, so failed or stale patches never pollute the list. Fresh installs with no pins/recents keep today's flat list with no section chrome.

## User Impact

iOS users can now switch models from the chat composer, pin the models they use most, and reach recently used models first instead of scrolling the full catalog. macOS webchat gets the same pinning/recents behavior.

## Evidence

- `swift test --package-path apps/shared/OpenClawKit` — full shared-kit suite green (431 Swift Testing tests / 39 suites, 21 XCTest).
- New coverage: `ChatModelPickerStoreTests` (persistence round-trip, recents dedupe/cap/sentinel-skip, pin-order sectioning) and `ChatViewModelTests` additions (recents recorded only on confirmed selection success, stale-completion protection, pin toggling), plus iOS transport params/decoding tests.
- `swiftformat --lint` via the iOS filelist — clean; `node scripts/ios-write-swift-filelist.mjs` regenerated with the new shared source registered.
- `corepack pnpm native:i18n:sync` run for the new picker strings.
