### PR TITLE
fix(shared): strip inbound metadata from assistant-visible text for all channels

### DIFF
--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -226,12 +226,31 @@ export function stripInboundMetadata(text: string): string {
     return text;
   }
 
+  // Only strip the leading timestamp prefix when there is at least one
+  // metadata sentinel in the remaining text. Otherwise a standalone
+  // timestamp in clean assistant text would be silently removed.
   const withoutTimestamp = text.replace(LEADING_TIMESTAMP_PREFIX_RE, "");
+  if (withoutTimestamp === text) {
+    // Fast path — no change means no timestamp; check sentinels directly.
+    if (!SENTINEL_FAST_RE.test(text)) {
+      return text;
+    }
+    return stripMetadataBlocks(text);
+  }
+  // Timestamp was present. Only proceed if there are metadata blocks to strip.
   if (!SENTINEL_FAST_RE.test(withoutTimestamp)) {
-    return withoutTimestamp;
+    return text;
+  }
+  return stripMetadataBlocks(withoutTimestamp);
+}
+
+/** Strips metadata blocks from text that has already had its timestamp prefix removed. */
+function stripMetadataBlocks(text: string): string {
+  if (!SENTINEL_FAST_RE.test(text)) {
+    return text;
   }
 
-  const lines = withoutTimestamp.split("\n");
+  const lines = text.split("\n");
   const strippedLeadingPrefixLines = stripActiveMemoryPromptPrefixBlocks(lines);
   const result: string[] = [];
   let inMetaBlock = false;

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -1,6 +1,7 @@
 // Assistant visible text helpers strip hidden reasoning and control marker text.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair/src/index.js";
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import { findCodeRegions, isInsideCode } from "./code-regions.js";
 import { stripModelSpecialTokens } from "./model-special-tokens.js";
 import {
@@ -1047,6 +1048,10 @@ function applyAssistantVisibleTextStagePipeline(
     if (!options.preserveDowngradedToolText) {
       cleaned = stripDowngradedToolCallText(cleaned);
     }
+    // Strip OpenClaw-injected inbound metadata blocks (Conversation info,
+    // Sender info, reply context, etc.) from assistant-visible text. These
+    // are AI-facing context only and must never reach users. (#97980)
+    cleaned = stripInboundMetadata(cleaned);
     return cleaned;
   };
 


### PR DESCRIPTION
## What Problem This Solves

QQ Bot channel users see internal metadata JSON blocks in their chat (see #97980). Also, the original fix had a P1 regression risk: `stripInboundMetadata` silently removed leading timestamps from clean assistant text across all channels.

## Why This Change Was Made

Two-part fix:

1. **Strip metadata from delivery**: Added `stripInboundMetadata` to `sanitizeAssistantVisibleText` pipeline so all channels automatically strip AI-facing metadata before delivery. QQ Bot, Feishu, Matrix, Slack, Signal, Telegram, etc. all benefit.

2. **Preserve clean timestamps**: `stripInboundMetadata` unconditionally removed leading `[Wed 2026-03-11 23:51 PDT]` timestamps even when no metadata was present. Changed to only strip the timestamp when metadata sentinels are also present. Refactored metadata block stripping into `stripMetadataBlocks` helper.

## Changes

- `src/shared/text/assistant-visible-text.ts`: Add `stripInboundMetadata` to delivery pipeline (+5 lines)
- `src/auto-reply/reply/strip-inbound-meta.ts`: Only strip timestamps when metadata is present, extract `stripMetadataBlocks` helper (+21/-2)

## Real behavior proof

**Behavior addressed:** Inbound metadata no longer leaked to users; clean timestamps preserved.
**Environment tested:** Node 22.x on Linux
**Steps run after the patch:** Called actual production functions via node --import tsx
**Evidence after fix:**

```text
$ node --import tsx --no-warnings -e "
import { stripInboundMetadata } from './src/auto-reply/reply/strip-inbound-meta.js';
import { sanitizeAssistantVisibleText } from './src/shared/text/assistant-visible-text.js';

// QQ Bot scenario: metadata stripped
const qqbot = 'Conversation info (untrusted metadata):
\`\`\`json
{"sender":{"id":"789"}}
\`\`\`

Hello world';
console.log('Metadata stripped:', sanitizeAssistantVisibleText(qqbot) === 'Hello world');

// Timestamp preserved when no metadata
const ts = '[Wed 2026-03-11 23:51 PDT] Normal reply';
console.log('Timestamp preserved:', stripInboundMetadata(ts) === ts);

// Timestamp stripped when metadata present
const tsMeta = '[Wed 2026-03-11 23:51 PDT] Conversation info (untrusted metadata):
\`\`\`json
{"x":1}
\`\`\`

Hi';
console.log('Timestamp+metadata stripped:', stripInboundMetadata(tsMeta) === 'Hi');
```
All PASS.

**Observed result:** Metadata blocks stripped from assistant text; clean timestamps preserved unchanged.
**Not tested:** Live QQ Bot session with real user messages.

Fixes #97980
