### PR TITLE
fix(memory): fall back to wiki for missing all-corpus reads

### DIFF
--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -666,4 +666,42 @@ describe("memory tools", () => {
       lineCount: 5,
     });
   });
+
+  it("preserves an empty in-file range for memory_get corpus=all", async () => {
+    setMemoryReadFileImpl(async (params: MemoryReadParams) => ({
+      text: "",
+      path: params.relPath,
+      from: params.from ?? 1,
+      lines: 0,
+    }));
+    const getSupplement = vi.fn(async () => ({
+      corpus: "wiki" as const,
+      path: "memory/entities/alpha.md",
+      title: "Alpha",
+      kind: "entity",
+      content: "Alpha wiki entry",
+      fromLine: 10,
+      lineCount: 5,
+    }));
+    registerMemoryCorpusSupplement("memory-wiki", {
+      search: async () => [],
+      get: getSupplement,
+    });
+
+    const tool = createMemoryGetToolOrThrow();
+    const result = await tool.execute("call_get_all_empty_range", {
+      path: "memory/entities/alpha.md",
+      from: 10,
+      lines: 5,
+      corpus: "all",
+    });
+
+    expect(result.details).toEqual({
+      text: "",
+      path: "memory/entities/alpha.md",
+      from: 10,
+      lines: 0,
+    });
+    expect(getSupplement).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/memory-core/src/tools.citations.test.ts
+++ b/extensions/memory-core/src/tools.citations.test.ts
@@ -629,4 +629,41 @@ describe("memory tools", () => {
       lineCount: 5,
     });
   });
+
+  it("falls back to a wiki corpus supplement when memory_get corpus=all misses memory without throwing", async () => {
+    setMemoryReadFileImpl(async (params: MemoryReadParams) => ({
+      text: "",
+      path: params.relPath,
+    }));
+    registerMemoryCorpusSupplement("memory-wiki", {
+      search: async () => [],
+      get: async () => ({
+        corpus: "wiki",
+        path: "memory/entities/alpha.md",
+        title: "Alpha",
+        kind: "entity",
+        content: "Alpha wiki entry after empty miss",
+        fromLine: 3,
+        lineCount: 5,
+      }),
+    });
+
+    const tool = createMemoryGetToolOrThrow();
+    const result = await tool.execute("call_get_all_empty_miss_fallback", {
+      path: "memory/entities/alpha.md",
+      from: 3,
+      lines: 5,
+      corpus: "all",
+    });
+
+    expect(result.details).toEqual({
+      corpus: "wiki",
+      path: "memory/entities/alpha.md",
+      title: "Alpha",
+      kind: "entity",
+      text: "Alpha wiki entry after empty miss",
+      fromLine: 3,
+      lineCount: 5,
+    });
+  });
 });

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -1,6 +1,9 @@
 // Memory Core plugin module implements tools behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import type {
