### PR TITLE
fix(agents): preserve blank lines in multi-question user input fallback parsing

### DIFF
--- a/src/agents/harness/user-input-bridge.ts
+++ b/src/agents/harness/user-input-bridge.ts
@@ -92,8 +92,7 @@ export function buildAgentHarnessUserInputAnswers(
   const keyed = parseKeyedAnswers(inputText);
   const fallbackLines = inputText
     .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean);
+    .map((line) => line.trim());
   questions.forEach((question, index) => {
     const key =
       keyed.get(question.id.toLowerCase()) ??

--- a/src/plugin-sdk/agent-harness-runtime.test.ts
+++ b/src/plugin-sdk/agent-harness-runtime.test.ts
@@ -241,4 +241,23 @@ describe("agent harness user input helpers", () => {
       ),
     ).toContain("a &lt; b");
   });
+
+  it("preserves blank fallback lines so skipped answers stay aligned", () => {
+    expect(
+      buildAgentHarnessUserInputAnswers(
+        [
+          { id: "q1", header: "Q1", question: "First?" },
+          { id: "q2", header: "Q2", question: "Second?" },
+          { id: "q3", header: "Q3", question: "Third?" },
+        ],
+        "\nyes\nno",
+      ),
+    ).toEqual({
+      answers: {
+        q1: { answers: [] },
+        q2: { answers: ["yes"] },
+        q3: { answers: ["no"] },
+      },
+    });
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

When an agent is presented with multiple sequential questions, and the user skips a question (by submitting an empty line), the parser previously split the input using `.filter(Boolean)`. This stripped out empty lines, causing all subsequent answers to shift up by one index, resulting in incorrect answer-to-question mapping.

## Fix

Remove the `.filter(Boolean)` step in `buildAgentHarnessUserInputAnswers` to preserve blank lines, keeping the fallback lines array correctly aligned index-to-index with the questions list.

## Evidence

Input with 3 questions, skipping Q1:
```
Q1: Name? -> (blank)
Q2: Color? -> "blue"
Q3: Food? -> "pizza"
```
Before:
- Q1 maps to "blue"
- Q2 maps to "pizza"
- Q3 maps to empty

After:
- Q1 is empty
- Q2 is "blue"
- Q3 is "pizza"

## Test plan

Added unit test `preserves blank fallback lines so skipped answers stay aligned` in `src/plugin-sdk/agent-harness-runtime.test.ts`. Verified that all 16 tests pass.

### Real Behavior Proof
Running the multi-question fallback answer parser with a skipped first answer:
```
=== Raw User Reply ===
"\nTo seek the Holy Grail\nBlue"
======================
=== Parsed Answers ===
{
  "answers": {
    "q1": {
      "answers": []
    },
    "q2": {
      "answers": [
        "To seek the Holy Grail"
      ]
    },
    "q3": {
      "answers": [
        "Blue"
      ]
    }
  }
}
======================
```
