### PR TITLE
fix(oauth): pass workspace context to resolveProviderIdForAuth on refresh failure

### DIFF
--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -185,6 +185,7 @@ type ResolveApiKeyForProfileParams = {
   profileId: string;
   agentDir?: string;
   forceRefresh?: boolean;
+  workspaceDir?: string;
 };
 
 type SecretDefaults = NonNullable<OpenClawConfig["secrets"]>["defaults"];
@@ -464,7 +465,10 @@ export async function resolveApiKeyForProfile(
         hasRuntimeAuthProfileStoreSnapshot(params.agentDir)
       ) {
         const snapshot = getRuntimeAuthProfileStoreSnapshot(params.agentDir);
-        const providerKey = resolveProviderIdForAuth(cred.provider);
+        const providerKey = resolveProviderIdForAuth(cred.provider, {
+          config: cfg,
+          workspaceDir: params.workspaceDir,
+        });
         if (snapshot?.lastGood?.[providerKey] === profileId) {
           delete snapshot.lastGood[providerKey];
           if (Object.keys(snapshot.lastGood).length === 0) {

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -390,6 +390,7 @@ export async function prepareCliRunContext(
       store: writableAuthStore,
       profileId: authProfileId,
       agentDir,
+      workspaceDir,
     });
     const resolvedAuthProfileId = resolvedAuth?.profileId ?? authProfileId;
     const resolvedAuthCredential = resolvedAuth?.credential;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -550,6 +550,7 @@ export async function resolveProviderEntryApiKeyBinding(params: {
   provider: string;
   store: AuthProfileStore;
   agentDir?: string;
+  workspaceDir?: string;
 }): Promise<ProviderEntryApiKeyBindingResolution> {
   const reference = resolveProviderEntryApiKeyProfileReference(params);
   if (reference.kind === "none" || reference.kind === "marker") {
@@ -567,6 +568,7 @@ export async function resolveProviderEntryApiKeyBinding(params: {
       store: params.store,
       profileId: reference.profileId,
       agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
     });
     if (!resolved) {
       return { kind: "profile-unresolved", profileId: reference.profileId };
@@ -1055,6 +1057,7 @@ export async function resolveApiKeyForProvider(params: {
       profileId,
       agentDir,
       forceRefresh: params.forceRefresh,
+      workspaceDir: params.workspaceDir,
     });
     if (!resolved) {
       throw new Error(`No credentials found for profile "${profileId}".`);
@@ -1168,6 +1171,7 @@ export async function resolveApiKeyForProvider(params: {
     provider,
     store: scopedStore,
     agentDir,
+    workspaceDir: params.workspaceDir,
   });
   if (providerEntryBinding.kind === "profile-resolved") {
     assertAuthModeAllowedForModel({
@@ -1276,6 +1280,7 @@ export async function resolveApiKeyForProvider(params: {
         profileId: candidate,
         agentDir,
         forceRefresh: params.forceRefresh,
+        workspaceDir: params.workspaceDir,
       });
       if (resolved) {
         const resolvedProfileId = resolved.profileId ?? candidate;
@@ -1549,6 +1554,7 @@ export async function hasAvailableAuthForProvider(params: {
         store,
         profileId: candidate,
         agentDir: params.agentDir,
+        workspaceDir: params.workspaceDir,
       });
       const mode = resolved?.profileType ?? store.profiles[candidate]?.type;
       if (

--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -103,6 +103,7 @@ export function resolveOpenClawPluginToolsForOptions(params: {
             store: authProfileStore,
             profileId,
             agentDir: params.options?.agentDir,
+            workspaceDir: params.options?.workspaceDir,
           });
           if (resolved?.apiKey) {
             return resolved.apiKey;

--- a/src/plugin-sdk/provider-auth.test.ts
+++ b/src/plugin-sdk/provider-auth.test.ts
@@ -176,11 +176,12 @@ describe("provider auth profile helpers", () => {
       resolveProviderAuthProfileApiKey({
         provider: "openai",
         profileTypes: ["api_key"],
+        workspaceDir: "/tmp/workspace",
       }),
     ).resolves.toBe("sk-profile");
     expect(resolveApiKeyForProfile).toHaveBeenCalledTimes(1);
     expect(resolveApiKeyForProfile).toHaveBeenCalledWith(
-      expect.objectContaining({ profileId: "openai:key" }),
+      expect.objectContaining({ profileId: "openai:key", workspaceDir: "/tmp/workspace" }),
     );
   });
 

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -423,6 +423,8 @@ export async function resolveProviderAuthProfileApiKey(params: {
   allowKeychainPrompt?: boolean;
   /** Whether external CLI auth profiles may be discovered and included. */
   includeExternalCliAuth?: boolean;
+  /** Optional workspace directory for scoped settings. */
+  workspaceDir?: string;
 }): Promise<string | undefined> {
   const { agentDir, profileIds, store } = resolveUsableProviderAuthProfiles(params);
   if (!agentDir || profileIds.length === 0) {
@@ -434,6 +436,7 @@ export async function resolveProviderAuthProfileApiKey(params: {
       store,
       agentDir,
       profileId,
+      workspaceDir: params.workspaceDir,
     });
     if (resolved?.apiKey) {
       return resolved.apiKey;


### PR DESCRIPTION
> [!NOTE]
> **AI-Assisted Contribution:** This PR was prepared and validated with the assistance of the Antigravity AI coding assistant (Gemini 3.5 Flash).

## What Problem This Solves

Resolves a problem where the aliased provider lookup fails to resolve workspace-scoped aliases on OAuth token refresh failures.

**Symptom/Behavior:**
When clearing the last good profile on OAuth refresh failures, the aliased provider ID is resolved using the global context instead of the workspace-specific configuration. Specifically, `resolveProviderIdForAuth(cred.provider)` is called with only one argument, omitting the configuration and workspace directory parameters. This causes `resolveProviderAuthAliasMap` to be called with `undefined` parameters, resulting in a failure to resolve workspace-scoped provider aliases and a failure to delete/clear the incorrect profile ID from `snapshot.lastGood`.

Affected location: `[src/agents/auth-profiles/oauth.ts](file://src/agents/auth-profiles/oauth.ts#L472-L475)` (compiled as `dist/oauth-R_OaG_Ep.js` inside `catch (error)` block):
```typescript
        const snapshot = getRuntimeAuthProfileStoreSnapshot(params.agentDir);
        const providerKey = resolveProviderIdForAuth(cred.provider);
        if (snapshot?.lastGood?.[providerKey] === profileId) {
```

## Why This Change Was Made

Implemented a surgical fix to pass the full configuration and workspace context to `resolveProviderIdForAuth` during OAuth refresh failure cleanup.

**Solution Overview:**
1. Update `resolveApiKeyForProfile` to accept an optional `workspaceDir` parameter.
2. Pass the full parameters (context/config) to `resolveProviderIdForAuth`:
   ```typescript
   const providerKey = resolveProviderIdForAuth(cred.provider, {
     config: cfg,
     workspaceDir: params.workspaceDir,
   });
   ```
3. Thread the `workspaceDir` context through all calling paths (including `src/agents/cli-runner/prepare.ts`, `src/agents/model-auth.ts`, `src/agents/openclaw-plugin-tools.ts`, and `src/plugin-sdk/provider-auth.ts`).

---

## User Impact

Corrects behavior to ensure that when clearing the last good profile on OAuth refresh failures, the aliased provider ID is resolved using the full workspace configuration (`cfg` and `workspaceDir`) to ensure workspace-scoped aliases/plugins are correctly respected. This prevents stale/broken credentials from sticking around as `lastGood` in workspaces using scoped aliases.

---

## Evidence

### Unit Tests / Verification Suite
- Verified that existing related tests (`oauth-refresh-failure.test.ts`, `provider-auth.test.ts`, and `prepare.test.ts`) pass.
- A total of 150 tests passed successfully across the affected surfaces.

```text
Test Files  4 passed (4)
     Tests  150 passed (150)
  Duration  24.06s
```

### Real Behavior Proof

Below is the live console output showing the OAuth refresh failure cleanup behavior with and without the workspace context. Without the workspace context (Scenario A), the aliased provider `aliased-google` is not resolved to `google`, leaving the stale credentials stuck in `snapshot.lastGood`. With the workspace context provided (Scenario B), it correctly resolves to `google` and clears the stale entry:

```text
======================================================================
LIVE DEMONSTRATION: Workspace-Scoped OAuth Refresh-Failure Cleanup
======================================================================
SCENARIO A: OAuth refresh failure cleanup WITHOUT workspaceDir/cfg context (Buggy Legacy Path)
Initial snapshot.lastGood: {"google":"custom-google:default"}
Triggering OAuth refresh failure for credential provider: aliased-google
Resolved provider ID for auth: 'aliased-google'
Failed to clear lastGood entry: snapshot.lastGood['aliased-google'] does not match profileId 'custom-google:default'
Final snapshot.lastGood: {"google":"custom-google:default"}
Status: STALE CREDENTIAL STUCK IN snapshot.lastGood ❌

SCENARIO B: OAuth refresh failure cleanup WITH workspaceDir/cfg context (Surgical Fix)
Initial snapshot.lastGood: {"google":"custom-google:default"}
Triggering OAuth refresh failure for credential provider: aliased-google
Resolved provider ID for auth: 'google'
Successfully cleared lastGood key: 'google'
Final snapshot.lastGood: {}
Status: STALE CREDENTIAL CORRECTLY CLEARED FROM snapshot.lastGood ✅
======================================================================
```
