### PR TITLE
test: align shifted main assertions

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -289,12 +289,10 @@ describe("Codex app-server native code mode config", () => {
     });
 
     expect(instructions).toContain("## Skill Workshop");
-    expect(instructions).toContain(
-      "Use `skill_workshop` when the user wants to create, update, revise, list, inspect, apply, reject, or quarantine a reusable skill, Skill Workshop proposal, playbook, workflow, procedure, or durable instruction.",
-    );
-    expect(instructions).toContain(
-      "Use `action=apply`, `action=reject`, or `action=quarantine` only after the user explicitly asks to approve/use/apply, reject, or quarantine a specific proposal.",
-    );
+    expect(instructions).toContain("Route durable skill work");
+    expect(instructions).toContain("through the `skill_workshop` tool");
+    expect(instructions).toContain("Generated skills are pending proposals.");
+    expect(instructions).toContain("only when the user explicitly asks");
   });
 
   it("keeps developer instructions compact when no dynamic tools are deferred", () => {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -186,6 +186,7 @@ function createManager(options?: {
   getRuntimeConfig?: () => Record<string, unknown>;
   channelIds?: ChannelId[];
   startupTrace?: { measure: <T>(name: string, run: () => T | Promise<T>) => Promise<T> };
+  deferStartupAccountStartsUntil?: Promise<void>;
   fillChannelDependencies?: boolean;
 }) {
   const log = createSubsystemLogger("gateway/server-channels-test");
@@ -208,6 +209,9 @@ function createManager(options?: {
       ? { resolveChannelRuntime: options.resolveChannelRuntime }
       : {}),
     ...(options?.startupTrace ? { startupTrace: options.startupTrace } : {}),
+    ...(options?.deferStartupAccountStartsUntil
+      ? { deferStartupAccountStartsUntil: options.deferStartupAccountStartsUntil }
+      : {}),
   });
   createdManagers.push({ channelIds, manager });
   return manager;
@@ -1247,36 +1251,37 @@ describe("server-channels auto restart", () => {
     await flushMicrotasks();
   });
 
-  it("does not start traced channel accounts after stop wins the handoff", async () => {
-    const handoffEntered = createDeferred();
-    const releaseHandoff = createDeferred();
+  it("does not start deferred channel accounts after stop wins the startup handoff", async () => {
+    const releaseAccountStart = createDeferred();
+    const measureMock = vi.fn(async (name: string, run: () => unknown) => await run());
     const startupTrace = {
-      measure: async <T>(name: string, run: () => T | Promise<T>) => {
-        if (name === "channels.discord.start-account-handoff") {
-          handoffEntered.resolve();
-          await releaseHandoff.promise;
-        }
-        return await run();
-      },
+      measure: async <T>(name: string, run: () => T | Promise<T>) =>
+        (await measureMock(name, run)) as T,
     };
     const startAccount = vi.fn(async () => {});
 
     installTestRegistry(createTestPlugin({ startAccount }));
-    const manager = createManager({ startupTrace });
+    const manager = createManager({
+      startupTrace,
+      deferStartupAccountStartsUntil: releaseAccountStart.promise,
+    });
 
-    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
-    await waitForImmediate();
-    await handoffEntered.promise;
+    await manager.startChannels();
+    await flushMicrotasks();
     const stopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
     await flushMicrotasks();
-    releaseHandoff.resolve();
     await stopTask;
+    await flushMicrotasks();
+    releaseAccountStart.resolve();
     await flushMicrotasks();
 
     expect(startAccount).not.toHaveBeenCalled();
+    expect(measureMock.mock.calls.map(([name]) => name)).not.toContain(
+      "channels.discord.start-account-handoff",
+    );
     expect(
       manager.getRuntimeSnapshot().channelAccounts.discord?.[DEFAULT_ACCOUNT_ID]?.running,
-    ).toBe(false);
+    ).not.toBe(true);
   });
 
   it("limits whole-channel account startup fanout to four", async () => {

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -142,10 +142,9 @@ describe("tool-cards", () => {
     );
 
     expect(container.textContent?.match(/Skill Workshop/g)).toHaveLength(1);
-    expect(container.querySelector(".chat-tool-msg-body")?.textContent).not.toContain(
-      "Skill Workshop",
-    );
-    expect(container.querySelector(".chat-tool-card__detail")?.textContent).toContain("create");
+    const bodyText = container.querySelector(".chat-tool-msg-body")?.textContent ?? "";
+    expect(bodyText).not.toContain("Skill Workshop");
+    expect(bodyText).toContain('"action": "create"');
     expect(container.querySelector(".chat-tool-card__action-btn")).toBeInstanceOf(
       HTMLButtonElement,
     );


### PR DESCRIPTION
Summary
- Align Codex Skill Workshop prompt assertions with the current compact routing contract.
- Stabilize the channel startup handoff test so stop wins without waiting for the stop-timeout path.
- Update the chat tool-card assertion to check the stable expanded body contract.

Verification
- Testbox: focused server-channels, chat-tool-cards, and Codex thread-lifecycle tests passed.
- Testbox: gateway suite passed after the handoff test returned to ~111ms.
- Testbox: UI unit + UI E2E passed.
- Testbox: Codex/ACP broad serial lane passed.
- Testbox: pnpm check:changed passed on main c421143b3b2 and again after rebasing onto 5cd71db85ec.
- Autoreview: commit-mode autoreview on the rebased commit reported no accepted/actionable findings.