### PR TITLE
fix(macos): preserve launchd Node gateway in PortGuardian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - **Tlon image upload bounds:** cap remote image fetches before upload and fail closed on oversized or stalled responses instead of buffering them without a limit. (#100374) Thanks @hugenshen.
 - **Control UI approval prompts:** keep stale resolve failures and busy-state cleanup from leaking across newer approvals or Gateway reconnects. (#98394) Thanks @haruaiclone-droid.
 - **macOS service SecretRefs:** preserve generated env-file values for SecretRefs that remain in config when stale Gateway LaunchAgents are repaired or reinstalled without those variables in the invoking shell. (#99124) Thanks @mushuiyu886.
+- **macOS Gateway PortGuardian:** preserve launchd-managed Node Gateway processes launched from the OpenClaw dist entrypoint, preventing local mode from killing a valid Homebrew or git-checkout Gateway. (#94476) Thanks @lsr911 for the earlier #94488 allowlist attempt.
 - **Anthropic OAuth callbacks:** keep the provider-required `localhost` redirect URI stable while allowing the local callback listener to bind an explicit loopback host. (#96917) Thanks @xialonglee.
 - **Prompt-release media delivery:** accept active-leaf-preserving side appends while an embedded run temporarily releases its session lock, so successive message-tool media replies merge without a false session-takeover failure. (#100033, #100490) Thanks @scotthuang.
 - **Control UI Skills filters:** align agent and search controls, use translated labels, and preserve native checkbox and radio sizing. (#100526, #99996) Thanks @evan-YM.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ Docs: https://docs.openclaw.ai
 - **Tlon image upload bounds:** cap remote image fetches before upload and fail closed on oversized or stalled responses instead of buffering them without a limit. (#100374) Thanks @hugenshen.
 - **Control UI approval prompts:** keep stale resolve failures and busy-state cleanup from leaking across newer approvals or Gateway reconnects. (#98394) Thanks @haruaiclone-droid.
 - **macOS service SecretRefs:** preserve generated env-file values for SecretRefs that remain in config when stale Gateway LaunchAgents are repaired or reinstalled without those variables in the invoking shell. (#99124) Thanks @mushuiyu886.
-- **macOS Gateway PortGuardian:** preserve launchd-managed Node Gateway processes launched from the OpenClaw dist entrypoint, preventing local mode from killing a valid Homebrew or git-checkout Gateway. (#94476) Thanks @lsr911 for the earlier #94488 allowlist attempt.
 - **Anthropic OAuth callbacks:** keep the provider-required `localhost` redirect URI stable while allowing the local callback listener to bind an explicit loopback host. (#96917) Thanks @xialonglee.
 - **Prompt-release media delivery:** accept active-leaf-preserving side appends while an embedded run temporarily releases its session lock, so successive message-tool media replies merge without a false session-takeover failure. (#100033, #100490) Thanks @scotthuang.
 - **Control UI Skills filters:** align agent and search controls, use translated labels, and preserve native checkbox and radio sizing. (#100526, #99996) Thanks @evan-YM.

--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -534,12 +534,45 @@ actor PortGuardian {
             {
                 return true
             }
+            if self.isNodeOpenClawGatewayCommand(full) { return true }
             // If args are unavailable, treat a CLI listener as expected.
             if cmd.contains("openclaw"), full == cmd { return true }
             return false
         case .unconfigured:
             return false
         }
+    }
+
+    private static func isNodeOpenClawGatewayCommand(_ fullCommand: String) -> Bool {
+        let tokens = fullCommand
+            .split(whereSeparator: \.isWhitespace)
+            .map { self.unquoteCommandToken(String($0)) }
+        guard tokens.count >= 3 else { return false }
+        guard URL(fileURLWithPath: tokens[0]).lastPathComponent.lowercased() == "node" else {
+            return false
+        }
+        guard let entrypointIndex = tokens.firstIndex(where: self.isOpenClawDistEntrypointToken),
+              entrypointIndex + 1 < tokens.count
+        else {
+            return false
+        }
+        return tokens[entrypointIndex + 1].lowercased() == "gateway"
+    }
+
+    private static func isOpenClawDistEntrypointToken(_ token: String) -> Bool {
+        let normalized = token.replacingOccurrences(of: "\\", with: "/").lowercased()
+        guard normalized.hasSuffix("/dist/index.js") else { return false }
+        return normalized
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .contains { component in
+                component == "openclaw"
+                    || component.hasPrefix("openclaw-")
+                    || component.hasSuffix("-openclaw")
+            }
+    }
+
+    private static func unquoteCommandToken(_ token: String) -> String {
+        token.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
     }
 
     private func probeGatewayHealthIfNeeded(

--- a/apps/macos/Sources/OpenClaw/PortGuardian.swift
+++ b/apps/macos/Sources/OpenClaw/PortGuardian.swift
@@ -551,12 +551,8 @@ actor PortGuardian {
         guard URL(fileURLWithPath: tokens[0]).lastPathComponent.lowercased() == "node" else {
             return false
         }
-        guard let entrypointIndex = tokens.firstIndex(where: self.isOpenClawDistEntrypointToken),
-              entrypointIndex + 1 < tokens.count
-        else {
-            return false
-        }
-        return tokens[entrypointIndex + 1].lowercased() == "gateway"
+        return self.isOpenClawDistEntrypointToken(tokens[1])
+            && tokens[2].lowercased() == "gateway"
     }
 
     private static func isOpenClawDistEntrypointToken(_ token: String) -> Bool {
@@ -564,11 +560,7 @@ actor PortGuardian {
         guard normalized.hasSuffix("/dist/index.js") else { return false }
         return normalized
             .split(separator: "/", omittingEmptySubsequences: true)
-            .contains { component in
-                component == "openclaw"
-                    || component.hasPrefix("openclaw-")
-                    || component.hasSuffix("-openclaw")
-            }
+            .contains("openclaw")
     }
 
     private static func unquoteCommandToken(_ token: String) -> String {

--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianIsExpectedTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianIsExpectedTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct PortGuardianIsExpectedTests {
+    @Test func `local mode preserves launchd node dist gateway command`() {
+        let fullCommand = """
+        /opt/homebrew/bin/node /opt/homebrew/lib/node_modules/openclaw/dist/index.js gateway --port 18789 --bind loopback
+        """
+
+        #expect(PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: fullCommand,
+            port: 18789,
+            mode: .local))
+    }
+
+    @Test func `local mode preserves git checkout node dist gateway command`() {
+        let fullCommand = """
+        /usr/local/bin/node /Users/dev/Projects/openclaw-openclaw/dist/index.js gateway --port 18789
+        """
+
+        #expect(PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: fullCommand,
+            port: 18789,
+            mode: .local))
+    }
+
+    @Test func `local mode rejects node dist entrypoint without gateway subcommand`() {
+        #expect(!PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: "/opt/homebrew/bin/node /opt/homebrew/lib/node_modules/openclaw/dist/index.js doctor",
+            port: 18789,
+            mode: .local))
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianIsExpectedTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianIsExpectedTests.swift
@@ -17,12 +17,28 @@ struct PortGuardianIsExpectedTests {
 
     @Test func `local mode preserves git checkout node dist gateway command`() {
         let fullCommand = """
-        /usr/local/bin/node /Users/dev/Projects/openclaw-openclaw/dist/index.js gateway --port 18789
+        /usr/local/bin/node /Users/dev/Projects/openclaw/dist/index.js gateway --port 18789
         """
 
         #expect(PortGuardian._testIsExpected(
             command: "node",
             fullCommand: fullCommand,
+            port: 18789,
+            mode: .local))
+    }
+
+    @Test func `local mode rejects similarly named node project`() {
+        #expect(!PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: "/usr/local/bin/node /tmp/openclaw-tools/dist/index.js gateway --port 18789",
+            port: 18789,
+            mode: .local))
+    }
+
+    @Test func `local mode rejects gateway appearing after another node argument`() {
+        #expect(!PortGuardian._testIsExpected(
+            command: "node",
+            fullCommand: "/usr/local/bin/node --inspect /tmp/openclaw/dist/index.js gateway --port 18789",
             port: 18789,
             mode: .local))
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes #94476. On macOS, PortGuardian can terminate a valid launchd-managed local Gateway when `ps` reports the runtime command line, for example `node .../openclaw/dist/index.js gateway --port 18789`, instead of the expected process title.

## Why This Change Was Made

The fix should add a conservative local-mode matcher for OpenClaw gateway entrypoint command lines and keep the older process-title checks intact. This replaces the closed, uneditable non-security attempt #94488 while carrying attribution forward: #94488 by @lsr911 is credited as the source PR for the earlier Homebrew Node/git checkout gateway allowlist approach.

## User Impact

A valid macOS launchd Gateway should no longer be killed mid-turn solely because it is shown as a Homebrew Node or git-checkout `dist/index.js gateway` process.

## Evidence

Planned validation: `pnpm check:changed`, focused Swift matcher coverage for the Node dist Gateway command, and macOS launchd/PortGuardian behavior proof if available before merge. Security-sensitive #94492 is intentionally excluded from this replacement lineage and routed separately. Blocked-lineage PRs #95511 and #95517 are also intentionally excluded from this replacement lineage because deterministic validation reports blocked `merge-risk: 🚨 availability` labels for both refs.

Clownfish 🐠 replacement reef notes:
- Cluster: gitcrawl-1020-autonomous-drip-20260706
- Source PRs: https://github.com/openclaw/openclaw/pull/94488
- Credit: Credit @lsr911 for https://github.com/openclaw/openclaw/pull/94488 as an earlier Homebrew Node/git checkout gateway allowlist attempt.; Do not use #94492 as a source PR in the replacement lineage because the hydrated preflight marks it security-sensitive and routes it separately.; Do not use #95511 or #95517 as source PRs in the replacement lineage because deterministic validation reports blocked `merge-risk: 🚨 availability` labels for both refs.
- Validation: pnpm check:changed

fish notes: model gpt-5.5, reasoning medium; reviewed against 55a6d2da1f5d.
