### PR TITLE
fix(auth): preserve copied auth profile order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent auth copy order:** preserve the source agent's portable auth-profile precedence when copying credentials to a new agent while excluding skipped profiles and transient auth state. (#100833) Thanks @machine3at.
 - **Cron edit delivery:** preserve each job's implicit delivery mode when applying partial delivery updates, so disabling best-effort delivery no longer turns detached job announcements off. (#100846) Thanks @machine3at.
 - **Control UI session creation:** keep newly created sessions at the front of the stable sidebar order after selecting another session. Thanks @shakkernerd.
 - **FTS-only memory startup:** skip plugin capability discovery when `memorySearch.provider` is explicitly `none`, avoiding an unnecessary cold-start scan.

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -48,7 +48,7 @@ export {
   suggestOAuthProfileIdForLegacyDefault,
 } from "./auth-profiles/repair.js";
 export {
-  buildPortableAuthProfileSecretsStoreForAgentCopy,
+  buildPortableAuthProfileStoreForAgentCopy,
   isAuthProfileCredentialPortableForAgentCopy,
   resolveAuthProfilePortability,
   type AuthProfilePortability,

--- a/src/agents/auth-profiles/portability.test.ts
+++ b/src/agents/auth-profiles/portability.test.ts
@@ -88,4 +88,89 @@ describe("auth profile portability", () => {
       reason: "credential-opted-out",
     });
   });
+
+  it("preserves order filtered to copied profile IDs", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:api-key": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-test",
+        },
+        "github-copilot:default": {
+          type: "token",
+          provider: "github-copilot",
+          token: "gho-test",
+        },
+        "openai:default": {
+          type: "oauth",
+          provider: "openai",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+      },
+      order: {
+        openai: ["openai:default", "openai:api-key"],
+        "github-copilot": ["github-copilot:default"],
+      },
+    };
+
+    const portable = buildPortableAuthProfileSecretsStoreForAgentCopy(store);
+
+    // "openai:default" is OAuth and skipped, so only "openai:api-key" remains
+    expect(portable.store.order).toEqual({
+      openai: ["openai:api-key"],
+      "github-copilot": ["github-copilot:default"],
+    });
+  });
+
+  it("omits order when the input store has no order", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:api-key": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-test",
+        },
+      },
+    };
+
+    const portable = buildPortableAuthProfileSecretsStoreForAgentCopy(store);
+
+    expect(portable.store.order).toBeUndefined();
+  });
+
+  it("drops provider from order when all its profile IDs are skipped", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "oauth",
+          provider: "openai",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+        "github-copilot:default": {
+          type: "token",
+          provider: "github-copilot",
+          token: "gho-test",
+        },
+      },
+      order: {
+        openai: ["openai:default"],
+        "github-copilot": ["github-copilot:default"],
+      },
+    };
+
+    const portable = buildPortableAuthProfileSecretsStoreForAgentCopy(store);
+
+    // openai provider entirely removed since its only profile was skipped
+    expect(portable.store.order).toEqual({
+      "github-copilot": ["github-copilot:default"],
+    });
+  });
 });

--- a/src/agents/auth-profiles/portability.test.ts
+++ b/src/agents/auth-profiles/portability.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, expect, it } from "vitest";
 import {
-  buildPortableAuthProfileSecretsStoreForAgentCopy,
+  buildPortableAuthProfileStoreForAgentCopy,
   resolveAuthProfilePortability,
 } from "./portability.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
@@ -35,7 +35,7 @@ describe("auth profile portability", () => {
       },
     };
 
-    const portable = buildPortableAuthProfileSecretsStoreForAgentCopy(store);
+    const portable = buildPortableAuthProfileStoreForAgentCopy(store);
 
     expect(portable.copiedProfileIds).toEqual(["openai:api-key", "github-copilot:default"]);
     expect(portable.skippedProfileIds).toEqual(["openai:default"]);
