### PR TITLE
fix(auto-reply): skip preflight compaction on transient LLM failures instead of locking session

### DIFF
--- a/src/agents/embedded-agent-runner/compact-reasons.test.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.test.ts
@@ -55,6 +55,21 @@ describe("classifyCompactionReason", () => {
     ).toBe("guard_blocked");
   });
 
+  it("classifies timeout failures", () => {
+    expect(classifyCompactionReason("Compaction timed out")).toBe("timeout");
+    expect(classifyCompactionReason("request timeout after 30s")).toBe("timeout");
+  });
+
+  it("classifies provider 4xx errors", () => {
+    expect(classifyCompactionReason("HTTP 429 Too Many Requests")).toBe("provider_error_4xx");
+    expect(classifyCompactionReason("401 Unauthorized")).toBe("provider_error_4xx");
+  });
+
+  it("classifies provider 5xx errors", () => {
+    expect(classifyCompactionReason("HTTP 503 Service Unavailable")).toBe("provider_error_5xx");
+    expect(classifyCompactionReason("Internal Server Error 500")).toBe("provider_error_5xx");
+  });
+
   it("keeps unclassified provider errors in the stable unknown bucket", () => {
     expect(classifyCompactionReason("No API provider registered for api: ollama")).toBe("unknown");
   });

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1111,6 +1111,128 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "skipped");
   });
 
+  it.each([
+    ["timeout", "Compaction timed out"],
+    ["provider 4xx error", "HTTP 429 Too Many Requests"],
+    ["provider 5xx error", "HTTP 503 Service Unavailable"],
+  ])(
+    "skips preflight compaction when the compaction LLM call hits a transient %s failure (ok: false)",
+    async (_label, reason) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+        "utf8",
+      );
+      registerMemoryFlushPlanResolverForTest(() => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 0,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
+      compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+        ok: false,
+        compacted: false,
+        reason,
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        sessionFile,
+        updatedAt: Date.now(),
+        totalTokens: 120,
+        totalTokensFresh: true,
+      };
+      const onCompactionNotice = vi.fn();
+
+      const entry = await runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:main",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore: { "agent:main:main": sessionEntry },
+        sessionKey: "agent:main:main",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+        onCompactionNotice,
+      });
+
+      expect(entry).toBe(sessionEntry);
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "skipped");
+    },
+  );
+
+  it.each([
+    ["timeout", "request timeout after 30s"],
+    ["provider 4xx error", "401 Unauthorized"],
+    ["provider 5xx error", "Internal Server Error 500"],
+  ])(
+    "skips preflight compaction when the compaction LLM call hits a transient %s failure (ok: true, compacted: false)",
+    async (_label, reason) => {
+      const sessionFile = path.join(rootDir, "session.jsonl");
+      await fs.writeFile(
+        sessionFile,
+        `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+        "utf8",
+      );
+      registerMemoryFlushPlanResolverForTest(() => ({
+        softThresholdTokens: 1,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        reserveTokensFloor: 0,
+        prompt: "Pre-compaction memory flush.\nNO_REPLY",
+        systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+        relativePath: "memory/2023-11-14.md",
+      }));
+      compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+        ok: true,
+        compacted: false,
+        reason,
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "session",
+        sessionFile,
+        updatedAt: Date.now(),
+        totalTokens: 120,
+        totalTokensFresh: true,
+      };
+      const onCompactionNotice = vi.fn();
+
+      const entry = await runPreflightCompactionIfNeeded({
+        cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+        followupRun: createTestFollowupRun({
+          sessionId: "session",
+          sessionFile,
+          sessionKey: "agent:main:main",
+        }),
+        defaultModel: "anthropic/claude-opus-4-6",
+        agentCfgContextTokens: 100,
+        sessionEntry,
+        sessionStore: { "agent:main:main": sessionEntry },
+        sessionKey: "agent:main:main",
+        storePath: path.join(rootDir, "sessions.json"),
+        isHeartbeat: false,
+        replyOperation: createReplyOperation(),
+        onCompactionNotice,
+      });
+
+      expect(entry).toBe(sessionEntry);
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+      expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
+      expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "skipped");
+    },
+  );
+
   it("fails when required preflight context-engine compaction is deferred to background maintenance", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -204,12 +204,16 @@ function resolveEffectivePromptTokens(
 function isPreflightCompactionSkipReason(reason?: string): boolean {
   const classification = classifyCompactionReason(reason);
   // Preflight compaction is a guardrail, not a hard dependency. These classes
-  // mean the context engine found nothing useful to compact, so the reply should
-  // continue instead of surfacing a generic user-facing failure.
+  // mean the context engine found nothing useful to compact or the compaction
+  // LLM call hit a transient failure, so the reply should continue instead of
+  // surfacing a generic user-facing failure and permanently locking the session.
   return (
     classification === "below_threshold" ||
     classification === "no_compactable_entries" ||
-    classification === "already_compacted_recently"
+    classification === "already_compacted_recently" ||
+    classification === "timeout" ||
+    classification === "provider_error_4xx" ||
+    classification === "provider_error_5xx"
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #100778 — transient preflight compaction LLM failures (timeout, provider 4xx/5xx) permanently lock the Composer into "terminated" state, requiring a page refresh to recover.

### Root cause
`isPreflightCompactionSkipReason` in `agent-runner-memory.ts` only skipped benign reasons (`below_threshold`, `no_compactable_entries`, `already_compacted_recently`) but did not skip transient failures that were already classified by `classifyCompactionReason` as `timeout`, `provider_error_4xx`, and `provider_error_5xx`. The code comment at line 206 explicitly states "Preflight compaction is a guardrail, not a hard dependency" — this change aligns behavior with that stated intent.

### Failure chain
1. Compaction LLM call fails (timeout/rate limit/5xx)
2. `isPreflightCompactionSkipReason` returns `false`
3. `runPreflightCompactionIfNeeded` throws `Preflight compaction required but failed`
4. Gateway records `dispatch-error`, removes chat run, emits `chat.dispatch-error`
5. UI reconciler clears `chatRunId` → Composer permanently disabled showing "已终止"

## Why This Change Was Made

The fix is narrow and targeted: expand the skip predicate to include transient compaction failures. This matches the existing guardrail philosophy and prevents the downstream UI lockout. Non-transient failures (e.g., `thread not found`, `guard_blocked`, `summary_failed`) continue to throw as before.

## User Impact

- **Before**: User sees "已终止" with disabled Composer, no error message, must refresh page
- **After**: Transient compaction failure is logged and skipped; the agent run proceeds with the current context, letting the LLM handle context-too-long gracefully

## Evidence

- 53 existing + 6 new tests pass in `agent-runner-memory.test.ts`
- 11 existing + 3 new tests pass in `compact-reasons.test.ts`
- Covers both failure paths: `ok: false` (line 992) and `ok: true, compacted: false` (line 1004)
- Covers all three transient classifications: `timeout`, `provider_error_4xx`, `provider_error_5xx`

Closes #100778

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>