### PR TITLE
fix(browser): foreground tabs before screenshots

### DIFF
--- a/extensions/browser/src/browser/cdp.internal.test.ts
+++ b/extensions/browser/src/browser/cdp.internal.test.ts
@@ -87,6 +87,7 @@ async function startMockWsServer(handle: CdpReplyHandler) {
       handle(msg, socket);
       if (
         msg.method === "Page.enable" ||
+        msg.method === "Page.bringToFront" ||
         msg.method === "Runtime.enable" ||
         msg.method === "Network.enable" ||
         msg.method === "DOM.enable" ||

--- a/extensions/browser/src/browser/cdp.screenshot-params.test.ts
+++ b/extensions/browser/src/browser/cdp.screenshot-params.test.ts
@@ -13,6 +13,7 @@ const sentMessages = vi.hoisted(() => {
 // Tracks whether emulation has been cleared so post-clear Runtime.evaluate
 // can return different values for the "emulated tab" vs "non-emulated tab" tests.
 const mockState = vi.hoisted(() => ({
+  bringToFrontError: undefined as Error | undefined,
   emulationCleared: false,
   emulatedTab: true,
   viewport: { w: 800, h: 600, dpr: 2, sw: 800, sh: 600 } as Record<string, unknown>,
@@ -28,6 +29,9 @@ vi.mock("./cdp.helpers.js", () => ({
     ) => {
       const send = (method: string, params?: Record<string, unknown>) => {
         sentMessages.push({ method, params });
+        if (method === "Page.bringToFront" && mockState.bringToFrontError) {
+          return Promise.reject(mockState.bringToFrontError);
+        }
         if (method === "Page.captureScreenshot") {
           return Promise.resolve({ data: "AAAA" });
         }
@@ -89,6 +93,7 @@ const localProfile: ResolvedBrowserProfile = {
 
 beforeEach(() => {
   sentMessages.length = 0;
+  mockState.bringToFrontError = undefined;
   mockState.emulationCleared = false;
   mockState.emulatedTab = true;
   mockState.viewport = { w: 800, h: 600, dpr: 2, sw: 800, sh: 600 };
@@ -113,10 +118,25 @@ describe("CDP screenshot params", () => {
     expect(call.params).not.toHaveProperty("captureBeyondViewport");
     expect(call.params).not.toHaveProperty("clip");
 
+    const methods = sentMessages.map((message) => message.method);
+    expect(methods).toContain("Page.bringToFront");
+    expect(methods.indexOf("Page.enable")).toBeLessThan(methods.indexOf("Page.bringToFront"));
+    expect(methods.indexOf("Page.bringToFront")).toBeLessThan(
+      methods.indexOf("Page.captureScreenshot"),
+    );
+
     const emulationCalls = sentMessages.filter(
       (m) => m.method === "Emulation.setDeviceMetricsOverride",
     );
     expect(emulationCalls).toHaveLength(0);
+  });
+
+  it("captures when Page.bringToFront is unsupported", async () => {
+    mockState.bringToFrontError = new Error("unsupported");
+
+    await captureScreenshot({ wsUrl: "ws://localhost:9222/devtools/page/X" });
+
+    requireSentMessage("Page.captureScreenshot");
   });
 
   it("uses the requested timeout as the raw CDP command timeout", async () => {

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -79,6 +79,10 @@ export async function captureScreenshot(opts: {
     async (send) => {
       await send("Page.enable");
 
+      // Background surface captures can stall until CDP times out; activate to force a frame.
+      // Ignore protocol rejection so browsers that already capture correctly still proceed.
+      await send("Page.bringToFront").catch(() => {});
+
       // For full-page captures, temporarily expand the viewport to the content
       // size so the entire page is within the viewport bounds.  We save the
       // current viewport state and restore it after capture so pre-existing


### PR DESCRIPTION
## What Problem This Solves

Direct-CDP screenshots can stall until the command timeout when the selected managed-Chromium tab is backgrounded. This takes #89576 as the contributor base; the replacement is necessary because GitHub cannot update that organization-fork branch through either maintainer push path.

## Why This Change Was Made

Issue `Page.bringToFront` after `Page.enable` and before `Page.captureScreenshot`, matching the official CDP activation contract and the existing Playwright/Chrome-MCP focus surfaces. Protocol rejection is tolerated so browsers that already capture correctly can continue.

The original 57-line patch was tightened to 25 lines: production behavior remains two lines plus its invariant comment, the shared WebSocket fixture acknowledges the new command, and ordering/failure coverage lives in the existing focused screenshot-parameter suite. The landed commit preserves Spencer Fuller's co-author credit.

## User Impact

Agents can capture a selected background tab without waiting for the screenshot timeout. Capturing intentionally activates that tab; no config, protocol, auth, or trust-boundary behavior changes.

## Evidence

- Source and sibling-path review: direct CDP route, screenshot route selection, Playwright focus fallback, Chrome MCP page selection, command-timeout handling, and adjacent screenshot tests.
- Official CDP contract: `Page.bringToFront` activates the tab; `Page.captureScreenshot` captures from the surface by default.
- Focused test coverage asserts `Page.enable -> Page.bringToFront -> Page.captureScreenshot` and capture fallback on protocol rejection.
- Targeted `oxfmt --check` and `git diff --check`: passed.
- Fresh full-branch structured autoreview: clean, no actionable findings.
- Sanitized AWS Crabbox `safe-screenshot-2` / `cbx_de88b948ede9`, run `run_5e380ad8a3d2`: trusted bootstrap verified the exact SHA and empty IAM role, installed pinned Node/pnpm, and passed 39/39 focused tests.
- Live AWS run `run_ed88147a45bd`: exact-head full build, isolated Dev Gateway, OpenAI `gpt-5.4-mini` agent, and managed Chromium. The agent kept two randomized stable tabs, captured background target `t1` twice, returned two 16,930-byte PNGs, retained both tabs, and reported no browser error.
- Chrome 148 run `run_4a6fd2f24c75`: three raw background captures and three activation-first captures all succeeded; activation-first remained consistently fast at 65-66 ms. The original slow baseline did not reproduce on this x86 Chrome-for-Testing build.
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/28787142048 (success).