+  MemoryReadResult,
+  MemorySource,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import {
   asToolParamsRecord,
   jsonResult,
@@ -360,34 +363,12 @@ async function resolveMemoryReadFailureResult(params: {
   return jsonResult({ path: params.relPath, text: "", disabled: true, error: message });
 }
 
-function isMissingMemoryReadResult(value: unknown, relPath: string): boolean {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return false;
-  }
-  const result = value as {
-    text?: unknown;
-    path?: unknown;
-    disabled?: unknown;
-    error?: unknown;
-    from?: unknown;
-    lines?: unknown;
-    truncated?: unknown;
-    nextFrom?: unknown;
-  };
-  return (
-    result.path === relPath &&
-    result.text === "" &&
-    result.disabled === undefined &&
-    result.error === undefined &&
-    result.from === undefined &&
-    result.lines === undefined &&
-    result.truncated === undefined &&
-    result.nextFrom === undefined
-  );
+function isMissingMemoryReadResult(result: MemoryReadResult, relPath: string): boolean {
+  return result.path === relPath && result.text === "" && result.from === undefined;
 }
 
-async function executeMemoryReadResult<T>(params: {
-  read: () => Promise<T>;
+async function executeMemoryReadResult(params: {
+  read: () => Promise<MemoryReadResult>;
   requestedCorpus?: "memory" | "wiki" | "all";
   relPath: string;
   from?: number;

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -360,6 +360,32 @@ async function resolveMemoryReadFailureResult(params: {
   return jsonResult({ path: params.relPath, text: "", disabled: true, error: message });
 }
 
+function isMissingMemoryReadResult(value: unknown, relPath: string): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const result = value as {
+    text?: unknown;
+    path?: unknown;
+    disabled?: unknown;
+    error?: unknown;
+    from?: unknown;
+    lines?: unknown;
+    truncated?: unknown;
+    nextFrom?: unknown;
+  };
+  return (
+    result.path === relPath &&
+    result.text === "" &&
+    result.disabled === undefined &&
+    result.error === undefined &&
+    result.from === undefined &&
+    result.lines === undefined &&
+    result.truncated === undefined &&
+    result.nextFrom === undefined
+  );
+}
+
 async function executeMemoryReadResult<T>(params: {
   read: () => Promise<T>;
   requestedCorpus?: "memory" | "wiki" | "all";
@@ -369,7 +395,20 @@ async function executeMemoryReadResult<T>(params: {
   agentSessionKey?: string;
 }) {
   try {
-    return jsonResult(await params.read());
+    const result = await params.read();
+    if (params.requestedCorpus === "all" && isMissingMemoryReadResult(result, params.relPath)) {
+      const supplement = await getSupplementMemoryReadResult({
+        relPath: params.relPath,
+        from: params.from,
+        lines: params.lines,
+        agentSessionKey: params.agentSessionKey,
+        corpus: params.requestedCorpus,
+      });
+      if (supplement) {
+        return jsonResult(supplement);
+      }
+    }
+    return jsonResult(result);
   } catch (error) {
     return await resolveMemoryReadFailureResult({
       error,


### PR DESCRIPTION
## Summary
- Fix `memory_get` with `corpus=all` so a valid empty memory miss can still read a registered wiki supplement.
- Add regression coverage for the non-throwing miss shape returned by the real memory file reader.

## Origin / follow-up
- Follows #77356.
- Gap this fills: the existing `corpus=all` fallback handled thrown read failures, but not the successful empty miss result returned for missing `memory/*.md` files.
- Consistency: keeps exact reads aligned with the existing wiki supplement fallback path for read errors and explicit `corpus=wiki` reads.

## Root Cause
- **Root cause:**
  The root cause is a success-path contract mismatch in `executeMemoryReadResult`. The memory host source of truth returns a missing but valid in-workspace memory file as `{ text: "", path }`, while `executeMemoryReadResult` treated every successful read as final by immediately returning `jsonResult(result)`. That caused `memory_get corpus=all` to stop before the wiki supplement lookup even though the `corpus=all` contract selected both memory and wiki sources.
- **Why this is root-cause fix:**
  This fixes the root contract mismatch at the tool boundary that consumes memory read results. It recognizes only the real missing-file result shape: matching `path`, empty `text`, and no `from`/`lines`/truncation/error metadata. For `corpus=all`, that exact state now enters the existing supplement read path; existing file reads, partial empty excerpts, disabled results, and `corpus=memory` behavior still return the original memory result.
- **Why it matters / User impact:**
  A user asking for `corpus=all` expects the exact read to search both memory and wiki sources. Before this patch, a missing memory file could hide an available wiki entry even though `corpus=all` selected both corpora.
- **What did NOT change:**
  The patch does not change memory indexing, search ranking, provider routing, session visibility, file path validation, `corpus=memory`, explicit `corpus=wiki`, or normal successful reads. It only changes the empty-miss branch for `memory_get corpus=all`.
- **Architecture / source-of-truth check:**
  The source-of-truth contract is `readMemoryFile` returning `{ text: "", path }` for missing valid memory files, while `buildMemoryReadResult` adds `from`/`lines` metadata for existing reads. The fix consumes that contract in memory-core rather than changing storage schema, validation, provider routing, or session-state ownership.

## Real behavior proof
- **Behavior or issue addressed:**
  `memory_get` with `corpus=all` should return a wiki supplement when the memory backend returns a non-throwing empty miss for the requested valid memory path.
- **Real environment tested:**
  Local OpenClaw worktree on the patched commit using the production `createMemoryGetTool` implementation, builtin memory backend, real filesystem workspace, and registered wiki supplement. The proof script confirms `memory/entities/alpha.md` does not exist on disk before calling the tool.
- **Exact steps or command run after this patch:**
  ```bash
  node --import tsx "$EVIDENCE_DIR/proof-memory-get-empty-miss.mts"
  ```
- **Evidence after fix:**
  ```json
  {
    "backend": "builtin",
    "corpus": "all",
    "requestedPath": "memory/entities/alpha.md",
    "targetExistsBeforeRead": false,
    "resultDetails": {
      "corpus": "wiki",
      "path": "memory/entities/alpha.md",
      "title": "Alpha",
      "kind": "entity",
      "fromLine": 7,
      "lineCount": 2,
      "text": "Alpha wiki supplement served after a real empty memory miss."
    }
  }
  ```
- **Observed result after fix:**
  The exact `memory_get` call returned the wiki supplement details instead of `{ text: "", path: "memory/entities/alpha.md" }` while the requested memory file was absent from the real workspace.
- **What was not tested:**
  No hosted wiki process or remote agent session was used. The proof covers the local production tool boundary, builtin memory file reader, filesystem miss behavior, and supplement registry path.

## Regression Test Plan
- **Target test file:**
  `extensions/memory-core/src/tools.citations.test.ts`
- **Scenario locked in:**
  A `memory_get` request with `corpus=all` reads `memory/entities/alpha.md`, the memory read returns the production missing-file shape `{ text: "", path }`, and a registered wiki supplement for the same path must be returned.
- **Why this is the smallest reliable guardrail:**
  The regression test locks the exact successful-empty-miss branch that used to bypass the supplement lookup, while existing `memory_get|corpus=all` tests continue to cover the thrown-error fallback and neighboring corpus behavior.
- **Exact steps or command run after this patch:**
  ```bash
  node scripts/run-vitest.mjs extensions/memory-core/src/tools.citations.test.ts -t "memory_get|corpus=all"
  ```
- **Evidence after fix:**
  ```text
  Test Files  1 passed (1)
  Tests  10 passed | 11 skipped (21)
  ```
- **Observed result after fix:**
  The new regression test passes with the existing `corpus=all` and `memory_get` coverage.
- **What was not tested:**
  The full `tools.citations.test.ts` file was not used as the final gate because an unrelated existing citation test timed out before this patch; the focused `memory_get|corpus=all` subset passed after the fix.

## Merge risk
- **Risk labels considered:**
  No merge-risk label should be needed. `merge-risk: session-state` was considered because this touches memory-core exact read behavior, but the change does not alter stored session data, session visibility, memory indexing, search ranking, provider routing, message delivery, auth, security boundaries, dependencies, or repository infrastructure.
- **Risk explanation:**
  The new supplement lookup runs only when `requestedCorpus === "all"` and the memory read result exactly matches a missing-file empty result. Results that include `from`/`lines`, truncation metadata, disabled/error fields, or any non-empty text continue to bypass this fallback.
- **Why acceptable:**
  The branch adds the behavior that `corpus=all` already promises without broadening `corpus=memory`, explicit `corpus=wiki`, or normal successful memory reads.

## Patch quality
- **Fix classification:**
  Root cause fix.
- **Maintainer-ready confidence:**
  High. The root cause is isolated to a single success-path early return, the patch is gated to one exact result shape, and both focused regression tests and production-tool proof pass.
- **Patch quality notes:**
  No unrelated cleanup, docs changes, dependency changes, or generated artifacts are included. The helper's default `return false` is intentional: non-object values, arrays, and any read result that is not the exact missing-file contract must keep the previous direct-return behavior.
