### PR TITLE
feat(ios): word-paced fade-in for streaming assistant prose

### DIFF
--- a/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
+++ b/apps/ios/Tests/SwiftUIRenderSmokeTests.swift
@@ -140,6 +140,30 @@ struct SwiftUIRenderSmokeTests {
         }
     }
 
+    @Test @MainActor func `streaming assistant bubble builds mixed prose and code`() {
+        let text = """
+        Earlier prose stays visible.
+
+        ```swift
+        let answer = 42
+        ```
+
+        Trailing streamed words fade in.
+        """
+
+        let root = ChatStreamingAssistantBubble(
+            text: text,
+            markdownVariant: .standard,
+            showsAssistantTrace: false,
+            assistantName: "OpenClaw",
+            assistantAvatarText: "OC",
+            assistantAvatarTint: nil,
+            showsAssistantAvatar: true,
+            isClean: false)
+
+        _ = Self.host(root, size: CGSize(width: 393, height: 400))
+    }
+
     @Test @MainActor func `root tabs builds device orientation shell matrix`() {
         for scenario in Self.rootTabsShellScenarios() {
             let appModel = NodeAppModel()

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMarkdownRenderer.swift
@@ -14,36 +14,62 @@ struct ChatMarkdownRenderer: View {
         case assistant
     }
 
-    let text: String
+    let snapshot: ChatMarkdownRenderSnapshot
     let context: Context
     let variant: ChatMarkdownVariant
     let font: Font
     let textColor: Color
-    /// False while the message is still streaming: trailing open fences and
-    /// growing tables then stay on the cheap plain-text path.
-    var isComplete: Bool = true
+    var reveal: ChatMarkdownProseReveal?
+
+    init(
+        text: String,
+        context: Context,
+        variant: ChatMarkdownVariant,
+        font: Font,
+        textColor: Color,
+        isComplete: Bool = true)
+    {
+        self.init(
+            snapshot: ChatMarkdownRenderSnapshot(text: text, isComplete: isComplete),
+            context: context,
+            variant: variant,
+            font: font,
+            textColor: textColor)
+    }
+
+    init(
+        snapshot: ChatMarkdownRenderSnapshot,
+        context: Context,
+        variant: ChatMarkdownVariant,
+        font: Font,
+        textColor: Color,
+        reveal: ChatMarkdownProseReveal? = nil)
+    {
+        self.snapshot = snapshot
+        self.context = context
+        self.variant = variant
+        self.font = font
+        self.textColor = textColor
+        self.reveal = reveal
+    }
 
     var body: some View {
-        let processed = ChatMarkdownPreprocessor.preprocess(markdown: self.text)
-        let blocks = ChatMarkdownBlockSegmenter.segments(
-            markdown: processed.cleaned,
-            isComplete: self.isComplete)
         VStack(alignment: .leading, spacing: 10) {
-            ForEach(Array(blocks.enumerated()), id: \.offset) { entry in
-                self.blockView(entry.element)
+            ForEach(Array(self.snapshot.blocks.enumerated()), id: \.offset) { entry in
+                self.blockView(entry.element, index: entry.offset)
             }
 
-            if !processed.images.isEmpty {
-                InlineImageList(images: processed.images)
+            if !self.snapshot.images.isEmpty {
+                InlineImageList(images: self.snapshot.images)
             }
         }
     }
 
     @ViewBuilder
-    private func blockView(_ block: ChatMarkdownBlock) -> some View {
+    private func blockView(_ block: ChatMarkdownRenderedBlock, index: Int) -> some View {
         switch block {
-        case let .prose(markdown):
-            Text(self.markdownText(ChatMarkdownDisplayPreprocessor.preserveChatSoftBreaks(in: markdown)))
+        case let .prose(prose):
+            self.proseText(prose, index: index)
                 .font(self.font)
                 .foregroundStyle(self.textColor)
                 .tint(self.linkColor)
@@ -58,15 +84,154 @@ struct ChatMarkdownRenderer: View {
         }
     }
 
+    private func proseText(_ prose: ChatMarkdownProse, index: Int) -> SwiftUI.Text {
+        guard let reveal = self.reveal, reveal.blockIndex == index else {
+            return SwiftUI.Text(prose.attributed)
+        }
+        return prose.revealedText(
+            frame: revealedOpacities(state: reveal.state, now: reveal.now),
+            textColor: self.textColor)
+    }
+
     private var linkColor: Color {
         self.context == .user ? self.textColor : OpenClawChatTheme.accent
     }
+}
 
-    private func markdownText(_ markdown: String) -> AttributedString {
+struct ChatMarkdownProseReveal {
+    let blockIndex: Int
+    let state: ChatStreamingRevealState
+    let now: TimeInterval
+}
+
+struct ChatMarkdownRenderSnapshot {
+    let blocks: [ChatMarkdownRenderedBlock]
+    let images: [ChatMarkdownPreprocessor.InlineImage]
+
+    init(text: String, isComplete: Bool, preparesReveal: Bool = false) {
+        let processed = ChatMarkdownPreprocessor.preprocess(markdown: text)
+        self.blocks = ChatMarkdownBlockSegmenter.segments(
+            markdown: processed.cleaned,
+            isComplete: isComplete).map { block in
+            switch block {
+            case let .prose(markdown):
+                .prose(ChatMarkdownProse(markdown: markdown, preparesReveal: preparesReveal))
+            case let .code(code):
+                .code(code)
+            case let .math(math):
+                .math(math)
+            case let .table(table):
+                .table(table)
+            }
+        }
+        self.images = processed.images
+    }
+
+    var lastProseIndex: Int? {
+        self.blocks.lastIndex {
+            if case .prose = $0 { return true }
+            return false
+        }
+    }
+}
+
+enum ChatMarkdownRenderedBlock {
+    case prose(ChatMarkdownProse)
+    case code(ChatCodeBlock)
+    case math(ChatMathBlock)
+    case table(ChatMarkdownTable)
+}
+
+struct ChatMarkdownProse {
+    struct TailPiece {
+        let attributed: AttributedString
+        let wordRange: Range<Int>?
+    }
+
+    let attributed: AttributedString
+    let plainText: String
+    let prefix: AttributedString
+    let tail: [TailPiece]
+
+    init(markdown: String, preparesReveal: Bool) {
+        let displayMarkdown = ChatMarkdownDisplayPreprocessor.preserveChatSoftBreaks(in: markdown)
         let options = AttributedString.MarkdownParsingOptions(
             interpretedSyntax: .full,
             failurePolicy: .returnPartiallyParsedIfPossible)
-        return (try? AttributedString(markdown: markdown, options: options)) ?? AttributedString(markdown)
+        let attributed = (try? AttributedString(markdown: displayMarkdown, options: options))
+            ?? AttributedString(displayMarkdown)
+        let plainText = preparesReveal ? String(attributed.characters) : ""
+        let wordRanges = preparesReveal
+            ? Array(chatStreamingWordRanges(in: plainText).suffix(24))
+            : []
+        let tailStart = wordRanges.first?.lowerBound ?? plainText.count
+
+        self.attributed = attributed
+        self.plainText = plainText
+        if preparesReveal {
+            self.prefix = Self.slice(attributed, characterRange: 0..<tailStart)
+            self.tail = Self.tailPieces(
+                attributed: attributed,
+                textLength: plainText.count,
+                wordRanges: wordRanges,
+                tailStart: tailStart)
+        } else {
+            self.prefix = AttributedString()
+            self.tail = []
+        }
+    }
+
+    func revealedText(frame: ChatStreamingRevealFrame, textColor: Color) -> SwiftUI.Text {
+        self.tail.reduce(SwiftUI.Text(self.prefix)) { text, piece in
+            var attributed = piece.attributed
+            if let wordRange = piece.wordRange,
+               let fading = frame.fading.first(where: { $0.characterRange == wordRange })
+            {
+                attributed.foregroundColor = textColor.opacity(fading.opacity)
+            }
+            return text + SwiftUI.Text(attributed)
+        }
+    }
+
+    private static func tailPieces(
+        attributed: AttributedString,
+        textLength: Int,
+        wordRanges: [Range<Int>],
+        tailStart: Int) -> [TailPiece]
+    {
+        guard !wordRanges.isEmpty else { return [] }
+        var pieces: [TailPiece] = []
+        var cursor = tailStart
+        for wordRange in wordRanges {
+            if cursor < wordRange.lowerBound {
+                pieces.append(TailPiece(
+                    attributed: self.slice(attributed, characterRange: cursor..<wordRange.lowerBound),
+                    wordRange: nil))
+            }
+            pieces.append(TailPiece(
+                attributed: self.slice(attributed, characterRange: wordRange),
+                wordRange: wordRange))
+            cursor = wordRange.upperBound
+        }
+        if cursor < textLength {
+            pieces.append(TailPiece(
+                attributed: self.slice(attributed, characterRange: cursor..<textLength),
+                wordRange: nil))
+        }
+        return pieces
+    }
+
+    private static func slice(
+        _ attributed: AttributedString,
+        characterRange: Range<Int>) -> AttributedString
+    {
+        let lower = attributed.characters.index(
+            attributed.startIndex,
+            offsetBy: characterRange.lowerBound)
+        let upper = attributed.characters.index(
+            attributed.startIndex,
+            offsetBy: characterRange.upperBound)
+        return AttributedString(attributed[lower..<upper])
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -842,8 +842,19 @@ private struct ChatAssistantTextBody: View {
     var isComplete: Bool = true
 
     var body: some View {
+        if self.isComplete {
+            self.completeBody
+        } else {
+            ChatStreamingAssistantTextBody(
+                text: self.text,
+                markdownVariant: self.markdownVariant,
+                includesThinking: self.includesThinking)
+        }
+    }
+
+    private var completeBody: some View {
         let segments = AssistantTextParser.segments(from: self.text, includeThinking: self.includesThinking)
-        VStack(alignment: .leading, spacing: 10) {
+        return VStack(alignment: .leading, spacing: 10) {
             ForEach(segments) { segment in
                 let font = segment.kind == .thinking
                     ? OpenClawChatTypography.callout.italic()
@@ -856,6 +867,182 @@ private struct ChatAssistantTextBody: View {
                     textColor: OpenClawChatTheme.assistantText,
                     isComplete: self.isComplete)
             }
+        }
+    }
+}
+
+@MainActor
+private struct ChatStreamingAssistantTextBody: View {
+    let text: String
+    let markdownVariant: ChatMarkdownVariant
+    let includesThinking: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var snapshot: Snapshot
+    @State private var revealState: ChatStreamingRevealState
+    @State private var revealLocation: Snapshot.ProseLocation?
+    @State private var pendingUntil: TimeInterval?
+
+    init(text: String, markdownVariant: ChatMarkdownVariant, includesThinking: Bool) {
+        self.text = text
+        self.markdownVariant = markdownVariant
+        self.includesThinking = includesThinking
+
+        let now = Date.timeIntervalSinceReferenceDate
+        let snapshot = Snapshot(text: text, includesThinking: includesThinking)
+        let location = snapshot.lastProseLocation
+        let revealState = location.map {
+            step(state: ChatStreamingRevealState(), newText: snapshot.prose(at: $0).plainText, now: now)
+        } ?? ChatStreamingRevealState()
+        self._snapshot = State(initialValue: snapshot)
+        self._revealState = State(initialValue: revealState)
+        self._revealLocation = State(initialValue: location)
+        self._pendingUntil = State(initialValue: revealState.latestDeadline)
+    }
+
+    var body: some View {
+        Group {
+            if self.reduceMotion || self.pendingUntil == nil {
+                self.render(now: nil)
+            } else {
+                TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { timeline in
+                    self.render(now: timeline.date.timeIntervalSinceReferenceDate)
+                }
+            }
+        }
+        .onChange(of: self.text) { _, _ in
+            self.updateSnapshot()
+        }
+        .onChange(of: self.includesThinking) { _, _ in
+            self.updateSnapshot()
+        }
+        .onChange(of: self.reduceMotion) { _, reduceMotion in
+            self.pendingUntil = reduceMotion ? nil : self.futureDeadline()
+        }
+        .onAppear {
+            if self.snapshot.sourceText != self.text || self.snapshot.includesThinking != self.includesThinking {
+                self.updateSnapshot()
+            }
+        }
+        .task(id: self.pendingUntil) {
+            guard let pendingUntil = self.pendingUntil else { return }
+            let delay = max(0, pendingUntil - Date.timeIntervalSinceReferenceDate)
+            if delay > 0 {
+                try? await Task.sleep(for: .seconds(delay))
+            }
+            guard !Task.isCancelled, self.pendingUntil == pendingUntil else { return }
+            self.pendingUntil = nil
+        }
+    }
+
+    private func render(now: TimeInterval?) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(Array(self.snapshot.segments.enumerated()), id: \.offset) { entry in
+                let segment = entry.element
+                let font = segment.kind == .thinking
+                    ? OpenClawChatTypography.callout.italic()
+                    : OpenClawChatTypography.body
+                let reveal = self.reveal(
+                    segmentIndex: entry.offset,
+                    now: now)
+                ChatMarkdownRenderer(
+                    snapshot: segment.markdown,
+                    context: .assistant,
+                    variant: self.markdownVariant,
+                    font: font,
+                    textColor: OpenClawChatTheme.assistantText,
+                    reveal: reveal)
+            }
+        }
+    }
+
+    private func reveal(segmentIndex: Int, now: TimeInterval?) -> ChatMarkdownProseReveal? {
+        guard let now,
+              let location = self.revealLocation,
+              location.segmentIndex == segmentIndex
+        else { return nil }
+        return ChatMarkdownProseReveal(
+            blockIndex: location.blockIndex,
+            state: self.revealState,
+            now: now)
+    }
+
+    private func updateSnapshot() {
+        let now = Date.timeIntervalSinceReferenceDate
+        let nextSnapshot = Snapshot(text: self.text, includesThinking: self.includesThinking)
+        let nextLocation = nextSnapshot.lastProseLocation
+        let nextRevealState: ChatStreamingRevealState
+        if let nextLocation {
+            let nextText = nextSnapshot.prose(at: nextLocation).plainText
+            if nextLocation == self.revealLocation {
+                nextRevealState = step(state: self.revealState, newText: nextText, now: now)
+            } else {
+                nextRevealState = step(state: ChatStreamingRevealState(), newText: nextText, now: now)
+            }
+        } else {
+            nextRevealState = ChatStreamingRevealState()
+        }
+
+        self.snapshot = nextSnapshot
+        self.revealLocation = nextLocation
+        self.revealState = nextRevealState
+        self.pendingUntil = self.reduceMotion ? nil : self.futureDeadline(now: now, state: nextRevealState)
+    }
+
+    private func futureDeadline(
+        now: TimeInterval = Date.timeIntervalSinceReferenceDate,
+        state: ChatStreamingRevealState? = nil) -> TimeInterval?
+    {
+        guard let deadline = (state ?? self.revealState).latestDeadline, deadline > now else {
+            return nil
+        }
+        return deadline
+    }
+
+    private struct Snapshot {
+        struct Segment {
+            let kind: AssistantTextSegment.Kind
+            let markdown: ChatMarkdownRenderSnapshot
+        }
+
+        struct ProseLocation: Equatable {
+            let segmentIndex: Int
+            let blockIndex: Int
+        }
+
+        let segments: [Segment]
+        let lastProseLocation: ProseLocation?
+        let sourceText: String
+        let includesThinking: Bool
+
+        init(text: String, includesThinking: Bool) {
+            let segments = AssistantTextParser.segments(
+                from: text,
+                includeThinking: includesThinking).map {
+                Segment(
+                    kind: $0.kind,
+                    markdown: ChatMarkdownRenderSnapshot(
+                        text: $0.text,
+                        isComplete: false,
+                        preparesReveal: true))
+            }
+            self.segments = segments
+            self.sourceText = text
+            self.includesThinking = includesThinking
+            self.lastProseLocation = segments.indices.reversed().compactMap { segmentIndex in
+                segments[segmentIndex].markdown.lastProseIndex.map {
+                    ProseLocation(segmentIndex: segmentIndex, blockIndex: $0)
+                }
+            }.first
+        }
+
+        func prose(at location: ProseLocation) -> ChatMarkdownProse {
+            guard case let .prose(prose) = self.segments[location.segmentIndex]
+                .markdown.blocks[location.blockIndex]
+            else {
+                preconditionFailure("Streaming reveal location must identify prose")
+            }
+            return prose
         }
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatStreamingReveal.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatStreamingReveal.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+struct ChatStreamingRevealState: Equatable {
+    struct Word: Equatable {
+        let characterRange: Range<Int>
+        let fadeStart: TimeInterval
+        let deadline: TimeInterval
+    }
+
+    var text: String
+    var words: [Word]
+
+    init(text: String = "", words: [Word] = []) {
+        self.text = text
+        self.words = words
+    }
+
+    var latestDeadline: TimeInterval? {
+        self.words.map(\.deadline).max()
+    }
+}
+
+struct ChatStreamingRevealFrame: Equatable {
+    struct FadingWord: Equatable {
+        let characterRange: Range<Int>
+        let opacity: Double
+    }
+
+    let fullyRevealedPrefixCharacterOffset: Int
+    let fading: [FadingWord]
+}
+
+private enum ChatStreamingRevealConstants {
+    static let wordInterval: TimeInterval = 0.04
+    static let fadeDuration: TimeInterval = 0.12
+    static let maximumCatchUpDuration: TimeInterval = 0.4
+    static let maximumFadingWords = 24
+}
+
+func step(
+    state: ChatStreamingRevealState,
+    newText: String,
+    now: TimeInterval) -> ChatStreamingRevealState
+{
+    guard newText.hasPrefix(state.text) else {
+        // Rewrites are uncommon and can invalidate every old character range.
+        // Reveal the replacement immediately; later appends start a new pace.
+        return ChatStreamingRevealState(text: newText)
+    }
+    guard newText != state.text else {
+        return ChatStreamingRevealState(
+            text: newText,
+            words: state.words.filter { $0.deadline > now })
+    }
+
+    let oldCharacterCount = state.text.count
+    let ranges = chatStreamingWordRanges(in: newText)
+    let rangesByStart = Dictionary(uniqueKeysWithValues: ranges.map { ($0.lowerBound, $0) })
+
+    var words = state.words.compactMap { word -> ChatStreamingRevealState.Word? in
+        guard word.deadline > now,
+              let updatedRange = rangesByStart[word.characterRange.lowerBound]
+        else { return nil }
+        return ChatStreamingRevealState.Word(
+            characterRange: updatedRange,
+            fadeStart: word.fadeStart,
+            deadline: word.deadline)
+    }
+
+    let trackedStarts = Set(words.map(\.characterRange.lowerBound))
+    let appendedRanges = ranges.filter {
+        $0.lowerBound >= oldCharacterCount && !trackedStarts.contains($0.lowerBound)
+    }
+    words.append(contentsOf: appendedRanges.map {
+        ChatStreamingRevealState.Word(
+            characterRange: $0,
+            fadeStart: now,
+            deadline: now + ChatStreamingRevealConstants.fadeDuration)
+    })
+    words.sort { $0.characterRange.lowerBound < $1.characterRange.lowerBound }
+
+    if words.count > ChatStreamingRevealConstants.maximumFadingWords {
+        words.removeFirst(words.count - ChatStreamingRevealConstants.maximumFadingWords)
+    }
+
+    let spacing: TimeInterval
+    if words.count > 1 {
+        let catchUpSpacing =
+            (ChatStreamingRevealConstants.maximumCatchUpDuration - ChatStreamingRevealConstants.fadeDuration)
+            / Double(words.count - 1)
+        spacing = min(ChatStreamingRevealConstants.wordInterval, catchUpSpacing)
+    } else {
+        spacing = 0
+    }
+
+    words = words.enumerated().map { index, word in
+        let scheduledStart = now + Double(index) * spacing
+        let scheduledDeadline = scheduledStart + ChatStreamingRevealConstants.fadeDuration
+        let isExistingWord = trackedStarts.contains(word.characterRange.lowerBound)
+        return ChatStreamingRevealState.Word(
+            characterRange: word.characterRange,
+            fadeStart: isExistingWord ? word.fadeStart : scheduledStart,
+            // Catch-up may move an existing deadline earlier, never later. That
+            // preserves or increases its current opacity across append steps.
+            deadline: isExistingWord ? min(word.deadline, scheduledDeadline) : scheduledDeadline)
+    }
+
+    return ChatStreamingRevealState(text: newText, words: words)
+}
+
+func revealedOpacities(
+    state: ChatStreamingRevealState,
+    now: TimeInterval) -> ChatStreamingRevealFrame
+{
+    let fading = state.words.compactMap { word -> ChatStreamingRevealFrame.FadingWord? in
+        guard now < word.deadline else { return nil }
+        let duration = word.deadline - word.fadeStart
+        let opacity = duration > 0
+            ? min(1, max(0, (now - word.fadeStart) / duration))
+            : 1
+        return ChatStreamingRevealFrame.FadingWord(
+            characterRange: word.characterRange,
+            opacity: opacity)
+    }
+    return ChatStreamingRevealFrame(
+        fullyRevealedPrefixCharacterOffset: fading.first?.characterRange.lowerBound ?? state.text.count,
+        fading: fading)
+}
+
+func chatStreamingWordRanges(in text: String) -> [Range<Int>] {
+    var ranges: [Range<Int>] = []
+    var wordStart: Int?
+
+    for (offset, character) in text.enumerated() {
+        if character.isWhitespace {
+            if let start = wordStart {
+                ranges.append(start..<offset)
+                wordStart = nil
+            }
+        } else if wordStart == nil {
+            wordStart = offset
+        }
+    }
+    if let wordStart {
+        ranges.append(wordStart..<text.count)
+    }
+    return ranges
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamReplayTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamReplayTests.swift
@@ -573,4 +573,52 @@ struct ChatStreamReplayTests {
             #expect(Array(rowText.utf8) == Array(markdownShapesFixture.utf8))
         }
     }
+
+    @Test func `consecutive assistant streams keep independent full text`() async throws {
+        let now = Date().timeIntervalSince1970 * 1000 - 10000
+        let harness = try await StreamReplayHarness.bootstrapped()
+        let firstText = "First streamed response."
+        let secondText = "Second response starts fresh."
+
+        let firstRunId = try await harness.send("first")
+        try await harness.streamCumulativeChunks(
+            runId: firstRunId,
+            fullText: firstText,
+            chunkLength: 3)
+        harness.transport.emit(
+            replayFinalEvent(runId: firstRunId, text: firstText, timestamp: now + 1000))
+        harness.transport.emit(
+            replaySessionMessageEvent(
+                text: firstText,
+                timestamp: now + 1100,
+                idempotencyKey: firstRunId,
+                messageId: "durable-first"))
+        try await harness.converge("first stream finalized") { vm in
+            vm.streamingAssistantText == nil && vm.replayAssistantRows(text: firstText).count == 1
+        }
+
+        let secondRunId = try await harness.send("second")
+        try await harness.streamCumulativeChunks(
+            runId: secondRunId,
+            fullText: secondText,
+            chunkLength: 4)
+        await MainActor.run {
+            #expect(harness.vm.streamingAssistantText == secondText)
+            #expect(harness.vm.replayAssistantRows(text: firstText).count == 1)
+        }
+
+        harness.transport.emit(
+            replayFinalEvent(runId: secondRunId, text: secondText, timestamp: now + 2000))
+        harness.transport.emit(
+            replaySessionMessageEvent(
+                text: secondText,
+                timestamp: now + 2100,
+                idempotencyKey: secondRunId,
+                messageId: "durable-second"))
+        try await harness.converge("second stream finalized independently") { vm in
+            vm.streamingAssistantText == nil &&
+                vm.replayAssistantRows(text: firstText).count == 1 &&
+                vm.replayAssistantRows(text: secondText).count == 1
+        }
+    }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamingRevealTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamingRevealTests.swift
@@ -1,0 +1,78 @@
+import Testing
+@testable import OpenClawChatUI
+
+struct ChatStreamingRevealTests {
+    @Test func `word boundaries use whitespace and preserve gaps`() {
+        let text = "one  two\n\nthree\tfour"
+        let words = chatStreamingWordRanges(in: text).map { range in
+            let lower = text.index(text.startIndex, offsetBy: range.lowerBound)
+            let upper = text.index(text.startIndex, offsetBy: range.upperBound)
+            return String(text[lower..<upper])
+        }
+
+        #expect(words == ["one", "two", "three", "four"])
+    }
+
+    @Test func `appended words receive staggered deadlines`() {
+        let state = step(
+            state: ChatStreamingRevealState(),
+            newText: "one two three",
+            now: 10)
+
+        #expect(state.words.count == 3)
+        #expect(abs(state.words[1].deadline - state.words[0].deadline - 0.04) < 0.0001)
+        #expect(abs(state.words[2].deadline - state.words[1].deadline - 0.04) < 0.0001)
+    }
+
+    @Test func `burst catch up is capped and retains only trailing window`() throws {
+        let text = (0..<40).map { "word\($0)" }.joined(separator: " ")
+        let state = step(state: ChatStreamingRevealState(), newText: text, now: 20)
+
+        #expect(state.words.count == 24)
+        #expect((state.latestDeadline ?? .infinity) <= 20.400001)
+        #expect(try state.words.first?.characterRange.lowerBound == text.distance(
+            from: text.startIndex,
+            to: #require(text.range(of: "word16")?.lowerBound)))
+    }
+
+    @Test func `revealed word never becomes hidden after append`() {
+        let initial = step(state: ChatStreamingRevealState(), newText: "one", now: 0)
+        let revealed = revealedOpacities(state: initial, now: 0.2)
+        #expect(revealed.fading.isEmpty)
+
+        let appended = step(state: initial, newText: "one two", now: 0.2)
+        let frame = revealedOpacities(state: appended, now: 0.2)
+        #expect(frame.fullyRevealedPrefixCharacterOffset == 4)
+        #expect(frame.fading.count == 1)
+    }
+
+    @Test func `non append rewrite reveals replacement immediately then restarts`() {
+        let initial = step(state: ChatStreamingRevealState(), newText: "draft words", now: 0)
+        let rewritten = step(state: initial, newText: "replacement text", now: 0.01)
+
+        #expect(rewritten.words.isEmpty)
+        #expect(revealedOpacities(state: rewritten, now: 0.01).fading.isEmpty)
+
+        let appended = step(state: rewritten, newText: "replacement text continues", now: 0.02)
+        #expect(appended.words.count == 1)
+    }
+
+    @Test func `empty state schedules first delta`() {
+        let empty = step(state: ChatStreamingRevealState(), newText: "", now: 0)
+        let first = step(state: empty, newText: "hello", now: 1)
+
+        #expect(empty.words.isEmpty)
+        #expect(first.words.count == 1)
+        #expect(revealedOpacities(state: first, now: 1).fading.first?.opacity == 0)
+    }
+
+    @Test func `unicode runs are one word without whitespace and reveal fully`() {
+        let text = "👋🏽你好世界"
+        let state = step(state: ChatStreamingRevealState(), newText: text, now: 5)
+
+        #expect(state.words.count == 1)
+        #expect(state.words.first?.characterRange == 0..<text.count)
+        #expect(revealedOpacities(state: state, now: 6).fading.isEmpty)
+        #expect(revealedOpacities(state: state, now: 6).fullyRevealedPrefixCharacterOffset == text.count)
+    }
+}

--- a/scripts/ios-write-swift-filelist.mjs
+++ b/scripts/ios-write-swift-filelist.mjs
@@ -26,6 +26,7 @@ const sharedSwiftFiles = [
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatPayloadDecoding.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+  "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatStreamingReveal.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift",
   "../shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift",


### PR DESCRIPTION
Related: #100699

## What Problem This Solves

Streamed assistant prose in the iOS/macOS chat currently appears in raw chunks — text pops in a delta at a time, which reads as jittery compared to modern chat clients.

## Why This Change Was Made

Adds a word-paced fade-in for streaming assistant prose in the shared renderer. The pacing core is a pure, deterministic module (no timers, callers pass `now`): appended words get staggered 40ms reveals with a 120ms fade, a burst catch-up rule compresses backlogs so the queue clears within 400ms, reveal is strictly monotonic (a shown word never un-shows), and non-append rewrites (e.g., markdown that reformats earlier text when a `**` closes) reveal instantly and restart pacing. Only the last prose block of the streaming bubble animates; code, tables, and math keep their existing render-plain-until-complete behavior. Markdown is parsed once per delta and cached — per-frame work is opacity restyling of a bounded 24-word tail only, and the driving `TimelineView` stops when nothing is fading. Reduce Motion bypasses the effect entirely. Final transcript rendering is untouched.

## User Impact

Streaming responses read smoothly word by word instead of popping in chunks; users with Reduce Motion enabled keep the current instant behavior; completed messages render exactly as before.

## Evidence

- `swift test --package-path apps/shared/OpenClawKit` — full suite green (453 Swift Testing + 21 XCTest). New `ChatStreamingRevealTests` (word boundaries incl. Unicode/CJK, staggered deadlines, burst catch-up cap, monotonicity, rewrite reset); `ChatStreamReplayTests` extended with consecutive streamed-turn convergence (final transcript text always equals the full streamed text, no state leaks between turns).
- iOS `xcodebuild build-for-testing` green; streaming-bubble smoke case added to `SwiftUIRenderSmokeTests`.
- `swiftformat --lint` via the iOS filelist — clean; i18n inventory unchanged (`native:i18n:sync` idempotent on this diff).
- Structured review (codex) — one lifecycle finding fixed during development, second pass clean.
- Known gap: live visual smoothness/Reduce Motion not observed on-device in this environment; logic-level proof only.
