### PR TITLE
fix(web): apply Control UI text size to content typography

### DIFF
--- a/ui/src/components/file-preview-modal.ts
+++ b/ui/src/components/file-preview-modal.ts
@@ -99,7 +99,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
 
     .search-icon {
       color: var(--muted);
-      font-size: 18px;
+      font-size: calc(18px * var(--control-ui-text-scale));
     }
 
     .search {
@@ -109,7 +109,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       outline: none;
       color: var(--text-strong);
       font: inherit;
-      font-size: 18px;
+      font-size: calc(18px * var(--control-ui-text-scale));
       font-weight: 400;
       padding: 4px 0;
     }
@@ -129,7 +129,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       display: inline-flex;
       align-items: center;
       gap: 8px;
-      font-size: 12px;
+      font-size: var(--control-ui-text-sm);
       color: var(--muted);
       padding: 5px 10px;
       border: 1px solid var(--border);
@@ -160,7 +160,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
     }
 
     .list-section {
-      font-size: 11px;
+      font-size: var(--control-ui-text-xs);
       text-transform: uppercase;
       letter-spacing: 0.08em;
       color: var(--muted);
@@ -225,7 +225,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
 
     .item-name {
       font-family: var(--mono);
-      font-size: 14px;
+      font-size: var(--control-ui-text-md);
       color: var(--text);
       overflow: hidden;
       text-overflow: ellipsis;
@@ -234,12 +234,12 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
 
     .item-meta {
       color: var(--muted);
-      font-size: 12px;
+      font-size: var(--control-ui-text-sm);
     }
 
     .empty-list {
       color: var(--muted);
-      font-size: 13px;
+      font-size: var(--control-ui-text-compact);
       padding: 12px;
     }
 
@@ -274,7 +274,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       min-width: 0;
       margin: 0;
       font-family: var(--mono);
-      font-size: 22px;
+      font-size: var(--control-ui-text-2xl);
       color: var(--text-strong);
       font-weight: 700;
       letter-spacing: -0.01em;
@@ -371,7 +371,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       align-items: center;
       padding: 3px 10px;
       border-radius: 999px;
-      font-size: 11.5px;
+      font-size: calc(11.5px * var(--control-ui-text-scale));
       background: var(--bg-elevated);
       border: 1px solid var(--border);
       color: var(--muted);
@@ -404,7 +404,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       margin: 0;
       min-width: 0;
       font-family: var(--mono);
-      font-size: 13px;
+      font-size: var(--control-ui-text-compact);
       line-height: 1.7;
       color: var(--text);
       white-space: pre-wrap;
@@ -420,7 +420,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
       padding: 12px 20px;
       border-top: 1px solid var(--border);
       background: var(--bg);
-      font-size: 12px;
+      font-size: var(--control-ui-text-sm);
       color: var(--muted);
     }
 
@@ -431,7 +431,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
     }
 
     .kbd {
-      font-size: 10.5px;
+      font-size: calc(10.5px * var(--control-ui-text-scale));
       padding: 2px 6px;
       border-radius: 4px;
       background: var(--bg-elevated);
@@ -458,7 +458,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
     }
 
     .empty-title {
-      font-size: 16px;
+      font-size: var(--control-ui-text-lg);
       font-weight: 600;
       color: var(--text-strong);
       margin: 0 0 8px;
@@ -466,7 +466,7 @@ export class OpenClawFilePreviewModal extends OpenClawLitElement {
 
     .empty-subtitle {
       margin: 0;
-      font-size: 13px;
+      font-size: var(--control-ui-text-compact);
       color: var(--muted);
       max-width: 380px;
     }

--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -59,7 +59,7 @@ function controlsHtml() {
   `;
 }
 
-async function openMobileFixture(): Promise<MobileFixture> {
+async function openMobileFixture(textScale = 1): Promise<MobileFixture> {
   const browser = await chromium.launch({ executablePath: chromiumExecutablePath, headless: true });
   let page: Page | undefined;
   try {
@@ -69,7 +69,7 @@ async function openMobileFixture(): Promise<MobileFixture> {
       viewport: { width: 390, height: 844 },
     });
     await page.setContent(
-      `<!doctype html><html data-theme-mode="light"><head><style>${readUiCss()}</style></head><body>${controlsHtml()}</body></html>`,
+      `<!doctype html><html data-theme-mode="light" style="--control-ui-text-scale: ${textScale};"><head><style>${readUiCss()}</style></head><body>${controlsHtml()}</body></html>`,
     );
     return { browser, page };
   } catch (error) {
@@ -86,7 +86,7 @@ async function closeMobileFixture(fixture: MobileFixture): Promise<void> {
 
 describeBrowserLayout("touch-primary form controls", () => {
   it("keeps text-entry controls large enough to avoid mobile focus zoom", async () => {
-    const fixture = await openMobileFixture();
+    const fixture = await openMobileFixture(0.9);
     const { page } = fixture;
     try {
       const metrics = await page.evaluate(() => {

--- a/ui/src/components/terminal/terminal-panel.ts
+++ b/ui/src/components/terminal/terminal-panel.ts
@@ -1062,7 +1062,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       height: 36px;
       color: var(--muted, #8a919e);
       white-space: nowrap;
-      font-size: 12.5px;
+      font-size: calc(12.5px * var(--control-ui-text-scale));
       /* Reserve the active underline height so tabs don't shift on selection. */
       border-bottom: 2px solid transparent;
       transition:
@@ -1091,7 +1091,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
       font-variant-numeric: tabular-nums;
     }
     .tp-tab__status {
-      font-size: 11px;
+      font-size: var(--control-ui-text-xs);
       color: var(--muted, #8a919e);
     }
     .tp-tab__close {
@@ -1160,7 +1160,7 @@ export class OpenClawTerminalPanel extends OpenClawLitElement {
     .tp-empty,
     .tp-error {
       padding: 10px 12px;
-      font-size: 12px;
+      font-size: var(--control-ui-text-sm);
       color: var(--muted, #8a919e);
     }
     .tp-error {

--- a/ui/src/pages/agents/panels-status-files.ts
+++ b/ui/src/pages/agents/panels-status-files.ts
@@ -301,7 +301,7 @@ export function renderAgentChannels(params: {
                                   href="https://docs.openclaw.ai/channels"
                                   target="_blank"
                                   rel="noopener"
-                                  style="color: var(--accent); font-size: 12px"
+                                  style="color: var(--accent); font-size: var(--control-ui-text-sm)"
                                   >${t("agents.channels.setupGuide")}</a
                                 >
                               </div>

--- a/ui/src/pages/channels/view.nostr-profile-form.ts
+++ b/ui/src/pages/channels/view.nostr-profile-form.ts
@@ -110,12 +110,16 @@ export function renderNostrProfileForm(params: {
             ?disabled=${state.saving}
           ></textarea>
           ${help
-            ? html`<div style="font-size: 12px; color: var(--text-muted); margin-top: 2px;">
+            ? html`<div
+                style="font-size: var(--control-ui-text-sm); color: var(--text-muted); margin-top: 2px;"
+              >
                 ${help}
               </div>`
             : nothing}
           ${error
-            ? html`<div style="font-size: 12px; color: var(--danger-color); margin-top: 2px;">
+            ? html`<div
+                style="font-size: var(--control-ui-text-sm); color: var(--danger-color); margin-top: 2px;"
+              >
                 ${error}
               </div>`
             : nothing}
@@ -142,12 +146,16 @@ export function renderNostrProfileForm(params: {
           ?disabled=${state.saving}
         />
         ${help
-          ? html`<div style="font-size: 12px; color: var(--text-muted); margin-top: 2px;">
+          ? html`<div
+              style="font-size: var(--control-ui-text-sm); color: var(--text-muted); margin-top: 2px;"
+            >
               ${help}
             </div>`
           : nothing}
         ${error
-          ? html`<div style="font-size: 12px; color: var(--danger-color); margin-top: 2px;">
+          ? html`<div
+              style="font-size: var(--control-ui-text-sm); color: var(--danger-color); margin-top: 2px;"
+            >
               ${error}
             </div>`
           : nothing}
@@ -188,8 +196,10 @@ export function renderNostrProfileForm(params: {
       <div
         style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;"
       >
-        <div style="font-weight: 600; font-size: 16px;">${t("channels.nostr.editProfile")}</div>
-        <div style="font-size: 12px; color: var(--text-muted);">
+        <div style="font-weight: 600; font-size: var(--control-ui-text-lg);">
+          ${t("channels.nostr.editProfile")}
+        </div>
+        <div style="font-size: var(--control-ui-text-sm); color: var(--text-muted);">
           ${t("channels.nostr.account")}: ${accountId}
         </div>
       </div>
@@ -281,7 +291,9 @@ export function renderNostrProfileForm(params: {
 
       ${isDirty
         ? html`
-            <div style="font-size: 12px; color: var(--warning-color); margin-top: 8px">
+            <div
+              style="font-size: var(--control-ui-text-sm); color: var(--warning-color); margin-top: 8px"
+            >
               ${t("common.unsavedChanges")}
             </div>
           `

--- a/ui/src/pages/channels/view.nostr.ts
+++ b/ui/src/pages/channels/view.nostr.ts
@@ -135,7 +135,7 @@ export function renderNostrCard(params: {
                 <button
                   class="btn btn--sm"
                   @click=${onEditProfile}
-                  style="font-size: 12px; padding: 4px 8px;"
+                  style="font-size: var(--control-ui-text-sm); padding: 4px 8px;"
                 >
                   ${t("channels.nostr.editProfile")}
                 </button>
@@ -184,7 +184,7 @@ export function renderNostrCard(params: {
               </div>
             `
           : html`
-              <div style="color: var(--text-muted); font-size: 13px">
+              <div style="color: var(--text-muted); font-size: var(--control-ui-text-compact)">
                 ${t("channels.nostr.noProfile")} ${t("channels.nostr.noProfileHint")}
               </div>
             `}

--- a/ui/src/pages/chat/components/chat-controls.ts
+++ b/ui/src/pages/chat/components/chat-controls.ts
@@ -148,7 +148,7 @@ function renderCronFilterIcon(hiddenCount: number) {
               background: var(--color-accent, #6366f1);
               color: #fff;
               border-radius: var(--radius-full);
-              font-size: 9px;
+              font-size: calc(9px * var(--control-ui-text-scale));
               line-height: 1;
               padding: 1px 3px;
               pointer-events: none;

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -298,7 +298,7 @@ export function renderSkills(props: SkillsProps) {
       <div style="margin-top: 16px; border-top: 1px solid var(--border); padding-top: 16px;">
         <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 12px;">
           <div style="font-weight: 600;">ClawHub</div>
-          <div class="muted" style="font-size: 13px;">
+          <div class="muted" style="font-size: var(--control-ui-text-compact);">
             Search and install skills from the registry
           </div>
         </div>
@@ -414,7 +414,9 @@ function renderClawHubResults(props: SkillsProps) {
             </div>
             <div class="list-meta" style="display: flex; align-items: center; gap: 8px;">
               ${r.version
-                ? html`<span class="muted" style="font-size: 12px;">v${r.version}</span>`
+                ? html`<span class="muted" style="font-size: var(--control-ui-text-sm);"
+                    >v${r.version}</span
+                  >`
                 : nothing}
               <button
                 class="btn btn--sm"
@@ -470,11 +472,11 @@ function renderClawHubDetailDialog(props: SkillsProps) {
               ? html`<div class="callout danger">${props.clawhubDetailError}</div>`
               : detail?.skill
                 ? html`
-                    <div style="font-size: 14px; line-height: 1.5;">
+                    <div style="font-size: var(--control-ui-text-md); line-height: 1.5;">
                       ${detail.skill.summary ?? ""}
                     </div>
                     ${detail.owner?.displayName
-                      ? html`<div class="muted" style="font-size: 13px;">
+                      ? html`<div class="muted" style="font-size: var(--control-ui-text-compact);">
                           By
                           ${detail.owner.displayName}${detail.owner.handle
                             ? html` (@${detail.owner.handle})`
@@ -482,19 +484,19 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                         </div>`
                       : nothing}
                     ${detail.latestVersion
-                      ? html`<div class="muted" style="font-size: 13px;">
+                      ? html`<div class="muted" style="font-size: var(--control-ui-text-compact);">
                           Latest: v${detail.latestVersion.version}
                         </div>`
                       : nothing}
                     ${detail.latestVersion?.changelog
                       ? html`<div
-                          style="font-size: 13px; border-top: 1px solid var(--border); padding-top: 12px; white-space: pre-wrap;"
+                          style="font-size: var(--control-ui-text-compact); border-top: 1px solid var(--border); padding-top: 12px; white-space: pre-wrap;"
                         >
                           ${detail.latestVersion.changelog}
                         </div>`
                       : nothing}
                     ${detail.metadata?.os
-                      ? html`<div class="muted" style="font-size: 12px;">
+                      ? html`<div class="muted" style="font-size: var(--control-ui-text-sm);">
                           Platforms: ${detail.metadata.os.join(", ")}
                         </div>`
                       : nothing}
@@ -591,7 +593,11 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             style="display: flex; align-items: center; gap: 8px;"
           >
             <span class="statusDot ${skillStatusClass(skill)}"></span>
-            ${skill.emoji ? html`<span style="font-size: 18px;">${skill.emoji}</span>` : nothing}
+            ${skill.emoji
+              ? html`<span style="font-size: calc(18px * var(--control-ui-text-scale));"
+                  >${skill.emoji}</span
+                >`
+              : nothing}
             <span>${skill.name}</span>
           </div>
           <button
@@ -605,7 +611,9 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
         </div>
         <div class="md-preview-dialog__body" style="display: grid; gap: 16px;">
           <div>
-            <div style="font-size: 14px; line-height: 1.5; color: var(--text);">
+            <div
+              style="font-size: var(--control-ui-text-md); line-height: 1.5; color: var(--text);"
+            >
               ${skill.description}
             </div>
             ${renderSkillStatusChips({ skill, showBundledBadge })}
@@ -647,7 +655,9 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             : nothing}
           ${reasons.length > 0
             ? html`
-                <div class="muted" style="font-size: 13px;">Reason: ${reasons.join(", ")}</div>
+                <div class="muted" style="font-size: var(--control-ui-text-compact);">
+                  Reason: ${reasons.join(", ")}
+                </div>
               `
             : nothing}
 
@@ -661,7 +671,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                 @change=${() => props.onToggle(skill.skillKey, skill.disabled)}
               />
             </label>
-            <span style="font-size: 13px; font-weight: 500;">
+            <span style="font-size: var(--control-ui-text-compact); font-weight: 500;">
               ${skill.disabled ? "Disabled" : "Enabled"}
             </span>
             ${canInstall
@@ -700,7 +710,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                   ${(() => {
                     const href = safeExternalHref(skill.homepage);
                     return href
-                      ? html`<div class="muted" style="font-size: 13px;">
+                      ? html`<div class="muted" style="font-size: var(--control-ui-text-compact);">
                           Get your key:
                           <a href="${href}" target="_blank" rel="noopener noreferrer"
                             >${skill.homepage}</a
@@ -720,7 +730,7 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             : nothing}
 
           <div
-            style="border-top: 1px solid var(--border); padding-top: 12px; display: grid; gap: 6px; font-size: 12px; color: var(--muted);"
+            style="border-top: 1px solid var(--border); padding-top: 12px; display: grid; gap: 6px; font-size: var(--control-ui-text-sm); color: var(--muted);"
           >
             <div><span style="font-weight: 600;">Source:</span> ${skill.source}</div>
             <div style="font-family: var(--mono); word-break: break-all;">${skill.filePath}</div>
@@ -765,16 +775,22 @@ function renderInstalledClawHubOverview(
     >
       <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
         <span class="chip ${verdictChipClass(verdict)}">${verdictLabel(verdict)}</span>
-        <span class="muted" style="font-size: 12px;">${link.slug}@${link.installedVersion}</span>
+        <span class="muted" style="font-size: var(--control-ui-text-sm);"
+          >${link.slug}@${link.installedVersion}</span
+        >
         ${props.clawhubVerdictsLoading ? html`<span class="muted">Refreshing…</span>` : nothing}
       </div>
       ${props.clawhubVerdictsError
-        ? html`<div class="muted" style="font-size: 13px;">${props.clawhubVerdictsError}</div>`
+        ? html`<div class="muted" style="font-size: var(--control-ui-text-compact);">
+            ${props.clawhubVerdictsError}
+          </div>`
         : reasonText
-          ? html`<div class="muted" style="font-size: 13px;">${reasonText}</div>`
+          ? html`<div class="muted" style="font-size: var(--control-ui-text-compact);">
+              ${reasonText}
+            </div>`
           : nothing}
       ${auditHref
-        ? html`<div style="font-size: 13px;">
+        ? html`<div style="font-size: var(--control-ui-text-compact);">
             <a href="${auditHref}" target="_blank" rel="noopener noreferrer"
               >Full security report</a
             >
@@ -795,7 +811,7 @@ function renderInstalledSkillCard(skill: SkillStatusEntry, props: SkillsProps) {
     if (error) {
       return html`<div class="callout danger">${error}</div>`;
     }
-    return html`<div class="muted" style="font-size: 13px;">
+    return html`<div class="muted" style="font-size: var(--control-ui-text-compact);">
       ${props.skillCardLoadingKey === skill.skillKey
         ? "Loading Skill Card..."
         : "Skill Card not loaded."}

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -198,7 +198,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   padding: 0 8px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 650;
   text-transform: uppercase;
 }

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -86,10 +86,15 @@
   --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   --font-display: var(--font-body);
   --control-ui-text-scale: 1;
+  --control-ui-text-2xs: calc(10px * var(--control-ui-text-scale));
   --control-ui-text-xs: calc(11px * var(--control-ui-text-scale));
   --control-ui-text-sm: calc(12px * var(--control-ui-text-scale));
+  --control-ui-text-compact: calc(13px * var(--control-ui-text-scale));
   --control-ui-text-md: calc(14px * var(--control-ui-text-scale));
+  --control-ui-text-title: calc(15px * var(--control-ui-text-scale));
   --control-ui-text-lg: calc(16px * var(--control-ui-text-scale));
+  --control-ui-text-xl: calc(20px * var(--control-ui-text-scale));
+  --control-ui-text-2xl: calc(22px * var(--control-ui-text-scale));
   --control-ui-input-text-size: max(16px, calc(14px * var(--control-ui-text-scale)));
   --chat-text-size: var(--control-ui-text-md);
 
@@ -512,7 +517,7 @@ body {
 
 body {
   margin: 0;
-  font: 400 14px/1.55 var(--font-body);
+  font: 400 var(--control-ui-text-md) / 1.55 var(--font-body);
   letter-spacing: -0.01em;
   background: var(--bg);
   color: var(--text);
@@ -522,7 +527,7 @@ body {
 
 @media (min-width: 1600px) {
   body {
-    font-size: 15px;
+    font-size: var(--control-ui-text-title);
   }
 }
 

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -109,7 +109,7 @@
    long configurable sender names must never wrap it taller than the gap. */
 .chat-sender-name {
   font-weight: 500;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   min-width: 0;
   white-space: nowrap;
@@ -118,7 +118,7 @@
 }
 
 .chat-group-timestamp {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   opacity: 0.7;
   line-height: 1.2;
@@ -178,7 +178,7 @@
   gap: 10px;
   margin: 18px 8px;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   letter-spacing: 0;
   user-select: none;
 }
@@ -218,7 +218,7 @@
 .chat-divider__description {
   max-width: min(620px, 100%);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.4;
 }
 
@@ -235,7 +235,7 @@
   display: grid;
   place-items: center;
   font-weight: 600;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   flex-shrink: 0;
   align-self: flex-end;
   margin-bottom: 4px;
@@ -348,7 +348,7 @@ img.chat-avatar {
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--panel) 72%, transparent);
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   line-height: 1;
 }
@@ -513,7 +513,7 @@ img.chat-avatar {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
   color: var(--muted);
   position: relative;
@@ -646,7 +646,7 @@ details.msg-meta:not([open]) .msg-meta__details {
 
 .chat-delete-confirm__text {
   margin: 0 0 8px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
   color: var(--fg, #fff);
 }
@@ -655,7 +655,7 @@ details.msg-meta:not([open]) .msg-meta__details {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted, #888);
   margin-bottom: 10px;
   user-select: none;
@@ -678,7 +678,7 @@ details.msg-meta:not([open]) .msg-meta__details {
   border: none;
   border-radius: var(--radius-sm, 4px);
   padding: 4px 12px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   transition: background 120ms ease-out;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -109,7 +109,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   gap: 6px;
   padding: 6px 12px;
   margin: 8px auto 0;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
   font-family: var(--font-body);
   color: var(--text);
@@ -161,7 +161,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   padding: 0 7px;
   border-radius: var(--radius-full);
   color: currentColor;
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   line-height: 1;
   list-style: none;
   user-select: none;
@@ -234,14 +234,14 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .context-usage__title,
 .context-usage__section-label {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
 .context-usage__context-value {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -295,7 +295,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 
 .context-usage__plan-badge {
   color: var(--text);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 650;
   letter-spacing: 0.02em;
   text-transform: none;
@@ -318,7 +318,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .context-usage__limit-label {
   overflow: hidden;
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 550;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -329,13 +329,13 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   align-items: baseline;
   gap: 8px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   white-space: nowrap;
 }
 
 .context-usage__limit-meta strong {
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 650;
   font-variant-numeric: tabular-nums;
 }
@@ -384,7 +384,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 
 .context-usage__stats dt {
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--control-ui-text-2xs);
   font-weight: 650;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -394,7 +394,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   margin: 4px 0 0;
   overflow: hidden;
   color: var(--text);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   text-overflow: ellipsis;
@@ -405,7 +405,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   margin-top: 12px;
   overflow: hidden;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -431,7 +431,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: color-mix(in srgb, currentColor 12%, transparent);
   color: currentColor;
   font: inherit;
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   line-height: 1;
   transition:
     background 150ms ease-out,
@@ -476,7 +476,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: color-mix(in srgb, var(--bg-elevated) 84%, transparent);
   border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
   border-radius: var(--radius-lg);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.25;
 }
 
@@ -641,7 +641,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   border: none;
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
   display: flex;
   align-items: center;
@@ -756,14 +756,14 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .chat-assistant-attachment-card__title,
 .chat-assistant-attachment-card__link {
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   text-decoration: none;
   word-break: break-word;
 }
 
 .chat-assistant-attachment-card__reason {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.4;
 }
 
@@ -787,7 +787,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   width: fit-content;
   max-width: 100%;
   border-radius: 999px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .chat-assistant-attachment-badge {
@@ -826,7 +826,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: color-mix(in srgb, var(--accent) 8%, transparent);
   border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
   border-radius: 8px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
@@ -942,7 +942,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: none;
   color: var(--fg);
   border-radius: 6px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   white-space: nowrap;
 }
 
@@ -1011,7 +1011,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 
 .task-suggestion__eyebrow {
   color: var(--accent);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -1026,7 +1026,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .task-suggestion__summary {
   margin-top: 3px;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.35;
 }
 
@@ -1042,7 +1042,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   gap: 8px;
   align-items: start;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
 }
 
 .task-suggestion__detail > span {
@@ -1114,7 +1114,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   border: 1px solid var(--border);
   border-radius: 10px;
   background: var(--panel);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .chat-pr[data-state="merged"] {
@@ -1240,7 +1240,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   border-radius: var(--radius-full);
   background: color-mix(in srgb, currentColor 12%, transparent);
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   list-style: none;
   user-select: none;
@@ -1269,7 +1269,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: var(--panel);
   box-shadow: var(--shadow-md, 0 8px 24px rgb(0 0 0 / 0.18));
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
 }
 
@@ -1280,7 +1280,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   gap: 12px;
   margin-bottom: 6px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .chat-pr__checks-menu-header a {
@@ -1388,7 +1388,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: color-mix(in srgb, var(--muted) 14%, transparent);
   color: var(--muted);
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
 }
 
@@ -1695,7 +1695,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 
 .chat-settings-popover__label {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 650;
   letter-spacing: 0;
   text-transform: uppercase;
@@ -1746,7 +1746,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   min-width: 0;
   overflow: hidden;
   color: currentColor;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   line-height: 1;
   text-overflow: ellipsis;
@@ -1757,7 +1757,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   display: grid;
   gap: 6px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
 }
 
@@ -1915,7 +1915,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   text-align: left;
 }
 
@@ -2093,7 +2093,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   max-width: 200px;
   overflow: hidden;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2104,7 +2104,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   min-width: 0;
   overflow-wrap: anywhere;
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.45;
   white-space: pre-wrap;
 }
@@ -2158,7 +2158,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   flex-direction: column;
   gap: 6px;
   min-width: 0;
-  font-size: 0.68rem;
+  font-size: calc(0.68rem * var(--control-ui-text-scale));
   color: var(--muted);
 }
 
@@ -2172,7 +2172,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: color-mix(in srgb, var(--card) 92%, var(--bg-elevated) 8%);
   color: var(--text);
   font: inherit;
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--control-ui-text-scale));
   line-height: 1;
   padding: 0 10px;
   box-sizing: border-box;
@@ -2201,7 +2201,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: transparent;
   color: var(--muted);
   font: inherit;
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
 }
 
 .agent-chat__talk-settings-link:hover,
@@ -2245,7 +2245,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--card) 92%, var(--bg-elevated) 8%);
   color: var(--text);
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--control-ui-text-scale));
   line-height: 1.35;
   overflow: hidden;
   user-select: none;
@@ -2324,7 +2324,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--control-ui-text-scale));
   line-height: 1;
   text-align: left;
 }
@@ -2468,7 +2468,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 }
 
 .agent-chat__token-count {
-  font-size: 0.7rem;
+  font-size: calc(0.7rem * var(--control-ui-text-scale));
   line-height: 1;
   color: var(--muted);
   white-space: nowrap;
@@ -2943,7 +2943,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 
 .slash-menu-group__label {
   padding: 4px 10px 2px;
-  font-size: 0.68rem;
+  font-size: calc(0.68rem * var(--control-ui-text-scale));
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -3002,7 +3002,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 }
 
 .slash-menu-args {
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   color: var(--muted);
   font-family: var(--mono);
   opacity: 0.65;
@@ -3014,7 +3014,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   text-overflow: ellipsis;
   white-space: nowrap;
   text-align: right;
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   color: var(--muted);
 }
 
@@ -3027,7 +3027,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 }
 
 .slash-menu-badge {
-  font-size: 0.65rem;
+  font-size: calc(0.65rem * var(--control-ui-text-scale));
   font-weight: 600;
   padding: 1px 6px;
   border-radius: var(--radius-sm);
@@ -3045,7 +3045,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   width: 100%;
   padding: 8px 10px;
   margin-top: 4px;
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   font-weight: 600;
   color: var(--accent);
   background: none;
@@ -3065,7 +3065,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   display: flex;
   gap: 10px;
   padding: 6px 10px 4px;
-  font-size: 0.68rem;
+  font-size: calc(0.68rem * var(--control-ui-text-scale));
   color: var(--muted);
   border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
   margin-top: 4px;
@@ -3074,7 +3074,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .slash-menu-footer kbd {
   display: inline-block;
   padding: 1px 4px;
-  font-size: 0.65rem;
+  font-size: calc(0.65rem * var(--control-ui-text-scale));
   font-family: var(--mono);
   border: 1px solid var(--border);
   border-radius: 3px;
@@ -3122,7 +3122,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   border: none;
   background: rgba(0, 0, 0, 0.6);
   color: #fff;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
   display: flex;
   align-items: center;
@@ -3222,7 +3222,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: var(--bg-elevated);
   color: var(--text);
   font: inherit;
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   line-height: 1.2;
   min-width: 0;
   transition:
@@ -3275,7 +3275,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .chat-controls__session-notice {
   width: 100%;
   min-height: 16px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 16px;
   color: var(--muted);
 }
@@ -3341,7 +3341,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.35;
   overflow: hidden;
   user-select: none;
@@ -3423,7 +3423,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   text-align: left;
 }
 
@@ -3475,7 +3475,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   overflow: hidden;
   flex: 1 1 auto;
   color: var(--text-strong);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -3487,7 +3487,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
   border-radius: var(--radius-full);
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--control-ui-text-2xs);
   font-weight: 650;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -3516,7 +3516,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: transparent;
   color: var(--muted);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 550;
   text-align: left;
 }
@@ -3529,7 +3529,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 }
 
 .chat-controls__provider-icon.provider-brand-icon--fallback {
-  font-size: 9px;
+  font-size: calc(9px * var(--control-ui-text-scale));
 }
 
 .chat-controls__inline-select-trigger > .chat-controls__provider-icon {
@@ -3569,7 +3569,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .chat-controls__inline-select-section-label {
   padding: 3px 6px 2px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -3606,7 +3606,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   align-items: center;
   gap: 6px;
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
 }
 
@@ -3622,7 +3622,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   gap: 4px;
   flex: 0 0 auto;
   color: color-mix(in srgb, var(--accent) 76%, var(--text));
-  font-size: 9px;
+  font-size: calc(9px * var(--control-ui-text-scale));
   font-weight: 700;
   letter-spacing: 0.08em;
   line-height: 1;
@@ -3639,7 +3639,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 
 .chat-controls__model-option-provider {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 450;
 }
 
@@ -3675,7 +3675,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .chat-controls__reasoning-value {
   overflow: hidden;
   color: var(--text-strong);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -3857,7 +3857,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: color-mix(in srgb, var(--text) 4%, var(--card));
   color: var(--muted);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 550;
   line-height: 1;
 }
@@ -3915,7 +3915,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   background: color-mix(in srgb, var(--card) 74%, transparent);
   color: var(--muted);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
 }
 
@@ -3950,7 +3950,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 /* Controls separator: the visible divider is the background; any glyph content
@@ -3964,7 +3964,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   overflow: hidden;
   background: color-mix(in srgb, var(--border-strong) 72%, transparent);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
   font-weight: 300;
   user-select: none;
@@ -3993,7 +3993,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   border-color: color-mix(in srgb, var(--input) 88%, transparent);
   border-radius: var(--radius-lg);
   background-color: color-mix(in srgb, var(--card) 92%, var(--bg-elevated) 8%);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -4002,7 +4002,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   display: flex;
   align-items: center;
   gap: 4px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   padding: 4px 10px;
   background: rgba(255, 255, 255, 0.04);
   border-radius: var(--radius-sm);
@@ -4127,7 +4127,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 
   .chat-controls__provider-option {
     padding-inline: 8px;
-    font-size: 12px;
+    font-size: var(--control-ui-text-sm);
   }
 
   .chat-controls {
@@ -4183,7 +4183,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 }
 
 .agent-chat__welcome h2 {
-  font-size: 20px;
+  font-size: var(--control-ui-text-xl);
   font-weight: 600;
   margin: 0;
   color: var(--foreground);
@@ -4209,7 +4209,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   color: var(--foreground);
   display: grid;
   place-items: center;
-  font-size: 20px;
+  font-size: var(--control-ui-text-xl);
   font-weight: 700;
 }
 
@@ -4230,7 +4230,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   color: var(--muted);
   background: var(--panel);
@@ -4246,7 +4246,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 }
 
 .agent-chat__hint {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--muted);
   margin: 0;
 }
@@ -4254,7 +4254,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 .agent-chat__hint kbd {
   display: inline-block;
   padding: 1px 6px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-family: var(--font-mono);
   background: var(--panel-strong);
   border: 1px solid var(--border);
@@ -4271,7 +4271,7 @@ openclaw-chat-pane:has(> .chat-pane__header) .chat-thread {
 
 .agent-chat__suggestion {
   min-height: 40px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.4;
   padding: 10px 16px;
   border-radius: var(--radius-md);

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -519,7 +519,7 @@
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--danger, #ef4444) 12%, transparent);
   color: var(--danger, #ef4444);
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   line-height: 1.2;
 }
 
@@ -946,7 +946,7 @@
 /* Smaller close button for sidebar */
 .sidebar-header .btn {
   padding: 4px 8px;
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   min-width: auto;
   line-height: 1;
 }
@@ -999,7 +999,7 @@
   flex: 1;
   overflow: hidden;
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1060,7 +1060,7 @@
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   text-align: left;
 }
 
@@ -1091,7 +1091,7 @@
   background: var(--bg);
   color: var(--text);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .file-view__search input:focus-visible {
@@ -1103,7 +1103,7 @@
   min-width: 4.5ch;
   color: var(--muted);
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   text-align: right;
 }
 
@@ -1130,7 +1130,7 @@
   overflow: auto;
   padding: 8px 0;
   font-family: var(--mono);
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   line-height: 1.6;
   tab-size: 2;
 }
@@ -1319,7 +1319,7 @@
   gap: 8px;
   min-width: 0;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -1521,7 +1521,7 @@
   border: none;
   padding: 0;
   font-family: inherit;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   line-height: 1.55;
 }
 
