### PR TITLE
fix(agents): handle stdout stream errors in shell snapshot runShell

### DIFF
--- a/scripts/proof/shell-snapshot-stdout-stream-errors.mts
+++ b/scripts/proof/shell-snapshot-stdout-stream-errors.mts
@@ -1,0 +1,60 @@
+// Real behavior proof: shell-snapshot runShell handles stdout stream error
+// events without crashing the agent.
+//
+// The proof patches child_process.spawn so the shell child is a real process
+// whose stdout stream emits an error event after runShell attaches listeners.
+// With the fix the promise resolves to a null-status result; without the stdout
+// error listener the unhandled error would terminate the process.
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process") as typeof import("node:child_process");
+const originalSpawn = childProcess.spawn;
+
+let emitError: (() => void) | null = null;
+
+childProcess.spawn = (...args: Parameters<typeof originalSpawn>) => {
+  const child = originalSpawn.apply(childProcess, args);
+  emitError = () => {
+    child.stdout?.emit("error", new Error("stdout read failed"));
+  };
+  return child;
+};
+
+const { testing } = await import(path.join(repoRoot, "src/agents/shell-snapshot.js"));
+
+console.log("=== Proof: shell-snapshot runShell stdout stream error handling ===\n");
+
+try {
+  const resultPromise = testing.runShell({
+    shell: "/bin/sh",
+    shellArgs: ["-c"],
+    command: "sleep 1",
+    cwd: "/tmp",
+    env: {},
+    timeoutMs: 5_000,
+  });
+
+  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  emitError?.();
+
+  const result = await resultPromise;
+  console.log(`Result: status=${result.status}, stdout=${JSON.stringify(result.stdout)}`);
+  if (result.status === null) {
+    console.log("\nPASS: stdout stream error was caught and runShell returned a null-status result.");
+  } else {
+    console.log("\nFAIL: runShell did not treat the stdout error as a failure.");
+    process.exitCode = 1;
+  }
+} catch (err) {
+  console.error("\nFAIL: runShell rejected with:");
+  console.error(err);
+  process.exitCode = 1;
+} finally {
+  childProcess.spawn = originalSpawn;
+}

--- a/scripts/proof/shell-snapshot-stdout-stream-errors.mts
+++ b/scripts/proof/shell-snapshot-stdout-stream-errors.mts
@@ -40,7 +40,9 @@ try {
     timeoutMs: 5_000,
   });
 
-  await new Promise<void>((resolve) => setTimeout(resolve, 50));
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 50);
+  });
   emitError?.();
 
   const result = await resultPromise;

--- a/src/agents/shell-snapshot.run-shell.test.ts
+++ b/src/agents/shell-snapshot.run-shell.test.ts
@@ -1,0 +1,47 @@
+/** Tests for runShell stream error handling. */
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { testing } from "./shell-snapshot.js";
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+const { spawn } = await import("node:child_process");
+
+describe("runShell", () => {
+  it("finishes gracefully when stdout emits an error", async () => {
+    const mockSpawn = vi.mocked(spawn);
+    const child = new EventEmitter() as EventEmitter & {
+      pid: number;
+      stdout: EventEmitter & { setEncoding: (enc: string) => void; destroy: () => void };
+    };
+    const stdout = new EventEmitter() as EventEmitter & {
+      setEncoding: (enc: string) => void;
+      destroy: () => void;
+    };
+    stdout.setEncoding = () => {};
+    stdout.destroy = () => {};
+    child.pid = 1234;
+    child.stdout = stdout;
+    mockSpawn.mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+    const resultPromise = testing.runShell({
+      shell: "/bin/bash",
+      shellArgs: ["-c"],
+      command: "echo hello",
+      cwd: "/tmp",
+      env: {},
+      timeoutMs: 30_000,
+    });
+
+    stdout.emit("error", new Error("stdout EPIPE"));
+
+    const result = await resultPromise;
+    expect(result.status).toBeNull();
+  });
+});

--- a/src/agents/shell-snapshot.ts
+++ b/src/agents/shell-snapshot.ts
@@ -469,6 +469,9 @@ async function runShell(opts: {
     child.stdout.on("data", (chunk) => {
       stdout += chunk;
     });
+    child.stdout.on("error", () => {
+      finish(null);
+    });
     child.on("error", () => {
       finish(null);
     });
@@ -507,3 +510,7 @@ async function cleanupStaleSnapshots(snapshotDir: string): Promise<void> {
       }),
   );
 }
+
+export const testing = {
+  runShell,
+} as const;


### PR DESCRIPTION
## What Problem This Solves

`runShell` in `src/agents/shell-snapshot.ts` reads the child shell's stdout but only attaches a `"data"` listener. If stdout emits an `"error"` event during spawn teardown or stream destruction, the error is unhandled and can crash the agent process.

## Why This Change Was Made

Added an `"error"` listener to `child.stdout` that calls the existing `finish(null)` path, treating a stdout failure the same as a shell timeout or process error. This follows the same stream-error handling pattern already applied to other child-process runners.

## User Impact

Shell snapshot capture no longer crashes on stdout stream errors; it returns a null-status result instead.

## Evidence

Regression test:

```bash
pnpm test src/agents/shell-snapshot.run-shell.test.ts
```

```
Test Files  1 passed (1)
     Tests  1 passed (1)
```


## Real behavior proof

Real process-level proof that a stdout stream error no longer crashes the agent:

```bash
node_modules/.bin/tsx scripts/proof/shell-snapshot-stdout-stream-errors.mts
```

```
=== Proof: shell-snapshot runShell stdout stream error handling ===

Result: status=null, stdout=""

PASS: stdout stream error was caught and runShell returned a null-status result.
```