### PR TITLE
fix(browser): bound client fetch success JSON reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Browser control response bounds:** cap successful absolute-HTTP control JSON reads while preserving the browser tool's supported large response bodies. (#100889) Thanks @mushuiyu886.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **Agent auth copy order:** preserve the source agent's portable auth-profile precedence when copying credentials to a new agent while excluding skipped profiles and transient auth state. (#100833) Thanks @machine3at.
 - **Cron edit delivery:** preserve each job's implicit delivery mode when applying partial delivery updates, so disabling best-effort delivery no longer turns detached job announcements off. (#100846) Thanks @machine3at.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Browser control response bounds:** cap successful absolute-HTTP control JSON reads while preserving the browser tool's supported large response bodies. (#100889) Thanks @mushuiyu886.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **Agent auth copy order:** preserve the source agent's portable auth-profile precedence when copying credentials to a new agent while excluding skipped profiles and transient auth state. (#100833) Thanks @machine3at.
 - **Cron edit delivery:** preserve each job's implicit delivery mode when applying partial delivery updates, so disabling best-effort delivery no longer turns detached job announcements off. (#100846) Thanks @machine3at.

--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -23,8 +23,8 @@ const { fetchBrowserJson } = await import("./client-fetch.js");
 const STREAM_CHUNK = Buffer.alloc(4 * 1024, "x");
 const STREAM_BODY_BYTES = 1024 * 1024;
 const SUCCESS_STREAM_CHUNK = Buffer.alloc(64 * 1024, "x");
-const SUCCESS_STREAM_BODY_BYTES = 17 * 1024 * 1024;
-const BROWSER_SUCCESS_BODY_LIMIT_BYTES = 16 * 1024 * 1024;
+const SUCCESS_STREAM_BODY_BYTES = 33 * 1024 * 1024;
+const BROWSER_SUCCESS_BODY_LIMIT_BYTES = 32 * 1024 * 1024;
 
 describe("fetchHttpJson error body boundary", () => {
   let server: http.Server;
@@ -62,6 +62,11 @@ describe("fetchHttpJson error body boundary", () => {
     streamCompleted = false;
     successStreamCompleted = false;
     server = http.createServer((req, res) => {
+      if (req.url === "/success-small") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end('{"payload":"control"}');
+        return;
+      }
       if (req.url === "/success-large") {
         let written = 0;
         let closed = false;
@@ -165,6 +170,12 @@ describe("fetchHttpJson error body boundary", () => {
     });
     await expect(successStreamClosed).resolves.toBeUndefined();
     expect(successStreamCompleted).toBe(false);
+  });
+
+  it("preserves a normal successful JSON response", async () => {
+    await expect(fetchBrowserJson(`${baseUrl}/success-small`)).resolves.toEqual({
+      payload: "control",
+    });
   });
 
   it("preserves a complete diagnostic body within the limit", async () => {

--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -22,6 +22,9 @@ const { fetchBrowserJson } = await import("./client-fetch.js");
 
 const STREAM_CHUNK = Buffer.alloc(4 * 1024, "x");
 const STREAM_BODY_BYTES = 1024 * 1024;
+const SUCCESS_STREAM_CHUNK = Buffer.alloc(64 * 1024, "x");
+const SUCCESS_STREAM_BODY_BYTES = 17 * 1024 * 1024;
+const BROWSER_SUCCESS_BODY_LIMIT_BYTES = 16 * 1024 * 1024;
 
 describe("fetchHttpJson error body boundary", () => {
   let server: http.Server;
@@ -30,7 +33,10 @@ describe("fetchHttpJson error body boundary", () => {
   let resolveStreamClosed: () => void;
   let smallConnectionClosed: Promise<void>;
   let resolveSmallConnectionClosed: () => void;
+  let successStreamClosed: Promise<void>;
+  let resolveSuccessStreamClosed: () => void;
   let streamCompleted: boolean;
+  let successStreamCompleted: boolean;
 
   beforeEach(async () => {
     for (const key of [
@@ -50,8 +56,47 @@ describe("fetchHttpJson error body boundary", () => {
     smallConnectionClosed = new Promise<void>((resolve) => {
       resolveSmallConnectionClosed = resolve;
     });
+    successStreamClosed = new Promise<void>((resolve) => {
+      resolveSuccessStreamClosed = resolve;
+    });
     streamCompleted = false;
+    successStreamCompleted = false;
     server = http.createServer((req, res) => {
+      if (req.url === "/success-large") {
+        let written = 0;
+        let closed = false;
+        res.once("close", () => {
+          closed = true;
+          resolveSuccessStreamClosed();
+        });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.write('{"payload":"');
+        const writeNext = () => {
+          if (closed) {
+            return;
+          }
+          if (written >= SUCCESS_STREAM_BODY_BYTES) {
+            successStreamCompleted = true;
+            res.end('"}');
+            return;
+          }
+          const remaining = SUCCESS_STREAM_BODY_BYTES - written;
+          const chunk =
+            remaining >= SUCCESS_STREAM_CHUNK.byteLength
+              ? SUCCESS_STREAM_CHUNK
+              : SUCCESS_STREAM_CHUNK.subarray(0, remaining);
+          written += chunk.byteLength;
+          const scheduleNext = () => setTimeout(writeNext, 2);
+          if (res.write(chunk)) {
+            scheduleNext();
+          } else {
+            res.once("drain", scheduleNext);
+          }
+        };
+        writeNext();
+        return;
+      }
+
       if (req.url === "/small") {
         req.socket.once("close", () => resolveSmallConnectionClosed());
         res.writeHead(500, { "Content-Type": "text/plain" });
@@ -109,6 +154,17 @@ describe("fetchHttpJson error body boundary", () => {
     expect(error).toMatchObject({ name: "BrowserServiceError", message: "HTTP 500" });
     await expect(streamClosed).resolves.toBeUndefined();
     expect(streamCompleted).toBe(false);
+  });
+
+  it("cancels an overflowing successful JSON response", async () => {
+    const error = await fetchBrowserJson(`${baseUrl}/success-large`).catch((err: unknown) => err);
+
+    expect(error).toMatchObject({
+      name: "BrowserServiceError",
+      message: `Browser control response exceeded ${BROWSER_SUCCESS_BODY_LIMIT_BYTES} bytes`,
+    });
+    await expect(successStreamClosed).resolves.toBeUndefined();
+    expect(successStreamCompleted).toBe(false);
   });
 
   it("preserves a complete diagnostic body within the limit", async () => {

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -106,6 +106,7 @@ const BROWSER_TOOL_MODEL_HINT =
   "Use an alternative approach or inform the user that the browser is currently unavailable.";
 
 const BROWSER_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
+const BROWSER_SUCCESS_BODY_LIMIT_BYTES = 16 * 1024 * 1024;
 
 function isRateLimitStatus(status: number): boolean {
   return status === 429;
@@ -277,7 +278,11 @@ async function fetchHttpJson<T>(
       const text = body ? new TextDecoder().decode(body) : "";
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
-    return (await res.json()) as T;
+    const body = await readResponseWithLimit(res, BROWSER_SUCCESS_BODY_LIMIT_BYTES, {
+      onOverflow: ({ maxBytes }) =>
+        new BrowserServiceError(`Browser control response exceeded ${maxBytes} bytes`),
+    });
+    return JSON.parse(new TextDecoder().decode(body)) as T;
   } finally {
     clearTimeout(t);
     await release?.();

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -106,7 +106,8 @@ const BROWSER_TOOL_MODEL_HINT =
   "Use an alternative approach or inform the user that the browser is currently unavailable.";
 
 const BROWSER_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
-const BROWSER_SUCCESS_BODY_LIMIT_BYTES = 16 * 1024 * 1024;
+// `response/body` supports 5M characters; 32 MiB covers worst-case JSON escaping while staying bounded.
+const BROWSER_SUCCESS_BODY_LIMIT_BYTES = 32 * 1024 * 1024;
 
 function isRateLimitStatus(status: number): boolean {
   return status === 429;


### PR DESCRIPTION
## Summary

- Problem: successful HTTP responses in the browser-control client used unbounded `res.json()` reads.
- Solution: read successful HTTP JSON responses with `readResponseWithLimit` before `JSON.parse`.
- What changed: one production success-response read path plus focused regression coverage in the existing browser client boundary test file.
- What was not changed: non-2xx handling, 429/rate-limit messaging, auth, SSRF policy, timeout wiring, response schema, and local dispatcher handling.

## What Problem This Solves

`fetchHttpJson` already bounded non-2xx response bodies, but successful HTTP responses still used `res.json()`. A browser-control HTTP endpoint could stream an oversized 2xx JSON body and have the client read and parse the whole response before returning or failing.

## User Impact

- **Why it matters / User impact:** A malformed, compromised, or buggy browser-control HTTP service can no longer make the client fully buffer and parse an oversized successful JSON body. The user-visible behavior becomes a stable `BrowserServiceError` at the response-size boundary while ordinary small successful JSON responses keep working.

## Origin / follow-up

- **Follows / completes:** #97490
- **Gap this fills:** #97490 bounded a same-class successful external JSON response read; this patch applies that missing bound to the browser-control HTTP success path.
- **Consistency:** The fix uses the existing `readResponseWithLimit` runtime helper already used by this file's error path and other bounded response-read patches.

## Competition / linked PR analysis

- **Linked PR(s):** N/A; related open PR scan before implementation found no open PR covering this `client-fetch` / `fetchBrowserJson` / `fetchHttpJson` success JSON bound path.
- **Gap in linked PR(s):** N/A; no linked competing PR was found for this exact browser client success-response boundary.
- **Why this patch is better/canonical:** The patch fixes the owner module that performs the unbounded HTTP success read, instead of adding a downstream guard after JSON parsing.
- **Local real behavior proof advantage:** The proof drives the production browser client HTTP URL path with a real loopback HTTP server and shows before oversized resolution, after bounded rejection, and small-success control behavior.

## Real behavior proof

- **Behavior or issue addressed:** The browser-control HTTP client success path no longer reads and parses an oversized successful JSON response with `res.json()`.
- **Real environment tested:** Sanitized public-network AWS Crabbox, exact reviewed head, production `fetchBrowserJson` HTTP URL path, a real Node HTTP server bound to `127.0.0.1`, and a real Gateway-managed Chromium session. The boundary proof drives the public browser client transport rather than mocking the response reader.
- **Exact hosted proof after this patch:**

Sanitized public-network AWS Crabbox, exact reviewed head `26a91f63ef7e18986477ffc73bc8e418db8823db`, no Tailscale, no IAM role, no credential hydration:

- `run_95d4ed5764a6`: real streamed HTTP boundary proof.
- `run_9cbfb6525ff0`: focused regression file, 4 tests passed.
- `run_87950fa36760`: real Gateway plus managed Chromium start/open/navigate/snapshot proof.

- **Evidence after fix:**

Before the patch, the same real HTTP proof completed and parsed the oversized success body:

```text
before.largeResolved=true
before.payloadLength=34603008
before.serverCompleted=true
before.serverClosed=true
before.controlOk=true
```

After the patch, the oversized success body is rejected at the 32 MiB bound, the server observes cancellation before completing the 33 MiB stream, and a small successful JSON response still works:

```text
oversized_error_name=BrowserServiceError
oversized_error_message=Browser control response exceeded 33554432 bytes
stream_bytes=34603008
server_completed=false
small_payload=control
browser_http_boundary=pass
```

Focused regression coverage also passes:

```text
Test Files  1 passed (1)
     Tests  4 passed (4)
[test] passed 1 Vitest shard in 17.35s
```

The end-to-end managed-browser control also passed:

```text
managed_browser_url=https://example.com/?openclaw-pr-100889=live
managed_browser_snapshot=Example Domain
gateway_managed_browser=pass
```

- **Observed result after fix:** The production HTTP transport now raises `BrowserServiceError: Browser control response exceeded 33554432 bytes` instead of resolving a 33 MiB JSON payload, while the normal small JSON control request still resolves. The real Gateway and managed Chromium flow remains healthy.
- **What was not tested:** No visual screenshot was captured because this is a non-UI transport-boundary change. The local dispatcher path is intentionally unchanged.
- **Fix classification:** Root cause fix

## Review findings addressed

No prior review findings on this branch.

## Regression Test Plan

- **Target test file:** `extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts`
- **Scenario locked in:** A real local HTTP server returns a successful JSON response with a 33 MiB string payload. `fetchBrowserJson` must reject at `33554432` bytes, the server must observe the stream closing before completing the oversized response, and a small successful JSON response must still resolve.
- **Why this is the smallest reliable guardrail:** The regression test uses the public browser client transport entry point and a real HTTP response stream. The test-only `.catch((err: unknown) => err)` pattern is used to assert the rejection object and does not add a production catch, fallback, or retry path.

Hosted proof runs: `run_95d4ed5764a6`, `run_9cbfb6525ff0`, and `run_87950fa36760`.

## Risk / Compatibility

- **Risk labels considered:** `merge-risk: security-boundary`, `merge-risk: compatibility`, `merge-risk: availability`.
- **Risk explanation:** The touched file participates in the browser-control transport boundary, and the patch deliberately changes public HTTP success behavior for oversized JSON responses. The contract scope is limited to response body size enforcement; it does not change the HTTP method, URL shape, auth behavior, SSRF policy, status handling, or JSON schema for normal-sized responses. Related open PR scan found no competing open PR for this exact `client-fetch` success JSON bound.
- **Why acceptable:** The new behavior only activates when a successful browser-control HTTP JSON body exceeds 32 MiB. This preserves the existing `response/body` contract of up to 5,000,000 characters even for worst-case JSON escaping, while still bounding a malformed or compromised service. The proof shows the ordinary small success response still resolves. The limit is applied before parsing to avoid buffering the entire oversized body, while all unrelated browser-control paths remain unchanged.

## What was not changed

- **What did NOT change:** Request bodies, auth headers, SSRF policy, timeout wiring, 429/rate-limit messaging, non-2xx error-body handling, response schema, local dispatcher handling, docs, formatting-only edits, and lockfiles remain unchanged.
- Public API / schema / protocol / defaults: normal-sized successful JSON responses keep the same parsed response shape; only oversized success bodies now fail at the body-size boundary.
- Channel/provider/session/security behavior outside the fixed path: unchanged.
- Unrelated cleanup, docs, formatting, lockfiles: none.

## Root Cause

- **Root cause:** The browser-control HTTP transport had two response-body paths with different invariants. The non-2xx path used `readResponseWithLimit`, which cancels overflowing streams before surfacing a service error, but the successful 2xx path skipped that client-owned byte boundary and delegated directly to the Fetch API JSON parser with `res.json()`. That caused the successful response reader to fully consume an oversized body before this module could reject it.
- **Why this is root-cause fix:** The patch moves successful HTTP JSON consumption back under the browser client transport invariant by replacing the unbounded reader with `readResponseWithLimit(..., BROWSER_SUCCESS_BODY_LIMIT_BYTES)` before `JSON.parse`. The oversized body is now rejected at the source response-read boundary, before buffering and parsing the full payload, rather than masked by a downstream error handler.
- **Maintainer-ready confidence:** High. The diff is limited to two target files, the production change is a single success-reader replacement, and the before/after proof exercises the production HTTP boundary with a real streamed response plus a small-success control.
- **Patch quality notes:** Patch-quality warning reviewed: the added `.catch((err: unknown) => err)` is test-only assertion code in the existing style of this file, used to inspect the rejection object. No production broad catch, fallback, retry, feature flag, or unrelated refactor was added.
- **Architecture / source-of-truth check:** The source-of-truth boundary is the absolute HTTP `fetchHttpJson` response-reader path: `fetchWithSsrFGuard` returns the real `Response`, `readResponseWithLimit` owns byte-limit enforcement, and `JSON.parse` only sees bounded bytes. The local dispatcher path is a separate in-process contract and remains unchanged because it never called `res.json()`.
