### PR TITLE
fix: block side effects while steer is pending

### DIFF
--- a/src/agents/embedded-agent-runner/run-state.ts
+++ b/src/agents/embedded-agent-runner/run-state.ts
@@ -21,6 +21,7 @@ export type EmbeddedAgentQueueHandle = {
   kind?: "embedded";
   runId?: string;
   queueMessage: (text: string, options?: EmbeddedAgentQueueMessageOptions) => Promise<void>;
+  getSteeringMessages?: () => readonly string[];
   isStreaming: () => boolean;
   isStopped?: () => boolean;
   isAbortable?: () => boolean;

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -3750,6 +3750,7 @@ export async function runEmbeddedAttempt(
           }
           await steerActiveSessionWithOptionalDeliveryWait(activeSession, text, options);
         },
+        getSteeringMessages: () => activeSession.getSteeringMessages?.() ?? [],
         isStreaming: () => activeSession.isStreaming,
         isStopped: () => !acceptingSteerMessages || aborted || runAbortController.signal.aborted,
         isCompacting: () => subscription.isCompacting(),

--- a/src/agents/embedded-agent-runner/runs.test.ts
+++ b/src/agents/embedded-agent-runner/runs.test.ts
@@ -26,6 +26,7 @@ import {
   clearEmbeddedAgentRunAbortabilityForRunId,
   clearEmbeddedRunAbandonment,
   getActiveEmbeddedRunSnapshot,
+  hasPendingEmbeddedRunSteering,
   isEmbeddedAgentRunAbortableForRunId,
   isEmbeddedAgentRunAbortableForCompaction,
   isEmbeddedAgentRunHandleActive,
@@ -59,6 +60,7 @@ function createRunHandle(
       text: string,
       options?: Parameters<RunHandle["queueMessage"]>[1],
     ) => Promise<void>;
+    getSteeringMessages?: () => readonly string[];
     supportsTranscriptCommitWait?: boolean;
   } = {},
 ): RunHandle {
@@ -68,6 +70,9 @@ function createRunHandle(
   return {
     runId: overrides.runId,
     queueMessage: overrides.queueMessage ?? (async () => {}),
+    ...(overrides.getSteeringMessages
+      ? { getSteeringMessages: overrides.getSteeringMessages }
+      : {}),
     isStreaming: () => overrides.isStreaming ?? true,
     ...(overrides.isStopped ? { isStopped: overrides.isStopped } : {}),
     ...(overrides.isAbortable !== undefined
@@ -766,6 +771,22 @@ describe("embedded-agent runner run registry", () => {
 
     expect(isEmbeddedAgentRunHandleActive("session-a")).toBe(false);
     expect(resolveActiveEmbeddedRunHandleSessionId("agent:main:main")).toBeUndefined();
+  });
+
+  it("reports pending steering messages on active embedded handles", () => {
+    const handle = createRunHandle({
+      getSteeringMessages: () => ["should we still send?"],
+    });
+
+    expect(hasPendingEmbeddedRunSteering("session-a")).toBe(false);
+
+    setActiveEmbeddedRun("session-a", handle, "agent:main:main");
+
+    expect(hasPendingEmbeddedRunSteering("session-a")).toBe(true);
+
+    clearActiveEmbeddedRun("session-a", handle, "agent:main:main");
+
+    expect(hasPendingEmbeddedRunSteering("session-a")).toBe(false);
   });
 
   it("tracks timeout abandonment by session id, key, and file until a new run starts", () => {

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -631,6 +631,11 @@ export function isEmbeddedAgentRunStreaming(sessionId: string): boolean {
   return handle.isStreaming();
 }
 
+export function hasPendingEmbeddedRunSteering(sessionId: string): boolean {
+  const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  return (handle?.getSteeringMessages?.().length ?? 0) > 0;
+}
+
 export function resolveActiveEmbeddedRunHandleSessionId(sessionKey: string): string | undefined {
   const normalizedSessionKey = sessionKey.trim();
   if (!normalizedSessionKey) {

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -135,6 +135,7 @@ function installMessagingTestRegistry() {
 
 function createOpenClawTools(options?: {
   agentSessionKey?: string;
+  sessionId?: string;
   agentChannel?: string;
   sandboxed?: boolean;
   config?: OpenClawConfig;
@@ -157,6 +158,7 @@ function createOpenClawTools(options?: {
     }),
     createSessionsSendTool({
       agentSessionKey: options?.agentSessionKey,
+      sessionId: options?.sessionId,
       agentChannel: options?.agentChannel as never,
       sandboxed: options?.sandboxed,
       config,
@@ -361,6 +363,46 @@ describe("sessions tools", () => {
       .find((call) => call.method === "agent");
     expect(agentCall).toBeDefined();
     expect(agentParams(agentCall ?? {}).message).toContain(value);
+  });
+
+  it("sessions_send blocks transfer while the current active run has pending steering", async () => {
+    const requesterKey = "agent:main:main";
+    setActiveEmbeddedRun(
+      "current-active-session",
+      {
+        queueMessage: vi.fn(async () => {}),
+        getSteeringMessages: () => ["is this even needed?"],
+        isStreaming: () => true,
+        isCompacting: () => false,
+        supportsTranscriptCommitWait: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+        abort: () => {},
+      },
+      requesterKey,
+    );
+    callGatewayMock.mockImplementation(async (opts: unknown) => opts);
+
+    const tool = createOpenClawTools({
+      agentSessionKey: requesterKey,
+      sessionId: "current-active-session",
+      agentChannel: "telegram",
+    }).find((candidate) => candidate.name === "sessions_send");
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-pending-steer", {
+      sessionKey: "agent:founder:qip",
+      message: "transfer this context",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "blocked",
+      reason: "pending_steer_before_side_effect",
+      tool: "sessions_send",
+    });
+    expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
   it("sessions_send sanitizes formatted reasoning from aliases", async () => {

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -515,6 +515,7 @@ export function createOpenClawTools(
       : [
           createSessionsSendTool({
             agentSessionKey: options?.agentSessionKey,
+            sessionId: options?.sessionId,
             agentChannel: options?.agentChannel,
             sandboxed: options?.sandboxed,
             config: resolvedConfig,

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -15,6 +15,7 @@ import { wrapToolWithBeforeToolCallHook } from "../agent-tools.before-tool-call.
 import { CRITICAL_THRESHOLD } from "../tool-loop-detection.js";
 type CreateMessageTool = typeof import("./message-tool.js").createMessageTool;
 type CreateOpenClawTools = typeof import("../openclaw-tools.js").createOpenClawTools;
+type EmbeddedRunsModule = typeof import("../embedded-agent-runner/runs.js");
 type ResetPluginRuntimeStateForTest =
   typeof import("../../plugins/runtime.js").resetPluginRuntimeStateForTest;
 type SetActivePluginRegistry = typeof import("../../plugins/runtime.js").setActivePluginRegistry;
@@ -22,6 +23,7 @@ type CreateTestRegistry = typeof import("../../test-utils/channel-plugins.js").c
 
 let createMessageTool: CreateMessageTool;
 let createOpenClawTools: CreateOpenClawTools;
+let embeddedRuns: EmbeddedRunsModule;
 let resetPluginRuntimeStateForTest: ResetPluginRuntimeStateForTest;
 let setActivePluginRegistry: SetActivePluginRegistry;
 let createTestRegistry: CreateTestRegistry;
@@ -332,9 +334,11 @@ beforeAll(async () => {
   ({ createTestRegistry } = await import("../../test-utils/channel-plugins.js"));
   ({ createMessageTool } = await import("./message-tool.js"));
   ({ createOpenClawTools } = await import("../openclaw-tools.js"));
+  embeddedRuns = await import("../embedded-agent-runner/runs.js");
 });
 
 beforeEach(() => {
+  embeddedRuns?.testing.resetActiveEmbeddedRuns();
   resetPluginRuntimeStateForTest();
   resetDiagnosticSessionStateForTest();
   mocks.runMessageAction.mockReset();
@@ -1717,6 +1721,80 @@ describe("message tool loop detection action runner proof", () => {
       status: "blocked",
       deniedReason: "tool-loop",
     });
+  });
+});
+
+describe("message tool pending steering side-effect guard", () => {
+  beforeEach(() => {
+    mockSendResult();
+  });
+
+  it("blocks side-effect actions while pending steering exists for the active run", async () => {
+    embeddedRuns.setActiveEmbeddedRun(
+      "message-tool-active-session",
+      {
+        queueMessage: vi.fn(async () => {}),
+        getSteeringMessages: () => ["should this send happen?"],
+        isStreaming: () => true,
+        isCompacting: () => false,
+        abort: () => {},
+      },
+      "agent:main:main",
+    );
+    const messageTool = createMessageTool({
+      agentSessionKey: "agent:main:main",
+      sessionId: "message-tool-active-session",
+      runMessageAction: mocks.runMessageAction as never,
+    });
+
+    const result = await messageTool.execute("message-send-pending-steer", {
+      action: "send",
+      target: "channel:loop-room",
+      message: "context transfer",
+    });
+
+    expect(result.details).toMatchObject({
+      status: "blocked",
+      reason: "pending_steer_before_side_effect",
+      tool: "message",
+    });
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+  });
+
+  it("allows read actions while pending steering exists for the active run", async () => {
+    embeddedRuns.setActiveEmbeddedRun(
+      "message-tool-active-session",
+      {
+        queueMessage: vi.fn(async () => {}),
+        getSteeringMessages: () => ["answer this first"],
+        isStreaming: () => true,
+        isCompacting: () => false,
+        abort: () => {},
+      },
+      "agent:main:main",
+    );
+    mocks.runMessageAction.mockResolvedValueOnce({
+      kind: "action",
+      action: "read",
+      channel: "qa-channel",
+      handledBy: "dry-run",
+      payload: { messages: [] },
+      dryRun: true,
+    } satisfies MessageActionRunResult);
+    const messageTool = createMessageTool({
+      agentSessionKey: "agent:main:main",
+      sessionId: "message-tool-active-session",
+      runMessageAction: mocks.runMessageAction as never,
+    });
+
+    const result = await messageTool.execute("message-read-pending-steer", {
+      action: "read",
+      channel: "qa-channel",
+      target: "channel:loop-room",
+    });
+
+    expect(result.details).toMatchObject({ messages: [] });
+    expect(mocks.runMessageAction).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -67,6 +67,10 @@ import { stripFormattedReasoningMessage } from "../../shared/text/formatted-reas
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listAllChannelSupportedActions, listChannelSupportedActions } from "../channel-tools.js";
+import {
+  hasPendingEmbeddedRunSteering,
+  resolveActiveEmbeddedRunSessionId,
+} from "../embedded-agent-runner/runs.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
 import {
   channelTargetSchema,
@@ -871,6 +875,7 @@ const MessageToolSchema = buildMessageToolSchemaFromActions(AllMessageActions, {
   includeDeliveryPin: true,
   includeBestEffort: false,
 });
+const MESSAGE_TOOL_ACTIONS_ALLOWED_DURING_PENDING_STEER = new Set<string>(["read"]);
 
 type MessageToolOptions = {
   agentAccountId?: string;
@@ -1171,6 +1176,24 @@ function buildMessageToolDescription(options?: {
   );
 }
 
+function resolvePendingSteerSideEffectBlock(options: MessageToolOptions | undefined) {
+  const sessionId =
+    normalizeOptionalString(options?.sessionId) ??
+    (options?.agentSessionKey
+      ? resolveActiveEmbeddedRunSessionId(options.agentSessionKey)
+      : undefined);
+  if (!sessionId || !hasPendingEmbeddedRunSteering(sessionId)) {
+    return undefined;
+  }
+  return jsonResult({
+    status: "blocked",
+    reason: "pending_steer_before_side_effect",
+    error:
+      "Pending /steer message detected for the active run. Resolve the steering instruction before sending messages or transferring context.",
+    tool: "message",
+  });
+}
+
 function appendMessageToolVisibleReplyHint(
   description: string,
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode,
@@ -1331,6 +1354,12 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       const action = readStringParam(params, "action", {
         required: true,
       }) as ChannelMessageActionName;
+      if (!MESSAGE_TOOL_ACTIONS_ALLOWED_DURING_PENDING_STEER.has(action)) {
+        const pendingSteerBlock = resolvePendingSteerSideEffectBlock(options);
+        if (pendingSteerBlock) {
+          return pendingSteerBlock;
+        }
+      }
       if (
         suppressedVisiblePayloadReason &&
         action === "send" &&

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -33,6 +33,7 @@ import {
   type EmbeddedAgentQueueMessageOptions,
   type EmbeddedAgentQueueMessageOutcome,
   formatEmbeddedAgentQueueFailureSummary,
+  hasPendingEmbeddedRunSteering,
   queueEmbeddedAgentMessageWithOutcomeAsync,
   resolveActiveEmbeddedRunSessionId,
 } from "../embedded-agent-runner/runs.js";
@@ -92,6 +93,25 @@ function normalizeSessionsSendArguments(args: unknown): Record<string, unknown> 
     delete params[alias];
   }
   return params;
+}
+
+function resolvePendingSteerSideEffectBlock(opts: {
+  agentSessionKey?: string;
+  sessionId?: string;
+}) {
+  const sessionId =
+    normalizeOptionalString(opts.sessionId) ??
+    (opts.agentSessionKey ? resolveActiveEmbeddedRunSessionId(opts.agentSessionKey) : undefined);
+  if (!sessionId || !hasPendingEmbeddedRunSteering(sessionId)) {
+    return undefined;
+  }
+  return jsonResult({
+    status: "blocked",
+    reason: "pending_steer_before_side_effect",
+    error:
+      "Pending /steer message detected for the active run. Resolve the steering instruction before sending messages or transferring context.",
+    tool: "sessions_send",
+  });
 }
 
 function resolveConfiguredAgentMainSessionKey(params: {
@@ -342,6 +362,7 @@ async function startAgentRun(params: {
 
 export function createSessionsSendTool(opts?: {
   agentSessionKey?: string;
+  sessionId?: string;
   agentChannel?: GatewayMessageChannel;
   sandboxed?: boolean;
   config?: OpenClawConfig;
@@ -356,6 +377,13 @@ export function createSessionsSendTool(opts?: {
     prepareArguments: normalizeSessionsSendArguments,
     execute: async (_toolCallId, args) => {
       const params = normalizeSessionsSendArguments(args);
+      const pendingSteerBlock = resolvePendingSteerSideEffectBlock({
+        agentSessionKey: opts?.agentSessionKey,
+        sessionId: opts?.sessionId,
+      });
+      if (pendingSteerBlock) {
+        return pendingSteerBlock;
+      }
       const gatewayCall = opts?.callGateway ?? callGateway;
       const message = readStringParam(params, "message", { required: true });
       const timeoutSeconds = readNonNegativeIntegerParam(params, "timeoutSeconds") ?? 30;


### PR DESCRIPTION
## Summary
- Exposes pending steering state from active embedded run handles.
- Blocks `message` side-effect actions while a pending `/steer` exists, while still allowing `message(action=read)`.
- Blocks `sessions_send` context transfer while the current active session has pending steering.
- Passes the current session id through to the `sessions_send` tool so the guard can resolve the active run safely.

## What Problem This Solves
`/steer` is intentionally delivered after the current tool-call boundary and is not a hard abort. That is fine for ordinary steering, but it leaves a race at side-effect boundaries: an agent can send a message or transfer session context before it reads and resolves the steering correction.

This change keeps `/steer` as steering rather than changing it into a hard interrupt, but prevents `message` side effects and `sessions_send` context transfer from racing ahead while a steering message is pending on the active run.

## Evidence
Local targeted regression proof passed on this branch:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/runs.test.ts src/agents/openclaw-tools.sessions.test.ts src/agents/tools/message-tool.test.ts`
- `pnpm check:test-types`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/agents/embedded-agent-runner/run-state.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/runs.ts src/agents/embedded-agent-runner/runs.test.ts src/agents/openclaw-tools.ts src/agents/openclaw-tools.sessions.test.ts src/agents/tools/message-tool.ts src/agents/tools/message-tool.test.ts src/agents/tools/sessions-send-tool.ts`
- `pnpm exec oxlint src/agents/embedded-agent-runner/run-state.ts src/agents/embedded-agent-runner/run/attempt.ts src/agents/embedded-agent-runner/runs.ts src/agents/embedded-agent-runner/runs.test.ts src/agents/openclaw-tools.ts src/agents/openclaw-tools.sessions.test.ts src/agents/tools/message-tool.ts src/agents/tools/message-tool.test.ts src/agents/tools/sessions-send-tool.ts`

The new tests cover:

- active embedded handles report pending steering messages
- `sessions_send` blocks transfer while current active run steering is pending
- `message(action=send)` blocks while steering is pending
- `message(action=read)` remains allowed while steering is pending
