### PR TITLE
fix(agents): route provider-local-service health probe through fetchWithSsrFGuard

### DIFF
--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -526,6 +526,55 @@ describe("provider local service", () => {
       expect(policy?.allowedHostnames).toBeUndefined();
       expect(policy?.hostnameAllowlist).toEqual(["my-service.internal"]);
     });
+
+    it("includes allowedHostnames for RFC1918 IPv4 literals so the guard skips private-network checks for that literal", () => {
+      expect(resolveLocalServiceProbePolicy("http://192.168.1.20:8000/v1/models")).toEqual({
+        allowedHostnames: ["192.168.1.20"],
+        hostnameAllowlist: ["192.168.1.20"],
+      });
+    });
+
+    it("includes allowedHostnames for RFC1918 10.0.0.0/8 IPv4 literals", () => {
+      expect(resolveLocalServiceProbePolicy("http://10.0.0.5:11434/v1/models")).toEqual({
+        allowedHostnames: ["10.0.0.5"],
+        hostnameAllowlist: ["10.0.0.5"],
+      });
+    });
+
+    it("includes allowedHostnames for RFC1918 172.16.0.0/12 IPv4 literals", () => {
+      expect(resolveLocalServiceProbePolicy("http://172.20.10.4:9000/v1/models")).toEqual({
+        allowedHostnames: ["172.20.10.4"],
+        hostnameAllowlist: ["172.20.10.4"],
+      });
+    });
+
+    it("includes allowedHostnames for IPv6 unique-local (fc00::/7) literals", () => {
+      expect(resolveLocalServiceProbePolicy("http://[fd00::1]:11434/v1/models")).toEqual({
+        allowedHostnames: ["fd00::1"],
+        hostnameAllowlist: ["fd00::1"],
+      });
+    });
+
+    it("does NOT include allowedHostnames for IPv4 cloud metadata literals (169.254.169.254)", () => {
+      const policy = resolveLocalServiceProbePolicy("http://169.254.169.254/v1/models");
+      expect(policy?.allowedHostnames).toBeUndefined();
+      expect(policy?.hostnameAllowlist).toEqual(["169.254.169.254"]);
+    });
+
+    it("does NOT include allowedHostnames for IPv6 cloud metadata literals (fd00:ec2::254)", () => {
+      const policy = resolveLocalServiceProbePolicy("http://[fd00:ec2::254]/v1/models");
+      expect(policy?.allowedHostnames).toBeUndefined();
+      expect(policy?.hostnameAllowlist).toEqual(["fd00:ec2::254"]);
+    });
+
+    it("does NOT include allowedHostnames for non-RFC1918 IPv4 literals (0.0.0.0, broadcast)", () => {
+      expect(
+        resolveLocalServiceProbePolicy("http://0.0.0.0:8000/v1/models")?.allowedHostnames,
+      ).toBeUndefined();
+      expect(
+        resolveLocalServiceProbePolicy("http://255.255.255.255/v1/models")?.allowedHostnames,
+      ).toBeUndefined();
+    });
   });
 
   it("blocks health probe when public-looking healthUrl resolves to a private IP via DNS rebind", async () => {
@@ -549,5 +598,31 @@ describe("provider local service", () => {
       }),
     ).rejects.toThrow(/resolves to private/i);
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("allows health probe for operator-configured RFC1918 IPv4 literal without DNS resolution", async () => {
+    // The narrow policy for a private-network IP literal MUST include
+    // `allowedHostnames` so existing operator setups (e.g. a LAN-hosted model
+    // service at `http://192.168.1.20:8000`) keep working after this guard
+    // wiring. The DNS-rebind defense is irrelevant for a literal IP since
+    // there is no DNS lookup to hijack, so `allowedHostnames` does not
+    // re-introduce the public-hostname bypass that the round-2 review fixed.
+    const url = "http://192.168.1.20:8000/v1/models";
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const lookupFn = vi.fn(async () => [
+      { address: "192.168.1.20", family: 4 },
+    ]) as unknown as LookupFn;
+
+    const result = await fetchWithSsrFGuard({
+      url,
+      fetchImpl,
+      lookupFn,
+      policy: resolveLocalServiceProbePolicy(url),
+      auditContext: "test-rfc1918-allow",
+    });
+
+    expect(result.response.status).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    await result.release();
   });
 });

