### PR TITLE
fix(android): hide internal chat history rows

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -5235,7 +5235,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 150,
+      "line": 151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Thinking...",
       "surface": "android",
@@ -5243,7 +5243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 169,
+      "line": 170,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Running tools...",
       "surface": "android",
@@ -5251,7 +5251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 172,
+      "line": 173,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "${display.emoji} ${display.label}",
       "surface": "android",
@@ -5259,7 +5259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 190,
+      "line": 191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "... +${toolCalls.size - 6} more",
       "surface": "android",
@@ -5267,7 +5267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 235,
+      "line": 236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Retry",
       "surface": "android",
@@ -5275,7 +5275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 238,
+      "line": 239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Delete",
       "surface": "android",
@@ -5283,7 +5283,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 306,
+      "line": 307,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "You",
       "surface": "android",
@@ -5291,7 +5291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 307,
+      "line": 308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "System",
       "surface": "android",
@@ -5299,7 +5299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 308,
+      "line": 309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5307,7 +5307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 334,
+      "line": 335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Android chat history now excludes internal, reasoning, and tool-result rows from rendered messages and the offline transcript cache.
+
 The OpenClaw mascot now comes alive across onboarding and the app headers with the same float, blink, antenna-wiggle, and claw-snap animation as openclaw.ai.
 
 Adds read-only Cron Job details in Settings, including schedule, payload and delivery state, job ID copy, refresh, and nested back navigation.

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -1645,7 +1645,7 @@ class ChatController internal constructor(
     val messages =
       array.mapNotNull { item ->
         val obj = item.asObjectOrNull() ?: return@mapNotNull null
-        val role = obj["role"].asStringOrNull() ?: return@mapNotNull null
+        val role = normalizeVisibleChatMessageRole(obj["role"].asStringOrNull()) ?: return@mapNotNull null
         val content = parseChatMessageContents(obj)
         val ts = obj["timestamp"].asLongOrNull()
         ChatMessage(

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -1,5 +1,16 @@
 package ai.openclaw.app.chat
 
+import java.util.Locale
+
+private val visibleChatMessageRoles = setOf("user", "assistant", "system", "custom")
+
+/** Keeps transcript rows limited to roles Android renders as user-visible chat. */
+internal fun normalizeVisibleChatMessageRole(role: String?): String? =
+  role
+    ?.trim()
+    ?.lowercase(Locale.US)
+    ?.takeIf(visibleChatMessageRoles::contains)
+
 /**
  * Chat transcript item as delivered by gateway chat history and live chat events.
  */
@@ -56,7 +67,6 @@ data class ChatCommandEntry(
   val textAliases: List<String> = emptyList(),
   val acceptsArgs: Boolean = false,
 )
-
 
 /**
  * Run still streaming on the gateway when a chat.history snapshot was captured;

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
@@ -234,10 +234,11 @@ class RoomChatTranscriptCache internal constructor(
   ): List<ChatMessage> {
     val gateway = scopedGatewayId(gatewayId) ?: return emptyList()
     val key = sessionKey.trim().takeIf { it.isNotEmpty() } ?: return emptyList()
-    return database.dao().messages(gateway, key).map { row ->
+    return database.dao().messages(gateway, key).mapNotNull { row ->
+      val role = normalizeVisibleChatMessageRole(row.role) ?: return@mapNotNull null
       ChatMessage(
         id = UUID.randomUUID().toString(),
-        role = row.role,
+        role = role,
         content = decodeTextParts(row.textPartsJson).map { ChatMessageContent(type = "text", text = it) },
         timestampMs = row.timestampMs,
         idempotencyKey = row.idempotencyKey,
@@ -300,16 +301,17 @@ class RoomChatTranscriptCache internal constructor(
     val rows =
       messages
         .mapNotNull { message ->
+          val role = normalizeVisibleChatMessageRole(message.role) ?: return@mapNotNull null
           val textParts = message.content.filter { it.type == "text" }.mapNotNull { it.text }
           if (textParts.isEmpty()) return@mapNotNull null
-          message to textParts
+          Triple(message, role, textParts)
         }.takeLast(MAX_CACHED_MESSAGES_PER_SESSION)
-        .mapIndexed { index, (message, textParts) ->
+        .mapIndexed { index, (message, role, textParts) ->
           CachedMessageEntity(
             gatewayId = gateway,
             sessionKey = key,
             rowOrder = index,
-            role = message.role,
+            role = role,
             textPartsJson = json.encodeToString(textPartsSerializer, textParts),
             timestampMs = message.timestampMs,
             idempotencyKey = message.idempotencyKey,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -5,6 +5,7 @@ import ai.openclaw.app.chat.ChatMessageContent
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatOutboxStatus
 import ai.openclaw.app.chat.ChatPendingToolCall
+import ai.openclaw.app.chat.normalizeVisibleChatMessageRole
 import ai.openclaw.app.tools.ToolDisplayRegistry
 import ai.openclaw.app.ui.MobileColorsAccessor
 import ai.openclaw.app.ui.mobileAccent
@@ -60,7 +61,7 @@ private data class ChatBubbleStyle(
 /** Renders one persisted chat message as text and image parts. */
 @Composable
 fun ChatMessageBubble(message: ChatMessage) {
-  val role = message.role.trim().lowercase(Locale.US)
+  val role = normalizeVisibleChatMessageRole(message.role) ?: return
   val style = bubbleStyle(role)
 
   // Filter to only displayable content parts (text with content, or base64 images).

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerMessageIdentityTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerMessageIdentityTest.kt
@@ -1,5 +1,8 @@
 package ai.openclaw.app.chat
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import org.junit.Assert.assertEquals
@@ -38,6 +41,43 @@ class ChatControllerMessageIdentityTest {
 
     assertEquals(listOf(ChatMessageContent(type = "text", text = "Hi there")), content)
   }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun liveHistoryDropsInternalRoleRows() =
+    runTest {
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, _ ->
+            if (method == "chat.history") {
+              """
+              {
+                "messages": [
+                  { "role": "user", "content": "hello" },
+                  { "role": "toolResult", "content": "private tool output" },
+                  { "role": "internal", "text": "private reasoning" },
+                  { "role": "custom", "content": "visible plugin notice" },
+                  { "role": "Assistant", "content": "reply" }
+                ]
+              }
+              """.trimIndent()
+            } else {
+              "{}"
+            }
+          },
+        )
+
+      controller.load("main")
+      advanceUntilIdle()
+
+      assertEquals(listOf("user", "custom", "assistant"), controller.messages.value.map { it.role })
+      assertEquals(
+        listOf("hello", "visible plugin notice", "reply"),
+        controller.messages.value.map { it.content.single().text },
+      )
+    }
 
   @Test
   fun reconcileMessageIdsReusesMatchingIdsAcrossHistoryReload() {

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatTranscriptCacheTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatTranscriptCacheTest.kt
@@ -105,6 +105,28 @@ class RoomChatTranscriptCacheTest {
     }
 
   @Test
+  fun transcriptRoundTripDropsInternalRoleRows() =
+    runTest {
+      val store = cache()
+      store.saveTranscript(
+        gatewayId = "gateway-a",
+        sessionKey = "main",
+        messages =
+          listOf(
+            message("hello", role = "user"),
+            message("private tool output", role = "toolResult"),
+            message("visible plugin notice", role = "custom"),
+            message("reply", role = "assistant"),
+          ),
+      )
+
+      val loaded = store.loadTranscript("gateway-a", "main")
+
+      assertEquals(listOf("hello", "visible plugin notice", "reply"), loaded.map { it.content.single().text })
+      assertEquals(listOf("user", "custom", "assistant"), loaded.map { it.role })
+    }
+
+  @Test
   fun transcriptWriteKeepsOnlyNewestBoundedMessages() =
     runTest {
       val store = cache()


### PR DESCRIPTION
## What Problem This Solves

Fixes #87918. Android chat history accepted every gateway message role, so text-bearing `toolResult` or internal rows could be cached and rendered as normal OpenClaw chat bubbles.

## Why This Change Was Made

The gateway display projection intentionally preserves some non-chat rows for richer clients such as Control UI, so globally deleting tool rows would regress those clients. Android now applies one normalized user-visible role contract (`user`, `assistant`, `system`, and projected `custom`) at live-history parsing, transcript-cache writes and reads, and the final renderer.

## User Impact

Internal reasoning, tool-result payloads, and unknown internal roles no longer appear as Android chat messages or return from the offline transcript cache. User messages, assistant replies, system notices, and explicitly projected custom/plugin notices remain visible.

## Evidence

- Blacksmith Testbox `tbx_01kwvdq979j6y6kf62z0t0mnep`: `ChatControllerMessageIdentityTest` and `RoomChatTranscriptCacheTest` passed.
- Native i18n inventory check passed after the final rebase.
- Fresh high-effort autoreview accepted the visible-custom compatibility finding, then completed clean at confidence 0.96.
- Physical Android screenshot validation remains unavailable in this environment; the changed live-history and cache paths are covered at their production seams.
