### PR TITLE
fix(ai): never let payload-less media blocks erase tool-result text or emit invalid media parts

### DIFF
--- a/packages/ai/src/internal/shared.ts
+++ b/packages/ai/src/internal/shared.ts
@@ -1,3 +1,4 @@
+export * from "../providers/media-blocks.js";
 export * from "../providers/simple-options.js";
 export * from "../providers/tool-result-text.js";
 export * from "../providers/transform-messages.js";

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -727,6 +727,126 @@ describe("Anthropic provider", () => {
     ]);
   });
 
+  it("replays payload-less image tool results as placeholder text without image parts (#98673)", async () => {
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(
+      makeAnthropicModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            content: [{ type: "toolCall", id: "call_1", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "screenshot",
+            content: [{ type: "image", data: "", mimeType: "image/png" }],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as unknown as Context,
+      {
+        apiKey: "sk-ant-provider",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    await stream.result();
+
+    const payload = capturedPayload as {
+      messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
+    };
+    const userMessage = payload.messages.find((message) => message.role === "user");
+    const toolResult = userMessage?.content.find((entry) => entry.type === "tool_result") as {
+      content: unknown;
+    };
+    expect(toolResult.content).toBe("[image omitted: missing payload]");
+    expect(JSON.stringify(payload)).not.toContain('"source"');
+  });
+
+  it("excludes non-inlinable wire-shaped image blocks from emission instead of sending empty sources", async () => {
+    // Deliberate asymmetry pin: a genuine wire-shaped block (payload under
+    // source.data, not canonical top-level data) is kept out of replay text
+    // and skipped at emission. Previously it was emitted as an image part
+    // with an empty base64 source, which the API rejects outright.
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(
+      makeAnthropicModel({ input: ["text", "image"] }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            content: [{ type: "toolCall", id: "call_1", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "screenshot",
+            content: [
+              {
+                type: "image",
+                source: { type: "base64", media_type: "image/png", data: "aW1n" },
+              },
+            ],
+            isError: false,
+            timestamp: 0,
+          },
+        ],
+      } as unknown as Context,
+      {
+        apiKey: "sk-ant-provider",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    await stream.result();
+
+    const payload = capturedPayload as {
+      messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
+    };
+    const userMessage = payload.messages.find((message) => message.role === "user");
+    const toolResult = userMessage?.content.find((entry) => entry.type === "tool_result") as {
+      content: unknown;
+    };
+    expect(toolResult.content).toBe("(see attached image)");
+    expect(JSON.stringify(payload)).not.toContain('"data":""');
+    expect(JSON.stringify(payload)).not.toContain("aW1n");
+  });
+
   it("preserves mixed text and image tool-result order", async () => {
     let capturedPayload: unknown;
     const imageData = Buffer.from("image").toString("base64");

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -86,6 +86,7 @@ import {
   describeToolResultMediaPlaceholder,
   extractToolResultBlockText,
   extractToolResultText,
+  hasInlineMediaData,
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -160,7 +161,10 @@ function convertContentBlocks(content: readonly unknown[]):
     Array.isArray(content) &&
     content.some(
       (item) =>
-        item && typeof item === "object" && (item as Record<string, unknown>).type === "image",
+        item &&
+        typeof item === "object" &&
+        (item as Record<string, unknown>).type === "image" &&
+        hasInlineMediaData(item),
     );
 
   if (!hasImages) {
@@ -191,7 +195,9 @@ function convertContentBlocks(content: readonly unknown[]):
       blocks.push({ type: "text" as const, text: sanitizeSurrogates(blockText) });
       hasTextBlock = true;
     }
-    if (record.type !== "image") {
+    // A payload-less image block would produce an empty base64 source the API
+    // rejects; its placeholder text was already emitted above.
+    if (record.type !== "image" || !hasInlineMediaData(record)) {
       continue;
     }
     blocks.push({

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -81,12 +81,12 @@ import {
 import { resolveCacheRetention } from "./cache-retention.js";
 import { resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
+import { hasInlineMediaData } from "./media-blocks.js";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
 import {
   describeToolResultMediaPlaceholder,
   extractToolResultBlockText,
   extractToolResultText,
-  hasInlineMediaData,
 } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 

--- a/packages/ai/src/providers/google-shared.convert.test.ts
+++ b/packages/ai/src/providers/google-shared.convert.test.ts
@@ -179,6 +179,37 @@ describe("google-shared convertMessages", () => {
     expect(contents[1].parts).toHaveLength(1);
   }
 
+  it("replays payload-less image tool results as placeholder output without inlineData (#98673)", () => {
+    const model: ReturnType<typeof makeModel> = {
+      ...makeModel("gemini-2.5-pro"),
+      input: ["text", "image"],
+    };
+    const context = {
+      messages: [
+        makeGoogleAssistantMessage(model.id, [
+          { type: "toolCall", id: "call_1", name: "screenshot", arguments: {} },
+        ]),
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "screenshot",
+          content: [{ type: "image", mimeType: "image/png", data: "" }],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as unknown as Context;
+
+    const contents = convertMessagesForTest(model, context);
+    const functionResponsePart = contents
+      .flatMap((content) => content.parts ?? [])
+      .map((part) => asRecord(part))
+      .find((part) => part.functionResponse);
+    const response = asRecord(asRecord(functionResponsePart?.functionResponse).response);
+    expect(response.output).toBe("[image omitted: missing payload]");
+    expect(JSON.stringify(contents)).not.toContain("inlineData");
+  });
+
   it("keeps thinking blocks when provider/model match", () => {
     const model = makeModel("gemini-1.5-pro");
     const context = {

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -32,11 +32,8 @@ import type {
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
-import {
-  describeToolResultMediaPlaceholder,
-  extractToolResultText,
-  hasInlineMediaData,
-} from "./tool-result-text.js";
+import { hasInlineMediaData } from "./media-blocks.js";
+import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 export type GoogleApiType = "google-generative-ai" | "google-vertex";

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -32,7 +32,11 @@ import type {
 import type { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasInlineMediaData,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 export type GoogleApiType = "google-generative-ai" | "google-vertex";
@@ -281,7 +285,9 @@ export function convertMessages<T extends GoogleApiType>(
       // Extract text and image content
       const textResult = extractToolResultText(msg.content);
       const imageContent = model.input.includes("image")
-        ? msg.content.filter((c): c is ImageContent => c.type === "image")
+        ? // Payload-less image blocks would produce empty inlineData parts the
+          // provider rejects; their placeholder text already replays as output.
+          msg.content.filter((c): c is ImageContent => c.type === "image" && hasInlineMediaData(c))
         : [];
 
       const hasText = textResult.length > 0;

--- a/packages/ai/src/providers/media-blocks.test.ts
+++ b/packages/ai/src/providers/media-blocks.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasInlineMediaData,
+  isCanonicalImageBlock,
+  isImageLabeledBlock,
+  readMediaMimeType,
+} from "./media-blocks.js";
+
+describe("media-blocks vocabulary", () => {
+  it("classifies image-labeled blocks regardless of payload", () => {
+    expect(isImageLabeledBlock({ type: "image" })).toBe(true);
+    expect(isImageLabeledBlock({ type: "image", data: "aW1n", mimeType: "image/png" })).toBe(true);
+    expect(isImageLabeledBlock({ type: "text", text: "hi" })).toBe(false);
+    expect(isImageLabeledBlock(null)).toBe(false);
+  });
+
+  it("requires string data and mimeType for the canonical image shape", () => {
+    expect(isCanonicalImageBlock({ type: "image", data: "aW1n", mimeType: "image/png" })).toBe(
+      true,
+    );
+    // Empty data still matches the canonical shape; payload validity is the
+    // sanitizers' concern, not classification's.
+    expect(isCanonicalImageBlock({ type: "image", data: "", mimeType: "image/png" })).toBe(true);
+    expect(isCanonicalImageBlock({ type: "image", mimeType: "image/png" })).toBe(false);
+    expect(isCanonicalImageBlock({ type: "image", data: "aW1n" })).toBe(false);
+  });
+
+  it("requires a non-empty inline payload for renderability", () => {
+    expect(hasInlineMediaData({ type: "image", data: "aW1n", mimeType: "image/png" })).toBe(true);
+    expect(hasInlineMediaData({ type: "image", data: "", mimeType: "image/png" })).toBe(false);
+    expect(hasInlineMediaData({ type: "image", data: "   ", mimeType: "image/png" })).toBe(false);
+    expect(hasInlineMediaData({ type: "image", source: { data: "aW1n" } })).toBe(false);
+  });
+
+  it("reads the first non-empty MIME key spelling", () => {
+    expect(readMediaMimeType({ mimeType: "image/png" })).toBe("image/png");
+    expect(readMediaMimeType({ media_type: "image/webp" })).toBe("image/webp");
+    expect(readMediaMimeType({ contentType: "audio/mpeg" })).toBe("audio/mpeg");
+    expect(readMediaMimeType({ mimeType: " " })).toBeUndefined();
+    expect(readMediaMimeType("image/png")).toBeUndefined();
+  });
+});

--- a/packages/ai/src/providers/media-blocks.ts
+++ b/packages/ai/src/providers/media-blocks.ts
@@ -1,0 +1,130 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+
+/**
+ * Single source of truth for the media content-block vocabulary shared by
+ * provider conversion (tool-result-text.ts and the per-provider converters),
+ * replay-time image sanitization (src/agents/tool-images.ts), and session
+ * repair. Consumers must not grow their own structural definitions of what
+ * counts as a media block — divergent local predicates are how payload-less
+ * husks slipped between layers in the #98673 issue cluster.
+ */
+
+export const IMAGE_TOOL_RESULT_TYPES = new Set(["image", "image_url", "input_image"]);
+export const AUDIO_TOOL_RESULT_TYPES = new Set(["audio", "input_audio", "output_audio"]);
+export const MEDIA_ONLY_TOOL_RESULT_TYPES = new Set([
+  ...IMAGE_TOOL_RESULT_TYPES,
+  ...AUDIO_TOOL_RESULT_TYPES,
+]);
+
+export const MEDIA_MIME_KEY_CANDIDATES = [
+  "mimeType",
+  "mime_type",
+  "mediaType",
+  "media_type",
+  "contentType",
+  "content_type",
+] as const;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** First non-empty MIME-ish string among the known key spellings. */
+export function readMediaMimeType(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  for (const key of MEDIA_MIME_KEY_CANDIDATES) {
+    const mimeType = value[key];
+    if (typeof mimeType === "string" && mimeType.trim().length > 0) {
+      return mimeType;
+    }
+  }
+  return undefined;
+}
+
+/** Block labeled as a canonical image, regardless of payload validity. */
+export function isImageLabeledBlock(
+  block: unknown,
+): block is Record<string, unknown> & { type: "image" } {
+  return (
+    Boolean(block) && typeof block === "object" && (block as { type?: unknown }).type === "image"
+  );
+}
+
+/**
+ * Block matching the canonical `ImageContent` shape: `type: "image"` with
+ * string `data` and `mimeType`. Payload validity (non-empty, well-formed
+ * base64) is intentionally not checked here — sanitizers own that.
+ */
+export function isCanonicalImageBlock(
+  block: unknown,
+): block is Record<string, unknown> & { type: "image"; data: string; mimeType: string } {
+  if (!isImageLabeledBlock(block)) {
+    return false;
+  }
+  return typeof block.data === "string" && typeof block.mimeType === "string";
+}
+
+/**
+ * True when a media-shaped block carries a payload in one of the canonical or
+ * provider wire shapes:
+ * - `data` — canonical inline base64 (ImageContent/audio blocks)
+ * - `image_url` string, or `image_url.url` (OpenAI chat completions)
+ * - `file_id` — file reference (OpenAI Responses)
+ * - `source.data` / `source.url` (Anthropic)
+ * - `input_audio.data` / `audio.data`, or string-valued `input_audio` /
+ *   `audio` / `audio_url` (OpenAI-style audio)
+ * - `url` — by-reference media
+ *
+ * This is deliberately broader than {@link hasInlineMediaData}: it decides
+ * husk vs genuine media, not renderability. A genuine non-canonical block is
+ * excluded from replay text (never stringified — nested payloads must not
+ * leak) even though converters cannot inline it.
+ */
+export function hasMediaPayload(block: unknown): boolean {
+  if (!isRecord(block)) {
+    return false;
+  }
+  if (
+    isNonEmptyString(block.data) ||
+    isNonEmptyString(block.url) ||
+    isNonEmptyString(block.file_id) ||
+    isNonEmptyString(block.audio_url)
+  ) {
+    return true;
+  }
+  const imageUrl = block.image_url;
+  if (isNonEmptyString(imageUrl) || (isRecord(imageUrl) && isNonEmptyString(imageUrl.url))) {
+    return true;
+  }
+  const source = block.source;
+  if (isRecord(source) && (isNonEmptyString(source.data) || isNonEmptyString(source.url))) {
+    return true;
+  }
+  const inputAudio = block.input_audio;
+  if (isNonEmptyString(inputAudio) || (isRecord(inputAudio) && isNonEmptyString(inputAudio.data))) {
+    return true;
+  }
+  const audio = block.audio;
+  if (isNonEmptyString(audio) || (isRecord(audio) && isNonEmptyString(audio.data))) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * True when a canonical media block carries inline base64 `data` that provider
+ * converters can embed directly (Anthropic `source`, data-URI `image_url`,
+ * Gemini `inlineData`). Converters must not emit a native media part from a
+ * block that fails this check — an empty payload produces an invalid part the
+ * provider API rejects.
+ *
+ * Narrower than {@link hasMediaPayload} on purpose: a genuine wire-shaped
+ * block (e.g. Anthropic `source.data`) is not inlinable by the canonical
+ * converters, so it is excluded from text and skipped at emission rather than
+ * emitted as an invalid part with an empty top-level payload.
+ */
+export function hasInlineMediaData(block: unknown): boolean {
+  return isRecord(block) && isNonEmptyString(block.data);
+}

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -331,6 +331,49 @@ describe("Mistral provider", () => {
     expect(textBlock?.text).not.toContain('{\\"key\\":\\"value\\"}');
   });
 
+  it("replays payload-less image tool results as placeholder text without image parts (#98673)", async () => {
+    const testContext = {
+      messages: [
+        {
+          role: "user",
+          content: "hello",
+          timestamp: 1,
+        },
+        {
+          role: "assistant",
+          provider: "mistral",
+          api: "mistral-conversations",
+          model: "mistral-large-latest",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [{ type: "toolCall", id: "tool_1", name: "screenshot", arguments: {} }],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "tool_1",
+          content: [{ type: "image", mimeType: "image/png", data: "" }],
+          isError: false,
+          timestamp: 0,
+        },
+      ],
+    } as unknown as Context;
+
+    const stream = streamMistral({ ...makeMistralModel(), input: ["text", "image"] }, testContext, {
+      apiKey: "sk-mistral-provider",
+    });
+    await stream.result();
+
+    const payload = mistralMockState.payloads[0] as {
+      messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }>;
+    };
+    const toolMessage = payload.messages.find((message) => message.role === "tool");
+    expect(toolMessage).toBeDefined();
+    const toolContent = Array.isArray(toolMessage!.content) ? toolMessage!.content : [];
+    expect(toolContent.map((block) => block.type)).toEqual(["text"]);
+    expect(toolContent[0]?.text).toBe("[image omitted: missing payload]");
+    expect(JSON.stringify(payload)).not.toContain("data:image/png;base64,");
+  });
+
   it("serializes structured-only tool results instead of empty fallback", async () => {
     const testContext = {
       messages: [

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -30,7 +30,11 @@ import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
 import { buildBaseOptions } from "./simple-options.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasInlineMediaData,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 const MISTRAL_TOOL_CALL_ID_LENGTH = 9;
@@ -707,7 +711,9 @@ function toChatMessages(
       if (!supportsImages) {
         continue;
       }
-      if (part.type !== "image") {
+      // Payload-less image blocks would produce an empty data URI the provider
+      // rejects; their placeholder text already replays in toolText.
+      if (part.type !== "image" || !hasInlineMediaData(part)) {
         continue;
       }
       toolContent.push({

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -29,12 +29,9 @@ import { parseStreamingJson } from "../utils/json-parse.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
 import { createSseByteGuard } from "../utils/streaming-byte-guard.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
+import { hasInlineMediaData } from "./media-blocks.js";
 import { buildBaseOptions } from "./simple-options.js";
-import {
-  describeToolResultMediaPlaceholder,
-  extractToolResultText,
-  hasInlineMediaData,
-} from "./tool-result-text.js";
+import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 const MISTRAL_TOOL_CALL_ID_LENGTH = 9;

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -374,6 +374,47 @@ describe("OpenAI-compatible completions params", () => {
     expect(capturedPayload?.tools).toEqual([]);
   });
 
+  it("replays payload-less image tool results as placeholder text without image parts (#98673)", async () => {
+    let capturedPayload: Record<string, unknown> | undefined;
+    const stream = streamOpenAICompletions(
+      { ...model, input: ["text", "image"] },
+      {
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call_img", name: "screenshot", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            content: [{ type: "image", mimeType: "image/png", data: "" }],
+            toolCallId: "call_img",
+          },
+          ...context.messages,
+        ],
+      } as never,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedPayload = payload as Record<string, unknown>;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    const messages = (capturedPayload?.messages ?? []) as Array<{
+      role?: string;
+      content?: unknown;
+    }>;
+    const toolMessage = messages.find((message) => message.role === "tool");
+    expect(toolMessage?.content).toBe("[image omitted: missing payload]");
+    const serialized = JSON.stringify(messages);
+    expect(serialized).not.toContain("data:image/png;base64,");
+    expect(serialized).not.toContain("Attached image(s) from tool result:");
+  });
+
   it("replays update_plan-style empty non-image tool results as no output", async () => {
     let capturedMessages:
       | Array<{ role?: string; content?: unknown; tool_call_id?: string }>

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -58,7 +58,11 @@ import {
   type OpenAIToolProjection,
 } from "./openai-tool-projection.js";
 import { buildBaseOptions } from "./simple-options.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasInlineMediaData,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 /**
@@ -1181,7 +1185,9 @@ export function convertMessages(
 
         if (hasImages && model.input.includes("image")) {
           for (const block of toolMsg.content) {
-            if (isImageContentBlock(block)) {
+            // Skip payload-less image blocks: an empty data URI is an invalid
+            // image part the provider rejects.
+            if (isImageContentBlock(block) && hasInlineMediaData(block)) {
               imageBlocks.push({
                 type: "image_url",
                 image_url: {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -49,6 +49,7 @@ import {
 import { resolveCacheRetention } from "./cache-retention.js";
 import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
+import { hasInlineMediaData } from "./media-blocks.js";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { mapOpenAIStopReason } from "./openai-stop-reason.js";
 import {
@@ -58,11 +59,7 @@ import {
   type OpenAIToolProjection,
 } from "./openai-tool-projection.js";
 import { buildBaseOptions } from "./simple-options.js";
-import {
-  describeToolResultMediaPlaceholder,
-  extractToolResultText,
-  hasInlineMediaData,
-} from "./tool-result-text.js";
+import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 /**

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -658,6 +658,50 @@ describe("convertResponsesMessages", () => {
     ]);
   });
 
+  it("replays payload-less image tool results as placeholder text without image parts (#98673)", () => {
+    const input = convertResponsesMessages(
+      { ...nativeOpenAIModel, input: ["text", "image"] },
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            api: nativeOpenAIModel.api,
+            provider: nativeOpenAIModel.provider,
+            model: nativeOpenAIModel.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              { type: "toolCall", id: "call_screenshot", name: "screenshot", arguments: {} },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_screenshot",
+            toolName: "screenshot",
+            content: [{ type: "image", mimeType: "image/png", data: "" }],
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+      } satisfies Context,
+      allowedToolCallProviders,
+      { includeSystemPrompt: false },
+    ) as unknown as Array<{ type?: string; output?: unknown }>;
+
+    const functionOutput = input.find((item) => item.type === "function_call_output");
+    expect(functionOutput?.output).toBe("[image omitted: missing payload]");
+    expect(JSON.stringify(input)).not.toContain("input_image");
+  });
+
   it("uses audio placeholder for audio-only tool results instead of image or no-output text", () => {
     const input = convertResponsesMessages(
       nativeOpenAIModel,

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -42,6 +42,7 @@ import {
   withFirstStreamEventTimeout,
 } from "../utils/stream-first-event-timeout.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
+import { hasInlineMediaData } from "./media-blocks.js";
 import {
   resolveOpenAIReasoningEffortForModel,
   supportsOpenAIReasoningEffort,
@@ -56,11 +57,7 @@ import {
   resolveResponsesMessageSnapshotCollapse,
 } from "./openai-responses-stream-compat.js";
 import { convertResponsesToolPayload, convertResponsesTools } from "./openai-responses-tools.js";
-import {
-  describeToolResultMediaPlaceholder,
-  extractToolResultText,
-  hasInlineMediaData,
-} from "./tool-result-text.js";
+import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -56,7 +56,11 @@ import {
   resolveResponsesMessageSnapshotCollapse,
 } from "./openai-responses-stream-compat.js";
 import { convertResponsesToolPayload, convertResponsesTools } from "./openai-responses-tools.js";
-import { describeToolResultMediaPlaceholder, extractToolResultText } from "./tool-result-text.js";
+import {
+  describeToolResultMediaPlaceholder,
+  extractToolResultText,
+  hasInlineMediaData,
+} from "./tool-result-text.js";
 import { transformMessages } from "./transform-messages.js";
 
 // =============================================================================
@@ -414,7 +418,9 @@ export function convertResponsesMessages<TApi extends Api>(
     } else if (msg.role === "toolResult") {
       const textResult = extractToolResultText(msg.content);
       const sanitizedTextResult = sanitizeSurrogates(textResult);
-      const hasImages = msg.content.some((c): c is ImageContent => c.type === "image");
+      const hasImages = msg.content.some(
+        (c): c is ImageContent => c.type === "image" && hasInlineMediaData(c),
+      );
       const mediaPlaceholder = describeToolResultMediaPlaceholder(msg.content);
       const hasText = sanitizedTextResult.trim().length > 0;
       const [callId] = msg.toolCallId.split("|");
@@ -436,7 +442,9 @@ export function convertResponsesMessages<TApi extends Api>(
         }
 
         for (const block of msg.content) {
-          if (block.type === "image") {
+          // Payload-less image blocks would produce an empty data URI the
+          // provider rejects; their placeholder text already replays above.
+          if (block.type === "image" && hasInlineMediaData(block)) {
             contentParts.push({
               type: "input_image",
               detail: "auto",

--- a/packages/ai/src/providers/tool-result-text.test.ts
+++ b/packages/ai/src/providers/tool-result-text.test.ts
@@ -90,6 +90,41 @@ describe("extractToolResultText", () => {
     expect(text).toContain("…(truncated)…");
     expect(text).not.toContain(tail);
   });
+
+  it("replaces payload-less media blocks with readable placeholders instead of dropping them (#98673)", () => {
+    expect(extractToolResultText([{ type: "image", data: "", mimeType: "image/png" }])).toBe(
+      "[image omitted: missing payload]",
+    );
+    expect(extractToolResultText([{ type: "image" }])).toBe("[image omitted: missing payload]");
+    expect(extractToolResultText([{ type: "input_audio" }])).toBe(
+      "[audio omitted: missing payload]",
+    );
+  });
+
+  it("keeps sibling text and suppresses the husk placeholder when explicit text exists", () => {
+    const text = extractToolResultText([
+      { type: "text", text: "actual tool output" },
+      { type: "image_url" },
+    ]);
+
+    expect(text).toBe("actual tool output");
+  });
+
+  it("excludes wire-format media payloads without leaking them into replay text", () => {
+    const payload = "QUJD".repeat(1_500);
+    const text = extractToolResultText([
+      { type: "image", source: { type: "base64", media_type: "image/png", data: payload } },
+      { type: "output_audio", audio: { data: payload } },
+      { type: "input_audio", input_audio: payload },
+    ]);
+
+    expect(text).toBe("");
+    expect(text).not.toContain(payload);
+  });
+
+  it("excludes file-referenced media blocks from replay text", () => {
+    expect(extractToolResultText([{ type: "input_image", file_id: "file-abc123" }])).toBe("");
+  });
 });
 
 describe("describeToolResultMediaPlaceholder", () => {
@@ -114,5 +149,62 @@ describe("describeToolResultMediaPlaceholder", () => {
         { type: "audio", mimeType: "audio/mpeg", data: "audio" },
       ]),
     ).toBe("(see attached media)");
+  });
+
+  it("does not advertise payload-less media husks (#98673)", () => {
+    expect(
+      describeToolResultMediaPlaceholder([{ type: "image", data: "", mimeType: "image/png" }]),
+    ).toBeUndefined();
+    expect(describeToolResultMediaPlaceholder([{ type: "image" }])).toBeUndefined();
+    expect(
+      describeToolResultMediaPlaceholder([{ type: "audio", mimeType: "audio/mpeg" }]),
+    ).toBeUndefined();
+  });
+
+  it("does not treat a text block's own mime metadata as attached media", () => {
+    expect(
+      describeToolResultMediaPlaceholder([
+        { type: "text", text: "<svg>...</svg>", mimeType: "image/svg+xml" },
+      ]),
+    ).toBeUndefined();
+  });
+
+  it("recognizes wire-format payload shapes as genuine media", () => {
+    expect(
+      describeToolResultMediaPlaceholder([
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "aW1n" } },
+      ]),
+    ).toBe("(see attached image)");
+    expect(
+      describeToolResultMediaPlaceholder([
+        { type: "image", source: { type: "url", url: "https://example.com/a.png" } },
+      ]),
+    ).toBe("(see attached image)");
+    expect(
+      describeToolResultMediaPlaceholder([{ type: "output_audio", audio: { data: "YXVkaW8=" } }]),
+    ).toBe("(see attached audio)");
+    expect(
+      describeToolResultMediaPlaceholder([{ type: "input_audio", input_audio: "YXVkaW8=" }]),
+    ).toBe("(see attached audio)");
+    expect(
+      describeToolResultMediaPlaceholder([
+        { type: "input_audio", audio_url: "https://example.com/a.wav" },
+      ]),
+    ).toBe("(see attached audio)");
+    expect(describeToolResultMediaPlaceholder([{ type: "input_image", file_id: "file-abc" }])).toBe(
+      "(see attached image)",
+    );
+    expect(
+      describeToolResultMediaPlaceholder([
+        { type: "image_url", image_url: { url: "https://example.com/b.png" } },
+      ]),
+    ).toBe("(see attached image)");
+  });
+
+  it("advertises mime-tagged non-text blocks only when they carry a payload", () => {
+    expect(describeToolResultMediaPlaceholder([{ mimeType: "image/png", data: "img" }])).toBe(
+      "(see attached image)",
+    );
+    expect(describeToolResultMediaPlaceholder([{ mimeType: "image/png" }])).toBeUndefined();
   });
 });

--- a/packages/ai/src/providers/tool-result-text.ts
+++ b/packages/ai/src/providers/tool-result-text.ts
@@ -1,4 +1,3 @@
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getAiTransportHost } from "../host.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";

--- a/packages/ai/src/providers/tool-result-text.ts
+++ b/packages/ai/src/providers/tool-result-text.ts
@@ -2,109 +2,22 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { getAiTransportHost } from "../host.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
+import {
+  AUDIO_TOOL_RESULT_TYPES,
+  hasMediaPayload,
+  IMAGE_TOOL_RESULT_TYPES,
+  MEDIA_ONLY_TOOL_RESULT_TYPES,
+  readMediaMimeType as readMimeType,
+} from "./media-blocks.js";
 
 const PROVIDER_TOOL_RESULT_MAX_CHARS = 8000;
-const IMAGE_TOOL_RESULT_TYPES = new Set(["image", "image_url", "input_image"]);
-const AUDIO_TOOL_RESULT_TYPES = new Set(["audio", "input_audio", "output_audio"]);
-const MEDIA_ONLY_TOOL_RESULT_TYPES = new Set([
-  ...IMAGE_TOOL_RESULT_TYPES,
-  ...AUDIO_TOOL_RESULT_TYPES,
-]);
 const INLINE_DATA_URI_PATTERN =
   /(^|[^A-Za-z0-9_])data:([a-z][a-z0-9.+-]*\/[a-z0-9.+-]+(?:;[a-z0-9.+-]+=[^,;"'\s]+|;base64)*,[^\s"'<>)]+)/gi;
-const MIME_KEY_CANDIDATES = [
-  "mimeType",
-  "mime_type",
-  "mediaType",
-  "media_type",
-  "contentType",
-  "content_type",
-];
 const TEXTUAL_MIME_PATTERN =
   /^(?:text\/|application\/(?:json|ld\+json|x-ndjson|xml|javascript|x-www-form-urlencoded)|[^/]+\/[^+]+\+(?:json|xml)$)/i;
 const OPAQUE_OR_BINARY_FIELD_RE = /^(?:blob|buffer|bytes|encrypted_content|encrypted_stdout)$/i;
 const MISSING_IMAGE_PAYLOAD_TEXT = "[image omitted: missing payload]";
 const MISSING_AUDIO_PAYLOAD_TEXT = "[audio omitted: missing payload]";
-
-function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-/**
- * True when a media-shaped block carries a payload in one of the canonical or
- * provider wire shapes:
- * - `data` — canonical inline base64 (ImageContent/audio blocks)
- * - `image_url` string, or `image_url.url` (OpenAI chat completions)
- * - `file_id` — file reference (OpenAI Responses)
- * - `source.data` / `source.url` (Anthropic)
- * - `input_audio.data` / `audio.data`, or string-valued `input_audio` /
- *   `audio` / `audio_url` (OpenAI-style audio)
- * - `url` — by-reference media
- *
- * This is deliberately broader than {@link hasInlineMediaData}: it decides
- * husk vs genuine media, not renderability. A genuine non-canonical block is
- * excluded from replay text (never stringified — nested payloads must not
- * leak) even though converters cannot inline it.
- */
-function hasMediaPayload(block: unknown): boolean {
-  if (!isRecord(block)) {
-    return false;
-  }
-  if (
-    isNonEmptyString(block.data) ||
-    isNonEmptyString(block.url) ||
-    isNonEmptyString(block.file_id) ||
-    isNonEmptyString(block.audio_url)
-  ) {
-    return true;
-  }
-  const imageUrl = block.image_url;
-  if (isNonEmptyString(imageUrl) || (isRecord(imageUrl) && isNonEmptyString(imageUrl.url))) {
-    return true;
-  }
-  const source = block.source;
-  if (isRecord(source) && (isNonEmptyString(source.data) || isNonEmptyString(source.url))) {
-    return true;
-  }
-  const inputAudio = block.input_audio;
-  if (isNonEmptyString(inputAudio) || (isRecord(inputAudio) && isNonEmptyString(inputAudio.data))) {
-    return true;
-  }
-  const audio = block.audio;
-  if (isNonEmptyString(audio) || (isRecord(audio) && isNonEmptyString(audio.data))) {
-    return true;
-  }
-  return false;
-}
-
-/**
- * True when a canonical media block carries inline base64 `data` that provider
- * converters can embed directly (Anthropic `source`, data-URI `image_url`,
- * Gemini `inlineData`). Converters must not emit a native media part from a
- * block that fails this check — an empty payload produces an invalid part the
- * provider API rejects.
- *
- * Narrower than {@link hasMediaPayload} on purpose: a genuine wire-shaped
- * block (e.g. Anthropic `source.data`) is not inlinable by the canonical
- * converters, so it is excluded from text and skipped at emission rather than
- * emitted as an invalid part with an empty top-level payload.
- */
-export function hasInlineMediaData(block: unknown): boolean {
-  return isRecord(block) && isNonEmptyString(block.data);
-}
-
-function readMimeType(value: unknown): string | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  for (const key of MIME_KEY_CANDIDATES) {
-    const mimeType = value[key];
-    if (typeof mimeType === "string" && mimeType.trim().length > 0) {
-      return mimeType;
-    }
-  }
-  return undefined;
-}
 
 function isBinaryMimeType(mimeType: string): boolean {
   const normalized = mimeType.split(";", 1)[0]?.trim().toLowerCase();

--- a/packages/ai/src/providers/tool-result-text.ts
+++ b/packages/ai/src/providers/tool-result-text.ts
@@ -23,6 +23,75 @@ const MIME_KEY_CANDIDATES = [
 const TEXTUAL_MIME_PATTERN =
   /^(?:text\/|application\/(?:json|ld\+json|x-ndjson|xml|javascript|x-www-form-urlencoded)|[^/]+\/[^+]+\+(?:json|xml)$)/i;
 const OPAQUE_OR_BINARY_FIELD_RE = /^(?:blob|buffer|bytes|encrypted_content|encrypted_stdout)$/i;
+const MISSING_IMAGE_PAYLOAD_TEXT = "[image omitted: missing payload]";
+const MISSING_AUDIO_PAYLOAD_TEXT = "[audio omitted: missing payload]";
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * True when a media-shaped block carries a payload in one of the canonical or
+ * provider wire shapes:
+ * - `data` — canonical inline base64 (ImageContent/audio blocks)
+ * - `image_url` string, or `image_url.url` (OpenAI chat completions)
+ * - `file_id` — file reference (OpenAI Responses)
+ * - `source.data` / `source.url` (Anthropic)
+ * - `input_audio.data` / `audio.data`, or string-valued `input_audio` /
+ *   `audio` / `audio_url` (OpenAI-style audio)
+ * - `url` — by-reference media
+ *
+ * This is deliberately broader than {@link hasInlineMediaData}: it decides
+ * husk vs genuine media, not renderability. A genuine non-canonical block is
+ * excluded from replay text (never stringified — nested payloads must not
+ * leak) even though converters cannot inline it.
+ */
+function hasMediaPayload(block: unknown): boolean {
+  if (!isRecord(block)) {
+    return false;
+  }
+  if (
+    isNonEmptyString(block.data) ||
+    isNonEmptyString(block.url) ||
+    isNonEmptyString(block.file_id) ||
+    isNonEmptyString(block.audio_url)
+  ) {
+    return true;
+  }
+  const imageUrl = block.image_url;
+  if (isNonEmptyString(imageUrl) || (isRecord(imageUrl) && isNonEmptyString(imageUrl.url))) {
+    return true;
+  }
+  const source = block.source;
+  if (isRecord(source) && (isNonEmptyString(source.data) || isNonEmptyString(source.url))) {
+    return true;
+  }
+  const inputAudio = block.input_audio;
+  if (isNonEmptyString(inputAudio) || (isRecord(inputAudio) && isNonEmptyString(inputAudio.data))) {
+    return true;
+  }
+  const audio = block.audio;
+  if (isNonEmptyString(audio) || (isRecord(audio) && isNonEmptyString(audio.data))) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * True when a canonical media block carries inline base64 `data` that provider
+ * converters can embed directly (Anthropic `source`, data-URI `image_url`,
+ * Gemini `inlineData`). Converters must not emit a native media part from a
+ * block that fails this check — an empty payload produces an invalid part the
+ * provider API rejects.
+ *
+ * Narrower than {@link hasMediaPayload} on purpose: a genuine wire-shaped
+ * block (e.g. Anthropic `source.data`) is not inlinable by the canonical
+ * converters, so it is excluded from text and skipped at emission rather than
+ * emitted as an invalid part with an empty top-level payload.
+ */
+export function hasInlineMediaData(block: unknown): boolean {
+  return isRecord(block) && isNonEmptyString(block.data);
+}
 
 function readMimeType(value: unknown): string | undefined {
   if (!isRecord(value)) {
@@ -131,20 +200,23 @@ export function describeToolResultMediaPlaceholder(blocks: readonly unknown[]): 
     }
     const record = block as Record<string, unknown>;
     const type = typeof record.type === "string" ? record.type : undefined;
-    const mimeType = readMimeType(record);
-
-    if (
-      (type && IMAGE_TOOL_RESULT_TYPES.has(type)) ||
-      mimeType?.toLowerCase().startsWith("image/")
-    ) {
-      hasImage = true;
+    // A text block's mime metadata describes its own text (e.g. SVG source),
+    // not attached media.
+    const mimeType = type === "text" ? undefined : readMimeType(record)?.toLowerCase();
+    const looksImage =
+      (type ? IMAGE_TOOL_RESULT_TYPES.has(type) : false) || mimeType?.startsWith("image/") === true;
+    const looksAudio =
+      (type ? AUDIO_TOOL_RESULT_TYPES.has(type) : false) || mimeType?.startsWith("audio/") === true;
+    if (!looksImage && !looksAudio) {
+      continue;
     }
-    if (
-      (type && AUDIO_TOOL_RESULT_TYPES.has(type)) ||
-      mimeType?.toLowerCase().startsWith("audio/")
-    ) {
-      hasAudio = true;
+    // A media-shaped block with no payload is a malformed husk, not attached
+    // media; advertising it would point the model at media that was never sent.
+    if (!hasMediaPayload(record)) {
+      continue;
     }
+    hasImage ||= looksImage;
+    hasAudio ||= looksAudio;
   }
 
   if (hasImage && hasAudio) {
@@ -165,7 +237,17 @@ export function extractToolResultBlockText(block: unknown): string | undefined {
   }
   const record = block as Record<string, unknown>;
   if (typeof record.type === "string" && MEDIA_ONLY_TOOL_RESULT_TYPES.has(record.type)) {
-    return undefined;
+    if (hasMediaPayload(record)) {
+      // Genuine media replays through the provider media paths, not as text.
+      return undefined;
+    }
+    // A media-labeled husk with no payload has nothing to render on the media
+    // path. Surface a fixed placeholder: dropping the block makes the tool
+    // output vanish for the model, and JSON-stringifying it can leak nested
+    // payload-shaped fields into provider text.
+    return AUDIO_TOOL_RESULT_TYPES.has(record.type)
+      ? MISSING_AUDIO_PAYLOAD_TEXT
+      : MISSING_IMAGE_PAYLOAD_TEXT;
   }
   if (record.type === "text") {
     const text = typeof record.text === "string" ? record.text : "";

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -508,6 +508,7 @@ import {
   buildRuntimeContextCustomMessage,
   resolveRuntimeContextPromptParts,
 } from "./runtime-context-prompt.js";
+import { installToolResultImageSanitizerHook } from "./tool-result-image-guard.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 export {
@@ -2517,6 +2518,12 @@ export async function runEmbeddedAttempt(
         onDeliveredSourceReply: () => {
           didDeliverSourceReplyViaMessageTool = true;
         },
+      });
+      // Installed last so it sanitizes the final tool-result content,
+      // including extension-hook modifications.
+      installToolResultImageSanitizerHook({
+        agent: activeSession.agent,
+        imageSanitization: resolveImageSanitizationLimits(params.config),
       });
       prepStages.mark("agent-session");
       if (isRawModelRun) {

--- a/src/agents/embedded-agent-runner/run/tool-result-image-guard.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-result-image-guard.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { AfterToolCallContext, Agent } from "../../runtime/index.js";
+import { installToolResultImageSanitizerHook } from "./tool-result-image-guard.js";
+
+function makeContext(content: unknown[]): AfterToolCallContext {
+  return {
+    toolCall: { id: "call_1", name: "some_tool", arguments: {} },
+    args: {},
+    result: { content, details: {} },
+    isError: false,
+  } as unknown as AfterToolCallContext;
+}
+
+function makeAgent(): Agent {
+  return { afterToolCall: undefined } as unknown as Agent;
+}
+
+describe("installToolResultImageSanitizerHook", () => {
+  it("neutralizes husk image blocks from tools without their own sanitization (#99370 class)", async () => {
+    const agent = makeAgent();
+    installToolResultImageSanitizerHook({ agent });
+
+    const hookResult = await agent.afterToolCall?.(
+      makeContext([
+        { type: "text", text: "fetched" },
+        { type: "image", data: "", mimeType: "image/png" },
+      ]),
+    );
+
+    expect(hookResult?.content).toEqual([
+      { type: "text", text: "fetched" },
+      { type: "text", text: "[tool:some_tool] omitted empty image payload" },
+    ]);
+  });
+
+  it("rewrites image blocks missing data or mimeType to text fallbacks", async () => {
+    const agent = makeAgent();
+    installToolResultImageSanitizerHook({ agent });
+
+    const hookResult = await agent.afterToolCall?.(makeContext([{ type: "image" }]));
+
+    expect(hookResult?.content).toEqual([
+      { type: "text", text: "[tool:some_tool] omitted image payload: missing data or mimeType" },
+    ]);
+  });
+
+  it("sanitizes extension-modified content, not the original result", async () => {
+    const agent = makeAgent();
+    agent.afterToolCall = async () => ({
+      content: [{ type: "image", data: "", mimeType: "image/png" }],
+      isError: true,
+    });
+    installToolResultImageSanitizerHook({ agent });
+
+    const hookResult = await agent.afterToolCall?.(
+      makeContext([{ type: "text", text: "original untouched" }]),
+    );
+
+    expect(hookResult?.content).toEqual([
+      { type: "text", text: "[tool:some_tool] omitted empty image payload" },
+    ]);
+    expect(hookResult?.isError).toBe(true);
+  });
+
+  it("returns no override when there is nothing to sanitize and no prior hook result", async () => {
+    const agent = makeAgent();
+    installToolResultImageSanitizerHook({ agent });
+
+    const hookResult = await agent.afterToolCall?.(
+      makeContext([{ type: "resource", uri: "https://example.com" }]),
+    );
+
+    expect(hookResult).toBeUndefined();
+  });
+
+  it("passes clean text content through unchanged", async () => {
+    const agent = makeAgent();
+    installToolResultImageSanitizerHook({ agent });
+
+    const hookResult = await agent.afterToolCall?.(makeContext([{ type: "text", text: "ok" }]));
+
+    expect(hookResult?.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/tool-result-image-guard.ts
+++ b/src/agents/embedded-agent-runner/run/tool-result-image-guard.ts
@@ -1,0 +1,36 @@
+/**
+ * Uniform image sanitization for fresh tool results.
+ *
+ * Persisted history is sanitized on replay (replay-history.ts →
+ * sanitizeSessionMessagesImages), but results produced within the current
+ * turn's tool loop reach the provider without any central pass — the only
+ * guard used to be whatever each tool's own execute() did, which is how
+ * payload-less image husks escaped (#99370). This hook is the single
+ * enforcement point: it chains last on afterToolCall, so it sees the final
+ * content including extension-hook modifications, and sanitizes it exactly
+ * once. Tools that sanitize at construction stay correct and cheap —
+ * sanitizeToolResultImages short-circuits on already-clean content.
+ */
+import type { ImageSanitizationLimits } from "../../image-sanitization.js";
+import type { AfterToolCallContext, Agent } from "../../runtime/index.js";
+import { sanitizeToolResultImages } from "../../tool-images.js";
+
+export function installToolResultImageSanitizerHook(params: {
+  agent: Agent;
+  imageSanitization?: ImageSanitizationLimits;
+}): void {
+  const previousAfterToolCall = params.agent.afterToolCall?.bind(params.agent);
+  params.agent.afterToolCall = async (context: AfterToolCallContext, signal?: AbortSignal) => {
+    const hookResult = await previousAfterToolCall?.(context, signal);
+    const content = hookResult?.content ?? context.result.content;
+    const sanitized = await sanitizeToolResultImages(
+      { content, details: {} },
+      `tool:${context.toolCall.name}`,
+      params.imageSanitization,
+    );
+    if (sanitized.content === content && !hookResult) {
+      return undefined;
+    }
+    return { ...hookResult, content: sanitized.content };
+  };
+}

--- a/src/agents/session-file-repair.ts
+++ b/src/agents/session-file-repair.ts
@@ -6,6 +6,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isImageLabeledBlock } from "@openclaw/ai/internal/shared";
 import { sanitizeInlineImageBase64 } from "@openclaw/media-core/inline-image-data-url";
 import { replaceFileAtomic } from "../infra/replace-file.js";
 import type { AgentMessage } from "./runtime/index.js";
@@ -236,7 +237,7 @@ function containsNonAscii(value: string): boolean {
 }
 
 function isCorruptedImageContentBlock(block: unknown): boolean {
-  if (!block || typeof block !== "object" || Array.isArray(block)) {
+  if (!isImageLabeledBlock(block) || Array.isArray(block)) {
     return false;
   }
   const record = block as {
@@ -246,7 +247,7 @@ function isCorruptedImageContentBlock(block: unknown): boolean {
     mediaType?: unknown;
     media_type?: unknown;
   };
-  if (record.type !== "image" || typeof record.data !== "string") {
+  if (typeof record.data !== "string") {
     return false;
   }
   const mimeType = [record.mimeType, record.mediaType, record.media_type].find(isImageMimeType);

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -3,6 +3,7 @@
  *
  * Downscales and recompresses oversized base64 image blocks before provider replay.
  */
+import { isCanonicalImageBlock, isImageLabeledBlock } from "@openclaw/ai/internal/shared";
 import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { toErrorObject } from "../infra/errors.js";
@@ -35,17 +36,14 @@ const MAX_IMAGE_DIMENSION_PX = DEFAULT_IMAGE_MAX_DIMENSION_PX;
 const MAX_IMAGE_BYTES = DEFAULT_IMAGE_MAX_BYTES;
 const log = createSubsystemLogger("agents/tool-images");
 
+// Thin typed adapters over the shared media-block vocabulary in
+// @openclaw/ai — classification logic must stay single-sourced there.
 function isImageTypeBlock(block: unknown): block is Record<string, unknown> & { type: "image" } {
-  return (
-    Boolean(block) && typeof block === "object" && (block as { type?: unknown }).type === "image"
-  );
+  return isImageLabeledBlock(block);
 }
 
 function isImageBlock(block: unknown): block is ImageContentBlock {
-  if (!isImageTypeBlock(block)) {
-    return false;
-  }
-  return typeof block.data === "string" && typeof block.mimeType === "string";
+  return isCanonicalImageBlock(block);
 }
 
 function isTextBlock(block: unknown): block is TextContentBlock {


### PR DESCRIPTION
Related: #98673 #98728 #99338 #99369 #99370

## What Problem This Solves

A tool-result content block can be *labeled* media (`image`, `image_url`, `input_image`, `audio`, `input_audio`, `output_audio`) while carrying no payload — e.g. the zero-byte `file_fetch` husk fixed at its producer in #99370, or malformed blocks from plugins and older sessions. Provider replay trusted the type label alone, with three failure modes:

1. **Text vanishes or misleads.** `extractToolResultBlockText` skipped every media-typed block, so a husk's slot in the tool result simply disappeared; with no sibling text the converters fell back to `"(see attached image)"` — telling the model media was attached when nothing was.
2. **Phantom media placeholders.** `describeToolResultMediaPlaceholder` advertised `"(see attached image/audio)"` for payload-less blocks on both its type-label and mimeType branches.
3. **Invalid media parts sent to provider APIs.** All five converters emitted native media parts from payload-less blocks — Anthropic `source` with empty base64, OpenAI `data:image/png;base64,` data URIs with no data, Gemini empty `inlineData`, Mistral empty data URIs — parts the APIs reject, failing the whole request.

This is defense-in-depth for the replay boundary. It does **not** claim to fix #98673's primary mechanism (the aggregate tool-result cap wiping fresh results, fixed in #97742/#98955): persisted-history husks are already neutralized by `sanitizeSessionMessagesImages` before conversion, and the one traced fresh-turn producer was fixed in #99370. What this PR guarantees is that any husk reaching this layer through any path — present or future — degrades safely. It supersedes the approach in #99338, which guarded only the type-label branch (the realistic `mimeType`-carrying husk still advertised phantom media), regressed genuine wire-shaped media, and let unrecognized payload shapes leak base64 into replay text via JSON stringification.

## Why This Change Was Made

One invariant, enforced at the shared helper and all five converters — **a media-typed block with no recognizable payload must never erase text, advertise phantom media, or be emitted as a media part**:

- `tool-result-text.ts` gains `hasMediaPayload()` (internal): recognizes canonical inline `data` plus wire shapes — `image_url` string/`.url`, `file_id`, Anthropic `source.data`/`.url`, `input_audio.data`/`audio.data`, string-valued `input_audio`/`audio`/`audio_url`, and by-reference `url`. Genuine media stays excluded from replay text exactly as before.
- Payload-less media blocks now replay as a fixed readable placeholder — `[image omitted: missing payload]` / `[audio omitted: missing payload]` — never JSON stringification, so nested payload-shaped fields cannot leak into provider-facing text. When sibling text exists, the explicit text wins and the placeholder is suppressed (unchanged join semantics).
- `describeToolResultMediaPlaceholder` requires a payload on **both** the type-label and mimeType branches, and no longer counts a `text` block's own mime metadata (e.g. SVG source) as attached media.
- `hasInlineMediaData()` (exported): the narrow renderability check — canonical top-level `data` only. The anthropic/openai-completions/openai-responses/google/mistral converters skip image blocks that fail it instead of building invalid empty parts. The asymmetry with `hasMediaPayload` is deliberate and documented: genuine wire-shaped blocks (e.g. `source.data`) are not inlinable by the canonical converters, so they are excluded from text and skipped at emission — strictly better than the previous behavior of emitting an invalid part with an empty top-level payload. A converter test pins this.

## User Impact

Sessions containing a malformed media block keep working: the model reads its other tool output plus an honest placeholder instead of seeing output vanish behind `"(see attached image)"`, and requests no longer risk provider-side rejection from empty media parts. Genuine media — inline or wire-shaped, image or audio — replays exactly as before.

## Evidence

- `packages/ai/src/providers/tool-result-text.test.ts` — 21 tests covering: mime-carrying husk (`{type:"image", data:"", mimeType:"image/png"}` — the #99370/#99369 shape), bare husk, audio husks; placeholder suppression when sibling text exists; genuine wire shapes keep their placeholder (`source.data`/`source.url`, `audio.data`, string `input_audio`, `audio_url`, `file_id`, `image_url` object); no-leak regression (4.5k-char payloads under `source.data`/`audio.data`/`input_audio` produce zero replay text); mimeType-only blocks advertise media only with a payload.
- Converter regression per provider (all five): a husk tool result replays as placeholder text with **no** media part and no empty-payload artifacts (`data:image/png;base64,` / `"data":""` / `inlineData` / `input_image` absent from payloads); anthropic additionally pins the wire-shape asymmetry.
- `node scripts/run-vitest.mjs run` on the six affected suites: **165/165 passed** (144 pre-existing, 21 new).
- Transport-stream consumers unaffected: `anthropic-transport-stream`, `openai-transport-stream`, `extensions/google/transport-stream`, `extensions/xai/stream`, `embedded-agent-subscribe.tools` — all pass.
- `tsgo --noEmit -p packages/ai/tsconfig.json`: no errors in changed code. `oxfmt --check` and `git diff --check` clean.
- Independent adversarial review (Codex/gpt-5.5) on the draft surfaced two findings — the predicate asymmetry (now documented + converter-pinned) and missing string-audio/`audio_url` payload shapes (now recognized + tested) — both addressed in this revision.
- Consolidation commits: `media-blocks.test.ts` (new vocabulary tests) and `tool-result-image-guard.test.ts` — including the regression this class needed all along: a tool with **no** sanitization of its own returning a husk gets it neutralized centrally (`[tool:<name>] omitted empty image payload`), extension-modified content is sanitized (not the pre-hook original), and clean structured-only results produce no override. Full battery re-run across `packages/ai` provider suites + `tool-images` + `session-file-repair` + guard + `attempt.queue-message` smoke: all pass.
- A second independent Codex review of the consolidation commits reported nothing blocking, verifying behavior preservation of the refactor, override merge semantics against `agent-loop.ts`, the throw path (per-block catches in `tool-images.ts`), and that raw-model runs are unaffected (no tools constructed).
- **Blacksmith Testbox proof (crabbox, delegated Linux one-shots):**
  - Checks lane (`pnpm check:changed`, lanes `core`/`coreTests`/`docs`): typecheck core + core tests, full oxlint core sweep (0 warnings / 0 errors incl. 982 `packages/` files), and all repo guards green — exit 0, 15m36s ([run](https://github.com/openclaw/openclaw/actions/runs/28784797651)). An earlier testbox pass caught the orphaned `isRecord` import under `tsconfig.core.json` `noUnusedLocals` (my local package-scoped typecheck missed it); fixed in `7f89f2cf0e` before the green run.
  - Vitest battery (16 affected suites: all five converter suites, `media-blocks`, `tool-result-text`, `tool-images`, `session-file-repair`, `tool-result-image-guard`, `attempt.queue-message`, both agent transport streams, `embedded-agent-subscribe.tools`, google/xai extension streams): 4 shards, 16/16 files passed — exit 0 ([run](https://github.com/openclaw/openclaw/actions/runs/28785727159)).
  - **Manual live E2E of the husk path** ([run](https://github.com/openclaw/openclaw/actions/runs/28789308832)): booted openclaw from this head on a testbox with an isolated HOME, registered a probe tool returning real text **plus** `{type:"image", data:"", mimeType:"image/png"}`, and drove one real agent turn against live OpenAI (`openai/gpt-5.5`, the `openai-completions` path from the original issue) with the model declared vision-capable. Hand-read artifacts: two `POST /v1/chat/completions` both **200**; persisted toolResult = `["HUSK_PROBE_MARKER_47…", "[tool:husk_probe] omitted empty image payload"]` (the loop-boundary hook fired on a real turn — sibling text preserved, husk neutralized before conversion/persistence); zero `"data":""` anywhere; and the live model's reply quoted the marker verbatim and described the attachment as "empty/omitted — no actual image content appeared". That is the user-facing outcome the #98673 cluster was denied. (Anthropic attempts on the same box failed only on CI-key billing; the layered design means the hook sanitizes fresh results before the converter guards, which remain covered by the converter-level payload tests.)
  - **End-to-end QA smoke** (`openclaw qa run --qa-profile smoke-ci`, packaged app, real gateway/sessions/tool loop over the crabline Telegram QA channel against mock-openai): 29 suite reports, **72/72 executed scenarios passed, 0 failed**, exit 0, 10m24s ([run](https://github.com/openclaw/openclaw/actions/runs/28786225678)). Every scenario's tool results crossed the new loop-boundary sanitizer hook; replay-safety scenarios (`empty-response-recovery-replay-safe-read`, `reasoning-only-recovery-replay-safe-read`, `anthropic-thinking-error-recovery-replay-safe-read`, `compaction-retry-mutating-tool`, `model-switch-tool-continuity`) and the runtime tool suite (`exec`/`bash`/`fs-read`/`fs-write`/`edit`/`grep`/`apply-patch`/`message-tool`/skills) all green. (Profile advertises 81 scenarios; the remainder are skipped as N/A in the mock smoke environment.)

## Structure (three commits, reviewable independently)

1. **`fix(ai)` — boundary invariant** (12 files, ~2/3 tests): the helper + converter changes described above. Why enforce at this layer, given `sanitizeSessionMessagesImages` already cleans persisted history: since the #99059 extraction, `packages/ai` is a reusable runtime consumed by plugin-SDK transports as well as the embedded agent. It cannot assume openclaw's `src/agents` sanitizers ran upstream, so the package boundary owns its input contract — boundary validation, not another sanitizer.

2. **`refactor(ai)` — one media-block vocabulary, behavior-preserving.** The repo had grown divergent structural definitions of a "valid media block": `tool-images.ts` (`isImageBlock`), `session-file-repair.ts` (shape gate inside `isCorruptedImageContentBlock`), and the new predicates from commit 1. Divergent local predicates are how husks slipped between layers in this issue cluster. New `packages/ai/src/providers/media-blocks.ts` is now the single source (type sets, MIME key spellings, `isImageLabeledBlock`/`isCanonicalImageBlock`, `hasMediaPayload`/`hasInlineMediaData`); `tool-result-text.ts`, all five converters, `tool-images.ts` (thin typed adapters), and `session-file-repair.ts` delegate to it.

3. **`fix(agents)` — uniform fresh-result sanitization at the loop boundary.** Persisted history was sanitized on replay, but same-turn results reached the provider with no central pass — sanitization was per-tool opt-in (`tools/common.ts` helpers), which is exactly how the #99370 zero-byte `file_fetch` husk escaped. A final `afterToolCall` wrapper (`tool-result-image-guard.ts`, installed last in `attempt.ts` so it sees extension-modified content) now sanitizes every fresh tool result exactly once, whatever tool produced it. `agent-loop`'s `createToolResultMessage` is the only `toolResult` producer in the embedded path, so this one hook closes the gap for every tool. Per-tool constructor sanitization is deliberately kept: tools stay correct when `execute()` is called outside the loop, and `sanitizeToolResultImages` short-circuits on already-clean content (header read only, no re-encode), so the second pass is near-free.

Deliberately out of scope: tightening the tool-result content type at ingest ("parse, don't validate") — a cross-cutting type change that should be its own discussion — and deleting the per-tool constructor calls (safe only if direct-`execute()` callers are audited first).
