### PR TITLE
fix(web-fetch): auto-detect keyless providers without credentials

### DIFF
--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -200,13 +200,13 @@ describe("web fetch runtime", () => {
     expect(requireResolvedWebFetch(resolved).provider.id).toBe("firecrawl");
   });
 
-  it("does not auto-detect a keyless provider without a credential", () => {
+  it("auto-detects a keyless provider without a credential", () => {
     const provider = createFirecrawlProvider({
       requiresCredential: false,
     });
     resolvePluginWebFetchProvidersMock.mockReturnValue([provider]);
 
-    expect(resolveWebFetchDefinition({ config: {} })).toBeNull();
+    expect(resolveWebFetchDefinition({ config: {} })?.provider.id).toBe("firecrawl");
   });
 
   it("auto-detects providers from configured fallback credentials", () => {

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -147,9 +147,6 @@ function resolveWebFetchProviderId(params: {
 
   for (const provider of providers) {
     if (!providerRequiresCredential(provider)) {
-      if (!hasAutoDetectCredential(provider, params.config, params.fetch)) {
-        continue;
-      }
       logVerbose(
         `web_fetch: ${raw ? `invalid configured provider "${raw}", ` : ""}auto-detected keyless provider "${provider.id}"`,
       );


### PR DESCRIPTION
Fixes #100659

When auto-detecting providers, we shouldn't require keyless providers to have credentials. This PR removes the incorrect hasAutoDetectCredential check for providers where requiresCredential is false, and updates the tests.
