### PR TITLE
fix(android): Talk voice fails when gateway allows local TTS fallback

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -387,7 +387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1229,
+      "line": 1231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -395,7 +395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1229,
+      "line": 1231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -87,6 +87,7 @@ data class GatewayConnectErrorDetails(
   val clientMaxProtocol: Int? = null,
   val expectedProtocol: Int? = null,
   val minimumProbeProtocol: Int? = null,
+  val fallbackEligible: Boolean? = null,
 )
 
 private val gatewayApprovalRequestIdPattern = Regex("^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
@@ -1089,6 +1090,7 @@ class GatewaySession(
                 clientMaxProtocol = it["clientMaxProtocol"].asIntOrNull(),
                 expectedProtocol = it["expectedProtocol"].asIntOrNull(),
                 minimumProbeProtocol = it["minimumProbeProtocol"].asIntOrNull(),
+                fallbackEligible = it["fallbackEligible"].asBooleanOrNull(),
               )
             }
           ErrorShape(code, msg, details)

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkSpeakClient.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkSpeakClient.kt
@@ -98,10 +98,9 @@ internal class TalkSpeakClient(
   }
 
   private fun isFallbackEligible(error: GatewaySession.ErrorShape?): Boolean {
+    error?.details?.fallbackEligible?.let { return it }
     val reason = error?.details?.reason
     if (reason == null) return true
-    // Only provider/config absence should fall back to Android TTS; payload and
-    // transport errors should stay visible to the caller.
     return reason == "talk_unconfigured" ||
       reason == "talk_provider_unsupported" ||
       reason == "method_unavailable"

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkSpeakClientTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkSpeakClientTest.kt
@@ -78,6 +78,36 @@ class TalkSpeakClientTest {
     }
 
   @Test
+  fun fallsBackWhenGatewayMarksSynthesisFailureEligible() =
+    runTest {
+      val client =
+        TalkSpeakClient(
+          requestDetailed = { _, _, _ ->
+            GatewaySession.RpcResult(
+              ok = false,
+              payloadJson = null,
+              error =
+                GatewaySession.ErrorShape(
+                  code = "UNAVAILABLE",
+                  message = "provider failed",
+                  details =
+                    GatewayConnectErrorDetails(
+                      code = null,
+                      canRetryWithDeviceToken = false,
+                      recommendedNextStep = null,
+                      reason = "synthesis_failed",
+                      fallbackEligible = true,
+                    ),
+                ),
+            )
+          },
+        )
+
+      val result = client.synthesize(text = "Hello", directive = null)
+      assertTrue(result is TalkSpeakResult.FallbackToLocal)
+    }
+
+  @Test
   fun doesNotFallBackForSynthesisFailure() =
     runTest {
       val client =


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android Talk users could lose spoken replies instead of falling back to local TTS when gateway `talk.speak` reports a fallback-eligible failure.

The affected path is a remote synthesis failure: gateway returns a structured `talk.speak` error with `details.reason = "synthesis_failed"`, and Android needs the server-provided `details.fallbackEligible` decision to choose local TTS fallback instead of treating the reply as a hard failure.

## Why This Change Was Made

Android now preserves the gateway `details.fallbackEligible` field when parsing RPC errors, and `TalkSpeakClient` uses that server-provided decision before falling back to the legacy reason allowlist.

Gateway `talk.speak` now also marks `synthesis_failed` as fallback-eligible, so the runtime contract matches the Android fallback path. The existing reason-based Android fallback remains in place for older gateway responses that do not include the field.

The Android native i18n inventory is refreshed for the source line shift introduced by the gateway details model change.

## User Impact

Android Talk can fall back to device-local TTS when remote gateway speech synthesis fails in a fallback-eligible way, instead of leaving the user without spoken output. Errors that the gateway marks as ineligible still remain visible as failures.

## Evidence

- Real local OpenClaw gateway proof exercised the affected issue path through `gateway:dev` WebSocket RPC: a client called `talk.speak`, the configured speech provider failed synthesis, and the gateway returned fallback eligibility for Android to consume.

  ```text
  proof: real_gateway_talk_speak_issue_path
  runtime: OpenClaw gateway:dev WebSocket RPC
  method: talk.speak
  observed.errorCode: UNAVAILABLE
  observed.details.reason: synthesis_failed
  observed.details.fallbackEligible: true
  pass: true
  ```

- Gateway regression test passed for the same server contract:

  ```text
  src/gateway/server.talk-runtime.test.ts
  Tests 6 passed
  ```

- Focused Android TalkSpeakClient test passed for the client fallback decision:

  ```text
  :app:testPlayDebugUnitTest --tests ai.openclaw.app.voice.TalkSpeakClientTest
  BUILD SUCCESSFUL
  ```

- Supporting Android/Robolectric behavior proof shows a gateway-style `talk.speak` error reaches Android system TTS playback instead of remote audio playback:

  ```text
  REAL_BEHAVIOR_PROOF gatewayMethod=talk.speak reason=synthesis_failed fallbackEligible=true androidSystemTtsText=redacted proof phrase remoteAudioPlayerUsed=false
  ```

- `pnpm native:i18n:check` passed after refreshing the native Android i18n inventory.

  ```text
  native-app-i18n: entries=2590 changed=false
  ```
