### PR TITLE
docs(memory): add QMD CPU-only VPS guidance

### DIFF
--- a/docs/concepts/memory-qmd.md
+++ b/docs/concepts/memory-qmd.md
@@ -91,6 +91,44 @@ The first search may be slow - QMD auto-downloads GGUF models (~2 GB) for
 reranking and query expansion on the first `qmd query` run.
 </Info>
 
+### CPU-only VPS guidance
+
+Small CPU-only hosts are a better fit for QMD's default BM25 mode than for the
+semantic modes. `searchMode: "search"` uses lexical search only, so OpenClaw
+does not run QMD embedding maintenance or vector readiness probes. That is the
+recommended starting point for shared 2-4 vCPU VPS deployments where the
+gateway must stay responsive.
+
+`vsearch` and `query` enable local embedding, vector search, query expansion,
+and optional reranking work. Those modes can download multi-GB GGUF models on
+first use and can saturate a small CPU-only VPS while `qmd embed` or reranking
+runs. If you enable them on a CPU-only host, roll out during a quiet window,
+keep startup work disabled, and lengthen the embed cadence before indexing a
+large corpus:
+
+```json5
+{
+  memory: {
+    backend: "qmd",
+    qmd: {
+      searchMode: "search", // BM25-only, safest for small CPU-only VPSes
+      update: {
+        startup: "off",
+        onBoot: false,
+        embedInterval: "6h",
+      },
+    },
+  },
+}
+```
+
+When you are ready to test semantic search, switch `searchMode` to `query` and
+set `rerank: false` first so QMD skips the reranker on QMD 2.1 or newer. Watch
+host CPU and memory during the first `qmd embed` cycle, then shorten
+`memory.qmd.update.embedInterval` or re-enable reranking only if the machine
+has enough headroom. For always-on semantic recall on a busy agent, prefer a
+larger CPU instance or a box dedicated to local model work.
+
 ## Search performance and compatibility
 
 OpenClaw keeps the QMD search path compatible with both current and older QMD

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -2361,6 +2361,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Layout and names
   - H2: Provision ignored files
   - H2: Run repository setup
+  - H2: Session worktrees
   - H2: Snapshots, cleanup, and restore
   - H2: CLI
   - H2: Gateway methods
@@ -2448,6 +2449,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: Prerequisites
   - H3: Enable
   - H2: How the sidecar works
+  - H3: CPU-only VPS guidance
   - H2: Search performance and compatibility
   - H2: Model overrides
   - H2: Indexing extra paths

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -580,7 +580,7 @@ Set `memory.backend = "qmd"` to enable. All QMD settings live under `memory.qmd`
 | `sessions.retentionDays` | `number`  | --       | Transcript retention                                                                  |
 | `sessions.exportDir`     | `string`  | --       | Export directory                                                                      |
 
-`searchMode: "search"` is lexical/BM25-only. OpenClaw does not run semantic vector readiness probes or QMD embedding maintenance for that mode, including during `memory status --deep`; `vsearch` and `query` continue to require QMD vector readiness and embeddings.
+`searchMode: "search"` is lexical/BM25-only. OpenClaw does not run semantic vector readiness probes or QMD embedding maintenance for that mode, including during `memory status --deep`; `vsearch` and `query` continue to require QMD vector readiness and embeddings. Start with `search` on small CPU-only VPS deployments, then opt into `query`/`vsearch` only after you have CPU headroom for embedding and optional reranking. See the [QMD CPU-only VPS guidance](/concepts/memory-qmd#cpu-only-vps-guidance) for a safe rollout pattern.
 
 `rerank: false` only changes QMD `query` mode and requires QMD 2.1 or newer. In direct CLI mode OpenClaw passes `--no-rerank`; in mcporter-backed MCP mode it passes `rerank: false` to QMD's unified query tool. Leave it unset to use QMD's default query reranking behavior.
 


### PR DESCRIPTION
## Summary

- documents a safe QMD starting configuration for small CPU-only VPS deployments
- explains why BM25-only `searchMode: "search"` avoids embedding maintenance and vector readiness probes
- cross-links the memory config reference to the new CPU-only VPS rollout guidance

## Issue/Motivation

Fixes #90746.

The issue asks whether QMD is practical on CPU-only VPS hosts after reports of 4-vCPU machines becoming saturated during local embedding work. Current docs describe QMD setup and tuning knobs, but do not tell operators which mode is safe to start with or how to roll out semantic search without making the gateway unresponsive.

## Changes

- Added `docs/concepts/memory-qmd.md` guidance for CPU-only VPS deployments.
- Added a BM25-first sample config with `startup: "off"`, `onBoot: false`, and a longer `embedInterval` for semantic rollout.
- Updated `docs/reference/memory-config.md` to point `searchMode` readers to the deployment guidance.

## Testing

- `pnpm docs:list`
- `pnpm docs:check-mdx` — passed, 694 files
- `pnpm docs:check-links` — passed, checked_internal_links=5727, broken_links=0
- `git diff --check`
- diff secret scan — no high-confidence patterns in diff

## What Problem This Solves

Small VPS users can now see the practical CPU tradeoff before enabling QMD semantic modes. The docs recommend the already-supported BM25-only mode for small CPU-only hosts and describe a cautious path for trying `query`/`vsearch` with reduced startup and embedding pressure.

## Evidence

- Confirmed issue #90746 is open and unassigned before publishing.
- Searched open PRs by `90746` and `"CPU-only" QMD VPS`; no PR was found that covers this deployment guidance. Existing QMD PRs found by broad search target embed timeout/vector timeout behavior, not CPU-only VPS documentation.
- `pnpm docs:list`
- `pnpm docs:check-mdx` passed: `Docs MDX check passed (694 files, 11965ms).`
- `pnpm docs:check-links` passed: `checked_internal_links=5727`, `broken_links=0`.
- `git diff --check` passed.
- Diff secret scan found no high-confidence secret patterns.
