### PR TITLE
fix(auth-profiles): do not cooldown on no_error_details Azure Foundry failures (#100600)

### DIFF
--- a/src/agents/auth-profiles/failure-copy.test.ts
+++ b/src/agents/auth-profiles/failure-copy.test.ts
@@ -30,6 +30,7 @@ const REASONS_WITHOUT_RECOVERY: readonly FailoverReason[] = [
   "server_error",
   "model_not_found",
   "format",
+  "no_error_details",
 ];
 
 describe("formatAuthProfileFailureMessage", () => {
@@ -78,6 +79,16 @@ describe("formatAuthProfileFailureMessage", () => {
         });
         expect(message, `reason=${reason}`).toContain(PROVIDER);
       }
+    });
+
+    it("describes no_error_details as a transient upstream response, not a login failure", () => {
+      const message = formatAuthProfileFailureMessage({
+        reason: "no_error_details",
+        provider: PROVIDER,
+        allInCooldown: true,
+      });
+      expect(message).toContain("incomplete error response");
+      expect(message).not.toContain("saved logins");
     });
   });
 

--- a/src/agents/auth-profiles/failure-copy.ts
+++ b/src/agents/auth-profiles/failure-copy.ts
@@ -50,6 +50,8 @@ function describeReason(
         return `${provider} is overloaded right now. Please wait a moment before trying again.`;
       case "timeout":
         return `${provider} hasn't been responding. Please wait a moment before trying again.`;
+      case "no_error_details":
+        return `${provider} returned an incomplete error response. Please wait a moment before trying again.`;
       case "model_not_found":
         return `${provider} can't find the model you're using right now.`;
       case "server_error":
@@ -84,6 +86,7 @@ function shouldIncludeRecoveryHint(reason: FailoverReason): boolean {
     case "server_error":
     case "model_not_found":
     case "format":
+    case "no_error_details":
       return false;
     default:
       return true;

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.test.ts
@@ -126,4 +126,20 @@ describe("resolveAuthProfileFailureReason", () => {
       }),
     ).toBeNull();
   });
+
+  it("does not persist empty-detail response.failed as auth-profile health (#100600)", () => {
+    // Azure Foundry can return response.failed with no error object. Without
+    // affirmative auth evidence, do not cooldown the profile.
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "no_error_details",
+      }),
+    ).toBeNull();
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "no_error_details",
+        policy: "shared",
+      }),
+    ).toBeNull();
+  });
 });

--- a/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/embedded-agent-runner/run/auth-profile-failure-policy.ts
@@ -35,7 +35,8 @@ export function resolveAuthProfileFailureReason(params: {
     params.failoverReason === "server_error" ||
     params.failoverReason === "empty_response" ||
     params.failoverReason === "context_overflow" ||
-    params.failoverReason === "format"
+    params.failoverReason === "format" ||
+    params.failoverReason === "no_error_details"
   ) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves
Fixes #100600. When Azure AI Foundry returns `response.failed` with an empty `error` object, OpenClaw currently buckets the failure as `no_error_details`, puts the auth profile into cooldown, and falls back to secondary providers — even though the credential is valid and the endpoint is healthy.

## Why This Change Was Made
`no_error_details` means there is no affirmative evidence of an authentication problem. Treating it like an auth failure causes unnecessary cooldown of valid credentials, misleading "saved logins" copy, and cost-increasing failover cascades.

The fix treats `no_error_details` as a transient upstream outcome, similar to `server_error`, `empty_response`, and `format`.

## User Impact
Azure Foundry users will no longer have their auth profile cooled down for non-auth `response.failed` gaps, and will see transient/upstream copy instead of a login prompt.

## Evidence
- Added unit tests in `auth-profile-failure-policy.test.ts` verifying `no_error_details` is not persisted as shared auth-profile health.
- Added unit tests in `failure-copy.test.ts` verifying `no_error_details` renders transient copy without login recovery hints.
- Ran focused suites: `auth-profile-failure-policy.test.ts` (8 passed), `failure-copy.test.ts` (9 passed), `usage.test.ts` (74 passed).
- `oxlint` and `oxfmt` pass on changed files.