### PR TITLE
fix(llm): correctly handle reasoning=off in Anthropic and Google adapters

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -999,13 +999,15 @@ export const streamSimpleAnthropic: StreamFunction<"anthropic-messages", SimpleS
   }
 
   const base = buildBaseOptions(model, options, apiKey);
-  if (!options?.reasoning) {
+  if (!options?.reasoning || options.reasoning === "off") {
     const mandatoryAdaptiveThinking = requiresClaudeAdaptiveThinking(model);
     return streamAnthropic(model, context, {
       ...base,
       thinkingEnabled: mandatoryAdaptiveThinking,
-      ...(mandatoryAdaptiveThinking ? { effort: "high" as const } : {}),
-    } satisfies AnthropicOptions);
+      ...(mandatoryAdaptiveThinking
+        ? { effort: options?.reasoning === "off" ? "low" : "high" }
+        : {}),
+    } as AnthropicOptions);
   }
 
   // For Opus 4.6 and Sonnet 4.6: use adaptive thinking with effort level

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1005,7 +1005,7 @@ export const streamSimpleAnthropic: StreamFunction<"anthropic-messages", SimpleS
       ...base,
       thinkingEnabled: mandatoryAdaptiveThinking,
       ...(mandatoryAdaptiveThinking
-        ? { effort: options?.reasoning === "off" ? "low" : "high" }
+        ? { effort: options?.reasoning === "off" ? ("low" as const) : ("high" as const) }
         : {}),
     } as AnthropicOptions);
   }

--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -552,7 +552,7 @@ export function buildGoogleSimpleThinking<T extends GoogleApiType>(
     useFlashLiteBudgets?: boolean;
   },
 ): GoogleThinkingOptions {
-  if (!options?.reasoning) {
+  if (!options?.reasoning || options.reasoning === "off") {
     return { enabled: false };
   }
 


### PR DESCRIPTION
Fixes #100926

When users pass `reasoning: "off"` to `SimpleStreamOptions`, the adapters incorrectly evaluated it as truthy since `"off"` is a non-empty string. This PR explicitly checks for `"off"` to disable reasoning in the Anthropic and Google providers. For models with mandatory adaptive thinking (like Claude Fable 5), `"off"` now explicitly maps to `"low"` effort.
