### PR TITLE
fix(irc): monitor stays disconnected after IRC socket closes

### DIFF
--- a/extensions/irc/src/client.test.ts
+++ b/extensions/irc/src/client.test.ts
@@ -9,6 +9,14 @@ type LoopbackIrcServer = {
   close(): Promise<void>;
 };
 
+type HangingIrcServer = {
+  port: number;
+  acceptedCount: number;
+  closedCount: number;
+  openSocketCount(): number;
+  close(): Promise<void>;
+};
+
 async function startLoopbackIrcServer(): Promise<LoopbackIrcServer> {
   const lines: string[] = [];
   const sockets = new Set<net.Socket>();
@@ -43,6 +51,69 @@ async function startLoopbackIrcServer(): Promise<LoopbackIrcServer> {
   return {
     port: address.port,
     lines,
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function waitForIrcCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(message);
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+}
+
+async function startHangingIrcServer(): Promise<HangingIrcServer> {
+  const sockets = new Set<net.Socket>();
+  let acceptedCount = 0;
+  let closedCount = 0;
+  const server = net.createServer((socket) => {
+    acceptedCount += 1;
+    sockets.add(socket);
+    socket.setEncoding("utf8");
+    socket.on("data", () => {});
+    socket.on("close", () => {
+      sockets.delete(socket);
+      closedCount += 1;
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback IRC server to bind a TCP port");
+  }
+  return {
+    port: address.port,
+    get acceptedCount() {
+      return acceptedCount;
+    },
+    get closedCount() {
+      return closedCount;
+    },
+    openSocketCount: () => sockets.size,
     close: async () => {
       for (const socket of sockets) {
         socket.destroy();
@@ -98,6 +169,33 @@ describe("irc client nickserv", () => {
         password: "secret\r\nJOIN #bad",
       }),
     ).toEqual(["PRIVMSG NickServ :IDENTIFY secret JOIN #bad"]);
+  });
+});
+
+describe("irc client readiness timeout", () => {
+  it("closes the socket when registration never becomes ready", async () => {
+    const server = await startHangingIrcServer();
+    try {
+      await expect(
+        connectIrcClient({
+          host: "127.0.0.1",
+          port: server.port,
+          tls: false,
+          nick: "bot",
+          username: "bot",
+          realname: "OpenClaw Bot",
+          connectTimeoutMs: 50,
+        }),
+      ).rejects.toThrow(/IRC connect/);
+
+      expect(server.acceptedCount).toBeGreaterThanOrEqual(1);
+      await waitForIrcCondition(
+        () => server.closedCount >= 1 && server.openSocketCount() === 0,
+        `expected timed-out IRC connect socket to close; accepted=${server.acceptedCount} closed=${server.closedCount} open=${server.openSocketCount()}`,
+      );
+    } finally {
+      await server.close();
+    }
   });
 });
 

--- a/extensions/irc/src/client.ts
+++ b/extensions/irc/src/client.ts
@@ -69,6 +69,7 @@ export type IrcClientOptions = {
   onPrivmsg?: (event: IrcPrivmsgEvent) => void | Promise<void>;
   onNotice?: (text: string, target?: string) => void;
   onError?: (error: Error) => void;
+  onDisconnect?: () => void;
   onLine?: (line: string) => void;
 };
 
@@ -430,8 +431,12 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
   socket.once("close", () => {
     if (!closed) {
       closed = true;
+      removeAbortListener?.();
+      removeAbortListener = null;
       if (!ready) {
         fail(new Error("IRC connection closed before ready"));
+      } else {
+        options.onDisconnect?.();
       }
     }
   });
@@ -452,7 +457,12 @@ export async function connectIrcClient(options: IrcClientOptions): Promise<IrcCl
     }
   }
 
-  await withTimeout(readyPromise, timeoutMs, "IRC connect");
+  try {
+    await withTimeout(readyPromise, timeoutMs, "IRC connect");
+  } catch (error) {
+    close();
+    throw error;
+  }
 
   return {
     get nick() {

--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -1,6 +1,153 @@
 // Irc tests cover monitor plugin behavior.
-import { describe, expect, it } from "vitest";
-import { resolveIrcInboundTarget } from "./monitor.js";
+import net from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { monitorIrcProvider, resolveIrcInboundTarget } from "./monitor.js";
+import { clearIrcRuntime, setIrcRuntime } from "./runtime.js";
+import type { CoreConfig } from "./types.js";
+
+type DisconnectingIrcServer = {
+  port: number;
+  lines: string[];
+  connectionCount: number;
+  close(): Promise<void>;
+};
+
+async function waitForIrcCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 3000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error(message);
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+}
+
+async function startDisconnectingIrcServer(): Promise<DisconnectingIrcServer> {
+  const lines: string[] = [];
+  const sockets = new Set<net.Socket>();
+  let connectionCount = 0;
+
+  const server = net.createServer((socket) => {
+    const connectionNumber = ++connectionCount;
+    sockets.add(socket);
+    socket.setEncoding("utf8");
+    let buffer = "";
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      let idx = buffer.indexOf("\n");
+      while (idx !== -1) {
+        const line = buffer.slice(0, idx).replace(/\r$/, "");
+        buffer = buffer.slice(idx + 1);
+        idx = buffer.indexOf("\n");
+        lines.push(line);
+        if (line.startsWith("USER ")) {
+          socket.write(":server 001 bot :welcome\r\n");
+          if (connectionNumber === 1) {
+            setTimeout(() => socket.destroy(), 10);
+          }
+        }
+      }
+    });
+    socket.on("close", () => {
+      sockets.delete(socket);
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback IRC server to bind a TCP port");
+  }
+
+  return {
+    port: address.port,
+    lines,
+    get connectionCount() {
+      return connectionCount;
+    },
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+function installMonitorRuntime() {
+  setIrcRuntime({
+    logging: {
+      shouldLogVerbose: vi.fn(() => false),
+      getChildLogger: vi.fn(() => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      })),
+    },
+    channel: {
+      activity: {
+        record: vi.fn(),
+      },
+    },
+  } as never);
+}
+
+afterEach(() => {
+  clearIrcRuntime();
+});
+
+describe("irc monitor reconnect", () => {
+  it("reconnects when an established IRC socket closes", async () => {
+    installMonitorRuntime();
+    const server = await startDisconnectingIrcServer();
+    const config = {
+      channels: {
+        irc: {
+          host: "127.0.0.1",
+          port: server.port,
+          tls: false,
+          nick: "bot",
+          username: "bot",
+          realname: "OpenClaw",
+          channels: ["#openclaw"],
+        },
+      },
+    } as CoreConfig;
+    let monitor: { stop: () => void } | undefined;
+
+    try {
+      monitor = await monitorIrcProvider({ config });
+      await waitForIrcCondition(
+        () =>
+          server.connectionCount >= 2 &&
+          server.lines.filter((line) => line === "USER bot 0 * :OpenClaw").length >= 2,
+        "expected IRC monitor to reconnect after the first socket closed",
+      );
+
+      expect(server.connectionCount).toBeGreaterThanOrEqual(2);
+    } finally {
+      monitor?.stop();
+      await server.close();
+    }
+  });
+});
 
 describe("irc monitor inbound target", () => {
   it("keeps channel target for group messages", () => {

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -20,6 +20,8 @@ type IrcMonitorOptions = {
   onMessage?: (message: IrcInboundMessage, client: IrcClient) => void | Promise<void>;
 };
 
+const IRC_MONITOR_RECONNECT_DELAY_MS = 1000;
+
 export function resolveIrcInboundTarget(params: { target: string; senderNick: string }): {
   isGroup: boolean;
   target: string;
@@ -59,90 +61,152 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
   });
 
   let client: IrcClient | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  const monitorAbort = new AbortController();
+  let removeAbortListener: (() => void) | null = null;
+  if (opts.abortSignal) {
+    const forwardAbort = () => monitorAbort.abort();
+    if (opts.abortSignal.aborted) {
+      forwardAbort();
+    } else {
+      opts.abortSignal.addEventListener("abort", forwardAbort, { once: true });
+      removeAbortListener = () => opts.abortSignal?.removeEventListener("abort", forwardAbort);
+    }
+  }
 
-  client = await connectIrcClient(
-    buildIrcConnectOptions(account, {
-      channels: account.config.channels,
-      abortSignal: opts.abortSignal,
-      onLine: (line) => {
-        if (core.logging.shouldLogVerbose()) {
-          logger.debug?.(`[${account.accountId}] << ${line}`);
-        }
-      },
-      onNotice: (text, target) => {
-        if (core.logging.shouldLogVerbose()) {
-          logger.debug?.(`[${account.accountId}] notice ${target ?? ""}: ${text}`);
-        }
-      },
-      onError: (error) => {
-        logger.error(`[${account.accountId}] IRC error: ${error.message}`);
-      },
-      onPrivmsg: async (event) => {
-        if (!client) {
+  function scheduleReconnect() {
+    if (stopped || monitorAbort.signal.aborted || reconnectTimer) {
+      return;
+    }
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      void connect().catch((error: unknown) => {
+        if (stopped || monitorAbort.signal.aborted) {
           return;
         }
-        if (
-          normalizeLowercaseStringOrEmpty(event.senderNick) ===
-          normalizeLowercaseStringOrEmpty(client.nick)
-        ) {
-          return;
-        }
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(`[${account.accountId}] IRC reconnect failed: ${message}`);
+        scheduleReconnect();
+      });
+    }, IRC_MONITOR_RECONNECT_DELAY_MS);
+  }
 
-        const inboundTarget = resolveIrcInboundTarget({
-          target: event.target,
-          senderNick: event.senderNick,
-        });
-        const message: IrcInboundMessage = {
-          messageId: makeIrcMessageId(),
-          target: inboundTarget.target,
-          rawTarget: inboundTarget.rawTarget,
-          senderNick: event.senderNick,
-          senderUser: event.senderUser,
-          senderHost: event.senderHost,
-          text: event.text,
-          timestamp: Date.now(),
-          isGroup: inboundTarget.isGroup,
-        };
+  async function connect() {
+    if (stopped || monitorAbort.signal.aborted) {
+      return;
+    }
+    const nextClient = await connectIrcClient(
+      buildIrcConnectOptions(account, {
+        channels: account.config.channels,
+        abortSignal: monitorAbort.signal,
+        onLine: (line) => {
+          if (core.logging.shouldLogVerbose()) {
+            logger.debug?.(`[${account.accountId}] << ${line}`);
+          }
+        },
+        onNotice: (text, target) => {
+          if (core.logging.shouldLogVerbose()) {
+            logger.debug?.(`[${account.accountId}] notice ${target ?? ""}: ${text}`);
+          }
+        },
+        onError: (error) => {
+          logger.error(`[${account.accountId}] IRC error: ${error.message}`);
+        },
+        onDisconnect: () => {
+          if (stopped || monitorAbort.signal.aborted) {
+            return;
+          }
+          client = null;
+          logger.warn?.(
+            `[${account.accountId}] IRC connection closed; reconnecting in ${IRC_MONITOR_RECONNECT_DELAY_MS}ms`,
+          );
+          scheduleReconnect();
+        },
+        onPrivmsg: async (event) => {
+          if (!client) {
+            return;
+          }
+          if (
+            normalizeLowercaseStringOrEmpty(event.senderNick) ===
+            normalizeLowercaseStringOrEmpty(client.nick)
+          ) {
+            return;
+          }
 
-        core.channel.activity.record({
-          channel: "irc",
-          accountId: account.accountId,
-          direction: "inbound",
-          at: message.timestamp,
-        });
+          const inboundTarget = resolveIrcInboundTarget({
+            target: event.target,
+            senderNick: event.senderNick,
+          });
+          const message: IrcInboundMessage = {
+            messageId: makeIrcMessageId(),
+            target: inboundTarget.target,
+            rawTarget: inboundTarget.rawTarget,
+            senderNick: event.senderNick,
+            senderUser: event.senderUser,
+            senderHost: event.senderHost,
+            text: event.text,
+            timestamp: Date.now(),
+            isGroup: inboundTarget.isGroup,
+          };
 
-        if (opts.onMessage) {
-          await opts.onMessage(message, client);
-          return;
-        }
+          core.channel.activity.record({
+            channel: "irc",
+            accountId: account.accountId,
+            direction: "inbound",
+            at: message.timestamp,
+          });
 
-        await handleIrcInbound({
-          message,
-          account,
-          config: cfg,
-          runtime,
-          connectedNick: client.nick,
-          sendReply: async (target, text) => {
-            client?.sendPrivmsg(target, text);
-            opts.statusSink?.({ lastOutboundAt: Date.now() });
-            core.channel.activity.record({
-              channel: "irc",
-              accountId: account.accountId,
-              direction: "outbound",
-            });
-          },
-          statusSink: opts.statusSink,
-        });
-      },
-    }),
-  );
+          if (opts.onMessage) {
+            await opts.onMessage(message, client);
+            return;
+          }
 
-  logger.info(
-    `[${account.accountId}] connected to ${account.host}:${account.port}${account.tls ? " (tls)" : ""} as ${client.nick}`,
-  );
+          await handleIrcInbound({
+            message,
+            account,
+            config: cfg,
+            runtime,
+            connectedNick: client.nick,
+            sendReply: async (target, text) => {
+              client?.sendPrivmsg(target, text);
+              opts.statusSink?.({ lastOutboundAt: Date.now() });
+              core.channel.activity.record({
+                channel: "irc",
+                accountId: account.accountId,
+                direction: "outbound",
+              });
+            },
+            statusSink: opts.statusSink,
+          });
+        },
+      }),
+    );
+    if (stopped || monitorAbort.signal.aborted) {
+      nextClient.quit("shutdown");
+      return;
+    }
+    client = nextClient;
+
+    logger.info(
+      `[${account.accountId}] connected to ${account.host}:${account.port}${account.tls ? " (tls)" : ""} as ${nextClient.nick}`,
+    );
+  }
+
+  await connect();
 
   return {
     stop: () => {
+      stopped = true;
+      removeAbortListener?.();
+      removeAbortListener = null;
+      if (!monitorAbort.signal.aborted) {
+        monitorAbort.abort();
+      }
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
       client?.quit("shutdown");
       client = null;
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where IRC channel users would stop receiving bot responses after the IRC server closed an already-established monitor connection. The monitor logged the socket error/close but did not establish a new IRC session, so inbound IRC messages were missed until the OpenClaw process was restarted.

## Why This Change Was Made

The IRC client now reports unexpected post-ready socket closes to the monitor, and the monitor schedules a reconnect that reuses the same account config and channel join list. The client also closes sockets when IRC registration times out, so repeated reconnect attempts do not leave accepted-but-not-ready sockets behind. This does not change IRC config, auth, message parsing, or outbound send contracts.

## User Impact

IRC channel monitors recover from transient network/server disconnects without requiring a manual OpenClaw restart. After reconnecting, the bot logs in again and rejoins its configured channels so inbound messages can be handled normally.

## Evidence

Near-real IRC runtime proof uses the real `monitorIrcProvider` against a real loopback TCP IRC server. The server accepts a ready IRC session, observes `JOIN #openclaw`, closes that established socket, and then observes the monitor reconnect and rejoin the configured channel.

```text
[server] accepted tcp connection #1
[server] #1 <= NICK bot
[server] #1 <= USER bot 0 * :OpenClaw Proof
[server] #1 => 001 welcome
[monitor info] [default] connected to 127.0.0.1:34279 as bot
[server] #1 <= JOIN #openclaw
[server] closing established connection #1 after JOIN #openclaw
[monitor warn] [default] IRC connection closed; reconnecting in 1000ms
[server] tcp connection #1 closed
[server] accepted tcp connection #2
[server] #2 <= NICK bot
[server] #2 <= USER bot 0 * :OpenClaw Proof
[server] #2 => 001 welcome
[monitor info] [default] connected to 127.0.0.1:34279 as bot
[server] #2 <= JOIN #openclaw
[proof] tcp_connections=2
[proof] user_registrations=2
[proof] channel_joins=2
[proof] PASS IRC monitor recovers after post-ready disconnect and rejoins configured channel
```

Focused regression checks:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-irc.config.ts extensions/irc/src/monitor.test.ts`

  ```text
  Test Files  1 passed (1)
       Tests  4 passed (4)
  ```

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-irc.config.ts extensions/irc/src/client.test.ts -t "closes the socket when registration never becomes ready"`

  ```text
  Test Files  1 passed (1)
       Tests  1 passed | 15 skipped (16)
  ```

After syncing with current `main`, the previously failing unrelated CI areas were rechecked locally:

- `pnpm tsgo:prod`

  ```text
  $ pnpm tsgo:core && pnpm tsgo:extensions
  $ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
  $ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
  ```

- `pnpm lint --threads=2`

  ```text
  [oxlint:core] finished
  [oxlint:extensions] finished
  [oxlint:scripts] finished
  ```

- `node scripts/run-vitest.mjs run test/scripts/android-app-i18n.test.ts`

  ```text
  android-app-i18n: keys=26 locales=zh-CN,zh-TW,pt-BR,de,es,ja-JP,ko,fr,hi,ar,it,tr,uk,id,pl,th,vi,nl,fa,ru,sv
  Test Files  1 passed (1)
       Tests  2 passed (2)
  ```
