### PR TITLE
fix(acp): optimize trimSqliteLedger to O(N) by incrementally tracking serializedBytes

### DIFF
--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -747,13 +747,14 @@ function trimSqliteLedger(
   while (serializedBytes > state.maxSerializedBytes) {
     const event = db
       .prepare(
-        `SELECT e.session_id AS session_id, e.seq AS seq
+        `SELECT e.session_id AS session_id, e.seq AS seq,
+                length(e.session_id) + length(e.session_key) + length(e.update_json) + COALESCE(length(e.run_id), 0) + 32 AS event_bytes
            FROM acp_replay_events e
            JOIN acp_replay_sessions s ON s.session_id = e.session_id
           ORDER BY s.updated_at ASC, e.seq ASC
           LIMIT 1`,
       )
-      .get() as { session_id: string; seq: number | bigint } | undefined;
+      .get() as { session_id: string; seq: number | bigint; event_bytes: number | bigint } | undefined;
     if (!event) {
       break;
     }
@@ -764,23 +765,24 @@ function trimSqliteLedger(
     db.prepare("UPDATE acp_replay_sessions SET complete = 0 WHERE session_id = ?").run(
       event.session_id,
     );
-    serializedBytes = estimateSqliteLedgerBytes(db);
+    serializedBytes -= normalizeSqliteInteger(event.event_bytes);
   }
 
   while (serializedBytes > state.maxSerializedBytes) {
     const session = db
       .prepare(
-        `SELECT session_id
+        `SELECT session_id,
+                length(session_id) + length(session_key) + length(cwd) + 32 AS session_bytes
            FROM acp_replay_sessions
           ORDER BY updated_at ASC, session_id ASC
           LIMIT 1`,
       )
-      .get() as { session_id: string } | undefined;
+      .get() as { session_id: string; session_bytes: number | bigint } | undefined;
     if (!session) {
       break;
     }
     db.prepare("DELETE FROM acp_replay_sessions WHERE session_id = ?").run(session.session_id);
-    serializedBytes = estimateSqliteLedgerBytes(db);
+    serializedBytes -= normalizeSqliteInteger(session.session_bytes);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

The `trimSqliteLedger` function in `src/acp/event-ledger.ts` was calling `estimateSqliteLedgerBytes()` in a tight loop (3 calls per iteration). Each call does a full table scan of both `acp_replay_sessions` and `acp_replay_events`, making the trimming operation O(N²) for large ledgers.

This is the exact issue described in #100622: `estimateSqliteLedgerBytes()` runs full scans repeatedly.

## Evidence

**Before (O(N²)):**
- `estimateSqliteLedgerBytes()` called at line 746 (initial), 767 (per event deleted), 783 (per session deleted)
- Each call: `SELECT ... FROM acp_replay_sessions ... SELECT ... FROM acp_replay_events` → full table scans

**After (O(N)):**
- Single `estimateSqliteLedgerBytes()` call upfront (line 746)
- Each deletion query now `SELECT ... length(...) AS event_bytes` to get the exact byte size of the row being deleted
- Decrement `serializedBytes -= event_bytes` instead of re-scanning
- Same for sessions: `SELECT ... length(...) AS session_bytes`

**Verification logic (tested locally):**
```js
const event = db.prepare(`SELECT ..., length(...) AS event_bytes ... LIMIT 1`).get();
db.prepare("DELETE ...").run(event.session_id, event.seq);
serializedBytes -= event.event_bytes;  // matches full re-scan result
```

## Changes

- `src/acp/event-ledger.ts`: Modified `trimSqliteLedger` to track `serializedBytes` incrementally
- Added `event_bytes` and `session_bytes` columns to deletion queries
- Removed 2 calls to `estimateSqliteLedgerBytes()` inside loops

Closes #100622