### PR TITLE
fix: code-block copy jumps chat to message top

### DIFF
--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -775,7 +775,12 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     const gateway = await installMockGateway(page, {
       historyMessages: [
         {
-          content: [{ text: `\`\`\`js\n${code}\n\`\`\``, type: "text" }],
+          content: [
+            {
+              text: `${"long response line\n\n".repeat(80)}\`\`\`js\n${code}\n\`\`\``,
+              type: "text",
+            },
+          ],
           role: "assistant",
           timestamp: Date.now(),
         },
@@ -786,6 +791,11 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
       await page.goto(`${server.baseUrl}chat`);
       const copyButton = page.locator(".code-block-copy").first();
       await copyButton.waitFor({ timeout: 10_000 });
+      await copyButton.evaluate((element) => element.scrollIntoView({ block: "center" }));
+      const thread = page.locator(".chat-thread");
+      const scrollTopBefore = await thread.evaluate((element) =>
+        Math.round((element as HTMLElement).scrollTop),
+      );
       await copyButton.click();
 
       await expect
@@ -794,6 +804,9 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
         })
         .toBe(true);
       expect(await copiedViaExec(page)).toContain(code);
+      await expect
+        .poll(() => thread.evaluate((element) => Math.round((element as HTMLElement).scrollTop)))
+        .toBe(scrollTopBefore);
       expect(await gateway.getRequests("chat.send")).toHaveLength(0);
     } finally {
       await closeBrowserContext(context);

--- a/ui/src/lib/clipboard.test.ts
+++ b/ui/src/lib/clipboard.test.ts
@@ -70,14 +70,17 @@ describe("copyToClipboard", () => {
     const button = document.createElement("button");
     document.body.append(button);
     button.focus();
+    const focus = vi.spyOn(button, "focus");
     button.disabled = true;
 
     expect(await copyToClipboard("hello")).toBe(true);
     button.disabled = false;
+    button.blur();
     await new Promise<void>((resolve) => {
       window.setTimeout(resolve, 0);
     });
     expect(document.activeElement).toBe(button);
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
 
     button.remove();
   });

--- a/ui/src/lib/clipboard.ts
+++ b/ui/src/lib/clipboard.ts
@@ -41,7 +41,7 @@ function copyWithExecCommand(text: string): boolean {
       window.setTimeout(() => {
         const activeElement = document.activeElement;
         if (previouslyFocused.isConnected && (!activeElement || activeElement === document.body)) {
-          previouslyFocused.focus();
+          previouslyFocused.focus({ preventScroll: true });
         }
       }, 0);
     }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

## What Problem This Solves

Fixes an issue where users clicking a code-block Copy button in the Control UI chat could be jumped back to the top of the current assistant output.

This affected the chat workflow when copying code from rendered assistant messages, especially in longer responses where the code block was lower in the message.

## Why This Change Was Made

The copy interaction now avoids focus-driven scroll jumps and preserves the chat thread scroll position around the copy action. 

## User Impact

Users can copy code blocks from chat responses without losing their current reading position in the conversation.

## Evidence

My prompt.

```bash
tell me how to install openclaw. I am going to test you now; the longer the content, the better.
```

When clicking "Copy," the page no longer scrolls back to the top but remains at the current position.

<img width="941" height="720" alt="image" src="https://github.com/user-attachments/assets/94525f38-debf-4072-8089-2d5dc00222aa" />

Tests pass:

```bash
cd ui
node ../scripts/run-vitest.mjs run --config vitest.config.ts src/pages/chat/chat-view.test.ts src/lib/clipboard.test.ts
```

Result:

```bash
 ✓  unit  src/lib/clipboard.test.ts (6 tests) 32ms
 ✓  unit  src/pages/chat/chat-view.test.ts (100 tests) 954ms

 Test Files  2 passed (2)
      Tests  106 passed (106)
   Start at  17:16:49
   Duration  2.78s (transform 860ms, setup 57ms, import 1.10s, tests 986ms, environment 1.32s)
```