### PR TITLE
fix(android): tune screenshot mode visual sizing

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -443,7 +443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 89,
+      "line": 75,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -451,7 +451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 96,
+      "line": 82,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Connected",
       "surface": "android",
@@ -459,7 +459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 121,
+      "line": 107,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Gateway paired",
       "surface": "android",
@@ -467,7 +467,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 121,
+      "line": 107,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Mac Studio - Tailnet",
       "surface": "android",
@@ -475,7 +475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 122,
+      "line": 108,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Node",
       "surface": "android",
@@ -483,7 +483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 123,
+      "line": 109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Transport",
       "surface": "android",
@@ -491,7 +491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 124,
+      "line": 110,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Capabilities",
       "surface": "android",
@@ -499,7 +499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 127,
+      "line": 113,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -507,7 +507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 139,
+      "line": 125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Hi Molty, are you there?",
       "surface": "android",
@@ -515,7 +515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 139,
+      "line": 125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "You",
       "surface": "android",
@@ -523,7 +523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 141,
+      "line": 127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Molty",
       "surface": "android",
@@ -531,7 +531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 142,
+      "line": 128,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Always. Lurking in the shadows, exfoliating.",
       "surface": "android",
@@ -539,7 +539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 177,
+      "line": 156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Listening on device",
       "surface": "android",
@@ -547,7 +547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 177,
+      "line": 156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Talk mode",
       "surface": "android",
@@ -555,7 +555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 178,
+      "line": 157,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Wake phrase",
       "surface": "android",
@@ -563,7 +563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 179,
+      "line": 158,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Latency",
       "surface": "android",
@@ -571,7 +571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 185,
+      "line": 164,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Screen tools",
       "surface": "android",
@@ -579,7 +579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 185,
+      "line": 164,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Shared with your gateway",
       "surface": "android",
@@ -587,7 +587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 186,
+      "line": 165,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Canvas",
       "surface": "android",
@@ -595,7 +595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 197,
+      "line": 176,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Live context",
       "surface": "android",
@@ -603,7 +603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 198,
+      "line": 177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Camera",
       "surface": "android",
@@ -611,7 +611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 199,
+      "line": 178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Screen",
       "surface": "android",
@@ -619,7 +619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 200,
+      "line": 179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Location",
       "surface": "android",
@@ -627,7 +627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 208,
+      "line": 187,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Security",
       "surface": "android",
@@ -635,7 +635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 212,
+      "line": 191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Notifications",
       "surface": "android",
@@ -643,7 +643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 418,
+      "line": 397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Connect",
       "surface": "android",
@@ -651,7 +651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 419,
+      "line": 398,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -659,7 +659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 420,
+      "line": 399,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -667,7 +667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 421,
+      "line": 400,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Device tools",
       "surface": "android",
@@ -675,7 +675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 422,
+      "line": 401,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Settings",
       "surface": "android",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -443,7 +443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 67,
+      "line": 89,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -451,7 +451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 74,
+      "line": 96,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Connected",
       "surface": "android",
@@ -459,7 +459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 99,
+      "line": 121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Gateway paired",
       "surface": "android",
@@ -467,7 +467,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 99,
+      "line": 121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Mac Studio - Tailnet",
       "surface": "android",
@@ -475,7 +475,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 100,
+      "line": 122,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Node",
       "surface": "android",
@@ -483,7 +483,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 101,
+      "line": 123,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Transport",
       "surface": "android",
@@ -491,7 +491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 102,
+      "line": 124,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Capabilities",
       "surface": "android",
@@ -499,7 +499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 105,
+      "line": 127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Ready",
       "surface": "android",
@@ -507,7 +507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 117,
+      "line": 139,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Hi Molty, are you there?",
       "surface": "android",
@@ -515,7 +515,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 117,
+      "line": 139,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "You",
       "surface": "android",
@@ -523,7 +523,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 119,
+      "line": 141,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Molty",
       "surface": "android",
@@ -531,7 +531,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 120,
+      "line": 142,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Always. Lurking in the shadows, exfoliating.",
       "surface": "android",
