### PR TITLE
feat(ios): hide the thinking-level control for models without reasoning support

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -21155,7 +21155,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 195,
+      "line": 197,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -21163,7 +21163,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 216,
+      "line": 218,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Model",
       "surface": "apple",
@@ -21171,7 +21171,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 233,
+      "line": 235,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -21179,7 +21179,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 241,
+      "line": 243,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Recent",
       "surface": "apple",
@@ -21187,7 +21187,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 249,
+      "line": 251,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Models",
       "surface": "apple",
@@ -21195,7 +21195,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 278,
+      "line": 280,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pin model",
       "surface": "apple",
@@ -21203,7 +21203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 278,
+      "line": 280,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Unpin model",
       "surface": "apple",
@@ -21211,7 +21211,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 282,
+      "line": 284,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Session",
       "surface": "apple",
@@ -21219,7 +21219,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 346,
+      "line": 348,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Add Image",
       "surface": "apple",
@@ -21227,7 +21227,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 347,
+      "line": 349,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Attachments",
       "surface": "apple",
@@ -21235,7 +21235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 517,
+      "line": 519,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
@@ -21243,7 +21243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 563,
+      "line": 565,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
@@ -21251,7 +21251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 563,
+      "line": 565,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
@@ -21259,7 +21259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 596,
+      "line": 598,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -21267,7 +21267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 596,
+      "line": 598,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -21275,7 +21275,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 706,
+      "line": 708,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -21283,7 +21283,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 715,
+      "line": 717,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -21291,7 +21291,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 724,
+      "line": 726,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -21299,7 +21299,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 733,
+      "line": 735,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -21307,7 +21307,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 865,
+      "line": 867,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -21315,7 +21315,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 890,
+      "line": 892,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -21323,7 +21323,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 905,
+      "line": 907,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -21331,7 +21331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1013,
+      "line": 1015,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -21339,7 +21339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1013,
+      "line": 1015,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -80,6 +80,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             var name: String
             var provider: String
             var contextWindow: Int?
+            var reasoning: Bool?
         }
     }
 
@@ -224,7 +225,8 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
                 modelID: model.id,
                 name: name.isEmpty ? model.id : model.name,
                 provider: model.provider,
-                contextWindow: model.contextWindow)
+                contextWindow: model.contextWindow,
+                reasoning: model.reasoning)
         }
     }
 

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -111,9 +111,14 @@ struct IOSGatewayChatTransportTests {
         #expect(params["model"] is NSNull)
     }
 
