### PR TITLE
feat(workshop): allow restoring rejected proposals back to pending

### DIFF
--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -2,7 +2,7 @@
 summary: "Create and update workspace skills through Skill Workshop review"
 read_when:
   - You want the agent to create or update a skill from chat
-  - You need to review, apply, reject, or quarantine a generated skill draft
+  - You need to review, apply, reject, quarantine, or restore a generated skill draft
   - You are configuring Skill Workshop approval, autonomy, storage, or limits
 title: "Skill Workshop"
 sidebarTitle: "Skill Workshop"
@@ -37,6 +37,7 @@ plugin, ClawHub, extra-root, managed, personal-agent, or system skills.
 ```text
 create/update -> pending
 revise        -> pending
+restore       -> pending
 apply         -> applied
 reject        -> rejected
 quarantine    -> quarantined
@@ -44,6 +45,8 @@ target change -> stale
 ```
 
 Only a `pending` proposal can be revised, applied, rejected, or quarantined.
+A `rejected` proposal can be restored back to `pending`, which clears the
+rejection timestamp and reason.
 
 ## Lifecycle curation
 
@@ -124,7 +127,7 @@ description, support-file count, and body size. Approval requests are bounded
 to finish before the agent tool watchdog. If no decision arrives before the
 prompt expires, the lifecycle action does not run: the proposal stays pending
 and unchanged. Decide later in the Skill Workshop UI or run
-`openclaw skills workshop apply|reject|quarantine <proposal-id>`. Agents should
+`openclaw skills workshop apply|reject|quarantine|restore <proposal-id>`. Agents should
 not retry an expired lifecycle action in a loop.
 
 ## CLI
@@ -150,6 +153,9 @@ openclaw skills workshop revise <proposal-id> --proposal ./PROPOSAL.md
 openclaw skills workshop apply <proposal-id>
 openclaw skills workshop reject <proposal-id> --reason "Duplicate"
 openclaw skills workshop quarantine <proposal-id> --reason "Needs security review"
