### PR TITLE
fix(android): add missing new_chat_in_worktree locale strings

### DIFF
--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">هل تثق بهذه البوابة؟</string>
     <string name="trust_and_continue">الثقة والمتابعة</string>
     <string name="cancel">إلغاء</string>
+    <string name="new_chat_in_worktree">دردشة جديدة في worktree</string>
     <string name="endpoint">نقطة النهاية</string>
     <string name="status">الحالة</string>
     <string name="connected_gateway_ready">بوابتك نشطة وجاهزة.</string>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Diesem Gateway vertrauen?</string>
     <string name="trust_and_continue">Vertrauen und fortfahren</string>
     <string name="cancel">Abbrechen</string>
+    <string name="new_chat_in_worktree">Neuer Chat im Worktree</string>
     <string name="endpoint">Endpunkt</string>
     <string name="status">Status</string>
     <string name="connected_gateway_ready">Ihr Gateway ist aktiv und bereit.</string>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">¿Confiar en este gateway?</string>
     <string name="trust_and_continue">Confiar y continuar</string>
     <string name="cancel">Cancelar</string>
+    <string name="new_chat_in_worktree">Nuevo chat en worktree</string>
     <string name="endpoint">Endpoint</string>
     <string name="status">Estado</string>
     <string name="connected_gateway_ready">Tu gateway está activo y listo.</string>

--- a/apps/android/app/src/main/res/values-fa/strings.xml
+++ b/apps/android/app/src/main/res/values-fa/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">به این دروازه اعتماد دارید؟</string>
     <string name="trust_and_continue">اعتماد و ادامه</string>
     <string name="cancel">لغو</string>
+    <string name="new_chat_in_worktree">چت جدید در worktree</string>
     <string name="endpoint">نقطه پایانی</string>
     <string name="status">وضعیت</string>
     <string name="connected_gateway_ready">دروازه شما فعال و آماده است.</string>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Faire confiance à cette passerelle ?</string>
     <string name="trust_and_continue">Faire confiance et continuer</string>
     <string name="cancel">Annuler</string>
+    <string name="new_chat_in_worktree">Nouveau chat dans le worktree</string>
     <string name="endpoint">Point de terminaison</string>
     <string name="status">État</string>
     <string name="connected_gateway_ready">Votre passerelle est active et prête.</string>

--- a/apps/android/app/src/main/res/values-hi/strings.xml
+++ b/apps/android/app/src/main/res/values-hi/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">इस गेटवे पर भरोसा करें?</string>
     <string name="trust_and_continue">भरोसा करें और जारी रखें</string>
     <string name="cancel">रद्द करें</string>
+    <string name="new_chat_in_worktree">worktree में नया चैट</string>
     <string name="endpoint">एंडपॉइंट</string>
     <string name="status">स्थिति</string>
     <string name="connected_gateway_ready">आपका गेटवे सक्रिय और तैयार है।</string>

--- a/apps/android/app/src/main/res/values-in/strings.xml
+++ b/apps/android/app/src/main/res/values-in/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Percayai gateway ini?</string>
     <string name="trust_and_continue">Percayai dan lanjutkan</string>
     <string name="cancel">Batal</string>
+    <string name="new_chat_in_worktree">Chat baru di worktree</string>
     <string name="endpoint">Endpoint</string>
     <string name="status">Status</string>
     <string name="connected_gateway_ready">Gateway Anda aktif dan siap.</string>

--- a/apps/android/app/src/main/res/values-it/strings.xml
+++ b/apps/android/app/src/main/res/values-it/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Considerare attendibile questo gateway?</string>
     <string name="trust_and_continue">Considera attendibile e continua</string>
     <string name="cancel">Annulla</string>
+    <string name="new_chat_in_worktree">Nuova chat nel worktree</string>
     <string name="endpoint">Endpoint</string>
     <string name="status">Stato</string>
     <string name="connected_gateway_ready">Il tuo gateway è attivo e pronto.</string>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">このゲートウェイを信頼しますか？</string>
     <string name="trust_and_continue">信頼して続行</string>
     <string name="cancel">キャンセル</string>
