### PR TITLE
fix(cron): allow null fallbacks in cron tool patch payload schema

### DIFF
--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -224,7 +224,9 @@ describe("createCronToolSchema", () => {
           displayName: null,
           sessionKey: null,
           payload: {
+            model: null,
             toolsAllow: null,
+            fallbacks: null,
           },
         },
       }),
@@ -261,6 +263,8 @@ describe("createCronToolSchema", () => {
     expect(patchProps?.payload?.properties?.toolsAllow?.description).toMatch(/null to clear/i);
     expect(patchProps?.payload?.properties?.model?.type).toBe("string");
     expect(patchProps?.payload?.properties?.model?.description).toMatch(/null to clear/i);
+    expect(patchProps?.payload?.properties?.fallbacks?.type).toBe("array");
+    expect(patchProps?.payload?.properties?.fallbacks?.description).toMatch(/null to clear/i);
   });
 
   it("projects nullable cron fields for Gemini models behind OpenAI-compatible providers", () => {
@@ -271,6 +275,9 @@ describe("createCronToolSchema", () => {
       type: "string",
     });
     expect(propertyAt(jjccGeminiSchemaRecord, "patch.payload.toolsAllow")).toMatchObject({
+      type: "array",
+    });
+    expect(propertyAt(jjccGeminiSchemaRecord, "patch.payload.fallbacks")).toMatchObject({
       type: "array",
     });
     expect(propertyAt(jjccGeminiSchemaRecord, "patch.delivery.channel")).toMatchObject({

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -109,7 +109,11 @@ function failureDestinationModeSchema(params: { nullableClears: boolean }) {
   return Type.Optional(Type.Union(variants));
 }
 
-function cronPayloadObjectSchema(params: { model: TSchema; toolsAllow: TSchema }) {
+function cronPayloadObjectSchema(params: {
+  model: TSchema;
+  toolsAllow: TSchema;
+  fallbacks: TSchema;
+}) {
   return Type.Object(
     {
       kind: optionalStringEnum(CRON_PAYLOAD_KINDS, { description: "Payload kind" }),
@@ -120,7 +124,7 @@ function cronPayloadObjectSchema(params: { model: TSchema; toolsAllow: TSchema }
       timeoutSeconds: optionalFiniteNumberSchema({ minimum: 0 }),
       lightContext: Type.Optional(Type.Boolean()),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
-      fallbacks: Type.Optional(Type.Array(Type.String(), { description: "Fallback models" })),
+      fallbacks: params.fallbacks,
       toolsAllow: params.toolsAllow,
     },
     { additionalProperties: true },
@@ -161,6 +165,7 @@ function createCronPayloadSchema(): TSchema {
     cronPayloadObjectSchema({
       model: Type.Optional(Type.String({ description: "Model override" })),
       toolsAllow: Type.Optional(Type.Array(Type.String(), { description: "Allowed tools" })),
+      fallbacks: Type.Optional(Type.Array(Type.String(), { description: "Fallback models" })),
     }),
   );
 }
@@ -313,6 +318,7 @@ function createCronPatchObjectSchema(): TSchema {
           cronPayloadObjectSchema({
             model: nullableStringSchema("Model override, or null to clear"),
             toolsAllow: nullableStringArraySchema("Allowed tool ids, or null to clear"),
+            fallbacks: nullableStringArraySchema("Fallback models, or null to clear"),
           }),
         ),
         delivery: createCronDeliveryPatchSchema(),


### PR DESCRIPTION
## What Problem This Solves

Fixes #100707 — the cron tool's agent-facing TypeBox schema rejected `null` for `patch.payload.fallbacks`, preventing users from clearing per-job fallback overrides via the agent tool to restore global inheritance.

The underlying Gateway protocol types and `mergeCronPayload` service layer already support null clears for `fallbacks`. The gap was only in the tool schema validation layer.

## Why This Change Was Made

`cronPayloadObjectSchema` had `fallbacks` hardcoded as `Type.Optional(Type.Array(Type.String()))`, while `model` and `toolsAllow` were already parameterized and made nullable in the patch schema. This change adds a `fallbacks` parameter to match the existing pattern, passing a non-nullable schema for job creation and a nullable `string[] | null` schema for patch/update operations.

## User Impact

Users can now clear per-job fallback overrides via the cron agent tool with `patch.payload.fallbacks: null`, restoring global agent defaults without deleting and recreating the cron job.

## Evidence

- `pnpm test src/agents/tools/cron-tool.schema.test.ts`: 17 passed, 0 failed
- `pnpm test src/agents/tools/cron-tool.test.ts`: 140 passed, 0 failed

Changes:
- [src/agents/tools/cron-tool.ts](src/agents/tools/cron-tool.ts) — parameterize `fallbacks` in `cronPayloadObjectSchema`, pass nullable variant in patch schema
- [src/agents/tools/cron-tool.schema.test.ts](src/agents/tools/cron-tool.schema.test.ts) — add `model: null` and `fallbacks: null` assertions in null-clear tests, add provider projection assertions for `fallbacks`

Note: An existing PR (#100720) addresses the related zod config schema layer (`src/config/zod-schema.agent-model.ts`). This PR fixes the TypeBox agent tool schema layer, which is where the actual user-facing validation rejection occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
