### PR TITLE
fix(browser): close peer-owned tabs on session reset

### DIFF
--- a/extensions/browser/src/browser/routes/tabs.test.ts
+++ b/extensions/browser/src/browser/routes/tabs.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover tabs plugin behavior.
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { toBrowserErrorResponse } from "../errors.js";
 import { createBrowserRouteApp, createBrowserRouteResponse } from "./test-helpers.js";
 
 const navigationGuardMocks = vi.hoisted(() => ({
@@ -42,25 +43,36 @@ const internalTab = (overrides: Partial<TabFixture> = {}): TabFixture => ({
   ...overrides,
 });
 
+function ssrfBlockedError() {
+  return Object.assign(new Error("blocked"), { name: "SsrFBlockedError" });
+}
+
 const createProfileWithTabs = (tabs: TabFixture[]) =>
   createProfileContext({
     listTabs: vi.fn(async () => tabs),
   });
 
 async function expectBrowserNotRunningAction(action: "close" | "select") {
+  vi.useFakeTimers();
   const profileCtx = createProfileContext({
     isReachable: vi.fn(async () => false),
   });
 
-  const response = await callTabsAction({
-    body: { action, index: 0 },
-    profileCtx,
-  });
+  try {
+    const pending = callTabsAction({
+      body: { action, index: 0 },
+      profileCtx,
+    });
+    await vi.runAllTimersAsync();
+    const response = await pending;
 
-  expect(response.statusCode).toBe(409);
-  expect(response.body).toEqual({ error: "browser not running" });
-  expect(profileCtx.listTabs).not.toHaveBeenCalled();
-  expect(action === "close" ? profileCtx.closeTab : profileCtx.focusTab).not.toHaveBeenCalled();
+    expect(response.statusCode).toBe(409);
+    expect(response.body).toEqual({ error: "browser not running" });
+    expect(profileCtx.listTabs).not.toHaveBeenCalled();
+    expect(action === "close" ? profileCtx.closeTab : profileCtx.focusTab).not.toHaveBeenCalled();
+  } finally {
+    vi.useRealTimers();
+  }
 }
 
 function createProfileContext(overrides?: Partial<ReturnType<typeof baseProfileContext>>) {
@@ -127,13 +139,7 @@ function createRouteContext(
     }),
     forProfile: () => profileCtx,
     listProfiles: vi.fn(async () => []),
-    mapTabError: vi.fn((err: unknown) => {
-      if (!(err instanceof Error)) {
-        return null;
-      }
-      const status = "status" in err && typeof err.status === "number" ? err.status : 400;
-      return { status, message: err.message };
-    }),
+    mapTabError: vi.fn(toBrowserErrorResponse),
     ensureBrowserAvailable: profileCtx.ensureBrowserAvailable,
     ensureTabAvailable: profileCtx.ensureTabAvailable,
     isHttpReachable: profileCtx.isHttpReachable,
@@ -227,6 +233,56 @@ describe("browser tab routes", () => {
     await expectBrowserNotRunningAction("select");
   });
 
+  it("retries a transient reachability miss before mutating a tab", async () => {
+    vi.useFakeTimers();
+    const isReachable = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    const profileCtx = createProfileContext({ isReachable });
+
+    try {
+      const pending = callTabsAction({
+        body: { action: "close", index: 0 },
+        profileCtx,
+      });
+      await vi.runAllTimersAsync();
+      const response = await pending;
+
+      expect(response.statusCode).toBe(200);
+      expect(isReachable).toHaveBeenCalledTimes(2);
+      expect(profileCtx.closeTab).toHaveBeenCalledWith("T1");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry or mutate after cancellation during the retry delay", async () => {
+    vi.useFakeTimers();
+    const abort = new AbortController();
+    const isReachable = vi.fn(async () => false);
+    const profileCtx = createProfileContext({ isReachable });
+
+    try {
+      const pending = callTabsAction({
+        body: { action: "close", index: 0 },
+        profileCtx,
+        signal: abort.signal,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(isReachable).toHaveBeenCalledTimes(1);
+
+      const abortReason = new Error("cancelled");
+      abort.abort(abortReason);
+      await vi.runAllTimersAsync();
+      const response = await pending;
+
+      expect(response.statusCode).toBe(500);
+      expect(response.body).toEqual({ error: "Error: cancelled" });
+      expect(isReachable).toHaveBeenCalledTimes(1);
+      expect(profileCtx.closeTab).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses the configured action timeout for existing-session tab reachability", async () => {
     const isReachable = vi.fn(async () => true);
     const abort = new AbortController();
@@ -317,7 +373,7 @@ describe("browser tab routes", () => {
 
   it("blocks /tabs/focus when target tab URL fails SSRF checks", async () => {
     navigationGuardMocks.assertBrowserNavigationResultAllowed.mockRejectedValueOnce(
-      new Error("blocked"),
+      ssrfBlockedError(),
     );
     const profileCtx = createProfileWithTabs([internalTab()]);
 
@@ -402,7 +458,7 @@ describe("browser tab routes", () => {
 
   it("blocks /tabs/action select when target tab URL fails SSRF checks", async () => {
     navigationGuardMocks.assertBrowserNavigationResultAllowed.mockRejectedValueOnce(
-      new Error("blocked"),
+      ssrfBlockedError(),
     );
     const profileCtx = createProfileWithTabs([publicTab(), internalTab()]);
 

--- a/extensions/browser/src/browser/routes/tabs.ts
+++ b/extensions/browser/src/browser/routes/tabs.ts
@@ -24,6 +24,7 @@ import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./t
 import { asyncBrowserRoute, jsonError, toStringOrEmpty } from "./utils.js";
 
 const DEFAULT_TAB_REACHABILITY_TIMEOUT_MS = 300;
+const TAB_REACHABILITY_RETRY_DELAY_MS = 250;
 
 function handleTabsRouteError(
   ctx: BrowserRouteContext,
@@ -88,7 +89,18 @@ async function ensureBrowserRunning(
   res: BrowserResponse,
   signal?: AbortSignal,
 ) {
-  if (!(await checkTabReachability(ctx, profileCtx, signal))) {
+  let isReachable = await checkTabReachability(ctx, profileCtx, signal);
+  // A running browser can outlive one short CDP probe; retry once before
+  // rejecting a tab mutation and leaving session-owned tabs behind.
+  if (!isReachable && !signal?.aborted) {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, TAB_REACHABILITY_RETRY_DELAY_MS);
+    });
+    // Keep false reserved for paths where jsonError already wrote a response.
+    signal?.throwIfAborted();
+    isReachable = await checkTabReachability(ctx, profileCtx, signal);
+  }
+  if (!isReachable) {
     jsonError(
       res,
       new BrowserProfileUnavailableError("browser not running").status,

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2821,6 +2821,43 @@ describe("initSessionState browser tab cleanup", () => {
     expect(result.isNewSession).toBe(true);
     expect(browserMaintenanceMocks.closeTrackedBrowserTabsForSessions).not.toHaveBeenCalled();
   });
+
+  it("includes the peer-scoped runtime key for direct-message cleanup", async () => {
+    const storePath = await createStorePath("openclaw-tab-cleanup-peer-key-");
+    const canonicalKey = "agent:main:main";
+    const existingSessionId = "tab-peer-key-session-id";
+    await writeSessionStoreFast(storePath, {
+      [canonicalKey]: {
+        sessionId: existingSessionId,
+        updatedAt: Date.now(),
+      },
+    });
+
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        From: "12345",
+        Provider: "telegram",
+        ChatType: "direct",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    const cleanupParams = requireMockCallArg(
+      browserMaintenanceMocks.closeTrackedBrowserTabsForSessions,
+      "closeTrackedBrowserTabsForSessions",
+    );
+    expect(cleanupParams.sessionKeys).toEqual([
+      existingSessionId,
+      canonicalKey,
+      "agent:main:telegram:default:direct:12345",
+    ]);
+  });
 });
 
 describe("initSessionState channel reset overrides", () => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -80,6 +80,7 @@ import { normalizeInboundTextNewlines } from "./inbound-text.js";
 import { stripMentions, stripStructuralPrefixes } from "./mentions.js";
 import { replyRunRegistry } from "./reply-run-registry.js";
 import { isResetAuthorizedForContext } from "./reset-authorization.js";
+import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
 import {
   maybeRetireLegacyMainDeliveryRoute,
   resolveLastChannelRaw,
@@ -1054,9 +1055,13 @@ async function initSessionStateAttemptLocked(
       sessionFile: previousSessionEntry.sessionFile,
       reason: previousSessionEndReason ?? "unknown",
     });
+    // Direct-message browser tabs use a peer-scoped runtime identity even when
+    // their transcript aliases main; cleanup must carry both exact keys.
+    const runtimePolicySessionKey =
+      resolveRuntimePolicySessionKey({ cfg, ctx: sessionCtxForState, sessionKey }) ?? sessionKey;
     void cleanupBrowserSessionsForLifecycleEnd({
       cfg,
-      sessionKeys: [previousSessionEntry.sessionId, sessionKey],
+      sessionKeys: [previousSessionEntry.sessionId, sessionKey, runtimePolicySessionKey],
       onWarn: (message) => log.warn(message),
       onError: (error) => log.warn(`browser tab cleanup failed: ${String(error)}`),
     });


### PR DESCRIPTION
Supersedes #93934. Preserves @FMLS's contribution as a co-author; release-note context remains here for release-owned changelog generation.

## What Problem This Solves

Fixes an issue where direct-message users resetting a canonical main session with `/new` or `/reset` could leave that peer's managed-browser tabs open because the tabs were owned by the peer-scoped runtime identity rather than the canonical transcript key.

## Why This Change Was Made

Session rollover now resolves the existing runtime-policy session key and supplies that exact key to browser lifecycle cleanup alongside the prior session id and canonical key. It does not fuzzy-match or close an agent's other peer-owned tabs. A single bounded, cancellation-safe reachability retry lives at the tab-route boundary because live validation found that one short CDP miss could otherwise leave a correctly selected tab open.

## User Impact

`/new` and `/reset` close the resetting direct-message peer's tracked browser tabs without closing tabs owned by another peer. Transient managed-browser reachability misses no longer defeat tab mutations, and cancelled requests still cannot mutate tabs afterward.

## Evidence

- Blacksmith Testbox `tidal-shrimp` (`tbx_01kwvc817e5sdgdcf6c46r79q5`, [run 28781807714](https://github.com/openclaw/openclaw/actions/runs/28781807714)): byte-identical replacement-head hashes, oxfmt clean, 134/134 auto-reply tests and 24/24 browser tests passed.
- AWS Crabbox `blue-prawn` (`cbx_956a9376ac99`), run `run_716882521292`: sanitized exact-head checkout and full build passed on Node 24.15.0 / pnpm 11.2.2.
- AWS Crabbox `blue-prawn`, run `run_f049ff6f0a13`: isolated Dev Gateway, real `openai/gpt-5.4-mini` agent turns, and managed Chromium. Peer A and B each opened a randomized target; resetting peer A rotated the session and changed target counts A `1 -> 0`, B `1 -> 1`. The replacement branch's four runtime/test files are byte-identical to the executed signed tree.
- Fresh structured autoreview: clean after moving retry ownership to the tab route and making cancellation stop before a second probe or mutation.

No docs or config surface changes.
