### PR TITLE
docs(changelog): add landed PR closeout entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **PDF page selections:** reject fractional page tokens at the shared parser boundary instead of silently dropping them during fallback extraction. (#99393, #99399) Thanks @qingminglong.
+- **Control UI protocol mismatch:** preserve structured mismatch details and stop retrying unrecoverable browser connections while keeping transient reconnects unchanged. (#98413, #98414) Thanks @haruaiclone-droid.
+- **Google Gemini latest aliases:** apply Gemini 3 thought-signature replay to floating Pro, Flash, and Flash Lite aliases across native and OpenAI-compatible transports. (#100566, #100605) Thanks @chenxiaoyu209.
+- **Compaction participant deduplication:** include canonical sender identity in duplicate long-message keys so identical turns from different participants remain in compacted transcripts. (#98310, #98336) Thanks @SunnyShu0925.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.


### PR DESCRIPTION
## What Problem This Solves

The final changelog audit for the completed maintainer batch found four landed user-visible fixes missing from the current `Unreleased` notes. #100617 was already documented and is intentionally not duplicated.

## Why This Change Was Made

Add one concise entry for each missing landed fix, following the existing changelog style and preserving contributor credit:

- #99399 PDF fractional page selection validation
- #98414 Control UI protocol-mismatch reconnect gating
- #100605 Gemini latest-alias thought-signature replay
- #98336 sender-aware compaction deduplication

## User Impact

Release notes now cover all five fixes in the completed batch and thank each contributor.

## Evidence

- `git diff --check`
- Audited current `CHANGELOG.md` for #99399, #98414, #100605, #98336, and #100617; only #100617 already had an entry.
- Changelog-only change: four insertions, no runtime or generated-file changes.
