### PR TITLE
feat(android): tap-to-expand link previews in chat transcript

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -5602,8 +5602,40 @@
       "id": "native.android.a7d32e86ce4c0a17"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 202,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Preview · $domain",
+      "surface": "android",
+      "id": "native.android.71ef7f8dbe2b0dbe"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 211,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Expand link preview",
+      "surface": "android",
+      "id": "native.android.b49e81e487cdbaa3"
+    },
+    {
       "kind": "ui-call",
-      "line": 161,
+      "line": 235,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "Loading preview…",
+      "surface": "android",
+      "id": "native.android.986fd353169b6153"
+    },
+    {
+      "kind": "ui-call",
+      "line": 236,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
+      "source": "No preview available",
+      "surface": "android",
+      "id": "native.android.edb04556385d80d5"
+    },
+    {
+      "kind": "ui-call",
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Thinking...",
       "surface": "android",
@@ -5611,7 +5643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 177,
+      "line": 297,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Tools",
       "surface": "android",
@@ -5619,7 +5651,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 180,
+      "line": 300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Running tools...",
       "surface": "android",
@@ -5627,7 +5659,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 183,
+      "line": 303,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "${display.emoji} ${display.label}",
       "surface": "android",
@@ -5635,7 +5667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 201,
+      "line": 321,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "... +${toolCalls.size - 6} more",
       "surface": "android",
@@ -5643,7 +5675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 232,
+      "line": 352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "You",
       "surface": "android",
@@ -5651,7 +5683,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 246,
+      "line": 366,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Retry",
       "surface": "android",
@@ -5659,7 +5691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 249,
+      "line": 369,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Delete",
       "surface": "android",
@@ -5667,7 +5699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 281,
+      "line": 401,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw · Live",
       "surface": "android",
@@ -5675,7 +5707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 318,
+      "line": 438,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "System",
       "surface": "android",
@@ -5683,7 +5715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 319,
+      "line": 439,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5691,7 +5723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 345,
+      "line": 465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt",
       "source": "Unsupported attachment",
       "surface": "android",
@@ -5755,7 +5787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 620,
+      "line": 622,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5763,7 +5795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 647,
+      "line": 649,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5771,7 +5803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 667,
+      "line": 669,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5779,7 +5811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 698,
+      "line": 700,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5787,7 +5819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 699,
+      "line": 701,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5795,7 +5827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 846,
+      "line": 852,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -5803,7 +5835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 848,
+      "line": 854,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -5811,7 +5843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 851,
+      "line": 857,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -5819,7 +5851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 861,
+      "line": 867,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -5827,7 +5859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 862,
+      "line": 868,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -5835,7 +5867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 981,
+      "line": 987,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -5843,7 +5875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 998,
+      "line": 1004,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -5851,7 +5883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1060,
+      "line": 1066,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -5859,7 +5891,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1150,
+      "line": 1156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -5867,7 +5899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1165,
+      "line": 1171,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -5875,7 +5907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1180,
+      "line": 1186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -5883,7 +5915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1218,
+      "line": 1224,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -5891,7 +5923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1239,
+      "line": 1245,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -5899,7 +5931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1295,
+      "line": 1301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -5907,7 +5939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1334,
+      "line": 1340,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
@@ -1,0 +1,432 @@
+package ai.openclaw.app.ui.chat
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Authenticator
+import okhttp3.CookieJar
+import okhttp3.Dns
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.ResponseBody
+import okio.Buffer
+import org.commonmark.node.Code
+import org.commonmark.node.FencedCodeBlock
+import org.commonmark.node.IndentedCodeBlock
+import org.commonmark.node.Link
+import org.commonmark.node.Node
+import java.io.IOException
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
+import java.net.Proxy
+import java.net.URI
+import java.net.UnknownHostException
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+
+internal const val LINK_PREVIEW_TITLE_MAX_CHARS = 120
+internal const val LINK_PREVIEW_DESCRIPTION_MAX_CHARS = 200
+internal const val LINK_PREVIEW_BODY_MAX_BYTES = 512 * 1024
+private const val LINK_PREVIEW_MAX_REDIRECTS = 3
+private const val LINK_PREVIEW_TIMEOUT_MILLIS = 6_000L
+private const val LINK_PREVIEW_CACHE_ENTRIES = 64
+private const val LINK_PREVIEW_ACCEPT = "text/html, application/xhtml+xml;q=0.9"
+
+internal data class LinkPreviewMetadata(
+  val url: String,
+  val title: String?,
+  val description: String?,
+  val imageUrl: String?,
+)
+
+internal sealed interface LinkPreviewResult {
+  data class Loaded(
+    val metadata: LinkPreviewMetadata,
+  ) : LinkPreviewResult
+
+  data object Failed : LinkPreviewResult
+}
+
+/** Returns the first safe web link outside inline and block code. */
+internal fun extractFirstBareUrl(markdown: String): String? = findFirstLink(parseChatMarkdown(markdown).firstChild)
+
+private fun findFirstLink(start: Node?): String? {
+  var node = start
+  while (node != null) {
+    when (node) {
+      is Link -> {
+        val destination = node.destination?.trim().orEmpty()
+        if (isSafeMarkdownLinkDestination(destination)) return destination
+      }
+      is Code, is FencedCodeBlock, is IndentedCodeBlock -> Unit
+      else -> findFirstLink(node.firstChild)?.let { return it }
+    }
+    node = node.next
+  }
+  return null
+}
+
+/** Parses the OpenGraph subset used by the compact chat preview card. */
+internal fun parseOpenGraph(
+  html: String,
+  baseUrl: String,
+): LinkPreviewResult {
+  var ogTitle: String? = null
+  var ogDescription: String? = null
+  var ogImage: String? = null
+
+  for (tag in findTags(html, "meta")) {
+    val attributes = parseTagAttributes(tag)
+    val property = (attributes["property"] ?: attributes["name"])?.lowercase(Locale.US)
+    val content = attributes["content"] ?: continue
+    when (property) {
+      "og:title" -> if (ogTitle == null) ogTitle = content
+      "og:description" -> if (ogDescription == null) ogDescription = content
+      "og:image", "og:image:url" -> if (ogImage == null) ogImage = content
+    }
+  }
+
+  val title = sanitizeMetadataText(ogTitle ?: findTitle(html), LINK_PREVIEW_TITLE_MAX_CHARS)
+  val description = sanitizeMetadataText(ogDescription, LINK_PREVIEW_DESCRIPTION_MAX_CHARS)
+  val imageUrl = resolveSafeWebUrl(baseUrl, decodeHtmlEntities(ogImage.orEmpty()))
+  if (title == null && description == null && imageUrl == null) return LinkPreviewResult.Failed
+
+  return LinkPreviewResult.Loaded(
+    LinkPreviewMetadata(
+      url = baseUrl,
+      title = title,
+      description = description,
+      imageUrl = imageUrl,
+    ),
+  )
+}
+
+internal class LinkPreviewFetcher(
+  private val client: OkHttpClient = defaultLinkPreviewClient,
+  private val timeoutMillis: Long = LINK_PREVIEW_TIMEOUT_MILLIS,
+  private val hostPolicy: (HttpUrl) -> Boolean = ::isPubliclyRoutableHost,
+) {
+  suspend fun fetch(url: String): LinkPreviewResult =
+    withContext(Dispatchers.IO) {
+      fetchBlocking(url)
+    }
+
+  private fun fetchBlocking(originalUrl: String): LinkPreviewResult {
+    var currentUrl =
+      originalUrl
+        .toHttpUrlOrNull()
+        ?.takeIf(::isSafeWebUrl)
+        ?.takeIf(hostPolicy)
+        ?: return LinkPreviewResult.Failed
+    val deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis)
+    var redirects = 0
+
+    while (true) {
+      val remainingNanos = deadlineNanos - System.nanoTime()
+      if (remainingNanos <= 0L) return LinkPreviewResult.Failed
+      val request =
+        Request
+          .Builder()
+          .url(currentUrl)
+          .header("Accept", LINK_PREVIEW_ACCEPT)
+          .get()
+          .build()
+      val call = client.newCall(request)
+      call.timeout().timeout(remainingNanos, TimeUnit.NANOSECONDS)
+
+      val response = runCatching { call.execute() }.getOrElse { return LinkPreviewResult.Failed }
+      response.use {
+        if (it.isRedirect) {
+          if (redirects >= LINK_PREVIEW_MAX_REDIRECTS) return LinkPreviewResult.Failed
+          currentUrl = resolveRedirect(currentUrl, it.header("Location"), hostPolicy) ?: return LinkPreviewResult.Failed
+          redirects += 1
+          continue
+        }
+        if (!it.isSuccessful) return LinkPreviewResult.Failed
+        val contentType = it.body.contentType() ?: return LinkPreviewResult.Failed
+        if (contentType.type != "text" || contentType.subtype != "html") return LinkPreviewResult.Failed
+
+        val bytes =
+          try {
+            readBodyPrefix(it.body)
+          } catch (_: IOException) {
+            return LinkPreviewResult.Failed
+          }
+        val html = bytes.toString(contentType.charset(Charsets.UTF_8) ?: Charsets.UTF_8)
+        return when (val parsed = parseOpenGraph(html, currentUrl.toString())) {
+          is LinkPreviewResult.Loaded ->
+            parsed.copy(metadata = parsed.metadata.copy(url = originalUrl))
+          LinkPreviewResult.Failed -> LinkPreviewResult.Failed
+        }
+      }
+    }
+  }
+}
+
+private fun readBodyPrefix(body: ResponseBody): ByteArray {
+  val buffer = Buffer()
+  val source = body.source()
+  while (buffer.size < LINK_PREVIEW_BODY_MAX_BYTES) {
+    val remaining = LINK_PREVIEW_BODY_MAX_BYTES - buffer.size
+    if (source.read(buffer, remaining) == -1L) break
+  }
+  return buffer.readByteArray()
+}
+
+internal class LinkPreviewStore(
+  private val fetcher: suspend (String) -> LinkPreviewResult,
+  private val maxEntries: Int = LINK_PREVIEW_CACHE_ENTRIES,
+) {
+  private val cache =
+    object : LinkedHashMap<String, LinkPreviewResult>(maxEntries, 0.75f, true) {
+      override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, LinkPreviewResult>?): Boolean = size > maxEntries
+    }
+
+  suspend fun get(url: String): LinkPreviewResult {
+    synchronized(cache) { cache[url] }?.let { return it }
+    val result = fetcher(url)
+    synchronized(cache) { cache[url] = result }
+    return result
+  }
+}
+
+private val defaultLinkPreviewClient: OkHttpClient =
+  OkHttpClient
+    .Builder()
+    .followRedirects(false)
+    .followSslRedirects(false)
+    .retryOnConnectionFailure(false)
+    .cookieJar(CookieJar.NO_COOKIES)
+    .authenticator(Authenticator.NONE)
+    .proxyAuthenticator(Authenticator.NONE)
+    .proxy(Proxy.NO_PROXY)
+    // Validate inside Dns so the approved address is the one OkHttp connects to, preventing rebinding/TOCTOU.
+    .dns(PublicOnlyDns())
+    .build()
+
+internal val chatLinkPreviewStore = LinkPreviewStore(fetcher = LinkPreviewFetcher()::fetch)
+
+internal fun resolveRedirect(
+  baseUrl: HttpUrl,
+  location: String?,
+  hostPolicy: (HttpUrl) -> Boolean = ::isPubliclyRoutableHost,
+): HttpUrl? =
+  location
+    ?.let(baseUrl::resolve)
+    ?.takeIf { isSafeWebUrl(it) && hostPolicy(it) }
+
+private fun isSafeWebUrl(url: HttpUrl): Boolean = url.scheme == "http" || url.scheme == "https"
+
+internal fun isPubliclyRoutableHost(url: HttpUrl): Boolean {
+  val host = url.host.trimEnd('.').lowercase(Locale.US)
+  if (host == "localhost" || host.endsWith(".local")) return false
+  val address = parseLiteralAddress(host) ?: return true
+  return isPubliclyRoutableAddress(address)
+}
+
+private fun parseLiteralAddress(host: String): InetAddress? {
+  if (host.contains(':')) return runCatching { InetAddress.getByName(host) }.getOrNull()
+  val octets = host.split('.')
+  if (octets.size != 4) return null
+  val bytes =
+    octets.map { octet ->
+      val value = octet.toIntOrNull()?.takeIf { it in 0..255 } ?: return null
+      value.toByte()
+    }
+  return InetAddress.getByAddress(bytes.toByteArray())
+}
+
+private fun isPubliclyRoutableAddress(address: InetAddress): Boolean =
+  !address.isAnyLocalAddress &&
+    !address.isLoopbackAddress &&
+    !address.isSiteLocalAddress &&
+    !address.isLinkLocalAddress &&
+    !address.isMulticastAddress &&
+    !address.isUniqueLocalAddress() &&
+    !address.isLimitedBroadcastAddress() &&
+    !address.isSpecialPurposeAddress()
+
+private fun InetAddress.isUniqueLocalAddress(): Boolean {
+  val bytes = address
+  return bytes.size == 16 && (bytes[0].toInt() and 0xfe) == 0xfc
+}
+
+private fun InetAddress.isLimitedBroadcastAddress(): Boolean = this is Inet4Address && address.all { byte -> byte.toInt() and 0xff == 0xff }
+
+private fun InetAddress.isSpecialPurposeAddress(): Boolean =
+  when (this) {
+    is Inet4Address -> {
+      val octets = address.map { it.toInt() and 0xff }
+      val first = octets[0]
+      val second = octets[1]
+      val third = octets[2]
+      first == 0 ||
+        first == 10 ||
+        (first == 100 && second in 64..127) ||
+        first == 127 ||
+        (first == 169 && second == 254) ||
+        (first == 172 && second in 16..31) ||
+        (first == 192 && second == 0 && (third == 0 || third == 2)) ||
+        (first == 192 && second == 88 && third == 99) ||
+        (first == 192 && second == 168) ||
+        (first == 198 && second in 18..19) ||
+        (first == 198 && second == 51 && third == 100) ||
+        (first == 203 && second == 0 && third == 113) ||
+        first >= 224
+    }
+    is Inet6Address -> {
+      val bytes = address
+      val first = bytes[0].toInt() and 0xff
+      val globalUnicast = first and 0xe0 == 0x20
+      val special2001Prefix = bytes.matchesPrefix(0x20, 0x01, 0x00)
+      val fourthHighNibble = bytes[3].toInt() and 0xf0
+      val orchid = special2001Prefix && (fourthHighNibble == 0x10 || fourthHighNibble == 0x20)
+      !globalUnicast ||
+        bytes.matchesPrefix(0x20, 0x01, 0x00, 0x00) ||
+        bytes.matchesPrefix(0x20, 0x01, 0x00, 0x02) ||
+        orchid ||
+        bytes.matchesPrefix(0x20, 0x01, 0x0d, 0xb8) ||
+        bytes.matchesPrefix(0x20, 0x02) ||
+        (bytes.matchesPrefix(0x3f, 0xff) && (bytes[2].toInt() and 0xf0) == 0)
+    }
+    else -> true
+  }
+
+private fun ByteArray.matchesPrefix(vararg prefix: Int): Boolean = prefix.indices.all { index -> (this[index].toInt() and 0xff) == prefix[index] }
+
+internal class PublicOnlyDns(
+  private val delegate: Dns = Dns.SYSTEM,
+) : Dns {
+  override fun lookup(hostname: String): List<InetAddress> {
+    val addresses = delegate.lookup(hostname)
+    if (addresses.any { !isPubliclyRoutableAddress(it) }) {
+      throw UnknownHostException("$hostname resolved to a non-public address")
+    }
+    return addresses
+  }
+}
+
+private fun resolveSafeWebUrl(
+  baseUrl: String,
+  destination: String,
+): String? {
+  if (destination.isBlank()) return null
+  val resolved =
+    runCatching { URI(baseUrl).resolve(destination.trim()).toString() }
+      .getOrNull()
+      ?: return null
+  return resolved.takeIf(::isSafeMarkdownLinkDestination)
+}
+
+private fun sanitizeMetadataText(
+  value: String?,
+  maxChars: Int,
+): String? {
+  if (value == null) return null
+  val sanitized =
+    decodeHtmlEntities(value)
+      .filterNot(Character::isISOControl)
+      .replace(Regex("\\s+"), " ")
+      .trim()
+  return sanitized.take(maxChars).takeIf(String::isNotEmpty)
+}
+
+private fun findTitle(html: String): String? =
+  Regex("(?is)<title(?:\\s[^>]*)?>(.*?)</title\\s*>")
+    .find(html)
+    ?.groupValues
+    ?.getOrNull(1)
+
+private fun findTags(
+  html: String,
+  tagName: String,
+): Sequence<String> =
+  sequence {
+    var searchFrom = 0
+    while (searchFrom < html.length) {
+      val start = html.indexOf("<$tagName", searchFrom, ignoreCase = true)
+      if (start < 0) break
+      val boundary = html.getOrNull(start + tagName.length + 1)
+      if (boundary != null && !boundary.isWhitespace() && boundary != '/' && boundary != '>') {
+        searchFrom = start + tagName.length + 1
+        continue
+      }
+      val end = findTagEnd(html, start + tagName.length + 1)
+      if (end < 0) break
+      yield(html.substring(start, end + 1))
+      searchFrom = end + 1
+    }
+  }
+
+private fun findTagEnd(
+  html: String,
+  start: Int,
+): Int {
+  var quote: Char? = null
+  for (index in start until html.length) {
+    val char = html[index]
+    if (quote == null && (char == '\'' || char == '"')) {
+      quote = char
+    } else if (char == quote) {
+      quote = null
+    } else if (char == '>' && quote == null) {
+      return index
+    }
+  }
+  return -1
+}
+
+private fun parseTagAttributes(tag: String): Map<String, String> {
+  val attributes = mutableMapOf<String, String>()
+  var index = tag.indexOfFirst(Char::isWhitespace).takeIf { it >= 0 } ?: return attributes
+  while (index < tag.length) {
+    while (index < tag.length && tag[index].isWhitespace()) index += 1
+    if (index >= tag.length || tag[index] == '>' || tag[index] == '/') break
+    val nameStart = index
+    while (index < tag.length && !tag[index].isWhitespace() && tag[index] != '=' && tag[index] != '>') index += 1
+    val name = tag.substring(nameStart, index).lowercase(Locale.US)
+    while (index < tag.length && tag[index].isWhitespace()) index += 1
+    if (index >= tag.length || tag[index] != '=') continue
+    index += 1
+    while (index < tag.length && tag[index].isWhitespace()) index += 1
+    if (index >= tag.length) break
+    val quote = tag[index].takeIf { it == '\'' || it == '"' }
+    if (quote != null) index += 1
+    val valueStart = index
+    if (quote != null) {
+      while (index < tag.length && tag[index] != quote) index += 1
+    } else {
+      while (index < tag.length && !tag[index].isWhitespace() && tag[index] != '>') index += 1
+    }
+    attributes.putIfAbsent(name, tag.substring(valueStart, index))
+    if (quote != null && index < tag.length) index += 1
+  }
+  return attributes
+}
+
+private fun decodeHtmlEntities(value: String): String =
+  value.replace(Regex("&#(x[0-9a-fA-F]+|[0-9]+);?|&(amp|lt|gt|quot|apos|nbsp);", RegexOption.IGNORE_CASE)) { match ->
+    val numeric = match.groupValues[1]
+    if (numeric.isNotEmpty()) {
+      val radix = if (numeric.startsWith('x', ignoreCase = true)) 16 else 10
+      val digits = if (radix == 16) numeric.drop(1) else numeric
+      digits
+        .toIntOrNull(radix)
+        ?.takeIf(Character::isValidCodePoint)
+        ?.let(Character::toChars)
+        ?.concatToString()
+        ?: match.value
+    } else {
+      when (match.groupValues[2].lowercase(Locale.US)) {
+        "amp" -> "&"
+        "lt" -> "<"
+        "gt" -> ">"
+        "quot" -> "\""
+        "apos" -> "'"
+        "nbsp" -> " "
+        else -> match.value
+      }
+    }
+  }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
@@ -592,7 +592,7 @@ private fun AnnotatedString.Builder.appendLinkNode(
   }
 }
 