@@ -86,91 +86,6 @@ describe("auth profile portability", () => {
     ).toEqual({
       portable: false,
       reason: "credential-opted-out",
-    });
-  });
-
-  it("preserves order filtered to copied profile IDs", () => {
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: {
-        "openai:api-key": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-test",
-        },
-        "github-copilot:default": {
-          type: "token",
-          provider: "github-copilot",
-          token: "gho-test",
-        },
-        "openai:default": {
-          type: "oauth",
-          provider: "openai",
-          access: "access-token",
-          refresh: "refresh-token",
-          expires: Date.now() + 60_000,
-        },
-      },
-      order: {
-        openai: ["openai:default", "openai:api-key"],
-        "github-copilot": ["github-copilot:default"],
-      },
-    };
-
-    const portable = buildPortableAuthProfileSecretsStoreForAgentCopy(store);
-
-    // "openai:default" is OAuth and skipped, so only "openai:api-key" remains
-    expect(portable.store.order).toEqual({
-      openai: ["openai:api-key"],
-      "github-copilot": ["github-copilot:default"],
-    });
-  });
-
-  it("omits order when the input store has no order", () => {
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: {
-        "openai:api-key": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-test",
-        },
-      },
-    };
-
-    const portable = buildPortableAuthProfileSecretsStoreForAgentCopy(store);
-
-    expect(portable.store.order).toBeUndefined();
-  });
-
-  it("drops provider from order when all its profile IDs are skipped", () => {
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: {
-        "openai:default": {
-          type: "oauth",
-          provider: "openai",
-          access: "access-token",
-          refresh: "refresh-token",
-          expires: Date.now() + 60_000,
-        },
-        "github-copilot:default": {
-          type: "token",
-          provider: "github-copilot",
-          token: "gho-test",
-        },
-      },
-      order: {
-        openai: ["openai:default"],
-        "github-copilot": ["github-copilot:default"],
-      },
-    };
-
-    const portable = buildPortableAuthProfileSecretsStoreForAgentCopy(store);
-
-    // openai provider entirely removed since its only profile was skipped
-    expect(portable.store.order).toEqual({
-      "github-copilot": ["github-copilot:default"],
     });
   });
 });

--- a/src/agents/auth-profiles/portability.ts
+++ b/src/agents/auth-profiles/portability.ts
@@ -60,9 +60,9 @@ export function isAuthProfileCredentialPortableForAgentCopy(
   return resolveAuthProfilePortability(credential).portable;
 }
 
