### PR TITLE
fix(android): open system notifications on tap

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -179,7 +179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 249,
+      "line": 239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Listening",
       "surface": "android",
@@ -187,7 +187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 249,
+      "line": 239,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Pending",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Android system notifications now open OpenClaw when tapped without accepting arbitrary external deeplinks.
+
 Android chat history now excludes internal, reasoning, and tool-result rows from rendered messages and the offline transcript cache.
 
 Android chat messages now expose long-press actions for whole-message copy, selective text copy, sharing, and quoted replies.

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainActivityPendingIntent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainActivityPendingIntent.kt
@@ -1,0 +1,22 @@
+package ai.openclaw.app
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+
+/** Reuses the existing app task when a system surface brings OpenClaw forward. */
+internal fun mainActivityPendingIntent(
+  context: Context,
+  requestCode: Int,
+): PendingIntent {
+  val intent =
+    Intent(context, MainActivity::class.java).apply {
+      flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+    }
+  return PendingIntent.getActivity(
+    context,
+    requestCode,
+    intent,
+    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+  )
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -145,17 +145,7 @@ class NodeForegroundService : Service() {
     title: String,
     text: String,
   ): Notification {
-    val launchIntent =
-      Intent(this, MainActivity::class.java).apply {
-        flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
-      }
-    val launchPending =
-      PendingIntent.getActivity(
-        this,
-        1,
-        launchIntent,
-        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
-      )
+    val launchPending = mainActivityPendingIntent(this, requestCode = 1)
 
     val stopIntent = Intent(this, NodeForegroundService::class.java).setAction(ACTION_STOP)
     val stopPending =

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/SystemHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/SystemHandler.kt
@@ -1,7 +1,9 @@
 package ai.openclaw.app.node
 
 import ai.openclaw.app.gateway.GatewaySession
+import ai.openclaw.app.mainActivityPendingIntent
 import android.Manifest
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
@@ -16,6 +18,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 
 private const val NOTIFICATION_CHANNEL_BASE_ID = "openclaw.system.notify"
+private const val NOTIFICATION_CONTENT_REQUEST_CODE = 3
 
 /** Parsed payload for system.notify invocations. */
 internal data class SystemNotifyRequest(
@@ -49,18 +52,7 @@ private class AndroidSystemNotificationPoster(
   /** Posts through a priority-specific channel so Android's immutable channel importance is respected. */
   override fun post(request: SystemNotifyRequest) {
     val channelId = ensureChannel(request.priority)
-    val silent = isSilentSound(request.sound)
-    val notification =
-      NotificationCompat
-        .Builder(appContext, channelId)
-        .setSmallIcon(android.R.drawable.ic_dialog_info)
-        .setContentTitle(request.title)
-        .setContentText(request.body)
-        .setPriority(compatPriority(request.priority))
-        .setAutoCancel(true)
-        .setOnlyAlertOnce(true)
-        .setSilent(silent)
-        .build()
+    val notification = buildSystemNotification(appContext, channelId, request)
     if (
       Build.VERSION.SDK_INT >= 33 &&
       ContextCompat.checkSelfPermission(appContext, Manifest.permission.POST_NOTIFICATIONS) !=
@@ -89,19 +81,36 @@ private class AndroidSystemNotificationPoster(
     }
     return channelId
   }
-
-  private fun compatPriority(priority: String?): Int =
-    when (priority.orEmpty().trim().lowercase()) {
-      "passive" -> NotificationCompat.PRIORITY_LOW
-      "timesensitive" -> NotificationCompat.PRIORITY_HIGH
-      else -> NotificationCompat.PRIORITY_DEFAULT
-    }
-
-  private fun isSilentSound(sound: String?): Boolean {
-    val normalized = sound?.trim()?.lowercase() ?: return false
-    return normalized in setOf("none", "silent", "off", "false", "0")
-  }
 }
+
+private fun compatPriority(priority: String?): Int =
+  when (priority.orEmpty().trim().lowercase()) {
+    "passive" -> NotificationCompat.PRIORITY_LOW
+    "timesensitive" -> NotificationCompat.PRIORITY_HIGH
+    else -> NotificationCompat.PRIORITY_DEFAULT
+  }
+
+private fun isSilentSound(sound: String?): Boolean {
+  val normalized = sound?.trim()?.lowercase() ?: return false
+  return normalized in setOf("none", "silent", "off", "false", "0")
+}
+
+internal fun buildSystemNotification(
+  appContext: Context,
+  channelId: String,
+  request: SystemNotifyRequest,
+): Notification =
+  NotificationCompat
+    .Builder(appContext, channelId)
+    .setSmallIcon(android.R.drawable.ic_dialog_info)
+    .setContentTitle(request.title)
+    .setContentText(request.body)
+    .setContentIntent(mainActivityPendingIntent(appContext, NOTIFICATION_CONTENT_REQUEST_CODE))
+    .setPriority(compatPriority(request.priority))
+    .setAutoCancel(true)
+    .setOnlyAlertOnce(true)
+    .setSilent(isSilentSound(request.sound))
+    .build()
 
 /** Handles system-level node.invoke commands implemented by Android services. */
 class SystemHandler private constructor(

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/SystemHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/SystemHandlerTest.kt
@@ -1,10 +1,21 @@
 package ai.openclaw.app.node
 
+import ai.openclaw.app.MainActivity
+import android.content.Context
+import android.content.Intent
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
 class SystemHandlerTest {
   @Test
   fun handleSystemNotify_rejectsUnauthorized() {
@@ -62,6 +73,26 @@ class SystemHandlerTest {
     assertEquals("done", poster.lastRequest?.body)
     assertEquals("passive", poster.lastRequest?.priority)
     assertEquals("silent", poster.lastRequest?.sound)
+  }
+
+  @Test
+  fun buildSystemNotificationSetsImmutableAppLaunchIntent() {
+    val context: Context = RuntimeEnvironment.getApplication()
+    val notification =
+      buildSystemNotification(
+        appContext = context,
+        channelId = "test",
+        request = SystemNotifyRequest("OpenClaw", "done", sound = null, priority = null),
+      )
+
+    val pendingIntent = notification.contentIntent
+    assertNotNull(pendingIntent)
+    assertTrue(pendingIntent.isImmutable)
+
+    val savedIntent = Shadows.shadowOf(pendingIntent).savedIntent
+    assertEquals(MainActivity::class.java.name, savedIntent.component?.className)
+    val expectedFlags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+    assertEquals(expectedFlags, savedIntent.flags and expectedFlags)
   }
 
   @Test


### PR DESCRIPTION
Closes #96350

Related: #88293

## What Problem This Solves

Fixes an issue where Android users tapping a notification created by `system.notify` would see nothing happen because the notification had no content intent.

## Why This Change Was Made

Adds the same explicit, immutable `MainActivity` pending intent already used by Android's foreground-service notification. Taps reuse the existing OpenClaw task with `SINGLE_TOP | CLEAR_TOP`, and the shared helper keeps both notification surfaces on one launch contract.

This deliberately does not accept a raw `deeplink` value. Current CLI and agent-tool callers do not expose that field, Android has no matching app-deeplink route, and passing arbitrary targets through would create a new native launch surface. Broader allowlisted local URL/deeplink behavior remains tracked by #88293.

## User Impact

Tapping an OpenClaw `system.notify` notification now opens the Android app. Existing notification priority, sound, auto-cancel, and permission behavior are unchanged.

## Evidence

- Fresh structured autoreview: clean; no accepted/actionable findings.
- Blacksmith Testbox: focused `SystemHandlerTest` and `NodeForegroundServiceTest` passed from a clean rerun.
- Blacksmith Testbox: complete third-party Android unit suite passed from a clean rerun (968 tests on the final post-#100879 tree).
- `pnpm native:i18n:check` passes after regenerating the inventory for the moved Android source lines.
- Robolectric verifies the content intent is immutable, explicitly targets `MainActivity`, and preserves `SINGLE_TOP | CLEAR_TOP`.
- Full Android ktlint reached the changed sources without findings; it remains red only on unrelated pre-existing test-file violations elsewhere on current `main`.
- `git diff --check` passed.
