### PR TITLE
improve(ui): move Settings navigation to the sidebar and unify page width

### DIFF
--- a/ui/src/app-navigation.ts
+++ b/ui/src/app-navigation.ts
@@ -76,6 +76,33 @@ export const SETTINGS_NAVIGATION_ROUTES = [
   "logs",
 ] as const satisfies readonly NavigationRouteId[];
 
+export const SETTINGS_NAVIGATION_GROUPS = [
+  {
+    id: "general",
+    titleKey: "tabs.config",
+    routes: ["config", "appearance"],
+  },
+  {
+    id: "communications",
+    titleKey: "tabs.communications",
+    routes: ["channels", "communications"],
+  },
+  {
+    id: "automation",
+    titleKey: "tabs.automation",
+    routes: ["automation", "mcp"],
+  },
+  {
+    id: "system",
+    titleKey: "tabs.infrastructure",
+    routes: ["infrastructure", "worktrees", "ai-agents", "debug", "logs"],
+  },
+] as const satisfies readonly {
+  id: string;
+  titleKey: string;
+  routes: readonly NavigationRouteId[];
+}[];
+
 const NAVIGATION_ICONS: NavigationItem = {
   agents: "bot",
   activity: "activity",

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -14,7 +14,7 @@ import "../components/login-gate.ts";
 import "../components/terminal/terminal-panel.ts";
 import "../components/tooltip.ts";
 import "../components/update-banner.ts";
-import type { SidebarNavRoute } from "../app-navigation.ts";
+import { isSettingsNavigationRoute, type SidebarNavRoute } from "../app-navigation.ts";
 import { APP_ROUTE_IDS, isRouteId, pathForRoute, type RouteId } from "../app-routes.ts";
 import {
   COMMAND_PALETTE_TARGET_EVENT,
@@ -67,6 +67,24 @@ function equalShellRouteState(previous: ShellRouteState, next: ShellRouteState):
     previous.location?.search === next.location?.search &&
     previous.location?.hash === next.location?.hash
   );
+}
+
+function optionsForRouteLocation(
+  location?: RouteLocation,
+): ApplicationNavigationOptions | undefined {
+  if (!location?.search && !location?.hash) {
+    return undefined;
+  }
+  return {
+    search: location.search,
+    hash: location.hash,
+  };
+}
+
+function hrefForRouteState(routeState: ShellRouteState, basePath: string): string {
+  const routeId = routeState.routeId ?? "chat";
+  const location = routeState.location;
+  return `${pathForRoute(routeId, basePath)}${location?.search ?? ""}${location?.hash ?? ""}`;
 }
 
 function resolveAgentLabel(sessionKey: string, agentsList: AgentsListResult | null): string {
@@ -341,6 +359,7 @@ class OpenClawShell extends LitElement {
   @state() private activeSessionKey = "";
   @state() private agentLabel = "";
   @state() private routeState: ShellRouteState = {};
+  @state() private settingsBackRouteState: ShellRouteState = { routeId: "chat" };
   @state() private overlaySnapshot: ApplicationOverlaySnapshot = {
     updateAvailable: null,
     updateRunning: false,
@@ -492,6 +511,11 @@ class OpenClawShell extends LitElement {
     context.navigate(routeId, routeId === "chat" ? this.chatNavigationOptions(options) : options);
   }
 
+  private navigateBackFromSettings() {
+    const routeId = this.settingsBackRouteState.routeId ?? "chat";
+    this.navigate(routeId, optionsForRouteLocation(this.settingsBackRouteState.location));
+  }
+
   private replaceChatWithCurrentSession() {
     this.context?.replace("chat", this.chatNavigationOptions());
   }
@@ -629,6 +653,9 @@ class OpenClawShell extends LitElement {
 
   private updateRouteState(routeState: ShellRouteState) {
     this.routeState = routeState;
+    if (routeState.routeId && !isSettingsNavigationRoute(routeState.routeId)) {
+      this.settingsBackRouteState = routeState;
+    }
     const context = this.context;
     if (context) {
       this.ensureAgentsList(context.gateway.snapshot);
@@ -675,9 +702,10 @@ class OpenClawShell extends LitElement {
         ? pluginTabKey(pluginTabRefFromSearch(this.routeState.location?.search ?? ""))
         : "";
     const navDrawerOpen = this.navDrawerOpen && !this.onboarding;
-    // Drawer navigation always opens expanded; the desktop collapse preference
-    // stays persisted for when the viewport returns to the desktop layout.
-    const navCollapsed = this.navCollapsed && !navDrawerOpen;
+    const isSettingsRoute = activeRoute !== undefined && isSettingsNavigationRoute(activeRoute);
+    // Drawer navigation and Settings navigation always render expanded; the
+    // desktop collapse preference stays persisted for normal sidebar routes.
+    const navCollapsed = this.navCollapsed && !navDrawerOpen && !isSettingsRoute;
     return html`
       <openclaw-command-palette
         .onNavigate=${(routeId: RouteId) => this.navigate(routeId)}
@@ -735,6 +763,7 @@ class OpenClawShell extends LitElement {
             .sidebarPinnedRoutes=${this.sidebarPinnedRoutes}
             .sidebarMoreExpanded=${this.sidebarMoreExpanded}
             .themeMode=${context.theme.mode}
+            .settingsBackHref=${hrefForRouteState(this.settingsBackRouteState, context.basePath)}
             .onOpenPalette=${this.openPalette}
             .onToggleMore=${() =>
               context.navigation.update({
@@ -743,6 +772,7 @@ class OpenClawShell extends LitElement {
             .onUpdatePinnedRoutes=${(routes: SidebarNavRoute[]) =>
               context.navigation.update({ sidebarPinnedRoutes: routes })}
             .onPairMobile=${() => void context.overlays.openDevicePairSetup()}
+            .onSettingsBack=${() => this.navigateBackFromSettings()}
             .onNavigate=${(routeId: string, options?: ApplicationNavigationOptions) =>
               this.navigate(routeId, options)}
             .onPreloadRoute=${(routeId: string) =>
@@ -753,7 +783,7 @@ class OpenClawShell extends LitElement {
           class="content ${activeRoute === "chat" ? "content--chat" : ""} ${activeRoute ===
           "workboard"
             ? "content--workboard"
-            : ""}"
+            : ""} ${isSettingsRoute ? "content--settings" : ""}"
         >
           ${this.gatewayConnected
             ? nothing

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -15,7 +15,6 @@ import {
   SETTINGS_NAVIGATION_GROUPS,
   type SidebarNavRoute,
   sidebarMoreRoutes,
-  subtitleForRoute,
   titleForRoute,
 } from "../app-navigation.ts";
 import { pathForRoute, type RouteId } from "../app-route-paths.ts";

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -93,14 +93,6 @@ type SidebarSessionGroupMenuState = {
 };
 
 type SidebarSessionSortMode = "created" | "updated";
-type SettingsSearchResult =
-  | { kind: "route"; routeId: NavigationRouteId }
-  | {
-      kind: "item";
-      routeId: NavigationRouteId;
-      titleKey: "nav.contextProfile";
-      keywords: readonly string[];
-    };
 
 const SIDEBAR_SESSION_GROUPING_STORAGE_KEY = "openclaw:sidebar:sessions:grouping";
 
@@ -108,15 +100,6 @@ const SIDEBAR_SESSION_GROUPING_STORAGE_KEY = "openclaw:sidebar:sessions:grouping
 const PALETTE_SHORTCUT = /Mac|iP(hone|ad|od)/i.test(globalThis.navigator?.platform ?? "")
   ? "⌘K"
   : "Ctrl K";
-
-const SETTINGS_SEARCH_ITEMS = [
-  {
-    kind: "item",
-    routeId: "config",
-    titleKey: "nav.contextProfile",
-    keywords: ["context", "profile", "workspace context", "bootstrap", "reinjection", "profiles"],
-  },
-] as const satisfies readonly SettingsSearchResult[];
 
 function loadStoredSidebarSessionsGrouping(): SidebarSessionsGrouping {
   return normalizeSidebarSessionsGrouping(
@@ -183,7 +166,6 @@ export class AppSidebar extends LitElement {
   @state() private sessionsResult: SessionsListResult | null = null;
   @state() private sessionsAgentId: string | null = null;
   @state() private sessionsLoading = false;
-  @state() private settingsSearchQuery = "";
 
   private stopSessionsSubscription: (() => void) | undefined;
   private stopSessionCreatedSubscription: (() => void) | undefined;
@@ -1657,84 +1639,6 @@ export class AppSidebar extends LitElement {
     `;
   }
 
-  private settingsSearchResults(): SettingsSearchResult[] {
-    const query = this.settingsSearchQuery.trim().toLowerCase();
-    if (!query) {
-      return [];
-    }
-    const routeResults = SETTINGS_NAVIGATION_GROUPS.flatMap((group) => group.routes)
-      .filter((routeId) => this.isRouteEnabled(routeId))
-      .filter((routeId, index, routes) => routes.indexOf(routeId) === index)
-      .filter((routeId) => {
-        const haystack = `${titleForRoute(routeId)} ${subtitleForRoute(routeId)} ${routeId}`
-          .toLowerCase()
-          .replace(/[-_]/g, " ");
-        return haystack.includes(query);
-      })
-      .map((routeId) => ({ kind: "route" as const, routeId }));
-    const itemResults = SETTINGS_SEARCH_ITEMS.filter((item) =>
-      this.isRouteEnabled(item.routeId),
-    ).filter((item) => {
-      const haystack =
-        `${t(item.titleKey)} ${titleForRoute(item.routeId)} ${item.routeId} ${item.keywords.join(" ")}`
-          .toLowerCase()
-          .replace(/[-_]/g, " ");
-      return haystack.includes(query);
-    });
-    return [...routeResults, ...itemResults];
-  }
-
-  private renderSettingsSearchItem(result: Extract<SettingsSearchResult, { kind: "item" }>) {
-    const href = pathForRoute(result.routeId as RouteId, this.basePath);
-    return html`
-      <a
-        href=${href}
-        class="settings-sidebar-link settings-sidebar-link--search-item"
-        @focus=${(event: Event) => this.preloadRoute(result.routeId, event)}
-        @blur=${this.cancelPreload}
-        @pointerenter=${(event: Event) => this.preloadRoute(result.routeId, event)}
-        @pointerleave=${this.cancelPreload}
-        @touchstart=${(event: TouchEvent) => this.preloadRoute(result.routeId, event, true)}
-        @click=${(event: MouseEvent) => {
-          if (!shouldHandleNavigationClick(event)) {
-            return;
-          }
-          event.preventDefault();
-          this.onNavigate?.(result.routeId);
-        }}
-      >
-        <span class="settings-sidebar-link__icon" aria-hidden="true"
-          >${icons[navigationIconForRoute(result.routeId)]}</span
-        >
-        <span class="settings-sidebar-link__text-stack">
-          <span class="settings-sidebar-link__text">${t(result.titleKey)}</span>
-          <span class="settings-sidebar-link__meta">${titleForRoute(result.routeId)}</span>
-        </span>
-      </a>
-    `;
-  }
-
-  private renderSettingsSearchResults() {
-    const query = this.settingsSearchQuery.trim();
-    if (!query) {
-      return nothing;
-    }
-    const results = this.settingsSearchResults();
-    return html`
-      <section class="settings-sidebar-section" aria-label=${t("nav.settingsSearchResults")}>
-        <div class="settings-sidebar-section__items">
-          ${results.length
-            ? results.map((result) =>
-                result.kind === "route"
-                  ? this.renderSettingsRoute(result.routeId)
-                  : this.renderSettingsSearchItem(result),
-              )
-            : html`<div class="settings-sidebar-empty">${t("nav.noSettingsResults")}</div>`}
-        </div>
-      </section>
-    `;
-  }
-
   private renderSettingsSidebar() {
     return html`
       <aside class="sidebar sidebar--settings">
@@ -1760,43 +1664,22 @@ export class AppSidebar extends LitElement {
               >
               <span>${t("nav.backToOpenClaw")}</span>
             </a>
-            <div class="settings-sidebar-title">
-              <span class="settings-sidebar-title__icon" aria-hidden="true">${icons.settings}</span>
-              <span>${titleForRoute("config")}</span>
-            </div>
-          </div>
-          <div class="settings-sidebar-search">
-            <span class="settings-sidebar-search__icon" aria-hidden="true">${icons.search}</span>
-            <input
-              class="settings-sidebar-search__input"
-              type="search"
-              spellcheck="false"
-              placeholder=${t("nav.searchSettings")}
-              aria-label=${t("nav.searchSettings")}
-              .value=${this.settingsSearchQuery}
-              @keydown=${(event: KeyboardEvent) => event.stopPropagation()}
-              @input=${(event: Event) => {
-                this.settingsSearchQuery = (event.target as HTMLInputElement).value;
-              }}
-            />
           </div>
           <nav class="settings-sidebar-nav" aria-label=${t("common.settingsSections")}>
-            ${this.settingsSearchQuery.trim()
-              ? this.renderSettingsSearchResults()
-              : SETTINGS_NAVIGATION_GROUPS.map((group) => {
-                  const routes = group.routes.filter((routeId) => this.isRouteEnabled(routeId));
-                  if (!routes.length) {
-                    return nothing;
-                  }
-                  return html`
-                    <section class="settings-sidebar-section">
-                      <div class="settings-sidebar-section__label">${t(group.titleKey)}</div>
-                      <div class="settings-sidebar-section__items">
-                        ${routes.map((routeId) => this.renderSettingsRoute(routeId))}
-                      </div>
-                    </section>
-                  `;
-                })}
+            ${SETTINGS_NAVIGATION_GROUPS.map((group) => {
+              const routes = group.routes.filter((routeId) => this.isRouteEnabled(routeId));
+              if (!routes.length) {
+                return nothing;
+              }
+              return html`
+                <section class="settings-sidebar-section">
+                  <div class="settings-sidebar-section__label">${t(group.titleKey)}</div>
+                  <div class="settings-sidebar-section__items">
+                    ${routes.map((routeId) => this.renderSettingsRoute(routeId))}
+                  </div>
+                </section>
+              `;
+            })}
           </nav>
         </div>
       </aside>

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -12,8 +12,10 @@ import {
   scheduleRoutePreload,
   type NavigationRouteId,
   SIDEBAR_NAV_ROUTES,
+  SETTINGS_NAVIGATION_GROUPS,
   type SidebarNavRoute,
   sidebarMoreRoutes,
+  subtitleForRoute,
   titleForRoute,
 } from "../app-navigation.ts";
 import { pathForRoute, type RouteId } from "../app-route-paths.ts";
@@ -91,6 +93,14 @@ type SidebarSessionGroupMenuState = {
 };
 
 type SidebarSessionSortMode = "created" | "updated";
+type SettingsSearchResult =
+  | { kind: "route"; routeId: NavigationRouteId }
+  | {
+      kind: "item";
+      routeId: NavigationRouteId;
+      titleKey: "nav.contextProfile";
+      keywords: readonly string[];
+    };
 
 const SIDEBAR_SESSION_GROUPING_STORAGE_KEY = "openclaw:sidebar:sessions:grouping";
 
@@ -98,6 +108,15 @@ const SIDEBAR_SESSION_GROUPING_STORAGE_KEY = "openclaw:sidebar:sessions:grouping
 const PALETTE_SHORTCUT = /Mac|iP(hone|ad|od)/i.test(globalThis.navigator?.platform ?? "")
   ? "⌘K"
   : "Ctrl K";
+
+const SETTINGS_SEARCH_ITEMS = [
+  {
+    kind: "item",
+    routeId: "config",
+    titleKey: "nav.contextProfile",
+    keywords: ["context", "profile", "workspace context", "bootstrap", "reinjection", "profiles"],
+  },
+] as const satisfies readonly SettingsSearchResult[];
 
 function loadStoredSidebarSessionsGrouping(): SidebarSessionsGrouping {
   return normalizeSidebarSessionsGrouping(
@@ -141,10 +160,12 @@ export class AppSidebar extends LitElement {
     DEFAULT_SIDEBAR_PINNED_ROUTES;
   @property({ attribute: false }) sidebarMoreExpanded = false;
   @property({ attribute: false }) themeMode: ThemeMode = "system";
+  @property({ attribute: false }) settingsBackHref = "";
   @property({ attribute: false }) onOpenPalette?: () => void;
   @property({ attribute: false }) onToggleMore?: () => void;
   @property({ attribute: false }) onUpdatePinnedRoutes?: (routes: SidebarNavRoute[]) => void;
   @property({ attribute: false }) onPairMobile?: () => void;
+  @property({ attribute: false }) onSettingsBack?: () => void;
   @property({ attribute: false })
   onNavigate?: (routeId: NavigationRouteId, options?: ApplicationNavigationOptions) => void;
   @property({ attribute: false }) onPreloadRoute?: (routeId: NavigationRouteId) => Promise<void>;
@@ -162,6 +183,7 @@ export class AppSidebar extends LitElement {
   @state() private sessionsResult: SessionsListResult | null = null;
   @state() private sessionsAgentId: string | null = null;
   @state() private sessionsLoading = false;
+  @state() private settingsSearchQuery = "";
 
   private stopSessionsSubscription: (() => void) | undefined;
   private stopSessionCreatedSubscription: (() => void) | undefined;
@@ -1605,12 +1627,191 @@ export class AppSidebar extends LitElement {
     `;
   }
 
+  private renderSettingsRoute(routeId: NavigationRouteId) {
+    const active = this.activeRouteId === routeId;
+    const href = pathForRoute(routeId as RouteId, this.basePath);
+    const title = titleForRoute(routeId);
+    return html`
+      <a
+        href=${href}
+        class="settings-sidebar-link ${active ? "settings-sidebar-link--active" : ""}"
+        aria-current=${active ? "page" : nothing}
+        @focus=${(event: Event) => this.preloadRoute(routeId, event)}
+        @blur=${this.cancelPreload}
+        @pointerenter=${(event: Event) => this.preloadRoute(routeId, event)}
+        @pointerleave=${this.cancelPreload}
+        @touchstart=${(event: TouchEvent) => this.preloadRoute(routeId, event, true)}
+        @click=${(event: MouseEvent) => {
+          if (!shouldHandleNavigationClick(event)) {
+            return;
+          }
+          event.preventDefault();
+          this.onNavigate?.(routeId);
+        }}
+      >
+        <span class="settings-sidebar-link__icon" aria-hidden="true"
+          >${icons[navigationIconForRoute(routeId)]}</span
+        >
+        <span class="settings-sidebar-link__text">${title}</span>
+      </a>
+    `;
+  }
+
+  private settingsSearchResults(): SettingsSearchResult[] {
+    const query = this.settingsSearchQuery.trim().toLowerCase();
+    if (!query) {
+      return [];
+    }
+    const routeResults = SETTINGS_NAVIGATION_GROUPS.flatMap((group) => group.routes)
+      .filter((routeId) => this.isRouteEnabled(routeId))
+      .filter((routeId, index, routes) => routes.indexOf(routeId) === index)
+      .filter((routeId) => {
+        const haystack = `${titleForRoute(routeId)} ${subtitleForRoute(routeId)} ${routeId}`
+          .toLowerCase()
+          .replace(/[-_]/g, " ");
+        return haystack.includes(query);
+      })
+      .map((routeId) => ({ kind: "route" as const, routeId }));
+    const itemResults = SETTINGS_SEARCH_ITEMS.filter((item) =>
+      this.isRouteEnabled(item.routeId),
+    ).filter((item) => {
+      const haystack =
+        `${t(item.titleKey)} ${titleForRoute(item.routeId)} ${item.routeId} ${item.keywords.join(" ")}`
+          .toLowerCase()
+          .replace(/[-_]/g, " ");
+      return haystack.includes(query);
+    });
+    return [...routeResults, ...itemResults];
+  }
+
+  private renderSettingsSearchItem(result: Extract<SettingsSearchResult, { kind: "item" }>) {
+    const href = pathForRoute(result.routeId as RouteId, this.basePath);
+    return html`
+      <a
+        href=${href}
+        class="settings-sidebar-link settings-sidebar-link--search-item"
+        @focus=${(event: Event) => this.preloadRoute(result.routeId, event)}
+        @blur=${this.cancelPreload}
+        @pointerenter=${(event: Event) => this.preloadRoute(result.routeId, event)}
+        @pointerleave=${this.cancelPreload}
+        @touchstart=${(event: TouchEvent) => this.preloadRoute(result.routeId, event, true)}
+        @click=${(event: MouseEvent) => {
+          if (!shouldHandleNavigationClick(event)) {
+            return;
+          }
+          event.preventDefault();
+          this.onNavigate?.(result.routeId);
+        }}
+      >
+        <span class="settings-sidebar-link__icon" aria-hidden="true"
+          >${icons[navigationIconForRoute(result.routeId)]}</span
+        >
+        <span class="settings-sidebar-link__text-stack">
+          <span class="settings-sidebar-link__text">${t(result.titleKey)}</span>
+          <span class="settings-sidebar-link__meta">${titleForRoute(result.routeId)}</span>
+        </span>
+      </a>
+    `;
+  }
+
+  private renderSettingsSearchResults() {
+    const query = this.settingsSearchQuery.trim();
+    if (!query) {
+      return nothing;
+    }
+    const results = this.settingsSearchResults();
+    return html`
+      <section class="settings-sidebar-section" aria-label=${t("nav.settingsSearchResults")}>
+        <div class="settings-sidebar-section__items">
+          ${results.length
+            ? results.map((result) =>
+                result.kind === "route"
+                  ? this.renderSettingsRoute(result.routeId)
+                  : this.renderSettingsSearchItem(result),
+              )
+            : html`<div class="settings-sidebar-empty">${t("nav.noSettingsResults")}</div>`}
+        </div>
+      </section>
+    `;
+  }
+
+  private renderSettingsSidebar() {
+    return html`
+      <aside class="sidebar sidebar--settings">
+        <div class="sidebar-shell sidebar-shell--settings">
+          <div class="settings-sidebar-header">
+            <a
+              href=${this.settingsBackHref || pathForRoute("chat", this.basePath)}
+              class="settings-sidebar-back"
+              @click=${(event: MouseEvent) => {
+                if (!shouldHandleNavigationClick(event)) {
+                  return;
+                }
+                event.preventDefault();
+                if (this.onSettingsBack) {
+                  this.onSettingsBack();
+                  return;
+                }
+                this.onNavigate?.("chat");
+              }}
+            >
+              <span class="settings-sidebar-back__icon" aria-hidden="true"
+                >${icons.chevronRight}</span
+              >
+              <span>${t("nav.backToOpenClaw")}</span>
+            </a>
+            <div class="settings-sidebar-title">
+              <span class="settings-sidebar-title__icon" aria-hidden="true">${icons.settings}</span>
+              <span>${titleForRoute("config")}</span>
+            </div>
+          </div>
+          <div class="settings-sidebar-search">
+            <span class="settings-sidebar-search__icon" aria-hidden="true">${icons.search}</span>
+            <input
+              class="settings-sidebar-search__input"
+              type="search"
+              spellcheck="false"
+              placeholder=${t("nav.searchSettings")}
+              aria-label=${t("nav.searchSettings")}
+              .value=${this.settingsSearchQuery}
+              @keydown=${(event: KeyboardEvent) => event.stopPropagation()}
+              @input=${(event: Event) => {
+                this.settingsSearchQuery = (event.target as HTMLInputElement).value;
+              }}
+            />
+          </div>
+          <nav class="settings-sidebar-nav" aria-label=${t("common.settingsSections")}>
+            ${this.settingsSearchQuery.trim()
+              ? this.renderSettingsSearchResults()
+              : SETTINGS_NAVIGATION_GROUPS.map((group) => {
+                  const routes = group.routes.filter((routeId) => this.isRouteEnabled(routeId));
+                  if (!routes.length) {
+                    return nothing;
+                  }
+                  return html`
+                    <section class="settings-sidebar-section">
+                      <div class="settings-sidebar-section__label">${t(group.titleKey)}</div>
+                      <div class="settings-sidebar-section__items">
+                        ${routes.map((routeId) => this.renderSettingsRoute(routeId))}
+                      </div>
+                    </section>
+                  `;
+                })}
+          </nav>
+        </div>
+      </aside>
+    `;
+  }
+
   override render() {
     const gatewayStatus = t("chat.gatewayStatus", {
       status: this.connected ? t("common.online") : t("common.offline"),
     });
     const settingsActive =
       this.activeRouteId !== undefined && isSettingsNavigationRoute(this.activeRouteId);
+    if (settingsActive) {
+      return this.renderSettingsSidebar();
+    }
     return html`
       <aside class="sidebar ${this.collapsed ? "sidebar--collapsed" : ""}">
         <!-- macOS app only (CSS-gated on html.openclaw-native-macos): use the

--- a/ui/src/components/settings-workspace.ts
+++ b/ui/src/components/settings-workspace.ts
@@ -1,20 +1,43 @@
 import { html } from "lit";
+import { isSettingsNavigationRoute } from "../app-navigation.ts";
 import type { RouteId } from "../app-route-paths.ts";
 
 export function renderSettingsWorkspace(
   _basePath: string,
   body: unknown,
-  _routeId: RouteId,
+  routeId: RouteId,
   _navigate: (routeId: RouteId) => void,
   _preload?: (routeId: RouteId) => Promise<void> | void,
   options: { fillHeight?: boolean } = {},
 ) {
-  const className = options.fillHeight
-    ? "settings-workspace settings-workspace--fill-height"
-    : "settings-workspace";
+  const classes = ["settings-workspace"];
+  if (isSettingsNavigationRoute(routeId)) {
+    classes.push("settings-workspace--settings");
+  }
+  if (options.fillHeight) {
+    classes.push("settings-workspace--fill-height");
+  }
   return html`
-    <section class=${className}>
+    <section class=${classes.join(" ")}>
       <div class="settings-workspace__body">${body}</div>
     </section>
+  `;
+}
+
+export function renderSettingsPage(
+  basePath: string,
+  header: unknown,
+  body: unknown,
+  routeId: RouteId,
+  navigate: (routeId: RouteId) => void,
+  preload?: (routeId: RouteId) => Promise<void> | void,
+  options: { afterHeader?: unknown; fillHeight?: boolean } = {},
+) {
+  return html`
+    <section class="content-header content-header--settings">${header}</section>
+    ${options.afterHeader}
+    ${renderSettingsWorkspace(basePath, body, routeId, navigate, preload, {
+      fillHeight: options.fillHeight,
+    })}
   `;
 }

--- a/ui/src/components/settings-workspace.ts
+++ b/ui/src/components/settings-workspace.ts
@@ -1,77 +1,12 @@
-import { html, nothing } from "lit";
-import {
-  cancelRoutePreload,
-  isSettingsNavigationRoute,
-  navigationIconForRoute,
-  SETTINGS_NAVIGATION_ROUTES,
-  scheduleRoutePreload,
-  titleForRoute,
-} from "../app-navigation.ts";
-import { isRouteId, pathForRoute, type RouteId } from "../app-route-paths.ts";
-import { icons } from "../components/icons.ts";
-import { t } from "../i18n/index.ts";
-
-const preloadTimers = new Map<EventTarget, ReturnType<typeof globalThis.setTimeout>>();
-
-function renderSettingsSectionNav(
-  basePath: string,
-  currentRouteId: RouteId,
-  navigate: (routeId: RouteId) => void,
-  preload?: (routeId: RouteId) => Promise<void> | void,
-) {
-  if (!isSettingsNavigationRoute(currentRouteId)) {
-    return nothing;
-  }
-  const routes = SETTINGS_NAVIGATION_ROUTES.filter(isRouteId);
-  return html`
-    <nav class="settings-section-nav" aria-label=${t("common.settingsSections")}>
-      ${routes.map((routeId) => {
-        const active = currentRouteId === routeId;
-        const href = pathForRoute(routeId, basePath);
-        return html`
-          <a
-            href=${href}
-            class="settings-section-nav__item ${active ? "settings-section-nav__item--active" : ""}"
-            @focus=${(event: Event) =>
-              scheduleRoutePreload(preloadTimers, routeId, event, preload, active)}
-            @blur=${(event: Event) => cancelRoutePreload(preloadTimers, event)}
-            @pointerenter=${(event: Event) =>
-              scheduleRoutePreload(preloadTimers, routeId, event, preload, active)}
-            @pointerleave=${(event: Event) => cancelRoutePreload(preloadTimers, event)}
-            @touchstart=${(event: TouchEvent) =>
-              scheduleRoutePreload(preloadTimers, routeId, event, preload, active, true)}
-            @click=${(event: MouseEvent) => {
-              if (
-                event.defaultPrevented ||
-                event.button !== 0 ||
-                event.metaKey ||
-                event.ctrlKey ||
-                event.shiftKey ||
-                event.altKey
-              ) {
-                return;
-              }
-              event.preventDefault();
-              navigate(routeId);
-            }}
-          >
-            <span class="settings-section-nav__icon" aria-hidden="true"
-              >${icons[navigationIconForRoute(routeId)]}</span
-            >
-            <span class="settings-section-nav__label">${titleForRoute(routeId)}</span>
-          </a>
-        `;
-      })}
-    </nav>
-  `;
-}
+import { html } from "lit";
+import type { RouteId } from "../app-route-paths.ts";
 
 export function renderSettingsWorkspace(
-  basePath: string,
+  _basePath: string,
   body: unknown,
-  routeId: RouteId,
-  navigate: (routeId: RouteId) => void,
-  preload?: (routeId: RouteId) => Promise<void> | void,
+  _routeId: RouteId,
+  _navigate: (routeId: RouteId) => void,
+  _preload?: (routeId: RouteId) => Promise<void> | void,
   options: { fillHeight?: boolean } = {},
 ) {
   const className = options.fillHeight
@@ -79,7 +14,6 @@ export function renderSettingsWorkspace(
     : "settings-workspace";
   return html`
     <section class=${className}>
-      ${renderSettingsSectionNav(basePath, routeId, navigate, preload)}
       <div class="settings-workspace__body">${body}</div>
     </section>
   `;

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -76,8 +76,6 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await settingsLink.click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/config");
       await expect.poll(() => settingsLink.getAttribute("aria-current")).toBe("page");
-      await sidebar.getByRole("searchbox", { name: "Search settings" }).fill("context");
-      await expect.poll(() => sidebar.getByText("Context Profile").isVisible()).toBe(true);
       await sidebar.getByRole("link", { name: "Back to OpenClaw" }).click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/overview");
       await captureUiProof(page, "01-default-pinned.png");

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -76,7 +76,9 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
       await settingsLink.click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/config");
       await expect.poll(() => settingsLink.getAttribute("aria-current")).toBe("page");
-      await sidebar.getByRole("link", { name: "Overview" }).click();
+      await sidebar.getByRole("searchbox", { name: "Search settings" }).fill("context");
+      await expect.poll(() => sidebar.getByText("Context Profile").isVisible()).toBe(true);
+      await sidebar.getByRole("link", { name: "Back to OpenClaw" }).click();
       await expect.poll(() => new URL(page.url()).pathname).toBe("/overview");
       await captureUiProof(page, "01-default-pinned.png");
 
@@ -161,6 +163,23 @@ describeControlUiE2e("Control UI sidebar customization mocked Gateway E2E", () =
         .toBe(true);
       await captureUiProof(page, "04-persisted-collapsed.png");
 
+      await page.goto(`${server.baseUrl}config`);
+      await expect
+        .poll(() => page.locator(".shell").getAttribute("class"))
+        .not.toContain("shell--nav-collapsed");
+      await expect
+        .poll(() =>
+          sidebar.evaluate(
+            (element) => (element as HTMLElement & { collapsed: boolean }).collapsed,
+          ),
+        )
+        .toBe(false);
+      await expect
+        .poll(() => sidebar.getByRole("link", { name: "Worktrees" }).isVisible())
+        .toBe(true);
+      await captureUiProof(page, "04b-settings-ignores-persisted-collapsed.png");
+
+      await page.goto(`${server.baseUrl}chat`);
       await page.setViewportSize({ height: 900, width: 900 });
       const drawerButton = page.locator(".topbar-nav-toggle");
       await expect.poll(() => drawerButton.isVisible()).toBe(true);

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:32.656Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:57.256Z",
   "locale": "ar",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:57.256Z",
+  "generatedAt": "2026-07-07T13:19:23.960Z",
   "locale": "ar",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:23.960Z",
   "locale": "ar",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:24.981Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:56.539Z",
   "locale": "de",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:23.247Z",
   "locale": "de",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:56.539Z",
+  "generatedAt": "2026-07-07T13:19:23.247Z",
   "locale": "de",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:23.361Z",
   "locale": "es",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:26.317Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:56.651Z",
   "locale": "es",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:56.651Z",
+  "generatedAt": "2026-07-07T13:19:23.361Z",
   "locale": "es",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:25.053Z",
   "locale": "fa",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:58.306Z",
+  "generatedAt": "2026-07-07T13:19:25.053Z",
   "locale": "fa",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:43.221Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:58.306Z",
   "locale": "fa",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:30.068Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:57.003Z",
   "locale": "fr",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:57.003Z",
+  "generatedAt": "2026-07-07T13:19:23.715Z",
   "locale": "fr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:23.715Z",
   "locale": "fr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:23.828Z",
   "locale": "hi",
   "model": "gpt-5.5",
   "provider": "openai",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:57.128Z",
+  "generatedAt": "2026-07-07T13:19:23.828Z",
   "locale": "hi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/hi.meta.json
+++ b/ui/src/i18n/.i18n/hi.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:31.678Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:57.128Z",
   "locale": "hi",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:24.422Z",
   "locale": "id",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:57.728Z",
+  "generatedAt": "2026-07-07T13:19:24.422Z",
   "locale": "id",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:37.327Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:57.728Z",
   "locale": "id",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:33.970Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:57.370Z",
   "locale": "it",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:24.075Z",
   "locale": "it",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:57.370Z",
+  "generatedAt": "2026-07-07T13:19:24.075Z",
   "locale": "it",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:56.770Z",
+  "generatedAt": "2026-07-07T13:19:23.481Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:23.481Z",
   "locale": "ja-JP",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:27.648Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:56.770Z",
   "locale": "ja-JP",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:56.885Z",
+  "generatedAt": "2026-07-07T13:19:23.604Z",
   "locale": "ko",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:23.604Z",
   "locale": "ko",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:29.117Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:56.885Z",
   "locale": "ko",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:24.935Z",
   "locale": "nl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:58.193Z",
+  "generatedAt": "2026-07-07T13:19:24.935Z",
   "locale": "nl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:41.995Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:58.193Z",
   "locale": "nl",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:24.547Z",
   "locale": "pl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:57.838Z",
+  "generatedAt": "2026-07-07T13:19:24.547Z",
   "locale": "pl",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:38.593Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:57.838Z",
   "locale": "pl",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:23.799Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:56.425Z",
   "locale": "pt-BR",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:23.134Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:56.425Z",
+  "generatedAt": "2026-07-07T13:19:23.134Z",
   "locale": "pt-BR",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -3926,6 +3926,13 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/pages/nodes/view-exec-approvals.ts",
+      "text": "Default action"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-exec-approvals.ts",
       "text": "Defaults"
     },
     {
@@ -3982,6 +3989,13 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/pages/nodes/view-exec-approvals.ts",
+      "text": "Host-native policy"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-exec-approvals.ts",
       "text": "Load exec approvals to edit allowlists."
     },
     {
@@ -3990,6 +4004,13 @@
       "name": "text",
       "path": "ui/src/pages/nodes/view-exec-approvals.ts",
       "text": "Mode"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-exec-approvals.ts",
+      "text": "Native"
     },
     {
       "count": 1,
@@ -4018,6 +4039,13 @@
       "name": "text",
       "path": "ui/src/pages/nodes/view-exec-approvals.ts",
       "text": "Pattern"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/pages/nodes/view-exec-approvals.ts",
+      "text": "Read-only here. Edit from the companion app or CLI."
     },
     {
       "count": 1,

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:58.431Z",
+  "generatedAt": "2026-07-07T13:19:25.181Z",
   "locale": "ru",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:25.181Z",
   "locale": "ru",
   "model": "gpt-5.5",
   "provider": "openai",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ru.meta.json
+++ b/ui/src/i18n/.i18n/ru.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:46.145Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:58.431Z",
   "locale": "ru",
   "model": "gpt-5.5",
   "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:39.502Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:57.954Z",
   "locale": "th",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:24.679Z",
   "locale": "th",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:57.954Z",
+  "generatedAt": "2026-07-07T13:19:24.679Z",
   "locale": "th",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:57.481Z",
+  "generatedAt": "2026-07-07T13:19:24.191Z",
   "locale": "tr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:24.191Z",
   "locale": "tr",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:34.970Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:57.481Z",
   "locale": "tr",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:24.310Z",
   "locale": "uk",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:35.919Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:57.605Z",
   "locale": "uk",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:57.605Z",
+  "generatedAt": "2026-07-07T13:19:24.310Z",
   "locale": "uk",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:40.747Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:58.070Z",
   "locale": "vi",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:58.070Z",
+  "generatedAt": "2026-07-07T13:19:24.806Z",
   "locale": "vi",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:24.806Z",
   "locale": "vi",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:22.819Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:56.185Z",
+  "generatedAt": "2026-07-07T13:19:22.819Z",
   "locale": "zh-CN",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:21.379Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:56.185Z",
   "locale": "zh-CN",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,13 +1,11 @@
 {
-  "fallbackKeys": [
-    "nav.backToOpenClaw"
-  ],
+  "fallbackKeys": [],
   "generatedAt": "2026-07-07T13:19:22.962Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
   "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
   "totalKeys": 1670,
-  "translatedKeys": 1669,
+  "translatedKeys": 1670,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,17 @@
 {
-  "fallbackKeys": [],
-  "generatedAt": "2026-07-07T08:47:22.571Z",
+  "fallbackKeys": [
+    "nav.backToOpenClaw",
+    "nav.contextProfile",
+    "nav.noSettingsResults",
+    "nav.searchSettings",
+    "nav.settingsSearchResults"
+  ],
+  "generatedAt": "2026-07-07T12:29:56.315Z",
   "locale": "zh-TW",
-  "model": "gpt-5.5",
-  "provider": "openai",
-  "sourceHash": "d012bf7dea64cb5e4858358eb65d806374d86512260f7e16949b761b8bc0627b",
-  "totalKeys": 1669,
+  "model": "claude-opus-4-8",
+  "provider": "anthropic",
+  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
+  "totalKeys": 1674,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,17 +1,13 @@
 {
   "fallbackKeys": [
-    "nav.backToOpenClaw",
-    "nav.contextProfile",
-    "nav.noSettingsResults",
-    "nav.searchSettings",
-    "nav.settingsSearchResults"
+    "nav.backToOpenClaw"
   ],
-  "generatedAt": "2026-07-07T12:29:56.315Z",
+  "generatedAt": "2026-07-07T13:19:22.962Z",
   "locale": "zh-TW",
   "model": "claude-opus-4-8",
   "provider": "anthropic",
-  "sourceHash": "543e3cab838ec82e0ef5cef98324a36334b6768393534e965bc941f5a95daf5e",
-  "totalKeys": 1674,
+  "sourceHash": "1865cabe5f5dc9df41b08fe5a60cae60edc68a89566cb50e805eec5a9d264e3e",
+  "totalKeys": 1670,
   "translatedKeys": 1669,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -475,7 +475,7 @@ export const ar: TranslationMap = {
     more: "المزيد",
     customize: "تخصيص الشريط الجانبي",
     customizeReset: "إعادة التعيين إلى الإعدادات الافتراضية",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "العودة إلى OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -476,10 +476,6 @@ export const ar: TranslationMap = {
     customize: "تخصيص الشريط الجانبي",
     customizeReset: "إعادة التعيين إلى الإعدادات الافتراضية",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -475,6 +475,11 @@ export const ar: TranslationMap = {
     more: "المزيد",
     customize: "تخصيص الشريط الجانبي",
     customizeReset: "إعادة التعيين إلى الإعدادات الافتراضية",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -481,10 +481,6 @@ export const de: TranslationMap = {
     customize: "Seitenleiste anpassen",
     customizeReset: "Auf Standardwerte zurücksetzen",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -480,7 +480,7 @@ export const de: TranslationMap = {
     more: "Mehr",
     customize: "Seitenleiste anpassen",
     customizeReset: "Auf Standardwerte zurücksetzen",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Zurück zu OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -480,6 +480,11 @@ export const de: TranslationMap = {
     more: "Mehr",
     customize: "Seitenleiste anpassen",
     customizeReset: "Auf Standardwerte zurücksetzen",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -474,6 +474,11 @@ export const en: TranslationMap = {
     more: "More",
     customize: "Customize sidebar",
     customizeReset: "Reset to defaults",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -475,10 +475,6 @@ export const en: TranslationMap = {
     customize: "Customize sidebar",
     customizeReset: "Reset to defaults",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -477,6 +477,11 @@ export const es: TranslationMap = {
     more: "Más",
     customize: "Personalizar barra lateral",
     customizeReset: "Restablecer valores predeterminados",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -477,7 +477,7 @@ export const es: TranslationMap = {
     more: "Más",
     customize: "Personalizar barra lateral",
     customizeReset: "Restablecer valores predeterminados",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Volver a OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -478,10 +478,6 @@ export const es: TranslationMap = {
     customize: "Personalizar barra lateral",
     customizeReset: "Restablecer valores predeterminados",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -477,7 +477,7 @@ export const fa: TranslationMap = {
     more: "بیشتر",
     customize: "سفارشی‌سازی نوار کناری",
     customizeReset: "بازنشانی به پیش‌فرض‌ها",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "بازگشت به OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -477,6 +477,11 @@ export const fa: TranslationMap = {
     more: "بیشتر",
     customize: "سفارشی‌سازی نوار کناری",
     customizeReset: "بازنشانی به پیش‌فرض‌ها",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -478,10 +478,6 @@ export const fa: TranslationMap = {
     customize: "سفارشی‌سازی نوار کناری",
     customizeReset: "بازنشانی به پیش‌فرض‌ها",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -482,10 +482,6 @@ export const fr: TranslationMap = {
     customize: "Personnaliser la barre latérale",
     customizeReset: "Réinitialiser les paramètres par défaut",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -481,6 +481,11 @@ export const fr: TranslationMap = {
     more: "Plus",
     customize: "Personnaliser la barre latérale",
     customizeReset: "Réinitialiser les paramètres par défaut",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -481,7 +481,7 @@ export const fr: TranslationMap = {
     more: "Plus",
     customize: "Personnaliser la barre latérale",
     customizeReset: "Réinitialiser les paramètres par défaut",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Retour à OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -477,10 +477,6 @@ export const hi: TranslationMap = {
     customize: "साइडबार कस्टमाइज़ करें",
     customizeReset: "डिफ़ॉल्ट पर रीसेट करें",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "टर्मिनल",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -476,6 +476,11 @@ export const hi: TranslationMap = {
     more: "अधिक",
     customize: "साइडबार कस्टमाइज़ करें",
     customizeReset: "डिफ़ॉल्ट पर रीसेट करें",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "टर्मिनल",

--- a/ui/src/i18n/locales/hi.ts
+++ b/ui/src/i18n/locales/hi.ts
@@ -476,7 +476,7 @@ export const hi: TranslationMap = {
     more: "अधिक",
     customize: "साइडबार कस्टमाइज़ करें",
     customizeReset: "डिफ़ॉल्ट पर रीसेट करें",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "OpenClaw पर वापस जाएँ",
   },
   terminal: {
     title: "टर्मिनल",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -477,7 +477,7 @@ export const id: TranslationMap = {
     more: "Lainnya",
     customize: "Sesuaikan bilah samping",
     customizeReset: "Atur ulang ke default",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Kembali ke OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -478,10 +478,6 @@ export const id: TranslationMap = {
     customize: "Sesuaikan bilah samping",
     customizeReset: "Atur ulang ke default",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -477,6 +477,11 @@ export const id: TranslationMap = {
     more: "Lainnya",
     customize: "Sesuaikan bilah samping",
     customizeReset: "Atur ulang ke default",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -481,6 +481,11 @@ export const it: TranslationMap = {
     more: "Altro",
     customize: "Personalizza barra laterale",
     customizeReset: "Ripristina impostazioni predefinite",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -481,7 +481,7 @@ export const it: TranslationMap = {
     more: "Altro",
     customize: "Personalizza barra laterale",
     customizeReset: "Ripristina impostazioni predefinite",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Torna a OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -482,10 +482,6 @@ export const it: TranslationMap = {
     customize: "Personalizza barra laterale",
     customizeReset: "Ripristina impostazioni predefinite",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -483,10 +483,6 @@ export const ja_JP: TranslationMap = {
     customize: "サイドバーをカスタマイズ",
     customizeReset: "デフォルトに戻す",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -482,6 +482,11 @@ export const ja_JP: TranslationMap = {
     more: "その他",
     customize: "サイドバーをカスタマイズ",
     customizeReset: "デフォルトに戻す",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -482,7 +482,7 @@ export const ja_JP: TranslationMap = {
     more: "その他",
     customize: "サイドバーをカスタマイズ",
     customizeReset: "デフォルトに戻す",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "OpenClawに戻る",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -475,7 +475,7 @@ export const ko: TranslationMap = {
     more: "더 보기",
     customize: "사이드바 사용자 지정",
     customizeReset: "기본값으로 재설정",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "OpenClaw로 돌아가기",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -476,10 +476,6 @@ export const ko: TranslationMap = {
     customize: "사이드바 사용자 지정",
     customizeReset: "기본값으로 재설정",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -475,6 +475,11 @@ export const ko: TranslationMap = {
     more: "더 보기",
     customize: "사이드바 사용자 지정",
     customizeReset: "기본값으로 재설정",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -480,10 +480,6 @@ export const nl: TranslationMap = {
     customize: "Zijbalk aanpassen",
     customizeReset: "Standaardinstellingen herstellen",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -479,7 +479,7 @@ export const nl: TranslationMap = {
     more: "Meer",
     customize: "Zijbalk aanpassen",
     customizeReset: "Standaardinstellingen herstellen",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Terug naar OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -479,6 +479,11 @@ export const nl: TranslationMap = {
     more: "Meer",
     customize: "Zijbalk aanpassen",
     customizeReset: "Standaardinstellingen herstellen",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -478,10 +478,6 @@ export const pl: TranslationMap = {
     customize: "Dostosuj pasek boczny",
     customizeReset: "Przywróć ustawienia domyślne",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -477,7 +477,7 @@ export const pl: TranslationMap = {
     more: "Więcej",
     customize: "Dostosuj pasek boczny",
     customizeReset: "Przywróć ustawienia domyślne",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Wróć do OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -477,6 +477,11 @@ export const pl: TranslationMap = {
     more: "Więcej",
     customize: "Dostosuj pasek boczny",
     customizeReset: "Przywróć ustawienia domyślne",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -476,6 +476,11 @@ export const pt_BR: TranslationMap = {
     more: "Mais",
     customize: "Personalizar barra lateral",
     customizeReset: "Restaurar padrões",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -477,10 +477,6 @@ export const pt_BR: TranslationMap = {
     customize: "Personalizar barra lateral",
     customizeReset: "Restaurar padrões",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -476,7 +476,7 @@ export const pt_BR: TranslationMap = {
     more: "Mais",
     customize: "Personalizar barra lateral",
     customizeReset: "Restaurar padrões",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Voltar para o OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -481,10 +481,6 @@ export const ru: TranslationMap = {
     customize: "Настроить боковую панель",
     customizeReset: "Сбросить настройки",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Терминал",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -480,6 +480,11 @@ export const ru: TranslationMap = {
     more: "Ещё",
     customize: "Настроить боковую панель",
     customizeReset: "Сбросить настройки",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Терминал",

--- a/ui/src/i18n/locales/ru.ts
+++ b/ui/src/i18n/locales/ru.ts
@@ -480,7 +480,7 @@ export const ru: TranslationMap = {
     more: "Ещё",
     customize: "Настроить боковую панель",
     customizeReset: "Сбросить настройки",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Вернуться к OpenClaw",
   },
   terminal: {
     title: "Терминал",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -475,10 +475,6 @@ export const th: TranslationMap = {
     customize: "ปรับแต่งแถบด้านข้าง",
     customizeReset: "รีเซ็ตเป็นค่าเริ่มต้น",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -474,7 +474,7 @@ export const th: TranslationMap = {
     more: "เพิ่มเติม",
     customize: "ปรับแต่งแถบด้านข้าง",
     customizeReset: "รีเซ็ตเป็นค่าเริ่มต้น",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "กลับไปที่ OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -474,6 +474,11 @@ export const th: TranslationMap = {
     more: "เพิ่มเติม",
     customize: "ปรับแต่งแถบด้านข้าง",
     customizeReset: "รีเซ็ตเป็นค่าเริ่มต้น",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -479,6 +479,11 @@ export const tr: TranslationMap = {
     more: "Daha fazla",
     customize: "Kenar çubuğunu özelleştir",
     customizeReset: "Varsayılanlara sıfırla",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -479,7 +479,7 @@ export const tr: TranslationMap = {
     more: "Daha fazla",
     customize: "Kenar çubuğunu özelleştir",
     customizeReset: "Varsayılanlara sıfırla",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "OpenClaw'a dön",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -480,10 +480,6 @@ export const tr: TranslationMap = {
     customize: "Kenar çubuğunu özelleştir",
     customizeReset: "Varsayılanlara sıfırla",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -477,7 +477,7 @@ export const uk: TranslationMap = {
     more: "Більше",
     customize: "Налаштувати бічну панель",
     customizeReset: "Скинути до типових налаштувань",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Повернутися до OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -478,10 +478,6 @@ export const uk: TranslationMap = {
     customize: "Налаштувати бічну панель",
     customizeReset: "Скинути до типових налаштувань",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -477,6 +477,11 @@ export const uk: TranslationMap = {
     more: "Більше",
     customize: "Налаштувати бічну панель",
     customizeReset: "Скинути до типових налаштувань",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -476,7 +476,7 @@ export const vi: TranslationMap = {
     more: "Thêm",
     customize: "Tùy chỉnh thanh bên",
     customizeReset: "Đặt lại về mặc định",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "Quay lại OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -476,6 +476,11 @@ export const vi: TranslationMap = {
     more: "Thêm",
     customize: "Tùy chỉnh thanh bên",
     customizeReset: "Đặt lại về mặc định",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -477,10 +477,6 @@ export const vi: TranslationMap = {
     customize: "Tùy chỉnh thanh bên",
     customizeReset: "Đặt lại về mặc định",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -474,10 +474,6 @@ export const zh_CN: TranslationMap = {
     customize: "自定义侧边栏",
     customizeReset: "恢复默认设置",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -473,6 +473,11 @@ export const zh_CN: TranslationMap = {
     more: "更多",
     customize: "自定义侧边栏",
     customizeReset: "恢复默认设置",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -473,7 +473,7 @@ export const zh_CN: TranslationMap = {
     more: "更多",
     customize: "自定义侧边栏",
     customizeReset: "恢复默认设置",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "返回 OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -473,6 +473,11 @@ export const zh_TW: TranslationMap = {
     more: "更多",
     customize: "自訂側邊欄",
     customizeReset: "重設為預設值",
+    backToOpenClaw: "Back to OpenClaw",
+    searchSettings: "Search settings...",
+    settingsSearchResults: "Settings search results",
+    noSettingsResults: "No matching settings.",
+    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -473,7 +473,7 @@ export const zh_TW: TranslationMap = {
     more: "更多",
     customize: "自訂側邊欄",
     customizeReset: "重設為預設值",
-    backToOpenClaw: "Back to OpenClaw",
+    backToOpenClaw: "返回 OpenClaw",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -474,10 +474,6 @@ export const zh_TW: TranslationMap = {
     customize: "自訂側邊欄",
     customizeReset: "重設為預設值",
     backToOpenClaw: "Back to OpenClaw",
-    searchSettings: "Search settings...",
-    settingsSearchResults: "Settings search results",
-    noSettingsResults: "No matching settings.",
-    contextProfile: "Context Profile",
   },
   terminal: {
     title: "Terminal",

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -5,7 +5,7 @@ import type { NostrProfile } from "../../api/types.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { resolveControlUiAuthHeader } from "../../app/control-ui-auth.ts";
-import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { renderSettingsPage } from "../../components/settings-workspace.ts";
 import { createNostrProfileFormState } from "./view.nostr-profile-form.ts";
 import { renderChannels } from "./view.ts";
 
@@ -331,52 +331,50 @@ class ChannelsPage extends LitElement {
     const context = this.context;
     const channels = context.channels.state;
     const config = context.runtimeConfig.state;
-    return html`
-      <section class="content-header">
+    return renderSettingsPage(
+      context.basePath,
+      html`
         <div>
           <div class="page-title">${titleForRoute("channels")}</div>
           <div class="page-sub">${subtitleForRoute("channels")}</div>
         </div>
-      </section>
-      ${renderSettingsWorkspace(
-        context.basePath,
-        renderChannels({
-          connected: channels.connected,
-          loading: channels.channelsLoading,
-          snapshot: channels.channelsSnapshot,
-          lastError: channels.channelsError,
-          lastSuccessAt: channels.channelsLastSuccess,
-          whatsappMessage: channels.whatsappLoginMessage,
-          whatsappQrDataUrl: channels.whatsappLoginQrDataUrl,
-          whatsappConnected: channels.whatsappLoginConnected,
-          whatsappBusy: channels.whatsappBusy,
-          configSchema: config.configSchema,
-          configSchemaLoading: config.configSchemaLoading,
-          configForm: config.configForm,
-          configUiHints: config.configUiHints,
-          configSaving: config.configSaving,
-          configFormDirty: config.configFormDirty,
-          nostrProfileFormState: this.nostrProfileFormState,
-          nostrProfileAccountId: this.nostrProfileAccountId,
-          onRefresh: (probe) => void context.channels.refresh(probe),
-          onWhatsAppStart: (force) => void context.channels.startWhatsApp(force),
-          onWhatsAppWait: () => void context.channels.waitWhatsApp(),
-          onWhatsAppLogout: () => void context.channels.logoutWhatsApp(),
-          onConfigPatch: (path, value) => context.runtimeConfig.patchForm(path, value),
-          onConfigSave: () => void this.saveChannelConfig(),
-          onConfigReload: () => void this.reloadChannelConfig(),
-          onNostrProfileEdit: (accountId, profile) => this.editNostrProfile(accountId, profile),
-          onNostrProfileCancel: () => this.cancelNostrProfile(),
-          onNostrProfileFieldChange: (field, value) => this.changeNostrProfileField(field, value),
-          onNostrProfileSave: () => void this.saveNostrProfile(),
-          onNostrProfileImport: () => void this.importNostrProfile(),
-          onNostrProfileToggleAdvanced: () => this.toggleNostrProfileAdvanced(),
-        }),
-        "channels",
-        (routeId) => context.navigate(routeId),
-        (routeId) => context.preload(routeId),
-      )}
-    `;
+      `,
+      renderChannels({
+        connected: channels.connected,
+        loading: channels.channelsLoading,
+        snapshot: channels.channelsSnapshot,
+        lastError: channels.channelsError,
+        lastSuccessAt: channels.channelsLastSuccess,
+        whatsappMessage: channels.whatsappLoginMessage,
+        whatsappQrDataUrl: channels.whatsappLoginQrDataUrl,
+        whatsappConnected: channels.whatsappLoginConnected,
+        whatsappBusy: channels.whatsappBusy,
+        configSchema: config.configSchema,
+        configSchemaLoading: config.configSchemaLoading,
+        configForm: config.configForm,
+        configUiHints: config.configUiHints,
+        configSaving: config.configSaving,
+        configFormDirty: config.configFormDirty,
+        nostrProfileFormState: this.nostrProfileFormState,
+        nostrProfileAccountId: this.nostrProfileAccountId,
+        onRefresh: (probe) => void context.channels.refresh(probe),
+        onWhatsAppStart: (force) => void context.channels.startWhatsApp(force),
+        onWhatsAppWait: () => void context.channels.waitWhatsApp(),
+        onWhatsAppLogout: () => void context.channels.logoutWhatsApp(),
+        onConfigPatch: (path, value) => context.runtimeConfig.patchForm(path, value),
+        onConfigSave: () => void this.saveChannelConfig(),
+        onConfigReload: () => void this.reloadChannelConfig(),
+        onNostrProfileEdit: (accountId, profile) => this.editNostrProfile(accountId, profile),
+        onNostrProfileCancel: () => this.cancelNostrProfile(),
+        onNostrProfileFieldChange: (field, value) => this.changeNostrProfileField(field, value),
+        onNostrProfileSave: () => void this.saveNostrProfile(),
+        onNostrProfileImport: () => void this.importNostrProfile(),
+        onNostrProfileToggleAdvanced: () => this.toggleNostrProfileAdvanced(),
+      }),
+      "channels",
+      (routeId) => context.navigate(routeId),
+      (routeId) => context.preload(routeId),
+    );
   }
 }
 

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -60,7 +60,7 @@ export function renderChannels(props: ChannelsProps) {
   const partialWarnings = props.snapshot?.warnings?.filter((warning) => warning.trim()) ?? [];
 
   return html`
-    <section class="grid grid-cols-2">
+    <section class="grid channels-grid">
       ${orderedChannels.map((channel) =>
         renderChannel(channel.key, props, {
           whatsapp,

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -20,7 +20,7 @@ import {
 } from "../../app/settings.ts";
 import { startThemeTransition } from "../../app/theme-transition.ts";
 import { resolveTheme, type ThemeMode, type ThemeName } from "../../app/theme.ts";
-import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { renderSettingsPage } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
 import { renderMcp } from "./mcp.ts";
@@ -905,25 +905,26 @@ export class ConfigPage extends LitElement {
       this.pageId === "config" && this.settingsMode === "quick"
         ? this.renderQuickConfig(configObject)
         : this.renderAdvancedConfig(configObject);
-    return html`
-      <section class="content-header">
+    return renderSettingsPage(
+      this.context.basePath,
+      html`
         <div>
           <div class="page-title">${configPageTitle(this.pageId)}</div>
           <div class="page-sub">${configPageSubtitle(this.pageId)}</div>
         </div>
         ${this.renderSettingsModeToggle()}
-      </section>
-      ${this.pageId === "config"
-        ? html`<div class="config-view-toggle-row">${this.renderSettingsModeToggle()}</div>`
-        : nothing}
-      ${renderSettingsWorkspace(
-        this.context.basePath,
-        body,
-        this.pageId,
-        (routeId) => this.navigate(routeId),
-        (routeId) => this.context.preload(routeId),
-      )}
-    `;
+      `,
+      body,
+      this.pageId,
+      (routeId) => this.navigate(routeId),
+      (routeId) => this.context.preload(routeId),
+      {
+        afterHeader:
+          this.pageId === "config"
+            ? html`<div class="config-view-toggle-row">${this.renderSettingsModeToggle()}</div>`
+            : nothing,
+      },
+    );
   }
 }
 

--- a/ui/src/pages/debug/debug-page.ts
+++ b/ui/src/pages/debug/debug-page.ts
@@ -6,7 +6,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { HealthSnapshot, StatusSummary } from "../../api/types.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
-import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { renderSettingsPage } from "../../components/settings-workspace.ts";
 import { loadGatewayDiagnostics } from "../../lib/gateway-diagnostics.ts";
 import { renderDebug } from "./view.ts";
 
@@ -176,21 +176,19 @@ class DebugPage extends LitElement {
       onRefresh: () => void this.loadDiagnostics(),
       onCall: () => void this.callDebugMethod(),
     });
-    return html`
-      <section class="content-header">
+    return renderSettingsPage(
+      this.context.basePath,
+      html`
         <div>
           <div class="page-title">${titleForRoute("debug")}</div>
           <div class="page-sub">${subtitleForRoute("debug")}</div>
         </div>
-      </section>
-      ${renderSettingsWorkspace(
-        this.context.basePath,
-        body,
-        "debug",
-        (routeId) => this.context.navigate(routeId),
-        (routeId) => this.context.preload(routeId),
-      )}
-    `;
+      `,
+      body,
+      "debug",
+      (routeId) => this.context.navigate(routeId),
+      (routeId) => this.context.preload(routeId),
+    );
   }
 }
 

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -4,7 +4,7 @@ import { state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
-import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
+import { renderSettingsPage } from "../../components/settings-workspace.ts";
 import {
   formatMissingOperatorReadScopeMessage,
   isMissingOperatorReadScopeError,
@@ -267,22 +267,20 @@ class LogsPage extends LitElement {
       onExport: (lines, label) => this.exportLogs(lines, label),
       onScroll: (event) => this.handleScroll(event),
     });
-    return html`
-      <section class="content-header">
+    return renderSettingsPage(
+      this.context.basePath,
+      html`
         <div>
           <div class="page-title">${titleForRoute("logs")}</div>
           <div class="page-sub">${subtitleForRoute("logs")}</div>
         </div>
-      </section>
-      ${renderSettingsWorkspace(
-        this.context.basePath,
-        body,
-        "logs",
-        (routeId) => this.context.navigate(routeId),
-        (routeId) => this.context.preload(routeId),
-        { fillHeight: true },
-      )}
-    `;
+      `,
+      body,
+      "logs",
+      (routeId) => this.context.navigate(routeId),
+      (routeId) => this.context.preload(routeId),
+      { fillHeight: true },
+    );
   }
 }
 

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -2,9 +2,12 @@
 
 .settings-workspace {
   width: 100%;
-  max-width: 980px;
-  margin: 0 auto;
-  padding: 0 16px 56px;
+}
+
+.settings-workspace--settings {
+  width: 100%;
+  max-width: var(--settings-content-width);
+  margin-inline: auto;
 }
 
 .settings-workspace__body {
@@ -70,9 +73,9 @@ openclaw-logs-page {
 
 .qs-container {
   width: 100%;
-  max-width: 100%;
-  margin: 0 auto;
-  padding: 12px 0 0;
+  max-width: var(--settings-content-width);
+  margin: 0;
+  padding: 28px 0 56px;
 }
 
 /* Persistent Simple/Advanced switch in the page header; keeps the way back
@@ -94,9 +97,9 @@ openclaw-logs-page {
     display: flex;
     justify-content: flex-end;
     width: 100%;
-    max-width: 980px;
+    max-width: var(--settings-content-width);
     margin: 0 auto;
-    padding: 12px 16px 0;
+    padding: 12px 0 0;
   }
 }
 
@@ -104,9 +107,9 @@ openclaw-logs-page {
 
 .qs-grid {
   display: grid;
-  grid-template-columns: repeat(12, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr);
   align-items: stretch;
-  gap: 14px;
+  gap: 12px;
 }
 
 /* ── Card ── */
@@ -135,7 +138,7 @@ openclaw-logs-page {
 .qs-card--channels,
 .qs-card--security,
 .qs-card--automations {
-  grid-column: span 4;
+  grid-column: 1 / -1;
 }
 
 .qs-card--appearance,
@@ -144,7 +147,7 @@ openclaw-logs-page {
 }
 
 .qs-card--personal {
-  grid-column: span 8;
+  grid-column: 1 / -1;
 }
 
 .qs-card--personal .qs-identity-grid {
@@ -1009,12 +1012,12 @@ openclaw-logs-page {
 
 @media (max-width: 1100px) {
   .qs-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
     align-items: stretch;
   }
 
   .qs-card {
-    grid-column: span 1;
+    grid-column: 1 / -1;
   }
 
   .qs-card--appearance,

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -2,6 +2,9 @@
 
 .settings-workspace {
   width: 100%;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 0 16px 56px;
 }
 
 .settings-workspace__body {
@@ -45,10 +48,6 @@ openclaw-logs-page {
   flex-direction: column;
 }
 
-.settings-workspace--fill-height > .settings-section-nav {
-  flex: 0 0 auto;
-}
-
 .settings-workspace--fill-height > .settings-workspace__body {
   flex: 1 1 auto;
   min-height: 0;
@@ -69,84 +68,11 @@ openclaw-logs-page {
   max-height: none;
 }
 
-.settings-section-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  width: 100%;
-  max-width: 1520px;
-  margin: 0 auto;
-  padding: 24px 16px 16px;
-}
-
-.settings-section-nav__item {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  min-height: 34px;
-  padding: 6px 10px;
-  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
-  border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--card) 82%, transparent);
-  color: var(--muted);
-  font-size: 0.8125rem;
-  font-weight: 550;
-  text-decoration: none;
-  transition:
-    background var(--duration-fast) var(--ease-out),
-    border-color var(--duration-fast) var(--ease-out),
-    color var(--duration-fast) var(--ease-out);
-}
-
-.settings-section-nav__item:hover {
-  background: var(--bg-hover);
-  border-color: var(--border-strong);
-  color: var(--text);
-}
-
-.settings-section-nav__item:focus-visible {
-  outline: none;
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--border) 45%);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
-}
-
-.settings-section-nav__item--active {
-  background: color-mix(in srgb, var(--accent) 14%, var(--card) 86%);
-  border-color: color-mix(in srgb, var(--accent) 44%, var(--border) 56%);
-  color: var(--text-strong);
-}
-
-.settings-section-nav__icon {
-  display: inline-flex;
-  width: 14px;
-  height: 14px;
-  color: currentColor;
-}
-
-.settings-section-nav__icon svg {
-  width: 14px;
-  height: 14px;
-  stroke: currentColor;
-  fill: none;
-  stroke-width: 1.7px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.settings-section-nav__icon svg * {
-  stroke: currentColor;
-  fill: none;
-}
-
-.settings-section-nav__label {
-  overflow-wrap: anywhere;
-}
-
 .qs-container {
   width: 100%;
-  max-width: 1520px;
+  max-width: 100%;
   margin: 0 auto;
-  padding: 32px 16px 56px;
+  padding: 12px 0 0;
 }
 
 /* Persistent Simple/Advanced switch in the page header; keeps the way back
@@ -168,7 +94,7 @@ openclaw-logs-page {
     display: flex;
     justify-content: flex-end;
     width: 100%;
-    max-width: 1520px;
+    max-width: 980px;
     margin: 0 auto;
     padding: 12px 16px 0;
   }
@@ -1121,15 +1047,6 @@ openclaw-logs-page {
 }
 
 @media (max-width: 480px) {
-  .settings-section-nav {
-    padding: 16px 0 12px;
-  }
-
-  .settings-section-nav__item {
-    flex: 1 1 calc(50% - 4px);
-    justify-content: center;
-  }
-
   .qs-container {
     padding: 20px 0 40px;
   }

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -5,6 +5,8 @@
 /* Layout Container */
 .config-layout {
   display: block;
+  width: 100%;
+  max-width: var(--settings-content-width, 840px);
   margin: 0;
   background: transparent;
   overflow: visible;
@@ -2262,8 +2264,6 @@
 
 @media (max-width: 768px) {
   .config-layout {
-    height: calc(100vh - 100px);
-    height: calc(100dvh - 100px);
     margin: 8px 0 0;
     border-radius: var(--radius-md);
   }

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -4,16 +4,10 @@
 
 /* Layout Container */
 .config-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 0;
-  height: calc(100vh - 160px);
-  margin: 12px 0 0;
-  border-radius: var(--radius-xl);
-  border: 1px solid var(--border);
-  background: var(--panel);
-  overflow: hidden;
-  overflow: clip;
+  display: block;
+  margin: 0;
+  background: transparent;
+  overflow: visible;
   animation: config-enter 0.3s var(--ease-out);
 }
 
@@ -172,10 +166,8 @@
   flex-direction: column;
   min-height: 0;
   min-width: 0;
-  background: var(--panel);
-  overflow: hidden;
-  /* fallback for older browsers */
-  overflow: clip;
+  background: transparent;
+  overflow: visible;
 }
 
 /* Actions Bar */
@@ -505,7 +497,7 @@
 /* Content Area */
 .config-content {
   flex: 1;
-  overflow-y: auto;
+  overflow: visible;
   padding: 20px 22px;
   min-width: 0;
   scroll-behavior: smooth;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2,6 +2,10 @@
    Shell Layout
    =========================================== */
 
+:root {
+  --settings-content-width: 840px;
+}
+
 .shell {
   --shell-pad: 16px;
   --shell-gap: 16px;
@@ -320,8 +324,6 @@
 }
 
 .settings-sidebar-back__icon svg,
-.settings-sidebar-title__icon svg,
-.settings-sidebar-search__icon svg,
 .settings-sidebar-link__icon svg {
   width: 100%;
   height: 100%;
@@ -332,69 +334,11 @@
   stroke-linejoin: round;
 }
 
-.settings-sidebar-title {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  min-width: 0;
-  padding: 0 6px;
-  color: var(--text-strong);
-  font-size: 15px;
-  font-weight: 650;
-  line-height: 1.2;
-}
-
-.settings-sidebar-title__icon {
-  display: inline-flex;
-  width: 17px;
-  height: 17px;
-  color: var(--accent);
-}
-
-.settings-sidebar-search {
-  position: relative;
-  flex: 0 0 auto;
-}
-
-.settings-sidebar-search__icon {
-  position: absolute;
-  left: 10px;
-  top: 50%;
-  display: inline-flex;
-  width: 14px;
-  height: 14px;
-  color: var(--muted);
-  pointer-events: none;
-  transform: translateY(-50%);
-}
-
-.settings-sidebar-search__input {
-  width: 100%;
-  min-height: 34px;
-  padding: 7px 10px 7px 31px;
-  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--bg-elevated) 78%, transparent);
-  color: var(--text);
-  font: inherit;
-  font-size: 12.5px;
-  outline: none;
-}
-
-.settings-sidebar-search__input::placeholder {
-  color: var(--muted);
-}
-
-.settings-sidebar-search__input:focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
-  box-shadow: var(--focus-ring);
-}
-
 .settings-sidebar-nav {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
-  gap: 14px;
+  gap: 19px;
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
@@ -404,17 +348,17 @@
 
 .settings-sidebar-section {
   display: grid;
-  gap: 5px;
+  gap: 8px;
 }
 
 .settings-sidebar-section__label {
   padding: 0 8px;
-  color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
-  font-size: 11px;
-  font-weight: 650;
-  letter-spacing: 0.07em;
-  line-height: 1.2;
-  text-transform: uppercase;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.25;
+  text-transform: none;
 }
 
 .settings-sidebar-section__items {
@@ -473,35 +417,6 @@
   color: inherit;
   font-size: 13px;
   font-weight: 550;
-}
-
-.settings-sidebar-link--search-item {
-  min-height: 42px;
-  align-items: flex-start;
-  padding-block: 6px;
-}
-
-.settings-sidebar-link__text-stack {
-  display: grid;
-  min-width: 0;
-  gap: 2px;
-}
-
-.settings-sidebar-link__meta {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--muted);
-  font-size: 11px;
-  line-height: 1.2;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.settings-sidebar-empty {
-  padding: 8px 9px;
-  color: var(--muted);
-  font-size: 12px;
-  line-height: 1.35;
 }
 
 .sidebar-shell__footer {
@@ -1777,11 +1692,11 @@
   gap: 14px;
 }
 
-.content--settings .content-header {
+.content:has(.settings-workspace--settings) .content-header {
   width: 100%;
-  max-width: 980px;
+  max-width: var(--settings-content-width);
   margin: 0 auto;
-  padding-inline: 16px;
+  padding-inline: 0;
 }
 
 :root[data-theme-mode="light"] .content {
@@ -1996,6 +1911,11 @@
 
 .grid-cols-3 {
   grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.settings-workspace--settings .channels-grid {
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .stat-grid {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -267,6 +267,243 @@
   flex: 0 0 var(--shell-nav-rail-width);
 }
 
+.sidebar--settings {
+  background: color-mix(in srgb, var(--bg) 98%, var(--bg-elevated) 2%);
+}
+
+.sidebar-shell--settings {
+  gap: 14px;
+  padding: 14px 12px;
+}
+
+.settings-sidebar-header {
+  display: grid;
+  gap: 14px;
+  flex: 0 0 auto;
+}
+
+.settings-sidebar-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: max-content;
+  max-width: 100%;
+  min-height: 30px;
+  padding: 0 8px 0 6px;
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    background var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.settings-sidebar-back:hover,
+.settings-sidebar-back:focus-visible {
+  background: color-mix(in srgb, var(--bg-hover) 78%, transparent);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.settings-sidebar-back:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.settings-sidebar-back__icon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  transform: rotate(180deg);
+}
+
+.settings-sidebar-back__icon svg,
+.settings-sidebar-title__icon svg,
+.settings-sidebar-search__icon svg,
+.settings-sidebar-link__icon svg {
+  width: 100%;
+  height: 100%;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.7px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.settings-sidebar-title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  padding: 0 6px;
+  color: var(--text-strong);
+  font-size: 15px;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.settings-sidebar-title__icon {
+  display: inline-flex;
+  width: 17px;
+  height: 17px;
+  color: var(--accent);
+}
+
+.settings-sidebar-search {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.settings-sidebar-search__icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  color: var(--muted);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
+.settings-sidebar-search__input {
+  width: 100%;
+  min-height: 34px;
+  padding: 7px 10px 7px 31px;
+  border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-elevated) 78%, transparent);
+  color: var(--text);
+  font: inherit;
+  font-size: 12.5px;
+  outline: none;
+}
+
+.settings-sidebar-search__input::placeholder {
+  color: var(--muted);
+}
+
+.settings-sidebar-search__input:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  box-shadow: var(--focus-ring);
+}
+
+.settings-sidebar-nav {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 14px;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 2px 0 6px;
+  scrollbar-width: thin;
+}
+
+.settings-sidebar-section {
+  display: grid;
+  gap: 5px;
+}
+
+.settings-sidebar-section__label {
+  padding: 0 8px;
+  color: color-mix(in srgb, var(--muted) 72%, var(--text) 28%);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.07em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.settings-sidebar-section__items {
+  display: grid;
+  gap: 2px;
+}
+
+.settings-sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  min-height: 34px;
+  padding: 0 9px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  text-decoration: none;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.settings-sidebar-link:hover,
+.settings-sidebar-link:focus-visible {
+  background: color-mix(in srgb, var(--bg-hover) 78%, transparent);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.settings-sidebar-link:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.settings-sidebar-link--active {
+  border-color: color-mix(in srgb, var(--accent) 18%, transparent);
+  background: color-mix(in srgb, var(--accent-subtle) 68%, transparent);
+  color: var(--text-strong);
+}
+
+.settings-sidebar-link__icon {
+  display: inline-flex;
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+  color: currentColor;
+}
+
+.settings-sidebar-link__text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: inherit;
+  font-size: 13px;
+  font-weight: 550;
+}
+
+.settings-sidebar-link--search-item {
+  min-height: 42px;
+  align-items: flex-start;
+  padding-block: 6px;
+}
+
+.settings-sidebar-link__text-stack {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.settings-sidebar-link__meta {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-sidebar-empty {
+  padding: 8px 9px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
 .sidebar-shell__footer {
   flex-shrink: 0;
 }
@@ -1538,6 +1775,13 @@
 
 .content--workboard openclaw-workboard-page {
   gap: 14px;
+}
+
+.content--settings .content-header {
+  width: 100%;
+  max-width: 980px;
+  margin: 0 auto;
+  padding-inline: 16px;
 }
 
 :root[data-theme-mode="light"] .content {


### PR DESCRIPTION
## What Problem This Solves

Settings pages mixed route-level horizontal settings navigation with page-local width and overflow behavior. That made General, Channels, Debug, Logs, Appearance, Worktrees, and related Settings pages feel inconsistent, and some pages could escape the intended Settings width.

## Why This Change Was Made

In this PR, Settings route navigation moves into a Settings-only sidebar with grouped existing Settings routes and a Back to OpenClaw exit. Settings pages share a proposed 840px content workspace, and the config wrapper no longer creates an artificial nested scroll area.

Language/control reorganization is intentionally deferred, and internal card styling is preserved.

## User Impact

Users get a consistent Settings workspace across existing Settings routes and can leave Settings back to their previous non-Settings route. This is a layout/navigation change only.

## Evidence

- `git diff --check`
- `node --import tsx scripts/control-ui-i18n.ts check`
- `node_modules/.bin/oxfmt --check ui/src/components/app-sidebar.ts ui/src/styles/layout.css ui/src/e2e/sidebar-customization.e2e.test.ts ui/src/i18n/locales/en.ts`
- `node node_modules/vitest/vitest.mjs run ui/src/e2e/sidebar-customization.e2e.test.ts --config test/vitest/vitest.ui-e2e.config.ts`
- `/Applications/Codex.app/Contents/Resources/codex review --uncommitted`
- Browser screenshots for 11 Settings routes, each verified with active route/header and no Settings search input.

Updated in this refresh:

- Removed Settings search from the sidebar.
- Preserved Worktrees in the grouped Settings sidebar.
- Settings routes ignore the persisted collapsed-sidebar shell class while keeping the preference for normal sidebar routes.
- Updated Back to OpenClaw so Settings returns to the previous non-Settings route, with chat as fallback.
- Narrowed Settings header/content to the proposed 840px token across Config, Channels, Debug, and Logs.
- Kept Channels as one channel per row.

## Screenshots

Settings:

![Settings route in this PR](https://gilded-lantern-q4zp.here.now/01-config.png)

Appearance:

![Appearance route in this PR](https://gilded-lantern-q4zp.here.now/02-appearance.png)

Channels:

![Channels route in this PR](https://gilded-lantern-q4zp.here.now/03-channels.png)

Communications:

![Communications route in this PR](https://gilded-lantern-q4zp.here.now/04-communications.png)

Automation:

![Automation route in this PR](https://gilded-lantern-q4zp.here.now/05-automation.png)

MCP:

![MCP route in this PR](https://gilded-lantern-q4zp.here.now/06-mcp.png)

Infrastructure:

![Infrastructure route in this PR](https://gilded-lantern-q4zp.here.now/07-infrastructure.png)

Worktrees:

![Worktrees route in this PR](https://gilded-lantern-q4zp.here.now/08-worktrees.png)

AI & Agents:

![AI and Agents route in this PR](https://gilded-lantern-q4zp.here.now/09-ai-agents.png)

Debug:

![Debug route in this PR](https://gilded-lantern-q4zp.here.now/10-debug.png)

Logs:

![Logs route in this PR](https://gilded-lantern-q4zp.here.now/11-logs.png)
