### PR TITLE
fix(acp): close shared state database on ACP server shutdown

### DIFF
--- a/src/acp/server.startup.test.ts
+++ b/src/acp/server.startup.test.ts
@@ -35,6 +35,7 @@ const mockState = vi.hoisted(() => ({
   agentSideConnectionCtor: vi.fn(),
   agentStart: vi.fn(),
   routeLogsToStderr: vi.fn(),
+  closeOpenClawStateDatabase: vi.fn(),
   startProxy: vi.fn(async (_configForTest: unknown) => null as unknown),
   stopProxy: vi.fn(async (_handle: unknown) => {}),
   resolveGatewayClientBootstrap: vi.fn<ResolveGatewayClientBootstrap>(async (_params) => ({
@@ -154,6 +155,10 @@ vi.mock("../infra/is-main.js", () => ({
 
 vi.mock("../logging/console.js", () => ({
   routeLogsToStderr: () => mockState.routeLogsToStderr(),
+}));
+
+vi.mock("../state/openclaw-state-db.js", () => ({
+  closeOpenClawStateDatabase: () => mockState.closeOpenClawStateDatabase(),
 }));
 
 vi.mock("../infra/net/proxy/proxy-lifecycle.js", () => ({
@@ -287,6 +292,7 @@ describe("serveAcpGateway startup", () => {
     mockState.routeLogsToStderr.mockReset();
     mockState.startProxy.mockReset();
     mockState.stopProxy.mockReset();
+    mockState.closeOpenClawStateDatabase.mockReset();
     mockState.startProxy.mockResolvedValue(null);
     mockState.stopProxy.mockResolvedValue(undefined);
     mockState.resolveGatewayClientBootstrap.mockReset();
@@ -535,5 +541,22 @@ describe("serveAcpGateway startup", () => {
 
     const [message] = await captureAcpMessagesAfterStartup([sessionRequest]);
     expect(message).toBe(sessionRequest);
+  });
+
+  it("closes the shared state database on shutdown", async () => {
+    const { signalHandlers, onceSpy } = captureProcessSignalHandlers();
+
+    try {
+      const servePromise = serveAcpGateway({});
+      await emitHelloAndWaitForAgentSideConnection();
+
+      expect(mockState.closeOpenClawStateDatabase).not.toHaveBeenCalled();
+
+      await stopServeWithSigint(signalHandlers, servePromise);
+
+      expect(mockState.closeOpenClawStateDatabase).toHaveBeenCalledTimes(1);
+    } finally {
+      onceSpy.mockRestore();
+    }
   });
 });

--- a/src/acp/server.ts
+++ b/src/acp/server.ts
@@ -21,6 +21,7 @@ import { startGatewayClientWhenEventLoopReady } from "../gateway/client-start-re
 import { GatewayClient } from "../gateway/client.js";
 import { isMainModule } from "../infra/is-main.js";
 import { routeLogsToStderr } from "../logging/console.js";
+import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
   createSqliteAcpEventLedger,
   migrateFileAcpEventLedgerToSqlite,
@@ -124,6 +125,7 @@ export async function serveAcpGateway(opts: AcpServerOptions = {}): Promise<void
     // If no WebSocket is active (e.g. between reconnect attempts),
     // gateway.stop() won't trigger onClose, so resolve directly.
     onClosed();
+    closeOpenClawStateDatabase();
   };
 
   process.once("SIGINT", shutdown);


### PR DESCRIPTION
## What Problem This Solves

When the ACP server (`serveAcpGateway`) starts, it calls `createSqliteAcpEventLedger()` which opens shared state database handles via `openOpenClawStateDatabase()`. On shutdown (SIGINT/SIGTERM), these `DatabaseSync` handles are never closed, leaking file descriptors and causing SQLite lock contention during gateway hot reload or ACP process respawn.

Fixes #100637.

## Why This Change Was Made

The shared state DB already has a well-defined lifecycle owner — `closeOpenClawStateDatabase()` in `src/state/openclaw-state-db.ts` — which closes WAL maintenance, clears the Kysely cache, and closes all open `DatabaseSync` handles. The gateway shutdown path already calls this via `closePluginStateDatabase()` → `closeOpenClawStateDatabase()`, but the ACP server's standalone shutdown path was missing it.

The fix adds a single call to the existing `closeOpenClawStateDatabase()` in the ACP server's `shutdown()` function, placed after `gateway.stop()` and `onClosed()` so all pending ledger writes complete before the DB is closed.

## Evidence

**Before fix** — the ACP server shutdown did not close the shared state DB:

```
src/acp/server.ts shutdown():
  stopped = true
  resolveGatewayReady()
  gateway.stop()
  onClosed()
  // ← shared state DB handles remain open
```

**After fix** — regression test confirms `closeOpenClawStateDatabase` is called exactly once on SIGINT:

```
 ✓ closes the shared state database on shutdown
```

Test file: `src/acp/server.startup.test.ts` — new test added next to existing shutdown tests.

All 55 tests pass across the 3 relevant test files:

```
✓ src/acp/server.startup.test.ts  (9 tests)
✓ src/acp/event-ledger.test.ts    (16 tests)
✓ src/state/openclaw-state-db.test.ts  (30 tests)
Test Files  4 passed (4)
     Tests  55 passed (55)
```

**Not tested:** A live hot-reload reproduction with file lock diagnostics was not run. This fix targets the source-level gap where the production shutdown path omits the close call. The `closeOpenClawStateDatabase` function is already tested extensively in `openclaw-state-db.test.ts`.

## Merge Risk

Low. The change adds a cleanup call that the gateway shutdown path already performs. The `closeOpenClawStateDatabase()` function is idempotent (iterates cached handles, closes open ones, clears the cache). Placed after `onClosed()`, it runs after the gateway client has disconnected and the closed promise has resolved, so no in-flight writes can race with the close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)