### PR TITLE
fix #98864: dynamic tool hard timeout should honor timeoutSeconds when timeoutMs is absent

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -163,6 +163,121 @@ describe("dynamic tool execution helpers", () => {
     ).toBe(CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS);
   });
 
+  describe("timeoutSeconds fallback", () => {
+    it("uses timeoutSeconds when timeoutMs is absent", () => {
+      expect(
+        resolveDynamicToolCallTimeoutMs({
+          call: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: "call-seconds",
+            namespace: null,
+            tool: "session_status",
+            arguments: { timeoutSeconds: 30 },
+          },
+          config: undefined,
+        }),
+      ).toBe(30_000);
+    });
+
+    it("prefers timeoutMs when both timeoutMs and timeoutSeconds are provided", () => {
+      expect(
+        resolveDynamicToolCallTimeoutMs({
+          call: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: "call-both",
+            namespace: null,
+            tool: "session_status",
+            arguments: { timeoutMs: 15_000, timeoutSeconds: 60 },
+          },
+          config: undefined,
+        }),
+      ).toBe(15_000);
+    });
+
+    it("ignores non-number timeoutSeconds", () => {
+      expect(
+        resolveDynamicToolCallTimeoutMs({
+          call: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: "call-str-seconds",
+            namespace: null,
+            tool: "session_status",
+            arguments: { timeoutSeconds: "30" },
+          },
+          config: undefined,
+        }),
+      ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
+    });
+
+    it("ignores non-positive timeoutSeconds", () => {
+      expect(
+        resolveDynamicToolCallTimeoutMs({
+          call: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: "call-zero",
+            namespace: null,
+            tool: "session_status",
+            arguments: { timeoutSeconds: 0 },
+          },
+          config: undefined,
+        }),
+      ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
+    });
+
+    it("ignores negative timeoutSeconds", () => {
+      expect(
+        resolveDynamicToolCallTimeoutMs({
+          call: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: "call-neg",
+            namespace: null,
+            tool: "session_status",
+            arguments: { timeoutSeconds: -5 },
+          },
+          config: undefined,
+        }),
+      ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
+    });
+
+    it("caps timeoutSeconds exceeding the maximum", () => {
+      expect(
+        resolveDynamicToolCallTimeoutMs({
+          call: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: "call-huge-seconds",
+            namespace: null,
+            tool: "session_status",
+            arguments: { timeoutSeconds: 9999 },
+          },
+          config: undefined,
+        }),
+      ).toBe(CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS);
+    });
+
+    it("preserves existing timeoutMs behavior unchanged", () => {
+      const timeoutMs = CODEX_DYNAMIC_TOOL_TIMEOUT_MS + 1_000;
+      expect(
+        resolveDynamicToolCallTimeoutMs({
+          call: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            callId: "call-ms-only",
+            namespace: null,
+            tool: "session_status",
+            arguments: { timeoutMs },
+          },
+          config: undefined,
+        }),
+      ).toBe(timeoutMs);
+    });
+  });
+
   it("uses a 90 second default for generic Codex dynamic tool calls", () => {
     expect(
       resolveDynamicToolCallTimeoutMs({

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -443,7 +443,10 @@ function readDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | un
   if (!isJsonObject(value)) {
     return undefined;
   }
-  return readPositiveFiniteTimeoutMs(value.timeoutMs);
+  return (
+    readPositiveFiniteTimeoutMs(value.timeoutMs) ??
+    readTimeoutSecondsAsMs(value.timeoutSeconds)
+  );
 }
 
 function readConfiguredDynamicToolTimeoutMs(


### PR DESCRIPTION
## Summary

- **Problem**: Dynamic tool calls can carry a `timeoutSeconds` field while omitting `timeoutMs`. The hard-call timeout reader (`readDynamicToolCallTimeoutMs`) only checked `timeoutMs`, so a tool configured with `timeoutSeconds` fell through to the default hard-call guard (90s). This affects long-running tools such as session send helpers.
- **Solution**: Update `readDynamicToolCallTimeoutMs` to treat `timeoutSeconds` as the seconds-form fallback when `timeoutMs` is absent, reusing the existing `readTimeoutSecondsAsMs` helper for consistency.
- **What changed**: `dynamic-tool-execution.ts` — 3-line change in `readDynamicToolCallTimeoutMs`. `dynamic-tool-execution.test.ts` — 7 new tests covering timeoutSeconds fallback, precedence, invalid values, and max-capping.
- **What did NOT change**: No schema, config, API, or provider changes. `readTimeoutSecondsAsMs` and `readPositiveFiniteTimeoutMs` helpers unchanged.

## Maintainer checklist

- Fix classification: Root-cause bug fix in Codex dynamic tool timeout resolution
- Maintainer-ready confidence: High — all 20 tests pass on upstream/main base, including 7 new timeoutSeconds fallback tests

## Real behavior proof

**Behavior or issue addressed:**
Dynamic tool calls with `timeoutSeconds` but no `timeoutMs` silently fall through to the default 90s hard-call guard instead of honoring the caller-specified timeout.

**Real environment tested:**
- Platform: Linux x86_64
- Node.js: v22.22.0
- Runtime: Vitest v4.1.8
- Branch: fix/dynamic-tool-timeout-seconds-98864 (bea01835f) — based on upstream/main

**Exact steps or command run after the patch:**
```sh
node ./node_modules/vitest/vitest.mjs run extensions/codex/src/app-server/dynamic-tool-execution.test.ts --reporter=verbose
```

**After-fix evidence:**
All 20 tests pass including 7 new timeoutSeconds fallback tests:
- uses timeoutSeconds when timeoutMs is absent (30 → 30,000ms) ✓
- prefers timeoutMs when both timeoutMs and timeoutSeconds are provided ✓
- ignores non-number timeoutSeconds ("30" → default) ✓
- ignores non-positive timeoutSeconds (0 → default) ✓
- ignores negative timeoutSeconds (-5 → default) ✓
- caps timeoutSeconds exceeding the maximum (9999 → 600,000ms) ✓
- preserves existing timeoutMs behavior unchanged ✓

**Acceptance criteria satisfied:**
- A dynamic tool call with `timeoutMs` keeps existing behavior ✓
- A dynamic tool call with only `timeoutSeconds` uses that value as the hard timeout ✓
- Invalid or non-positive `timeoutSeconds` values are ignored ✓
- Timeout values exceeding CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS are capped ✓

**What was not tested:**
- End-to-end with live model calling `sessions_send` with `timeoutSeconds`
- Gateway restart + dynamic tool call integration flow

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)