-/** Builds an agent-copy store containing only portable credentials. */
-export function buildPortableAuthProfileSecretsStoreForAgentCopy(store: AuthProfileStore): {
-  store: AuthProfileSecretsStore & Pick<AuthProfileStore, "order">;
+/** Builds an agent-copy store containing only portable credentials and their order. */
+export function buildPortableAuthProfileStoreForAgentCopy(store: AuthProfileStore): {
+  store: AuthProfileStore;
   copiedProfileIds: string[];
   skippedProfileIds: string[];
 } {
@@ -80,16 +80,18 @@ export function buildPortableAuthProfileSecretsStoreForAgentCopy(store: AuthProf
   ) as AuthProfileSecretsStore["profiles"];
 
   const copiedSet = new Set(copiedProfileIds);
-  const order = store.order
-    ? Object.fromEntries(
-        Object.entries(store.order)
-          .map(([provider, ids]) => [provider, ids.filter((id) => copiedSet.has(id))] as const)
-          .filter(([, ids]) => ids.length > 0),
-      )
-    : undefined;
+  const order = Object.fromEntries(
+    Object.entries(store.order ?? {})
+      .map(([provider, ids]) => [provider, ids.filter((id) => copiedSet.has(id))] as const)
+      .filter(([, ids]) => ids.length > 0),
+  );
 
   return {
-    store: { version: AUTH_STORE_VERSION, profiles, ...(order && { order }) },
+    store: {
+      version: AUTH_STORE_VERSION,
+      profiles,
+      ...(Object.keys(order).length > 0 ? { order } : {}),
+    },
     copiedProfileIds,
     skippedProfileIds,
   };

--- a/src/agents/auth-profiles/portability.ts
+++ b/src/agents/auth-profiles/portability.ts
@@ -62,7 +62,7 @@ export function isAuthProfileCredentialPortableForAgentCopy(
 
 /** Builds an agent-copy store containing only portable credentials. */
 export function buildPortableAuthProfileSecretsStoreForAgentCopy(store: AuthProfileStore): {
-  store: AuthProfileSecretsStore;
+  store: AuthProfileSecretsStore & Pick<AuthProfileStore, "order">;
   copiedProfileIds: string[];
   skippedProfileIds: string[];
 } {
@@ -79,8 +79,17 @@ export function buildPortableAuthProfileSecretsStoreForAgentCopy(store: AuthProf
     }),
   ) as AuthProfileSecretsStore["profiles"];
 
+  const copiedSet = new Set(copiedProfileIds);
+  const order = store.order
+    ? Object.fromEntries(
+        Object.entries(store.order)
+          .map(([provider, ids]) => [provider, ids.filter((id) => copiedSet.has(id))] as const)
+          .filter(([, ids]) => ids.length > 0),
+      )
+    : undefined;
+
   return {
-    store: { version: AUTH_STORE_VERSION, profiles },
+    store: { version: AUTH_STORE_VERSION, profiles, ...(order && { order }) },
     copiedProfileIds,
     skippedProfileIds,
   };

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
+import { resolveAuthProfileOrder } from "../agents/auth-profiles/order.js";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -237,6 +238,11 @@ describe("agents add command", () => {
               provider: "openai",
               key: "sk-test",
             },
+            "openai:backup": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-backup",
+            },
             "github-copilot:default": {
               type: "token",
               provider: "github-copilot",
@@ -250,6 +256,12 @@ describe("agents add command", () => {
               expires: Date.now() + 60_000,
             },
           },
+          order: {
+            openai: ["openai:oauth", "openai:backup", "openai:default"],
+            "github-copilot": ["github-copilot:default"],
+          },
+          lastGood: { openai: "openai:default" },
+          usageStats: { "openai:default": { lastUsed: 1_000 } },
         },
         sourceAgentDir,
       );
@@ -259,10 +271,21 @@ describe("agents add command", () => {
         destAgentDir,
       });
 
-      expect(result).toEqual({ copied: 2, skipped: 1 });
+      expect(result).toEqual({ copied: 3, skipped: 1 });
       const copied = loadPersistedAuthProfileStore(destAgentDir);
       expect(Object.keys(copied?.profiles ?? {}).toSorted()).toEqual([
         "github-copilot:default",
+        "openai:backup",
+        "openai:default",
+      ]);
+      expect(copied?.order).toEqual({
+        openai: ["openai:backup", "openai:default"],
+        "github-copilot": ["github-copilot:default"],
+      });
+      expect(copied?.lastGood).toBeUndefined();
+      expect(copied?.usageStats).toBeUndefined();
+      expect(resolveAuthProfileOrder({ store: copied!, provider: "openai" })).toEqual([
+        "openai:backup",
         "openai:default",
       ]);
     });

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -11,7 +11,7 @@ import {
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
 import {
-  buildPortableAuthProfileSecretsStoreForAgentCopy,
+  buildPortableAuthProfileStoreForAgentCopy,
   ensureAuthProfileStore,
 } from "../agents/auth-profiles.js";
 import { resolveAuthStorePath } from "../agents/auth-profiles/paths.js";
@@ -79,7 +79,7 @@ async function copyPortableAuthProfiles(params: {
   if (!sourceStore || Object.keys(sourceStore.profiles).length === 0) {
     return { copied: 0, skipped: 0 };
   }
-  const portable = buildPortableAuthProfileSecretsStoreForAgentCopy(sourceStore);
+  const portable = buildPortableAuthProfileStoreForAgentCopy(sourceStore);
   if (portable.copiedProfileIds.length === 0) {
     return { copied: 0, skipped: portable.skippedProfileIds.length };
   }
@@ -337,7 +337,7 @@ export async function agentsAddCommand(
         const sourceStore = loadPersistedAuthProfileStore(sourceAgentDir);
         const destStore = loadPersistedAuthProfileStore(agentDir);
         const portable = sourceStore
-          ? buildPortableAuthProfileSecretsStoreForAgentCopy(sourceStore)
+          ? buildPortableAuthProfileStoreForAgentCopy(sourceStore)
           : undefined;
         if (
           portable &&


### PR DESCRIPTION
## What Problem This Solves

Copying credentials into a new agent preserved portable profiles but discarded the source agent's configured provider order. The destination could therefore select a different credential than the source agent.

## Why This Change Was Made

The repaired portability helper constructs the complete destination store at the auth-store owner boundary. It filters each provider's order to profiles that are actually copied and deliberately excludes source-agent transient state such as last-good selection, cooldowns, and usage metadata.

## User Impact

Agents created with copied credentials keep the source agent's portable credential precedence without inheriting stale runtime state.

## Evidence

- Blacksmith Testbox `tbx_01kww7c2kejb3w4jew4grf9tcv`: 15 focused portability and real SQLite add/copy integration tests passed.
- The integration test resolves the destination order after persistence and verifies skipped OAuth profiles and transient metadata are absent.
- Same Testbox: `pnpm check:changed` passed.
- Fresh Codex autoreview: no actionable findings.

AI-assisted: yes. Maintainer repair, full owner/caller/sibling review, regression proof, and final validation were performed before landing.
