### PR TITLE
fix(cron): accept null fallbacks in update patch payload (#100707)

### DIFF
--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -231,13 +231,14 @@ describe("createCronToolSchema", () => {
     ).toBe(true);
   });
 
-  it("accepts payload.fallbacks null in patch (clear-to-inherit)", () => {
+  it("accepts payload.model and payload.fallbacks null in patch (clear-to-inherit)", () => {
     expect(
       Value.Check(createCronToolSchema(), {
         action: "update",
         jobId: "job-1",
         patch: {
           payload: {
+            model: null,
             fallbacks: null,
           },
         },

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -231,6 +231,20 @@ describe("createCronToolSchema", () => {
     ).toBe(true);
   });
 
+  it("accepts payload.fallbacks null in patch (clear-to-inherit)", () => {
+    expect(
+      Value.Check(createCronToolSchema(), {
+        action: "update",
+        jobId: "job-1",
+        patch: {
+          payload: {
+            fallbacks: null,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("job.agentId and job.sessionKey project to plain string type for OpenAPI 3.0 compat", () => {
     const root = providerSchemaRecord.properties as
       | Record<string, { properties?: Record<string, unknown> }>

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -109,7 +109,11 @@ function failureDestinationModeSchema(params: { nullableClears: boolean }) {
   return Type.Optional(Type.Union(variants));
 }
 
-function cronPayloadObjectSchema(params: { model: TSchema; toolsAllow: TSchema }) {
+function cronPayloadObjectSchema(params: {
+  model: TSchema;
+  toolsAllow: TSchema;
+  fallbacks: TSchema;
+}) {
   return Type.Object(
     {
       kind: optionalStringEnum(CRON_PAYLOAD_KINDS, { description: "Payload kind" }),
@@ -120,7 +124,7 @@ function cronPayloadObjectSchema(params: { model: TSchema; toolsAllow: TSchema }
       timeoutSeconds: optionalFiniteNumberSchema({ minimum: 0 }),
       lightContext: Type.Optional(Type.Boolean()),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
-      fallbacks: Type.Optional(Type.Array(Type.String(), { description: "Fallback models" })),
+      fallbacks: params.fallbacks,
       toolsAllow: params.toolsAllow,
     },
     { additionalProperties: true },
@@ -161,6 +165,7 @@ function createCronPayloadSchema(): TSchema {
     cronPayloadObjectSchema({
       model: Type.Optional(Type.String({ description: "Model override" })),
       toolsAllow: Type.Optional(Type.Array(Type.String(), { description: "Allowed tools" })),
+      fallbacks: Type.Optional(Type.Array(Type.String(), { description: "Fallback models" })),
     }),
   );
 }
@@ -313,6 +318,7 @@ function createCronPatchObjectSchema(): TSchema {
           cronPayloadObjectSchema({
             model: nullableStringSchema("Model override, or null to clear"),
             toolsAllow: nullableStringArraySchema("Allowed tool ids, or null to clear"),
+            fallbacks: nullableStringArraySchema("Fallback models, or null to clear"),
           }),
         ),
         delivery: createCronDeliveryPatchSchema(),

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -904,11 +904,18 @@
                       "type": "boolean"
                     },
                     "fallbacks": {
-                      "description": "Fallback models",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Fallback models, or null to clear"
                     },
                     "kind": {
                       "description": "Payload kind",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -900,11 +900,18 @@
                       "type": "boolean"
                     },
                     "fallbacks": {
-                      "description": "Fallback models",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Fallback models, or null to clear"
                     },
                     "kind": {
                       "description": "Payload kind",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -900,11 +900,18 @@
                       "type": "boolean"
                     },
                     "fallbacks": {
-                      "description": "Fallback models",
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "description": "Fallback models, or null to clear"
                     },
                     "kind": {
                       "description": "Payload kind",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 51703,
-    "roughTokens": 12926
+    "chars": 51940,
+    "roughTokens": 12985
   },
   "openClawDeveloperInstructions": {
     "chars": 3045,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6893
   },
   "totalWithDynamicToolsJson": {
-    "chars": 79275,
-    "roughTokens": 19819
+    "chars": 79512,
+    "roughTokens": 19878
   },
   "userInputText": {
     "chars": 1442,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 51392,
-    "roughTokens": 12848
+    "chars": 51629,
+    "roughTokens": 12908
   },
   "openClawDeveloperInstructions": {
     "chars": 1936,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6513
   },
   "totalWithDynamicToolsJson": {
-    "chars": 77446,
-    "roughTokens": 19362
+    "chars": 77683,
+    "roughTokens": 19421
   },
   "userInputText": {
     "chars": 1033,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -228,8 +228,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 52682,
-    "roughTokens": 13171
+    "chars": 52919,
+    "roughTokens": 13230
   },
   "openClawDeveloperInstructions": {
     "chars": 1955,
@@ -240,8 +240,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6749
   },
   "totalWithDynamicToolsJson": {
-    "chars": 79679,
-    "roughTokens": 19920
+    "chars": 79916,
+    "roughTokens": 19979
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
## What Problem This Solves

`cron update --patch '{"payload":{"fallbacks":null}}'` fails with `Validation failed: patch.payload.fallbacks: must be array`, blocking users from clearing per-job fallback overrides to restore global agent defaults.

- **Problem**: `cronPayloadObjectSchema` hardcodes `fallbacks` as `Type.Optional(Type.Array(Type.String()))` — non-nullable — while `model` and `toolsAllow` are parameterized so the patch context can pass nullable variants
- **Solution**: Add `fallbacks` as a parameter to `cronPayloadObjectSchema`, matching the existing pattern for `model` and `toolsAllow`
- **What changed**: `src/agents/tools/cron-tool.ts` (schema parameter + both callers), `src/agents/tools/cron-tool.schema.test.ts` (null fallback test)
- **What did NOT change**: Config schema (`zod-schema.agent-model.ts`), Gateway types (`cron/types.ts`), service layer (`cron/service/jobs.ts`) — all already support null clears

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #100707
- [x] This PR fixes a bug or regression

## Motivation

Users need to clear per-job `fallbacks` overrides so cron jobs inherit the global agent-level default fallbacks. The CLI (`--clear-fallbacks`) and Gateway service (`mergeCronPayload`) already support this, but the tool schema rejects `null` before it reaches the service layer. This is the last remaining gap after the `model` null-clear fix in `cfeaf6897f` (#93369 follow-up).

## Evidence

- Behavior addressed: `cron update --patch` now accepts `payload.fallbacks: null` for clear-to-inherit
- Real environment tested: Linux, Node 22, branch `fix/cron-fallback-null-clear-100707`

Exact steps before and after this patch:

```console
$ node --import tsx -e "import { Value } from 'typebox/value'; import { createCronToolSchema } from './src/agents/tools/cron-tool.ts'; ..."

=== BEFORE fix (main branch) ===
patch fallbacks=null  => REJECTED
patch fallbacks=[...] => PASS
create fallbacks=null => REJECTED (strict)

=== AFTER fix (nullable fallbacks) ===
patch fallbacks=null  => ✅ PASS (fixed)
patch fallbacks=[...] => ✅ PASS
patch model=null      => ✅ PASS (already worked)
create fallbacks=null => ✅ REJECTED (strict create)
```

Unit test results:

```console
$ pnpm test src/agents/tools/cron-tool.schema.test.ts
 Test Files  1 passed (1)
      Tests  18 passed (18)   # +1: "accepts payload.fallbacks null in patch"

$ pnpm test src/agents/tools/cron-tool.test.ts
 Test Files  1 passed (1)
      Tests  137 passed (137)
```

Schema comparison (before vs after):

| Input | Before | After |
|---|---|---|
| `patch.payload.fallbacks: null` | `Value.Check` → false | `Value.Check` → true |
| `patch.payload.fallbacks: ["gpt-5"]` | `Value.Check` → true | `Value.Check` → true |
| `create job.payload.fallbacks: null` | `Value.Check` → false | `Value.Check` → false (unchanged) |

- Observed result after fix: Before: null fallbacks rejected by tool schema, never reaching Gateway service. After: null accepted, reaches service layer which correctly clears the stored override.
- What was not tested: No live Gateway `cron update --patch` E2E (requires running Gateway with persistent cron state); the schema-level proof covers the reported rejection path because that path is purely a schema validation gate
## Root Cause (if applicable)

Commit `cfeaf6897f` parameterized `model` in `cronPayloadObjectSchema` to enable null clears for the patch context, but did not extend the same parameterization to `fallbacks`. The field remained hardcoded as `Type.Optional(Type.Array(Type.String()))`.

## User-visible / Behavior Changes

Users can now run `cron update --patch '{"payload":{"fallbacks":null}}'` to clear per-job fallbacks and revert to global agent defaults.

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Human Verification (required)

- Verified scenarios: `Value.Check` for create schema (non-nullable), patch schema (nullable), and array acceptance
- Edge cases checked: null rejected in create context (unchanged), null accepted in patch context (fixed), non-array non-null rejected (unchanged)
- What you did NOT verify: Live Gateway `cron update` E2E

## Compatibility / Migration

- [x] Backward compatible? Yes — null was previously rejected, now accepted. No existing valid input breaks.
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — parameterizing `fallbacks` is the exact same pattern used for `model` and `toolsAllow` in the same function
- **Refactor needed**: No
- **Alternative considered**: Making `fallbacks` directly nullable in `cronPayloadObjectSchema` (simpler but would also accept null in create context, which is semantically unnecessary)

## AI Assistance 🤖

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

None — narrow schema change. The patch context was already designed to accept nullable fields; `fallbacks` was simply missed. All existing tests pass.

