### PR TITLE
fix(macos): keep node invokes responsive during system.run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS app node invokes:** keep the app node WebSocket responsive when `node.invoke` sends an unsupported `system.run`, returning a structured node error instead of letting the Gateway mark the node offline. (#89423) Thanks @Lvan185.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **macOS app node invokes:** keep the app node WebSocket responsive when `node.invoke` sends an unsupported `system.run`, returning a structured node error instead of letting the Gateway mark the node offline. (#89423) Thanks @Lvan185.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -541,22 +541,41 @@ public actor GatewayNodeSession {
                 command: request.command,
                 paramsJSON: request.paramsJSON,
                 nodeId: request.nodeId)
-            self.logger.info("node invoke executing id=\(request.id, privacy: .public)")
-            let response = await Self.invokeWithTimeout(
-                request: req,
-                timeoutMs: request.timeoutMs,
-                onInvoke: onInvoke)
-            // Invoke output belongs to the requesting channel. A target switch while the device
-            // command is running must discard it instead of disclosing it to the replacement.
-            guard self.channelGeneration == channelGeneration,
-                  self.channel === channel
-            else { return }
-            self.logger.info(
-                "node invoke completed id=\(request.id, privacy: .public) ok=\(response.ok, privacy: .public)")
-            await self.sendInvokeResult(request: request, response: response, channel: channel)
+            Task { [weak self] in
+                await self?.handleInvokeRequest(
+                    request: request,
+                    bridgeRequest: req,
+                    timeoutMs: request.timeoutMs,
+                    onInvoke: onInvoke,
+                    channel: channel,
+                    channelGeneration: channelGeneration)
+            }
         } catch {
             self.logger.error("node invoke decode failed: \(error.localizedDescription, privacy: .public)")
         }
