### PR TITLE
fix(sessions): exclude status done from terminal-main transcript rollover guard (#99964)

### DIFF
--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -218,6 +218,12 @@ export function resolveTerminalMainSessionTranscriptRegistryCheck(
     // Callers already rotate failed rows when the transcript is missing.
     return undefined;
   }
+  if (params.entry.status === "done") {
+    // Successful rows stay reusable.  Transcript mtime can naturally be
+    // newer than the registry timestamp after post-run transcript writes,
+    // which would force a spurious rollover on the next inbound message.
+    return undefined;
+  }
   // updatedAt is touched after managed transcript appends; endedAt can predate
   // healthy post-run transcript writes and would rotate valid sessions.
   const registryTimestampMs = resolvePositiveTimestamp(params.entry.updatedAt);

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1285,10 +1285,7 @@ describe("gateway agent handler", () => {
     expect(capturedEntry?.sessionFile).toBeUndefined();
   });
 
-  it.each([
-    { name: "status terminal row", status: "done" as const },
-    { name: "endedAt-only terminal row" },
-  ])(
+  it.each([{ name: "endedAt-only terminal row" }])(
     "rotates a terminal main session from a $name when its transcript is newer",
     async (scenario) => {
       const now = Date.parse("2026-05-18T09:47:00.000Z");
@@ -1354,6 +1351,50 @@ describe("gateway agent handler", () => {
       );
     },
   );
+
+  it("reuses a terminal main session with status done when its transcript is newer", async () => {
+    const now = Date.parse("2026-05-18T09:47:00.000Z");
+    vi.useFakeTimers({ toFake: ["Date"] });
+    dateOnlyFakeClockActive = true;
+    vi.setSystemTime(now);
+
+    await withTempDir(
+      { prefix: "openclaw-gateway-terminal-main-done-newer-transcript-" },
+      async (root) => {
+        const sessionsDir = `${root}/sessions`;
+        await fs.mkdir(sessionsDir, { recursive: true });
+        const sessionFile = "done-main-session.jsonl";
+        const transcriptPath = `${sessionsDir}/${sessionFile}`;
+        await fs.writeFile(
+          transcriptPath,
+          `${JSON.stringify({ type: "session", id: "done-main-session" })}\n`,
+          "utf8",
+        );
+        await fs.utimes(transcriptPath, new Date(now - 1_000), new Date(now - 1_000));
+        mocks.loadSessionEntry.mockReturnValue({
+          cfg: {},
+          storePath: `${sessionsDir}/sessions.json`,
+          entry: {
+            sessionId: "done-main-session",
+            sessionFile,
+            status: "done" as const,
+            updatedAt: now - 10_000,
+            sessionStartedAt: now - 60_000,
+            lastInteractionAt: now - 10_000,
+          },
+          canonicalKey: "agent:main:main",
+        });
+
+        const capturedEntry = await runMainAgentAndCaptureEntry("test-idem-done-newer-transcript");
+
+        const call = await waitForAgentCommandCall<{ sessionId?: string }>();
+        // A successful status=done session stays reusable; do not force
+        // a spurious rollover just because the transcript mtime is newer.
+        expect(call.sessionId).toBe("done-main-session");
+        expect(capturedEntry?.sessionId).toBe("done-main-session");
+      },
+    );
+  });
 
   it("reuses terminal main sessions when the fresh store row has the transcript marker", async () => {
     const now = Date.parse("2026-05-18T09:47:30.000Z");


### PR DESCRIPTION
## What Problem This Solves

After a successful main-agent run in OpenClaw 2026.6.11, the session can roll over into a new session ID on the next inbound message. The old transcript is archived as `.jsonl.reset.*` even though the session completed normally with `status: "done"`.

The rollover is caused by `resolveTerminalMainSessionTranscriptRegistryCheck()` in `src/config/sessions/lifecycle.ts` treating `status: "done"` sessions the same as `timeout`/`killed` sessions. When the transcript file mtime is newer than `sessions.json.updatedAt` — which is normal after post-run transcript writes — the guard triggers and forces a new session ID instead of reusing the existing one.

Fixes #99964.

## Why This Change Was Made

In `resolveTerminalMainSessionTranscriptRegistryCheck()`, the guard already skips `status: "failed"` rows because "failed rows with a present transcript stay reusable for retry/recovery." The same logic applies to `status: "done"` — a successfully completed session should remain reusable for the next user message.

This change adds a parallel exclusion for `status: "done"`, returning `undefined` (skip the check) just like `status: "failed"`. The guard still applies to `status: "timeout"`, `status: "killed"`, and `endedAt`-only terminal rows.

**Not modified**: Session persistence, transcript archiving, gateway message delivery, idle/expiry reset logic.

## User Impact

Users running the main agent no longer experience spurious session rollovers after successful runs. Session continuity is preserved across inbound messages, and transcripts are not incorrectly archived as `.jsonl.reset`.

## Evidence

**Behavior addressed**: Successful (`done`) main-agent sessions roll over when transcript mtime > registry updatedAt

**Real environment tested**: `npx tsx` importing production code directly

**Exact steps or command run after this patch**:

```
$ npx tsx scripts/repro-99964-before-after.mjs
```

**Evidence after fix**:

```
[PASS] status=done: check=false (want=false)
[PASS] status=failed: check=false (want=false)
[PASS] status=timeout: check=true (want=true)
[PASS] status=killed: check=true (want=true)
[PASS] endedAt only (no status): check=true (want=true)

5/5 passed
```

--- [BEFORE fix] ---
```
[FAIL --> [CRITICAL_FAIL]] status=done: check=true (want=false)
  → done sessions were incorrectly triggering the rollover guard
```

--- [AFTER fix] ---
```
[PASS] status=done: check=false (want=false)
  → done sessions skip the guard and stay reusable
```

**Observed result after fix**: `resolveTerminalMainSessionTranscriptRegistryCheck` returns `undefined` for `status: "done"` — the session is reusable. `timeout`, `killed`, and `endedAt`-only terminal rows still trigger the check as expected.

**What was not tested**: Full gateway hot-reload cycle, cross-agent session migration, Windows/macOS filesystem mtime precision edge cases.

## Regression Test Plan

```
$ npx vitest run src/gateway/server-methods/agent.test.ts --run
 Test Files  2 passed (2)
      Tests  376 passed (376)

$ node scripts/run-oxlint.mjs src/config/sessions/lifecycle.ts \
    src/gateway/server-methods/agent.test.ts
→ exit 0
```

## AI Assistance

This PR was created with assistance from Claude Opus 4.8 (Anthropic). The author understands and takes responsibility for all code changes.
