### PR TITLE
Use Codex OAuth auth for ACPX isolated home

### DIFF
--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -36,12 +36,14 @@ function restoreEnv(name: keyof typeof previousEnv): void {
 }
 
 function generatedCodexPaths(stateDir: string): {
+  authPath: string;
   configPath: string;
   wrapperPath: string;
 } {
   const baseDir = path.join(stateDir, "acpx");
   const codexHome = path.join(baseDir, "codex-home");
   return {
+    authPath: path.join(codexHome, "auth.json"),
     configPath: path.join(codexHome, "config.toml"),
     wrapperPath: path.join(baseDir, "codex-acp-wrapper.mjs"),
   };
@@ -98,8 +100,9 @@ afterEach(async () => {
 });
 
 describe("prepareAcpxCodexAuthConfig", () => {
-  it("installs an isolated Codex ACP wrapper without synthesizing auth from canonical OpenClaw OAuth", async () => {
+  it("installs an isolated Codex ACP wrapper and seeds OAuth auth from source Codex home", async () => {
     const root = await makeTempDir();
+    const sourceCodexHome = path.join(root, "source-codex");
     const agentDir = path.join(root, "agent");
     const stateDir = path.join(root, "state");
     const generated = generatedCodexPaths(stateDir);
@@ -112,6 +115,15 @@ describe("prepareAcpxCodexAuthConfig", () => {
       "bin",
       "codex-acp.js",
     );
+    const sourceAuth = {
+      auth_mode: "chatgpt",
+      OPENAI_API_KEY: null,
+      tokens: { access_token: "source-access-token", refresh_token: "source-refresh-token" },
+      last_refresh: "2026-07-06T00:00:00.000Z",
+    };
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sourceCodexHome, "auth.json"), `${JSON.stringify(sourceAuth)}\n`);
+    process.env.CODEX_HOME = sourceCodexHome;
     process.env.OPENCLAW_AGENT_DIR = agentDir;
 
     const pluginConfig = resolveAcpxPluginConfig({
@@ -131,7 +143,73 @@ describe("prepareAcpxCodexAuthConfig", () => {
     const wrapper = await fs.readFile(generated.wrapperPath, "utf8");
     expect(wrapper).toContain(JSON.stringify(installedBinPath));
     expect(wrapper).toContain("defaultArgs = [installedBinPath]");
+    expect(JSON.parse(await fs.readFile(generated.authPath, "utf8"))).toEqual(sourceAuth);
+    if (process.platform !== "win32") {
+      const mode = (await fs.stat(generated.authPath)).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
     await expectPathMissing(path.join(agentDir, "acp-auth", "codex", "auth.json"));
+  });
+
+  it("replaces existing isolated Codex API-key auth with source OAuth auth during preparation", async () => {
+    const root = await makeTempDir();
+    const sourceCodexHome = path.join(root, "source-codex");
+    const stateDir = path.join(root, "state");
+    const generated = generatedCodexPaths(stateDir);
+    const sourceAuth = {
+      auth_mode: "chatgpt",
+      OPENAI_API_KEY: null,
+      tokens: { access_token: "source-access-token" },
+      last_refresh: null,
+    };
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sourceCodexHome, "auth.json"), `${JSON.stringify(sourceAuth)}\n`);
+    await fs.mkdir(path.dirname(generated.authPath), { recursive: true });
+    await fs.writeFile(
+      generated.authPath,
+      `${JSON.stringify({ OPENAI_API_KEY: "sk-old-api-key", tokens: null })}\n`,
+      { mode: 0o600 },
+    );
+    process.env.CODEX_HOME = sourceCodexHome;
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+    });
+
+    expect(JSON.parse(await fs.readFile(generated.authPath, "utf8"))).toEqual(sourceAuth);
+    if (process.platform !== "win32") {
+      const mode = (await fs.stat(generated.authPath)).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
+  });
+
+  it("does not copy malformed source Codex OAuth auth", async () => {
+    const root = await makeTempDir();
+    const sourceCodexHome = path.join(root, "source-codex");
+    const stateDir = path.join(root, "state");
+    const generated = generatedCodexPaths(stateDir);
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceCodexHome, "auth.json"),
+      `${JSON.stringify({ auth_mode: "chatgpt", OPENAI_API_KEY: null, tokens: {} })}\n`,
+    );
+    process.env.CODEX_HOME = sourceCodexHome;
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+    });
+
+    await expectPathMissing(generated.authPath);
   });
 
   it("keeps generated wrappers usable when chmod is rejected by the state filesystem", async () => {
@@ -324,6 +402,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
 
   it("writes API-key auth into the isolated Codex ACP home when env auth is present", async () => {
     const root = await makeTempDir();
+    const sourceCodexHome = path.join(root, "source-codex-without-auth");
     const stateDir = path.join(root, "state");
     const generated = generatedCodexPaths(stateDir);
     const installedBinPath = path.join(root, "codex-acp-bin.js");
@@ -332,6 +411,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
       "console.log(JSON.stringify({ codexHome: process.env.CODEX_HOME }));\n",
       "utf8",
     );
+    process.env.CODEX_HOME = sourceCodexHome;
     const pluginConfig = resolveAcpxPluginConfig({
       rawConfig: {},
       workspaceDir: root,
@@ -394,6 +474,43 @@ describe("prepareAcpxCodexAuthConfig", () => {
     });
 
     expect(JSON.parse(await fs.readFile(authPath, "utf8"))).toEqual(existingAuth);
+  });
+
+  it("updates malformed isolated Codex OAuth auth when env auth is present", async () => {
+    const root = await makeTempDir();
+    const sourceCodexHome = path.join(root, "source-codex-without-auth");
+    const stateDir = path.join(root, "state");
+    const generated = generatedCodexPaths(stateDir);
+    const installedBinPath = path.join(root, "codex-acp-bin.js");
+    await fs.writeFile(installedBinPath, "console.log('ok');\n", "utf8");
+    process.env.CODEX_HOME = sourceCodexHome;
+    const pluginConfig = resolveAcpxPluginConfig({
+      rawConfig: {},
+      workspaceDir: root,
+    });
+
+    await prepareAcpxCodexAuthConfig({
+      pluginConfig,
+      stateDir,
+      resolveInstalledCodexAcpBinPath: async () => installedBinPath,
+    });
+
+    await fs.writeFile(
+      generated.authPath,
+      `${JSON.stringify({ auth_mode: "chatgpt", OPENAI_API_KEY: null, tokens: {} })}\n`,
+      { mode: 0o600 },
+    );
+
+    await execFileAsync(process.execPath, [generated.wrapperPath], {
+      cwd: root,
+      env: { ...process.env, OPENAI_API_KEY: "sk-test-api-key" },
+    });
+
+    expect(JSON.parse(await fs.readFile(generated.authPath, "utf8"))).toMatchObject({
+      OPENAI_API_KEY: "sk-test-api-key",
+      tokens: null,
+      last_refresh: null,
+    });
   });
 
   it("updates existing isolated Codex API-key auth when env auth changes", async () => {
@@ -469,7 +586,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
     expect(launched.codexHome).toBeNull();
   });
 
-  it("does not copy source Codex auth", async () => {
+  it("does not copy source Codex API-key auth", async () => {
     const root = await makeTempDir();
     const sourceCodexHome = path.join(root, "source-codex");
     const agentDir = path.join(root, "agent");
@@ -547,6 +664,7 @@ describe("prepareAcpxCodexAuthConfig", () => {
     const wrapper = await fs.readFile(generated.wrapperPath, "utf8");
     expect(wrapper).toContain("CODEX_HOME: codexHome");
     expect(wrapper).not.toContain(sourceCodexHome);
+    await expectPathMissing(generated.authPath);
     await expectPathMissing(path.join(agentDir, "acp-auth", "codex-source", "auth.json"));
     await expectPathMissing(path.join(agentDir, "acp-auth", "codex", "auth.json"));
   });

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -540,6 +540,19 @@ function buildCodexAcpWrapperScript(installedBinPath?: string): string {
     envSetup: `const codexHome = fileURLToPath(new URL("./codex-home/", import.meta.url));
 const codexAuthPath = fileURLToPath(new URL("./codex-home/auth.json", import.meta.url));
 const codexApiKey = (process.env.CODEX_API_KEY || process.env.OPENAI_API_KEY || "").trim();
+function hasUsableCodexOAuthAuth(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    value.tokens &&
+    typeof value.tokens === "object" &&
+    !Array.isArray(value.tokens) &&
+    typeof value.OPENAI_API_KEY !== "string" &&
+    typeof value.tokens.access_token === "string" &&
+    value.tokens.access_token.trim().length > 0
+  );
+}
 let shouldWriteCodexApiKeyAuth = false;
 if (codexApiKey) {
   if (!existsSync(codexAuthPath)) {
@@ -547,10 +560,7 @@ if (codexApiKey) {
   } else {
     try {
       const existingCodexAuth = JSON.parse(readFileSync(codexAuthPath, "utf8"));
-      shouldWriteCodexApiKeyAuth =
-        !existingCodexAuth ||
-        typeof existingCodexAuth !== "object" ||
-        typeof existingCodexAuth.OPENAI_API_KEY === "string";
+      shouldWriteCodexApiKeyAuth = !hasUsableCodexOAuthAuth(existingCodexAuth);
     } catch {
       shouldWriteCodexApiKeyAuth = true;
     }
@@ -598,6 +608,63 @@ async function readSourceCodexConfig(codexHome: string): Promise<string | undefi
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isCodexOAuthAuth(value: unknown): value is Record<string, unknown> {
+  if (!isRecord(value) || !isRecord(value.tokens) || typeof value.OPENAI_API_KEY === "string") {
+    return false;
+  }
+  return (
+    typeof value.tokens.access_token === "string" && value.tokens.access_token.trim().length > 0
+  );
+}
+
+async function readCodexAuthFileIfExists(authPath: string): Promise<unknown | undefined> {
+  try {
+    const { value } = await readJsonFileWithFallback<unknown>(authPath, undefined);
+    return value;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function makeCodexAuthFilePrivateIfPossible(authPath: string): Promise<void> {
+  try {
+    await fs.chmod(authPath, 0o600);
+  } catch {
+    // Best effort: auth still lives inside OpenClaw state, and chmod is unavailable on some FSes.
+  }
+}
+
+async function seedIsolatedCodexOAuthAuth(params: {
+  sourceCodexHome: string;
+  codexHome: string;
+}): Promise<void> {
+  const isolatedAuthPath = path.join(params.codexHome, "auth.json");
+  const existingAuth = await readCodexAuthFileIfExists(isolatedAuthPath);
+  if (isCodexOAuthAuth(existingAuth)) {
+    return;
+  }
+
+  const sourceAuth = await readCodexAuthFileIfExists(
+    path.join(params.sourceCodexHome, "auth.json"),
+  );
+  if (!isCodexOAuthAuth(sourceAuth)) {
+    return;
+  }
+
+  await fs.writeFile(isolatedAuthPath, `${JSON.stringify(sourceAuth, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await makeCodexAuthFilePrivateIfPossible(isolatedAuthPath);
+}
+
 async function prepareIsolatedCodexHome(params: {
   baseDir: string;
   workspaceDir: string;
@@ -610,6 +677,7 @@ async function prepareIsolatedCodexHome(params: {
   ];
   const codexHome = path.join(params.baseDir, "codex-home");
   await fs.mkdir(codexHome, { recursive: true });
+  await seedIsolatedCodexOAuthAuth({ sourceCodexHome, codexHome });
   await fs.writeFile(
     path.join(codexHome, "config.toml"),
     renderIsolatedCodexConfig({


### PR DESCRIPTION
## What Problem This Solves

ACPX Codex prepares an isolated Codex home, but that home could end up using API-key auth even when the host Codex install has working OAuth auth. That makes ACP Codex spawns hit API-key quota failures while host Codex OAuth still works.

## Why This Change Was Made

This copies only token-based host Codex auth into the isolated ACPX Codex home, requiring a usable OAuth access token and no string OPENAI_API_KEY. It preserves existing isolated OAuth auth, rejects source API-key auth, keeps isolated config/trust rendering, and leaves the generated wrapper API-key fallback available when no valid OAuth auth exists.

## User Impact

ACP Codex spawn can use the same OAuth entitlement as host Codex and avoid false quota failures. API-key users keep the existing fallback behavior, and malformed OAuth auth no longer blocks env API-key fallback.

## Evidence

- `pnpm test extensions/acpx/src/codex-auth-bridge.test.ts` passed, 22/22
- `git diff --check origin/main...HEAD` passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main ...` clean: no accepted/actionable findings