@@ -1530,7 +1530,7 @@
   min-width: 100%;
   width: max-content;
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-variant-ligatures: none;
   letter-spacing: 0;
   line-height: 0.86;
@@ -1565,7 +1565,7 @@
   margin-top: 0.75em;
   border-collapse: collapse;
   width: 100%;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   display: block;
   overflow-x: auto;
 }
@@ -1579,7 +1579,7 @@
 
 .sidebar-markdown :where(th) {
   font-weight: 600;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   background: var(--secondary);
   text-transform: uppercase;
@@ -1651,7 +1651,7 @@
 .sidebar-markdown :where(summary) {
   padding: 8px 12px;
   font-weight: 500;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   user-select: none;
   transition: background var(--duration-fast) ease;
 }

--- a/ui/src/styles/chat/split-view.css
+++ b/ui/src/styles/chat/split-view.css
@@ -88,7 +88,7 @@ openclaw-chat-pane {
   border-radius: 999px;
   background: var(--panel);
   color: var(--text);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 500;
   white-space: nowrap;
   pointer-events: none;
@@ -154,7 +154,7 @@ openclaw-chat-pane {
   min-width: 0;
   overflow: hidden;
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   white-space: nowrap;
   text-overflow: ellipsis;
 }

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -37,7 +37,7 @@
   border-collapse: collapse;
   width: 100%;
   max-width: 100%;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   display: block;
   overflow-x: auto;
 }
@@ -143,7 +143,7 @@
 .chat-text :where(pre code) {
   background: none;
   padding: 0;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   white-space: pre;
 }
 
@@ -153,7 +153,7 @@
   width: max-content;
   color: var(--text);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-variant-ligatures: none;
   letter-spacing: 0;
   line-height: 0.86;
@@ -236,7 +236,7 @@
 
 @media (max-width: 640px) {
   .chat-text :where(pre) {
-    font-size: 12px;
+    font-size: var(--control-ui-text-sm);
   }
 
   .chat-text :where(.markdown-inline-image) {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -66,7 +66,7 @@
   align-items: center;
   justify-content: center;
   width: 9px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
   color: var(--muted);
   opacity: 0.7;
@@ -279,7 +279,7 @@
   border-radius: var(--radius-full, 999px);
   background: color-mix(in srgb, var(--destructive, #ef4444) 14%, transparent);
   color: var(--destructive, #ef4444);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
   line-height: 1.5;
 }
@@ -309,7 +309,7 @@
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--secondary) 55%, transparent);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.55;
   overflow-x: auto;
   overflow-y: auto;
@@ -401,7 +401,7 @@
   gap: 8px;
   padding: 8px 12px 0;
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.55;
   color: var(--text);
 }
@@ -423,7 +423,7 @@
   margin: 0;
   padding: 6px 12px 10px 12px;
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: color-mix(in srgb, var(--text) 82%, var(--muted) 18%);
   white-space: pre-wrap;
@@ -518,7 +518,7 @@
   margin: 0;
   overflow: auto;
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.55;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -656,7 +656,7 @@
 }
 
 .chat-tool-card__block-label {
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -672,7 +672,7 @@
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--secondary) 82%, transparent);
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.45;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -697,7 +697,7 @@
   width: max-content;
   color: var(--text);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-variant-ligatures: none;
   letter-spacing: 0;
   line-height: 0.86;
