### PR TITLE
fix(android): finish PTT relay handoff safely

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2447,
+      "line": 2474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2449,
+      "line": 2476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2451,
+      "line": 2478,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2474,
+      "line": 2464,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2476,
+      "line": 2466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2478,
+      "line": 2468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -5699,7 +5699,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 503,
+      "line": 546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -5707,7 +5707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 503,
+      "line": 546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -5715,7 +5715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 906,
+      "line": 954,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -5723,7 +5723,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 907,
+      "line": 955,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
@@ -5731,7 +5731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 908,
+      "line": 956,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
@@ -5739,7 +5739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1911,
+      "line": 1998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -5747,7 +5747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1911,
+      "line": 1998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -14,6 +14,8 @@ Voice settings now stay within their intended width instead of overflowing or cl
 
 Camera clip capture no longer emits release-path diagnostics containing temporary file details.
 
+Push-to-talk now waits for realtime input and output to stop, keeps finishing turns serialized, and safely resumes the matching relay capture.
+
 ## 2026.6.11 - 2026-07-01
 
 Improves Android gateway setup with localized onboarding, QR pairing fixes, and support for local mDNS gateway hosts.

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1774,15 +1774,17 @@ class NodeRuntime private constructor(
 
   private suspend fun handleTalkPttOnce(): GatewaySession.InvokeResult =
     runTalkPttCommand {
-      val busyCaptureId = talkMode.activePushToTalkCaptureId ?: talkMode.finishingPushToTalkCaptureId
-      busyCaptureId?.let { captureId ->
-        val payload = TalkPttStopPayload(captureId = captureId, transcript = null, status = "busy")
-        return@runTalkPttCommand GatewaySession.InvokeResult.ok(payload.toJson())
+      currentTalkPttOnceBusy()?.let { busy ->
+        return@runTalkPttCommand GatewaySession.InvokeResult.ok(busy.payload.toJson())
       }
       val lifecycleEpoch = voiceLifecycleEpoch.get()
       val commandEpoch = talkPttCommandEpoch.get()
       val start =
-        withPreparedTalkPttCommand(lifecycleEpoch, commandEpoch) { ownershipEpoch ->
+        withPreparedTalkPttCommand(
+          lifecycleEpoch = lifecycleEpoch,
+          commandEpoch = commandEpoch,
+          beforePrepare = ::currentTalkPttOnceBusy,
+        ) { ownershipEpoch ->
           val started =
             talkMode.beginPushToTalkOnce(
               canStartCapture = {
@@ -1792,12 +1794,11 @@ class NodeRuntime private constructor(
                   voiceCaptureOwnershipEpoch.get() == ownershipEpoch
               },
             )
-          val captureId =
-            when (started) {
-              is TalkPttOnceStart.Busy -> started.payload.captureId
-              is TalkPttOnceStart.Started -> started.captureId
-            }
-          recordTalkPttOwnership(captureId = captureId, ownershipEpoch = ownershipEpoch)
+          when (started) {
+            is TalkPttOnceStart.Busy -> cleanupFailedTalkCapture(ownershipEpoch)
+            is TalkPttOnceStart.Started ->
+              recordTalkPttOwnership(captureId = started.captureId, ownershipEpoch = ownershipEpoch)
+          }
           started
         }
       val payload =
@@ -1811,9 +1812,17 @@ class NodeRuntime private constructor(
       GatewaySession.InvokeResult.ok(payload.toJson())
     }
 
+  private fun currentTalkPttOnceBusy(): TalkPttOnceStart.Busy? {
+    val captureId = talkMode.activePushToTalkCaptureId ?: talkMode.finishingPushToTalkCaptureId ?: return null
+    return TalkPttOnceStart.Busy(
+      TalkPttStopPayload(captureId = captureId, transcript = null, status = "busy"),
+    )
+  }
+
   private suspend fun <T> withPreparedTalkPttCommand(
     lifecycleEpoch: Long,
     commandEpoch: Long,
+    beforePrepare: () -> T? = { null },
     block: suspend (ownershipEpoch: Long) -> T,
   ): T =
     voiceCapturePreparationMutex.withLock {
@@ -1826,6 +1835,7 @@ class NodeRuntime private constructor(
       ) {
         throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
       }
+      beforePrepare()?.let { return@withLock it }
       val ownershipEpoch = prepareTalkCapture(lifecycleEpoch, commandEpoch)
       try {
         if (

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1730,6 +1730,12 @@ class NodeRuntime private constructor(
 
   private suspend fun handleTalkPttStart(): GatewaySession.InvokeResult =
     runTalkPttCommand {
+      talkMode.finishingPushToTalkCaptureId?.let {
+        return@runTalkPttCommand GatewaySession.InvokeResult.error(
+          code = "PTT_BUSY",
+          message = "PTT_BUSY: previous push-to-talk turn is still finishing",
+        )
+      }
       val lifecycleEpoch = voiceLifecycleEpoch.get()
       val commandEpoch = talkPttCommandEpoch.get()
       if (!_isForeground.value) {
@@ -1768,7 +1774,8 @@ class NodeRuntime private constructor(
 
   private suspend fun handleTalkPttOnce(): GatewaySession.InvokeResult =
     runTalkPttCommand {
-      talkMode.activePushToTalkCaptureId?.let { captureId ->
+      val busyCaptureId = talkMode.activePushToTalkCaptureId ?: talkMode.finishingPushToTalkCaptureId
+      busyCaptureId?.let { captureId ->
         val payload = TalkPttStopPayload(captureId = captureId, transcript = null, status = "busy")
         return@runTalkPttCommand GatewaySession.InvokeResult.ok(payload.toJson())
       }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -28,6 +28,7 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -146,6 +147,7 @@ class TalkModeManager internal constructor(
   private val onStoppedByRelay: () -> Unit = {},
   private val talkSpeakClient: TalkSpeechSynthesizing = TalkSpeakClient(session = session),
   private val talkAudioPlayer: TalkAudioPlaying = TalkAudioPlayer(context),
+  private val realtimeCaptureDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
   companion object {
     private const val tag = "TalkMode"
@@ -965,7 +967,7 @@ class TalkModeManager internal constructor(
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
       )
     realtimeAppendJob =
-      scope.launch(Dispatchers.IO) {
+      scope.launch(realtimeCaptureDispatcher) {
         for (frame in audioFrames) {
           if (realtimeSessionId != sessionId) continue
           if (isRealtimePlaybackActive()) continue
@@ -993,7 +995,7 @@ class TalkModeManager internal constructor(
         }
       }
     realtimeCaptureJob =
-      scope.launch(Dispatchers.IO) {
+      scope.launch(realtimeCaptureDispatcher) {
         var audioInput: AndroidAudioInputSession? = null
         try {
           val frameBytes = realtimeSampleRateHz * 2 * realtimeAudioFrameMs / 1000

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -214,7 +214,9 @@ class TalkModeManager internal constructor(
   private var realtimeCapturePause: RealtimeCapturePause? = null
 
   private val finishingPttLock = Any()
+
   @Volatile private var finishingPttCaptureId: String? = null
+
   @Volatile private var finishingPttJob: Job? = null
 
   // Realtime tool calls can complete before their chat final arrives; cache by call/run id until both sides meet.
@@ -422,9 +424,9 @@ class TalkModeManager internal constructor(
           }
           if (
             activePttCaptureId != captureId ||
-              captureGeneration != startGeneration.get() ||
-              !canStartCapture() ||
-              stopRequested
+            captureGeneration != startGeneration.get() ||
+            !canStartCapture() ||
+            stopRequested
           ) {
             throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
           }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -29,6 +29,7 @@ import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -36,11 +37,14 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
@@ -209,6 +213,10 @@ class TalkModeManager internal constructor(
   private val realtimeCapturePauseLock = Any()
   private var realtimeCapturePause: RealtimeCapturePause? = null
 
+  private val finishingPttLock = Any()
+  @Volatile private var finishingPttCaptureId: String? = null
+  @Volatile private var finishingPttJob: Job? = null
+
   // Realtime tool calls can complete before their chat final arrives; cache by call/run id until both sides meet.
   private val realtimeToolLock = Any()
   private val realtimeToolRuns = LinkedHashMap<String, RealtimeToolRun>()
@@ -223,6 +231,9 @@ class TalkModeManager internal constructor(
   private var realtimeAudioQueue: Channel<ByteArray>? = null
   private var realtimeAudioWriterJob: Job? = null
   private var realtimePlaybackIdleJob: Job? = null
+
+  @Volatile private var pendingRealtimeOutputClear: CompletableDeferred<Unit>? = null
+  private val realtimeOutputCancellationMutex = Mutex()
 
   @Volatile
   private var realtimePlaybackEndsAtMs = 0L
@@ -290,6 +301,9 @@ class TalkModeManager internal constructor(
   internal val activePushToTalkCaptureId: String?
     get() = activePttCaptureId
 
+  internal val finishingPushToTalkCaptureId: String?
+    get() = finishingPttCaptureId
+
   /** Starts a push-to-talk capture session for gateway node.invoke callers. */
   suspend fun beginPushToTalk(
     allowNewCapture: Boolean,
@@ -323,11 +337,13 @@ class TalkModeManager internal constructor(
     // prevents a late relay response from opening a second microphone capture.
     val sessionId: String?,
     val pttCaptureId: String,
+    val restartRelay: Boolean = false,
   )
 
   private enum class RealtimeCaptureResume {
     Skipped,
     Resumed,
+    Restart,
     Disconnected,
   }
 
@@ -347,6 +363,9 @@ class TalkModeManager internal constructor(
     // PTT begin is idempotent so gateway retries don't start multiple recognizers.
     activePttCaptureId?.let {
       return PushToTalkStartResult.Existing(TalkPttStartPayload(captureId = it))
+    }
+    finishingPttCaptureId?.let {
+      throw IllegalStateException("PTT_BUSY: previous push-to-talk turn is still finishing")
     }
     if (!isConnected()) {
       _statusText.value = "Gateway not connected"
@@ -372,6 +391,9 @@ class TalkModeManager internal constructor(
         activePttCaptureId?.let {
           return@withContext PushToTalkStartResult.Existing(TalkPttStartPayload(captureId = it))
         }
+        finishingPttCaptureId?.let {
+          throw IllegalStateException("PTT_BUSY: previous push-to-talk turn is still finishing")
+        }
         if (captureGeneration != startGeneration.get() || !canStartCapture()) {
           throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
         }
@@ -382,8 +404,12 @@ class TalkModeManager internal constructor(
         silenceJob?.cancel()
         silenceJob = null
         listeningMode = false
+        _isListening.value = false
         finalizeInFlight = false
         stopRequested = false
+        recognizer?.cancel()
+        recognizer?.destroy()
+        recognizer = null
         lastTranscript = ""
         lastHeardAtMs = null
         activePttCaptureId = captureId
@@ -402,8 +428,6 @@ class TalkModeManager internal constructor(
           ) {
             throw IllegalStateException("NODE_BACKGROUND_UNAVAILABLE: command requires foreground")
           }
-          recognizer?.cancel()
-          recognizer?.destroy()
           recognizer = SpeechRecognizer.createSpeechRecognizer(context).also { it.setRecognitionListener(listener) }
           startListeningInternal(markListening = true)
         } catch (err: Throwable) {
@@ -476,12 +500,27 @@ class TalkModeManager internal constructor(
       }
 
       _statusText.value = "Thinking…"
-      scope.launch {
-        try {
-          finalizeTranscript(transcript)
-        } finally {
-          resumeRealtimeCaptureAfterPushToTalk(captureId)
+      lateinit var finishingJob: Job
+      finishingJob =
+        scope.launch(start = CoroutineStart.LAZY) {
+          try {
+            finalizeTranscript(transcript)
+          } finally {
+            withContext(NonCancellable + Dispatchers.Main) {
+              resumeRealtimeCaptureAfterPushToTalk(captureId)
+              clearFinishingPushToTalk(captureId, finishingJob)
+            }
+          }
         }
+      // Cancellation can win before a lazy coroutine enters its body, in which
+      // case its finally block never runs. Completion still releases ownership.
+      finishingJob.invokeOnCompletion { clearFinishingPushToTalk(captureId, finishingJob) }
+      // Publish the job before it can run so stop() cannot clear ownership while
+      // an untracked finalizer still uses shared chat and playback state.
+      synchronized(finishingPttLock) {
+        finishingPttCaptureId = captureId
+        finishingPttJob = finishingJob
+        finishingJob.start()
       }
       finishPushToTalk(
         TalkPttStopPayload(captureId = captureId, transcript = transcript, status = "queued"),
@@ -513,10 +552,11 @@ class TalkModeManager internal constructor(
     maxDurationMs: Long = 12_000L,
     canStartCapture: () -> Boolean = { true },
   ): TalkPttOnceStart {
-    if (activePttCaptureId != null) {
+    val busyCaptureId = activePttCaptureId ?: finishingPttCaptureId
+    if (busyCaptureId != null) {
       return TalkPttOnceStart.Busy(
         TalkPttStopPayload(
-          captureId = activePttCaptureId ?: UUID.randomUUID().toString(),
+          captureId = busyCaptureId,
           transcript = null,
           status = "busy",
         ),
@@ -766,6 +806,9 @@ class TalkModeManager internal constructor(
     finalizeInFlight = false
     listeningMode = false
     activePttCaptureId = null
+    synchronized(finishingPttLock) {
+      finishingPttJob?.cancel()
+    }
     pttAutoStopEnabled = false
     pttCompletion?.cancel()
     pttCompletion = null
@@ -860,7 +903,6 @@ class TalkModeManager internal constructor(
       throw CancellationException("realtime talk stopped while connecting")
     }
 
-    realtimeOutputSuppressed = false
     val capturePaused =
       synchronized(realtimeCapturePauseLock) {
         // Session publication and capture installation are one transition. PTT
@@ -869,8 +911,10 @@ class TalkModeManager internal constructor(
         val pause = realtimeCapturePause
         if (pause != null) {
           realtimeCapturePause = pause.copy(sessionId = sessionId)
+          realtimeOutputSuppressed = true
           true
         } else {
+          realtimeOutputSuppressed = false
           _isListening.value = true
           _statusText.value = "Listening"
           startRealtimeCaptureLocked(sessionId)
@@ -989,10 +1033,17 @@ class TalkModeManager internal constructor(
 
     when (val type = obj["type"].asStringOrNull()) {
       "ready" -> {
+        if (isRealtimeCapturePaused()) return
         _isListening.value = true
         _statusText.value = "Listening"
       }
       "inputAudio" -> {
+        synchronized(realtimeCapturePauseLock) {
+          if (realtimeCapturePause != null) return
+          // Output remains suppressed through the cancelled pre-PTT turn. The
+          // first accepted resumed frame establishes the next provider turn.
+          realtimeOutputSuppressed = false
+        }
         _isListening.value = true
       }
       "audio" -> {
@@ -1008,7 +1059,10 @@ class TalkModeManager internal constructor(
           }
         playRealtimeAudio(bytes)
       }
-      "clear" -> stopRealtimePlayback()
+      "clear" -> {
+        stopRealtimePlayback()
+        pendingRealtimeOutputClear?.complete(Unit)
+      }
       "mark" -> Unit
       "transcript" -> {
         val role = obj["role"].asStringOrNull()
@@ -1028,7 +1082,6 @@ class TalkModeManager internal constructor(
           _lastAssistantText.value = assistantText.trim()
         }
         if (isFinal && role == "user") {
-          realtimeOutputSuppressed = false
           _statusText.value = "Thinking…"
         } else if (isFinal && role == "assistant") {
           scheduleRealtimePlaybackIdle()
@@ -1235,6 +1288,8 @@ class TalkModeManager internal constructor(
         currentSessionId to currentCaptureJobs
       }
     realtimeOutputSuppressed = false
+    pendingRealtimeOutputClear?.cancel()
+    pendingRealtimeOutputClear = null
     if (cancelCapture) {
       captureJobs.first?.cancel()
     }
@@ -1268,14 +1323,33 @@ class TalkModeManager internal constructor(
         val currentSessionId = realtimeSessionId
         val currentCaptureJobs = realtimeCaptureJob to realtimeAppendJob
         realtimeCapturePause = RealtimeCapturePause(sessionId = currentSessionId, pttCaptureId = captureId)
+        realtimeOutputSuppressed = true
         realtimeCaptureJob = null
         realtimeAppendJob = null
         currentCaptureJobs
       }
+    stopRealtimePlayback()
     val (captureJob, appendJob) = captureJobs
     captureJob?.cancelAndJoin()
     appendJob?.cancelAndJoin()
+    // Stop input first so no frame can create new provider output while the
+    // cancellation boundary is being established.
+    if (!cancelRealtimeOutput(reason = "android-push-to-talk")) {
+      Log.w(tag, "realtime output cancellation was not confirmed; closing relay")
+      stopRealtimeRelay(preserveStatus = true)
+      synchronized(realtimeCapturePauseLock) {
+        realtimeCapturePause =
+          RealtimeCapturePause(
+            sessionId = null,
+            pttCaptureId = captureId,
+            restartRelay = true,
+          )
+        realtimeOutputSuppressed = true
+      }
+    }
   }
+
+  private fun isRealtimeCapturePaused(): Boolean = synchronized(realtimeCapturePauseLock) { realtimeCapturePause != null }
 
   internal fun resumeRealtimeCaptureAfterPushToTalk(captureId: String) {
     val outcome =
@@ -1284,8 +1358,16 @@ class TalkModeManager internal constructor(
         if (current.pttCaptureId != captureId || activePttCaptureId != null) {
           return@synchronized RealtimeCaptureResume.Skipped
         }
+        if (!_isEnabled.value || stopRequested) {
+          realtimeCapturePause = null
+          return@synchronized RealtimeCaptureResume.Skipped
+        }
+        if (current.restartRelay && current.sessionId == null) {
+          realtimeCapturePause = null
+          return@synchronized RealtimeCaptureResume.Restart
+        }
         val sessionId = current.sessionId
-        if (!_isEnabled.value || stopRequested || sessionId == null || realtimeSessionId != sessionId) {
+        if (sessionId == null || realtimeSessionId != sessionId) {
           realtimeCapturePause = null
           return@synchronized RealtimeCaptureResume.Skipped
         }
@@ -1303,6 +1385,7 @@ class TalkModeManager internal constructor(
     when (outcome) {
       RealtimeCaptureResume.Skipped -> return
       RealtimeCaptureResume.Resumed -> return
+      RealtimeCaptureResume.Restart -> start()
       RealtimeCaptureResume.Disconnected -> {
         _statusText.value = "Gateway not connected"
         stopRealtimeRelay(preserveStatus = true)
@@ -1978,6 +2061,18 @@ class TalkModeManager internal constructor(
     return payload
   }
 
+  private fun clearFinishingPushToTalk(
+    captureId: String,
+    job: Job,
+  ) {
+    synchronized(finishingPttLock) {
+      if (finishingPttCaptureId == captureId && finishingPttJob === job) {
+        finishingPttCaptureId = null
+        finishingPttJob = null
+      }
+    }
+  }
+
   private fun buildPrompt(transcript: String): String {
     val lines =
       mutableListOf(
@@ -2339,15 +2434,17 @@ class TalkModeManager internal constructor(
   fun stopTts() {
     realtimeOutputSuppressed = true
     stopRealtimePlayback()
-    cancelRealtimeOutput(reason = "android-stop-tts")
+    scope.launch { cancelRealtimeOutput(reason = "android-stop-tts") }
     stopSpeaking(resetInterrupt = true)
     _isSpeaking.value = false
     _statusText.value = "Listening"
   }
 
-  private fun cancelRealtimeOutput(reason: String) {
-    val sessionId = realtimeSessionId ?: return
-    scope.launch {
+  private suspend fun cancelRealtimeOutput(reason: String): Boolean =
+    realtimeOutputCancellationMutex.withLock {
+      val sessionId = realtimeSessionId ?: return@withLock true
+      val clear = CompletableDeferred<Unit>()
+      pendingRealtimeOutputClear = clear
       try {
         val params =
           buildJsonObject {
@@ -2355,13 +2452,26 @@ class TalkModeManager internal constructor(
             put("reason", JsonPrimitive(reason))
           }
         session.request("talk.session.cancelOutput", params.toString(), timeoutMs = 5_000)
+        // The response confirms provider cancellation; clear confirms that the
+        // old playback boundary reached Android before capture can resume.
+        withTimeout(2_000) { clear.await() }
+        true
+      } catch (err: TimeoutCancellationException) {
+        Log.d(tag, "realtime cancelOutput unconfirmed: ${err.message ?: "timeout"}")
+        false
+      } catch (err: CancellationException) {
+        if (!currentCoroutineContext().isActive) throw err
+        Log.d(tag, "realtime cancelOutput interrupted by relay shutdown")
+        false
       } catch (err: Throwable) {
-        if (err !is CancellationException) {
-          Log.d(tag, "realtime cancelOutput ignored: ${err.message ?: err::class.simpleName}")
+        Log.d(tag, "realtime cancelOutput failed: ${err.message ?: err::class.simpleName}")
+        false
+      } finally {
+        if (pendingRealtimeOutputClear === clear) {
+          pendingRealtimeOutputClear = null
         }
       }
     }
-  }
 
   private fun stopSpeaking(resetInterrupt: Boolean = true) {
     playbackGeneration.incrementAndGet()
@@ -2378,7 +2488,7 @@ class TalkModeManager internal constructor(
     abandonAudioFocus()
   }
 
-  private fun shouldAllowSpeechInterrupt(): Boolean = !finalizeInFlight
+  internal fun shouldAllowSpeechInterrupt(): Boolean = !finalizeInFlight && !isRealtimeCapturePaused()
 
   private fun clearListenWatchdog() {
     listenWatchdogJob?.cancel()
@@ -2577,12 +2687,12 @@ class TalkModeManager internal constructor(
 
   private fun ensureInterruptListener() {
     if (!interruptOnSpeech || !_isEnabled.value || !shouldAllowSpeechInterrupt()) return
-    // Don't create a new recognizer when we just destroyed one for TTS (finalizeInFlight=true).
-    // Starting a new recognizer mid-TTS causes audio session conflict that kills AudioTrack
-    // writes (returns 0) and MediaPlayer on OxygenOS/OnePlus devices.
-    if (finalizeInFlight) return
+    // Starting a recognizer during finalization or a paused PTT turn can kill
+    // TTS playback and compete with the realtime recorder for microphone ownership.
     mainHandler.post {
-      if (stopRequested || finalizeInFlight) return@post
+      // Recheck after dispatch so a listener queued before PTT cannot reclaim
+      // the microphone while the full PTT turn still owns it.
+      if (stopRequested || !shouldAllowSpeechInterrupt()) return@post
       if (!SpeechRecognizer.isRecognitionAvailable(context)) return@post
       try {
         if (recognizer == null) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -1016,6 +1016,29 @@ class GatewayBootstrapAuthTest {
     }
 
   @Test
+  fun talkPttStartRejectsFinishingTurnWithoutPreparingCapture() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+      val runtime = createTestRuntime(app)
+      val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+      writeField(talkMode, "finishingPttCaptureId", "capture-1")
+      val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
+      val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
+      preparationMutex.lock()
+      try {
+        val retry =
+          withTimeout(1_000) { dispatcher.handleInvoke(OpenClawTalkCommand.PttStart.rawValue, null) }
+
+        assertEquals("PTT_BUSY", retry.error?.code)
+        assertEquals("PTT_BUSY: previous push-to-talk turn is still finishing", retry.error?.message)
+        assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+      } finally {
+        preparationMutex.unlock()
+      }
+    }
+
+  @Test
   @OptIn(ExperimentalCoroutinesApi::class)
   fun pttStartQueuedAfterCancelUsesNewCommandEpoch() =
     runBlocking {

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -1016,6 +1016,34 @@ class GatewayBootstrapAuthTest {
     }
 
   @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun talkPttOnceRechecksFinishingTurnAfterPreparationWait() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+      val runtime = createTestRuntime(app)
+      val talkMode = readField<Lazy<TalkModeManager>>(runtime, "talkMode\$delegate").value
+      val dispatcher = readField<InvokeDispatcher>(runtime, "invokeDispatcher")
+      val preparationMutex = readField<Mutex>(runtime, "voiceCapturePreparationMutex")
+      preparationMutex.lock()
+      try {
+        val request = async { dispatcher.handleInvoke(OpenClawTalkCommand.PttOnce.rawValue, null) }
+        yield()
+        writeField(talkMode, "finishingPttCaptureId", "capture-finishing")
+        preparationMutex.unlock()
+
+        val result = withTimeout(5_000) { request.await() }
+
+        assertNull(result.error)
+        assertEquals("""{"captureId":"capture-finishing","status":"busy"}""", result.payloadJson)
+        assertFalse(readField<MutableStateFlow<Boolean>>(runtime, "externalAudioCaptureActive").value)
+        assertEquals(VoiceCaptureMode.Off, runtime.voiceCaptureMode.value)
+      } finally {
+        if (preparationMutex.isLocked) preparationMutex.unlock()
+      }
+    }
+
+  @Test
   fun talkPttStartRejectsFinishingTurnWithoutPreparingCapture() =
     runBlocking {
       val app = RuntimeEnvironment.getApplication()

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -6,7 +6,6 @@ import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewaySession
 import android.Manifest
 import android.content.ComponentName
-import android.content.Intent
 import android.content.IntentFilter
 import android.os.SystemClock
 import android.speech.RecognitionService
@@ -125,12 +124,17 @@ class TalkModeManagerTest {
   @Test
   fun stopAllCaptureClearsPttWhenContinuousModeIsDisabled() {
     val manager = createManager()
+    val finishingJob = Job()
     setPrivateField(manager, "activePttCaptureId", "capture-1")
+    setPrivateField(manager, "finishingPttCaptureId", "capture-finishing")
+    setPrivateField(manager, "finishingPttJob", finishingJob)
     setMutableStateFlow(manager, "_isListening", true)
 
     manager.stopAllCapture()
 
     assertNull(readPrivateField(manager, "activePttCaptureId"))
+    assertEquals("capture-finishing", manager.finishingPushToTalkCaptureId)
+    assertTrue(finishingJob.isCancelled)
     assertFalse(manager.isEnabled.value)
     assertFalse(manager.isListening.value)
     assertEquals("Off", manager.statusText.value)
@@ -658,7 +662,6 @@ class TalkModeManagerTest {
       val manager = createManager()
       val captureJob = Job()
       val appendJob = Job()
-      setPrivateField(manager, "realtimeSessionId", "relay-1")
       setPrivateField(manager, "realtimeCaptureJob", captureJob)
       setPrivateField(manager, "realtimeAppendJob", appendJob)
       setMutableStateFlow(manager, "_isEnabled", true)
@@ -673,10 +676,31 @@ class TalkModeManagerTest {
     }
 
   @Test
+  fun unconfirmedOutputCancellationClosesRealtimeRelay() =
+    runTest {
+      var stoppedByRelay = false
+      val manager =
+        createManager(
+          scope = this,
+          onStoppedByRelay = { stoppedByRelay = true },
+        )
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setMutableStateFlow(manager, "_isEnabled", true)
+
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+
+      assertNull(readPrivateField(manager, "realtimeSessionId"))
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      assertEquals("capture-1", readPrivateField(pause, "pttCaptureId"))
+      assertTrue(readPrivateField(pause, "restartRelay") as Boolean)
+      assertTrue(manager.isEnabled.value)
+      assertFalse(stoppedByRelay)
+    }
+
+  @Test
   fun stalePushToTalkCompletionCannotResumeNewerPause() =
     runTest {
       val manager = createManager()
-      setPrivateField(manager, "realtimeSessionId", "relay-1")
       setMutableStateFlow(manager, "_isEnabled", true)
       manager.pauseRealtimeCaptureForPushToTalk("capture-new")
       setPrivateField(manager, "activePttCaptureId", "capture-new")
@@ -709,9 +733,11 @@ class TalkModeManagerTest {
   fun resumingRealtimeCaptureRestoresListeningState() =
     runTest {
       val manager = createManager(scope = this)
-      setPrivateField(manager, "realtimeSessionId", "relay-1")
       setMutableStateFlow(manager, "_isEnabled", true)
       manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      setPrivateField(pause, "sessionId", "relay-1")
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
       setMutableStateFlow(manager, "_isListening", false)
       setMutableStateFlow(manager, "_statusText", "Thinking…")
 
@@ -719,7 +745,106 @@ class TalkModeManagerTest {
 
       assertTrue(manager.isListening.value)
       assertEquals("Listening", manager.statusText.value)
+      assertTrue(readPrivateField(manager, "realtimeOutputSuppressed") as Boolean)
+
+      manager.handleGatewayEvent(
+        "talk.event",
+        """{"relaySessionId":"relay-1","type":"transcript","role":"user","text":"stale","final":true}""",
+      )
+
+      assertTrue(readPrivateField(manager, "realtimeOutputSuppressed") as Boolean)
+
+      manager.handleGatewayEvent(
+        "talk.event",
+        """{"relaySessionId":"relay-1","type":"inputAudio","byteLength":4800}""",
+      )
+
+      assertFalse(readPrivateField(manager, "realtimeOutputSuppressed") as Boolean)
       manager.stopAllCapture()
+    }
+
+  @Test
+  fun replacementRelayPublishedDuringPushToTalkResumesCapture() =
+    runTest {
+      val manager = createManager(scope = this)
+      setMutableStateFlow(manager, "_isEnabled", true)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      setPrivateField(pause, "sessionId", "relay-replacement")
+      setPrivateField(pause, "restartRelay", true)
+      setPrivateField(manager, "realtimeSessionId", "relay-replacement")
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      assertNull(readPrivateField(manager, "realtimeCapturePause"))
+      assertTrue(manager.isListening.value)
+      assertTrue((readPrivateField(manager, "realtimeCaptureJob") as Job).isActive)
+      assertTrue((readPrivateField(manager, "realtimeAppendJob") as Job).isActive)
+      manager.stopAllCapture()
+    }
+
+  @Test
+  fun stoppedTalkModeDoesNotRestartRelayAfterPushToTalk() =
+    runTest {
+      val manager = createManager(scope = this)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      setPrivateField(pause, "restartRelay", true)
+      setPrivateField(manager, "stopRequested", true)
+      setMutableStateFlow(manager, "_statusText", "Off")
+
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+
+      assertNull(readPrivateField(manager, "realtimeCapturePause"))
+      assertNull(readPrivateField(manager, "realtimeSessionId"))
+      assertFalse(manager.isEnabled.value)
+      assertEquals("Off", manager.statusText.value)
+    }
+
+  @Test
+  fun pausedPushToTalkTurnSuppressesSpeechInterruptListener() =
+    runTest {
+      val manager = createManager(scope = this)
+      assertTrue(manager.shouldAllowSpeechInterrupt())
+
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+
+      assertFalse(manager.shouldAllowSpeechInterrupt())
+      manager.resumeRealtimeCaptureAfterPushToTalk("capture-1")
+      assertTrue(manager.shouldAllowSpeechInterrupt())
+    }
+
+  @Test
+  fun finishingPushToTalkTurnRejectsReplacementCapture() =
+    runTest {
+      val manager = createManager(scope = this)
+      setPrivateField(manager, "finishingPttCaptureId", "capture-1")
+
+      val error =
+        runCatching { manager.beginPushToTalk(allowNewCapture = true) }
+          .exceptionOrNull()
+      val oneShot = manager.beginPushToTalkOnce()
+
+      assertEquals("PTT_BUSY: previous push-to-talk turn is still finishing", error?.message)
+      assertTrue(oneShot is TalkPttOnceStart.Busy)
+      assertEquals("capture-1", (oneShot as TalkPttOnceStart.Busy).payload.captureId)
+    }
+
+  @Test
+  fun relayClosePreservesFinishingPushToTalkOwnership() =
+    runTest {
+      val manager = createManager(scope = this)
+      manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
+      setPrivateField(manager, "finishingPttCaptureId", "capture-1")
+
+      manager.handleGatewayEvent(
+        "talk.event",
+        """{"relaySessionId":"relay-1","type":"close","reason":"completed"}""",
+      )
+
+      assertNull(readPrivateField(manager, "realtimeCapturePause"))
+      assertEquals("capture-1", manager.finishingPushToTalkCaptureId)
     }
 
   @Test
@@ -732,9 +857,11 @@ class TalkModeManagerTest {
           isConnected = { false },
           onStoppedByRelay = { stoppedByRelay = true },
         )
-      setPrivateField(manager, "realtimeSessionId", "relay-1")
       setMutableStateFlow(manager, "_isEnabled", true)
       manager.pauseRealtimeCaptureForPushToTalk("capture-1")
+      val pause = readPrivateField(manager, "realtimeCapturePause")!!
+      setPrivateField(pause, "sessionId", "relay-1")
+      setPrivateField(manager, "realtimeSessionId", "relay-1")
       setMutableStateFlow(manager, "_isListening", false)
       setMutableStateFlow(manager, "_statusText", "Gateway not connected")
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -10,6 +10,7 @@ import android.content.IntentFilter
 import android.os.SystemClock
 import android.speech.RecognitionService
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -732,7 +733,11 @@ class TalkModeManagerTest {
   @Test
   fun resumingRealtimeCaptureRestoresListeningState() =
     runTest {
-      val manager = createManager(scope = this)
+      val manager =
+        createManager(
+          scope = this,
+          realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
+        )
       setMutableStateFlow(manager, "_isEnabled", true)
       manager.pauseRealtimeCaptureForPushToTalk("capture-1")
       val pause = readPrivateField(manager, "realtimeCapturePause")!!
@@ -766,7 +771,11 @@ class TalkModeManagerTest {
   @Test
   fun replacementRelayPublishedDuringPushToTalkResumesCapture() =
     runTest {
-      val manager = createManager(scope = this)
+      val manager =
+        createManager(
+          scope = this,
+          realtimeCaptureDispatcher = StandardTestDispatcher(testScheduler),
+        )
       setMutableStateFlow(manager, "_isEnabled", true)
       manager.pauseRealtimeCaptureForPushToTalk("capture-1")
       val pause = readPrivateField(manager, "realtimeCapturePause")!!
@@ -895,6 +904,7 @@ class TalkModeManagerTest {
     scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     isConnected: () -> Boolean = { true },
     onStoppedByRelay: () -> Unit = {},
+    realtimeCaptureDispatcher: CoroutineDispatcher = Dispatchers.IO,
   ): TalkModeManager {
     val app = RuntimeEnvironment.getApplication()
     val sessionJob = SupervisorJob()
@@ -915,6 +925,7 @@ class TalkModeManagerTest {
       onStoppedByRelay = onStoppedByRelay,
       talkSpeakClient = talkSpeakClient,
       talkAudioPlayer = talkAudioPlayer ?: TalkAudioPlayer(app),
+      realtimeCaptureDispatcher = realtimeCaptureDispatcher,
     )
   }
 


### PR DESCRIPTION
## What Problem This Solves

The initial Android PTT microphone-ownership fix in #99986 pauses realtime input, but deeper lifecycle races can still overlap a finishing PTT turn with a replacement capture or admit stale relay output around the handoff.

## Why This Change Was Made

- Keep the PTT owner until transcript finalization and relay resumption complete.
- Serialize realtime output cancellation and require both the gateway response and local clear boundary before continuing.
- Close and safely restart an unconfirmed relay without invalidating the foreground PTT command.
- Suppress queued recognizers and stale relay audio throughout the paused turn.
- Recheck ownership at the Main-thread mutation point and preserve stop/disconnect authority.

## User Impact

Push-to-talk no longer competes with realtime recording or stale relay playback. Rapid or repeated PTT commands return a stable busy result while the prior turn finishes, and Talk Mode resumes only the matching live relay capture.

## Evidence

- Six high-effort autoreview passes; all accepted findings fixed; final pass reports no findings.
- Regression coverage in `TalkModeManagerTest` and `GatewayBootstrapAuthTest` for finishing-turn serialization, stale-output suppression, relay close/restart ordering, lifecycle stop, and command preparation.
- `git diff --check` clean.
- Exact-head remote Android unit and formatting proof will be posted before merge.

Follow-up to #99986 and a0c0f43ab3721688ca79c1e4e4ab6581df051b19.
