### PR TITLE
refactor(core): remove stale internal exports

### DIFF
--- a/src/agents/worktrees/registry.test.ts
+++ b/src/agents/worktrees/registry.test.ts
@@ -6,7 +6,7 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import {
   deleteRegistryWorktree,
   findRegistryWorktreeByPath,
-  findLiveRegistryWorktree,
+  findLiveRegistryWorktreeByPath,
   getRegistryWorktree,
   insertRegistryWorktree,
   listRegistryWorktrees,
@@ -54,7 +54,7 @@ describe("managed worktree registry", () => {
     });
 
     expect(listRegistryWorktrees(env).map((entry) => entry.id)).toEqual(["second", "first"]);
-    expect(findLiveRegistryWorktree(env, record.repoFingerprint, record.path)).toMatchObject({
+    expect(findLiveRegistryWorktreeByPath(env, record.path)).toMatchObject({
       id: "first",
       ownerKind: "workboard",
       ownerId: "card-1",
@@ -70,6 +70,7 @@ describe("managed worktree registry", () => {
       removedAt: 40,
       snapshotRef: "refs/openclaw/snapshots/first",
     });
+    expect(findLiveRegistryWorktreeByPath(env, record.path)).toBeUndefined();
     expect(findRegistryWorktreeByPath(env, record.path)?.id).toBe("first");
 
     deleteRegistryWorktree(env, "first");

--- a/src/agents/worktrees/registry.ts
+++ b/src/agents/worktrees/registry.ts
@@ -75,24 +75,6 @@ export function getRegistryWorktree(
   return row ? rowToRecord(row) : undefined;
 }
 
-export function findLiveRegistryWorktree(
-  env: NodeJS.ProcessEnv,
-  repoFingerprint: string,
-  worktreePath: string,
-): ManagedWorktreeRecord | undefined {
-  const db = dbFor(env);
-  const query = kyselyFor(db)
-    .selectFrom("worktrees")
-    .selectAll()
-    .where("repo_fingerprint", "=", repoFingerprint)
-    .where("path", "=", worktreePath)
-    .where("removed_at", "is", null)
-    .orderBy("created_at", "desc")
-    .limit(1);
-  const row = executeSqliteQuerySync(db, query).rows[0];
-  return row ? rowToRecord(row) : undefined;
-}
-
 export function findLiveRegistryWorktreeByPath(
   env: NodeJS.ProcessEnv,
   worktreePath: string,

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -23,7 +23,6 @@ import {
   markSessionAbortTarget,
   patchSessionEntry,
   persistSessionResetLifecycle,
-  persistSessionRolloverLifecycle,
   persistSessionTranscriptTurn,
   purgeDeletedAgentSessionEntries,
   publishTranscriptUpdate,
@@ -1788,63 +1787,6 @@ describe("session accessor file-backed seam", () => {
     );
     expect(fs.readFileSync(archivedPreviousTranscript, "utf-8")).toContain('"content":"hi"');
     expect(fs.readFileSync(nextTranscript, "utf-8")).toContain('"content":"hello"');
-  });
-
-  it("persists rollover entries and returns archived previous transcript info", async () => {
-    const now = Date.now();
-    const sessionKey = "agent:main:telegram:dm:user";
-    const retiredKey = "agent:main:main";
-    const previousTranscript = path.join(tempDir, "previous-rollover.jsonl");
-    const previousEntry: SessionEntry = {
-      sessionFile: previousTranscript,
-      sessionId: "previous-rollover",
-      updatedAt: now,
-    };
-    const nextEntry: SessionEntry = {
-      sessionFile: path.join(tempDir, "next-rollover.jsonl"),
-      sessionId: "next-rollover",
-      updatedAt: now + 1,
-    };
-    fs.writeFileSync(previousTranscript, '{"type":"session","id":"previous-rollover"}\n', "utf-8");
-    await upsertSessionEntry({ sessionKey, storePath }, previousEntry);
-    await upsertSessionEntry(
-      { sessionKey: retiredKey, storePath },
-      {
-        lastChannel: "telegram",
-        lastTo: "user",
-        sessionId: "legacy-main",
-        updatedAt: now,
-      },
-    );
-
-    const result = await persistSessionRolloverLifecycle({
-      activeSessionKey: sessionKey,
-      agentId: "main",
-      previousEntry,
-      retiredEntry: {
-        key: retiredKey,
-        entry: {
-          sessionId: "legacy-main",
-          updatedAt: now,
-        },
-      },
-      sessionEntry: nextEntry,
-      sessionKey,
-      storePath,
-    });
-
-    expect(result.sessionEntry).toMatchObject(nextEntry);
-    expect(result.previousSessionTranscript.transcriptArchived).toBe(true);
-    expect(result.previousSessionTranscript.sessionFile).toContain(
-      "previous-rollover.jsonl.reset.",
-    );
-    expect(loadSessionEntry({ sessionKey, storePath })).toMatchObject(nextEntry);
-    expect(loadSessionEntry({ sessionKey: retiredKey, storePath })).toEqual({
-      sessionId: "legacy-main",
-      updatedAt: expect.any(Number),
-    });
-    expect(fs.existsSync(previousTranscript)).toBe(false);
-    expect(fs.existsSync(result.previousSessionTranscript.sessionFile ?? "")).toBe(true);
   });
 
   it("appends transcript events through a session scope", async () => {

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -408,11 +408,6 @@ export type SessionLifecycleTranscriptInfo = {
   transcriptArchived?: boolean;
 };
 
-export type SessionLifecycleRolloverResult = {
-  previousSessionTranscript: SessionLifecycleTranscriptInfo;
-  sessionEntry: SessionEntry;
-};
-
 export type ReplySessionInitializationSnapshot = {
   currentEntry?: SessionEntry;
   readEntry: (sessionKey: string) => SessionEntry | undefined;
@@ -1759,54 +1754,6 @@ export async function persistSessionResetLifecycle(params: {
     throw persistError;
   }
   return { replayedMessages };
-}
-
-/**
- * Persists a reply session rollover and returns stable previous-transcript
- * data for lifecycle hooks. Non-storage runtime cleanup remains with callers.
- */
-export async function persistSessionRolloverLifecycle(params: {
-  activeSessionKey: string;
-  agentId: string;
-  maintenanceConfig?: ResolvedSessionMaintenanceConfig;
-  onArchiveError?: (error: unknown, sourcePath: string) => void;
-  onMaintenanceWarning?: (warning: SessionMaintenanceWarning) => void | Promise<void>;
-  previousEntry?: SessionEntry;
-  retiredEntry?: SessionEntryRetirement;
-  sessionEntry: SessionEntry;
-  sessionKey: string;
-  storePath: string;
-}): Promise<SessionLifecycleRolloverResult> {
-  await updateSessionStore(
-    params.storePath,
-    (store) => {
-      store[params.sessionKey] = {
-        ...store[params.sessionKey],
-        ...params.sessionEntry,
-      };
-      if (params.retiredEntry) {
-        store[params.retiredEntry.key] = params.retiredEntry.entry;
-      }
-      return store[params.sessionKey] ?? params.sessionEntry;
-    },
-    {
-      activeSessionKey: params.activeSessionKey,
-      maintenanceConfig: params.maintenanceConfig,
-      onWarn: params.onMaintenanceWarning,
-    },
-  );
-
-  const previousSessionTranscript = await archivePreviousSessionTranscript({
-    agentId: params.agentId,
-    onArchiveError: params.onArchiveError,
-    previousEntry: params.previousEntry,
-    storePath: params.storePath,
-  });
-
-  return {
-    previousSessionTranscript,
-    sessionEntry: params.sessionEntry,
-  };
 }
 
 /** Loads the reply-session initialization rows without exposing a mutable store. */

--- a/src/gateway/gateway-codex-bind.live.test.ts
+++ b/src/gateway/gateway-codex-bind.live.test.ts
@@ -11,7 +11,7 @@ import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.j
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
-import { resolveBundledPluginWorkspaceSourcePath } from "../plugins/bundled-plugin-metadata.js";
+import { findBundledPluginMetadataById } from "../plugins/bundled-plugin-metadata.js";
 import { pluginCommands } from "../plugins/command-registry-state.js";
 import { clearPluginLoaderCache } from "../plugins/loader.js";
 import {
@@ -278,14 +278,15 @@ function resolveCodexPluginRoot(): string {
   if (command?.pluginRoot) {
     return command.pluginRoot;
   }
-  const pluginRoot = resolveBundledPluginWorkspaceSourcePath({
+  const metadata = findBundledPluginMetadataById("codex", {
     rootDir: process.cwd(),
-    pluginId: "codex",
+    includeChannelConfigs: false,
+    includeSyntheticChannelConfigs: false,
   });
-  if (!pluginRoot) {
+  if (!metadata) {
     throw new Error("Codex bundled plugin root was not found");
   }
-  return pluginRoot;
+  return path.resolve(process.cwd(), "extensions", metadata.dirName);
 }
 
 function resolveBoundSessionKey(params: {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -139,13 +139,6 @@ export type ClawHubPackageSecurityResponse = {
   } | null;
   trust: ClawHubPackageSecurityTrust;
 };
-export type ClawHubPackageReadiness = {
-  ok?: boolean;
-  ready?: boolean;
-  status?: string | null;
-  reasons?: string[];
-  checks?: Record<string, unknown>;
-} & Record<string, unknown>;
 export type ClawHubPackageClawPackSummary = {
   available: boolean;
   specVersion?: number | null;
@@ -1114,22 +1107,6 @@ export async function fetchClawHubPackageSecurity(params: {
     fetchImpl: params.fetchImpl,
   });
   return parseClawHubPackageSecurityResponse(response);
-}
-
-export async function fetchClawHubPackageReadiness(params: {
-  name: string;
-  baseUrl?: string;
-  token?: string;
-  timeoutMs?: number;
-  fetchImpl?: FetchLike;
-}): Promise<ClawHubPackageReadiness> {
-  return await fetchJson<ClawHubPackageReadiness>({
-    baseUrl: params.baseUrl,
-    path: `/api/v1/packages/${encodeURIComponent(params.name)}/readiness`,
-    token: params.token,
-    timeoutMs: params.timeoutMs,
-    fetchImpl: params.fetchImpl,
-  });
 }
 
 export async function searchClawHubPackages(params: {

--- a/src/infra/windows-gateway-firewall-diagnostics.ts
+++ b/src/infra/windows-gateway-firewall-diagnostics.ts
@@ -1026,15 +1026,3 @@ export function formatWindowsGatewayFirewallGuidance(params: {
     "Windows firewall: if another device cannot connect to the LAN URL, run `openclaw gateway status --deep` from this Windows host.",
   ];
 }
-
-export function formatWindowsGatewayFirewallDiagnostic(
-  diagnostic: WindowsGatewayFirewallDiagnostic,
-): string[] {
-  if (!diagnostic.applies || diagnostic.severity !== "warning") {
-    return [];
-  }
-  return [
-    `Windows firewall: ${diagnostic.message}`,
-    ...diagnostic.details.map((line) => `  ${line}`),
-  ];
-}

--- a/src/plugins/bundled-plugin-metadata.ts
+++ b/src/plugins/bundled-plugin-metadata.ts
@@ -206,29 +206,6 @@ export function findBundledPluginMetadataById(
   return listBundledPluginMetadata(params).find((entry) => entry.manifest.id === pluginId);
 }
 
-/** Resolves the source directory for a bundled plugin in the current workspace. */
-export function resolveBundledPluginWorkspaceSourcePath(params: {
-  rootDir: string;
-  scanDir?: string;
-  pluginId: string;
-}): string | null {
-  const metadata = findBundledPluginMetadataById(params.pluginId, {
-    ...resolveBundledPluginLookupParams({
-      rootDir: params.rootDir,
-      scanDir: params.scanDir,
-    }),
-    includeChannelConfigs: false,
-    includeSyntheticChannelConfigs: false,
-  });
-  if (!metadata) {
-    return null;
-  }
-  if (params.scanDir) {
-    return path.resolve(params.scanDir, metadata.dirName);
-  }
-  return path.resolve(params.rootDir, "extensions", metadata.dirName);
-}
-
 function listBundledPluginEntryBaseDirs(params: {
   rootDir: string;
   pluginDirName?: string;

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -36,7 +36,6 @@ import {
   drainPluginNextTurnInjections,
   enqueuePluginNextTurnInjection,
   patchPluginSessionExtension,
-  projectPluginSessionExtensions,
   projectPluginSessionExtensionsSync,
 } from "../host-hook-state.js";
 import { buildPluginAgentTurnPrepareContext, isPluginJsonValue } from "../host-hooks.js";
@@ -1389,9 +1388,6 @@ describe("host-hook fixture plugin contract", () => {
     expect(projectPluginSessionExtensionsSync({ sessionKey: "agent:main:main", entry })).toEqual(
       [],
     );
-    await expect(
-      projectPluginSessionExtensions({ sessionKey: "agent:main:main", entry }),
-    ).resolves.toStrictEqual([]);
   });
 
   it("skips throwing session extension projectors without losing other projections", () => {

--- a/src/plugins/host-hook-state.ts
+++ b/src/plugins/host-hook-state.ts
@@ -416,13 +416,6 @@ function projectSessionExtensionValueForSlot(params: {
   return copyJsonValue(projected);
 }
 
-export async function projectPluginSessionExtensions(params: {
-  sessionKey: string;
-  entry: SessionEntry;
-}): Promise<PluginSessionExtensionProjection[]> {
-  return collectPluginSessionExtensionProjections(params);
-}
-
 function collectPluginSessionExtensionProjections(params: {
   sessionKey: string;
   entry: SessionEntry;

--- a/src/plugins/host-hooks.ts
+++ b/src/plugins/host-hooks.ts
@@ -259,11 +259,6 @@ export type PluginSessionAttachmentResult =
     }
   | { ok: false; error: string };
 
-export type PluginSessionTurnSchedule =
-  | { at: string | number | Date }
-  | { delayMs: number }
-  | { cron: string; tz?: string };
-
 type PluginSessionTurnScheduleCommonParams = {
   sessionKey: string;
   message: string;

--- a/src/plugins/managed-npm-retention.ts
+++ b/src/plugins/managed-npm-retention.ts
@@ -5,7 +5,6 @@ import { safePathSegmentHashed } from "../infra/install-safe-path.js";
 import { resolveDefaultPluginNpmDir, resolvePluginNpmProjectsDir } from "./install-paths.js";
 import { listManagedPluginNpmRootsSync } from "./npm-project-roots.js";
 
-export const RETAINED_MANAGED_NPM_INSTALL_MARKER = ".openclaw-retained-npm-install.json";
 const RETAINED_MANAGED_NPM_INSTALL_MARKER_DIR = ".openclaw-retained-npm-installs";
 
 export function resolveRetainedManagedNpmInstallPackageInfo(packageDir: string): {

--- a/src/plugins/plugin-registry-snapshot.test.ts
+++ b/src/plugins/plugin-registry-snapshot.test.ts
@@ -16,10 +16,7 @@ import {
   resolveInstalledPluginIndexPolicyHash,
   type InstalledPluginIndex,
 } from "./installed-plugin-index.js";
-import {
-  markRetainedManagedNpmInstall,
-  RETAINED_MANAGED_NPM_INSTALL_MARKER,
-} from "./managed-npm-retention.js";
+import { markRetainedManagedNpmInstall } from "./managed-npm-retention.js";
 import { loadPluginManifestRegistryForInstalledIndex } from "./manifest-registry-installed.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
@@ -507,7 +504,7 @@ describe("loadPluginRegistrySnapshotWithMetadata", () => {
       version: "2026.6.10-beta.1",
     });
     fs.writeFileSync(
-      path.join(codexDir, RETAINED_MANAGED_NPM_INSTALL_MARKER),
+      path.join(codexDir, ".openclaw-retained-npm-install.json"),
       '{"version":1,"pluginId":"codex"}\n',
       "utf8",
     );

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -293,12 +293,12 @@ describe("bundled plugin public surface loader", () => {
       typeof import("./public-surface-loader.js")
     >(import.meta.url, "./public-surface-loader.js?scope=missing-location-retry");
 
-    expect(
-      publicSurfaceLoader.resolveBundledPluginPublicArtifactPath({
+    expect(() =>
+      publicSurfaceLoader.loadBundledPluginPublicArtifactModuleSync({
         dirName: "demo",
         artifactBasename: "api.js",
       }),
-    ).toBeNull();
+    ).toThrow("Unable to resolve bundled plugin public surface demo/api.js");
 
     const modulePath = path.join(bundledPluginsDir, "demo", "api.js");
     fs.mkdirSync(path.dirname(modulePath), { recursive: true });

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -193,13 +193,6 @@ export function loadBundledPluginPublicArtifactModuleFromCandidatesSync<T extend
   return null;
 }
 
-export function resolveBundledPluginPublicArtifactPath(params: {
-  dirName: string;
-  artifactBasename: string;
-}): string | null {
-  return resolvePublicSurfaceLocation(params)?.modulePath ?? null;
-}
-
 export function resetBundledPluginPublicArtifactLoaderForTest(): void {
   publicSurfaceModuleCache.clear();
   publicSurfaceLocationCache.clear();

--- a/src/plugins/runtime/runtime-web-channel-plugin.test.ts
+++ b/src/plugins/runtime/runtime-web-channel-plugin.test.ts
@@ -61,24 +61,4 @@ describe("runtime web channel plugin", () => {
       "web channel plugin runtime is missing export 'resolveDefaultWebAuthDir'",
     );
   });
-
-  it("forwards the explicit connection wait policy to the heavy runtime", async () => {
-    const waitForWaConnection = vi.fn().mockResolvedValue(undefined);
-    const sock = { id: "socket" };
-
-    vi.doMock("./runtime-plugin-boundary.js", () => ({
-      loadPluginBoundaryModule: () => ({ waitForWaConnection }),
-      resolvePluginRuntimeModulePath: () => "/tmp/runtime-api.js",
-      resolvePluginRuntimeRecordByEntryBaseNames: () => ({
-        origin: "bundled",
-        source: "test",
-      }),
-    }));
-
-    const { waitForWebChannelConnection } = await import("./runtime-web-channel-plugin.js");
-
-    await waitForWebChannelConnection(sock, { timeoutMs: 12_345 });
-
-    expect(waitForWaConnection).toHaveBeenCalledWith(sock, { timeoutMs: 12_345 });
-  });
 });

--- a/src/plugins/runtime/runtime-web-channel-plugin.ts
+++ b/src/plugins/runtime/runtime-web-channel-plugin.ts
@@ -22,14 +22,6 @@ type WebChannelPluginRecord = {
   source: string;
 };
 
-type WebChannelConnectionWaitOptions =
-  | {
-      timeout: "none";
-    }
-  | {
-      timeoutMs: number;
-    };
-
 type WebChannelLightRuntimeModule = {
   getActiveWebListener: (accountId?: string | null) => unknown;
   getWebAuthAgeMs: (authDir?: string) => number | null;
@@ -62,7 +54,6 @@ type WebChannelHeavyRuntimeModule = {
   monitorWebChannel: (...args: unknown[]) => Promise<unknown>;
   monitorWebInbox: (...args: unknown[]) => Promise<unknown>;
   startWebLoginWithQr: (...args: unknown[]) => Promise<unknown>;
-  waitForWaConnection: (sock: unknown, options: WebChannelConnectionWaitOptions) => Promise<void>;
   waitForWebLogin: (...args: unknown[]) => Promise<unknown>;
   extractMediaPlaceholder: (...args: unknown[]) => unknown;
   extractText: (...args: unknown[]) => unknown;
@@ -294,13 +285,6 @@ export async function startWebLoginWithQr(
   ...args: Parameters<WebChannelHeavyRuntimeModule["startWebLoginWithQr"]>
 ): ReturnType<WebChannelHeavyRuntimeModule["startWebLoginWithQr"]> {
   return (await getHeavyExport("startWebLoginWithQr"))(...args);
-}
-
-/** Waits for web-channel socket connection through the heavy runtime API. */
-export async function waitForWebChannelConnection(
-  ...args: Parameters<WebChannelHeavyRuntimeModule["waitForWaConnection"]>
-): ReturnType<WebChannelHeavyRuntimeModule["waitForWaConnection"]> {
-  return (await getHeavyExport("waitForWaConnection"))(...args);
 }
 
 /** Waits for web-channel login through the heavy runtime API. */


### PR DESCRIPTION
Closes #100854

## What Problem This Solves

Resolves a maintenance problem where stale internal exports left duplicate lifecycle, loader, registry, and plugin-runtime paths after their production callers had moved or disappeared.

## Why This Change Was Made

The change removes graph-verified definition-only helpers, including a ClawHub endpoint client accidentally reintroduced after an earlier cleanup. Tests now exercise the canonical production seam or keep test-only literals local. Manifest-loaded hooks and public plugin SDK/protocol exports were deliberately preserved.

## User Impact

No user-visible behavior changes. The internal runtime surface is smaller and has fewer misleading or duplicate paths.

## Evidence

- Codebase-memory graph: 272,931 nodes and 1,087,146 edges after indexing the rebased branch.
- Focused Blacksmith Testbox proof: 197 tests passed across worktree registry, session lifecycle, plugin loading/metadata, host hooks, runtime facade, and retention.
- `pnpm check:changed` on Testbox `tbx_01kwvgdznssnm9ax170cgccvxs`: core, core-test, extension, and extension-test typechecks passed; full core and extension lint passed; import-cycle and policy guards passed.
- Fresh Codex autoreview: no accepted/actionable findings.
- Diff: 17 files, 14 insertions, 262 deletions.
