### PR TITLE
feat(model): support one-turn chat model override

### DIFF
--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -100,6 +100,8 @@ export type GetReplyOptions = {
   suppressTyping?: boolean;
   /** Resolved heartbeat model override (provider/model string from merged per-agent config). */
   heartbeatModelOverride?: string;
+  /** One-shot provider/model override for this run; does not persist to the session. */
+  oneTurnModelOverride?: string;
   /** One-shot thinking level override for this run; does not persist to the session. */
   thinkingLevelOverride?: string;
   /** One-shot fast-mode override for this run; does not persist to the session. */

--- a/src/auto-reply/model.test.ts
+++ b/src/auto-reply/model.test.ts
@@ -30,6 +30,13 @@ describe("extractModelDirective", () => {
       expect(result.rawModel).toBe("anthropic/claude-opus-4-6");
     });
 
+    it("keeps trailing text as the cleaned message", () => {
+      const result = extractModelDirective("/model anthropic/claude-opus-4-6 fix this bug");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("anthropic/claude-opus-4-6");
+      expect(result.cleaned).toBe("fix this bug");
+    });
+
     it("extracts /model with a runtime override", () => {
       const result = extractModelDirective("/model anthropic/claude-opus-4-7 --runtime claude-cli");
       expect(result.hasDirective).toBe(true);

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -683,6 +683,23 @@ export async function getReplyFromConfig(
     model = resolvedChannelModelOverride.ref.model;
   }
 
+  const oneTurnModelOverrideRaw = normalizeOptionalString(resolvedOpts?.oneTurnModelOverride);
+  const oneTurnModelOverride = oneTurnModelOverrideRaw
+    ? resolveModelRefFromString({
+        raw: oneTurnModelOverrideRaw,
+        defaultProvider,
+        aliasIndex,
+      })
+    : null;
+  if (oneTurnModelOverrideRaw && !oneTurnModelOverride) {
+    typing.cleanup();
+    return { text: `Unrecognized model "${oneTurnModelOverrideRaw}".` };
+  }
+  if (oneTurnModelOverride) {
+    provider = oneTurnModelOverride.ref.provider;
+    model = oneTurnModelOverride.ref.model;
+  }
+
   if (
     shouldUseReplyFastDirectiveExecution({
       isFastTestBootstrap: useFastTestRuntime,
@@ -790,6 +807,7 @@ export async function getReplyFromConfig(
       aliasIndex,
       provider,
       model,
+      hasOneTurnModelOverride: oneTurnModelOverride !== null,
       hasResolvedHeartbeatModelOverride,
       typing,
       opts: withExtractedFileImages(resolvedOpts, extractedFileImages),

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -990,6 +990,70 @@ describe("createModelSelectionState respects session model override", () => {
     expect(state.model).toBe("qwen2.5-coder:7b");
   });
 
+  it("uses one-turn overrides without persisting over stored session overrides", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "inferencer/deepseek-v3-4bit-mlx": {},
+            "openai/gpt-4o": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:main";
+    const sessionEntry = makeEntry({
+      providerOverride: "kimi-coding",
+      modelOverride: "kimi-code",
+      modelOverrideSource: "user",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider,
+      defaultModel,
+      provider: "openai",
+      model: "gpt-4o",
+      hasModelDirective: false,
+      hasOneTurnModelOverride: true,
+    });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o");
+    expect(sessionStore[sessionKey]?.providerOverride).toBe("kimi-coding");
+    expect(sessionStore[sessionKey]?.modelOverride).toBe("kimi-code");
+  });
+
+  it("rejects one-turn overrides outside the agent allowlist", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "inferencer/deepseek-v3-4bit-mlx": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      createModelSelectionState({
+        cfg,
+        agentCfg: cfg.agents?.defaults,
+        defaultProvider,
+        defaultModel,
+        provider: "openai",
+        model: "gpt-4o",
+        hasModelDirective: false,
+        hasOneTurnModelOverride: true,
+      }),
+    ).rejects.toThrow('Model override "openai/gpt-4o" is not allowed for this agent.');
+  });
+
   it("normalizes deprecated xai beta session overrides before allowlist checks", async () => {
     const cfg = {
       agents: {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -203,6 +203,7 @@ export async function createModelSelectionState(params: {
   const configuredModelCatalog = buildConfiguredModelCatalog({ cfg });
   const needsModelCatalog =
     params.hasModelDirective ||
+    hasOneTurnModelOverride ||
     Boolean(
       hasAllowlist && visibility.providerWildcards.size > 0 && !defaultProviderVisibleByWildcard,
     );
@@ -408,7 +409,20 @@ export async function createModelSelectionState(params: {
     }
   }
 
-  if (!params.hasModelDirective && !hasOneTurnModelOverride) {
+  if (hasOneTurnModelOverride) {
+    const normalizedOneTurnSelection = normalizeRuntimeModelRef(provider, model);
+    const oneTurnKey = modelKey(
+      normalizedOneTurnSelection.provider,
+      normalizedOneTurnSelection.model,
+    );
+    if (!visibilityPolicy.allowsKey(oneTurnKey)) {
+      throw new Error(
+        `Model override "${modelKey(provider, model)}" is not allowed for this agent.`,
+      );
+    }
+    provider = normalizedOneTurnSelection.provider;
+    model = normalizedOneTurnSelection.model;
+  } else if (!params.hasModelDirective) {
     const allowedInitialSelection = visibilityPolicy.resolveSelection({
       provider,
       model,

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -87,6 +87,7 @@ const mockState = vi.hoisted(() => ({
   lastDispatchImages: undefined as Array<{ mimeType: string; data: string }> | undefined,
   lastDispatchImageOrder: undefined as string[] | undefined,
   lastDispatchThinkingLevelOverride: undefined as string | undefined,
+  lastDispatchOneTurnModelOverride: undefined as string | undefined,
   lastDispatchUserTurnInput: undefined as unknown,
   modelCatalog: null as ModelCatalogEntry[] | null,
   emittedTranscriptUpdates: [] as Array<{
@@ -243,12 +244,14 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
         images?: Array<{ mimeType: string; data: string }>;
         imageOrder?: string[];
         thinkingLevelOverride?: string;
+        oneTurnModelOverride?: string;
       };
     }) => {
       mockState.lastDispatchCtx = params.ctx;
       mockState.lastDispatchImages = params.replyOptions?.images;
       mockState.lastDispatchImageOrder = params.replyOptions?.imageOrder;
       mockState.lastDispatchThinkingLevelOverride = params.replyOptions?.thinkingLevelOverride;
+      mockState.lastDispatchOneTurnModelOverride = params.replyOptions?.oneTurnModelOverride;
       const recorder = params.replyOptions?.userTurnTranscriptRecorder;
       mockState.lastDispatchUserTurnInput = recorder?.resolveMessage
         ? await recorder.resolveMessage()
@@ -839,6 +842,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     mockState.lastDispatchImages = undefined;
     mockState.lastDispatchImageOrder = undefined;
     mockState.lastDispatchThinkingLevelOverride = undefined;
+    mockState.lastDispatchOneTurnModelOverride = undefined;
     mockState.lastDispatchUserTurnInput = undefined;
     mockState.modelCatalog = null;
     mockState.emittedTranscriptUpdates = [];
@@ -905,6 +909,29 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     await waitForAssertion(() => {
       expect(context.dedupe.has("chat:idem-command-session-metadata")).toBe(true);
     });
+  });
+
+  it("treats /model with trailing text as a one-turn chat.send model override", async () => {
+    createTranscriptFixture("openclaw-chat-send-one-turn-model-");
+    const context = createChatContext();
+    const respond = vi.fn();
+
+    await runNonStreamingChatSend({
+      context,
+      respond,
+      idempotencyKey: "idem-one-turn-model",
+      message: "/model openai/gpt-5.5 explain this diff",
+      waitFor: "none",
+    });
+
+    await waitForAssertion(() => {
+      expect(mockState.lastDispatchCtx).toBeDefined();
+    });
+    expect(mockState.lastDispatchOneTurnModelOverride).toBe("openai/gpt-5.5");
+    expect(mockState.lastDispatchCtx?.Body).toBe("explain this diff");
+    expect(mockState.lastDispatchCtx?.BodyForAgent).toBe("explain this diff");
+    expect(mockState.lastDispatchCtx?.CommandBody).toBe("explain this diff");
+    expect(mockState.lastDispatchCtx?.RawBody).toBe("/model openai/gpt-5.5 explain this diff");
   });
 
   it("broadcasts session metadata changes before later command dispatch failure", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -50,6 +50,7 @@ import type { AgentMessage } from "../../agents/runtime/index.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
+import { extractModelDirective } from "../../auto-reply/model.js";
 import {
   getReplyPayloadMetadata,
   isReplyPayloadStatusNotice,
@@ -4338,8 +4339,22 @@ export const chatHandlers: GatewayRequestHandlers = {
       const preparedUserTurnMediaPromise =
         normalizedAttachments.length > 0 ? getPersistedMediaForTranscript() : Promise.resolve([]);
       const userTurnMediaPromise = preparedUserTurnMediaPromise.then(buildChatSendUserTurnMedia);
+      const inlineModelDirective = suppressCommandInterpretation
+        ? { cleaned: parsedMessage, hasDirective: false as const }
+        : extractModelDirective(parsedMessage);
+      const oneTurnModelOverride =
+        inlineModelDirective.hasDirective &&
+        inlineModelDirective.rawModel &&
+        !inlineModelDirective.rawProfile &&
+        !inlineModelDirective.rawRuntime &&
+        inlineModelDirective.cleaned.trim().length > 0
+          ? inlineModelDirective.rawModel
+          : undefined;
+      const effectiveParsedMessage = oneTurnModelOverride
+        ? inlineModelDirective.cleaned
+        : parsedMessage;
       const baseUserTurnInput: UserTurnInput = {
-        text: rawMessage,
+        text: effectiveParsedMessage.trim(),
         timestamp: now,
         idempotencyKey: `${clientRunId}:user`,
         ...(hasGatewayAdminScope(client) ? { senderIsOwner: true } : {}),
@@ -4358,14 +4373,13 @@ export const chatHandlers: GatewayRequestHandlers = {
         explicitOriginTargetsPlugin && parsedImages.length > 0
           ? preparedUserTurnMediaPromise.then(resolveChatSendManagedMediaFields)
           : Promise.resolve({});
-
-      const trimmedMessage = parsedMessage.trim();
-      const commandBody = parsedMessage;
+      const trimmedMessage = effectiveParsedMessage.trim();
+      const commandBody = effectiveParsedMessage;
       const commandSource =
         !suppressCommandInterpretation && trimmedMessage.startsWith("/") ? "text" : undefined;
       const messageForAgent = systemProvenanceReceipt
-        ? [systemProvenanceReceipt, parsedMessage].filter(Boolean).join("\n\n")
-        : parsedMessage;
+        ? [systemProvenanceReceipt, effectiveParsedMessage].filter(Boolean).join("\n\n")
+        : effectiveParsedMessage;
       const queuedFollowupOwnerDeviceId = normalizeOptionalText(client?.connect?.device?.id);
       const queuedFollowupOwnerConnId = normalizeOptionalText(client?.connId);
       const queuedFollowupOwnerKey = queuedFollowupOwnerDeviceId
@@ -4707,6 +4721,7 @@ export const chatHandlers: GatewayRequestHandlers = {
                     : {}),
                   requestedSessionId,
                   resumeRequestedSession: controlUiReconnectResume.resumeRequested,
+                  ...(oneTurnModelOverride ? { oneTurnModelOverride } : {}),
                   abortSignal: activeRunAbort.controller.signal,
                   // Keep a Gateway-owned cancel identity after this chat.send
                   // terminalizes while the prompt waits in followup/collect queue.


### PR DESCRIPTION
## Summary

- Add a one-turn model override path for `chat.send` messages like `/model openai/gpt-5.5 explain this diff`.
- Strip the inline `/model` directive from the prompt sent to the agent while passing the selected model as a non-persistent run override.
- Validate one-turn overrides against the agent model visibility/allowlist instead of silently falling back to the default model.

## Verification

- `pnpm test src/auto-reply/model.test.ts src/auto-reply/reply/model-selection.test.ts`
- `pnpm test src/gateway/server-methods/chat.directive-tags.test.ts -- -t "one-turn chat.send model override"`
- `pnpm test src/auto-reply/model.test.ts src/auto-reply/reply/model-selection.test.ts src/gateway/server-methods/chat.directive-tags.test.ts -- -t "one-turn chat.send model override|extractModelDirective|one-turn overrides"`
- `pnpm exec oxfmt --check src/auto-reply/get-reply-options.types.ts src/auto-reply/model.test.ts src/auto-reply/reply/get-reply.ts src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/model-selection.ts src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server-methods/chat.ts`
- `node scripts/run-oxlint.mjs src/auto-reply/get-reply-options.types.ts src/auto-reply/model.test.ts src/auto-reply/reply/get-reply.ts src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/model-selection.ts src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server-methods/chat.ts`
- `git diff --check`
