### PR TITLE
fix(auth): use sanitized profile name for Codex import even without id- prefix

### DIFF
--- a/src/plugin-sdk/provider-openai-chatgpt-auth.test.ts
+++ b/src/plugin-sdk/provider-openai-chatgpt-auth.test.ts
@@ -84,4 +84,11 @@ describe("OpenAI Codex provider auth helpers", () => {
     ).toBeUndefined();
     expect(resolveOpenAICodexAccessTokenExpiry("not-a-jwt")).toBeUndefined();
   });
+
+  it("uses sanitized profileName even when not starting with id- prefix", () => {
+    const identity = {
+      profileName: "peter@example.com",
+    };
+    expect(resolveOpenAICodexImportProfileName(identity, "codex-import")).toBe("peter-example.com");
+  });
 });

--- a/src/plugin-sdk/provider-openai-chatgpt-auth.ts
+++ b/src/plugin-sdk/provider-openai-chatgpt-auth.ts
@@ -132,8 +132,8 @@ export function resolveOpenAICodexImportProfileName(
   if (identity.accountId) {
     return `account-${identity.accountId.replaceAll(/[^A-Za-z0-9._-]+/gu, "-")}`;
   }
-  if (identity.profileName?.startsWith("id-")) {
-    return identity.profileName;
+  if (identity.profileName) {
+    return identity.profileName.replaceAll(/[^A-Za-z0-9._-]+/gu, "-");
   }
   return fallback;
 }


### PR DESCRIPTION
> [!NOTE]
> **AI-Assisted Contribution:** This PR was prepared and validated with the assistance of an AI coding assistant (Antigravity/Gemini).

## What Problem This Solves
Fixes an issue where If `accountId` is missing, the function only accepts `profileName` if it starts with `"id-"` (which is the case for subject-based names, not email-based names). If `profileName` is an email (e.g. `user@example.com`), it does not start with `"id-"`, so the function falls back to a static `fallback` string (e.g. `"hermes-import"`). When migrating multiple credentials, they will all share the same fallback profile name, causing migrations to collide or overwrite each other..

## Why This Change Was Made
Sanitize and return the profile name (such as emails) even if it doesn't start with `"id-"`:
```javascript
function resolveOpenAICodexImportProfileName(identity, fallback) {
if (identity.accountId) return `account-${identity.accountId.replaceAll(/[^A-Za-z0-9._-]+/gu, "-")}`;
if (identity.profileName) return identity.profileName.replaceAll(/[^A-Za-z0-9._-]+/gu, "-");
return fallback;
}
```


## User Impact
When migrating OpenAI Codex profiles (e.g. from Hermes), stable identity details like the profile email should be used to construct a unique, sanitized profile name if `accountId` is not present, avoiding name collisions.

## Evidence

### Unit Tests / Verification Suite
- Branch: `fix/1.5-codex-import-profile-name-collision`
- Commit: `85395a0003`
- Test command: `pnpm test src/plugin-sdk/provider-openai-chatgpt-auth.test.ts`

### Real Behavior Proof

#### Before (Failing Reproduction)
```text
FAIL  |unit-fast| src/plugin-sdk/provider-openai-chatgpt-auth.test.ts > OpenAI Codex provider auth helpers > uses sanitized profileName even when not starting with id- prefix
AssertionError: expected 'codex-import' to be 'peter-example.com' // Object.is equality

Expected: "peter-example.com"
Received: "codex-import"

 ❯ src/plugin-sdk/provider-openai-chatgpt-auth.test.ts:92:75
     90|       profileName: "peter@example.com",
     91|     };
     92|     expect(resolveOpenAICodexImportProfileName(identity, "codex-import")).toBe("peter-example.com");
     93|   });
     94| });
```

#### After (Passing Verification)
```text
RUN  v4.1.9 /home/dietpi/.gemini/openclaw

 ✓ |unit-fast| src/plugin-sdk/provider-openai-chatgpt-auth.test.ts (5 tests) 5ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  11:34:23
   Duration  1.78s (transform 730ms, setup 27ms, import 1.63s, tests 5ms, environment 0ms)

test passed 1 Vitest shard in 6.30s
```
