### PR TITLE
feat(android): in-chat model picker with favorites and recents

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -147,7 +147,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 202,
+      "line": 204,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -155,7 +155,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 212,
+      "line": 214,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2465,
+      "line": 2467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2467,
+      "line": 2469,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2469,
+      "line": 2471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -5867,7 +5867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 236,
+      "line": 272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -5875,7 +5875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 378,
+      "line": 430,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -5883,7 +5883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 436,
+      "line": 488,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5891,7 +5891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 457,
+      "line": 509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -5899,7 +5899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 462,
+      "line": 514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "More new chat options",
       "surface": "android",
@@ -5907,7 +5907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 477,
+      "line": 529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -5915,7 +5915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 480,
+      "line": 532,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -5923,7 +5923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 622,
+      "line": 674,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5931,7 +5931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 649,
+      "line": 701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5939,7 +5939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 669,
+      "line": 721,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5947,7 +5947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 700,
+      "line": 752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5955,7 +5955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 701,
+      "line": 753,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5963,7 +5963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 852,
+      "line": 904,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -5971,7 +5971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 854,
+      "line": 906,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -5979,7 +5979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 857,
+      "line": 909,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -5987,7 +5987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 867,
+      "line": 919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -5995,7 +5995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 868,
+      "line": 920,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -6003,7 +6003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 987,
+      "line": 1054,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -6011,7 +6011,31 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1004,
+      "line": 1120,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Default",
+      "surface": "android",
+      "id": "native.android.2cb3ec7379426dfe"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1186,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Pin model",
+      "surface": "android",
+      "id": "native.android.f8d0f6ba7608abc3"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 1186,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "Unpin model",
+      "surface": "android",
+      "id": "native.android.09a13ed8f039a9c3"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -6019,7 +6043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1066,
+      "line": 1265,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -6027,7 +6051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1156,
+      "line": 1355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -6035,7 +6059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1171,
+      "line": 1370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -6043,7 +6067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1186,
+      "line": 1385,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -6051,7 +6075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1224,
+      "line": 1423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -6059,7 +6083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1245,
+      "line": 1444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -6067,7 +6091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1301,
+      "line": 1500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -6075,7 +6099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1340,
+      "line": 1539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -141,6 +141,8 @@ class MainViewModel(
   val modelAuthProviders: StateFlow<List<GatewayModelProviderSummary>> = runtimeState(initial = emptyList()) { it.modelAuthProviders }
   val modelCatalogRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.modelCatalogRefreshing }
   val modelCatalogErrorText: StateFlow<String?> = runtimeState(initial = null) { it.modelCatalogErrorText }
+  val modelFavorites: StateFlow<List<String>> = prefs.modelFavorites
+  val modelRecents: StateFlow<List<String>> = prefs.modelRecents
   val talkSetupReadiness: StateFlow<GatewayTalkSetupReadiness> =
     runtimeState(initial = GatewayTalkSetupReadiness.unverified()) { it.talkSetupReadiness }
   val gatewayDefaultAgentId: StateFlow<String?> = runtimeState(initial = null) { it.gatewayDefaultAgentId }
