### PR TITLE
fix: keep /steer working for active runs

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -158,29 +158,31 @@ async function visibleChatBubbleTexts(page: Page): Promise<string[]> {
       .filter(Boolean);
   });
 }
-function chatSessionListResponse() {
+function chatSessionListResponse(
+  sessions: Array<Record<string, unknown>> = [
+    {
+      key: "agent:main:session-a",
+      kind: "direct",
+      label: "Session A",
+      updatedAt: 2,
+    },
+    {
+      key: "agent:main:session-b",
+      kind: "direct",
+      label: "Session B",
+      updatedAt: 1,
+    },
+  ],
+) {
   return {
-    count: 2,
+    count: sessions.length,
     defaults: {
       contextTokens: null,
       model: "gpt-5.5",
       modelProvider: "openai",
     },
     path: "",
-    sessions: [
-      {
-        key: "agent:main:session-a",
-        kind: "direct",
-        label: "Session A",
-        updatedAt: 2,
-      },
-      {
-        key: "agent:main:session-b",
-        kind: "direct",
-        label: "Session B",
-        updatedAt: 1,
-      },
-    ],
+    sessions,
     ts: Date.now(),
   };
 }
@@ -193,33 +195,6 @@ async function sidebarSessionOrder(page: Page): Promise<string[]> {
         .map((row) => row.getAttribute("data-session-key") ?? "")
         .filter((key) => key.startsWith("agent:main:session-")),
     );
-}
-
-function activeRunFlagOnlySessionListResponse() {
-  return {
-    count: 1,
-    defaults: {
-      contextTokens: null,
-      model: "gpt-5.5",
-      modelProvider: "openai",
-    },
-    path: "",
-    sessions: [
-      {
-        contextTokens: null,
-        displayName: "Main",
-        hasActiveRun: true,
-        key: "main",
-        kind: "direct",
-        label: "Main",
-        model: "gpt-5.5",
-        modelProvider: "openai",
-        totalTokens: 0,
-        updatedAt: Date.now(),
-      },
-    ],
-    ts: Date.now(),
-  };
 }
 
 describeControlUiE2e("Control UI mocked Gateway E2E", () => {
@@ -361,7 +336,15 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         },
       ],
       methodResponses: {
-        "sessions.list": activeRunFlagOnlySessionListResponse(),
+        "sessions.list": chatSessionListResponse([
+          {
+            hasActiveRun: true,
+            key: "main",
+            kind: "direct",
+            label: "Main",
+            updatedAt: Date.now(),
+          },
+        ]),
       },
     });
 

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -159,7 +159,14 @@ async function visibleChatBubbleTexts(page: Page): Promise<string[]> {
   });
 }
 function chatSessionListResponse(
-  sessions: Array<Record<string, unknown>> = [
+  sessions: Array<
+    Record<string, unknown> & {
+      key: string;
+      kind: string;
+      label: string;
+      updatedAt: number;
+    }
+  > = [
     {
       key: "agent:main:session-a",
       kind: "direct",

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -195,6 +195,33 @@ async function sidebarSessionOrder(page: Page): Promise<string[]> {
     );
 }
 
+function activeRunFlagOnlySessionListResponse() {
+  return {
+    count: 1,
+    defaults: {
+      contextTokens: null,
+      model: "gpt-5.5",
+      modelProvider: "openai",
+    },
+    path: "",
+    sessions: [
+      {
+        contextTokens: null,
+        displayName: "Main",
+        hasActiveRun: true,
+        key: "main",
+        kind: "direct",
+        label: "Main",
+        model: "gpt-5.5",
+        modelProvider: "openai",
+        totalTokens: 0,
+        updatedAt: Date.now(),
+      },
+    ],
+    ts: Date.now(),
+  };
+}
+
 describeControlUiE2e("Control UI mocked Gateway E2E", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
@@ -313,6 +340,49 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await composer.press("Meta+Enter");
       const modifierRequest = await gateway.waitForRequest("chat.send");
       expect(requireRecord(modifierRequest.params).message).toBe("modifier send");
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
+  it("steers an active run when the session row only reports hasActiveRun", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ text: "Active run is waiting for steering.", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+      methodResponses: {
+        "sessions.list": activeRunFlagOnlySessionListResponse(),
+      },
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.getByText("Active run is waiting for steering.").waitFor({ timeout: 10_000 });
+      await gateway.waitForRequest("sessions.list");
+
+      await page
+        .locator(".agent-chat__composer-combobox textarea")
+        .fill("/steer use the smaller fix");
+      await page.getByRole("button", { name: "Queue message" }).click();
+
+      const steerRequest = await gateway.waitForRequest("chat.send");
+      const params = requireRecord(steerRequest.params);
+      expect(params.sessionKey).toBe("main");
+      expect(params.message).toBe("use the smaller fix");
+      expect(params.deliver).toBe(false);
+
+      await page.getByText("Steered.", { exact: true }).waitFor({ timeout: 10_000 });
+      expect(await page.getByText("No active run").count()).toBe(0);
     } finally {
       await closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/chat-command-executor.test.ts
+++ b/ui/src/pages/chat/chat-command-executor.test.ts
@@ -995,6 +995,34 @@ describe("executeSlashCommand /steer (soft inject)", () => {
     expect(chatSend.payload.deliver).toBe(false);
   });
 
+  it("uses canonical active-run state when the session row only reports hasActiveRun", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.list") {
+        return { sessions: [row("agent:main:main", { hasActiveRun: true })] };
+      }
+      if (method === "chat.send") {
+        return { status: "started", runId: "run-active-flag", messageSeq: 2 };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "steer",
+      "continue with the smaller fix",
+    );
+
+    expect(result.content).toBe("Steered.");
+    expect(result.pendingCurrentRun).toBe(true);
+    const chatSend = requireRequestCall(request, "chat.send");
+    expect(chatSend.payload).toMatchObject({
+      sessionKey: "agent:main:main",
+      message: "continue with the smaller fix",
+      deliver: false,
+    });
+  });
+
   it("does not mark the current run pending when chat.send returns terminal ok", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "sessions.list") {

--- a/ui/src/pages/chat/chat-command-executor.ts
+++ b/ui/src/pages/chat/chat-command-executor.ts
@@ -28,6 +28,7 @@ import {
   resolveThinkingLevelInput,
 } from "../../lib/chat/thinking.ts";
 import { formatCompactTokenCount } from "../../lib/format.ts";
+import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import type { SessionCapability, SessionPatch } from "../../lib/sessions/index.ts";
 import {
   DEFAULT_AGENT_ID,
@@ -644,7 +645,7 @@ async function resolveSteerTarget(
 }
 
 function isActiveSteerSession(session: GatewaySessionRow | undefined): boolean {
-  return session?.status === "running" && session.endedAt == null;
+  return Boolean(session && isSessionRunActive(session));
 }
 
 type SteerChatSendAckStatus = "started" | "in_flight" | "ok" | "timeout" | "error";


### PR DESCRIPTION
Closes #100796

## What Problem This Solves

Fixes an issue where users running `/steer <message>` during an active chat run could see `No active run. Use the chat input or /redirect instead.` when the session row reported the live run through `hasActiveRun` instead of `status: "running"`.

## Why This Change Was Made

`/steer` now uses the shared Control UI active-run helper instead of maintaining a separate status-only check. This keeps `/steer` aligned with the rest of chat run lifecycle handling while preserving terminal status behavior and the legacy `status: "running"` fallback.

## User Impact

Users can steer an active run again from the slash command when Gateway session state exposes the run with `hasActiveRun`. The change is limited to the preflight active-run check before the existing `chat.send` steering request.

## Evidence

Current head after rebasing onto `8ce620f3e675b25111dcbed6d1e124fedd4756a3` is `c1de2fb4469f06cf76ffbd56627d956279f68c9e`.

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-command-executor.test.ts ui/src/lib/session-run-state.test.ts` - passed, 2 files / 53 tests.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.e2e.test.ts` - passed, 1 file / 29 tests. The new browser E2E opens the real Control UI chat route with a mocked Gateway `sessions.list` row that has `hasActiveRun: true`, no `activeRunIds`, and no `status`, submits `/steer use the smaller fix`, and verifies `chat.send` uses `deliver: false` plus visible `Steered.` feedback.
- Independent Chromium recording of the same mocked Control UI browser flow passed locally; text manifest: https://gist.github.com/Hackerismydream/f096d42324f30674f0d3fe8d809ba0f0. Screenshot/video files were generated under `.artifacts/control-ui-e2e/steer-active-run/` but not committed.
- `node_modules/.bin/oxfmt --check --threads=1 ui/src/pages/chat/chat-command-executor.ts ui/src/pages/chat/chat-command-executor.test.ts ui/src/e2e/chat-flow.e2e.test.ts` - passed.
- `node_modules/.bin/oxlint --threads=1 ui/src/pages/chat/chat-command-executor.ts ui/src/pages/chat/chat-command-executor.test.ts ui/src/e2e/chat-flow.e2e.test.ts` - passed.
- `git diff --check` - passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings.

Testbox-through-Crabbox was attempted first but is unavailable in this checkout: `node scripts/crabbox-wrapper.mjs warmup --provider blacksmith-testbox --keep --timing-json` failed with `selected binary failed basic --version/--help sanity checks`, so the focused local Codex-worktree fallback and repo-native mocked Control UI E2E lane were used.

AI-assisted with Codex. I understand the change: it swaps `/steer` to the existing shared run-state predicate and adds regression coverage for rows that only report `hasActiveRun`.
