### PR TITLE
fix(ui): make login-gate recovery commands copyable

### DIFF
--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -9,15 +9,19 @@ type LoginGateElement = HTMLElement & {
   updateComplete: Promise<boolean>;
 };
 
-async function mountFailure(lastError: string, lastErrorCode: string | null) {
+async function mountFailure(
+  lastError: string,
+  lastErrorCode: string | null,
+  auth: { hasToken?: boolean; hasPassword?: boolean } = {},
+) {
   const element = document.createElement("openclaw-login-gate") as LoginGateElement;
   element.props = {
     basePath: "",
     connected: false,
     lastError,
     lastErrorCode,
-    hasToken: false,
-    hasPassword: false,
+    hasToken: auth.hasToken ?? false,
+    hasPassword: auth.hasPassword ?? false,
     gatewayUrl: "ws://127.0.0.1:18789",
     token: "",
     password: "",
@@ -83,22 +87,64 @@ describe("login gate failure recovery", () => {
     expect(element.querySelector(".login-gate__failure-refresh")).toBeNull();
   });
 
-  it("offers a one-command recovery before manual pairing approval", async () => {
+  it("offers exact copyable commands before manual pairing approval", async () => {
     const element = await mountFailure(
-      "pairing required",
+      "scope upgrade pending approval (requestId: req-123)",
       ConnectErrorDetailCodes.PAIRING_REQUIRED,
     );
 
-    const steps = Array.from(
-      element.querySelectorAll<HTMLElement>(".login-gate__failure-steps li"),
-      (entry) => entry.textContent?.trim(),
+    const commands = Array.from(
+      element.querySelectorAll<HTMLElement>(".login-gate__failure-steps code"),
+      (entry) => entry.textContent,
     );
-    expect(steps).toEqual([
-      "On the Gateway host, run openclaw dashboard to open a secure one-time pairing link.",
-      "Run openclaw devices list on the Gateway host.",
-      "Approve the pending browser/device request from that list.",
-      "Reconnect after the approval completes.",
+    expect(commands).toEqual([
+      "openclaw dashboard",
+      "openclaw devices list",
+      "openclaw devices approve req-123",
     ]);
+  });
+
+  it.each([
+    {
+      name: "auth-required",
+      error: "unauthorized: gateway token required",
+      code: ConnectErrorDetailCodes.AUTH_REQUIRED,
+      auth: {},
+      commands: [
+        "openclaw gateway auth-token --show",
+        "openclaw doctor --generate-gateway-token",
+      ],
+    },
+    {
+      name: "auth-failed",
+      error: "unauthorized: gateway token mismatch",
+      code: ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
+      auth: { hasToken: true },
+      commands: ["openclaw dashboard --no-open", "openclaw gateway auth-token --show"],
+    },
+    {
+      name: "protocol-mismatch",
+      error: "protocol mismatch",
+      code: ConnectErrorDetailCodes.PROTOCOL_MISMATCH,
+      auth: {},
+      commands: ["openclaw dashboard", "pnpm ui:dev"],
+    },
+    {
+      name: "network",
+      error: "WebSocket connection failed",
+      code: null,
+      auth: {},
+      commands: ["openclaw status", "openclaw gateway run", "openclaw dashboard --no-open"],
+    },
+  ])("renders the supported $name recovery commands", async (fixture) => {
+    const element = await mountFailure(fixture.error, fixture.code, fixture.auth);
+
+    expect(
+      Array.from(
+        element.querySelectorAll<HTMLElement>(".login-gate__failure-steps code"),
+        (entry) => entry.textContent,
+      ),
+    ).toEqual(fixture.commands);
   });
 
   it("offers only supported recovery for an insecure browser context", async () => {
@@ -125,8 +171,12 @@ describe("login gate failure recovery", () => {
       vi.stubGlobal("navigator", { clipboard: { writeText } });
       Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand });
       const element = await mountFailure("WebSocket connection failed", null);
-      const command = element.querySelector<HTMLElement>(".login-gate__command");
+      const command = element.querySelector<HTMLElement>(
+        ".login-gate__failure .login-gate__command",
+      );
       const button = command?.querySelector<HTMLButtonElement>(".chat-copy-btn");
+
+      expect(command?.querySelector("code")?.textContent).toBe("openclaw status");
 
       if (interaction === "nested button") {
         button?.click();
@@ -155,8 +205,12 @@ describe("login gate failure recovery", () => {
     Object.defineProperty(document, "execCommand", { configurable: true, value: execCommand });
     const schedule = vi.spyOn(window, "setTimeout");
     const element = await mountFailure("WebSocket connection failed", null);
-    const command = element.querySelector<HTMLElement>(".login-gate__command");
+    const command = element.querySelector<HTMLElement>(
+      ".login-gate__failure .login-gate__command",
+    );
     const button = command?.querySelector<HTMLButtonElement>(".chat-copy-btn");
+
+    expect(command?.querySelector("code")?.textContent).toBe("openclaw status");
 
     command?.click();
     await vi.waitFor(() => expect(button?.getAttribute("aria-label")).toBe("Copy failed"));

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -27,12 +27,24 @@ type LoginFailureKind =
   | "protocol-mismatch"
   | "network";
 
+type LoginFailureStep = {
+  text: string;
+  commands: string[];
+};
+
+type LoginFailureStepInput =
+  | string
+  | {
+      key: string;
+      commands: string[];
+    };
+
 type LoginFailureFeedback = {
   kind: LoginFailureKind;
   title: string;
   summary: string;
   refreshAction?: { label: string };
-  steps: string[];
+  steps: LoginFailureStep[];
   docsHref: string;
   docsLabel: string;
   rawError: string;
@@ -96,7 +108,7 @@ function buildFeedback(params: {
   docsHref?: string;
   titleKey: string;
   summaryKey: string;
-  stepKeys: string[];
+  steps: LoginFailureStepInput[];
   stepParams?: Record<string, string>;
   refreshAction?: { label: string };
 }): LoginFailureFeedback {
@@ -106,11 +118,21 @@ function buildFeedback(params: {
     title: t(params.titleKey, params.stepParams),
     summary: t(params.summaryKey, params.stepParams),
     refreshAction: params.refreshAction,
-    steps: params.stepKeys.map((key) => t(key, params.stepParams)),
+    steps: params.steps.map((step) => {
+      const key = typeof step === "string" ? step : step.key;
+      return {
+        text: t(key, params.stepParams),
+        commands: typeof step === "string" ? [] : step.commands,
+      };
+    }),
     docsHref,
     docsLabel: resolveDocsLabel(docsHref),
     rawError: redactLoginFailureError(params.rawError),
   };
+}
+
+function commandStep(key: string, ...commands: string[]): LoginFailureStepInput {
+  return { key, commands };
 }
 
 function resolveLoginFailureFeedback(
@@ -131,7 +153,7 @@ function resolveLoginFailureFeedback(
       titleKey: "chat.sidebar.serverUpdatedTitle",
       summaryKey: "chat.sidebar.serverUpdatedRefresh",
       refreshAction: { label: t("login.failure.protocol.refresh") },
-      stepKeys: [],
+      steps: [],
       docsHref: "https://docs.openclaw.ai/web/control-ui",
     });
   }
@@ -154,11 +176,14 @@ function resolveLoginFailureFeedback(
         pairing.kind === "pairing-required"
           ? "login.failure.pairing.summary"
           : "login.failure.pairing.upgradeSummary",
-      stepKeys: [
-        "login.failure.pairing.stepDashboard",
-        "login.failure.pairing.stepList",
+      steps: [
+        commandStep("login.failure.pairing.stepDashboard", "openclaw dashboard"),
+        commandStep("login.failure.pairing.stepList", "openclaw devices list"),
         pairing.requestId
-          ? "login.failure.pairing.stepApproveId"
+          ? commandStep(
+              "login.failure.pairing.stepApproveId",
+              `openclaw devices approve ${pairing.requestId}`,
+            )
           : "login.failure.pairing.stepApprove",
         "login.failure.pairing.stepReconnect",
       ],
@@ -176,7 +201,7 @@ function resolveLoginFailureFeedback(
       rawError,
       titleKey: "login.failure.rateLimited.title",
       summaryKey: "login.failure.rateLimited.summary",
-      stepKeys: [
+      steps: [
         "login.failure.rateLimited.stepStop",
         "login.failure.rateLimited.stepWait",
         "login.failure.rateLimited.stepCheckClients",
@@ -191,7 +216,7 @@ function resolveLoginFailureFeedback(
       docsHref: "https://docs.openclaw.ai/web/control-ui#insecure-http",
       titleKey: "login.failure.insecure.title",
       summaryKey: "login.failure.insecure.summary",
-      stepKeys: ["login.failure.insecure.stepHttps", "login.failure.insecure.stepAvoidDisable"],
+      steps: ["login.failure.insecure.stepHttps", "login.failure.insecure.stepAvoidDisable"],
     });
   }
 
@@ -206,7 +231,7 @@ function resolveLoginFailureFeedback(
         "https://docs.openclaw.ai/web/control-ui#debuggingtesting-dev-server--remote-gateway",
       titleKey: "login.failure.origin.title",
       summaryKey: "login.failure.origin.summary",
-      stepKeys: [
+      steps: [
         "login.failure.origin.stepAllowedOrigins",
         "login.failure.origin.stepFullOrigin",
         "login.failure.origin.stepRestart",
@@ -223,9 +248,9 @@ function resolveLoginFailureFeedback(
       titleKey: "login.failure.protocol.title",
       summaryKey: "login.failure.protocol.summary",
       refreshAction: { label: t("login.failure.protocol.refresh") },
-      stepKeys: [
-        "login.failure.protocol.stepDashboard",
-        "login.failure.protocol.stepDevUi",
+      steps: [
+        commandStep("login.failure.protocol.stepDashboard", "openclaw dashboard"),
+        commandStep("login.failure.protocol.stepDevUi", "pnpm ui:dev"),
         "login.failure.protocol.stepRestart",
       ],
     });
@@ -244,9 +269,15 @@ function resolveLoginFailureFeedback(
       rawError,
       titleKey: "login.failure.authRequired.title",
       summaryKey: "login.failure.authRequired.summary",
-      stepKeys: [
-        "login.failure.authRequired.stepPaste",
-        "login.failure.authRequired.stepGenerate",
+      steps: [
+        commandStep(
+          "login.failure.authRequired.stepPaste",
+          "openclaw gateway auth-token --show",
+        ),
+        commandStep(
+          "login.failure.authRequired.stepGenerate",
+          "openclaw doctor --generate-gateway-token",
+        ),
         "login.failure.authRequired.stepConnect",
       ],
     });
@@ -257,8 +288,12 @@ function resolveLoginFailureFeedback(
       rawError,
       titleKey: "login.failure.authFailed.title",
       summaryKey: "login.failure.authFailed.summary",
-      stepKeys: [
-        "login.failure.authFailed.stepDashboard",
+      steps: [
+        commandStep(
+          "login.failure.authFailed.stepDashboard",
+          "openclaw dashboard --no-open",
+          "openclaw gateway auth-token --show",
+        ),
         "login.failure.authFailed.stepReplace",
         "login.failure.authFailed.stepMode",
       ],
@@ -270,10 +305,14 @@ function resolveLoginFailureFeedback(
     rawError,
     titleKey: "login.failure.network.title",
     summaryKey: "login.failure.network.summary",
-    stepKeys: [
-      "login.failure.network.stepGateway",
+    steps: [
+      commandStep(
+        "login.failure.network.stepGateway",
+        "openclaw status",
+        "openclaw gateway run",
+      ),
       "login.failure.network.stepUrl",
-      "login.failure.network.stepDashboard",
+      commandStep("login.failure.network.stepDashboard", "openclaw dashboard --no-open"),
     ],
   });
 }
@@ -305,7 +344,14 @@ function renderLoginFailure(feedback: LoginFailureFeedback) {
           `
         : nothing}
       <ol class="login-gate__failure-steps">
-        ${feedback.steps.map((step) => html`<li>${step}</li>`)}
+        ${feedback.steps.map(
+          (step) => html`
+            <li>
+              ${step.text}
+              ${step.commands.map((command) => renderConnectCommand(command))}
+            </li>
+          `,
+        )}
       </ol>
       <details class="login-gate__failure-detail">
         <summary>${t("login.failure.rawError")}</summary>

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -147,16 +147,29 @@ suite.define(() => {
       },
       expectedKind: "auth-required",
       expectedTitle: "Auth required",
+      expectedCommands: [
+        "openclaw gateway auth-token --show",
+        "openclaw doctor --generate-gateway-token",
+      ],
     },
     {
       name: "pairing approval",
       error: {
         code: "NOT_PAIRED",
         message: "device is not approved",
-        details: { code: ConnectErrorDetailCodes.PAIRING_REQUIRED },
+        details: {
+          code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+          reason: "not-paired",
+          requestId: "req-browser-123",
+        },
       },
       expectedKind: "pairing-required",
       expectedTitle: "Device pairing required",
+      expectedCommands: [
+        "openclaw dashboard",
+        "openclaw devices list",
+        "openclaw devices approve req-browser-123",
+      ],
     },
     {
       name: "generic transport",
@@ -166,6 +179,11 @@ suite.define(() => {
       },
       expectedKind: "network",
       expectedTitle: "Could not connect",
+      expectedCommands: [
+        "openclaw status",
+        "openclaw gateway run",
+        "openclaw dashboard --no-open",
+      ],
     },
   ])("renders $name guidance from the application gateway snapshot", async (fixture) => {
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
@@ -182,6 +200,54 @@ suite.define(() => {
       expect(await failure.locator(".login-gate__failure-title").textContent()).toBe(
         fixture.expectedTitle,
       );
+      expect(await failure.locator(".login-gate__command code").allTextContents()).toEqual(
+        fixture.expectedCommands,
+      );
+    } finally {
+      await closeContext(context);
+    }
+  });
+
+  it("copies the exact pairing approval command from the recovery card", async () => {
+    const requestId = `req-${"a".repeat(124)}`;
+    const context = await suite.browser.newContext({
+      permissions: ["clipboard-read", "clipboard-write"],
+      viewport: { height: 800, width: 375 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+    const expectedCommand = `openclaw devices approve ${requestId}`;
+
+    try {
+      await page.goto(suite.server.baseUrl);
+      await gateway.waitForRequest("connect");
+      await gateway.rejectDeferred("connect", {
+        code: "NOT_PAIRED",
+        message: "device is not approved",
+        details: {
+          code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+          reason: "not-paired",
+          requestId,
+        },
+      });
+
+      const failure = page.locator('.login-gate__failure[data-kind="pairing-required"]');
+      await failure.waitFor({ timeout: 10_000 });
+      const command = failure.locator(".login-gate__command").filter({ hasText: expectedCommand });
+      await command.click();
+
+      await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(
+        expectedCommand,
+      );
+      await expect
+        .poll(() => command.locator(".chat-copy-btn").getAttribute("aria-label"))
+        .toBe("Copied!");
+      expect(
+        await page.evaluate(() => {
+          const card = document.querySelector<HTMLElement>(".login-gate__card");
+          return card ? card.scrollWidth - card.clientWidth : Number.POSITIVE_INFINITY;
+        }),
+      ).toBeLessThanOrEqual(0);
     } finally {
       await closeContext(context);
     }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4515,18 +4515,15 @@ export const en: TranslationMap = {
         title: "Auth required",
         summary:
           "The Gateway is reachable, but it needs a matching token or password before this browser can connect.",
-        stepPaste:
-          "Paste the token from openclaw gateway auth-token --show or enter the configured password.",
-        stepGenerate:
-          "If no token is configured, run openclaw doctor --generate-gateway-token on the gateway host.",
+        stepPaste: "Recover and paste the configured token, or enter the configured password.",
+        stepGenerate: "If no token is configured, generate one on the Gateway host.",
         stepConnect: "Click Connect again after updating the credential.",
       },
       authFailed: {
         title: "Auth did not match",
         summary:
           "The supplied credential was rejected. The most common cause is a stale token or a token copied from another Gateway URL.",
-        stepDashboard:
-          "Run openclaw dashboard --no-open for a fresh URL, or openclaw gateway auth-token --show to recover the token.",
+        stepDashboard: "Recover a fresh dashboard URL or the current Gateway token.",
         stepReplace:
           "Replace stale token/password values; do not reuse a token from another Gateway URL.",
         stepMode:
@@ -4549,10 +4546,9 @@ export const en: TranslationMap = {
           "This browser needs one-time approval from the Gateway host before it can use the Control UI.",
         upgradeSummary:
           "This browser is already known, but the requested access changed and needs a fresh approval.",
-        stepDashboard:
-          "On the Gateway host, run openclaw dashboard to open a secure one-time pairing link.",
-        stepList: "Run openclaw devices list on the Gateway host.",
-        stepApproveId: "Approve this request: openclaw devices approve {requestId}.",
+        stepDashboard: "On the Gateway host, open a secure one-time pairing link.",
+        stepList: "List pending device requests on the Gateway host.",
+        stepApproveId: "Approve this request.",
         stepApprove: "Approve the pending browser/device request from that list.",
         stepReconnect: "Reconnect after the approval completes.",
       },
@@ -4578,9 +4574,9 @@ export const en: TranslationMap = {
           "The served Control UI and the running Gateway do not agree on the supported connection protocol.",
         refresh: "Refresh page",
         stepDashboard:
-          "Reopen the served dashboard with openclaw dashboard so the UI and Gateway come from the same install.",
+          "Reopen the served dashboard so the UI and Gateway come from the same install.",
         stepDevUi:
-          "If using pnpm ui:dev, rebuild or restart the dev UI against the current checkout.",
+          "If using the development UI, rebuild or restart it against the current checkout.",
         stepRestart:
           "Restart the Gateway after updating OpenClaw so it serves the current protocol.",
       },
@@ -4588,11 +4584,10 @@ export const en: TranslationMap = {
         title: "Could not connect",
         summary:
           "The browser could not complete the Gateway connection. Check the target and transport before retrying credentials.",
-        stepGateway: "Confirm the Gateway is running with openclaw status or openclaw gateway run.",
+        stepGateway: "Confirm the Gateway is running.",
         stepUrl:
           "Check the WebSocket URL and use wss:// when the Gateway is behind HTTPS/Tailscale Serve.",
-        stepDashboard:
-          "Reopen the dashboard with openclaw dashboard --no-open to recopy the current URL and auth details.",
+        stepDashboard: "Reopen the dashboard to recopy the current URL and auth details.",
       },
     },
   },

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -349,6 +349,16 @@ openclaw-session-owner-chip {
   border: 0;
 }
 
+.login-gate__failure .login-gate__command {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.login-gate__failure .login-gate__command code {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .login-gate__docs {
   margin-top: 10px;
   font-size: 12px;


### PR DESCRIPTION
## What Problem This Solves

The login gate's failure panels (pairing required, auth required, auth failed, protocol mismatch, could not connect) render their recovery CLI commands as plain prose inside translated sentences. Operators must select-and-copy or hand-retype the commands on the Gateway host, including the full UUID in `openclaw devices approve <requestId>` for the device pairing flow. On mobile, selecting a UUID out of a styled list item is genuinely painful, and the same gate already ships a copy-chip affordance (`renderConnectCommand`) two sections lower in the "How to connect" help.

## Why This Change Was Made

Failure steps become `{ text, command? }` pairs. Steps that name a CLI command now render it with the existing `renderConnectCommand` copy chip below the step text, so the recovery flow is: read step, click, paste on the Gateway host. The pairing panel chips carry the exact `openclaw devices approve <requestId>` for the pending request.

This also moves CLI commands out of translatable strings and into code. Commands are product syntax, not prose; keeping them inside locale sentences invites machine-translation drift (the eight affected sentences were reworded into lead-ins, so the old keys were renamed rather than mutated to avoid reusing stale translations with orphaned placeholders).

## User Impact

- Pairing-required, auth-required, auth-failed, protocol-mismatch, and network failure panels show one-click copyable commands instead of prose-embedded ones.
- The `devices approve` chip includes the request ID, removing UUID retyping entirely.
- No behavior change for panels without commands (rate limited, insecure context, origin not allowed).

## Evidence

- `pnpm test ui/src/e2e/login-gate.e2e.test.ts`: 5 passed (2 new tests: pairing chips render the exact commands and clicking copies to clipboard; auth-required chips render both token commands).
- `pnpm ui:i18n:sync` + `pnpm ui:i18n:check`: clean; locale bundles and `.i18n` metadata regenerated.
- Lint (`scripts/run-oxlint.mjs`) and `oxfmt` clean on touched files.
- Before/after screenshots of the pairing-required and auth-required cards attached below.

Known gap, called out deliberately: the eight renamed step keys currently carry English fallback values in the 20 generated locale bundles because contributor-side `ui:i18n:sync` has no translation provider configured. They are recorded as `fallbackKeys` in `.i18n/*.meta.json`, so one maintainer `pnpm ui:i18n:sync` run with a provider key translates them through the standard pipeline. `ui/src/i18n/test/translate.test.ts` ("keeps login failure guidance localized") fails until that run happens; everything else is green. Maintainer edits are enabled on this branch.
