### PR TITLE
fix(tests): restore shared-kit test module compilation after NSNull coalesce

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -313,7 +313,7 @@ private final class FakeGatewayWebSocketTask: WebSocketTasking, @unchecked Senda
                 "id": id,
                 "nodeId": "test-node",
                 "command": command,
-                "paramsJSON": paramsJSON ?? NSNull(),
+                "paramsJSON": paramsJSON ?? (NSNull() as Any),
             ],
         ]
         return (try? JSONSerialization.data(withJSONObject: frame)) ?? Data()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the shared OpenClawKit test module no longer compiles: `swift test --package-path apps/shared/OpenClawKit` fails with `error: cannot convert value of type 'NSNull' to expected argument type 'String'` at `GatewayNodeSessionTests.swift:316`, blocking every local shared-kit test run (any iOS/macOS chat work validates through this suite).

## Why This Change Was Made

`paramsJSON ?? NSNull()` cannot type-check — `??` needs both sides to unify and `String? ?? NSNull` has no common type. Introduced in #100842 ("keep node invokes responsive during system.run"); hosted CI does not compile the shared-kit test module on macOS, so it slipped through. The fix is the standard idiom for heterogeneous JSON dictionaries: `paramsJSON ?? (NSNull() as Any)`, preserving the intended "JSON null when params absent" wire fixture exactly.

## User Impact

None at runtime — test-only compile fix. Developers get `swift test` back on the shared package.

## Evidence

- Before: `swift test --package-path apps/shared/OpenClawKit` fails to compile at `GatewayNodeSessionTests.swift:316` on a clean `origin/main` checkout.
- After: `swift test --package-path apps/shared/OpenClawKit --filter GatewayNodeSessionTests` — 27/27 pass (module compiles, fixture behavior unchanged).
