### PR TITLE
fix(feishu): avoid mention forwarding when bot open id is unavailable

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -140,13 +140,16 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.mentionedBot).toBe(false);
   });
 
-  it("does not create mention-forward targets when botOpenId is undefined", () => {
-    const event = makeEvent("p2p", [
-      { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },
-    ]);
-    const ctx = parseFeishuMessageEvent(event, undefined);
-    expect(ctx.mentionTargets).toBeUndefined();
-  });
+  it.each([undefined, "", "  "])(
+    "does not create mention-forward targets when botOpenId is %j",
+    (botOpenId) => {
+      const event = makeEvent("p2p", [
+        { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },
+      ]);
+      const ctx = parseFeishuMessageEvent(event, botOpenId);
+      expect(ctx.mentionTargets).toBeUndefined();
+    },
+  );
 
   it("returns mentionedBot=false when botOpenId is empty string (probe failed)", () => {
     const event = makeEvent("group", [

--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -140,6 +140,14 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.mentionedBot).toBe(false);
   });
 
+  it("does not create mention-forward targets when botOpenId is undefined", () => {
+    const event = makeEvent("p2p", [
+      { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event, undefined);
+    expect(ctx.mentionTargets).toBeUndefined();
+  });
+
   it("returns mentionedBot=false when botOpenId is empty string (probe failed)", () => {
     const event = makeEvent("group", [
       { key: "@_user_1", name: "Alice", id: { open_id: "ou_alice" } },

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -319,8 +319,9 @@ export function parseFeishuMessageEvent(
   };
 
   // Detect mention forward request: message mentions bot + at least one other user
-  if (isMentionForwardRequest(event, botOpenId)) {
-    const mentionTargets = extractMentionTargets(event, botOpenId);
+  const mentionForwardBotOpenId = botOpenId?.trim();
+  if (mentionForwardBotOpenId && isMentionForwardRequest(event, mentionForwardBotOpenId)) {
+    const mentionTargets = extractMentionTargets(event, mentionForwardBotOpenId);
     if (mentionTargets.length > 0) {
       ctx.mentionTargets = mentionTargets;
     }

--- a/extensions/feishu/src/mention.ts
+++ b/extensions/feishu/src/mention.ts
@@ -62,6 +62,9 @@ export function isMentionForwardRequest(event: FeishuMessageEvent, botOpenId?: s
   if (mentions.length === 0) {
     return false;
   }
+  if (!botOpenId) {
+    return false;
+  }
 
   const isDirectMessage = !isFeishuGroupChatType(event.message.chat_type);
   const userMentions = mentions.filter((m) => !isFeishuBroadcastMention(m));

--- a/extensions/feishu/src/mention.ts
+++ b/extensions/feishu/src/mention.ts
@@ -28,7 +28,7 @@ export function isFeishuBroadcastMention(mention: FeishuMentionLike): boolean {
  */
 export function extractMentionTargets(
   event: FeishuMessageEvent,
-  botOpenId?: string,
+  botOpenId: string,
 ): MentionTarget[] {
   const mentions = event.message.mentions ?? [];
 
@@ -38,7 +38,7 @@ export function extractMentionTargets(
         return false;
       }
       // Exclude the bot itself
-      if (botOpenId && m.id.open_id === botOpenId) {
+      if (m.id.open_id === botOpenId) {
         return false;
       }
       // Must have open_id
@@ -62,20 +62,21 @@ export function isMentionForwardRequest(event: FeishuMessageEvent, botOpenId?: s
   if (mentions.length === 0) {
     return false;
   }
-  if (!botOpenId) {
+  const normalizedBotOpenId = botOpenId?.trim();
+  if (!normalizedBotOpenId) {
     return false;
   }
 
   const isDirectMessage = !isFeishuGroupChatType(event.message.chat_type);
   const userMentions = mentions.filter((m) => !isFeishuBroadcastMention(m));
-  const hasOtherMention = userMentions.some((m) => m.id.open_id !== botOpenId);
+  const hasOtherMention = userMentions.some((m) => m.id.open_id !== normalizedBotOpenId);
 
   if (isDirectMessage) {
     // DM: trigger if any non-bot user is mentioned
     return hasOtherMention;
   }
   // Group: need to mention both bot and other users
-  const hasBotMention = userMentions.some((m) => m.id.open_id === botOpenId);
+  const hasBotMention = userMentions.some((m) => m.id.open_id === normalizedBotOpenId);
   return hasBotMention && hasOtherMention;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu direct-message mention forwarding could be triggered when the bot open id was unavailable. In that state, ordinary user mentions were treated as mention-forward targets even though OpenClaw could not reliably know whether the bot was addressed.

## Why This Change Was Made

The Feishu mention-forward check now stops early when the bot open id is missing, so it only evaluates “bot plus other user” or direct-message mention forwarding when the bot identity is known. This keeps the change scoped to mention-forward detection and does not change Feishu message parsing, broadcast mention filtering, or outbound mention formatting.

## User Impact

Feishu users should no longer see accidental mention-forward behavior during bot identity probe/configuration gaps. Normal mention forwarding remains unchanged when the bot open id is available.

## Evidence

- Signed Feishu webhook runtime proof, using the same monitor path as webhook mode: `monitorSingleAccount(webhook) -> signed HTTP POST -> EventDispatcher -> handleFeishuMessage -> channel.inbound.run`. Payload IDs below are synthetic/redacted local proof values.

  ```text
  Feishu signed webhook runtime proof for mention-forward detection
  Surface: monitorSingleAccount(webhook) -> signed HTTP POST -> EventDispatcher -> handleFeishuMessage -> channel.inbound.run

  === missing botOpenId DM with Alice mention ===
  HTTP POST status: 200
  Dispatch count: 1
  Runtime logs:
    feishu[proof-missing-bot]: bot open_id resolved: unknown
    feishu[proof-missing-bot]: received message from ou_sender_1 in oc_dm_missing_bot (p2p)
    feishu[proof-missing-bot]: dispatching to agent (session=agent:main:feishu:direct:ou_sender_1)
    feishu[proof-missing-bot]: dispatch complete (queuedFinal=false, replies=0)
  Agent BodyForAgent mention-target line:
    <none>

  === known botOpenId group with bot + Alice mentions ===
  HTTP POST status: 200
  Dispatch count: 1
  Runtime logs:
    feishu[proof-known-bot]: bot open_id resolved: ou_bot_1
    feishu[proof-known-bot]: received message from ou_sender_1 in oc_proof_group (group)
    feishu[proof-known-bot]: detected @ forward request, targets: [Alice]
    feishu[proof-known-bot]: dispatching to agent (session=agent:main:feishu:group:oc_proof_group)
    feishu[proof-known-bot]: dispatch complete (queuedFinal=false, replies=0)
  Agent BodyForAgent mention-target line:
    [System: Feishu users mentioned in the incoming message, for context only: "Alice". Do not notify or mention these users solely because they are listed here.]

  RESULT: PASS
  ```

- `corepack pnpm@11.2.2 exec node scripts/run-vitest.mjs run extensions/feishu/src/bot.checkBotMentioned.test.ts`

  ```text
  [test] starting test/vitest/vitest.extension-feishu.config.ts
  The `envFile` option is deprecated, please use `envDir: false` instead.
  
   RUN  v4.1.9 [local path redacted]
  
  
   Test Files  1 passed (1)
        Tests  24 passed (24)
     Start at  20:43:09
     Duration  18.05s (transform 9.86s, setup 79ms, import 17.58s, tests 20ms, environment 0ms)
  
  [test] passed 1 Vitest shard in 29.56s
  ```

- `corepack pnpm@11.2.2 exec node scripts/run-vitest.mjs run extensions/feishu/src/monitor.message-handler.test.ts`

  ```text
  [test] starting test/vitest/vitest.extension-feishu.config.ts
  The `envFile` option is deprecated, please use `envDir: false` instead.
  
   RUN  v4.1.9 [local path redacted]
  
  
   Test Files  1 passed (1)
        Tests  2 passed (2)
     Start at  20:43:58
     Duration  789ms (transform 283ms, setup 71ms, import 373ms, tests 14ms, environment 0ms)
  
  [test] passed 1 Vitest shard in 12.00s
  ```
