### PR TITLE
fix(auto-reply): gracefully skip preflight compaction on transient failures

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1380,6 +1380,69 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(incrementCompactionCountMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["timeout", "compaction timed out after 30s"],
+    ["provider_error_4xx", "provider returned 429 rate limit exceeded"],
+    ["provider_error_5xx", "provider returned 502 bad gateway"],
+    ["summary_failed", "summary generation failed: model unavailable"],
+  ])(
+    "gracefully skips preflight compaction on transient %s failure instead of throwing",
+    async (_classification, reason) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+        "utf8",
+      );
+      registerMemoryFlushPlanResolverForTest(() => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 0,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
+      compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+        ok: false,
+        compacted: false,
+        reason,
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        sessionFile,
+        updatedAt: Date.now(),
+        totalTokens: 120,
+        totalTokensFresh: true,
+      };
+      const onCompactionNotice = vi.fn();
+
+      const entry = await runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:telegram:group:redacted",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore: { "agent:main:telegram:group:redacted": sessionEntry },
+        sessionKey: "agent:main:telegram:group:redacted",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+        onCompactionNotice,
+      });
+
+      // Should return the session entry instead of throwing
+      expect(entry).toBe(sessionEntry);
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "incomplete");
+    },
+  );
+
   it("passes resolved context budget and auth profile to preflight compaction", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -213,6 +213,23 @@ function isPreflightCompactionSkipReason(reason?: string): boolean {
   );
 }
 
+/**
+ * Transient infrastructure failures that should not terminate the reply
+ * operation. When preflight compaction fails due to a provider/network issue
+ * the agent run should proceed instead of permanently locking the Composer.
+ * The downstream LLM call may still fail with a context-too-long error, but
+ * that produces a proper user-visible message rather than a silent lockout.
+ */
+function isTransientCompactionFailure(reason?: string): boolean {
+  const classification = classifyCompactionReason(reason);
+  return (
+    classification === "timeout" ||
+    classification === "provider_error_4xx" ||
+    classification === "provider_error_5xx" ||
+    classification === "summary_failed"
+  );
+}
+
 function resolveMemoryFlushModelFallbackOptions(
   run: FollowupRun["run"],
   model?: string,
@@ -996,6 +1013,13 @@ export async function runPreflightCompactionIfNeeded(params: {
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
         return entry ?? params.sessionEntry;
       }
+      if (isTransientCompactionFailure(reason)) {
+        await notifyTerminalCompaction("incomplete");
+        logVerbose(
+          `preflightCompaction transient failure, continuing without compaction: sessionKey=${params.sessionKey} reason=${reason}`,
+        );
+        return entry ?? params.sessionEntry;
+      }
       await notifyTerminalCompaction("incomplete");
       logVerbose(`preflightCompaction failed: sessionKey=${params.sessionKey} reason=${reason}`);
       throw new Error(`Preflight compaction required but failed: ${reason}`);
@@ -1006,6 +1030,13 @@ export async function runPreflightCompactionIfNeeded(params: {
       if (isPreflightCompactionSkipReason(reason)) {
         await notifyTerminalCompaction("skipped");
         logVerbose(`preflightCompaction skipped: sessionKey=${params.sessionKey} reason=${reason}`);
+        return entry ?? params.sessionEntry;
+      }
+      if (isTransientCompactionFailure(reason)) {
+        await notifyTerminalCompaction("incomplete");
+        logVerbose(
+          `preflightCompaction transient failure, continuing without compaction: sessionKey=${params.sessionKey} reason=${reason}`,
+        );
         return entry ?? params.sessionEntry;
       }
       await notifyTerminalCompaction("incomplete");


### PR DESCRIPTION
Fixes #100778

## What Problem This Solves

Fixes an issue where users sending a message when their session context approaches the compaction threshold would experience a permanently locked Composer ("terminated" state) when the preflight compaction LLM call fails due to transient infrastructure issues (timeout, rate limit, provider 5xx). Users cannot type or send any new messages without manually refreshing the page.

## Why This Change Was Made

The existing code comment states preflight compaction is "a guardrail, not a hard dependency," but transient failures (timeout, provider 4xx/5xx, summary generation failure) caused a hard throw that terminated the entire reply operation before the agent even started. This change adds a `isTransientCompactionFailure()` classification that allows the agent run to proceed without compaction when infrastructure issues occur. Fatal failures (guard_blocked, deferred_background, unknown) still throw to preserve safety semantics.

## User Impact

Users whose sessions trigger preflight compaction during transient provider instability will no longer be locked out. The agent run proceeds — if context is genuinely too long, the downstream LLM returns a proper user-visible error message instead of silently locking the Composer. Users can always retry.

## Evidence

All 51 tests pass including 4 new parameterized test cases covering each transient failure class:

✓ gracefully skips preflight compaction on transient timeout failure instead of throwing ✓ gracefully skips preflight compaction on transient provider_error_4xx failure instead of throwing ✓ gracefully skips preflight compaction on transient provider_error_5xx failure instead of throwing ✓ gracefully skips preflight compaction on transient summary_failed failure instead of throwing


Each test verifies: no throw, returns session entry, emits "incomplete" notice, does not increment compaction count. Existing tests for fatal failures (deferred_background, thread-not-found, auth_profile_mismatch) continue to assert the throw behavior is preserved.