### PR TITLE
fix(media): map sandbox media with active workdir

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -364,6 +364,7 @@ export function createOpenClawTools(
         hasRepliedRef: options?.hasRepliedRef,
         sameChannelThreadRequired: options?.sameChannelThreadRequired,
         sandboxRoot: options?.sandboxRoot,
+        sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
         requireExplicitTarget: options?.requireExplicitMessageTarget,
         sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,
         inboundEventKind: options?.inboundEventKind,

--- a/src/agents/sandbox-paths.test.ts
+++ b/src/agents/sandbox-paths.test.ts
@@ -201,6 +201,32 @@ describe("resolveSandboxedMediaSource", () => {
     });
   });
 
+  it.each([
+    { media: "/sandbox/media/pic.png", containerWorkdir: "/sandbox" },
+    { media: "file:///sandbox/media/pic.png", containerWorkdir: "/sandbox/" },
+  ])("maps active container workdir media source $media", async ({ media, containerWorkdir }) => {
+    await withSandboxRoot(async (sandboxDir) => {
+      const result = await resolveSandboxedMediaSource({
+        media,
+        sandboxRoot: sandboxDir,
+        containerWorkdir,
+      });
+      expect(result).toBe(path.join(sandboxDir, "media", "pic.png"));
+    });
+  });
+
+  it("does not map similarly named active container workdir paths", async () => {
+    await withSandboxRoot(async (sandboxDir) => {
+      await expect(
+        resolveSandboxedMediaSource({
+          media: "/sandboxer/media/pic.png",
+          sandboxRoot: sandboxDir,
+          containerWorkdir: "/sandbox",
+        }),
+      ).rejects.toThrow(/sandbox/i);
+    });
+  });
+
   it("preserves remote mxc:// media sources", async () => {
     await withSandboxRoot(async (sandboxDir) => {
       const result = await resolveSandboxedMediaSource({

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -151,7 +151,9 @@ export async function resolveAllowedManagedMediaPath(
 export async function resolveSandboxedMediaSource(params: {
   media: string;
   sandboxRoot: string;
+  containerWorkdir?: string;
 }): Promise<string> {
+  const containerWorkdir = normalizeSandboxContainerWorkdir(params.containerWorkdir);
   const raw = params.media.trim();
   if (!raw) {
     return raw;
@@ -164,6 +166,7 @@ export async function resolveSandboxedMediaSource(params: {
     const workspaceMappedFromUrl = mapContainerWorkspaceFileUrl({
       fileUrl: candidate,
       sandboxRoot: params.sandboxRoot,
+      containerWorkdir,
     });
     if (workspaceMappedFromUrl) {
       candidate = workspaceMappedFromUrl;
@@ -180,6 +183,7 @@ export async function resolveSandboxedMediaSource(params: {
   const containerWorkspaceMapped = mapContainerWorkspacePath({
     candidate,
     sandboxRoot: params.sandboxRoot,
+    containerWorkdir,
   });
   if (containerWorkspaceMapped) {
     candidate = containerWorkspaceMapped;
@@ -218,6 +222,7 @@ async function assertNoManagedMediaAliasEscape(params: {
 function mapContainerWorkspaceFileUrl(params: {
   fileUrl: string;
   sandboxRoot: string;
+  containerWorkdir: string;
 }): string | undefined {
   let parsed: URL;
   try {
@@ -244,26 +249,28 @@ function mapContainerWorkspaceFileUrl(params: {
     return undefined;
   }
   if (
-    normalizedPathname !== SANDBOX_CONTAINER_WORKDIR &&
-    !normalizedPathname.startsWith(`${SANDBOX_CONTAINER_WORKDIR}/`)
+    normalizedPathname !== params.containerWorkdir &&
+    !normalizedPathname.startsWith(`${params.containerWorkdir}/`)
   ) {
     return undefined;
   }
   return mapContainerWorkspacePath({
     candidate: normalizedPathname,
     sandboxRoot: params.sandboxRoot,
+    containerWorkdir: params.containerWorkdir,
   });
 }
 
 function mapContainerWorkspacePath(params: {
   candidate: string;
   sandboxRoot: string;
+  containerWorkdir: string;
 }): string | undefined {
   const normalized = params.candidate.replace(/\\/g, "/");
-  if (normalized === SANDBOX_CONTAINER_WORKDIR) {
+  if (normalized === params.containerWorkdir) {
     return path.resolve(params.sandboxRoot);
   }
-  const prefix = `${SANDBOX_CONTAINER_WORKDIR}/`;
+  const prefix = `${params.containerWorkdir}/`;
   if (!normalized.startsWith(prefix)) {
     return undefined;
   }
@@ -272,6 +279,13 @@ function mapContainerWorkspacePath(params: {
     return path.resolve(params.sandboxRoot);
   }
   return path.resolve(params.sandboxRoot, ...rel.split("/").filter(Boolean));
+}
+
+function normalizeSandboxContainerWorkdir(containerWorkdir?: string): string {
+  const normalized = path.posix.normalize(
+    (containerWorkdir?.trim() || SANDBOX_CONTAINER_WORKDIR).replace(/\\/g, "/"),
+  );
+  return normalized === "." ? SANDBOX_CONTAINER_WORKDIR : normalized.replace(/\/+$/, "") || "/";
 }
 
 async function resolveAllowedTmpMediaPath(params: {

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -137,6 +137,7 @@ type RunMessageActionInput = {
   params?: Record<string, unknown>;
   requesterSenderId?: string;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   sessionKey?: string;
   sourceReplyDeliveryMode?: string;
   inboundAudio?: boolean;
@@ -3182,15 +3183,17 @@ describe("message tool sandbox passthrough", () => {
   it.each([
     {
       name: "forwards sandboxRoot to runMessageAction",
-      toolOptions: { sandboxRoot: "/tmp/sandbox" },
-      expected: "/tmp/sandbox",
+      toolOptions: { sandboxRoot: "/tmp/sandbox", sandboxContainerWorkdir: "/sandbox" },
+      expectedRoot: "/tmp/sandbox",
+      expectedWorkdir: "/sandbox",
     },
     {
       name: "omits sandboxRoot when not configured",
       toolOptions: {},
-      expected: undefined,
+      expectedRoot: undefined,
+      expectedWorkdir: undefined,
     },
-  ])("$name", async ({ toolOptions, expected }) => {
+  ])("$name", async ({ toolOptions, expectedRoot, expectedWorkdir }) => {
     mockSendResult({ to: "telegram:123" });
 
     const call = await executeSend({
@@ -3200,7 +3203,8 @@ describe("message tool sandbox passthrough", () => {
         message: "",
       },
     });
-    expect(call?.sandboxRoot).toBe(expected);
+    expect(call?.sandboxRoot).toBe(expectedRoot);
+    expect(call?.sandboxContainerWorkdir).toBe(expectedWorkdir);
   });
 
   it("forwards trusted requesterSenderId to runMessageAction", async () => {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -894,6 +894,7 @@ type MessageToolOptions = {
   hasRepliedRef?: { value: boolean };
   sameChannelThreadRequired?: boolean;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   requireExplicitTarget?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   inboundEventKind?: InboundEventKind;
@@ -1501,6 +1502,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           sessionId: options?.sessionId,
           agentId: resolvedAgentId,
           sandboxRoot: options?.sandboxRoot,
+          sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
           sourceReplyDeliveryMode: sourceReplySinkDeliveryMode,
           inboundEventKind: options?.inboundEventKind,
           inboundAudio: options?.currentInboundAudio,

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -44,8 +44,8 @@ function requireRecord(value: unknown, label: string): Record<string, unknown> {
 }
 
 function expectMedia(result: NormalizedReply, mediaUrl: string, mediaUrls: string[]): void {
-  expect(result.mediaUrl).toBe(mediaUrl);
-  expect(result.mediaUrls).toEqual(mediaUrls);
+  expectPathLike(result.mediaUrl).toBePathLike(mediaUrl);
+  expectPathLikeList(result.mediaUrls).toEqualPathLikeList(mediaUrls);
 }
 
 function expectNoMedia(result: NormalizedReply): void {
@@ -62,7 +62,7 @@ function expectOutboundAttachmentCall(
   if (!call) {
     throw new Error(`missing outbound attachment call ${index + 1}`);
   }
-  expect(call[0]).toBe(mediaUrl);
+  expectPathLike(call[0]).toBePathLike(mediaUrl);
   expect(call[1]).toBe(mediaMaxBytes);
   return requireRecord(call[2], "outbound attachment options");
 }
@@ -73,6 +73,37 @@ function expectAgentScopedMediaAccessCall(): Record<string, unknown> {
     throw new Error("missing agent scoped media access call");
   }
   return requireRecord(call[0], "agent scoped media access request");
+}
+
+function normalizePathLike(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  if (/^[a-z][a-z0-9+.-]*:/iu.test(value) && !/^[a-z]:[\\/]/iu.test(value)) {
+    return value;
+  }
+  const normalized = path.normalize(value);
+  return normalized.replace(/^[A-Z]:/iu, "");
+}
+
+function normalizePathLikeList(value: unknown): unknown {
+  return Array.isArray(value) ? value.map(normalizePathLike) : value;
+}
+
+function expectPathLike(value: unknown) {
+  return {
+    toBePathLike(expected: string) {
+      expect(normalizePathLike(value)).toBe(normalizePathLike(expected));
+    },
+  };
+}
+
+function expectPathLikeList(value: unknown) {
+  return {
+    toEqualPathLikeList(expected: string[]) {
+      expect(normalizePathLikeList(value)).toEqual(normalizePathLikeList(expected));
+    },
+  };
 }
 
 describe("createReplyMediaPathNormalizer", () => {
@@ -177,6 +208,28 @@ describe("createReplyMediaPathNormalizer", () => {
       path.join("/tmp/sandboxes/session-1", "screens", "final.png"),
       5 * 1024 * 1024,
     );
+  });
+
+  it("maps active sandbox container workdir media back to the host sandbox workspace", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/sandbox/",
+    });
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["file:///sandbox/screens/final.png"],
+    });
+
+    const stagedPath = path.join("/tmp/outbound-media", "final.png");
+    expectMedia(result, stagedPath, [stagedPath]);
+    const call = resolveOutboundAttachmentFromUrl.mock.calls[0] as unknown[] | undefined;
+    expect(call?.[0]).toEqual(expect.stringMatching(/[\\/]screens[\\/]final\.png$/));
+    expect(call?.[1]).toBe(5 * 1024 * 1024);
   });
 
   it("drops sandbox-mapped media when staging fails instead of retrying the workspace fallback", async () => {
@@ -519,11 +572,15 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(resolveAgentScopedOutboundMediaAccess).toHaveBeenCalledTimes(1);
-    expect(expectAgentScopedMediaAccessCall()).toEqual({
+    const accessRequest = expectAgentScopedMediaAccessCall();
+    expect({
+      ...accessRequest,
+      mediaSources: normalizePathLikeList(accessRequest.mediaSources),
+    }).toEqual({
       cfg: {},
       agentId: undefined,
       workspaceDir: "/tmp/agent-workspace",
-      mediaSources: [path.join("/tmp/agent-workspace", "out", "photo.png")],
+      mediaSources: normalizePathLikeList([path.join("/tmp/agent-workspace", "out", "photo.png")]),
       sessionKey: undefined,
       messageProvider: "whatsapp",
       accountId: "source-account",
@@ -552,11 +609,15 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(resolveAgentScopedOutboundMediaAccess).toHaveBeenCalledTimes(1);
     const accessRequest = expectAgentScopedMediaAccessCall();
     expect(typeof accessRequest.agentId).toBe("string");
-    expect({ ...accessRequest, agentId: undefined }).toEqual({
+    expect({
+      ...accessRequest,
+      agentId: undefined,
+      mediaSources: normalizePathLikeList(accessRequest.mediaSources),
+    }).toEqual({
       cfg: { tools: { fs: { workspaceOnly: false } } },
       agentId: undefined,
       workspaceDir: "/tmp/agent-workspace",
-      mediaSources: [absolutePath],
+      mediaSources: normalizePathLikeList([absolutePath]),
       sessionKey: "session-key",
       messageProvider: undefined,
       accountId: undefined,
@@ -586,11 +647,15 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(resolveAgentScopedOutboundMediaAccess).toHaveBeenCalledTimes(1);
     const accessRequest = expectAgentScopedMediaAccessCall();
     expect(typeof accessRequest.agentId).toBe("string");
-    expect({ ...accessRequest, agentId: undefined }).toEqual({
+    expect({
+      ...accessRequest,
+      agentId: undefined,
+      mediaSources: normalizePathLikeList(accessRequest.mediaSources),
+    }).toEqual({
       cfg: { tools: { fs: { workspaceOnly: false } } },
       agentId: undefined,
       workspaceDir: "/tmp/agent-workspace",
-      mediaSources: [homeRelativePath],
+      mediaSources: normalizePathLikeList([homeRelativePath]),
       sessionKey: "session-key",
       messageProvider: undefined,
       accountId: undefined,

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -82,18 +82,29 @@ export function createReplyMediaPathNormalizer(params: {
     channel: params.messageProvider,
     accountId: params.accountId,
   });
-  let sandboxRootPromise: Promise<string | undefined> | undefined;
+  let sandboxWorkspacePromise:
+    | Promise<{ workspaceDir: string; containerWorkdir?: string } | undefined>
+    | undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 
-  const resolveSandboxRoot = async (): Promise<string | undefined> => {
-    if (!sandboxRootPromise) {
-      sandboxRootPromise = ensureSandboxWorkspaceForSession({
+  const resolveSandboxWorkspace = async (): Promise<
+    { workspaceDir: string; containerWorkdir?: string } | undefined
+  > => {
+    if (!sandboxWorkspacePromise) {
+      sandboxWorkspacePromise = ensureSandboxWorkspaceForSession({
         config: params.cfg,
         sessionKey: params.sessionKey,
         workspaceDir: params.workspaceDir,
-      }).then((sandbox) => sandbox?.workspaceDir);
+      }).then((sandbox) =>
+        sandbox
+          ? {
+              workspaceDir: sandbox.workspaceDir,
+              ...(sandbox.containerWorkdir ? { containerWorkdir: sandbox.containerWorkdir } : {}),
+            }
+          : undefined,
+      );
     }
-    return await sandboxRootPromise;
+    return await sandboxWorkspacePromise;
   };
 
   const resolveMediaAccessForSource = (media: string) =>
@@ -175,13 +186,14 @@ export function createReplyMediaPathNormalizer(params: {
       !media.startsWith("~") &&
       !path.isAbsolute(media) &&
       !WINDOWS_DRIVE_RE.test(media);
-    const sandboxRoot = await resolveSandboxRoot();
-    if (sandboxRoot) {
+    const sandboxWorkspace = await resolveSandboxWorkspace();
+    if (sandboxWorkspace) {
       let sandboxResolvedMedia: string;
       try {
         sandboxResolvedMedia = await resolveSandboxedMediaSource({
           media,
-          sandboxRoot,
+          sandboxRoot: sandboxWorkspace.workspaceDir,
+          containerWorkdir: sandboxWorkspace.containerWorkdir,
         });
       } catch (err) {
         if (FILE_URL_RE.test(media)) {

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -162,6 +162,21 @@ describe("message action media helpers", () => {
     }
   });
 
+  maybeIt("normalizes sandbox media lists with the active container workdir", async () => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-list-sandbox-"));
+    try {
+      await expect(
+        normalizeSandboxMediaList({
+          values: [" file:///sandbox/assets/photo.png ", "/sandbox/assets/photo.png"],
+          sandboxRoot,
+          sandboxContainerWorkdir: "/sandbox/",
+        }),
+      ).resolves.toEqual([path.join(sandboxRoot, "assets", "photo.png")]);
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+
   maybeIt("normalizes mediaUrl and fileUrl sandbox media params", async () => {
     const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-alias-"));
     try {
@@ -225,6 +240,30 @@ describe("message action media helpers", () => {
 
       expect(args.avatarPath).toBe(path.join(sandboxRoot, "avatars", "profile.png"));
       expect(args.avatarUrl).toBe(path.join(sandboxRoot, "avatars", "remote-avatar.jpg"));
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+
+  maybeIt("normalizes sandbox media params with the active container workdir", async () => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-active-workdir-"));
+    try {
+      const args: Record<string, unknown> = {
+        mediaUrl: " file:///sandbox/assets/photo.png ",
+        fileUrl: "/sandbox/docs/report.pdf",
+      };
+
+      await normalizeSandboxMediaParams({
+        args,
+        mediaPolicy: {
+          mode: "sandbox",
+          sandboxRoot,
+          containerWorkdir: "/sandbox/",
+        },
+      });
+
+      expect(args.mediaUrl).toBe(path.join(sandboxRoot, "assets", "photo.png"));
+      expect(args.fileUrl).toBe(path.join(sandboxRoot, "docs", "report.pdf"));
     } finally {
       await fs.rm(sandboxRoot, { recursive: true, force: true });
     }

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -400,6 +400,7 @@ export type AttachmentMediaPolicy =
   | {
       mode: "sandbox";
       sandboxRoot: string;
+      containerWorkdir?: string;
     }
   | {
       mode: "host";
@@ -411,6 +412,7 @@ export type AttachmentMediaPolicy =
 /** Chooses sandbox or host media loading policy for attachment hydration. */
 export function resolveAttachmentMediaPolicy(params: {
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[] | "any";
   mediaReadFile?: OutboundMediaReadFile;
@@ -420,6 +422,9 @@ export function resolveAttachmentMediaPolicy(params: {
     return {
       mode: "sandbox",
       sandboxRoot,
+      ...(params.sandboxContainerWorkdir?.trim()
+        ? { containerWorkdir: params.sandboxContainerWorkdir }
+        : {}),
     };
   }
   const explicitLocalRoots = resolveOutboundMediaLocalRoots(params.mediaLocalRoots);
@@ -558,7 +563,12 @@ export async function normalizeSandboxMediaParams(params: {
     if (!sandboxRoot) {
       continue;
     }
-    const normalized = await resolveSandboxedMediaSource({ media: entry.value, sandboxRoot });
+    const normalized = await resolveSandboxedMediaSource({
+      media: entry.value,
+      sandboxRoot,
+      containerWorkdir:
+        params.mediaPolicy.mode === "sandbox" ? params.mediaPolicy.containerWorkdir : undefined,
+    });
     if (normalized !== entry.value) {
       params.args[entry.key] = normalized;
     }
@@ -580,6 +590,8 @@ export async function normalizeSandboxMediaParams(params: {
     const normalized = await resolveSandboxedMediaSource({
       media: attachmentSource.value,
       sandboxRoot,
+      containerWorkdir:
+        params.mediaPolicy.mode === "sandbox" ? params.mediaPolicy.containerWorkdir : undefined,
     });
     if (normalized !== attachmentSource.value) {
       attachmentSource.attachment[attachmentSource.key] = normalized;
@@ -591,6 +603,7 @@ export async function normalizeSandboxMediaParams(params: {
 export async function normalizeSandboxMediaList(params: {
   values: string[];
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
 }): Promise<string[]> {
   const sandboxRoot = params.sandboxRoot?.trim();
   const normalized: string[] = [];
@@ -602,7 +615,11 @@ export async function normalizeSandboxMediaList(params: {
     }
     assertMediaNotDataUrl(raw);
     const resolved = sandboxRoot
-      ? await resolveSandboxedMediaSource({ media: raw, sandboxRoot })
+      ? await resolveSandboxedMediaSource({
+          media: raw,
+          sandboxRoot,
+          containerWorkdir: params.sandboxContainerWorkdir,
+        })
       : raw;
     if (seen.has(resolved)) {
       continue;

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -110,6 +110,7 @@ const runDrySend = (params: {
   cfg: OpenClawConfig;
   actionParams: Record<string, unknown>;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
 }) =>
   runMessageAction({
     cfg: params.cfg,
@@ -117,6 +118,7 @@ const runDrySend = (params: {
     params: params.actionParams as never,
     dryRun: true,
     sandboxRoot: params.sandboxRoot,
+    sandboxContainerWorkdir: params.sandboxContainerWorkdir,
   });
 
 function requireRecord(value: unknown): Record<string, unknown> {
@@ -558,6 +560,40 @@ describe("runMessageAction media behavior", () => {
       const sendMediaAccess = requireRecord(sendCtx.mediaAccess);
       expect(sendMediaAccess.localRoots).toEqual(expect.arrayContaining([sandboxDir]));
       expect(sendParams.mediaUrls).toEqual([
+        path.join(sandboxDir, "one.png"),
+        path.join(sandboxDir, "two.png"),
+      ]);
+    });
+  });
+
+  it("maps send mediaUrls through the active sandbox container workdir", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: workspacePlugin,
+        },
+      ]),
+    );
+
+    await withSandbox(async (sandboxDir) => {
+      const result = await runDrySend({
+        cfg: workspaceConfig,
+        actionParams: {
+          channel: "workspace",
+          target: "12345678",
+          mediaUrls: ["file:///sandbox/one.png", "/sandbox/two.png"],
+        },
+        sandboxRoot: sandboxDir,
+        sandboxContainerWorkdir: "/sandbox/",
+      });
+
+      expect(result.kind).toBe("send");
+      if (result.kind !== "send") {
+        throw new Error("expected send result");
+      }
+      expect(result.sendResult?.mediaUrls).toEqual([
         path.join(sandboxDir, "one.png"),
         path.join(sandboxDir, "two.png"),
       ]);

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -130,6 +130,7 @@ export type RunMessageActionParams = {
   sessionKey?: string;
   agentId?: string;
   sandboxRoot?: string;
+  sandboxContainerWorkdir?: string;
   dryRun?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   inboundEventKind?: InboundEventKind;
@@ -949,6 +950,7 @@ async function buildSendPayloadParts(params: {
   const normalizedMediaUrls = await normalizeSandboxMediaList({
     values: mergedMediaUrls,
     sandboxRoot: input.sandboxRoot,
+    sandboxContainerWorkdir: input.sandboxContainerWorkdir,
   });
   mergedMediaUrls.length = 0;
   mergedMediaUrls.push(...normalizedMediaUrls);
@@ -1512,6 +1514,7 @@ export async function runMessageAction(
   const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
   const normalizationPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
+    sandboxContainerWorkdir: input.sandboxContainerWorkdir,
     mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, resolvedAgentId),
   });
   const extraActionMediaSourceParamKeys = resolveExtraActionMediaSourceParamKeys({
@@ -1551,6 +1554,7 @@ export async function runMessageAction(
   });
   const mediaPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
+    sandboxContainerWorkdir: input.sandboxContainerWorkdir,
     mediaAccess,
   });
   const gateway = resolveGateway(input);


### PR DESCRIPTION
Closes #98446

## What Problem This Solves

Fixes an issue where OpenShell sandbox users could generate media under `/sandbox/...` but reply/message media handling only recognized `/workspace/...`, causing sandbox media transfer to be rejected before outbound delivery.

## Why This Change Was Made

The fix threads the active sandbox `containerWorkdir` into sandbox media normalization and outbound message-action media policy. It keeps `/workspace` as the default for Docker-style sandboxes, normalizes trailing slash spellings such as `/sandbox/`, and does not loosen OpenShell managed-root validation.

## User Impact

OpenShell sandbox media paths under `/sandbox/...` can now resolve to the host sandbox workspace for reply and message-action delivery. Docker `/workspace/...` behavior is unchanged, and similarly named paths such as `/sandboxer/...` remain rejected.

## Evidence

Head SHA: d272cf5ef95dac88d3da48d4d3b2a803704a3e9d

- `git diff --check` passed.
- `node scripts/run-vitest.mjs src/auto-reply/reply/reply-media-paths.test.ts` passed: 1 file, 23 tests.
- `node scripts/run-vitest.mjs src/agents/sandbox-paths.test.ts src/infra/outbound/message-action-params.test.ts src/infra/outbound/message-action-runner.media.test.ts src/agents/tools/message-tool.test.ts` passed: 4 files, 208 passed / 13 skipped.
- Real OpenShell backend proof passed on the contributor fork at the same head: https://github.com/qingminglong/openclaw/actions/runs/28793386124
  - Workflow: `OpenClaw Live And E2E Checks (Reusable)` with focused `openshell-e2e` only.
  - Job: `validate_special_e2e (openshell-e2e, OpenShell repo E2E, pnpm test:e2e:openshell, 60, true, false)` passed on Ubuntu 24.04.
  - The job checked out `qingminglong/openclaw` at `d272cf5ef95dac88d3da48d4d3b2a803704a3e9d`, installed the OpenShell CLI, bootstrapped a local registered OpenShell gateway, and ran `pnpm test:e2e:openshell`.
  - The E2E test `creates a remote-canonical sandbox through OpenShell and executes over SSH` passed. It builds a custom OpenShell sandbox image whose `WORKDIR` is `/sandbox`, creates the sandbox through OpenShell, executes over SSH, asserts remote `pwd` contains `/sandbox`, reads seeded workspace data, verifies the OpenShell SSH config path, and exercises OpenShell host policy allow/deny behavior.

Related PR state:
- #98474 remains open but carries `rating: unranked` and `status: re-review loop`; this PR keeps the fix focused on the active sandbox workdir path and covers trailing-slash `/sandbox/` mapping plus `/sandboxer/...` rejection.

Not tested / proof gaps:
- The fork OpenShell E2E proves the real OpenShell `/sandbox` backend, gateway, SSH execution, and filesystem bridge path at this PR head. It does not separately send a channel/Gateway outbound media message from `/sandbox/...`; that media normalization and outbound delivery path remains covered by the focused `reply-media-paths`, `message-action-params`, `message-action-runner.media`, and `message-tool` tests above.