### PR TITLE
fix(ui): refine chat composer send, text size, and model controls

### DIFF
--- a/ui/src/components/icons.ts
+++ b/ui/src/components/icons.ts
@@ -385,8 +385,8 @@ export const icons = {
   `,
   send: html`
     <svg viewBox="0 0 24 24">
-      <path d="m22 2-7 20-4-9-9-4Z" />
-      <path d="M22 2 11 13" />
+      <path d="M12 19V5" />
+      <path d="m5 12 7-7 7 7" />
     </svg>
   `,
   stop: html` <svg viewBox="0 0 24 24"><rect width="14" height="14" x="5" y="5" rx="1" /></svg> `,

--- a/ui/src/e2e/chat-flow.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.e2e.test.ts
@@ -1674,6 +1674,57 @@ describeControlUiE2e("Control UI mocked Gateway E2E", () => {
     }
   });
 
+  it("keeps composer controls from focusing the textarea", async () => {
+    const context = await newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const baseSessions = chatSessionListResponse();
+    const thinkingLevels = [
+      { id: "low", label: "low" },
+      { id: "medium", label: "medium" },
+      { id: "high", label: "high" },
+    ];
+    const sessions = {
+      ...baseSessions,
+      defaults: {
+        ...baseSessions.defaults,
+        thinkingDefault: "low",
+        thinkingLevels,
+      },
+      sessions: baseSessions.sessions.map((session, index) =>
+        index === 0 ? { ...session, thinkingLevel: "high", thinkingLevels } : session,
+      ),
+    };
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessions,
+      },
+      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
+      sessionKey: "agent:main:session-a",
+    });
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+
+      const textarea = page.locator(".agent-chat__composer-combobox textarea");
+      await textarea.fill("sixteen px");
+      expect(await textarea.evaluate((el) => getComputedStyle(el).fontSize)).toBe("16px");
+
+      const trigger = page.getByRole("main").locator('[data-chat-model-select="true"]').first();
+      await trigger.click();
+      expect(
+        await page.evaluate(
+          () => document.activeElement?.matches(".agent-chat__composer-combobox textarea") ?? false,
+        ),
+      ).toBe(false);
+    } finally {
+      await closeBrowserContext(context);
+    }
+  });
+
   it("restores the selected agent model after clearing a session override", async () => {
     const context = await newBrowserContext({
       locale: "en-US",

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -932,12 +932,13 @@ openclaw-chat-page {
   min-height: 36px;
   max-height: calc(7em + 24px);
   resize: none;
-  padding: var(--chat-box-inset);
+  padding: calc(var(--chat-box-inset) - 2px) var(--chat-box-inset)
+    var(--chat-box-inset);
   padding-left: calc(var(--chat-box-inset) - 4px);
   border: none;
   background: transparent;
   color: var(--text);
-  font-size: var(--control-ui-text-md);
+  font-size: var(--control-ui-input-text-size);
   font-family: inherit;
   line-height: 1.4;
   outline: none;
@@ -2685,7 +2686,31 @@ openclaw-chat-page {
   white-space: nowrap;
 }
 
-/* Keep the chevron pinned right when the mobile trigger stretches. */
+/* Effort chip inside the model trigger is decorative; the trigger aria-label
+   carries the full model + thinking state. */
+.chat-controls__effort-chip {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  height: 18px;
+  padding: 0 7px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.chat-controls__effort-chip--override {
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  color: var(--muted);
+}
+
+/* Chevron pins right so label+chip stay grouped when the trigger stretches
+   (mobile grid cell); on desktop the trigger is content-sized so this is a
+   no-op vs the old space-between layout. */
 .chat-controls__inline-select-icon {
   display: inline-flex;
   width: 14px;

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -616,8 +616,7 @@
   }
 
   .agent-chat__input-btn svg,
-  .agent-chat__toolbar .btn--ghost svg,
-  .chat-send-btn svg {
+  .agent-chat__toolbar .btn--ghost svg {
     width: 16px;
     height: 16px;
   }


### PR DESCRIPTION
## What Problem This Solves

The chat composer controls need a tighter visual pass: the send affordance should read as an up-arrow send action, the composer text should stay at the 16px input size, and model/thinking override states should not look like alert badges.

## Why This Change Was Made

In this PR, the composer changes stay scoped to visual and focus behavior. It updates the shared send icon, enlarges the send SVG without changing the button hit target, slightly reduces the textarea top padding, keeps mobile from shrinking the send SVG, and makes the thinking override chip neutral.

It does not change model/provider option data or model catalog behavior.

## Proposed User Impact

Users would get a clearer send control and quieter model/thinking chrome. Clicking the model/thinking control stays out of the textarea focus path, while direct textarea focus keeps the expected 16px input text.

## Proposed UI

Desktop:

![Proposed desktop chat composer controls](https://tropic-vessel-p9hf.here.now/pr-100925-chat-composer-desktop.png)

Mobile:

![Proposed mobile chat composer controls](https://tropic-vessel-p9hf.here.now/pr-100925-chat-composer-mobile.png)

## Evidence

- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner -- ui/src/e2e/chat-flow.e2e.test.ts -t 'keeps composer controls from focusing the textarea'`