+    <string name="new_chat_in_worktree">worktree で新規チャット</string>
     <string name="endpoint">エンドポイント</string>
     <string name="status">ステータス</string>
     <string name="connected_gateway_ready">ゲートウェイはアクティブで準備完了です。</string>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">이 게이트웨이를 신뢰하시겠습니까?</string>
     <string name="trust_and_continue">신뢰하고 계속</string>
     <string name="cancel">취소</string>
+    <string name="new_chat_in_worktree">worktree에서 새 채팅</string>
     <string name="endpoint">엔드포인트</string>
     <string name="status">상태</string>
     <string name="connected_gateway_ready">게이트웨이가 활성화되어 준비되었습니다.</string>

--- a/apps/android/app/src/main/res/values-nl/strings.xml
+++ b/apps/android/app/src/main/res/values-nl/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Deze gateway vertrouwen?</string>
     <string name="trust_and_continue">Vertrouwen en doorgaan</string>
     <string name="cancel">Annuleren</string>
+    <string name="new_chat_in_worktree">Nieuwe chat in worktree</string>
     <string name="endpoint">Endpoint</string>
     <string name="status">Status</string>
     <string name="connected_gateway_ready">Je gateway is actief en klaar voor gebruik.</string>

--- a/apps/android/app/src/main/res/values-pl/strings.xml
+++ b/apps/android/app/src/main/res/values-pl/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Ufać tej bramie?</string>
     <string name="trust_and_continue">Zaufaj i kontynuuj</string>
     <string name="cancel">Anuluj</string>
+    <string name="new_chat_in_worktree">Nowy czat w worktree</string>
     <string name="endpoint">Punkt końcowy</string>
     <string name="status">Status</string>
     <string name="connected_gateway_ready">Twoja brama jest aktywna i gotowa.</string>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Confiar neste gateway?</string>
     <string name="trust_and_continue">Confiar e continuar</string>
     <string name="cancel">Cancelar</string>
+    <string name="new_chat_in_worktree">Novo chat no worktree</string>
     <string name="endpoint">Endpoint</string>
     <string name="status">Status</string>
     <string name="connected_gateway_ready">Seu gateway está ativo e pronto.</string>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Доверять этому шлюзу?</string>
     <string name="trust_and_continue">Доверять и продолжить</string>
     <string name="cancel">Отмена</string>
+    <string name="new_chat_in_worktree">Новый чат в worktree</string>
     <string name="endpoint">Конечная точка</string>
     <string name="status">Статус</string>
     <string name="connected_gateway_ready">Ваш шлюз активен и готов.</string>

--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Lita på denna gateway?</string>
     <string name="trust_and_continue">Lita på och fortsätt</string>
     <string name="cancel">Avbryt</string>
+    <string name="new_chat_in_worktree">Ny chatt i worktree</string>
     <string name="endpoint">Slutpunkt</string>
     <string name="status">Status</string>
     <string name="connected_gateway_ready">Din gateway är aktiv och redo.</string>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">เชื่อถือเกตเวย์นี้หรือไม่?</string>
     <string name="trust_and_continue">เชื่อถือและดำเนินการต่อ</string>
     <string name="cancel">ยกเลิก</string>
+    <string name="new_chat_in_worktree">แชทใหม่ใน worktree</string>
     <string name="endpoint">เอนด์พอยต์</string>
     <string name="status">สถานะ</string>
     <string name="connected_gateway_ready">เกตเวย์ของคุณเปิดใช้งานและพร้อมใช้งานแล้ว</string>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Bu ağ geçidine güvenilsin mi?</string>
     <string name="trust_and_continue">Güven ve devam et</string>
     <string name="cancel">İptal</string>
