### PR TITLE
fix(qa): accept completed waits in broken-turn scenarios

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -689,6 +689,9 @@ describe("qa scenario catalog", () => {
       expect(config?.requiredProvider).toBe("mock-openai");
       expect(config?.prompt).toContain("check");
       expect(scenario.execution.flow?.steps.length).toBeGreaterThan(0);
+      const flowText = JSON.stringify(scenario.execution.flow);
+      expect(flowText).toContain('"call":"runAgentPrompt"');
+      expect(flowText).not.toContain("agent.wait");
     }
   });
 

--- a/qa/scenarios/runtime/empty-response-retry-budget-exhausted.yaml
+++ b/qa/scenarios/runtime/empty-response-retry-budget-exhausted.yaml
@@ -45,8 +45,8 @@ flow:
         - set: sessionKey
           value:
             expr: "`agent:qa:empty-response-exhausted:${randomUUID().slice(0, 8)}`"
-        - call: startAgentRun
-          saveAs: started
+        - call: runAgentPrompt
+          saveAs: run
           args:
             - ref: env
             - sessionKey:
@@ -55,13 +55,6 @@ flow:
                 expr: config.prompt
               timeoutMs:
                 expr: liveTurnTimeoutMs(env, 45000)
-        - set: waited
-          value:
-            expr: "await env.gateway.call('agent.wait', { runId: started.runId, timeoutMs: liveTurnTimeoutMs(env, 45000) }, { timeoutMs: liveTurnTimeoutMs(env, 50000) })"
-        - assert:
-            expr: "waited?.status === 'ok'"
-            message:
-              expr: "`agent.wait returned ${String(waited?.status ?? 'unknown')}: ${String(waited?.error ?? '')}`"
         - if:
             expr: "Boolean(env.mock)"
             then:
@@ -74,4 +67,4 @@ flow:
               - assert:
                   expr: "scenarioRequests.length >= 2"
                   message: expected at least the replay-safe read request and one terminal post-read turn
-      detailsExpr: "env.mock ? `requests=${String(scenarioRequests?.length ?? 0)}` : String(waited?.status ?? '')"
+      detailsExpr: "env.mock ? `requests=${String(scenarioRequests?.length ?? 0)}` : String(run?.waited?.status ?? '')"

--- a/qa/scenarios/runtime/reasoning-only-no-auto-retry-after-write.yaml
+++ b/qa/scenarios/runtime/reasoning-only-no-auto-retry-after-write.yaml
@@ -47,8 +47,8 @@ flow:
         - set: sessionKey
           value:
             expr: "`agent:qa:reasoning-only-write:${randomUUID().slice(0, 8)}`"
-        - call: startAgentRun
-          saveAs: started
+        - call: runAgentPrompt
+          saveAs: run
           args:
             - ref: env
             - sessionKey:
@@ -57,13 +57,6 @@ flow:
                 expr: config.prompt
               timeoutMs:
                 expr: liveTurnTimeoutMs(env, 45000)
-        - set: waited
-          value:
-            expr: "await env.gateway.call('agent.wait', { runId: started.runId, timeoutMs: liveTurnTimeoutMs(env, 45000) }, { timeoutMs: liveTurnTimeoutMs(env, 50000) })"
-        - assert:
-            expr: "waited?.status === 'ok'"
-            message:
-              expr: "`agent.wait returned ${String(waited?.status ?? 'unknown')}: ${String(waited?.error ?? '')}`"
         - call: fs.readFile
           saveAs: sideEffect
           args:


### PR DESCRIPTION
Related: #100828

## What Problem This Solves

Resolves an operational problem where QA Smoke CI can reject a valid terminal `agent.wait` result for the broken-turn scenarios, leaving unrelated pull requests blocked even though the runtime scenario completed successfully.

## Why This Change Was Made

The two scenarios now use the QA flow runner's canonical `runAgentPrompt` helper, which already normalizes supported terminal wait envelopes. A catalog regression assertion prevents seeded broken-turn scenarios from reintroducing direct `agent.wait` handling.

## User Impact

No product behavior changes. Maintainers get reliable QA Smoke results for the reasoning-only and empty-response recovery scenarios.

## Evidence

- `pnpm check:changed` passed in Testbox, including typecheck, lint, import cycles, and changed-surface guards.
- Focused local QA Lab tests: 3 files, 66 tests passed.
- Testbox focused unit tests: 2 files, 58 tests passed.
- Testbox scenario run: both `reasoning-only-no-auto-retry-after-write` and `empty-response-retry-budget-exhausted` passed.
- Local `codex review --base origin/main`: no findings, patch correct (0.86 confidence).
- `git diff --check`: clean.
- Confirms the repeated failures in #100828 QA Smoke attempt 2 are shared scenario-harness failures, not product regressions.