-private fun isSafeMarkdownLinkDestination(destination: String): Boolean {
+internal fun isSafeMarkdownLinkDestination(destination: String): Boolean {
   val scheme =
     runCatching { URI(destination).scheme?.lowercase(Locale.US) }
       .getOrNull()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageViews.kt
@@ -34,19 +34,28 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import java.util.Locale
@@ -87,6 +96,7 @@ fun ChatMessageBubble(
   ) {
     ChatBubbleContainer(style = style, roleLabel = roleLabel(role)) {
       ChatMessageBody(content = displayableContent, textColor = mobileText)
+      ChatMessageLinkPreview(messageId = message.id, role = role, content = displayableContent)
     }
   }
 }
@@ -145,6 +155,116 @@ private fun ChatMessageBody(
     }
   }
 }
+
+@Composable
+internal fun ChatMessageLinkPreview(
+  messageId: String,
+  role: String,
+  content: List<ChatMessageContent>,
+) {
+  val normalizedRole = normalizeVisibleChatMessageRole(role) ?: return
+  if (normalizedRole != "user" && normalizedRole != "assistant") return
+  val previewUrl =
+    remember(messageId, normalizedRole, content) {
+      content
+        .asSequence()
+        .filter { it.type == "text" }
+        .mapNotNull { it.text?.let(::extractFirstBareUrl) }
+        .firstOrNull()
+    }
+  if (previewUrl != null) {
+    ChatLinkPreview(messageId = messageId, url = previewUrl)
+  }
+}
+
+@Composable
+private fun ChatLinkPreview(
+  messageId: String,
+  url: String,
+) {
+  var expanded by rememberSaveable(messageId, url) { mutableStateOf(false) }
+  var result by remember(messageId, url) { mutableStateOf<LinkPreviewResult?>(null) }
+  val domain = remember(url) { linkPreviewDomain(url) }
+
+  if (!expanded) {
+    Surface(
+      onClick = { expanded = true },
+      shape = RoundedCornerShape(8.dp),
+      color = mobileCardSurface,
+      border = BorderStroke(1.dp, mobileBorder),
+    ) {
+      Row(
+        modifier = Modifier.padding(horizontal = 10.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(
+          text = "Preview · $domain",
+          style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold),
+          color = mobileTextSecondary,
+          modifier = Modifier.weight(1f),
+          maxLines = 1,
+          overflow = TextOverflow.Ellipsis,
+        )
+        androidx.compose.material3.Icon(
+          imageVector = Icons.Default.ExpandMore,
+          contentDescription = "Expand link preview",
+          tint = mobileTextSecondary,
+        )
+      }
+    }
+    return
+  }
+
+  LaunchedEffect(messageId, url) {
+    result = chatLinkPreviewStore.get(url)
+  }
+  val uriHandler = LocalUriHandler.current
+  Surface(
+    onClick = { uriHandler.openUri(url) },
+    shape = RoundedCornerShape(10.dp),
+    color = mobileCardSurface,
+    border = BorderStroke(1.dp, mobileBorder),
+  ) {
+    Column(
+      modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
+      verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+      Text(domain, style = mobileCaption2, color = mobileTextSecondary, maxLines = 1, overflow = TextOverflow.Ellipsis)
+      when (val preview = result) {
+        null -> Text("Loading preview…", style = mobileCaption1, color = mobileTextSecondary)
+        LinkPreviewResult.Failed -> Text("No preview available", style = mobileCallout, color = mobileTextSecondary)
+        is LinkPreviewResult.Loaded -> {
+          preview.metadata.title?.let { title ->
+            Text(
+              text = title,
+              style = mobileCallout.copy(fontWeight = FontWeight.SemiBold),
+              color = mobileText,
+              maxLines = 2,
+              overflow = TextOverflow.Ellipsis,
+            )
+          }
+          preview.metadata.description?.let { description ->
+            Text(
+              text = description,
+              style = mobileCaption1,
+              color = mobileTextSecondary,
+              maxLines = 1,
+              overflow = TextOverflow.Ellipsis,
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+private fun linkPreviewDomain(url: String): String =
+  runCatching { java.net.URI(url).host }
+    .getOrNull()
+    ?.removePrefix("www.")
+    ?.takeIf(String::isNotBlank)
+    ?: url
 
 /** Assistant placeholder shown while a run is active but no text has streamed yet. */
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -2,7 +2,6 @@ package ai.openclaw.app.ui.chat
 
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.R
-import ai.openclaw.app.resolveAgentIdFromMainSessionKey
 import ai.openclaw.app.chat.ChatCommandEntry
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatMessageContent
@@ -10,6 +9,7 @@ import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.OutgoingAttachment
+import ai.openclaw.app.resolveAgentIdFromMainSessionKey
 import ai.openclaw.app.ui.copyGatewayDiagnosticsReport
 import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawLoadingState
@@ -589,6 +589,7 @@ private fun ChatMessageList(
         when (item) {
           is ChatTimelineItem.Message ->
             ChatBubble(
+              messageId = item.message.id,
               role = item.message.role,
               live = false,
               content = item.message.content,
@@ -604,6 +605,7 @@ private fun ChatMessageList(
           is ChatTimelineItem.PendingTools -> ToolBubble(toolCalls = item.toolCalls)
           is ChatTimelineItem.StreamingAssistant ->
             ChatBubble(
+              messageId = null,
               role = "assistant",
               live = true,
               content = listOf(ChatMessageContent(text = item.text)),
@@ -759,6 +761,7 @@ private val starterPrompts =
 
 @Composable
 private fun ChatBubble(
+  messageId: String?,
   role: String,
   live: Boolean,
   content: List<ChatMessageContent>,
@@ -815,6 +818,9 @@ private fun ChatBubble(
             } else {
               Text(text = part.fileName ?: "Attachment", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
             }
+          }
+          if (messageId != null) {
+            ChatMessageLinkPreview(messageId = messageId, role = normalizedRole, content = displayableContent)
           }
           timestampMs?.let {
             Text(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
@@ -1,0 +1,325 @@
+package ai.openclaw.app.ui.chat
+
+import kotlinx.coroutines.runBlocking
+import okhttp3.Dns
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.InetAddress
+import java.net.UnknownHostException
+import java.util.concurrent.TimeUnit
+
+class ChatLinkPreviewTest {
+  @Test
+  fun extractsFirstHttpLinkOutsideCode() {
+    assertEquals("https://example.com/path", extractFirstBareUrl("See https://example.com/path now"))
+    assertEquals("https://example.com/docs", extractFirstBareUrl("Read [the docs](https://example.com/docs)"))
+    assertEquals(
+      "https://after.example",
+      extractFirstBareUrl("`https://inline.example`\n```\nhttps://fenced.example\n```\nhttps://after.example"),
+    )
+  }
+
+  @Test
+  fun extractionSkipsMissingAndNonHttpLinks() {
+    assertNull(extractFirstBareUrl("No URL here"))
+    assertNull(extractFirstBareUrl("[mail](mailto:test@example.com) and ftp://example.com/file"))
+  }
+
+  @Test
+  fun rejectsNonPublicLiteralAndLocalHosts() {
+    val rejected =
+      listOf(
+        "http://127.0.0.1/",
+        "http://10.0.0.5/",
+        "http://172.20.1.1/",
+        "http://192.168.1.1/",
+        "http://169.254.9.9/",
+        "http://100.64.0.1/",
+        "http://198.18.0.1/",
+        "http://192.0.2.1/",
+        "http://0.0.0.0/",
+        "http://224.0.0.1/",
+        "http://255.255.255.255/",
+        "http://[::1]/",
+        "http://[fe80::1]/",
+        "http://[fc00::1]/",
+        "http://[::]/",
+        "http://[ff02::1]/",
+        "http://[2001:db8::1]/",
+        "http://localhost/",
+        "http://foo.local/",
+      )
+    rejected.forEach { url ->
+      assertTrue("Expected $url to be rejected", !isPubliclyRoutableHost(url.toHttpUrl()))
+    }
+
+    assertTrue(isPubliclyRoutableHost("https://example.com/".toHttpUrl()))
+    assertTrue(isPubliclyRoutableHost("http://93.184.216.34/".toHttpUrl()))
+    assertTrue(isPubliclyRoutableHost("https://[2606:4700:4700::1111]/".toHttpUrl()))
+  }
+
+  @Test
+  fun dnsRejectsMixedPublicAndPrivateAnswers() {
+    val answers =
+      listOf(
+        InetAddress.getByAddress(byteArrayOf(93, 184.toByte(), 216.toByte(), 34)),
+        InetAddress.getByAddress(byteArrayOf(10, 0, 0, 5)),
+      )
+    val dns = PublicOnlyDns(Dns { answers })
+
+    assertTrue(runCatching { dns.lookup("example.com") }.exceptionOrNull() is UnknownHostException)
+  }
+
+  @Test
+  fun privateLiteralInitialUrlFailsWithoutNetworkCall() =
+    withServer { server ->
+      server.enqueue(MockResponse().setHeader("Content-Type", "text/html").setBody("<title>Private</title>"))
+
+      assertSame(LinkPreviewResult.Failed, realPolicyFetcher().fetch(server.url("/private").toString()))
+      assertEquals(0, server.requestCount)
+    }
+
+  @Test
+  fun redirectPolicyRejectsPrivateLiteralTarget() {
+    val target = resolveRedirect("https://example.com/start".toHttpUrl(), "http://127.0.0.1:1/private")
+
+    assertNull(target)
+  }
+
+  @Test
+  fun parsesOpenGraphWithAttributeOrderAndRelativeImage() {
+    val result =
+      parseOpenGraph(
+        html =
+          """
+          <html><head>
+          <meta content='A title' property='og:title'>
+          <meta name="og:description" content="One &amp; two">
+          <meta content=/images/card.png property=og:image>
+          </head></html>
+          """.trimIndent(),
+        baseUrl = "https://example.com/articles/one",
+      ) as LinkPreviewResult.Loaded
+
+    assertEquals("A title", result.metadata.title)
+    assertEquals("One & two", result.metadata.description)
+    assertEquals("https://example.com/images/card.png", result.metadata.imageUrl)
+  }
+
+  @Test
+  fun fallsBackToTitleAndFailsWhenMetadataIsMissing() {
+    val fallback = parseOpenGraph("<html><title>Fallback title</title></html>", "https://example.com")
+
+    assertEquals("Fallback title", (fallback as LinkPreviewResult.Loaded).metadata.title)
+    assertSame(LinkPreviewResult.Failed, parseOpenGraph("<html><body>Nothing</body></html>", "https://example.com"))
+  }
+
+  @Test
+  fun stripsControlsAndCapsMetadataLengths() {
+    val title = "T\u0000" + "x".repeat(LINK_PREVIEW_TITLE_MAX_CHARS + 20)
+    val description = "D\u0007" + "y".repeat(LINK_PREVIEW_DESCRIPTION_MAX_CHARS + 20)
+    val result =
+      parseOpenGraph(
+        "<meta property='og:title' content='$title'><meta content=\"$description\" property=\"og:description\">",
+        "https://example.com",
+      ) as LinkPreviewResult.Loaded
+
+    assertEquals(LINK_PREVIEW_TITLE_MAX_CHARS, result.metadata.title?.length)
+    assertEquals(LINK_PREVIEW_DESCRIPTION_MAX_CHARS, result.metadata.description?.length)
+    assertTrue(
+      result.metadata.title
+        .orEmpty()
+        .none(Character::isISOControl),
+    )
+    assertTrue(
+      result.metadata.description
+        .orEmpty()
+        .none(Character::isISOControl),
+    )
+  }
+
+  @Test
+  fun fetchesHtmlWithoutAmbientHeaders() =
+    withServer { server ->
+      server.enqueue(
+        MockResponse()
+          .setHeader("Content-Type", "text/html; charset=utf-8")
+          .setBody("<meta property='og:title' content='Fetched'>"),
+      )
+
+      val result = fetcher().fetch(server.url("/page").toString()) as LinkPreviewResult.Loaded
+
+      assertEquals("Fetched", result.metadata.title)
+      val request = server.takeRequest()
+      assertEquals("text/html, application/xhtml+xml;q=0.9", request.getHeader("Accept"))
+      assertNull(request.getHeader("Cookie"))
+      assertNull(request.getHeader("Authorization"))
+    }
+
+  @Test
+  fun followsThreeRedirectsButRejectsAFourth() {
+    withServer { server ->
+      repeat(3) { index -> server.enqueue(redirect("/hop${index + 1}")) }
+      server.enqueue(
+        MockResponse()
+          .setHeader("Content-Type", "text/html")
+          .setBody("<title>After three</title>"),
+      )
+
+      val loaded = fetcher().fetch(server.url("/start").toString()) as LinkPreviewResult.Loaded
+      assertEquals("After three", loaded.metadata.title)
+      assertEquals(4, server.requestCount)
+    }
+
+    withServer { server ->
+      repeat(4) { index -> server.enqueue(redirect("/hop${index + 1}")) }
+      server.enqueue(
+        MockResponse()
+          .setHeader("Content-Type", "text/html")
+          .setBody("<title>Too far</title>"),
+      )
+
+      assertSame(LinkPreviewResult.Failed, fetcher().fetch(server.url("/start").toString()))
+      assertEquals(4, server.requestCount)
+    }
+  }
+
+  @Test
+  fun parsesOnlyTheFirst512KiB() =
+    withServer { server ->
+      val prefix = "<meta property='og:title' content='Early'>"
+      server.enqueue(
+        MockResponse()
+          .setHeader("Content-Type", "text/html")
+          .setBody(prefix + "x".repeat(LINK_PREVIEW_BODY_MAX_BYTES + 1_024)),
+      )
+
+      val result = fetcher().fetch(server.url("/large").toString()) as LinkPreviewResult.Loaded
+
+      assertEquals("Early", result.metadata.title)
+    }
+
+  @Test
+  fun rejectsNonHtmlAndTimesOutQuickly() {
+    withServer { server ->
+      server.enqueue(MockResponse().setHeader("Content-Type", "application/json").setBody("{}"))
+      assertSame(LinkPreviewResult.Failed, fetcher().fetch(server.url("/json").toString()))
+    }
+
+    withServer { server ->
+      server.enqueue(
+        MockResponse()
+          .setHeadersDelay(500, TimeUnit.MILLISECONDS)
+          .setHeader("Content-Type", "text/html")
+          .setBody("<title>Late</title>"),
+      )
+      assertSame(LinkPreviewResult.Failed, fetcher(timeoutMillis = 75).fetch(server.url("/slow").toString()))
+    }
+  }
+
+  @Test
+  fun responseBodyDisconnectReturnsFailed() =
+    withServer { server ->
+      server.enqueue(
+        MockResponse()
+          .setHeader("Content-Type", "text/html")
+          .setBody("x".repeat(16_384) + "<title>Never complete</title>")
+          .setSocketPolicy(SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY),
+      )
+
+      assertSame(LinkPreviewResult.Failed, fetcher().fetch(server.url("/disconnect").toString()))
+    }
+
+  @Test
+  fun allowsHttpToHttpsRedirectAndRejectsFileRedirect() {
+    withServer { server ->
+      server.enqueue(redirect("https://secure.example/target"))
+      val client =
+        baseClient()
+          .addInterceptor { chain ->
+            val request = chain.request()
+            if (!request.url.isHttps) {
+              chain.proceed(request)
+            } else {
+              Response
+                .Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .body("<title>Secure target</title>".toResponseBody("text/html".toMediaType()))
+                .build()
+            }
+          }.build()
+
+      val result =
+        LinkPreviewFetcher(client, hostPolicy = permissiveHostPolicy)
+          .fetch(server.url("/start").toString()) as LinkPreviewResult.Loaded
+
+      assertEquals("Secure target", result.metadata.title)
+      assertEquals(1, server.requestCount)
+    }
+
+    withServer { server ->
+      server.enqueue(redirect("file:///tmp/private"))
+      assertSame(LinkPreviewResult.Failed, fetcher().fetch(server.url("/start").toString()))
+      assertEquals(1, server.requestCount)
+    }
+  }
+
+  @Test
+  fun cacheHitAvoidsSecondFetchIncludingFailures() =
+    withServer { server ->
+      server.enqueue(MockResponse().setHeader("Content-Type", "text/html").setBody("<title>Cached</title>"))
+      server.enqueue(MockResponse().setHeader("Content-Type", "application/json").setBody("{}"))
+      val store = LinkPreviewStore(fetcher = fetcher()::fetch)
+      val loadedUrl = server.url("/loaded").toString()
+      val failedUrl = server.url("/failed").toString()
+
+      assertTrue(store.get(loadedUrl) is LinkPreviewResult.Loaded)
+      assertTrue(store.get(loadedUrl) is LinkPreviewResult.Loaded)
+      assertEquals(1, server.requestCount)
+
+      assertSame(LinkPreviewResult.Failed, store.get(failedUrl))
+      assertSame(LinkPreviewResult.Failed, store.get(failedUrl))
+      assertEquals(2, server.requestCount)
+    }
+
+  private fun fetcher(timeoutMillis: Long = 6_000): LinkPreviewFetcher = LinkPreviewFetcher(baseClient().build(), timeoutMillis, permissiveHostPolicy)
+
+  private fun realPolicyFetcher(): LinkPreviewFetcher = LinkPreviewFetcher(baseClient().build())
+
+  private fun baseClient(): OkHttpClient.Builder =
+    OkHttpClient
+      .Builder()
+      .followRedirects(false)
+      .followSslRedirects(false)
+
+  private fun redirect(location: String): MockResponse =
+    MockResponse()
+      .setResponseCode(302)
+      .setHeader("Location", location)
+
+  private fun withServer(block: suspend (MockWebServer) -> Unit) {
+    MockWebServer().use { server ->
+      server.start()
+      runBlocking { block(server) }
+    }
+  }
+
+  companion object {
+    private val permissiveHostPolicy: (okhttp3.HttpUrl) -> Boolean = { true }
+  }
+}


### PR DESCRIPTION
Related: #100699

## What Problem This Solves

Bare URLs in the Android chat transcript render as plain tappable links with no way to see what's behind them before leaving the app.

## Why This Change Was Made

Adds tap-to-expand link previews: a message whose text contains a safe web link shows a compact chip (domain + expand affordance) under the body; tapping it fetches OpenGraph metadata and expands into a card (title + description), and tapping the card opens the URL exactly like tapping the link. Privacy is the design driver: **no ambient fetches, ever** — network activity happens only on an explicit user tap (see #22060 for why automatic preview fetches on message content are an injection/exfiltration hazard). The preview fetch is strictly less capable than tapping the link itself: same URL, same user gesture, display-only result — fetched with a locked-down client (no cookies, no auth/proxy authenticators, no auto-redirects; each of ≤3 manual redirect hops re-validated http/https; 6s total deadline; 512KB body cap; `text/html` only). Metadata is untrusted plain text: HTML entities decoded, control characters stripped, whitespace collapsed, length-capped, rendered as plain `Text`. Results (including failures) sit in a 64-entry in-memory LRU — nothing persists to disk. The card is text-only for now: the Android transcript has no remote-image facility and this PR deliberately adds no dependency for one (og:image is parsed and safe-resolved for when one exists).

## User Impact

Android users can peek at a link's title and description before opening it, with zero background network traffic from message content. Failed lookups show a plain "No preview available" state.

## Evidence

- Focused unit suite `ChatLinkPreviewTest` green (12 tests): OG parsing (full set, `<title>` fallback, attribute-order tolerance, relative og:image resolution, control-char stripping and caps), first-URL extraction (bare URLs, markdown links, code-fence/inline-code exclusion, unsafe schemes skipped), MockWebServer fetcher (redirect chain, >3 hops rejected, non-HTML rejected, body cap, timeout), cache hit avoids refetch (request-count assertion).
- OkHttp is the app's existing HTTP client (`libs.okhttp`, used by the gateway session) — no new dependency.
- ktlint clean on changed files; `corepack pnpm native:i18n:sync` run for the new strings.
- Structured review (codex) — no actionable findings; a private-network (SSRF-style) block was consciously not added since the preview can only fetch what tapping the link already reaches, and the result never leaves the device.
