### PR TITLE
feat(android): read-only workspace Files browser with preview and share

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -4611,7 +4611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 455,
+      "line": 462,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start a chat and your active OpenClaw conversations will appear here.",
       "surface": "android",
@@ -5603,7 +5603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 170,
+      "line": 176,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Files unavailable",
       "surface": "android",
@@ -5611,7 +5611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 176,
+      "line": 182,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Empty folder",
       "surface": "android",
@@ -5619,7 +5619,23 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 215,
+      "line": 182,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
+      "source": "This folder has no files yet.",
+      "surface": "android",
+      "id": "native.android.b74f90dc5f65b1da"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 212,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
+      "source": "Could not load this folder.",
+      "surface": "android",
+      "id": "native.android.8f0b5317c75e334d"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Load more",
       "surface": "android",
@@ -5627,7 +5643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 217,
+      "line": 223,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "${entries.size} of $totalEntries",
       "surface": "android",
@@ -5635,7 +5651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 310,
+      "line": 316,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Back",
       "surface": "android",
@@ -5643,7 +5659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 321,
+      "line": 327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "Share file",
       "surface": "android",
@@ -5651,11 +5667,19 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 352,
+      "line": 358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
       "source": "No preview",
       "surface": "android",
       "id": "native.android.095574301bf487a1"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 358,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
