### PR TITLE
test(embedded-agent): deflake fast-mode-auto tests under CI load

### DIFF
--- a/src/agents/embedded-agent-runner/run.fast-mode-auto.test.ts
+++ b/src/agents/embedded-agent-runner/run.fast-mode-auto.test.ts
@@ -94,7 +94,9 @@ describe("runEmbeddedAgent fast auto progress", () => {
         resolve(successAttempt("ollama", "glm-5.1:cloud"));
       };
     });
-    mockedRunEmbeddedAttempt.mockImplementationOnce(async (params) => {
+    // Use a persistent implementation so CI timing variations that cause a
+    // retry do not break the test with an unhandled second attempt.
+    mockedRunEmbeddedAttempt.mockImplementation(async (params) => {
       attemptParams = params as FastModeAttemptParams;
       resolveAttemptFastMode(params);
       return attemptDone;
@@ -107,6 +109,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
       runId: "run-fast-auto-retry",
       fastMode: "auto",
       fastModeAutoOnSeconds: 30,
+      timeoutMs: 120_000,
       onAgentEvent: (event) => {
         events.push(event);
       },
@@ -115,9 +118,12 @@ describe("runEmbeddedAgent fast auto progress", () => {
       },
     });
 
-    await vi.waitFor(() => {
-      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    });
+    await vi.waitFor(
+      () => {
+        expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 10_000 },
+    );
     await vi.advanceTimersByTimeAsync(31_000);
 
     expect(events.map((event) => event.data?.summary).filter(Boolean)).toHaveLength(0);
@@ -190,7 +196,9 @@ describe("runEmbeddedAgent fast auto progress", () => {
         resolve(successAttempt("ollama", "glm-5.1:cloud"));
       };
     });
-    mockedRunEmbeddedAttempt.mockImplementationOnce(async (params) => {
+    // Use a persistent implementation so CI timing variations that cause a
+    // retry do not break the test with an unhandled second attempt.
+    mockedRunEmbeddedAttempt.mockImplementation(async (params) => {
       attemptParams = params as FastModeAttemptParams;
       resolveAttemptFastMode(params);
       return attemptDone;
@@ -203,6 +211,7 @@ describe("runEmbeddedAgent fast auto progress", () => {
       runId: "run-fast-auto-single-off",
       fastMode: "auto",
       fastModeAutoOnSeconds: 30,
+      timeoutMs: 120_000,
       onAgentEvent: (event) => {
         events.push(event);
       },
@@ -211,9 +220,12 @@ describe("runEmbeddedAgent fast auto progress", () => {
       },
     });
 
-    await vi.waitFor(() => {
-      expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-    });
+    await vi.waitFor(
+      () => {
+        expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 10_000 },
+    );
     await vi.advanceTimersByTimeAsync(31_000);
     await attemptParams?.onAgentEvent?.({
       stream: "tool",
@@ -266,7 +278,9 @@ describe("runEmbeddedAgent fast auto progress", () => {
           resolve(successAttempt("ollama", "glm-5.1:cloud"));
         };
       });
-      mockedRunEmbeddedAttempt.mockImplementationOnce(async (params) => {
+      // Use a persistent implementation so CI timing variations that cause a
+      // retry do not break the test with an unhandled second attempt.
+      mockedRunEmbeddedAttempt.mockImplementation(async (params) => {
         attemptParams = params as FastModeAttemptParams;
         resolveAttemptFastMode(params);
         return attemptDone;
@@ -298,9 +312,12 @@ describe("runEmbeddedAgent fast auto progress", () => {
         },
       });
 
-      await vi.waitFor(() => {
-        expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-      });
+      await vi.waitFor(
+        () => {
+          expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 10_000 },
+      );
       await vi.advanceTimersByTimeAsync(61_000);
       await attemptParams?.onAgentEvent?.({
         stream: "tool",
@@ -341,7 +358,9 @@ describe("runEmbeddedAgent fast auto progress", () => {
           resolve(successAttempt("ollama", "glm-5.1:cloud"));
         };
       });
-      mockedRunEmbeddedAttempt.mockImplementationOnce(async (params) => {
+      // Use a persistent implementation so CI timing variations that cause a
+      // retry do not break the test with an unhandled second attempt.
+      mockedRunEmbeddedAttempt.mockImplementation(async (params) => {
         attemptParams = params as FastModeAttemptParams;
         resolveAttemptFastMode(params);
         return attemptDone;
@@ -368,9 +387,12 @@ describe("runEmbeddedAgent fast auto progress", () => {
         },
       });
 
-      await vi.waitFor(() => {
-        expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
-      });
+      await vi.waitFor(
+        () => {
+          expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 10_000 },
+      );
       await vi.advanceTimersByTimeAsync(61_000);
       await attemptParams?.onAgentEvent?.({
         stream: "tool",


### PR DESCRIPTION
Related: #100722

## What Problem This Solves

Fixes flaky CI failures in `src/agents/embedded-agent-runner/run.fast-mode-auto.test.ts` that block unrelated PRs (e.g., #100722). In `checks-node-compact-large-whole-1` the two fast-mode-auto progress tests fail intermittently with mismatched `mockedRunEmbeddedAttempt` call counts (expected 1, got 0 or 2).

## Why This Change Was Made

CI shards run with limited workers and CPU contention, so `runEmbeddedAgent` sometimes retries or takes longer to start the embedded attempt than the default `vi.waitFor` timeout allows. The original tests used `mockImplementationOnce`, which leaves any retry unhandled and returns `undefined`, making the flake worse. This change:

- Switches all four tests to a persistent `mockImplementation` so a retry returns the same pending attempt result instead of `undefined`.
- Extends the `vi.waitFor` timeout from the default 1s to 10s to tolerate slow attempt startup under load.
- Aligns the first two tests with the others by setting `timeoutMs: 120_000`, removing the 30s run timeout as a source of retries.

## User Impact

No user-facing behavior change. This only improves CI reliability for contributors whose PRs hit this shard.

## Evidence

- CI failure log from #100722 (`checks-node-compact-large-whole-1`):
  - `emits auto-off after a tool execution boundary crosses the threshold`: expected 1 call, got 0.
  - `emits one auto-off notice at the first completed boundary past the threshold`: expected 1 call, got 2.
- Local verification after the change:
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.fast-mode-auto.test.ts --run`: 6/6 pass.
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run.*.test.ts --run`: 282/282 pass.
  - Repeated runs of the target file also pass.
