### PR TITLE
fix(feishu): send card JSON message params as cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Feishu card sends:** send valid plain interactive-card JSON from Feishu `message(action=send)` as native cards instead of post text. (#53486) Thanks @ZenoRewn and @martingarramon.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Feishu card sends:** send valid plain interactive-card JSON from Feishu `message(action=send)` as native cards instead of post text. (#53486) Thanks @ZenoRewn and @martingarramon.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.
 - **Small-context compaction:** cap the effective reserve against the known model context window so small local models do not enter compaction from the first token. (#100621) Thanks @vincentkoc.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -139,7 +139,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 103,
+      "line": 113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -147,7 +147,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 192,
+      "line": 202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -155,7 +155,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 202,
+      "line": 212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -467,6 +467,14 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 99,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
+      "source": "Mac Studio - Tailnet",
+      "surface": "android",
+      "id": "native.android.d6a820ac673a7e99"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 100,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Node",
@@ -533,6 +541,14 @@
       "kind": "ui-named-argument",
       "line": 144,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
+      "source": "Listening on device",
+      "surface": "android",
+      "id": "native.android.6b036c7f4efe72a0"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 144,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Talk mode",
       "surface": "android",
       "id": "native.android.3b61a88d99e08f21"
@@ -560,6 +576,14 @@
       "source": "Screen tools",
       "surface": "android",
       "id": "native.android.e263b68101dc6920"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 152,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
+      "source": "Shared with your gateway",
+      "surface": "android",
+      "id": "native.android.addea052bcd9ea96"
     },
     {
       "kind": "ui-named-argument",
@@ -682,6 +706,14 @@
       "id": "native.android.82ab699f88638b8a"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 59,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
+      "source": "Current screen output and interactive app surface.",
+      "surface": "android",
+      "id": "native.android.d5938abf7b7a7ee9"
+    },
+    {
       "kind": "conditional-branch",
       "line": 66,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CanvasSettingsScreen.kt",
@@ -778,6 +810,14 @@
       "id": "native.android.624fec3507aca6ed"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 48,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
+      "source": "Messaging surfaces connected to this gateway.",
+      "surface": "android",
+      "id": "native.android.269dcd676377df1a"
+    },
+    {
       "kind": "conditional-branch",
       "line": 63,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt",
@@ -872,6 +912,14 @@
       "source": "No actions found",
       "surface": "android",
       "id": "native.android.7c4288229860edf1"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 118,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
+      "source": "Try Chat, Voice, Sessions, Providers, or Settings.",
+      "surface": "android",
+      "id": "native.android.48ad0ae0e930e02b"
     },
     {
       "kind": "ui-named-argument",
@@ -1088,6 +1136,14 @@
       "source": "Dreaming",
       "surface": "android",
       "id": "native.android.b735fb6c7d284ecf"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 53,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/DreamingSettingsScreen.kt",
+      "source": "Memory consolidation and dream diary.",
+      "surface": "android",
+      "id": "native.android.4f96e0e1568d3220"
     },
     {
       "kind": "conditional-branch",
@@ -1370,6 +1426,14 @@
       "id": "native.android.d5902896d7b92cc9"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 71,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
+      "source": "Gateway status, phone node readiness, and recent log stream.",
+      "surface": "android",
+      "id": "native.android.6c1eb72c4b19c43a"
+    },
+    {
       "kind": "conditional-branch",
       "line": 78,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
@@ -1448,6 +1512,14 @@
       "source": "Log Entry",
       "surface": "android",
       "id": "native.android.3abbc8d1a0faf105"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 122,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/HealthLogsSettingsScreen.kt",
+      "source": "Readable gateway log detail.",
+      "surface": "android",
+      "id": "native.android.dd65a0b8f32f1441"
     },
     {
       "kind": "ui-named-argument",
@@ -1552,6 +1624,14 @@
       "source": "Nodes & Devices",
       "surface": "android",
       "id": "native.android.7eda627dad7e16cf"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 56,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt",
+      "source": "Live nodes, paired phones, and pending device requests.",
+      "surface": "android",
+      "id": "native.android.006a92f5811c5406"
     },
     {
       "kind": "conditional-branch",
@@ -1731,6 +1811,14 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 868,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Turn this device into a secure OpenClaw node for chat, voice, camera, and device tools.",
+      "surface": "android",
+      "id": "native.android.c38e106cc8f1e9ff"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 893,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw logo",
@@ -1786,6 +1874,14 @@
       "id": "native.android.63c31ee564d63347"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 1017,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Scan a QR code or use the setup code from your OpenClaw Gateway.",
+      "surface": "android",
+      "id": "native.android.f50a9c1ee6d47055"
+    },
+    {
       "kind": "ui-toast",
       "line": 1026,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
@@ -1827,11 +1923,27 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 1069,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Have a terminal open on the device running OpenClaw.",
+      "surface": "android",
+      "id": "native.android.c8a43dbba02941f0"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 1072,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Phone can reach the Gateway",
       "surface": "android",
       "id": "native.android.71ce00f359981a0b"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1073,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Use the same network, or a secure remote Gateway URL.",
+      "surface": "android",
+      "id": "native.android.08aa33afe19b0c9c"
     },
     {
       "kind": "ui-named-argument",
@@ -1859,11 +1971,27 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 1129,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "openclaw gateway",
+      "surface": "android",
+      "id": "native.android.d4b295b5146af4b8"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 1134,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Generate a QR code.",
       "surface": "android",
       "id": "native.android.c6f9da7008df05a6"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1135,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "openclaw qr",
+      "surface": "android",
+      "id": "native.android.db24e4be7a1b5547"
     },
     {
       "kind": "ui-named-argument",
@@ -2187,6 +2315,14 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 1974,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
+      "source": "Checking approval…",
+      "surface": "android",
+      "id": "native.android.0d4dd8ed358a6fb2"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 1986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still waiting for approval",
@@ -2376,6 +2512,14 @@
       "source": "Connected providers",
       "surface": "android",
       "id": "native.android.0a5b541f486e6760"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 115,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt",
+      "source": "Connect your Gateway to load provider readiness.",
+      "surface": "android",
+      "id": "native.android.c76ebb6f80eaad93"
     },
     {
       "kind": "ui-named-argument",
@@ -2645,6 +2789,14 @@
       "kind": "ui-named-argument",
       "line": 214,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Provider limits and quota health.",
+      "surface": "android",
+      "id": "native.android.dcb7d5956029bbc4"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 214,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
       "id": "native.android.aa3fb483f7e264fe"
@@ -2683,6 +2835,14 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 275,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Scheduled OpenClaw work from your gateway.",
+      "surface": "android",
+      "id": "native.android.5e3e4cd42004cb28"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android shows scheduled work status. Create and edit schedules from the desktop app.",
@@ -2712,6 +2872,14 @@
       "source": "Create recurring OpenClaw work from the desktop app.",
       "surface": "android",
       "id": "native.android.fe85be29a00c5e58"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 337,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Inspect scheduled gateway work.",
+      "surface": "android",
+      "id": "native.android.f6dd71419863574c"
     },
     {
       "kind": "ui-named-argument",
@@ -2747,6 +2915,14 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 381,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Choose and inspect the assistants available on this gateway.",
+      "surface": "android",
+      "id": "native.android.0f33ca43db97b2a9"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
@@ -2768,6 +2944,14 @@
       "source": "Approvals",
       "surface": "android",
       "id": "native.android.1ba6a31da5ad58e7"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 422,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Review actions that need your attention.",
+      "surface": "android",
+      "id": "native.android.b53cdcaacd0eb0f2"
     },
     {
       "kind": "conditional-branch",
@@ -2837,6 +3021,14 @@
       "kind": "ui-named-argument",
       "line": 476,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "How this phone appears to OpenClaw.",
+      "surface": "android",
+      "id": "native.android.fea93eda5bf97d9e"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 476,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
       "id": "native.android.695229fd01afbc2d"
@@ -2856,6 +3048,14 @@
       "source": "Save Profile",
       "surface": "android",
       "id": "native.android.18cd027f897c1ba8"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 499,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Configure voice, transport, and playback.",
+      "surface": "android",
+      "id": "native.android.19f0834b4dbcc85a"
     },
     {
       "kind": "ui-named-argument",
@@ -2973,6 +3173,14 @@
       "kind": "ui-named-argument",
       "line": 685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Choose what reaches OpenClaw.",
+      "surface": "android",
+      "id": "native.android.9feed8722db5d2cc"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 685,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
       "id": "native.android.d32071018de11907"
@@ -3075,6 +3283,14 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 781,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Include Android and background packages.",
+      "surface": "android",
+      "id": "native.android.4859d7f773be5e98"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 788,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
@@ -3088,6 +3304,14 @@
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
       "id": "native.android.7c979f32e6ea115f"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 934,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Choose what this phone can share.",
+      "surface": "android",
+      "id": "native.android.ae3122660b0489fc"
     },
     {
       "kind": "ui-named-argument",
@@ -3168,6 +3392,14 @@
       "source": "Cancel",
       "surface": "android",
       "id": "native.android.c6c8e0c4b8a9a7cf"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1033,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Connection between this phone and OpenClaw.",
+      "surface": "android",
+      "id": "native.android.9d658ff26e59274b"
     },
     {
       "kind": "conditional-branch",
@@ -3323,6 +3555,22 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 1113,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Enter a valid setup code or gateway address.",
+      "surface": "android",
+      "id": "native.android.633d0dcf4b6d6ed8"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1136,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "A calm, high-contrast OpenClaw interface.",
+      "surface": "android",
+      "id": "native.android.6f19c75742af5126"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 1136,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
@@ -3352,6 +3600,14 @@
       "source": "About",
       "surface": "android",
       "id": "native.android.2df2dec704f91977"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1199,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "OpenClaw for Android.",
+      "surface": "android",
+      "id": "native.android.c2d37ac2ad4c9e3c"
     },
     {
       "kind": "ui-named-argument",
@@ -4187,6 +4443,14 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 455,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
+      "source": "Start a chat and your active OpenClaw conversations will appear here.",
+      "surface": "android",
+      "id": "native.android.2e33a4fd5f60b550"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 456,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
@@ -4578,6 +4842,14 @@
       "id": "native.android.4590ee99228ab55f"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 68,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
+      "source": "Installed capabilities available to OpenClaw.",
+      "surface": "android",
+      "id": "native.android.73a666b0a4a0e617"
+    },
+    {
       "kind": "conditional-branch",
       "line": 82,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
@@ -4616,6 +4888,14 @@
       "source": "Skills installed on the gateway will appear here.",
       "surface": "android",
       "id": "native.android.ab93e3d2d6496eda"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 121,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt",
+      "source": "Inspect installed skill capability and setup state.",
+      "surface": "android",
+      "id": "native.android.81d900273232ce39"
     },
     {
       "kind": "ui-named-argument",
@@ -5139,7 +5419,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 181,
+      "line": 201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Type a message…",
       "surface": "android",
@@ -5147,7 +5427,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 191,
+      "line": 211,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Gateway is offline. Text messages are queued and sent after reconnecting.",
       "surface": "android",
@@ -5155,7 +5435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 220,
+      "line": 240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Select thinking level",
       "surface": "android",
@@ -5163,7 +5443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 244,
+      "line": 264,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Attach",
       "surface": "android",
@@ -5171,7 +5451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 252,
+      "line": 272,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Refresh",
       "surface": "android",
@@ -5179,7 +5459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 260,
+      "line": 280,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Abort",
       "surface": "android",
@@ -5187,7 +5467,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 305,
+      "line": 325,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Send",
       "surface": "android",
@@ -5195,11 +5475,19 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 331,
+      "line": 351,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "No commands found",
       "surface": "android",
       "id": "native.android.ff4e568bce360d5f"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 315,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt",
+      "source": "$index.",
+      "surface": "android",
+      "id": "native.android.cd2033b0a82a72dd"
     },
     {
       "kind": "ui-named-argument",
@@ -5210,8 +5498,88 @@
       "id": "native.android.bef360f847488651"
     },
     {
+      "kind": "conditional-branch",
+      "line": 44,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "$quoted\n\n",
+      "surface": "android",
+      "id": "native.android.e64a6673728dadcb"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 70,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Message actions",
+      "surface": "android",
+      "id": "native.android.7bf61a1da504c271"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 78,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Copy",
+      "surface": "android",
+      "id": "native.android.fab176fe78fc2500"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 82,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Select text",
+      "surface": "android",
+      "id": "native.android.319b4a29df279bb3"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 86,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Share",
+      "surface": "android",
+      "id": "native.android.fc50d4d9ec3b5a0b"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 90,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Reply",
+      "surface": "android",
+      "id": "native.android.7b896902a024d85f"
+    },
+    {
       "kind": "ui-call",
       "line": 116,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Done",
+      "surface": "android",
+      "id": "native.android.3f40011c9f02a65a"
+    },
+    {
+      "kind": "ui-toast",
+      "line": 137,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Message copied",
+      "surface": "android",
+      "id": "native.android.833dec4c78ab5eae"
+    },
+    {
+      "kind": "ui-chooser",
+      "line": 148,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "Share message",
+      "surface": "android",
+      "id": "native.android.7fecaa645b302769"
+    },
+    {
+      "kind": "ui-toast",
+      "line": 152,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt",
+      "source": "No app can share this message",
+      "surface": "android",
+      "id": "native.android.d06711f88020d74e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5219,7 +5587,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 137,
+      "line": 142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5227,7 +5595,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 157,
+      "line": 162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "No messages yet",
       "surface": "android",
@@ -5235,15 +5603,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 151,
+      "line": 161,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Thinking...",
       "surface": "android",
       "id": "native.android.a50e44d8f380f9ad"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 177,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Tools",
+      "surface": "android",
+      "id": "native.android.ff4a092a02bd5d17"
+    },
+    {
       "kind": "ui-call",
-      "line": 170,
+      "line": 180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Running tools...",
       "surface": "android",
@@ -5251,7 +5627,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 173,
+      "line": 183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "${display.emoji} ${display.label}",
       "surface": "android",
@@ -5259,7 +5635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 191,
+      "line": 201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "... +${toolCalls.size - 6} more",
       "surface": "android",
@@ -5267,7 +5643,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 236,
+      "line": 232,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "You",
+      "surface": "android",
+      "id": "native.android.b3ff30d4e0b3ce58"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Retry",
       "surface": "android",
@@ -5275,23 +5659,23 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 239,
+      "line": 249,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Delete",
       "surface": "android",
       "id": "native.android.b728b15914267f57"
     },
     {
-      "kind": "conditional-branch",
-      "line": 307,
+      "kind": "ui-named-argument",
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
-      "source": "You",
+      "source": "OpenClaw · Live",
       "surface": "android",
-      "id": "native.android.1d0bb431f08154a6"
+      "id": "native.android.dfbd755eb43b4d26"
     },
     {
       "kind": "conditional-branch",
-      "line": 308,
+      "line": 318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "System",
       "surface": "android",
@@ -5299,7 +5683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 309,
+      "line": 319,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5307,7 +5691,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 335,
+      "line": 345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",
@@ -5315,7 +5699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 237,
+      "line": 236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -5371,7 +5755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 617,
+      "line": 620,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5379,7 +5763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 644,
+      "line": 647,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5387,7 +5771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 664,
+      "line": 667,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5395,7 +5779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 695,
+      "line": 698,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5403,7 +5787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 696,
+      "line": 699,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5411,7 +5795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 834,
+      "line": 846,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -5419,7 +5803,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 839,
+      "line": 848,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
+      "source": "OpenClaw is working",
+      "surface": "android",
+      "id": "native.android.d851a32f367f8b31"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 851,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -5427,7 +5819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 849,
+      "line": 861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -5435,7 +5827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 850,
+      "line": 862,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -5443,7 +5835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 969,
+      "line": 981,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -5451,7 +5843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 986,
+      "line": 998,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -5459,7 +5851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1048,
+      "line": 1060,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -5467,7 +5859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1138,
+      "line": 1150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -5475,7 +5867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1153,
+      "line": 1165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -5483,7 +5875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1168,
+      "line": 1180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -5491,7 +5883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1206,
+      "line": 1218,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -5499,7 +5891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1227,
+      "line": 1239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -5507,7 +5899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1283,
+      "line": 1295,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -5515,7 +5907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1322,
+      "line": 1334,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -5523,11 +5915,19 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 269,
+      "line": 270,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt",
       "source": "CHAT ERROR",
       "surface": "android",
       "id": "native.android.826804c0189e03d0"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 537,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
+      "source": "Local command center",
+      "surface": "android",
+      "id": "native.android.64459adde73e63f2"
     },
     {
       "kind": "ui-named-argument",
@@ -5587,11 +5987,27 @@
     },
     {
       "kind": "ui-named-argument",
+      "line": 567,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
+      "source": "14 messages · Android",
+      "surface": "android",
+      "id": "native.android.9ffcbda6cdb9bc00"
+    },
+    {
+      "kind": "ui-named-argument",
       "line": 571,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
       "source": "Provider setup",
       "surface": "android",
       "id": "native.android.5c84ed8a78a5c5d5"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 572,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
+      "source": "OpenClaw gateway",
+      "surface": "android",
+      "id": "native.android.794873efdfcdff4f"
     },
     {
       "kind": "ui-named-argument",
@@ -5648,6 +6064,14 @@
       "source": "Nothing needs your attention",
       "surface": "android",
       "id": "native.android.994ac738d819f2e6"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 592,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt",
+      "source": "OpenClaw will surface approvals, failed jobs, and channel issues here.",
+      "surface": "android",
+      "id": "native.android.3457b4ee28d964ee"
     },
     {
       "kind": "conditional-branch",
@@ -15906,6 +16330,14 @@
       "id": "native.apple.2e33f01115fd73dd"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 450,
+      "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
+      "source": "/Users/you/.ssh/id_ed25519",
+      "surface": "apple",
+      "id": "native.apple.5eaffd822af43300"
+    },
+    {
       "kind": "ui-call",
       "line": 452,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
@@ -15914,12 +16346,28 @@
       "id": "native.apple.8bd4eccc71e5668f"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 454,
+      "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
+      "source": "/home/you/Projects/openclaw",
+      "surface": "apple",
+      "id": "native.apple.c663b8a50de8a7d8"
+    },
+    {
       "kind": "ui-call",
       "line": 456,
       "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
       "source": "CLI path",
       "surface": "apple",
       "id": "native.apple.938ee646aac4ce66"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 458,
+      "path": "apps/macos/Sources/OpenClaw/GeneralSettings.swift",
+      "source": "/Applications/OpenClaw.app/.../openclaw",
+      "surface": "apple",
+      "id": "native.apple.09f99e863e081f9f"
     },
     {
       "kind": "ui-call",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Android chat history now excludes internal, reasoning, and tool-result rows from rendered messages and the offline transcript cache.
 
+Android chat messages now expose long-press actions for whole-message copy, selective text copy, sharing, and quoted replies.
+
 The OpenClaw mascot now comes alive across onboarding and the app headers with the same float, blink, antenna-wiggle, and claw-snap animation as openclaw.ai.
 
 Adds read-only Cron Job details in Settings, including schedule, payload and delivery state, job ID copy, refresh, and nested back navigation.

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -28,6 +28,16 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+enum class ChatDraftPlacement {
+  Replace,
+  BeforeExisting,
+}
+
+data class ChatDraft(
+  val text: String,
+  val placement: ChatDraftPlacement,
+)
+
 /**
  * UI-facing bridge that exposes NodeRuntime and preference state as Compose-friendly StateFlows.
  */
@@ -47,8 +57,8 @@ class MainViewModel(
   val requestedHomeDestination: StateFlow<HomeDestination?> = _requestedHomeDestination
   private val _startOnboardingAtGatewaySetup = MutableStateFlow(false)
   val startOnboardingAtGatewaySetup: StateFlow<Boolean> = _startOnboardingAtGatewaySetup
-  private val _chatDraft = MutableStateFlow<String?>(null)
-  val chatDraft: StateFlow<String?> = _chatDraft
+  private val _chatDraft = MutableStateFlow<ChatDraft?>(null)
+  val chatDraft: StateFlow<ChatDraft?> = _chatDraft
   private val _pendingAssistantAutoSend = MutableStateFlow<String?>(null)
   val pendingAssistantAutoSend: StateFlow<String?> = _pendingAssistantAutoSend
   private val _assistantAutoSendInFlight = MutableStateFlow(false)
@@ -415,7 +425,7 @@ class MainViewModel(
       return
     }
     _pendingAssistantAutoSend.value = null
-    _chatDraft.value = request.prompt
+    _chatDraft.value = request.prompt?.let { ChatDraft(text = it, placement = ChatDraftPlacement.Replace) }
   }
 
   fun clearRequestedHomeDestination() {
@@ -428,6 +438,11 @@ class MainViewModel(
 
   fun clearChatDraft() {
     _chatDraft.value = null
+  }
+
+  fun setChatReplyDraft(value: String) {
+    _pendingAssistantAutoSend.value = null
+    _chatDraft.value = ChatDraft(text = value, placement = ChatDraftPlacement.BeforeExisting)
   }
 
   /** Claims an assistant prompt before sending so Compose effect restarts cannot dispatch it twice. */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
@@ -1,5 +1,7 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.ChatDraft
+import ai.openclaw.app.ChatDraftPlacement
 import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.ui.mobileAccent
 import ai.openclaw.app.ui.mobileAccentBorderStrong
@@ -70,6 +72,17 @@ internal data class DraftApplication(
   val consumed: Boolean,
 )
 
+internal fun mergeChatDraft(
+  draft: ChatDraft?,
+  currentInput: String,
+): String? {
+  val text = draft?.text?.takeIf { it.isNotBlank() } ?: return null
+  return when (draft.placement) {
+    ChatDraftPlacement.Replace -> text
+    ChatDraftPlacement.BeforeExisting -> text + currentInput
+  }
+}
+
 internal data class SheetSlashCommandSelection(
   val input: String,
 )
@@ -86,17 +99,24 @@ internal fun resolveSheetComposerSendAction(input: String): SheetComposerSendAct
 
 /** Applies a draft exactly once so restored prompts do not overwrite user edits. */
 internal fun applyDraftText(
-  draftText: String?,
+  draft: ChatDraft?,
   currentInput: String,
   lastAppliedDraft: String?,
 ): DraftApplication {
-  val draft =
-    draftText?.trim()?.ifEmpty { null } ?: return DraftApplication(
+  val appliedDraft =
+    draft ?: return DraftApplication(
       input = currentInput,
       lastAppliedDraft = null,
       consumed = false,
     )
-  if (draft == lastAppliedDraft) {
+  val nextInput =
+    mergeChatDraft(appliedDraft, currentInput) ?: return DraftApplication(
+      input = currentInput,
+      lastAppliedDraft = null,
+      consumed = false,
+    )
+  val draftText = appliedDraft.text
+  if (draftText == lastAppliedDraft) {
     return DraftApplication(
       input = currentInput,
       lastAppliedDraft = lastAppliedDraft,
@@ -104,8 +124,8 @@ internal fun applyDraftText(
     )
   }
   return DraftApplication(
-    input = draft,
-    lastAppliedDraft = draft,
+    input = nextInput,
+    lastAppliedDraft = draftText,
     consumed = true,
   )
 }
@@ -113,7 +133,7 @@ internal fun applyDraftText(
 /** Chat input surface for text, image attachments, thinking level, and run controls. */
 @Composable
 fun ChatComposer(
-  draftText: String?,
+  draftText: ChatDraft?,
   healthOk: Boolean,
   thinkingLevel: String,
   pendingRunCount: Int,
@@ -138,7 +158,7 @@ fun ChatComposer(
     }
 
   LaunchedEffect(draftText) {
-    val next = applyDraftText(draftText = draftText, currentInput = input, lastAppliedDraft = lastAppliedDraft)
+    val next = applyDraftText(draft = draftText, currentInput = input, lastAppliedDraft = lastAppliedDraft)
     input = next.input
     lastAppliedDraft = next.lastAppliedDraft
     if (next.consumed) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageActions.kt
@@ -1,0 +1,154 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.chat.ChatMessageContent
+import android.app.Activity
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+
+internal fun chatMessagePlainText(content: List<ChatMessageContent>): String =
+  content
+    .asSequence()
+    .filter { it.type == "text" }
+    .mapNotNull(ChatMessageContent::text)
+    .filter(String::isNotBlank)
+    .joinToString("\n\n")
+
+internal fun quoteChatMessage(text: String): String {
+  val quoted =
+    text
+      .lineSequence()
+      .joinToString("\n") { line -> if (line.isEmpty()) ">" else "> $line" }
+  return "$quoted\n\n"
+}
+
+/** Long-press message actions shared by the full Chat tab and compact chat sheet. */
+@Composable
+internal fun ChatMessageActionHost(
+  text: String,
+  onReply: (String) -> Unit,
+  modifier: Modifier = Modifier,
+  enabled: Boolean = true,
+  content: @Composable () -> Unit,
+) {
+  if (!enabled || text.isBlank()) {
+    Box(modifier = modifier) { content() }
+    return
+  }
+
+  val context = LocalContext.current
+  var menuExpanded by remember { mutableStateOf(false) }
+  var selectText by remember { mutableStateOf(false) }
+
+  Box(
+    modifier =
+      modifier.combinedClickable(
+        onClick = {},
+        onLongClick = { menuExpanded = true },
+        onLongClickLabel = "Message actions",
+      ),
+  ) {
+    content()
+    DropdownMenu(
+      expanded = menuExpanded,
+      onDismissRequest = { menuExpanded = false },
+    ) {
+      MessageActionItem(label = "Copy") {
+        copyChatMessage(context, text)
+        menuExpanded = false
+      }
+      MessageActionItem(label = "Select text") {
+        menuExpanded = false
+        selectText = true
+      }
+      MessageActionItem(label = "Share") {
+        shareChatMessage(context, text)
+        menuExpanded = false
+      }
+      MessageActionItem(label = "Reply") {
+        onReply(quoteChatMessage(text))
+        menuExpanded = false
+      }
+    }
+  }
+
+  if (selectText) {
+    AlertDialog(
+      onDismissRequest = { selectText = false },
+      title = { Text("Select text") },
+      text = {
+        Box(
+          modifier =
+            Modifier
+              .fillMaxWidth()
+              .heightIn(max = 400.dp)
+              .verticalScroll(rememberScrollState()),
+        ) {
+          SelectionContainer {
+            Text(text)
+          }
+        }
+      },
+      confirmButton = {
+        TextButton(onClick = { selectText = false }) {
+          Text("Done")
+        }
+      },
+    )
+  }
+}
+
+@Composable
+private fun MessageActionItem(
+  label: String,
+  onClick: () -> Unit,
+) {
+  DropdownMenuItem(text = { Text(label) }, onClick = onClick)
+}
+
+private fun copyChatMessage(
+  context: Context,
+  text: String,
+) {
+  val clipboard = context.getSystemService(ClipboardManager::class.java)
+  clipboard.setPrimaryClip(ClipData.newPlainText("OpenClaw chat message", text))
+  Toast.makeText(context, "Message copied", Toast.LENGTH_SHORT).show()
+}
+
+private fun shareChatMessage(
+  context: Context,
+  text: String,
+) {
+  val sendIntent =
+    Intent(Intent.ACTION_SEND)
+      .setType("text/plain")
+      .putExtra(Intent.EXTRA_TEXT, text)
+  val chooser = Intent.createChooser(sendIntent, "Share message")
+  if (context !is Activity) chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+  runCatching { context.startActivity(chooser) }
+    .onFailure {
+      Toast.makeText(context, "No app can share this message", Toast.LENGTH_SHORT).show()
+    }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt
@@ -46,6 +46,7 @@ fun ChatMessageListCard(
   outboxItems: List<ChatOutboxItem> = emptyList(),
   onRetryOutbox: (String) -> Unit = {},
   onDeleteOutbox: (String) -> Unit = {},
+  onReplyMessage: (String) -> Unit = {},
 ) {
   val timeline =
     remember(messages, pendingRunCount, pendingToolCalls, streamingAssistantText, outboxItems) {
@@ -76,7 +77,11 @@ fun ChatMessageListCard(
     ) {
       itemsIndexed(items = timeline.items, key = { _, item -> chatTimelineItemKey(item) }) { _, item ->
         when (item) {
-          is ChatTimelineItem.Message -> ChatMessageBubble(message = item.message)
+          is ChatTimelineItem.Message ->
+            ChatMessageBubble(
+              message = item.message,
+              onReplyMessage = onReplyMessage,
+            )
           is ChatTimelineItem.OutboxCommand ->
             ChatOutboxBubble(
               item = item.item,

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -60,7 +60,10 @@ private data class ChatBubbleStyle(
 
 /** Renders one persisted chat message as text and image parts. */
 @Composable
-fun ChatMessageBubble(message: ChatMessage) {
+fun ChatMessageBubble(
+  message: ChatMessage,
+  onReplyMessage: (String) -> Unit = {},
+) {
   val role = normalizeVisibleChatMessageRole(message.role) ?: return
   val style = bubbleStyle(role)
 
@@ -76,8 +79,15 @@ fun ChatMessageBubble(message: ChatMessage) {
 
   if (displayableContent.isEmpty()) return
 
-  ChatBubbleContainer(style = style, roleLabel = roleLabel(role)) {
-    ChatMessageBody(content = displayableContent, textColor = mobileText)
+  val messageText = chatMessagePlainText(displayableContent)
+  ChatMessageActionHost(
+    text = messageText,
+    onReply = onReplyMessage,
+    modifier = Modifier.fillMaxWidth(),
+  ) {
+    ChatBubbleContainer(style = style, roleLabel = roleLabel(role)) {
+      ChatMessageBody(content = displayableContent, textColor = mobileText)
+    }
   }
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -178,8 +178,7 @@ fun ChatScreen(
   var input by rememberSaveable { mutableStateOf("") }
 
   LaunchedEffect(chatDraft) {
-    val draft = chatDraft?.trim()?.ifEmpty { null } ?: return@LaunchedEffect
-    input = draft
+    input = mergeChatDraft(chatDraft, input) ?: return@LaunchedEffect
     viewModel.clearChatDraft()
   }
 
@@ -257,6 +256,7 @@ fun ChatScreen(
       onRetryOutbox = viewModel::retryChatOutboxCommand,
       onDeleteOutbox = viewModel::deleteChatOutboxCommand,
       onStarterPrompt = { prompt -> input = prompt },
+      onReplyMessage = viewModel::setChatReplyDraft,
       modifier = Modifier.weight(1f),
     )
 
@@ -557,6 +557,7 @@ private fun ChatMessageList(
   onRetryOutbox: (String) -> Unit,
   onDeleteOutbox: (String) -> Unit,
   onStarterPrompt: (String) -> Unit,
+  onReplyMessage: (String) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val timeline =
@@ -592,6 +593,7 @@ private fun ChatMessageList(
               live = false,
               content = item.message.content,
               timestampMs = item.message.timestampMs,
+              onReplyMessage = onReplyMessage,
             )
           is ChatTimelineItem.OutboxCommand ->
             ChatOutboxBubble(
@@ -606,6 +608,7 @@ private fun ChatMessageList(
               live = true,
               content = listOf(ChatMessageContent(text = item.text)),
               timestampMs = null,
+              onReplyMessage = onReplyMessage,
             )
           ChatTimelineItem.Thinking -> ChatThinkingBubble()
         }
@@ -760,6 +763,7 @@ private fun ChatBubble(
   live: Boolean,
   content: List<ChatMessageContent>,
   timestampMs: Long?,
+  onReplyMessage: (String) -> Unit,
 ) {
   val normalizedRole = role.trim().lowercase(Locale.US)
   val isUser = normalizedRole == "user"
@@ -777,41 +781,49 @@ private fun ChatBubble(
     modifier = Modifier.fillMaxWidth(),
     horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
   ) {
-    Surface(
+    val messageText = chatMessagePlainText(displayableContent)
+    ChatMessageActionHost(
+      text = messageText,
+      onReply = onReplyMessage,
+      enabled = !live,
       modifier = Modifier.fillMaxWidth(if (isUser) 0.84f else 0.94f),
-      shape = RoundedCornerShape(7.dp),
-      color = if (isUser) ClawTheme.colors.surfacePressed.copy(alpha = 0.86f) else ClawTheme.colors.surfaceRaised.copy(alpha = 0.84f),
-      contentColor = ClawTheme.colors.text,
-      border = BorderStroke(1.dp, if (live) ClawTheme.colors.borderStrong else ClawTheme.colors.border.copy(alpha = 0.45f)),
-      tonalElevation = 1.dp,
-      shadowElevation = 2.dp,
     ) {
-      Column(modifier = Modifier.padding(horizontal = 11.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text(
-          text =
-            when {
-              live -> "OpenClaw · Live"
-              isUser -> "You"
-              normalizedRole == "system" -> "System"
-              else -> "OpenClaw"
-            },
-          style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp, fontWeight = FontWeight.SemiBold),
-          color = ClawTheme.colors.text,
-        )
-        displayableContent.forEach { part ->
-          if (part.type == "text") {
-            ChatText(text = part.text.orEmpty(), textColor = ClawTheme.colors.text, isStreaming = live)
-          } else {
-            Text(text = part.fileName ?: "Attachment", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
-          }
-        }
-        timestampMs?.let {
+      Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(7.dp),
+        color = if (isUser) ClawTheme.colors.surfacePressed.copy(alpha = 0.86f) else ClawTheme.colors.surfaceRaised.copy(alpha = 0.84f),
+        contentColor = ClawTheme.colors.text,
+        border = BorderStroke(1.dp, if (live) ClawTheme.colors.borderStrong else ClawTheme.colors.border.copy(alpha = 0.45f)),
+        tonalElevation = 1.dp,
+        shadowElevation = 2.dp,
+      ) {
+        Column(modifier = Modifier.padding(horizontal = 11.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
           Text(
-            text = formatChatTimestamp(it),
-            style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
-            color = ClawTheme.colors.textMuted,
-            modifier = Modifier.align(Alignment.End),
+            text =
+              when {
+                live -> "OpenClaw · Live"
+                isUser -> "You"
+                normalizedRole == "system" -> "System"
+                else -> "OpenClaw"
+              },
+            style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp, fontWeight = FontWeight.SemiBold),
+            color = ClawTheme.colors.text,
           )
+          displayableContent.forEach { part ->
+            if (part.type == "text") {
+              ChatText(text = part.text.orEmpty(), textColor = ClawTheme.colors.text, isStreaming = live)
+            } else {
+              Text(text = part.fileName ?: "Attachment", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+            }
+          }
+          timestampMs?.let {
+            Text(
+              text = formatChatTimestamp(it),
+              style = ClawTheme.type.caption.copy(fontSize = 12.5.sp, lineHeight = 16.sp),
+              color = ClawTheme.colors.textMuted,
+              modifier = Modifier.align(Alignment.End),
+            )
+          }
         }
       }
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
@@ -173,6 +173,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
         ),
       onRetryOutbox = viewModel::retryChatOutboxCommand,
       onDeleteOutbox = viewModel::deleteChatOutboxCommand,
+      onReplyMessage = viewModel::setChatReplyDraft,
     )
 
     Row(modifier = Modifier.fillMaxWidth().imePadding()) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerDraftTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerDraftTest.kt
@@ -1,5 +1,7 @@
 package ai.openclaw.app.ui.chat
 
+import ai.openclaw.app.ChatDraft
+import ai.openclaw.app.ChatDraftPlacement
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -7,10 +9,33 @@ import org.junit.Test
 
 class ChatComposerDraftTest {
   @Test
+  fun replyDraftPreservesExistingComposerText() {
+    val draft = ChatDraft(text = "> quoted\n\n", placement = ChatDraftPlacement.BeforeExisting)
+
+    assertEquals("> quoted\n\nmy reply", mergeChatDraft(draft, "my reply"))
+  }
+
+  @Test
+  fun preservesReplySeparatorWhitespace() {
+    val draft = ChatDraft(text = "> quoted\n\n", placement = ChatDraftPlacement.BeforeExisting)
+
+    val applied =
+      applyDraftText(
+        draft = draft,
+        currentInput = "",
+        lastAppliedDraft = null,
+      )
+
+    assertEquals(draft.text, applied.input)
+    assertEquals(draft.text, applied.lastAppliedDraft)
+    assertTrue(applied.consumed)
+  }
+
+  @Test
   fun clearsLastAppliedDraftWhenViewModelDraftResets() {
     val consumed =
       applyDraftText(
-        draftText = "repeat this",
+        draft = ChatDraft(text = "repeat this", placement = ChatDraftPlacement.Replace),
         currentInput = "",
         lastAppliedDraft = null,
       )
@@ -21,7 +46,7 @@ class ChatComposerDraftTest {
 
     val cleared =
       applyDraftText(
-        draftText = null,
+        draft = null,
         currentInput = consumed.input,
         lastAppliedDraft = consumed.lastAppliedDraft,
       )
@@ -32,7 +57,7 @@ class ChatComposerDraftTest {
 
     val repeated =
       applyDraftText(
-        draftText = "repeat this",
+        draft = ChatDraft(text = "repeat this", placement = ChatDraftPlacement.Replace),
         currentInput = cleared.input,
         lastAppliedDraft = cleared.lastAppliedDraft,
       )

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageActionsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMessageActionsTest.kt
@@ -1,0 +1,33 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.chat.ChatMessageContent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChatMessageActionsTest {
+  @Test
+  fun plainTextJoinsTextPartsAndIgnoresAttachments() {
+    val content =
+      listOf(
+        ChatMessageContent(type = "text", text = "First paragraph"),
+        ChatMessageContent(type = "image", fileName = "photo.png", base64 = "AAAA"),
+        ChatMessageContent(type = "text", text = "Second paragraph"),
+      )
+
+    assertEquals("First paragraph\n\nSecond paragraph", chatMessagePlainText(content))
+  }
+
+  @Test
+  fun replyQuotesEveryLineAndLeavesComposerSpace() {
+    assertEquals("> first\n>\n> second\n\n", quoteChatMessage("first\n\nsecond"))
+  }
+
+  @Test
+  fun copyAndReplyPreserveWhitespaceSensitiveContent() {
+    val text = "    indented code\nnext line  "
+    val content = listOf(ChatMessageContent(type = "text", text = text))
+
+    assertEquals(text, chatMessagePlainText(content))
+    assertEquals(">     indented code\n> next line  \n\n", quoteChatMessage(text))
+  }
+}

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1,4 +1,7 @@
 // Diagnostics Otel tests cover service plugin behavior.
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterAll, afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const telemetryState = vi.hoisted(() => {
@@ -60,6 +63,8 @@ const traceExporterCtor = vi.hoisted(() => vi.fn());
 const metricExporterCtor = vi.hoisted(() => vi.fn());
 const logExporterCtor = vi.hoisted(() => vi.fn());
 const spanProcessorCtor = vi.hoisted(() => vi.fn());
+const nodeProxyAgent = vi.hoisted(() => ({ kind: "node-proxy-agent" }));
+const createNodeProxyAgentMock = vi.hoisted(() => vi.fn());
 const unhandledRejectionHandlerState = vi.hoisted(() => {
   let handlers: Array<(reason: unknown) => boolean> = [];
   return {
@@ -126,6 +131,10 @@ vi.mock("@opentelemetry/exporter-logs-otlp-proto", () => ({
 
 vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
   registerUnhandledRejectionHandler: unhandledRejectionHandlerState.register,
+}));
+
+vi.mock("openclaw/plugin-sdk/fetch-runtime", () => ({
+  createNodeProxyAgent: createNodeProxyAgentMock,
 }));
 
 vi.mock("@opentelemetry/sdk-logs", () => ({
@@ -206,6 +215,23 @@ const ORIGINAL_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT =
   process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
 const ORIGINAL_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
 const ORIGINAL_OTEL_SEMCONV_STABILITY_OPT_IN = process.env.OTEL_SEMCONV_STABILITY_OPT_IN;
+const OTEL_CERT_ENV_KEYS = [
+  "OTEL_EXPORTER_OTLP_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_CLIENT_KEY",
+  "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY",
+  "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY",
+  "OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE",
+  "OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY",
+] as const;
+const ORIGINAL_OTEL_CERT_ENV = Object.fromEntries(
+  OTEL_CERT_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof OTEL_CERT_ENV_KEYS)[number], string | undefined>;
 
 function createLogger() {
   return {
@@ -318,8 +344,46 @@ function mockCallArg(mock: { mock: { calls: unknown[][] } }, argIndex: number, c
   return mockCall(mock, callIndex)[argIndex];
 }
 
-function firstExporterOptions(mock: { mock: { calls: unknown[][] } }): { url?: string } {
-  return mockCallArg(mock, 0) as { url?: string };
+type TestExporterOptions = {
+  url?: string;
+  httpAgentOptions?: (protocol: string) => unknown;
+};
+
+function firstExporterOptions(mock: { mock: { calls: unknown[][] } }): TestExporterOptions {
+  return mockCallArg(mock, 0) as TestExporterOptions;
+}
+
+function createNodeProxyAgentCalls(): Array<{
+  mode?: string;
+  targetUrl?: string;
+  agentOptions?: {
+    keepAlive?: boolean;
+    ca?: Buffer;
+    cert?: Buffer;
+    key?: Buffer;
+  };
+}> {
+  return createNodeProxyAgentMock.mock.calls.map(
+    ([options]) =>
+      options as {
+        mode?: string;
+        targetUrl?: string;
+        agentOptions?: {
+          keepAlive?: boolean;
+          ca?: Buffer;
+          cert?: Buffer;
+          key?: Buffer;
+        };
+      },
+  );
+}
+
+function findCreateNodeProxyAgentCall(targetUrl: string) {
+  const call = createNodeProxyAgentCalls().find((candidate) => candidate.targetUrl === targetUrl);
+  if (!call) {
+    throw new Error(`Expected createNodeProxyAgent call for ${targetUrl}`);
+  }
+  return call;
 }
 
 function firstSpanProcessorOptions(): { scheduledDelayMillis?: number } {
@@ -489,6 +553,7 @@ afterAll(() => {
   vi.doUnmock("@opentelemetry/sdk-logs");
   vi.doUnmock("@opentelemetry/sdk-metrics");
   vi.doUnmock("@opentelemetry/sdk-trace-base");
+  vi.doUnmock("openclaw/plugin-sdk/fetch-runtime");
   vi.doUnmock("@opentelemetry/resources");
   vi.doUnmock("@opentelemetry/semantic-conventions");
   vi.resetModules();
@@ -514,11 +579,16 @@ describe("diagnostics-otel service", () => {
     metricExporterCtor.mockClear();
     logExporterCtor.mockClear();
     spanProcessorCtor.mockClear();
+    createNodeProxyAgentMock.mockReset();
+    createNodeProxyAgentMock.mockReturnValue(undefined);
     unhandledRejectionHandlerState.reset();
     unhandledRejectionHandlerState.register.mockClear();
     delete process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
     delete process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
     delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
+    for (const key of OTEL_CERT_ENV_KEYS) {
+      delete process.env[key];
+    }
   });
 
   afterEach(() => {
@@ -548,6 +618,14 @@ describe("diagnostics-otel service", () => {
       delete process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
     } else {
       process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = ORIGINAL_OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
+    }
+    for (const key of OTEL_CERT_ENV_KEYS) {
+      const value = ORIGINAL_OTEL_CERT_ENV[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
     }
   });
 
@@ -1573,6 +1651,162 @@ describe("diagnostics-otel service", () => {
     expect(traceOptions.url).toBe("https://trace-env.example.com/v1/traces");
     expect(metricOptions.url).toBe("https://metric-env.example.com/otlp/v1/metrics");
     expect(logOptions.url).toBe("https://log-env.example.com/otlp/v1/logs");
+    await service.stop?.(ctx);
+  });
+
+  test("passes env proxy agents to OTLP HTTP exporters", async () => {
+    createNodeProxyAgentMock.mockReturnValue(nodeProxyAgent);
+
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext("https://collector.example.com/otlp", {
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+    await service.start(ctx);
+
+    const traceOptions = firstExporterOptions(traceExporterCtor);
+    const metricOptions = firstExporterOptions(metricExporterCtor);
+    const logOptions = firstExporterOptions(logExporterCtor);
+    expect(traceOptions.httpAgentOptions?.("https:")).toBe(nodeProxyAgent);
+    expect(metricOptions.httpAgentOptions?.("https:")).toBe(nodeProxyAgent);
+    expect(logOptions.httpAgentOptions?.("https:")).toBe(nodeProxyAgent);
+    expect(createNodeProxyAgentCalls()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          mode: "env",
+          targetUrl: "https://collector.example.com/otlp/v1/traces",
+          agentOptions: expect.objectContaining({ keepAlive: true }),
+        }),
+        expect.objectContaining({
+          mode: "env",
+          targetUrl: "https://collector.example.com/otlp/v1/metrics",
+          agentOptions: expect.objectContaining({ keepAlive: true }),
+        }),
+        expect.objectContaining({
+          mode: "env",
+          targetUrl: "https://collector.example.com/otlp/v1/logs",
+          agentOptions: expect.objectContaining({ keepAlive: true }),
+        }),
+      ]),
+    );
+    await service.stop?.(ctx);
+  });
+
+  test("preserves OTLP TLS env options when passing env proxy agents", async () => {
+    const certDir = mkdtempSync(path.join(tmpdir(), "openclaw-otel-tls-"));
+    try {
+      const rootCertificatePath = path.join(certDir, "root.pem");
+      const clientCertificatePath = path.join(certDir, "client.pem");
+      const clientKeyPath = path.join(certDir, "client-key.pem");
+      writeFileSync(rootCertificatePath, "root-certificate");
+      writeFileSync(clientCertificatePath, "trace-client-certificate");
+      writeFileSync(clientKeyPath, "client-key");
+      process.env.OTEL_EXPORTER_OTLP_CERTIFICATE = rootCertificatePath;
+      process.env.OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE = clientCertificatePath;
+      process.env.OTEL_EXPORTER_OTLP_CLIENT_KEY = clientKeyPath;
+      createNodeProxyAgentMock.mockReturnValue(nodeProxyAgent);
+
+      const service = createDiagnosticsOtelService();
+      const ctx = createOtelContext("https://collector.example.com/otlp", {
+        traces: true,
+        metrics: true,
+        logs: true,
+      });
+      await service.start(ctx);
+
+      const traceCall = findCreateNodeProxyAgentCall(
+        "https://collector.example.com/otlp/v1/traces",
+      );
+      const metricCall = findCreateNodeProxyAgentCall(
+        "https://collector.example.com/otlp/v1/metrics",
+      );
+      expect(traceCall.agentOptions).toEqual({
+        keepAlive: true,
+        ca: Buffer.from("root-certificate"),
+        cert: Buffer.from("trace-client-certificate"),
+        key: Buffer.from("client-key"),
+      });
+      expect(metricCall.agentOptions).toEqual({
+        keepAlive: true,
+        ca: Buffer.from("root-certificate"),
+        key: Buffer.from("client-key"),
+      });
+      await service.stop?.(ctx);
+    } finally {
+      rmSync(certDir, { force: true, recursive: true });
+    }
+  });
+
+  test("falls back to shared OTLP TLS env options when signal-specific values are empty", async () => {
+    const certDir = mkdtempSync(path.join(tmpdir(), "openclaw-otel-tls-"));
+    try {
+      const rootCertificatePath = path.join(certDir, "root.pem");
+      writeFileSync(rootCertificatePath, "shared-root-certificate");
+      process.env.OTEL_EXPORTER_OTLP_CERTIFICATE = rootCertificatePath;
+      process.env.OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE = "   ";
+      createNodeProxyAgentMock.mockReturnValue(nodeProxyAgent);
+
+      const service = createDiagnosticsOtelService();
+      const ctx = createOtelContext("https://collector.example.com/otlp", {
+        traces: true,
+      });
+      await service.start(ctx);
+
+      const traceCall = findCreateNodeProxyAgentCall(
+        "https://collector.example.com/otlp/v1/traces",
+      );
+      expect(traceCall.agentOptions).toEqual({
+        keepAlive: true,
+        ca: Buffer.from("shared-root-certificate"),
+      });
+      await service.stop?.(ctx);
+    } finally {
+      rmSync(certDir, { force: true, recursive: true });
+    }
+  });
+
+  test("falls back to default OTLP agents when env proxy agent creation fails", async () => {
+    createNodeProxyAgentMock.mockImplementation(() => {
+      throw new Error("unsupported proxy protocol");
+    });
+
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext("https://collector.example.com/otlp", {
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+    await service.start(ctx);
+
+    expect(firstExporterOptions(traceExporterCtor).httpAgentOptions).toBeUndefined();
+    expect(firstExporterOptions(metricExporterCtor).httpAgentOptions).toBeUndefined();
+    expect(firstExporterOptions(logExporterCtor).httpAgentOptions).toBeUndefined();
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "diagnostics-otel: env proxy agent unavailable for OTLP traces exporter; falling back to default Node agent",
+    );
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "diagnostics-otel: env proxy agent unavailable for OTLP metrics exporter; falling back to default Node agent",
+    );
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      "diagnostics-otel: env proxy agent unavailable for OTLP logs exporter; falling back to default Node agent",
+    );
+    await service.stop?.(ctx);
+  });
+
+  test("leaves OTLP HTTP exporters on their default agents when env proxy is bypassed", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext("https://collector.example.com/otlp", {
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+    await service.start(ctx);
+
+    expect(firstExporterOptions(traceExporterCtor).httpAgentOptions).toBeUndefined();
+    expect(firstExporterOptions(metricExporterCtor).httpAgentOptions).toBeUndefined();
+    expect(firstExporterOptions(logExporterCtor).httpAgentOptions).toBeUndefined();
+    expect(createNodeProxyAgentMock).toHaveBeenCalledTimes(3);
     await service.stop?.(ctx);
   });
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -1,4 +1,8 @@
 // Diagnostics Otel plugin module implements service behavior.
+import { readFileSync } from "node:fs";
+import type { Agent as HttpAgent } from "node:http";
+import type { Agent as HttpsAgent, AgentOptions as HttpsAgentOptions } from "node:https";
+import nodePath from "node:path";
 import {
   context as otelContextApi,
   metrics,
@@ -29,6 +33,7 @@ import {
   ATTR_GEN_AI_TOOL_DEFINITIONS,
 } from "@opentelemetry/semantic-conventions/incubating";
 import { waitForDiagnosticEventsDrained } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { createNodeProxyAgent } from "openclaw/plugin-sdk/fetch-runtime";
 import { registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime-env";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
@@ -36,6 +41,7 @@ import type {
   DiagnosticEventPayload,
   DiagnosticTraceContext,
   OpenClawPluginService,
+  OpenClawPluginServiceContext,
 } from "../api.js";
 import {
   isValidDiagnosticSpanId,
@@ -83,6 +89,9 @@ const OTEL_EXPORTER_OTLP_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_ENDPOINT";
 const OTEL_EXPORTER_OTLP_TRACES_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
 const OTEL_EXPORTER_OTLP_METRICS_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
 const OTEL_EXPORTER_OTLP_LOGS_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT";
+const OTEL_EXPORTER_OTLP_CERTIFICATE_ENV = "OTEL_EXPORTER_OTLP_CERTIFICATE";
+const OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE_ENV = "OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE";
+const OTEL_EXPORTER_OTLP_CLIENT_KEY_ENV = "OTEL_EXPORTER_OTLP_CLIENT_KEY";
 const OTEL_SEMCONV_STABILITY_OPT_IN_ENV = "OTEL_SEMCONV_STABILITY_OPT_IN";
 const GEN_AI_LATEST_EXPERIMENTAL_OPT_IN = "gen_ai_latest_experimental";
 const GEN_AI_TOKEN_USAGE_BUCKETS = [
@@ -105,6 +114,13 @@ type OtelContentCapturePolicy = {
 };
 
 type OtelLogsExporter = "otlp" | "stdout" | "both";
+type OtelHttpAgent = HttpAgent | HttpsAgent;
+type OtelHttpAgentFactory = (protocol: string) => OtelHttpAgent | Promise<OtelHttpAgent>;
+type OtelSignalIdentifier = "TRACES" | "METRICS" | "LOGS";
+type OtelHttpAgentOptions = HttpsAgentOptions & {
+  keepAlive: true;
+};
+type OtelLogger = OpenClawPluginServiceContext["logger"];
 
 type BuiltOtelLogRecord = {
   logRecord: LogRecord;
@@ -196,6 +212,80 @@ function resolveSignalOtelUrl(params: {
     normalizeEndpoint(params.signalEndpoint ?? params.signalEnvEndpoint) ?? params.endpoint,
     params.path,
   );
+}
+
+function readOtelEnvFile(params: {
+  signalIdentifier: OtelSignalIdentifier;
+  signalSuffix: "CERTIFICATE" | "CLIENT_CERTIFICATE" | "CLIENT_KEY";
+  sharedEnvName: string;
+  logger: OtelLogger;
+  warning: string;
+}): Buffer | undefined {
+  const signalEnvName = `OTEL_EXPORTER_OTLP_${params.signalIdentifier}_${params.signalSuffix}`;
+  const filePath =
+    normalizeOtelEnvValue(process.env[signalEnvName]) ??
+    normalizeOtelEnvValue(process.env[params.sharedEnvName]);
+  if (!filePath) {
+    return undefined;
+  }
+  try {
+    return readFileSync(nodePath.resolve(process.cwd(), filePath));
+  } catch {
+    params.logger.warn(`diagnostics-otel: ${params.warning}`);
+    return undefined;
+  }
+}
+
+function normalizeOtelEnvValue(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function resolveOtelHttpAgentOptions(params: {
+  url: string | undefined;
+  signalIdentifier: OtelSignalIdentifier;
+  logger: OtelLogger;
+}): OtelHttpAgentFactory | undefined {
+  const { url, signalIdentifier, logger } = params;
+  if (!url) {
+    return undefined;
+  }
+  const ca = readOtelEnvFile({
+    signalIdentifier,
+    signalSuffix: "CERTIFICATE",
+    sharedEnvName: OTEL_EXPORTER_OTLP_CERTIFICATE_ENV,
+    logger,
+    warning: "failed to read root certificate file",
+  });
+  const cert = readOtelEnvFile({
+    signalIdentifier,
+    signalSuffix: "CLIENT_CERTIFICATE",
+    sharedEnvName: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE_ENV,
+    logger,
+    warning: "failed to read client certificate chain file",
+  });
+  const key = readOtelEnvFile({
+    signalIdentifier,
+    signalSuffix: "CLIENT_KEY",
+    sharedEnvName: OTEL_EXPORTER_OTLP_CLIENT_KEY_ENV,
+    logger,
+    warning: "failed to read client certificate private key file",
+  });
+  const agentOptions: OtelHttpAgentOptions = {
+    keepAlive: true,
+    ...(ca !== undefined ? { ca } : {}),
+    ...(cert !== undefined ? { cert } : {}),
+    ...(key !== undefined ? { key } : {}),
+  };
+  try {
+    const agent = createNodeProxyAgent({ mode: "env", targetUrl: url, agentOptions });
+    return agent ? () => agent : undefined;
+  } catch {
+    logger.warn(
+      `diagnostics-otel: env proxy agent unavailable for OTLP ${signalIdentifier.toLowerCase()} exporter; falling back to default Node agent`,
+    );
+    return undefined;
+  }
 }
 
 function resolveSampleRate(value: number | undefined): number | undefined {
@@ -1482,10 +1572,21 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           endpoint,
           path: "v1/metrics",
         });
+        const traceHttpAgentOptions = resolveOtelHttpAgentOptions({
+          url: traceUrl,
+          signalIdentifier: "TRACES",
+          logger: ctx.logger,
+        });
+        const metricHttpAgentOptions = resolveOtelHttpAgentOptions({
+          url: metricUrl,
+          signalIdentifier: "METRICS",
+          logger: ctx.logger,
+        });
         const traceExporter = tracesEnabled
           ? new OTLPTraceExporter({
               ...(traceUrl ? { url: traceUrl } : {}),
               ...(headers ? { headers } : {}),
+              ...(traceHttpAgentOptions ? { httpAgentOptions: traceHttpAgentOptions } : {}),
             })
           : undefined;
         const spanProcessors =
@@ -1501,6 +1602,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           ? new OTLPMetricExporter({
               ...(metricUrl ? { url: metricUrl } : {}),
               ...(headers ? { headers } : {}),
+              ...(metricHttpAgentOptions ? { httpAgentOptions: metricHttpAgentOptions } : {}),
             })
           : undefined;
 
@@ -1904,9 +2006,15 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
 
         let otelLogger: { emit: (logRecord: LogRecord) => void } | undefined;
         if (logsToOtlp) {
+          const logHttpAgentOptions = resolveOtelHttpAgentOptions({
+            url: logUrl,
+            signalIdentifier: "LOGS",
+            logger: ctx.logger,
+          });
           const logExporter = new OTLPLogExporter({
             ...(logUrl ? { url: logUrl } : {}),
             ...(headers ? { headers } : {}),
+            ...(logHttpAgentOptions ? { httpAgentOptions: logHttpAgentOptions } : {}),
           });
           const logProcessor = new BatchLogRecordProcessor(
             logExporter,

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -403,6 +403,122 @@ describe("feishuPlugin actions", () => {
     expect(details.chatId).toBe("oc_group_1");
   });
 
+  it("sends legacy top-level elements card JSON as a native Feishu card", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: JSON.stringify({
+          header: {
+            title: { tag: "plain_text", content: "Legacy JSON card" },
+            template: "green",
+          },
+          elements: [{ tag: "markdown", content: "Legacy body" }],
+        }),
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    const sendCardArgs = requireRecord(
+      mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
+      "send card args",
+    );
+    const card = requireRecord(sendCardArgs.card, "card");
+    expect(card.header).toEqual({
+      title: { tag: "plain_text", content: "Legacy JSON card" },
+      template: "green",
+    });
+    expect(card.body).toEqual({
+      elements: [{ tag: "markdown", content: "Legacy body" }],
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("sends wrapped interactive card JSON as a Feishu thread reply card", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "thread-reply",
+      params: {
+        to: "chat:oc_group_1",
+        messageId: "om_parent",
+        text: JSON.stringify({
+          type: "interactive",
+          card: {
+            body: {
+              elements: [{ tag: "markdown", content: "Reply card" }],
+            },
+          },
+        }),
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    const sendCardArgs = requireRecord(
+      mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
+      "send card args",
+    );
+    expect(sendCardArgs.replyToMessageId).toBe("om_parent");
+    expect(sendCardArgs.replyInThread).toBe(true);
+    const card = requireRecord(sendCardArgs.card, "card");
+    expect(card.body).toEqual({
+      elements: [{ tag: "markdown", content: "Reply card" }],
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps ordinary JSON messages on the text path", async () => {
+    sendMessageFeishuMock.mockResolvedValueOnce({ messageId: "om_sent", chatId: "oc_group_1" });
+    const message = JSON.stringify({ ok: true, elements: "not-a-card" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: { to: "chat:oc_group_1", message },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith({
+      cfg,
+      to: "chat:oc_group_1",
+      text: message,
+      accountId: undefined,
+      replyToMessageId: undefined,
+      replyInThread: false,
+    });
+  });
+
+  it("rejects card JSON sent with media", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "send",
+        params: {
+          to: "chat:oc_group_1",
+          message: JSON.stringify({
+            elements: [{ tag: "markdown", content: "Card body" }],
+          }),
+          media: "/tmp/image.png",
+        },
+        cfg,
+        accountId: undefined,
+        toolContext: {},
+        mediaLocalRoots: ["/tmp"],
+      } as never),
+    ).rejects.toThrow("Feishu send does not support card with media.");
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(feishuOutboundSendMediaMock).not.toHaveBeenCalled();
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
   it("renders presentation messages as cards", async () => {
     sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
 

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -415,7 +415,16 @@ describe("feishuPlugin actions", () => {
             title: { tag: "plain_text", content: "Legacy JSON card" },
             template: "green",
           },
-          elements: [{ tag: "markdown", content: "Legacy body" }],
+          elements: [
+            {
+              tag: "div",
+              text: { tag: "lark_md", content: '**Legacy** <at id="ou_1">body</at>' },
+            },
+            {
+              tag: "div",
+              text: { tag: "plain_text", content: "Literal *text*" },
+            },
+          ],
         }),
       },
       cfg,
@@ -433,7 +442,46 @@ describe("feishuPlugin actions", () => {
       template: "green",
     });
     expect(card.body).toEqual({
-      elements: [{ tag: "markdown", content: "Legacy body" }],
+      elements: [
+        {
+          tag: "markdown",
+          content: '**Legacy** &lt;at id="ou_1"&gt;body&lt;/at&gt;',
+        },
+        { tag: "markdown", content: "Literal \\*text\\*" },
+      ],
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("detects message card JSON after the configured response prefix", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+    const cardJson = JSON.stringify({
+      body: {
+        elements: [{ tag: "markdown", content: "Prefixed card" }],
+      },
+    });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: `[Nexus] ${cardJson}`,
+      },
+      cfg: {
+        ...cfg,
+        messages: { responsePrefix: "[Nexus]" },
+      },
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    const sendCardArgs = requireRecord(
+      mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
+      "send card args",
+    );
+    const card = requireRecord(sendCardArgs.card, "card");
+    expect(card.body).toEqual({
+      elements: [{ tag: "markdown", content: "Prefixed card" }],
     });
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
   });
@@ -563,6 +611,72 @@ describe("feishuPlugin actions", () => {
     expect(details.ok).toBe(true);
     expect(details.messageId).toBe("om_card");
     expect(details.chatId).toBe("oc_group_1");
+  });
+
+  it("prefers structured presentation over raw card JSON text", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: JSON.stringify({
+          header: { title: { tag: "plain_text", content: "Raw card" } },
+          elements: [{ tag: "markdown", content: "Raw body" }],
+        }),
+        presentation: {
+          title: "Structured card",
+          blocks: [{ type: "text", text: "Structured body" }],
+        },
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    const sendCardArgs = requireRecord(
+      mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
+      "send card args",
+    );
+    const card = requireRecord(sendCardArgs.card, "card");
+    expect(card.header).toEqual({
+      title: { tag: "plain_text", content: "Structured card" },
+      template: "blue",
+    });
+    expect(card.body).toEqual({
+      elements: [{ tag: "markdown", content: "Structured body" }],
+    });
+  });
+
+  it("prefers structured interactive input over raw card JSON text", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+
+    await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: JSON.stringify({
+          header: { title: { tag: "plain_text", content: "Raw card" } },
+          elements: [{ tag: "markdown", content: "Raw body" }],
+        }),
+        interactive: {
+          blocks: [{ type: "text", text: "Interactive body" }],
+        },
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    const sendCardArgs = requireRecord(
+      mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
+      "send card args",
+    );
+    const card = requireRecord(sendCardArgs.card, "card");
+    expect(card.header).toBeUndefined();
+    expect(card.body).toEqual({
+      elements: [{ tag: "markdown", content: "Interactive body" }],
+    });
   });
 
   it("renders presentation buttons as native Feishu card buttons", async () => {

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -356,6 +356,53 @@ describe("feishuPlugin actions", () => {
     expect(details.chatId).toBe("oc_group_1");
   });
 
+  it("sends plain message card JSON as a native Feishu card", async () => {
+    sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "send",
+      params: {
+        to: "chat:oc_group_1",
+        message: JSON.stringify({
+          schema: "2.0",
+          header: {
+            title: { tag: "plain_text", content: "Plain JSON card" },
+            template: "green",
+          },
+          body: {
+            elements: [{ tag: "markdown", content: "Card body" }],
+          },
+        }),
+      },
+      cfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    const sendCardArgs = requireRecord(
+      mockCallArg(sendCardFeishuMock, 0, 0, "sendCardFeishu"),
+      "send card args",
+    );
+    expect(sendCardArgs.cfg).toBe(cfg);
+    expect(sendCardArgs.to).toBe("chat:oc_group_1");
+    expect(sendCardArgs.accountId).toBeUndefined();
+    expect(sendCardArgs.replyToMessageId).toBeUndefined();
+    expect(sendCardArgs.replyInThread).toBe(false);
+    const card = requireRecord(sendCardArgs.card, "card");
+    expect(card.header).toEqual({
+      title: { tag: "plain_text", content: "Plain JSON card" },
+      template: "green",
+    });
+    expect(card.body).toEqual({
+      elements: [{ tag: "markdown", content: "Card body" }],
+    });
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    const details = resultDetails(result);
+    expect(details.ok).toBe(true);
+    expect(details.messageId).toBe("om_card");
+    expect(details.chatId).toBe("oc_group_1");
+  });
+
   it("renders presentation messages as cards", async () => {
     sendCardFeishuMock.mockResolvedValueOnce({ messageId: "om_card", chatId: "oc_group_1" });
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -72,6 +72,7 @@ import {
 import { listFeishuDirectoryGroups, listFeishuDirectoryPeers } from "./directory.static.js";
 import { feishuDoctor } from "./doctor.js";
 import { messageActionTargetAliases } from "./message-action-contract.js";
+import { readNativeFeishuCardJson } from "./native-card.js";
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
 import { buildFeishuPresentationCard } from "./presentation-card.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
@@ -807,7 +808,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             const audioAsVoice = readBooleanParam(ctx.params, ["asVoice", "audioAsVoice"]);
             const card = presentation
               ? buildFeishuPresentationCard({ presentation, fallbackText: text })
-              : undefined;
+              : readNativeFeishuCardJson(text);
             if (card && mediaUrl) {
               throw new Error(`Feishu ${ctx.action} does not support card with media.`);
             }

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -28,7 +28,12 @@ import {
   createChannelDirectoryAdapter,
   createRuntimeDirectoryLiveAdapter,
 } from "openclaw/plugin-sdk/directory-runtime";
-import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
+import {
+  interactiveReplyToPresentation,
+  normalizeInteractiveReply,
+  normalizeMessagePresentation,
+  resolveInteractiveTextFallback,
+} from "openclaw/plugin-sdk/interactive-runtime";
 import { createLazyRuntimeNamedExport } from "openclaw/plugin-sdk/lazy-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { createComputedAccountStatusAdapter } from "openclaw/plugin-sdk/status-helpers";
@@ -585,6 +590,26 @@ function readFirstString(
   return undefined;
 }
 
+const UNRESOLVED_RESPONSE_PREFIX_VAR_PATTERN = /\{[a-zA-Z][a-zA-Z0-9.]*\}/;
+
+function resolveFeishuMessageActionResponsePrefix(ctx: ChannelMessageActionContext) {
+  const configured = ctx.cfg.messages?.responsePrefix;
+  if (!configured) {
+    return undefined;
+  }
+  const agentId = (ctx.agentId?.trim() || "main").toLowerCase();
+  const identityName = ctx.cfg.agents?.list
+    ?.find((agent) => agent.id.trim().toLowerCase() === agentId)
+    ?.identity?.name?.trim();
+  const resolved =
+    configured === "auto"
+      ? identityName
+        ? `[${identityName}]`
+        : undefined
+      : configured.replace(/\{(?:identity\.name|identityname)\}/gi, identityName ?? "$&");
+  return resolved && !UNRESOLVED_RESPONSE_PREFIX_VAR_PATTERN.test(resolved) ? resolved : undefined;
+}
+
 function readOptionalPositiveInteger(
   params: Record<string, unknown>,
   keys: string[],
@@ -802,13 +827,24 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
             if (ctx.action === "thread-reply" && !replyToMessageId) {
               throw new Error("Feishu thread-reply requires messageId.");
             }
-            const presentation = normalizeMessagePresentation(ctx.params.presentation);
             const text = readFirstString(ctx.params, ["text", "message"]);
+            const textCard = readNativeFeishuCardJson(text, {
+              responsePrefix: resolveFeishuMessageActionResponsePrefix(ctx),
+            });
+            const interactive = normalizeInteractiveReply(ctx.params.interactive);
+            const presentation =
+              normalizeMessagePresentation(ctx.params.presentation) ??
+              (interactive ? interactiveReplyToPresentation(interactive) : undefined);
             const mediaUrl = readFeishuMediaParam(ctx.params);
             const audioAsVoice = readBooleanParam(ctx.params, ["asVoice", "audioAsVoice"]);
             const card = presentation
-              ? buildFeishuPresentationCard({ presentation, fallbackText: text })
-              : readNativeFeishuCardJson(text);
+              ? buildFeishuPresentationCard({
+                  presentation,
+                  fallbackText: textCard
+                    ? undefined
+                    : resolveInteractiveTextFallback({ text, interactive }),
+                })
+              : textCard;
             if (card && mediaUrl) {
               throw new Error(`Feishu ${ctx.action} does not support card with media.`);
             }

--- a/extensions/feishu/src/native-card.ts
+++ b/extensions/feishu/src/native-card.ts
@@ -143,8 +143,13 @@ function sanitizeNativeFeishuCardElements(element: unknown): Record<string, unkn
 export function sanitizeNativeFeishuCard(
   card: Record<string, unknown>,
 ): Record<string, unknown> | undefined {
-  const body = isRecord(card.body) ? card.body : undefined;
-  const rawElements = Array.isArray(body?.elements) ? body.elements : [];
+  const normalizedCard = card.type === "interactive" && isRecord(card.card) ? card.card : card;
+  const body = isRecord(normalizedCard.body) ? normalizedCard.body : undefined;
+  const rawElements = Array.isArray(body?.elements)
+    ? body.elements
+    : Array.isArray(normalizedCard.elements)
+      ? normalizedCard.elements
+      : [];
   const elements = rawElements
     .flatMap((element) => sanitizeNativeFeishuCardElements(element))
     .filter((element): element is Record<string, unknown> => Boolean(element));
@@ -152,7 +157,7 @@ export function sanitizeNativeFeishuCard(
     return undefined;
   }
 
-  const header = isRecord(card.header) ? card.header : undefined;
+  const header = isRecord(normalizedCard.header) ? normalizedCard.header : undefined;
   const title =
     isRecord(header?.title) && typeof header.title.content === "string"
       ? header.title.content

--- a/extensions/feishu/src/native-card.ts
+++ b/extensions/feishu/src/native-card.ts
@@ -124,22 +124,11 @@ function sanitizeNativeFeishuCardElements(element: unknown): Record<string, unkn
   if (element.tag === "hr") {
     return [{ tag: "hr" }];
   }
-  if (
-    (element.tag === "markdown" || element.tag === "lark_md") &&
-    typeof element.content === "string"
-  ) {
+  if (element.tag === "markdown" && typeof element.content === "string") {
     return [
       {
         tag: "markdown",
         content: escapeFeishuCardMarkdownText(element.content),
-      },
-    ];
-  }
-  if (element.tag === "plain_text" && typeof element.content === "string") {
-    return [
-      {
-        tag: "markdown",
-        content: escapeFeishuCardPlainText(element.content),
       },
     ];
   }

--- a/extensions/feishu/src/native-card.ts
+++ b/extensions/feishu/src/native-card.ts
@@ -43,6 +43,10 @@ function escapeFeishuCardMarkdownText(text: string): string {
   });
 }
 
+function escapeFeishuCardPlainText(text: string): string {
+  return escapeFeishuCardMarkdownText(text).replace(/([\\`*_{}[\]()#+\-!|>~])/g, "\\$1");
+}
+
 function resolveSafeFeishuButtonUrl(url: unknown): string | undefined {
   const trimmed = typeof url === "string" ? url.trim() : "";
   if (!trimmed) {
@@ -120,13 +124,44 @@ function sanitizeNativeFeishuCardElements(element: unknown): Record<string, unkn
   if (element.tag === "hr") {
     return [{ tag: "hr" }];
   }
-  if (element.tag === "markdown" && typeof element.content === "string") {
+  if (
+    (element.tag === "markdown" || element.tag === "lark_md") &&
+    typeof element.content === "string"
+  ) {
     return [
       {
         tag: "markdown",
         content: escapeFeishuCardMarkdownText(element.content),
       },
     ];
+  }
+  if (element.tag === "plain_text" && typeof element.content === "string") {
+    return [
+      {
+        tag: "markdown",
+        content: escapeFeishuCardPlainText(element.content),
+      },
+    ];
+  }
+  if (element.tag === "div" && isRecord(element.text)) {
+    const text = element.text;
+    if (text.tag === "lark_md" && typeof text.content === "string") {
+      return [
+        {
+          tag: "markdown",
+          content: escapeFeishuCardMarkdownText(text.content),
+        },
+      ];
+    }
+    if (text.tag === "plain_text" && typeof text.content === "string") {
+      return [
+        {
+          tag: "markdown",
+          content: escapeFeishuCardPlainText(text.content),
+        },
+      ];
+    }
+    return [];
   }
   if (element.tag === "button") {
     const button = sanitizeNativeFeishuCardButton(element);
@@ -182,8 +217,18 @@ export function sanitizeNativeFeishuCard(
 
 export function readNativeFeishuCardJson(
   text: string | undefined,
+  options?: { responsePrefix?: string },
 ): Record<string, unknown> | undefined {
-  const trimmed = text?.trim();
+  let trimmed = text?.trim();
+  const responsePrefix = options?.responsePrefix;
+  if (trimmed && responsePrefix && trimmed.startsWith(responsePrefix)) {
+    const suffix = trimmed.slice(responsePrefix.length);
+    // The runner inserts one separator before the original message. Requiring it
+    // avoids treating arbitrary prose before a JSON object as a native card.
+    if (/^\s+\{/.test(suffix)) {
+      trimmed = suffix.trimStart();
+    }
+  }
   if (!trimmed?.startsWith("{") || !trimmed.endsWith("}")) {
     return undefined;
   }

--- a/extensions/feishu/src/native-card.ts
+++ b/extensions/feishu/src/native-card.ts
@@ -1,0 +1,191 @@
+// Feishu native interactive card helpers shared by action and outbound delivery.
+import {
+  isRecord,
+  normalizeOptionalLowercaseString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const FEISHU_CARD_TEMPLATES = new Set([
+  "blue",
+  "green",
+  "red",
+  "orange",
+  "purple",
+  "indigo",
+  "wathet",
+  "turquoise",
+  "yellow",
+  "grey",
+  "carmine",
+  "violet",
+  "lime",
+]);
+
+export function resolveFeishuCardTemplate(template?: string): string | undefined {
+  const normalized = normalizeOptionalLowercaseString(template);
+  if (!normalized || !FEISHU_CARD_TEMPLATES.has(normalized)) {
+    return undefined;
+  }
+  return normalized;
+}
+
+function escapeFeishuCardMarkdownText(text: string): string {
+  return text.replace(/[&<>]/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      default:
+        return char;
+    }
+  });
+}
+
+function resolveSafeFeishuButtonUrl(url: unknown): string | undefined {
+  const trimmed = typeof url === "string" ? url.trim() : "";
+  if (!trimmed) {
+    return undefined;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "https:" || parsed.protocol === "http:" ? trimmed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function sanitizeNativeFeishuButtonBehavior(
+  behavior: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(behavior)) {
+    return undefined;
+  }
+  if (behavior.type === "open_url") {
+    const safeUrl =
+      resolveSafeFeishuButtonUrl(behavior.default_url) ?? resolveSafeFeishuButtonUrl(behavior.url);
+    return safeUrl ? { type: "open_url", default_url: safeUrl } : undefined;
+  }
+  if (behavior.type === "callback" && isRecord(behavior.value) && behavior.value.oc === "ocf1") {
+    return { type: "callback", value: behavior.value };
+  }
+  return undefined;
+}
+
+function sanitizeNativeFeishuCardButton(button: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(button)) {
+    return undefined;
+  }
+  const text =
+    isRecord(button.text) && typeof button.text.content === "string"
+      ? button.text.content
+      : undefined;
+  if (!text?.trim()) {
+    return undefined;
+  }
+  const style =
+    button.type === "danger"
+      ? "danger"
+      : button.type === "primary" || button.type === "success"
+        ? "primary"
+        : undefined;
+  const behaviors = Array.isArray(button.behaviors)
+    ? button.behaviors
+        .map((behavior) => sanitizeNativeFeishuButtonBehavior(behavior))
+        .filter((behavior): behavior is Record<string, unknown> => Boolean(behavior))
+    : [];
+  const rootSafeUrl = resolveSafeFeishuButtonUrl(button.url);
+  if (rootSafeUrl) {
+    behaviors.push({ type: "open_url", default_url: rootSafeUrl });
+  }
+  if (isRecord(button.value) && button.value.oc === "ocf1") {
+    behaviors.push({ type: "callback", value: button.value });
+  }
+  if (behaviors.length === 0) {
+    return undefined;
+  }
+  return {
+    tag: "button",
+    text: { tag: "plain_text", content: text },
+    type: style === "danger" ? "danger" : style === "primary" ? "primary" : "default",
+    behaviors,
+  };
+}
+
+function sanitizeNativeFeishuCardElements(element: unknown): Record<string, unknown>[] {
+  if (!isRecord(element) || typeof element.tag !== "string") {
+    return [];
+  }
+  if (element.tag === "hr") {
+    return [{ tag: "hr" }];
+  }
+  if (element.tag === "markdown" && typeof element.content === "string") {
+    return [
+      {
+        tag: "markdown",
+        content: escapeFeishuCardMarkdownText(element.content),
+      },
+    ];
+  }
+  if (element.tag === "button") {
+    const button = sanitizeNativeFeishuCardButton(element);
+    return button ? [button] : [];
+  }
+  if (element.tag === "action" && Array.isArray(element.actions)) {
+    return element.actions
+      .map((action) => sanitizeNativeFeishuCardButton(action))
+      .filter((action): action is Record<string, unknown> => Boolean(action));
+  }
+  return [];
+}
+
+export function sanitizeNativeFeishuCard(
+  card: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const body = isRecord(card.body) ? card.body : undefined;
+  const rawElements = Array.isArray(body?.elements) ? body.elements : [];
+  const elements = rawElements
+    .flatMap((element) => sanitizeNativeFeishuCardElements(element))
+    .filter((element): element is Record<string, unknown> => Boolean(element));
+  if (elements.length === 0) {
+    return undefined;
+  }
+
+  const header = isRecord(card.header) ? card.header : undefined;
+  const title =
+    isRecord(header?.title) && typeof header.title.content === "string"
+      ? header.title.content
+      : undefined;
+  return {
+    schema: "2.0",
+    config: { width_mode: "fill" },
+    ...(title?.trim()
+      ? {
+          header: {
+            title: { tag: "plain_text", content: title },
+            template:
+              resolveFeishuCardTemplate(
+                typeof header?.template === "string" ? header.template : undefined,
+              ) ?? "blue",
+          },
+        }
+      : {}),
+    body: { elements },
+  };
+}
+
+export function readNativeFeishuCardJson(
+  text: string | undefined,
+): Record<string, unknown> | undefined {
+  const trimmed = text?.trim();
+  if (!trimmed?.startsWith("{") || !trimmed.endsWith("}")) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return isRecord(parsed) ? sanitizeNativeFeishuCard(parsed) : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -854,7 +854,16 @@ describe("feishuOutbound.sendPayload native cards", () => {
         title: { tag: "plain_text", content: "Legacy JSON card" },
         template: "green",
       },
-      elements: [{ tag: "markdown", content: "Legacy body" }],
+      elements: [
+        {
+          tag: "div",
+          text: { tag: "lark_md", content: "**Legacy body**" },
+        },
+        {
+          tag: "plain_text",
+          content: "Literal *text*",
+        },
+      ],
     });
 
     const result = await feishuOutbound.sendPayload?.({
@@ -870,8 +879,88 @@ describe("feishuOutbound.sendPayload native cards", () => {
       title: { tag: "plain_text", content: "Legacy JSON card" },
       template: "green",
     });
-    expect(card.body.elements).toEqual([{ tag: "markdown", content: "Legacy body" }]);
+    expect(card.body.elements).toEqual([
+      { tag: "markdown", content: "**Legacy body**" },
+      { tag: "markdown", content: "Literal \\*text\\*" },
+    ]);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expectFeishuResult(result, "native_card_msg");
+  });
+
+  it("keeps unsupported legacy element shapes on the text fallback path", async () => {
+    const text = JSON.stringify({
+      elements: [
+        {
+          tag: "div",
+          text: { tag: "unsupported", content: "Not a supported legacy text element" },
+        },
+      ],
+    });
+
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: { text },
+    });
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageCall()?.text).toBe(text);
+    expectFeishuResult(result, "text_msg");
+  });
+
+  it("prefers structured presentation over raw card JSON payload text", async () => {
+    const text = JSON.stringify({
+      header: { title: { tag: "plain_text", content: "Raw card" } },
+      elements: [{ tag: "markdown", content: "Raw body" }],
+    });
+
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: {
+        text,
+        presentation: {
+          title: "Structured card",
+          blocks: [{ type: "text", text: "Structured body" }],
+        },
+      },
+    });
+
+    const card = sendCardCall()?.card;
+    expect(card.header).toEqual({
+      title: { tag: "plain_text", content: "Structured card" },
+      template: "blue",
+    });
+    expect(card.body.elements).toEqual([{ tag: "markdown", content: "Structured body" }]);
+    expectFeishuResult(result, "native_card_msg");
+  });
+
+  it("prefers structured interactive input over raw card JSON payload text", async () => {
+    const text = JSON.stringify({
+      header: { title: { tag: "plain_text", content: "Raw card" } },
+      elements: [{ tag: "markdown", content: "Raw body" }],
+    });
+
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: {
+        text,
+        interactive: {
+          blocks: [{ type: "text", text: "Interactive body" }],
+        },
+      },
+    });
+
+    const card = sendCardCall()?.card;
+    expect(card.header).toBeUndefined();
+    expect(card.body.elements).toEqual([{ tag: "markdown", content: "Interactive body" }]);
     expectFeishuResult(result, "native_card_msg");
   });
 

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -860,8 +860,8 @@ describe("feishuOutbound.sendPayload native cards", () => {
           text: { tag: "lark_md", content: "**Legacy body**" },
         },
         {
-          tag: "plain_text",
-          content: "Literal *text*",
+          tag: "div",
+          text: { tag: "plain_text", content: "Literal *text*" },
         },
       ],
     });
@@ -886,6 +886,27 @@ describe("feishuOutbound.sendPayload native cards", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expectFeishuResult(result, "native_card_msg");
   });
+
+  it.each(["lark_md", "plain_text"])(
+    "keeps top-level legacy %s text items on the text fallback path",
+    async (tag) => {
+      const text = JSON.stringify({
+        elements: [{ tag, content: "Not a valid root legacy card element" }],
+      });
+
+      const result = await feishuOutbound.sendPayload?.({
+        cfg: emptyConfig,
+        to: "chat_1",
+        text,
+        accountId: "main",
+        payload: { text },
+      });
+
+      expect(sendCardFeishuMock).not.toHaveBeenCalled();
+      expect(sendMessageCall()?.text).toBe(text);
+      expectFeishuResult(result, "text_msg");
+    },
+  );
 
   it("keeps unsupported legacy element shapes on the text fallback path", async () => {
     const text = JSON.stringify({
@@ -1061,6 +1082,51 @@ describe("feishuOutbound.sendPayload native cards", () => {
     );
     expectFeishuResult(result, "reply_msg");
   });
+
+  it.each([
+    [
+      "presentation",
+      {
+        presentation: {
+          title: "Structured card",
+          blocks: [{ type: "text" as const, text: "Structured body" }],
+        },
+      },
+      "Structured card\n\nStructured body",
+    ],
+    [
+      "interactive",
+      {
+        interactive: {
+          blocks: [{ type: "text" as const, text: "Interactive body" }],
+        },
+      },
+      "Interactive body",
+    ],
+  ])(
+    "prefers structured %s over raw card JSON for document comments",
+    async (_kind, structuredPayload, expectedText) => {
+      const text = JSON.stringify({
+        header: { title: { tag: "plain_text", content: "Raw card" } },
+        elements: [{ tag: "markdown", content: "Raw body" }],
+      });
+
+      const result = await feishuOutbound.sendPayload?.({
+        cfg: emptyConfig,
+        to: "comment:docx:doxcn123:7623358762119646411",
+        text,
+        accountId: "main",
+        payload: {
+          text,
+          ...structuredPayload,
+        },
+      });
+
+      expect(sendCardFeishuMock).not.toHaveBeenCalled();
+      expect(commentThreadParams()?.content).toBe(expectedText);
+      expectFeishuResult(result, "reply_msg");
+    },
+  );
 
   it("omits command guidance when all command buttons have URLs overriding the fallback text", async () => {
     const result = await feishuOutbound.sendPayload?.({

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -790,6 +790,57 @@ describe("feishuOutbound.sendPayload native cards", () => {
     expect(JSON.stringify(card)).not.toContain("image-secret");
   });
 
+  it("sends plain payload text card JSON as a native Feishu card", async () => {
+    const text = JSON.stringify({
+      schema: "2.0",
+      header: {
+        title: { tag: "plain_text", content: "Plain JSON card" },
+        template: "green",
+      },
+      body: {
+        elements: [{ tag: "markdown", content: "Card body" }],
+      },
+    });
+
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: { text },
+    });
+
+    const card = sendCardCall()?.card;
+    expect(card.header).toEqual({
+      title: { tag: "plain_text", content: "Plain JSON card" },
+      template: "green",
+    });
+    expect(card.body.elements).toEqual([{ tag: "markdown", content: "Card body" }]);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expectFeishuResult(result, "native_card_msg");
+  });
+
+  it("keeps invalid plain card JSON on the text fallback path", async () => {
+    const text = JSON.stringify({
+      schema: "2.0",
+      body: {
+        elements: [{ tag: "img", img_key: "image-secret" }],
+      },
+    });
+
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: { text },
+    });
+
+    expect(sendCardFeishuMock).not.toHaveBeenCalled();
+    expect(sendMessageCall()?.text).toBe(text);
+    expectFeishuResult(result, "text_msg");
+  });
+
   it("sends payload media before final native cards", async () => {
     const result = await feishuOutbound.sendPayload?.({
       cfg: emptyConfig,

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -329,6 +329,34 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     expect(sendMessageCall()?.accountId).toBe("main");
   });
 
+  it("sends wrapped interactive card text as a native Feishu card", async () => {
+    const text = JSON.stringify({
+      type: "interactive",
+      card: {
+        body: {
+          elements: [{ tag: "markdown", content: "Wrapped body" }],
+        },
+      },
+    });
+
+    const result = await sendText({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      replyToId: "om_reply_1",
+    });
+
+    expect(sendCardCall()?.to).toBe("chat_1");
+    expect(sendCardCall()?.accountId).toBe("main");
+    expect(sendCardCall()?.replyToMessageId).toBe("om_reply_1");
+    expect(sendCardCall()?.card?.body?.elements).toEqual([
+      { tag: "markdown", content: "Wrapped body" },
+    ]);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expectFeishuResult(result, "native_card_msg");
+  });
+
   it("falls back to plain text if local-image media send fails", async () => {
     const { dir, file } = await createTmpImage();
     sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
@@ -816,6 +844,33 @@ describe("feishuOutbound.sendPayload native cards", () => {
       template: "green",
     });
     expect(card.body.elements).toEqual([{ tag: "markdown", content: "Card body" }]);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expectFeishuResult(result, "native_card_msg");
+  });
+
+  it("sends legacy top-level elements payload text card JSON as a native Feishu card", async () => {
+    const text = JSON.stringify({
+      header: {
+        title: { tag: "plain_text", content: "Legacy JSON card" },
+        template: "green",
+      },
+      elements: [{ tag: "markdown", content: "Legacy body" }],
+    });
+
+    const result = await feishuOutbound.sendPayload?.({
+      cfg: emptyConfig,
+      to: "chat_1",
+      text,
+      accountId: "main",
+      payload: { text },
+    });
+
+    const card = sendCardCall()?.card;
+    expect(card.header).toEqual({
+      title: { tag: "plain_text", content: "Legacy JSON card" },
+      template: "green",
+    });
+    expect(card.body.elements).toEqual([{ tag: "markdown", content: "Legacy body" }]);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expectFeishuResult(result, "native_card_msg");
   });

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -34,10 +34,14 @@ import {
   shouldSuppressFeishuTextForVoiceMedia,
   type SendMediaResult,
 } from "./media.js";
+import {
+  readNativeFeishuCardJson,
+  resolveFeishuCardTemplate,
+  sanitizeNativeFeishuCard,
+} from "./native-card.js";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "./outbound-runtime-api.js";
 import { buildFeishuPresentationCardElements } from "./presentation-card.js";
 import {
-  resolveFeishuCardTemplate,
   sendCardFeishu,
   sendMarkdownCardFeishu,
   sendMessageFeishu,
@@ -99,159 +103,6 @@ function markRenderedFeishuCard(card: Record<string, unknown>): Record<string, u
   return card;
 }
 
-function escapeFeishuCardMarkdownText(text: string): string {
-  return text.replace(/[&<>]/g, (char) => {
-    switch (char) {
-      case "&":
-        return "&amp;";
-      case "<":
-        return "&lt;";
-      case ">":
-        return "&gt;";
-      default:
-        return char;
-    }
-  });
-}
-
-function resolveSafeFeishuButtonUrl(url: unknown): string | undefined {
-  const trimmed = typeof url === "string" ? url.trim() : "";
-  if (!trimmed) {
-    return undefined;
-  }
-  try {
-    const parsed = new URL(trimmed);
-    return parsed.protocol === "https:" || parsed.protocol === "http:" ? trimmed : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function sanitizeNativeFeishuButtonBehavior(
-  behavior: unknown,
-): Record<string, unknown> | undefined {
-  if (!isRecord(behavior)) {
-    return undefined;
-  }
-  if (behavior.type === "open_url") {
-    const safeUrl =
-      resolveSafeFeishuButtonUrl(behavior.default_url) ?? resolveSafeFeishuButtonUrl(behavior.url);
-    return safeUrl ? { type: "open_url", default_url: safeUrl } : undefined;
-  }
-  if (behavior.type === "callback" && isRecord(behavior.value) && behavior.value.oc === "ocf1") {
-    return { type: "callback", value: behavior.value };
-  }
-  return undefined;
-}
-
-function sanitizeNativeFeishuCardButton(button: unknown): Record<string, unknown> | undefined {
-  if (!isRecord(button)) {
-    return undefined;
-  }
-  const text =
-    isRecord(button.text) && typeof button.text.content === "string"
-      ? button.text.content
-      : undefined;
-  if (!text?.trim()) {
-    return undefined;
-  }
-  const style =
-    button.type === "danger"
-      ? "danger"
-      : button.type === "primary" || button.type === "success"
-        ? "primary"
-        : undefined;
-  const behaviors = Array.isArray(button.behaviors)
-    ? button.behaviors
-        .map((behavior) => sanitizeNativeFeishuButtonBehavior(behavior))
-        .filter((behavior): behavior is Record<string, unknown> => Boolean(behavior))
-    : [];
-  const rootSafeUrl = resolveSafeFeishuButtonUrl(button.url);
-  if (rootSafeUrl) {
-    behaviors.push({ type: "open_url", default_url: rootSafeUrl });
-  }
-  if (isRecord(button.value) && button.value.oc === "ocf1") {
-    behaviors.push({ type: "callback", value: button.value });
-  }
-  if (behaviors.length === 0) {
-    return undefined;
-  }
-  const rendered: Record<string, unknown> = {
-    tag: "button",
-    text: { tag: "plain_text", content: text },
-    type:
-      style === "danger"
-        ? "danger"
-        : style === "primary" || style === "success"
-          ? "primary"
-          : "default",
-    behaviors,
-  };
-  return rendered;
-}
-
-function sanitizeNativeFeishuCardElements(element: unknown): Record<string, unknown>[] {
-  if (!isRecord(element) || typeof element.tag !== "string") {
-    return [];
-  }
-  if (element.tag === "hr") {
-    return [{ tag: "hr" }];
-  }
-  if (element.tag === "markdown" && typeof element.content === "string") {
-    return [
-      {
-        tag: "markdown",
-        content: escapeFeishuCardMarkdownText(element.content),
-      },
-    ];
-  }
-  if (element.tag === "button") {
-    const button = sanitizeNativeFeishuCardButton(element);
-    return button ? [button] : [];
-  }
-  if (element.tag === "action" && Array.isArray(element.actions)) {
-    return element.actions
-      .map((action) => sanitizeNativeFeishuCardButton(action))
-      .filter((action): action is Record<string, unknown> => Boolean(action));
-  }
-  return [];
-}
-
-function sanitizeNativeFeishuCard(
-  card: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-  const body = isRecord(card.body) ? card.body : undefined;
-  const rawElements = Array.isArray(body?.elements) ? body.elements : [];
-  const elements = rawElements
-    .flatMap((element) => sanitizeNativeFeishuCardElements(element))
-    .filter((element): element is Record<string, unknown> => Boolean(element));
-  if (elements.length === 0) {
-    return undefined;
-  }
-
-  const header = isRecord(card.header) ? card.header : undefined;
-  const title =
-    isRecord(header?.title) && typeof header.title.content === "string"
-      ? header.title.content
-      : undefined;
-  return markRenderedFeishuCard({
-    schema: "2.0",
-    config: { width_mode: "fill" },
-    ...(title?.trim()
-      ? {
-          header: {
-            title: { tag: "plain_text", content: title },
-            template:
-              resolveFeishuCardTemplate(
-                typeof header?.template === "string" ? header.template : undefined,
-              ) ?? "blue",
-          },
-        }
-      : {}),
-    body: { elements },
-  });
-}
-
 function readNativeFeishuCard(payload: { channelData?: Record<string, unknown> }) {
   const feishuData = payload.channelData?.feishu;
   if (!isRecord(feishuData)) {
@@ -264,7 +115,8 @@ function readNativeFeishuCard(payload: { channelData?: Record<string, unknown> }
   if ((card as { [RENDERED_FEISHU_CARD]?: true })[RENDERED_FEISHU_CARD] === true) {
     return card;
   }
-  return sanitizeNativeFeishuCard(card);
+  const sanitizedCard = sanitizeNativeFeishuCard(card);
+  return sanitizedCard ? markRenderedFeishuCard(sanitizedCard) : undefined;
 }
 
 function buildFeishuPayloadCard(params: {
@@ -275,6 +127,10 @@ function buildFeishuPayloadCard(params: {
   const nativeCard = readNativeFeishuCard(params.payload);
   if (nativeCard) {
     return nativeCard;
+  }
+  const textCard = readNativeFeishuCardJson(params.text ?? params.payload.text);
+  if (textCard) {
+    return markRenderedFeishuCard(textCard);
   }
 
   const interactive = normalizeInteractiveReply(params.payload.interactive);
@@ -647,6 +503,18 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           cfg,
           to,
           text,
+          accountId: accountId ?? undefined,
+          replyToMessageId,
+          replyInThread,
+        });
+      }
+
+      const card = readNativeFeishuCardJson(text);
+      if (card) {
+        return await sendCardFeishu({
+          cfg,
+          to,
+          card: markRenderedFeishuCard(card),
           accountId: accountId ?? undefined,
           replyToMessageId,
           replyInThread,

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -396,8 +396,14 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           const interactive = normalizeInteractiveReply(ctx.payload.interactive);
           return interactive ? interactiveReplyToPresentation(interactive) : undefined;
         })();
+      // Structured content replaces raw card JSON; document comments should
+      // render only the usable text fallback instead of exposing both forms.
+      const fallbackSourceText =
+        normalizedPresentation && readNativeFeishuCardJson(ctx.payload.text)
+          ? undefined
+          : ctx.payload.text;
       const presentationFallbackText = renderMessagePresentationFallbackText({
-        text: ctx.payload.text,
+        text: fallbackSourceText,
         presentation: normalizedPresentation,
       });
       // Direct delivery retains blocks; core-rendered delivery carries the fact.

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -128,23 +128,23 @@ function buildFeishuPayloadCard(params: {
   if (nativeCard) {
     return nativeCard;
   }
-  const textCard = readNativeFeishuCardJson(params.text ?? params.payload.text);
-  if (textCard) {
-    return markRenderedFeishuCard(textCard);
-  }
 
+  const rawText = params.text ?? params.payload.text;
+  const textCard = readNativeFeishuCardJson(rawText);
   const interactive = normalizeInteractiveReply(params.payload.interactive);
   const presentation =
     normalizeMessagePresentation(params.payload.presentation) ??
     (interactive ? interactiveReplyToPresentation(interactive) : undefined);
   if (!presentation && !interactive) {
-    return undefined;
+    return textCard ? markRenderedFeishuCard(textCard) : undefined;
   }
 
-  const text = resolveInteractiveTextFallback({
-    text: params.text ?? params.payload.text,
-    interactive,
-  });
+  const text = textCard
+    ? undefined
+    : resolveInteractiveTextFallback({
+        text: rawText,
+        interactive,
+      });
   const elements = presentation
     ? buildFeishuPresentationCardElements({ presentation, fallbackText: text })
     : [

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -4,7 +4,6 @@ import { parseStrictNonNegativeInteger } from "openclaw/plugin-sdk/number-runtim
 import {
   isRecord,
   normalizeLowercaseStringOrEmpty,
-  normalizeOptionalLowercaseString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-chunking";
 import type { ClawdbotConfig } from "../runtime-api.js";
@@ -13,6 +12,7 @@ import { createFeishuClient } from "./client.js";
 import { requestFeishuApi } from "./comment-shared.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent } from "./mention.js";
+import { resolveFeishuCardTemplate } from "./native-card.js";
 import { parsePostContent } from "./post.js";
 import {
   assertFeishuMessageApiSuccess,
@@ -22,25 +22,11 @@ import {
 import { resolveFeishuSendTarget } from "./send-target.js";
 import type { FeishuChatType, FeishuMessageInfo, FeishuSendResult } from "./types.js";
 
+export { resolveFeishuCardTemplate };
+
 const WITHDRAWN_REPLY_ERROR_CODES = new Set([230011, 231003]);
 const INTERACTIVE_CARD_FALLBACK_TEXT = "[Interactive Card]";
 const POST_FALLBACK_TEXT = "[Rich text message]";
-const FEISHU_CARD_TEMPLATES = new Set([
-  "blue",
-  "green",
-  "red",
-  "orange",
-  "purple",
-  "indigo",
-  "wathet",
-  "turquoise",
-  "yellow",
-  "grey",
-  "carmine",
-  "violet",
-  "lime",
-]);
-
 function shouldFallbackFromReplyTarget(response: { code?: number; msg?: string }): boolean {
   if (response.code !== undefined && WITHDRAWN_REPLY_ERROR_CODES.has(response.code)) {
     return true;
@@ -744,14 +730,6 @@ export type CardHeaderConfig = {
   /** Feishu header color template (blue, green, red, orange, purple, grey, etc.). Defaults to "blue". */
   template?: string;
 };
-
-export function resolveFeishuCardTemplate(template?: string): string | undefined {
-  const normalized = normalizeOptionalLowercaseString(template);
-  if (!normalized || !FEISHU_CARD_TEMPLATES.has(normalized)) {
-    return undefined;
-  }
-  return normalized;
-}
 
 /**
  * Build a Feishu interactive card with optional header and note footer.

--- a/extensions/opencode-go/api.ts
+++ b/extensions/opencode-go/api.ts
@@ -1,28 +1,6 @@
 // Opencode Go API module exposes the plugin public contract.
-import {
-  applyAgentDefaultModelPrimary,
-  resolveAgentModelPrimaryValue,
-} from "openclaw/plugin-sdk/provider-onboard";
-import { OPENCODE_GO_DEFAULT_MODEL_REF } from "./onboard.js";
-
 export {
   applyOpencodeGoConfig,
   applyOpencodeGoProviderConfig,
   OPENCODE_GO_DEFAULT_MODEL_REF,
 } from "./onboard.js";
-
-export function applyOpencodeGoModelDefault(
-  cfg: import("openclaw/plugin-sdk/provider-onboard").OpenClawConfig,
-): {
-  next: import("openclaw/plugin-sdk/provider-onboard").OpenClawConfig;
-  changed: boolean;
-} {
-  const current = resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model);
-  if (current === OPENCODE_GO_DEFAULT_MODEL_REF) {
-    return { next: cfg, changed: false };
-  }
-  return {
-    next: applyAgentDefaultModelPrimary(cfg, OPENCODE_GO_DEFAULT_MODEL_REF),
-    changed: true,
-  };
-}

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -627,16 +627,20 @@ describe("qa scenario catalog", () => {
 
   it("keeps provider-sensitive QA flow scenarios on their supported lanes", () => {
     const strandedConfig = readQaScenarioExecutionConfig("message-tool-stranded-final-reply") as
-      | { requiredProviderMode?: string }
+      | { requiredChannelDriver?: string; requiredProviderMode?: string }
       | undefined;
     const stranded = readQaScenarioById("message-tool-stranded-final-reply");
+    const strandedFlow = JSON.stringify(stranded.execution.flow);
     const heartbeat = readQaScenarioById("commitments-heartbeat-target-none");
     const heartbeatFlow = JSON.stringify(heartbeat.execution.flow);
 
     expect(strandedConfig?.requiredProviderMode).toBe("mock-openai");
-    expect(JSON.stringify(stranded.execution.flow)).toContain(
-      "this seeded scenario is mock-openai only",
-    );
+    expect(strandedConfig?.requiredChannelDriver).toBe("qa-channel");
+    expect(strandedFlow).toContain("this seeded scenario is mock-openai only");
+    expect(strandedFlow).toContain("state.getSnapshot().events.slice(eventStartIndex)");
+    expect(strandedFlow).toContain("message.deleted !== true");
+    expect(strandedFlow).toContain("config.expectedMarker");
+    expect(strandedFlow).not.toContain("waitForNoOutbound");
     expect(heartbeatFlow).toContain("sessionKey");
     expect(heartbeatFlow).toContain("commitmentOutbound.length === 0");
     expect(heartbeatFlow).not.toContain("waitForNoOutbound");

--- a/extensions/xai/api.ts
+++ b/extensions/xai/api.ts
@@ -90,18 +90,3 @@ export function resolveXaiTransport(params: {
     baseUrl: readStringValue(params.baseUrl),
   };
 }
-
-export function resolveXaiBaseUrl(baseUrlOrConfig?: unknown): string {
-  let candidate = baseUrlOrConfig;
-  if (
-    baseUrlOrConfig &&
-    typeof baseUrlOrConfig === "object" &&
-    !Array.isArray(baseUrlOrConfig) &&
-    "cfg" in baseUrlOrConfig
-  ) {
-    candidate =
-      (baseUrlOrConfig as { cfg?: { models?: { providers?: { xai?: { baseUrl?: unknown } } } } })
-        .cfg?.models?.providers?.xai?.baseUrl ?? baseUrlOrConfig;
-  }
-  return readStringValue(candidate) || "https://api.x.ai/v1";
-}

--- a/qa/scenarios/channels/message-tool-stranded-final-reply.yaml
+++ b/qa/scenarios/channels/message-tool-stranded-final-reply.yaml
@@ -9,13 +9,13 @@ scenario:
     secondary:
       - channels.qa-channel
       - tools.message
-  objective: Reproduce #85714 — under messages.visibleReplies=message_tool a long private final reply that never calls the message tool is kept private (no outbound), and the gateway emits the private-final WARN.
+  objective: Reproduce #85714 — under messages.visibleReplies=message_tool a long private final reply that never calls the message tool is never delivered, and the gateway emits the private-final WARN.
   gatewayConfigPatch:
     messages:
       visibleReplies: message_tool
   successCriteria:
     - The mock provider returns a long normal final answer and does not plan the message tool.
-    - Under message_tool_only delivery the reply is kept private, so the direct conversation receives no outbound message.
+    - Under message_tool_only delivery the private final is absent from the complete outbound event history, and any progress lifecycle output is deleted.
     - The gateway logs the private-final WARN from source-reply/private-final.
   docsRefs:
     - docs/channels/qa-channel.md
@@ -25,9 +25,10 @@ scenario:
     - src/auto-reply/reply/dispatch-from-config.ts
   execution:
     kind: flow
-    summary: Send a direct message_tool_only turn whose model reply omits the message tool, and verify a substantive private final warns without outbound delivery.
+    summary: Send a direct message_tool_only turn whose model reply omits the message tool, and verify the private final never reaches outbound event history.
     config:
       requiredProviderMode: mock-openai
+      requiredChannelDriver: qa-channel
       conversationId: qa-stranded-dm
       promptSnippet: qa private final reply warning check
       prompt: "qa private final reply warning check. Reply to me directly in two complete sentences with `QA-STRANDED-85714` in the first sentence and a short explanation in the second sentence. Do NOT call any tool. Do NOT use the message tool."
@@ -50,6 +51,12 @@ flow:
             - ref: env
             - 60000
         - call: reset
+        - set: eventStartIndex
+          value:
+            expr: state.getSnapshot().events.length
+        - set: outboundStartIndex
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length"
         - set: logCursor
           value:
             expr: markGatewayLogCursor()
@@ -65,9 +72,32 @@ flow:
             senderName: Alice
             text:
               expr: config.prompt
-        - waitForNoOutbound:
-            quietMs:
-              expr: liveTurnTimeoutMs(env, 30000)
+        - call: waitForCondition
+          args:
+            - lambda:
+                expr: "String(readGatewayLogs() ?? '').slice(logCursor).includes(config.privateFinalLogNeedle) ? true : undefined"
+            - expr: liveTurnTimeoutMs(env, 30000)
+            - 100
+        - call: sleep
+          args:
+            - expr: liveTurnTimeoutMs(env, 30000)
+        - set: scenarioOutbound
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').slice(outboundStartIndex)"
+        - set: scenarioOutboundEvents
+          value:
+            expr: "state.getSnapshot().events.slice(eventStartIndex).filter((event) => ['outbound-message', 'message-edited', 'message-deleted'].includes(event.kind) && event.message?.direction === 'outbound')"
+        - set: survivingOutbound
+          value:
+            expr: "scenarioOutbound.filter((message) => message.deleted !== true)"
+        - assert:
+            expr: "scenarioOutboundEvents.every((event) => !String(event.message?.text ?? '').includes(config.expectedMarker))"
+            message:
+              expr: "`private final marker escaped into outbound event history: ${JSON.stringify(scenarioOutboundEvents.map((event) => ({ kind: event.kind, text: event.message?.text ?? '' })))} `"
+        - assert:
+            expr: survivingOutbound.length === 0
+            message:
+              expr: "`expected no surviving outbound messages, saw ${JSON.stringify(survivingOutbound.map((message) => message.text))}`"
         - set: scenarioRequests
           value:
             expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests`)).slice(requestCountBefore).filter((request) => String(request.allInputText ?? '').includes(config.promptSnippet)) : []"
@@ -88,4 +118,4 @@ flow:
             expr: "privateFinalLog.includes(config.privateFinalLogNeedle)"
             message:
               expr: "`expected the gateway to log ${config.privateFinalLogNeedle} after a substantive private message_tool_only reply, but it was absent`"
-      detailsExpr: "`no-outbound private final; WARN logged=${privateFinalLog.includes(config.privateFinalLogNeedle)}; mock requests=${scenarioRequests.length}; gateway log: ${privateFinalLine}`"
+      detailsExpr: "`private final absent from ${scenarioOutboundEvents.length} outbound lifecycle events; transient deleted=${scenarioOutbound.filter((message) => message.deleted === true).length}; WARN logged=${privateFinalLog.includes(config.privateFinalLogNeedle)}; mock requests=${scenarioRequests.length}; gateway log: ${privateFinalLine}`"

--- a/qa/scenarios/runtime/empty-response-retry-budget-exhausted.yaml
+++ b/qa/scenarios/runtime/empty-response-retry-budget-exhausted.yaml
@@ -59,7 +59,7 @@ flow:
           value:
             expr: "await env.gateway.call('agent.wait', { runId: started.runId, timeoutMs: liveTurnTimeoutMs(env, 45000) }, { timeoutMs: liveTurnTimeoutMs(env, 50000) })"
         - assert:
-            expr: "waited?.status === 'ok'"
+            expr: "['ok', 'completed', 'succeeded'].includes(String(waited?.status)) || (waited?.status === 'error' && String(waited?.error ?? '').trim().toLowerCase() === 'completed')"
             message:
               expr: "`agent.wait returned ${String(waited?.status ?? 'unknown')}: ${String(waited?.error ?? '')}`"
         - if:

--- a/qa/scenarios/runtime/reasoning-only-no-auto-retry-after-write.yaml
+++ b/qa/scenarios/runtime/reasoning-only-no-auto-retry-after-write.yaml
@@ -61,7 +61,7 @@ flow:
           value:
             expr: "await env.gateway.call('agent.wait', { runId: started.runId, timeoutMs: liveTurnTimeoutMs(env, 45000) }, { timeoutMs: liveTurnTimeoutMs(env, 50000) })"
         - assert:
-            expr: "waited?.status === 'ok'"
+            expr: "['ok', 'completed', 'succeeded'].includes(String(waited?.status)) || (waited?.status === 'error' && String(waited?.error ?? '').trim().toLowerCase() === 'completed')"
             message:
               expr: "`agent.wait returned ${String(waited?.status ?? 'unknown')}: ${String(waited?.error ?? '')}`"
         - call: fs.readFile

--- a/scripts/native-app-i18n.ts
+++ b/scripts/native-app-i18n.ts
@@ -86,10 +86,10 @@ const APPLE_MODIFIER_MULTILINE_CALLS =
   /\.(?:navigationTitle|accessibilityLabel|accessibilityHint|help|alert|confirmationDialog)\s*\(\s*"""([\s\S]*?)"""/gu;
 const ANDROID_CALLS =
   /\b(?:Text|OutlinedTextField|BasicTextField|Button|IconButton|TopAppBar|Snackbar|AlertDialog)\s*\(\s*(?:text\s*=\s*)?"((?:\\.|[^"\\])*)"/gu;
-const ANDROID_NAMED_LITERALS =
-  /\b(?:contentDescription|label|placeholder|title|message|supportingText|text)\s*=\s*"((?:\\.|[^"\\])*)"/gu;
+const ANDROID_NAMED_LITERALS = /\b([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"((?:\\.|[^"\\])*)"/gu;
 const ANDROID_TOAST_ARGS =
   /\b(?:Toast\.makeText|Snackbar\.make)\s*\([^,\n]*,\s*"((?:\\.|[^"\\])*)"/gu;
+const ANDROID_CHOOSER_ARGS = /\bIntent\.createChooser\s*\([^,\n]*,\s*"((?:\\.|[^"\\])*)"/gu;
 const ANDROID_DIALOG_CALLS =
   /\.(?:setTitle|setMessage|setPositiveButton|setNegativeButton|setNeutralButton)\s*\(\s*"((?:\\.|[^"\\])*)"/gu;
 const ANDROID_UI_STATE_TEXT =
@@ -104,6 +104,7 @@ const ANDROID_BUILTIN_UI_CALLS = new Set([
   "Card",
   "Checkbox",
   "Column",
+  "combinedClickable",
   "DropdownMenuItem",
   "Icon",
   "IconButton",
@@ -127,7 +128,7 @@ const CONDITIONAL_BRANCHES = [
   /\?\s*"((?:\\.|[^"\\])*)"\s*:\s*"((?:\\.|[^"\\])*)"/gu,
 ];
 const UI_STRING_NAME_RE =
-  /(?:title|subtitle|body|message|label|text|description|detail|prompt|help)$/iu;
+  /(?:title|subtitle|body|message|label|text|description|detail|prompt|placeholder|help)$/iu;
 const APPLE_STRING_PROPERTY = /\bvar\s+([A-Za-z_][A-Za-z0-9_]*)\s*:\s*String\s*\{/gu;
 const APPLE_SWITCH_BRANCH =
   /(?:\bcase\b[^:\n]+|\bdefault)\s*:\s*(?:return\s+)?"((?:\\.|[^"\\])*)"/gu;
@@ -658,6 +659,7 @@ function extractCandidates(
       : [
           [ANDROID_CALLS, "ui-call"],
           [ANDROID_TOAST_ARGS, "ui-toast"],
+          [ANDROID_CHOOSER_ARGS, "ui-chooser"],
           [ANDROID_DIALOG_CALLS, "ui-dialog"],
           [ANDROID_UI_STATE_TEXT, "ui-state-text"],
           ...CONDITIONAL_BRANCHES.map((pattern) => [pattern, "conditional-branch"] as const),
@@ -795,15 +797,22 @@ function extractCandidates(
       }
     }
     for (const match of source.matchAll(ANDROID_NAMED_LITERALS)) {
+      const argumentName = match[1];
       const callName = enclosingCallName(source, match.index ?? 0);
-      if (!callName || !uiCallNames.has(callName) || !match[1]) {
+      if (
+        !argumentName ||
+        !UI_STRING_NAME_RE.test(argumentName) ||
+        !callName ||
+        !uiCallNames.has(callName) ||
+        !match[2]
+      ) {
         continue;
       }
       addCandidate(
         entries,
         surface,
         repoPath,
-        match[1],
+        match[2],
         "ui-named-argument",
         lineNumber(source, match.index ?? 0),
       );

--- a/src/agents/embedded-agent-runner/session-manager-init.test.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.test.ts
@@ -3,7 +3,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../sessions/session-manager.js";
 import { prepareSessionManagerForRun } from "./session-manager-init.js";
 
@@ -46,6 +46,7 @@ describe("prepareSessionManagerForRun", () => {
       labelsById: new Map([["old", {}]]),
       leafId: "old",
     };
+    const readFileSpy = vi.spyOn(fs, "readFile");
 
     await prepareSessionManagerForRun({
       sessionManager,
@@ -68,6 +69,8 @@ describe("prepareSessionManagerForRun", () => {
     expect(sessionManager.labelsById.size).toBe(0);
     expect(sessionManager.leafId).toBeNull();
     expect(sessionManager.flushed).toBe(false);
+    expect(readFileSpy).not.toHaveBeenCalled();
+    readFileSpy.mockRestore();
     expect(await fs.readFile(sessionFile, "utf-8")).toBe("");
   });
 
@@ -349,6 +352,119 @@ describe("prepareSessionManagerForRun", () => {
       },
     ]);
     expect(sessionManager.flushed).toBe(true);
+  });
+
+  it("does not truncate a blank-prefixed transcript with a corrupted header", async () => {
+    const sessionFile = await makeTempFile();
+    const originalTranscript =
+      [
+        "",
+        "   ",
+        '{"type":"session","id":"broken"',
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-27T00:00:01.000Z",
+          message: { role: "user", content: "persisted prompt" },
+        }),
+      ].join("\n") + "\n";
+    await fs.writeFile(sessionFile, originalTranscript, "utf-8");
+    const sessionManager = {
+      sessionId: "fresh-session",
+      cwd: "/srv/openclaw/main",
+      flushed: true,
+      fileEntries: [
+        {
+          type: "session",
+          id: "fresh-session",
+          cwd: "/srv/openclaw/main",
+        },
+        {
+          type: "message",
+          message: { role: "user" },
+        },
+      ],
+      byId: new Map([["user-1", {}]]),
+      labelsById: new Map(),
+      leafId: "user-1",
+    };
+
+    await expect(
+      prepareSessionManagerForRun({
+        sessionManager,
+        sessionFile,
+        hadSessionFile: true,
+        sessionId: "new-session",
+        cwd: "/tmp/task-repo",
+      }),
+    ).rejects.toThrow("Refusing to reset session transcript with unreadable header");
+
+    expect(await fs.readFile(sessionFile, "utf-8")).toBe(originalTranscript);
+    expect(sessionManager.flushed).toBe(true);
+  });
+
+  it("resets when the first non-empty header is beyond the old scan cap", async () => {
+    const sessionFile = await makeTempFile();
+    const blankPrefix = " \n".repeat(33_000);
+    const originalTranscript =
+      blankPrefix +
+      [
+        JSON.stringify({
+          type: "session",
+          id: "fresh-session",
+          cwd: "/srv/openclaw/main",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-27T00:00:01.000Z",
+          message: { role: "user", content: "persisted prompt" },
+        }),
+      ].join("\n") +
+      "\n";
+    await fs.writeFile(sessionFile, originalTranscript, "utf-8");
+    const sessionManager = {
+      sessionId: "fresh-session",
+      cwd: "/srv/openclaw/main",
+      flushed: true,
+      fileEntries: [
+        {
+          type: "session",
+          id: "fresh-session",
+          cwd: "/srv/openclaw/main",
+        },
+        {
+          type: "message",
+          message: { role: "user" },
+        },
+      ],
+      byId: new Map([["user-1", {}]]),
+      labelsById: new Map(),
+      leafId: "user-1",
+    };
+
+    await prepareSessionManagerForRun({
+      sessionManager,
+      sessionFile,
+      hadSessionFile: true,
+      sessionId: "new-session",
+      cwd: "/tmp/task-repo",
+    });
+
+    expect(await fs.readFile(sessionFile, "utf-8")).toBe("");
+    expect(sessionManager.fileEntries).toEqual([
+      {
+        type: "session",
+        id: "new-session",
+        cwd: "/tmp/task-repo",
+      },
+    ]);
+    expect(sessionManager.byId.size).toBe(0);
+    expect(sessionManager.labelsById.size).toBe(0);
+    expect(sessionManager.leafId).toBeNull();
+    expect(sessionManager.flushed).toBe(false);
   });
 
   it("keeps recovered user-only transcripts through open and run preparation", async () => {

--- a/src/agents/embedded-agent-runner/session-manager-init.ts
+++ b/src/agents/embedded-agent-runner/session-manager-init.ts
@@ -2,6 +2,7 @@
  * Prepares session managers and transcript state before embedded runs.
  */
 import fs from "node:fs/promises";
+import { StringDecoder } from "node:string_decoder";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { serializeJsonlLine, writeJsonlLines } from "../../config/sessions/transcript-jsonl.js";
 import { invalidateSessionFileRepairCache } from "../session-file-repair.js";
@@ -14,9 +15,63 @@ type SessionHeaderEntry = {
 };
 type SessionMessageEntry = { type: "message"; message?: { role?: string } };
 
+const SESSION_HEADER_READ_CHUNK_BYTES = 4096;
+
+async function readFirstSessionFileLine(sessionFile: string): Promise<string | undefined> {
+  const handle = await fs.open(sessionFile, "r");
+  try {
+    const decoder = new StringDecoder("utf8");
+    const buffer = Buffer.alloc(SESSION_HEADER_READ_CHUNK_BYTES);
+    let line = "";
+    let lineHasContent = false;
+
+    const scanText = (text: string): string | undefined => {
+      let start = 0;
+      while (start <= text.length) {
+        const newlineIndex = text.indexOf("\n", start);
+        const segment = newlineIndex === -1 ? text.slice(start) : text.slice(start, newlineIndex);
+        if (lineHasContent) {
+          line += segment;
+        } else {
+          const trimmedStart = segment.trimStart();
+          if (trimmedStart.length > 0) {
+            lineHasContent = true;
+            line = trimmedStart;
+          }
+        }
+        if (newlineIndex === -1) {
+          break;
+        }
+        if (lineHasContent) {
+          return line.trim();
+        }
+        start = newlineIndex + 1;
+      }
+      return undefined;
+    };
+
+    while (true) {
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) {
+        break;
+      }
+      const firstLine = scanText(decoder.write(buffer.subarray(0, bytesRead)));
+      if (firstLine) {
+        return firstLine;
+      }
+    }
+    const trailingLine = scanText(decoder.end());
+    if (trailingLine) {
+      return trailingLine;
+    }
+    return lineHasContent ? line.trim() : undefined;
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+}
+
 async function assertExistingHeaderIsReadable(sessionFile: string): Promise<void> {
-  const content = await fs.readFile(sessionFile, "utf-8");
-  const firstLine = content.split("\n").find((line) => line.trim());
+  const firstLine = await readFirstSessionFileLine(sessionFile);
   if (!firstLine) {
     return;
   }

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -22,10 +22,17 @@ const hoisted = await vi.hoisted(async () => {
     accessMock: vi.fn(async (_filePath: string) => undefined),
     pathExistsMock: vi.fn(async (_filePath: string) => true),
     migrateSessionEntriesMock: vi.fn((_entries: unknown[]) => undefined),
+    readAcpSessionMetaForEntryMock: vi.fn<
+      (params: { sessionKey: string; entry?: { sessionId?: string } }) => unknown
+    >(() => undefined),
     exportHtmlTemplateContents: new Map<string, string>(),
     sessionTranscriptContent: "",
   };
 });
+
+vi.mock("../../acp/runtime/session-meta.js", () => ({
+  readAcpSessionMetaForEntry: hoisted.readAcpSessionMetaForEntryMock,
+}));
 
 vi.mock("../../config/sessions/paths.js", () => ({
   resolveDefaultSessionStorePath: hoisted.resolveDefaultSessionStorePathMock,
@@ -164,6 +171,14 @@ function writtenHtml(): string {
   return value;
 }
 
+function sessionDataFromHtml(html: string): Record<string, unknown> {
+  const match = html.match(/id="session-data"[^>]*>([^<]+)</);
+  if (!match) {
+    throw new Error("Expected session-data script in exported HTML");
+  }
+  return JSON.parse(Buffer.from(match[1].trim(), "base64").toString("utf-8"));
+}
+
 describe("buildExportSessionReply", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -192,6 +207,7 @@ describe("buildExportSessionReply", () => {
     });
     hoisted.accessMock.mockResolvedValue(undefined);
     hoisted.pathExistsMock.mockResolvedValue(true);
+    hoisted.readAcpSessionMetaForEntryMock.mockReturnValue(undefined);
     hoisted.exportHtmlTemplateContents.clear();
     hoisted.sessionTranscriptContent = "";
   });
@@ -549,5 +565,178 @@ describe("buildExportSessionReply", () => {
       "⚠️ Skipped 1 malformed transcript row that was not a session entry. rows 4",
     );
     expect(reply.text).not.toMatch(/Unexpected|SyntaxError|position/i);
+  });
+
+  it("warns when the session only contains user messages (backend-delegated transcript)", async () => {
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:target:session": {
+        sessionId: "session-1",
+        updatedAt: 1,
+        cliSessionBindings: {
+          "claude-cli": { sessionId: "backend-session-1" },
+        },
+      },
+    });
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-2",
+        timestamp: "2026-05-16T00:00:01.000Z",
+        message: { role: "user", content: "world" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).toContain("backend runtime");
+    expect(reply.text).toContain("not included in this export");
+    const data = sessionDataFromHtml(writtenHtml());
+    expect(typeof data.warning).toBe("string");
+    expect(data.warning).toContain("backend runtime");
+  });
+
+  it("warns when persisted ACP metadata is stored outside the session entry", async () => {
+    hoisted.readAcpSessionMetaForEntryMock.mockReturnValue({
+      backend: "acpx",
+      mode: "persistent",
+      agent: "claude",
+      runtimeSessionName: "backend-session-1",
+      state: "idle",
+      lastActivityAt: 1,
+    });
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(hoisted.readAcpSessionMetaForEntryMock).toHaveBeenCalledWith({
+      sessionKey: "agent:target:session",
+      entry: {
+        sessionId: "session-1",
+        updatedAt: 1,
+      },
+    });
+    expect(reply.text).toContain("backend runtime");
+    expect(sessionDataFromHtml(writtenHtml()).warning).toContain("backend runtime");
+  });
+
+  it("continues exporting when persisted ACP metadata cannot be read", async () => {
+    hoisted.readAcpSessionMetaForEntryMock.mockImplementation(() => {
+      throw new Error("state database unavailable");
+    });
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).toContain("Session exported");
+    expect(reply.text).not.toContain("backend runtime");
+    expect(sessionDataFromHtml(writtenHtml()).warning).toBeUndefined();
+  });
+
+  it("does not warn for a normal user-only transcript without backend session metadata", async () => {
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).not.toContain("backend runtime");
+    expect(sessionDataFromHtml(writtenHtml()).warning).toBeUndefined();
+  });
+
+  it("ignores malformed persisted backend session metadata", async () => {
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:target:session": {
+        sessionId: "session-1",
+        updatedAt: 1,
+        claudeCliSessionId: 123,
+        cliSessionBindings: {
+          "claude-cli": null,
+        },
+        cliSessionIds: {
+          acpx: 123,
+        },
+      },
+    } as never);
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).not.toContain("backend runtime");
+    expect(sessionDataFromHtml(writtenHtml()).warning).toBeUndefined();
+  });
+
+  it("does not warn when the transcript includes assistant messages", async () => {
+    hoisted.loadSessionStoreMock.mockReturnValue({
+      "agent:target:session": {
+        sessionId: "session-1",
+        updatedAt: 1,
+        acp: {
+          backend: "acpx",
+          mode: "persistent",
+          agent: "claude",
+          runtimeSessionName: "backend-session-1",
+          state: "idle",
+          lastActivityAt: 1,
+        },
+      },
+    });
+    hoisted.sessionTranscriptContent = [
+      JSON.stringify({ type: "session", version: 3, id: "session-1" }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-1",
+        timestamp: "2026-05-16T00:00:00.000Z",
+        message: { role: "user", content: "hello" },
+      }),
+      JSON.stringify({
+        type: "message",
+        id: "entry-2",
+        timestamp: "2026-05-16T00:00:01.000Z",
+        message: { role: "assistant", content: "hi" },
+      }),
+    ].join("\n");
+
+    const reply = await buildExportSessionReply(makeParams());
+
+    expect(reply.text).not.toContain("backend runtime");
+    expect(reply.text).not.toContain("not included in this export");
+    expect(sessionDataFromHtml(writtenHtml()).warning).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -2,6 +2,7 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { readAcpSessionMetaForEntry } from "../../acp/runtime/session-meta.js";
 import {
   parseSessionFileEntriesWithWarnings,
   type SessionFileParseWarning,
@@ -10,8 +11,10 @@ import {
   migrateSessionEntries,
   type SessionEntry as AgentSessionEntry,
   type SessionHeader,
+  type SessionMessageEntry,
 } from "../../agents/sessions/session-manager.js";
 import { scanSessionTranscriptTree } from "../../config/sessions/transcript-tree.js";
+import type { SessionEntry as StoredSessionEntry } from "../../config/sessions/types.js";
 import { pathExists } from "../../infra/fs-safe.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -32,6 +35,59 @@ interface SessionData {
   hasLeafControl: boolean;
   systemPrompt?: string;
   tools?: Array<{ name: string; description?: string; parameters?: unknown }>;
+  warning?: string;
+}
+
+const BACKEND_DELEGATED_WARNING =
+  "This session was handled by a backend runtime (e.g. CLI/ACP). Assistant replies, tool calls, and usage data are stored in the backend transcript and are not included in this export.";
+
+function hasNonEmptyString(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasBackendSession(entry: StoredSessionEntry, hasStoredAcpSession: boolean): boolean {
+  return (
+    hasStoredAcpSession ||
+    hasNonEmptyString(entry.claudeCliSessionId) ||
+    Object.values(entry.cliSessionBindings ?? {}).some((binding) =>
+      hasNonEmptyString(binding?.sessionId),
+    ) ||
+    Object.values(entry.cliSessionIds ?? {}).some(hasNonEmptyString)
+  );
+}
+
+function hasPersistedAcpSession(params: {
+  sessionKey: string;
+  entry: StoredSessionEntry;
+}): boolean {
+  if (params.entry.acp) {
+    return true;
+  }
+  try {
+    return Boolean(readAcpSessionMetaForEntry(params));
+  } catch {
+    return false;
+  }
+}
+
+function isBackendDelegatedSession(
+  entry: StoredSessionEntry,
+  entries: AgentSessionEntry[],
+  hasStoredAcpSession: boolean,
+): boolean {
+  if (!hasBackendSession(entry, hasStoredAcpSession)) {
+    return false;
+  }
+  if (entries.length === 0) {
+    return false;
+  }
+  const messages = entries.filter(
+    (transcriptEntry): transcriptEntry is SessionMessageEntry => transcriptEntry.type === "message",
+  );
+  return (
+    messages.length > 0 &&
+    messages.every((transcriptEntry) => transcriptEntry.message.role === "user")
+  );
 }
 
 type SessionExportWarningSummary = {
@@ -261,6 +317,13 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
   });
 
   // 4. Prepare session data
+  const hasStoredAcpSession = hasPersistedAcpSession({
+    sessionKey: params.sessionKey,
+    entry,
+  });
+  const backendWarning = isBackendDelegatedSession(entry, entries, hasStoredAcpSession)
+    ? BACKEND_DELEGATED_WARNING
+    : undefined;
   const sessionData: SessionData = {
     header,
     entries,
@@ -272,6 +335,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
       description: t.description,
       parameters: t.parameters,
     })),
+    warning: backendWarning,
   };
 
   // 5. Generate HTML
@@ -309,6 +373,7 @@ export async function buildExportSessionReply(params: HandleCommandsParams): Pro
       `📄 File: ${displayPath}`,
       `📊 Entries: ${entries.length}`,
       ...warnings.map(formatSessionExportWarning),
+      ...(backendWarning ? [`⚠️ ${backendWarning}`] : []),
       `🧠 System prompt: ${systemPrompt.length.toLocaleString()} chars`,
       `🔧 Tools: ${tools.length}`,
     ].join("\n"),

--- a/src/auto-reply/reply/commands-export-test-mocks.ts
+++ b/src/auto-reply/reply/commands-export-test-mocks.ts
@@ -1,5 +1,6 @@
 /** Test mocks for export-command session path and store helpers. */
 import type { vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
 
 type ViLike = Pick<typeof vi, "fn">;
 
@@ -11,7 +12,7 @@ export function createExportCommandSessionMocks(viInstance: ViLike) {
     resolveSessionFilePathOptionsMock: viInstance.fn(
       (params: { agentId: string; storePath: string }) => params,
     ),
-    loadSessionStoreMock: viInstance.fn(() => ({
+    loadSessionStoreMock: viInstance.fn<() => Record<string, SessionEntry>>(() => ({
       "agent:target:session": {
         sessionId: "session-1",
         updatedAt: 1,

--- a/src/auto-reply/reply/export-html/template.css
+++ b/src/auto-reply/reply/export-html/template.css
@@ -256,6 +256,17 @@ body {
   border-color: var(--borderAccent);
 }
 
+/* Export warnings */
+.export-warning {
+  background: var(--userMsgBg);
+  border: 1px solid var(--warning);
+  border-radius: 4px;
+  color: var(--warning);
+  font-size: 12px;
+  margin-bottom: var(--line-height);
+  padding: var(--line-height);
+}
+
 /* Header */
 .header {
   background: var(--container-bg);

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -21,6 +21,7 @@
     systemPrompt,
     tools,
     renderedTools,
+    warning,
   } = data;
 
   // ============================================================
@@ -1567,7 +1568,11 @@
       msgParts.push(`${globalStats.branchSummaries} branch summaries`);
     }
 
-    let html = `
+    let html = "";
+    if (warning) {
+      html += `<div class="export-warning">${escapeHtml(warning)}</div>`;
+    }
+    html += `
           <div class="header">
             <h1>Session: ${escapeHtml(header?.id || "unknown")}</h1>
             <div class="help-bar">

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -29,6 +29,7 @@ type SessionData = {
   hasLeafControl?: boolean;
   systemPrompt: string;
   tools: unknown[];
+  warning?: string;
 };
 
 type ParsedHtml = {
@@ -212,6 +213,42 @@ describe("export html sidebar trigger affordance", () => {
 });
 
 describe("export html security hardening", () => {
+  it("renders export warnings in the header without interpreting HTML", async () => {
+    const warning = 'Backend <img src=x onerror="alert(1)"> transcript is incomplete';
+    const session: SessionData = {
+      header: { id: "session-warning", timestamp: now() },
+      entries: [
+        {
+          id: "1",
+          parentId: null,
+          timestamp: now(),
+          type: "message",
+          message: { role: "user", content: "hello" },
+        },
+      ],
+      leafId: "1",
+      systemPrompt: "",
+      tools: [],
+      warning,
+    };
+
+    const { document } = await renderTemplate(session);
+    const header = requireElement(
+      document.getElementById("header-container"),
+      "header root missing",
+    );
+    const warningNode = requireElement(
+      header.querySelector(".export-warning"),
+      "export warning missing",
+    );
+
+    expect(warningNode.textContent).toBe(warning);
+    expect(warningNode.querySelector("img[onerror]")).toBeNull();
+    expect(warningNode.innerHTML).toContain(
+      'Backend &lt;img src=x onerror="alert(1)"&gt; transcript is incomplete',
+    );
+  });
+
   it("renders an explicitly selected empty branch without inactive messages", async () => {
     const session: SessionData = {
       header: { id: "session-empty", timestamp: now() },

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -179,7 +179,6 @@ export async function runGatewayLoop(params: {
   };
   const reacquireLockForInProcessRestart = async (): Promise<boolean> => {
     try {
-      startupStartedAt = Date.now();
       lock = await acquireGatewayLock({ port: params.lockPort });
       return true;
     } catch (err) {

--- a/src/gateway/server-sidecar-startup-mode.ts
+++ b/src/gateway/server-sidecar-startup-mode.ts
@@ -1,0 +1,2 @@
+// Startup mode shared by the server implementation and post-ready sidecar scheduler.
+export type GatewaySidecarStartupMode = "start" | "defer";

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -23,6 +23,7 @@ import {
 } from "./events.js";
 import { STARTUP_UNAVAILABLE_GATEWAY_METHODS } from "./methods/core-descriptors.js";
 import type { refreshLatestUpdateRestartSentinel } from "./server-restart-sentinel.js";
+import type { GatewaySidecarStartupMode } from "./server-sidecar-startup-mode.js";
 import type { logGatewayStartup } from "./server-startup-log.js";
 import type { startGatewayTailscaleExposure } from "./server-tailscale.js";
 
@@ -70,8 +71,6 @@ const loadGatewayRestartSentinelModule = createLazyRuntimeModule(
 export type GatewayPostReadySidecarHandle = {
   stop: () => Awaitable<void>;
 };
-
-export type GatewaySidecarStartupMode = "start" | "defer";
 
 /** Stop sidecars immediately when shutdown has already started before they are reported. */
 export function stopPostReadySidecarsAfterCloseStarted(params: {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -108,7 +108,7 @@ import {
   getRequiredSharedGatewaySessionGeneration,
   type SharedGatewaySessionGenerationState,
 } from "./server-shared-auth-generation.js";
-import type { GatewaySidecarStartupMode } from "./server-startup-post-attach.js";
+import type { GatewaySidecarStartupMode } from "./server-sidecar-startup-mode.js";
 import { createWizardSessionTracker } from "./server-wizard-sessions.js";
 import { createGatewayEventLoopHealthMonitor } from "./server/event-loop-health.js";
 import {

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -268,6 +268,110 @@ describe("runHeartbeatOnce ack handling", () => {
     });
   });
 
+  it("records completed tasks when HEARTBEAT_OK delivery fails", async () => {
+    await withTempTelegramHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const nowMs = Date.parse("2026-07-06T12:00:00.000Z");
+      await fs.writeFile(
+        `${tmpDir}/HEARTBEAT.md`,
+        `tasks:
+  - name: check-deployment
+    interval: 5m
+    prompt: Check deployment status
+`,
+        "utf-8",
+      );
+      const cfg = createHeartbeatConfig({
+        tmpDir,
+        storePath,
+        heartbeat: { every: "5m", target: "telegram" },
+        channels: {
+          telegram: {
+            token: "test-token",
+            allowFrom: ["*"],
+            heartbeat: { showOk: true },
+          },
+        },
+      });
+      const sessionKey = await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: TELEGRAM_GROUP,
+      });
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+      const sendTelegram = vi.fn().mockRejectedValue(new Error("delivery unavailable"));
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          ...makeTelegramDeps({ sendTelegram, nowMs: () => nowMs }),
+          getReplyFromConfig: replySpy,
+        },
+      });
+
+      const sessionStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        { heartbeatTaskState?: Record<string, number> }
+      >;
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sessionStore[sessionKey]?.heartbeatTaskState).toEqual({
+        "check-deployment": nowMs,
+      });
+    });
+  });
+
+  it("records completed tasks when HEARTBEAT_OK readiness checks fail", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const nowMs = Date.parse("2026-07-06T12:00:00.000Z");
+      await fs.writeFile(
+        `${tmpDir}/HEARTBEAT.md`,
+        `tasks:
+  - name: check-deployment
+    interval: 5m
+    prompt: Check deployment status
+`,
+        "utf-8",
+      );
+      const cfg = createWhatsAppHeartbeatConfig({
+        tmpDir,
+        storePath,
+        heartbeat: {},
+        visibility: { showOk: true },
+      });
+      const sessionKey = await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: WHATSAPP_GROUP,
+      });
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+      const sendWhatsApp = createMessageSendSpy();
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          ...makeWhatsAppDeps({
+            sendWhatsApp,
+            nowMs: () => nowMs,
+            webAuthExists: async () => {
+              throw new Error("readiness unavailable");
+            },
+          }),
+          getReplyFromConfig: replySpy,
+        },
+      });
+
+      const sessionStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        { heartbeatTaskState?: Record<string, number> }
+      >;
+      expect(result.status).toBe("ran");
+      expect(sendWhatsApp).not.toHaveBeenCalled();
+      expect(sessionStore[sessionKey]?.heartbeatTaskState).toEqual({
+        "check-deployment": nowMs,
+      });
+    });
+  });
+
   it.each([
     {
       title: "does not deliver HEARTBEAT_OK to telegram when showOk is false",

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1914,32 +1914,37 @@ export async function runHeartbeatOnce(opts: {
     if (!canAttemptHeartbeatOk || delivery.channel === "none" || !delivery.to) {
       return false;
     }
-    const heartbeatPlugin = resolveHeartbeatChannelPlugin(delivery.channel);
-    if (heartbeatPlugin?.heartbeat?.checkReady) {
-      const readiness = await heartbeatPlugin.heartbeat.checkReady({
+    try {
+      const heartbeatPlugin = resolveHeartbeatChannelPlugin(delivery.channel);
+      if (heartbeatPlugin?.heartbeat?.checkReady) {
+        const readiness = await heartbeatPlugin.heartbeat.checkReady({
+          cfg,
+          accountId: delivery.accountId,
+          deps: opts.deps,
+        });
+        if (!readiness.ok) {
+          return false;
+        }
+      }
+      const send = await sendDurableMessageBatch({
         cfg,
+        channel: delivery.channel,
+        to: delivery.to,
         accountId: delivery.accountId,
+        threadId: delivery.threadId,
+        payloads: [{ text: resolveHeartbeatOkText() }],
+        session: outboundSession,
+        identity: outboundIdentity,
         deps: opts.deps,
       });
-      if (!readiness.ok) {
-        return false;
+      if (send.status === "failed" || send.status === "partial_failed") {
+        throw send.error;
       }
+      return true;
+    } catch (err) {
+      log.warn(`heartbeat: HEARTBEAT_OK delivery failed: ${formatErrorMessage(err)}`);
+      return false;
     }
-    const send = await sendDurableMessageBatch({
-      cfg,
-      channel: delivery.channel,
-      to: delivery.to,
-      accountId: delivery.accountId,
-      threadId: delivery.threadId,
-      payloads: [{ text: resolveHeartbeatOkText() }],
-      session: outboundSession,
-      identity: outboundIdentity,
-      deps: opts.deps,
-    });
-    if (send.status === "failed" || send.status === "partial_failed") {
-      throw send.error;
-    }
-    return true;
   };
 
   try {

--- a/src/infra/net/node-proxy-agent.test.ts
+++ b/src/infra/net/node-proxy-agent.test.ts
@@ -1,0 +1,62 @@
+// Node proxy agent tests cover shared Node HTTP(S) proxy agent construction.
+import { describe, expect, it } from "vitest";
+import { withEnv } from "../../test-utils/env.js";
+import { createNodeProxyAgent } from "./node-proxy-agent.js";
+
+const PROXY_ENV_KEYS = [
+  "http_proxy",
+  "HTTP_PROXY",
+  "https_proxy",
+  "HTTPS_PROXY",
+  "all_proxy",
+  "ALL_PROXY",
+  "no_proxy",
+  "NO_PROXY",
+] as const;
+
+function withProxyEnv<T>(
+  env: Partial<Record<(typeof PROXY_ENV_KEYS)[number], string | undefined>>,
+  fn: () => T,
+): T {
+  const clearedEnv = Object.fromEntries(PROXY_ENV_KEYS.map((key) => [key, undefined])) as Record<
+    (typeof PROXY_ENV_KEYS)[number],
+    undefined
+  >;
+  return withEnv({ ...clearedEnv, ...env }, fn);
+}
+
+describe("createNodeProxyAgent", () => {
+  it("preserves caller Node agent options on env proxy agents", () => {
+    withProxyEnv({ HTTPS_PROXY: "http://proxy.example:8080" }, () => {
+      const agent = createNodeProxyAgent({
+        mode: "env",
+        targetUrl: "https://collector.example.test/v1/traces",
+        agentOptions: {
+          keepAlive: true,
+          ca: "collector-ca",
+          cert: "collector-cert",
+          key: "collector-key",
+        },
+      });
+
+      const agentState = agent as
+        | {
+            options?: {
+              keepAlive?: boolean;
+              ca?: string;
+              cert?: string;
+              key?: string;
+            };
+            keepAlive?: boolean;
+          }
+        | undefined;
+      expect(agentState?.options).toMatchObject({
+        keepAlive: true,
+        ca: "collector-ca",
+        cert: "collector-cert",
+        key: "collector-key",
+      });
+      expect(agentState?.keepAlive).toBe(true);
+    });
+  });
+});

--- a/src/infra/net/node-proxy-agent.ts
+++ b/src/infra/net/node-proxy-agent.ts
@@ -1,9 +1,10 @@
 // Node proxy agent helpers adapt env or explicit proxy settings for libraries
 // that need node:http Agent instances.
-import type { Agent as HttpAgent } from "node:http";
+import type { Agent as HttpAgent, AgentOptions as HttpAgentOptions } from "node:http";
+import type { AgentOptions as HttpsAgentOptions } from "node:https";
 import { createRequire } from "node:module";
 import { matchesNoProxy, resolveEnvHttpProxyAgentOptions } from "./proxy-env.js";
-import { resolveActiveManagedProxyTlsOptions } from "./proxy/managed-proxy-undici.js";
+import { resolveActiveManagedProxyTlsOptions } from "./proxy/active-managed-proxy-tls.js";
 
 export const UNSUPPORTED_PROXY_PROTOCOL_MESSAGE =
   "Unsupported proxy protocol. SOCKS and PAC proxy URLs are not supported; use an HTTP or HTTPS proxy URL.";
@@ -14,6 +15,17 @@ type ProxylineCreateAmbientNodeProxyAgent =
 type ProxylineAgentOptions = NonNullable<Parameters<ProxylineCreateAmbientNodeProxyAgent>[0]>;
 type ProxylineEnvSnapshot = NonNullable<ProxylineAgentOptions["env"]>;
 type ProxylineTlsOptions = ProxylineAgentOptions["proxyTls"];
+type NodeProxyAgentOptions = HttpAgentOptions & HttpsAgentOptions;
+type NodeProxyAgentWithOptions = HttpAgent & {
+  keepAlive: boolean;
+  keepAliveMsecs: number;
+  maxFreeSockets: number;
+  maxSockets: number;
+  maxTotalSockets: number;
+  options?: NodeProxyAgentOptions;
+  scheduling?: "fifo" | "lifo";
+  timeout?: number;
+};
 
 const require = createRequire(import.meta.url);
 
@@ -23,11 +35,13 @@ export type CreateNodeProxyAgentOptions =
       mode: "env";
       targetUrl: string | URL;
       protocol?: NodeProxyProtocol;
+      agentOptions?: NodeProxyAgentOptions;
     }
   | {
       mode: "explicit";
       proxyUrl: string | URL;
       protocol?: NodeProxyProtocol;
+      agentOptions?: NodeProxyAgentOptions;
     };
 
 function inferTargetProtocol(targetUrl: string | URL): NodeProxyProtocol | undefined {
@@ -110,6 +124,38 @@ function loadCreateAmbientNodeProxyAgent(): ProxylineCreateAmbientNodeProxyAgent
     .createAmbientNodeProxyAgent;
 }
 
+function applyNodeAgentOptions(agent: HttpAgent, options: NodeProxyAgentOptions | undefined): void {
+  if (options === undefined) {
+    return;
+  }
+  const agentWithOptions = agent as NodeProxyAgentWithOptions;
+  agentWithOptions.options = {
+    ...agentWithOptions.options,
+    ...options,
+  };
+  if (typeof options.keepAlive === "boolean") {
+    agentWithOptions.keepAlive = options.keepAlive;
+  }
+  if (typeof options.keepAliveMsecs === "number") {
+    agentWithOptions.keepAliveMsecs = options.keepAliveMsecs;
+  }
+  if (typeof options.maxFreeSockets === "number") {
+    agentWithOptions.maxFreeSockets = options.maxFreeSockets;
+  }
+  if (typeof options.maxSockets === "number") {
+    agentWithOptions.maxSockets = options.maxSockets;
+  }
+  if (typeof options.maxTotalSockets === "number") {
+    agentWithOptions.maxTotalSockets = options.maxTotalSockets;
+  }
+  if (options.scheduling === "fifo" || options.scheduling === "lifo") {
+    agentWithOptions.scheduling = options.scheduling;
+  }
+  if (typeof options.timeout === "number") {
+    agentWithOptions.timeout = options.timeout;
+  }
+}
+
 /** Resolves the env proxy URL that should be used for a specific Node target. */
 export function resolveEnvNodeProxyUrlForTarget(
   targetUrl: string | URL,
@@ -136,6 +182,7 @@ function createFixedNodeProxyAgent(
   options: {
     protocol?: NodeProxyProtocol;
     proxyTls?: ProxylineTlsOptions;
+    agentOptions?: NodeProxyAgentOptions;
   } = {},
 ): HttpAgent {
   const parsedProxyUrl =
@@ -150,6 +197,7 @@ function createFixedNodeProxyAgent(
   if (agent === undefined) {
     throw new Error(`${UNSUPPORTED_PROXY_PROTOCOL_MESSAGE} Got ${parsedProxyUrl.protocol}`);
   }
+  applyNodeAgentOptions(agent as HttpAgent, options.agentOptions);
   return agent as HttpAgent;
 }
 
@@ -163,15 +211,22 @@ export function createNodeProxyAgent(
 ): HttpAgent | undefined;
 export function createNodeProxyAgent(options: CreateNodeProxyAgentOptions): HttpAgent | undefined {
   if (options.mode === "explicit") {
-    return createFixedNodeProxyAgent(options.proxyUrl, { protocol: options.protocol });
+    return createFixedNodeProxyAgent(options.proxyUrl, {
+      protocol: options.protocol,
+      agentOptions: options.agentOptions,
+    });
   }
-  return createEnvNodeProxyAgentForTarget(options.targetUrl, { protocol: options.protocol });
+  return createEnvNodeProxyAgentForTarget(options.targetUrl, {
+    protocol: options.protocol,
+    agentOptions: options.agentOptions,
+  });
 }
 
 function createEnvNodeProxyAgentForTarget(
   targetUrl: string | URL,
   options: {
     protocol?: NodeProxyProtocol;
+    agentOptions?: NodeProxyAgentOptions;
   } = {},
 ): HttpAgent | undefined {
   const proxyUrl = resolveEnvNodeProxyUrlForTarget(targetUrl);
@@ -181,6 +236,7 @@ function createEnvNodeProxyAgentForTarget(
   return createFixedNodeProxyAgent(proxyUrl, {
     protocol: options.protocol ?? inferTargetProtocol(targetUrl) ?? "https",
     proxyTls: resolveActiveManagedProxyTlsOptions({ proxyUrl: proxyUrl.href }),
+    agentOptions: options.agentOptions,
   });
 }
 

--- a/src/infra/net/proxy/active-managed-proxy-tls.ts
+++ b/src/infra/net/proxy/active-managed-proxy-tls.ts
@@ -1,0 +1,71 @@
+// Resolves OpenClaw-managed proxy TLS trust for non-Undici transports.
+import { resolveEnvHttpProxyUrl } from "../proxy-env.js";
+import { getActiveManagedProxyTlsOptions, getActiveManagedProxyUrl } from "./active-proxy-state.js";
+import {
+  loadManagedProxyTlsOptionsSync,
+  resolveManagedProxyCaFileForUrl,
+  type ManagedProxyTlsOptions,
+} from "./proxy-tls.js";
+
+type ManagedProxyTlsEnv = NodeJS.ProcessEnv;
+
+type ResolveActiveManagedProxyTlsOptionsParams = {
+  proxyUrl?: string;
+  env?: ManagedProxyTlsEnv;
+};
+
+const MANAGED_PROXY_ENV_PREFIX = ["OPENCLAW", "PROXY"].join("_");
+const MANAGED_PROXY_ACTIVE_ENV_KEY = `${MANAGED_PROXY_ENV_PREFIX}_ACTIVE`;
+const MANAGED_PROXY_CA_FILE_ENV_KEY = `${MANAGED_PROXY_ENV_PREFIX}_CA_FILE`;
+
+function normalizeProxyUrl(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  try {
+    return new URL(value).href;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveManagedProxyUrl(env: ManagedProxyTlsEnv = process.env): string | undefined {
+  const activeProxyUrl = getActiveManagedProxyUrl();
+  if (activeProxyUrl) {
+    return activeProxyUrl.href;
+  }
+  if (env[MANAGED_PROXY_ACTIVE_ENV_KEY] !== "1") {
+    return undefined;
+  }
+  // Child processes inherit only env, so recover the managed proxy URL from
+  // HTTPS proxy settings when the active in-process registration is absent.
+  return normalizeProxyUrl(resolveEnvHttpProxyUrl("https", env));
+}
+
+/** Resolves managed proxy TLS trust only when the target proxy is OpenClaw's active proxy. */
+export function resolveActiveManagedProxyTlsOptions(
+  params?: ResolveActiveManagedProxyTlsOptionsParams,
+): ManagedProxyTlsOptions | undefined {
+  const env = params?.env ?? process.env;
+  const managedProxyUrl = resolveManagedProxyUrl(env);
+  const targetProxyUrl = normalizeProxyUrl(
+    params?.proxyUrl ?? resolveEnvHttpProxyUrl("https", env),
+  );
+  if (!managedProxyUrl || targetProxyUrl !== managedProxyUrl) {
+    return undefined;
+  }
+  const activeProxyTls = getActiveManagedProxyTlsOptions();
+  if (activeProxyTls) {
+    return activeProxyTls;
+  }
+  const proxyCaFile = resolveManagedProxyCaFileForUrl({
+    proxyUrl: managedProxyUrl,
+    caFileOverride: env[MANAGED_PROXY_CA_FILE_ENV_KEY],
+  });
+  try {
+    return loadManagedProxyTlsOptionsSync(proxyCaFile);
+  } catch {
+    // Missing inherited CA files should not break non-managed or caller-owned proxies.
+    return undefined;
+  }
+}

--- a/src/infra/net/proxy/managed-proxy-undici.ts
+++ b/src/infra/net/proxy/managed-proxy-undici.ts
@@ -2,13 +2,11 @@
 // explicit ProxyAgent options without changing unrelated operator proxies.
 import { isRecord as isProxyTlsRecord } from "@openclaw/normalization-core/record-coerce";
 import type { EnvHttpProxyAgent } from "undici";
-import { resolveEnvHttpProxyAgentOptions, resolveEnvHttpProxyUrl } from "../proxy-env.js";
-import { getActiveManagedProxyTlsOptions, getActiveManagedProxyUrl } from "./active-proxy-state.js";
-import {
-  loadManagedProxyTlsOptionsSync,
-  resolveManagedProxyCaFileForUrl,
-  type ManagedProxyTlsOptions,
-} from "./proxy-tls.js";
+import { resolveEnvHttpProxyAgentOptions } from "../proxy-env.js";
+import { resolveActiveManagedProxyTlsOptions } from "./active-managed-proxy-tls.js";
+import type { ManagedProxyTlsOptions } from "./proxy-tls.js";
+
+export { resolveActiveManagedProxyTlsOptions } from "./active-managed-proxy-tls.js";
 
 type ManagedEnvHttpProxyAgentOptions = ConstructorParameters<typeof EnvHttpProxyAgent>[0];
 
@@ -39,68 +37,11 @@ function readProxyUrlFromOptions(options: object | undefined): string | undefine
   return undefined;
 }
 
-function normalizeProxyUrl(value: string | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  try {
-    return new URL(value).href;
-  } catch {
-    return undefined;
-  }
-}
-
 type ManagedProxyTlsEnv = NodeJS.ProcessEnv;
-
-type ResolveActiveManagedProxyTlsOptionsParams = {
-  proxyUrl?: string;
-  env?: ManagedProxyTlsEnv;
-};
 
 type AddActiveManagedProxyTlsOptionsParams = {
   env?: ManagedProxyTlsEnv;
 };
-
-function resolveManagedProxyUrl(env: ManagedProxyTlsEnv = process.env): string | undefined {
-  const activeProxyUrl = getActiveManagedProxyUrl();
-  if (activeProxyUrl) {
-    return activeProxyUrl.href;
-  }
-  if (env["OPENCLAW_PROXY_ACTIVE"] !== "1") {
-    return undefined;
-  }
-  // Child processes inherit only env, so recover the managed proxy URL from
-  // HTTPS proxy settings when the active in-process registration is absent.
-  return normalizeProxyUrl(resolveEnvHttpProxyUrl("https", env));
-}
-
-/** Resolves managed proxy TLS trust only when the target proxy is OpenClaw's active proxy. */
-export function resolveActiveManagedProxyTlsOptions(
-  params?: ResolveActiveManagedProxyTlsOptionsParams,
-): ManagedProxyTlsOptions | undefined {
-  const env = params?.env ?? process.env;
-  const managedProxyUrl = resolveManagedProxyUrl(env);
-  const targetProxyUrl = normalizeProxyUrl(
-    params?.proxyUrl ?? resolveEnvHttpProxyUrl("https", env),
-  );
-  if (!managedProxyUrl || targetProxyUrl !== managedProxyUrl) {
-    return undefined;
-  }
-  const activeProxyTls = getActiveManagedProxyTlsOptions();
-  if (activeProxyTls) {
-    return activeProxyTls;
-  }
-  const proxyCaFile = resolveManagedProxyCaFileForUrl({
-    proxyUrl: managedProxyUrl,
-    caFileOverride: env["OPENCLAW_PROXY_CA_FILE"],
-  });
-  try {
-    return loadManagedProxyTlsOptionsSync(proxyCaFile);
-  } catch {
-    // Missing inherited CA files should not break non-managed or caller-owned proxies.
-    return undefined;
-  }
-}
 
 /** Adds active managed proxy TLS options to env proxy agent options. */
 export function addActiveManagedProxyTlsOptions(

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -1657,12 +1657,27 @@ describe("runMessageAction plugin dispatch", () => {
   });
 
   describe("presentation-only send behavior", () => {
-    const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>
-      jsonResult({
-        ok: true,
-        presentation: params.presentation ?? null,
-        message: params.message ?? null,
-      }),
+    const handleAction = vi.fn(
+      async ({ cfg, params }: { cfg: OpenClawConfig; params: Record<string, unknown> }) => {
+        const message = typeof params.message === "string" ? params.message : "";
+        const responsePrefix = cfg.messages?.responsePrefix;
+        const rawMessage =
+          responsePrefix && message.startsWith(`${responsePrefix} `)
+            ? message.slice(responsePrefix.length + 1)
+            : message;
+        let detectedCard = false;
+        try {
+          detectedCard = isRecord((JSON.parse(rawMessage) as { body?: unknown }).body);
+        } catch {
+          // Non-JSON text remains a normal plugin message.
+        }
+        return jsonResult({
+          ok: true,
+          presentation: params.presentation ?? null,
+          message: params.message ?? null,
+          detectedCard,
+        });
+      },
     );
 
     const cardPlugin: ChannelPlugin = {
@@ -1736,6 +1751,44 @@ describe("runMessageAction plugin dispatch", () => {
         },
         "result payload",
       );
+    });
+
+    it("keeps prefixed JSON recoverable by plugin-owned card detection", async () => {
+      const cardJson = JSON.stringify({
+        body: {
+          elements: [{ tag: "markdown", content: "Card body" }],
+        },
+      });
+      const result = await runMessageAction({
+        cfg: {
+          channels: {
+            cardchat: {
+              enabled: true,
+            },
+          },
+          messages: { responsePrefix: "[Nexus]" },
+        } as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "cardchat",
+          target: "channel:test-card",
+          message: cardJson,
+        },
+        dryRun: false,
+      });
+
+      expect(result.kind).toBe("send");
+      expect(result.handledBy).toBe("plugin");
+      expectRecordFields(
+        readRecordField(result, "payload", "result payload"),
+        {
+          ok: true,
+          detectedCard: true,
+        },
+        "result payload",
+      );
+      const pluginParams = readRecordField(readFirstPluginCall(handleAction), "params", "params");
+      expect(pluginParams.message).toBe(`[Nexus] ${cardJson}`);
     });
   });
 

--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -74,6 +74,38 @@ describe("native app i18n inventory", () => {
     expect(entries.some((entry) => entry.source === "Searching…")).toBe(true);
     expect(entries.some((entry) => entry.source === "Run now")).toBe(true);
     expect(entries.some((entry) => entry.source === "Loading chat")).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.surface === "android" &&
+          entry.kind === "ui-named-argument" &&
+          entry.source === "Search OpenClaw",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.path.endsWith("/ChatMessageActions.kt") &&
+          entry.kind === "ui-named-argument" &&
+          entry.source === "Message actions",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.path.endsWith("/ChatMessageActions.kt") &&
+          entry.kind === "ui-named-argument" &&
+          entry.source === "Reply",
+      ),
+    ).toBe(true);
+    expect(
+      entries.some(
+        (entry) =>
+          entry.path.endsWith("/ChatMessageActions.kt") &&
+          entry.kind === "ui-chooser" &&
+          entry.source === "Share message",
+      ),
+    ).toBe(true);
     expect(entries.some((entry) => entry.source === "What would you like to work on?")).toBe(true);
     expect(entries.some((entry) => entry.source === "Check OpenClaw status")).toBe(true);
     expect(entries.some((entry) => entry.source === "What can I control here?")).toBe(true);

--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -38,7 +38,7 @@ export type GatewayEventFrame = {
   stateVersion?: { presence: number; health: number };
 };
 
-export type GatewayResponseFrame = {
+type GatewayResponseFrame = {
   type: "res";
   id: string;
   ok: boolean;
@@ -251,7 +251,7 @@ export type GatewayConnectClientInfo = {
   instanceId?: string;
 };
 
-export type GatewayConnectParams = {
+type GatewayConnectParams = {
   minProtocol: typeof MIN_CLIENT_PROTOCOL_VERSION;
   maxProtocol: typeof PROTOCOL_VERSION;
   client: GatewayConnectClientInfo;
@@ -309,7 +309,7 @@ export type GatewayBrowserClientOptions = {
 
 export type GatewayEventListener = (evt: GatewayEventFrame) => void;
 
-export type GatewayRequestTiming = {
+type GatewayRequestTiming = {
   id: string;
   method: string;
   ok: boolean;

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -177,12 +177,12 @@ export type GoogleChatStatus = {
   lastProbeAt?: number | null;
 };
 
-export type SlackBot = {
+type SlackBot = {
   id?: string | null;
   name?: string | null;
 };
 
-export type SlackTeam = {
+type SlackTeam = {
   id?: string | null;
   name?: string | null;
 };
@@ -265,7 +265,7 @@ export type NostrStatus = {
   profile?: NostrProfile | null;
 };
 
-export type ConfigSnapshotIssue = {
+type ConfigSnapshotIssue = {
   path: string;
   message: string;
 };
@@ -379,7 +379,7 @@ export type SessionWorkspaceFileEntry = {
   content?: string;
 };
 
-export type SessionWorkspaceBrowserEntry = {
+type SessionWorkspaceBrowserEntry = {
   path: string;
   name: string;
   kind: "file" | "directory";
@@ -388,7 +388,7 @@ export type SessionWorkspaceBrowserEntry = {
   updatedAtMs?: number;
 };
 
-export type SessionWorkspaceBrowserResult = {
+type SessionWorkspaceBrowserResult = {
   path: string;
   parentPath?: string;
   search?: string;
@@ -734,7 +734,7 @@ export type CronRunsResult = {
   hasMore?: boolean;
 };
 
-export type SkillsStatusConfigCheck = {
+type SkillsStatusConfigCheck = {
   path: string;
   satisfied: boolean;
 };
@@ -769,7 +769,7 @@ export type SkillClawHubLink =
       lockPath?: string;
     };
 
-export type SkillCardStatus = {
+type SkillCardStatus = {
   present: true;
   path: string;
   sizeBytes: number;
@@ -881,7 +881,7 @@ export type ModelAuthStatusResult =
 
 // ── Attention ───────────────────────────────────────
 
-export type AttentionSeverity = "error" | "warning" | "info";
+type AttentionSeverity = "error" | "warning" | "info";
 
 export type AttentionItem = {
   severity: AttentionSeverity;

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -32,9 +32,9 @@ export type ApplicationRouter = Router<
   AppRouteModule,
   unknown
 >;
-export type AppRoute = PageDefinition<RouteId, ApplicationContext<RouteId>, AppRouteModule>;
+type AppRoute = PageDefinition<RouteId, ApplicationContext<RouteId>, AppRouteModule>;
 
-export const APP_ROUTE_TREE = [
+const APP_ROUTE_TREE = [
   chatPage,
   overviewPage,
   activityPage,

--- a/ui/src/app/assistant-identity.ts
+++ b/ui/src/app/assistant-identity.ts
@@ -5,7 +5,7 @@ import { getSafeLocalStorage } from "../local-storage.ts";
 
 const LOCAL_ASSISTANT_IDENTITY_KEY = "openclaw.control.assistant.v1";
 
-export type LocalAssistantIdentity = { avatar: string | null; agentId?: string | null };
+type LocalAssistantIdentity = { avatar: string | null; agentId?: string | null };
 
 type PersistedLocalAssistantIdentities = {
   avatars?: Record<string, unknown>;

--- a/ui/src/app/config.ts
+++ b/ui/src/app/config.ts
@@ -62,7 +62,7 @@ function readDocumentTerminalEnabled(): boolean | null {
   return value === "true" ? true : value === "false" ? false : null;
 }
 
-export const DEFAULT_APPLICATION_CONFIG: ApplicationConfig = {
+const DEFAULT_APPLICATION_CONFIG: ApplicationConfig = {
   assistantIdentity: {
     agentId: null,
     name: "Assistant",
@@ -118,7 +118,7 @@ function applyControlUiSeamColor(value: unknown): void {
   );
 }
 
-export function normalizeApplicationConfig(parsed: ControlUiBootstrapConfig): ApplicationConfig {
+function normalizeApplicationConfig(parsed: ControlUiBootstrapConfig): ApplicationConfig {
   const identity = normalizeAssistantIdentity({
     agentId: parsed.assistantAgentId ?? null,
     name: parsed.assistantName,
@@ -155,7 +155,7 @@ export function normalizeApplicationConfig(parsed: ControlUiBootstrapConfig): Ap
   };
 }
 
-export async function loadApplicationConfig(params: {
+async function loadApplicationConfig(params: {
   basePath: string;
   auth?: ApplicationConfigAuthSource;
   skipWithoutAuthCandidate?: boolean;

--- a/ui/src/app/native-bridge.ts
+++ b/ui/src/app/native-bridge.ts
@@ -5,7 +5,7 @@ type WebView2Bridge = {
   removeEventListener(type: "message", listener: (event: MessageEvent) => void): void;
 };
 
-export type NativeBridgeMessage =
+type NativeBridgeMessage =
   | { type: "draft-text"; payload: { text: string } }
   | { type: "ready"; payload?: Record<string, unknown> };
 

--- a/ui/src/app/router-outlet.ts
+++ b/ui/src/app/router-outlet.ts
@@ -115,7 +115,7 @@ function renderError<TRouteId extends string, TLoadContext, TModule, TData>(
   `;
 }
 
-export function renderRouterOutlet<TRouteId extends string, TLoadContext, TModule, TData = unknown>(
+function renderRouterOutlet<TRouteId extends string, TLoadContext, TModule, TData = unknown>(
   router: Router<TRouteId, TLoadContext, TModule, TData>,
   selection: RouterOutletSelection<TRouteId, TModule, TData>,
   options: RouterOutletOptions<TLoadContext> = {},
@@ -283,7 +283,7 @@ class RouterOutletDirective extends AsyncDirective {
 
 const routerOutletDirective = directive(RouterOutletDirective);
 
-export function routerOutlet<TRouteId extends string, TModule, TData, TContext>(
+function routerOutlet<TRouteId extends string, TModule, TData, TContext>(
   router: Router<TRouteId, TContext, TModule, TData>,
   boundaryOptions: RouterOutletBoundaryOptions,
   options: RouterOutletOptions<TContext> = {},
@@ -291,7 +291,7 @@ export function routerOutlet<TRouteId extends string, TModule, TData, TContext>(
   return routerOutletDirective(router, options.retryContext, boundaryOptions);
 }
 
-export class OpenClawRouterOutlet<
+class OpenClawRouterOutlet<
   TRouteId extends string = string,
   TLoadContext = unknown,
   TModule = unknown,

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -147,7 +147,7 @@ type NativeControlAuth = {
   password?: string | null;
 };
 
-export type ApplicationStartupSettings = {
+type ApplicationStartupSettings = {
   settings: UiSettings;
   password: string | null;
   pendingGatewayUrl: string | null;

--- a/ui/src/app/theme-transition.ts
+++ b/ui/src/app/theme-transition.ts
@@ -7,7 +7,7 @@ export type ThemeTransitionContext = {
   pointerClientY?: number;
 };
 
-export type ThemeTransitionOptions = {
+type ThemeTransitionOptions = {
   nextTheme: ResolvedTheme;
   applyTheme: () => void;
   // Retained so callers from stacked slices can keep passing pointer metadata

--- a/ui/src/app/theme.ts
+++ b/ui/src/app/theme.ts
@@ -11,7 +11,7 @@ export type ResolvedTheme =
   | "custom"
   | "custom-light";
 
-export const VALID_THEME_NAMES = new Set<ThemeName>(["claw", "knot", "dash", "custom"]);
+const VALID_THEME_NAMES = new Set<ThemeName>(["claw", "knot", "dash", "custom"]);
 const VALID_THEME_MODES = new Set<ThemeMode>(["system", "light", "dark"]);
 
 type ThemeSelection = { theme: ThemeName; mode: ThemeMode };

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -36,7 +36,7 @@ export type AgentToolSection = {
   tools: AgentToolEntry[];
 };
 
-export const FALLBACK_TOOL_SECTIONS: AgentToolSection[] = [
+const FALLBACK_TOOL_SECTIONS: AgentToolSection[] = [
   {
     id: "fs",
     label: "Files",

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -90,7 +90,7 @@ export async function loadAgentsList(client: GatewayBrowserClient): Promise<Agen
   return client.request<AgentsListResult>("agents.list", {});
 }
 
-export async function loadAgentFilesList(
+async function loadAgentFilesList(
   client: GatewayBrowserClient,
   agentId: string,
 ): Promise<AgentsFilesListResult | null> {

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -48,9 +48,7 @@ export type ChannelCapability = {
   dispose: () => void;
 };
 
-export function createInitialChannelsState(
-  snapshot: Partial<ChannelGatewaySnapshot> = {},
-): ChannelsState {
+function createInitialChannelsState(snapshot: Partial<ChannelGatewaySnapshot> = {}): ChannelsState {
   return {
     client: snapshot.client ?? null,
     connected: snapshot.connected ?? false,

--- a/ui/src/lib/chat/model-ref.ts
+++ b/ui/src/lib/chat/model-ref.ts
@@ -242,7 +242,7 @@ export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<str
   return displayLookup;
 }
 
-export function formatCatalogEntryDisplay(
+function formatCatalogEntryDisplay(
   entry: ModelCatalogEntry,
   displayLookup: ChatModelDisplayLookup,
 ): string {

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -29,7 +29,7 @@ export type ChatModelSelectOption = {
   label: string;
 };
 
-export type ChatModelSelectState = {
+type ChatModelSelectState = {
   currentOverride: string;
   defaultModel: string;
   defaultDisplay: string;

--- a/ui/src/lib/chat/thinking.ts
+++ b/ui/src/lib/chat/thinking.ts
@@ -78,7 +78,7 @@ export function resolveThinkingDefaultForModel(params: {
 
 type ThinkingSessionDefaults = SessionsListResult["defaults"] | undefined;
 
-export type ChatThinkingSelectState = {
+type ChatThinkingSelectState = {
   currentOverride: string;
   defaultLabel: string;
   defaultValue: string;

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -521,7 +521,7 @@ export async function patchConfig(
   }
 }
 
-export async function lookupConfigSchemaPath(
+async function lookupConfigSchemaPath(
   state: { client: ConfigGatewayClient | null; connected: boolean },
   path: string,
 ): Promise<unknown> {
@@ -659,7 +659,7 @@ export function resetConfigPendingChanges(state: ConfigState) {
   autoAllowlistedPluginIdsByState.delete(state);
 }
 
-export function removeConfigFormValue(state: ConfigState, path: Array<string | number>) {
+function removeConfigFormValue(state: ConfigState, path: Array<string | number>) {
   mutateConfigForm(state, (draft) => removePathValue(draft, path));
 }
 

--- a/ui/src/lib/cron-status.ts
+++ b/ui/src/lib/cron-status.ts
@@ -1,7 +1,7 @@
 // Control UI module implements cron status behavior.
 import type { CronJob, CronRunStatus } from "../api/types.ts";
 
-export type CronJobLastRunStatus = CronRunStatus | "unknown";
+type CronJobLastRunStatus = CronRunStatus | "unknown";
 
 export function resolveCronJobLastRunStatus(job: CronJob): CronJobLastRunStatus {
   return job.state?.lastRunStatus ?? job.state?.lastStatus ?? "unknown";

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -93,7 +93,7 @@ export function getCronJobPayload(job: CronJob): CronPayload | null {
   return isCronPayload(payload) ? payload : null;
 }
 
-export function hasCronJobPayload(job: CronJob): boolean {
+function hasCronJobPayload(job: CronJob): boolean {
   return getCronJobPayload(job) !== null;
 }
 
@@ -155,7 +155,7 @@ export type CronFieldErrors = Partial<Record<CronFieldKey, string>>;
 
 export type CronJobsScheduleKindFilter = "all" | "at" | "every" | "cron" | "on-exit";
 export type CronJobsLastStatusFilter = "all" | CronRunStatus | "unknown";
-export type CronRunsLoadStatus = "ok" | "error" | "skipped";
+type CronRunsLoadStatus = "ok" | "error" | "skipped";
 
 export type CronState = {
   client: GatewayBrowserClient | null;

--- a/ui/src/lib/gateway-diagnostics.ts
+++ b/ui/src/lib/gateway-diagnostics.ts
@@ -1,7 +1,7 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { HealthSnapshot, StatusSummary } from "../api/types.ts";
 
-export type GatewayDiagnosticsSnapshot = {
+type GatewayDiagnosticsSnapshot = {
   status: StatusSummary;
   health: HealthSnapshot;
   models: unknown[];

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -14,7 +14,7 @@ type GatewayRequestClient = {
   request<T = unknown>(method: string, params?: unknown): Promise<T>;
 };
 
-export type NodesGatewaySnapshot = {
+type NodesGatewaySnapshot = {
   client: GatewayRequestClient | null;
   connected: boolean;
 };

--- a/ui/src/lib/open-external-url.ts
+++ b/ui/src/lib/open-external-url.ts
@@ -56,7 +56,7 @@ export function resolveSafeExternalUrl(
   }
 }
 
-export type OpenExternalUrlSafeOptions = ResolveSafeExternalUrlOptions & {
+type OpenExternalUrlSafeOptions = ResolveSafeExternalUrlOptions & {
   baseHref?: string;
 };
 

--- a/ui/src/lib/overview-hints.ts
+++ b/ui/src/lib/overview-hints.ts
@@ -36,7 +36,7 @@ const INSECURE_CONTEXT_CODES = new Set<string>([
 
 type AuthHintKind = "required" | "failed";
 
-export type PairingHint =
+type PairingHint =
   | {
       kind: "pairing-required";
       requestId: string | null;

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -16,7 +16,7 @@ const CHANNEL_LABELS: Record<string, string> = {
 const KNOWN_CHANNEL_KEYS = Object.keys(CHANNEL_LABELS);
 
 /** Parsed type / context extracted from a session key. */
-export type SessionKeyInfo = {
+type SessionKeyInfo = {
   /** Prefix for typed sessions (Subagent:/Cron:). Empty for others. */
   prefix: string;
   /** Human-readable fallback when no label / displayName is available. */

--- a/ui/src/lib/sessions/grouping.ts
+++ b/ui/src/lib/sessions/grouping.ts
@@ -47,7 +47,7 @@ function dateBucketId(updatedAt: number | null | undefined, now: number): string
   return "older";
 }
 
-export function sessionRowChannel(row: GatewaySessionRow): string {
+function sessionRowChannel(row: GatewaySessionRow): string {
   return row.channel ?? parseSessionKeyParts(row.key)?.channel ?? UNGROUPED_ID;
 }
 

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -273,7 +273,7 @@ function buildSessionListParams(options: SessionListOptions = {}): Record<string
   return params;
 }
 
-export async function requestSessionList(
+async function requestSessionList(
   client: SessionRequestClient,
   options: SessionListOptions = {},
 ): Promise<SessionsListResult | null> {
@@ -284,7 +284,7 @@ export async function requestSessionList(
   return result ?? null;
 }
 
-export function requestSessionPatch(
+function requestSessionPatch(
   client: SessionRequestClient,
   key: string,
   patch: SessionPatch,
@@ -307,7 +307,7 @@ export function requestSessionDelete(
   });
 }
 
-export function requestSessionReset(
+function requestSessionReset(
   client: SessionRequestClient,
   key: string,
   options: SessionResetOptions = {},
@@ -319,7 +319,7 @@ export function requestSessionReset(
     .then(() => undefined);
 }
 
-export function requestSessionCompact(
+function requestSessionCompact(
   client: SessionRequestClient,
   key: string,
   options: { agentId?: string | null } = {},
@@ -329,7 +329,7 @@ export function requestSessionCompact(
   });
 }
 
-export function requestSessionSteer(
+function requestSessionSteer(
   client: SessionRequestClient,
   key: string,
   message: string,
@@ -341,7 +341,7 @@ export function requestSessionSteer(
   });
 }
 
-export function requestSessionFilesList(
+function requestSessionFilesList(
   client: SessionRequestClient,
   key: string,
   options: { agentId?: string | null; path?: string; search?: string } = {},
@@ -354,7 +354,7 @@ export function requestSessionFilesList(
   });
 }
 
-export function requestSessionFile(
+function requestSessionFile(
   client: SessionRequestClient,
   key: string,
   path: string,
@@ -367,11 +367,11 @@ export function requestSessionFile(
   });
 }
 
-export function subscribeSessionGateway(client: SessionRequestClient): Promise<void> {
+function subscribeSessionGateway(client: SessionRequestClient): Promise<void> {
   return client.request("sessions.subscribe", {}).then(() => undefined);
 }
 
-export async function subscribeSessionMessages(
+async function subscribeSessionMessages(
   client: SessionRequestClient,
   key: string,
   options: { agentId?: string | null } = {},
@@ -401,7 +401,7 @@ export function unsubscribeSessionMessages(
     .then(() => undefined);
 }
 
-export async function listSessionCheckpoints(
+async function listSessionCheckpoints(
   client: SessionRequestClient,
   key: string,
   options: { agentId?: string | null } = {},
@@ -412,7 +412,7 @@ export async function listSessionCheckpoints(
   );
 }
 
-export function branchSessionCheckpoint(
+function branchSessionCheckpoint(
   client: SessionRequestClient,
   key: string,
   checkpointId: string,
@@ -424,7 +424,7 @@ export function branchSessionCheckpoint(
   });
 }
 
-export function restoreSessionCheckpoint(
+function restoreSessionCheckpoint(
   client: SessionRequestClient,
   key: string,
   checkpointId: string,

--- a/ui/src/lib/skill-workshop/index.ts
+++ b/ui/src/lib/skill-workshop/index.ts
@@ -5,7 +5,7 @@ export type SkillWorkshopProposalStatus =
   | "quarantined"
   | "stale";
 
-export type SkillWorkshopFile = {
+type SkillWorkshopFile = {
   path: string;
   size: string;
   contents: string;

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -176,7 +176,7 @@ function currentSkillCardCacheKey(state: SkillsState, skillKey: string): string 
   return skill ? skillCardCacheKey(skill) : undefined;
 }
 
-export function skillsAgentParams(agentId: string | null | undefined): { agentId?: string } {
+function skillsAgentParams(agentId: string | null | undefined): { agentId?: string } {
   const normalized = agentId?.trim();
   return normalized ? { agentId: normalized } : {};
 }

--- a/ui/src/lib/workboard/index.ts
+++ b/ui/src/lib/workboard/index.ts
@@ -279,7 +279,7 @@ export type WorkboardCard = {
   metadata?: WorkboardMetadata;
 };
 
-export type WorkboardLifecycleState =
+type WorkboardLifecycleState =
   | "unlinked"
   | "missing"
   | "idle"

--- a/ui/src/pages/activity/activity-page.ts
+++ b/ui/src/pages/activity/activity-page.ts
@@ -18,7 +18,7 @@ import { renderActivity } from "./view.ts";
 
 let activityClearBoundary: EventLogEntry | undefined;
 
-export class ActivityPage extends LitElement {
+class ActivityPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/activity/tool-activity.ts
+++ b/ui/src/pages/activity/tool-activity.ts
@@ -1,8 +1,8 @@
 // Control UI module implements activity model behavior.
 import { formatUnknownText, truncateText } from "../../lib/format.ts";
 
-export const ACTIVITY_ENTRY_LIMIT = 100;
-export const ACTIVITY_OUTPUT_PREVIEW_LIMIT = 2_000;
+const ACTIVITY_ENTRY_LIMIT = 100;
+const ACTIVITY_OUTPUT_PREVIEW_LIMIT = 2_000;
 
 export type ActivityStatus = "running" | "done" | "error";
 

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -49,7 +49,7 @@ export type AgentsRouteData = {
   error: string | null;
 };
 
-export class AgentsPage extends LitElement implements AgentsState {
+class AgentsPage extends LitElement implements AgentsState {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/agents/view.ts
+++ b/ui/src/pages/agents/view.ts
@@ -63,7 +63,7 @@ export type AgentSkillsState = {
   filter: string;
 };
 
-export type ToolsCatalogState = {
+type ToolsCatalogState = {
   loading: boolean;
   error: string | null;
   result: ToolsCatalogResult | null;

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -37,7 +37,7 @@ function buildNostrProfileUrl(accountId: string, suffix = ""): string {
   return `/api/channels/nostr/${encodeURIComponent(accountId)}/profile${suffix}`;
 }
 
-export class ChannelsPage extends LitElement {
+class ChannelsPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/channels/view.config.ts
+++ b/ui/src/pages/channels/view.config.ts
@@ -89,7 +89,7 @@ function renderExtraChannelFields(value: Record<string, unknown>) {
   `;
 }
 
-export function renderChannelConfigForm(props: ChannelConfigFormProps) {
+function renderChannelConfigForm(props: ChannelConfigFormProps) {
   const analysis = analyzeConfigSchema(props.schema);
   const normalized = analysis.schema;
   if (!normalized) {

--- a/ui/src/pages/channels/view.shared.ts
+++ b/ui/src/pages/channels/view.shared.ts
@@ -26,7 +26,7 @@ function resolveChannelStatus(
   return channels?.[key] as Record<string, unknown> | undefined;
 }
 
-export function resolveDefaultChannelAccount(
+function resolveDefaultChannelAccount(
   key: ChannelKey,
   props: ChannelsProps,
 ): ChannelAccountSnapshot | null {
@@ -131,7 +131,7 @@ export function renderSingleAccountChannelCard(params: {
   `;
 }
 
-export function getChannelAccountCount(
+function getChannelAccountCount(
   key: ChannelKey,
   channelAccounts?: Record<string, ChannelAccountSnapshot[]> | null,
 ): number {

--- a/ui/src/pages/chat/chat-commands.ts
+++ b/ui/src/pages/chat/chat-commands.ts
@@ -36,7 +36,7 @@ export type ChatCommandResetOptions = {
   restoreDraft?: boolean;
 };
 
-export type ChatCommandSendOptions = ChatCommandResetOptions & {
+type ChatCommandSendOptions = ChatCommandResetOptions & {
   sendResetMessage: (message: string, opts: ChatCommandResetOptions) => Promise<void>;
 };
 

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -96,7 +96,7 @@ const NEW_SESSION_LIST_LOADING_MESSAGE =
 const NEW_SESSION_CREATE_FAILED_MESSAGE =
   "New Chat could not create a new session. Try again in a moment.";
 
-export class ChatPage extends LitElement {
+class ChatPage extends LitElement {
   @consume({ context: applicationContext, subscribe: false })
   private context!: ChatPageContext;
   @property({ attribute: false }) data!: ChatRouteData;

--- a/ui/src/pages/chat/chat-send.ts
+++ b/ui/src/pages/chat/chat-send.ts
@@ -335,7 +335,7 @@ export async function requestSkillWorkshopRevisionChatSend(
   return normalizeChatSendAck(payload, params.runId);
 }
 
-export function appendUserChatMessage(
+function appendUserChatMessage(
   state: ChatState,
   message: string,
   attachments?: ChatAttachment[],

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -59,7 +59,7 @@ const COMPOSER_CHROME_INTERACTIVE_SELECTOR = [
 ].join(",");
 const SLASH_MENU_LISTBOX_ID = "chat-slash-menu-listbox";
 const SLASH_MENU_ACTIVE_ANNOUNCEMENT_ID = "chat-slash-active-announcement";
-export const CHAT_ATTACHMENT_ACCEPT =
+const CHAT_ATTACHMENT_ACCEPT =
   "image/*,audio/*,application/pdf,text/*,.csv,.json,.md,.txt,.zip," +
   ".doc,.docx,.xls,.xlsx,.ppt,.pptx";
 
@@ -870,7 +870,7 @@ export type ChatAttachmentControlsProps = {
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
 };
 
-export type ChatQueueProps = {
+type ChatQueueProps = {
   queue: ChatQueueItem[];
   canAbort?: boolean;
   onQueueRetry?: (id: string) => void;
@@ -1014,7 +1014,7 @@ function isSupportedChatAttachmentFile(file: Pick<File, "name" | "type">): boole
   return !/\.(?:avi|m4v|mov|mp4|mpeg|mpg|webm)$/i.test(file.name);
 }
 
-export function clickComposerFileInput(event: MouseEvent) {
+function clickComposerFileInput(event: MouseEvent) {
   const target = event.currentTarget;
   if (!(target instanceof HTMLElement)) {
     return;
@@ -1069,7 +1069,7 @@ function isImageAttachment(att: ChatAttachment): boolean {
   return att.mimeType.startsWith("image/");
 }
 
-export function handleChatAttachmentPaste(e: ClipboardEvent, props: ChatAttachmentControlsProps) {
+function handleChatAttachmentPaste(e: ClipboardEvent, props: ChatAttachmentControlsProps) {
   const items = e.clipboardData?.items;
   if (!items || !props.onAttachmentsChange) {
     return;
@@ -1110,7 +1110,7 @@ export function handleChatAttachmentPaste(e: ClipboardEvent, props: ChatAttachme
   }
 }
 
-export function handleChatAttachmentFileSelect(e: Event, props: ChatAttachmentControlsProps) {
+function handleChatAttachmentFileSelect(e: Event, props: ChatAttachmentControlsProps) {
   const input = e.target as HTMLInputElement;
   if (!input.files || !props.onAttachmentsChange) {
     return;
@@ -1162,7 +1162,7 @@ export function handleChatAttachmentDrop(e: DragEvent, props: ChatAttachmentCont
   }
 }
 
-export function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
+function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
   const attachments = props.attachments ?? [];
   if (attachments.length === 0) {
     return nothing;
@@ -1212,7 +1212,7 @@ export function renderAttachmentPreview(props: ChatAttachmentControlsProps) {
   `;
 }
 
-export type ComposerRunStatus =
+type ComposerRunStatus =
   | ChatRunUiStatus
   | {
       phase: "in-progress";
@@ -1321,7 +1321,7 @@ export function renderFallbackIndicator(status: FallbackStatus | null | undefine
   `;
 }
 
-export type ContextNoticeOptions = {
+type ContextNoticeOptions = {
   compactBusy?: boolean;
   compactDisabled?: boolean;
   messages?: unknown[];

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -76,7 +76,7 @@ const ASSISTANT_ATTACHMENT_UNAVAILABLE_RETRY_MS = 5_000;
 const ASSISTANT_ATTACHMENT_MEDIA_TICKET_REFRESH_SKEW_MS = 30_000;
 let assistantAttachmentAvailabilityRenderVersion = 0;
 
-export type ChatTimestampDisplay = {
+type ChatTimestampDisplay = {
   label: string;
   title: string;
   dateTime: string;
@@ -548,7 +548,7 @@ function extractTranscriptAttachments(message: unknown): AttachmentItem[] {
 }
 
 /** A contiguous run of in-flight streaming items rendered under one assistant group. */
-export type StreamGroupPart = Extract<ChatItem, { kind: "stream" } | { kind: "reading-indicator" }>;
+type StreamGroupPart = Extract<ChatItem, { kind: "stream" } | { kind: "reading-indicator" }>;
 
 type StreamGroupOptions = {
   onOpenSidebar?: (content: SidebarContent) => void;

--- a/ui/src/pages/chat/components/chat-realtime-controls.ts
+++ b/ui/src/pages/chat/components/chat-realtime-controls.ts
@@ -30,7 +30,7 @@ export type RealtimeTalkOptions = {
   vadThreshold: string;
 };
 
-export type ChatRealtimeTalkOptionsProps = {
+type ChatRealtimeTalkOptionsProps = {
   realtimeTalkOptionsOpen?: boolean;
   realtimeTalkOptions?: RealtimeTalkOptions;
   onRealtimeTalkOptionsChange?: (next: Partial<RealtimeTalkOptions>) => void;
@@ -38,7 +38,7 @@ export type ChatRealtimeTalkOptionsProps = {
   onOpenRealtimeTalkSettings?: () => void;
 };
 
-export type ChatRealtimeTalkConversationProps = {
+type ChatRealtimeTalkConversationProps = {
   assistantName: string;
   userName?: string | null;
   realtimeTalkConversation?: RealtimeTalkConversationEntry[];

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -55,7 +55,7 @@ type OpenRequest = {
   sessionKey: string;
 };
 
-export type SessionWorkspaceOpenRequest = OpenRequest;
+type SessionWorkspaceOpenRequest = OpenRequest;
 
 export type SessionWorkspaceHost = {
   sessionKey: string;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -101,7 +101,7 @@ export type ChatThreadProps = {
   onFocusComposer?: () => void;
 };
 
-export type ChatPinnedMessagesProps = Pick<
+type ChatPinnedMessagesProps = Pick<
   ChatThreadProps,
   "sessionKey" | "messages" | "userName" | "userAvatar"
 >;

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -186,7 +186,7 @@ export function renderToolPreview(
   `;
 }
 
-export function buildSidebarContent(
+function buildSidebarContent(
   value: string,
   options?: {
     rawText?: string | null;
@@ -201,7 +201,7 @@ export function buildSidebarContent(
   };
 }
 
-export function buildPreviewSidebarContent(
+function buildPreviewSidebarContent(
   preview: ToolPreview,
   rawText?: string | null,
   options?: { fullMessageRequest?: FullMessageRequest },
@@ -308,7 +308,7 @@ export function resolveCollapsedToolDetail(card: ToolCard, displayDetail: string
   return formatCollapsedToolPreviewText(inputText);
 }
 
-export function resolveCollapsedToolSummaryParts(params: {
+function resolveCollapsedToolSummaryParts(params: {
   card: ToolCard;
   displayLabel: string;
   displayDetail: string | undefined;

--- a/ui/src/pages/chat/composer-persistence.ts
+++ b/ui/src/pages/chat/composer-persistence.ts
@@ -17,7 +17,7 @@ import type { RealtimeTalkOptions } from "./components/chat-realtime-controls.ts
 const STORAGE_KEY_PREFIX = "openclaw.control.chatComposer.v1:";
 const MAX_STORED_SESSIONS = 20;
 const MAX_STORED_QUEUE_ITEMS = 50;
-export const CHAT_COMPOSER_DRAFT_PERSIST_DELAY_MS = 200;
+const CHAT_COMPOSER_DRAFT_PERSIST_DELAY_MS = 200;
 export const INTERRUPTED_MODEL_WAIT_ERROR =
   "Model selection was interrupted. Review and retry when ready.";
 

--- a/ui/src/pages/chat/realtime-talk-audio.ts
+++ b/ui/src/pages/chat/realtime-talk-audio.ts
@@ -28,7 +28,7 @@ export function floatToPcm16(samples: Float32Array): Uint8Array {
   return bytes;
 }
 
-export function pcm16ToFloat(bytes: Uint8Array): Float32Array {
+function pcm16ToFloat(bytes: Uint8Array): Float32Array {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const samples = new Float32Array(Math.floor(bytes.byteLength / 2));
   for (let i = 0; i < samples.length; i += 1) {

--- a/ui/src/pages/chat/realtime-talk-conversation.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.ts
@@ -17,7 +17,7 @@ export type RealtimeTalkConversationState = {
   assistantEntryId: string | null;
 };
 
-export type RealtimeTalkTranscriptUpdate = {
+type RealtimeTalkTranscriptUpdate = {
   role: RealtimeTalkConversationRole;
   text: string;
   final: boolean;

--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -78,7 +78,7 @@ export type RealtimeTalkGatewayRelaySessionResult = {
   consultFastMode?: boolean;
 };
 
-export type RealtimeTalkManagedRoomSessionResult = {
+type RealtimeTalkManagedRoomSessionResult = {
   provider: string;
   transport: "managed-room";
   roomUrl: string;

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -18,7 +18,7 @@ export type ChatRunUiStatus = {
   occurredAt: number;
 };
 
-export type LocalTerminalReconcile = {
+type LocalTerminalReconcile = {
   sessionKey: string;
   runId: string | null;
   phase: ChatRunUiStatus["phase"];
@@ -112,7 +112,7 @@ export function isChatStopCommand(text: string) {
   return CHAT_STOP_COMMANDS.has(normalizeLowercaseStringOrEmpty(text.trim()));
 }
 
-export type ChatAbortOptions = { preserveDraft?: boolean };
+type ChatAbortOptions = { preserveDraft?: boolean };
 
 export async function abortChatRun(state: ChatAbortRunState): Promise<boolean> {
   if (!state.client || !state.connected) {

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -20,7 +20,7 @@ export type AgentEventPayload = {
   data: Record<string, unknown>;
 };
 
-export type SessionOperationEventPayload = {
+type SessionOperationEventPayload = {
   operationId?: string;
   operation?: string;
   phase?: string;
@@ -289,7 +289,7 @@ export function flushToolStreamSync(host: ToolStreamHost) {
   syncToolStreamMessages(host);
 }
 
-export function scheduleToolStreamSync(host: ToolStreamHost, force = false) {
+function scheduleToolStreamSync(host: ToolStreamHost, force = false) {
   if (force) {
     flushToolStreamSync(host);
     return;
@@ -427,7 +427,7 @@ export function handleSessionOperationEvent(
   compactionHost.compactionStatus = null;
 }
 
-export function handleCompactionEvent(host: CompactionHost, payload: AgentEventPayload) {
+function handleCompactionEvent(host: CompactionHost, payload: AgentEventPayload) {
   const data = payload.data ?? {};
   const phase = typeof data.phase === "string" ? data.phase : "";
   const completed = data.completed === true;

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -216,7 +216,7 @@ function quickChannels(config: unknown): QuickSettingsChannel[] {
   });
 }
 
-export function extractQuickSettingsSecurity(config: unknown): QuickSettingsSecurity {
+function extractQuickSettingsSecurity(config: unknown): QuickSettingsSecurity {
   const root =
     asConfigRecord((config as { configForm?: unknown } | null)?.configForm) ??
     asConfigRecord(config);

--- a/ui/src/pages/config/presets.ts
+++ b/ui/src/pages/config/presets.ts
@@ -5,7 +5,7 @@
 
 export type ConfigPresetId = "personal" | "codeAgent" | "teamBot" | "minimal";
 
-export type ConfigPresetPatch = {
+type ConfigPresetPatch = {
   agents: {
     defaults: {
       bootstrapMaxChars: number;

--- a/ui/src/pages/config/quick.ts
+++ b/ui/src/pages/config/quick.ts
@@ -40,7 +40,7 @@ export type QuickSettingsChannel = {
   detail?: string;
 };
 
-export type QuickSettingsAutomation = {
+type QuickSettingsAutomation = {
   cronJobCount: number;
   skillCount: number;
   mcpServerCount: number;

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -46,7 +46,7 @@ const TEXT_SCALE_LABELS: Record<TextScaleStop, string> = {
   140: "XXL",
 };
 
-export type WebPushUiState = {
+type WebPushUiState = {
   supported: boolean;
   permission: NotificationPermission | "unsupported";
   subscribed: boolean;

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -55,7 +55,7 @@ function unique(values: string[]): string[] {
   return sortUniqueStrings(values.map((value) => value.trim()).filter(Boolean));
 }
 
-export class CronPage extends LitElement {
+class CronPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/debug/debug-page.ts
+++ b/ui/src/pages/debug/debug-page.ts
@@ -12,7 +12,7 @@ import { renderDebug } from "./view.ts";
 
 const DEBUG_POLL_INTERVAL_MS = 3000;
 
-export class DebugPage extends LitElement {
+class DebugPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/dreams/dreams-page.ts
+++ b/ui/src/pages/dreams/dreams-page.ts
@@ -97,7 +97,7 @@ function readWikiPagePreview(value: unknown, lookup: string): WikiPagePreview {
   };
 }
 
-export class DreamsPage extends LitElement {
+class DreamsPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/instances/instances-page.ts
+++ b/ui/src/pages/instances/instances-page.ts
@@ -21,7 +21,7 @@ function readPresence(value: unknown): PresenceEntry[] | null {
   return Array.isArray(presence) ? (presence as PresenceEntry[]) : null;
 }
 
-export class InstancesPage extends LitElement {
+class InstancesPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/instances/view.ts
+++ b/ui/src/pages/instances/view.ts
@@ -6,7 +6,7 @@ import "../../components/tooltip.ts";
 import { t } from "../../i18n/index.ts";
 import { formatPresenceAge } from "../../lib/presenter.ts";
 
-export type InstancesProps = {
+type InstancesProps = {
   loading: boolean;
   entries: PresenceEntry[];
   lastError: string | null;

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -20,7 +20,7 @@ import { renderLogs } from "./view.ts";
 const LOG_BUFFER_LIMIT = 2000;
 const LOGS_POLL_INTERVAL_MS = 2000;
 
-export class LogsPage extends LitElement {
+class LogsPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/nodes/nodes-page.ts
+++ b/ui/src/pages/nodes/nodes-page.ts
@@ -32,7 +32,7 @@ export type NodesRouteData = {
 
 const NODES_ACTIVE_POLL_INTERVAL_MS = 30_000;
 
-export class NodesPage extends LitElement implements NodesPageDataState {
+class NodesPage extends LitElement implements NodesPageDataState {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/nodes/view-pairing.ts
+++ b/ui/src/pages/nodes/view-pairing.ts
@@ -8,7 +8,7 @@ import type { DevicePairSetup } from "../../lib/device-pair-setup.ts";
 const PAIRING_DOCS_URL =
   "https://docs.openclaw.ai/channels/pairing#pair-from-the-control-ui-recommended";
 
-export type DevicePairSetupProps = {
+type DevicePairSetupProps = {
   open: boolean;
   loading: boolean;
   error: string | null;

--- a/ui/src/pages/overview/attention.ts
+++ b/ui/src/pages/overview/attention.ts
@@ -5,7 +5,7 @@ import { icons, type IconName } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../../lib/external-link.ts";
 
-export type OverviewAttentionProps = {
+type OverviewAttentionProps = {
   items: AttentionItem[];
 };
 

--- a/ui/src/pages/overview/event-log.ts
+++ b/ui/src/pages/overview/event-log.ts
@@ -6,7 +6,7 @@ import { t } from "../../i18n/index.ts";
 import { formatTimeMs } from "../../lib/format.ts";
 import { formatEventPayload } from "../../lib/presenter.ts";
 
-export type OverviewEventLogProps = {
+type OverviewEventLogProps = {
   events: readonly EventLogEntry[];
 };
 

--- a/ui/src/pages/overview/log-tail.ts
+++ b/ui/src/pages/overview/log-tail.ts
@@ -15,7 +15,7 @@ function stripAnsi(text: string): string {
   return text.replace(OSC8_LINK_RE, "").replace(SGR_RE, "");
 }
 
-export type OverviewLogTailProps = {
+type OverviewLogTailProps = {
   lines: string[];
   onRefreshLogs: () => void;
 };

--- a/ui/src/pages/overview/overview-page.ts
+++ b/ui/src/pages/overview/overview-page.ts
@@ -56,7 +56,7 @@ function addNamedAttention(
   }
 }
 
-export class OverviewPage extends LitElement {
+class OverviewPage extends LitElement {
   readonly i18nController = new I18nController(this);
 
   override createRenderRoot() {

--- a/ui/src/pages/plugin/logbook-controller.ts
+++ b/ui/src/pages/plugin/logbook-controller.ts
@@ -21,7 +21,7 @@ export type LogbookStatusPayload = {
   timeZone: string;
 };
 
-export type LogbookDistractionPayload = { startMs: number; endMs: number; title: string };
+type LogbookDistractionPayload = { startMs: number; endMs: number; title: string };
 
 export type LogbookCardPayload = {
   id: number;
@@ -38,7 +38,7 @@ export type LogbookCardPayload = {
   keyframeId?: number;
 };
 
-export type LogbookDayStatsPayload = {
+type LogbookDayStatsPayload = {
   trackedMs: number;
   distractionMs: number;
   categories: Array<{ category: string; ms: number }>;

--- a/ui/src/pages/plugin/logbook-view.ts
+++ b/ui/src/pages/plugin/logbook-view.ts
@@ -22,7 +22,7 @@ import {
   type LogbookUiState,
 } from "./logbook-controller.ts";
 
-export type LogbookProps = {
+type LogbookProps = {
   host: object;
   client: GatewayBrowserClient | null;
   connected: boolean;

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -72,7 +72,7 @@ function parseFilterInteger(value: string): number | undefined {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
 }
 
-export class SessionsPage extends LitElement {
+class SessionsPage extends LitElement {
   @consume({ context: applicationContext, subscribe: false })
   private context?: ApplicationContext;
 

--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -186,7 +186,7 @@ function renderSkillWorkshopHeaderControls(state: SkillWorkshopState, requestUpd
   `;
 }
 
-export function renderSkillWorkshopPage(
+function renderSkillWorkshopPage(
   state: SkillWorkshopState,
   { context, workshopAgentName, onRevisionRequest }: SkillWorkshopRenderContext,
   requestUpdate: () => void,
@@ -339,7 +339,7 @@ export function renderSkillWorkshopPage(
   `;
 }
 
-export class SkillWorkshopPage extends LitElement {
+class SkillWorkshopPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -35,7 +35,7 @@ export type SkillsRouteData = {
   error: string | null;
 };
 
-export class SkillsPage extends LitElement {
+class SkillsPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/usage/types.ts
+++ b/ui/src/pages/usage/types.ts
@@ -25,7 +25,7 @@ export type UsageColumnId =
 
 export type TimeSeriesPoint = SessionUsageTimePoint;
 
-export type UsageDataState = {
+type UsageDataState = {
   loading: boolean;
   error: string | null;
   sessions: UsageSessionEntry[];
@@ -51,7 +51,7 @@ export type UsageFilterState = {
   timeZone: "local" | "utc";
 };
 
-export type UsageDisplayState = {
+type UsageDisplayState = {
   chartMode: "tokens" | "cost";
   dailyChartMode: "total" | "by-type";
   sessionSort: "tokens" | "cost" | "recent" | "messages" | "errors";
@@ -63,7 +63,7 @@ export type UsageDisplayState = {
   headerPinned: boolean;
 };
 
-export type UsageDetailState = {
+type UsageDetailState = {
   timeSeriesMode: "cumulative" | "per-turn";
   timeSeriesBreakdownMode: "total" | "by-type";
   timeSeries: { points: TimeSeriesPoint[] } | null;
@@ -81,7 +81,7 @@ export type UsageDetailState = {
   };
 };
 
-export type UsageCallbacks = {
+type UsageCallbacks = {
   filters: {
     onStartDateChange: (date: string) => void;
     onEndDateChange: (date: string) => void;

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -79,7 +79,7 @@ function toErrorMessage(error: unknown): string {
   return "request failed";
 }
 
-export class UsagePage extends LitElement {
+class UsagePage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/workboard/workboard-page.ts
+++ b/ui/src/pages/workboard/workboard-page.ts
@@ -14,7 +14,7 @@ import {
 } from "../../lib/workboard/index.ts";
 import { renderWorkboard } from "./view.ts";
 
-export class WorkboardPage extends LitElement {
+class WorkboardPage extends LitElement {
   override createRenderRoot() {
     return this;
   }

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -14,7 +14,7 @@ function repoName(repoRoot: string): string {
   return repoRoot.split(/[\\/]/).findLast(Boolean) ?? repoRoot;
 }
 
-export class WorktreesPage extends LitElement {
+class WorktreesPage extends LitElement {
   override createRenderRoot() {
     return this;
   }


### PR DESCRIPTION
Fixes #53486.

## What Problem This Solves

Feishu `message(action=send)` and thread replies rendered valid native interactive-card JSON from the plain `message` or `text` parameter as raw text. This also affected the real runtime path where `messages.responsePrefix` is applied before plugin dispatch.

## Why This Change Was Made

Feishu now detects and sanitizes supported native card JSON locally, including v2 `body.elements`, legacy top-level `elements`, wrapped interactive cards, and valid legacy `div` text elements. Explicit structured `presentation` or `interactive` input remains authoritative over raw card JSON, including document-comment fallback rendering. Malformed JSON, invalid root legacy text shapes, ordinary JSON, and card-plus-media requests keep their existing fallback or rejection behavior.

This preserves contributor credit for @martingarramon from #77268 and reporter credit for @ZenoRewn. Blocked lineage PRs #93706 and #94262 were evidence only and were not used as executable sources.

## User Impact

Feishu proactive sends can render valid card JSON as interactive cards again, including when a configured response prefix is present. Structured card content is no longer discarded or preceded by raw JSON text.

## Evidence

- 125 focused Feishu tests passed.
- 28 message-action runner tests passed, including the real response-prefix plugin-dispatch path.
- Final compatibility repair: 60 outbound tests and 69 channel tests passed.
- Regression coverage includes v2 cards, valid legacy `div` + `lark_md`/`plain_text`, invalid root legacy text fallback, wrapped cards, structured-input precedence, malformed/ordinary JSON fallback, and card-plus-media rejection.
- Extension import-boundary, targeted formatting, and `git diff --check` passed.
- Rebased through the native fork-update path onto current main.
- Fresh exact-head hosted CI is running on `b9eb00afe45f747dca4420bcb2c93e4423bcd921`.
- Maintainer proof override: no live Feishu tenant was used; parser, outbound adapter, action handler, and runtime prefix behavior are covered directly by focused tests and hosted CI.