-    @Test func `models list response decodes choices and falls back blank names`() throws {
+    @Test func `models list response decodes choices reasoning and blank names`() throws {
         let data = Data(
-            #"{"models":[{"id":"claude-opus-4","name":"Claude Opus 4","provider":"anthropic","contextWindow":200000,"reasoning":true},{"id":"gpt-5","name":"  ","provider":"openai","extra":"ignored"}]}"#.utf8)
+            #"""
+            {"models":[
+              {"id":"claude-opus-4","name":"Claude Opus 4","provider":"anthropic","contextWindow":200000,"reasoning":true},
+              {"id":"gpt-5","name":"  ","provider":"openai","extra":"ignored"}
+            ]}
+            """#.utf8)
         let choices = try IOSGatewayChatTransport.decodeModelChoices(data)
 
         #expect(choices.count == 2)
@@ -121,10 +126,12 @@ struct IOSGatewayChatTransportTests {
         #expect(choices[0].name == "Claude Opus 4")
         #expect(choices[0].provider == "anthropic")
         #expect(choices[0].contextWindow == 200_000)
+        #expect(choices[0].reasoning == true)
         #expect(choices[1].modelID == "gpt-5")
         #expect(choices[1].name == "gpt-5")
         #expect(choices[1].provider == "openai")
         #expect(choices[1].contextWindow == nil)
+        #expect(choices[1].reasoning == nil)
     }
 
     @Test func `commands list params request text scope with args`() throws {

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -232,7 +232,8 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             modelID: model.id,
             name: model.name,
             provider: model.provider,
-            contextWindow: model.contextwindow)
+            contextWindow: model.contextwindow,
+            reasoning: model.reasoning)
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -170,7 +170,9 @@ struct OpenClawChatComposer: View {
                 HStack(spacing: 5) {
                     if self.showsSessionSwitcher {
                         self.sessionPicker
-                        self.thinkingPicker
+                        if self.viewModel.showsThinkingPicker {
+                            self.thinkingPicker
+                        }
                     }
                     if self.viewModel.showsModelPicker {
                         self.modelPicker

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -19,12 +19,20 @@ public struct OpenClawChatModelChoice: Identifiable, Codable, Sendable, Hashable
     public let name: String
     public let provider: String
     public let contextWindow: Int?
+    public let reasoning: Bool?
 
-    public init(modelID: String, name: String, provider: String, contextWindow: Int?) {
+    public init(
+        modelID: String,
+        name: String,
+        provider: String,
+        contextWindow: Int?,
+        reasoning: Bool? = nil)
+    {
         self.modelID = modelID
         self.name = name
         self.provider = provider
         self.contextWindow = contextWindow
+        self.reasoning = reasoning
     }
 
     /// Provider-qualified model ref used for picker identity and selection tags.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -69,7 +69,7 @@ extension OpenClawChatViewModel {
             id: UUID().uuidString,
             sessionKey: session.key,
             text: text,
-            thinking: self.thinkingLevel,
+            thinking: self.effectiveThinkingLevelForSend,
             createdAt: Date().timeIntervalSince1970,
             status: .queued,
             retryCount: 0,
@@ -311,9 +311,11 @@ extension OpenClawChatViewModel {
                 let response = try await self.transport.sendMessage(
                     sessionKey: next.sessionKey,
                     message: next.text,
-                    // Thinking level captured at enqueue time, never the
-                    // visible session's current setting.
-                    thinking: next.thinking,
+                    // Preserve the queued level when supported, but never send
+                    // an explicit unsupported level after the gate changes.
+                    thinking: self.effectiveThinkingLevelForSend(
+                        next.thinking,
+                        sessionKey: next.sessionKey),
                     idempotencyKey: next.id,
                     attachments: [])
                 if response.status == "error" || response.status == "timeout" {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Thinking.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Thinking.swift
@@ -5,20 +5,61 @@ import Foundation
 // extension owns collapsing them into the canonical option list.
 
 extension OpenClawChatViewModel {
+    /// `agent-command.ts` throws for explicit unsupported levels, so hidden controls must send `off`.
+    var effectiveThinkingLevelForSend: String {
+        self.effectiveThinkingLevelForSend(self.thinkingLevel)
+    }
+
+    func effectiveThinkingLevelForSend(_ storedLevel: String, sessionKey: String? = nil) -> String {
+        let showsPicker: Bool
+        if let sessionKey, sessionKey != self.sessionKey {
+            // Sessions absent from the loaded list resolve to no metadata and fail
+            // open, preserving the queued level — matches shipped flush behavior;
+            // downgrading unknown sessions to "off" would silently strip levels
+            // users explicitly queued for reasoning-capable models.
+            let session = self.sessions.first(where: { $0.key == sessionKey })
+            showsPicker = self.thinkingPickerIsAvailable(
+                for: session,
+                modelChoice: self.sessionModelChoice(for: session))
+        } else {
+            showsPicker = self.showsThinkingPicker
+        }
+        return showsPicker ? storedLevel : "off"
+    }
+
     func syncThinkingLevelOptions() {
         let currentSession = self.sessions.first(where: { $0.key == self.sessionKey })
-        var options = self.resolvedThinkingLevelOptions(for: currentSession)
+        self.showsThinkingPicker = self.thinkingPickerIsAvailable(
+            for: currentSession,
+            modelChoice: self.selectedModelChoice(for: currentSession))
+
+        var options = self.resolvedThinkingLevelOptions(for: currentSession).options
         if let current = Self.normalizedThinkingLevel(thinkingLevel) {
             options = Self.withCurrentThinkingOption(options, current: current)
         }
         self.thinkingLevelOptions = options
     }
 
+    private func thinkingPickerIsAvailable(
+        for session: OpenClawChatSessionEntry?,
+        modelChoice: OpenClawChatModelChoice?) -> Bool
+    {
+        let resolved = self.resolvedThinkingLevelOptions(for: session)
+        let gatewayAllowsOnlyOff = resolved.isGatewayMetadata &&
+            resolved.options.allSatisfy { $0.id == "off" }
+        return !gatewayAllowsOnlyOff && modelChoice?.reasoning != false
+    }
+
+    private struct ThinkingLevelOptionsResolution {
+        let options: [OpenClawChatThinkingLevelOption]
+        let isGatewayMetadata: Bool
+    }
+
     private func resolvedThinkingLevelOptions(
-        for currentSession: OpenClawChatSessionEntry?) -> [OpenClawChatThinkingLevelOption]
+        for currentSession: OpenClawChatSessionEntry?) -> ThinkingLevelOptionsResolution
     {
         if let levels = Self.normalizedThinkingLevelOptions(currentSession?.thinkingLevels), !levels.isEmpty {
-            return levels
+            return ThinkingLevelOptionsResolution(options: levels, isGatewayMetadata: true)
         }
 
         let defaultsMatch = currentSession.map {
@@ -29,21 +70,62 @@ extension OpenClawChatViewModel {
            let levels = Self.normalizedThinkingLevelOptions(sessionDefaults?.thinkingLevels),
            !levels.isEmpty
         {
-            return levels
+            return ThinkingLevelOptionsResolution(options: levels, isGatewayMetadata: true)
         }
 
         if let options = Self.thinkingOptions(from: currentSession?.thinkingOptions), !options.isEmpty {
-            return options
+            return ThinkingLevelOptionsResolution(options: options, isGatewayMetadata: true)
         }
 
         if defaultsMatch,
            let options = Self.thinkingOptions(from: sessionDefaults?.thinkingOptions),
            !options.isEmpty
         {
-            return options
+            return ThinkingLevelOptionsResolution(options: options, isGatewayMetadata: true)
         }
 
-        return Self.baseThinkingLevelOptions
+        return ThinkingLevelOptionsResolution(options: Self.baseThinkingLevelOptions, isGatewayMetadata: false)
+    }
+
+    private func selectedModelChoice(
+        for currentSession: OpenClawChatSessionEntry?) -> OpenClawChatModelChoice?
+    {
+        if self.modelSelectionID != Self.defaultModelSelectionID {
+            return self.modelChoices.first(where: { $0.selectionID == self.modelSelectionID })
+        }
+
+        return self.sessionModelChoice(for: currentSession)
+    }
+
+    private func sessionModelChoice(
+        for currentSession: OpenClawChatSessionEntry?) -> OpenClawChatModelChoice?
+    {
+        if Self.normalizedModelID(currentSession?.model) != nil {
+            return self.modelChoice(modelID: currentSession?.model, provider: currentSession?.modelProvider)
+        }
+        return self.modelChoice(modelID: self.sessionDefaults?.model, provider: self.sessionDefaults?.modelProvider)
+    }
+
+    private func modelChoice(modelID: String?, provider: String?) -> OpenClawChatModelChoice? {
+        guard let modelID = Self.normalizedModelID(modelID) else { return nil }
+        let provider = provider?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let provider, !provider.isEmpty {
+            let prefix = "\(provider)/"
+            let selectionID = modelID.hasPrefix(prefix) ? modelID : "\(prefix)\(modelID)"
+            return self.modelChoices.first(where: {
+                $0.selectionID == selectionID ||
+                    ($0.modelID == modelID && $0.provider == provider)
+            })
+        }
+
+        let matches = self.modelChoices.filter { $0.selectionID == modelID || $0.modelID == modelID }
+        return matches.count == 1 ? matches[0] : nil
+    }
+
+    private static func normalizedModelID(_ modelID: String?) -> String? {
+        let trimmed = modelID?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let trimmed, !trimmed.isEmpty else { return nil }
+        return trimmed
     }
 
     private static func sessionModelMatchesDefaults(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -18,6 +18,8 @@ public final class OpenClawChatViewModel {
     public private(set) var thinkingLevel: String
     /// Setter is module-internal for the thinking-level extension only.
     public internal(set) var thinkingLevelOptions: [OpenClawChatThinkingLevelOption]
+    /// Setter is module-internal for the thinking-level extension only.
+    public internal(set) var showsThinkingPicker = true
     public private(set) var modelSelectionID: String = "__default__"
     public private(set) var modelChoices: [OpenClawChatModelChoice] = []
     private var modelPickerFavorites: [String]
@@ -1092,7 +1094,7 @@ public final class OpenClawChatViewModel {
         self.errorText = nil
         let runId = UUID().uuidString
         let messageText = trimmed.isEmpty && !self.attachments.isEmpty ? "See attached." : trimmed
-        let thinkingLevel = self.thinkingLevel
+        let storedThinkingLevel = self.thinkingLevel
         self.pendingRuns.insert(runId)
         self.armPendingRunTimeout(runId: runId)
         self.logDiagnostic(
@@ -1158,6 +1160,7 @@ public final class OpenClawChatViewModel {
             self.logDiagnostic(
                 "chat.ui transport send start sessionKey=\(sessionKey) "
                     + "localRunId=\(runId)")
+            let thinkingLevel = self.effectiveThinkingLevelForSend(storedThinkingLevel)
             let response = try await transport.sendMessage(
                 sessionKey: sessionKey,
                 message: messageText,
@@ -1237,7 +1240,7 @@ public final class OpenClawChatViewModel {
                 let requeued = await self.requeueFailedLiveSend(
                     runId: runId,
                     text: messageText,
-                    thinking: thinkingLevel,
+                    thinking: self.effectiveThinkingLevelForSend(storedThinkingLevel),
                     messageID: userMessageID,
                     session: sessionSnapshot)
                 if requeued {
@@ -1301,6 +1304,7 @@ public final class OpenClawChatViewModel {
             if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
             self.modelChoices = modelChoices
             self.syncSelectedModel()
+            self.syncThinkingLevelOptions()
         } catch {
             // Best-effort.
         }
@@ -1471,6 +1475,7 @@ public final class OpenClawChatViewModel {
         self.latestModelSelectionIDsBySession[sessionKey] = next
         self.beginModelPatch(for: sessionKey)
         self.modelSelectionID = next
+        self.syncThinkingLevelOptions()
         self.errorText = nil
         defer { self.endModelPatch(for: sessionKey) }
 
@@ -1503,6 +1508,7 @@ public final class OpenClawChatViewModel {
             }
             guard sessionKey == self.sessionKey else { return }
             self.modelSelectionID = previous
+            self.syncThinkingLevelOptions()
             self.errorText = error.localizedDescription
             chatUILogger.error("sessions.patch(model) failed \(error.localizedDescription, privacy: .public)")
         }
@@ -1661,7 +1667,11 @@ public final class OpenClawChatViewModel {
     }
 
     private static func normalizedProvider(_ provider: String?) -> String? {
-        let trimmed = provider?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.normalizedModelIdentityComponent(provider)
+    }
+
+    private static func normalizedModelIdentityComponent(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let trimmed, !trimmed.isEmpty else { return nil }
         return trimmed
     }
@@ -1717,6 +1727,12 @@ public final class OpenClawChatViewModel {
     {
         if let index = sessions.firstIndex(where: { $0.key == sessionKey }) {
             let current = self.sessions[index]
+            let preservesThinkingMetadata =
+                Self.normalizedModelIdentityComponent(current.model) ==
+                Self.normalizedModelIdentityComponent(modelID) &&
+                Self.normalizedModelIdentityComponent(current.modelProvider) ==
+                Self.normalizedModelIdentityComponent(modelProvider)
+            // Thinking metadata follows model identity; stale options must not survive a model change.
             self.sessions[index] = OpenClawChatSessionEntry(
                 key: current.key,
                 kind: current.kind,
@@ -1737,6 +1753,9 @@ public final class OpenClawChatViewModel {
                 modelProvider: modelProvider,
                 model: modelID,
                 contextTokens: current.contextTokens,
+                thinkingLevels: preservesThinkingMetadata ? current.thinkingLevels : nil,
+                thinkingOptions: preservesThinkingMetadata ? current.thinkingOptions : nil,
+                thinkingDefault: preservesThinkingMetadata ? current.thinkingDefault : nil,
                 label: current.label,
                 category: current.category,
                 pinned: current.pinned,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
@@ -76,11 +76,17 @@ private actor OutboxTransportState {
 /// every accepted send (what the gateway would persist).
 private final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransport {
     let state: OutboxTransportState
+    private let sessions: [OpenClawChatSessionEntry]
     private let stream: AsyncStream<OpenClawChatTransportEvent>
     private let continuation: AsyncStream<OpenClawChatTransportEvent>.Continuation
 
-    init(healthy: Bool, sendFails: Bool = false) {
+    init(
+        healthy: Bool,
+        sendFails: Bool = false,
+        sessions: [OpenClawChatSessionEntry] = [])
+    {
         self.state = OutboxTransportState(healthy: healthy, sendFails: sendFails)
+        self.sessions = sessions
         var cont: AsyncStream<OpenClawChatTransportEvent>.Continuation!
         self.stream = AsyncStream { c in cont = c }
         self.continuation = cont
@@ -164,7 +170,12 @@ private final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransp
     }
 
     func listSessions(limit _: Int?) async throws -> OpenClawChatSessionsListResponse {
-        OpenClawChatSessionsListResponse(ts: nil, path: nil, count: 0, defaults: nil, sessions: [])
+        OpenClawChatSessionsListResponse(
+            ts: nil,
+            path: nil,
+            count: self.sessions.count,
+            defaults: nil,
+            sessions: self.sessions)
     }
 
     func requestHealth(timeoutMs _: Int) async throws -> Bool {
@@ -174,6 +185,33 @@ private final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransp
     func events() -> AsyncStream<OpenClawChatTransportEvent> {
         self.stream
     }
+}
+
+private func outboxSessionEntry(
+    key: String,
+    thinkingLevels: [String]) -> OpenClawChatSessionEntry
+{
+    OpenClawChatSessionEntry(
+        key: key,
+        kind: nil,
+        displayName: nil,
+        surface: nil,
+        subject: nil,
+        room: nil,
+        space: nil,
+        updatedAt: nil,
+        sessionId: nil,
+        systemSent: nil,
+        abortedLastRun: nil,
+        thinkingLevel: nil,
+        verboseLevel: nil,
+        inputTokens: nil,
+        outputTokens: nil,
+        totalTokens: nil,
+        modelProvider: nil,
+        model: nil,
+        contextTokens: nil,
+        thinkingLevels: thinkingLevels.map { OpenClawChatThinkingLevelOption(id: $0, label: $0) })
 }
 
 private func makeOutboxViewModel(
@@ -555,33 +593,51 @@ struct ChatViewModelOutboxTests {
         #expect(await transport.state.sentMessages == ["old message"])
     }
 
-    @Test func `flush sends the thinking level captured with the queued command`() async throws {
+    @Test func `flush gates captured thinking using the queued session metadata`() async throws {
         let url = try makeOutboxDatabaseURL()
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
         let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-test")
-        // Queued earlier under a session running "high"; the visible session's
-        // current level is "off" and must not leak into the flush.
+        let now = Date().timeIntervalSince1970
         #expect(await store.enqueueCommand(
             OpenClawChatOutboxCommand(
                 id: "c-think",
-                sessionKey: "other-session",
+                sessionKey: "reasoning-session",
                 text: "think hard",
                 thinking: "high",
-                createdAt: Date().timeIntervalSince1970,
+                createdAt: now,
                 status: .queued,
                 retryCount: 0,
                 lastError: nil)))
-        let transport = OutboxTestTransport(healthy: false)
+        #expect(await store.enqueueCommand(
+            OpenClawChatOutboxCommand(
+                id: "c-plain",
+                sessionKey: "plain-session",
+                text: "no thinking",
+                thinking: "medium",
+                createdAt: now + 1,
+                status: .queued,
+                retryCount: 0,
+                lastError: nil)))
+        let sessionEntries = [
+            outboxSessionEntry(key: "main", thinkingLevels: ["off"]),
+            outboxSessionEntry(key: "reasoning-session", thinkingLevels: ["off", "high"]),
+            outboxSessionEntry(key: "plain-session", thinkingLevels: ["off"]),
+        ]
+        let transport = OutboxTestTransport(healthy: false, sessions: sessionEntries)
         let vm = await makeOutboxViewModel(transport: transport, outbox: store)
-        #expect(await MainActor.run { vm.thinkingLevel } == "off")
 
         await MainActor.run { vm.load() }
+        await MainActor.run {
+            vm.sessions = sessionEntries
+            vm.syncThinkingLevelOptions()
+        }
+        #expect(await MainActor.run { !vm.showsThinkingPicker })
         await transport.goOnline()
         try await waitUntil("outbox drained") {
             await store.loadCommands().isEmpty
         }
-        #expect(await transport.state.sentThinkingLevels == ["high"])
-        #expect(await transport.state.sentSessionKeys == ["other-session"])
+        #expect(await transport.state.sentThinkingLevels == ["high", "off"])
+        #expect(await transport.state.sentSessionKeys == ["reasoning-session", "plain-session"])
         _ = vm
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -114,7 +114,11 @@ private func sessionEntry(
     key: String,
     updatedAt: Double,
     model: String?,
-    modelProvider: String? = nil) -> OpenClawChatSessionEntry
+    modelProvider: String? = nil,
+    thinkingLevel: String? = nil,
+    thinkingLevels: [OpenClawChatThinkingLevelOption]? = nil,
+    thinkingOptions: [String]? = nil,
+    thinkingDefault: String? = nil) -> OpenClawChatSessionEntry
 {
     OpenClawChatSessionEntry(
         key: key,
@@ -128,18 +132,43 @@ private func sessionEntry(
         sessionId: nil,
         systemSent: nil,
         abortedLastRun: nil,
-        thinkingLevel: nil,
+        thinkingLevel: thinkingLevel,
         verboseLevel: nil,
         inputTokens: nil,
         outputTokens: nil,
         totalTokens: nil,
         modelProvider: modelProvider,
         model: model,
-        contextTokens: nil)
+        contextTokens: nil,
+        thinkingLevels: thinkingLevels,
+        thinkingOptions: thinkingOptions,
+        thinkingDefault: thinkingDefault)
 }
 
-private func modelChoice(id: String, name: String, provider: String = "anthropic") -> OpenClawChatModelChoice {
-    OpenClawChatModelChoice(modelID: id, name: name, provider: provider, contextWindow: nil)
+private func modelChoice(
+    id: String,
+    name: String,
+    provider: String = "anthropic",
+    reasoning: Bool? = nil) -> OpenClawChatModelChoice
+{
+    OpenClawChatModelChoice(
+        modelID: id,
+        name: name,
+        provider: provider,
+        contextWindow: nil,
+        reasoning: reasoning)
+}
+
+private func sessionsResponse(
+    _ session: OpenClawChatSessionEntry,
+    defaults: OpenClawChatSessionsDefaults? = nil) -> OpenClawChatSessionsListResponse
+{
+    OpenClawChatSessionsListResponse(
+        ts: 1,
+        path: nil,
+        count: 1,
+        defaults: defaults,
+        sessions: [session])
 }
 
 private func commandChoice(
@@ -6364,6 +6393,408 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.thinkingLevel } == "adaptive")
         #expect(await MainActor.run { vm.thinkingLevelOptions.map(\.id) } == ["off", "adaptive", "max"])
         #expect(await MainActor.run { vm.thinkingLevelOptions.map(\.label) } == ["off", "adaptive", "maximum"])
+    }
+
+    @Test func `thinking picker follows gateway metadata before current level augmentation`() async throws {
+        let history = historyPayload(sessionId: "sess-main")
+        let offOnlySessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: "reasoning-model",
+                modelProvider: "openai",
+                thinkingLevel: "medium",
+                thinkingLevels: [thinkingOption("off")]))
+        let reasoningValues: [Bool?] = [true, nil]
+        for reasoning in reasoningValues {
+            let models = [
+                modelChoice(
+                    id: "reasoning-model",
+                    name: "Reasoning Model",
+                    provider: "openai",
+                    reasoning: reasoning),
+            ]
+            let (_, vm) = await makeViewModel(
+                historyResponses: [history],
+                sessionsResponses: [offOnlySessions],
+                modelResponses: [models],
+                initialThinkingLevel: "medium")
+
+            try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+            try await waitUntil("off-only thinking metadata applied") {
+                await MainActor.run { vm.thinkingLevelOptions.map(\.id) == ["off", "medium"] }
+            }
+
+            #expect(await MainActor.run { !vm.showsThinkingPicker })
+        }
+
+        let multiLevelSessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: nil,
+                thinkingLevels: [thinkingOption("off"), thinkingOption("high")]))
+        let (_, multiLevelVM) = await makeViewModel(
+            historyResponses: [history],
+            sessionsResponses: [multiLevelSessions])
+
+        try await loadAndWaitBootstrap(vm: multiLevelVM, sessionId: "sess-main")
+        try await waitUntil("multi-level thinking metadata applied") {
+            await MainActor.run { multiLevelVM.thinkingLevelOptions.map(\.id) == ["off", "high"] }
+        }
+
+        #expect(await MainActor.run { multiLevelVM.showsThinkingPicker })
+
+        let (_, legacyVM) = await makeViewModel(historyResponses: [history])
+        try await loadAndWaitBootstrap(vm: legacyVM, sessionId: "sess-main")
+
+        #expect(await MainActor.run { legacyVM.showsThinkingPicker })
+        #expect(await MainActor.run { legacyVM.thinkingLevelOptions.map(\.id) } ==
+            ["off", "minimal", "low", "medium", "high"])
+    }
+
+    @Test func `gated thinking picker sends off without changing stored level`() async throws {
+        let history = historyPayload(sessionId: "sess-main")
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: "plain-model",
+                modelProvider: "openai",
+                thinkingLevels: [thinkingOption("off"), thinkingOption("medium")]))
+        let models = [
+            modelChoice(id: "plain-model", name: "Plain Model", provider: "openai", reasoning: false),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            initialThinkingLevel: "medium")
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        #expect(await MainActor.run { !vm.showsThinkingPicker })
+
+        await sendUserMessage(vm, text: "hello")
+        try await waitUntil("gated send uses off") {
+            await transport.sentThinkingLevels() == ["off"]
+        }
+
+        #expect(await MainActor.run { vm.thinkingLevel } == "medium")
+    }
+
+    @Test func `ungated thinking picker sends stored level`() async throws {
+        let history = historyPayload(sessionId: "sess-main")
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: "reasoning-model",
+                modelProvider: "openai",
+                thinkingLevels: [thinkingOption("off"), thinkingOption("medium")]))
+        let models = [
+            modelChoice(
+                id: "reasoning-model",
+                name: "Reasoning Model",
+                provider: "openai",
+                reasoning: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            initialThinkingLevel: "medium")
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        #expect(await MainActor.run { vm.showsThinkingPicker })
+
+        await sendUserMessage(vm, text: "hello")
+        try await waitUntil("ungated send uses stored level") {
+            await transport.sentThinkingLevels() == ["medium"]
+        }
+    }
+
+    @Test func `switching back to reasoning model restores stored thinking level for send`() async throws {
+        let history = historyPayload(sessionId: "sess-main")
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: "reasoning-model",
+                modelProvider: "openai",
+                thinkingLevels: [thinkingOption("off"), thinkingOption("medium")]))
+        let models = [
+            modelChoice(
+                id: "reasoning-model",
+                name: "Reasoning Model",
+                provider: "openai",
+                reasoning: true),
+            modelChoice(id: "plain-model", name: "Plain Model", provider: "openai", reasoning: false),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            initialThinkingLevel: "medium")
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        await MainActor.run { vm.selectModel("openai/plain-model") }
+        try await waitUntil("plain model selected") {
+            await MainActor.run {
+                vm.sessions.first?.model == "plain-model" && !vm.showsThinkingPicker
+            }
+        }
+
+        await sendUserMessage(vm, text: "plain send")
+        try await waitUntil("plain send uses off") {
+            await transport.sentThinkingLevels() == ["off"]
+        }
+        try await waitUntil("plain send completed") {
+            await MainActor.run { !vm.isSending && vm.pendingRunCount == 0 }
+        }
+
+        await MainActor.run { vm.selectModel("openai/reasoning-model") }
+        try await waitUntil("reasoning model restored") {
+            await MainActor.run {
+                vm.sessions.first?.model == "reasoning-model" && vm.showsThinkingPicker
+            }
+        }
+        await sendUserMessage(vm, text: "reasoning send")
+        try await waitUntil("reasoning send restores stored level") {
+            await transport.sentThinkingLevels() == ["off", "medium"]
+        }
+
+        #expect(await MainActor.run { vm.thinkingLevel } == "medium")
+    }
+
+    @Test func `send reapplies thinking gate after model patch rollback`() async throws {
+        let modelPatchGate = SessionSubscribeGate()
+        let history = historyPayload(sessionId: "sess-main")
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: "plain-model",
+                modelProvider: "openai",
+                thinkingLevels: [thinkingOption("off"), thinkingOption("medium")]))
+        let models = [
+            modelChoice(id: "plain-model", name: "Plain Model", provider: "openai", reasoning: false),
+            modelChoice(
+                id: "reasoning-model",
+                name: "Reasoning Model",
+                provider: "openai",
+                reasoning: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            setSessionModelHook: { model in
+                if model == "openai/reasoning-model" {
+                    await modelPatchGate.wait()
+                    throw NSError(domain: "test", code: 1)
+                }
+            },
+            initialThinkingLevel: "medium")
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        await MainActor.run { vm.selectModel("openai/reasoning-model") }
+        try await waitUntil("reasoning model patch started") {
+            let pickerShown = await MainActor.run { vm.showsThinkingPicker }
+            let patchedModels = await transport.patchedModels()
+            return pickerShown && patchedModels == ["openai/reasoning-model"]
+        }
+
+        await sendUserMessage(vm, text: "send after rollback")
+        try await waitUntil("send waits for model patch") {
+            let isSending = await MainActor.run { vm.isSending }
+            let sentThinkingLevels = await transport.sentThinkingLevels()
+            return isSending && sentThinkingLevels.isEmpty
+        }
+        await modelPatchGate.release()
+        try await waitUntil("rolled back send uses off") {
+            let rolledBack = await MainActor.run {
+                vm.modelSelectionID == "openai/plain-model" && !vm.showsThinkingPicker
+            }
+            let sentThinkingLevels = await transport.sentThinkingLevels()
+            return rolledBack && sentThinkingLevels == ["off"]
+        }
+
+        #expect(await MainActor.run { vm.thinkingLevel } == "medium")
+    }
+
+    @Test func `non-reasoning model selection hides picker before session refresh`() async throws {
+        let modelPatchGate = SessionSubscribeGate()
+        let history = historyPayload(sessionId: "sess-main")
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: "reasoning-model",
+                modelProvider: "openai",
+                thinkingLevels: [thinkingOption("off"), thinkingOption("high")]))
+        let models = [
+            modelChoice(
+                id: "reasoning-model",
+                name: "Reasoning Model",
+                provider: "openai",
+                reasoning: true),
+            modelChoice(
+                id: "plain-model",
+                name: "Plain Model",
+                provider: "openai",
+                reasoning: false),
+        ]
+        let (_, vm) = await makeViewModel(
+            historyResponses: [history],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            setSessionModelHook: { model in
+                if model == "openai/plain-model" {
+                    await modelPatchGate.wait()
+                }
+            })
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        try await waitUntil("reasoning model loaded") {
+            await MainActor.run {
+                vm.modelSelectionID == "openai/reasoning-model" && vm.showsThinkingPicker
+            }
+        }
+
+        await MainActor.run { vm.selectModel("openai/plain-model") }
+        try await waitUntil("local non-reasoning selection gated") {
+            await MainActor.run {
+                vm.modelSelectionID == "openai/plain-model" &&
+                    !vm.showsThinkingPicker &&
+                    vm.sessions.first?.model == "reasoning-model"
+            }
+        }
+        await modelPatchGate.release()
+    }
+
+    @Test func `reselecting the same model preserves thinking metadata`() async throws {
+        let modelPatchGate = SessionSubscribeGate()
+        let history = historyPayload(sessionId: "sess-main")
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: " model-x ",
+                modelProvider: " openai ",
+                thinkingLevels: [thinkingOption("off")],
+                thinkingOptions: ["off"],
+                thinkingDefault: "off"))
+        let models = [
+            modelChoice(id: "model-x", name: "Model X", provider: "openai", reasoning: true),
+            modelChoice(id: "model-y", name: "Model Y", provider: "openai", reasoning: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history],
+            sessionsResponses: [sessions],
+            modelResponses: [models],
+            setSessionModelHook: { model in
+                if model == "openai/model-y" {
+                    await modelPatchGate.wait()
+                }
+            })
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        #expect(await MainActor.run { !vm.showsThinkingPicker })
+
+        await MainActor.run { vm.selectModel("openai/model-y") }
+        try await waitUntil("model Y patch started") {
+            await transport.patchedModels() == ["openai/model-y"]
+        }
+        await MainActor.run { vm.selectModel("openai/model-x") }
+        try await waitUntil("model X re-selection patched") {
+            await transport.patchedModels() == ["openai/model-y", "openai/model-x"]
+        }
+        await modelPatchGate.release()
+        await vm.waitForPendingModelPatches(in: "main")
+
+        #expect(await MainActor.run { vm.sessions.first?.thinkingLevels?.map(\.id) } == ["off"])
+        #expect(await MainActor.run { vm.sessions.first?.thinkingOptions } == ["off"])
+        #expect(await MainActor.run { vm.sessions.first?.thinkingDefault } == "off")
+        #expect(await MainActor.run { !vm.showsThinkingPicker })
+    }
+
+    @Test func `switching models drops stale thinking metadata`() async throws {
+        let history = historyPayload(sessionId: "sess-main")
+        let sessions = sessionsResponse(
+            sessionEntry(
+                key: "main",
+                updatedAt: 1,
+                model: "model-x",
+                modelProvider: "openai",
+                thinkingLevels: [thinkingOption("off")],
+                thinkingOptions: ["off"],
+                thinkingDefault: "off"))
+        let models = [
+            modelChoice(id: "model-x", name: "Model X", provider: "openai", reasoning: true),
+            modelChoice(id: "model-y", name: "Model Y", provider: "openai", reasoning: true),
+        ]
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [history],
+            sessionsResponses: [sessions],
+            modelResponses: [models])
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        #expect(await MainActor.run { !vm.showsThinkingPicker })
+
+        await MainActor.run { vm.selectModel("openai/model-y") }
+        try await waitUntil("model Y patch completed") {
+            await MainActor.run {
+                vm.sessions.first?.model == "model-y" && vm.showsThinkingPicker
+            }
+        }
+
+        #expect(await transport.patchedModels() == ["openai/model-y"])
+        #expect(await MainActor.run { vm.sessions.first?.thinkingLevels == nil })
+        #expect(await MainActor.run { vm.sessions.first?.thinkingOptions == nil })
+        #expect(await MainActor.run { vm.sessions.first?.thinkingDefault == nil })
+    }
+
+    @Test func `default model selection resolves session model reasoning`() async throws {
+        let history = historyPayload(sessionId: "sess-main")
+        let models = [
+            modelChoice(id: "plain-model", name: "Plain Model", provider: "openai", reasoning: false),
+            modelChoice(id: "reasoning-model", name: "Reasoning Model", provider: "openai", reasoning: true),
+        ]
+        let (_, vm) = await makeViewModel(
+            historyResponses: [history],
+            modelResponses: [models])
+
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        try await waitUntil("models loaded with default selection") {
+            await MainActor.run {
+                vm.modelChoices.count == 2 &&
+                    vm.modelSelectionID == OpenClawChatViewModel.defaultModelSelectionID
+            }
+        }
+
+        await MainActor.run {
+            vm.sessions = [
+                sessionEntry(
+                    key: "main",
+                    updatedAt: 1,
+                    model: "plain-model",
+                    modelProvider: "openai"),
+            ]
+            vm.syncThinkingLevelOptions()
+        }
+        #expect(await MainActor.run { !vm.showsThinkingPicker })
+
+        await MainActor.run {
+            vm.sessions = [
+                sessionEntry(
+                    key: "main",
+                    updatedAt: 1,
+                    model: "reasoning-model",
+                    modelProvider: "openai"),
+            ]
+            vm.syncThinkingLevelOptions()
+        }
+        #expect(await MainActor.run { vm.showsThinkingPicker })
     }
 
     @Test func `thinking options fallback and current unsupported level stay visible`() async throws {


### PR DESCRIPTION
Related: #100699

## What Problem This Solves

Fixes an issue where iOS/macOS chat users would see and set a thinking-level control even when the selected model does not support configurable reasoning effort — the control silently did nothing for those models, which reads as broken.

## Why This Change Was Made

The gateway already computes per-model thinking capability: models with catalog `reasoning: false` resolve to an off-only thinking profile, and `models.list` carries a per-model `reasoning` flag. This PR consumes that existing metadata client-side — no protocol changes. The shared chat view model now hides the thinking picker when (a) gateway-provided session/default thinking metadata resolves to off-only, or (b) the locally selected model choice carries `reasoning == false` (which covers the window right after a model switch, before the session metadata refreshes). Legacy gateways that send no thinking metadata keep the picker (fail open). While the control is gated off, sends carry an effective thinking level of `off` instead of the stored preference — the gateway treats an explicit unsupported level as a hard error (`agent-command.ts` throws for explicit levels the model doesn't support), and with the control hidden the user would have no way to fix a stale non-off level. The stored preference itself is never mutated, so switching back to a reasoning-capable model restores the user's level. Session thinking metadata is preserved across same-model patches but deliberately dropped when the model changes (stale metadata must not gate the new model). The `reasoning` flag is threaded through `OpenClawChatModelChoice` and both transports (iOS gateway transport decode, macOS webchat mapping) with default-nil compatibility for existing call sites.

## User Impact

The thinking-level control now appears only when it actually does something for the selected model. Switching to a non-reasoning model hides it immediately; switching back restores it.

## Evidence

- `swift test --package-path apps/shared/OpenClawKit` — full suite green; `ChatViewModelTests` now 147 tests including: off-only metadata hides, multi-level shows, metadata-absent legacy shows, local `reasoning == false` hides immediately despite stale multi-level metadata, default-sentinel selection resolves the session model for gating, the current-level augmentation cannot flip gating, same-model patches preserve thinking metadata while model changes drop it, and gated sends carry `off` while the stored level survives; `ChatViewModelOutboxTests` (20) cover queued/retry sends re-evaluating the gate per session at flush time.
- iOS `xcodebuild build-for-testing` + focused `IOSGatewayChatTransportTests` green (reasoning decode assertion added); macOS `swift build` green.
- `swiftformat --lint` via the iOS filelist — clean.
- Structured review (codex) — clean at head.
