### PR TITLE
fix(memory-wiki): bridge status crashes on malformed memory-plugin artifacts and ignores readMemoryArtifacts=false

### DIFF
--- a/extensions/memory-wiki/src/status.test.ts
+++ b/extensions/memory-wiki/src/status.test.ts
@@ -92,6 +92,40 @@ describe("resolveMemoryWikiStatus", () => {
     expect(status.warnings.map((warning) => warning.code)).toContain("bridge-artifacts-missing");
   });
 
+  it("skips artifact enumeration when readMemoryArtifacts is disabled", async () => {
+    const config = resolveMemoryWikiConfig(
+      {
+        vaultMode: "bridge",
+        bridge: {
+          enabled: true,
+          readMemoryArtifacts: false,
+        },
+      },
+      { homedir: "/Users/tester" },
+    );
+
+    let listCalls = 0;
+    const status = await resolveMemoryWikiStatus(config, {
+      appConfig: {
+        agents: {
+          list: [{ id: "main", default: true, workspace: "/tmp/workspace" }],
+        },
+      } as OpenClawConfig,
+      listPublicArtifacts: async () => {
+        listCalls += 1;
+        return [];
+      },
+      pathExists: async () => true,
+      resolveCommand: async () => null,
+    });
+
+    expect(listCalls).toBe(0);
+    expect(status.bridgePublicArtifactCount).toBeNull();
+    expect(status.warnings.map((warning) => warning.code)).not.toContain(
+      "bridge-artifacts-missing",
+    );
+  });
+
   it("discovers pages in nested subdirectories", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-nested-",

--- a/extensions/memory-wiki/src/status.ts
+++ b/extensions/memory-wiki/src/status.ts
@@ -211,7 +211,10 @@ export async function resolveMemoryWikiStatus(
   const exists = deps?.pathExists ?? pathExists;
   const vaultExists = await exists(config.vault.path);
   const bridgePublicArtifactCount =
-    deps?.appConfig && config.vaultMode === "bridge" && config.bridge.enabled
+    deps?.appConfig &&
+    config.vaultMode === "bridge" &&
+    config.bridge.enabled &&
+    config.bridge.readMemoryArtifacts
       ? (
           await (deps.listPublicArtifacts ?? listActiveMemoryPublicArtifacts)({
             cfg: deps.appConfig,

--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -234,6 +234,58 @@ describe("memory plugin state", () => {
     ]);
   });
 
+  it("drops malformed public memory artifacts instead of crashing the sort", async () => {
+    // Record-shaped artifact as shipped by @mem0/openclaw-mem0 <= 1.0.14 —
+    // none of the file-backed fields the sort dereferences.
+    const recordShapedArtifact = {
+      id: "mem0:memory:1",
+      type: "memory",
+      title: "A memory",
+      content: "memory text",
+    } as unknown as MemoryPluginPublicArtifact;
+
+    registerMemoryCapability("openclaw-mem0", {
+      publicArtifacts: {
+        async listArtifacts() {
+          return [
+            recordShapedArtifact,
+            {
+              kind: "memory-root",
+              workspaceDir: "/tmp/workspace",
+              relativePath: "MEMORY.md",
+              absolutePath: "/tmp/workspace/MEMORY.md",
+              agentIds: ["main"],
+              contentType: "markdown" as const,
+            },
+          ];
+        },
+      },
+    });
+
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/workspace",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/workspace/MEMORY.md",
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
+  });
+
+  it("ignores a non-array public artifact listing", async () => {
+    registerMemoryCapability("openclaw-mem0", {
+      publicArtifacts: {
+        async listArtifacts() {
+          return { artifacts: [] } as unknown as MemoryPluginPublicArtifact[];
+        },
+      },
+    });
+
+    await expect(listActiveMemoryPublicArtifacts({ cfg: {} as never })).resolves.toEqual([]);
+  });
+
   it("preserves sidecar runtime fields when a memory plugin adds public artifacts only", async () => {
     const runtime = createMemoryRuntime();
     const flushPlanResolver = () => createMemoryFlushPlan("memory/sidecar.md");

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -1,7 +1,10 @@
 /** Registry state for plugin memory runtimes, prompt supplements, and flush planning. */
 import type { MemoryCitationsMode } from "../config/types.memory.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { MemorySearchManager } from "../memory-host-sdk/host/types.js";
+
+const log = createSubsystemLogger("plugins/memory-state");
 
 export type MemoryPromptSectionBuilder = (params: {
   availableTools: Set<string>;
@@ -317,11 +320,36 @@ function cloneMemoryPublicArtifact(
   };
 }
 
+// The sort below dereferences these fields, so a plugin-supplied artifact
+// missing any of them would crash every status/bridge consumer.
+function isValidMemoryPublicArtifact(
+  artifact: MemoryPluginPublicArtifact | null | undefined,
+): artifact is MemoryPluginPublicArtifact {
+  return (
+    typeof artifact?.kind === "string" &&
+    typeof artifact.workspaceDir === "string" &&
+    typeof artifact.relativePath === "string" &&
+    typeof artifact.absolutePath === "string" &&
+    typeof artifact.contentType === "string"
+  );
+}
+
 export async function listActiveMemoryPublicArtifacts(params: {
   cfg: OpenClawConfig;
 }): Promise<MemoryPluginPublicArtifact[]> {
-  const artifacts =
+  const pluginId = memoryPluginState.capability?.pluginId;
+  const listed =
     (await memoryPluginState.capability?.capability.publicArtifacts?.listArtifacts(params)) ?? [];
+  if (!Array.isArray(listed)) {
+    log.warn(`ignoring public memory artifacts from plugin "${pluginId}": not an array`);
+    return [];
+  }
+  const artifacts = listed.filter(isValidMemoryPublicArtifact);
+  if (artifacts.length < listed.length) {
+    log.warn(
+      `ignoring ${listed.length - artifacts.length} malformed public memory artifact(s) from plugin "${pluginId}": artifacts must include string kind, workspaceDir, relativePath, absolutePath, and contentType`,
+    );
+  }
   return artifacts.map(cloneMemoryPublicArtifact).toSorted((left, right) => {
     const workspaceOrder = left.workspaceDir.localeCompare(right.workspaceDir);
     if (workspaceOrder !== 0) {


### PR DESCRIPTION
Closes #100899

## What Problem This Solves

Fixes an issue where users running memory-wiki in bridge mode with a memory plugin that exports malformed public artifacts would get `Cannot read properties of undefined (reading 'localeCompare')` from `wiki status` and the `wiki_status` agent tool — and where setting `bridge.readMemoryArtifacts: false` did not stop the agent-tool crash, because the status path never consulted that flag.

Concretely hit by `@mem0/openclaw-mem0` ≤ 1.0.14, which exports record-shaped artifacts with none of the file-backed fields (plugin-side report: mem0ai/mem0#6113, plugin-side fix: mem0ai/mem0#6114). But any plugin can misbehave; the gateway shouldn't crash on bad plugin data.

## Why This Change Was Made

Two small changes:

- `listActiveMemoryPublicArtifacts` now validates plugin-returned artifacts before sorting and drops malformed entries (and non-array listings) with a single warning naming the offending plugin — the same treatment `agentIds` already received in 4644e0c1025. Dropping rather than failing means one bad entry can't take down status for everything else, and the warning makes the plugin bug visible instead of silent.
- `resolveMemoryWikiStatus` now gates artifact enumeration on `bridge.readMemoryArtifacts`, matching the sync path in `bridge.ts` and the CLI's gateway routing, which already honor it. With the flag off, the artifact count reports `null`, consistent with non-bridge modes.

## User Impact

Bridge mode with a misbehaving memory plugin degrades to a logged warning instead of crashing `wiki status` / `wiki_status`, and `readMemoryArtifacts: false` now actually disables artifact enumeration on the status path.

## Evidence

- Crash reproduced end-to-end on `ghcr.io/openclaw/openclaw:2026.6.11` in Docker with `@mem0/openclaw-mem0` 1.0.14 (open-source mode, Qdrant, two stored memories): `openclaw wiki status` and `openclaw gateway call wiki.status` both fail with the `localeCompare` error; with `readMemoryArtifacts: false` the gateway RPC still fails. Full repro in the linked issue. Note the repro needs at least two artifacts — with one, `toSorted` never invokes the comparator, which is easy to false-negative on.
- After-fix output from this branch (same Docker rig, image built from this branch via the repo Dockerfile, stock `@mem0/openclaw-mem0` 1.0.14, same two seeded memories). With `readMemoryArtifacts: true`, both previously-crashing commands now succeed:

  ```
  $ openclaw wiki status
  Wiki vault mode: bridge  Vault: ready (/home/node/.openclaw/wiki/main)  Render mode: native
  Bridge: enabled (0 exported artifacts)  ...
  Warnings: - Bridge mode is enabled but the active memory plugin is not exporting any public memory artifacts yet.

  $ openclaw gateway call wiki.status
  Gateway call: wiki.status
  { "vaultMode": "bridge", ..., "bridge": { "enabled": true, "readMemoryArtifacts": true, ... }, ... }
  ```

  and the gateway log shows the new guard firing instead of the crash:

  ```
  [plugins/memory-state] ignoring 3 malformed public memory artifact(s) from plugin "openclaw-mem0":
  artifacts must include string kind, workspaceDir, relativePath, absolutePath, and contentType
  ```

  (3, not 2 — the plugin derives a third "entity" artifact from the two memories.) With `readMemoryArtifacts: false`, the gateway RPC that previously crashed now returns status with the flag reflected:

  ```
  $ openclaw gateway call wiki.status
  Gateway call: wiki.status
  { "vaultMode": "bridge", ..., "bridge": { "enabled": true, "readMemoryArtifacts": false, ... }, ... }
  ```

- New regression tests use the plugin's exact malformed shape: `src/plugins/memory-state.test.ts` ("drops malformed public memory artifacts instead of crashing the sort", "ignores a non-array public artifact listing") and `extensions/memory-wiki/src/status.test.ts` ("skips artifact enumeration when readMemoryArtifacts is disabled"). All three fail without the fix.
- Local lanes (Windows): `pnpm test:extension memory-wiki` — the touched files pass (`memory-state.test.ts` 17/17, `status.test.ts` 10/10, both including the new tests). The lane's four failures are symlink/hardlink safety tests in `bridge.test.ts`/`okf.test.ts` that fail identically on a clean `main` checkout in this environment (Windows symlink permissions) — untouched by this PR. `pnpm test:contracts:plugins` — one failure (`session-attachments.contract.test.ts`), also identical on clean `main`. `node scripts/check-src-extension-import-boundary.mjs --json` — clean (`[]`). Repo lint (oxlint shards) passes.

---

AI-assisted. I've reviewed every change and validated the behavior end-to-end myself (Docker repro above).