@@ -220,6 +222,7 @@ class MainViewModel(
   val chatError: StateFlow<String?> = runtimeState(initial = null) { it.chatError }
   val chatHealthOk: StateFlow<Boolean> = runtimeState(initial = false) { it.chatHealthOk }
   val chatThinkingLevel: StateFlow<String> = runtimeState(initial = "off") { it.chatThinkingLevel }
+  val chatSelectedModelRef: StateFlow<String?> = runtimeState(initial = null) { it.chatSelectedModelRef }
   val chatStreamingAssistantText: StateFlow<String?> = runtimeState(initial = null) { it.chatStreamingAssistantText }
   val chatPendingToolCalls: StateFlow<List<ChatPendingToolCall>> = runtimeState(initial = emptyList()) { it.chatPendingToolCalls }
   val chatSessions: StateFlow<List<ChatSessionEntry>> = runtimeState(initial = emptyList()) { it.chatSessions }
@@ -664,6 +667,17 @@ class MainViewModel(
 
   fun setChatThinkingLevel(level: String) {
     ensureRuntime().setChatThinkingLevel(level)
+  }
+
+  fun setChatSessionModel(
+    sessionKey: String,
+    modelRef: String?,
+  ) {
+    ensureRuntime().setChatSessionModel(sessionKey = sessionKey, modelRef = modelRef)
+  }
+
+  fun toggleModelFavorite(ref: String) {
+    prefs.toggleModelFavorite(ref)
   }
 
   fun switchChatSession(sessionKey: String) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -939,6 +939,7 @@ class NodeRuntime private constructor(
       transcriptCache = chatTranscriptCache,
       cacheScope = ::chatCacheScope,
       commandOutbox = chatCommandOutbox,
+      recordModelRecent = prefs::recordModelRecent,
     ).also {
       it.applyMainSessionKey(_mainSessionKey.value)
     }
@@ -1441,6 +1442,7 @@ class NodeRuntime private constructor(
   val chatError: StateFlow<String?> = chat.errorText
   val chatHealthOk: StateFlow<Boolean> = chat.healthOk
   val chatThinkingLevel: StateFlow<String> = chat.thinkingLevel
+  val chatSelectedModelRef: StateFlow<String?> = chat.selectedModelRef
   val chatStreamingAssistantText: StateFlow<String?> = chat.streamingAssistantText
   val chatPendingToolCalls: StateFlow<List<ChatPendingToolCall>> = chat.pendingToolCalls
   val chatSessions: StateFlow<List<ChatSessionEntry>> = chat.sessions
@@ -2688,6 +2690,13 @@ class NodeRuntime private constructor(
 
   fun setChatThinkingLevel(level: String) {
     chat.setThinkingLevel(level)
+  }
+
+  fun setChatSessionModel(
+    sessionKey: String,
+    modelRef: String?,
+  ) {
+    chat.setSessionModel(sessionKey = sessionKey, modelRef = modelRef)
   }
 
   fun switchChatSession(sessionKey: String) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -44,6 +44,9 @@ class SecurePrefs(
     private const val cameraEnabledKey = "camera.enabled"
     private const val voiceMicEnabledKey = "voice.micEnabled"
     private const val appearanceThemeModeKey = "appearance.themeMode"
+    private const val chatModelFavoritesKey = "chat.modelFavorites"
+    private const val chatModelRecentsKey = "chat.modelRecents"
+    private const val maxChatModelRecents = 5
   }
 
   private val appContext = context.applicationContext
@@ -187,6 +190,12 @@ class SecurePrefs(
   private val _appearanceThemeMode =
     MutableStateFlow(AppearanceThemeMode.fromRawValue(plainPrefs.getString(appearanceThemeModeKey, null)))
   val appearanceThemeMode: StateFlow<AppearanceThemeMode> = _appearanceThemeMode
+
+  private val _modelFavorites = MutableStateFlow(loadChatModelRefs(chatModelFavoritesKey))
+  val modelFavorites: StateFlow<List<String>> = _modelFavorites
+
+  private val _modelRecents = MutableStateFlow(loadChatModelRefs(chatModelRecentsKey))
+  val modelRecents: StateFlow<List<String>> = _modelRecents
 
   fun setLastDiscoveredStableId(value: String) {
     val trimmed = value.trim()
@@ -532,6 +541,35 @@ class SecurePrefs(
     _appearanceThemeMode.value = mode
   }
 
+  fun toggleModelFavorite(ref: String) {
+    val trimmed = ref.trim()
+    if (trimmed.isEmpty()) return
+    val next =
+      if (trimmed in _modelFavorites.value) {
+        _modelFavorites.value - trimmed
+      } else {
+        _modelFavorites.value + trimmed
+      }
+    persistChatModelRefs(chatModelFavoritesKey, next)
+    _modelFavorites.value = next
+  }
+
+  fun recordModelRecent(ref: String) {
+    val trimmed = ref.trim()
+    if (trimmed.isEmpty()) return
+    val next = (listOf(trimmed) + _modelRecents.value.filterNot { it == trimmed }).take(maxChatModelRecents)
+    persistChatModelRefs(chatModelRecentsKey, next)
+    _modelRecents.value = next
+  }
+
+  private fun persistChatModelRefs(
+    key: String,
+    refs: List<String>,
+  ) {
+    val encoded = JsonArray(refs.map(::JsonPrimitive)).toString()
+    plainPrefs.edit { putString(key, encoded) }
+  }
+
   private fun loadNotificationForwardingPackages(): Set<String> {
     val raw = plainPrefs.getString(notificationsForwardingPackagesKey, null)?.trim()
     if (raw.isNullOrEmpty()) {
@@ -601,6 +639,24 @@ class SecurePrefs(
       WakeWords.sanitize(decoded, defaultWakeWords)
     } catch (_: Throwable) {
       defaultWakeWords
+    }
+  }
+
+  private fun loadChatModelRefs(key: String): List<String> {
+    val raw = plainPrefs.getString(key, null)?.trim()
+    if (raw.isNullOrEmpty()) return emptyList()
+    return try {
+      val array = json.parseToJsonElement(raw) as? JsonArray ?: return emptyList()
+      array
+        .mapNotNull { item ->
+          when (item) {
+            is JsonNull -> null
+            is JsonPrimitive -> item.content.trim().takeIf { it.isNotEmpty() }
+            else -> null
+          }
+        }.distinct()
+    } catch (_: Throwable) {
+      emptyList()
     }
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -6,6 +6,7 @@ import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.parseChatSendAck
 import ai.openclaw.app.resolveAgentIdFromMainSessionKey
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -40,6 +41,7 @@ class ChatController internal constructor(
   private val transcriptCache: ChatTranscriptCache? = null,
   private val cacheScope: () -> ChatCacheScope? = { null },
   private val commandOutbox: ChatCommandOutbox? = null,
+  private val recordModelRecent: (String) -> Unit = {},
 ) {
   internal constructor(
     scope: CoroutineScope,
@@ -48,6 +50,7 @@ class ChatController internal constructor(
     transcriptCache: ChatTranscriptCache? = null,
     cacheScope: () -> ChatCacheScope? = { null },
     commandOutbox: ChatCommandOutbox? = null,
+    recordModelRecent: (String) -> Unit = {},
   ) : this(
     scope = scope,
     json = json,
@@ -55,10 +58,12 @@ class ChatController internal constructor(
     transcriptCache = transcriptCache,
     cacheScope = cacheScope,
     commandOutbox = commandOutbox,
+    recordModelRecent = recordModelRecent,
   )
 
   private var appliedMainSessionKey = "main"
   private val cacheMutationMutex = Mutex()
+  private val modelSelectionMutex = Mutex()
   private val _sessionKey = MutableStateFlow("main")
   val sessionKey: StateFlow<String> = _sessionKey.asStateFlow()
 
@@ -83,6 +88,9 @@ class ChatController internal constructor(
 
   private val _thinkingLevel = MutableStateFlow("off")
   val thinkingLevel: StateFlow<String> = _thinkingLevel.asStateFlow()
+
+  private val _selectedModelRef = MutableStateFlow<String?>(null)
+  val selectedModelRef: StateFlow<String?> = _selectedModelRef.asStateFlow()
 
   private val _pendingRunCount = MutableStateFlow(0)
   val pendingRunCount: StateFlow<Int> = _pendingRunCount.asStateFlow()
@@ -427,6 +435,46 @@ class ChatController internal constructor(
     _thinkingLevel.value = normalized
   }
 
+  /** Patches the active session model without blocking the Compose caller. */
+  fun setSessionModel(
+    sessionKey: String,
+    modelRef: String?,
+  ) {
+    // Enter the model-selection queue before returning so an immediate send cannot overtake it.
+    scope.launch(start = CoroutineStart.UNDISPATCHED) {
+      setSessionModelAwait(sessionKey = sessionKey, modelRef = modelRef)
+    }
+  }
+
+  /** Patches a session model and updates picker state only after gateway acceptance. */
+  internal suspend fun setSessionModelAwait(
+    sessionKey: String,
+    modelRef: String?,
+  ): Boolean =
+    modelSelectionMutex.withLock {
+      val key = normalizeRequestedSessionKey(sessionKey)
+      val normalizedModelRef = modelRef?.trim()?.takeIf { it.isNotEmpty() }
+      updateErrorText(null)
+      try {
+        val params =
+          buildJsonObject {
+            put("key", JsonPrimitive(key))
+            put("model", normalizedModelRef?.let(::JsonPrimitive) ?: JsonNull)
+          }
+        requestGateway("sessions.patch", params.toString())
+        normalizedModelRef?.let(recordModelRecent)
+        if (_sessionKey.value == key) {
+          _selectedModelRef.value = normalizedModelRef
+        }
+        true
+      } catch (err: CancellationException) {
+        throw err
+      } catch (err: Throwable) {
+        updateErrorText(err.message ?: "Could not update model.")
+        false
+      }
+    }
+
   /** Switches to another gateway chat session and starts a fresh history load. */
   fun switchSession(sessionKey: String) {
     val key = normalizeRequestedSessionKey(sessionKey)
@@ -450,6 +498,7 @@ class ChatController internal constructor(
   ): Long {
     val generation = historyLoadGeneration.incrementAndGet()
     _sessionKey.value = key
+    _selectedModelRef.value = null
     lastHandledTerminalRunId = null
     val nextAgentId = resolveAgentIdForSessionKey(key)
     if (commandsAgentId != nextAgentId) {
@@ -503,6 +552,9 @@ class ChatController internal constructor(
   ): Boolean {
     val trimmed = message.trim()
     if (trimmed.isEmpty() && attachments.isEmpty()) return false
+    // Model patches and sends share one ordering boundary; the first post-selection turn
+    // must not leave on the previous model while sessions.patch is still in flight.
+    modelSelectionMutex.withLock {}
     if (!_healthOk.value) {
       // Offline capture: text-only commands become durable outbox rows and flush on reconnect.
       // Attachments stay blocked (text-only v1) so large payloads never sit in the database.

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
@@ -41,6 +41,9 @@ class ConnectionManager(
 
     internal val nativeClientOperatorScopes: List<String> =
       listOf(
+        // admin matches iOS fresh token/password connects and is required for
+        // sessions.patch (model switching); stored tokens keep their granted scopes.
+        "operator.admin",
         "operator.approvals",
         "operator.read",
         "operator.talk.secrets",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatModelPicker.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatModelPicker.kt
@@ -1,0 +1,35 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.GatewayModelSummary
+
+internal data class ChatModelPickerSections(
+  val pinned: List<GatewayModelSummary>,
+  val recent: List<GatewayModelSummary>,
+  val remaining: List<GatewayModelSummary>,
+)
+
+internal fun GatewayModelSummary.providerQualifiedRef(): String {
+  val trimmedProvider = provider.trim()
+  if (trimmedProvider.isEmpty()) return id
+  val providerPrefix = "$trimmedProvider/"
+  return if (id.startsWith(providerPrefix)) id else "$providerPrefix$id"
+}
+
+internal fun chatModelPickerSections(
+  catalog: List<GatewayModelSummary>,
+  favorites: List<String>,
+  recents: List<String>,
+): ChatModelPickerSections {
+  val modelsByRef = catalog.associateBy { it.providerQualifiedRef() }
+  val includedRefs = mutableSetOf<String>()
+  val pinned =
+    favorites.mapNotNull { ref ->
+      modelsByRef[ref]?.takeIf { includedRefs.add(ref) }
+    }
+  val recent =
+    recents.mapNotNull { ref ->
+      modelsByRef[ref]?.takeIf { includedRefs.add(ref) }
+    }
+  val remaining = catalog.filter { model -> includedRefs.add(model.providerQualifiedRef()) }
+  return ChatModelPickerSections(pinned = pinned, recent = recent, remaining = remaining)
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.GatewayModelSummary
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.R
 import ai.openclaw.app.chat.ChatCommandEntry
@@ -57,10 +58,15 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.MoreHoriz
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -123,6 +129,10 @@ fun ChatScreen(
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
+  val modelCatalog by viewModel.modelCatalog.collectAsState()
+  val modelFavorites by viewModel.modelFavorites.collectAsState()
+  val modelRecents by viewModel.modelRecents.collectAsState()
+  val selectedModelRef by viewModel.chatSelectedModelRef.collectAsState()
   val contextUsage = resolveChatContextUsage(sessionKey = sessionKey, mainSessionKey = mainSessionKey, sessions = sessions)
   val gatewayAddress = gatewayDiagnosticsEndpoint(remoteAddress = remoteAddress, manualHost = manualHost, manualPort = manualPort, manualTls = manualTls)
   val gatewayProblemMessage = gatewayConnectionDisplay.problem?.message?.takeIf { it.isNotBlank() }
@@ -134,6 +144,20 @@ fun ChatScreen(
   val resolver = context.contentResolver
   val scope = rememberCoroutineScope()
   val attachments = remember { mutableStateListOf<PendingImageAttachment>() }
+  var showModelPicker by rememberSaveable { mutableStateOf(false) }
+  val modelSections =
+    remember(modelCatalog, modelFavorites, modelRecents) {
+      chatModelPickerSections(
+        catalog = modelCatalog,
+        favorites = modelFavorites,
+        recents = modelRecents,
+      )
+    }
+  val selectedModelLabel =
+    selectedModelRef?.let { selected ->
+      modelCatalog.firstOrNull { it.providerQualifiedRef() == selected }?.name?.takeIf { it.isNotBlank() }
+        ?: selected.substringAfterLast('/')
+    } ?: "Model"
   val pickImages =
     rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
       if (uris.isNullOrEmpty()) return@rememberLauncherForActivityResult
@@ -180,6 +204,18 @@ fun ChatScreen(
   LaunchedEffect(chatDraft) {
     input = mergeChatDraft(chatDraft, input) ?: return@LaunchedEffect
     viewModel.clearChatDraft()
+  }
+
+  LaunchedEffect(showModelPicker) {
+    if (showModelPicker && modelCatalog.isEmpty()) {
+      viewModel.refreshModelCatalog()
+    }
+  }
+
+  LaunchedEffect(gatewayConnectionDisplay.isConnected) {
+    if (!gatewayConnectionDisplay.isConnected) {
+      showModelPicker = false
+    }
   }
 
   val newChatEnabled =
@@ -266,12 +302,15 @@ fun ChatScreen(
       attachments = attachments,
       thinkingLevel = thinkingLevel,
       contextUsage = contextUsage,
+      selectedModelLabel = selectedModelLabel,
+      modelPickerEnabled = gatewayConnectionDisplay.isConnected,
       healthOk = healthOk,
       gatewayOffline = gatewayOffline,
       offlineStatus = offlineStatus,
       pendingRunCount = pendingRunCount,
       commands = chatCommands,
       onThinkingLevelChange = viewModel::setChatThinkingLevel,
+      onOpenModelPicker = { showModelPicker = true },
       onPickImages = { pickImages.launch("image/*") },
       onRemoveAttachment = { id -> attachments.removeAll { it.id == id } },
       onVoice = onVoice,
@@ -310,6 +349,19 @@ fun ChatScreen(
           }
         }
       },
+    )
+  }
+
+  if (showModelPicker) {
+    ChatModelPickerSheet(
+      sections = modelSections,
+      favorites = modelFavorites.toSet(),
+      onDismiss = { showModelPicker = false },
+      onSelect = { modelRef ->
+        viewModel.setChatSessionModel(sessionKey = sessionKey, modelRef = modelRef)
+        showModelPicker = false
+      },
+      onToggleFavorite = viewModel::toggleModelFavorite,
     )
   }
 }
@@ -903,12 +955,15 @@ private fun ChatComposer(
   attachments: List<PendingImageAttachment>,
   thinkingLevel: String,
   contextUsage: ChatContextUsage,
+  selectedModelLabel: String,
+  modelPickerEnabled: Boolean,
   healthOk: Boolean,
   gatewayOffline: Boolean,
   offlineStatus: String,
   pendingRunCount: Int,
   commands: List<ChatCommandEntry>,
   onThinkingLevelChange: (String) -> Unit,
+  onOpenModelPicker: () -> Unit,
   onPickImages: () -> Unit,
   onRemoveAttachment: (String) -> Unit,
   onVoice: () -> Unit,
@@ -927,11 +982,23 @@ private fun ChatComposer(
       AttachmentStrip(attachments = attachments, onRemoveAttachment = onRemoveAttachment)
     }
 
-    ChatContextMeter(
-      thinkingLevel = thinkingLevel,
-      contextUsage = contextUsage,
-      onClick = { onThinkingLevelChange(nextThinkingValue(thinkingLevel)) },
-    )
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+      ChatModelChip(
+        label = selectedModelLabel,
+        enabled = modelPickerEnabled,
+        onClick = onOpenModelPicker,
+        modifier = Modifier.weight(1f),
+      )
+      ChatContextMeter(
+        thinkingLevel = thinkingLevel,
+        contextUsage = contextUsage,
+        onClick = { onThinkingLevelChange(nextThinkingValue(thinkingLevel)) },
+      )
+    }
 
     if (shouldShowSlashCommandMenu(value)) {
       SlashCommandPanel(
@@ -987,6 +1054,138 @@ private fun ChatComposer(
             Text(text = "Stop", style = ClawTheme.type.label)
           }
         }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ChatModelChip(
+  label: String,
+  enabled: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Surface(
+    onClick = onClick,
+    enabled = enabled,
+    modifier = modifier.heightIn(min = ClawTheme.spacing.touchTarget),
+    shape = RoundedCornerShape(ClawTheme.radii.pill),
+    color = ClawTheme.colors.canvas,
+    contentColor = if (enabled) ClawTheme.colors.text else ClawTheme.colors.textMuted,
+  ) {
+    Row(
+      modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+      Icon(imageVector = Icons.Default.ArrowDropDown, contentDescription = null, modifier = Modifier.size(13.dp), tint = ClawTheme.colors.textSubtle)
+      Text(
+        text = label,
+        style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
+        color = if (enabled) ClawTheme.colors.textMuted else ClawTheme.colors.textSubtle,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+    }
+  }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ChatModelPickerSheet(
+  sections: ChatModelPickerSections,
+  favorites: Set<String>,
+  onDismiss: () -> Unit,
+  onSelect: (String?) -> Unit,
+  onToggleFavorite: (String) -> Unit,
+) {
+  ModalBottomSheet(
+    onDismissRequest = onDismiss,
+    containerColor = ClawTheme.colors.surface,
+    contentColor = ClawTheme.colors.text,
+  ) {
+    LazyColumn(
+      modifier = Modifier.fillMaxWidth().heightIn(max = 560.dp),
+      contentPadding = PaddingValues(bottom = 24.dp),
+    ) {
+      item {
+        Surface(
+          onClick = { onSelect(null) },
+          modifier = Modifier.fillMaxWidth().heightIn(min = ClawTheme.spacing.touchTarget),
+          color = Color.Transparent,
+          contentColor = ClawTheme.colors.text,
+        ) {
+          Text(
+            text = "Default",
+            modifier = Modifier.padding(horizontal = 20.dp, vertical = 14.dp),
+            style = ClawTheme.type.body,
+          )
+        }
+      }
+      item {
+        HorizontalDivider(color = ClawTheme.colors.border, thickness = 1.dp)
+      }
+      listOf(
+        "Pinned" to sections.pinned,
+        "Recent" to sections.recent,
+        "Models" to sections.remaining,
+      ).forEach { (title, models) ->
+        if (models.isNotEmpty()) {
+          item(key = "section-$title") {
+            Text(
+              text = title,
+              modifier = Modifier.padding(start = 20.dp, top = 16.dp, end = 20.dp, bottom = 6.dp),
+              style = ClawTheme.type.caption,
+              color = ClawTheme.colors.textMuted,
+            )
+          }
+          itemsIndexed(
+            items = models,
+            key = { _, model -> model.providerQualifiedRef() },
+          ) { _, model ->
+            val ref = model.providerQualifiedRef()
+            ChatModelPickerRow(
+              model = model,
+              pinned = ref in favorites,
+              onSelect = { onSelect(ref) },
+              onToggleFavorite = { onToggleFavorite(ref) },
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun ChatModelPickerRow(
+  model: GatewayModelSummary,
+  pinned: Boolean,
+  onSelect: () -> Unit,
+  onToggleFavorite: () -> Unit,
+) {
+  Surface(
+    onClick = onSelect,
+    modifier = Modifier.fillMaxWidth().heightIn(min = 58.dp),
+    color = Color.Transparent,
+    contentColor = ClawTheme.colors.text,
+  ) {
+    Row(
+      modifier = Modifier.padding(start = 20.dp, end = 8.dp, top = 6.dp, bottom = 6.dp),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(text = model.name, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(text = model.provider, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
+      }
+      IconButton(onClick = onToggleFavorite) {
+        Icon(
+          imageVector = if (pinned) Icons.Default.Star else Icons.Default.StarBorder,
+          contentDescription = if (pinned) "Unpin model" else "Pin model",
+          tint = if (pinned) ClawTheme.colors.primary else ClawTheme.colors.textMuted,
+        )
       }
     }
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -358,7 +358,13 @@ class GatewayBootstrapAuthTest {
   @Test
   fun operatorConnectScopesForAuthUsesNativeScopesWhenNoStoredOperatorMetadata() {
     assertEquals(
-      ConnectionManager.nativeClientOperatorScopes,
+      listOf(
+        "operator.admin",
+        "operator.approvals",
+        "operator.read",
+        "operator.talk.secrets",
+        "operator.write",
+      ),
       operatorConnectScopesForAuth(
         usesStoredDeviceToken = false,
         storedOperatorScopes = null,

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -167,4 +167,48 @@ class SecurePrefsTest {
     assertNull(prefs.loadGatewayBootstrapToken())
     assertNull(prefs.loadGatewayPassword())
   }
+
+  @Test
+  fun modelFavorites_togglePersistsPinOrder() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().commit()
+    val prefs = SecurePrefs(context)
+
+    prefs.toggleModelFavorite(" anthropic/claude-opus-4 ")
+    prefs.toggleModelFavorite("openai/gpt-5")
+    prefs.toggleModelFavorite("anthropic/claude-opus-4")
+    prefs.toggleModelFavorite("anthropic/claude-opus-4")
+    prefs.toggleModelFavorite("  ")
+
+    assertEquals(
+      listOf("openai/gpt-5", "anthropic/claude-opus-4"),
+      prefs.modelFavorites.value,
+    )
+    assertEquals(prefs.modelFavorites.value, SecurePrefs(context).modelFavorites.value)
+  }
+
+  @Test
+  fun modelRecents_dedupesToFrontAndCapsAtFive() {
+    val context = RuntimeEnvironment.getApplication()
+    val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plainPrefs.edit().clear().commit()
+    val prefs = SecurePrefs(context)
+
+    (1..6).forEach { index -> prefs.recordModelRecent("provider/model-$index") }
+    prefs.recordModelRecent(" provider/model-3 ")
+    prefs.recordModelRecent(" ")
+
+    assertEquals(
+      listOf(
+        "provider/model-3",
+        "provider/model-6",
+        "provider/model-5",
+        "provider/model-4",
+        "provider/model-2",
+      ),
+      prefs.modelRecents.value,
+    )
+    assertEquals(prefs.modelRecents.value, SecurePrefs(context).modelRecents.value)
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
@@ -1,0 +1,130 @@
+package ai.openclaw.app.chat
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatControllerModelSelectionTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun successfulSelectionRecordsRecentAndUpdatesSelectedModel() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val recents = mutableListOf<String>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            "{}"
+          },
+          recordModelRecent = recents::add,
+        )
+
+      assertTrue(controller.setSessionModelAwait("main", " anthropic/claude-opus-4 "))
+
+      assertEquals(listOf("anthropic/claude-opus-4"), recents)
+      assertEquals("anthropic/claude-opus-4", controller.selectedModelRef.value)
+      assertEquals(
+        "sessions.patch" to "{\"key\":\"main\",\"model\":\"anthropic/claude-opus-4\"}",
+        requests.single(),
+      )
+    }
+
+  @Test
+  fun failedSelectionDoesNotRecordRecentOrUpdateSelectedModel() =
+    runTest {
+      val recents = mutableListOf<String>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { _, _ -> error("patch failed") },
+          recordModelRecent = recents::add,
+        )
+
+      assertFalse(controller.setSessionModelAwait("main", "openai/gpt-5"))
+
+      assertEquals(emptyList<String>(), recents)
+      assertNull(controller.selectedModelRef.value)
+      assertEquals("patch failed", controller.errorText.value)
+    }
+
+  @Test
+  fun successfulDefaultSelectionDoesNotRecordRecent() =
+    runTest {
+      val requests = mutableListOf<String?>()
+      val recents = mutableListOf<String>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { _, paramsJson ->
+            requests += paramsJson
+            "{}"
+          },
+          recordModelRecent = recents::add,
+        )
+
+      assertTrue(controller.setSessionModelAwait("main", null))
+
+      assertEquals(emptyList<String>(), recents)
+      assertEquals("{\"key\":\"main\",\"model\":null}", requests.single())
+    }
+
+  @Test
+  fun immediateSendWaitsForPendingModelSelection() =
+    runTest {
+      val patchStarted = CompletableDeferred<Unit>()
+      val releasePatch = CompletableDeferred<Unit>()
+      val requests = mutableListOf<String>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, _ ->
+            requests += method
+            when (method) {
+              "sessions.patch" -> {
+                patchStarted.complete(Unit)
+                releasePatch.await()
+                "{}"
+              }
+              "chat.send" -> """{"runId":"run-ok","status":"ok"}"""
+              else -> "{}"
+            }
+          },
+        )
+      controller.handleGatewayEvent("health", null)
+
+      controller.setSessionModel("main", "openai/gpt-5")
+      patchStarted.await()
+      val send =
+        async {
+          controller.sendMessageAwaitAcceptance(
+            message = "hello",
+            thinkingLevel = "off",
+            attachments = emptyList(),
+          )
+        }
+      yield()
+
+      assertEquals(listOf("sessions.patch"), requests.filter { it == "sessions.patch" || it == "chat.send" })
+
+      releasePatch.complete(Unit)
+      assertTrue(send.await())
+      assertEquals(
+        listOf("sessions.patch", "chat.send"),
+        requests.filter { it == "sessions.patch" || it == "chat.send" },
+      )
+    }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -431,7 +431,13 @@ class ConnectionManagerTest {
     val options = newManager().buildOperatorConnectOptions()
 
     assertEquals(
-      ConnectionManager.nativeClientOperatorScopes,
+      listOf(
+        "operator.admin",
+        "operator.approvals",
+        "operator.read",
+        "operator.talk.secrets",
+        "operator.write",
+      ),
       options.scopes,
     )
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatModelPickerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatModelPickerTest.kt
@@ -1,0 +1,51 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.GatewayModelSummary
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatModelPickerTest {
+  @Test
+  fun providerQualifiedRefAddsProviderOnlyWhenNeeded() {
+    assertEquals("anthropic/claude-opus-4", model(id = "claude-opus-4", provider = "anthropic").providerQualifiedRef())
+    assertEquals("anthropic/claude-opus-4", model(id = "anthropic/claude-opus-4", provider = "anthropic").providerQualifiedRef())
+  }
+
+  @Test
+  fun sectionsPreservePinAndRecentOrderAndKeepRemainingCatalogOrder() {
+    val catalog =
+      listOf(
+        model(id = "a", provider = "one"),
+        model(id = "b", provider = "two"),
+        model(id = "c", provider = "one"),
+        model(id = "d", provider = "three"),
+      )
+
+    val sections =
+      chatModelPickerSections(
+        catalog = catalog,
+        favorites = listOf("one/c", "missing/model", "one/a"),
+        recents = listOf("one/a", "three/d", "missing/recent"),
+      )
+
+    assertEquals(listOf("one/c", "one/a"), sections.pinned.map { it.providerQualifiedRef() })
+    assertEquals(listOf("three/d"), sections.recent.map { it.providerQualifiedRef() })
+    assertEquals(listOf("two/b"), sections.remaining.map { it.providerQualifiedRef() })
+  }
+
+  private fun model(
+    id: String,
+    provider: String,
+  ): GatewayModelSummary =
+    GatewayModelSummary(
+      id = id,
+      name = id.substringAfterLast('/'),
+      provider = provider,
+      available = true,
+      supportsVision = false,
+      supportsAudio = false,
+      supportsDocuments = false,
+      supportsReasoning = false,
+      contextTokens = null,
+    )
+}


### PR DESCRIPTION
Related: #100699

## What Problem This Solves

Fixes an issue where Android users could not switch models in chat at all: the app had no model picker anywhere — the model catalog was only visible as a read-only provider readiness overview in Settings. iOS/macOS users can switch the session model from the composer; Android had no equivalent.

## Why This Change Was Made

Adds a model chip to the Android chat composer that opens a bottom-sheet picker fed by the existing gateway model catalog, with Pinned / Recent / Models sections: star to pin/unpin without closing the sheet, tap to select. Selection patches the session via `sessions.patch { key, model }` (the same wire contract iOS/macOS use); pins and recents (capped at 5) persist in the app's plain preferences, and a recent is recorded only after gateway acceptance. A selection mutex orders model patches ahead of sends so the first post-selection message can never leave on the previous model. Because `sessions.patch` requires `operator.admin`, fresh Android connects now request that scope — exact parity with iOS, which already requests admin for token/password connects; previously paired device tokens keep their granted scopes (existing stored-scope narrowing) and simply can't patch models until re-paired, mirroring how `operator.talk.secrets` rolled out.

**Security note (deliberate decision, please weigh in):** `sessions.patch` is classified `operator.admin` in the gateway method descriptors, so this PR adds `operator.admin` to Android's fresh-connect scope request. This is exact parity with iOS, which already requests admin for every token/password connect (`shouldRequestOperatorAdminScope` in `apps/ios/Sources/Model/NodeAppModel.swift`), and follows the same rollout pattern as `operator.talk.secrets`: previously paired device tokens keep their narrower granted scopes. The alternative — a narrower gateway permission for model-only session patches — is a protocol/security contract change beyond this client PR's boundary; if maintainers prefer that, it should be its own gateway-side follow-up, and this scope request can be revisited then.

## User Impact

Android users can now switch the session model from the chat composer, pin favorites, and reach recently used models first. On gateways where the operator connection lacks admin scope, selection fails with a visible chat error and no state is polluted.

## Evidence

- `./gradlew :app:testPlayDebugUnitTest` focused suites green: `ChatModelPickerTest` (section ordering, provider-qualified ref derivation), `SecurePrefsTest` (favorites/recents persistence round-trip, dedupe/cap), `ChatControllerModelSelectionTest` (recent recorded only on RPC success, rejection surfaces error and records nothing, send-after-select ordering), `ConnectionManagerTest`/`GatewayBootstrapAuthTest` (fresh-connect scope set incl. `operator.admin`, stored-token narrowing unchanged).
- `:app:ktlintFormat` clean on changed files; `:app:ktlintCheck` failures are pre-existing in five untouched test files (called out for transparency).
- `corepack pnpm native:i18n:sync` run for the new picker strings.