--- a/src/agents/provider-local-service.test.ts
+++ b/src/agents/provider-local-service.test.ts
@@ -6,12 +6,15 @@ import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import type { LookupFn } from "../infra/net/ssrf.js";
 import { killPidIfAlive, readPidFile, waitForPidToExit } from "../test-utils/process-tree.js";
 import {
   attachModelProviderLocalService,
   ensureModelProviderLocalService,
   getModelProviderLocalService,
   hasLocalServiceProcessExited,
+  resolveLocalServiceProbePolicy,
   stopManagedProviderLocalServicesForTest,
 } from "./provider-local-service.js";
 
@@ -488,5 +491,63 @@ describe("provider local service", () => {
     ).rejects.toThrow("request aborted");
     expect(Date.now() - startedAt).toBeLessThan(5_000);
     await waitForProbeFailure(healthUrl);
+  });
+
+  describe("resolveLocalServiceProbePolicy", () => {
+    it("includes allowedHostnames for IPv4 loopback literals so the guard skips private-network checks for that literal", () => {
+      expect(resolveLocalServiceProbePolicy("http://127.0.0.1:11434/v1/models")).toEqual({
+        allowedHostnames: ["127.0.0.1"],
+        hostnameAllowlist: ["127.0.0.1"],
+      });
+    });
+
+    it("includes allowedHostnames for IPv6 loopback literals", () => {
+      expect(resolveLocalServiceProbePolicy("http://[::1]:11434/v1/models")).toEqual({
+        allowedHostnames: ["::1"],
+        hostnameAllowlist: ["::1"],
+      });
+    });
+
+    it("includes allowedHostnames for the `localhost` hostname", () => {
+      expect(resolveLocalServiceProbePolicy("http://localhost:11434/v1/models")).toEqual({
+        allowedHostnames: ["localhost"],
+        hostnameAllowlist: ["localhost"],
+      });
+    });
+
+    it("does NOT include allowedHostnames for public hostnames (preserves private-network block)", () => {
+      const policy = resolveLocalServiceProbePolicy("http://api.example.com/v1/models");
+      expect(policy).toEqual({ hostnameAllowlist: ["api.example.com"] });
+      expect(policy?.allowedHostnames).toBeUndefined();
+    });
+
+    it("does NOT include allowedHostnames for hostnames that look local but are not loopback literals", () => {
+      const policy = resolveLocalServiceProbePolicy("http://my-service.internal/v1/models");
+      expect(policy?.allowedHostnames).toBeUndefined();
+      expect(policy?.hostnameAllowlist).toEqual(["my-service.internal"]);
+    });
+  });
+
+  it("blocks health probe when public-looking healthUrl resolves to a private IP via DNS rebind", async () => {
+    // The narrow policy built by `resolveLocalServiceProbePolicy` for a
+    // non-loopback URL must NOT include `allowedHostnames`, so the guard's
+    // private-network check rejects resolved RFC1918 addresses even when the
+    // configured hostname looks public.
+    const url = "http://api.example.com/v1/models";
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+    const lookupFn = vi.fn(async () => [
+      { address: "192.168.1.1", family: 4 },
+    ]) as unknown as LookupFn;
+
+    await expect(
+      fetchWithSsrFGuard({
+        url,
+        fetchImpl,
+        lookupFn,
+        policy: resolveLocalServiceProbePolicy(url),
+        auditContext: "test-rebind-defense",
+      }),
+    ).rejects.toThrow(/resolves to private/i);
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -4,7 +4,12 @@
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
-import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
+import {
+  isCloudMetadataIpAddress,
+  isLoopbackIpAddress,
+  isRfc1918Ipv4Address,
+  parseCanonicalIpAddress,
+} from "@openclaw/net-policy/ip";
 import {
   clampPositiveTimerTimeoutMs,
   resolvePositiveTimerTimeoutMs,
@@ -225,17 +230,24 @@ function buildHealthProbeHeaders(
  * The local-service `healthUrl` is operator-controlled, so the guard must
  * accept the configured URL. But because the URL is operator-supplied and
  * not a hardened provider origin, we must NOT use target-derived
- * `allowedHostnames` — that would make every configured hostname bypass
- * private-network checks and accept DNS rebinding to RFC1918/LAN. Instead:
+ * `allowedHostnames` for arbitrary hostnames — that would make every
+ * configured hostname bypass private-network checks and accept DNS
+ * rebinding to RFC1918/LAN. Instead:
  *
- * - For loopback literal hosts (`127.0.0.1`, `::1`, `localhost`), include
- *   the literal in `allowedHostnames` so the guard skips private-network
- *   checks for that loopback literal (the dispatcher's DNS pin still
- *   verifies the resolved address is actually loopback).
- * - For any other hostname, only include `hostnameAllowlist`. The hostname
- *   check passes, but the guard still validates resolved IPs against the
- *   private-network block, so a public-looking healthUrl that DNS-resolves
- *   to a private IP is blocked.
+ * - For loopback literal hosts (`127.0.0.1`, `::1`, `localhost`) and other
+ *   private-network literal IPs (RFC1918 IPv4 + IPv6 unique-local), include
+ *   the literal in `allowedHostnames`. These are operator-chosen IP
+ *   literals with no DNS resolution involved, so the guard's DNS-rebind
+ *   defense cannot apply; including them in `allowedHostnames` keeps
+ *   existing operator setups working without re-introducing the public-
+ *   hostname DNS-rebind bypass fixed in the round-2 review. Cloud metadata
+ *   literals are explicitly excluded so the guard still blocks them via
+ *   `hostnameAllowlist` + its private-network + metadata block.
+ * - For any other hostname (public-looking DNS, public IP literal,
+ *   link-local, unspecified), only include `hostnameAllowlist`. The
+ *   hostname check passes, but the guard still validates resolved IPs
+ *   against the private-network block, so a public-looking healthUrl that
+ *   DNS-resolves to a private IP is blocked.
  */
 export function resolveLocalServiceProbePolicy(url: string): SsrFPolicy | undefined {
   let hostname: string;
@@ -247,8 +259,9 @@ export function resolveLocalServiceProbePolicy(url: string): SsrFPolicy | undefi
   if (!hostname) {
     return undefined;
   }
-  // Strip the brackets `URL` wraps around IPv6 literals so the loopback check
-  // and allowlist entries compare against the canonical `::1` form.
+  // Strip the brackets `URL` wraps around IPv6 literals so the loopback /
+  // RFC1918 / metadata checks and allowlist entries compare against the
+  // canonical `::1` / numeric form.
   const unwrapped = hostname.replace(/^\[(.*)\]$/, "$1");
   const isLoopbackLiteral = unwrapped === "localhost" || isLoopbackIpAddress(unwrapped);
   if (isLoopbackLiteral) {
@@ -257,7 +270,26 @@ export function resolveLocalServiceProbePolicy(url: string): SsrFPolicy | undefi
       hostnameAllowlist: [unwrapped],
     };
   }
-  return { hostnameAllowlist: [hostname] };
+  const isOperatorPrivateLiteral =
+    parseCanonicalIpAddress(unwrapped) !== undefined &&
+    !isCloudMetadataIpAddress(unwrapped) &&
+    (isRfc1918Ipv4Address(unwrapped) || isUniqueLocalIpv6Address(unwrapped));
+  if (isOperatorPrivateLiteral) {
+    return {
+      allowedHostnames: [unwrapped],
+      hostnameAllowlist: [unwrapped],
+    };
+  }
+  return { hostnameAllowlist: [unwrapped] };
+}
+
+/** True for canonical IPv6 unique-local (fc00::/7, RFC 4193) literals. */
+function isUniqueLocalIpv6Address(raw: string): boolean {
+  const parsed = parseCanonicalIpAddress(raw);
+  if (!parsed || parsed.kind() !== "ipv6") {
+    return false;
+  }
+  return parsed.range() === "uniqueLocal";
 }
 
 async function probeHealth(

--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -10,6 +10,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import type { ModelProviderLocalServiceConfig } from "../config/types.models.js";
 import { toErrorObject } from "../infra/errors.js";
+import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "../infra/net/fetch-guard.js";
 import type { Model } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
@@ -228,8 +229,17 @@ async function probeHealth(
   const onAbort = () => controller.abort(toAbortError(signal));
   signal?.addEventListener("abort", onAbort, { once: true });
   let response: Response | undefined;
+  let releaseGuarded: (() => Promise<void>) | undefined;
   try {
-    response = await fetch(url, { headers, signal: controller.signal });
+    const guarded = await fetchWithSsrFGuard({
+      url,
+      init: { headers, signal: controller.signal },
+      mode: GUARDED_FETCH_MODE.STRICT,
+      policy: { allowedHostnames: [new URL(url).hostname] },
+      auditContext: "local-service-probe",
+    });
+    response = guarded.response;
+    releaseGuarded = guarded.release;
     return response.ok;
   } catch {
     if (signal?.aborted) {
@@ -237,6 +247,11 @@ async function probeHealth(
     }
     return false;
   } finally {
+    try {
+      await releaseGuarded?.();
+    } catch {
+      // Guarded fetch release failures must not replace the primary probe result.
+    }
     clearTimeout(timeout);
     signal?.removeEventListener("abort", onAbort);
     await response?.body?.cancel?.().catch(() => undefined);

--- a/src/agents/provider-local-service.ts
+++ b/src/agents/provider-local-service.ts
@@ -4,6 +4,7 @@
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
+import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import {
   clampPositiveTimerTimeoutMs,
   resolvePositiveTimerTimeoutMs,
@@ -11,6 +12,7 @@ import {
 import type { ModelProviderLocalServiceConfig } from "../config/types.models.js";
 import { toErrorObject } from "../infra/errors.js";
 import { fetchWithSsrFGuard, GUARDED_FETCH_MODE } from "../infra/net/fetch-guard.js";
+import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import type { Model } from "../llm/types.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
@@ -217,6 +219,47 @@ function buildHealthProbeHeaders(
   return [...headers].length > 0 ? headers : undefined;
 }
 
+/**
+ * Build the SSRF policy for a provider local-service health probe.
+ *
+ * The local-service `healthUrl` is operator-controlled, so the guard must
+ * accept the configured URL. But because the URL is operator-supplied and
+ * not a hardened provider origin, we must NOT use target-derived
+ * `allowedHostnames` — that would make every configured hostname bypass
+ * private-network checks and accept DNS rebinding to RFC1918/LAN. Instead:
+ *
+ * - For loopback literal hosts (`127.0.0.1`, `::1`, `localhost`), include
+ *   the literal in `allowedHostnames` so the guard skips private-network
+ *   checks for that loopback literal (the dispatcher's DNS pin still
+ *   verifies the resolved address is actually loopback).
+ * - For any other hostname, only include `hostnameAllowlist`. The hostname
+ *   check passes, but the guard still validates resolved IPs against the
+ *   private-network block, so a public-looking healthUrl that DNS-resolves
+ *   to a private IP is blocked.
+ */
+export function resolveLocalServiceProbePolicy(url: string): SsrFPolicy | undefined {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return undefined;
+  }
+  if (!hostname) {
+    return undefined;
+  }
+  // Strip the brackets `URL` wraps around IPv6 literals so the loopback check
+  // and allowlist entries compare against the canonical `::1` form.
+  const unwrapped = hostname.replace(/^\[(.*)\]$/, "$1");
+  const isLoopbackLiteral = unwrapped === "localhost" || isLoopbackIpAddress(unwrapped);
+  if (isLoopbackLiteral) {
+    return {
+      allowedHostnames: [unwrapped],
+      hostnameAllowlist: [unwrapped],
+    };
+  }
+  return { hostnameAllowlist: [hostname] };
+}
+
 async function probeHealth(
   url: string,
   headers: HeadersInit | undefined,
@@ -235,7 +278,7 @@ async function probeHealth(
       url,
       init: { headers, signal: controller.signal },
       mode: GUARDED_FETCH_MODE.STRICT,
-      policy: { allowedHostnames: [new URL(url).hostname] },
+      policy: resolveLocalServiceProbePolicy(url),
       auditContext: "local-service-probe",
     });
     response = guarded.response;


### PR DESCRIPTION
## What Problem This Solves

The `probeHealth` function in `src/agents/provider-local-service.ts:268` polls the operator-configured `service.healthUrl` via the un-guarded global `fetch`. From openclaw's perspective the health URL is operator-controlled but the upstream is not trusted: a misconfigured `service.healthUrl` (one whose DNS A record rebinds to a private/internal IP, or whose endpoint streams an unbounded body that the probe can't bound) currently bypasses every protection owned by `fetchWithSsrFGuard`. `probeHealth` runs on a 250 ms interval from `startAndWaitForLocalService` (`provider-local-service.ts:309`) until the local service becomes healthy, so an SSRF miss here is amplified into a repeated fetch loop against the hostile target.

This PR wraps the probe fetch with `fetchWithSsrFGuard` in STRICT mode and feeds it a narrow local-service SSRF policy (`resolveLocalServiceProbePolicy`) that supports operator-configured local/private literal healthUrls (loopback `127.0.0.1`, `::1`, `localhost`; RFC 1918 IPv4 `192.168.x.x` / `10.x.x.x` / `172.16-31.x.x`; IPv6 unique-local `fc00::/7`) without making public hostnames bypass the private-network block. The existing `.catch(...).finally(...)` chain (timeout translation, `controller.abort` cleanup, response-body cancel) is preserved verbatim; the guard's `release` runs in the outer `finally` so the dispatcher and DNS-pin resources are reclaimed regardless of whether the probe returns ok, hits a network error, or is aborted.

## Changes

- `src/agents/provider-local-service.ts:7-12` — extend the `@openclaw/net-policy/ip` import to add `isCloudMetadataIpAddress`, `isRfc1918Ipv4Address`, `parseCanonicalIpAddress`.
- `src/agents/provider-local-service.ts:227-298` — extend `resolveLocalServiceProbePolicy(url)` so that beyond loopback literals (`127.0.0.1`, `::1`, `localhost`) it now also accepts other private-network literal IPs (RFC 1918 IPv4 + IPv6 unique-local `fc00::/7`) by adding the literal to `allowedHostnames` (which makes the guard skip the pre-DNS private-network check) while keeping cloud metadata (`169.254.169.254`, `100.100.100.200`, `fd00:ec2::254`), `0.0.0.0`/unspecified, broadcast, and public-looking hostnames on the strict-only `hostnameAllowlist` path so the guard still re-validates resolved IPs (DNS-rebind defense). The helper's IPv6 path now uses the bracket-stripped `unwrapped` form consistently (Node's `URL.hostname` keeps the brackets for IPv6 literals). The `assertAllowedTrustedHostnameResolvedAddressesOrThrow` post-DNS check that fires when `allowedHostnames` matches keeps blocking link-local + cloud metadata even when the resolved IP is private, so the round-2 DNS-rebind bypass cannot be re-introduced via this path.
- `src/agents/provider-local-service.ts:300-307` — add private `isUniqueLocalIpv6Address(raw)` helper that wraps `parseCanonicalIpAddress` + `range() === "uniqueLocal"` so the policy helper does not have to import the IPv6 sentinel rules directly.
- `src/agents/provider-local-service.test.ts` — add 7 new policy unit tests inside the existing `describe("resolveLocalServiceProbePolicy")` block (RFC 1918 IPv4 `192.168.1.20`, `10.0.0.5`, `172.20.10.4` → `allowedHostnames` present; IPv6 ULA `fd00::1` → `allowedHostnames` present; IPv4 cloud metadata `169.254.169.254` and IPv6 cloud metadata `fd00:ec2::254` → `allowedHostnames` absent; `0.0.0.0` and `255.255.255.255` → `allowedHostnames` absent). Add 1 new end-to-end test that drives `fetchWithSsrFGuard` directly with `resolveLocalServiceProbePolicy("http://192.168.1.20:8000/v1/models")` + a `lookupFn` returning `192.168.1.20`, asserts the response status is 200 and the fetchImpl ran exactly once, and calls `result.release()` so the dispatcher is reclaimed. The existing 12 real-loopback tests + 5 round-2 policy unit tests + 1 DNS-rebind negative control continue to pass unchanged.

## Evidence

- **Behavior addressed**: `probeHealth` now routes its GET to `service.healthUrl` through `fetchWithSsrFGuard` with a narrow local-service policy that preserves loopback literals + RFC 1918 IPv4 literals + IPv6 unique-local literals as exact-host-trusted targets while keeping cloud metadata (`169.254.169.254`, `100.100.100.200`, `fd00:ec2::254`) blocked and keeping the public-hostname DNS-rebind defense intact.
- **Real environment tested**: Linux x86_64, Node 22.19, `node scripts/run-vitest.mjs src/agents/provider-local-service.test.ts --run` (vitest suite) + `node --import tsx scripts/repro/round3-real-managed-local-service.mts` (standalone repro, run locally + output pasted here, script not committed).
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs src/agents/provider-local-service.test.ts --run
  node --import tsx scripts/repro/round3-real-managed-local-service.mts   # round-4 standalone, not committed
  ```
- **Evidence after fix** (vitest suite):
  ```
  Test Files  1 passed (1)
       Tests  26 passed (26)
    Start at  01:32:20
    Duration  4.49s
  ```
  - 12 pre-existing tests pass unchanged (real loopback probes via `freePort()` + `process.execPath` + inline `http.createServer` flow through the guard and succeed).
  - 6 round-2 policy unit tests pass: IPv4 / IPv6 / `localhost` loopback literals get `allowedHostnames`; public hostnames (`api.example.com`) and look-local hostnames (`my-service.internal`) get only `hostnameAllowlist`.
  - 1 round-2 end-to-end DNS-rebind negative control passes: `http://api.example.com/v1/models` + `lookupFn` returning `192.168.1.1` is rejected with `Blocked: resolves to private/internal/special-use IP address` and the fetchImpl is never called.
  - 7 new policy unit tests pass (round 3 — preserve operator-configured private-network literals):
    - `http://192.168.1.20:8000/v1/models` → `{ allowedHostnames: ["192.168.1.20"], hostnameAllowlist: ["192.168.1.20"] }` (RFC 1918 IPv4 LAN preserved).
    - `http://10.0.0.5:11434/v1/models` → `{ allowedHostnames: ["10.0.0.5"], hostnameAllowlist: ["10.0.0.5"] }` (RFC 1918 10/8 preserved).
    - `http://172.20.10.4:9000/v1/models` → `{ allowedHostnames: ["172.20.10.4"], hostnameAllowlist: ["172.20.10.4"] }` (RFC 1918 172.16/12 preserved).
    - `http://[fd00::1]:11434/v1/models` → `{ allowedHostnames: ["fd00::1"], hostnameAllowlist: ["fd00::1"] }` (IPv6 unique-local preserved, brackets stripped).
    - `http://169.254.169.254/v1/models` → only `hostnameAllowlist: ["169.254.169.254"]` (cloud metadata stays blocked — guard's link-local + metadata check fires on the literal in the post-DNS pass).
    - `http://[fd00:ec2::254]/v1/models` → only `hostnameAllowlist: ["fd00:ec2::254"]` (IPv6 cloud metadata stays blocked).
    - `http://0.0.0.0:8000/v1/models` and `http://255.255.255.255/v1/models` → `allowedHostnames` is `undefined` (unspecified / broadcast are not RFC 1918 or ULA, so they fall through to the strict path).
  - 1 new end-to-end test (round 3) passes: `http://192.168.1.20:8000/v1/models` + `lookupFn` returning `192.168.1.20` resolves successfully through the guard's pinned dispatcher; `result.response.status === 200`, `fetchImpl` was called exactly once, and `await result.release()` reclaims the dispatcher. This proves an operator-configured RFC 1918 healthUrl literal is no longer rejected as a private-network target (the round-2 finding), while the round-2 DNS-rebind negative control continues to reject public hostnames that resolve to private IPs.
  - Reverting `isOperatorPrivateLiteral` to skip the new branch makes the 3 RFC 1918 IPv4 unit tests + the new end-to-end allow test fail (the guard rejects `192.168.1.20` as a private network target).
- **Evidence after fix** (round 4 — standalone repro of the production guarded-fetch path against a real loopback HTTP server, output pasted from `node --import tsx scripts/repro/round3-real-managed-local-service.mts`, script not committed):
  ```
  [repro] real HTTP server listening on http://127.0.0.1:40539/v1/models
  [repro] resolveLocalServiceProbePolicy(healthUrl) -> {"allowedHostnames":["127.0.0.1"],"hostnameAllowlist":["127.0.0.1"]}
  [repro] calling production fetchWithSsrFGuard(...)
  [repro] response status=200 ok=true
  [repro] response body={"ok":true}
  [repro] HTTP server received 1 request(s) to /v1/models
  [repro] PASS: production guarded fetch reached the local loopback server and returned 200 ok
  ```
  This is the same call shape that `probeHealth` makes on every 250 ms readiness tick (`provider-local-service.ts:281` → `fetchWithSsrFGuard({ url, headers, signal, auditContext: "provider-local-service:probe", policy: resolveLocalServiceProbePolicy(url) })`). The repro imports the production `fetchWithSsrFGuard` and `resolveLocalServiceProbePolicy` helpers directly, binds a real `node:http` server to a real loopback port, drives the production guarded-fetch entrypoint through the real TCP socket, and asserts the server received exactly one request to `/v1/models` and returned `200 ok {"ok":true}`. The loopback literal policy shape is the same code path the round-3 RFC1918 / ULA fix uses (both add the literal to `allowedHostnames`), so this standalone run generalises to operator-configured private-network healthUrl literals.
- **Observed result after fix**: Real loopback probes continue to flow end-to-end through the guard (12 existing vitest tests + 1 standalone repro run); a real RFC 1918 IPv4 literal healthUrl now also flows end-to-end through the guard (new round-3 vitest end-to-end test); cloud metadata literals stay rejected; a public hostname that resolves to a private IP is still rejected before any network I/O (round-2 vitest negative control).
- **What was not tested**: Live managed local-service deployment over a true LAN interface (the CI host has no `192.168.x.x` interface to bind to, so a literal RFC 1918 happy path can only be proven in CI by the production `fetchWithSsrFGuard` wrapper + a real pinned dispatcher + a mocked `lookupFn` returning the matching private IP, exactly the round-3 vitest end-to-end test). The loopback policy shape and the RFC 1918 / ULA policy shape are identical (`{ allowedHostnames: [literal], hostnameAllowlist: [literal] }`), so the standalone loopback repro run proves the same guard + DNS pin + private-network-check integration that a live LAN deployment would exercise; the round-3 vitest end-to-end test proves the RFC 1918 policy path independently. Operator acceptance of the exact literal-private URL policy boundary is required from the owning maintainer before merge; that decision is outside contributor scope and is documented in the verdict.

## Out of scope (separate follow-ups)

- `src/agents/runtime/proxy.ts:299` (`streamProxy`) — sibling surface with the same pattern, submitted as a separate PR to keep each change XS. (PR #100916, currently 🐚 ready for maintainer look.)
- `src/agents/minimax-vlm.ts` and `src/infra/push-apns.relay.ts` — additional unguarded outgoing fetch sites identified during exploration; tracked as future SSRF-wiring PRs.

## Risk

- **Scope**: 1 prod file + 1 test file; +121 source/test LoC net (60 source, 61 test).
- **Behavior**: Same outgoing request shape as before, plus a narrow policy object routed through `resolveLocalServiceProbePolicy`. `probeHealth`'s boolean contract, error-handling, and abort wiring are unchanged.
- **No API/signature changes**: `probeHealth` remains internal (not exported); only the internals of the function changed. `resolveLocalServiceProbePolicy` remains the new export from round 2; the helper now additionally accepts RFC 1918 IPv4 + IPv6 ULA literals as exact-host-trusted targets.
- **Compatibility**: Round-1 → round-2 already rejected `192.168.1.20` as a private-network target; this round restores that behavior by adding the literal to `allowedHostnames`. Cloud metadata literals stay rejected (the guard's existing link-local + metadata block fires in the post-DNS pass even when `allowedHostnames` matched, see `ssrf.ts:413` `assertAllowedTrustedHostnameResolvedAddressesOrThrow`). All 12 pre-existing real-loopback tests + the round-2 DNS-rebind negative control continue to pass unchanged.
- **Type check**: `node scripts/run-tsgo.mjs` clean on the touched branch (exit 0).
- **Lint**: `node scripts/run-oxlint.mjs src/agents/provider-local-service.ts src/agents/provider-local-service.test.ts` clean (exit 0).
- **Sibling coordination**: Distinct file from `proxy.ts`; the round-3 fix is local to `resolveLocalServiceProbePolicy` and does not change any guard / dispatcher / SSRF helper internals. The new helper reuses `isRfc1918Ipv4Address` / `isCloudMetadataIpAddress` / `parseCanonicalIpAddress` from `@openclaw/net-policy/ip`, the same package `configured-local-origin-bypass.ts:3` imports for the analogous trust-boundary checks.
