### PR TITLE
refactor: remove unused internal exports

### DIFF
--- a/extensions/opencode-go/api.ts
+++ b/extensions/opencode-go/api.ts
@@ -1,28 +1,6 @@
 // Opencode Go API module exposes the plugin public contract.
-import {
-  applyAgentDefaultModelPrimary,
-  resolveAgentModelPrimaryValue,
-} from "openclaw/plugin-sdk/provider-onboard";
-import { OPENCODE_GO_DEFAULT_MODEL_REF } from "./onboard.js";
-
 export {
   applyOpencodeGoConfig,
   applyOpencodeGoProviderConfig,
   OPENCODE_GO_DEFAULT_MODEL_REF,
 } from "./onboard.js";
-
-export function applyOpencodeGoModelDefault(
-  cfg: import("openclaw/plugin-sdk/provider-onboard").OpenClawConfig,
-): {
-  next: import("openclaw/plugin-sdk/provider-onboard").OpenClawConfig;
-  changed: boolean;
-} {
-  const current = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model);
-  if (current === OPENCODE_GO_DEFAULT_MODEL_REF) {
-    return { next: cfg, changed: false };
-  }
-  return {
-    next: applyAgentDefaultModelPrimary(cfg, OPENCODE_GO_DEFAULT_MODEL_REF),
-    changed: true,
-  };
-}

--- a/extensions/xai/api.ts
+++ b/extensions/xai/api.ts
@@ -90,18 +90,3 @@ export function resolveXaiTransport(params: {
     baseUrl: readStringValue(params.baseUrl),
   };
 }
-
-export function resolveXaiBaseUrl(baseUrlOrConfig?: unknown): string {
-  let candidate = baseUrlOrConfig;
-  if (
-    baseUrlOrConfig &&
-    typeof baseUrlOrConfig === "object" &&
-    !Array.isArray(baseUrlOrConfig) &&
-    "cfg" in baseUrlOrConfig
-  ) {
-    candidate =
-      (baseUrlOrConfig as { cfg?: { models?: { providers?: { xai?: { baseUrl?: unknown } } } } })
-        .cfg?.models?.providers?.xai?.baseUrl ?? baseUrlOrConfig;
-  }
-  return readStringValue(candidate) || "https://api.x.ai/v1";
-}

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -38,7 +38,7 @@ export type GatewayEventFrame = {
   stateVersion?: { presence: number; health: number };
 };
 
