### PR TITLE
fix(openai): strip status from replayed input items for custom openai-responses endpoints

### DIFF
--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -268,7 +268,14 @@ describe("openai responses payload policy", () => {
         {
           type: "message",
           role: "assistant",
-          content: [{ type: "output_text", text: "Hello", annotations: [] }],
+          content: [
+            {
+              type: "output_text",
+              text: "Hello",
+              annotations: [],
+              status: "nested-domain-value",
+            },
+          ],
           status: "completed",
         },
         {
@@ -287,19 +294,26 @@ describe("openai responses payload policy", () => {
     applyOpenAIResponsesPayloadPolicy(payload, policy);
     expect((payload.input[0] as Record<string, unknown>).status).toBeUndefined();
     expect((payload.input[2] as Record<string, unknown>).status).toBeUndefined();
+    expect((payload.input[0] as { content: Array<{ status?: string }> }).content[0]?.status).toBe(
+      "nested-domain-value",
+    );
   });
 
-  it("preserves status in input items for native OpenAI openai-responses endpoints", () => {
-    const model = {
-      id: "gpt-5.5",
+  it.each([
+    {
       api: "openai-responses",
       provider: "openai",
       baseUrl: "https://api.openai.com/v1",
-    } satisfies {
-      api: unknown;
-      baseUrl: unknown;
-      id: unknown;
-      provider: unknown;
+    },
+    {
+      api: "azure-openai-responses",
+      provider: "azure-openai",
+      baseUrl: "https://example.openai.azure.com/openai/v1",
+    },
+  ])("preserves status for native $provider Responses endpoints", (route) => {
+    const model = {
+      ...route,
+      id: "native-model",
     };
     const policy = resolveOpenAIResponsesPayloadPolicy(model);
     expect(policy.shouldStripInputStatus).toBe(false);

--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -247,4 +247,74 @@ describe("openai responses payload policy", () => {
     expect(policy.allowsServiceTier).toBe(true);
     expect(policy.shouldStripStore).toBe(false);
   });
+
+  it("strips status from input items for custom openai-responses endpoints", () => {
+    const model = {
+      id: "gpt-5.5",
+      api: "openai-responses",
+      provider: "custom-provider",
+      baseUrl: "http://custom-host:8317/v1",
+    } satisfies {
+      api: unknown;
+      baseUrl: unknown;
+      id: unknown;
+      provider: unknown;
+    };
+    const policy = resolveOpenAIResponsesPayloadPolicy(model);
+    expect(policy.shouldStripInputStatus).toBe(true);
+
+    const payload = {
+      input: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Hello", annotations: [] }],
+          status: "completed",
+        },
+        {
+          type: "function_call",
+          call_id: "call_1",
+          name: "test",
+          arguments: "{}",
+        },
+        {
+          type: "reasoning",
+          summary: [{ type: "summary_text", text: "Thinking..." }],
+          status: "completed",
+        },
+      ],
+    };
+    applyOpenAIResponsesPayloadPolicy(payload, policy);
+    expect((payload.input[0] as Record<string, unknown>).status).toBeUndefined();
+    expect((payload.input[2] as Record<string, unknown>).status).toBeUndefined();
+  });
+
+  it("preserves status in input items for native OpenAI openai-responses endpoints", () => {
+    const model = {
+      id: "gpt-5.5",
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+    } satisfies {
+      api: unknown;
+      baseUrl: unknown;
+      id: unknown;
+      provider: unknown;
+    };
+    const policy = resolveOpenAIResponsesPayloadPolicy(model);
+    expect(policy.shouldStripInputStatus).toBe(false);
+
+    const payload = {
+      input: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Hello", annotations: [] }],
+          status: "completed",
+        },
+      ],
+    };
+    applyOpenAIResponsesPayloadPolicy(payload, policy);
+    expect((payload.input[0] as Record<string, unknown>).status).toBe("completed");
+  });
 });

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -326,27 +326,15 @@ function stripDisabledOpenAIReasoningPayload(payloadObj: Record<string, unknown>
   }
 }
 
-/**
- * Recursively strip `status` fields from input items.
- * Strict OpenAI-compatible Responses endpoints reject the output-only `status`
- * field on replayed message items in `input[]` (HTTP 400 "Unknown parameter").
- * Known-native routes (api.openai.com, Azure) silently accept it.
- */
-export function stripInputStatusFromInput(input: unknown): void {
-  if (Array.isArray(input)) {
-    for (const item of input) {
-      stripInputStatusFromInput(item);
-    }
+/** Strip returned-item metadata rejected by strict Responses-compatible endpoints. */
+function stripInputItemStatuses(input: unknown): void {
+  if (!Array.isArray(input)) {
     return;
   }
-  if (!input || typeof input !== "object") {
-    return;
-  }
-  const record = input as Record<string, unknown>;
-  delete record.status;
-  for (const value of Object.values(record)) {
-    if (typeof value === "object" && value !== null) {
-      stripInputStatusFromInput(value);
+  for (const item of input) {
+    if (item && typeof item === "object" && !Array.isArray(item)) {
+      // Only item-level status is provider metadata. Nested values may be user or tool payloads.
+      delete (item as Record<string, unknown>).status;
     }
   }
 }
@@ -427,6 +415,6 @@ export function applyOpenAIResponsesPayloadPolicy(
     stripDisabledOpenAIReasoningPayload(payloadObj);
   }
   if (policy.shouldStripInputStatus) {
-    stripInputStatusFromInput(payloadObj.input);
+    stripInputItemStatuses(payloadObj.input);
   }
 }

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -53,6 +53,7 @@ type OpenAIResponsesPayloadPolicy = {
   compactThreshold: number;
   explicitStore: boolean | undefined;
   shouldStripDisabledReasoningPayload: boolean;
+  shouldStripInputStatus: boolean;
   shouldStripPromptCache: boolean;
   shouldStripStore: boolean;
   useServerCompaction: boolean;
@@ -325,6 +326,31 @@ function stripDisabledOpenAIReasoningPayload(payloadObj: Record<string, unknown>
   }
 }
 
+/**
+ * Recursively strip `status` fields from input items.
+ * Strict OpenAI-compatible Responses endpoints reject the output-only `status`
+ * field on replayed message items in `input[]` (HTTP 400 "Unknown parameter").
+ * Known-native routes (api.openai.com, Azure) silently accept it.
+ */
+export function stripInputStatusFromInput(input: unknown): void {
+  if (Array.isArray(input)) {
+    for (const item of input) {
+      stripInputStatusFromInput(item);
+    }
+    return;
+  }
+  if (!input || typeof input !== "object") {
+    return;
+  }
+  const record = input as Record<string, unknown>;
+  delete record.status;
+  for (const value of Object.values(record)) {
+    if (typeof value === "object" && value !== null) {
+      stripInputStatusFromInput(value);
+    }
+  }
+}
+
 /** Resolve payload mutation policy for one OpenAI Responses-style model endpoint. */
 export function resolveOpenAIResponsesPayloadPolicy(
   model: OpenAIResponsesPayloadModel,
@@ -346,6 +372,9 @@ export function resolveOpenAIResponsesPayloadPolicy(
   const shouldStripDisabledReasoningPayload =
     isResponsesApi &&
     (!capabilities.usesKnownNativeOpenAIRoute || !supportsOpenAIReasoningEffort(model, "none"));
+  // Strict OpenAI-compatible Responses endpoints reject output-only fields
+  // such as `status` on replayed input items. Strip them for non-native routes.
+  const shouldStripInputStatus = isResponsesApi && !capabilities.usesKnownNativeOpenAIRoute;
 
   return {
     allowsServiceTier: capabilities.allowsOpenAIServiceTier,
@@ -354,6 +383,7 @@ export function resolveOpenAIResponsesPayloadPolicy(
       resolveOpenAIResponsesCompactThreshold(model),
     explicitStore,
     shouldStripDisabledReasoningPayload,
+    shouldStripInputStatus,
     shouldStripPromptCache:
       options.enablePromptCacheStripping === true && capabilities.shouldStripResponsesPromptCache,
     shouldStripStore:
@@ -395,5 +425,8 @@ export function applyOpenAIResponsesPayloadPolicy(
   }
   if (policy.shouldStripDisabledReasoningPayload) {
     stripDisabledOpenAIReasoningPayload(payloadObj);
+  }
+  if (policy.shouldStripInputStatus) {
+    stripInputStatusFromInput(payloadObj.input);
   }
 }

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4268,6 +4268,7 @@ describe("openai transport stream", () => {
         id?: string;
         call_id?: string;
         phase?: string;
+        status?: string;
         encrypted_content?: string;
         summary?: unknown;
       }>;
@@ -4290,6 +4291,7 @@ describe("openai transport stream", () => {
       phase: "commentary",
     });
     expect(assistantMessage?.id).toBeUndefined();
+    expect(assistantMessage?.status).toBeUndefined();
     const functionCall = params.input?.find((item) => item.type === "function_call");
     expectRecordFields(functionCall, {
       type: "function_call",
@@ -4376,6 +4378,7 @@ describe("openai transport stream", () => {
         id?: string;
         call_id?: string;
         phase?: string;
+        status?: string;
         encrypted_content?: string;
         summary?: unknown;
       }>;
@@ -4395,6 +4398,7 @@ describe("openai transport stream", () => {
       role: "assistant",
       id: "msg_prior",
       phase: "commentary",
+      status: "completed",
     });
     const functionCall = params.input?.find((item) => item.type === "function_call");
     expectRecordFields(functionCall, {


### PR DESCRIPTION
## What Problem This Solves

Fixes #100657 — when using a custom provider configured with `api: "openai-responses"`, OpenClaw replays prior Responses items into the next request's `input[]` with a `status` field (e.g. `"completed"`). Strict OpenAI-compatible endpoints reject this output-only field with HTTP 400, causing OpenClaw to misclassify the primary model as having a format error and triggering unnecessary fallback.

## Why This Change Was Made

The `status` field on replayed message items (`input[n].status`) is an output-only field that OpenAI's native API silently accepts but strict third-party compatible endpoints reject. This change strips `status` from all `input[]` items specifically for non-native (custom/compatible) `openai-responses` providers, matching the existing pattern used for `shouldStripDisabledReasoningPayload`.

## User Impact

Custom `openai-responses` providers no longer see `400 Unknown parameter: 'input[n].status'` errors when OpenClaw replays conversation history. The primary model is correctly used instead of being unnecessarily fallen back.

## Evidence

- `pnpm test src/agents/openai-responses-payload-policy.test.ts`: 12 passed, 0 failed

Changes:
- [src/agents/openai-responses-payload-policy.ts](src/agents/openai-responses-payload-policy.ts) — add `shouldStripInputStatus` policy flag, `stripInputStatusFromInput` helper, and call from `applyOpenAIResponsesPayloadPolicy`
- [src/agents/openai-responses-payload-policy.test.ts](src/agents/openai-responses-payload-policy.test.ts) — add tests for stripping status on custom endpoints and preserving it on native OpenAI endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)
