### PR TITLE
fix(memory-wiki): shared search crashes with "search is not a function" when the memory plugin lacks a full search manager

### DIFF
--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -716,6 +716,31 @@ describe("searchMemoryWiki", () => {
     });
   });
 
+  it("reports a contract error when the shared manager lacks search()", async () => {
+    const { config } = await createQueryVault({
+      initialize: true,
+      config: {
+        search: { backend: "shared", corpus: "all" },
+      },
+    });
+    // Partial manager as registered by @mem0/openclaw-mem0 <= 1.0.14.
+    const partialManager = {
+      status: vi.fn().mockReturnValue({ backend: "builtin", provider: "builtin" }),
+      probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    getActiveMemorySearchManagerMock.mockResolvedValue({ manager: partialManager });
+
+    await expect(
+      searchMemoryWiki({
+        config,
+        appConfig: createAppConfig(),
+        query: "alpha",
+        maxResults: 5,
+      }),
+    ).rejects.toThrow("does not implement search() from the MemorySearchManager contract");
+  });
+
   it("includes memory results and backfills wiki capacity for all-corpus search", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,
@@ -1538,6 +1563,28 @@ describe("getMemoryWikiPage", () => {
       from: 2,
       lines: 2,
     });
+  });
+
+  it("reports a contract error when the shared manager lacks readFile()", async () => {
+    const { config } = await createQueryVault({
+      initialize: true,
+      config: {
+        search: { backend: "shared", corpus: "memory" },
+      },
+    });
+    const partialManager = {
+      search: vi.fn().mockResolvedValue([]),
+      status: vi.fn().mockReturnValue({ backend: "builtin", provider: "builtin" }),
+    };
+    getActiveMemorySearchManagerMock.mockResolvedValue({ manager: partialManager });
+
+    await expect(
+      getMemoryWikiPage({
+        config,
+        appConfig: createAppConfig(),
+        lookup: "MEMORY.md",
+      }),
+    ).rejects.toThrow("does not implement readFile() from the MemorySearchManager contract");
   });
 
   it("defaults non-finite memory line options before memory reads", async () => {

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -1079,6 +1079,16 @@ async function resolveActiveMemoryManager(params: {
   }
 }
 
+// Registered managers come from the active memory plugin; nothing enforces
+// the MemorySearchManager contract at runtime, so a partial manager would
+// otherwise surface as "... is not a function" from inside the bundle.
+function buildMemoryManagerContractError(method: "search" | "readFile"): Error {
+  return new Error(
+    `The active memory plugin's search manager does not implement ${method}() from the MemorySearchManager contract. ` +
+      `Set search.backend to "local" for wiki-only access, or use a memory plugin that implements the contract.`,
+  );
+}
+
 function buildMemorySearchTitle(resultPath: string): string {
   const basename = path.basename(resultPath, path.extname(resultPath));
   return basename.length > 0 ? basename : resultPath;
@@ -1498,6 +1508,9 @@ export async function searchMemoryWiki(params: {
         agentSessionKey: params.agentSessionKey,
       })
     : null;
+  if (sharedMemoryManager && typeof sharedMemoryManager.search !== "function") {
+    throw buildMemoryManagerContractError("search");
+  }
   let rawMemoryResults = sharedMemoryManager
     ? await sharedMemoryManager.search(params.query, { maxResults })
     : [];
@@ -1594,6 +1607,9 @@ export async function getMemoryWikiPage(params: {
   });
   if (!manager) {
     return null;
+  }
+  if (typeof manager.readFile !== "function") {
+    throw buildMemoryManagerContractError("readFile");
   }
 
   const lookupCandidates = buildLookupCandidates(params.lookup);


### PR DESCRIPTION
Closes #100901

## What Problem This Solves

Fixes an issue where users running `wiki search` / `wiki_search` with `search.backend: "shared"` would get `TypeError: sharedMemoryManager.search is not a function` when the active memory plugin registers a search manager that doesn't implement the `MemorySearchManager` contract. `wiki_get` had the same exposure via `manager.readFile`. Concretely hit by `@mem0/openclaw-mem0` ≤ 1.0.14 (plugin-side report: mem0ai/mem0#6113, fix: mem0ai/mem0#6114).

## Why This Change Was Made

Both call sites in `extensions/memory-wiki/src/query.ts` now check the method exists before calling it and throw an actionable error that names the missing contract method and points at `search.backend: "local"` for wiki-only access. An explicit error was chosen over silently skipping the memory corpus: the user explicitly configured shared search, so silent degradation would hide the misconfiguration. A `manager: null` result keeps its existing graceful handling — this only covers truthy-but-partial managers.

## User Impact

Instead of a bare TypeError from inside the bundle, users get:

```
The active memory plugin's search manager does not implement search() from the MemorySearchManager contract. Set search.backend to "local" for wiki-only access, or use a memory plugin that implements the contract.
```

No behavior change for plugins that implement the contract or report `manager: null`.

## Evidence

- Crash reproduced end-to-end on `ghcr.io/openclaw/openclaw:2026.6.11` in Docker with `@mem0/openclaw-mem0` 1.0.14 (open-source mode, Qdrant): `openclaw wiki search "anything" --backend shared --corpus all` fails with the TypeError above. Full repro in the linked issue.
- After-fix output from this branch (same Docker rig, image built from this branch via the repo Dockerfile, stock `@mem0/openclaw-mem0` 1.0.14). The same command now reports the contract violation instead of the TypeError:

  ```
  $ openclaw wiki search "anything" --backend shared --corpus all
  [openclaw] Could not start the CLI.
  [openclaw] Reason: The active memory plugin's search manager does not implement search() from the
  MemorySearchManager contract. Set search.backend to "local" for wiki-only access, or use a memory
  plugin that implements the contract.
  ```

- New regression tests register a manager with the plugin's exact partial shape: `extensions/memory-wiki/src/query.test.ts` ("reports a contract error when the shared manager lacks search()", "reports a contract error when the shared manager lacks readFile()"). Both fail without the fix.
- Local lanes (Windows): `pnpm test:extension memory-wiki` — `query.test.ts` passes 41/41 including the two new tests. The lane's four failures are symlink/hardlink safety tests in `bridge.test.ts`/`okf.test.ts` that fail identically on a clean `main` checkout in this environment (Windows symlink permissions) — untouched by this PR. Repo lint (oxlint shards) passes.

---

AI-assisted. I've reviewed every change and validated the behavior end-to-end myself (Docker repro above).