@@ -730,7 +730,7 @@
 }
 
 .chat-tool-card__preview-label {
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -759,7 +759,7 @@
   background: transparent;
   color: var(--muted);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   transition: color 150ms ease-out;
 }
 
@@ -806,7 +806,7 @@
   align-items: center;
   gap: 6px;
   padding: 6px 10px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   user-select: none;
   list-style: none;
@@ -821,7 +821,7 @@
 
 .chat-json-summary::before {
   content: "▸";
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   flex-shrink: 0;
   transition: transform 150ms ease;
 }
@@ -842,7 +842,7 @@
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--accent) 15%, transparent);
   color: var(--accent);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -852,7 +852,7 @@
 
 .chat-json-label {
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -863,7 +863,7 @@
   padding: 10px 12px;
   border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--text);
   overflow-x: auto;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -87,14 +87,14 @@
 }
 
 .login-gate__title {
-  font-size: 22px;
+  font-size: var(--control-ui-text-2xl);
   font-weight: 700;
   letter-spacing: -0.02em;
 }
 
 .login-gate__sub {
   color: var(--muted);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   margin-top: 4px;
 }
 
@@ -125,7 +125,7 @@
   width: 100%;
   justify-content: center;
   padding: 10px 16px;
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
   font-weight: 600;
 }
 
@@ -134,21 +134,21 @@
 }
 
 .login-gate__failure-title {
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 700;
   color: var(--fg);
 }
 
 .login-gate__failure-summary {
   margin-top: 6px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.45;
 }
 
 .login-gate__failure-steps {
   margin: 10px 0 0;
   padding-left: 18px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.55;
 }
 
