### PR TITLE
fix(discord): limit implicit reply fanout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
-- **Discord reply fanout:** attach implicit `first` and `batched` native reply references only to the first physical message while preserving `all`, direct, and explicit replies across text, media, video, voice, and component sends. (#99150) Thanks @qingminglong.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Detail-less provider failures:** keep opaque upstream failures from cooling API-key auth profiles while preserving WHAM-backed OpenAI OAuth health checks and configured model fallback. (#100600, #100617) Thanks @fengjikui.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
+- **Discord reply fanout:** attach implicit `first` and `batched` native reply references only to the first physical message while preserving `all`, direct, and explicit replies across text, media, video, voice, and component sends. (#99150) Thanks @qingminglong.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.
 - **Detail-less provider failures:** keep opaque upstream failures from cooling API-key auth profiles while preserving WHAM-backed OpenAI OAuth health checks and configured model fallback. (#100600, #100617) Thanks @fengjikui.
 - **Plugin install diagnostics:** suppress the misleading hook-pack fallback after plugin install failures only when the hook manifest is absent, while preserving actionable malformed hook-pack errors. (#100554) Thanks @vincentkoc.

--- a/extensions/discord/src/actions/runtime.messaging.send.ts
+++ b/extensions/discord/src/actions/runtime.messaging.send.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements runtime.messaging.send behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { createReusableDiscordReplyReference } from "../reply-reference.js";
 import {
   assertMediaNotDataUrl,
   jsonResult,
@@ -250,7 +251,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
           {
             ...ctx.withOpts(),
             silent,
-            replyTo: replyTo ?? undefined,
+            reply: createReusableDiscordReplyReference(replyTo),
             sessionKey: sessionKey ?? undefined,
             agentId: agentId ?? undefined,
             mediaUrl: mediaUrl ?? undefined,
@@ -284,7 +285,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
         assertMediaNotDataUrl(mediaUrl);
         const result = await discordMessagingActionRuntime.sendVoiceMessageDiscord(to, mediaUrl, {
           ...ctx.withOpts(),
-          replyTo,
+          reply: createReusableDiscordReplyReference(replyTo),
           silent,
         });
         return jsonResult(
@@ -303,7 +304,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
         filename: filename ?? undefined,
         mediaLocalRoots: ctx.options?.mediaLocalRoots,
         mediaReadFile: ctx.options?.mediaReadFile,
-        replyTo,
+        reply: createReusableDiscordReplyReference(replyTo),
         components,
         embeds,
         silent,
@@ -413,7 +414,7 @@ export async function handleDiscordMessageSendAction(ctx: DiscordMessagingAction
           mediaUrl,
           mediaLocalRoots: ctx.options?.mediaLocalRoots,
           mediaReadFile: ctx.options?.mediaReadFile,
-          replyTo,
+          reply: createReusableDiscordReplyReference(replyTo),
         },
       );
       return jsonResult({ ok: true, result });

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -1309,7 +1309,7 @@ describe("handleDiscordMessagingAction", () => {
 
     expect(sendVoiceMessageDiscord).toHaveBeenCalledWith("channel:123", "/tmp/voice.mp3", {
       cfg: DISCORD_TEST_CFG,
-      replyTo: undefined,
+      reply: undefined,
       silent: true,
     });
     expect(sendMessageDiscord).not.toHaveBeenCalled();
@@ -1445,7 +1445,7 @@ describe("handleDiscordMessagingAction", () => {
       filename: undefined,
       mediaLocalRoots: undefined,
       mediaReadFile: undefined,
-      replyTo: undefined,
+      reply: undefined,
       components: undefined,
       embeds: undefined,
       silent: false,

--- a/extensions/discord/src/channel.message-adapter.test.ts
+++ b/extensions/discord/src/channel.message-adapter.test.ts
@@ -93,7 +93,7 @@ describe("discord channel message adapter", () => {
       });
       expect(hoisted.sendMessageDiscordMock).toHaveBeenLastCalledWith("channel:123456", "hello", {
         verbose: false,
-        replyTo: undefined,
+        reply: undefined,
         accountId: "default",
         silent: undefined,
         cfg: {},
@@ -121,7 +121,7 @@ describe("discord channel message adapter", () => {
         mediaAccess: undefined,
         mediaLocalRoots: undefined,
         mediaReadFile: undefined,
-        replyTo: undefined,
+        reply: undefined,
         accountId: "default",
         silent: undefined,
         cfg: {},
@@ -147,7 +147,7 @@ describe("discord channel message adapter", () => {
         "payload",
         expect.objectContaining({
           verbose: false,
-          replyTo: undefined,
+          reply: undefined,
           accountId: "default",
           silent: undefined,
           cfg: {},
@@ -199,7 +199,7 @@ describe("discord channel message adapter", () => {
         {
           verbose: false,
           accountId: "default",
-          replyTo: "reply-1",
+          reply: { messageId: "reply-1", scope: "all" },
           silent: true,
           cfg: {},
           textLimit: undefined,

--- a/extensions/discord/src/channel.test.ts
+++ b/extensions/discord/src/channel.test.ts
@@ -326,7 +326,7 @@ describe("discordPlugin outbound", () => {
     expect(sendOptions.mediaUrl).toBe("/tmp/image.png");
     expect(sendOptions.mediaLocalRoots).toEqual(["/tmp/agent-root"]);
     expect(sendOptions.mediaReadFile).toBe(mediaReadFile);
-    expect(sendOptions.replyTo).toBe("reply-123");
+    expect(sendOptions.reply).toEqual({ messageId: "reply-123", scope: "all" });
     expect(result.channel).toBe("discord");
     expect(result.messageId).toBe("m1");
   });
@@ -353,7 +353,10 @@ describe("discordPlugin outbound", () => {
     expect(sendMessageDiscord).toHaveBeenCalledTimes(2);
     expect(argAt(sendMessageDiscord, 0, 0)).toBe("channel:thread-123");
     expect(argAt(sendMessageDiscord, 0, 1)).toBe("done - tiny cyber-lobster clip incoming");
-    expect(objectArgAt(sendMessageDiscord, 0, 2).replyTo).toBe("reply-123");
+    expect(objectArgAt(sendMessageDiscord, 0, 2).reply).toEqual({
+      messageId: "reply-123",
+      scope: "all",
+    });
     expect(argAt(sendMessageDiscord, 1, 0)).toBe("channel:thread-123");
     expect(argAt(sendMessageDiscord, 1, 1)).toBe("");
     expect(objectArgAt(sendMessageDiscord, 1, 2).mediaUrl).toBe("/tmp/molty.mp4");

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -515,7 +515,7 @@ describe("deliverDiscordReply", () => {
     const deps = firstDeliverParams().deps!;
     await deps.discordVoice("channel:123", "https://example.com/voice.ogg", {
       cfg,
-      replyTo: "reply-1",
+      reply: { messageId: "reply-1", scope: "all" },
     });
 
     expect(firstMockArg(sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord", 0)).toBe(
@@ -527,7 +527,7 @@ describe("deliverDiscordReply", () => {
     const voiceOptions = objectArgAt(sendVoiceMessageDiscordMock, 2);
     expect(voiceOptions.cfg).toBe(cfg);
     expect(voiceOptions.token).toBe("token");
-    expect(voiceOptions.replyTo).toBe("reply-1");
+    expect(voiceOptions.reply).toEqual({ messageId: "reply-1", scope: "all" });
   });
 
   it("rewrites bound thread replies to parent target plus thread id and persona", async () => {

--- a/extensions/discord/src/outbound-adapter.interactive-order.test.ts
+++ b/extensions/discord/src/outbound-adapter.interactive-order.test.ts
@@ -67,7 +67,7 @@ describe("discordOutbound shared interactive ordering", () => {
         chunkMode: undefined,
         cfg: {},
         maxLinesPerMessage: undefined,
-        replyTo: undefined,
+        reply: undefined,
         silent: undefined,
         tableMode: undefined,
         textLimit: undefined,

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -330,6 +330,7 @@ describe("discordOutbound", () => {
       },
       accountId: "default",
       replyToId: "reply-1",
+      replyToIdSource: "implicit",
       replyToMode: "first",
       onDeliveryResult,
     });
@@ -356,7 +357,7 @@ describe("discordOutbound", () => {
       2,
     );
     expect(messageOptions.accountId).toBe("default");
-    expect(messageOptions.replyTo).toBe("reply-1");
+    expect(messageOptions.replyTo).toBeUndefined();
 
     const mediaCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1);
     expect(mediaCall[0]).toBe("channel:123456");
@@ -364,7 +365,7 @@ describe("discordOutbound", () => {
     const mediaOptions = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1, 2);
     expect(mediaOptions.accountId).toBe("default");
     expect(mediaOptions.mediaUrl).toBe("https://example.com/extra.png");
-    expect(mediaOptions.replyTo).toBe("reply-1");
+    expect(mediaOptions.replyTo).toBeUndefined();
     expect(result).toEqual({
       channel: "discord",
       messageId: "msg-1",
@@ -377,7 +378,7 @@ describe("discordOutbound", () => {
     ]);
   });
 
-  it("keeps captured replyTo on audioAsVoice sends when replyToMode is batched", async () => {
+  it("uses a single implicit reply on audioAsVoice sends when replyToMode is batched", async () => {
     await discordOutbound.sendPayload?.({
       cfg: {},
       to: "channel:123456",
@@ -389,6 +390,7 @@ describe("discordOutbound", () => {
       },
       accountId: "default",
       replyToId: "reply-1",
+      replyToIdSource: "implicit",
       replyToMode: "batched",
     });
 
@@ -399,7 +401,7 @@ describe("discordOutbound", () => {
       hoisted.sendMessageDiscordMock.mock.calls.map(
         (call) => (call[2] as { replyTo?: unknown } | undefined)?.replyTo,
       ),
-    ).toEqual(["reply-1", "reply-1"]);
+    ).toEqual([undefined, undefined]);
   });
 
   it.each([
@@ -556,7 +558,26 @@ describe("discordOutbound", () => {
     ).toEqual(["explicit-reply-1", "explicit-reply-1"]);
   });
 
-  it("sends video captions as text before a media-only video follow-up", async () => {
+  it.each([
+    {
+      name: "implicit first-mode",
+      replyToIdSource: "implicit" as const,
+      replyToMode: "first" as const,
+      expectedReplyIds: ["reply-1", undefined],
+    },
+    {
+      name: "implicit all-mode",
+      replyToIdSource: "implicit" as const,
+      replyToMode: "all" as const,
+      expectedReplyIds: ["reply-1", "reply-1"],
+    },
+    {
+      name: "explicit first-mode",
+      replyToIdSource: "explicit" as const,
+      replyToMode: "first" as const,
+      expectedReplyIds: ["reply-1", "reply-1"],
+    },
+  ])("sends $name video captions before media with the expected replies", async (testCase) => {
     await discordOutbound.sendMedia?.({
       cfg: {},
       to: "channel:123456",
@@ -564,6 +585,8 @@ describe("discordOutbound", () => {
       mediaUrl: "/tmp/render.mp4",
       accountId: "default",
       replyToId: "reply-1",
+      replyToIdSource: testCase.replyToIdSource,
+      replyToMode: testCase.replyToMode,
     });
 
     const captionCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0);
@@ -576,7 +599,7 @@ describe("discordOutbound", () => {
       2,
     );
     expect(captionOptions.accountId).toBe("default");
-    expect(captionOptions.replyTo).toBe("reply-1");
+    expect(captionOptions.replyTo).toBe(testCase.expectedReplyIds[0]);
 
     const mediaCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1);
     expect(mediaCall[0]).toBe("channel:123456");
@@ -584,6 +607,25 @@ describe("discordOutbound", () => {
     const mediaOptions = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1, 2);
     expect(mediaOptions.accountId).toBe("default");
     expect(mediaOptions.mediaUrl).toBe("/tmp/render.mp4");
+    expect(mediaOptions.replyTo).toBe(testCase.expectedReplyIds[1]);
+  });
+
+  it("marks implicit first-mode media sends for first-chunk native replies only", async () => {
+    await discordOutbound.sendMedia?.({
+      cfg: {},
+      to: "channel:123456",
+      text: "caption\nfollow-up",
+      mediaUrl: "https://example.com/photo.png",
+      accountId: "default",
+      replyToId: "reply-1",
+      replyToIdSource: "implicit",
+      replyToMode: "first",
+      formatting: { maxLinesPerMessage: 1 },
+    });
+
+    const options = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2);
+    expect(options.replyTo).toBe("reply-1");
+    expect(options.replyToFirstChunkOnly).toBe(true);
   });
 
   it("touches bound thread activity after shared outbound delivery succeeds", async () => {
@@ -685,6 +727,7 @@ describe("discordOutbound", () => {
       accountId: "default",
       mediaLocalRoots: ["/tmp/media"],
       replyToId: "reply-1",
+      replyToIdSource: "implicit",
       replyToMode: "first",
     });
 
@@ -707,6 +750,7 @@ describe("discordOutbound", () => {
     expect(componentOptions.mediaLocalRoots).toEqual(["/tmp/media"]);
     expect(componentOptions.accountId).toBe("default");
     expect(componentOptions.replyTo).toBe("reply-1");
+    expect(componentOptions.replyToFirstChunkOnly).toBe(true);
 
     const messageCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord");
     expect(messageCall[0]).toBe("channel:123456");
@@ -833,6 +877,8 @@ describe("discordOutbound", () => {
       },
       accountId: "default",
       replyToId: "reply-1",
+      replyToIdSource: "implicit",
+      replyToMode: "first",
     });
 
     const call = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord");
@@ -844,6 +890,7 @@ describe("discordOutbound", () => {
     expect(options.filename).toBe("photo.png");
     expect(options.accountId).toBe("default");
     expect(options.replyTo).toBe("reply-1");
+    expect(options.replyToFirstChunkOnly).toBe(true);
   });
 
   it("preserves explicit component payload replies when replyToMode is off", async () => {
@@ -978,6 +1025,27 @@ describe("discordOutbound", () => {
         (call) => (call[2] as { replyTo?: unknown } | undefined)?.replyTo,
       ),
     ).toEqual(["reply-1", undefined]);
+  });
+
+  it.each([
+    { name: "implicit", replyToIdSource: "implicit" as const, firstChunkOnly: true },
+    { name: "source-omitted", replyToIdSource: undefined, firstChunkOnly: true },
+    { name: "explicit", replyToIdSource: "explicit" as const, firstChunkOnly: false },
+  ])("sets $name first-mode text chunk fanout", async (testCase) => {
+    await discordOutbound.sendText?.({
+      cfg: {},
+      to: "channel:123456",
+      text: "line one\nline two",
+      accountId: "default",
+      replyToId: "reply-1",
+      replyToIdSource: testCase.replyToIdSource,
+      replyToMode: "first",
+      formatting: { maxLinesPerMessage: 1 },
+    });
+
+    const options = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2);
+    expect(options.replyTo).toBe("reply-1");
+    expect(options.replyToFirstChunkOnly).toBe(testCase.firstChunkOnly);
   });
 
   it("leaves non-approval mentions unchanged", async () => {

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -345,7 +345,7 @@ describe("discordOutbound", () => {
       2,
     );
     expect(voiceOptions.accountId).toBe("default");
-    expect(voiceOptions.replyTo).toBe("reply-1");
+    expect(voiceOptions.reply).toEqual({ messageId: "reply-1", scope: "first" });
 
     const messageCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0);
     expect(messageCall[0]).toBe("channel:123456");
@@ -357,7 +357,7 @@ describe("discordOutbound", () => {
       2,
     );
     expect(messageOptions.accountId).toBe("default");
-    expect(messageOptions.replyTo).toBeUndefined();
+    expect(messageOptions.reply).toBeUndefined();
 
     const mediaCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1);
     expect(mediaCall[0]).toBe("channel:123456");
@@ -365,7 +365,7 @@ describe("discordOutbound", () => {
     const mediaOptions = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1, 2);
     expect(mediaOptions.accountId).toBe("default");
     expect(mediaOptions.mediaUrl).toBe("https://example.com/extra.png");
-    expect(mediaOptions.replyTo).toBeUndefined();
+    expect(mediaOptions.reply).toBeUndefined();
     expect(result).toEqual({
       channel: "discord",
       messageId: "msg-1",
@@ -395,11 +395,11 @@ describe("discordOutbound", () => {
     });
 
     expect(
-      mockObjectArg(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord", 0, 2).replyTo,
-    ).toBe("reply-1");
+      mockObjectArg(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord", 0, 2).reply,
+    ).toEqual({ messageId: "reply-1", scope: "first" });
     expect(
       hoisted.sendMessageDiscordMock.mock.calls.map(
-        (call) => (call[2] as { replyTo?: unknown } | undefined)?.replyTo,
+        (call) => (call[2] as { reply?: unknown } | undefined)?.reply,
       ),
     ).toEqual([undefined, undefined]);
   });
@@ -443,8 +443,8 @@ describe("discordOutbound", () => {
     const messageCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0);
     expect(messageCall[0]).toBe("channel:123456");
     expect(messageCall[1]).toBe(expectedText);
-    expect(mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2).replyTo).toBe(
-      "reply-1",
+    expect(mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2).reply).toEqual(
+      { messageId: "reply-1", scope: "first" },
     );
     expect(result).toEqual({
       channel: "discord",
@@ -524,13 +524,16 @@ describe("discordOutbound", () => {
     });
 
     expect(
-      mockObjectArg(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord", 0, 2).replyTo,
-    ).toBe("reply-1");
+      mockObjectArg(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord", 0, 2).reply,
+    ).toEqual({ messageId: "reply-1", scope: "all" });
     expect(
       hoisted.sendMessageDiscordMock.mock.calls.map(
-        (call) => (call[2] as { replyTo?: unknown } | undefined)?.replyTo,
+        (call) => (call[2] as { reply?: unknown } | undefined)?.reply,
       ),
-    ).toEqual(["reply-1", "reply-1"]);
+    ).toEqual([
+      { messageId: "reply-1", scope: "all" },
+      { messageId: "reply-1", scope: "all" },
+    ]);
   });
 
   it("preserves explicit audioAsVoice payload replies when replyToMode is off", async () => {
@@ -549,13 +552,16 @@ describe("discordOutbound", () => {
     });
 
     expect(
-      mockObjectArg(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord", 0, 2).replyTo,
-    ).toBe("explicit-reply-1");
+      mockObjectArg(hoisted.sendVoiceMessageDiscordMock, "sendVoiceMessageDiscord", 0, 2).reply,
+    ).toEqual({ messageId: "explicit-reply-1", scope: "all" });
     expect(
       hoisted.sendMessageDiscordMock.mock.calls.map(
-        (call) => (call[2] as { replyTo?: unknown } | undefined)?.replyTo,
+        (call) => (call[2] as { reply?: unknown } | undefined)?.reply,
       ),
-    ).toEqual(["explicit-reply-1", "explicit-reply-1"]);
+    ).toEqual([
+      { messageId: "explicit-reply-1", scope: "all" },
+      { messageId: "explicit-reply-1", scope: "all" },
+    ]);
   });
 
   it.each([
@@ -563,19 +569,25 @@ describe("discordOutbound", () => {
       name: "implicit first-mode",
       replyToIdSource: "implicit" as const,
       replyToMode: "first" as const,
-      expectedReplyIds: ["reply-1", undefined],
+      expectedReplies: [{ messageId: "reply-1", scope: "first" }, undefined],
     },
     {
       name: "implicit all-mode",
       replyToIdSource: "implicit" as const,
       replyToMode: "all" as const,
-      expectedReplyIds: ["reply-1", "reply-1"],
+      expectedReplies: [
+        { messageId: "reply-1", scope: "all" },
+        { messageId: "reply-1", scope: "all" },
+      ],
     },
     {
       name: "explicit first-mode",
       replyToIdSource: "explicit" as const,
       replyToMode: "first" as const,
-      expectedReplyIds: ["reply-1", "reply-1"],
+      expectedReplies: [
+        { messageId: "reply-1", scope: "all" },
+        { messageId: "reply-1", scope: "all" },
+      ],
     },
   ])("sends $name video captions before media with the expected replies", async (testCase) => {
     await discordOutbound.sendMedia?.({
@@ -599,7 +611,7 @@ describe("discordOutbound", () => {
       2,
     );
     expect(captionOptions.accountId).toBe("default");
-    expect(captionOptions.replyTo).toBe(testCase.expectedReplyIds[0]);
+    expect(captionOptions.reply).toEqual(testCase.expectedReplies[0]);
 
     const mediaCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1);
     expect(mediaCall[0]).toBe("channel:123456");
@@ -607,7 +619,7 @@ describe("discordOutbound", () => {
     const mediaOptions = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 1, 2);
     expect(mediaOptions.accountId).toBe("default");
     expect(mediaOptions.mediaUrl).toBe("/tmp/render.mp4");
-    expect(mediaOptions.replyTo).toBe(testCase.expectedReplyIds[1]);
+    expect(mediaOptions.reply).toEqual(testCase.expectedReplies[1]);
   });
 
   it("marks implicit first-mode media sends for first-chunk native replies only", async () => {
@@ -624,8 +636,7 @@ describe("discordOutbound", () => {
     });
 
     const options = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2);
-    expect(options.replyTo).toBe("reply-1");
-    expect(options.replyToFirstChunkOnly).toBe(true);
+    expect(options.reply).toEqual({ messageId: "reply-1", scope: "first" });
   });
 
   it("touches bound thread activity after shared outbound delivery succeeds", async () => {
@@ -749,8 +760,7 @@ describe("discordOutbound", () => {
     expect(componentOptions.mediaUrl).toBe("https://example.com/1.png");
     expect(componentOptions.mediaLocalRoots).toEqual(["/tmp/media"]);
     expect(componentOptions.accountId).toBe("default");
-    expect(componentOptions.replyTo).toBe("reply-1");
-    expect(componentOptions.replyToFirstChunkOnly).toBe(true);
+    expect(componentOptions.reply).toEqual({ messageId: "reply-1", scope: "first" });
 
     const messageCall = mockCall(hoisted.sendMessageDiscordMock, "sendMessageDiscord");
     expect(messageCall[0]).toBe("channel:123456");
@@ -764,7 +774,7 @@ describe("discordOutbound", () => {
     expect(messageOptions.mediaUrl).toBe("https://example.com/2.png");
     expect(messageOptions.mediaLocalRoots).toEqual(["/tmp/media"]);
     expect(messageOptions.accountId).toBe("default");
-    expect(messageOptions.replyTo).toBeUndefined();
+    expect(messageOptions.reply).toBeUndefined();
     expect(result).toEqual({
       channel: "discord",
       messageId: "msg-2",
@@ -853,10 +863,10 @@ describe("discordOutbound", () => {
 
     expect(
       mockObjectArg(hoisted.sendDiscordComponentMessageMock, "sendDiscordComponentMessage", 0, 2)
-        .replyTo,
-    ).toBe("reply-1");
-    expect(mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2).replyTo).toBe(
-      "reply-1",
+        .reply,
+    ).toEqual({ messageId: "reply-1", scope: "all" });
+    expect(mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2).reply).toEqual(
+      { messageId: "reply-1", scope: "all" },
     );
   });
 
@@ -889,8 +899,7 @@ describe("discordOutbound", () => {
     expect(options.components).toEqual([{ type: 1, components: [] }]);
     expect(options.filename).toBe("photo.png");
     expect(options.accountId).toBe("default");
-    expect(options.replyTo).toBe("reply-1");
-    expect(options.replyToFirstChunkOnly).toBe(true);
+    expect(options.reply).toEqual({ messageId: "reply-1", scope: "first" });
   });
 
   it("preserves explicit component payload replies when replyToMode is off", async () => {
@@ -924,10 +933,10 @@ describe("discordOutbound", () => {
 
     expect(
       mockObjectArg(hoisted.sendDiscordComponentMessageMock, "sendDiscordComponentMessage", 0, 2)
-        .replyTo,
-    ).toBe("explicit-reply-1");
-    expect(mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2).replyTo).toBe(
-      "explicit-reply-1",
+        .reply,
+    ).toEqual({ messageId: "explicit-reply-1", scope: "all" });
+    expect(mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2).reply).toEqual(
+      { messageId: "explicit-reply-1", scope: "all" },
     );
   });
 
@@ -1022,15 +1031,15 @@ describe("discordOutbound", () => {
 
     expect(
       hoisted.sendMessageDiscordMock.mock.calls.map(
-        (call) => (call[2] as { replyTo?: unknown } | undefined)?.replyTo,
+        (call) => (call[2] as { reply?: unknown } | undefined)?.reply,
       ),
-    ).toEqual(["reply-1", undefined]);
+    ).toEqual([{ messageId: "reply-1", scope: "first" }, undefined]);
   });
 
   it.each([
-    { name: "implicit", replyToIdSource: "implicit" as const, firstChunkOnly: true },
-    { name: "source-omitted", replyToIdSource: undefined, firstChunkOnly: true },
-    { name: "explicit", replyToIdSource: "explicit" as const, firstChunkOnly: false },
+    { name: "implicit", replyToIdSource: "implicit" as const, scope: "first" as const },
+    { name: "source-omitted", replyToIdSource: undefined, scope: "first" as const },
+    { name: "explicit", replyToIdSource: "explicit" as const, scope: "all" as const },
   ])("sets $name first-mode text chunk fanout", async (testCase) => {
     await discordOutbound.sendText?.({
       cfg: {},
@@ -1044,8 +1053,7 @@ describe("discordOutbound", () => {
     });
 
     const options = mockObjectArg(hoisted.sendMessageDiscordMock, "sendMessageDiscord", 0, 2);
-    expect(options.replyTo).toBe("reply-1");
-    expect(options.replyToFirstChunkOnly).toBe(testCase.firstChunkOnly);
+    expect(options.reply).toEqual({ messageId: "reply-1", scope: testCase.scope });
   });
 
   it("leaves non-approval mentions unchanged", async () => {

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -25,6 +25,7 @@ import {
   loadDiscordSendRuntime,
   resolveDiscordFormattingOptions,
   resolveDiscordOutboundTarget,
+  shouldReplyToFirstDiscordChunkOnly,
   type DiscordSendFn,
   type DiscordVoiceSendFn,
 } from "./outbound-send-context.js";
@@ -171,6 +172,8 @@ export const discordOutbound: ChannelOutboundAdapter = {
       accountId,
       deps,
       replyToId,
+      replyToIdSource,
+      replyToMode,
       threadId,
       identity,
       silent,
@@ -200,6 +203,10 @@ export const discordOutbound: ChannelOutboundAdapter = {
           await send(resolveDiscordOutboundTarget({ to, threadId }), text, {
             verbose: false,
             replyTo: replyToId ?? undefined,
+            replyToFirstChunkOnly: shouldReplyToFirstDiscordChunkOnly({
+              replyToIdSource,
+              replyToMode,
+            }),
             accountId: accountId ?? undefined,
             silent: silent ?? undefined,
             cfg,
@@ -224,6 +231,8 @@ export const discordOutbound: ChannelOutboundAdapter = {
       accountId,
       deps,
       replyToId,
+      replyToIdSource,
+      replyToMode,
       threadId,
       silent,
       formatting,
@@ -234,6 +243,11 @@ export const discordOutbound: ChannelOutboundAdapter = {
         (await loadDiscordSendRuntime()).sendMessageDiscord;
       const target = resolveDiscordOutboundTarget({ to, threadId });
       const formattingOptions = resolveDiscordFormattingOptions({ formatting });
+      const replyTo = replyToId ?? undefined;
+      const replyToFirstChunkOnly = shouldReplyToFirstDiscordChunkOnly({
+        replyToIdSource,
+        replyToMode,
+      });
       if (audioAsVoice && mediaUrl) {
         const sendVoice =
           resolveOutboundSendDep<DiscordVoiceSendFn>(deps, "discordVoice") ??
@@ -244,7 +258,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
           fn: async () =>
             await sendVoice(target, mediaUrl, {
               cfg,
-              replyTo: replyToId ?? undefined,
+              replyTo,
               accountId: accountId ?? undefined,
               silent: silent ?? undefined,
             }),
@@ -257,7 +271,8 @@ export const discordOutbound: ChannelOutboundAdapter = {
           fn: async () =>
             await send(target, text, {
               verbose: false,
-              replyTo: replyToId ?? undefined,
+              replyTo,
+              replyToFirstChunkOnly,
               accountId: accountId ?? undefined,
               silent: silent ?? undefined,
               cfg,
@@ -276,6 +291,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
             await send(target, "", {
               verbose: false,
               mediaUrl,
+              replyTo: replyToFirstChunkOnly ? undefined : replyTo,
               mediaAccess,
               mediaLocalRoots,
               mediaReadFile,
@@ -301,7 +317,8 @@ export const discordOutbound: ChannelOutboundAdapter = {
             mediaAccess,
             mediaLocalRoots,
             mediaReadFile,
-            replyTo: replyToId ?? undefined,
+            replyTo,
+            replyToFirstChunkOnly,
             accountId: accountId ?? undefined,
             silent: silent ?? undefined,
             cfg,

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -25,10 +25,10 @@ import {
   loadDiscordSendRuntime,
   resolveDiscordFormattingOptions,
   resolveDiscordOutboundTarget,
-  shouldReplyToFirstDiscordChunkOnly,
   type DiscordSendFn,
   type DiscordVoiceSendFn,
 } from "./outbound-send-context.js";
+import { resolveDiscordReplyReference } from "./reply-reference.js";
 
 export const DISCORD_TEXT_CHUNK_LIMIT = 2000;
 const DISCORD_INTERNAL_RUNTIME_SCAFFOLDING_BLOCK_RE =
@@ -202,8 +202,8 @@ export const discordOutbound: ChannelOutboundAdapter = {
         fn: async () =>
           await send(resolveDiscordOutboundTarget({ to, threadId }), text, {
             verbose: false,
-            replyTo: replyToId ?? undefined,
-            replyToFirstChunkOnly: shouldReplyToFirstDiscordChunkOnly({
+            reply: resolveDiscordReplyReference({
+              replyToId,
               replyToIdSource,
               replyToMode,
             }),
@@ -243,8 +243,8 @@ export const discordOutbound: ChannelOutboundAdapter = {
         (await loadDiscordSendRuntime()).sendMessageDiscord;
       const target = resolveDiscordOutboundTarget({ to, threadId });
       const formattingOptions = resolveDiscordFormattingOptions({ formatting });
-      const replyTo = replyToId ?? undefined;
-      const replyToFirstChunkOnly = shouldReplyToFirstDiscordChunkOnly({
+      const reply = resolveDiscordReplyReference({
+        replyToId,
         replyToIdSource,
         replyToMode,
       });
@@ -258,7 +258,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
           fn: async () =>
             await sendVoice(target, mediaUrl, {
               cfg,
-              replyTo,
+              reply,
               accountId: accountId ?? undefined,
               silent: silent ?? undefined,
             }),
@@ -271,8 +271,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
           fn: async () =>
             await send(target, text, {
               verbose: false,
-              replyTo,
-              replyToFirstChunkOnly,
+              reply,
               accountId: accountId ?? undefined,
               silent: silent ?? undefined,
               cfg,
@@ -291,7 +290,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
             await send(target, "", {
               verbose: false,
               mediaUrl,
-              replyTo: replyToFirstChunkOnly ? undefined : replyTo,
+              reply: reply?.scope === "all" ? reply : undefined,
               mediaAccess,
               mediaLocalRoots,
               mediaReadFile,
@@ -317,8 +316,7 @@ export const discordOutbound: ChannelOutboundAdapter = {
             mediaAccess,
             mediaLocalRoots,
             mediaReadFile,
-            replyTo,
-            replyToFirstChunkOnly,
+            reply,
             accountId: accountId ?? undefined,
             silent: silent ?? undefined,
             cfg,

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -47,9 +47,10 @@ function createDiscordUnknownPayloadResult(target: string) {
 function resolveDiscordDeliveryOptions(
   ctx: DiscordOutboundPayloadContext,
   sendContext: DiscordPayloadSendContext,
+  reply = sendContext.resolveReply(),
 ) {
   return {
-    replyTo: sendContext.resolveReplyTo(),
+    reply,
     accountId: ctx.accountId ?? undefined,
     silent: ctx.silent ?? undefined,
     cfg: ctx.cfg,
@@ -59,9 +60,10 @@ function resolveDiscordDeliveryOptions(
 function resolveDiscordFormattedDeliveryOptions(
   ctx: DiscordOutboundPayloadContext,
   sendContext: DiscordPayloadSendContext,
+  reply = sendContext.resolveReply(),
 ) {
   return {
-    ...resolveDiscordDeliveryOptions(ctx, sendContext),
+    ...resolveDiscordDeliveryOptions(ctx, sendContext, reply),
     ...sendContext.formatting,
   };
 }
@@ -95,15 +97,14 @@ export async function sendDiscordOutboundPayload(params: {
   if (payload.audioAsVoice && mediaUrls.length > 0) {
     // audioAsVoice emits one logical Discord reply across voice/text/media sends.
     // Capture before helper calls consume implicit single-use reply targets.
-    const voiceReplyTo = sendContext.resolveReplyTo();
+    const voiceReply = sendContext.resolveReply();
     let deliveredVoice = false;
     let lastResult: Awaited<ReturnType<DiscordPayloadSendContext["send"]>>;
     try {
       lastResult = await sendContext.withRetry(
         async () =>
           await sendContext.sendVoice(sendContext.target, mediaUrls[0], {
-            ...resolveDiscordDeliveryOptions(ctx, sendContext),
-            replyTo: voiceReplyTo,
+            ...resolveDiscordDeliveryOptions(ctx, sendContext, voiceReply),
           }),
       );
       deliveredVoice = true;
@@ -125,9 +126,7 @@ export async function sendDiscordOutboundPayload(params: {
           async () =>
             await sendContext.send(sendContext.target, fallbackText, {
               verbose: false,
-              ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
-              replyTo: voiceReplyTo,
-              replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
+              ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext, voiceReply),
               onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
             }),
         );
@@ -142,7 +141,6 @@ export async function sendDiscordOutboundPayload(params: {
           await sendContext.send(sendContext.target, payload.text, {
             verbose: false,
             ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
-            replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
             onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
@@ -153,7 +151,6 @@ export async function sendDiscordOutboundPayload(params: {
           await sendContext.send(sendContext.target, "", {
             verbose: false,
             ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
-            replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
             onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
@@ -189,7 +186,6 @@ export async function sendDiscordOutboundPayload(params: {
                 components: nativeComponents,
                 embeds,
                 filename,
-                replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
                 ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
                 onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
               }),
@@ -203,7 +199,6 @@ export async function sendDiscordOutboundPayload(params: {
                 components: isFirst ? nativeComponents : undefined,
                 embeds: isFirst ? embeds : undefined,
                 filename: isFirst ? filename : undefined,
-                replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
                 onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
               }),
           ),
@@ -229,7 +224,6 @@ export async function sendDiscordOutboundPayload(params: {
         async () =>
           await sendDiscordComponentMessageLazy(sendContext.target, componentSpec, {
             ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
-            replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
             onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
@@ -240,7 +234,6 @@ export async function sendDiscordOutboundPayload(params: {
           async () =>
             await sendDiscordComponentMessageLazy(sendContext.target, componentSpec, {
               ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
-              replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
               onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
             }),
         );
@@ -250,7 +243,6 @@ export async function sendDiscordOutboundPayload(params: {
           await sendContext.send(sendContext.target, text, {
             verbose: false,
             ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
-            replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
             onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );

--- a/extensions/discord/src/outbound-payload.ts
+++ b/extensions/discord/src/outbound-payload.ts
@@ -127,6 +127,7 @@ export async function sendDiscordOutboundPayload(params: {
               verbose: false,
               ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
               replyTo: voiceReplyTo,
+              replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
               onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
             }),
         );
@@ -141,7 +142,7 @@ export async function sendDiscordOutboundPayload(params: {
           await sendContext.send(sendContext.target, payload.text, {
             verbose: false,
             ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
-            replyTo: voiceReplyTo,
+            replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
             onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
@@ -152,7 +153,7 @@ export async function sendDiscordOutboundPayload(params: {
           await sendContext.send(sendContext.target, "", {
             verbose: false,
             ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
-            replyTo: voiceReplyTo,
+            replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
             onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
@@ -188,6 +189,7 @@ export async function sendDiscordOutboundPayload(params: {
                 components: nativeComponents,
                 embeds,
                 filename,
+                replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
                 ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
                 onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
               }),
@@ -201,6 +203,7 @@ export async function sendDiscordOutboundPayload(params: {
                 components: isFirst ? nativeComponents : undefined,
                 embeds: isFirst ? embeds : undefined,
                 filename: isFirst ? filename : undefined,
+                replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
                 onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
               }),
           ),
@@ -226,6 +229,7 @@ export async function sendDiscordOutboundPayload(params: {
         async () =>
           await sendDiscordComponentMessageLazy(sendContext.target, componentSpec, {
             ...resolveDiscordFormattedDeliveryOptions(ctx, sendContext),
+            replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
             onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );
@@ -236,6 +240,7 @@ export async function sendDiscordOutboundPayload(params: {
           async () =>
             await sendDiscordComponentMessageLazy(sendContext.target, componentSpec, {
               ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
+              replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
               onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
             }),
         );
@@ -245,6 +250,7 @@ export async function sendDiscordOutboundPayload(params: {
           await sendContext.send(sendContext.target, text, {
             verbose: false,
             ...resolveDiscordMediaDeliveryOptions(ctx, sendContext, mediaUrl),
+            replyToFirstChunkOnly: sendContext.replyToFirstChunkOnly,
             onDeliveryResult: resolveDiscordDeliveryProgress(ctx),
           }),
       );

--- a/extensions/discord/src/outbound-send-context.ts
+++ b/extensions/discord/src/outbound-send-context.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig, ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { normalizeOptionalStringifiedId } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withDiscordDeliveryRetry } from "./delivery-retry.js";
 
@@ -48,6 +49,17 @@ export function resolveDiscordFormattingOptions(ctx: {
   };
 }
 
+export function shouldReplyToFirstDiscordChunkOnly(params: {
+  replyToIdSource?: ReplyToResolution["source"];
+  replyToMode?: ReplyToMode;
+}): boolean {
+  return (
+    params.replyToIdSource !== "explicit" &&
+    params.replyToMode !== undefined &&
+    isSingleUseReplyToMode(params.replyToMode)
+  );
+}
+
 export async function createDiscordPayloadSendContext(ctx: {
   cfg: OpenClawConfig;
   to: string;
@@ -61,6 +73,7 @@ export async function createDiscordPayloadSendContext(ctx: {
 }): Promise<{
   target: string;
   formatting: DiscordFormattingOptions;
+  replyToFirstChunkOnly: boolean;
   resolveReplyTo: () => string | undefined;
   send: DiscordSendFn;
   sendVoice: DiscordVoiceSendFn;
@@ -70,6 +83,10 @@ export async function createDiscordPayloadSendContext(ctx: {
   return {
     target: resolveDiscordOutboundTarget({ to: ctx.to, threadId: ctx.threadId }),
     formatting: resolveDiscordFormattingOptions(ctx),
+    replyToFirstChunkOnly: shouldReplyToFirstDiscordChunkOnly({
+      replyToIdSource: ctx.replyToIdSource,
+      replyToMode: ctx.replyToMode,
+    }),
     resolveReplyTo: createReplyToFanout({
       replyToId: ctx.replyToId,
       replyToIdSource: ctx.replyToIdSource,

--- a/extensions/discord/src/outbound-send-context.ts
+++ b/extensions/discord/src/outbound-send-context.ts
@@ -1,14 +1,15 @@
 // Discord plugin module implements outbound send context behavior.
-import { createReplyToFanout, type ReplyToResolution } from "openclaw/plugin-sdk/channel-outbound";
 import {
+  createReplyToFanout,
   resolveOutboundSendDep,
   type OutboundSendDeps,
+  type ReplyToResolution,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig, ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { normalizeOptionalStringifiedId } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { withDiscordDeliveryRetry } from "./delivery-retry.js";
+import { resolveDiscordReplyReference } from "./reply-reference.js";
 
 type DiscordSendRuntime = typeof import("./send.js");
 
@@ -49,17 +50,6 @@ export function resolveDiscordFormattingOptions(ctx: {
   };
 }
 
-export function shouldReplyToFirstDiscordChunkOnly(params: {
-  replyToIdSource?: ReplyToResolution["source"];
-  replyToMode?: ReplyToMode;
-}): boolean {
-  return (
-    params.replyToIdSource !== "explicit" &&
-    params.replyToMode !== undefined &&
-    isSingleUseReplyToMode(params.replyToMode)
-  );
-}
-
 export async function createDiscordPayloadSendContext(ctx: {
   cfg: OpenClawConfig;
   to: string;
@@ -73,25 +63,22 @@ export async function createDiscordPayloadSendContext(ctx: {
 }): Promise<{
   target: string;
   formatting: DiscordFormattingOptions;
-  replyToFirstChunkOnly: boolean;
-  resolveReplyTo: () => string | undefined;
+  resolveReply: () => ReturnType<typeof resolveDiscordReplyReference>;
   send: DiscordSendFn;
   sendVoice: DiscordVoiceSendFn;
   withRetry: <T>(fn: () => Promise<T>) => Promise<T>;
 }> {
   const runtime = await loadDiscordSendRuntime();
+  const nextReplyToId = createReplyToFanout(ctx);
   return {
     target: resolveDiscordOutboundTarget({ to: ctx.to, threadId: ctx.threadId }),
     formatting: resolveDiscordFormattingOptions(ctx),
-    replyToFirstChunkOnly: shouldReplyToFirstDiscordChunkOnly({
-      replyToIdSource: ctx.replyToIdSource,
-      replyToMode: ctx.replyToMode,
-    }),
-    resolveReplyTo: createReplyToFanout({
-      replyToId: ctx.replyToId,
-      replyToIdSource: ctx.replyToIdSource,
-      replyToMode: ctx.replyToMode,
-    }),
+    resolveReply: () =>
+      resolveDiscordReplyReference({
+        replyToId: nextReplyToId(),
+        replyToIdSource: ctx.replyToIdSource,
+        replyToMode: ctx.replyToMode,
+      }),
     send: resolveOutboundSendDep<DiscordSendFn>(ctx.deps, "discord") ?? runtime.sendMessageDiscord,
     sendVoice:
       resolveOutboundSendDep<DiscordVoiceSendFn>(ctx.deps, "discordVoice") ??

--- a/extensions/discord/src/reply-reference.ts
+++ b/extensions/discord/src/reply-reference.ts
@@ -1,0 +1,38 @@
+import type { ReplyToResolution } from "openclaw/plugin-sdk/channel-outbound";
+import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
+import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
+
+// Keep the native reference and its physical-send scope together so text, media,
+// component, and voice paths cannot desynchronize parallel reply options.
+export type DiscordReplyReference = Readonly<{
+  messageId: string;
+  scope: "all" | "first";
+}>;
+
+export function resolveDiscordReplyReference(params: {
+  replyToId?: string | null;
+  replyToIdSource?: ReplyToResolution["source"];
+  replyToMode?: ReplyToMode;
+}): DiscordReplyReference | undefined {
+  if (!params.replyToId) {
+    return undefined;
+  }
+  const singleUse =
+    params.replyToIdSource !== "explicit" &&
+    params.replyToMode !== undefined &&
+    isSingleUseReplyToMode(params.replyToMode);
+  return { messageId: params.replyToId, scope: singleUse ? "first" : "all" };
+}
+
+export function createReusableDiscordReplyReference(
+  messageId?: string | null,
+): DiscordReplyReference | undefined {
+  return messageId ? { messageId, scope: "all" } : undefined;
+}
+
+export function resolveDiscordReplyMessageId(
+  reply: DiscordReplyReference | undefined,
+  isFirst: boolean,
+): string | undefined {
+  return reply && (isFirst || reply.scope === "all") ? reply.messageId : undefined;
+}

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -313,8 +313,7 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
         mediaLocalRoots: undefined,
         mediaReadFile: readFileMock,
         mediaAccess,
-        replyTo: undefined,
-        replyToFirstChunkOnly: undefined,
+        reply: undefined,
         silent: undefined,
         textLimit: undefined,
         maxLinesPerMessage: undefined,
@@ -333,18 +332,15 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
         cfg: DISCORD_TEST_CFG,
         token: "t",
         mediaUrl: "https://example.com/report.pdf",
-        replyTo: "source-1",
-        replyToFirstChunkOnly: true,
+        reply: { messageId: "source-1", scope: "first" },
       },
     );
 
     expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
     const options = readMockCall(sendMessageDiscordMock, 0)[2] as {
-      replyTo?: string;
-      replyToFirstChunkOnly?: boolean;
+      reply?: { messageId: string; scope: "all" | "first" };
     };
-    expect(options.replyTo).toBe("source-1");
-    expect(options.replyToFirstChunkOnly).toBe(true);
+    expect(options.reply).toEqual({ messageId: "source-1", scope: "first" });
   });
 
   it("keeps modal component messages on the component path", async () => {

--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -314,6 +314,7 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
         mediaReadFile: readFileMock,
         mediaAccess,
         replyTo: undefined,
+        replyToFirstChunkOnly: undefined,
         silent: undefined,
         textLimit: undefined,
         maxLinesPerMessage: undefined,
@@ -322,6 +323,28 @@ describe("sendDiscordComponentMessage classic message downgrade", () => {
         onDeliveryResult,
       },
     ]);
+  });
+
+  it("forwards first-chunk reply fanout through classic media downgrades", async () => {
+    await sendDiscordComponentMessage(
+      "channel:chan-1",
+      { blocks: [{ type: "text", text: "report" }] },
+      {
+        cfg: DISCORD_TEST_CFG,
+        token: "t",
+        mediaUrl: "https://example.com/report.pdf",
+        replyTo: "source-1",
+        replyToFirstChunkOnly: true,
+      },
+    );
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+    const options = readMockCall(sendMessageDiscordMock, 0)[2] as {
+      replyTo?: string;
+      replyToFirstChunkOnly?: boolean;
+    };
+    expect(options.replyTo).toBe("source-1");
+    expect(options.replyToFirstChunkOnly).toBe(true);
   });
 
   it("keeps modal component messages on the component path", async () => {

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -24,6 +24,7 @@ import {
   type RequestClient,
 } from "./internal/discord.js";
 import { parseAndResolveChannelRecipient } from "./recipient-resolution.js";
+import type { DiscordReplyReference } from "./reply-reference.js";
 import { loadOutboundMediaFromUrl } from "./runtime-api.js";
 import { sendMessageDiscord } from "./send.outbound.js";
 import { createDiscordSendResult } from "./send.receipt.js";
@@ -154,8 +155,7 @@ type DiscordComponentSendOpts = {
   token?: string;
   rest?: RequestClient;
   silent?: boolean;
-  replyTo?: string;
-  replyToFirstChunkOnly?: boolean;
+  reply?: DiscordReplyReference;
   sessionKey?: string;
   agentId?: string;
   mediaUrl?: string;
@@ -202,8 +202,8 @@ async function buildDiscordComponentPayload(params: {
   body: ReturnType<typeof stripUndefinedFields>;
   buildResult: ReturnType<typeof buildDiscordComponentMessage>;
 }> {
-  const messageReference = params.opts.replyTo
-    ? { message_id: params.opts.replyTo, fail_if_not_exists: false }
+  const messageReference = params.opts.reply
+    ? { message_id: params.opts.reply.messageId, fail_if_not_exists: false }
     : undefined;
 
   let spec = params.spec;
@@ -282,8 +282,7 @@ export async function sendDiscordComponentMessage(
       mediaLocalRoots: opts.mediaLocalRoots,
       mediaReadFile: opts.mediaReadFile,
       mediaAccess: opts.mediaAccess,
-      replyTo: opts.replyTo,
-      replyToFirstChunkOnly: opts.replyToFirstChunkOnly,
+      reply: opts.reply,
       silent: opts.silent,
       textLimit: opts.textLimit,
       maxLinesPerMessage: opts.maxLinesPerMessage,
@@ -335,7 +334,7 @@ export async function sendDiscordComponentMessage(
     result,
     fallbackChannelId: channelId,
     kind: "card",
-    ...(opts.replyTo ? { replyToId: opts.replyTo } : {}),
+    ...(opts.reply ? { reply: opts.reply } : {}),
   });
   await opts.onDeliveryResult?.(deliveryResult);
 
@@ -409,6 +408,6 @@ export async function editDiscordComponentMessage(
     },
     fallbackChannelId: channelId,
     kind: "card",
-    ...(opts.replyTo ? { replyToId: opts.replyTo } : {}),
+    ...(opts.reply ? { reply: opts.reply } : {}),
   });
 }

--- a/extensions/discord/src/send.components.ts
+++ b/extensions/discord/src/send.components.ts
@@ -155,6 +155,7 @@ type DiscordComponentSendOpts = {
   rest?: RequestClient;
   silent?: boolean;
   replyTo?: string;
+  replyToFirstChunkOnly?: boolean;
   sessionKey?: string;
   agentId?: string;
   mediaUrl?: string;
@@ -282,6 +283,7 @@ export async function sendDiscordComponentMessage(
       mediaReadFile: opts.mediaReadFile,
       mediaAccess: opts.mediaAccess,
       replyTo: opts.replyTo,
+      replyToFirstChunkOnly: opts.replyToFirstChunkOnly,
       silent: opts.silent,
       textLimit: opts.textLimit,
       maxLinesPerMessage: opts.maxLinesPerMessage,

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -79,22 +79,18 @@ async function sendDiscordThreadTextChunks(params: {
   onResult?: DiscordSendProgress;
 }): Promise<void> {
   for (const chunk of params.chunks) {
-    await sendDiscordText(
-      params.rest,
-      params.threadId,
-      chunk,
-      undefined,
-      params.request,
-      params.maxLinesPerMessage,
-      undefined,
-      undefined,
-      params.chunkMode,
-      params.silent,
-      params.suppressEmbeds,
-      params.maxChars,
-      undefined,
-      params.onResult,
-    );
+    await sendDiscordText({
+      rest: params.rest,
+      channelId: params.threadId,
+      text: chunk,
+      request: params.request,
+      maxLinesPerMessage: params.maxLinesPerMessage,
+      chunkMode: params.chunkMode,
+      silent: params.silent,
+      suppressEmbeds: params.suppressEmbeds,
+      maxChars: params.maxChars,
+      onResult: params.onResult,
+    });
   }
 }
 
@@ -129,6 +125,7 @@ function toDiscordSendResult(
     kind?: Parameters<typeof createDiscordSendResult>[0]["kind"];
     threadId?: string | number;
     replyToId?: string;
+    replyToFirstMessageOnly?: boolean;
   } = {},
 ): DiscordSendResult {
   const resultParams: Parameters<typeof createDiscordSendResult>[0] = {
@@ -141,6 +138,9 @@ function toDiscordSendResult(
   }
   if (params.replyToId) {
     resultParams.replyToId = params.replyToId;
+  }
+  if (params.replyToFirstMessageOnly) {
+    resultParams.replyToFirstMessageOnly = true;
   }
   return createDiscordSendResult(resultParams);
 }
@@ -269,28 +269,24 @@ export async function sendMessageDiscord(
     try {
       if (opts.mediaUrl) {
         const [mediaCaption, ...afterMediaChunks] = remainingChunks;
-        await sendDiscordMedia(
+        await sendDiscordMedia({
           rest,
-          threadId,
-          mediaCaption ?? "",
-          opts.mediaUrl,
-          opts.filename,
-          opts.mediaAccess,
-          opts.mediaLocalRoots,
-          opts.mediaReadFile,
-          mediaMaxBytes,
-          undefined,
+          channelId: threadId,
+          text: mediaCaption ?? "",
+          mediaUrl: opts.mediaUrl,
+          filename: opts.filename,
+          mediaAccess: opts.mediaAccess,
+          mediaLocalRoots: opts.mediaLocalRoots,
+          mediaReadFile: opts.mediaReadFile,
+          maxBytes: mediaMaxBytes,
           request,
           maxLinesPerMessage,
-          undefined,
-          undefined,
           chunkMode,
-          opts.silent,
+          silent: opts.silent,
           suppressEmbeds,
-          textLimit,
-          undefined,
-          reportThreadResult,
-        );
+          maxChars: textLimit,
+          onResult: reportThreadResult,
+        });
         await sendDiscordThreadTextChunks({
           rest,
           threadId,
@@ -343,55 +339,55 @@ export async function sendMessageDiscord(
   }
 
   let result: DiscordChannelMessageResult;
-  const reportResult: DiscordSendProgress = async (progressResult, kind) => {
+  const reportResult: DiscordSendProgress = async (progressResult, kind, replyToId) => {
     await opts.onDeliveryResult?.(
       toDiscordSendResult(progressResult, channelId, {
         kind,
-        replyToId: opts.replyTo,
+        replyToId,
       }),
     );
   };
   try {
     if (opts.mediaUrl) {
-      result = await sendDiscordMedia(
+      result = await sendDiscordMedia({
         rest,
         channelId,
-        textWithMentions,
-        opts.mediaUrl,
-        opts.filename,
-        opts.mediaAccess,
-        opts.mediaLocalRoots,
-        opts.mediaReadFile,
-        mediaMaxBytes,
-        opts.replyTo,
+        text: textWithMentions,
+        mediaUrl: opts.mediaUrl,
+        filename: opts.filename,
+        mediaAccess: opts.mediaAccess,
+        mediaLocalRoots: opts.mediaLocalRoots,
+        mediaReadFile: opts.mediaReadFile,
+        maxBytes: mediaMaxBytes,
+        replyTo: opts.replyTo,
         request,
         maxLinesPerMessage,
-        opts.components,
-        opts.embeds,
+        components: opts.components,
+        embeds: opts.embeds,
         chunkMode,
-        opts.silent,
+        silent: opts.silent,
         suppressEmbeds,
-        textLimit,
-        opts.replyToFirstChunkOnly,
-        reportResult,
-      );
+        maxChars: textLimit,
+        replyToFirstChunkOnly: opts.replyToFirstChunkOnly,
+        onResult: reportResult,
+      });
     } else {
-      result = await sendDiscordText(
+      result = await sendDiscordText({
         rest,
         channelId,
-        textWithMentions,
-        opts.replyTo,
+        text: textWithMentions,
+        replyTo: opts.replyTo,
         request,
         maxLinesPerMessage,
-        opts.components,
-        opts.embeds,
+        components: opts.components,
+        embeds: opts.embeds,
         chunkMode,
-        opts.silent,
+        silent: opts.silent,
         suppressEmbeds,
-        textLimit,
-        opts.replyToFirstChunkOnly,
-        reportResult,
-      );
+        maxChars: textLimit,
+        replyToFirstChunkOnly: opts.replyToFirstChunkOnly,
+        onResult: reportResult,
+      });
     }
   } catch (err) {
     throw await buildDiscordSendError(err, {
@@ -411,6 +407,7 @@ export async function sendMessageDiscord(
   return toDiscordSendResult(result, channelId, {
     kind: opts.mediaUrl ? "media" : opts.components || opts.embeds ? "card" : "text",
     replyToId: opts.replyTo,
+    replyToFirstMessageOnly: opts.replyToFirstChunkOnly,
   });
 }
 

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -46,6 +46,7 @@ type DiscordSendOpts = {
   verbose?: boolean;
   rest?: RequestClient;
   replyTo?: string;
+  replyToFirstChunkOnly?: boolean;
   retry?: RetryConfig;
   textLimit?: number;
   maxLinesPerMessage?: number;
@@ -91,6 +92,7 @@ async function sendDiscordThreadTextChunks(params: {
       params.silent,
       params.suppressEmbeds,
       params.maxChars,
+      undefined,
       params.onResult,
     );
   }
@@ -286,6 +288,7 @@ export async function sendMessageDiscord(
           opts.silent,
           suppressEmbeds,
           textLimit,
+          undefined,
           reportThreadResult,
         );
         await sendDiscordThreadTextChunks({
@@ -369,6 +372,7 @@ export async function sendMessageDiscord(
         opts.silent,
         suppressEmbeds,
         textLimit,
+        opts.replyToFirstChunkOnly,
         reportResult,
       );
     } else {
@@ -385,6 +389,7 @@ export async function sendMessageDiscord(
         opts.silent,
         suppressEmbeds,
         textLimit,
+        opts.replyToFirstChunkOnly,
         reportResult,
       );
     }

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -14,6 +14,10 @@ import { resolveDiscordAccount } from "./accounts.js";
 import { createChannelMessage, createThread, type RequestClient } from "./internal/discord.js";
 import { rewriteDiscordKnownMentions } from "./mentions.js";
 import { parseAndResolveChannelRecipient } from "./recipient-resolution.js";
+import {
+  createReusableDiscordReplyReference,
+  type DiscordReplyReference,
+} from "./reply-reference.js";
 import { createDiscordSendResult, type DiscordReceiptResultSource } from "./send.receipt.js";
 import {
   buildDiscordMessageRequest,
@@ -45,8 +49,7 @@ type DiscordSendOpts = {
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
   verbose?: boolean;
   rest?: RequestClient;
-  replyTo?: string;
-  replyToFirstChunkOnly?: boolean;
+  reply?: DiscordReplyReference;
   retry?: RetryConfig;
   textLimit?: number;
   maxLinesPerMessage?: number;
@@ -124,8 +127,7 @@ function toDiscordSendResult(
   params: {
     kind?: Parameters<typeof createDiscordSendResult>[0]["kind"];
     threadId?: string | number;
-    replyToId?: string;
-    replyToFirstMessageOnly?: boolean;
+    reply?: DiscordReplyReference;
   } = {},
 ): DiscordSendResult {
   const resultParams: Parameters<typeof createDiscordSendResult>[0] = {
@@ -136,11 +138,8 @@ function toDiscordSendResult(
   if (params.threadId != null) {
     resultParams.threadId = params.threadId;
   }
-  if (params.replyToId) {
-    resultParams.replyToId = params.replyToId;
-  }
-  if (params.replyToFirstMessageOnly) {
-    resultParams.replyToFirstMessageOnly = true;
+  if (params.reply) {
+    resultParams.reply = params.reply;
   }
   return createDiscordSendResult(resultParams);
 }
@@ -343,7 +342,7 @@ export async function sendMessageDiscord(
     await opts.onDeliveryResult?.(
       toDiscordSendResult(progressResult, channelId, {
         kind,
-        replyToId,
+        reply: createReusableDiscordReplyReference(replyToId),
       }),
     );
   };
@@ -359,7 +358,7 @@ export async function sendMessageDiscord(
         mediaLocalRoots: opts.mediaLocalRoots,
         mediaReadFile: opts.mediaReadFile,
         maxBytes: mediaMaxBytes,
-        replyTo: opts.replyTo,
+        reply: opts.reply,
         request,
         maxLinesPerMessage,
         components: opts.components,
@@ -368,7 +367,6 @@ export async function sendMessageDiscord(
         silent: opts.silent,
         suppressEmbeds,
         maxChars: textLimit,
-        replyToFirstChunkOnly: opts.replyToFirstChunkOnly,
         onResult: reportResult,
       });
     } else {
@@ -376,7 +374,7 @@ export async function sendMessageDiscord(
         rest,
         channelId,
         text: textWithMentions,
-        replyTo: opts.replyTo,
+        reply: opts.reply,
         request,
         maxLinesPerMessage,
         components: opts.components,
@@ -385,7 +383,6 @@ export async function sendMessageDiscord(
         silent: opts.silent,
         suppressEmbeds,
         maxChars: textLimit,
-        replyToFirstChunkOnly: opts.replyToFirstChunkOnly,
         onResult: reportResult,
       });
     }
@@ -406,8 +403,7 @@ export async function sendMessageDiscord(
   });
   return toDiscordSendResult(result, channelId, {
     kind: opts.mediaUrl ? "media" : opts.components || opts.embeds ? "card" : "text",
-    replyToId: opts.replyTo,
-    replyToFirstMessageOnly: opts.replyToFirstChunkOnly,
+    reply: opts.reply,
   });
 }
 

--- a/extensions/discord/src/send.receipt.ts
+++ b/extensions/discord/src/send.receipt.ts
@@ -26,7 +26,7 @@ export function createDiscordSendReceipt(params: {
     .filter((messageId) => messageId && messageId !== "unknown");
   const results: Array<MessageReceiptSourceResult & { receipt?: MessageReceipt }> =
     platformMessageIds.map((messageId, index) => {
-      const result: MessageReceiptSourceResult = {
+      const result: MessageReceiptSourceResult & { receipt?: MessageReceipt } = {
         channel: "discord",
         messageId,
       };
@@ -36,15 +36,19 @@ export function createDiscordSendReceipt(params: {
       if (params.replyToFirstMessageOnly && index === 0 && params.replyToId) {
         // A top-level replyToId would be copied onto every receipt part. Nest the
         // first receipt so persisted metadata matches Discord's one message_reference.
-        return {
-          ...result,
-          receipt: createMessageReceiptFromOutboundResults({
-            results: [result],
-            kind: params.kind,
-            threadId: params.threadId,
-            replyToId: params.replyToId,
-          }),
+        const rawResult: MessageReceiptSourceResult = {
+          channel: "discord",
+          messageId,
         };
+        if (params.channelId) {
+          rawResult.channelId = params.channelId;
+        }
+        result.receipt = createMessageReceiptFromOutboundResults({
+          results: [rawResult],
+          kind: params.kind,
+          threadId: params.threadId,
+          replyToId: params.replyToId,
+        });
       }
       return result;
     });

--- a/extensions/discord/src/send.receipt.ts
+++ b/extensions/discord/src/send.receipt.ts
@@ -5,6 +5,7 @@ import {
   type MessageReceiptPartKind,
   type MessageReceiptSourceResult,
 } from "openclaw/plugin-sdk/channel-outbound";
+import type { DiscordReplyReference } from "./reply-reference.js";
 import type { DiscordSendResult } from "./send.types.js";
 
 export type DiscordReceiptResultSource = {
@@ -18,8 +19,7 @@ export function createDiscordSendReceipt(params: {
   channelId?: string;
   kind: MessageReceiptPartKind;
   threadId?: string;
-  replyToId?: string;
-  replyToFirstMessageOnly?: boolean;
+  reply?: DiscordReplyReference;
 }): MessageReceipt {
   const platformMessageIds = params.platformMessageIds
     .map((messageId) => messageId.trim())
@@ -33,7 +33,7 @@ export function createDiscordSendReceipt(params: {
       if (params.channelId) {
         result.channelId = params.channelId;
       }
-      if (params.replyToFirstMessageOnly && index === 0 && params.replyToId) {
+      if (params.reply?.scope === "first" && index === 0) {
         // A top-level replyToId would be copied onto every receipt part. Nest the
         // first receipt so persisted metadata matches Discord's one message_reference.
         const rawResult: MessageReceiptSourceResult = {
@@ -47,7 +47,7 @@ export function createDiscordSendReceipt(params: {
           results: [rawResult],
           kind: params.kind,
           threadId: params.threadId,
-          replyToId: params.replyToId,
+          replyToId: params.reply.messageId,
         });
       }
       return result;
@@ -56,7 +56,7 @@ export function createDiscordSendReceipt(params: {
     results,
     kind: params.kind,
     threadId: params.threadId,
-    replyToId: params.replyToFirstMessageOnly ? undefined : params.replyToId,
+    replyToId: params.reply?.scope === "all" ? params.reply.messageId : undefined,
   });
 }
 
@@ -65,8 +65,7 @@ export function createDiscordSendResult(params: {
   fallbackChannelId: string;
   kind: MessageReceiptPartKind;
   threadId?: string | number;
-  replyToId?: string;
-  replyToFirstMessageOnly?: boolean;
+  reply?: DiscordReplyReference;
 }): DiscordSendResult {
   const messageId = params.result.id || "unknown";
   const channelId = params.result.channel_id ?? params.fallbackChannelId;
@@ -80,11 +79,8 @@ export function createDiscordSendResult(params: {
   if (params.threadId != null) {
     receiptParams.threadId = String(params.threadId);
   }
-  if (params.replyToId) {
-    receiptParams.replyToId = params.replyToId;
-  }
-  if (params.replyToFirstMessageOnly) {
-    receiptParams.replyToFirstMessageOnly = true;
+  if (params.reply) {
+    receiptParams.reply = params.reply;
   }
   return {
     messageId,

--- a/extensions/discord/src/send.receipt.ts
+++ b/extensions/discord/src/send.receipt.ts
@@ -19,12 +19,13 @@ export function createDiscordSendReceipt(params: {
   kind: MessageReceiptPartKind;
   threadId?: string;
   replyToId?: string;
+  replyToFirstMessageOnly?: boolean;
 }): MessageReceipt {
   const platformMessageIds = params.platformMessageIds
     .map((messageId) => messageId.trim())
     .filter((messageId) => messageId && messageId !== "unknown");
-  return createMessageReceiptFromOutboundResults({
-    results: platformMessageIds.map((messageId) => {
+  const results: Array<MessageReceiptSourceResult & { receipt?: MessageReceipt }> =
+    platformMessageIds.map((messageId, index) => {
       const result: MessageReceiptSourceResult = {
         channel: "discord",
         messageId,
@@ -32,11 +33,26 @@ export function createDiscordSendReceipt(params: {
       if (params.channelId) {
         result.channelId = params.channelId;
       }
+      if (params.replyToFirstMessageOnly && index === 0 && params.replyToId) {
+        // A top-level replyToId would be copied onto every receipt part. Nest the
+        // first receipt so persisted metadata matches Discord's one message_reference.
+        return {
+          ...result,
+          receipt: createMessageReceiptFromOutboundResults({
+            results: [result],
+            kind: params.kind,
+            threadId: params.threadId,
+            replyToId: params.replyToId,
+          }),
+        };
+      }
       return result;
-    }),
+    });
+  return createMessageReceiptFromOutboundResults({
+    results,
     kind: params.kind,
     threadId: params.threadId,
-    replyToId: params.replyToId,
+    replyToId: params.replyToFirstMessageOnly ? undefined : params.replyToId,
   });
 }
 
@@ -46,6 +62,7 @@ export function createDiscordSendResult(params: {
   kind: MessageReceiptPartKind;
   threadId?: string | number;
   replyToId?: string;
+  replyToFirstMessageOnly?: boolean;
 }): DiscordSendResult {
   const messageId = params.result.id || "unknown";
   const channelId = params.result.channel_id ?? params.fallbackChannelId;
@@ -61,6 +78,9 @@ export function createDiscordSendResult(params: {
   }
   if (params.replyToId) {
     receiptParams.replyToId = params.replyToId;
+  }
+  if (params.replyToFirstMessageOnly) {
+    receiptParams.replyToFirstMessageOnly = true;
   }
   return {
     messageId,

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -166,7 +166,15 @@ describe("sendMessageDiscord", () => {
     });
   }
 
-  async function sendChunkedReplyAndCollectBodies(params: { text: string; mediaUrl?: string }) {
+  function expectNoReplyReference(body: { message_reference?: unknown } | undefined) {
+    expect(body?.message_reference).toBeUndefined();
+  }
+
+  async function sendChunkedReplyAndCollectBodies(params: {
+    text: string;
+    mediaUrl?: string;
+    replyToFirstChunkOnly?: boolean;
+  }) {
     const { rest, postMock } = makeDiscordRest();
     postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
     await sendMessageDiscord("channel:789", params.text, {
@@ -174,6 +182,7 @@ describe("sendMessageDiscord", () => {
       token: "t",
       cfg: DISCORD_TEST_CFG,
       replyTo: "orig-123",
+      ...(params.replyToFirstChunkOnly ? { replyToFirstChunkOnly: true } : {}),
       ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),
     });
     expect(postMock).toHaveBeenCalledTimes(2);
@@ -769,7 +778,7 @@ describe("sendMessageDiscord", () => {
     });
   });
 
-  it("preserves reply reference across all text chunks", async () => {
+  it("preserves reply reference across all text chunks by default", async () => {
     const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2001),
     });
@@ -777,13 +786,32 @@ describe("sendMessageDiscord", () => {
     expectReplyReference(secondBody, "orig-123");
   });
 
-  it("preserves reply reference for follow-up text chunks after media caption split", async () => {
+  it("limits reply reference to the first text chunk when requested", async () => {
+    const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
+      text: "a".repeat(2001),
+      replyToFirstChunkOnly: true,
+    });
+    expectReplyReference(firstBody, "orig-123");
+    expectNoReplyReference(secondBody);
+  });
+
+  it("preserves reply reference for follow-up text chunks after media caption split by default", async () => {
     const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2500),
       mediaUrl: "file:///tmp/photo.jpg",
     });
     expectReplyReference(firstBody, "orig-123");
     expectReplyReference(secondBody, "orig-123");
+  });
+
+  it("limits media caption reply reference to the first physical message when requested", async () => {
+    const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
+      text: "a".repeat(2500),
+      mediaUrl: "file:///tmp/photo.jpg",
+      replyToFirstChunkOnly: true,
+    });
+    expectReplyReference(firstBody, "orig-123");
+    expectNoReplyReference(secondBody);
   });
 });
 

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -176,8 +176,10 @@ describe("sendMessageDiscord", () => {
     replyToFirstChunkOnly?: boolean;
   }) {
     const { rest, postMock } = makeDiscordRest();
-    postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
-    await sendMessageDiscord("channel:789", params.text, {
+    postMock
+      .mockResolvedValueOnce({ id: "msg1", channel_id: "789" })
+      .mockResolvedValueOnce({ id: "msg2", channel_id: "789" });
+    const result = await sendMessageDiscord("channel:789", params.text, {
       rest,
       token: "t",
       cfg: DISCORD_TEST_CFG,
@@ -189,6 +191,7 @@ describe("sendMessageDiscord", () => {
     return {
       firstBody: requireRestBody(postMock, 0) as { message_reference?: unknown },
       secondBody: requireRestBody(postMock, 1) as { message_reference?: unknown },
+      result,
     };
   }
 
@@ -668,6 +671,9 @@ describe("sendMessageDiscord", () => {
       "fallback-1",
       "fallback-2",
     ]);
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.receipt.parts[0]?.replyToId)).toEqual(
+      ["orig-123", undefined],
+    );
   });
 
   it("reports a media-only upload rejected with HTTP 413", async () => {
@@ -819,12 +825,14 @@ describe("sendMessageDiscord", () => {
   });
 
   it("limits reply reference to the first text chunk when requested", async () => {
-    const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
+    const { firstBody, secondBody, result } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2001),
       replyToFirstChunkOnly: true,
     });
     expectReplyReference(firstBody, "orig-123");
     expectNoReplyReference(secondBody);
+    expect(result.receipt.replyToId).toBe("orig-123");
+    expect(result.receipt.parts.map((part) => part.replyToId)).toEqual(["orig-123", undefined]);
   });
 
   it("preserves reply reference for follow-up text chunks after media caption split by default", async () => {

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -833,6 +833,7 @@ describe("sendMessageDiscord", () => {
     expectNoReplyReference(secondBody);
     expect(result.receipt.replyToId).toBe("orig-123");
     expect(result.receipt.parts.map((part) => part.replyToId)).toEqual(["orig-123", undefined]);
+    expect(() => JSON.stringify(result.receipt)).not.toThrow();
   });
 
   it("preserves reply reference for follow-up text chunks after media caption split by default", async () => {

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -638,6 +638,38 @@ describe("sendMessageDiscord", () => {
     expectReplyReference(fallbackBody, "orig-123");
   });
 
+  it("preserves implicit reply scope and delivery progress in upload fallback chunks", async () => {
+    const { rest, postMock } = makeDiscordRest();
+    postMock
+      .mockRejectedValueOnce(
+        Object.assign(new Error("Bad Request"), {
+          status: 400,
+          rawError: { code: 40005 },
+        }),
+      )
+      .mockResolvedValueOnce({ id: "fallback-1", channel_id: "789" })
+      .mockResolvedValueOnce({ id: "fallback-2", channel_id: "789" });
+    const onDeliveryResult = vi.fn();
+
+    await sendMessageDiscord("channel:789", "a".repeat(2500), {
+      rest,
+      token: "t",
+      cfg: DISCORD_TEST_CFG,
+      mediaUrl: "file:///tmp/report.pdf",
+      replyTo: "orig-123",
+      replyToFirstChunkOnly: true,
+      onDeliveryResult,
+    });
+
+    expect(postMock).toHaveBeenCalledTimes(3);
+    expectReplyReference(requireRestBody(postMock, 1), "orig-123");
+    expectNoReplyReference(requireRestBody(postMock, 2));
+    expect(onDeliveryResult.mock.calls.map((call) => call[0]?.messageId)).toEqual([
+      "fallback-1",
+      "fallback-2",
+    ]);
+  });
+
   it("reports a media-only upload rejected with HTTP 413", async () => {
     const { rest, postMock } = makeDiscordRest();
     postMock

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -173,7 +173,7 @@ describe("sendMessageDiscord", () => {
   async function sendChunkedReplyAndCollectBodies(params: {
     text: string;
     mediaUrl?: string;
-    replyToFirstChunkOnly?: boolean;
+    replyScope?: "all" | "first";
   }) {
     const { rest, postMock } = makeDiscordRest();
     postMock
@@ -183,8 +183,7 @@ describe("sendMessageDiscord", () => {
       rest,
       token: "t",
       cfg: DISCORD_TEST_CFG,
-      replyTo: "orig-123",
-      ...(params.replyToFirstChunkOnly ? { replyToFirstChunkOnly: true } : {}),
+      reply: { messageId: "orig-123", scope: params.replyScope ?? "all" },
       ...(params.mediaUrl ? { mediaUrl: params.mediaUrl } : {}),
     });
     expect(postMock).toHaveBeenCalledTimes(2);
@@ -623,7 +622,7 @@ describe("sendMessageDiscord", () => {
       token: "t",
       cfg: DISCORD_TEST_CFG,
       mediaUrl: "file:///tmp/report.pdf",
-      replyTo: "orig-123",
+      reply: { messageId: "orig-123", scope: "all" },
       components: [new Container([new TextDisplay("Attachment controls")])],
       embeds: [{ title: "Attachment preview" }],
     });
@@ -659,8 +658,7 @@ describe("sendMessageDiscord", () => {
       token: "t",
       cfg: DISCORD_TEST_CFG,
       mediaUrl: "file:///tmp/report.pdf",
-      replyTo: "orig-123",
-      replyToFirstChunkOnly: true,
+      reply: { messageId: "orig-123", scope: "first" },
       onDeliveryResult,
     });
 
@@ -807,7 +805,7 @@ describe("sendMessageDiscord", () => {
       rest,
       token: "t",
       cfg: DISCORD_TEST_CFG,
-      replyTo: "orig-123",
+      reply: { messageId: "orig-123", scope: "all" },
     });
     const body = requireRestBody(postMock);
     expect(body?.message_reference).toEqual({
@@ -827,7 +825,7 @@ describe("sendMessageDiscord", () => {
   it("limits reply reference to the first text chunk when requested", async () => {
     const { firstBody, secondBody, result } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2001),
-      replyToFirstChunkOnly: true,
+      replyScope: "first",
     });
     expectReplyReference(firstBody, "orig-123");
     expectNoReplyReference(secondBody);
@@ -849,7 +847,7 @@ describe("sendMessageDiscord", () => {
     const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2500),
       mediaUrl: "file:///tmp/photo.jpg",
-      replyToFirstChunkOnly: true,
+      replyScope: "first",
     });
     expectReplyReference(firstBody, "orig-123");
     expectNoReplyReference(secondBody);

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -464,6 +464,7 @@ async function sendDiscordMedia(
       silent,
       suppressEmbeds,
       maxChars,
+      replyToFirstChunkOnly,
       onResult,
     );
   }

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -314,29 +314,49 @@ export function toDiscordFileBlob(data: Blob | Uint8Array): Blob {
 export type DiscordSendProgress = (
   result: { id: string; channel_id: string },
   kind: "text" | "media",
+  replyToId?: string,
 ) => Promise<void> | void;
 
-async function sendDiscordText(
-  rest: RequestClient,
-  channelId: string,
-  text: string,
-  replyTo: string | undefined,
-  request: DiscordRequest,
-  maxLinesPerMessage?: number,
-  components?: DiscordSendComponents,
-  embeds?: DiscordSendEmbeds,
-  chunkMode?: ChunkMode,
-  silent?: boolean,
-  suppressEmbeds?: boolean,
-  maxChars?: number,
-  replyToFirstChunkOnly?: boolean,
-  onResult?: DiscordSendProgress,
-) {
+type DiscordTextSendParams = {
+  rest: RequestClient;
+  channelId: string;
+  text: string;
+  request: DiscordRequest;
+  replyTo?: string;
+  maxLinesPerMessage?: number;
+  components?: DiscordSendComponents;
+  embeds?: DiscordSendEmbeds;
+  chunkMode?: ChunkMode;
+  silent?: boolean;
+  suppressEmbeds?: boolean;
+  maxChars?: number;
+  replyToFirstChunkOnly?: boolean;
+  onResult?: DiscordSendProgress;
+};
+
+async function sendDiscordText(params: DiscordTextSendParams) {
+  const {
+    rest,
+    channelId,
+    text,
+    request,
+    replyTo,
+    maxLinesPerMessage,
+    components,
+    embeds,
+    chunkMode,
+    silent,
+    suppressEmbeds,
+    maxChars,
+    replyToFirstChunkOnly,
+    onResult,
+  } = params;
   if (!text.trim()) {
     throw new Error("Message must be non-empty for Discord sends");
   }
   const chunks = buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode, maxChars });
   const sendChunk = async (chunk: string, isFirst: boolean) => {
+    const chunkReplyTo = replyToFirstChunkOnly && !isFirst ? undefined : replyTo;
     const chunkComponents = resolveDiscordSendComponents({
       components,
       text: chunk,
@@ -352,23 +372,25 @@ async function sendDiscordText(
       components: chunkComponents,
       embeds: chunkEmbeds,
       flags,
-      replyTo: replyToFirstChunkOnly && !isFirst ? undefined : replyTo,
+      replyTo: chunkReplyTo,
     });
-    return (await request(
+    const result = (await request(
       () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
       "text",
     )) as { id: string; channel_id: string };
+    return { result, replyToId: chunkReplyTo };
   };
   if (chunks.length === 1) {
-    const result = await sendChunk(chunks[0], true);
-    await onResult?.(result, "text");
+    const { result, replyToId } = await sendChunk(chunks[0], true);
+    await onResult?.(result, "text", replyToId);
     return { ...result, platformMessageIds: result.id ? [result.id] : [] };
   }
   const platformMessageIds: string[] = [];
   let last: { id: string; channel_id: string } | null = null;
   for (const [index, chunk] of chunks.entries()) {
-    last = await sendChunk(chunk, index === 0);
-    await onResult?.(last, "text");
+    const sent = await sendChunk(chunk, index === 0);
+    last = sent.result;
+    await onResult?.(last, "text", sent.replyToId);
     if (last.id) {
       platformMessageIds.push(last.id);
     }
@@ -379,28 +401,38 @@ async function sendDiscordText(
   return { ...last, platformMessageIds };
 }
 
-async function sendDiscordMedia(
-  rest: RequestClient,
-  channelId: string,
-  text: string,
-  mediaUrl: string,
-  filename: string | undefined,
-  mediaAccess: OutboundMediaAccess | undefined,
-  mediaLocalRoots: readonly string[] | undefined,
-  mediaReadFile: ((filePath: string) => Promise<Buffer>) | undefined,
-  maxBytes: number | undefined,
-  replyTo: string | undefined,
-  request: DiscordRequest,
-  maxLinesPerMessage?: number,
-  components?: DiscordSendComponents,
-  embeds?: DiscordSendEmbeds,
-  chunkMode?: ChunkMode,
-  silent?: boolean,
-  suppressEmbeds?: boolean,
-  maxChars?: number,
-  replyToFirstChunkOnly?: boolean,
-  onResult?: DiscordSendProgress,
-) {
+type DiscordMediaSendParams = DiscordTextSendParams & {
+  mediaUrl: string;
+  filename?: string;
+  mediaAccess?: OutboundMediaAccess;
+  mediaLocalRoots?: readonly string[];
+  mediaReadFile?: (filePath: string) => Promise<Buffer>;
+  maxBytes?: number;
+};
+
+async function sendDiscordMedia(params: DiscordMediaSendParams) {
+  const {
+    rest,
+    channelId,
+    text,
+    mediaUrl,
+    filename,
+    mediaAccess,
+    mediaLocalRoots,
+    mediaReadFile,
+    maxBytes,
+    replyTo,
+    request,
+    maxLinesPerMessage,
+    components,
+    embeds,
+    chunkMode,
+    silent,
+    suppressEmbeds,
+    maxChars,
+    replyToFirstChunkOnly,
+    onResult,
+  } = params;
   const media = await loadWebMedia(
     mediaUrl,
     buildOutboundMediaLoadOptions({ maxBytes, mediaAccess, mediaLocalRoots, mediaReadFile }),
@@ -451,45 +483,41 @@ async function sendDiscordMedia(
     }
     // The multipart request is all-or-nothing. Retry the portable text only;
     // attachment-coupled embeds/components may be invalid or misleading without it.
-    return sendDiscordText(
+    return sendDiscordText({
       rest,
       channelId,
-      buildDiscordUploadTooLargeFallbackText(text),
+      text: buildDiscordUploadTooLargeFallbackText(text),
       replyTo,
       request,
       maxLinesPerMessage,
-      undefined,
-      undefined,
       chunkMode,
       silent,
       suppressEmbeds,
       maxChars,
       replyToFirstChunkOnly,
       onResult,
-    );
+    });
   }
-  await onResult?.(res, "media");
+  await onResult?.(res, "media", replyTo);
   const platformMessageIds = res.id ? [res.id] : [];
   for (const chunk of chunks.slice(1)) {
     if (!chunk.trim()) {
       continue;
     }
-    const followup = await sendDiscordText(
+    const followup = await sendDiscordText({
       rest,
       channelId,
-      chunk,
-      replyToFirstChunkOnly ? undefined : replyTo,
+      text: chunk,
+      replyTo: replyToFirstChunkOnly ? undefined : replyTo,
       request,
       maxLinesPerMessage,
-      undefined,
-      undefined,
       chunkMode,
       silent,
       suppressEmbeds,
       maxChars,
       replyToFirstChunkOnly,
       onResult,
-    );
+    });
     for (const id of followup.platformMessageIds) {
       if (id) {
         platformMessageIds.push(id);

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -26,6 +26,7 @@ import {
   RequestClient,
 } from "./internal/discord.js";
 import { parseAndResolveRecipient } from "./recipient-resolution.js";
+import { resolveDiscordReplyMessageId, type DiscordReplyReference } from "./reply-reference.js";
 import { fetchChannelPermissionsDiscord, isThreadChannelType } from "./send.permissions.js";
 import { DiscordSendError } from "./send.types.js";
 
@@ -322,7 +323,7 @@ type DiscordTextSendParams = {
   channelId: string;
   text: string;
   request: DiscordRequest;
-  replyTo?: string;
+  reply?: DiscordReplyReference;
   maxLinesPerMessage?: number;
   components?: DiscordSendComponents;
   embeds?: DiscordSendEmbeds;
@@ -330,7 +331,6 @@ type DiscordTextSendParams = {
   silent?: boolean;
   suppressEmbeds?: boolean;
   maxChars?: number;
-  replyToFirstChunkOnly?: boolean;
   onResult?: DiscordSendProgress;
 };
 
@@ -340,7 +340,7 @@ async function sendDiscordText(params: DiscordTextSendParams) {
     channelId,
     text,
     request,
-    replyTo,
+    reply,
     maxLinesPerMessage,
     components,
     embeds,
@@ -348,7 +348,6 @@ async function sendDiscordText(params: DiscordTextSendParams) {
     silent,
     suppressEmbeds,
     maxChars,
-    replyToFirstChunkOnly,
     onResult,
   } = params;
   if (!text.trim()) {
@@ -356,7 +355,7 @@ async function sendDiscordText(params: DiscordTextSendParams) {
   }
   const chunks = buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode, maxChars });
   const sendChunk = async (chunk: string, isFirst: boolean) => {
-    const chunkReplyTo = replyToFirstChunkOnly && !isFirst ? undefined : replyTo;
+    const chunkReplyTo = resolveDiscordReplyMessageId(reply, isFirst);
     const chunkComponents = resolveDiscordSendComponents({
       components,
       text: chunk,
@@ -421,7 +420,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     mediaLocalRoots,
     mediaReadFile,
     maxBytes,
-    replyTo,
+    reply,
     request,
     maxLinesPerMessage,
     components,
@@ -430,7 +429,6 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     silent,
     suppressEmbeds,
     maxChars,
-    replyToFirstChunkOnly,
     onResult,
   } = params;
   const media = await loadWebMedia(
@@ -463,7 +461,7 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
     components: captionComponents,
     embeds: captionEmbeds,
     flags,
-    replyTo,
+    replyTo: resolveDiscordReplyMessageId(reply, true),
     files: [
       {
         data: fileData,
@@ -487,19 +485,19 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
       rest,
       channelId,
       text: buildDiscordUploadTooLargeFallbackText(text),
-      replyTo,
+      reply,
       request,
       maxLinesPerMessage,
       chunkMode,
       silent,
       suppressEmbeds,
       maxChars,
-      replyToFirstChunkOnly,
       onResult,
     });
   }
-  await onResult?.(res, "media", replyTo);
+  await onResult?.(res, "media", reply?.messageId);
   const platformMessageIds = res.id ? [res.id] : [];
+  const followupReply = reply?.scope === "all" ? reply : undefined;
   for (const chunk of chunks.slice(1)) {
     if (!chunk.trim()) {
       continue;
@@ -508,14 +506,13 @@ async function sendDiscordMedia(params: DiscordMediaSendParams) {
       rest,
       channelId,
       text: chunk,
-      replyTo: replyToFirstChunkOnly ? undefined : replyTo,
+      reply: followupReply,
       request,
       maxLinesPerMessage,
       chunkMode,
       silent,
       suppressEmbeds,
       maxChars,
-      replyToFirstChunkOnly,
       onResult,
     });
     for (const id of followup.platformMessageIds) {

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -329,6 +329,7 @@ async function sendDiscordText(
   silent?: boolean,
   suppressEmbeds?: boolean,
   maxChars?: number,
+  replyToFirstChunkOnly?: boolean,
   onResult?: DiscordSendProgress,
 ) {
   if (!text.trim()) {
@@ -351,7 +352,7 @@ async function sendDiscordText(
       components: chunkComponents,
       embeds: chunkEmbeds,
       flags,
-      replyTo,
+      replyTo: replyToFirstChunkOnly && !isFirst ? undefined : replyTo,
     });
     return (await request(
       () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
@@ -397,6 +398,7 @@ async function sendDiscordMedia(
   silent?: boolean,
   suppressEmbeds?: boolean,
   maxChars?: number,
+  replyToFirstChunkOnly?: boolean,
   onResult?: DiscordSendProgress,
 ) {
   const media = await loadWebMedia(
@@ -475,7 +477,7 @@ async function sendDiscordMedia(
       rest,
       channelId,
       chunk,
-      replyTo,
+      replyToFirstChunkOnly ? undefined : replyTo,
       request,
       maxLinesPerMessage,
       undefined,
@@ -484,6 +486,7 @@ async function sendDiscordMedia(
       silent,
       suppressEmbeds,
       maxChars,
+      replyToFirstChunkOnly,
       onResult,
     );
     for (const id of followup.platformMessageIds) {

--- a/extensions/discord/src/send.voice.test.ts
+++ b/extensions/discord/src/send.voice.test.ts
@@ -61,4 +61,23 @@ describe("sendVoiceMessageDiscord", () => {
     expect(voiceMocks.sendDiscordVoiceMessage).toHaveBeenCalledTimes(1);
     expect(voiceMocks.sendDiscordVoiceMessage.mock.calls[0]?.[1]).toBe("273512430271856640");
   });
+
+  it("records the native reply target in voice receipts", async () => {
+    const { rest } = makeDiscordRest();
+
+    const result = await sendVoiceMessageDiscord(
+      "273512430271856640",
+      "https://example.com/voice.ogg",
+      {
+        cfg: DISCORD_TEST_CFG,
+        rest,
+        token: "t",
+        reply: { messageId: "reply-1", scope: "first" },
+      },
+    );
+
+    expect(voiceMocks.sendDiscordVoiceMessage.mock.calls[0]?.[4]).toBe("reply-1");
+    expect(result.receipt.replyToId).toBe("reply-1");
+    expect(result.receipt.parts[0]?.replyToId).toBe("reply-1");
+  });
 });

--- a/extensions/discord/src/send.voice.ts
+++ b/extensions/discord/src/send.voice.ts
@@ -15,6 +15,7 @@ import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { resolveDiscordAccount } from "./accounts.js";
 import type { RequestClient } from "./internal/discord.js";
 import { parseAndResolveChannelRecipient } from "./recipient-resolution.js";
+import type { DiscordReplyReference } from "./reply-reference.js";
 import { createDiscordSendResult } from "./send.receipt.js";
 import { buildDiscordSendError, createDiscordClient, resolveChannelId } from "./send.shared.js";
 import type { DiscordSendResult } from "./send.types.js";
@@ -30,7 +31,7 @@ type VoiceMessageOpts = {
   accountId?: string;
   verbose?: boolean;
   rest?: RequestClient;
-  replyTo?: string;
+  reply?: DiscordReplyReference;
   retry?: RetryConfig;
   silent?: boolean;
 };
@@ -38,11 +39,13 @@ type VoiceMessageOpts = {
 function toDiscordSendResult(
   result: { id?: string | null; channel_id?: string | null },
   fallbackChannelId: string,
+  reply?: DiscordReplyReference,
 ): DiscordSendResult {
   return createDiscordSendResult({
     result,
     fallbackChannelId,
     kind: "voice",
+    reply,
   });
 }
 
@@ -110,7 +113,7 @@ export async function sendVoiceMessageDiscord(
       channelId,
       audioBuffer,
       metadata,
-      opts.replyTo,
+      opts.reply?.messageId,
       request,
       opts.silent,
       token,
@@ -122,7 +125,7 @@ export async function sendVoiceMessageDiscord(
       direction: "outbound",
     });
 
-    return toDiscordSendResult(result, channelId);
+    return toDiscordSendResult(result, channelId, opts.reply);
   } catch (err) {
     if (channelId && rest && token) {
       throw await buildDiscordSendError(err, {

--- a/src/channels/message/receipt.test.ts
+++ b/src/channels/message/receipt.test.ts
@@ -86,6 +86,31 @@ describe("createMessageReceiptFromOutboundResults", () => {
     expect(receipt.sentAt).toBe(456);
   });
 
+  it("preserves mixed nested reply metadata when the route has a reply target", () => {
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [
+        {
+          channel: "discord",
+          messageId: "m2",
+          receipt: {
+            primaryPlatformMessageId: "m1",
+            platformMessageIds: ["m1", "m2"],
+            parts: [
+              { platformMessageId: "m1", kind: "text", index: 0, replyToId: "reply-1" },
+              { platformMessageId: "m2", kind: "text", index: 1 },
+            ],
+            replyToId: "reply-1",
+            sentAt: 123,
+          },
+        },
+      ],
+      replyToId: "reply-1",
+    });
+
+    expect(receipt.replyToId).toBe("reply-1");
+    expect(receipt.parts.map((part) => part.replyToId)).toEqual(["reply-1", undefined]);
+  });
+
   it("normalizes receipt ids for compatibility edges", () => {
     const receipt = {
       primaryPlatformMessageId: " ",

--- a/src/channels/message/receipt.ts
+++ b/src/channels/message/receipt.ts
@@ -52,21 +52,26 @@ export function createMessageReceiptFromOutboundResults(params: {
 }): MessageReceipt {
   const parts = params.results.flatMap((result, resultIndex) => {
     if (hasNestedReceiptData(result.receipt)) {
-      // Preserve adapter-supplied receipt parts first; only fill missing thread/reply metadata.
-      return result.receipt.parts.length > 0
-        ? result.receipt.parts.map((part, partIndex) => ({
-            ...part,
-            index: part.index ?? partIndex,
-            ...(part.threadId || !params.threadId ? {} : { threadId: params.threadId }),
-            ...(part.replyToId || !params.replyToId ? {} : { replyToId: params.replyToId }),
-          }))
-        : result.receipt.platformMessageIds.map((platformMessageId, partIndex) => ({
-            platformMessageId,
-            kind: params.kind ?? "unknown",
-            index: partIndex,
-            ...(params.threadId ? { threadId: params.threadId } : {}),
-            ...(params.replyToId ? { replyToId: params.replyToId } : {}),
-          }));
+      if (result.receipt.parts.length === 0) {
+        return result.receipt.platformMessageIds.map((platformMessageId, partIndex) => ({
+          platformMessageId,
+          kind: params.kind ?? "unknown",
+          index: partIndex,
+          ...(params.threadId ? { threadId: params.threadId } : {}),
+          ...(params.replyToId ? { replyToId: params.replyToId } : {}),
+        }));
+      }
+      // Mixed adapter-supplied reply metadata is authoritative: missing entries mean
+      // those physical messages were not native replies and must not inherit the route reply.
+      const hasPartReplyMetadata = result.receipt.parts.some((part) => part.replyToId);
+      return result.receipt.parts.map((part, partIndex) => ({
+        ...part,
+        index: part.index ?? partIndex,
+        ...(part.threadId || !params.threadId ? {} : { threadId: params.threadId }),
+        ...(part.replyToId || !params.replyToId || hasPartReplyMetadata
+          ? {}
+          : { replyToId: params.replyToId }),
+      }));
     }
     const platformMessageId = resolveReceiptMessageId(result);
     if (!platformMessageId) {


### PR DESCRIPTION
## What Problem This Solves

Closes #99068. Supersedes #99150.

Discord `replyToMode: "first"` and `"batched"` could attach the same native `message_reference` to every physical chunk of one logical reply. Long text, media captions, video caption/file pairs, voice payload fallbacks, and component downgrades could therefore notify the referenced user multiple times.

## Why This Change Was Made

The fix carries one source-aware `replyToFirstChunkOnly` decision from the Discord outbound policy boundary into every Discord-owned physical send path. Implicit single-use replies attach the reference once; `all`, direct sends without a single-use mode, and explicit reply tags remain reusable.

Maintainer review added the missing split-video matrix, aligned omitted `replyToIdSource` with the existing `createReplyToFanout` contract, and removed unused voice plumbing. It also replaced the 14-20 argument text/media helpers with named options, carried the actual per-message reply target into delivery progress, and made mixed adapter receipt metadata authoritative during final core aggregation. This maintainer-owned replacement is necessary because GitHub's verified fork-edit mutation for the old contributor branch exceeded the 45 MB request limit after rebasing; the original contributor remains co-author and is credited here.

## User Impact

One logical implicit Discord reply now produces one native reply notification even when Discord requires several physical messages. Explicit replies and `replyToMode: "all"` continue to attach native reply references to every intended message.

## Evidence

- Blacksmith Testbox-through-Crabbox `tbx_01kwv79p9t30gce0ekr460d14h`: 164 focused assertions across Discord outbound adapter, physical send, components, shared message planning, and Plugin SDK reply policy; a later exact patch run passed another 100 focused Discord/reply-policy assertions including upload fallback and per-message receipt coverage.
- Same Testbox: extension production/test typechecks, extension lint, architecture guards, database-first guard, media helper guard, and runtime cycle check passed on the reviewed patch.
- Worktree fallback after the replacement Testbox was reclaimed: `src/channels/message/receipt.test.ts`, 5/5 assertions, covering preservation of mixed nested reply metadata through final route aggregation.
- AutoReview caught and drove fixes for positional callback shifts, omitted reply-source compatibility, and route-level receipt reapplication; final whole-branch result clean at 0.84 confidence.
- Original PR live Discord HTTP-boundary proof showed implicit first-mode request references `[source, null, null]` and all-mode references `[source, source, source]` through real Discord sends.
- `git diff --check` and targeted oxfmt passed.

Known proof boundary: the real Discord send was performed on the contributor implementation before the bounded maintainer follow-up fixes; exact HTTP-boundary, receipt, type, and lint checks cover the final branch, with the native hosted gate required before merge.