-export type GatewayResponseFrame = {
+type GatewayResponseFrame = {
   type: "res";
   id: string;
   ok: boolean;
@@ -251,7 +251,7 @@ export type GatewayConnectClientInfo = {
   instanceId?: string;
 };
 
-export type GatewayConnectParams = {
+type GatewayConnectParams = {
   minProtocol: typeof MIN_CLIENT_PROTOCOL_VERSION;
   maxProtocol: typeof PROTOCOL_VERSION;
   client: GatewayConnectClientInfo;
@@ -309,7 +309,7 @@ export type GatewayBrowserClientOptions = {
 
 export type GatewayEventListener = (evt: GatewayEventFrame) => void;
 
-export type GatewayRequestTiming = {
+type GatewayRequestTiming = {
   id: string;
   method: string;
   ok: boolean;

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -177,12 +177,12 @@ export type GoogleChatStatus = {
   lastProbeAt?: number | null;
 };
 
-export type SlackBot = {
+type SlackBot = {
   id?: string | null;
   name?: string | null;
 };
 
-export type SlackTeam = {
+type SlackTeam = {
   id?: string | null;
   name?: string | null;
 };
@@ -265,7 +265,7 @@ export type NostrStatus = {
   profile?: NostrProfile | null;
 };
 
-export type ConfigSnapshotIssue = {
+type ConfigSnapshotIssue = {
   path: string;
   message: string;
 };
@@ -379,7 +379,7 @@ export type SessionWorkspaceFileEntry = {
   content?: string;
 };
 
-export type SessionWorkspaceBrowserEntry = {
+type SessionWorkspaceBrowserEntry = {
   path: string;
   name: string;
   kind: "file" | "directory";
@@ -388,7 +388,7 @@ export type SessionWorkspaceBrowserEntry = {
   updatedAtMs?: number;
 };
 
-export type SessionWorkspaceBrowserResult = {
+type SessionWorkspaceBrowserResult = {
   path: string;
   parentPath?: string;
   search?: string;
@@ -734,7 +734,7 @@ export type CronRunsResult = {
   hasMore?: boolean;
 };
 
-export type SkillsStatusConfigCheck = {
+type SkillsStatusConfigCheck = {
   path: string;
   satisfied: boolean;
 };
@@ -769,7 +769,7 @@ export type SkillClawHubLink =
       lockPath?: string;
     };
 
-export type SkillCardStatus = {
+type SkillCardStatus = {
   present: true;
   path: string;
   sizeBytes: number;
@@ -881,7 +881,7 @@ export type ModelAuthStatusResult =
 
 // ── Attention ───────────────────────────────────────
 
-export type AttentionSeverity = "error" | "warning" | "info";
+type AttentionSeverity = "error" | "warning" | "info";
 
 export type AttentionItem = {
   severity: AttentionSeverity;

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -32,9 +32,9 @@ export type ApplicationRouter = Router<
   AppRouteModule,
   unknown
 >;
-export type AppRoute = PageDefinition<RouteId, ApplicationContext<RouteId>, AppRouteModule>;
+type AppRoute = PageDefinition<RouteId, ApplicationContext<RouteId>, AppRouteModule>;
 
-export const APP_ROUTE_TREE = [
+const APP_ROUTE_TREE = [
   chatPage,
   overviewPage,
   activityPage,

--- a/ui/src/app/assistant-identity.ts
+++ b/ui/src/app/assistant-identity.ts
@@ -5,7 +5,7 @@ import { getSafeLocalStorage } from "../local-storage.ts";
 
 const LOCAL_ASSISTANT_IDENTITY_KEY = "openclaw.control.assistant.v1";
 
-export type LocalAssistantIdentity = { avatar: string | null; agentId?: string | null };
+type LocalAssistantIdentity = { avatar: string | null; agentId?: string | null };
 
 type PersistedLocalAssistantIdentities = {
   avatars?: Record<string, unknown>;

--- a/ui/src/app/config.ts
+++ b/ui/src/app/config.ts
@@ -62,7 +62,7 @@ function readDocumentTerminalEnabled(): boolean | null {
   return value === "true" ? true : value === "false" ? false : null;
 }
 
-export const DEFAULT_APPLICATION_CONFIG: ApplicationConfig = {
+const DEFAULT_APPLICATION_CONFIG: ApplicationConfig = {
   assistantIdentity: {
     agentId: null,
     name: "Assistant",
@@ -118,7 +118,7 @@ function applyControlUiSeamColor(value: unknown): void {
   );
 }
 
-export function normalizeApplicationConfig(parsed: ControlUiBootstrapConfig): ApplicationConfig {
+function normalizeApplicationConfig(parsed: ControlUiBootstrapConfig): ApplicationConfig {
   const identity = normalizeAssistantIdentity({
     agentId: parsed.assistantAgentId ?? null,
     name: parsed.assistantName,
@@ -155,7 +155,7 @@ export function normalizeApplicationConfig(parsed: ControlUiBootstrapConfig): Ap
   };
 }
 
-export async function loadApplicationConfig(params: {
+async function loadApplicationConfig(params: {
   basePath: string;
   auth?: ApplicationConfigAuthSource;
   skipWithoutAuthCandidate?: boolean;

--- a/ui/src/app/native-bridge.ts
+++ b/ui/src/app/native-bridge.ts
@@ -5,7 +5,7 @@ type WebView2Bridge = {
   removeEventListener(type: "message", listener: (event: MessageEvent) => void): void;
 };
 
-export type NativeBridgeMessage =
+type NativeBridgeMessage =
   | { type: "draft-text"; payload: { text: string } }
   | { type: "ready"; payload?: Record<string, unknown> };
 

--- a/ui/src/app/router-outlet.ts
+++ b/ui/src/app/router-outlet.ts
@@ -115,7 +115,7 @@ function renderError<TRouteId extends string, TLoadContext, TModule, TData>(
   `;
 }
 
-export function renderRouterOutlet<TRouteId extends string, TLoadContext, TModule, TData = unknown>(
+function renderRouterOutlet<TRouteId extends string, TLoadContext, TModule, TData = unknown>(
   router: Router<TRouteId, TLoadContext, TModule, TData>,
   selection: RouterOutletSelection<TRouteId, TModule, TData>,
   options: RouterOutletOptions<TLoadContext> = {},
@@ -283,7 +283,7 @@ class RouterOutletDirective extends AsyncDirective {
 
 const routerOutletDirective = directive(RouterOutletDirective);
 
-export function routerOutlet<TRouteId extends string, TModule, TData, TContext>(
+function routerOutlet<TRouteId extends string, TModule, TData, TContext>(
   router: Router<TRouteId, TContext, TModule, TData>,
   boundaryOptions: RouterOutletBoundaryOptions,
   options: RouterOutletOptions<TContext> = {},
@@ -291,7 +291,7 @@ export function routerOutlet<TRouteId extends string, TModule, TData, TContext>(
   return routerOutletDirective(router, options.retryContext, boundaryOptions);
 }
 
-export class OpenClawRouterOutlet<
+class OpenClawRouterOutlet<
   TRouteId extends string = string,
   TLoadContext = unknown,
   TModule = unknown,

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -147,7 +147,7 @@ type NativeControlAuth = {
   password?: string | null;
 };
 
-export type ApplicationStartupSettings = {
+type ApplicationStartupSettings = {
   settings: UiSettings;
   password: string | null;
   pendingGatewayUrl: string | null;

--- a/ui/src/app/theme-transition.ts
+++ b/ui/src/app/theme-transition.ts
@@ -7,7 +7,7 @@ export type ThemeTransitionContext = {
   pointerClientY?: number;
 };
 
-export type ThemeTransitionOptions = {
+type ThemeTransitionOptions = {
   nextTheme: ResolvedTheme;
   applyTheme: () => void;
   // Retained so callers from stacked slices can keep passing pointer metadata

--- a/ui/src/app/theme.ts
+++ b/ui/src/app/theme.ts
@@ -11,7 +11,7 @@ export type ResolvedTheme =
   | "custom"
   | "custom-light";
 
-export const VALID_THEME_NAMES = new Set<ThemeName>(["claw", "knot", "dash", "custom"]);
+const VALID_THEME_NAMES = new Set<ThemeName>(["claw", "knot", "dash", "custom"]);
 const VALID_THEME_MODES = new Set<ThemeMode>(["system", "light", "dark"]);
 
 type ThemeSelection = { theme: ThemeName; mode: ThemeMode };

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -36,7 +36,7 @@ export type AgentToolSection = {
   tools: AgentToolEntry[];
 };
 
-export const FALLBACK_TOOL_SECTIONS: AgentToolSection[] = [
+const FALLBACK_TOOL_SECTIONS: AgentToolSection[] = [
   {
     id: "fs",
     label: "Files",

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -90,7 +90,7 @@ export async function loadAgentsList(client: GatewayBrowserClient): Promise<Agen
   return client.request<AgentsListResult>("agents.list", {});
 }
 
-export async function loadAgentFilesList(
+async function loadAgentFilesList(
   client: GatewayBrowserClient,
   agentId: string,
 ): Promise<AgentsFilesListResult | null> {

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -48,9 +48,7 @@ export type ChannelCapability = {
   dispose: () => void;
 };
 
-export function createInitialChannelsState(
-  snapshot: Partial<ChannelGatewaySnapshot> = {},
-): ChannelsState {
+function createInitialChannelsState(snapshot: Partial<ChannelGatewaySnapshot> = {}): ChannelsState {
   return {
     client: snapshot.client ?? null,
     connected: snapshot.connected ?? false,

--- a/ui/src/lib/chat/model-ref.ts
+++ b/ui/src/lib/chat/model-ref.ts
@@ -242,7 +242,7 @@ export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<str
   return displayLookup;
 }
 
-export function formatCatalogEntryDisplay(
+function formatCatalogEntryDisplay(
   entry: ModelCatalogEntry,
   displayLookup: ChatModelDisplayLookup,
 ): string {

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -29,7 +29,7 @@ export type ChatModelSelectOption = {
   label: string;
 };
 
-export type ChatModelSelectState = {
+type ChatModelSelectState = {
   currentOverride: string;
   defaultModel: string;
   defaultDisplay: string;

--- a/ui/src/lib/chat/thinking.ts
+++ b/ui/src/lib/chat/thinking.ts
@@ -78,7 +78,7 @@ export function resolveThinkingDefaultForModel(params: {
 
 type ThinkingSessionDefaults = SessionsListResult["defaults"] | undefined;
 
-export type ChatThinkingSelectState = {
+type ChatThinkingSelectState = {
   currentOverride: string;
   defaultLabel: string;
   defaultValue: string;

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -521,7 +521,7 @@ export async function patchConfig(
   }
 }
 
-export async function lookupConfigSchemaPath(
+async function lookupConfigSchemaPath(
   state: { client: ConfigGatewayClient | null; connected: boolean },
   path: string,
 ): Promise<unknown> {
@@ -659,7 +659,7 @@ export function resetConfigPendingChanges(state: ConfigState) {
   autoAllowlistedPluginIdsByState.delete(state);
 }
 
-export function removeConfigFormValue(state: ConfigState, path: Array<string | number>) {
+function removeConfigFormValue(state: ConfigState, path: Array<string | number>) {
   mutateConfigForm(state, (draft) => removePathValue(draft, path));
 }
 

--- a/ui/src/lib/cron-status.ts
+++ b/ui/src/lib/cron-status.ts
@@ -1,7 +1,7 @@
 // Control UI module implements cron status behavior.
 import type { CronJob, CronRunStatus } from "../api/types.ts";
 
-export type CronJobLastRunStatus = CronRunStatus | "unknown";
+type CronJobLastRunStatus = CronRunStatus | "unknown";
 
 export function resolveCronJobLastRunStatus(job: CronJob): CronJobLastRunStatus {
   return job.state?.lastRunStatus ?? job.state?.lastStatus ?? "unknown";

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -93,7 +93,7 @@ export function getCronJobPayload(job: CronJob): CronPayload | null {
   return isCronPayload(payload) ? payload : null;
 }
 
-export function hasCronJobPayload(job: CronJob): boolean {
+function hasCronJobPayload(job: CronJob): boolean {
   return getCronJobPayload(job) !== null;
 }
 
@@ -155,7 +155,7 @@ export type CronFieldErrors = Partial<Record<CronFieldKey, string>>;
 
 export type CronJobsScheduleKindFilter = "all" | "at" | "every" | "cron" | "on-exit";
 export type CronJobsLastStatusFilter = "all" | CronRunStatus | "unknown";
-export type CronRunsLoadStatus = "ok" | "error" | "skipped";
+type CronRunsLoadStatus = "ok" | "error" | "skipped";
 
 export type CronState = {
   client: GatewayBrowserClient | null;

--- a/ui/src/lib/gateway-diagnostics.ts
+++ b/ui/src/lib/gateway-diagnostics.ts
@@ -1,7 +1,7 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { HealthSnapshot, StatusSummary } from "../api/types.ts";
 
-export type GatewayDiagnosticsSnapshot = {
+type GatewayDiagnosticsSnapshot = {
   status: StatusSummary;
   health: HealthSnapshot;
   models: unknown[];

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -14,7 +14,7 @@ type GatewayRequestClient = {
   request<T = unknown>(method: string, params?: unknown): Promise<T>;
 };
 
-export type NodesGatewaySnapshot = {
+type NodesGatewaySnapshot = {
   client: GatewayRequestClient | null;
   connected: boolean;
 };

--- a/ui/src/lib/open-external-url.ts
+++ b/ui/src/lib/open-external-url.ts
@@ -56,7 +56,7 @@ export function resolveSafeExternalUrl(
   }
 }
 
-export type OpenExternalUrlSafeOptions = ResolveSafeExternalUrlOptions & {
+type OpenExternalUrlSafeOptions = ResolveSafeExternalUrlOptions & {
   baseHref?: string;
 };
 

--- a/ui/src/lib/overview-hints.ts
+++ b/ui/src/lib/overview-hints.ts
@@ -36,7 +36,7 @@ const INSECURE_CONTEXT_CODES = new Set<string>([
 
 type AuthHintKind = "required" | "failed";
 
-export type PairingHint =
+type PairingHint =
   | {
       kind: "pairing-required";
       requestId: string | null;

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -16,7 +16,7 @@ const CHANNEL_LABELS: Record<string, string> = {
 const KNOWN_CHANNEL_KEYS = Object.keys(CHANNEL_LABELS);
 
 /** Parsed type / context extracted from a session key. */
-export type SessionKeyInfo = {
+type SessionKeyInfo = {
   /** Prefix for typed sessions (Subagent:/Cron:). Empty for others. */
   prefix: string;
   /** Human-readable fallback when no label / displayName is available. */

--- a/ui/src/lib/sessions/grouping.ts
+++ b/ui/src/lib/sessions/grouping.ts
@@ -47,7 +47,7 @@ function dateBucketId(updatedAt: number | null | undefined, now: number): string
   return "older";
 }
 
-export function sessionRowChannel(row: GatewaySessionRow): string {
+function sessionRowChannel(row: GatewaySessionRow): string {
   return row.channel ?? parseSessionKeyParts(row.key)?.channel ?? UNGROUPED_ID;
 }
 

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -273,7 +273,7 @@ function buildSessionListParams(options: SessionListOptions = {}): Record<string
   return params;
 }
 
-export async function requestSessionList(
+async function requestSessionList(
   client: SessionRequestClient,
   options: SessionListOptions = {},
 ): Promise<SessionsListResult | null> {
@@ -284,7 +284,7 @@ export async function requestSessionList(
   return result ?? null;
 }
 
-export function requestSessionPatch(
+function requestSessionPatch(
   client: SessionRequestClient,
   key: string,
   patch: SessionPatch,
@@ -307,7 +307,7 @@ export function requestSessionDelete(
   });
 }
 
-export function requestSessionReset(
+function requestSessionReset(
   client: SessionRequestClient,
   key: string,
   options: SessionResetOptions = {},
@@ -319,7 +319,7 @@ export function requestSessionReset(
     .then(() => undefined);
 }
 
-export function requestSessionCompact(
+function requestSessionCompact(
   client: SessionRequestClient,
   key: string,
   options: { agentId?: string | null } = {},
@@ -329,7 +329,7 @@ export function requestSessionCompact(
   });
 }
 
-export function requestSessionSteer(
+function requestSessionSteer(
   client: SessionRequestClient,
   key: string,
   message: string,
@@ -341,7 +341,7 @@ export function requestSessionSteer(
   });
 }
 
-export function requestSessionFilesList(
+function requestSessionFilesList(
   client: SessionRequestClient,
   key: string,
   options: { agentId?: string | null; path?: string; search?: string } = {},
@@ -354,7 +354,7 @@ export function requestSessionFilesList(
   });
 }
 
-export function requestSessionFile(
+function requestSessionFile(
   client: SessionRequestClient,
   key: string,
   path: string,
@@ -367,11 +367,11 @@ export function requestSessionFile(
   });
 }
 
-export function subscribeSessionGateway(client: SessionRequestClient): Promise<void> {
+function subscribeSessionGateway(client: SessionRequestClient): Promise<void> {
   return client.request("sessions.subscribe", {}).then(() => undefined);
 }
 
-export async function subscribeSessionMessages(
+async function subscribeSessionMessages(
   client: SessionRequestClient,
   key: string,
   options: { agentId?: string | null } = {},
@@ -401,7 +401,7 @@ export function unsubscribeSessionMessages(
     .then(() => undefined);
 }
 
-export async function listSessionCheckpoints(
+async function listSessionCheckpoints(
   client: SessionRequestClient,
   key: string,
   options: { agentId?: string | null } = {},
@@ -412,7 +412,7 @@ export async function listSessionCheckpoints(
   );
 }
 
-export function branchSessionCheckpoint(
+function branchSessionCheckpoint(
   client: SessionRequestClient,
   key: string,
   checkpointId: string,
@@ -424,7 +424,7 @@ export function branchSessionCheckpoint(
   });
 }
 
-export function restoreSessionCheckpoint(
+function restoreSessionCheckpoint(
   client: SessionRequestClient,
   key: string,
   checkpointId: string,

--- a/ui/src/lib/skill-workshop/index.ts
+++ b/ui/src/lib/skill-workshop/index.ts
@@ -5,7 +5,7 @@ export type SkillWorkshopProposalStatus =
   | "quarantined"
   | "stale";
 
-export type SkillWorkshopFile = {
+type SkillWorkshopFile = {
   path: string;
   size: string;
   contents: string;

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -176,7 +176,7 @@ function currentSkillCardCacheKey(state: SkillsState, skillKey: string): string 
   return skill ? skillCardCacheKey(skill) : undefined;
 }
 
-export function skillsAgentParams(agentId: string | null | undefined): { agentId?: string } {
+function skillsAgentParams(agentId: string | null | undefined): { agentId?: string } {
   const normalized = agentId?.trim();
   return normalized ? { agentId: normalized } : {};
 }

--- a/ui/src/lib/workboard/index.ts
+++ b/ui/src/lib/workboard/index.ts
@@ -279,7 +279,7 @@ export type WorkboardCard = {
   metadata?: WorkboardMetadata;
 };
 
-export type WorkboardLifecycleState =
+type WorkboardLifecycleState =
   | "unlinked"
   | "missing"
   | "idle"

--- a/ui/src/pages/activity/activity-page.ts
+++ b/ui/src/pages/activity/activity-page.ts
@@ -18,7 +18,7 @@ import { renderActivity } from "./view.ts";
 
 let activityClearBoundary: EventLogEntry | undefined;
 
-export class ActivityPage extends LitElement {
+class ActivityPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/activity/tool-activity.ts
+++ b/ui/src/pages/activity/tool-activity.ts
@@ -1,8 +1,8 @@
 // Control UI module implements activity model behavior.
 import { formatUnknownText, truncateText } from "../../lib/format.ts";
 
-export const ACTIVITY_ENTRY_LIMIT = 100;
-export const ACTIVITY_OUTPUT_PREVIEW_LIMIT = 2_000;
+const ACTIVITY_ENTRY_LIMIT = 100;
+const ACTIVITY_OUTPUT_PREVIEW_LIMIT = 2_000;
 
 export type ActivityStatus = "running" | "done" | "error";
 

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -49,7 +49,7 @@ export type AgentsRouteData = {
   error: string | null;
 };
 
-export class AgentsPage extends LitElement implements AgentsState {
+class AgentsPage extends LitElement implements AgentsState {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/agents/view.ts
+++ b/ui/src/pages/agents/view.ts
@@ -63,7 +63,7 @@ export type AgentSkillsState = {
   filter: string;
 };
 
-export type ToolsCatalogState = {
+type ToolsCatalogState = {
   loading: boolean;
   error: string | null;
   result: ToolsCatalogResult | null;

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -37,7 +37,7 @@ function buildNostrProfileUrl(accountId: string, suffix = ""): string {
   return `/api/channels/nostr/${encodeURIComponent(accountId)}/profile${suffix}`;
 }
 
-export class ChannelsPage extends LitElement {
+class ChannelsPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/channels/view.config.ts
+++ b/ui/src/pages/channels/view.config.ts
@@ -89,7 +89,7 @@ function renderExtraChannelFields(value: Record<string, unknown>) {
   `;
 }
 
-export function renderChannelConfigForm(props: ChannelConfigFormProps) {
+function renderChannelConfigForm(props: ChannelConfigFormProps) {
   const analysis = analyzeConfigSchema(props.schema);
   const normalized = analysis.schema;
   if (!normalized) {

--- a/ui/src/pages/channels/view.shared.ts
+++ b/ui/src/pages/channels/view.shared.ts
@@ -26,7 +26,7 @@ function resolveChannelStatus(
   return channels?.[key] as Record<string, unknown> | undefined;
 }
 
-export function resolveDefaultChannelAccount(
+function resolveDefaultChannelAccount(
   key: ChannelKey,
   props: ChannelsProps,
 ): ChannelAccountSnapshot | null {
@@ -131,7 +131,7 @@ export function renderSingleAccountChannelCard(params: {
   `;
 }
 
-export function getChannelAccountCount(
+function getChannelAccountCount(
   key: ChannelKey,
   channelAccounts?: Record<string, ChannelAccountSnapshot[]> | null,
 ): number {

--- a/ui/src/pages/chat/chat-commands.ts
+++ b/ui/src/pages/chat/chat-commands.ts
@@ -36,7 +36,7 @@ export type ChatCommandResetOptions = {
   restoreDraft?: boolean;
 };
 
-export type ChatCommandSendOptions = ChatCommandResetOptions & {
+type ChatCommandSendOptions = ChatCommandResetOptions & {
   sendResetMessage: (message: string, opts: ChatCommandResetOptions) => Promise<void>;
 };
 

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -96,7 +96,7 @@ const NEW_SESSION_LIST_LOADING_MESSAGE =
 const NEW_SESSION_CREATE_FAILED_MESSAGE =
   "New Chat could not create a new session. Try again in a moment.";
 
-export class ChatPage extends LitElement {
+class ChatPage extends LitElement {
   @consume({ context: applicationContext, subscribe: false })
   private context!: ChatPageContext;
   @property({ attribute: false }) data!: ChatRouteData;

--- a/ui/src/pages/chat/chat-send.ts
+++ b/ui/src/pages/chat/chat-send.ts
@@ -335,7 +335,7 @@ export async function requestSkillWorkshopRevisionChatSend(
   return normalizeChatSendAck(payload, params.runId);
 }
 
-export function appendUserChatMessage(
+function appendUserChatMessage(
   state: ChatState,
   message: string,
   attachments?: ChatAttachment[],

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -59,7 +59,7 @@ const COMPOSER_CHROME_INTERACTIVE_SELECTOR = [
 ].join(",");
 const SLASH_MENU_LISTBOX_ID = "chat-slash-menu-listbox";
 const SLASH_MENU_ACTIVE_ANNOUNCEMENT_ID = "chat-slash-active-announcement";
-export const CHAT_ATTACHMENT_ACCEPT =
+const CHAT_ATTACHMENT_ACCEPT =
   "image/*,audio/*,application/pdf,text/*,.csv,.json,.md,.txt,.zip," +
   ".doc,.docx,.xls,.xlsx,.ppt,.pptx";
 
@@ -870,7 +870,7 @@ export type ChatAttachmentControlsProps = {
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
 };
 
-export type ChatQueueProps = {
+type ChatQueueProps = {
   queue: ChatQueueItem[];
   canAbort?: boolean;
   onQueueRetry?: (id: string) => void;
@@ -1014,7 +1014,7 @@ function isSupportedChatAttachmentFile(file: Pick<File, "name" | "type">): boole
   return !/\.(?:avi|m4v|mov|mp4|mpeg|mpg|webm)$/i.test(file.name);
 }
 
-export function clickComposerFileInput(event: MouseEvent) {
+function clickComposerFileInput(event: MouseEvent) {
   const target = event.currentTarget;
   if (!(target instanceof HTMLElement)) {
     return;
@@ -1069,7 +1069,7 @@ function isImageAttachment(att: ChatAttachment): boolean {
   return att.mimeType.startsWith("image/");
 }
 
-export function handleChatAttachmentPaste(e: ClipboardEvent, props: ChatAttachmentControlsProps) {
+function handleChatAttachmentPaste(e: ClipboardEvent, props: ChatAttachmentControlsProps) {
   const items = e.clipboardData?.items;
   if (!items || !props.onAttachmentsChange) {
     return;
@@ -1110,7 +1110,7 @@ export function handleChatAttachmentPaste(e: ClipboardEvent, props: ChatAttachme
   }
 }
 
-export function handleChatAttachmentFileSelect(e: Event, props: ChatAttachmentControlsProps) {
+function handleChatAttachmentFileSelect(e: Event, props: ChatAttachmentControlsProps) {
   const input = e.target as HTMLInputElement;
   if (!input.files || !props.onAttachmentsChange) {
     return;
@@ -1162,7 +1162,7 @@ export function handleChatAttachmentDrop(e: DragEvent, props: ChatAttachmentCont
   }
 }
 
-export function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
+function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
   const attachments = props.attachments ?? [];
   if (attachments.length === 0) {
     return nothing;
@@ -1212,7 +1212,7 @@ export function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
   `;
 }
 
-export type ComposerRunStatus =
+type ComposerRunStatus =
   | ChatRunUiStatus
   | {
       phase: "in-progress";
@@ -1321,7 +1321,7 @@ export function renderFallbackIndicator(status: FallbackStatus | null | undefine
   `;
 }
 
-export type ContextNoticeOptions = {
+type ContextNoticeOptions = {
   compactBusy?: boolean;
   compactDisabled?: boolean;
   messages?: unknown[];

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -76,7 +76,7 @@ const ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS = 5_000;
 const ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS = 30_000;
 let assistantAttachmentAvailabilityRenderVersion = 0;
 
-export type ChatTimestampDisplay = {
+type ChatTimestampDisplay = {
   label: string;
   title: string;
   dateTime: string;
@@ -548,7 +548,7 @@ function extractTranscriptAttachments(message: unknown): AttachmentItem[] {
 }
 
 /** A contiguous run of in-flight streaming items rendered under one assistant group. */
-export type StreamGroupPart = Extract<ChatItem, { kind: "stream" } | { kind: "reading-indicator" }>;
+type StreamGroupPart = Extract<ChatItem, { kind: "stream" } | { kind: "reading-indicator" }>;
 
 type StreamGroupOptions = {
   onOpenSidebar?: (content: SidebarContent) => void;

--- a/ui/src/pages/chat/components/chat-realtime-controls.ts
+++ b/ui/src/pages/chat/components/chat-realtime-controls.ts
@@ -30,7 +30,7 @@ export type RealtimeTalkOptions = {
   vadThreshold: string;
 };
 
-export type ChatRealtimeTalkOptionsProps = {
+type ChatRealtimeTalkOptionsProps = {
   realtimeTalkOptionsOpen?: boolean;
   realtimeTalkOptions?: RealtimeTalkOptions;
   onRealtimeTalkOptionsChange?: (next: Partial<RealtimeTalkOptions>) => void;
@@ -38,7 +38,7 @@ export type ChatRealtimeTalkOptionsProps = {
   onOpenRealtimeTalkSettings?: () => void;
 };
 
-export type ChatRealtimeTalkConversationProps = {
+type ChatRealtimeTalkConversationProps = {
   assistantName: string;
   userName?: string | null;
   realtimeTalkConversation?: RealtimeTalkConversationEntry[];

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -55,7 +55,7 @@ type OpenRequest = {
   sessionKey: string;
 };
 
-export type SessionWorkspaceOpenRequest = OpenRequest;
+type SessionWorkspaceOpenRequest = OpenRequest;
 
 export type SessionWorkspaceHost = {
   sessionKey: string;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -101,7 +101,7 @@ export type ChatThreadProps = {
   onFocusComposer?: () => void;
 };
 
-export type ChatPinnedMessagesProps = Pick<
+type ChatPinnedMessagesProps = Pick<
   ChatThreadProps,
   "sessionKey" | "messages" | "userName" | "userAvatar"
 >;

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -186,7 +186,7 @@ export function renderToolPreview(
   `;
 }
 
-export function buildSidebarContent(
+function buildSidebarContent(
   value: string,
   options?: {
     rawText?: string | null;
@@ -201,7 +201,7 @@ export function buildSidebarContent(
   };
 }
 
-export function buildPreviewSidebarContent(
+function buildPreviewSidebarContent(
   preview: ToolPreview,
   rawText?: string | null,
   options?: { fullMessageRequest?: FullMessageRequest },
@@ -308,7 +308,7 @@ export function resolveCollapsedToolDetail(card: ToolCard, displayDetail: string
   return formatCollapsedToolPreviewText(inputText);
 }
 
-export function resolveCollapsedToolSummaryParts(params: {
+function resolveCollapsedToolSummaryParts(params: {
   card: ToolCard;
   displayLabel: string;
   displayDetail: string | undefined;

--- a/ui/src/pages/chat/composer-persistence.ts
+++ b/ui/src/pages/chat/composer-persistence.ts
@@ -17,7 +17,7 @@ import type { RealtimeTalkOptions } from "./components/chat-realtime-controls.ts
 const STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v1:";
 const MAX_STORED_SESSIONS = 20;
 const MAX_STORED_QUEUE_ITEMS = 50;
-export const CHAT_COMPOSER_DRAFT_PERSIST_DELAY_MS = 200;
+const CHAT_COMPOSER_DRAFT_PERSIST_DELAY_MS = 200;
 export const INTERRUPTED_MODEL_WAIT_ERROR =
   "Model selection was interrupted. Review and retry when ready.";
 

--- a/ui/src/pages/chat/realtime-talk-audio.ts
+++ b/ui/src/pages/chat/realtime-talk-audio.ts
@@ -28,7 +28,7 @@ export function floatToPcm16(samples: Float32Array): Uint8Array {
   return bytes;
 }
 
-export function pcm16ToFloat(bytes: Uint8Array): Float32Array {
+function pcm16ToFloat(bytes: Uint8Array): Float32Array {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const samples = new Float32Array(Math.floor(bytes.byteLength / 2));
   for (let i = 0; i < samples.length; i += 1) {

--- a/ui/src/pages/chat/realtime-talk-conversation.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.ts
@@ -17,7 +17,7 @@ export type RealtimeTalkConversationState = {
   assistantEntryId: string | null;
 };
 
-export type RealtimeTalkTranscriptUpdate = {
+type RealtimeTalkTranscriptUpdate = {
   role: RealtimeTalkConversationRole;
   text: string;
   final: boolean;

--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -78,7 +78,7 @@ export type RealtimeTalkGatewayRelaySessionResult = {
   consultFastMode?: boolean;
 };
 
-export type RealtimeTalkManagedRoomSessionResult = {
+type RealtimeTalkManagedRoomSessionResult = {
   provider: string;
   transport: "managed-room";
   roomUrl: string;

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -18,7 +18,7 @@ export type ChatRunUiStatus = {
   occurredAt: number;
 };
 
-export type LocalTerminalReconcile = {
+type LocalTerminalReconcile = {
   sessionKey: string;
   runId: string | null;
   phase: ChatRunUiStatus["phase"];
@@ -112,7 +112,7 @@ export function isChatStopCommand(text: string) {
   return CHAT_STOP_COMMANDS.has(normalizeLowercaseStringOrEmpty(text.trim()));
 }
 
-export type ChatAbortOptions = { preserveDraft?: boolean };
+type ChatAbortOptions = { preserveDraft?: boolean };
 
 export async function abortChatRun(state: ChatAbortRunState): Promise<boolean> {
   if (!state.client || !state.connected) {

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -20,7 +20,7 @@ export type AgentEventPayload = {
   data: Record<string, unknown>;
 };
 
-export type SessionOperationEventPayload = {
+type SessionOperationEventPayload = {
   operationId?: string;
   operation?: string;
   phase?: string;
@@ -289,7 +289,7 @@ export function flushToolStreamSync(host: ToolStreamHost) {
   syncToolStreamMessages(host);
 }
 
-export function scheduleToolStreamSync(host: ToolStreamHost, force = false) {
+function scheduleToolStreamSync(host: ToolStreamHost, force = false) {
   if (force) {
     flushToolStreamSync(host);
     return;
@@ -427,7 +427,7 @@ export function handleSessionOperationEvent(
   compactionHost.compactionStatus = null;
 }
 
-export function handleCompactionEvent(host: CompactionHost, payload: AgentEventPayload) {
+function handleCompactionEvent(host: CompactionHost, payload: AgentEventPayload) {
   const data = payload.data ?? {};
   const phase = typeof data.phase === "string" ? data.phase : "";
   const completed = data.completed === true;

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -216,7 +216,7 @@ function quickChannels(config: unknown): QuickSettingsChannel[] {
   });
 }
 
-export function extractQuickSettingsSecurity(config: unknown): QuickSettingsSecurity {
+function extractQuickSettingsSecurity(config: unknown): QuickSettingsSecurity {
   const root =
     asConfigRecord((config as { configForm?: unknown } | null)?.configForm) ??
     asConfigRecord(config);

--- a/ui/src/pages/config/presets.ts
+++ b/ui/src/pages/config/presets.ts
@@ -5,7 +5,7 @@
 
 export type ConfigPresetId = "personal" | "codeAgent" | "teamBot" | "minimal";
 
-export type ConfigPresetPatch = {
+type ConfigPresetPatch = {
   agents: {
     defaults: {
       bootstrapMaxChars: number;

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -40,7 +40,7 @@ export type QuickSettingsChannel = {
   detail?: string;
 };
 
-export type QuickSettingsAutomation = {
+type QuickSettingsAutomation = {
   cronJobCount: number;
   skillCount: number;
   mcpServerCount: number;

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -46,7 +46,7 @@ const TEXT_SCALE_LABELS: Record<TextScaleStop, string> = {
   140: "XXL",
 };
 
-export type WebPushUiState = {
+type WebPushUiState = {
   supported: boolean;
   permission: NotificationPermission | "unsupported";
   subscribed: boolean;

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -55,7 +55,7 @@ function unique(values: string[]): string[] {
   return sortUniqueStrings(values.map((value) => value.trim()).filter(Boolean));
 }
 
-export class CronPage extends LitElement {
+class CronPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/debug/debug-page.ts
+++ b/ui/src/pages/debug/debug-page.ts
@@ -12,7 +12,7 @@ import { renderDebug } from "./view.ts";
 
 const DEBUG_POLL_INTERVAL_MS = 3000;
 
-export class DebugPage extends LitElement {
+class DebugPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/dreams/dreams-page.ts
+++ b/ui/src/pages/dreams/dreams-page.ts
@@ -97,7 +97,7 @@ function readWikiPagePreview(value: unknown, lookup: string): WikiPagePreview {
   };
 }
 
-export class DreamsPage extends LitElement {
+class DreamsPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/instances/instances-page.ts
+++ b/ui/src/pages/instances/instances-page.ts
@@ -21,7 +21,7 @@ function readPresence(value: unknown): PresenceEntry[] | null {
   return Array.isArray(presence) ? (presence as PresenceEntry[]) : null;
 }
 
-export class InstancesPage extends LitElement {
+class InstancesPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/instances/view.ts
+++ b/ui/src/pages/instances/view.ts
@@ -6,7 +6,7 @@ import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
 import { formatPresenceAge } from "../../lib/presenter.ts";
 
-export type InstancesProps = {
+type InstancesProps = {
   loading: boolean;
   entries: PresenceEntry[];
   lastError: string | null;

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -20,7 +20,7 @@ import { renderLogs } from "./view.ts";
 const LOG_BUFFER_LIMIT = 2000;
 const LOGS_POLL_INTERVAL_MS = 2000;
 
-export class LogsPage extends LitElement {
+class LogsPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/nodes/nodes-page.ts
+++ b/ui/src/pages/nodes/nodes-page.ts
@@ -32,7 +32,7 @@ export type NodesRouteData = {
 
 const NODES_ACTIVE_POLL_INTERVAL_MS = 30_000;
 
-export class NodesPage extends LitElement implements NodesPageDataState {
+class NodesPage extends LitElement implements NodesPageDataState {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/nodes/view-pairing.ts
+++ b/ui/src/pages/nodes/view-pairing.ts
@@ -8,7 +8,7 @@ import type { DevicePairSetup } from "../../lib/device-pair-setup.ts";
 const PAIRING_DOCS_URL =
   "https://docs.openclaw.ai/channels/pairing#pair-from-the-control-ui-recommended";
 
-export type DevicePairSetupProps = {
+type DevicePairSetupProps = {
   open: boolean;
   loading: boolean;
   error: string | null;

--- a/ui/src/pages/overview/attention.ts
+++ b/ui/src/pages/overview/attention.ts
@@ -5,7 +5,7 @@ import { icons, type IconName } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../../lib/external-link.ts";
 
-export type OverviewAttentionProps = {
+type OverviewAttentionProps = {
   items: AttentionItem[];
 };
 

--- a/ui/src/pages/overview/event-log.ts
+++ b/ui/src/pages/overview/event-log.ts
@@ -6,7 +6,7 @@ import { t } from "../../i18n/index.ts";
 import { formatTimeMs } from "../../lib/format.ts";
 import { formatEventPayload } from "../../lib/presenter.ts";
 
-export type OverviewEventLogProps = {
+type OverviewEventLogProps = {
   events: readonly EventLogEntry[];
 };
 

--- a/ui/src/pages/overview/log-tail.ts
+++ b/ui/src/pages/overview/log-tail.ts
@@ -15,7 +15,7 @@ function stripAnsi(text: string): string {
   return text.replace(OSC8_LINK_RE, "").replace(SGR_RE, "");
 }
 
-export type OverviewLogTailProps = {
+type OverviewLogTailProps = {
   lines: string[];
   onRefreshLogs: () => void;
 };

--- a/ui/src/pages/overview/overview-page.ts
+++ b/ui/src/pages/overview/overview-page.ts
@@ -56,7 +56,7 @@ function addNamedAttention(
   }
 }
 
-export class OverviewPage extends LitElement {
+class OverviewPage extends LitElement {
   readonly i18nController = new I18nController(this);
 
   override createRenderRoot() {

--- a/ui/src/pages/plugin/logbook-controller.ts
+++ b/ui/src/pages/plugin/logbook-controller.ts
@@ -21,7 +21,7 @@ export type LogbookStatusPayload = {
   timeZone: string;
 };
 
-export type LogbookDistractionPayload = { startMs: number; endMs: number; title: string };
+type LogbookDistractionPayload = { startMs: number; endMs: number; title: string };
 
 export type LogbookCardPayload = {
   id: number;
@@ -38,7 +38,7 @@ export type LogbookCardPayload = {
   keyframeId?: number;
 };
 
-export type LogbookDayStatsPayload = {
+type LogbookDayStatsPayload = {
   trackedMs: number;
   distractionMs: number;
   categories: Array<{ category: string; ms: number }>;

--- a/ui/src/pages/plugin/logbook-view.ts
+++ b/ui/src/pages/plugin/logbook-view.ts
@@ -22,7 +22,7 @@ import {
   type LogbookUiState,
 } from "./logbook-controller.ts";
 
-export type LogbookProps = {
+type LogbookProps = {
   host: object;
   client: GatewayBrowserClient | null;
   connected: boolean;

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -72,7 +72,7 @@ function parseFilterInteger(value: string): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
-export class SessionsPage extends LitElement {
+class SessionsPage extends LitElement {
   @consume({ context: applicationContext, subscribe: false })
   private context?: ApplicationContext;
 

--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -186,7 +186,7 @@ function renderSkillWorkshopHeaderControls(state: SkillWorkshopState, requestUpd
   `;
 }
 
-export function renderSkillWorkshopPage(
+function renderSkillWorkshopPage(
   state: SkillWorkshopState,
   { context, workshopAgentName, onRevisionRequest }: SkillWorkshopRenderContext,
   requestUpdate: () => void,
@@ -339,7 +339,7 @@ export function renderSkillWorkshopPage(
   `;
 }
 
-export class SkillWorkshopPage extends LitElement {
+class SkillWorkshopPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -35,7 +35,7 @@ export type SkillsRouteData = {
   error: string | null;
 };
 
-export class SkillsPage extends LitElement {
+class SkillsPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/usage/types.ts
+++ b/ui/src/pages/usage/types.ts
@@ -25,7 +25,7 @@ export type UsageColumnId =
 
 export type TimeSeriesPoint = SessionUsageTimePoint;
 
-export type UsageDataState = {
+type UsageDataState = {
   loading: boolean;
   error: string | null;
   sessions: UsageSessionEntry[];
@@ -51,7 +51,7 @@ export type UsageFilterState = {
   timeZone: "local" | "utc";
 };
 
-export type UsageDisplayState = {
+type UsageDisplayState = {
   chartMode: "tokens" | "cost";
   dailyChartMode: "total" | "by-type";
   sessionSort: "tokens" | "cost" | "recent" | "messages" | "errors";
@@ -63,7 +63,7 @@ export type UsageDisplayState = {
   headerPinned: boolean;
 };
 
-export type UsageDetailState = {
+type UsageDetailState = {
   timeSeriesMode: "cumulative" | "per-turn";
   timeSeriesBreakdownMode: "total" | "by-type";
   timeSeries: { points: TimeSeriesPoint[] } | null;
@@ -81,7 +81,7 @@ export type UsageDetailState = {
   };
 };
 
-export type UsageCallbacks = {
+type UsageCallbacks = {
   filters: {
     onStartDateChange: (date: string) => void;
     onEndDateChange: (date: string) => void;

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -79,7 +79,7 @@ function toErrorMessage(error: unknown): string {
   return "request failed";
 }
 
-export class UsagePage extends LitElement {
+class UsagePage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/workboard/workboard-page.ts
+++ b/ui/src/pages/workboard/workboard-page.ts
@@ -14,7 +14,7 @@ import {
 } from "../../lib/workboard/index.ts";
 import { renderWorkboard } from "./view.ts";
 
-export class WorkboardPage extends LitElement {
+class WorkboardPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -14,7 +14,7 @@ function repoName(repoRoot: string): string {
   return repoRoot.split(/[\\/]/).findLast(Boolean) ?? repoRoot;
 }
 
-export class WorktreesPage extends LitElement {
+class WorktreesPage extends LitElement {
   override createRenderRoot() {
     return this;
   }


### PR DESCRIPTION
Closes #100880

## What Problem This Solves

Removes stale internal API surface that obscures real dead-code findings in the private Control UI and provider plugins.

## Why This Change Was Made

The change makes 124 Control UI declarations module-private after repository-wide reference verification, and deletes two unreachable helpers from private OpenCode Go and xAI plugins. Runtime behavior and externally consumed exports are unchanged.

## User Impact

No user-visible behavior change. The codebase exposes fewer accidental internals and future dead-code scans have less noise.

## Evidence

- `node scripts/run-vitest.mjs extensions/opencode-go/index.test.ts extensions/opencode-go/onboard.test.ts extensions/xai/api.test.ts extensions/xai/index.test.ts` (33 tests passed)
- `pnpm check:changed` in Blacksmith Testbox `tbx_01kwvkyzstc9xb54xtccw5fme4` (passed)
- `oxfmt --check --threads=1` across all 78 changed files (passed)
- Structured autoreview with Codex `gpt-5.5`, high reasoning (clean, no actionable findings)
- Rebased onto current `origin/main`; the five intervening commits had zero touched-file overlap

AI-assisted. The implementation and validation were reviewed; no transcript is attached.