@@ -539,7 +539,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 144,
+      "line": 177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Listening on device",
       "surface": "android",
@@ -547,7 +547,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 144,
+      "line": 177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Talk mode",
       "surface": "android",
@@ -555,7 +555,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 145,
+      "line": 178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Wake phrase",
       "surface": "android",
@@ -563,7 +563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 146,
+      "line": 179,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Latency",
       "surface": "android",
@@ -571,7 +571,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 152,
+      "line": 185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Screen tools",
       "surface": "android",
@@ -579,7 +579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 152,
+      "line": 185,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Shared with your gateway",
       "surface": "android",
@@ -587,7 +587,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 153,
+      "line": 186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Canvas",
       "surface": "android",
@@ -595,7 +595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 164,
+      "line": 197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Live context",
       "surface": "android",
@@ -603,7 +603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 165,
+      "line": 198,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Camera",
       "surface": "android",
@@ -611,7 +611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 166,
+      "line": 199,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Screen",
       "surface": "android",
@@ -619,7 +619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 167,
+      "line": 200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Location",
       "surface": "android",
@@ -627,7 +627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 175,
+      "line": 208,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Security",
       "surface": "android",
@@ -635,7 +635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 179,
+      "line": 212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Notifications",
       "surface": "android",
@@ -643,7 +643,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 385,
+      "line": 418,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Connect",
       "surface": "android",
@@ -651,7 +651,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 386,
+      "line": 419,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -659,7 +659,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 387,
+      "line": 420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -667,7 +667,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 388,
+      "line": 421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Device tools",
       "surface": "android",
@@ -675,7 +675,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 389,
+      "line": 422,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt",
       "source": "Settings",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -12,6 +12,8 @@ Assistant messages now offer a long-press Listen action with gateway TTS playbac
 
 Android command-palette rows now align icon and navigation affordances consistently and truncate long session details cleanly. Thanks @IWhatsskill.
 