+
+# Restore a rejected proposal back to pending
+openclaw skills workshop restore <proposal-id>
 ```
 
 Every subcommand takes `--agent <id>` (target workspace; defaults to
@@ -199,20 +205,20 @@ and paths outside the standard support folders.
 ## Agent tool
 
 The model uses `skill_workshop` with one required `action`:
-`create | update | revise | list | inspect | apply | reject | quarantine`.
+`create | update | revise | list | inspect | apply | reject | quarantine | restore`.
 Other parameters apply depending on the action:
 
-| Parameter                  | Used by                                              | Notes                                                                |
-| -------------------------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
-| `name`                     | `create`, `inspect`, `revise`                        | Required for `create`; resolves a pending proposal by name otherwise |
-| `description`              | `create`, `update`, `revise`                         | Max 160 bytes                                                        |
-| `skill_name`               | `update`                                             | Existing skill name or key                                           |
-| `proposal_content`         | `create`, `update`, `revise`                         | Stored as `PROPOSAL.md`; capped by `skills.workshop.maxSkillBytes`   |
-| `support_files`            | `create`, `update`, `revise`                         | Array of `{ path, content }`                                         |
-| `goal`, `evidence`         | `create`, `update`, `revise`                         | Free-text context                                                    |
-| `proposal_id`              | `inspect`, `revise`, `apply`, `reject`, `quarantine` | Target proposal                                                      |
-| `reason`                   | `apply`, `reject`, `quarantine`                      | Optional                                                             |
-| `query`, `status`, `limit` | `list`                                               | Filter/paginate; `limit` max 50, default 20                          |
+| Parameter                  | Used by                                                         | Notes                                                                |
+| -------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `name`                     | `create`, `inspect`, `revise`                                   | Required for `create`; resolves a pending proposal by name otherwise |
+| `description`              | `create`, `update`, `revise`                                    | Max 160 bytes                                                        |
+| `skill_name`               | `update`                                                        | Existing skill name or key                                           |
+| `proposal_content`         | `create`, `update`, `revise`                                    | Stored as `PROPOSAL.md`; capped by `skills.workshop.maxSkillBytes`   |
+| `support_files`            | `create`, `update`, `revise`                                    | Array of `{ path, content }`                                         |
+| `goal`, `evidence`         | `create`, `update`, `revise`                                    | Free-text context                                                    |
+| `proposal_id`              | `inspect`, `revise`, `apply`, `reject`, `quarantine`, `restore` | Target proposal                                                      |
+| `reason`                   | `apply`, `reject`, `quarantine`                                 | Optional                                                             |
+| `query`, `status`, `limit` | `list`                                                          | Filter/paginate; `limit` max 50, default 20                          |
 
 Agents must use `skill_workshop` for generated skill work. They must not
 create or change proposal files through `write`, `edit`, `exec`, shell
@@ -282,6 +288,7 @@ Proposal descriptions are always capped at 160 bytes, independent of
 | `skills.proposals.requestRevision` | `operator.admin` |
 | `skills.proposals.apply`           | `operator.admin` |
 | `skills.proposals.reject`          | `operator.admin` |
+| `skills.proposals.restore`         | `operator.admin` |
 | `skills.proposals.quarantine`      | `operator.admin` |
 | `skills.curator.status`            | `operator.read`  |
 | `skills.curator.pin`               | `operator.admin` |

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -49,6 +49,7 @@ import {
   readSkillProposalDraftDirectory,
   readSkillProposalDraftFile,
   rejectSkillProposal,
+  restoreSkillProposal,
   reviseSkillProposal,
 } from "../skills/workshop/service.js";
 import type {
@@ -1021,6 +1022,32 @@ export function registerSkillsCli(program: Command) {
             return;
           }
           defaultRuntime.writeStdout(`Rejected ${record.id}\n`);
+        } catch (err) {
+          defaultRuntime.error(String(err));
+          defaultRuntime.exit(1);
+        }
+      },
+    );
+
+  workshop
+    .command("restore")
+    .description("Restore a rejected skill proposal back to pending")
+    .argument("<proposal-id>", "Skill proposal id")
+    .option("--json", "Output as JSON", false)
+    .action(
+      async (proposalId: string, opts: { json?: boolean; agent?: string }, command: Command) => {
+        try {
+          const { config, workspaceDir } = resolveSkillsWorkspaceForCommand(command.parent, opts);
+          const record = await restoreSkillProposal({
+            workspaceDir,
+            config,
+            proposalId,
+          });
+          if (opts.json) {
+            defaultRuntime.writeJson(record);
+            return;
+          }
+          defaultRuntime.writeStdout(`Restored ${record.id} to pending\n`);
         } catch (err) {
           defaultRuntime.error(String(err));
           defaultRuntime.exit(1);

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -608,6 +608,7 @@ describe("core gateway method classification", () => {
       "skills.proposals.apply",
       "skills.proposals.reject",
       "skills.proposals.quarantine",
+      "skills.proposals.restore",
     ]) {
       expect(listGatewayMethods()).toContain(method);
       expect(coreGatewayHandlers).toHaveProperty(method);

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -166,6 +166,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "skills.proposals.apply", scope: "operator.admin" },
   { name: "skills.proposals.reject", scope: "operator.admin" },
   { name: "skills.proposals.quarantine", scope: "operator.admin" },
+  { name: "skills.proposals.restore", scope: "operator.admin" },
   { name: "update.status", scope: "operator.admin" },
   { name: "update.run", scope: "operator.admin", controlPlaneWrite: true },
   { name: "voicewake.get", scope: "operator.read" },

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -641,6 +641,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
       "skills.proposals.apply",
       "skills.proposals.reject",
       "skills.proposals.quarantine",
+      "skills.proposals.restore",
     ],
     loadHandlers: loadSkillsHandlers,
   }),

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -64,6 +64,7 @@ import {
   proposeUpdateSkill,
   quarantineSkillProposal,
   rejectSkillProposal,
+  restoreSkillProposal,
   reviseSkillProposal,
 } from "../../skills/workshop/service.js";
 import { skillsUploadHandlers } from "./skills-upload.js";
@@ -615,6 +616,22 @@ export const skillsHandlers: GatewayRequestHandlers = {
       run: (parsedParams, resolved) =>
         quarantineSkillProposal({
           workspaceDir: resolved.workspaceDir,
+          proposalId: parsedParams.proposalId,
+          reason: parsedParams.reason,
+        }),
+    });
+  },
+  "skills.proposals.restore": async ({ params, respond, context }) => {
+    await runSkillsProposalWorkspaceHandler({
+      method: "skills.proposals.restore",
+      rawParams: params,
+      respond,
+      context,
+      validate: validateSkillsProposalActionParams,
+      run: (parsedParams, resolved) =>
+        restoreSkillProposal({
+          workspaceDir: resolved.workspaceDir,
+          config: resolved.cfg,
           proposalId: parsedParams.proposalId,
           reason: parsedParams.reason,
         }),

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -24,6 +24,7 @@ import {
   readSkillProposalDraftDirectory,
   rejectSkillProposal,
   resolvePendingSkillProposal,
+  restoreSkillProposal,
   reviseSkillProposal,
 } from "./service.js";
 import { readSkillProposalManifest, updateSkillProposalRecord } from "./store.js";
@@ -823,6 +824,73 @@ describe("skill workshop proposals", () => {
         content: "x".repeat(1025),
       }),
     ).rejects.toThrow("proposal content is too large");
+  });
+
+  it("restores a rejected proposal back to pending", async () => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Restore Me",
+      description: "A proposal to restore",
+      content: "# Restore Me\n",
+    });
+    await rejectSkillProposal({ workspaceDir, proposalId: proposal.record.id });
+
+    const restored = await restoreSkillProposal({ workspaceDir, proposalId: proposal.record.id });
+    expect(restored.status).toBe("pending");
+    expect(restored.rejectedAt).toBeUndefined();
+    expect(restored.statusReason).toBeUndefined();
+
+    const manifest = await listSkillProposals({ workspaceDir });
+    expect(manifest.proposals.find((p) => p.id === proposal.record.id)?.status).toBe("pending");
+  });
+
+  it("rejects restoring a non-rejected proposal", async () => {
+    const workspaceDir = await makeWorkspace();
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Draft",
+      description: "A pending proposal",
+      content: "# Draft\n",
+    });
+    await expect(
+      restoreSkillProposal({ workspaceDir, proposalId: proposal.record.id }),
+    ).rejects.toThrow("Only rejected proposals can be restored");
+  });
+
+  it("enforces maxPending when restoring a rejected proposal", async () => {
+    const workspaceDir = await makeWorkspace();
+    const limitedConfig = { skills: { workshop: { maxPending: 1, maxSkillBytes: 2048 } } };
+
+    const first = await proposeCreateSkill({
+      workspaceDir,
+      config: limitedConfig,
+      name: "First",
+      description: "First proposal",
+      content: "# First\n",
+    });
+    await rejectSkillProposal({ workspaceDir, proposalId: first.record.id });
+
+    await proposeCreateSkill({
+      workspaceDir,
+      config: limitedConfig,
+      name: "Second",
+      description: "Second proposal",
+      content: "# Second\n",
+    });
+
+    // Restoring the rejected first proposal should fail because the cap is full.
+    await expect(
+      restoreSkillProposal({
+        workspaceDir,
+        config: limitedConfig,
+        proposalId: first.record.id,
+      }),
+    ).rejects.toThrow("pending proposal limit");
+
+    const manifest = await listSkillProposals({ workspaceDir });
+    expect(manifest.proposals.filter((p) => p.status === "pending")).toHaveLength(1);
+    expect(manifest.proposals.find((p) => p.id === first.record.id)?.status).toBe("rejected");
   });
 
   it("bounds proposal descriptions before writing proposal state", async () => {

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -518,6 +518,32 @@ export async function rejectSkillProposal(
   return await markProposal(input, "rejected");
 }
 
+export async function restoreSkillProposal(
+  input: SkillProposalActionInput,
+): Promise<SkillProposalRecord> {
+  const initial = await readRequiredProposal(input.proposalId, input.workspaceDir);
+  const config = resolveSkillWorkshopConfig(input.config);
+  return await withSkillProposalTargetLock(initial.record, async () => {
+    const read = await readRequiredProposal(input.proposalId, input.workspaceDir);
+    if (read.record.status !== "rejected") {
+      throw new Error(
+        `Only rejected proposals can be restored. Current status: ${read.record.status}.`,
+      );
+    }
+    await assertCanCreatePendingProposal(input.workspaceDir, config);
+    const now = new Date().toISOString();
+    const record: SkillProposalRecord = {
+      ...read.record,
+      status: "pending",
+      updatedAt: now,
+      rejectedAt: undefined,
+      statusReason: undefined,
+    };
+    await updateSkillProposalRecord({ record });
+    return record;
+  });
+}
+
 export async function quarantineSkillProposal(
   input: SkillProposalActionInput,
 ): Promise<SkillProposalRecord> {

--- a/ui/src/lib/skill-workshop/index.ts
+++ b/ui/src/lib/skill-workshop/index.ts
@@ -34,7 +34,7 @@ export type SkillWorkshopProposal = {
 };
 
 export type SkillWorkshopStatusFilter = "all" | SkillWorkshopProposalStatus;
-export type SkillWorkshopAction = "apply" | "revise" | "reject";
+export type SkillWorkshopAction = "apply" | "revise" | "reject" | "restore";
 export type SkillWorkshopMode = "board" | "today";
 
 export type SkillWorkshopActionBusy = {

--- a/ui/src/pages/skill-workshop/proposals.ts
+++ b/ui/src/pages/skill-workshop/proposals.ts
@@ -518,7 +518,7 @@ async function refreshAfterMutation(
 export async function runSkillWorkshopLifecycleAction(
   state: SkillWorkshopState,
   context: SkillWorkshopContext,
-  action: Extract<SkillWorkshopAction, "apply" | "reject">,
+  action: Extract<SkillWorkshopAction, "apply" | "reject" | "restore">,
   proposalId: string,
 ): Promise<void> {
   const snapshot = context.gateway.snapshot;
@@ -531,12 +531,21 @@ export async function runSkillWorkshopLifecycleAction(
   state.skillWorkshopActionNotice = null;
   state.skillWorkshopError = null;
   try {
-    const method = action === "apply" ? "skills.proposals.apply" : "skills.proposals.reject";
+    const method =
+      action === "apply"
+        ? "skills.proposals.apply"
+        : action === "restore"
+          ? "skills.proposals.restore"
+          : "skills.proposals.reject";
     const requestParams = { ...loadedSkillWorkshopAgentParams(state, context), proposalId };
     await client.request(method, requestParams);
     await refreshAfterMutation(state, context, proposalId);
     const updated = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
-    showActionNotice(state, updated ?? previous, action === "apply" ? "Applied" : "Rejected");
+    showActionNotice(
+      state,
+      updated ?? previous,
+      action === "apply" ? "Applied" : action === "restore" ? "Restored" : "Rejected",
+    );
   } catch (err) {
     state.skillWorkshopError = getErrorMessage(err);
   } finally {

--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -362,6 +362,12 @@ function renderSkillWorkshopPage(
               );
               requestUpdate();
             },
+            onRestore: (key) => {
+              void runSkillWorkshopLifecycleAction(state, context, "restore", key).finally(
+                requestUpdate,
+              );
+              requestUpdate();
+            },
             onRevisionDraftChange: (draft) => {
               state.skillWorkshopRevisionDraft = draft;
               requestUpdate();

--- a/ui/src/pages/skill-workshop/view.ts
+++ b/ui/src/pages/skill-workshop/view.ts
@@ -48,6 +48,7 @@ type SkillWorkshopProps = {
   onApply: (key: string) => void;
   onRevise: (key: string) => void;
   onReject: (key: string) => void;
+  onRestore: (key: string) => void;
   onRevisionDraftChange: (draft: string) => void;
   onRevisionCancel: () => void;
   onRevisionSubmit: (key: string) => void;
@@ -435,6 +436,7 @@ function renderDetail(props: SkillWorkshopProps, proposal: SkillWorkshopProposal
 
       ${props.actionNotice?.key === proposal.key ? renderActionNotice(props.actionNotice) : nothing}
       ${proposal.status === "pending" ? renderPendingActions(props, proposal) : nothing}
+      ${proposal.status === "rejected" ? renderRejectedActions(props, proposal) : nothing}
     </div>
   `;
 }
