### PR TITLE
fix(ui): center chat scroll-to-bottom affordance

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1091,6 +1091,33 @@ describe("chat goal status", () => {
   });
 });
 
+describe("chat scroll-to-bottom affordance", () => {
+  it("renders a centered icon button above the composer when the transcript is away from latest", () => {
+    const onScrollToBottom = vi.fn();
+    const container = renderChatView({ showNewMessages: true, onScrollToBottom });
+
+    const button = container.querySelector<HTMLButtonElement>(".chat-scroll-to-bottom");
+    const wrapper = button?.closest(".chat-scroll-to-bottom-wrap");
+    expect(button?.getAttribute("aria-label")).toBe("Scroll to latest");
+    expect(wrapper?.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
+    expect(wrapper?.nextElementSibling?.classList.contains("agent-chat__composer-shell")).toBe(
+      true,
+    );
+    expect(button?.textContent?.trim()).toBe("");
+    expect(container.querySelector(".chat-new-messages")).toBeNull();
+
+    button?.click();
+
+    expect(onScrollToBottom).toHaveBeenCalledWith({ smooth: true });
+  });
+
+  it("hides the scroll-to-bottom button when the transcript is already latest", () => {
+    const container = renderChatView({ showNewMessages: false });
+
+    expect(container.querySelector(".chat-scroll-to-bottom")).toBeNull();
+  });
+});
+
 describe("chat composer workbench", () => {
   it("renders session controls in the composer and workspace files in the expanded rail", () => {
     const onToggleCollapsed = vi.fn();

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -100,7 +100,7 @@ export type ChatProps = {
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
   onAssistantAttachmentLoaded?: () => void;
   showNewMessages?: boolean;
-  onScrollToBottom?: () => void;
+  onScrollToBottom?: (options?: { smooth?: boolean }) => void;
   onRefresh: () => void;
   onToggleFocusMode?: () => void;
   getDraft?: () => string;
@@ -222,7 +222,6 @@ export function renderChat(props: ChatProps) {
     assistantName: props.assistantName,
     sendShortcut: props.sendShortcut,
     attachments: props.attachments,
-    showNewMessages: props.showNewMessages,
     replyTarget: props.replyTarget,
     realtimeTalkActive: props.realtimeTalkActive,
     realtimeTalkStatus: props.realtimeTalkStatus,
@@ -246,9 +245,23 @@ export function renderChat(props: ChatProps) {
     onDismissSideResult: props.onDismissSideResult,
     onNewSession: props.onNewSession,
     onClearReply: props.onClearReply,
-    onScrollToBottom: props.onScrollToBottom,
     onAttachmentsChange: props.onAttachmentsChange,
   });
+  const scrollToBottomButton =
+    props.showNewMessages && props.onScrollToBottom
+      ? html`
+          <div class="chat-scroll-to-bottom-wrap">
+            <button
+              class="chat-scroll-to-bottom"
+              type="button"
+              @click=${() => props.onScrollToBottom?.({ smooth: true })}
+              aria-label="Scroll to latest"
+            >
+              ${icons.arrowDown}
+            </button>
+          </div>
+        `
+      : nothing;
 
   return html`
     <section
@@ -343,7 +356,7 @@ export function renderChat(props: ChatProps) {
               class="chat-main"
               style="flex: ${sidebarOpen ? `0 1 ${splitRatio * 100}%` : "1 1 100%"}"
             >
-              ${thread} ${chatColumnFooter}
+              ${thread} ${scrollToBottomButton} ${chatColumnFooter}
             </div>
 
             ${sidebarOpen

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -86,7 +86,6 @@ type ChatComposerProps = {
   assistantName: string;
   sendShortcut?: ChatSendShortcut;
   attachments?: ChatAttachment[];
-  showNewMessages?: boolean;
   replyTarget?: { messageId: string; text: string; senderLabel?: string | null } | null;
   realtimeTalkActive?: boolean;
   realtimeTalkStatus?: RealtimeTalkStatus;
@@ -109,7 +108,6 @@ type ChatComposerProps = {
   onDismissSideResult?: () => void;
   onNewSession: () => void;
   onClearReply?: () => void;
-  onScrollToBottom?: () => void;
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
   onGoalCommand?: (command: string) => void;
 };
@@ -2184,14 +2182,6 @@ export function renderChatComposer(props: ChatComposerProps) {
       onQueueRemove: props.onQueueRemove,
     })}
     ${renderSideResult(props.sideResult, props.onDismissSideResult)}
-    ${props.showNewMessages
-      ? html`
-          <button class="chat-new-messages" type="button" @click=${props.onScrollToBottom}>
-            ${icons.arrowDown} New messages
-          </button>
-        `
-      : nothing}
-
     <div class="agent-chat__composer-shell">
       ${mobileRunStatusIndicator !== nothing && composerRunStatus
         ? html`

--- a/ui/src/pages/chat/scroll.test.ts
+++ b/ui/src/pages/chat/scroll.test.ts
@@ -107,6 +107,23 @@ describe("handleChatScroll", () => {
     expect(host.chatUserNearBottom).toBe(false);
   });
 
+  it("shows the scroll-to-bottom affordance after any scroll away from latest", () => {
+    const { host } = createScrollHost({});
+    host.chatLastScrollTop = 1600;
+
+    handleChatScroll(host, createScrollEvent(2000, 1598, 400));
+
+    expect(host.chatNewMessagesBelow).toBe(true);
+  });
+
+  it("keeps the scroll-to-bottom affordance hidden for short transcripts", () => {
+    const { host } = createScrollHost({});
+
+    handleChatScroll(host, createScrollEvent(300, 0, 400));
+
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
   it("sets chatUserNearBottom=false when scrolled past the near-bottom threshold", () => {
     const { host } = createScrollHost({});
     // distanceFromBottom = 2000 - 1100 - 400 = 500 → beyond threshold
@@ -358,7 +375,7 @@ describe("scheduleChatScroll", () => {
   it("does NOT scroll automatically when chat auto-scroll is off", async () => {
     const { host, container } = createScrollHost({
       scrollHeight: 2000,
-      scrollTop: 1600,
+      scrollTop: 1200,
       clientHeight: 400,
       chatAutoScroll: "off",
     });
@@ -382,6 +399,22 @@ describe("scheduleChatScroll", () => {
     host.chatUserNearBottom = false;
 
     scheduleChatScroll(host, true, false, { source: "manual" });
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(container.scrollHeight);
+    expect(host.chatNewMessagesBelow).toBe(false);
+  });
+
+  it("clears the scroll-to-bottom affordance immediately on manual scroll", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1200,
+      clientHeight: 400,
+    });
+    host.chatUserNearBottom = false;
+    host.chatNewMessagesBelow = true;
+
+    scheduleChatScroll(host, true, true, { source: "manual" });
     await host.updateComplete;
 
     expect(container.scrollTop).toBe(container.scrollHeight);
@@ -522,6 +555,7 @@ describe("programmatic scroll guard", () => {
     host.chatIsProgrammaticScroll = true;
     // We had targeted the bottom of a 3000px page.
     host.chatProgrammaticScrollTarget = 3000;
+    host.chatLastScrollTop = 2600;
 
     // User scrolled up to 500 during the guard window — far below the target (2600).
     const event = createScrollEvent(3000, 500, 400); // distanceFromBottom = 2100 > 450
@@ -585,19 +619,18 @@ describe("programmatic scroll guard", () => {
     expect(host.chatLastScrollTop).toBe(599);
   });
 
-  it("guard boundary: scrollTop exactly at threshold is suppressed", () => {
+  it("suppresses programmatic scroll events while scrolling down", () => {
     const { host } = createScrollHost({});
     host.chatUserNearBottom = true;
     host.chatIsProgrammaticScroll = true;
     host.chatProgrammaticScrollTarget = 1000;
     host.chatLastScrollTop = 0;
 
-    // scrollTop = 600 → 600 >= 600 is true → guard suppresses the event.
-    const event = createScrollEvent(1000, 600, 400);
+    const event = createScrollEvent(1000, 300, 400);
     handleChatScroll(host, event);
 
     // Scroll bookkeeping still advances so the next user scroll has the right direction.
-    expect(host.chatLastScrollTop).toBe(600);
+    expect(host.chatLastScrollTop).toBe(300);
   });
 
   it("suppressed programmatic scroll event does not mutate chatNewMessagesBelow", () => {

--- a/ui/src/pages/chat/scroll.ts
+++ b/ui/src/pages/chat/scroll.ts
@@ -3,6 +3,7 @@ import { normalizeChatAutoScrollMode, type ChatAutoScrollMode } from "../../app/
 
 /** Distance (px) from the bottom within which we consider the user "near bottom". */
 const NEAR_BOTTOM_THRESHOLD = 450;
+const LATEST_MESSAGE_THRESHOLD = 1;
 const FOLLOW_REACQUIRE_THRESHOLD = 8;
 const HEADER_HIDE_SCROLL_DELTA = 12;
 const HEADER_SHOW_TOP_THRESHOLD = 24;
@@ -21,6 +22,7 @@ type ChatScrollHost = {
   chatNewMessagesBelow: boolean;
   chatIsProgrammaticScroll: boolean;
   chatProgrammaticScrollTarget: number;
+  requestUpdate?: () => void;
   settings?: {
     chatAutoScroll?: ChatAutoScrollMode;
   };
@@ -28,6 +30,14 @@ type ChatScrollHost = {
 
 function queryHost(host: Partial<ChatScrollHost>, selectors: string): Element | null {
   return typeof host.querySelector === "function" ? host.querySelector(selectors) : null;
+}
+
+function setChatNewMessagesBelow(host: ChatScrollHost, next: boolean) {
+  if (host.chatNewMessagesBelow === next) {
+    return;
+  }
+  host.chatNewMessagesBelow = next;
+  host.requestUpdate?.();
 }
 
 type ChatScrollOptions = {
@@ -74,6 +84,9 @@ export function scheduleChatScroll(
       const contentGrew = target.scrollHeight > (host.chatLastScrollHeight ?? 0) + 1;
       host.chatLastScrollHeight = target.scrollHeight;
       const contentChanged = options.contentChanged ?? options.source !== "resize";
+      const canShowScrollButton =
+        target.scrollHeight - target.clientHeight > LATEST_MESSAGE_THRESHOLD &&
+        distanceFromBottom > LATEST_MESSAGE_THRESHOLD;
       const autoScrollMode = normalizeChatAutoScrollMode(host.settings?.chatAutoScroll);
       const manualScroll = options.source === "manual";
 
@@ -90,7 +103,7 @@ export function scheduleChatScroll(
 
       if (!shouldStick) {
         if (contentChanged || (options.source === "resize" && contentGrew)) {
-          host.chatNewMessagesBelow = true;
+          setChatNewMessagesBelow(host, canShowScrollButton);
         }
         return;
       }
@@ -116,7 +129,7 @@ export function scheduleChatScroll(
         host.chatIsProgrammaticScroll = false;
       });
       host.chatUserNearBottom = true;
-      host.chatNewMessagesBelow = false;
+      setChatNewMessagesBelow(host, false);
       const retryDelay = effectiveForce ? 150 : 120;
       host.chatScrollTimeout = window.setTimeout(() => {
         host.chatScrollTimeout = null;
@@ -143,6 +156,7 @@ export function scheduleChatScroll(
           host.chatIsProgrammaticScroll = false;
         });
         host.chatUserNearBottom = true;
+        setChatNewMessagesBelow(host, false);
       }, retryDelay);
     });
   });
@@ -164,14 +178,13 @@ export function handleChatScroll(host: ChatScrollHost, event: Event) {
   // process the event so streaming stops pinning them back to the bottom.
   const isUserScrollUp = delta < 0;
   const isDeliberateScrollUp = delta < -HEADER_HIDE_SCROLL_DELTA;
-  if (
-    host.chatIsProgrammaticScroll &&
-    !isUserScrollUp &&
-    container.scrollTop >= host.chatProgrammaticScrollTarget - container.clientHeight
-  ) {
+  if (host.chatIsProgrammaticScroll && !isUserScrollUp) {
     return;
   }
-  const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+  const distanceFromBottom = Math.max(
+    0,
+    container.scrollHeight - container.scrollTop - container.clientHeight,
+  );
   if (isUserScrollUp && distanceFromBottom > FOLLOW_REACQUIRE_THRESHOLD) {
     host.chatFollowLocked = true;
   } else if (distanceFromBottom <= FOLLOW_REACQUIRE_THRESHOLD) {
@@ -188,10 +201,11 @@ export function handleChatScroll(host: ChatScrollHost, event: Event) {
     host.chatHeaderControlsHidden = false;
   }
 
-  // Clear the "new messages below" indicator when user scrolls back to bottom.
-  if (host.chatUserNearBottom) {
-    host.chatNewMessagesBelow = false;
-  }
+  setChatNewMessagesBelow(
+    host,
+    container.scrollHeight - container.clientHeight > LATEST_MESSAGE_THRESHOLD &&
+      distanceFromBottom > LATEST_MESSAGE_THRESHOLD,
+  );
 }
 
 export function resetChatScroll(host: ChatScrollHost) {
@@ -201,7 +215,7 @@ export function resetChatScroll(host: ChatScrollHost) {
   host.chatLastScrollTop = 0;
   host.chatLastScrollHeight = 0;
   host.chatHeaderControlsHidden = false;
-  host.chatNewMessagesBelow = false;
+  setChatNewMessagesBelow(host, false);
   host.chatIsProgrammaticScroll = false;
   host.chatProgrammaticScrollTarget = 0;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -86,37 +86,41 @@ openclaw-chat-page {
   margin-top: 0 !important;
 }
 
-/* New messages indicator - floating pill above compose */
-.chat-new-messages {
-  align-self: center;
+/* Scroll-to-bottom affordance centered above the composer. */
+.chat-scroll-to-bottom-wrap {
+  position: absolute;
+  left: 50%;
+  bottom: 128px;
+  transform: translateX(-50%);
+  z-index: 10;
+  pointer-events: none;
+}
+
+.chat-scroll-to-bottom {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  margin: 8px auto 0;
-  font-size: 12px;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
   line-height: 1;
-  font-family: var(--font-body);
   color: var(--text);
   background: var(--panel-strong);
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
+  box-shadow: var(--shadow-sm);
   cursor: pointer;
-  white-space: nowrap;
-  z-index: 10;
-  transition:
-    background 150ms ease-out,
-    border-color 150ms ease-out;
+  pointer-events: auto;
 }
 
-.chat-new-messages:hover {
-  background: var(--panel);
-  border-color: var(--accent);
+.chat-scroll-to-bottom:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--text) 28%, transparent);
+  outline-offset: 2px;
 }
 
-.chat-new-messages svg {
-  width: 16px;
-  height: 16px;
+.chat-scroll-to-bottom svg {
+  width: 18px;
+  height: 18px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.5px;

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -40,6 +40,7 @@
 }
 
 .chat-main {
+  position: relative;
   min-width: 312px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
![Desktop screenshot showing the centered scroll-to-latest button above the composer](https://meadow-vault-brsr.here.now/pr-100922-desktop-scroll-to-bottom.png)

![Mobile screenshot showing the centered scroll-to-latest button above the composer](https://meadow-vault-brsr.here.now/pr-100922-mobile-scroll-to-bottom.png)

## What Problem This Solves

Fixes an issue where Control UI chat users who scroll slightly away from the latest message do not get a clear centered way to return to the bottom until later content changes the indicator state.

## Why This Change Was Made

This PR moves the scroll-to-bottom affordance out of the composer status stack and renders it as a neutral circular icon button centered above the composer. It also updates chat scroll state so the affordance is shown whenever the scrollable transcript is away from the latest message, including small manual scrolls, and clears it through the existing manual scroll-to-bottom path.

No transcript data behavior, message footer actions, or composer model controls changed.

## User Impact

Users can quickly return to the latest chat message after scrolling away, without the control overlapping the composer or changing transcript spacing/actions.

## Validation

- `node_modules/.bin/vitest run ui/src/pages/chat/scroll.test.ts ui/src/pages/chat/chat-view.test.ts --config test/vitest/vitest.ui.config.ts`
- `node_modules/.bin/oxfmt --check ui/src/pages/chat/chat-view.ts ui/src/pages/chat/components/chat-composer.ts ui/src/pages/chat/scroll.ts ui/src/pages/chat/chat-view.test.ts ui/src/pages/chat/scroll.test.ts ui/src/styles/chat/layout.css ui/src/styles/chat/sidebar.css`
- `git diff --check origin/main...HEAD`