+Android screenshot-mode voice and screen proof scenes now scale cleanly on compact capture widths. Thanks @IWhatsskill.
+
 The Settings About screen now shows the animated mascot with the app tagline plus Website, Docs, GitHub, and Discord links.
 
 Adds a read-only Files browser for agent workspaces with directory navigation, text and image previews, and system share export.

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt
@@ -7,12 +7,14 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -38,6 +40,23 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
+private val ScreenshotScreenHorizontalPadding = 20.dp
+private val ScreenshotScreenVerticalPadding = 26.dp
+private val ScreenshotBodyVerticalPadding = 20.dp
+private val ScreenshotBodyGap = 14.dp
+private val ScreenshotCardRadius = 8.dp
+private val ScreenshotCardPadding = 16.dp
+private val ScreenshotIconBoxSize = 44.dp
+private val ScreenshotFeatureIconSize = 22.dp
+private val ScreenshotTabIconSize = 20.dp
+private val ScreenshotTabIconRadius = 6.dp
+private val ScreenshotVoiceOrbMaxSize = 196.dp
+private val ScreenshotVoiceIconSize = 72.dp
+private val ScreenshotVoiceIconCompactSize = 60.dp
+private val ScreenshotContextPanelMinHeight = 160.dp
+private val ScreenshotContextBarHeight = 7.dp
+private val ScreenshotContextBarRadius = 4.dp
+
 @Composable
 fun AndroidScreenshotModeScreen(scene: AndroidScreenshotScene) {
   ClawDesignTheme(dark = true) {
@@ -46,7 +65,10 @@ fun AndroidScreenshotModeScreen(scene: AndroidScreenshotScene) {
         Modifier
           .fillMaxSize()
           .background(ClawTheme.colors.canvas)
-          .padding(horizontal = 20.dp, vertical = 26.dp),
+          .padding(
+            horizontal = ScreenshotScreenHorizontalPadding,
+            vertical = ScreenshotScreenVerticalPadding,
+          ),
       verticalArrangement = Arrangement.SpaceBetween,
     ) {
       ScreenshotHeader(scene)
@@ -81,8 +103,8 @@ private fun ScreenshotSceneBody(
   modifier: Modifier = Modifier,
 ) {
   Column(
-    modifier = modifier.fillMaxWidth().padding(vertical = 20.dp),
-    verticalArrangement = Arrangement.spacedBy(14.dp),
+    modifier = modifier.fillMaxWidth().padding(vertical = ScreenshotBodyVerticalPadding),
+    verticalArrangement = Arrangement.spacedBy(ScreenshotBodyGap),
   ) {
     when (scene) {
       AndroidScreenshotScene.Connect -> ConnectScene()
@@ -124,9 +146,20 @@ private fun ChatScene() {
 
 @Composable
 private fun VoiceScene() {
-  Box(modifier = Modifier.fillMaxWidth().padding(vertical = 20.dp), contentAlignment = Alignment.Center) {
+  BoxWithConstraints(
+    modifier = Modifier.fillMaxWidth().padding(vertical = ScreenshotBodyVerticalPadding),
+    contentAlignment = Alignment.Center,
+  ) {
+    val orbSize = minOf(maxWidth, ScreenshotVoiceOrbMaxSize)
+    val iconSize =
+      if (orbSize < ScreenshotVoiceOrbMaxSize) {
+        ScreenshotVoiceIconCompactSize
+      } else {
+        ScreenshotVoiceIconSize
+      }
+
     Surface(
-      modifier = Modifier.size(196.dp),
+      modifier = Modifier.size(orbSize),
       shape = CircleShape,
       color = ClawTheme.colors.surfaceRaised,
       border = BorderStroke(1.dp, ClawTheme.colors.borderStrong),
@@ -136,7 +169,7 @@ private fun VoiceScene() {
           imageVector = Icons.Default.Mic,
           contentDescription = null,
           tint = ClawTheme.colors.primary,
-          modifier = Modifier.size(72.dp),
+          modifier = Modifier.size(iconSize),
         )
       }
     }
@@ -155,12 +188,12 @@ private fun ScreenScene() {
     MetricRow(label = "Location", value = "On request")
   }
   Surface(
-    modifier = Modifier.fillMaxWidth().height(168.dp),
-    shape = RoundedCornerShape(8.dp),
+    modifier = Modifier.fillMaxWidth().heightIn(min = ScreenshotContextPanelMinHeight),
+    shape = RoundedCornerShape(ScreenshotCardRadius),
     color = ClawTheme.colors.surfaceRaised,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
-    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+    Column(modifier = Modifier.padding(ScreenshotCardPadding), verticalArrangement = Arrangement.spacedBy(10.dp)) {
       Text(text = "Live context", style = ClawTheme.type.section, color = ClawTheme.colors.text)
       ContextBar(label = "Camera", fraction = 0.74f)
       ContextBar(label = "Screen", fraction = 0.58f)
@@ -190,11 +223,11 @@ private fun FeaturePanel(
 ) {
   Surface(
     modifier = Modifier.fillMaxWidth(),
-    shape = RoundedCornerShape(8.dp),
+    shape = RoundedCornerShape(ScreenshotCardRadius),
     color = ClawTheme.colors.surface,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
-    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
+    Column(modifier = Modifier.padding(ScreenshotCardPadding), verticalArrangement = Arrangement.spacedBy(ScreenshotBodyGap)) {
       Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         IconBox(icon = icon)
         Column {
@@ -214,11 +247,11 @@ private fun CompactList(
 ) {
   Surface(
     modifier = Modifier.fillMaxWidth(),
-    shape = RoundedCornerShape(8.dp),
+    shape = RoundedCornerShape(ScreenshotCardRadius),
     color = ClawTheme.colors.surfaceRaised,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
-    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(modifier = Modifier.padding(ScreenshotCardPadding), verticalArrangement = Arrangement.spacedBy(12.dp)) {
       Text(text = title, style = ClawTheme.type.section, color = ClawTheme.colors.text)
       rows.forEach { row ->
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -239,11 +272,11 @@ private fun ChatBubble(
 ) {
   Surface(
     modifier = Modifier.fillMaxWidth(),
-    shape = RoundedCornerShape(8.dp),
+    shape = RoundedCornerShape(ScreenshotCardRadius),
     color = if (raised) ClawTheme.colors.surfaceRaised else ClawTheme.colors.surface,
     border = BorderStroke(1.dp, if (raised) ClawTheme.colors.borderStrong else ClawTheme.colors.border),
   ) {
-    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(modifier = Modifier.padding(ScreenshotCardPadding), verticalArrangement = Arrangement.spacedBy(8.dp)) {
       Text(text = label, style = ClawTheme.type.caption, color = ClawTheme.colors.textSubtle)
       Text(text = text, style = ClawTheme.type.body, color = ClawTheme.colors.text)
     }
@@ -278,15 +311,15 @@ private fun ContextBar(
       modifier =
         Modifier
           .fillMaxWidth()
-          .height(7.dp)
-          .clip(RoundedCornerShape(4.dp))
+          .height(ScreenshotContextBarHeight)
+          .clip(RoundedCornerShape(ScreenshotContextBarRadius))
           .background(ClawTheme.colors.surfacePressed),
     ) {
       Box(
         modifier =
           Modifier
             .fillMaxWidth(fraction)
-            .height(7.dp)
+            .height(ScreenshotContextBarHeight)
             .background(ClawTheme.colors.primary),
       )
     }
@@ -297,7 +330,7 @@ private fun ContextBar(
 private fun ScreenshotTabBar(activeScene: AndroidScreenshotScene) {
   Surface(
     modifier = Modifier.fillMaxWidth(),
-    shape = RoundedCornerShape(8.dp),
+    shape = RoundedCornerShape(ScreenshotCardRadius),
     color = ClawTheme.colors.surface,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
@@ -322,8 +355,8 @@ private fun TabIcon(
   Box(
     modifier =
       Modifier
-        .size(42.dp)
-        .clip(RoundedCornerShape(6.dp))
+        .size(ScreenshotIconBoxSize)
+        .clip(RoundedCornerShape(ScreenshotTabIconRadius))
         .background(if (active) ClawTheme.colors.surfacePressed else Color.Transparent),
     contentAlignment = Alignment.Center,
   ) {
@@ -331,7 +364,7 @@ private fun TabIcon(
       imageVector = icon,
       contentDescription = null,
       tint = if (active) ClawTheme.colors.text else ClawTheme.colors.textSubtle,
-      modifier = Modifier.size(20.dp),
+      modifier = Modifier.size(ScreenshotTabIconSize),
     )
   }
 }
@@ -341,8 +374,8 @@ private fun IconBox(icon: ImageVector) {
   Box(
     modifier =
       Modifier
-        .size(42.dp)
-        .clip(RoundedCornerShape(8.dp))
+        .size(ScreenshotIconBoxSize)
+        .clip(RoundedCornerShape(ScreenshotCardRadius))
         .background(ClawTheme.colors.surfacePressed),
     contentAlignment = Alignment.Center,
   ) {
@@ -350,7 +383,7 @@ private fun IconBox(icon: ImageVector) {
       imageVector = icon,
       contentDescription = null,
       tint = ClawTheme.colors.primary,
-      modifier = Modifier.size(22.dp),
+      modifier = Modifier.size(ScreenshotFeatureIconSize),
     )
   }
 }
@@ -361,7 +394,7 @@ private fun StatusPill(
   color: Color,
 ) {
   Surface(
-    shape = RoundedCornerShape(8.dp),
+    shape = RoundedCornerShape(ScreenshotCardRadius),
     color = ClawTheme.colors.surfaceRaised,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/AndroidScreenshotModeScreen.kt
@@ -7,10 +7,10 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -40,22 +41,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
-private val ScreenshotScreenHorizontalPadding = 20.dp
-private val ScreenshotScreenVerticalPadding = 26.dp
-private val ScreenshotBodyVerticalPadding = 20.dp
-private val ScreenshotBodyGap = 14.dp
-private val ScreenshotCardRadius = 8.dp
-private val ScreenshotCardPadding = 16.dp
 private val ScreenshotIconBoxSize = 44.dp
-private val ScreenshotFeatureIconSize = 22.dp
-private val ScreenshotTabIconSize = 20.dp
-private val ScreenshotTabIconRadius = 6.dp
-private val ScreenshotVoiceOrbMaxSize = 196.dp
-private val ScreenshotVoiceIconSize = 72.dp
-private val ScreenshotVoiceIconCompactSize = 60.dp
-private val ScreenshotContextPanelMinHeight = 160.dp
-private val ScreenshotContextBarHeight = 7.dp
-private val ScreenshotContextBarRadius = 4.dp
 
 @Composable
 fun AndroidScreenshotModeScreen(scene: AndroidScreenshotScene) {
@@ -66,8 +52,8 @@ fun AndroidScreenshotModeScreen(scene: AndroidScreenshotScene) {
           .fillMaxSize()
           .background(ClawTheme.colors.canvas)
           .padding(
-            horizontal = ScreenshotScreenHorizontalPadding,
-            vertical = ScreenshotScreenVerticalPadding,
+            horizontal = ClawTheme.spacing.md,
+            vertical = 26.dp,
           ),
       verticalArrangement = Arrangement.SpaceBetween,
     ) {
@@ -103,8 +89,8 @@ private fun ScreenshotSceneBody(
   modifier: Modifier = Modifier,
 ) {
   Column(
-    modifier = modifier.fillMaxWidth().padding(vertical = ScreenshotBodyVerticalPadding),
-    verticalArrangement = Arrangement.spacedBy(ScreenshotBodyGap),
+    modifier = modifier.fillMaxWidth().padding(vertical = ClawTheme.spacing.md),
+    verticalArrangement = Arrangement.spacedBy(14.dp),
   ) {
     when (scene) {
       AndroidScreenshotScene.Connect -> ConnectScene()
@@ -146,20 +132,13 @@ private fun ChatScene() {
 
 @Composable
 private fun VoiceScene() {
-  BoxWithConstraints(
-    modifier = Modifier.fillMaxWidth().padding(vertical = ScreenshotBodyVerticalPadding),
+  Box(
+    modifier = Modifier.fillMaxWidth().padding(vertical = ClawTheme.spacing.md),
     contentAlignment = Alignment.Center,
   ) {
-    val orbSize = minOf(maxWidth, ScreenshotVoiceOrbMaxSize)
-    val iconSize =
-      if (orbSize < ScreenshotVoiceOrbMaxSize) {
-        ScreenshotVoiceIconCompactSize
-      } else {
-        ScreenshotVoiceIconSize
-      }
-
+    // Scale the proof orb with compact capture widths while preserving its 196dp design cap.
     Surface(
-      modifier = Modifier.size(orbSize),
+      modifier = Modifier.widthIn(max = 196.dp).fillMaxWidth().aspectRatio(1f),
       shape = CircleShape,
       color = ClawTheme.colors.surfaceRaised,
       border = BorderStroke(1.dp, ClawTheme.colors.borderStrong),
@@ -169,7 +148,7 @@ private fun VoiceScene() {
           imageVector = Icons.Default.Mic,
           contentDescription = null,
           tint = ClawTheme.colors.primary,
-          modifier = Modifier.size(iconSize),
+          modifier = Modifier.fillMaxSize(0.37f),
         )
       }
     }
@@ -188,12 +167,12 @@ private fun ScreenScene() {
     MetricRow(label = "Location", value = "On request")
   }
   Surface(
-    modifier = Modifier.fillMaxWidth().heightIn(min = ScreenshotContextPanelMinHeight),
-    shape = RoundedCornerShape(ScreenshotCardRadius),
+    modifier = Modifier.fillMaxWidth().heightIn(min = 160.dp),
+    shape = RoundedCornerShape(ClawTheme.radii.button),
     color = ClawTheme.colors.surfaceRaised,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
-    Column(modifier = Modifier.padding(ScreenshotCardPadding), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+    Column(modifier = Modifier.padding(ClawTheme.spacing.sm), verticalArrangement = Arrangement.spacedBy(10.dp)) {
       Text(text = "Live context", style = ClawTheme.type.section, color = ClawTheme.colors.text)
       ContextBar(label = "Camera", fraction = 0.74f)
       ContextBar(label = "Screen", fraction = 0.58f)
@@ -223,11 +202,11 @@ private fun FeaturePanel(
 ) {
   Surface(
     modifier = Modifier.fillMaxWidth(),
-    shape = RoundedCornerShape(ScreenshotCardRadius),
+    shape = RoundedCornerShape(ClawTheme.radii.button),
     color = ClawTheme.colors.surface,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
-    Column(modifier = Modifier.padding(ScreenshotCardPadding), verticalArrangement = Arrangement.spacedBy(ScreenshotBodyGap)) {
+    Column(modifier = Modifier.padding(ClawTheme.spacing.sm), verticalArrangement = Arrangement.spacedBy(14.dp)) {
       Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         IconBox(icon = icon)
         Column {
@@ -247,11 +226,11 @@ private fun CompactList(
 ) {
   Surface(
     modifier = Modifier.fillMaxWidth(),
-    shape = RoundedCornerShape(ScreenshotCardRadius),
+    shape = RoundedCornerShape(ClawTheme.radii.button),
     color = ClawTheme.colors.surfaceRaised,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
-    Column(modifier = Modifier.padding(ScreenshotCardPadding), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+    Column(modifier = Modifier.padding(ClawTheme.spacing.sm), verticalArrangement = Arrangement.spacedBy(12.dp)) {
       Text(text = title, style = ClawTheme.type.section, color = ClawTheme.colors.text)
       rows.forEach { row ->
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -272,11 +251,11 @@ private fun ChatBubble(
 ) {
   Surface(
     modifier = Modifier.fillMaxWidth(),
-    shape = RoundedCornerShape(ScreenshotCardRadius),
+    shape = RoundedCornerShape(ClawTheme.radii.button),
     color = if (raised) ClawTheme.colors.surfaceRaised else ClawTheme.colors.surface,
     border = BorderStroke(1.dp, if (raised) ClawTheme.colors.borderStrong else ClawTheme.colors.border),
   ) {
-    Column(modifier = Modifier.padding(ScreenshotCardPadding), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(modifier = Modifier.padding(ClawTheme.spacing.sm), verticalArrangement = Arrangement.spacedBy(8.dp)) {
       Text(text = label, style = ClawTheme.type.caption, color = ClawTheme.colors.textSubtle)
       Text(text = text, style = ClawTheme.type.body, color = ClawTheme.colors.text)
     }
@@ -311,15 +290,15 @@ private fun ContextBar(
       modifier =
         Modifier
           .fillMaxWidth()
-          .height(ScreenshotContextBarHeight)
-          .clip(RoundedCornerShape(ScreenshotContextBarRadius))
+          .height(7.dp)
+          .clip(RoundedCornerShape(ClawTheme.radii.row))
           .background(ClawTheme.colors.surfacePressed),
     ) {
       Box(
         modifier =
           Modifier
             .fillMaxWidth(fraction)
-            .height(ScreenshotContextBarHeight)
+            .height(7.dp)
             .background(ClawTheme.colors.primary),
       )
     }
@@ -330,7 +309,7 @@ private fun ContextBar(
 private fun ScreenshotTabBar(activeScene: AndroidScreenshotScene) {
   Surface(
     modifier = Modifier.fillMaxWidth(),
-    shape = RoundedCornerShape(ScreenshotCardRadius),
+    shape = RoundedCornerShape(ClawTheme.radii.button),
     color = ClawTheme.colors.surface,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
@@ -356,7 +335,7 @@ private fun TabIcon(
     modifier =
       Modifier
         .size(ScreenshotIconBoxSize)
-        .clip(RoundedCornerShape(ScreenshotTabIconRadius))
+        .clip(RoundedCornerShape(ClawTheme.radii.control))
         .background(if (active) ClawTheme.colors.surfacePressed else Color.Transparent),
     contentAlignment = Alignment.Center,
   ) {
@@ -364,7 +343,7 @@ private fun TabIcon(
       imageVector = icon,
       contentDescription = null,
       tint = if (active) ClawTheme.colors.text else ClawTheme.colors.textSubtle,
-      modifier = Modifier.size(ScreenshotTabIconSize),
+      modifier = Modifier.size(20.dp),
     )
   }
 }
@@ -375,7 +354,7 @@ private fun IconBox(icon: ImageVector) {
     modifier =
       Modifier
         .size(ScreenshotIconBoxSize)
-        .clip(RoundedCornerShape(ScreenshotCardRadius))
+        .clip(RoundedCornerShape(ClawTheme.radii.button))
         .background(ClawTheme.colors.surfacePressed),
     contentAlignment = Alignment.Center,
   ) {
@@ -383,7 +362,7 @@ private fun IconBox(icon: ImageVector) {
       imageVector = icon,
       contentDescription = null,
       tint = ClawTheme.colors.primary,
-      modifier = Modifier.size(ScreenshotFeatureIconSize),
+      modifier = Modifier.size(22.dp),
     )
   }
 }
@@ -394,7 +373,7 @@ private fun StatusPill(
   color: Color,
 ) {
   Surface(
-    shape = RoundedCornerShape(ScreenshotCardRadius),
+    shape = RoundedCornerShape(ClawTheme.radii.button),
     color = ClawTheme.colors.surfaceRaised,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {


### PR DESCRIPTION
## What Problem This Solves

The Android screenshot-mode voice and screen tools scenes used repeated hard-coded dimensions and fixed containers. That made the visual proof screens less consistent across compact widths and harder to tune safely.

## Why This Change Was Made

This centralizes the screenshot-mode sizing values, caps the voice orb against available width, aligns icon and tab boxes at 44dp, and lets the screen live-context card grow from a minimum height instead of forcing a fixed box.

## User Impact

Screenshot-mode voice and screen tools previews render with cleaner, more consistent card, icon, orb, and context-panel sizing while keeping the existing dark OpenClaw visual style and navigation.

## Evidence

- `CI=true pnpm android:assemble` passed on refreshed `origin/main`.
- Real Android lane-a proof used `openclaw_api36_clean` / `emulator-5554` with the Gateway paired and Home showing Gateway Online, Nodes 1/1, Approvals 0.
- Final host-recorded proof videos were verified with ffprobe: each is 6.000000 seconds, 60 frames, 10 fps.
- Visual frames were checked for the correct target screen and no launcher, app-switch, or setup-code content.

### Voice mode

<p>
  <img width="360" alt="Before voice screenshot" src="https://github.com/user-attachments/assets/8e3a2aaf-902e-4ffc-9984-072f96661849" />
  <img width="360" alt="After voice screenshot" src="https://github.com/user-attachments/assets/92e69250-860d-495c-bc6b-f9c4082d3ed1" />
</p>

Before voice video:

https://github.com/user-attachments/assets/6d1a1089-1869-4219-9e5f-3a84885ec1dd

After voice video:

https://github.com/user-attachments/assets/047f30eb-c1d9-418e-8bc7-c6cebff09943

### Screen tools

<p>
  <img width="360" alt="Before screen tools screenshot" src="https://github.com/user-attachments/assets/e763709a-b819-4da5-a003-2f0a6f23365c" />
  <img width="360" alt="After screen tools screenshot" src="https://github.com/user-attachments/assets/5fccf59d-a9ac-407f-925e-b3853b7d65cf" />
</p>

Before screen tools video:

https://github.com/user-attachments/assets/0c233e42-99c9-4ee4-89f3-c9ce9d78820b

After screen tools video:

https://github.com/user-attachments/assets/d9a25b1a-b668-4c54-b80e-fd0f0284fb02