### PR TITLE
fix(cli): one-shot agent --local runs never export OTel diagnostics

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -76,6 +76,27 @@ and export only when `diagnostics.otel.logs` is explicitly `true`. Log export
 defaults to OTLP; set `diagnostics.otel.logsExporter` to `stdout` for JSONL on
 stdout, or `both` for both.
 
+## Which processes export
+
+- **Gateway** starts the exporter at startup and exports from the Gateway
+  process for every run it executes, including `openclaw agent` turns
+  dispatched to it.
+- **One-shot local runs** (`openclaw agent --local`) execute in the CLI
+  process. When OTel export is configured and
+  the plugin is enabled, that same CLI process starts one exporter instance for
+  the run and flushes buffered spans, metrics, and logs before the process exits.
+  The CLI waits at most 5 seconds for the diagnostic-event queue to drain and 10
+  more for the flush, so an unreachable collector cannot hold the command open.
+  A collector that accepts the connection but never answers can still delay exit
+  until the exporter's own request timeout (`OTEL_EXPORTER_OTLP_TIMEOUT`).
+  In JSON output mode, these one-shot runs suppress only the stdout JSONL log
+  sink so command stdout stays reserved for the JSON response; OTLP traces,
+  metrics, and logs continue when configured.
+- `openclaw agent exec` also runs the agent embedded in the CLI process, but
+  does not yet start this exporter, so its runs export no telemetry. Dispatch
+  through the Gateway, or use `openclaw agent --local`, when you need traces
+  from a headless run.
+
 ## Configuration reference
 
 ```json5

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -38,6 +38,7 @@ const isGatewayTransportError = vi.hoisted(() =>
 const agentCommand = vi.hoisted(() => vi.fn());
 const agentModuleLoadCount = vi.hoisted(() => vi.fn());
 const loadAgentSessionModuleMock = vi.hoisted(() => vi.fn());
+const startOneShotDiagnosticsExporters = vi.hoisted(() => vi.fn());
 
 const runtime: RuntimeEnv = {
   log: vi.fn(),
@@ -119,6 +120,17 @@ function requireFirstCallArg(mock: { mock: { calls: unknown[][] } }, label: stri
     throw new Error(`expected ${label} call`);
   }
   return arg;
+}
+
+function requireFirstCallOrder(
+  mock: { mock: { invocationCallOrder: number[] } },
+  label: string,
+): number {
+  const [order] = mock.mock.invocationCallOrder;
+  if (order === undefined) {
+    throw new Error(`expected ${label} call`);
+  }
+  return order;
 }
 
 function requireRecord(value: unknown, label: string): Record<string, unknown> {
@@ -233,12 +245,19 @@ vi.mock("./agent.js", () => {
   agentModuleLoadCount();
   return { agentCommand };
 });
+vi.mock("../plugins/one-shot-diagnostics.js", () => ({
+  startOneShotDiagnosticsExporters,
+}));
 
 let originalForceConsoleToStderr = false;
 let zeroTimeoutGatewayRequestMs: number | undefined;
 
 function resetAgentCliCommandMocksForTest() {
   vi.clearAllMocks();
+  // clearAllMocks keeps implementations, so a rejecting exporter stub would leak
+  // into every later --local test and silently route them through the failure path.
+  startOneShotDiagnosticsExporters.mockReset();
+  startOneShotDiagnosticsExporters.mockResolvedValue(null);
   vi.stubEnv("OPENCLAW_GATEWAY_URL", "");
   agentViaGatewayTesting.resetLazyImportsForTests();
   agentViaGatewayTesting.setGatewayAbortRetryDelaysMsForTests([0, 0, 0, 0]);
@@ -1782,6 +1801,90 @@ describe("agentCliCommand", () => {
             message.includes("Gateway agent call timed out") && message.includes("--local"),
         ),
       ).toBe(true);
+    });
+  });
+
+  it("starts and flushes the diagnostics exporter around local embedded runs", async () => {
+    await withTempStore(async () => {
+      const stop = vi.fn(async () => {});
+      startOneShotDiagnosticsExporters.mockResolvedValue({ stop });
+      mockLocalAgentReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555", local: true }, runtime);
+
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(startOneShotDiagnosticsExporters).toHaveBeenCalledTimes(1);
+      expect(startOneShotDiagnosticsExporters).toHaveBeenCalledWith(
+        expect.objectContaining({ suppressStdoutDiagnosticLogs: false }),
+      );
+      expect(loadRuntimeConfig).toHaveBeenCalledTimes(1);
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      expect(stop).toHaveBeenCalledTimes(1);
+      const startOrder = requireFirstCallOrder(startOneShotDiagnosticsExporters, "exporter start");
+      const runOrder = requireFirstCallOrder(agentCommand, "embedded agent");
+      const stopOrder = requireFirstCallOrder(stop, "exporter stop");
+      expect(startOrder).toBeLessThan(runOrder);
+      expect(runOrder).toBeLessThan(stopOrder);
+    });
+  });
+
+  it("suppresses stdout diagnostic logs around JSON local embedded runs", async () => {
+    await withTempStore(async () => {
+      const stop = vi.fn(async () => {});
+      startOneShotDiagnosticsExporters.mockResolvedValue({ stop });
+      mockLocalAgentReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555", local: true, json: true }, jsonRuntime);
+
+      expect(callGateway).not.toHaveBeenCalled();
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      expect(startOneShotDiagnosticsExporters).toHaveBeenCalledWith(
+        expect.objectContaining({ suppressStdoutDiagnosticLogs: true }),
+      );
+      expect(stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("flushes the diagnostics exporter when the embedded run fails", async () => {
+    await withTempStore(async () => {
+      const stop = vi.fn(async () => {});
+      startOneShotDiagnosticsExporters.mockResolvedValue({ stop });
+      agentCommand.mockRejectedValueOnce(new Error("embedded run failed"));
+
+      await expect(
+        agentCliCommand({ message: "hi", to: "+1555", local: true }, runtime),
+      ).rejects.toThrow("embedded run failed");
+
+      expect(stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("keeps the embedded run alive when diagnostics exporter startup fails", async () => {
+    await withTempStore(async () => {
+      startOneShotDiagnosticsExporters.mockRejectedValue(new Error("exporter start failed"));
+      mockLocalAgentReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555", local: true }, runtime);
+
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+      expect(runtime.log).toHaveBeenCalledWith("local");
+      expect(
+        mockMessages(runtime.error).some((message) =>
+          message.includes("diagnostics exporter startup failed"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("does not start the diagnostics exporter for gateway dispatch", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+
+      await agentCliCommand({ message: "hi", to: "+1555" }, runtime);
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      expect(startOneShotDiagnosticsExporters).not.toHaveBeenCalled();
+      expect(loadRuntimeConfig).not.toHaveBeenCalled();
     });
   });
 

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -32,6 +32,10 @@ import { readFileDescriptorBounded } from "../infra/boundary-file-read.js";
 import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
 import { routeLogsToStderr } from "../logging/console.js";
 import {
+  startOneShotDiagnosticsExporters,
+  type OneShotDiagnosticsHandle,
+} from "../plugins/one-shot-diagnostics.js";
+import {
   classifySessionKeyShape,
   isUnscopedSessionKeySentinel,
   normalizeAgentId,
@@ -139,6 +143,52 @@ function resolveGatewayAbortRetryDelaysMs(): readonly number[] {
 }
 
 const loadAgentSessionModule = agentSessionModuleCache.load;
+
+type EmbeddedAgentCommandOpts = Parameters<
+  Awaited<ReturnType<typeof embeddedAgentCommandLoader.load>>
+>[0];
+type EmbeddedRunDiagnosticsOptions = {
+  suppressStdoutDiagnosticLogs: boolean;
+};
+
+async function startEmbeddedRunDiagnosticsExporters(
+  runtime: RuntimeEnv,
+  options: EmbeddedRunDiagnosticsOptions,
+): Promise<OneShotDiagnosticsHandle | null> {
+  try {
+    return await startOneShotDiagnosticsExporters({
+      config: await loadRuntimeConfig(),
+      suppressStdoutDiagnosticLogs: options.suppressStdoutDiagnosticLogs,
+    });
+  } catch (err) {
+    // Exporter startup must never break the agent run itself.
+    runtime.error?.(`diagnostics exporter startup failed for embedded run: ${String(err)}`);
+    return null;
+  }
+}
+
+/**
+ * Run the embedded agent command with OTel diagnostics export for this
+ * one-shot process: the Gateway only starts diagnostics exporters in its own
+ * process, so embedded runs start one here and flush it before the CLI exits
+ * (including signal exits, which happen after this returns).
+ */
+async function runEmbeddedAgentCommand(
+  opts: EmbeddedAgentCommandOpts,
+  runtime: RuntimeEnv,
+  deps: AgentCliDeps | undefined,
+  diagnosticsOptions: EmbeddedRunDiagnosticsOptions,
+) {
+  const agentCommand = await measureAgentStartup("command-import", () =>
+    embeddedAgentCommandLoader.load(),
+  );
+  const diagnostics = await startEmbeddedRunDiagnosticsExporters(runtime, diagnosticsOptions);
+  try {
+    return await agentCommand(opts, runtime, deps);
+  } finally {
+    await diagnostics?.stop();
+  }
+}
 
 async function loadRuntimeConfig(): Promise<OpenClawConfig> {
   const { getRuntimeConfig } = await runtimeConfigModuleLoader.load();
@@ -920,10 +970,7 @@ export async function agentCliCommand(
   const signalBridge = createAgentCliSignalBridge(resolveAgentCliProcessLike(deps));
   try {
     if (dispatchOpts.local === true) {
-      const agentCommand = await measureAgentStartup("command-import", () =>
-        embeddedAgentCommandLoader.load(),
-      );
-      const result = await agentCommand(
+      const result = await runEmbeddedAgentCommand(
         {
           ...gatewayDispatchOpts,
           agentId: gatewayDispatchOpts.agent,
@@ -935,6 +982,7 @@ export async function agentCliCommand(
         },
         runtime,
         deps,
+        { suppressStdoutDiagnosticLogs: dispatchOpts.json === true },
       );
       return returnAfterSignalExit(result, signalBridge.getReceivedSignal(), runtime);
     }

--- a/src/plugins/one-shot-diagnostics.test.ts
+++ b/src/plugins/one-shot-diagnostics.test.ts
@@ -1,0 +1,223 @@
+// One-shot diagnostics exporter start/flush lifecycle for embedded CLI runs.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const loadOpenClawPlugins = vi.hoisted(() => vi.fn());
+const startPluginServices = vi.hoisted(() => vi.fn());
+const waitForDiagnosticEventsDrained = vi.hoisted(() => vi.fn(async () => {}));
+const warn = vi.hoisted(() => vi.fn());
+
+vi.mock("./loader.js", () => ({ loadOpenClawPlugins }));
+vi.mock("./services.js", () => ({ startPluginServices }));
+vi.mock("../logging/subsystem.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../logging/subsystem.js")>()),
+  createSubsystemLogger: () => ({ warn, info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+vi.mock("../infra/diagnostic-events.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/diagnostic-events.js")>()),
+  waitForDiagnosticEventsDrained,
+}));
+
+import { startOneShotDiagnosticsExporters } from "./one-shot-diagnostics.js";
+
+const otelEnabledConfig = {
+  diagnostics: { otel: { enabled: true, endpoint: "http://127.0.0.1:4318" } },
+} as OpenClawConfig;
+
+function mockRegistryWithServices(serviceIds: string[]) {
+  const registry = {
+    services: serviceIds.map((id) => ({
+      pluginId: id,
+      pluginName: id,
+      service: { id },
+      source: "test",
+      origin: "bundled",
+    })),
+  };
+  loadOpenClawPlugins.mockReturnValue(registry);
+  return registry;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  waitForDiagnosticEventsDrained.mockResolvedValue(undefined);
+});
+
+describe("startOneShotDiagnosticsExporters", () => {
+  it.each([
+    ["no diagnostics config", {}],
+    ["no otel config", { diagnostics: {} }],
+    ["diagnostics disabled", { diagnostics: { enabled: false, otel: { enabled: true } } }],
+    ["otel disabled", { diagnostics: { otel: { enabled: false } } }],
+  ])("skips plugin loading when otel export is not configured (%s)", async (_label, config) => {
+    const handle = await startOneShotDiagnosticsExporters({ config: config as OpenClawConfig });
+
+    expect(handle).toBeNull();
+    expect(loadOpenClawPlugins).not.toHaveBeenCalled();
+    expect(startPluginServices).not.toHaveBeenCalled();
+  });
+
+  it("starts only the diagnostics-otel service from a scoped non-activating load", async () => {
+    mockRegistryWithServices(["diagnostics-otel", "other-service"]);
+    startPluginServices.mockResolvedValue({ stop: vi.fn(async () => {}) });
+
+    const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
+
+    expect(handle).not.toBeNull();
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: otelEnabledConfig,
+        onlyPluginIds: ["diagnostics-otel"],
+        activate: false,
+        preferBuiltPluginArtifacts: true,
+      }),
+    );
+    expect(startPluginServices).toHaveBeenCalledTimes(1);
+    const startParams = startPluginServices.mock.calls[0]?.[0] as {
+      registry: { services: Array<{ service: { id: string } }> };
+      config: OpenClawConfig;
+    };
+    expect(startParams.config).toBe(otelEnabledConfig);
+    expect(startParams.registry.services.map((entry) => entry.service.id)).toEqual([
+      "diagnostics-otel",
+    ]);
+  });
+
+  it("keeps OTLP logs but suppresses stdout JSONL logs when requested", async () => {
+    const config = {
+      diagnostics: { otel: { enabled: true, logs: true, logsExporter: "both" } },
+    } as OpenClawConfig;
+    mockRegistryWithServices(["diagnostics-otel"]);
+    startPluginServices.mockResolvedValue({ stop: vi.fn(async () => {}) });
+
+    const handle = await startOneShotDiagnosticsExporters({
+      config,
+      suppressStdoutDiagnosticLogs: true,
+    });
+
+    expect(handle).not.toBeNull();
+    const startParams = startPluginServices.mock.calls[0]?.[0] as {
+      config: OpenClawConfig;
+    };
+    expect(startParams.config.diagnostics?.otel?.logs).toBe(true);
+    expect(startParams.config.diagnostics?.otel?.logsExporter).toBe("otlp");
+    expect(config.diagnostics?.otel?.logsExporter).toBe("both");
+  });
+
+  it("disables stdout-only JSONL logs when requested", async () => {
+    const config = {
+      diagnostics: { otel: { enabled: true, logs: true, logsExporter: "stdout" } },
+    } as OpenClawConfig;
+    mockRegistryWithServices(["diagnostics-otel"]);
+    startPluginServices.mockResolvedValue({ stop: vi.fn(async () => {}) });
+
+    const handle = await startOneShotDiagnosticsExporters({
+      config,
+      suppressStdoutDiagnosticLogs: true,
+    });
+
+    expect(handle).not.toBeNull();
+    const startParams = startPluginServices.mock.calls[0]?.[0] as {
+      config: OpenClawConfig;
+    };
+    expect(startParams.config.diagnostics?.otel?.logs).toBe(false);
+    expect(startParams.config.diagnostics?.otel?.logsExporter).toBe("otlp");
+    expect(config.diagnostics?.otel?.logsExporter).toBe("stdout");
+  });
+
+  it("returns null when the scoped load registers no exporter service", async () => {
+    mockRegistryWithServices(["other-service"]);
+
+    const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
+
+    expect(handle).toBeNull();
+    expect(startPluginServices).not.toHaveBeenCalled();
+  });
+
+  it("drains queued diagnostic events before stopping services on flush", async () => {
+    mockRegistryWithServices(["diagnostics-otel"]);
+    const servicesStop = vi.fn(async () => {});
+    startPluginServices.mockResolvedValue({ stop: servicesStop });
+    let releaseDrain = () => {};
+    waitForDiagnosticEventsDrained.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseDrain = resolve;
+        }),
+    );
+
+    const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
+    const stopPromise = handle?.stop();
+    await Promise.resolve();
+
+    expect(waitForDiagnosticEventsDrained).toHaveBeenCalledTimes(1);
+    expect(servicesStop).not.toHaveBeenCalled();
+
+    releaseDrain();
+    await stopPromise;
+
+    expect(servicesStop).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows service stop failures", async () => {
+    mockRegistryWithServices(["diagnostics-otel"]);
+    startPluginServices.mockResolvedValue({
+      stop: vi.fn(async () => {
+        throw new Error("exporter shutdown failed");
+      }),
+    });
+
+    const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
+
+    await expect(handle?.stop()).resolves.toBeUndefined();
+  });
+
+  it("still flushes the exporter when the diagnostic-event drain hangs", async () => {
+    vi.useFakeTimers();
+    try {
+      mockRegistryWithServices(["diagnostics-otel"]);
+      const servicesStop = vi.fn(async () => {});
+      startPluginServices.mockResolvedValue({ stop: servicesStop });
+      waitForDiagnosticEventsDrained.mockImplementation(() => new Promise<void>(() => {}));
+
+      const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
+      const stopPromise = handle?.stop();
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(stopPromise).resolves.toBeUndefined();
+      // A stalled drain must not consume the flush window: telemetry already
+      // buffered still has to reach the collector.
+      expect(servicesStop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("warns when otel is configured but the diagnostics-otel plugin is absent", async () => {
+    mockRegistryWithServices(["other-service"]);
+
+    const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
+
+    expect(handle).toBeNull();
+    expect(startPluginServices).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("diagnostics-otel plugin is not"));
+  });
+
+  it("bounds the flush with a timeout so a hung exporter cannot block exit", async () => {
+    vi.useFakeTimers();
+    try {
+      mockRegistryWithServices(["diagnostics-otel"]);
+      const servicesStop = vi.fn(() => new Promise<void>(() => {}));
+      startPluginServices.mockResolvedValue({ stop: servicesStop });
+
+      const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
+      const stopPromise = handle?.stop();
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expect(stopPromise).resolves.toBeUndefined();
+      expect(servicesStop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/plugins/one-shot-diagnostics.ts
+++ b/src/plugins/one-shot-diagnostics.ts
@@ -1,0 +1,145 @@
+/** Starts diagnostics exporter plugin services for one-shot CLI embedded agent runs. */
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { waitForDiagnosticEventsDrained } from "../infra/diagnostic-events.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("plugins");
+
+// Only push-based exporters that can flush before a short-lived process exits.
+// diagnostics-prometheus is pull-based (scrape server) and would bind a port
+// that races the gateway on the same host, so it stays gateway-only.
+const ONE_SHOT_DIAGNOSTICS_SERVICE_IDS = new Set(["diagnostics-otel"]);
+// Each exit step is bounded on its own so an unreachable OTLP endpoint cannot
+// hang the CLI, and a stalled drain cannot consume the flush window: sharing one
+// budget would drop telemetry that was already buffered and ready to send.
+const ONE_SHOT_DIAGNOSTICS_DRAIN_TIMEOUT_MS = 5_000;
+const ONE_SHOT_DIAGNOSTICS_FLUSH_TIMEOUT_MS = 10_000;
+
+export type OneShotDiagnosticsHandle = {
+  stop: () => Promise<void>;
+};
+
+function suppressOtelStdoutLogSink(config: OpenClawConfig): OpenClawConfig {
+  const diagnostics = config.diagnostics;
+  const otel = diagnostics?.otel;
+  if (otel?.logs !== true || (otel.logsExporter !== "stdout" && otel.logsExporter !== "both")) {
+    return config;
+  }
+  // JSON-mode agent CLI stdout is machine-readable output. The OTel stdout
+  // log sink writes directly to process.stdout, so suppress only that sink for
+  // one-shot exporters while preserving OTLP diagnostics where configured.
+  return {
+    ...config,
+    diagnostics: {
+      ...diagnostics,
+      otel: {
+        ...otel,
+        logs: otel.logsExporter === "both",
+        logsExporter: "otlp",
+      },
+    },
+  };
+}
+
+function isOtelExportConfigured(config: OpenClawConfig): boolean {
+  // Mirrors the diagnostics-otel service's own start() gate so disabled
+  // configs skip plugin loading entirely on the CLI hot path.
+  const diagnostics = config.diagnostics;
+  return Boolean(diagnostics && diagnostics.enabled !== false && diagnostics.otel?.enabled);
+}
+
+/**
+ * Bounds how long the CLI waits for one exit step. Timing out stops the wait but
+ * cannot cancel the work: a collector that accepts a connection and never answers
+ * keeps its socket open until the exporter's own request timeout
+ * (`OTEL_EXPORTER_OTLP_TIMEOUT`). Accepted — that bound is the exporter's to own,
+ * and cancelling an in-flight export would mean reaching into the OTel SDK.
+ */
+async function runBoundedExitStep(
+  label: string,
+  timeoutMs: number,
+  run: () => Promise<void>,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    await Promise.race([run(), timeout]);
+  } catch (err) {
+    log.warn(`one-shot diagnostics ${label} failed: ${String(err)}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Start the diagnostics OTel exporter for a one-shot embedded agent run.
+ *
+ * Gateway processes start diagnostics exporters via startPluginServices at
+ * startup; one-shot `openclaw agent --local` runs execute the agent in the CLI
+ * process where no plugin service ever starts, so diagnostic events had no OTel
+ * subscriber and spans were dropped.
+ * Returns null when OTel export is not configured or the plugin is not
+ * enabled/installed; the returned handle's stop() drains the diagnostic event
+ * queue and shuts the SDK down (force-flush) before the process exits.
+ */
+export async function startOneShotDiagnosticsExporters(params: {
+  config: OpenClawConfig;
+  suppressStdoutDiagnosticLogs?: boolean;
+}): Promise<OneShotDiagnosticsHandle | null> {
+  const config =
+    params.suppressStdoutDiagnosticLogs === true
+      ? suppressOtelStdoutLogSink(params.config)
+      : params.config;
+  if (!isOtelExportConfigured(config)) {
+    return null;
+  }
+  const [{ loadOpenClawPlugins }, { startPluginServices }] = await Promise.all([
+    import("./loader.js"),
+    import("./services.js"),
+  ]);
+  // Scoped, non-activating load: honors the same plugin enablement config as
+  // the gateway's startup load without replacing the active runtime registry
+  // the embedded run resolves providers/tools from.
+  const registry = loadOpenClawPlugins({
+    config,
+    onlyPluginIds: [...ONE_SHOT_DIAGNOSTICS_SERVICE_IDS],
+    activate: false,
+    preferBuiltPluginArtifacts: true,
+  });
+  // The scope-piggyback loader rules (e.g. dreaming sidecars) can widen a
+  // scoped load, so re-filter to the flush-safe exporter allowlist.
+  const services = registry.services.filter((entry) =>
+    ONE_SHOT_DIAGNOSTICS_SERVICE_IDS.has(entry.service.id),
+  );
+  if (services.length === 0) {
+    // diagnostics-otel is an external plugin, so "enabled in config, never
+    // installed" is an ordinary state. Say so: the run would otherwise export
+    // nothing with nothing explaining why.
+    log.warn(
+      "diagnostics.otel is enabled but the diagnostics-otel plugin is not installed or not enabled; this run exports no telemetry.",
+    );
+    return null;
+  }
+  const handle = await startPluginServices({
+    registry: { ...registry, services },
+    config,
+  });
+  return {
+    stop: async () => {
+      // Drain first: run-end diagnostic events dispatch async, and the exporter
+      // unsubscribes as its first stop step. The flush still runs when the drain
+      // stalls, so already-buffered telemetry is exported instead of lost.
+      await runBoundedExitStep(
+        "event drain",
+        ONE_SHOT_DIAGNOSTICS_DRAIN_TIMEOUT_MS,
+        waitForDiagnosticEventsDrained,
+      );
+      await runBoundedExitStep("exporter flush", ONE_SHOT_DIAGNOSTICS_FLUSH_TIMEOUT_MS, () =>
+        handle.stop(),
+      );
+    },
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where one-shot `openclaw agent --local` runs would export no OTel telemetry at all when `diagnostics.otel.enabled: true` and the `diagnostics-otel` plugin are configured: zero spans, metrics, or logs reached the OTLP collector, while the same turns dispatched through the Gateway exported fine. Exactly the runs that bypass the Gateway were invisible in tracing backends.

## Why This Change Was Made

Diagnostics exporters are plugin services and were only ever started inside the Gateway process (`startPluginServices` at gateway startup/reload); embedded CLI runs emit diagnostic events in the CLI process where nothing subscribes. The CLI now starts the `diagnostics-otel` service around embedded agent runs via a scoped, non-activating plugin load that honors the same plugin-enablement config as the Gateway, and flushes on exit: drain the async diagnostic-event queue, then shut the SDK down (force flush).

Each exit step is bounded separately (5s drain, 10s flush) so an unreachable collector cannot hold the CLI open, and a stalled drain cannot consume the flush window — sharing one budget would drop telemetry that was already buffered and ready to send. Timing out stops the wait but cannot cancel an in-flight export; a collector that accepts a connection and never answers is bounded by the exporter's own `OTEL_EXPORTER_OTLP_TIMEOUT` instead. That tradeoff is accepted and noted at the code site rather than reaching into the OTel SDK to cancel.

`diagnostics-prometheus` intentionally stays Gateway-only — it is a pull-based scrape server that is useless in a short-lived process and would race the Gateway for its port. No new config surface; configs without OTel enabled short-circuit before any plugin load.

## User Impact

Operators running one-shot `openclaw agent --local` turns now get the same OTel traces, metrics, and logs as Gateway-executed turns, flushed before the process exits. Setups without OTel export enabled are unaffected.

When `diagnostics.otel.enabled` is set but the `diagnostics-otel` plugin is not installed or not enabled, the run now logs a warning naming that gap instead of exporting nothing with nothing explaining why.

## Evidence

- Live before/after on macOS against a local Arize Phoenix OTLP collector: before, one-shot `--local` runs produced zero spans while Gateway runs exported fine; after, a one-shot run logs `diagnostics-otel: logs exporter enabled (OTLP/Protobuf)` and `openclaw.harness.run`, `openclaw.run`, and `openclaw.model.call` spans (with `gen_ai.*` attributes) arrive in Phoenix seconds after the process exits.
- Focused tests: `src/plugins/one-shot-diagnostics.test.ts` (13) covers config gating, the scoped non-activating load, exporter allowlist filtering, drain-before-flush ordering, independent drain/flush timeout bounds, and the configured-but-absent-plugin warning; `src/commands/agent-via-gateway.test.ts` (82) covers start/flush ordering around local runs, JSON-mode stdout sink suppression, flush when the embedded run fails, and run survival when exporter startup fails. Both pass on current `main`.
- `pnpm build` clean with no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings; `tsgo` core and core-test lanes clean; oxfmt/oxlint clean on touched files.

## Rebase and scope notes

Rebased from a stale merge base (`8f9e42f2a94`) onto current `main` as a single commit; the prior merge commit is gone. The `docs/docs_map.md` edit is also dropped — `main` has since reduced that file to a source stub, with the expanded heading mirror generated at publish time.

- **Gateway-to-embedded fallback half dropped.** `c5254f13ee2` (#112074) removed the automatic gateway→embedded fallback from `openclaw agent`. This PR originally also started the exporter on fallback runs; that path no longer exists, so its production code, its test, and the doc sentence describing it were dropped rather than resurrected. `--local` is now the only embedded execution path this touches.
- **`npm_execpath` build-wrapper change dropped.** Per the ClawSweeper owner-decision gate, the unrelated `scripts/run-node.mjs` / `src/infra/run-node.test.ts` change is removed entirely. This PR is now purely the OTel fix.
- **Sibling surface, explicit follow-up.** `openclaw agent exec` (`src/commands/agent-exec.ts:637,659`, `loadPlugins: "never"` in `src/cli/command-catalog.ts:93-100`) runs the agent embedded in the CLI process too and violates the same invariant, so it still exports nothing. Covering it is a design task, not a copy: it resolves a folder-scoped config, owns protocol stdout, and runs inside its own auth/plugin-root scopes. Tracked as follow-up; `docs/gateway/opentelemetry.md` states the gap rather than implying `agent exec` is covered.

## Closeout

- Root cause: diagnostic-event subscribers are plugin services whose lifecycle was owned exclusively by the Gateway process.
- Architectural owner: the CLI command that executes an agent run in its own process.
- Production LOC: +197 / −4 (net +193), tests +326, docs +21. The growth is a new capability — telemetry export for a process class that previously had none — and is not expressible through existing config or doctor behavior.

## Review

Two independent pre-land review passes (Claude and Codex/GPT-5.5) ran against the rebased diff. Applied findings:

- **Telemetry-dropping bug.** Drain and flush shared one 10s budget, so a stalled drain meant `handle.stop()` never ran, the SDK never shut down, and every buffered span was discarded. A test codified this (`expect(servicesStop).not.toHaveBeenCalled()`); it now asserts the flush still happens.
- **Silent failure.** Configured-but-absent `diagnostics-otel` returned `null` with no message. Now warns.
- **Docs overstated the bound.** Corrected to 5s + 10s plus the residual `OTEL_EXPORTER_OTLP_TIMEOUT` note.
- **Test isolation.** `vi.clearAllMocks()` preserves implementations, so the exporter-startup-failure stub leaked into every later `--local` test and silently routed them through the failure path. The shared reset now restores a deterministic default.

Verified as sound, not changed: the scoped `activate: false` load does not clobber the active runtime registry the embedded run resolves providers/tools from (scoped and unscoped loads use separate LRU stores, keyed distinctly on plugin scope, activation mode, and `preferBuiltPluginArtifacts`); the `finally`-block flush does complete before `returnAfterSignalExit`; `suppressOtelStdoutLogSink` is correct for each `logsExporter` value.
