### PR TITLE
fix(ui): move chat message actions into footers

### DIFF
--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -575,7 +575,7 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector('[aria-label="Read aloud"]')).toBeNull();
   });
 
-  it("reserves bubble space when assistant message actions render", () => {
+  it("renders assistant message actions in the role-scoped footer", () => {
     const container = document.createElement("div");
     renderAssistantMessage(container, {
       role: "assistant",
@@ -588,8 +588,24 @@ describe("grouped chat rendering", () => {
       ".chat-group.assistant .chat-bubble",
       HTMLElement,
     );
-    expect(assistantBubble.classList.contains("has-copy")).toBe(true);
-    expect(assistantBubble.querySelector(".chat-bubble-actions")).toBeInstanceOf(HTMLElement);
+    expect(assistantBubble.classList.contains("has-copy")).toBe(false);
+    expect(assistantBubble.classList.contains("chat-bubble--has-actions")).toBe(false);
+    expect(assistantBubble.querySelector(".chat-bubble-actions")).toBeNull();
+
+    const assistantFooter = expectElement(
+      container,
+      ".chat-group.assistant .chat-group-footer--assistant",
+      HTMLElement,
+    );
+    const assistantFooterActions = expectElement(
+      assistantFooter,
+      ".chat-group-footer__actions",
+      HTMLElement,
+    );
+    expect(assistantFooterActions.querySelector(".chat-copy-btn")).toBeInstanceOf(
+      HTMLButtonElement,
+    );
+    expect(assistantFooterActions.querySelector(".chat-expand-btn")).toBeNull();
 
     renderGroupedMessage(
       container,
@@ -604,6 +620,37 @@ describe("grouped chat rendering", () => {
     const userBubble = expectElement(container, ".chat-group.user .chat-bubble", HTMLElement);
     expect(userBubble.classList.contains("has-copy")).toBe(false);
     expect(userBubble.querySelector(".chat-bubble-actions")).toBeNull();
+    expect(container.querySelector(".chat-group.user .chat-copy-btn")).toBeNull();
+  });
+
+  it("keeps user footer actions inside the user footer boundary before timestamp and name", () => {
+    const container = document.createElement("div");
+    renderMessageGroups(
+      container,
+      [
+        createMessageGroup(
+          {
+            role: "user",
+            content: "hello from user",
+            timestamp: 1000,
+          },
+          "user",
+        ),
+      ],
+      { onDelete: vi.fn(), userName: "Ada" },
+    );
+
+    const footer = expectElement(
+      container,
+      ".chat-group.user .chat-group-footer--user",
+      HTMLElement,
+    );
+    const actions = expectElement(footer, ".chat-group-footer__actions", HTMLElement);
+    const meta = expectElement(footer, ".chat-group-footer__meta", HTMLElement);
+    expect(actions.querySelector(".chat-group-delete")).toBeInstanceOf(HTMLButtonElement);
+    expect(meta.querySelector(".chat-group-timestamp")).toBeInstanceOf(HTMLTimeElement);
+    expect(meta.querySelector(".chat-sender-name")?.textContent?.trim()).toBe("Ada");
+    expect([...footer.children]).toEqual([actions, meta]);
   });
 
   it("renders user markdown without code-block copy chrome", () => {
@@ -2879,7 +2926,7 @@ describe("grouped chat rendering", () => {
     expect(container.querySelector(".chat-tool-msg-summary")).not.toBeNull();
   });
 
-  it("reserves layout space for assistant message actions", () => {
+  it("keeps assistant message actions out of the bubble chrome", () => {
     const container = document.createElement("div");
     renderAssistantMessage(container, {
       id: "assistant-action-space",
@@ -2889,8 +2936,9 @@ describe("grouped chat rendering", () => {
     });
 
     const bubble = container.querySelector(".chat-group.assistant .chat-bubble");
-    expect(bubble?.classList.contains("chat-bubble--has-actions")).toBe(true);
-    expect(bubble?.querySelector(".chat-bubble-actions")).not.toBeNull();
+    expect(bubble?.classList.contains("chat-bubble--has-actions")).toBe(false);
+    expect(bubble?.querySelector(".chat-bubble-actions")).toBeNull();
+    expect(container.querySelector(".chat-group-footer--assistant .chat-copy-btn")).not.toBeNull();
   });
 
   it("renders hidden assistant_message canvas results with the configured sandbox", () => {

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -635,6 +635,7 @@ type RenderMessageGroupOptions = {
 };
 
 type GroupedMessageRenderOptions = Parameters<typeof renderGroupedMessage>[2];
+type MessageFooterActionOptions = Pick<GroupedMessageRenderOptions, "sessionKey" | "agentId">;
 
 function buildGroupedMessageRenderOptions(
   group: MessageGroup,
@@ -664,6 +665,91 @@ function buildGroupedMessageRenderOptions(
     embedSandboxMode: opts.embedSandboxMode,
     allowExternalEmbedUrls: opts.allowExternalEmbedUrls,
   };
+}
+
+function renderMessageFooterActions(
+  message: unknown,
+  opts: MessageFooterActionOptions,
+  onOpenSidebar?: (content: SidebarContent) => void,
+) {
+  const m = message as Record<string, unknown>;
+  const role = typeof m.role === "string" ? m.role : "unknown";
+  if (role !== "assistant") {
+    return nothing;
+  }
+
+  const normalizedMessage = normalizeMessage(message);
+  const markdown = normalizedMessage.content
+    .reduce<string[]>((lines, item) => {
+      if (item.type === "text" && typeof item.text === "string") {
+        lines.push(item.text);
+      }
+      return lines;
+    }, [])
+    .join("\n")
+    .trim();
+  if (!markdown) {
+    return nothing;
+  }
+
+  const transcriptMeta =
+    m["__openclaw"] && typeof m["__openclaw"] === "object" && !Array.isArray(m["__openclaw"])
+      ? (m["__openclaw"] as Record<string, unknown>)
+      : null;
+  const sidebarMessageId =
+    typeof transcriptMeta?.id === "string"
+      ? transcriptMeta.id
+      : typeof m.messageId === "string"
+        ? m.messageId
+        : undefined;
+  const shouldFetchFullMessage = Boolean(
+    sidebarMessageId &&
+    !m.openclawMessageToolMirror &&
+    (transcriptMeta?.truncated === true || markdown.includes("\n...(truncated)...")),
+  );
+
+  return html`
+    ${onOpenSidebar
+      ? renderExpandButton(markdown, onOpenSidebar, {
+          sessionKey: opts.sessionKey,
+          agentId: opts.agentId,
+          messageId: shouldFetchFullMessage ? sidebarMessageId : undefined,
+        })
+      : nothing}
+    ${renderCopyAsMarkdownButton(markdown)}
+  `;
+}
+
+function renderAssistantFooterActions(group: MessageGroup, opts: RenderMessageGroupOptions) {
+  let actionableMessage: MessageGroup["messages"][number] | null = null;
+  for (let index = group.messages.length - 1; index >= 0; index -= 1) {
+    const item = group.messages[index]!;
+    const m = item.message as Record<string, unknown>;
+    const role = typeof m.role === "string" ? m.role : "unknown";
+    if (role !== "assistant") {
+      continue;
+    }
+    const normalizedMessage = normalizeMessage(item.message);
+    if (
+      normalizedMessage.content.some(
+        (contentItem) => contentItem.type === "text" && Boolean(contentItem.text?.trim()),
+      )
+    ) {
+      actionableMessage = item;
+      break;
+    }
+  }
+  if (!actionableMessage) {
+    return nothing;
+  }
+  return renderMessageFooterActions(
+    actionableMessage.message,
+    {
+      sessionKey: opts.sessionKey,
+      agentId: opts.agentId,
+    },
+    opts.onOpenSidebar,
+  );
 }
 
 export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroupOptions) {
@@ -762,10 +848,14 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
                 `
               : nothing}
           </div>
-          <div class="chat-group-footer">
-            <span class="chat-sender-name">Activity</span>
-            ${renderChatTimestamp(group.timestamp)}
-            ${opts.onDelete ? renderDeleteButton(opts.onDelete, "right") : nothing}
+          <div class="chat-group-footer chat-group-footer--tool">
+            <span class="chat-group-footer__meta">
+              <span class="chat-sender-name">Activity</span>
+              ${renderChatTimestamp(group.timestamp)}
+            </span>
+            <span class="chat-group-footer__actions">
+              ${opts.onDelete ? renderDeleteButton(opts.onDelete, "right") : nothing}
+            </span>
           </div>
         </div>
       </div>
@@ -796,12 +886,29 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
             opts.onOpenSidebar,
           ),
         )}
-        <div class="chat-group-footer">
-          <span class="chat-sender-name">${who}</span>
-          ${renderMessageMeta(group.timestamp, meta)}
-          ${opts.onDelete
-            ? renderDeleteButton(opts.onDelete, normalizedRole === "user" ? "left" : "right")
-            : nothing}
+        <div class="chat-group-footer chat-group-footer--${roleClass}">
+          ${normalizedRole === "user"
+            ? html`
+                <span class="chat-group-footer__actions">
+                  ${opts.onDelete ? renderDeleteButton(opts.onDelete, "left") : nothing}
+                </span>
+                <span class="chat-group-footer__meta">
+                  ${renderMessageMeta(group.timestamp, meta)}
+                  <span class="chat-sender-name">${who}</span>
+                </span>
+              `
+            : html`
+                <span class="chat-group-footer__meta">
+                  <span class="chat-sender-name">${who}</span>
+                  ${renderMessageMeta(group.timestamp, meta)}
+                </span>
+                <span class="chat-group-footer__actions">
+                  ${normalizedRole === "assistant"
+                    ? renderAssistantFooterActions(group, opts)
+                    : nothing}
+                  ${opts.onDelete ? renderDeleteButton(opts.onDelete, "right") : nothing}
+                </span>
+              `}
         </div>
       </div>
     </div>
@@ -1929,34 +2036,12 @@ function renderGroupedMessage(
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
   const markdown = markdownBase;
   const markdownRenderOptions = role === "user" ? { codeBlockChrome: "none" as const } : undefined;
-  const canCopyMarkdown = role === "assistant" && Boolean(markdown?.trim());
-  const canExpand = role === "assistant" && Boolean(onOpenSidebar && markdown?.trim());
-  const hasActions = canCopyMarkdown || canExpand;
-  const transcriptMeta =
-    m["__openclaw"] && typeof m["__openclaw"] === "object" && !Array.isArray(m["__openclaw"])
-      ? (m["__openclaw"] as Record<string, unknown>)
-      : null;
-  const sidebarMessageId =
-    typeof transcriptMeta?.id === "string"
-      ? transcriptMeta.id
-      : typeof m.messageId === "string"
-        ? m.messageId
-        : undefined;
-  const shouldFetchFullMessage = Boolean(
-    sidebarMessageId &&
-    !m.openclawMessageToolMirror &&
-    (transcriptMeta?.truncated === true || markdown?.includes("\n...(truncated)...")),
-  );
-
   // Detect pure-JSON messages and render as collapsible block
   const jsonResult = markdown && !opts.isStreaming ? detectJson(markdown) : null;
 
-  const reserveActionSpace = hasActions && !isToolShell;
   const bubbleClasses = [
     "chat-bubble",
     isToolShell ? "chat-bubble--tool-shell" : "",
-    hasActions ? "has-copy" : "",
-    reserveActionSpace ? "chat-bubble--has-actions" : "",
     opts.isStreaming ? "streaming" : "",
     "fade-in",
   ]
@@ -2043,18 +2128,6 @@ function renderGroupedMessage(
       data-message-text=${extractedText || nothing}
     >
       ${renderReplyPill(normalizedMessage.replyTarget)}
-      ${hasActions
-        ? html`<div class="chat-bubble-actions">
-            ${canExpand
-              ? renderExpandButton(markdown!, onOpenSidebar!, {
-                  sessionKey: opts.sessionKey,
-                  agentId: opts.agentId,
-                  messageId: shouldFetchFullMessage ? sidebarMessageId : undefined,
-                })
-              : nothing}
-            ${canCopyMarkdown ? renderCopyAsMarkdownButton(markdown!) : nothing}
-          </div>`
-        : nothing}
       ${isStandaloneToolMessage
         ? html`
             <div

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -38,10 +38,6 @@
   max-width: min(980px, calc(100% - 46px));
 }
 
-.chat-group.user .chat-group-footer {
-  justify-content: flex-end;
-}
-
 /* Footer at bottom of message group (role + time) */
 .chat-group-footer {
   display: flex;
@@ -50,6 +46,46 @@
   align-items: center;
   flex-wrap: wrap;
   margin-top: 6px;
+}
+
+.chat-group-footer--assistant,
+.chat-group-footer--tool {
+  width: 100%;
+  justify-content: space-between;
+}
+
+.chat-group-footer--user {
+  align-self: flex-end;
+  justify-content: flex-end;
+}
+
+.chat-group-footer__meta,
+.chat-group-footer__actions {
+  display: inline-flex;
+  gap: 8px;
+  row-gap: 5px;
+  align-items: center;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.chat-group-footer__actions:empty {
+  display: none;
+}
+
+.chat-group-footer--assistant .chat-group-footer__actions,
+.chat-group-footer--tool .chat-group-footer__actions {
+  justify-content: flex-end;
+  margin-left: auto;
+}
+
+.chat-group-footer--user .chat-group-footer__actions {
+  order: 1;
+}
+
+.chat-group-footer--user .chat-group-footer__meta {
+  order: 2;
+  justify-content: flex-end;
 }
 
 .chat-sender-name {
@@ -86,7 +122,8 @@
   justify-content: center;
 }
 
-.chat-group:hover .chat-group-footer button {
+.chat-group:hover .chat-group-footer button,
+.chat-group:focus-within .chat-group-footer button {
   opacity: 0.6;
   pointer-events: auto;
 }
@@ -236,14 +273,6 @@ img.chat-avatar {
   box-shadow: none;
 }
 
-.chat-bubble.has-copy {
-  padding-right: 70px;
-}
-
-.chat-bubble--has-actions {
-  padding-right: 70px;
-}
-
 .chat-duplicate-count {
   display: inline-flex;
   align-items: center;
@@ -265,45 +294,16 @@ img.chat-avatar {
   color: color-mix(in srgb, var(--foreground) 80%, var(--primary) 20%);
 }
 
-.chat-bubble-actions {
-  position: absolute;
-  top: 6px;
-  right: 8px;
-  display: flex;
-  gap: 4px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 120ms ease-out;
-}
-
-.chat-bubble:hover .chat-bubble-actions {
-  opacity: 1;
-  pointer-events: auto;
-}
-
 @media (hover: none),
   (max-width: 768px),
   (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
-  .chat-bubble-actions {
-    opacity: 1;
+  .chat-group-footer button {
+    opacity: 0.72;
     pointer-events: auto;
   }
 
-  .chat-bubble--has-actions {
-    display: flex;
-    flex-direction: column;
-    padding-right: 14px;
-  }
-
-  .chat-bubble--has-actions .chat-bubble-actions {
-    position: static;
-    order: 2;
-    justify-content: flex-end;
-    margin-top: 8px;
-  }
-
-  .chat-bubble--has-actions .chat-copy-btn,
-  .chat-bubble--has-actions .chat-expand-btn {
+  .chat-group-footer .chat-copy-btn,
+  .chat-group-footer .chat-expand-btn {
     min-width: 44px;
     min-height: 44px;
   }
@@ -372,23 +372,10 @@ img.chat-avatar {
   height: 14px;
 }
 
-.chat-bubble:hover {
-  border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
-}
-
-:root[data-theme-mode="light"] .chat-bubble:not(:where(.chat-bubble--tool-shell)):hover {
-  border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
-}
-
 /* User bubbles have different styling */
 .chat-group.user .chat-bubble {
   background: var(--accent-subtle);
   border-color: transparent;
-}
-
-.chat-group.user .chat-bubble:hover {
-  border-color: color-mix(in srgb, var(--accent) 24%, transparent);
 }
 
 /* Light mode: restore borders. Order contract: stays below the role variants


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where assistant chat messages expose copy/open actions as bubble hover chrome, which adds hover border styling and keeps those actions separate from existing footer actions such as delete. User message footer actions also need to stay inside the user message boundary with timestamp/name metadata aligned on the right.

## Why This Change Was Made

In this PR, assistant copy/open actions move into the message footer next to existing footer actions, the bubble action overlay and hover border chrome are removed, and assistant, user, tool, and other footers get role-scoped classes so layout rules do not leak across roles. The user footer keeps actions first within the user footer boundary, followed by timestamp and user name metadata on the right.

## Proposed User Impact

In this PR, chat message actions sit in a consistent footer location. Assistant footer actions align to the right edge of the assistant message content, and user footer actions remain inside the user message boundary with timestamp immediately before the user name.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/pages/chat/components/chat-message.test.ts`
- `git diff --check`
- Browser smoke with the mock Control UI at desktop and 390px width: verified one assistant message and one user message, no `.chat-bubble-actions` overlay, assistant footer actions inside/right-aligned to the assistant footer, and user delete action inside the user footer left of timestamp/name.

## Screenshots

Proposed desktop view:

![Proposed desktop chat footer actions](https://calm-plume-56kz.here.now/pr-100923-desktop.png)

Proposed mobile view:

![Proposed mobile chat footer actions](https://calm-plume-56kz.here.now/pr-100923-mobile.png)
