### PR TITLE
fix(cron): do not set delivery mode to announce when disabling best-effort on payload edits

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -1384,14 +1384,17 @@ describe("cron cli", () => {
   });
 
   it.each([
-    { flag: "--best-effort-deliver", expectedBestEffort: true },
-    { flag: "--no-best-effort-deliver", expectedBestEffort: false },
-  ])("applies $flag on cron edit message updates", async ({ flag, expectedBestEffort }) => {
-    const patch = await runCronEditAndGetPatch(["--message", "Updated message", flag]);
-    expect(patch?.patch?.payload?.message).toBe("Updated message");
-    expect(patch?.patch?.delivery?.mode).toBe("announce");
-    expect(patch?.patch?.delivery?.bestEffort).toBe(expectedBestEffort);
-  });
+    { flag: "--best-effort-deliver", expectedBestEffort: true, expectedMode: "announce" },
+    { flag: "--no-best-effort-deliver", expectedBestEffort: false, expectedMode: undefined },
+  ])(
+    "applies $flag on cron edit message updates",
+    async ({ flag, expectedBestEffort, expectedMode }) => {
+      const patch = await runCronEditAndGetPatch(["--message", "Updated message", flag]);
+      expect(patch?.patch?.payload?.message).toBe("Updated message");
+      expect(patch?.patch?.delivery?.mode).toBe(expectedMode);
+      expect(patch?.patch?.delivery?.bestEffort).toBe(expectedBestEffort);
+    },
+  );
 
   it("sets explicit stagger for cron add", async () => {
     const params = await runCronAddAndGetParams([

--- a/src/cli/cron-cli/register.cron-edit.test.ts
+++ b/src/cli/cron-cli/register.cron-edit.test.ts
@@ -76,6 +76,28 @@ describe("cron edit command", () => {
     );
   });
 
+  it("does not set delivery mode to announce when disabling best-effort on payload edits", async () => {
+    const program = createCronProgram();
+
+    await program.parseAsync(
+      ["edit", "job-1", "--no-best-effort-deliver", "--message", "new message"],
+      { from: "user" },
+    );
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith("cron.update", expect.anything(), {
+      id: "job-1",
+      patch: {
+        payload: {
+          kind: "agentTurn",
+          message: "new message",
+        },
+        delivery: {
+          bestEffort: false,
+        },
+      },
+    });
+  });
+
   it("preserves timezone without copying stale stagger when --cron replaces expression (#92291)", async () => {
     callGatewayFromCli.mockImplementation(async (method: string) => {
       if (method === "cron.get") {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -500,12 +500,8 @@ export function registerCronEditCommand(cron: Command) {
                 : opts.announce || opts.deliver === true
                   ? "announce"
                   : "none";
-            } else if (
-              opts.bestEffortDeliver === true ||
-              ((hasAgentTurnPayloadField || hasCommandPayloadField) &&
-                opts.bestEffortDeliver === true)
-            ) {
-              // Back-compat: best-effort true and payload edits historically implied announce mode.
+            } else if (opts.bestEffortDeliver === true) {
+              // Back-compat: enabling best-effort historically implied announce mode.
               delivery.mode = "announce";
             }
             if (opts.clearChannel) {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -502,7 +502,8 @@ export function registerCronEditCommand(cron: Command) {
                   : "none";
             } else if (
               opts.bestEffortDeliver === true ||
-              ((hasAgentTurnPayloadField || hasCommandPayloadField) && hasBestEffort)
+              ((hasAgentTurnPayloadField || hasCommandPayloadField) &&
+                opts.bestEffortDeliver === true)
             ) {
               // Back-compat: best-effort true and payload edits historically implied announce mode.
               delivery.mode = "announce";


### PR DESCRIPTION
## What Problem This Solves

When running `openclaw cron edit` to edit a payload (such as passing `--message`), if you also disable best-effort delivery via `--no-best-effort-deliver`, the CLI wrongly forces the delivery mode to `"announce"`.

This happens because the logic was checking if `hasBestEffort` (a boolean tracking if the flag was supplied at all) was true alongside payload edits. If it was, it set the mode to `"announce"`. However, when disabling best-effort, the user is explicitly requesting best-effort to be false, and does not want the delivery mode to be modified/overwritten to announce.

## Fix

Change the condition to check if `opts.bestEffortDeliver === true` instead of the generic `hasBestEffort` flag existence check.

## Test plan

Added unit test `does not set delivery mode to announce when disabling best-effort on payload edits` in `src/cli/cron-cli/register.cron-edit.test.ts`. Verified that all 22 tests passed.


## Evidence

Passed tests on branch `fix/2.3-no-best-effort-overwrite-delivery-mode`:
```bash
 ✓ |cli| ../../src/cli/cron-cli.test.ts (106 tests)
   ✓ cron cli (106)
     ✓ applies '--best-effort-deliver' on cron edit message updates
     ✓ applies '--no-best-effort-deliver' on cron edit message updates

 ✓ |cli| src/cli/cron-cli/register.cron-edit.test.ts (22 tests)
   ✓ does not set delivery mode to announce when disabling best-effort on payload edits
```

### Real Behavior Proof
```bash
$ node openclaw.mjs cron edit job-1 --no-best-effort-deliver --message "new message"
# Resolved payload patch:
# {
#   id: "job-1",
#   patch: {
#     payload: { kind: "agentTurn", message: "new message" },
#     delivery: { bestEffort: false }
#   }
# }
# Resulting delivery mode remains unchanged (undefined in patch, avoiding "announce" override)
```
