### PR TITLE
fix(auto-reply): treat transient preflight compaction failures as skip reasons (#100778)

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -2498,4 +2498,64 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.bootstrapPromptWarningSignaturesSeen).toEqual(["sig-a", "sig-b"]);
     expect(flushCall.bootstrapPromptWarningSignature).toBe("sig-b");
   });
+
+  it.each([
+    ["timeout", "compaction timed out after 30s"],
+    ["provider_error_4xx", "provider returned 429 rate limit exceeded"],
+    ["provider_error_5xx", "provider returned 502 bad gateway"],
+    ["summary_failed", "summary generation failed: model unavailable"],
+  ])(
+    "gracefully skips preflight compaction on transient %s failure instead of throwing",
+    async (_classification, reason) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+        "utf8",
+      );
+      registerMemoryFlushPlanResolverForTest(() => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 0,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
+      compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+        ok: false,
+        compacted: false,
+        reason,
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        sessionFile,
+        updatedAt: Date.now(),
+        totalTokens: 120,
+        totalTokensFresh: true,
+      };
+      const onCompactionNotice = vi.fn();
+
+      const entry = await runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:telegram:group:redacted",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore: { "agent:main:telegram:group:redacted": sessionEntry },
+        sessionKey: "agent:main:telegram:group:redacted",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+        onCompactionNotice,
+      });
+
+      expect(entry).toBe(sessionEntry);
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -206,10 +206,24 @@ function isPreflightCompactionSkipReason(reason?: string): boolean {
   // Preflight compaction is a guardrail, not a hard dependency. These classes
   // mean the context engine found nothing useful to compact, so the reply should
   // continue instead of surfacing a generic user-facing failure.
-  return (
+  if (
     classification === "below_threshold" ||
     classification === "no_compactable_entries" ||
     classification === "already_compacted_recently"
+  ) {
+    return true;
+  }
+  // Transient infrastructure failures (timeout, provider errors, summary
+  // generation failure) should not terminate the reply operation.  Treating
+  // them as hard failures permanently locks the Composer in a "terminated"
+  // state with no user-visible recovery path.  The downstream LLM call may
+  // still fail with a context-too-long error, but that produces a proper
+  // user-visible message instead of a silent lockout.
+  return (
+    classification === "timeout" ||
+    classification === "provider_error_4xx" ||
+    classification === "provider_error_5xx" ||
+    classification === "summary_failed"
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Transient preflight compaction failures (timeout, provider 4xx/5xx, summary generation failure) are treated as hard failures. The reply throws `"Preflight compaction required but failed"`, which the gateway converts to a `chat.dispatch-error` and the Control UI renders as a permanently terminated Composer. The user has no recovery path except refreshing the page.

Fixes #100778.

## Why This Change Was Made

`isPreflightCompactionSkipReason` already skips benign outcomes (`below_threshold`, `no_compactable_entries`, `already_compacted_recently`) because "preflight compaction is a guardrail, not a hard dependency." Transient infrastructure failures fall into the same category — the correct response is to continue without compaction rather than lock the user out.

The compaction reason classifier (`classifyCompactionReason` in `compact-reasons.ts`) already maps timeout and provider error strings to stable classification names. This change simply adds those transient classes to the skip predicate so they follow the same graceful-degradation path as the existing skip reasons.

**Not modified**: The compaction reason classifier itself, gateway dispatch-error handling, Control UI lifecycle reconciliation, or the compaction execution pipeline.

## User Impact

Users whose preflight compaction hits a transient provider error or timeout no longer see their Composer permanently locked. The agent run proceeds without pre-compaction context reduction — the downstream LLM call may still fail with a context-too-long error, but that produces a proper user-visible error message instead of a silent UI lockout.

## Evidence

### Live production-code proof (`classifyCompactionReason` from `compact-reasons.ts`)

The proof script imports the **real** `classifyCompactionReason` production function — the exact same code the gateway executes — and exercises `isPreflightCompactionSkipReason` against all compaction reason classes:

```
$ npx tsx scripts/proof-100778-compaction-skip.mjs

[PASS] class=no_compactable_entries       skip=true  → existing
[PASS] class=below_threshold              skip=true  → existing
[PASS] class=already_compacted_recently   skip=true  → existing
[PASS] class=timeout                      skip=true  → THE FIX
[PASS] class=timeout                      skip=true  → THE FIX
[PASS] class=provider_error_4xx           skip=true  → THE FIX
[PASS] class=provider_error_5xx           skip=true  → THE FIX
[PASS] class=summary_failed               skip=true  → THE FIX
[PASS] class=unknown                      skip=false → hard failures still throw
[PASS] class=unknown                      skip=false → hard failures still throw
[PASS] class=unknown                      skip=false → empty reason still throws
[PASS] class=unknown                      skip=false → undefined still throws

12/12 passed
```

### Causality chain → Control UI

```
preflight compaction transient fail
  → classifyCompactionReason() → "timeout" / "provider_error_4xx" / …
  → isPreflightCompactionSkipReason() → TRUE (proved above, 5/5 transient)
  → runPreflightCompactionIfNeeded returns session entry (not throw)
  → gateway does NOT emit chat.dispatch-error
  → Control UI Composer stays ACTIVE
```

### Unit test regression

```
$ npx vitest run src/auto-reply/reply/agent-runner-memory.test.ts --run
 Test Files  1 passed (1)
      Tests  51 passed (51)
```

Includes 4 new parameterized tests covering `timeout`, `provider_error_4xx`, `provider_error_5xx`, and `summary_failed` through `runPreflightCompactionIfNeeded`.

### oxlint

```
$ node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner-memory.ts
→ exit 0
```

### What this proof covers and what it does not

| Proven | How |
|--------|-----|
| `classifyCompactionReason` correctly maps transient reason strings | Real production code imported by proof script |
| `isPreflightCompactionSkipReason` returns `true` for all 4 transient classes | Proof script, 5/5 transient cases |
| Existing skip reasons (`below_threshold`, `no_compactable_entries`, `already_compacted_recently`) are unaffected | Proof script, 3/3 existing cases |
| Unknown/hard failures still throw | Proof script, 4/4 hard-failure cases |
| `runPreflightCompactionIfNeeded` returns session entry instead of throwing | 4 parameterized vitest tests |

| Not proven | Why impractical |
|------------|----------------|
| Real provider timeout triggering compaction in a live gateway | Requires a running agent with memory plugin installed, `memoryFlush` config, enough context to cross the compaction threshold, AND a real provider timeout. Controlling all four variables simultaneously is a QA-lab scenario, not a per-PR gate. |
| Composer UI element visibly not-"terminated" after transient skip | The fix prevents the error from ever reaching the gateway dispatch layer. If the error is never emitted, the UI cannot render "terminated" — this is a mechanical consequence, not a UI behavior change. Verifying it visually would require a full macOS desktop app session with the exact failure conditions above. |

## Regression Test Plan

```
$ npx vitest run src/auto-reply/reply/agent-runner-memory.test.ts --run
 Test Files  1 passed (1)
      Tests  51 passed (51)

$ npx tsx scripts/proof-100778-compaction-skip.mjs
→ 12/12 passed, exit 0

$ node scripts/run-oxlint.mjs src/auto-reply/reply/agent-runner-memory.ts
→ exit 0
```

## Root Cause

In `isPreflightCompactionSkipReason()` (`src/auto-reply/reply/agent-runner-memory.ts:204`), the skip predicate only accepted `below_threshold`, `no_compactable_entries`, and `already_compacted_recently` — all "nothing to compact" outcomes. Transient infrastructure failures (`timeout`, `provider_error_4xx`, `provider_error_5xx`, `summary_failed`) were already classified by `classifyCompactionReason()` in `compact-reasons.ts:29` but were not included in the skip set, so they fell through to the hard-error path that throws and terminates the Composer.

## AI Assistance

This PR was created with assistance from Claude Opus 4.8 (Anthropic). The author understands and takes responsibility for all code changes.