### PR TITLE
fix(google): image generation unavailable when google provider set via config apiKey + custom baseUrl

### DIFF
--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -598,7 +598,10 @@ describe("Google image-generation provider", () => {
     ).toBe(false);
   });
 
-  it("treats an empty config apiKey as not configured", () => {
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", "   "],
+  ])("treats a %s config apiKey as not configured", (_label, apiKey) => {
     vi.spyOn(providerAuth, "isProviderApiKeyConfigured").mockReturnValue(false);
 
     const provider = buildGoogleImageGenerationProvider();
@@ -610,7 +613,7 @@ describe("Google image-generation provider", () => {
             providers: {
               google: {
                 baseUrl: "https://gateway.example.test/gemini/v1beta",
-                apiKey: "",
+                apiKey,
                 models: [],
               },
             },

--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -609,6 +609,7 @@ describe("Google image-generation provider", () => {
           models: {
             providers: {
               google: {
+                baseUrl: "https://gateway.example.test/gemini/v1beta",
                 apiKey: "",
                 models: [],
               },

--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -1,4 +1,5 @@
 // Google tests cover image generation provider plugin behavior.
+import * as providerAuth from "openclaw/plugin-sdk/provider-auth";
 import * as providerAuthRuntime from "openclaw/plugin-sdk/provider-auth-runtime";
 import * as providerHttp from "openclaw/plugin-sdk/provider-http";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
@@ -552,6 +553,70 @@ describe("Google image-generation provider", () => {
       "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-image-preview:generateContent",
     );
     expect(typeof request.method).toBe("string");
+  });
+
+  it("reports configured from a config apiKey (gateway-routed gemini) with no env/profile creds", () => {
+    vi.spyOn(providerAuth, "isProviderApiKeyConfigured").mockReturnValue(false);
+
+    const provider = buildGoogleImageGenerationProvider();
+    expect(
+      provider.isConfigured?.({
+        agentDir: "/tmp/agent",
+        cfg: {
+          models: {
+            providers: {
+              google: {
+                baseUrl: "https://gateway.example.test/gemini/v1beta",
+                apiKey: "gateway-token",
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("still reports not configured with a custom endpoint and no credentials", () => {
+    vi.spyOn(providerAuth, "isProviderApiKeyConfigured").mockReturnValue(false);
+
+    const provider = buildGoogleImageGenerationProvider();
+    expect(
+      provider.isConfigured?.({
+        agentDir: "/tmp/agent",
+        cfg: {
+          models: {
+            providers: {
+              google: {
+                baseUrl: "https://gateway.example.test/gemini/v1beta",
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats an empty config apiKey as not configured", () => {
+    vi.spyOn(providerAuth, "isProviderApiKeyConfigured").mockReturnValue(false);
+
+    const provider = buildGoogleImageGenerationProvider();
+    expect(
+      provider.isConfigured?.({
+        agentDir: "/tmp/agent",
+        cfg: {
+          models: {
+            providers: {
+              google: {
+                apiKey: "",
+                models: [],
+              },
+            },
+          },
+        },
+      }),
+    ).toBe(false);
   });
 
   it("prefers scoped configured Gemini API keys over environment fallbacks", () => {

--- a/extensions/google/image-generation-provider.ts
+++ b/extensions/google/image-generation-provider.ts
@@ -157,7 +157,11 @@ export function buildGoogleImageGenerationProvider(): ImageGenerationProvider {
     label: "Google",
     defaultModel: DEFAULT_GOOGLE_IMAGE_MODEL,
     models: [DEFAULT_GOOGLE_IMAGE_MODEL, "gemini-3-pro-image-preview"],
-    isConfigured: ({ agentDir }) =>
+    isConfigured: ({ cfg, agentDir }) =>
+      // generateImage already authenticates from a config apiKey; count a
+      // non-empty one as configured here too, so image gen works from config
+      // alone, like chat.
+      Boolean(cfg?.models?.providers?.google?.apiKey) ||
       isProviderApiKeyConfigured({
         provider: "google",
         agentDir,

--- a/extensions/google/image-generation-provider.ts
+++ b/extensions/google/image-generation-provider.ts
@@ -7,7 +7,10 @@ import {
 } from "openclaw/plugin-sdk/image-generation";
 import { MAX_IMAGE_BYTES } from "openclaw/plugin-sdk/media-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
-import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
+import {
+  hasConfiguredSecretInput,
+  isProviderApiKeyConfigured,
+} from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
@@ -159,9 +162,9 @@ export function buildGoogleImageGenerationProvider(): ImageGenerationProvider {
     models: [DEFAULT_GOOGLE_IMAGE_MODEL, "gemini-3-pro-image-preview"],
     isConfigured: ({ cfg, agentDir }) =>
       // generateImage already authenticates from a config apiKey; count a
-      // non-empty one as configured here too, so image gen works from config
-      // alone, like chat.
-      Boolean(cfg?.models?.providers?.google?.apiKey) ||
+      // usable one (non-blank literal or secret ref) as configured here too,
+      // so image gen works from config alone, like chat.
+      hasConfiguredSecretInput(cfg?.models?.providers?.google?.apiKey) ||
       isProviderApiKeyConfigured({
         provider: "google",
         agentDir,


### PR DESCRIPTION
## What Problem This Solves

Fixes the `google` twin of #100745: image generation reports "not configured" —
and is skipped by capability availability/auto-selection and shown as
unavailable in `image_generate`'s provider `list` — when the Google provider is
configured entirely through config: `models.providers.google.apiKey` plus an
optional custom `baseUrl` (for example a Gemini-compatible proxy/gateway), with
no `GEMINI_API_KEY`/`GOOGLE_API_KEY` environment variable and no auth profile.

Chat models configured the same way authenticate and appear available, but
image generation did not — even though generating with that same config
actually works.

## Why This Change Was Made

The `google` image provider's `isConfigured` consulted only
`isProviderApiKeyConfigured` (environment variables / auth profiles) and
ignored provider config entirely. Meanwhile `generateImage` already resolves a
config `apiKey` via `resolveApiKeyForProvider` and honors the config `baseUrl`.
Readiness was therefore stricter than generation, and inconsistent with chat
providers, which authenticate purely from provider config.

Same fix shape as #100745: the config key counts only when usable, decided by
`hasConfiguredSecretInput` — the same secret-presence contract runtime auth
uses — so a non-blank literal or a secret ref counts, while empty or
whitespace-only placeholders (which the generate path normalizes away and then
fails on) report not configured.

## User Impact

Operators can enable Google image generation purely via
`models.providers.google` (`apiKey` + optional `baseUrl`) — e.g. pointing at a
Gemini-compatible gateway — without setting `GEMINI_API_KEY`/`GOOGLE_API_KEY`
or adding an auth profile. The provider now reports configured, is eligible for
capability auto-selection, and appears in `image_generate`'s provider `list`.
No change for setups that use an environment variable or an auth profile.

## Evidence

- New regression test in `extensions/google/image-generation-provider.test.ts`:
  a custom `baseUrl` plus a config `apiKey`, with no env var and no auth
  profile, now reports `isConfigured: true`. Verified it fails without the
  source change (1 failed / 17 passed with only the source hunk reverted).
- Guard tests pin the boundaries: custom endpoint with no credentials → still
  not configured; empty (`""`) and whitespace-only (`"   "`) `apiKey` → not
  configured.
- Full file suite: 18/18 pass via
  `node scripts/run-vitest.mjs run extensions/google/image-generation-provider.test.ts`.
- `oxfmt --check` clean on the changed files.
- `tsgo -p extensions/google/tsconfig.json` introduces no new errors (the two
  pre-existing errors in `cli-backend-auth.runtime.ts` are present on `main`
  and untouched by this change).
- Behavior trace: `generateImage` resolves the config `apiKey`
  (`resolveApiKeyForProvider` at `image-generation-provider.ts:187`) and honors
  the config `baseUrl` (line 201); only `isConfigured` lagged.