+    }
+
+    private func handleInvokeRequest(
+        request: NodeInvokeRequestPayload,
+        bridgeRequest: BridgeInvokeRequest,
+        timeoutMs: Int?,
+        onInvoke: @escaping @Sendable (BridgeInvokeRequest) async -> BridgeInvokeResponse,
+        channel: GatewayChannelActor,
+        channelGeneration: UInt64) async
+    {
+        self.logger.info("node invoke executing id=\(request.id, privacy: .public)")
+        let response = await Self.invokeWithTimeout(
+            request: bridgeRequest,
+            timeoutMs: timeoutMs,
+            onInvoke: onInvoke)
+        // Invoke output belongs to the requesting channel. A target switch while the device
+        // command is running must discard it instead of disclosing it to the replacement.
+        guard self.channelGeneration == channelGeneration,
+              self.channel === channel
+        else { return }
+        self.logger.info(
+            "node invoke completed id=\(request.id, privacy: .public) ok=\(response.ok, privacy: .public)")
+        await self.sendInvokeResult(request: request, response: response, channel: channel)
     }
 
     private func decodeInvokeRequest(from payload: OpenClawProtocol.AnyCodable) throws -> NodeInvokeRequestPayload {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayNodeSession.swift
@@ -541,6 +541,8 @@ public actor GatewayNodeSession {
                 command: request.command,
                 paramsJSON: request.paramsJSON,
                 nodeId: request.nodeId)
+            // GatewayChannel waits for push handling before it rearms receive. Run device work
+            // separately so a long invoke cannot starve heartbeats or later node requests.
             Task { [weak self] in
                 await self?.handleInvokeRequest(
                     request: request,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -94,6 +94,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     private var connectAuth: [String: Any]?
     private var connectDevice: [String: Any]?
     private var sentRequestMethods: [String] = []
+    private var sentRequestPayloads: [[String: Any]] = []
     private var receivePhase = 0
     private var pendingReceiveHandler:
         (@Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)?
@@ -142,7 +143,10 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
            obj["type"] as? String == "req",
            let method = obj["method"] as? String
         {
-            self.lock.withLock { self.sentRequestMethods.append(method) }
+            self.lock.withLock {
+                self.sentRequestMethods.append(method)
+                self.sentRequestPayloads.append(obj)
+            }
             guard method == "connect", let id = obj["id"] as? String else { return }
             let params = obj["params"] as? [String: Any]
             let auth = (params?["auth"] as? [String: Any]) ?? [:]
@@ -165,6 +169,16 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
 
     func sentRequestCount(method: String) -> Int {
         self.lock.withLock { self.sentRequestMethods.count(where: { $0 == method }) }
+    }
+
+    func sentRequests(method: String) -> [[String: Any]] {
+        self.lock.withLock {
+            self.sentRequestPayloads.filter { $0["method"] as? String == method }
+        }
+    }
+
+    func hasPendingReceiveHandler() -> Bool {
+        self.lock.withLock { self.pendingReceiveHandler != nil }
     }
 
     func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
@@ -215,6 +229,10 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
     }
 
     func emitInvokeRequest(id: String, command: String) {
+        self.emitInvokeRequest(id: id, command: command, paramsJSON: "{}")
+    }
+
+    func emitInvokeRequest(id: String, command: String, paramsJSON: String?) {
         let handler = self.lock.withLock { () -> (@Sendable (Result<
             URLSessionWebSocketTask.Message,
             Error,
@@ -222,7 +240,10 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
             defer { self.pendingReceiveHandler = nil }
             return self.pendingReceiveHandler
         }
-        handler?(.success(.data(Self.invokeRequestData(id: id, command: command))))
+        handler?(.success(.data(Self.invokeRequestData(
+            id: id,
+            command: command,
+            paramsJSON: paramsJSON))))
     }
 
     private static func connectChallengeData(nonce: String) -> Data {
@@ -284,7 +305,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
         return (try? JSONSerialization.data(withJSONObject: frame)) ?? Data()
     }
 
-    private static func invokeRequestData(id: String, command: String) -> Data {
+    private static func invokeRequestData(id: String, command: String, paramsJSON: String?) -> Data {
         let frame: [String: Any] = [
             "type": "event",
             "event": "node.invoke.request",
@@ -292,7 +313,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
                 "id": id,
                 "nodeId": "test-node",
                 "command": command,
-                "paramsJSON": "{}",
+                "paramsJSON": paramsJSON ?? NSNull(),
             ],
         ]
         return (try? JSONSerialization.data(withJSONObject: frame)) ?? Data()
@@ -617,6 +638,86 @@ struct GatewayNodeSessionTests {
 
         #expect(firstTask.sentRequestCount(method: "node.invoke.result") == 0)
         #expect(replacementTask.sentRequestCount(method: "node.invoke.result") == 0)
+        await gateway.disconnect()
+    }
+
+    @Test
+    func `node invoke requests keep receiving while system run is blocked`() async throws {
+        let session = FakeGatewayWebSocketSession()
+        let gateway = GatewayNodeSession()
+        let systemRunStarted = AsyncStream<Void>.makeStream()
+        var startedIterator = systemRunStarted.stream.makeAsyncIterator()
+        let systemRunRelease = AsyncStream<Void>.makeStream()
+        let options = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: [],
+            commands: ["system.run"],
+            permissions: [:],
+            clientId: "openclaw-macos",
+            clientMode: "node",
+            clientDisplayName: "macOS Test",
+            includeDeviceIdentity: false)
+
+        try await gateway.connect(
+            url: #require(URL(string: "ws://example.invalid")),
+            token: nil,
+            bootstrapToken: nil,
+            password: nil,
+            connectOptions: options,
+            sessionBox: WebSocketSessionBox(session: session),
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { request in
+                if request.id == "system-run-blocked" {
+                    systemRunStarted.continuation.yield()
+                    for await _ in systemRunRelease.stream {
+                        return BridgeInvokeResponse(
+                            id: request.id,
+                            ok: false,
+                            error: OpenClawNodeError(
+                                code: .unavailable,
+                                message: "UNSUPPORTED: system.run unavailable"))
+                    }
+                }
+                return BridgeInvokeResponse(id: request.id, ok: true, payloadJSON: #"{"ok":true}"#)
+            })
+        let task = try #require(session.latestTask())
+
+        task.emitInvokeRequest(
+            id: "system-run-blocked",
+            command: "system.run",
+            paramsJSON: #"{"command":["/bin/echo","ok"]}"#)
+        _ = await startedIterator.next()
+        try await waitUntil("receive loop rearmed during system.run") {
+            task.hasPendingReceiveHandler()
+        }
+        task.emitInvokeRequest(id: "camera-after-system-run", command: "camera.snap")
+
+        try await waitUntil("second invoke result while system.run is blocked") {
+            task.sentRequestCount(method: "node.invoke.result") == 1
+        }
+        let earlyResults = task.sentRequests(method: "node.invoke.result")
+        #expect(earlyResults.count == 1)
+        let earlyParams = try #require(earlyResults.first?["params"] as? [String: Any])
+        #expect(earlyParams["id"] as? String == "camera-after-system-run")
+        #expect(earlyParams["ok"] as? Bool == true)
+
+        systemRunRelease.continuation.yield()
+        systemRunRelease.continuation.finish()
+        try await waitUntil("blocked system.run result") {
+            task.sentRequestCount(method: "node.invoke.result") == 2
+        }
+        let finalResults = task.sentRequests(method: "node.invoke.result")
+        #expect(finalResults.count == 2)
+        let blockedResult = try #require(finalResults.first {
+            ($0["params"] as? [String: Any])?["id"] as? String == "system-run-blocked"
+        })
+        let blockedParams = try #require(blockedResult["params"] as? [String: Any])
+        #expect(blockedParams["ok"] as? Bool == false)
+        let error = try #require(blockedParams["error"] as? [String: Any])
+        #expect(error["code"] as? String == OpenClawNodeErrorCode.unavailable.rawValue)
+
         await gateway.disconnect()
     }
 


### PR DESCRIPTION
Closes #89423

## What Problem This Solves

Fixes an issue where the macOS app node could stop receiving gateway frames while a `system.run` invoke was still in flight, causing the gateway to mark the otherwise-running node offline.

## Why This Change Was Made

Invoke execution now runs independently from the WebSocket receive callback while preserving the existing channel-generation guard, so late results cannot leak onto a replacement connection. The regression test blocks one `system.run`, proves a second invoke is received and answered before the first completes, then verifies the blocked result is delivered.

## User Impact

Longer macOS `system.run` commands no longer stall unrelated node traffic or force an avoidable reconnect.

## Evidence

- Exact PR head: `9310e393ef0e4434e86773d20d3dd249249202d2`.
- Hosted exact-head CI passed in run `28789889999`, including `macos-swift`, `macos-node`, iOS build, and Android build/test lanes.
- Native maintainer preparation passed on the same head against current `main` with `OPENCLAW_TESTBOX=1 bash scripts/pr prepare-run 100842`.
- `swiftformat --lint ... --config config/swiftformat` passed for both changed Swift files.
- `swift build --package-path apps/shared/OpenClawKit --target OpenClawKit` passed.
- Changelog is not required for this changed-file set.
