### PR TITLE
fix(ui): scope sidebar session active state to chat

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -70,6 +70,7 @@ type SidebarRecentSession = {
   meta: string;
   href: string;
   active: boolean;
+  visuallyActive: boolean;
   hasActiveRun: boolean;
   kind?: string;
   pinned: boolean;
@@ -316,12 +317,14 @@ export class AppSidebar extends LitElement {
       hello: context?.gateway.snapshot.hello,
       compareSessions: this.compareSidebarSessionRows,
     });
+    const highlightCurrentSession = this.activeRouteId === "chat";
     const toSidebarSession = (row: SessionsListResult["sessions"][number]) => ({
       key: row.key,
       label: resolveSessionDisplayName(row.key, row),
       meta: row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : "",
       href: `${pathForRoute("chat", context?.basePath ?? "")}${searchForSession(row.key)}`,
       active: row.key === navigation.activeRowKey,
+      visuallyActive: highlightCurrentSession && row.key === navigation.currentSessionKey,
       hasActiveRun: Boolean(row.hasActiveRun),
       kind: row.kind,
       pinned: row.pinned === true,
@@ -1206,7 +1209,7 @@ export class AppSidebar extends LitElement {
     const rowClass = [
       "sidebar-recent-session",
       "session-row-host",
-      session.active ? "sidebar-recent-session--active" : "",
+      session.visuallyActive ? "sidebar-recent-session--active" : "",
       session.pinned ? "session-row-host--pinned" : "",
       session.hasActiveRun ? "session-row-host--running" : "",
       this.draggingSessionKey === session.key ? "sidebar-recent-session--dragging" : "",

--- a/ui/src/e2e/session-management.e2e.test.ts
+++ b/ui/src/e2e/session-management.e2e.test.ts
@@ -530,4 +530,49 @@ describeControlUiE2e("Control UI session management mocked Gateway E2E", () => {
       await context.close();
     }
   });
+
+  it("only paints a sidebar session active on chat routes", async () => {
+    const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", baseTime),
+          sessionRow("agent:main:release", "Release planning", baseTime - 60_000),
+        ]),
+      },
+      sessionKey: "agent:main:main",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}overview`);
+      const activeRows = page.locator(".sidebar-recent-session--active");
+      const mainRow = page.locator('.sidebar-recent-session[data-session-key="agent:main:main"]');
+      await mainRow.waitFor({ state: "visible", timeout: 10_000 });
+      await expect.poll(() => activeRows.count()).toBe(0);
+
+      await page.goto(`${server.baseUrl}config`);
+      await mainRow.waitFor({ state: "visible", timeout: 10_000 });
+      await expect.poll(() => activeRows.count()).toBe(0);
+
+      await page.goto(`${server.baseUrl}chat?session=agent%3Amain%3Amain`);
+      await expect.poll(() => activeRows.count()).toBe(1);
+      await expect
+        .poll(() => activeRows.first().getAttribute("data-session-key"))
+        .toBe("agent:main:main");
+
+      await page.goto(`${server.baseUrl}chat`);
+      await expect.poll(() => activeRows.count()).toBe(1);
+      await expect
+        .poll(() => activeRows.first().getAttribute("data-session-key"))
+        .toBe("agent:main:main");
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/pages/overview/cards.ts
+++ b/ui/src/pages/overview/cards.ts
@@ -1,7 +1,6 @@
 // Control UI view renders overview cards screen content.
 import { asDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { html, nothing, type TemplateResult } from "lit";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type {
   SessionsUsageResult,
   SessionsListResult,
@@ -33,14 +32,6 @@ type OverviewCardsProps = {
   onNavigate: (routeId: NavigationRouteId) => void;
   canNavigate: (routeId: NavigationRouteId) => boolean;
 };
-
-const DIGIT_RUN = /\d{3,}/g;
-
-function blurDigits(value: string): TemplateResult {
-  const escaped = value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-  const blurred = escaped.replace(DIGIT_RUN, (m) => `<span class="blur-digits">${m}</span>`);
-  return html`${unsafeHTML(blurred)}`;
-}
 
 type StatCard = {
   kind: string;
@@ -295,9 +286,7 @@ export function renderOverviewCards(props: OverviewCardsProps) {
               ${sessions.map(
                 (s) => html`
                   <li class="ov-recent__row">
-                    <span class="ov-recent__key"
-                      >${blurDigits(resolveSessionDisplayName(s.key, s))}</span
-                    >
+                    <span class="ov-recent__key">${resolveSessionDisplayName(s.key, s)}</span>
                     <span class="ov-recent__model">${s.model ?? ""}</span>
                     <span class="ov-recent__time"
                       >${s.updatedAt ? formatRelativeTimestamp(s.updatedAt) : ""}</span

--- a/ui/src/pages/overview/view.render.test.ts
+++ b/ui/src/pages/overview/view.render.test.ts
@@ -140,6 +140,35 @@ describe("overview view rendering", () => {
     expect(recentNames).not.toContain("telegram:123:456");
   });
 
+  it("does not blur non-sensitive digits in recent session display names", async () => {
+    const container = document.createElement("div");
+    const props = createOverviewProps({
+      sessionsResult: {
+        ts: 0,
+        path: "",
+        count: 1,
+        defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+        sessions: [
+          {
+            key: "agent:main:build-review",
+            kind: "direct",
+            label: "Build 20260704 review",
+            model: "gpt-5",
+            updatedAt: null,
+          },
+        ],
+      },
+    });
+
+    render(renderOverview(props), container);
+    await Promise.resolve();
+
+    expect(container.querySelector(".ov-recent__key")?.textContent?.trim()).toBe(
+      "Build 20260704 review",
+    );
+    expect(container.querySelector(".blur-digits")).toBeNull();
+  });
+
   it("promotes provider quota into a dedicated overview card", async () => {
     const container = document.createElement("div");
     const props = createOverviewProps({

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5601,11 +5601,6 @@ td.data-table-key-col {
   white-space: nowrap;
 }
 
-.blur-digits {
-  filter: blur(4px);
-  user-select: none;
-}
-
 /* Section divider */
 .ov-section-divider {
   border-top: 1px solid var(--border);


### PR DESCRIPTION
## What Problem This Solves

The proposed Control UI sidebar behavior should not make a recent session row look selected while the operator is on Overview, Settings, or another non-chat route. A stored active session can still be useful for returning to Chat, but selected row styling outside Chat makes the non-chat page look like it is scoped to that session.

## Why This Change Was Made

This change separates the stored/current session from the visual active state in the sidebar. `AppSidebar` still preserves the current session key for Chat navigation and session actions, but it only applies `sidebar-recent-session--active` when the active route is Chat.

The Overview recent-session card also now renders display names directly after `resolveSessionDisplayName`. That keeps the existing provider-key display-name sanitization, while removing the extra digit blur from ordinary titles such as build numbers or dates.

Related existing PR: #97257 disables the session selection control on non-chat pages. This PR is narrower and only scopes the sidebar row active styling.

## User Impact

On non-chat routes, recent sessions remain visible and clickable, but none of them appear selected. Returning to Chat still restores/highlights the stored session, including direct `/chat` and `/chat?session=...` navigation.

Overview recent sessions show non-sensitive numeric suffixes normally instead of blurring them.

## Evidence

- `git diff --check`
- `node scripts/run-vitest.mjs ui/src/pages/overview/view.render.test.ts`
- `node scripts/run-vitest.mjs ui/src/e2e/session-management.e2e.test.ts`

Notes:
- Browser smoke covered `/overview`, `/config` as the current Settings route, `/chat?session=agent%3Amain%3Amain`, and direct `/chat` in the mocked Control UI E2E.
- `public_pr_preflight.sh` was run, but its default-branch diff check compared against a stale local `main` branch checked out in another worktree. The branch itself was verified against `origin/main` immediately before publishing: `git rev-list --left-right --count HEAD...origin/main` returned `1 0`.
- The local `codex` review binary could not run because its bundled vendor executable is missing (`ENOENT`).

## Screenshots

Desktop overview in this PR:

![Desktop overview showing sidebar recent sessions with no active session row](https://bronze-haven-3sqy.here.now/desktop-overview-no-active-session.png)

Mobile sidebar overview in this PR:

![Mobile sidebar showing recent sessions with no active session row](https://bronze-haven-3sqy.here.now/mobile-sidebar-overview-no-active-session.png)
