### PR TITLE
refactor(ui): localize internal-only symbols

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -73,12 +73,12 @@ export type ChannelAccountSnapshot = {
   application?: unknown;
 };
 
-export type WhatsAppSelf = {
+type WhatsAppSelf = {
   e164?: string | null;
   jid?: string | null;
 };
 
-export type WhatsAppDisconnect = {
+type WhatsAppDisconnect = {
   at: number;
   status?: number | null;
   error?: string | null;
@@ -105,7 +105,7 @@ export type TelegramBot = {
   username?: string | null;
 };
 
-export type TelegramWebhook = {
+type TelegramWebhook = {
   url?: string | null;
   hasCustomCert?: boolean | null;
 };
@@ -131,7 +131,7 @@ export type TelegramStatus = {
   lastProbeAt?: number | null;
 };
 
-export type DiscordBot = {
+type DiscordBot = {
   id?: string | null;
   username?: string | null;
 };
@@ -155,7 +155,7 @@ export type DiscordStatus = {
   lastProbeAt?: number | null;
 };
 
-export type GoogleChatProbe = {
+type GoogleChatProbe = {
   ok: boolean;
   status?: number | null;
   error?: string | null;

--- a/ui/src/app/exec-approval.ts
+++ b/ui/src/app/exec-approval.ts
@@ -214,10 +214,7 @@ export function addExecApproval(
   return next;
 }
 
-export function removeExecApproval(
-  queue: ExecApprovalRequest[],
-  id: string,
-): ExecApprovalRequest[] {
+function removeExecApproval(queue: ExecApprovalRequest[], id: string): ExecApprovalRequest[] {
   return pruneExecApprovalQueue(queue).filter((entry) => entry.id !== id);
 }
 

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -136,7 +136,7 @@ export async function loadChannels(
   await refresh;
 }
 
-export async function startWhatsAppLogin(state: ChannelsState, force: boolean) {
+async function startWhatsAppLogin(state: ChannelsState, force: boolean) {
   if (!state.client || !state.connected || state.whatsappBusy) {
     return;
   }

--- a/ui/src/pages/chat/realtime-talk-conversation.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.ts
@@ -201,11 +201,7 @@ function shouldStartNewRealtimeUserEntry(
   return true;
 }
 
-export function mergeRealtimeTranscriptText(
-  existing: string,
-  incoming: string,
-  isFinal: boolean,
-): string {
+function mergeRealtimeTranscriptText(existing: string, incoming: string, isFinal: boolean): string {
   if (existing.trim() === "") {
     return incoming.trimStart();
   }

--- a/ui/src/pages/tasks/data.ts
+++ b/ui/src/pages/tasks/data.ts
@@ -192,7 +192,7 @@ export function normalizeTasksCancelResult(value: unknown): TasksCancelResult | 
   };
 }
 
-export function normalizeTaskEventPayload(value: unknown): TaskEventPayload | null {
+function normalizeTaskEventPayload(value: unknown): TaskEventPayload | null {
   if (!isRecord(value)) {
     return null;
   }

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -23,7 +23,7 @@ function formatTaskError(error: unknown, fallback: string): string {
   return typeof error === "string" && error.trim() ? error.trim() : fallback;
 }
 
-export class TasksPage extends LitElement {
+class TasksPage extends LitElement {
   override createRenderRoot() {
     return this;
   }


### PR DESCRIPTION
## What Problem This Solves

The Control UI exposes ten symbols that have no consumers outside their defining modules. This unnecessarily broadens internal module APIs.

Fixes #100930

## Why This Change Was Made

Whole-repository TypeScript search and the current codebase-memory graph both show only module-local callers. This change removes the stale `export` modifiers while preserving every runtime call path and higher-level exported contract.

## User Impact

No behavior change. The Control UI keeps the same runtime behavior with a smaller internal API surface.

## Evidence

- `node scripts/run-vitest.mjs ui/src/app/exec-approval.test.ts ui/src/lib/channels/index.test.ts ui/src/pages/chat/realtime-talk-conversation.test.ts ui/src/pages/tasks/data.test.ts` - 39 tests passed.
- `oxfmt --check` on all six changed files - passed.
- `pnpm check:changed` through Crabbox Testbox `tbx_01kwvw53044xxajgexfsakkd7n` - passed.
- Fresh Codex autoreview with `gpt-5.5` high reasoning - no findings.
- Full codebase-memory index: 273,857 nodes and 1,091,336 edges; current graph queries show no cross-file incoming edges for the localized runtime symbols.