@@ -158,7 +158,7 @@
 
 .login-gate__failure-detail {
   margin-top: 10px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .login-gate__failure-detail summary {
@@ -174,7 +174,7 @@
 .login-gate__failure-docs {
   display: inline-flex;
   margin-top: 10px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .login-gate__help {
@@ -185,14 +185,14 @@
 
 .login-gate__help-title {
   font-weight: 600;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--fg);
 }
 
 .login-gate__steps {
   margin: 10px 0 0;
   padding-left: 20px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.6;
   color: var(--muted);
 }
@@ -210,7 +210,7 @@
   margin: 4px 0 2px;
   padding: 5px 10px;
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -250,7 +250,7 @@
 
 .login-gate__docs {
   margin-top: 10px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 /* Phones (matches the layout.mobile.css breakpoint). The gate renders outside
@@ -312,7 +312,7 @@
   margin-left: 8px;
   border-color: currentColor;
   color: currentColor;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   padding: 4px 12px;
 }
 
@@ -382,7 +382,7 @@
   backdrop-filter: blur(12px) saturate(1.2);
   -webkit-backdrop-filter: blur(12px) saturate(1.2);
   box-shadow: var(--shadow-lg);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1;
   animation: connection-banner-enter 0.25s var(--ease-out);
 }
@@ -455,7 +455,7 @@
   border-radius: 0 var(--radius-full) var(--radius-full) 0;
   background: transparent;
   color: var(--accent);
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   font-weight: 500;
   white-space: nowrap;
   transition: background var(--duration-fast) var(--ease-out);
@@ -497,7 +497,7 @@
 }
 
 .card-title {
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
   font-weight: 600;
   letter-spacing: -0.02em;
   color: var(--text-strong);
@@ -505,7 +505,7 @@
 
 .card-sub {
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   margin-top: 6px;
   line-height: 1.5;
 }
@@ -530,14 +530,14 @@
 
 .stat-label {
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
 
 .stat-value {
-  font-size: 24px;
+  font-size: calc(24px * var(--control-ui-text-scale));
   font-weight: 700;
   margin-top: 6px;
   letter-spacing: -0.03em;
@@ -585,7 +585,7 @@
 
 .account-count {
   margin-top: 10px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   color: var(--muted);
 }
@@ -621,13 +621,13 @@
 
 .account-card-id {
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
 .account-card-status {
   margin-top: 10px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .account-card-status div {
@@ -637,7 +637,7 @@
 .account-card-error {
   margin-top: 8px;
   color: var(--danger);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 /* ===========================================
@@ -646,7 +646,7 @@
 
 .label {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
 }
 
@@ -658,7 +658,7 @@
   padding: 5px 11px;
   border-radius: var(--radius-full);
   background: var(--secondary);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   transition: border-color var(--duration-fast) ease;
 }
@@ -772,7 +772,7 @@
   background: var(--bg-elevated);
   padding: 8px 14px;
   border-radius: var(--radius-md);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
   letter-spacing: -0.01em;
   transition:
@@ -823,7 +823,7 @@
   margin-left: 6px;
   padding: 2px 5px;
   font-family: var(--mono);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   line-height: 1;
   border-radius: var(--radius-sm);
@@ -862,12 +862,12 @@
 
 .btn--sm {
   padding: 6px 10px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .btn--xs {
   padding: 4px 6px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
 }
 
@@ -905,7 +905,7 @@
   background: color-mix(in srgb, var(--card) 94%, black 6%);
   box-shadow: var(--shadow-md);
   color: var(--text);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   line-height: 1.35;
   text-align: center;
@@ -1191,7 +1191,7 @@
 
 .field span {
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
 }
 
@@ -1218,7 +1218,7 @@
   .field input,
   .field textarea,
   .field select {
-    font-size: 16px;
+    font-size: var(--control-ui-input-text-size);
   }
 }
 
@@ -1330,7 +1330,7 @@
 
 .summary-stat__label {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -1338,7 +1338,7 @@
 
 .summary-stat__value {
   color: var(--text-strong);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 600;
   line-height: 1.3;
   display: flex;
@@ -1434,7 +1434,7 @@
 }
 
 .cron-workspace-form--collapsed .card-title {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .cron-form {
@@ -1459,7 +1459,7 @@
 }
 
 .cron-form-section__title {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--text-strong);
@@ -1467,7 +1467,7 @@
 
 .cron-form-section__sub {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.45;
 }
 
@@ -1478,7 +1478,7 @@
 
 .cron-help {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.45;
   margin-top: 2px;
 }
@@ -1489,7 +1489,7 @@
 
 .cron-required-legend {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.4;
 }
 
@@ -1527,7 +1527,7 @@
 
 .cron-form-status__title {
   color: var(--text-strong);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   margin-bottom: 6px;
 }
@@ -1544,7 +1544,7 @@
   border: 0;
   background: transparent;
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.4;
   padding: 0;
   text-align: left;
@@ -1575,7 +1575,7 @@
 
 .cron-checkbox .field-checkbox__label {
   color: var(--text-strong);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
 }
 
@@ -1600,7 +1600,7 @@
 
 .cron-advanced__summary {
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
 }
 
@@ -1621,7 +1621,7 @@
 
 .cron-submit-reason {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.4;
 }
 
@@ -1648,7 +1648,7 @@
   gap: 12px;
   padding: 10px 12px;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   list-style: none;
 }
@@ -1660,7 +1660,7 @@
 .cron-filter-panel__summary::after {
   content: "v";
   color: var(--muted);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   transition: transform var(--duration-fast) var(--ease-out);
 }
 
@@ -1686,13 +1686,13 @@
 
 .cron-empty-state__title {
   color: var(--text-strong);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 650;
 }
 
 .cron-empty-state__copy {
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.45;
   max-width: 520px;
 }
@@ -1768,7 +1768,7 @@
   gap: 8px;
   align-items: center;
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .cron-filter-dropdown__option input[type="checkbox"] {
@@ -2023,7 +2023,7 @@
   border-radius: var(--radius-md);
   background: var(--secondary);
   border: 1px solid var(--border);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.5;
   position: relative;
 }
@@ -2105,7 +2105,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.2;
   padding: 6px 14px;
   margin-bottom: 8px;
@@ -2212,7 +2212,7 @@
 .chat-side-result__label {
   display: inline-flex;
   align-items: center;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2224,7 +2224,7 @@
 }
 
 .chat-side-result__meta {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
@@ -2249,13 +2249,13 @@
 }
 
 .chat-side-result__question {
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 600;
   color: var(--foreground);
 }
 
 .chat-side-result__body {
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   line-height: 1.55;
   max-height: min(55vh, 480px);
   overflow-y: auto;
@@ -2308,7 +2308,7 @@
 
 .code-block {
   font-family: var(--mono);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.5;
   background: var(--secondary);
   padding: 12px;
@@ -2512,7 +2512,7 @@
   width: max-content;
   color: var(--text);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-variant-ligatures: none;
   letter-spacing: 0;
   line-height: 0.86;
@@ -2528,7 +2528,7 @@
   gap: 8px;
   padding: 4px 8px 4px 12px;
   background: rgba(0, 0, 0, 0.25);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
 }
 
@@ -2539,7 +2539,7 @@
 .code-block-lang {
   color: var(--muted);
   font-family: var(--mono);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   text-transform: lowercase;
   user-select: none;
 }
@@ -2549,7 +2549,7 @@
   border: none;
   background: transparent;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-family: var(--font-body);
   padding: 2px 6px;
   border-radius: var(--radius-sm);
@@ -2585,7 +2585,7 @@
 }
 
 .json-collapse summary {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   padding: 4px 8px;
   user-select: none;
@@ -2638,13 +2638,13 @@
 
 .list-sub {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .list-meta {
   text-align: right;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   display: grid;
   gap: 4px;
   min-width: 200px;
@@ -2678,7 +2678,7 @@
 /* Cron jobs: compact single-column rows with on-demand details. */
 .cron-job .list-title {
   font-weight: 600;
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
   letter-spacing: -0.015em;
   overflow-wrap: anywhere;
 }
@@ -2721,7 +2721,7 @@
   flex-wrap: wrap;
   gap: 2px 6px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   min-width: 0;
 }
 
@@ -2770,7 +2770,7 @@
 .cron-job-details__preview {
   flex: 1 1 auto;
   min-width: 0;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2796,14 +2796,14 @@
 
 .cron-job-detail-label {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
 
 .cron-job-detail-value {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.4;
   min-width: 0;
   overflow-wrap: anywhere;
@@ -2814,7 +2814,7 @@
 }
 
 .cron-job-status-pill {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
@@ -2889,7 +2889,7 @@
   border: none;
   background: transparent;
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   padding: 7px 10px;
   border-radius: var(--radius-sm);
 }
@@ -2933,7 +2933,7 @@
 }
 
 .chip {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
@@ -2992,7 +2992,7 @@
 }
 
 .table-head {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   color: var(--muted);
   padding: 0 12px;
@@ -3044,7 +3044,7 @@
   display: flex;
   flex-direction: column;
   gap: 4px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
@@ -3087,7 +3087,7 @@
 .data-table-search input {
   width: 100%;
   padding: 6px 10px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--text);
   background: var(--card);
   border: 1px solid var(--border);
@@ -3118,7 +3118,7 @@
   width: 100%;
   border-collapse: separate;
   border-spacing: 0;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .data-table th {
@@ -3128,7 +3128,7 @@
   padding: 10px 12px;
   text-align: left;
   font-weight: 600;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   background: var(--bg-elevated);
   border-bottom: 1px solid var(--border);
@@ -3275,7 +3275,7 @@ td.data-table-key-col {
   padding: 8px 12px;
   border-bottom: 1px solid var(--border);
   background: var(--accent-subtle);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
   color: var(--text);
 }
@@ -3294,7 +3294,7 @@ td.data-table-key-col {
   padding: 10px 12px;
   border-top: 1px solid var(--border);
   background: var(--bg-elevated);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--muted);
 }
 
@@ -3306,7 +3306,7 @@ td.data-table-key-col {
 
 .data-table-pagination__controls button {
   padding: 4px 12px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   background: var(--card);
@@ -3331,7 +3331,7 @@ td.data-table-key-col {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--text);
 }
 
@@ -3344,7 +3344,7 @@ td.data-table-key-col {
 .field-inline input[type="text"],
 .field-inline input:not([type]) {
   padding: 6px 10px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--text);
   background: var(--card);
   border: 1px solid var(--border);
@@ -3387,7 +3387,7 @@ td.data-table-key-col {
   align-items: start;
   padding: 8px 12px;
   border-bottom: 1px solid var(--border);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   transition: background var(--duration-fast) ease;
 }
 
@@ -3405,7 +3405,7 @@ td.data-table-key-col {
 }
 
 .log-level {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
@@ -3542,7 +3542,7 @@ td.data-table-key-col {
   border-radius: 999px;
   background: color-mix(in srgb, var(--fg) 12%, transparent);
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
   line-height: 1.5;
   white-space: nowrap;
@@ -3565,7 +3565,7 @@ td.data-table-key-col {
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--chat-text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.4;
 }
 
@@ -3578,7 +3578,7 @@ td.data-table-key-col {
   white-space: nowrap;
   padding: 0 0 3px 22px;
   color: var(--danger);
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--control-ui-text-scale));
   line-height: 1.35;
 }
 
@@ -3600,7 +3600,7 @@ td.data-table-key-col {
   border-radius: var(--radius-sm);
   background: none;
   color: var(--accent);
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--control-ui-text-scale));
   font-weight: 600;
   line-height: 1;
   cursor: pointer;
@@ -3776,7 +3776,7 @@ td.data-table-key-col {
   }
 
   .cron-job .cron-job-detail-value {
-    font-size: 13px;
+    font-size: var(--control-ui-text-compact);
     overflow-x: auto;
   }
 
@@ -3837,18 +3837,18 @@ td.data-table-key-col {
 }
 
 .exec-approval-title {
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 600;
 }
 
 .exec-approval-sub {
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   margin-top: 4px;
 }
 
 .exec-approval-queue {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   color: var(--muted);
   border: 1px solid var(--border);
@@ -3867,7 +3867,7 @@ td.data-table-key-col {
   word-break: break-word;
   white-space: pre-wrap;
   font-family: var(--mono);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .exec-approval-command-span {
@@ -3881,7 +3881,7 @@ td.data-table-key-col {
   margin-top: 12px;
   display: grid;
   gap: 6px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--muted);
 }
 
@@ -3898,13 +3898,13 @@ td.data-table-key-col {
 
 .exec-approval-error {
   margin-top: 10px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--danger);
 }
 
 .exec-approval-warning {
   margin-top: 10px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--warning, #b7791f);
 }
 
@@ -3968,7 +3968,7 @@ td.data-table-key-col {
   background: var(--bg-accent);
   color: var(--text);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
   outline: none;
   text-align: left;
@@ -4029,7 +4029,7 @@ td.data-table-key-col {
 
 .agent-select__avatar--text {
   background: var(--secondary);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
 }
 
@@ -4039,7 +4039,7 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--control-ui-text-2xs);
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -4072,7 +4072,7 @@ td.data-table-key-col {
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   text-align: left;
 }
 
@@ -4175,7 +4175,7 @@ td.data-table-key-col {
 .agent-avatar--lg {
   width: 48px;
   height: 48px;
-  font-size: 20px;
+  font-size: var(--control-ui-text-xl);
 }
 
 .agent-info {
@@ -4190,14 +4190,14 @@ td.data-table-key-col {
 
 .agent-sub {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .agent-pill {
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   padding: 4px 10px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   background: var(--secondary);
   text-transform: uppercase;
@@ -4241,7 +4241,7 @@ td.data-table-key-col {
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   padding: 6px 12px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   color: var(--muted);
   background: transparent;
@@ -4264,7 +4264,7 @@ td.data-table-key-col {
 
 .agent-tab-count {
   margin-left: 4px;
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   opacity: 0.7;
 }
@@ -4275,7 +4275,7 @@ td.data-table-key-col {
 
 .agent-tab-badge {
   margin-left: 4px;
-  font-size: 12px; /* was 9px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   text-transform: uppercase;
   color: var(--warn);
@@ -4301,7 +4301,7 @@ td.data-table-key-col {
 }
 
 .agent-kv-sub {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .agent-model-select {
@@ -4322,7 +4322,7 @@ td.data-table-key-col {
   background: transparent;
   color: var(--accent);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   padding: 2px 0;
   word-break: break-all;
   text-align: left;
@@ -4367,7 +4367,7 @@ td.data-table-key-col {
   background: transparent;
   outline: none;
   box-shadow: none;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   padding: 0;
 }
 
@@ -4444,7 +4444,7 @@ td.data-table-key-col {
 
 .agent-file-sub {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   margin-top: 4px;
 }
 
@@ -4518,7 +4518,7 @@ td.data-table-key-col {
   align-items: center;
   gap: 8px;
   min-width: 0;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -4549,7 +4549,7 @@ td.data-table-key-col {
 
 .md-preview-dialog__path {
   min-width: 0;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -4652,7 +4652,7 @@ td.data-table-key-col {
   border: 1px solid color-mix(in srgb, var(--border) 78%, white 10%);
   background: color-mix(in srgb, var(--secondary) 72%, transparent);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
   font-variant-numeric: tabular-nums;
 }
@@ -4720,7 +4720,7 @@ td.data-table-key-col {
 }
 
 .md-preview-dialog__reader.sidebar-markdown {
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
   line-height: 1.74;
   color: var(--text);
 }
@@ -5036,7 +5036,7 @@ td.data-table-key-col {
 
 .agent-tools-runtime-chip__meta {
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   white-space: nowrap;
 }
 
@@ -5073,7 +5073,7 @@ td.data-table-key-col {
 .agent-tools-group__summary::before {
   content: "▸";
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   line-height: 20px;
   transition: transform var(--duration-fast) var(--ease-in-out);
 }
@@ -5116,7 +5116,7 @@ td.data-table-key-col {
   flex-wrap: wrap;
   min-width: 0;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
 }
 
 .agent-tools-group__preview > span {
@@ -5138,7 +5138,7 @@ td.data-table-key-col {
   gap: 8px;
   flex-wrap: wrap;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-variant-numeric: tabular-nums;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -5193,7 +5193,7 @@ td.data-table-key-col {
   top: 18px;
   right: 64px;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   transition: transform var(--duration-fast) var(--ease-in-out);
 }
 
@@ -5248,7 +5248,7 @@ td.data-table-key-col {
 
 .agent-tool-summary__fact dd {
   margin: 2px 0 0;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .agent-tool-toggle {
@@ -5268,7 +5268,7 @@ td.data-table-key-col {
 
 .agent-tool-title {
   font-weight: 600;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
@@ -5278,7 +5278,7 @@ td.data-table-key-col {
 
 .agent-tool-sub {
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   margin-top: 3px;
   min-width: 0;
   overflow: hidden;
@@ -5419,7 +5419,7 @@ td.data-table-key-col {
   display: flex;
   align-items: center;
   font-weight: 600;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--muted);
@@ -5440,7 +5440,7 @@ td.data-table-key-col {
 
 .agent-skills-header::after {
   content: "▸";
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   transition: transform var(--duration-fast) ease;
   margin-left: 8px;
@@ -5560,7 +5560,7 @@ td.data-table-key-col {
   border: none;
   border-bottom: 1px solid var(--border);
   color: var(--text);
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
   outline: none;
 }
 
@@ -5577,7 +5577,7 @@ td.data-table-key-col {
 .cmd-palette__group-label {
   padding: 8px 18px 4px;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -5588,7 +5588,7 @@ td.data-table-key-col {
   align-items: center;
   gap: 10px;
   padding: 8px 18px;
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   transition: background var(--duration-fast) ease;
 }
 
@@ -5610,7 +5610,7 @@ td.data-table-key-col {
 
 .cmd-palette__item-desc {
   margin-left: auto;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .cmd-palette__empty {
@@ -5619,7 +5619,7 @@ td.data-table-key-col {
   gap: 8px;
   padding: 16px 18px;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .cmd-palette__footer {
@@ -5629,7 +5629,7 @@ td.data-table-key-col {
   gap: 12px;
   padding: 8px 18px;
   border-top: 1px solid var(--border);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
@@ -5642,7 +5642,7 @@ td.data-table-key-col {
   border-radius: var(--radius-sm);
   background: var(--bg);
   font-family: var(--mono);
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   line-height: 1.4;
 }
 
@@ -5683,7 +5683,7 @@ td.data-table-key-col {
 }
 
 .ov-card__label {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   color: var(--muted);
   text-transform: uppercase;
@@ -5691,7 +5691,7 @@ td.data-table-key-col {
 }
 
 .ov-card__value {
-  font-size: 22px;
+  font-size: var(--control-ui-text-2xl);
   font-weight: 700;
   letter-spacing: -0.03em;
   line-height: 1.15;
@@ -5707,7 +5707,7 @@ td.data-table-key-col {
 }
 
 .ov-card__hint {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   line-height: 1.35;
 }
@@ -5799,12 +5799,12 @@ td.data-table-key-col {
 }
 
 .ov-attention-title {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
 }
 
 .ov-attention-link {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--accent, #3b82f6);
   text-decoration: none;
 }
@@ -5819,7 +5819,7 @@ td.data-table-key-col {
 }
 
 .ov-recent__title {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   color: var(--muted);
   text-transform: uppercase;
@@ -5843,7 +5843,7 @@ td.data-table-key-col {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--card);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   align-items: center;
   transition: border-color var(--duration-fast) ease;
 }
@@ -5862,13 +5862,13 @@ td.data-table-key-col {
 
 .ov-recent__model {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-family: var(--mono);
 }
 
 .ov-recent__time {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   white-space: nowrap;
 }
 
@@ -5924,7 +5924,7 @@ td.data-table-key-col {
   align-items: center;
   gap: 8px;
   padding: 12px 16px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   color: var(--text-strong);
   letter-spacing: -0.01em;
@@ -5969,7 +5969,7 @@ details[open] > .ov-expandable-toggle::after {
 }
 
 .ov-count-badge {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   color: var(--muted);
   background: var(--bg-muted);
@@ -5990,7 +5990,7 @@ details[open] > .ov-expandable-toggle::after {
   align-items: baseline;
   gap: 10px;
   padding: 6px 16px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   border-bottom: 1px solid var(--border);
 }
@@ -6005,7 +6005,7 @@ details[open] > .ov-expandable-toggle::after {
 
 .ov-event-log-ts {
   font-family: var(--mono);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   flex-shrink: 0;
   min-width: 72px;
@@ -6013,7 +6013,7 @@ details[open] > .ov-expandable-toggle::after {
 
 .ov-event-log-name {
   font-family: var(--mono);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   color: var(--text);
   white-space: nowrap;
@@ -6021,7 +6021,7 @@ details[open] > .ov-expandable-toggle::after {
 
 .ov-event-log-payload {
   font-family: var(--mono);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -6035,7 +6035,7 @@ details[open] > .ov-expandable-toggle::after {
   padding: 12px 16px;
   border-top: 1px solid var(--border);
   font-family: var(--mono);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   line-height: 1.6;
   color: var(--text);
   max-height: 320px;
@@ -6082,7 +6082,7 @@ details[open] > .ov-expandable-toggle::after {
   }
 
   .ov-recent__model {
-    font-size: 12px; /* was 11px */
+    font-size: var(--control-ui-text-sm);
   }
 
   .ov-attention-item {
@@ -6098,7 +6098,7 @@ details[open] > .ov-expandable-toggle::after {
   .agent-avatar--lg {
     width: 40px;
     height: 40px;
-    font-size: 18px;
+    font-size: calc(18px * var(--control-ui-text-scale));
   }
 
   .agent-header {
@@ -6125,7 +6125,7 @@ details[open] > .ov-expandable-toggle::after {
   }
 
   .exec-approval-command {
-    font-size: 12px;
+    font-size: var(--control-ui-text-sm);
     padding: 8px 10px;
     max-height: 40dvh;
     overflow-y: auto;
@@ -6186,7 +6186,7 @@ details[open] > .ov-expandable-toggle::after {
 .device-pair-setup__header h2 {
   margin: 0;
   color: var(--text-strong);
-  font-size: 24px;
+  font-size: calc(24px * var(--control-ui-text-scale));
   font-weight: 600;
   letter-spacing: -0.025em;
 }
@@ -6195,7 +6195,7 @@ details[open] > .ov-expandable-toggle::after {
   max-width: 390px;
   margin: 7px 0 0;
   color: var(--muted);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   line-height: 1.5;
 }
 
@@ -6240,7 +6240,7 @@ details[open] > .ov-expandable-toggle::after {
   justify-content: center;
   gap: 10px;
   color: var(--muted);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
 }
 
 .device-pair-setup__spinner {
@@ -6298,7 +6298,7 @@ details[open] > .ov-expandable-toggle::after {
 .device-pair-setup__qr-unavailable {
   max-width: 220px;
   color: #444444;
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   line-height: 1.5;
   text-align: center;
 }
@@ -6315,7 +6315,7 @@ details[open] > .ov-expandable-toggle::after {
   overflow: hidden;
   color: var(--muted);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -6337,7 +6337,7 @@ details[open] > .ov-expandable-toggle::after {
 .device-pair-setup__fallback {
   width: min(420px, 100%);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .device-pair-setup__fallback summary {
@@ -6370,7 +6370,7 @@ details[open] > .ov-expandable-toggle::after {
 .device-pair-setup__waiting {
   margin: 0;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   text-align: center;
 }
 
@@ -6381,7 +6381,7 @@ details[open] > .ov-expandable-toggle::after {
   padding: 14px 20px;
   border-top: 1px solid var(--border);
   background: color-mix(in srgb, var(--bg-elevated) 45%, transparent);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .device-pair-setup__footer a {
@@ -6434,7 +6434,7 @@ details[open] > .ov-expandable-toggle::after {
   }
 
   .ov-card__value {
-    font-size: 18px;
+    font-size: calc(18px * var(--control-ui-text-scale));
   }
 
   .ov-bottom-grid {
@@ -6489,7 +6489,7 @@ details[open] > .ov-expandable-toggle::after {
   align-items: center;
   gap: 6px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   transition: opacity var(--duration-fast) ease;

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -188,7 +188,7 @@ openclaw-logs-page {
 }
 
 .qs-card__title {
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--control-ui-text-scale));
   font-weight: 650;
   letter-spacing: -0.01em;
   margin: 0;
@@ -220,7 +220,7 @@ openclaw-logs-page {
   gap: 8px;
   min-width: 0;
   flex: 1 1 auto;
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--control-ui-text-scale));
   font-weight: 450;
   color: var(--text);
   white-space: nowrap;
@@ -232,7 +232,7 @@ openclaw-logs-page {
   justify-content: flex-end;
   gap: 8px;
   min-width: 0;
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--control-ui-text-scale));
   color: var(--muted);
   text-align: right;
 }
@@ -247,7 +247,7 @@ openclaw-logs-page {
     border-color var(--duration-fast) var(--ease-out);
   color: var(--text);
   font: inherit;
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--control-ui-text-scale));
 }
 
 .qs-row__value--action:hover {
@@ -280,7 +280,7 @@ openclaw-logs-page {
 
 .qs-row__value--action code {
   font-family: var(--mono);
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   color: var(--accent);
 }
 
@@ -337,7 +337,7 @@ openclaw-logs-page {
   background: color-mix(in srgb, var(--bg) 80%, var(--bg-elevated) 20%);
   color: var(--text);
   font: inherit;
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--control-ui-text-scale));
   padding: 8px 10px;
 }
 
@@ -371,7 +371,7 @@ openclaw-logs-page {
 
 .qs-identity-card__eyebrow {
   margin-bottom: 2px;
-  font-size: 0.65rem;
+  font-size: calc(0.65rem * var(--control-ui-text-scale));
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -380,7 +380,7 @@ openclaw-logs-page {
 
 .qs-identity-card__title {
   color: var(--text-strong);
-  font-size: 0.95rem;
+  font-size: calc(0.95rem * var(--control-ui-text-scale));
   font-weight: 650;
   line-height: 1.2;
   overflow-wrap: anywhere;
@@ -389,7 +389,7 @@ openclaw-logs-page {
 .qs-identity-card__sub {
   margin-top: 4px;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   line-height: 1.35;
 }
 
@@ -400,7 +400,7 @@ openclaw-logs-page {
   padding-top: 9px;
   border-top: 1px solid color-mix(in srgb, var(--border) 45%, transparent);
   color: var(--muted);
-  font-size: 0.64rem;
+  font-size: calc(0.64rem * var(--control-ui-text-scale));
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -408,7 +408,7 @@ openclaw-logs-page {
 .qs-identity-card__source code {
   color: var(--text);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: 0.68rem;
+  font-size: calc(0.68rem * var(--control-ui-text-scale));
   font-weight: 650;
   letter-spacing: normal;
   text-transform: none;
@@ -425,7 +425,7 @@ openclaw-logs-page {
   border-radius: 999px;
   background: color-mix(in srgb, var(--warning, #f7b955) 10%, transparent);
   color: color-mix(in srgb, var(--warning, #f7b955) 82%, var(--text) 18%);
-  font-size: 0.68rem;
+  font-size: calc(0.68rem * var(--control-ui-text-scale));
   font-weight: 650;
   line-height: 1.2;
 }
@@ -445,7 +445,7 @@ openclaw-logs-page {
 }
 
 .qs-identity-card__repair .qs-row__label {
-  font-size: 0.68rem;
+  font-size: calc(0.68rem * var(--control-ui-text-scale));
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -453,7 +453,7 @@ openclaw-logs-page {
 }
 
 .qs-identity-card__repair .qs-field__input {
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--control-ui-text-scale));
   padding: 6px 9px;
 }
 
@@ -464,14 +464,14 @@ openclaw-logs-page {
 }
 
 .qs-identity-card__repair .muted {
-  font-size: 0.68rem;
+  font-size: calc(0.68rem * var(--control-ui-text-scale));
   line-height: 1.35;
 }
 
 .qs-identity-card__error {
   margin-top: 8px;
   color: var(--danger, #ff6b78);
-  font-size: 0.7rem;
+  font-size: calc(0.7rem * var(--control-ui-text-scale));
   line-height: 1.35;
 }
 
@@ -494,7 +494,7 @@ openclaw-logs-page {
   place-items: center;
   background: var(--accent-subtle);
   color: var(--accent);
-  font-size: 0.875rem;
+  font-size: calc(0.875rem * var(--control-ui-text-scale));
   font-weight: 650;
 }
 
@@ -531,7 +531,7 @@ openclaw-logs-page {
 }
 
 .qs-segmented__btn {
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   font-weight: 550;
   padding: 4px 12px;
   border: none;
@@ -618,7 +618,7 @@ openclaw-logs-page {
 }
 
 .qs-toggle__hint {
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   color: var(--muted);
 }
 
@@ -627,7 +627,7 @@ openclaw-logs-page {
 .qs-badge {
   display: inline-flex;
   align-items: center;
-  font-size: 0.6875rem;
+  font-size: calc(0.6875rem * var(--control-ui-text-scale));
   font-weight: 600;
   padding: 3px 9px;
   border-radius: var(--radius-full);
@@ -667,7 +667,7 @@ openclaw-logs-page {
 
 .qs-masked {
   font-family: var(--mono);
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   letter-spacing: 1.5px;
   color: var(--muted);
 }
@@ -675,7 +675,7 @@ openclaw-logs-page {
 /* ── Link button ── */
 
 .qs-link-btn {
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   font-weight: 600;
   color: var(--accent);
   background: none;
@@ -703,7 +703,7 @@ openclaw-logs-page {
 
 .qs-empty {
   padding: 14px 16px;
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--control-ui-text-scale));
   color: var(--muted);
 }
 
@@ -734,7 +734,7 @@ openclaw-logs-page {
 }
 
 .qs-system__meta {
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   line-height: 1.4;
   color: var(--muted);
 }
@@ -749,7 +749,7 @@ openclaw-logs-page {
   background: color-mix(in srgb, var(--bg-elevated) 84%, transparent);
   color: var(--text);
   font-family: var(--mono);
-  font-size: 0.7rem;
+  font-size: calc(0.7rem * var(--control-ui-text-scale));
   overflow-wrap: anywhere;
 }
 
@@ -771,7 +771,7 @@ openclaw-logs-page {
 }
 
 .qs-stat__label {
-  font-size: 0.65rem;
+  font-size: calc(0.65rem * var(--control-ui-text-scale));
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -791,14 +791,14 @@ openclaw-logs-page {
 }
 
 .qs-stat__unit {
-  font-size: 0.7rem;
+  font-size: calc(0.7rem * var(--control-ui-text-scale));
   font-weight: 550;
   letter-spacing: 0;
   color: var(--muted);
 }
 
 .qs-stat__detail {
-  font-size: 0.7rem;
+  font-size: calc(0.7rem * var(--control-ui-text-scale));
   line-height: 1.35;
   color: var(--muted);
   overflow-wrap: anywhere;
@@ -839,7 +839,7 @@ openclaw-logs-page {
   display: flex;
   align-items: center;
   gap: 5px;
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   color: var(--muted);
 }
 
@@ -867,7 +867,7 @@ openclaw-logs-page {
   gap: 10px;
   width: 100%;
   padding: 12px 16px;
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--control-ui-text-scale));
   font-weight: 650;
   letter-spacing: -0.01em;
   color: var(--text-strong);
@@ -918,7 +918,7 @@ openclaw-logs-page {
   gap: 8px;
   width: 100%;
   padding: 9px 16px 9px 40px;
-  font-size: 0.8125rem;
+  font-size: calc(0.8125rem * var(--control-ui-text-scale));
   font-weight: 450;
   color: var(--muted);
   background: none;
@@ -972,7 +972,7 @@ openclaw-logs-page {
 }
 
 .qs-pending__hint {
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   line-height: 1.4;
 }
 

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -69,7 +69,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   outline: none;
   transition:
     border-color var(--duration-fast) ease,
@@ -106,7 +106,7 @@
   border-radius: var(--radius-full);
   background: var(--bg-hover);
   color: var(--muted);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   line-height: 1;
   display: flex;
   align-items: center;
@@ -142,7 +142,7 @@
   border-radius: calc(var(--radius-md) - 3px);
   background: transparent;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   transition:
     background var(--duration-fast) ease,
@@ -263,7 +263,7 @@
   background: var(--accent-subtle);
   border: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
   color: var(--accent);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   animation: badge-enter 0.2s var(--ease-out);
 }
@@ -280,7 +280,7 @@
 }
 
 .config-status {
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   color: var(--muted);
   line-height: 1.35;
 }
@@ -330,7 +330,7 @@
   padding: 8px 14px;
   background: var(--bg-elevated);
   color: var(--muted);
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--control-ui-text-scale));
   font-weight: 600;
   white-space: nowrap;
   transition:
@@ -371,7 +371,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 16px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   color: var(--accent);
   list-style: none;
@@ -409,7 +409,7 @@
   padding: 8px 12px;
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--control-ui-text-scale));
   font-family: var(--mono);
 }
 
@@ -486,14 +486,14 @@
 }
 
 .config-section-hero__title {
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
   font-weight: 650;
   letter-spacing: -0.02em;
   line-height: 1.3;
 }
 
 .config-section-hero__desc {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   line-height: 1.4;
 }
@@ -527,7 +527,7 @@
 
 .settings-appearance__heading {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
   font-weight: 650;
   letter-spacing: -0.02em;
   color: var(--accent);
@@ -535,7 +535,7 @@
 
 .settings-appearance__hint {
   margin: -8px 0 0;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   color: var(--muted);
   line-height: 1.45;
 }
@@ -597,7 +597,7 @@
 }
 
 .settings-theme-card__label {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   color: var(--accent);
 }
@@ -617,14 +617,14 @@
 }
 
 .settings-theme-import__title {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 650;
   color: var(--text-strong);
 }
 
 .settings-theme-import__hint {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.45;
   color: var(--muted);
 }
@@ -636,7 +636,7 @@
   width: max-content;
   max-width: 100%;
   color: var(--accent);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   text-decoration: none;
 }
@@ -656,7 +656,7 @@
 
 .settings-theme-import__inline-hint {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);
 }
@@ -671,7 +671,7 @@
 }
 
 .settings-theme-import__label {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -711,7 +711,7 @@
 }
 
 .settings-theme-import__meta-label {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -719,7 +719,7 @@
 }
 
 .settings-theme-import__meta-value {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--text);
   overflow-wrap: anywhere;
 }
@@ -727,7 +727,7 @@
 .settings-theme-import__message {
   padding: 10px 12px;
   border-radius: var(--radius-md);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.45;
 }
 
@@ -782,13 +782,13 @@
 
 .settings-text-scale__sample {
   font-weight: 650;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.2;
 }
 
 .settings-text-scale__label {
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   line-height: 1.2;
 }
 
@@ -813,7 +813,7 @@
 }
 
 .settings-info-row__label {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   color: var(--muted);
   text-transform: uppercase;
@@ -825,7 +825,7 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
   color: var(--text);
   text-align: right;
@@ -904,7 +904,7 @@
 
 .settings-notifications__title {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 650;
   letter-spacing: -0.015em;
   line-height: 1.35;
@@ -914,7 +914,7 @@
 .settings-notifications__hint {
   margin: 0;
   max-width: 58ch;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.45;
   color: var(--muted);
 }
@@ -927,7 +927,7 @@
   padding: 4px 9px;
   border-radius: var(--radius-full);
   border: 1px solid transparent;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 650;
   line-height: 1;
   white-space: nowrap;
@@ -980,7 +980,7 @@
 }
 
 .settings-notifications__label {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 650;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -989,7 +989,7 @@
 
 .settings-notifications__value {
   min-width: 0;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   color: var(--text);
   overflow-wrap: anywhere;
@@ -1034,14 +1034,14 @@
   border-radius: var(--radius-md);
   background: var(--danger-subtle);
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.45;
 }
 
 .config-raw-field textarea {
   min-height: 500px;
   font-family: var(--mono);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.55;
 }
 
@@ -1098,7 +1098,7 @@
 
 .config-empty__text {
   color: var(--muted);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   max-width: 320px;
   line-height: 1.5;
 }
@@ -1190,7 +1190,7 @@
 
 .config-section-card__title {
   margin: 0;
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 650;
   letter-spacing: -0.015em;
   line-height: 1.35;
@@ -1198,7 +1198,7 @@
 
 .config-section-card__desc {
   margin: 3px 0 0;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   line-height: 1.45;
 }
@@ -1269,14 +1269,14 @@
 }
 
 .cfg-field__label {
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   font-weight: 600;
   color: var(--text);
   letter-spacing: -0.005em;
 }
 
 .cfg-field__help {
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--control-ui-text-scale));
   color: var(--muted);
   line-height: 1.45;
 }
@@ -1293,7 +1293,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   padding: 2px 8px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   background: var(--bg-elevated);
   white-space: nowrap;
@@ -1304,7 +1304,7 @@
 }
 
 .cfg-field__error {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--danger);
 }
 
@@ -1320,7 +1320,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-accent);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   outline: none;
   transition:
     border-color var(--duration-fast) ease,
@@ -1358,7 +1358,7 @@
 
 .cfg-input--sm {
   padding: 6px 10px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .cfg-input__reset {
@@ -1367,7 +1367,7 @@
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   transition:
     background var(--duration-fast) ease,
     color var(--duration-fast) ease;
@@ -1391,7 +1391,7 @@
   border-radius: var(--radius-md);
   background: var(--bg-accent);
   font-family: var(--mono);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.55;
   resize: vertical;
   outline: none;
@@ -1416,7 +1416,7 @@
 
 .cfg-textarea--sm {
   padding: 8px 12px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 /* Redacted (click-to-reveal) */
@@ -1477,7 +1477,7 @@
   border-left: 1px solid var(--border);
   border-right: 1px solid var(--border);
   background: transparent;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   text-align: center;
   outline: none;
   appearance: textfield;
@@ -1499,7 +1499,7 @@
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 24 24' fill='none' stroke='%23888' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 10px center;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   outline: none;
   appearance: none;
   transition:
@@ -1532,7 +1532,7 @@
   .cfg-textarea--sm,
   .cfg-number__input,
   .cfg-select {
-    font-size: 16px;
+    font-size: var(--control-ui-input-text-size);
   }
 }
 
@@ -1556,7 +1556,7 @@
   border-radius: calc(var(--radius-md) - 3px);
   background: transparent;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   transition:
     background var(--duration-fast) ease,
@@ -1620,7 +1620,7 @@
 
 .cfg-toggle-row__label {
   display: block;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   font-weight: 500;
   color: var(--text);
 }
@@ -1628,7 +1628,7 @@
 .cfg-toggle-row__help {
   display: block;
   margin-top: 2px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   line-height: 1.45;
 }
@@ -1729,7 +1729,7 @@
 }
 
 .cfg-object__title {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   color: var(--text);
   line-height: 1.35;
@@ -1761,7 +1761,7 @@
 
 .cfg-object__help {
   padding: 0 12px 10px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
@@ -1794,7 +1794,7 @@
 }
 
 .cfg-array__label {
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 600;
   color: var(--text);
 }
@@ -1807,7 +1807,7 @@
 }
 
 .cfg-array__count {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   padding: 4px 10px;
   background: var(--bg-elevated);
@@ -1828,7 +1828,7 @@
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   transition: background var(--duration-fast) ease;
 }
@@ -1854,7 +1854,7 @@
 
 .cfg-array__help {
   padding: 10px 12px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   border-bottom: 1px solid var(--border);
 }
@@ -1863,7 +1863,7 @@
   padding: 36px 18px;
   text-align: center;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .cfg-array__items {
@@ -1890,7 +1890,7 @@
 }
 
 .cfg-array__item-index {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   color: var(--muted);
   text-transform: uppercase;
@@ -1953,7 +1953,7 @@
 }
 
 .cfg-map__label {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   color: var(--muted);
 }
@@ -1967,7 +1967,7 @@
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   transition: background var(--duration-fast) ease;
 }
@@ -1990,7 +1990,7 @@
   padding: 28px 18px;
   text-align: center;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .cfg-map__items {
@@ -2059,7 +2059,7 @@
 /* Pill variants */
 .pill--sm {
   padding: 5px 12px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
 }
 
 .pill--ok {
@@ -2106,7 +2106,7 @@
   background: var(--bg-elevated);
   color: var(--text);
   font-family: var(--mono);
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--control-ui-text-scale));
   overflow-wrap: anywhere;
 }
 
@@ -2156,7 +2156,7 @@
 .mcp-server-row__launch {
   color: var(--muted);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   overflow-wrap: anywhere;
 }
 
@@ -2165,7 +2165,7 @@
   gap: 6px;
   flex-wrap: wrap;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -2307,7 +2307,7 @@
   }
 
   .config-section-card__title {
-    font-size: 16px;
+    font-size: var(--control-ui-text-lg);
   }
 
   .cfg-segmented {

--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -27,7 +27,7 @@
   background: transparent;
   color: var(--muted);
   font-family: inherit;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -145,21 +145,21 @@
 /* Z's originate from the lobster's head and float up-right at an angle.
    Use nth-of-type because Z's are <span> while stars/moon/glow are <div>. */
 .dreams__z:nth-of-type(1) {
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   left: calc(50% + 70px);
   top: calc(50% - 90px);
   animation-delay: 0s;
 }
 
 .dreams__z:nth-of-type(2) {
-  font-size: 20px;
+  font-size: var(--control-ui-text-xl);
   left: calc(50% + 100px);
   top: calc(50% - 130px);
   animation-delay: 1.2s;
 }
 
 .dreams__z:nth-of-type(3) {
-  font-size: 28px;
+  font-size: calc(28px * var(--control-ui-text-scale));
   left: calc(50% + 130px);
   top: calc(50% - 175px);
   animation-delay: 2.4s;
@@ -220,7 +220,7 @@
 }
 
 .dreams__bubble-label {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--accent-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -228,7 +228,7 @@
 }
 
 .dreams__bubble-text {
-  font-size: 16px;
+  font-size: var(--control-ui-text-lg);
   color: var(--accent);
   font-style: italic;
   opacity: 0.8;
@@ -353,7 +353,7 @@
 }
 
 .dreams__phase-name {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   color: var(--text);
   text-transform: uppercase;
@@ -361,7 +361,7 @@
 }
 
 .dreams__phase-next {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   font-variant-numeric: tabular-nums;
 }
@@ -377,7 +377,7 @@
   border: 1px solid var(--border);
   background: color-mix(in oklab, var(--panel) 70%, transparent);
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-family: inherit;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -418,7 +418,7 @@
 }
 
 .dreams__controls-error {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--danger);
 }
 
@@ -433,7 +433,7 @@
 }
 
 .dreams__status-label {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--muted);
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -444,7 +444,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--ok-muted);
 }
 
@@ -512,7 +512,7 @@
 
 .dreams-advanced__eyebrow {
   display: block;
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -522,7 +522,7 @@
 
 .dreams-advanced__title {
   margin: 0;
-  font-size: 24px;
+  font-size: calc(24px * var(--control-ui-text-scale));
   line-height: 1.1;
   color: var(--text);
 }
@@ -530,7 +530,7 @@
 .dreams-advanced__description {
   margin: 10px 0 0;
   max-width: 60ch;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.6;
   color: var(--muted);
 }
@@ -544,7 +544,7 @@
 
 .dreams-advanced__summary {
   margin-top: 12px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);
 }
@@ -581,7 +581,7 @@
 }
 
 .dreams-advanced__section-title {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -590,7 +590,7 @@
 
 .dreams-advanced__section-description {
   margin: 6px 0 0;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);
 }
@@ -612,7 +612,7 @@
   justify-content: center;
   background: color-mix(in oklab, var(--accent-subtle) 85%, transparent);
   color: var(--accent);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
 }
@@ -633,7 +633,7 @@
   color: var(--muted);
   padding: 6px 10px;
   border-radius: 999px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   line-height: 1;
   transition:
     background 0.2s ease,
@@ -667,7 +667,7 @@
   border-radius: 999px;
   background: color-mix(in oklab, var(--accent-subtle) 72%, transparent);
   color: var(--accent);
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -678,7 +678,7 @@
 }
 
 .dreams-advanced__snippet {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.45;
   color: var(--text);
 }
@@ -686,7 +686,7 @@
 .dreams-advanced__source,
 .dreams-advanced__meta,
 .dreams-advanced__empty {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   line-height: 1.45;
   color: var(--muted);
   margin-top: 8px;
@@ -745,7 +745,7 @@
 }
 
 .dreams-diary__title {
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   color: var(--muted);
   letter-spacing: 0.14em;
@@ -769,7 +769,7 @@
   color: var(--muted);
   border-radius: 999px;
   padding: 5px 10px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
 }
 
 .dreams-diary__subtab--active {
@@ -780,7 +780,7 @@
 .dreams-diary__explainer {
   width: min(100%, 920px);
   margin: 0 0 16px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.6;
   color: var(--muted);
 }
@@ -843,7 +843,7 @@
 
 .dreams-diary__date {
   display: block;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--text);
   font-weight: 600;
   margin-bottom: 16px;
@@ -875,7 +875,7 @@
   border: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
   background: color-mix(in oklab, var(--panel) 84%, transparent);
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-variant-numeric: tabular-nums;
   text-align: center;
   white-space: nowrap;
@@ -938,13 +938,13 @@
 }
 
 .dreams-diary__insight-title {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   color: var(--text);
 }
 
 .dreams-diary__insight-meta {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   margin-bottom: 10px;
 }
@@ -954,7 +954,7 @@
   align-items: center;
   border-radius: 999px;
   padding: 3px 8px;
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   border: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
@@ -979,7 +979,7 @@
 
 .dreams-diary__insight-line {
   margin: 0 0 8px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.6;
   color: var(--text);
   overflow-wrap: anywhere;
@@ -992,7 +992,7 @@
 .dreams-diary__insight-list strong {
   display: block;
   margin-bottom: 6px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   letter-spacing: 0.04em;
   text-transform: uppercase;
   color: var(--muted);
@@ -1017,7 +1017,7 @@
   align-items: center;
   padding: 4px 8px;
   border-radius: 999px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--text);
   background: color-mix(in oklab, var(--accent-subtle) 84%, transparent);
   border: 1px solid color-mix(in oklab, var(--accent) 24%, transparent);
@@ -1057,14 +1057,14 @@
 }
 
 .dreams-diary__preview-title {
-  font-size: 16px;
+  font-size: var(--control-ui-text-lg);
   font-weight: 600;
   color: var(--text);
 }
 
 .dreams-diary__preview-meta {
   margin-top: 6px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);
   overflow-wrap: anywhere;
@@ -1079,7 +1079,7 @@
 
 .dreams-diary__preview-hint {
   margin-bottom: 12px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);
 }
@@ -1089,14 +1089,14 @@
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.65;
   color: var(--text);
 }
 
 .dreams-diary__para {
   margin: 0 0 12px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.7;
   color: var(--text);
   overflow-wrap: anywhere;
@@ -1142,20 +1142,20 @@
 }
 
 .dreams-diary__empty-text {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-style: italic;
   color: var(--muted);
   opacity: 0.7;
 }
 
 .dreams-diary__empty-hint {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   opacity: 0.4;
 }
 
 .dreams-diary__error {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--danger);
   text-align: center;
   padding: 20px 0;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -212,7 +212,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   background: transparent;
   color: var(--muted);
   font: inherit;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   font-weight: 550;
   transition:
     background var(--duration-fast) ease,
@@ -253,7 +253,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   background: color-mix(in srgb, var(--card) 70%, transparent);
   color: var(--muted);
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 10px;
+  font-size: var(--control-ui-text-2xs);
   font-weight: 550;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -310,7 +310,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   background: color-mix(in srgb, var(--card) 72%, transparent);
   color: var(--text);
   font: inherit;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   outline: none;
   transition:
     border-color var(--duration-fast) ease,
@@ -378,7 +378,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 .settings-sidebar__empty {
   margin: 8px 9px 0;
   color: var(--muted);
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   line-height: 1.45;
 }
 
@@ -391,7 +391,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 .settings-sidebar__group-label {
   padding: 0 9px;
   margin: 0 0 4px;
-  font-size: 10.5px;
+  font-size: calc(10.5px * var(--control-ui-text-scale));
   font-weight: 650;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -468,7 +468,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 }
 
 .settings-sidebar__item-label {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
   white-space: nowrap;
   overflow: hidden;
@@ -482,7 +482,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   gap: 8px;
   padding: 12px 21px;
   border-top: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--control-ui-text-scale));
   color: var(--muted);
 }
 
@@ -566,7 +566,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   min-width: 0;
   overflow: hidden;
   color: var(--text-strong);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 650;
   letter-spacing: 0;
   text-overflow: ellipsis;
@@ -593,7 +593,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--bg-elevated) 84%, transparent);
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   transition:
     border-color var(--duration-fast) ease,
     background var(--duration-fast) ease,
@@ -758,7 +758,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   min-width: 0;
   overflow: hidden;
   color: var(--text-strong);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 650;
   letter-spacing: 0;
   text-overflow: ellipsis;
@@ -918,14 +918,14 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 
 .sidebar-update-card__title {
   color: var(--text-strong);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   line-height: 1.2;
 }
 
 .sidebar-update-card__subtitle {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.2;
 }
 
@@ -1132,7 +1132,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   width: 26px;
   flex: 0 0 auto;
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--control-ui-text-2xs);
   font-variant-numeric: tabular-nums;
   opacity: 0.7;
   text-align: center;
@@ -1242,7 +1242,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
    as metadata rather than a form control. */
 
 .sidebar-recent-sessions__label-text {
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 650;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -1323,7 +1323,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
   color: var(--text);
 }
@@ -1429,7 +1429,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 }
 
 .nav-section__label-text {
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 650;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -1491,7 +1491,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
 
 .sidebar-customize-menu__title {
   padding: 6px 10px 8px;
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 650;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -1510,7 +1510,7 @@ html.openclaw-native-nav .shell-nav-expand:focus-visible {
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   text-align: left;
 }
 
@@ -1588,7 +1588,7 @@ openclaw-session-menu[popover] {
 .sidebar-session-sort-menu__title {
   padding: 4px 8px 2px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 650;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -1607,7 +1607,7 @@ openclaw-session-menu[popover] {
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   text-align: left;
 }
 
@@ -1669,7 +1669,7 @@ openclaw-session-menu[popover] {
 .session-menu__shortcut {
   flex: 0 0 auto;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 550;
   letter-spacing: 0.04em;
 }
@@ -1743,7 +1743,7 @@ openclaw-session-menu[popover] {
 }
 
 .nav-item__text {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 500;
   white-space: nowrap;
 }
@@ -1793,7 +1793,7 @@ openclaw-session-menu[popover] {
   overflow: hidden;
   color: var(--muted);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   text-overflow: ellipsis;
   white-space: nowrap;
   text-decoration: none;
@@ -1817,7 +1817,7 @@ openclaw-session-menu[popover] {
   padding: 2px 8px;
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--danger) 12%, transparent);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-family: var(--font-mono);
   color: var(--danger);
 }
@@ -2105,7 +2105,7 @@ openclaw-session-menu[popover] {
 }
 
 .page-title {
-  font-size: 22px;
+  font-size: var(--control-ui-text-2xl);
   font-weight: 650;
   letter-spacing: -0.03em;
   line-height: 1.2;
@@ -2114,7 +2114,7 @@ openclaw-session-menu[popover] {
 
 .page-sub {
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 400;
   margin-top: 4px;
   letter-spacing: -0.005em;
@@ -2149,7 +2149,7 @@ openclaw-session-menu[popover] {
   padding: 4px 10px;
   background: transparent;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   line-height: 1.2;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -2199,7 +2199,7 @@ openclaw-session-menu[popover] {
   white-space: nowrap;
   text-transform: none;
   letter-spacing: normal;
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   color: color-mix(in srgb, var(--muted) 86%, var(--text) 14%);
   transition:
@@ -2389,7 +2389,7 @@ openclaw-session-menu[popover] {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   color: var(--muted);
 }
 
@@ -2425,7 +2425,7 @@ openclaw-session-menu[popover] {
   border-radius: 50%;
   background: color-mix(in srgb, var(--accent-subtle) 80%, transparent);
   color: var(--text-strong);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
   flex: none;
 }
@@ -2436,7 +2436,7 @@ openclaw-session-menu[popover] {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   color: var(--text);
 }

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -227,7 +227,7 @@
     margin: 0;
     min-height: 40px;
     padding: 0 12px;
-    font-size: 13px;
+    font-size: var(--control-ui-text-compact);
     border-radius: var(--radius-md);
     white-space: nowrap;
     flex: 0 0 auto;
@@ -328,7 +328,7 @@
   }
 
   .nav-item {
-    font-size: 12px;
+    font-size: var(--control-ui-text-sm);
   }
 
   /* Content */
@@ -429,7 +429,7 @@
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-trigger {
     min-height: 44px;
     padding: 10px 12px;
-    font-size: 14px;
+    font-size: var(--control-ui-text-md);
   }
 
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__model {
@@ -441,7 +441,7 @@
     width: 100%;
     max-width: none;
     min-height: 44px;
-    font-size: 14px;
+    font-size: var(--control-ui-text-md);
   }
 
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__inline-select-menu {
@@ -453,14 +453,14 @@
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session select,
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__session-trigger {
     width: 100%;
-    font-size: 14px;
+    font-size: var(--control-ui-text-md);
     min-height: 44px;
     padding: 10px 12px;
   }
 
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__agent select {
     width: 100%;
-    font-size: 14px;
+    font-size: var(--control-ui-text-md);
     min-height: 44px;
     padding: 10px 12px;
   }
@@ -493,7 +493,7 @@
   }
 
   .card-title {
-    font-size: 13px;
+    font-size: var(--control-ui-text-compact);
   }
 
   /* Stats */
@@ -508,11 +508,11 @@
   }
 
   .stat-label {
-    font-size: 12px; /* was 11px */
+    font-size: var(--control-ui-text-sm);
   }
 
   .stat-value {
-    font-size: 18px;
+    font-size: calc(18px * var(--control-ui-text-scale));
   }
 
   /* Notes */
@@ -532,19 +532,19 @@
   .field select {
     padding: 8px 10px;
     border-radius: var(--radius-md);
-    font-size: 14px;
+    font-size: var(--control-ui-text-md);
   }
 
   /* Buttons */
   .btn {
     padding: 8px 12px;
-    font-size: 12px;
+    font-size: var(--control-ui-text-sm);
   }
 
   /* Pills */
   .pill {
     padding: 4px 10px;
-    font-size: 12px;
+    font-size: var(--control-ui-text-sm);
   }
 
   /* Chat */
@@ -649,19 +649,19 @@
   }
 
   .log-time {
-    font-size: 12px; /* was 10px */
+    font-size: var(--control-ui-text-sm);
   }
 
   .log-level {
-    font-size: 12px; /* was 9px */
+    font-size: var(--control-ui-text-sm);
   }
 
   .log-subsystem {
-    font-size: 12px; /* was 11px */
+    font-size: var(--control-ui-text-sm);
   }
 
   .log-message {
-    font-size: 12px;
+    font-size: var(--control-ui-text-sm);
   }
 
   /* Lists */
@@ -671,18 +671,18 @@
   }
 
   .list-title {
-    font-size: 13px;
+    font-size: var(--control-ui-text-compact);
   }
 
   .list-sub {
-    font-size: 12px; /* was 11px */
+    font-size: var(--control-ui-text-sm);
   }
 
   /* Code blocks */
   .code-block {
     padding: 8px;
     border-radius: var(--radius-md);
-    font-size: 12px; /* was 11px */
+    font-size: var(--control-ui-text-sm);
   }
 }
 
@@ -697,12 +697,12 @@
   }
 
   .brand-title {
-    font-size: 13px;
+    font-size: var(--control-ui-text-compact);
   }
 
   .nav-item {
     padding: 6px 8px;
-    font-size: 12px; /* was 11px */
+    font-size: var(--control-ui-text-sm);
   }
 
   .content {
@@ -719,7 +719,7 @@
   }
 
   .stat-value {
-    font-size: 16px;
+    font-size: var(--control-ui-text-lg);
   }
 
   .chat-bubble {
@@ -728,7 +728,7 @@
 
   .btn {
     padding: 6px 10px;
-    font-size: 12px; /* was 11px */
+    font-size: var(--control-ui-text-sm);
   }
 }
 
@@ -766,7 +766,7 @@
   .data-table th,
   .data-table td {
     padding: 8px 6px;
-    font-size: 12px;
+    font-size: var(--control-ui-text-sm);
   }
 
   .data-table-pagination {
@@ -785,7 +785,7 @@
   }
 
   .data-table-search input {
-    font-size: 14px;
+    font-size: var(--control-ui-text-md);
     padding: 8px 10px;
   }
 
@@ -880,7 +880,7 @@
   .data-table th,
   .data-table td {
     padding: 6px 4px;
-    font-size: 12px; /* was 11px */
+    font-size: var(--control-ui-text-sm);
   }
 
   .session-key-cell {

--- a/ui/src/styles/logbook.css
+++ b/ui/src/styles/logbook.css
@@ -43,7 +43,7 @@
   gap: 5px;
   padding: 3px 9px;
   border-radius: 999px;
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   color: var(--muted);
   background: color-mix(in oklab, var(--panel) 80%, transparent);
   white-space: nowrap;
@@ -120,7 +120,7 @@
 
 .logbook__empty-sub {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .logbook-card {
@@ -150,7 +150,7 @@
 
 .logbook-card__time {
   font-variant-numeric: tabular-nums;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   white-space: nowrap;
 }
@@ -184,7 +184,7 @@
 
 .logbook-card__summary {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -202,7 +202,7 @@
 }
 
 .logbook-card__category {
-  font-size: 10px;
+  font-size: var(--control-ui-text-2xs);
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -213,12 +213,12 @@
 }
 
 .logbook-card__app {
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   color: var(--muted);
 }
 
 .logbook-card__duration {
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   color: var(--muted);
   font-variant-numeric: tabular-nums;
 }
@@ -242,12 +242,12 @@
   justify-content: center;
   height: 120px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .logbook-card__detail {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.5;
   white-space: pre-wrap;
 }
@@ -260,7 +260,7 @@
 }
 
 .logbook-card__distractions-label {
-  font-size: 10px;
+  font-size: var(--control-ui-text-2xs);
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
@@ -268,7 +268,7 @@
 }
 
 .logbook-card__distraction {
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   padding: 2px 8px;
   border-radius: 999px;
   color: var(--muted);
@@ -328,7 +328,7 @@
 .logbook-stats__focus-legend {
   display: flex;
   justify-content: space-between;
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   color: var(--muted);
   margin-top: 4px;
 }
@@ -344,7 +344,7 @@
   grid-template-columns: 72px minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
 }
 
 .logbook-stats__category-name {
@@ -379,7 +379,7 @@
 }
 
 .logbook-stats__app {
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   padding: 2px 8px;
   border-radius: 999px;
   color: var(--muted);
@@ -387,7 +387,7 @@
 }
 
 .logbook-standup__body {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .logbook-ask__form {
@@ -402,7 +402,7 @@
 
 .logbook-ask__answer {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.5;
   padding: 10px;
   border-radius: 8px;

--- a/ui/src/styles/sessions.css
+++ b/ui/src/styles/sessions.css
@@ -27,7 +27,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 650;
   line-height: 1.5;
   cursor: default;
@@ -93,7 +93,7 @@
 .sessions-overview__label {
   overflow: hidden;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 650;
   letter-spacing: 0.05em;
   text-overflow: ellipsis;
@@ -194,7 +194,7 @@
 .session-filter-label,
 .session-filter-check__label {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   line-height: 1;
   white-space: nowrap;
@@ -210,7 +210,7 @@
   border: none;
   border-radius: calc(var(--radius-sm) - 2px);
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   text-align: right;
   outline: none;
   transition: opacity var(--duration-fast) ease;
@@ -305,7 +305,7 @@
 
 .session-groupby__label {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   white-space: nowrap;
 }
 
@@ -316,7 +316,7 @@
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 /* --- Table --- */
@@ -470,7 +470,7 @@
 .session-key-display-name {
   min-width: 0;
   overflow: hidden;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -485,7 +485,7 @@
   color: var(--accent-2);
   background: var(--accent-2-subtle);
   border-radius: var(--radius-full);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -496,7 +496,7 @@
   display: inline-block;
   padding: 2px 8px;
   border-radius: var(--radius-full);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   letter-spacing: 0.02em;
   white-space: nowrap;
@@ -548,7 +548,7 @@
   gap: 7px;
   max-width: 116px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   letter-spacing: 0.02em;
   line-height: 1.2;
@@ -615,7 +615,7 @@
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   line-height: 1.2;
 }
 
@@ -729,7 +729,7 @@
 .session-token-cell {
   min-width: 96px;
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   white-space: nowrap;
 }
 
@@ -741,7 +741,7 @@
 
 .session-tokens__value {
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   white-space: nowrap;
 }
 
@@ -896,7 +896,7 @@
   background: var(--accent-2-subtle);
   border-radius: var(--radius-full);
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 650;
   line-height: 1.6;
 }
@@ -913,7 +913,7 @@
   align-items: center;
   gap: 8px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   letter-spacing: 0.02em;
 }
@@ -940,7 +940,7 @@
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 /* --- Row drawer: overrides, stats, compaction history --- */
@@ -978,7 +978,7 @@
 .session-details-panel__eyebrow {
   margin-bottom: 4px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 650;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -987,7 +987,7 @@
 .session-details-panel__title {
   max-width: min(720px, 72vw);
   overflow: hidden;
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -995,7 +995,7 @@
 
 .session-details-panel__subtitle {
   margin-top: 4px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .session-details-section {
@@ -1015,7 +1015,7 @@
 }
 
 .session-details-section__title {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 700;
 }
 
@@ -1033,7 +1033,7 @@
 
 .session-override-field__label {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 650;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -1048,7 +1048,7 @@
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   transition: border-color var(--duration-fast) ease;
 }
 
@@ -1079,7 +1079,7 @@ input.session-override-field__control {
 .session-detail-stat__label {
   margin-bottom: 5px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 650;
   letter-spacing: 0.03em;
   text-transform: uppercase;
@@ -1088,7 +1088,7 @@ input.session-override-field__control {
 .session-detail-stat__value {
   min-width: 0;
   overflow: hidden;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   line-height: 1.35;
   text-overflow: ellipsis;
@@ -1097,7 +1097,7 @@ input.session-override-field__control {
 
 .session-details-empty {
   padding: 4px 0;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .session-checkpoint-list {
@@ -1132,7 +1132,7 @@ input.session-override-field__control {
 
 .session-checkpoint-card__delta {
   flex: 0 1 auto;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .session-checkpoint-card__summary {

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -71,7 +71,7 @@
   padding: 9px 14px;
   color: var(--muted);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   display: flex;
   align-items: center;
   gap: 6px;
@@ -94,7 +94,7 @@
   color: var(--muted);
   padding: 1px 7px;
   border-radius: 999px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
 }
 
 .sw-lifecycle-tab.is-active .sw-lifecycle-tab__count {
@@ -152,12 +152,12 @@
 .sw-queue__count {
   font-weight: 700;
   color: var(--text-strong);
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
 }
 
 .sw-queue__sub {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   margin-left: auto;
 }
 
@@ -174,7 +174,7 @@
   padding: 7px 10px;
   border-radius: var(--radius-md);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .sw-queue__body {
@@ -184,7 +184,7 @@
 
 .sw-queue__group {
   padding: 10px 14px 4px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--muted);
@@ -199,7 +199,7 @@
   color: var(--muted);
   padding: 1px 7px;
   border-radius: 999px;
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
 }
 
 .sw-row {
@@ -244,7 +244,7 @@
 .sw-row__title {
   color: var(--text-strong);
   font-weight: 600;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .sw-row.is-seen .sw-row__title {
@@ -254,7 +254,7 @@
 
 .sw-row__desc {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   margin-top: 2px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -266,7 +266,7 @@
 
 .sw-row__meta {
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   white-space: nowrap;
   align-self: start;
   margin-top: 1px;
@@ -276,7 +276,7 @@
   padding: 28px 16px;
   text-align: center;
   color: var(--muted);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 /* ── Detail (right) ─────────────────────────────────────────────────── */
@@ -329,7 +329,7 @@
 }
 
 .sw-empty__title {
-  font-size: 16px;
+  font-size: var(--control-ui-text-lg);
   font-weight: 600;
   color: var(--text-strong);
   margin: 0;
@@ -337,7 +337,7 @@
 
 .sw-empty__sub {
   margin: 0;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   max-width: 380px;
 }
 
@@ -389,7 +389,7 @@
 .sw-empty-state__eyebrow {
   margin: 0 0 8px;
   color: var(--accent);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -398,7 +398,7 @@
 .sw-empty-state h2 {
   margin: 0;
   color: var(--text-strong);
-  font-size: 24px;
+  font-size: calc(24px * var(--control-ui-text-scale));
   line-height: 1.16;
 }
 
@@ -406,7 +406,7 @@
   margin: 12px auto 0;
   max-width: 330px;
   color: var(--muted);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   line-height: 1.55;
 }
 
@@ -415,7 +415,7 @@
   padding-top: 16px;
   border-top: 1px solid var(--border);
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .sw-detail__head {
@@ -435,14 +435,14 @@
 
 .sw-detail__title {
   margin: 0 0 4px;
-  font-size: 18px;
+  font-size: calc(18px * var(--control-ui-text-scale));
   color: var(--text-strong);
   font-weight: 700;
 }
 
 .sw-detail__one-line {
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .sw-detail__meta {
@@ -451,7 +451,7 @@
   align-items: center;
   margin-top: 10px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   flex-wrap: wrap;
 }
 
@@ -468,7 +468,7 @@
   border: 1px solid var(--border);
   background: var(--bg);
   color: var(--text);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
 }
 
 .sw-detail__body {
@@ -484,7 +484,7 @@
 
 .sw-section__label {
   margin: 0 0 8px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   color: var(--muted);
@@ -498,13 +498,13 @@
   border-radius: var(--radius-md);
   padding: 18px 22px;
   color: var(--text);
-  font-size: 13.5px;
+  font-size: calc(13.5px * var(--control-ui-text-scale));
   line-height: 1.65;
 }
 
 .sw-body-card h1 {
   margin: 0 0 14px;
-  font-size: 20px;
+  font-size: var(--control-ui-text-xl);
   color: var(--text-strong);
   font-weight: 700;
   font-family: var(--mono);
@@ -513,7 +513,7 @@
 
 .sw-body-card h3 {
   margin: 18px 0 6px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--text-strong);
   font-weight: 700;
   text-transform: none;
@@ -539,7 +539,7 @@
   padding: 1px 5px;
   border-radius: 3px;
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .sw-body-card pre {
@@ -548,7 +548,7 @@
   padding: 12px 14px;
   border-radius: var(--radius-md);
   font-family: var(--mono);
-  font-size: 11.5px;
+  font-size: calc(11.5px * var(--control-ui-text-scale));
   overflow: auto;
   color: var(--text);
   margin: 8px 0 0;
@@ -571,7 +571,7 @@
   border-radius: var(--radius-md);
   align-items: center;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--text);
   text-align: left;
   transition:
@@ -591,12 +591,12 @@
 
 .sw-file__size {
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
 }
 
 .sw-file__hint {
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   opacity: 0;
   transition: opacity 100ms;
   margin-left: 6px;
@@ -665,7 +665,7 @@
 .sw-revision-dialog__eyebrow {
   margin-bottom: 6px;
   color: var(--accent);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -675,7 +675,7 @@
   margin: 0;
   color: var(--text-strong);
   font-family: var(--mono, ui-monospace, monospace);
-  font-size: 20px;
+  font-size: var(--control-ui-text-xl);
   line-height: 1.25;
 }
 
@@ -687,7 +687,7 @@
   background: var(--bg-elevated);
   color: var(--muted);
   font: inherit;
-  font-size: 20px;
+  font-size: var(--control-ui-text-xl);
   line-height: 1;
 }
 
@@ -699,7 +699,7 @@
 .sw-revision-dialog__copy {
   margin: 16px 0 12px;
   color: var(--muted);
-  font-size: 13.5px;
+  font-size: calc(13.5px * var(--control-ui-text-scale));
   line-height: 1.55;
 }
 
@@ -713,7 +713,7 @@
   color: var(--text);
   padding: 12px 14px;
   font: inherit;
-  font-size: 13.5px;
+  font-size: calc(13.5px * var(--control-ui-text-scale));
   line-height: 1.55;
 }
 
@@ -729,7 +729,7 @@
   gap: 9px;
   margin-top: 12px;
   color: var(--muted);
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
 }
 
 .sw-revision-dialog__status-dot {
@@ -762,7 +762,7 @@
   padding: 7px 14px;
   border-radius: var(--radius-md);
   font: inherit;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   border: 1px solid var(--border-strong);
   background: var(--bg-elevated);
@@ -847,7 +847,7 @@
   padding: 0;
   margin: 0;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   text-decoration: underline dotted;
   text-underline-offset: 3px;
@@ -883,7 +883,7 @@
   align-items: center;
   gap: 8px;
   color: var(--muted);
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   font-weight: 500;
   white-space: nowrap;
 }
@@ -956,7 +956,7 @@
   padding: 6px 14px;
   border-radius: 999px;
   font: inherit;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   font-weight: 500;
   color: var(--muted);
   transition: color 160ms ease;
@@ -1067,7 +1067,7 @@
 }
 
 .sw-today__date {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--muted);
@@ -1076,7 +1076,7 @@
 }
 
 .sw-today__h1 {
-  font-size: 28px;
+  font-size: calc(28px * var(--control-ui-text-scale));
   font-weight: 700;
   color: var(--text-strong);
   margin: 0;
@@ -1085,7 +1085,7 @@
 
 .sw-today__sub {
   color: var(--muted);
-  font-size: 13.5px;
+  font-size: calc(13.5px * var(--control-ui-text-scale));
   margin-top: 6px;
 }
 
@@ -1102,7 +1102,7 @@
   border: 1px solid var(--border);
   padding: 6px 14px;
   border-radius: 999px;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   color: var(--muted);
   margin-top: 12px;
 }
@@ -1153,7 +1153,7 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   text-transform: uppercase;
   letter-spacing: 0.12em;
   color: var(--accent);
@@ -1170,7 +1170,7 @@
 }
 
 .sw-today__name {
-  font-size: 28px;
+  font-size: calc(28px * var(--control-ui-text-scale));
   font-weight: 700;
   color: var(--text-strong);
   margin: 0 0 10px;
@@ -1180,7 +1180,7 @@
 }
 
 .sw-today__one-liner {
-  font-size: 15.5px;
+  font-size: calc(15.5px * var(--control-ui-text-scale));
   color: var(--text);
   line-height: 1.55;
   margin: 0 0 24px;
@@ -1194,7 +1194,7 @@
 }
 
 .sw-today__does-h {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: var(--muted);
@@ -1210,7 +1210,7 @@
 
 .sw-today__does li {
   padding: 5px 0;
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   color: var(--text);
   display: flex;
   gap: 12px;
@@ -1231,7 +1231,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   color: var(--muted);
   margin-bottom: 24px;
   line-height: 1.5;
@@ -1251,7 +1251,7 @@
   border-radius: 50%;
   background: linear-gradient(135deg, #14b8a6, #0891b2);
   color: white;
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   flex-shrink: 0;
 }
@@ -1281,7 +1281,7 @@
   min-height: 60px;
   padding: 9px 12px;
   border-radius: 12px;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   font-weight: 600;
   font-family: inherit;
   border: 1px solid;
@@ -1306,7 +1306,7 @@
 }
 
 .sw-today__big-sub {
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 400;
   line-height: 1.25;
   opacity: 0.66;
@@ -1356,7 +1356,7 @@
 }
 
 .sw-today__section-head h3 {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   text-transform: uppercase;
   letter-spacing: 0.1em;
   color: var(--muted);
@@ -1369,7 +1369,7 @@
   border: none;
   padding: 0;
   font: inherit;
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   color: var(--accent);
   font-weight: 500;
 }
@@ -1407,7 +1407,7 @@
 }
 
 .sw-today__mini-name {
-  font-size: 13.5px;
+  font-size: calc(13.5px * var(--control-ui-text-scale));
   font-weight: 600;
   color: var(--text-strong);
   margin-bottom: 4px;
@@ -1415,7 +1415,7 @@
 }
 
 .sw-today__mini-desc {
-  font-size: 12.5px;
+  font-size: calc(12.5px * var(--control-ui-text-scale));
   color: var(--muted);
   line-height: 1.4;
   display: -webkit-box;
@@ -1425,7 +1425,7 @@
 }
 
 .sw-today__mini-meta {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   margin-top: 10px;
   font-family: var(--mono, ui-monospace, monospace);
@@ -1463,14 +1463,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   flex-shrink: 0;
 }
 
 .sw-today__applied-name {
   flex: 1;
-  font-size: 13.5px;
+  font-size: calc(13.5px * var(--control-ui-text-scale));
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1485,7 +1485,7 @@
 
 .sw-today__applied-when {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   flex-shrink: 0;
 }
 

--- a/ui/src/styles/usage.css
+++ b/ui/src/styles/usage.css
@@ -63,7 +63,7 @@
   border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
   background: color-mix(in srgb, var(--accent) 8%, var(--bg-muted));
   color: var(--accent);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 650;
 }
 
@@ -94,7 +94,7 @@
 
 .provider-usage-card__name {
   color: var(--text-strong);
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   font-weight: 700;
 }
 
@@ -102,7 +102,7 @@
 .provider-usage-reset,
 .provider-usage-summary {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
 }
 
 .provider-usage-plan {
@@ -122,7 +122,7 @@
 
 .provider-usage-window__meta,
 .provider-usage-billing-row {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .provider-usage-window__meta strong,
@@ -156,7 +156,7 @@
 
 .provider-usage-error {
   color: var(--danger);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .provider-cost-history {
@@ -185,7 +185,7 @@
 .provider-cost-window span,
 .provider-cost-breakdown__title {
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--control-ui-text-2xs);
   font-weight: 650;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -193,7 +193,7 @@
 
 .provider-cost-window strong {
   color: var(--text-strong);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-variant-numeric: tabular-nums;
 }
 
@@ -223,7 +223,7 @@
   flex-wrap: wrap;
   gap: 4px 10px;
   color: var(--muted);
-  font-size: 10px;
+  font-size: var(--control-ui-text-2xs);
   font-variant-numeric: tabular-nums;
 }
 
@@ -240,7 +240,7 @@
   gap: 8px;
   min-width: 0;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
 }
 
 .provider-cost-breakdown > div span {
@@ -304,7 +304,7 @@
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--accent) 10%, var(--bg-muted));
   color: var(--accent);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   letter-spacing: 0.01em;
 }
@@ -396,7 +396,7 @@
   background: transparent;
   min-height: 28px;
   padding: 4px 12px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .chart-toggle .toggle-btn:hover:not(.active) {
@@ -429,7 +429,7 @@
   background: var(--bg-elevated);
   color: var(--text);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   transition:
     border-color 0.18s var(--ease-out),
     box-shadow 0.18s var(--ease-out),
@@ -469,15 +469,15 @@
 .session-log-meta,
 .session-logs-header-count {
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
 }
 
 .usage-separator {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .usage-query-hint {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   letter-spacing: 0.01em;
 }
 
@@ -489,7 +489,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
   background: var(--bg-elevated);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   color: var(--muted);
   letter-spacing: 0.01em;
@@ -551,7 +551,7 @@
 .usage-query-input {
   width: 100%;
   padding: 8px 12px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 @media (hover: none) and (pointer: coarse) {
@@ -560,7 +560,7 @@
   .usage-query-input,
   .usage-filters-inline select,
   .usage-filters-inline input[type="text"] {
-    font-size: 16px;
+    font-size: var(--control-ui-input-text-size);
   }
 }
 
@@ -606,7 +606,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   transition:
     border-color 0.18s var(--ease-out),
@@ -634,7 +634,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   border-radius: var(--radius-full);
   background: var(--bg-muted);
   color: var(--muted);
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 700;
   letter-spacing: 0.02em;
 }
@@ -676,7 +676,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   padding: 6px 8px;
   border-radius: var(--radius-md);
   background: transparent;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   transition: background 0.12s ease;
 }
 
@@ -694,7 +694,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   color: var(--text);
   text-align: left;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   transition:
     border-color 0.18s var(--ease-out),
     background 0.18s var(--ease-out),
@@ -728,7 +728,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   border: 1px solid var(--border);
   background: var(--bg-elevated);
   color: var(--text);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
 }
 
@@ -737,7 +737,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   border: 0;
   background: transparent;
   color: inherit;
-  font-size: 14px;
+  font-size: var(--control-ui-text-md);
   line-height: 1;
 }
 
@@ -783,7 +783,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 }
 
 .usage-empty-state__title {
-  font-size: 20px;
+  font-size: var(--control-ui-text-xl);
   font-weight: 700;
   color: var(--text-strong);
 }
@@ -802,7 +802,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   border-radius: var(--radius-md);
   text-align: center;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .usage-empty-block--compact {
@@ -895,7 +895,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 .sessions-sort span,
 .cost-breakdown-header,
 .usage-mosaic-section-title {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   color: var(--muted);
   text-transform: uppercase;
@@ -936,7 +936,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 .session-summary-meta,
 .usage-list-sub,
 .usage-error-sub {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
   font-variant-numeric: tabular-nums;
 }
@@ -951,7 +951,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   border-radius: var(--radius-full);
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   color: var(--muted);
-  font-size: 12px; /* was 9px */
+  font-size: var(--control-ui-text-sm);
   cursor: help;
   opacity: 0.7;
   transition: opacity 0.15s var(--ease-out);
@@ -1008,7 +1008,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   align-items: baseline;
   padding: 8px 0;
   border-bottom: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .context-breakdown-item .mono {
@@ -1042,7 +1042,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 }
 
 .usage-error-rate {
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
   font-weight: 700;
   color: var(--danger);
   font-variant-numeric: tabular-nums;
@@ -1076,12 +1076,12 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .usage-mosaic-title,
 .session-detail-title {
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
   font-weight: 700;
 }
 
 .usage-mosaic-total {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
@@ -1125,12 +1125,12 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .usage-daypart-label,
 .usage-hour-labels {
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
 .usage-daypart-value {
-  font-size: 15px;
+  font-size: var(--control-ui-text-title);
   font-weight: 700;
   color: var(--text-strong);
 }
@@ -1169,7 +1169,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   display: flex;
   justify-content: space-between;
   gap: 8px;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
@@ -1236,7 +1236,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .cost-window-range-label {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-variant-numeric: tabular-nums;
 }
 
@@ -1263,7 +1263,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .cost-window-card__label {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-weight: 650;
   letter-spacing: 0.055em;
   text-transform: uppercase;
@@ -1279,7 +1279,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .cost-window-card__meta {
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-variant-numeric: tabular-nums;
 }
 
@@ -1319,7 +1319,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   height: 200px;
   padding-top: 6px;
   color: var(--muted);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
@@ -1338,7 +1338,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border));
   border-radius: var(--radius-full);
   color: var(--accent);
-  font-size: 11px;
+  font-size: var(--control-ui-text-xs);
   line-height: 1;
   cursor: help;
 }
@@ -1392,7 +1392,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .daily-bar-total,
 .daily-bar-label {
-  font-size: 12px; /* was 10px */
+  font-size: var(--control-ui-text-sm);
   line-height: 14px;
   color: var(--muted);
   white-space: nowrap;
@@ -1403,7 +1403,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 }
 
 .daily-bar-label--compact {
-  font-size: 12px; /* was 8px */
+  font-size: var(--control-ui-text-sm);
 }
 
 .cost-breakdown-bar {
@@ -1430,7 +1430,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
@@ -1492,7 +1492,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .cost-breakdown-total,
 .context-total {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--text);
 }
 
@@ -1592,7 +1592,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 }
 
 .session-bar-value {
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   font-weight: 700;
   color: var(--text-strong);
 }
@@ -1600,7 +1600,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 .usage-more-sessions {
   padding: 8px;
   text-align: center;
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
@@ -1625,12 +1625,12 @@ details.usage-filter-select summary::-webkit-details-marker,
   display: inline-flex;
   margin-left: 8px;
   color: var(--muted);
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
 }
 
 .usage-lineage-note {
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   margin-top: -6px;
 }
 
@@ -1640,7 +1640,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   align-items: center;
   gap: 8px 14px;
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
 }
 
 .session-detail-content,
@@ -1691,7 +1691,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 
 .ts-axis-label {
   fill: var(--muted);
-  font-size: 12px; /* was 8px */
+  font-size: var(--control-ui-text-sm);
 }
 
 .ts-bar {
@@ -1716,7 +1716,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 }
 
 .timeseries-summary {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .timeseries-summary__range {
@@ -1731,7 +1731,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 }
 
 .context-weight-desc {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .context-stacked-bar {
@@ -1759,7 +1759,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 }
 
 .context-breakdown-more {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   color: var(--muted);
 }
 
@@ -1825,7 +1825,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   display: flex;
   flex-wrap: wrap;
   gap: 6px 10px;
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
 }
 
 .session-log-role {
@@ -1837,7 +1837,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.5;
 }
 
@@ -1847,7 +1847,7 @@ details.usage-filter-select summary::-webkit-details-marker,
 }
 
 .session-log-tools summary {
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 600;
   color: var(--muted);
 }
@@ -1865,7 +1865,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   border-radius: var(--radius-full);
   background: color-mix(in srgb, var(--accent) 8%, var(--card));
   border: 1px solid color-mix(in srgb, var(--accent) 16%, var(--border));
-  font-size: 12px; /* was 11px */
+  font-size: var(--control-ui-text-sm);
 }
 
 :root[data-theme-mode="light"] .usage-daypart-cell,
@@ -1943,7 +1943,7 @@ details.usage-filter-select summary::-webkit-details-marker,
   }
 
   .usage-error-list--hours .usage-error-rate {
-    font-size: 18px;
+    font-size: calc(18px * var(--control-ui-text-scale));
   }
 }
 

--- a/ui/src/styles/workboard.css
+++ b/ui/src/styles/workboard.css
@@ -76,7 +76,7 @@
 .workboard-auto-refresh {
   gap: 6px;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   white-space: nowrap;
 }
 
@@ -194,7 +194,7 @@
   border-radius: var(--workboard-control-radius);
   background-color: var(--workboard-control-bg);
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--control-ui-text-compact);
   line-height: 1.25;
   box-shadow: inset 0 1px 0 color-mix(in srgb, white 4%, transparent);
   transition:
@@ -532,7 +532,7 @@
   min-width: 0;
   overflow: hidden;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   line-height: 1.2;
   text-overflow: ellipsis;
   white-space: normal;
@@ -655,7 +655,7 @@
 .workboard-column__header h2 {
   margin: 0;
   color: color-mix(in srgb, var(--text) 72%, var(--muted));
-  font-size: 0.75rem;
+  font-size: calc(0.75rem * var(--control-ui-text-scale));
   text-transform: uppercase;
 }
 
@@ -697,7 +697,7 @@
 
 .workboard-empty-state strong {
   color: var(--text);
-  font-size: 0.95rem;
+  font-size: calc(0.95rem * var(--control-ui-text-scale));
 }
 
 .workboard-empty-state span {
@@ -1050,7 +1050,7 @@
     5px 5px;
   background-repeat: no-repeat;
   color: var(--muted);
-  font-size: 12px;
+  font-size: var(--control-ui-text-sm);
   font-weight: 500;
   letter-spacing: 0;
   line-height: 1;
@@ -1227,7 +1227,7 @@
 
 .workboard-board--compact .workboard-card p {
   -webkit-line-clamp: 2;
-  font-size: 0.78rem;
+  font-size: calc(0.78rem * var(--control-ui-text-scale));
 }
 
 .workboard-board--compact .workboard-card__actions {
@@ -1412,7 +1412,7 @@
 .workboard-detail__row span {
   display: block;
   color: var(--muted);
-  font-size: 0.7rem;
+  font-size: calc(0.7rem * var(--control-ui-text-scale));
   font-weight: 650;
   text-transform: uppercase;
 }


### PR DESCRIPTION
## Summary

In this PR, the Appearance text-size setting applies across Control UI content typography instead of only affecting the chat transcript. Shared content font sizes now route through `--control-ui-text-scale`, while touch-primary text-entry controls keep the existing 16px minimum so the 90% text-size stop does not reintroduce mobile Safari focus zoom.

## Screenshots

Settings at the default M text size, showing the Appearance text-size control in English.

![Settings text size at M](https://mystic-bonnet-p3d4.here.now/pr-100934-settings-text-size-m-en.png)

Overview at XXL text size, showing the larger page typography across cards and form controls.

![Overview using XXL text size](https://mystic-bonnet-p3d4.here.now/pr-100934-overview-xxl-en.png)

Channels at XXL text size, showing the larger channel cards and actions.

![Channels using XXL text size](https://mystic-bonnet-p3d4.here.now/pr-100934-channels-xxl-en.png)

Mobile Overview at XXL text size, showing the narrow layout with scaled content typography.

![Mobile overview using XXL text size](https://mystic-bonnet-p3d4.here.now/pr-100934-mobile-overview-xxl-en.png)

## What Problem This Solves

Fixes the Appearance text-size setting so it affects Control UI content typography beyond the chat transcript. Before this PR, the setting could be saved while many Settings, quick settings, overview, channel, session, skill, and content surfaces still used fixed font sizes.

## Why This Change Was Made

In this PR, shared Control UI font sizes route through the existing `--control-ui-text-scale` value instead of hard-coded pixel sizes. The change keeps layout chrome and spacing stable while letting readable content, forms, cards, chat text, composer text, and page typography respond to S/M/L/XL/XXL.

Touch-primary text-entry controls keep the existing `--control-ui-input-text-size` minimum so the 90% text-size stop does not shrink mobile inputs below 16px and reintroduce Safari focus zoom.

## User Impact

Changing Text size in Appearance now produces visible typography changes across the main product surfaces, while M remains the normal/default size.

## Validation

- `node_modules/.bin/oxfmt --check $(git diff --name-only --diff-filter=ACMRTUXB | tr '\n' ' ')`
- `node_modules/.bin/vitest run ui/src/components/form-controls.browser.test.ts ui/src/pages/config/quick.test.ts ui/src/pages/config/view.browser.test.ts ui/src/app/settings.node.test.ts --config test/vitest/vitest.ui.config.ts`
- `git diff --check origin/main...HEAD`
- Playwright screenshot proof against the local mock server for Settings at M, Overview/Channels at XXL, and mobile Overview at XXL.