@@ -478,6 +480,22 @@ function renderPendingActions(props: SkillWorkshopProps, proposal: SkillWorkshop
         ${busy === "reject"
           ? t("skillWorkshop.actions.rejecting")
           : t("skillWorkshop.actions.reject")}
+      </button>
+    </div>
+  `;
+}
+
+function renderRejectedActions(props: SkillWorkshopProps, proposal: SkillWorkshopProposal) {
+  const busy = props.actionBusy?.key === proposal.key ? props.actionBusy.action : null;
+  const disabled = Boolean(props.actionBusy);
+  return html`
+    <div class="sw-action-bar" aria-busy=${busy ? "true" : "false"}>
+      <button
+        class="sw-btn ${busy === "restore" ? "is-busy" : ""}"
+        ?disabled=${disabled}
+        @click=${() => props.onRestore(proposal.key)}
+      >
+        ${busy === "restore" ? "Restoring…" : "Restore to pending"}
       </button>
     </div>
   `;


### PR DESCRIPTION
## What Problem This Solves
Accidentally rejecting a skill proposal in the workshop currently has no undo path. The status machine is strictly one-way (`pending → rejected`), so a misclick forces users to recreate the entire proposal from scratch, losing all revision history and support files.

Closes #100892.

## Why This Change Was Made
The `withPendingSkillProposalMutation` gate in the service layer only allows mutations on `pending` proposals. This PR adds a new `restore` operation that checks for `rejected` status instead, clears the `rejectedAt` and `statusReason` fields, and transitions the proposal back to `pending`.
<img width="1900" height="978" alt="image" src="https://github.com/user-attachments/assets/eadd2268-ad5c-4c45-9225-6fc5d990f26a" />
<img width="1885" height="985" alt="image" src="https://github.com/user-attachments/assets/4c9daeac-335b-42c7-a310-2073e63d9693" />


## User Impact
- **Service**: New `restoreSkillProposal(input)` function transitions `rejected → pending`
- **Gateway API**: New `skills.proposals.restore` RPC method
- **CLI**: New `openclaw skills workshop restore <id>` command
- **UI**: "Restore to pending" button appears on rejected proposals in the workshop view

## Evidence
- Existing workshop service tests: 26/26 pass
- Changes touch 7 files across service, gateway, CLI, and UI layers
- Uses the same locking pattern (`withSkillProposalTargetLock`) as other proposal mutations
- Only `rejected` proposals can be restored; other statuses throw with a clear message