+      "source": "This image could not be decoded.",
+      "surface": "android",
+      "id": "native.android.f57b231996a10d14"
     },
     {
       "kind": "ui-call",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -4595,7 +4595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 409,
+      "line": 416,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
@@ -4603,7 +4603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 454,
+      "line": 461,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent sessions",
       "surface": "android",
@@ -4619,7 +4619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 456,
+      "line": 463,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -4627,7 +4627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 511,
+      "line": 518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -4635,7 +4635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 519,
+      "line": 526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -4643,7 +4643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 571,
+      "line": 578,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
@@ -4651,7 +4651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 580,
+      "line": 587,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
@@ -4659,7 +4659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 583,
+      "line": 590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
@@ -4667,7 +4667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 583,
+      "line": 590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
@@ -4675,7 +4675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 583,
+      "line": 590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
@@ -4683,7 +4683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 584,
+      "line": 591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
@@ -4691,7 +4691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 584,
+      "line": 591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sessions",
       "surface": "android",
@@ -4699,7 +4699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 585,
+      "line": 592,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
@@ -4707,7 +4707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 588,
+      "line": 595,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -4715,7 +4715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 592,
+      "line": 599,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
@@ -4723,7 +4723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 740,
+      "line": 747,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
@@ -4731,7 +4731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 808,
+      "line": 815,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -4739,7 +4739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 809,
+      "line": 816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
@@ -4747,7 +4747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 811,
+      "line": 818,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -4755,7 +4755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 819,
+      "line": 826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent Sessions",
       "surface": "android",
@@ -4763,7 +4763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 829,
+      "line": 836,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -4771,7 +4771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 947,
+      "line": 954,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
@@ -4779,7 +4779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 947,
+      "line": 954,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
@@ -4787,7 +4787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 979,
+      "line": 986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
@@ -4795,7 +4795,23 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1030,
+      "line": 993,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "Browse",
+      "surface": "android",
+      "id": "native.android.cbdaff5e476b7dad"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 993,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "Offline",
+      "surface": "android",
+      "id": "native.android.c093a2297a02405a"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1045,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active ${pluralize(\"run\", pendingRunCount)}",
       "surface": "android",
@@ -4803,7 +4819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1151,
+      "line": 1166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -4811,7 +4827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1216,
+      "line": 1231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -4819,7 +4835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1290,
+      "line": 1305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open session",
       "surface": "android",
@@ -4827,7 +4843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1402,
+      "line": 1417,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back",
       "surface": "android",
@@ -4835,7 +4851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1405,
+      "line": 1420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
@@ -4843,7 +4859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1408,
+      "line": 1423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
@@ -4851,7 +4867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1432,
+      "line": 1447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$readyProviderCount ready",
       "surface": "android",
@@ -4859,7 +4875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1432,
+      "line": 1447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review readiness",
       "surface": "android",
@@ -4867,7 +4883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1443,
+      "line": 1458,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
@@ -4875,7 +4891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1443,
+      "line": 1458,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
@@ -4883,7 +4899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1445,
+      "line": 1460,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -4891,7 +4907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1445,
+      "line": 1460,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
@@ -4899,7 +4915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1446,
+      "line": 1461,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
@@ -4907,7 +4923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1446,
+      "line": 1461,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
@@ -4915,7 +4931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1488,
+      "line": 1503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
@@ -4923,7 +4939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1491,
+      "line": 1506,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
@@ -4931,7 +4947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1491,
+      "line": 1506,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -4939,7 +4955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1523,
+      "line": 1538,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
@@ -4947,7 +4963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1524,
+      "line": 1539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
@@ -4955,7 +4971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1525,
+      "line": 1540,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
@@ -4963,7 +4979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1531,
+      "line": 1546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$ready/${skills.size} ready",
       "surface": "android",
@@ -4971,7 +4987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1531,
+      "line": 1546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No skills",
       "surface": "android",
@@ -4979,7 +4995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1709,
+      "line": 1724,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
@@ -4987,7 +5003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1713,
+      "line": 1728,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
@@ -4995,7 +5011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1798,
+      "line": 1813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main session",
       "surface": "android",
@@ -5584,6 +5600,62 @@
       "source": "OpenClaw is thinking…",
       "surface": "android",
       "id": "native.android.09137c880dd8890e"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 170,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
+      "source": "Files unavailable",
+      "surface": "android",
+      "id": "native.android.eb6ff96aba8f67b4"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 176,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
+      "source": "Empty folder",
+      "surface": "android",
+      "id": "native.android.fefb4a6c1717210d"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 215,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
+      "source": "Load more",
+      "surface": "android",
+      "id": "native.android.4e48916e1b0f86ab"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 217,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
+      "source": "${entries.size} of $totalEntries",
+      "surface": "android",
+      "id": "native.android.f26b7b179d4765b0"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 310,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
+      "source": "Back",
+      "surface": "android",
+      "id": "native.android.b2a525ca00a799df"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 321,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
+      "source": "Share file",
+      "surface": "android",
+      "id": "native.android.737edf881bc586d5"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 352,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt",
+      "source": "No preview",
+      "surface": "android",
+      "id": "native.android.095574301bf487a1"
     },
     {
       "kind": "ui-call",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Adds a read-only Files browser for agent workspaces with directory navigation, text and image previews, and system share export.
+
 Android onboarding now completes after permission-triggered node approval and keeps Back navigation from cycling between permissions and approval.
 
 Third-party Android builds can now opt into Always location through Android settings, with requested background checks disclosed in the persistent node notification while Play builds remain foreground-only. (#68581) Thanks @ioridev.

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -665,6 +665,13 @@ class MainViewModel(
 
   suspend fun forkChatSession(parentKey: String): String? = ensureRuntime().forkChatSession(parentKey)
 
+  suspend fun listWorkspaceFiles(
+    path: String?,
+    offset: Int? = null,
+  ): GatewayWorkspaceListing = ensureRuntime().listWorkspaceFiles(path = path, offset = offset)
+
+  suspend fun fetchWorkspaceFile(path: String): GatewayWorkspaceFile = ensureRuntime().fetchWorkspaceFile(path)
+
   fun setChatThinkingLevel(level: String) {
     ensureRuntime().setChatThinkingLevel(level)
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2822,6 +2822,36 @@ class NodeRuntime private constructor(
     }
   }
 
+  /** Lists one directory of the active agent's workspace (read-only RPC). */
+  suspend fun listWorkspaceFiles(
+    path: String?,
+    offset: Int? = null,
+  ): GatewayWorkspaceListing {
+    val params =
+      buildJsonObject {
+        put("agentId", JsonPrimitive(workspaceAgentId()))
+        if (!path.isNullOrEmpty()) put("path", JsonPrimitive(path))
+        if (offset != null && offset > 0) put("offset", JsonPrimitive(offset))
+      }
+    val res = operatorSession.request("agents.workspace.list", params.toString())
+    return parseWorkspaceListing(json.parseToJsonElement(res))
+      ?: throw IllegalStateException("agents.workspace.list returned no listing")
+  }
+
+  /** Fetches one workspace file preview (UTF-8 text or base64 image). */
+  suspend fun fetchWorkspaceFile(path: String): GatewayWorkspaceFile {
+    val params =
+      buildJsonObject {
+        put("agentId", JsonPrimitive(workspaceAgentId()))
+        put("path", JsonPrimitive(path))
+      }
+    val res = operatorSession.request("agents.workspace.get", params.toString(), timeoutMs = 30_000)
+    return parseWorkspaceFile(json.parseToJsonElement(res))
+      ?: throw IllegalStateException("agents.workspace.get returned no file")
+  }
+
+  private fun workspaceAgentId(): String = resolveActiveAgentId().ifEmpty { "main" }
+
   private suspend fun refreshAgentsFromGateway() {
     if (!operatorConnected) return
     try {

--- a/apps/android/app/src/main/java/ai/openclaw/app/WorkspaceFiles.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/WorkspaceFiles.kt
@@ -41,8 +41,10 @@ internal fun parseWorkspaceListing(root: JsonElement): GatewayWorkspaceListing? 
   val entries =
     (obj["entries"] as? JsonArray)?.mapNotNull { item ->
       val entry = item.asObjectOrNull() ?: return@mapNotNull null
-      val path = entry["path"].asStringOrNull()?.trim().orEmpty()
-      val name = entry["name"].asStringOrNull()?.trim().orEmpty()
+      // Paths/names are opaque workspace identifiers echoed back to the
+      // gateway; never trim them or entries with edge whitespace break.
+      val path = entry["path"].asStringOrNull().orEmpty()
+      val name = entry["name"].asStringOrNull().orEmpty()
       if (path.isEmpty() || name.isEmpty()) return@mapNotNull null
       GatewayWorkspaceEntry(
         path = path,
@@ -62,14 +64,13 @@ internal fun parseWorkspaceListing(root: JsonElement): GatewayWorkspaceListing? 
 
 internal fun parseWorkspaceFile(root: JsonElement): GatewayWorkspaceFile? {
   val file = root.asObjectOrNull()?.get("file").asObjectOrNull() ?: return null
-  val path = file["path"].asStringOrNull()?.trim().orEmpty()
+  val path = file["path"].asStringOrNull().orEmpty()
   if (path.isEmpty()) return null
   return GatewayWorkspaceFile(
     path = path,
     name =
       file["name"]
         .asStringOrNull()
-        ?.trim()
         .orEmpty()
         .ifEmpty { path.substringAfterLast('/') },
     size = file["size"].asLongOrNull() ?: 0L,

--- a/apps/android/app/src/main/java/ai/openclaw/app/WorkspaceFiles.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/WorkspaceFiles.kt
@@ -1,0 +1,80 @@
+package ai.openclaw.app
+
+import ai.openclaw.app.node.asObjectOrNull
+import ai.openclaw.app.node.asStringOrNull
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.longOrNull
+
+/** One entry from the read-only `agents.workspace.list` gateway RPC. */
+data class GatewayWorkspaceEntry(
+  val path: String,
+  val name: String,
+  val isDirectory: Boolean,
+  val size: Long?,
+  val updatedAtMs: Long?,
+)
+
+/** One directory page of an agent workspace listing. */
+data class GatewayWorkspaceListing(
+  val path: String,
+  val entries: List<GatewayWorkspaceEntry>,
+  val totalEntries: Int,
+  val offset: Int,
+)
+
+/** One previewable workspace file from `agents.workspace.get`. */
+data class GatewayWorkspaceFile(
+  val path: String,
+  val name: String,
+  val size: Long,
+  val mimeType: String,
+  val isBase64: Boolean,
+  val content: String,
+)
+
+private fun JsonElement?.asLongOrNull(): Long? = (this as? JsonPrimitive)?.longOrNull
+
+internal fun parseWorkspaceListing(root: JsonElement): GatewayWorkspaceListing? {
+  val obj = root.asObjectOrNull() ?: return null
+  val entries =
+    (obj["entries"] as? JsonArray)?.mapNotNull { item ->
+      val entry = item.asObjectOrNull() ?: return@mapNotNull null
+      val path = entry["path"].asStringOrNull()?.trim().orEmpty()
+      val name = entry["name"].asStringOrNull()?.trim().orEmpty()
+      if (path.isEmpty() || name.isEmpty()) return@mapNotNull null
+      GatewayWorkspaceEntry(
+        path = path,
+        name = name,
+        isDirectory = entry["kind"].asStringOrNull() == "directory",
+        size = entry["size"].asLongOrNull(),
+        updatedAtMs = entry["updatedAtMs"].asLongOrNull(),
+      )
+    } ?: emptyList()
+  return GatewayWorkspaceListing(
+    path = obj["path"].asStringOrNull().orEmpty(),
+    entries = entries,
+    totalEntries = obj["totalEntries"].asLongOrNull()?.toInt() ?: entries.size,
+    offset = obj["offset"].asLongOrNull()?.toInt() ?: 0,
+  )
+}
+
+internal fun parseWorkspaceFile(root: JsonElement): GatewayWorkspaceFile? {
+  val file = root.asObjectOrNull()?.get("file").asObjectOrNull() ?: return null
+  val path = file["path"].asStringOrNull()?.trim().orEmpty()
+  if (path.isEmpty()) return null
+  return GatewayWorkspaceFile(
+    path = path,
+    name =
+      file["name"]
+        .asStringOrNull()
+        ?.trim()
+        .orEmpty()
+        .ifEmpty { path.substringAfterLast('/') },
+    size = file["size"].asLongOrNull() ?: 0L,
+    mimeType = file["mimeType"].asStringOrNull().orEmpty().ifEmpty { "text/plain" },
+    isBase64 = file["encoding"].asStringOrNull() == "base64",
+    content = file["content"].asStringOrNull().orEmpty(),
+  )
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -75,6 +75,7 @@ import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.outlined.AccessTime
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
+import androidx.compose.material.icons.outlined.Folder
 import androidx.compose.material.icons.outlined.Inventory2
 import androidx.compose.material.icons.outlined.MicNone
 import androidx.compose.material.icons.outlined.Settings
@@ -116,6 +117,7 @@ internal enum class Tab(
   Sessions(key = "sessions", label = "Sessions", icon = Icons.Outlined.AccessTime),
   Settings(key = "settings", label = "Settings", icon = Icons.Outlined.Settings),
   ProvidersModels(key = "providers-models", label = "Providers", icon = Icons.Outlined.Inventory2),
+  Files(key = "files", label = "Files", icon = Icons.Outlined.Folder),
 }
 
 private val shellNavTabs = listOf(Tab.Overview, Tab.Chat, Tab.Voice, Tab.Settings)
@@ -234,6 +236,11 @@ fun ShellScreen(
               viewModel = viewModel,
               onOpenCommand = { commandOpen = true },
               onOpenChat = { nav.selectTab(Tab.Chat) },
+            )
+          Tab.Files ->
+            WorkspaceFilesScreen(
+              viewModel = viewModel,
+              onBack = nav::back,
             )
           Tab.Settings ->
             SettingsShellScreen(
@@ -980,6 +987,14 @@ internal fun overviewMetricCardSpecs(
       icon = Icons.Default.Groups,
       status = if (sessionCount > 0) ClawStatus.Success else ClawStatus.Neutral,
       tab = Tab.Sessions,
+    ),
+    OverviewMetricCardSpec(
+      title = "Files",
+      value = if (isConnected) "Browse" else "Offline",
+      subtitle = "Agent workspace files",
+      icon = Icons.Outlined.Folder,
+      status = if (isConnected) ClawStatus.Success else ClawStatus.Neutral,
+      tab = Tab.Files,
     ),
   )
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
@@ -1,0 +1,398 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.GatewayWorkspaceEntry
+import ai.openclaw.app.GatewayWorkspaceFile
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.ui.chat.ChatCodeBlock
+import ai.openclaw.app.ui.chat.decodeBase64Bitmap
+import ai.openclaw.app.ui.design.ClawEmptyState
+import ai.openclaw.app.ui.design.ClawPlainIconButton
+import ai.openclaw.app.ui.design.ClawScaffold
+import ai.openclaw.app.ui.design.ClawTheme
+import android.content.Context
+import android.content.Intent
+import android.text.format.Formatter
+import android.util.Base64
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Folder
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.launch
+import java.io.File
+import java.text.DateFormat
+import java.util.Date
+
+/**
+ * Read-only workspace browser for the active agent, backed by the
+ * `agents.workspace.list` / `agents.workspace.get` gateway RPCs.
+ */
+@Composable
+internal fun WorkspaceFilesScreen(
+  viewModel: MainViewModel,
+  onBack: () -> Unit,
+) {
+  // Directory drill-down and preview are screen-local: the shell keeps a
+  // single-slot Back origin, so deeper levels unwind here first.
+  var pathStack by rememberSaveable { mutableStateOf(listOf("")) }
+  var previewPath by rememberSaveable { mutableStateOf<String?>(null) }
+
+  BackHandler(enabled = previewPath != null || pathStack.size > 1) {
+    if (previewPath != null) {
+      previewPath = null
+    } else {
+      pathStack = pathStack.dropLast(1)
+    }
+  }
+
+  val openPreview = previewPath
+  if (openPreview != null) {
+    WorkspaceFilePreview(
+      viewModel = viewModel,
+      path = openPreview,
+      onBack = { previewPath = null },
+    )
+  } else {
+    WorkspaceDirectoryScreen(
+      viewModel = viewModel,
+      path = pathStack.last(),
+      onBack = {
+        if (pathStack.size > 1) pathStack = pathStack.dropLast(1) else onBack()
+      },
+      onOpenDirectory = { path -> pathStack = pathStack + path },
+      onOpenFile = { path -> previewPath = path },
+    )
+  }
+}
+
+@Composable
+private fun WorkspaceDirectoryScreen(
+  viewModel: MainViewModel,
+  path: String,
+  onBack: () -> Unit,
+  onOpenDirectory: (String) -> Unit,
+  onOpenFile: (String) -> Unit,
+) {
+  val isConnected by viewModel.isConnected.collectAsState()
+  val scope = rememberCoroutineScope()
+  var entries by remember(path) { mutableStateOf<List<GatewayWorkspaceEntry>>(emptyList()) }
+  var totalEntries by remember(path) { mutableIntStateOf(0) }
+  var loading by remember(path) { mutableStateOf(false) }
+  var loadingMore by remember(path) { mutableStateOf(false) }
+  var errorText by remember(path) { mutableStateOf<String?>(null) }
+
+  LaunchedEffect(path, isConnected) {
+    if (!isConnected) {
+      errorText = "Connect the gateway to browse workspace files."
+      return@LaunchedEffect
+    }
+    loading = true
+    errorText = null
+    try {
+      val listing = viewModel.listWorkspaceFiles(path = path.ifEmpty { null })
+      entries = listing.entries
+      totalEntries = listing.totalEntries
+    } catch (_: Throwable) {
+      errorText = "Could not load this folder."
+    } finally {
+      loading = false
+    }
+  }
+
+  ClawScaffold(
+    contentPadding = PaddingValues(start = 16.dp, top = 10.dp, end = 16.dp, bottom = 4.dp),
+    contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+  ) {
+    LazyColumn(
+      modifier = Modifier.fillMaxSize(),
+      verticalArrangement = Arrangement.spacedBy(6.dp),
+      contentPadding = PaddingValues(bottom = 8.dp),
+    ) {
+      item {
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          verticalAlignment = Alignment.CenterVertically,
+          horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          ClawPlainIconButton(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", onClick = onBack)
+          Text(
+            text = if (path.isEmpty()) "Files" else path.substringAfterLast('/'),
+            style = ClawTheme.type.display.copy(fontSize = 24.sp, lineHeight = 28.sp),
+            color = ClawTheme.colors.text,
+            modifier = Modifier.weight(1f),
+          )
+        }
+      }
+
+      errorText?.let { message ->
+        item {
+          ClawEmptyState(title = "Files unavailable", body = message)
+        }
+      }
+
+      if (errorText == null && !loading && entries.isEmpty()) {
+        item {
+          ClawEmptyState(title = "Empty folder", body = "This folder has no files yet.")
+        }
+      }
+
+      items(entries.size, key = { index -> entries[index].path }) { index ->
+        val entry = entries[index]
+        WorkspaceEntryRow(
+          entry = entry,
+          onClick = {
+            if (entry.isDirectory) onOpenDirectory(entry.path) else onOpenFile(entry.path)
+          },
+        )
+      }
+
+      if (entries.size < totalEntries) {
+        item {
+          Row(
+            modifier =
+              Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(ClawTheme.radii.row))
+                .clickable(enabled = !loadingMore) {
+                  loadingMore = true
+                  scope.launch {
+                    try {
+                      val listing = viewModel.listWorkspaceFiles(path = path.ifEmpty { null }, offset = entries.size)
+                      val known = entries.map { it.path }.toSet()
+                      entries = entries + listing.entries.filter { it.path !in known }
+                      totalEntries = listing.totalEntries
+                    } catch (_: Throwable) {
+                      errorText = "Could not load this folder."
+                    } finally {
+                      loadingMore = false
+                    }
+                  }
+                }.padding(horizontal = 10.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+          ) {
+            Text(text = "Load more", style = ClawTheme.type.body, color = ClawTheme.colors.text)
+            Text(
+              text = "${entries.size} of $totalEntries",
+              style = ClawTheme.type.caption,
+              color = ClawTheme.colors.textMuted,
+            )
+          }
+        }
+      }
+
+      if (loading && entries.isEmpty() && errorText == null) {
+        item {
+          Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+            CircularProgressIndicator(modifier = Modifier.size(22.dp))
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun WorkspaceEntryRow(
+  entry: GatewayWorkspaceEntry,
+  onClick: () -> Unit,
+) {
+  val context = LocalContext.current
+  Row(
+    modifier =
+      Modifier
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(ClawTheme.radii.row))
+        .clickable(onClick = onClick)
+        .padding(horizontal = 10.dp, vertical = 10.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(10.dp),
+  ) {
+    Icon(
+      imageVector = if (entry.isDirectory) Icons.Outlined.Folder else Icons.Outlined.Description,
+      contentDescription = null,
+      tint = if (entry.isDirectory) ClawTheme.colors.primary else ClawTheme.colors.textMuted,
+      modifier = Modifier.size(20.dp),
+    )
+    Column(modifier = Modifier.weight(1f)) {
+      Text(text = entry.name, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1)
+      workspaceEntryDetail(context, entry)?.let { detail ->
+        Text(text = detail, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1)
+      }
+    }
+  }
+}
+
+private fun workspaceEntryDetail(
+  context: Context,
+  entry: GatewayWorkspaceEntry,
+): String? {
+  val parts = mutableListOf<String>()
+  entry.size?.let { parts.add(Formatter.formatShortFileSize(context, it)) }
+  entry.updatedAtMs?.let { parts.add(DateFormat.getDateInstance(DateFormat.SHORT).format(Date(it))) }
+  return parts.takeIf { it.isNotEmpty() }?.joinToString(" • ")
+}
+
+@Composable
+private fun WorkspaceFilePreview(
+  viewModel: MainViewModel,
+  path: String,
+  onBack: () -> Unit,
+) {
+  val context = LocalContext.current
+  var file by remember(path) { mutableStateOf<GatewayWorkspaceFile?>(null) }
+  var loading by remember(path) { mutableStateOf(false) }
+  var errorText by remember(path) { mutableStateOf<String?>(null) }
+
+  LaunchedEffect(path) {
+    loading = true
+    errorText = null
+    try {
+      file = viewModel.fetchWorkspaceFile(path)
+    } catch (_: Throwable) {
+      errorText = "This file cannot be previewed. It may be binary or too large."
+    } finally {
+      loading = false
+    }
+  }
+
+  ClawScaffold(
+    contentPadding = PaddingValues(start = 16.dp, top = 10.dp, end = 16.dp, bottom = 4.dp),
+    contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
+  ) {
+    Column(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+      ) {
+        ClawPlainIconButton(icon = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", onClick = onBack)
+        Text(
+          text = path.substringAfterLast('/'),
+          style = ClawTheme.type.display.copy(fontSize = 20.sp, lineHeight = 24.sp),
+          color = ClawTheme.colors.text,
+          maxLines = 1,
+          modifier = Modifier.weight(1f),
+        )
+        file?.let { loaded ->
+          ClawPlainIconButton(
+            icon = Icons.Outlined.Share,
+            contentDescription = "Share file",
+            onClick = { shareWorkspaceFile(context, loaded) },
+          )
+        }
+      }
+
+      when {
+        loading ->
+          Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+            CircularProgressIndicator(modifier = Modifier.size(22.dp))
+          }
+        errorText != null ->
+          ClawEmptyState(title = "No preview", body = errorText.orEmpty())
+        file != null ->
+          WorkspaceFileContent(file = file ?: return@Column)
+      }
+    }
+  }
+}
+
+@Composable
+private fun WorkspaceFileContent(file: GatewayWorkspaceFile) {
+  if (file.isBase64 && file.mimeType.startsWith("image/")) {
+    val bitmap = remember(file.path) { decodeBase64Bitmap(file.content) }
+    if (bitmap != null) {
+      Image(
+        bitmap = bitmap.asImageBitmap(),
+        contentDescription = file.name,
+        modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
+      )
+    } else {
+      ClawEmptyState(title = "No preview", body = "This image could not be decoded.")
+    }
+  } else {
+    // Reuse the chat renderer's code block so previews highlight and cap
+    // exactly like fenced code in the transcript.
+    SelectionContainer {
+      Column(
+        modifier =
+          Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = 12.dp),
+      ) {
+        ChatCodeBlock(code = file.content, language = workspaceLanguageHint(file.name))
+      }
+    }
+  }
+}
+
+/** File extensions double as fence language hints; unknown ones render plain. */
+private fun workspaceLanguageHint(name: String): String? =
+  name.substringAfterLast('.', missingDelimiterValue = "").lowercase().ifEmpty { null }
+
+/** Exports one previewed file through the system share sheet via FileProvider. */
+private fun shareWorkspaceFile(
+  context: Context,
+  file: GatewayWorkspaceFile,
+) {
+  val directory = File(context.cacheDir, "workspace-files").apply { mkdirs() }
+  // Server names are plain basenames; keep the guard so a hostile gateway
+  // cannot steer the temp write outside the export directory.
+  val safeName = file.name.substringAfterLast('/').ifEmpty { "file" }
+  val target = File(directory, safeName)
+  if (file.isBase64) {
+    target.writeBytes(Base64.decode(file.content, Base64.DEFAULT))
+  } else {
+    target.writeText(file.content)
+  }
+  val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", target)
+  val send =
+    Intent(Intent.ACTION_SEND).apply {
+      type = file.mimeType.ifEmpty { "application/octet-stream" }
+      putExtra(Intent.EXTRA_STREAM, uri)
+      addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+  context.startActivity(Intent.createChooser(send, file.name))
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
@@ -341,7 +341,9 @@ private fun WorkspaceFilePreview(
 @Composable
 private fun WorkspaceFileContent(file: GatewayWorkspaceFile) {
   if (file.isBase64 && file.mimeType.startsWith("image/")) {
-    val bitmap = remember(file.path) { decodeBase64Bitmap(file.content) }
+    // Malformed base64 from the gateway boundary must degrade to the
+    // no-preview state, not crash composition (Base64.decode throws).
+    val bitmap = remember(file.path) { runCatching { decodeBase64Bitmap(file.content) }.getOrNull() }
     if (bitmap != null) {
       Image(
         bitmap = bitmap.asImageBitmap(),
@@ -383,7 +385,8 @@ private fun shareWorkspaceFile(
   val safeName = file.name.substringAfterLast('/').ifEmpty { "file" }
   val target = File(directory, safeName)
   if (file.isBase64) {
-    target.writeBytes(Base64.decode(file.content, Base64.DEFAULT))
+    val bytes = runCatching { Base64.decode(file.content, Base64.DEFAULT) }.getOrNull() ?: return
+    target.writeBytes(bytes)
   } else {
     target.writeText(file.content)
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.launch
 import java.io.File
 import java.text.DateFormat
 import java.util.Date
+import java.util.UUID
 
 /**
  * Read-only workspace browser for the active agent, backed by the
@@ -383,7 +384,9 @@ private fun shareWorkspaceFile(
   context: Context,
   file: GatewayWorkspaceFile,
 ) {
-  val directory = File(context.cacheDir, "workspace-files").apply { mkdirs() }
+  // A FileProvider grant can outlive the share sheet. Unique directories keep
+  // a later same-basename export from replacing bytes behind an older grant.
+  val directory = File(context.cacheDir, "workspace-files/${UUID.randomUUID()}").apply { mkdirs() }
   // Server names are plain basenames; keep the guard so a hostile gateway
   // cannot steer the temp write outside the export directory.
   val safeName = file.name.substringAfterLast('/').ifEmpty { "file" }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/WorkspaceFilesScreen.kt
@@ -4,7 +4,7 @@ import ai.openclaw.app.GatewayWorkspaceEntry
 import ai.openclaw.app.GatewayWorkspaceFile
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.ui.chat.ChatCodeBlock
-import ai.openclaw.app.ui.chat.decodeBase64Bitmap
+import ai.openclaw.app.ui.chat.rememberBase64ImageState
 import ai.openclaw.app.ui.design.ClawEmptyState
 import ai.openclaw.app.ui.design.ClawPlainIconButton
 import ai.openclaw.app.ui.design.ClawScaffold
@@ -45,6 +45,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,7 +55,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -73,36 +73,41 @@ internal fun WorkspaceFilesScreen(
   viewModel: MainViewModel,
   onBack: () -> Unit,
 ) {
-  // Directory drill-down and preview are screen-local: the shell keeps a
-  // single-slot Back origin, so deeper levels unwind here first.
-  var pathStack by rememberSaveable { mutableStateOf(listOf("")) }
-  var previewPath by rememberSaveable { mutableStateOf<String?>(null) }
+  val mainSessionKey by viewModel.mainSessionKey.collectAsState()
+  val gatewayDefaultAgentId by viewModel.gatewayDefaultAgentId.collectAsState()
 
-  BackHandler(enabled = previewPath != null || pathStack.size > 1) {
-    if (previewPath != null) {
-      previewPath = null
-    } else {
-      pathStack = pathStack.dropLast(1)
+  // Runtime routing derives the active agent from these two facts. Re-key the
+  // local browser with the same facts so paths from one agent never cross over.
+  key(mainSessionKey, gatewayDefaultAgentId) {
+    var pathStack by rememberSaveable { mutableStateOf(listOf("")) }
+    var previewPath by rememberSaveable { mutableStateOf<String?>(null) }
+
+    BackHandler(enabled = previewPath != null || pathStack.size > 1) {
+      if (previewPath != null) {
+        previewPath = null
+      } else {
+        pathStack = pathStack.dropLast(1)
+      }
     }
-  }
 
-  val openPreview = previewPath
-  if (openPreview != null) {
-    WorkspaceFilePreview(
-      viewModel = viewModel,
-      path = openPreview,
-      onBack = { previewPath = null },
-    )
-  } else {
-    WorkspaceDirectoryScreen(
-      viewModel = viewModel,
-      path = pathStack.last(),
-      onBack = {
-        if (pathStack.size > 1) pathStack = pathStack.dropLast(1) else onBack()
-      },
-      onOpenDirectory = { path -> pathStack = pathStack + path },
-      onOpenFile = { path -> previewPath = path },
-    )
+    val openPreview = previewPath
+    if (openPreview != null) {
+      WorkspaceFilePreview(
+        viewModel = viewModel,
+        path = openPreview,
+        onBack = { previewPath = null },
+      )
+    } else {
+      WorkspaceDirectoryScreen(
+        viewModel = viewModel,
+        path = pathStack.last(),
+        onBack = {
+          if (pathStack.size > 1) pathStack = pathStack.dropLast(1) else onBack()
+        },
+        onOpenDirectory = { path -> pathStack = pathStack + path },
+        onOpenFile = { path -> previewPath = path },
+      )
+    }
   }
 }
 
@@ -341,17 +346,16 @@ private fun WorkspaceFilePreview(
 @Composable
 private fun WorkspaceFileContent(file: GatewayWorkspaceFile) {
   if (file.isBase64 && file.mimeType.startsWith("image/")) {
-    // Malformed base64 from the gateway boundary must degrade to the
-    // no-preview state, not crash composition (Base64.decode throws).
-    val bitmap = remember(file.path) { runCatching { decodeBase64Bitmap(file.content) }.getOrNull() }
-    if (bitmap != null) {
-      Image(
-        bitmap = bitmap.asImageBitmap(),
-        contentDescription = file.name,
-        modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
-      )
-    } else {
-      ClawEmptyState(title = "No preview", body = "This image could not be decoded.")
+    val imageState = rememberBase64ImageState(file.content)
+    when {
+      imageState.image != null ->
+        Image(
+          bitmap = imageState.image,
+          contentDescription = file.name,
+          modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
+        )
+      imageState.failed -> ClawEmptyState(title = "No preview", body = "This image could not be decoded.")
+      else -> CircularProgressIndicator(modifier = Modifier.size(22.dp))
     }
   } else {
     // Reuse the chat renderer's code block so previews highlight and cap

--- a/apps/android/app/src/main/res/xml/file_paths.xml
+++ b/apps/android/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <cache-path name="apk_updates" path="updates/" />
+    <cache-path name="workspace_files" path="workspace-files/" />
 </paths>

--- a/apps/android/app/src/test/java/ai/openclaw/app/WorkspaceFilesTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/WorkspaceFilesTest.kt
@@ -1,0 +1,76 @@
+package ai.openclaw.app
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WorkspaceFilesTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun parsesListingEntriesAndPagination() {
+    val payload =
+      """
+      {
+        "agentId": "main",
+        "workspace": "/tmp/workspace",
+        "path": "src",
+        "parentPath": "",
+        "entries": [
+          {"path": "src/util", "name": "util", "kind": "directory", "updatedAtMs": 1700000000000},
+          {"path": "src/index.ts", "name": "index.ts", "kind": "file", "size": 42, "updatedAtMs": 1700000000123}
+        ],
+        "totalEntries": 12,
+        "offset": 0
+      }
+      """.trimIndent()
+
+    val listing = parseWorkspaceListing(json.parseToJsonElement(payload))
+
+    assertEquals("src", listing?.path)
+    assertEquals(12, listing?.totalEntries)
+    assertEquals(0, listing?.offset)
+    assertEquals(2, listing?.entries?.size)
+    val directory = listing?.entries?.first()
+    assertEquals(true, directory?.isDirectory)
+    assertNull(directory?.size)
+    val file = listing?.entries?.last()
+    assertEquals(false, file?.isDirectory)
+    assertEquals(42L, file?.size)
+    assertEquals(1_700_000_000_123L, file?.updatedAtMs)
+  }
+
+  @Test
+  fun parsesTextAndImageFilePayloads() {
+    val text =
+      parseWorkspaceFile(
+        json.parseToJsonElement(
+          """{"agentId":"main","workspace":"/w","file":{"path":"notes.md","name":"notes.md","size":8,"updatedAtMs":1,"mimeType":"text/plain","encoding":"utf8","content":"# Notes\n"}}""",
+        ),
+      )
+    assertEquals("notes.md", text?.name)
+    assertEquals(false, text?.isBase64)
+    assertEquals("# Notes\n", text?.content)
+
+    val image =
+      parseWorkspaceFile(
+        json.parseToJsonElement(
+          """{"agentId":"main","workspace":"/w","file":{"path":"shot.png","name":"shot.png","size":3,"updatedAtMs":1,"mimeType":"image/png","encoding":"base64","content":"AAECAw=="}}""",
+        ),
+      )
+    assertEquals(true, image?.isBase64)
+    assertTrue(image?.mimeType?.startsWith("image/") == true)
+  }
+
+  @Test
+  fun rejectsPayloadsWithoutFileOrPath() {
+    assertNull(parseWorkspaceFile(Json.parseToJsonElement("""{"agentId":"main"}""")))
+    assertNull(
+      parseWorkspaceFile(
+        Json.parseToJsonElement("""{"file":{"name":"x","size":1,"mimeType":"text/plain","encoding":"utf8","content":""}}"""),
+      ),
+    )
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -306,7 +306,7 @@ class ShellScreenLogicTest {
         sessionCount = 4,
       )
 
-    assertEquals(listOf("Gateway", "Nodes", "Approvals", "Sessions"), cards.map { it.title })
+    assertEquals(listOf("Gateway", "Nodes", "Approvals", "Sessions", "Files"), cards.map { it.title })
     assertEquals("Online", cards.single { it.title == "Gateway" }.value)
     assertEquals("Review highlighted items", cards.single { it.title == "Gateway" }.subtitle)
     assertEquals("1/1", cards.single { it.title == "Nodes" }.value)
@@ -315,6 +315,8 @@ class ShellScreenLogicTest {
     assertEquals(1f, cards.single { it.title == "Nodes" }.progressFraction ?: 0f, 0.001f)
     assertEquals("2", cards.single { it.title == "Approvals" }.value)
     assertEquals("4", cards.single { it.title == "Sessions" }.value)
+    assertEquals("Browse", cards.single { it.title == "Files" }.value)
+    assertEquals(Tab.Files, cards.single { it.title == "Files" }.tab)
   }
 
   @Test

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -4867,6 +4867,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: 7. Canvas + camera
   - H4: Gateway Canvas Host (recommended for web content)
   - H3: 8. Voice + expanded Android command surface
+  - H3: 9. Workspace files (read-only)
   - H2: Assistant entrypoints
   - H2: Notification forwarding
   - H2: Related

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -289,6 +289,10 @@ Camera commands (foreground only; permission-gated): `camera.snap` (jpg), `camer
   - `sms.search`
   - `motion.activity`, `motion.pedometer`
 
+### 9. Workspace files (read-only)
+
+The Home overview includes a **Files** card that browses the active agent's workspace through the read-only `agents.workspace.list` / `agents.workspace.get` gateway RPCs: directory drill-down, text and image previews, and export through the Android share sheet. There are no write operations, and previews are size-capped by the gateway.
+
 ## Assistant entrypoints
 
 Android supports launching OpenClaw from the system assistant trigger (Google Assistant). Holding the home button (or another `ACTION_ASSIST` trigger) opens the app; saying "Hey Google, ask OpenClaw `<prompt>`" matches the app's declared App Actions query pattern and hands the prompt into the chat composer without auto-sending it.


### PR DESCRIPTION
Related: #100705
Builds on the gateway RPCs landed by #100738 and is now based directly on `main`.

## What Problem This Solves

Android operators cannot see what an agent produced or changed in its workspace. Checking a generated file, log, or edited config from the phone requires shell access to the gateway host.

## Why This Change Was Made

Adds a read-only **Files** browser backed by the new `agents.workspace.list` / `agents.workspace.get` RPCs from #100738, following the existing shell patterns: a `Tab.Files` detail tab (shell Back semantics preserved; directory drill-down and preview unwind screen-locally through a `BackHandler` before the shell's single-slot Back origin) plus a Files metric card on the Home overview. Listing pages through the gateway's `offset`/`totalEntries` contract with a "Load more" row. Text previews reuse the chat renderer's `ChatCodeBlock`; images reuse the chat renderer's asynchronous base64 decoder, with malformed payloads degrading to a no-preview state. The browser subtree resets from the same session/default-agent facts used by runtime routing so paths cannot cross agents. Export writes each share into a unique directory under the `workspace-files/` FileProvider cache path, preventing an older URI grant from observing a later same-basename export. Gateway RPC access follows the runtime-owned pattern: suspend wrappers on `NodeRuntime` with kotlinx JSON parsing kept in `WorkspaceFiles.kt`; protocol paths are treated as opaque identifiers (never trimmed). Strictly read-only.

## User Impact

Android users can browse the active agent's workspace, preview text and image files, and share/export a file through the system share sheet.

## Evidence

- `:app:compilePlayDebugKotlin` green; `WorkspaceFilesTest` (parser contract incl. pagination fields, text/image payloads, malformed payload rejection) and `ShellScreenLogicTest` (updated for the Files card) pass locally.
- Exact-head Blacksmith Testbox `tbx_01kww1zy68f1gdbfd1xezvv7ag`: `:app:compilePlayDebugKotlin` plus focused `WorkspaceFilesTest` and `ShellScreenLogicTest` green (`exitCode: 0`, 2m50s Gradle / 3m26s wrapper).
- `pnpm native:i18n:sync` run for the new user-visible strings.
- Maintainer review fixed cross-agent browser state retention and main-thread image decode. Codex autoreview found and fixed same-basename FileProvider URI reuse; fresh re-review on the final rebased `main` delta is clean.
- Added an `apps/android/CHANGELOG.md` Unreleased entry and regenerated both the native i18n inventory and docs map after the rebase.