+    <string name="new_chat_in_worktree">Worktree\'de yeni sohbet</string>
     <string name="endpoint">Uç nokta</string>
     <string name="status">Durum</string>
     <string name="connected_gateway_ready">Ağ geçidiniz etkin ve hazır.</string>

--- a/apps/android/app/src/main/res/values-uk/strings.xml
+++ b/apps/android/app/src/main/res/values-uk/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Довіряти цьому шлюзу?</string>
     <string name="trust_and_continue">Довіряти й продовжити</string>
     <string name="cancel">Скасувати</string>
+    <string name="new_chat_in_worktree">Новий чат у worktree</string>
     <string name="endpoint">Кінцева точка</string>
     <string name="status">Стан</string>
     <string name="connected_gateway_ready">Ваш шлюз активний і готовий.</string>

--- a/apps/android/app/src/main/res/values-vi/strings.xml
+++ b/apps/android/app/src/main/res/values-vi/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">Tin cậy cổng này?</string>
     <string name="trust_and_continue">Tin cậy và tiếp tục</string>
     <string name="cancel">Hủy</string>
+    <string name="new_chat_in_worktree">Trò chuyện mới trong worktree</string>
     <string name="endpoint">Điểm cuối</string>
     <string name="status">Trạng thái</string>
     <string name="connected_gateway_ready">Cổng của bạn đang hoạt động và sẵn sàng.</string>

--- a/apps/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">信任此网关？</string>
     <string name="trust_and_continue">信任并继续</string>
     <string name="cancel">取消</string>
+    <string name="new_chat_in_worktree">在 worktree 中新建聊天</string>
     <string name="endpoint">端点</string>
     <string name="status">状态</string>
     <string name="connected_gateway_ready">你的网关已激活并准备就绪。</string>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -6,6 +6,7 @@
     <string name="trust_this_gateway">信任此閘道？</string>
     <string name="trust_and_continue">信任並繼續</string>
     <string name="cancel">取消</string>
+    <string name="new_chat_in_worktree">在 worktree 中新增聊天</string>
     <string name="endpoint">端點</string>
     <string name="status">狀態</string>
     <string name="connected_gateway_ready">您的閘道已啟用並準備就緒。</string>


### PR DESCRIPTION
## What Problem This Solves

Unbreaks main CI: `test/scripts/android-app-i18n.test.ts` ("keeps every native
locale resource key aligned with English") fails on main because #100788 added
the `new_chat_in_worktree` string to the English Android resources only. Every
whole-suite test shard (`checks-node-compact-*-whole-*`) on every open PR is
currently red because of it.

## Why This Change Was Made

The native i18n pipeline already produced the translations: the locale-refresh
workflow committed them to the translation-memory artifacts
(`apps/.i18n/native/*.json`) in 24bca38cda. But those artifacts are a handoff —
the Android resource files are owned by the app slice and still lacked the key.
This PR materializes the artifact translations into all 21
`values-*/strings.xml` files, inserted at the same position as the English
entry.

All values come verbatim from the translation-memory artifacts (matched on the
android surface + exact source text "New chat in worktree"), with Android
resource escaping applied (e.g. Turkish `Worktree\'de yeni sohbet`).

## User Impact

Android users get a localized "New chat in worktree" label in all supported
locales instead of a build/test break. Repo-wide: whole-suite CI shards go
green again.

## Evidence

- `node scripts/run-vitest.mjs run test/scripts/android-app-i18n.test.ts` →
  2/2 pass (was failing with `missing=new_chat_in_worktree` for all 21
  locales).
- The checker also validates placeholder parity and Android apostrophe
  escaping; both pass (the string has no format placeholders; the one
  apostrophe, in Turkish, is escaped).
- Complements #100793, which fixes the remaining main breakages from the same
  merge window (gateway-protocol unused type exports + stale docs map). This
  PR's own docs/lint/prod-types checks will stay red until that lands; the two
  PRs touch disjoint files.
