### PR TITLE
fix #52972: track exec/bash openclaw cron add as successful reminder scheduling

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.test.ts
@@ -555,6 +555,136 @@ describe("handleToolExecutionEnd cron mutation tracking", () => {
     expect(ctx.state.lastToolError?.mutatingAction).toBe(true);
   });
 
+  it("increments successfulCronAdds when exec runs openclaw cron add", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-1",
+        args: { command: "openclaw cron add --at '5pm' --notes 'Remind me'" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-1",
+        isError: false,
+        result: { stdout: "Job created" },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(1);
+  });
+
+  it("increments successfulCronAdds when bash runs openclaw cron add", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "bash",
+        toolCallId: "tool-bash-cron-1",
+        args: { command: "openclaw cron add --at '5pm' --notes 'Ping Markus'" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "bash",
+        toolCallId: "tool-bash-cron-1",
+        isError: false,
+        result: { stdout: "Job created" },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(1);
+  });
+
+  it("does not increment successfulCronAdds when exec runs other commands", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-other",
+        args: { command: "ls -la" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-other",
+        isError: false,
+        result: { stdout: "total 42" },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(0);
+  });
+
+  it("does not increment successfulCronAdds when exec cron add fails", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-fail",
+        args: { command: "openclaw cron add --at '5pm'" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-fail",
+        isError: true,
+        result: { stderr: "Error: invalid schedule" },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(0);
+  });
+
+  it("does not increment successfulCronAdds when exec command contains cron sub-strings not matching the add pattern", async () => {
+    const { ctx } = createTestContext();
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-list",
+        args: { command: "openclaw cron list" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-cron-list",
+        isError: false,
+        result: { stdout: "No jobs" },
+      } as never,
+    );
+
+    expect(ctx.state.successfulCronAdds).toBe(0);
+  });
+
   it("records structured core read actions as replay-safe", async () => {
     for (const [toolName, action] of [
       ["cron", "status"],

--- a/src/agents/embedded-agent-subscribe.handlers.tools.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.ts
@@ -235,6 +235,19 @@ function isCronAddAction(args: unknown): boolean {
   return normalizeOptionalLowercaseString(action) === "add";
 }
 
+const EXEC_CRON_ADD_COMMAND_RE = /\bopenclaw\s+cron\s+add\b/;
+
+function isExecCronAddCommand(toolName: string, args: unknown): boolean {
+  if (!isExecToolName(toolName)) {
+    return false;
+  }
+  if (!args || typeof args !== "object") {
+    return false;
+  }
+  const command = (args as Record<string, unknown>).command;
+  return typeof command === "string" && EXEC_CRON_ADD_COMMAND_RE.test(command);
+}
+
 function buildToolCallSummary(
   toolName: string,
   args: unknown,
@@ -1303,8 +1316,13 @@ export async function handleToolExecutionEnd(
     }
   }
 
-  // Track committed reminders only when cron.add completed successfully.
-  if (!isToolError && toolName === "cron" && isCronAddAction(startArgs)) {
+  // Track committed reminders when cron.add completed successfully (structured
+  // tool path) or when openclaw cron add was invoked via exec/bash.
+  if (
+    !isToolError &&
+    ((toolName === "cron" && isCronAddAction(startArgs)) ||
+      isExecCronAddCommand(toolName, startArgs))
+  ) {
     ctx.state.successfulCronAdds += 1;
   }
   if (!isToolError && toolName === HEARTBEAT_RESPONSE_TOOL_NAME) {


### PR DESCRIPTION
## Summary

- **Problem**: When an agent schedules a reminder via exec/bash (e.g. `openclaw cron add --at "5pm"`), the `successfulCronAdds` counter is not incremented because only structured `cron` tool calls are tracked. This causes the reminder guard to append a misleading "Note: I did not schedule a reminder in this turn…" even when a cron job was successfully created.
- **Root cause**: `handleToolExecutionEnd` only checks `toolName === "cron" && isCronAddAction(startArgs)` — exec/bash tool calls have `toolName === "exec"` or `"bash"` and carry the command in `args.command`.
- **Solution**: Add `isExecCronAddCommand(toolName, args)` helper that detects `openclaw cron add` invocations in exec/bash command strings via the regex `\bopenclaw\s+cron\s+add\b`. Wire it into the `successfulCronAdds` increment path alongside the existing structured cron tool check.
- **What changed**: `embedded-agent-subscribe.handlers.tools.ts` — +20 lines (helper function + updated condition). `embedded-agent-subscribe.handlers.tools.test.ts` — +130 lines (5 new tests).
- **What did NOT change**: No schema, config, API, or CLI changes. Existing structured cron tool tracking is unchanged. The reminder guard logic in `agent-runner.ts` is unchanged — it already consumes `successfulCronAdds` correctly; it just needed the counter to be populated for the exec path.

## Maintainer checklist

- Fix classification: Root-cause bug fix in cron scheduling detection for shell-driven invocations
- Maintainer-ready confidence: High — all tests pass on upstream/main base, including 5 new exec cron add tests

## Real behavior proof

**Behavior or issue addressed:**
Shell-driven `openclaw cron add` invocations via exec/bash are not counted as successful reminder scheduling, causing the reminder guard to append a spurious "I did not schedule a reminder" note.

**Real environment tested:**
- Platform: Linux x86_64
- Node.js: v22.22.0
- Runtime: Vitest v4.1.8
- Branch: fix/exec-cron-add-reminder-guard-52972 (d8d37037e) — based on upstream/main

**Exact steps or command run after the patch:**
```sh
node ./node_modules/vitest/vitest.mjs run src/agents/embedded-agent-subscribe.handlers.tools.test.ts --reporter=verbose
```

**After-fix evidence:**
All 158 tests pass including 5 new exec cron add detection tests:
- increments successfulCronAdds when exec runs openclaw cron add ✓
- increments successfulCronAdds when bash runs openclaw cron add ✓
- does not increment successfulCronAdds when exec runs other commands (ls -la) ✓
- does not increment successfulCronAdds when exec cron add fails ✓
- does not increment successfulCronAdds when exec runs cron list (not add) ✓

**Acceptance criteria satisfied:**
- exec running `openclaw cron add` increments successfulCronAdds ✓
- bash running `openclaw cron add` increments successfulCronAdds ✓
- Other exec commands do NOT increment the counter ✓
- Failed exec cron add commands do NOT increment the counter ✓
- `openclaw cron list` does NOT match the add pattern ✓
- Existing structured cron.add tool tracking is unchanged ✓

**What was not tested:**
- End-to-end Telegram channel delivery with real cron scheduling
- Gateway restart + cron store persistence integration flow

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)