### PR TITLE
fix(codex-supervisor): suppress unhandled stdout/stderr stream errors in JsonRpcClient

### DIFF
--- a/extensions/codex-supervisor/src/json-rpc-client.stream-errors.test.ts
+++ b/extensions/codex-supervisor/src/json-rpc-client.stream-errors.test.ts
@@ -9,12 +9,9 @@ const { spawnMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("node:child_process", async () => {
-  const { mockNodeBuiltinModule } = await import(
-    "openclaw/plugin-sdk/test-node-mocks"
-  );
+  const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
   return mockNodeBuiltinModule(
-    () =>
-      vi.importActual<typeof import("node:child_process")>("node:child_process"),
+    () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
     { spawn: spawnMock },
   );
 });
@@ -39,7 +36,7 @@ describe("StdioCodexJsonRpcConnection stream error handling", () => {
       stdout,
       stderr,
       stdin,
-    }) as ChildProcess;
+    }) as unknown as ChildProcess;
 
     spawnMock.mockReturnValue(child);
 

--- a/extensions/codex-supervisor/src/json-rpc-client.stream-errors.test.ts
+++ b/extensions/codex-supervisor/src/json-rpc-client.stream-errors.test.ts
@@ -1,0 +1,62 @@
+// Stream-error handling tests for codex-supervisor StdioCodexJsonRpcConnection.
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { connectCodexAppServerEndpoint } from "./json-rpc-client.js";
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeBuiltinModule } = await import(
+    "openclaw/plugin-sdk/test-node-mocks"
+  );
+  return mockNodeBuiltinModule(
+    () =>
+      vi.importActual<typeof import("node:child_process")>("node:child_process"),
+    { spawn: spawnMock },
+  );
+});
+
+describe("StdioCodexJsonRpcConnection stream error handling", () => {
+  it("registers error listeners on stdout and stderr", async () => {
+    const stdout = Object.assign(new EventEmitter(), {
+      setEncoding: vi.fn(),
+    });
+    const stderr = Object.assign(new EventEmitter(), {
+      setEncoding: vi.fn(),
+    });
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn((_data: string, cb?: (err?: Error) => void) => cb?.()),
+    });
+
+    const stdoutOn = vi.spyOn(stdout, "on");
+    const stderrOn = vi.spyOn(stderr, "on");
+
+    const child = Object.assign(new EventEmitter(), {
+      pid: 1234,
+      stdout,
+      stderr,
+      stdin,
+    }) as ChildProcess;
+
+    spawnMock.mockReturnValue(child);
+
+    // Emit close after the constructor sets up listeners, failing initialization fast.
+    queueMicrotask(() => child.emit("close"));
+
+    await expect(
+      connectCodexAppServerEndpoint({
+        id: "test",
+        transport: "stdio-proxy",
+      }),
+    ).rejects.toThrow("Codex app-server stdio transport closed");
+
+    expect(stdoutOn).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(stderrOn).toHaveBeenCalledWith("error", expect.any(Function));
+
+    const options = spawnMock.mock.calls[0]?.[2] as SpawnOptions | undefined;
+    expect(options?.stdio).toBe("pipe");
+  });
+});

--- a/extensions/codex-supervisor/src/json-rpc-client.ts
+++ b/extensions/codex-supervisor/src/json-rpc-client.ts
@@ -190,10 +190,12 @@ class StdioCodexJsonRpcConnection extends BaseCodexJsonRpcConnection {
     this.proc.stdout.setEncoding("utf8");
     this.proc.stderr.setEncoding("utf8");
     this.proc.stdout.on("data", (chunk: string) => this.handleStdout(chunk));
+    this.proc.stdout.on("error", () => {});
     this.proc.stderr.on("data", (chunk: string) => {
       this.stderrTail.push(...chunk.split(/\r?\n/).filter(Boolean));
       this.stderrTail.splice(0, Math.max(0, this.stderrTail.length - 40));
     });
+    this.proc.stderr.on("error", () => {});
     this.proc.stdin.once("error", (error) => this.fail(error));
     this.proc.once("error", (error) => this.fail(error));
     this.proc.once("close", () =>


### PR DESCRIPTION
## What Problem This Solves

`JsonRpcClient.start()` attaches `data` listeners to `this.proc.stdout` and `this.proc.stderr`, but does not attach `error` listeners. If either stream emits an `error` event, the unhandled error can crash the OpenClaw process.

## Why This Change Was Made

Add no-op `error` handlers to both stdout and stderr streams:

```typescript
this.proc.stdout.on("error", () => {});
this.proc.stderr.on("error", () => {});
```

Stream read errors are treated as non-fatal because the process `error`/`close` handlers already report the real outcome.

## Evidence

### Vitest regression test

The branch includes `json-rpc-client.stream-errors.test.ts` which creates real EventEmitter-backed stdout/stderr streams, verifies error listeners are registered, and exercises `connectCodexAppServerEndpoint` through the actual production code path.

### CI

Latest commit fixes the `check-test-types` failure flagged by ClawSweeper (ChildProcess mock cast through `unknown`). All other CI checks are passing.

## Issue

Fixes #98584

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)