### PR TITLE
fix(telegram): pass proxy and apiRoot config when resolving setup allowFrom usernames

### DIFF
--- a/extensions/telegram/src/doctor.test.ts
+++ b/extensions/telegram/src/doctor.test.ts
@@ -438,6 +438,29 @@ describe("telegram doctor", () => {
     expect(result.changes[0]).toContain("@testuser");
   });
 
+  it("repairs @username entries using configured proxy and apiRoot", async () => {
+    lookupTelegramChatIdMock.mockResolvedValue("111");
+
+    const result = await maybeRepairTelegramAllowFromUsernames({
+      channels: {
+        telegram: {
+          botToken: "123:abc",
+          allowFrom: ["@testuser"],
+          proxy: "http://my-proxy",
+          apiRoot: "https://my-api-root",
+        },
+      },
+    } as unknown as OpenClawConfig);
+
+    expect(result.config.channels?.telegram?.allowFrom).toEqual(["111"]);
+    expect(lookupTelegramChatIdMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxyUrl: "http://my-proxy",
+        apiRoot: "https://my-api-root",
+      }),
+    );
+  });
+
   it("surfaces negative chat ids as invalid allowFrom sender entries", async () => {
     const result = await maybeRepairTelegramAllowFromUsernames({
       channels: {

--- a/extensions/telegram/src/doctor.ts
+++ b/extensions/telegram/src/doctor.ts
@@ -464,6 +464,8 @@ export async function maybeRepairTelegramAllowFromUsernames(cfg: OpenClawConfig)
         const id = await lookupTelegramChatId({
           token,
           chatId: username,
+          proxyUrl: account.config.proxy,
+          apiRoot: account.config.apiRoot,
           network: account.config.network,
           signal: undefined,
         });


### PR DESCRIPTION
## What Problem This Solves
During doctor setup verification (`maybeRepairTelegramAllowFromUsernames`), resolving `@username` entries to numeric user IDs via `lookupTelegramChatId` failed to pass the account's configured `proxyUrl` and `apiRoot`. This caused username lookups to bypass the proxy settings or fail in environments where direct access to Telegram is restricted.

This PR passes the configured `proxy` and `apiRoot` from the Telegram account config to `lookupTelegramChatId` during setup resolution.

## Evidence
Passed tests on branch `fix/5.2-telegram-setup-username-resolution-proxy`:
```
 ✓ |extension-telegram| extensions/telegram/src/doctor.test.ts (23 tests) 20ms
```