### PR TITLE
fix(cron): remove redundant loops and dead code in stagger calculations

### DIFF
--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -133,19 +133,9 @@ function computeStaggeredCronNextRunAtMs(job: CronJob, nowMs: number) {
 
   // Shift the schedule cursor backwards by the per-job offset so we can still
   // target the current schedule window if its staggered slot has not passed yet.
-  let cursorMs = Math.max(0, nowMs - offsetMs);
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    const baseNext = computeNextRunAtMs(job.schedule, cursorMs);
-    if (baseNext === undefined) {
-      return undefined;
-    }
-    const shifted = baseNext + offsetMs;
-    if (shifted > nowMs) {
-      return shifted;
-    }
-    cursorMs = Math.max(cursorMs + 1, baseNext + 1_000);
-  }
-  return undefined;
+  const cursorMs = Math.max(0, nowMs - offsetMs);
+  const baseNext = computeNextRunAtMs(job.schedule, cursorMs);
+  return baseNext !== undefined ? baseNext + offsetMs : undefined;
 }
 
 function computeStaggeredCronPreviousRunAtMs(job: CronJob, nowMs: number) {
@@ -161,19 +151,9 @@ function computeStaggeredCronPreviousRunAtMs(job: CronJob, nowMs: number) {
 
   // Shift the cursor backwards by the same per-job offset used for next-run
   // math so previous-run lookup matches the effective staggered schedule.
-  let cursorMs = Math.max(0, nowMs - offsetMs);
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    const basePrevious = computePreviousRunAtMs(job.schedule, cursorMs);
-    if (basePrevious === undefined) {
-      return undefined;
-    }
-    const shifted = basePrevious + offsetMs;
-    if (shifted <= nowMs) {
-      return shifted;
-    }
-    cursorMs = Math.max(0, basePrevious - 1_000);
-  }
-  return undefined;
+  const cursorMs = Math.max(0, nowMs - offsetMs);
+  const basePrevious = computePreviousRunAtMs(job.schedule, cursorMs);
+  return basePrevious !== undefined ? basePrevious + offsetMs : undefined;
 }
 
 function isStaggeredCronRunAtMs(job: CronJob, runAtMs: number): boolean {


### PR DESCRIPTION
> [!NOTE]
> **AI-Assisted Contribution:** This PR was prepared and validated with the assistance of an AI coding assistant (Antigravity/Gemini).

## What Problem This Solves

Resolves a problem where dead code / redundant iterations in staggered cron calculations (pr #100853).

**Symptom/Behavior:**
The conditions inside both loop blocks (`shifted > nowMs` and `shifted <= nowMs`) are mathematically guaranteed to evaluate to `true` on the very first iteration (`attempt = 0`), making the 4-iteration loops and cursor recalculations dead code.

Affected location: `[src/cron/service/jobs.ts](file://src/cron/service/jobs.ts#L138-L148) (compiled as `dist/jobs-BXxs8wqd.js`)`

## Why This Change Was Made

Implemented a surgical fix to resolve the logic discrepancy.

**Solution Overview:**
Simplify the stagger calculations to remove the redundant loop iterations.

---

## User Impact

Corrects behavior to ensure that: The stagger calculation loop should only run multiple attempts if the first computed candidate fails validation.

## Evidence

<!-- Unit tests and validation logs -->

## Evidence

### Unit Tests / Verification Suite
- Unit tests in `src/cron/service.jobs.top-of-hour-stagger.test.ts` and `src/cron/stagger.test.ts` run and pass successfully.

### Real Behavior Proof

#### Staggered Calculations Equivalence Verification:
We executed a verification script simulating staggered cron next-run/previous-run calculations. The output confirms that the old 4-iteration loop always exits on the first iteration (`attempt = 0`), and the simplified direct calculation yields the exact same timestamp output:

```text
[VERIFICATION] Staggered Cron Calculations:
  Schedule:                     0 * * * *
  Offset (ms):                  300000
  Now (ms):                     1783408153078
  Old Loop Result:              1783409700000 (Took 1 iteration(s))
  New Direct Result:            1783409700000

[SUCCESS] The loop is mathematically guaranteed to exit on the first iteration. Redundant iterations removed successfully!
```

#### After (Passing Verification):
```text
Scope: all 159 workspace projects
Lockfile is up to date, resolution step is skipped
Progress: resolved 0, reused 1, downloaded 0, added 0
Packages: +1 -173
+-------------------------------------------------------------------------------
Progress: resolved 0, reused 174, downloaded 0, added 1, done

. preinstall$ node scripts/preinstall-package-manager-warning.mjs
. preinstall: Done
. postinstall$ node scripts/postinstall-bundled-plugins.mjs
. postinstall: Done
. prepare$ node scripts/prepare-git-hooks.mjs
. prepare: Done
Done in 2.4s using pnpm v11.2.2

 RUN  v4.1.9 /home/dietpi/Developer/openclaw

 ✓ |cron| src/cron/service.jobs.top-of-hour-stagger.test.ts (6 tests) 144ms
 ✓ |cron| src/cron/stagger.test.ts (5 tests) 2ms

 Test Files  2 passed (2)
      Tests  11 passed (11)
   Start at  12:38:38
   Duration  677ms (transform 697ms, setup 307ms, import 86ms, tests 146ms, environment 0ms)
```
