### PR TITLE
feat(android): pair multiple gateways and switch between them without re-pairing

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -139,7 +139,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 114,
+      "line": 121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Searching…",
       "surface": "android",
@@ -147,7 +147,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 205,
+      "line": 212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -155,7 +155,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 215,
+      "line": 222,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 584,
+      "line": 605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2492,
+      "line": 2683,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2494,
+      "line": 2685,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2496,
+      "line": 2687,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -387,7 +387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1234,
+      "line": 1286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Connecting…",
       "surface": "android",
@@ -395,7 +395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1234,
+      "line": 1286,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt",
       "source": "Reconnecting…",
       "surface": "android",
@@ -1011,7 +1011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 335,
+      "line": 392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Last gateway error",
       "surface": "android",
@@ -1019,7 +1019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 335,
+      "line": 392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Pairing required",
       "surface": "android",
@@ -1027,7 +1027,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 346,
+      "line": 403,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "OpenClaw Android ${openClawAndroidVersionLabel()}",
       "surface": "android",
@@ -1035,7 +1035,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 387,
+      "line": 444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Setup code, endpoint, TLS, token, password, onboarding.",
       "surface": "android",
@@ -1043,7 +1043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 391,
+      "line": 448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Collapse advanced controls",
       "surface": "android",
@@ -1051,7 +1051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 391,
+      "line": 448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Expand advanced controls",
       "surface": "android",
@@ -1059,7 +1059,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 422,
+      "line": 479,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Run these on the gateway host:",
       "surface": "android",
@@ -1067,7 +1067,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 425,
+      "line": 482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "For Tailscale or public hosts, use wss:// or Tailscale Serve. Private LAN ws:// remains supported.",
       "surface": "android",
@@ -1075,7 +1075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 454,
+      "line": 511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Android Emulator",
       "surface": "android",
@@ -1083,7 +1083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 463,
+      "line": 520,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Localhost",
       "surface": "android",
@@ -1091,7 +1091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 490,
+      "line": 547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Port",
       "surface": "android",
@@ -1099,7 +1099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 490,
+      "line": 547,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Port (optional, defaults to 443)",
       "surface": "android",
@@ -1107,7 +1107,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 516,
+      "line": 573,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Turn this on for Tailscale or public hosts. Private LAN ws:// remains supported.",
       "surface": "android",
@@ -1115,7 +1115,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 542,
+      "line": 599,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Leave blank to keep saved token",
       "surface": "android",
@@ -1123,7 +1123,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 551,
+      "line": 608,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "Password (optional)",
       "surface": "android",
@@ -1131,7 +1131,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 653,
+      "line": 710,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt",
       "source": "CF-Access-Client-Id",
       "surface": "android",
@@ -1795,7 +1795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 694,
+      "line": 693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Trust",
       "surface": "android",
@@ -1803,7 +1803,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 699,
+      "line": 698,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Cancel",
       "surface": "android",
@@ -1811,7 +1811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 890,
+      "line": 889,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Welcome to OpenClaw",
       "surface": "android",
@@ -1819,7 +1819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 891,
+      "line": 890,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Turn this device into a secure OpenClaw node for chat, voice, camera, and device tools.",
       "surface": "android",
@@ -1827,7 +1827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 916,
+      "line": 915,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -1835,7 +1835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 972,
+      "line": 971,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect to your Gateway",
       "surface": "android",
@@ -1843,7 +1843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 973,
+      "line": 972,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose device permissions",
       "surface": "android",
@@ -1851,7 +1851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 974,
+      "line": 973,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use OpenClaw from your phone",
       "surface": "android",
@@ -1859,7 +1859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 996,
+      "line": 995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Security notice",
       "surface": "android",
@@ -1867,7 +1867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 998,
+      "line": 997,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The connected OpenClaw agent can use device capabilities you enable. Continue only if you trust the Gateway and agent you connect to.",
       "surface": "android",
@@ -1875,7 +1875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1039,
+      "line": 1038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connect Gateway",
       "surface": "android",
@@ -1883,7 +1883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1040,
+      "line": 1039,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan a QR code or use the setup code from your OpenClaw Gateway.",
       "surface": "android",
@@ -1891,7 +1891,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1049,
+      "line": 1048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not open setup guide.",
       "surface": "android",
@@ -1899,7 +1899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1057,
+      "line": 1056,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR or setup code",
       "surface": "android",
@@ -1907,7 +1907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1063,
+      "line": 1062,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Set up manually",
       "surface": "android",
@@ -1915,7 +1915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1085,
+      "line": 1084,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Before you start",
       "surface": "android",
@@ -1923,7 +1923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1091,
+      "line": 1090,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Access to the Gateway device",
       "surface": "android",
@@ -1931,7 +1931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1092,
+      "line": 1091,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Have a terminal open on the device running OpenClaw.",
       "surface": "android",
@@ -1939,7 +1939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1095,
+      "line": 1094,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Phone can reach the Gateway",
       "surface": "android",
@@ -1947,7 +1947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1096,
+      "line": 1095,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the same network, or a secure remote Gateway URL.",
       "surface": "android",
@@ -1955,7 +1955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1102,
+      "line": 1101,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Android setup guide",
       "surface": "android",
@@ -1963,7 +1963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1145,
+      "line": 1144,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup Gateway",
       "surface": "android",
@@ -1971,7 +1971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1151,
+      "line": 1150,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Start your Gateway.",
       "surface": "android",
@@ -1979,7 +1979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1152,
+      "line": 1151,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw gateway",
       "surface": "android",
@@ -1987,7 +1987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1157,
+      "line": 1156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Generate a QR code.",
       "surface": "android",
@@ -1995,7 +1995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1158,
+      "line": 1157,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "openclaw qr",
       "surface": "android",
@@ -2003,7 +2003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1178,
+      "line": 1177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose from gallery",
       "surface": "android",
@@ -2011,7 +2011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1232,
+      "line": 1231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "QR code not accepted",
       "surface": "android",
@@ -2019,7 +2019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1247,
+      "line": 1246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Choose another image",
       "surface": "android",
@@ -2027,7 +2027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1300,
+      "line": 1299,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Scan QR code",
       "surface": "android",
@@ -2035,7 +2035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1302,
+      "line": 1301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Open the camera and frame the code from openclaw qr.",
       "surface": "android",
@@ -2043,7 +2043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1336,
+      "line": 1335,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Align the QR code inside the square.",
       "surface": "android",
@@ -2051,7 +2051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1354,
+      "line": 1353,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Camera access is needed to scan the setup QR.",
       "surface": "android",
@@ -2059,7 +2059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1359,
+      "line": 1358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Allow camera",
       "surface": "android",
@@ -2067,7 +2067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1380,
+      "line": 1379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close scanner",
       "surface": "android",
@@ -2075,7 +2075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1542,
+      "line": 1541,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Enter setup code",
       "surface": "android",
@@ -2083,7 +2083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1543,
+      "line": 1542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code",
       "surface": "android",
@@ -2091,7 +2091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1547,
+      "line": 1546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste setup code",
       "surface": "android",
@@ -2099,7 +2099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1551,
+      "line": 1550,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Setup code was not accepted",
       "surface": "android",
@@ -2107,7 +2107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1555,
+      "line": 1554,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use setup code",
       "surface": "android",
@@ -2115,7 +2115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1586,
+      "line": 1585,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Manual setup",
       "surface": "android",
@@ -2123,7 +2123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1589,
+      "line": 1588,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway URL",
       "surface": "android",
@@ -2131,7 +2131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1591,
+      "line": 1590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Host",
       "surface": "android",
@@ -2139,7 +2139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1592,
+      "line": 1591,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Port",
       "surface": "android",
@@ -2147,7 +2147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1595,
+      "line": 1594,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the Gateway computer's LAN address or secure remote hostname.",
       "surface": "android",
@@ -2155,7 +2155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1602,
+      "line": 1601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Token",
       "surface": "android",
@@ -2163,7 +2163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1603,
+      "line": 1602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste token",
       "surface": "android",
@@ -2171,7 +2171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1605,
+      "line": 1604,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Paste a shared Gateway token or operator-issued token.",
       "surface": "android",
@@ -2179,7 +2179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1612,
+      "line": 1611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password",
       "surface": "android",
@@ -2187,7 +2187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1613,
+      "line": 1612,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Password optional",
       "surface": "android",
@@ -2195,7 +2195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1617,
+      "line": 1616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection type",
       "surface": "android",
@@ -2203,7 +2203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1619,
+      "line": 1618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Local network",
       "surface": "android",
@@ -2211,7 +2211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1620,
+      "line": 1619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Secure remote",
       "surface": "android",
@@ -2219,7 +2219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1623,
+      "line": 1622,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Local works for LAN or emulator hosts. Secure remote is for wss:// or Tailscale Serve/Funnel.",
       "surface": "android",
@@ -2227,7 +2227,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1631,
+      "line": 1630,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Could not test connection",
       "surface": "android",
@@ -2235,7 +2235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1636,
+      "line": 1635,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Test connection",
       "surface": "android",
@@ -2243,7 +2243,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1814,
+      "line": 1813,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "View details",
       "surface": "android",
@@ -2251,7 +2251,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1847,
+      "line": 1846,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Connection details",
       "surface": "android",
@@ -2259,7 +2259,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1859,
+      "line": 1858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy",
       "surface": "android",
@@ -2267,7 +2267,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1864,
+      "line": 1863,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Close",
       "surface": "android",
@@ -2275,7 +2275,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1876,
+      "line": 1875,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Details copied",
       "surface": "android",
@@ -2283,7 +2283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1961,
+      "line": 1960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approve node access",
       "surface": "android",
@@ -2291,7 +2291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1968,
+      "line": 1967,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway pairing is complete. Approve this phone as a node so OpenClaw can use the device capabilities you enable.",
       "surface": "android",
@@ -2299,7 +2299,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1976,
+      "line": 1975,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "On the Gateway computer, run:",
       "surface": "android",
@@ -2307,7 +2307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1985,
+      "line": 1984,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Use the requestId from the pending command in the approve command.",
       "surface": "android",
@@ -2315,7 +2315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1996,
+      "line": 1995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "I have approved",
       "surface": "android",
@@ -2323,7 +2323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1997,
+      "line": 1996,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Checking approval…",
       "surface": "android",
@@ -2331,7 +2331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2009,
+      "line": 2008,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Still waiting for approval",
       "surface": "android",
@@ -2339,7 +2339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2012,
+      "line": 2011,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Run the approve command on the Gateway computer, then check again.",
       "surface": "android",
@@ -2347,7 +2347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2019,
+      "line": 2018,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "OK",
       "surface": "android",
@@ -2355,7 +2355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2169,
+      "line": 2168,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Copy approval command",
       "surface": "android",
@@ -2363,7 +2363,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2195,
+      "line": 2194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Only enable access you are comfortable letting OpenClaw use while this phone is connected. You can change these later in Android Settings.",
       "surface": "android",
@@ -2371,7 +2371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2207,
+      "line": 2206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Continue",
       "surface": "android",
@@ -2379,7 +2379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2234,
+      "line": 2233,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Back",
       "surface": "android",
@@ -2387,7 +2387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 2281,
+      "line": 2280,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Permissions",
       "surface": "android",
@@ -2395,7 +2395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2606,
+      "line": 2605,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "The code may have expired or been generated for another Gateway.",
       "surface": "android",
@@ -2403,7 +2403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2610,
+      "line": 2609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -2411,7 +2411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2611,
+      "line": 2610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway password is invalid. Re-enter it or reset this gateway connection.",
       "surface": "android",
@@ -2419,7 +2419,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2612,
+      "line": 2611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway token is required. Enter it again or edit this connection.",
       "surface": "android",
@@ -2427,7 +2427,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2614,
+      "line": 2613,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway requires this device identity. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -2435,7 +2435,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2618,
+      "line": 2617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Saved authentication is invalid. Re-authenticate or reset this gateway connection.",
       "surface": "android",
@@ -2443,7 +2443,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2619,
+      "line": 2618,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication is not configured. Edit this connection and try again.",
       "surface": "android",
@@ -2451,7 +2451,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2620,
+      "line": 2619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Gateway authentication needs review. Check gateway settings, then retry.",
       "surface": "android",
@@ -2459,7 +2459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2637,
+      "line": 2636,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "$summary $it",
       "surface": "android",
@@ -2467,7 +2467,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 2759,
+      "line": 2758,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Approval command copied",
       "surface": "android",
@@ -2475,7 +2475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2821,
+      "line": 2820,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Granted",
       "surface": "android",
@@ -2483,7 +2483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2821,
+      "line": 2820,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt",
       "source": "Not granted",
       "surface": "android",
@@ -2931,7 +2931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 218,
+      "line": 220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
@@ -2939,7 +2939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 218,
+      "line": 220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -2947,7 +2947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 238,
+      "line": 240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -2955,7 +2955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 243,
+      "line": 245,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -2963,7 +2963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 244,
+      "line": 246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -2971,7 +2971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 279,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron Jobs",
       "surface": "android",
@@ -2979,7 +2979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 279,
+      "line": 281,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
@@ -2987,7 +2987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 290,
+      "line": 292,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android shows scheduled work status. Create and edit schedules from the desktop app.",
       "surface": "android",
@@ -2995,7 +2995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 300,
+      "line": 302,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load cron jobs.",
       "surface": "android",
@@ -3003,7 +3003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 305,
+      "line": 307,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No scheduled jobs.",
       "surface": "android",
@@ -3011,7 +3011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 306,
+      "line": 308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Create recurring OpenClaw work from the desktop app.",
       "surface": "android",
@@ -3019,7 +3019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 341,
+      "line": 343,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect scheduled gateway work.",
       "surface": "android",
@@ -3027,7 +3027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 355,
+      "line": 357,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect cron jobs.",
       "surface": "android",
@@ -3035,7 +3035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 363,
+      "line": 365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron job not loaded.",
       "surface": "android",
@@ -3043,7 +3043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 363,
+      "line": 365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading cron job…",
       "surface": "android",
@@ -3051,7 +3051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 385,
+      "line": 387,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -3059,7 +3059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 385,
+      "line": 387,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
@@ -3067,7 +3067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 396,
+      "line": 398,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -3075,7 +3075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 400,
+      "line": 402,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -3083,7 +3083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 426,
+      "line": 428,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -3091,7 +3091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 426,
+      "line": 428,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
@@ -3099,7 +3099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 437,
+      "line": 439,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -3107,7 +3107,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 437,
+      "line": 439,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -3115,7 +3115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 450,
+      "line": 452,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -3123,7 +3123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 451,
+      "line": 453,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -3131,7 +3131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 457,
+      "line": 459,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -3139,7 +3139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 458,
+      "line": 460,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -3147,7 +3147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 465,
+      "line": 467,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session activity",
       "surface": "android",
@@ -3155,7 +3155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 466,
+      "line": 468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active session remain visible here.",
       "surface": "android",
@@ -3163,7 +3163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 480,
+      "line": 482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
@@ -3171,7 +3171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 480,
+      "line": 482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -3179,7 +3179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 483,
+      "line": 485,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -3187,7 +3187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 484,
+      "line": 486,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -3195,7 +3195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 503,
+      "line": 505,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure voice, transport, and playback.",
       "surface": "android",
@@ -3203,7 +3203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 503,
+      "line": 505,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -3211,7 +3211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 506,
+      "line": 508,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -3219,7 +3219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 507,
+      "line": 509,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -3227,7 +3227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 510,
+      "line": 512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -3235,7 +3235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 510,
+      "line": 512,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -3243,7 +3243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 511,
+      "line": 513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -3251,7 +3251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 511,
+      "line": 513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -3259,7 +3259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 513,
+      "line": 515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -3267,7 +3267,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 513,
+      "line": 515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -3275,7 +3275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 517,
+      "line": 519,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -3283,7 +3283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 527,
+      "line": 529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -3291,7 +3291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 528,
+      "line": 530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
@@ -3299,7 +3299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 656,
+      "line": 658,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -3307,7 +3307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 656,
+      "line": 658,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -3315,7 +3315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 689,
+      "line": 691,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
@@ -3323,7 +3323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 689,
+      "line": 691,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -3331,7 +3331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 693,
+      "line": 695,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -3339,7 +3339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 693,
+      "line": 695,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -3347,7 +3347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 705,
+      "line": 707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -3355,7 +3355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 705,
+      "line": 707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -3363,7 +3363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 710,
+      "line": 712,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -3371,7 +3371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 710,
+      "line": 712,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -3379,7 +3379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 720,
+      "line": 722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -3387,7 +3387,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 769,
+      "line": 771,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -3395,7 +3395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 776,
+      "line": 778,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -3403,7 +3403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 776,
+      "line": 778,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -3411,7 +3411,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 781,
+      "line": 783,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -3419,7 +3419,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 784,
+      "line": 786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -3427,7 +3427,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 785,
+      "line": 787,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
@@ -3435,7 +3435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 792,
+      "line": 794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -3443,7 +3443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 803,
+      "line": 805,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -3451,7 +3451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1042,
+      "line": 1044,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
@@ -3459,7 +3459,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1042,
+      "line": 1044,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -3467,7 +3467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1051,
+      "line": 1053,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -3475,7 +3475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1051,
+      "line": 1053,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -3483,7 +3483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1061,
+      "line": 1063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -3491,7 +3491,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1061,
+      "line": 1063,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -3499,7 +3499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1072,
+      "line": 1074,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -3507,7 +3507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1080,
+      "line": 1082,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
@@ -3515,7 +3515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1105,
+      "line": 1107,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
@@ -3523,7 +3523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1107,
+      "line": 1109,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw only checks location when your paired Gateway requests it. ",
       "surface": "android",
@@ -3531,7 +3531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1120,
+      "line": 1122,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -3539,7 +3539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1125,
+      "line": 1127,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
@@ -3547,7 +3547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1163,
+      "line": 1168,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -3555,7 +3555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1178,
+      "line": 1183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -3563,7 +3563,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 1183,
+      "line": 1199,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Forget gateway?",
+      "surface": "android",
+      "id": "native.android.66aad1078731e6a3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -3571,7 +3579,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1190,
+      "line": 1218,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -3579,7 +3587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1194,
+      "line": 1222,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -3587,7 +3595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1194,
+      "line": 1222,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -3595,7 +3603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1195,
+      "line": 1223,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -3603,7 +3611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1195,
+      "line": 1223,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -3611,7 +3619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1205,
+      "line": 1233,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -3619,7 +3627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1206,
+      "line": 1234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -3627,23 +3635,55 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1212,
+      "line": 1238,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
+      "source": "Gateways",
       "surface": "android",
-      "id": "native.android.68959b6e93aec68b"
+      "id": "native.android.87eee1e2bafbf13b"
     },
     {
       "kind": "ui-named-argument",
-      "line": 1219,
+      "line": 1240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "Pair New Gateway",
+      "source": "No paired gateways.",
       "surface": "android",
-      "id": "native.android.7fd6bb4d56f1fb3f"
+      "id": "native.android.c3974020a08e239e"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1260,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Forget",
+      "surface": "android",
+      "id": "native.android.74ee3bbbd2e37e9c"
     },
     {
       "kind": "ui-named-argument",
-      "line": 1220,
+      "line": 1282,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Gateway setup",
+      "surface": "android",
+      "id": "native.android.56e98811c4e9b027"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1284,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "surface": "android",
+      "id": "native.android.c040d4ee72a810e0"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1291,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Add gateway",
+      "surface": "android",
+      "id": "native.android.a7c243ff3f1d6447"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1292,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
@@ -3651,7 +3691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1224,
+      "line": 1296,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -3659,7 +3699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1233,
+      "line": 1305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
@@ -3667,7 +3707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1234,
+      "line": 1306,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -3675,7 +3715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1236,
+      "line": 1308,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -3683,7 +3723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1237,
+      "line": 1309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -3691,7 +3731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1241,
+      "line": 1313,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Local",
       "surface": "android",
@@ -3699,7 +3739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1245,
+      "line": 1317,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -3707,7 +3747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1246,
+      "line": 1318,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -3715,7 +3755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1248,
+      "line": 1320,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -3723,7 +3763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1253,
+      "line": 1325,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -3731,7 +3771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1270,
+      "line": 1342,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -3739,7 +3779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1293,
+      "line": 1365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "A calm, high-contrast OpenClaw interface.",
       "surface": "android",
@@ -3747,7 +3787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1293,
+      "line": 1365,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -3755,7 +3795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1304,
+      "line": 1376,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -3763,7 +3803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1349,
+      "line": 1421,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -3771,7 +3811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1378,
+      "line": 1450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -3779,7 +3819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1378,
+      "line": 1450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -3787,7 +3827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1391,
+      "line": 1463,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -3795,7 +3835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1393,
+      "line": 1465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -3803,7 +3843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1396,
+      "line": 1468,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -3811,7 +3851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1407,
+      "line": 1479,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "© 2026 OpenClaw Foundation — MIT License.",
       "surface": "android",
@@ -3819,7 +3859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1424,
+      "line": 1496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw logo",
       "surface": "android",
@@ -3827,7 +3867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1426,
+      "line": 1498,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -3835,7 +3875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1427,
+      "line": 1499,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Personal AI on your devices",
       "surface": "android",
@@ -3843,7 +3883,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1486,
+      "line": 1558,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -3851,7 +3891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1487,
+      "line": 1559,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -3859,7 +3899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1496,
+      "line": 1568,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -3867,7 +3907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1522,
+      "line": 1594,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -3875,7 +3915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1557,
+      "line": 1629,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -3883,7 +3923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1590,
+      "line": 1662,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -3891,7 +3931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1664,
+      "line": 1736,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -3899,7 +3939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1673,
+      "line": 1745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -3907,7 +3947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1673,
+      "line": 1745,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowing",
       "surface": "android",
@@ -3915,7 +3955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1681,
+      "line": 1753,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -3923,7 +3963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1681,
+      "line": 1753,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving",
       "surface": "android",
@@ -3931,7 +3971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1689,
+      "line": 1761,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -3939,7 +3979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1689,
+      "line": 1761,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Denying",
       "surface": "android",
@@ -3947,7 +3987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1714,
+      "line": 1786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -3955,7 +3995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1742,
+      "line": 1814,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -3963,7 +4003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1772,
+      "line": 1844,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -3971,7 +4011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1786,
+      "line": 1858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -3979,7 +4019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1786,
+      "line": 1858,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -3987,7 +4027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1804,
+      "line": 1876,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -3995,7 +4035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1807,
+      "line": 1879,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -4003,7 +4043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1846,
+      "line": 1918,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -4011,7 +4051,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1861,
+      "line": 1933,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -4019,7 +4059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1899,
+      "line": 1971,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -4027,7 +4067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1901,
+      "line": 1973,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -4035,7 +4075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1957,
+      "line": 2029,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -4043,7 +4083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1960,
+      "line": 2032,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -4051,7 +4091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1960,
+      "line": 2032,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -4059,7 +4099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1988,
+      "line": 2060,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -4067,7 +4107,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1995,
+      "line": 2067,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -4075,7 +4115,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2026,
+      "line": 2098,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -4083,7 +4123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2047,
+      "line": 2119,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -4091,7 +4131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2048,
+      "line": 2120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -4099,7 +4139,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2049,
+      "line": 2121,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -4107,7 +4147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2050,
+      "line": 2122,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",
@@ -6483,7 +6523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 221,
+      "line": 228,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking · waiting for reply",
       "surface": "android",
@@ -6491,7 +6531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 221,
+      "line": 228,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -6499,7 +6539,15 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 415,
+      "line": 307,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
+      "source": "Mic on · waiting for gateway",
+      "surface": "android",
+      "id": "native.android.6fbf0916309dbaba"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off",
       "surface": "android",
@@ -6507,7 +6555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 415,
+      "line": 449,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Mic off · sending…",
       "surface": "android",
@@ -6515,7 +6563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 481,
+      "line": 515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Listening · sending queued voice",
       "surface": "android",
@@ -6523,7 +6571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 481,
+      "line": 515,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt",
       "source": "Sending queued voice",
       "surface": "android",
@@ -6531,7 +6579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 546,
+      "line": 598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Listening",
       "surface": "android",
@@ -6539,7 +6587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 546,
+      "line": 598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Ready",
       "surface": "android",
@@ -6547,7 +6595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 954,
+      "line": 1007,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Off",
       "surface": "android",
@@ -6555,7 +6603,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 955,
+      "line": 1008,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed unexpectedly.",
       "surface": "android",
@@ -6563,7 +6611,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 956,
+      "line": 1009,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Talk failed: Realtime provider closed: $reason",
       "surface": "android",
@@ -6571,7 +6619,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1998,
+      "line": 2051,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Aborted",
       "surface": "android",
@@ -6579,7 +6627,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1998,
+      "line": 2051,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt",
       "source": "Chat error",
       "surface": "android",
@@ -6872,6 +6920,30 @@
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "surface": "android",
       "id": "native.android.6ad2d3f084142bed"
+    },
+    {
+      "kind": "resource-string",
+      "line": 34,
+      "path": "apps/android/app/src/main/res/values/strings.xml",
+      "source": "Switch gateway",
+      "surface": "android",
+      "id": "native.android.7c49ec7fe94a9063"
+    },
+    {
+      "kind": "resource-string",
+      "line": 35,
+      "path": "apps/android/app/src/main/res/values/strings.xml",
+      "source": "Select gateway",
+      "surface": "android",
+      "id": "native.android.9e0a677fd629a15f"
+    },
+    {
+      "kind": "resource-string",
+      "line": 36,
+      "path": "apps/android/app/src/main/res/values/strings.xml",
+      "source": "Active gateway",
+      "surface": "android",
+      "id": "native.android.b0034ac5bbc6b25f"
     },
     {
       "kind": "plist-string",

--- a/apps/.i18n/native/ar.json
+++ b/apps/.i18n/native/ar.json
@@ -2229,6 +2229,11 @@
       "translated": "استبدال الإعداد"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "هل تريد نسيان Gateway؟"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "إلغاء"
@@ -2269,14 +2274,34 @@
       "translated": "قطع الاتصال"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "امسح وصول البوابة المحفوظ على هذا الهاتف وامسح رمز إعداد جديدًا."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "بوابات Gateway"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "إقران Gateway جديد"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "لا توجد بوابات Gateway مقترنة."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "نسيان"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "إعداد Gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "امسح رمز الإعداد ضوئيًا أو الصقه لإضافة Gateway آخر."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "إضافة Gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "يتحدث…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "الميكروفون قيد التشغيل · في انتظار Gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "الميكروفون متوقف"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "تغيّرت شهادة Gateway. تابع فقط إذا كنت تتوقع ذلك.\n\nSHA-256 القديم:\n%1$s\n\nSHA-256 الجديد:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "تبديل Gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "تحديد Gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Gateway النشط"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/de.json
+++ b/apps/.i18n/native/de.json
@@ -2229,6 +2229,11 @@
       "translated": "Einrichtung ersetzen"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Gateway vergessen?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Abbrechen"
@@ -2269,14 +2274,34 @@
       "translated": "Trennen"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Gespeicherten Gateway-Zugriff dieses Telefons löschen und einen neuen Einrichtungscode scannen."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Neue Gateway koppeln"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Keine gekoppelten Gateways."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Vergessen"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Gateway-Einrichtung"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Scannen Sie einen Einrichtungscode oder fügen Sie ihn ein, um ein weiteres Gateway hinzuzufügen."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Gateway hinzufügen"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Spricht…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Mikrofon an · wartet auf Gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Mikrofon aus"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Das Gateway-Zertifikat hat sich geändert. Fahren Sie nur fort, wenn Sie dies erwartet haben.\n\nAlter SHA-256:\n%1$s\n\nNeuer SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Gateway wechseln"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Gateway auswählen"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Aktives Gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/es.json
+++ b/apps/.i18n/native/es.json
@@ -2229,6 +2229,11 @@
       "translated": "Reemplazar configuración"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "¿Olvidar gateway?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Cancelar"
@@ -2269,14 +2274,34 @@
       "translated": "Desconectar"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Borrar el acceso de gateway guardado de este teléfono y escanear un código de configuración nuevo."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Emparejar Gateway nuevo"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "No hay gateways emparejados."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Olvidar"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Configuración de gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Escanea o pega un código de configuración para añadir otro gateway."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Añadir gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Hablando…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Micrófono activado · esperando al gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Micrófono apagado"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "El certificado del gateway ha cambiado. Continúa solo si esperabas esto.\n\nSHA-256 anterior:\n%1$s\n\nSHA-256 nuevo:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Cambiar de gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Seleccionar gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Gateway activo"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/fa.json
+++ b/apps/.i18n/native/fa.json
@@ -2229,6 +2229,11 @@
       "translated": "جایگزینی تنظیمات"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Gateway فراموش شود؟"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "لغو"
@@ -2269,14 +2274,34 @@
       "translated": "قطع اتصال"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "دسترسی ذخیره‌شدهٔ این تلفن به gateway را پاک کنید و یک کد راه‌اندازی تازه اسکن کنید."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gatewayها"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "جفت‌سازی Gateway جدید"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "هیچ Gateway جفت‌شده‌ای وجود ندارد."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "فراموش کردن"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "راه‌اندازی Gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "برای افزودن Gateway دیگر، کد راه‌اندازی را اسکن یا جای‌گذاری کنید."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "افزودن Gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "در حال صحبت…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "میکروفون روشن · در انتظار Gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "میکروفون خاموش"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "گواهی gateway تغییر کرده است. فقط در صورتی ادامه دهید که انتظار این تغییر را داشتید.\n\nSHA-256 قدیمی:\n%1$s\n\nSHA-256 جدید:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "تغییر Gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "انتخاب Gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Gateway فعال"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/fr.json
+++ b/apps/.i18n/native/fr.json
@@ -2229,6 +2229,11 @@
       "translated": "Remplacer la configuration"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Oublier le Gateway ?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Annuler"
@@ -2269,14 +2274,34 @@
       "translated": "Déconnecter"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Effacez l’accès au gateway enregistré sur ce téléphone et scannez un nouveau code de configuration."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Associer un nouveau Gateway"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Aucun Gateway associé."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Oublier"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Configuration du Gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Scannez ou collez un code de configuration pour ajouter un autre Gateway."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Ajouter un Gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Parle…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Micro activé · en attente du Gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Micro désactivé"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Le certificat de la gateway a changé. Continuez uniquement si vous vous y attendiez.\n\nAncien SHA-256 :\n%1$s\n\nNouveau SHA-256 :\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Changer de Gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Sélectionner un Gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Gateway actif"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/hi.json
+++ b/apps/.i18n/native/hi.json
@@ -2229,6 +2229,11 @@
       "translated": "सेटअप बदलें"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Gateway भूलें?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "रद्द करें"
@@ -2269,14 +2274,34 @@
       "translated": "डिस्कनेक्ट करें"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "इस फ़ोन की सहेजी गई gateway एक्सेस साफ़ करें और नया सेटअप कोड स्कैन करें।"
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "नया Gateway पेयर करें"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "कोई युग्मित gateways नहीं।"
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "भूलें"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Gateway सेटअप"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "कोई और gateway जोड़ने के लिए सेटअप कोड स्कैन करें या पेस्ट करें।"
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Gateway जोड़ें"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "बोल रहा है…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "माइक चालू · gateway की प्रतीक्षा में"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "माइक बंद"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "gateway प्रमाणपत्र बदल गया है। केवल तभी जारी रखें जब आपको इसकी अपेक्षा थी।\n\nपुराना SHA-256:\n%1$s\n\nनया SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Gateway बदलें"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Gateway चुनें"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "सक्रिय gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/id.json
+++ b/apps/.i18n/native/id.json
@@ -2229,6 +2229,11 @@
       "translated": "Ganti penyiapan"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Lupakan gateway?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Batal"
@@ -2269,14 +2274,34 @@
       "translated": "Putuskan sambungan"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Hapus akses gateway tersimpan ponsel ini dan pindai kode penyiapan baru."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Pasangkan Gateway Baru"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Tidak ada gateway yang dipasangkan."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Lupakan"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Penyiapan gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Pindai atau tempel kode penyiapan untuk menambahkan gateway lain."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Tambahkan gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Berbicara…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Mikrofon aktif · menunggu gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Mikrofon mati"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Sertifikat gateway berubah. Lanjutkan hanya jika Anda memang mengharapkan ini.\n\nSHA-256 lama:\n%1$s\n\nSHA-256 baru:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Ganti gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Pilih gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Gateway aktif"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/it.json
+++ b/apps/.i18n/native/it.json
@@ -2229,6 +2229,11 @@
       "translated": "Sostituisci configurazione"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Dimenticare il gateway?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Annulla"
@@ -2269,14 +2274,34 @@
       "translated": "Disconnetti"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Cancella l'accesso al gateway salvato su questo telefono e scansiona un nuovo codice di configurazione."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateway"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Abbina nuovo Gateway"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Nessun gateway associato."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Dimentica"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Configurazione del Gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Scansiona o incolla un codice di configurazione per aggiungere un altro gateway."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Aggiungi gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Parla…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Microfono attivo · in attesa del gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Microfono disattivato"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Il certificato del gateway è cambiato. Continua solo se te lo aspettavi.\n\nSHA-256 precedente:\n%1$s\n\nNuovo SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Cambia gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Seleziona gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Gateway attivo"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/ja-JP.json
+++ b/apps/.i18n/native/ja-JP.json
@@ -2229,6 +2229,11 @@
       "translated": "設定を置き換え"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Gatewayを削除しますか？"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "キャンセル"
@@ -2269,14 +2274,34 @@
       "translated": "切断"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "このスマートフォンに保存された Gateway アクセスをクリアし、新しいセットアップコードをスキャンします。"
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateway"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "新しい Gateway をペアリング"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "ペアリング済みのGatewayはありません。"
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "削除"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Gatewayのセットアップ"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "セットアップコードをスキャンするか貼り付けて、別のGatewayを追加します。"
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Gatewayを追加"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "発話中…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "マイクオン · Gatewayを待機中"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "マイク オフ"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Gatewayの証明書が変更されました。想定していた場合にのみ続行してください。\n\n古いSHA-256:\n%1$s\n\n新しいSHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Gatewayを切り替え"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Gatewayを選択"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "アクティブなGateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/ko.json
+++ b/apps/.i18n/native/ko.json
@@ -2229,6 +2229,11 @@
       "translated": "설정 교체"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Gateway를 잊어버리시겠습니까?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "취소"
@@ -2269,14 +2274,34 @@
       "translated": "연결 해제"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "이 휴대폰에 저장된 gateway 액세스를 지우고 새 설정 코드를 스캔하세요."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "새 Gateway 페어링"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "페어링된 Gateway가 없습니다."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "잊어버리기"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Gateway 설정"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "다른 Gateway를 추가하려면 설정 코드를 스캔하거나 붙여넣으세요."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Gateway 추가"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "말하는 중…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "마이크 켜짐 · Gateway 대기 중"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "마이크 꺼짐"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "게이트웨이 인증서가 변경되었습니다. 예상한 경우에만 계속하세요.\n\n이전 SHA-256:\n%1$s\n\n새 SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Gateway 전환"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Gateway 선택"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "활성 Gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/nl.json
+++ b/apps/.i18n/native/nl.json
@@ -2229,6 +2229,11 @@
       "translated": "Configuratie vervangen"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Gateway vergeten?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Annuleren"
@@ -2269,14 +2274,34 @@
       "translated": "Verbinding verbreken"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Wis de opgeslagen gateway-toegang van deze telefoon en scan een nieuwe setupcode."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Nieuwe Gateway koppelen"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Geen gekoppelde gateways."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Vergeten"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Gateway instellen"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Scan of plak een installatiecode om een andere gateway toe te voegen."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Gateway toevoegen"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Spreekt…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Microfoon aan · wachten op gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Microfoon uit"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Het gatewaycertificaat is gewijzigd. Ga alleen door als je dit verwachtte.\n\nOude SHA-256:\n%1$s\n\nNieuwe SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Van gateway wisselen"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Gateway selecteren"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Actieve gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/pl.json
+++ b/apps/.i18n/native/pl.json
@@ -2229,6 +2229,11 @@
       "translated": "Zastąp konfigurację"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Zapomnieć Gateway?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Anuluj"
@@ -2269,14 +2274,34 @@
       "translated": "Rozłącz"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Wyczyść zapisany na tym telefonie dostęp do gateway i zeskanuj nowy kod konfiguracji."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateway"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Sparuj nowy Gateway"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Brak sparowanych Gateway."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Zapomnij"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Konfiguracja Gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Zeskanuj lub wklej kod konfiguracji, aby dodać kolejne Gateway."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Dodaj Gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Mówienie…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Mikrofon włączony · oczekiwanie na Gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Mikrofon wyłączony"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Certyfikat gateway uległ zmianie. Kontynuuj tylko, jeśli tego oczekiwano.\n\nStary SHA-256:\n%1$s\n\nNowy SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Przełącz Gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Wybierz Gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Aktywne Gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/pt-BR.json
+++ b/apps/.i18n/native/pt-BR.json
@@ -2229,6 +2229,11 @@
       "translated": "Substituir configuração"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Esquecer Gateway?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Cancelar"
@@ -2269,14 +2274,34 @@
       "translated": "Desconectar"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Limpar o acesso ao Gateway salvo neste telefone e escanear um novo código de configuração."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Parear novo Gateway"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Nenhum Gateway emparelhado."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Esquecer"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Configuração do Gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Escaneie ou cole um código de configuração para adicionar outro Gateway."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Adicionar Gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Falando…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Microfone ligado · aguardando Gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Microfone desligado"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "O certificado do gateway foi alterado. Continue somente se você esperava isso.\n\nSHA-256 antigo:\n%1$s\n\nSHA-256 novo:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Trocar Gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Selecionar Gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Gateway ativo"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/ru.json
+++ b/apps/.i18n/native/ru.json
@@ -2229,6 +2229,11 @@
       "translated": "Заменить настройку"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Забыть gateway?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Отмена"
@@ -2269,14 +2274,34 @@
       "translated": "Отключиться"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Удалить сохраненный на этом телефоне доступ к gateway и отсканировать новый код настройки."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Сопряжение с новым Gateway"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Нет сопряженных gateways."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Забыть"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Настройка Gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Отсканируйте или вставьте код настройки, чтобы добавить еще один gateway."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Добавить gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Говорит…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Микрофон включен · ожидание gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Микрофон выключен"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Сертификат gateway изменился. Продолжайте, только если вы ожидали этого.\n\nСтарый SHA-256:\n%1$s\n\nНовый SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Переключить gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Выбрать gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Активный gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/sv.json
+++ b/apps/.i18n/native/sv.json
@@ -2229,6 +2229,11 @@
       "translated": "Ersätt konfiguration"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Glöm Gateway?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Avbryt"
@@ -2269,14 +2274,34 @@
       "translated": "Koppla från"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Rensa den här telefonens sparade gateway-åtkomst och skanna en ny konfigurationskod."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Parkoppla ny Gateway"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Inga parkopplade Gateways."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Glöm"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Gateway-konfiguration"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Skanna eller klistra in en konfigurationskod för att lägga till en till Gateway."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Lägg till Gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Talar…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Mikrofon på · väntar på Gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Mikrofon av"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Gateway-certifikatet har ändrats. Fortsätt endast om du förväntade dig detta.\n\nGammal SHA-256:\n%1$s\n\nNy SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Byt Gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Välj Gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Aktiv Gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/th.json
+++ b/apps/.i18n/native/th.json
@@ -2229,6 +2229,11 @@
       "translated": "แทนที่การตั้งค่า"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "ลืม Gateway หรือไม่?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "ยกเลิก"
@@ -2269,14 +2274,34 @@
       "translated": "ตัดการเชื่อมต่อ"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "ล้างการเข้าถึง Gateway ที่บันทึกไว้ในโทรศัพท์เครื่องนี้ และสแกนรหัสตั้งค่าใหม่"
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateway"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "จับคู่ Gateway ใหม่"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "ไม่มี Gateway ที่จับคู่แล้ว"
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "ลืม"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "การตั้งค่า Gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "สแกนหรือวางรหัสการตั้งค่าเพื่อเพิ่ม Gateway อื่น"
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "เพิ่ม Gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "กำลังพูด…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "ไมค์เปิด · กำลังรอ Gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "ปิดไมค์"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "ใบรับรอง Gateway เปลี่ยนแปลง ดำเนินการต่อเฉพาะเมื่อคุณคาดว่าจะเป็นเช่นนี้\n\nSHA-256 เก่า:\n%1$s\n\nSHA-256 ใหม่:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "สลับ Gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "เลือก Gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Gateway ที่ใช้งานอยู่"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/tr.json
+++ b/apps/.i18n/native/tr.json
@@ -2229,6 +2229,11 @@
       "translated": "Kurulumu değiştir"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Gateway unutulsun mu?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "İptal"
@@ -2269,14 +2274,34 @@
       "translated": "Bağlantıyı kes"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Bu telefonun kayıtlı gateway erişimini temizleyin ve yeni bir kurulum kodu tarayın."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateway'ler"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Yeni Gateway Eşleştir"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Eşleştirilmiş Gateway yok."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Unut"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Gateway kurulumu"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Başka bir Gateway eklemek için bir kurulum kodunu tarayın veya yapıştırın."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Gateway ekle"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Konuşuyor…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Mikrofon açık · Gateway bekleniyor"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Mikrofon kapalı"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Gateway sertifikası değişti. Yalnızca bunu bekliyorsanız devam edin.\n\nEski SHA-256:\n%1$s\n\nYeni SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Gateway değiştir"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Gateway seç"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Etkin Gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/uk.json
+++ b/apps/.i18n/native/uk.json
@@ -2229,6 +2229,11 @@
       "translated": "Замінити налаштування"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Забути gateway?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Скасувати"
@@ -2269,14 +2274,34 @@
       "translated": "Відключити"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Очистити збережений на цьому телефоні доступ до gateway і відсканувати новий код налаштування."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Спарити новий Gateway"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Немає спарених gateway."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Забути"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Налаштування Gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Відскануйте або вставте код налаштування, щоб додати ще один gateway."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Додати gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Говорить…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Мікрофон увімкнено · очікування gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Мікрофон вимкнено"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Сертифікат Gateway змінився. Продовжуйте лише якщо ви цього очікували.\n\nСтарий SHA-256:\n%1$s\n\nНовий SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Перемкнути gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Виберіть gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Активний gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/vi.json
+++ b/apps/.i18n/native/vi.json
@@ -2229,6 +2229,11 @@
       "translated": "Thay thế thiết lập"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "Quên Gateway?"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "Hủy"
@@ -2269,14 +2274,34 @@
       "translated": "Ngắt kết nối"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "Xóa quyền truy cập gateway đã lưu trên điện thoại này và quét mã thiết lập mới."
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateway"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "Ghép nối Gateway mới"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "Không có Gateway nào đã ghép nối."
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "Quên"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Thiết lập Gateway"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "Quét hoặc dán mã thiết lập để thêm Gateway khác."
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "Thêm Gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "Đang nói…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "Mic bật · đang chờ Gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "Mic tắt"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Chứng chỉ gateway đã thay đổi. Chỉ tiếp tục nếu bạn đã dự kiến điều này.\n\nSHA-256 cũ:\n%1$s\n\nSHA-256 mới:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "Chuyển Gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "Chọn Gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "Gateway đang hoạt động"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/zh-CN.json
+++ b/apps/.i18n/native/zh-CN.json
@@ -2229,6 +2229,11 @@
       "translated": "替换设置"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "忘记 Gateway？"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "取消"
@@ -2269,14 +2274,34 @@
       "translated": "断开连接"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "清除这部手机上已保存的 gateway 访问权限，并扫描新的设置码。"
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "配对新 Gateway"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "没有已配对的 Gateway。"
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "忘记"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Gateway 设置"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "扫描或粘贴设置代码以添加另一个 Gateway。"
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "添加 Gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "正在说话…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "麦克风开启 · 正在等待 Gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "麦克风关闭"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "gateway 证书已更改。仅在这是你预期的情况下继续。\n\n旧 SHA-256：\n%1$s\n\n新 SHA-256：\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "切换 Gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "选择 Gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "当前 Gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/.i18n/native/zh-TW.json
+++ b/apps/.i18n/native/zh-TW.json
@@ -2229,6 +2229,11 @@
       "translated": "取代設定"
     },
     {
+      "id": "native.android.66aad1078731e6a3",
+      "source": "Forget gateway?",
+      "translated": "忘記 Gateway？"
+    },
+    {
       "id": "native.android.c6c8e0c4b8a9a7cf",
       "source": "Cancel",
       "translated": "取消"
@@ -2269,14 +2274,34 @@
       "translated": "中斷連線"
     },
     {
-      "id": "native.android.68959b6e93aec68b",
-      "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
-      "translated": "清除此手機已儲存的 gateway 存取權限，並掃描新的設定代碼。"
+      "id": "native.android.87eee1e2bafbf13b",
+      "source": "Gateways",
+      "translated": "Gateways"
     },
     {
-      "id": "native.android.7fd6bb4d56f1fb3f",
-      "source": "Pair New Gateway",
-      "translated": "配對新的 Gateway"
+      "id": "native.android.c3974020a08e239e",
+      "source": "No paired gateways.",
+      "translated": "沒有已配對的 gateway。"
+    },
+    {
+      "id": "native.android.74ee3bbbd2e37e9c",
+      "source": "Forget",
+      "translated": "忘記"
+    },
+    {
+      "id": "native.android.56e98811c4e9b027",
+      "source": "Gateway setup",
+      "translated": "Gateway 設定"
+    },
+    {
+      "id": "native.android.c040d4ee72a810e0",
+      "source": "Scan or paste a setup code to add another gateway.",
+      "translated": "掃描或貼上設定代碼以新增另一個 gateway。"
+    },
+    {
+      "id": "native.android.a7c243ff3f1d6447",
+      "source": "Add gateway",
+      "translated": "新增 gateway"
     },
     {
       "id": "native.android.77a03c8c22155ec5",
@@ -4034,6 +4059,11 @@
       "translated": "正在說話…"
     },
     {
+      "id": "native.android.6fbf0916309dbaba",
+      "source": "Mic on · waiting for gateway",
+      "translated": "麥克風開啟 · 正在等待 gateway"
+    },
+    {
       "id": "native.android.d84c6c14e42763ff",
       "source": "Mic off",
       "translated": "麥克風關閉"
@@ -4267,6 +4297,21 @@
       "id": "native.android.6ad2d3f084142bed",
       "source": "The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s",
       "translated": "Gateway 憑證已變更。僅在這是你預期的情況下繼續。\n\n舊 SHA-256:\n%1$s\n\n新 SHA-256:\n%2$s"
+    },
+    {
+      "id": "native.android.7c49ec7fe94a9063",
+      "source": "Switch gateway",
+      "translated": "切換 gateway"
+    },
+    {
+      "id": "native.android.9e0a677fd629a15f",
+      "source": "Select gateway",
+      "translated": "選取 gateway"
+    },
+    {
+      "id": "native.android.b0034ac5bbc6b25f",
+      "source": "Active gateway",
+      "translated": "使用中的 gateway"
     },
     {
       "id": "native.apple.8f741d09cc1d5495",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Adds multi-gateway support: the app remembers every paired gateway, lists them in Settings with a quick switcher on the Connect tab, and switches between them without pairing again. Credentials, device tokens, TLS trust, notification routing, chat history, and queued offline messages stay scoped to their gateway, and forgetting a gateway removes all of its stored state.
+
 Android notification forwarding now excludes native WhatsApp, Telegram, Telegram X, Discord, and Signal channel apps to prevent duplicate cross-session replies. (#48516)
 
 Assistant messages now offer a long-press Listen action with gateway TTS playback, on-device fallback, and tap-to-stop status.

--- a/apps/android/app/src/debug/java/ai/openclaw/app/VoiceE2eReceiver.kt
+++ b/apps/android/app/src/debug/java/ai/openclaw/app/VoiceE2eReceiver.kt
@@ -148,11 +148,16 @@ class VoiceE2eService : Service() {
     runtime.setManualHost(host)
     runtime.setManualPort(port)
     runtime.setManualTls(intent.getBooleanExtra("tls", false))
-    runtime.setGatewayToken(intent.getDecodedStringExtra("token").orEmpty())
-    runtime.setGatewayBootstrapToken(intent.getDecodedStringExtra("bootstrapToken").orEmpty())
-    runtime.setGatewayPassword(intent.getDecodedStringExtra("password").orEmpty())
     runtime.setOnboardingCompleted(true)
-    runtime.connectManual()
+    runtime.connect(
+      ai.openclaw.app.gateway.GatewayEndpoint
+        .manual(host, port),
+      NodeRuntime.GatewayConnectAuth(
+        token = intent.getDecodedStringExtra("token"),
+        bootstrapToken = intent.getDecodedStringExtra("bootstrapToken"),
+        password = intent.getDecodedStringExtra("password"),
+      ),
+    )
   }
 
   private suspend fun awaitGateway(

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -8,6 +8,8 @@ import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.MessageSpeechState
 import ai.openclaw.app.chat.OutgoingAttachment
 import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.gateway.GatewayRegistryEntry
+import ai.openclaw.app.gateway.GatewayRegistryEntryKind
 import ai.openclaw.app.gateway.GatewayUpdateAvailableSummary
 import ai.openclaw.app.node.CameraCaptureManager
 import ai.openclaw.app.node.CanvasController
@@ -28,6 +30,9 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.atomic.AtomicLong
 
 enum class ChatDraftPlacement {
   Replace,
@@ -49,6 +54,8 @@ class MainViewModel(
   private val nodeApp = app as NodeApp
   private val prefs = nodeApp.prefs
   private val runtimeRef = MutableStateFlow<NodeRuntime?>(null)
+  private val gatewayConfigOperationSeq = AtomicLong()
+  private val gatewayConfigOperationMutex = Mutex()
 
   @Volatile private var foreground = false
 
@@ -191,8 +198,8 @@ class MainViewModel(
   val manualHost: StateFlow<String> = prefs.manualHost
   val manualPort: StateFlow<Int> = prefs.manualPort
   val manualTls: StateFlow<Boolean> = prefs.manualTls
-  val gatewayToken: StateFlow<String> = prefs.gatewayToken
-  val gatewayBootstrapToken: StateFlow<String> = prefs.gatewayBootstrapToken
+  val pairedGateways: StateFlow<List<GatewayRegistryEntry>> = prefs.gatewayRegistry.entries
+  val activeGatewayStableId: StateFlow<String?> = prefs.gatewayRegistry.activeStableId
   val onboardingCompleted: StateFlow<Boolean> = prefs.onboardingCompleted
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
   val installedAppsSharingEnabled: StateFlow<Boolean> = prefs.installedAppsSharingEnabled
@@ -306,54 +313,71 @@ class MainViewModel(
     prefs.setManualTls(value)
   }
 
-  fun setGatewayBootstrapToken(value: String) {
-    prefs.setGatewayBootstrapToken(value)
-  }
-
-  fun setGatewayPassword(value: String) {
-    prefs.setGatewayPassword(value)
-  }
-
   /** Clears setup credentials without starting the runtime just to discard first-run pairing auth. */
-  private suspend fun resetGatewaySetupAuth(): Boolean {
-    val reset = nodeApp.resetGatewaySetupAuth()
+  private suspend fun resetGatewaySetupAuth(stableId: String): Boolean {
+    val reset = nodeApp.resetGatewaySetupAuth(stableId)
     nodeApp.peekRuntime()?.let { runtimeRef.value = it }
     return reset
   }
 
   internal fun saveGatewayConfigAndConnect(plan: GatewayConnectPlan) {
+    val operation = gatewayConfigOperationSeq.incrementAndGet()
     // Gateway pairing touches encrypted prefs, identity files, and sockets; keep
     // the whole sequence off the Compose thread so retries cannot trigger ANRs.
     viewModelScope.launch(Dispatchers.Default) {
-      val config = plan.config
-      val replacesSavedAuth = plan.savedAuthAction != GatewaySavedAuthAction.PRESERVE
-      if (replacesSavedAuth && !resetGatewaySetupAuth()) return@launch
-      prefs.setManualEnabled(true)
-      prefs.setManualHost(config.host)
-      prefs.setManualPort(config.port)
-      prefs.setManualTls(config.tls)
+      gatewayConfigOperationMutex.withLock {
+        if (operation != gatewayConfigOperationSeq.get()) return@withLock
+        val config = plan.config
+        val endpoint = GatewayEndpoint.manual(host = config.host, port = config.port)
+        val targetAlreadyPaired =
+          prefs.gatewayRegistry.entries.value
+            .any { it.stableId == endpoint.stableId }
+        val blankCredentials = config.token.isEmpty() && config.bootstrapToken.isEmpty() && config.password.isEmpty()
+        val preservesPairedTarget =
+          targetAlreadyPaired && blankCredentials && plan.savedAuthAction == GatewaySavedAuthAction.REPLACE_ENDPOINT
+        val replacesSavedAuth = plan.savedAuthAction != GatewaySavedAuthAction.PRESERVE && !preservesPairedTarget
+        if (replacesSavedAuth && !resetGatewaySetupAuth(endpoint.stableId)) return@launch
+        if (operation != gatewayConfigOperationSeq.get()) return@launch
+        prefs.setManualEnabled(true)
+        prefs.setManualHost(config.host)
+        prefs.setManualPort(config.port)
+        prefs.setManualTls(config.tls)
 
-      // A blank same-endpoint save means "keep access". Secrets remain runtime-owned,
-      // including password-only setups that Compose deliberately cannot read back.
-      if (replacesSavedAuth) {
-        prefs.setGatewayBootstrapToken(config.bootstrapToken)
-        prefs.setGatewayToken(config.token)
-        prefs.setGatewayPassword(config.password)
-      }
+        // A blank same-endpoint save means "keep access". Secrets remain runtime-owned,
+        // including password-only setups that Compose deliberately cannot read back.
+        if (replacesSavedAuth) {
+          prefs.saveGatewayCredentials(
+            stableId = endpoint.stableId,
+            token = config.token,
+            bootstrapToken = config.bootstrapToken,
+            password = config.password,
+          )
+        }
 
-      val runtime = ensureRuntime()
-      val endpoint = GatewayEndpoint.manual(host = config.host, port = config.port)
-      if (replacesSavedAuth) {
-        runtime.connect(
-          endpoint,
-          NodeRuntime.GatewayConnectAuth(
-            token = config.token.ifEmpty { null },
-            bootstrapToken = config.bootstrapToken.ifEmpty { null },
-            password = config.password.ifEmpty { null },
+        prefs.gatewayRegistry.upsert(
+          GatewayRegistryEntry(
+            stableId = endpoint.stableId,
+            kind = GatewayRegistryEntryKind.MANUAL,
+            name = endpoint.name,
+            host = config.host,
+            port = config.port,
+            tls = config.tls,
           ),
         )
-      } else {
-        runtime.connect(endpoint)
+
+        val runtime = ensureRuntime()
+        if (replacesSavedAuth) {
+          runtime.connectSwitchingGateway(
+            endpoint,
+            NodeRuntime.GatewayConnectAuth(
+              token = config.token.ifEmpty { null },
+              bootstrapToken = config.bootstrapToken.ifEmpty { null },
+              password = config.password.ifEmpty { null },
+            ),
+          )
+        } else {
+          runtime.connectSwitchingGateway(endpoint)
+        }
       }
     }
   }
@@ -378,13 +402,19 @@ class MainViewModel(
 
   /** Re-enters gateway setup after disconnecting and clearing one-time setup credentials. */
   fun pairNewGateway() {
+    val operation = gatewayConfigOperationSeq.incrementAndGet()
     viewModelScope.launch(Dispatchers.Default) {
-      if (!resetGatewaySetupAuth()) return@launch
-      // Sign out is the explicit forget boundary for proxy credentials. Ordinary same-gateway
-      // auth replacement keeps these per-endpoint values so reconnects do not require re-entry.
-      prefs.clearGatewayCustomHeaders()
-      prefs.setOnboardingCompleted(false)
-      _startOnboardingAtGatewaySetup.value = true
+      gatewayConfigOperationMutex.withLock {
+        if (operation != gatewayConfigOperationSeq.get()) return@withLock
+        nodeApp.peekRuntime()?.also { runtime ->
+          runtimeRef.value = runtime
+          runtime.prepareForGatewaySetup()
+        }
+        // Pairing another gateway no longer forgets existing gateways; per-gateway
+        // credentials and proxy headers are removed only by forgetGateway.
+        prefs.setOnboardingCompleted(false)
+        _startOnboardingAtGatewaySetup.value = true
+      }
     }
   }
 
@@ -525,12 +555,14 @@ class MainViewModel(
   }
 
   fun connect(endpoint: GatewayEndpoint) {
-    ensureRuntime().connect(endpoint)
+    viewModelScope.launch(Dispatchers.Default) {
+      ensureRuntime().connectSwitchingGateway(endpoint)
+    }
   }
 
   fun connectInBackground(endpoint: GatewayEndpoint) {
     viewModelScope.launch(Dispatchers.Default) {
-      ensureRuntime().connect(endpoint)
+      ensureRuntime().connectSwitchingGateway(endpoint)
     }
   }
 
@@ -540,22 +572,53 @@ class MainViewModel(
     bootstrapToken: String?,
     password: String?,
   ) {
-    ensureRuntime().connect(
-      endpoint,
-      NodeRuntime.GatewayConnectAuth(
-        token = token,
-        bootstrapToken = bootstrapToken,
-        password = password,
-      ),
-    )
+    viewModelScope.launch(Dispatchers.Default) {
+      ensureRuntime().connectSwitchingGateway(
+        endpoint,
+        NodeRuntime.GatewayConnectAuth(
+          token = token,
+          bootstrapToken = bootstrapToken,
+          password = password,
+        ),
+      )
+    }
   }
 
   fun connectManual() {
     ensureRuntime().connectManual()
   }
 
+  fun switchToGateway(stableId: String) {
+    val operation = gatewayConfigOperationSeq.incrementAndGet()
+    viewModelScope.launch(Dispatchers.Default) {
+      gatewayConfigOperationMutex.withLock {
+        if (operation == gatewayConfigOperationSeq.get()) {
+          ensureRuntime().switchToGateway(stableId)
+        }
+      }
+    }
+  }
+
+  fun forgetGateway(stableId: String) {
+    val operation = gatewayConfigOperationSeq.incrementAndGet()
+    viewModelScope.launch(Dispatchers.Default) {
+      gatewayConfigOperationMutex.withLock {
+        if (operation == gatewayConfigOperationSeq.get()) {
+          ensureRuntime().forgetGateway(stableId)
+        }
+      }
+    }
+  }
+
   fun disconnect() {
-    runtimeRef.value?.disconnect()
+    val operation = gatewayConfigOperationSeq.incrementAndGet()
+    viewModelScope.launch(Dispatchers.Default) {
+      gatewayConfigOperationMutex.withLock {
+        if (operation == gatewayConfigOperationSeq.get()) {
+          runtimeRef.value?.disconnect()
+        }
+      }
+    }
   }
 
   fun acceptGatewayTrustPrompt() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeApp.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeApp.kt
@@ -1,10 +1,12 @@
 package ai.openclaw.app
 
-import ai.openclaw.app.chat.deleteChatTranscriptCacheDatabase
+import ai.openclaw.app.chat.ChatCacheDatabase
 import ai.openclaw.app.gateway.DeviceAuthStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
 import android.app.Application
 import android.os.StrictMode
+import androidx.room.withTransaction
+import kotlinx.coroutines.runBlocking
 
 /**
  * Android Application singleton that owns process-wide secure prefs and lazy NodeRuntime startup.
@@ -29,25 +31,36 @@ class NodeApp : Application() {
   fun peekRuntime(): NodeRuntime? = synchronized(runtimeLock) { runtimeInstance }
 
   /** Clears pairing auth without racing lazy process-runtime construction. */
-  suspend fun resetGatewaySetupAuth(): Boolean {
+  suspend fun resetGatewaySetupAuth(stableId: String): Boolean {
     val runtime =
       synchronized(runtimeLock) {
         runtimeInstance?.let { return@synchronized it }
         // Keep runtime construction blocked through the direct purge: a runtime built from the old
         // credentials could otherwise reconnect and rewrite device auth after this reset returns.
-        return runCatching { resetGatewaySetupAuthBeforeRuntime() }.getOrDefault(false)
+        return runCatching { resetGatewaySetupAuthBeforeRuntime(stableId) }.getOrDefault(false)
       }
-    return runtime.resetGatewaySetupAuth()
+    return runtime.resetGatewaySetupAuth(stableId)
   }
 
-  private fun resetGatewaySetupAuthBeforeRuntime(): Boolean {
-    // Delete first: credential destruction must not strand an unreadable cache after a failed purge.
-    if (!deleteChatTranscriptCacheDatabase(this)) return false
-    prefs.clearGatewaySetupAuth()
+  private fun resetGatewaySetupAuthBeforeRuntime(stableId: String): Boolean {
+    val gatewayId = stableId.trim().takeIf { it.isNotEmpty() } ?: return false
+    val database = ChatCacheDatabase.open(this)
+    try {
+      runBlocking {
+        database.withTransaction {
+          database.dao().deleteMessages(gatewayId)
+          database.dao().deleteSessions(gatewayId)
+          database.outboxDao().deleteGateway(gatewayId)
+        }
+      }
+    } finally {
+      database.close()
+    }
+    prefs.clearGatewayCredentials(gatewayId)
     val deviceId = DeviceIdentityStore(this).loadOrCreate().deviceId
     val deviceAuthStore = DeviceAuthStore(prefs)
-    deviceAuthStore.clearToken(deviceId, "node")
-    deviceAuthStore.clearToken(deviceId, "operator")
+    deviceAuthStore.clearToken(gatewayId, deviceId, "node")
+    deviceAuthStore.clearToken(gatewayId, deviceId, "operator")
     return true
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -22,6 +22,8 @@ import ai.openclaw.app.gateway.DeviceAuthStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewayDiscovery
 import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.gateway.GatewayRegistryEntry
+import ai.openclaw.app.gateway.GatewayRegistryEntryKind
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.GatewayTlsProbeFailure
 import ai.openclaw.app.gateway.GatewayTlsProbeResult
@@ -62,6 +64,7 @@ import ai.openclaw.app.node.asStringOrNull
 import ai.openclaw.app.node.invokeErrorFromThrowable
 import ai.openclaw.app.node.parseHexColorArgb
 import ai.openclaw.app.protocol.OpenClawCanvasA2UIAction
+import ai.openclaw.app.voice.GatewayTranscriptionSession
 import ai.openclaw.app.voice.MicCaptureManager
 import ai.openclaw.app.voice.TalkAudioPlayer
 import ai.openclaw.app.voice.TalkModeManager
@@ -76,6 +79,7 @@ import android.os.SystemClock
 import android.util.Base64
 import android.util.Log
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -113,6 +117,7 @@ private const val NODE_APPROVAL_COMMAND_FRESH_MS = 30_000L
 internal data class PendingNotificationNodeEvent(
   val event: String,
   val payloadJson: String?,
+  val gatewayId: String? = null,
 )
 
 private data class QueuedNotificationNodeEvent(
@@ -337,6 +342,18 @@ class NodeRuntime private constructor(
   private var gatewayConnectOperationsInFlight = 0
   private var gatewayConnectOperationsDrained = CompletableDeferred(Unit)
 
+  @Volatile private var connectingEndpointStableId: String? = null
+  private val gatewayDataScopeLock = Any()
+  private val gatewaySwitchMutex = Mutex()
+  private val gatewayLifecycleIntentLock = Any()
+  private val gatewayLifecycleIntentSeq = AtomicLong()
+  private var gatewayDataGeneration = 0L
+
+  private data class GatewayDataScope(
+    val stableId: String,
+    val generation: Long,
+  )
+
   constructor(
     context: Context,
     prefs: SecurePrefs = SecurePrefs(context.applicationContext),
@@ -498,7 +515,11 @@ class NodeRuntime private constructor(
       photosAvailable = { SensitiveFeatureConfig.photosEnabled },
       hasRecordAudioPermission = { hasRecordAudioPermission() },
       installedAppsSharingEnabled = { installedAppsSharingEnabled.value },
-      manualTls = { manualTls.value },
+      manualTls = { endpoint ->
+        prefs.gatewayRegistry.entries.value
+          .firstOrNull { it.stableId == endpoint.stableId }
+          ?.tls ?: manualTls.value
+      },
     )
 
   private val invokeDispatcher: InvokeDispatcher =
@@ -740,6 +761,7 @@ class NodeRuntime private constructor(
       identityStore = identityStore,
       deviceAuthStore = deviceAuthStore,
       onConnected = { hello ->
+        recordConnectedGateway()
         _serverName.value = hello.serverName
         _remoteAddress.value = hello.remoteAddress
         _gatewayVersion.value = hello.serverVersion
@@ -765,38 +787,7 @@ class NodeRuntime private constructor(
         }
       },
       onDisconnected = { message ->
-        invalidateNodeCapabilityApprovalState()
-        _serverName.value = null
-        _remoteAddress.value = null
-        _gatewayVersion.value = null
-        _gatewayUpdateAvailable.value = null
-        _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
-        _gatewayDefaultAgentId.value = null
-        _gatewayAgents.value = emptyList()
-        _modelCatalog.value = emptyList()
-        _modelAuthProviders.value = emptyList()
-        _talkSetupReadiness.value = GatewayTalkSetupReadiness.unverified()
-        _cronStatus.value = GatewayCronStatus(enabled = false, jobs = 0, nextWakeAtMs = null)
-        _cronJobs.value = emptyList()
-        cronJobDetailRequestGuard.cancel {
-          _cronJobDetailState.value = GatewayCronJobDetailState.Idle
-        }
-        _usageSummary.value = GatewayUsageSummary(updatedAtMs = null, providers = emptyList())
-        _skillsSummary.value = GatewaySkillsSummary(skills = emptyList())
-        _nodesDevicesSummary.value =
-          GatewayNodesDevicesSummary(
-            nodes = emptyList(),
-            pendingDevices = emptyList(),
-            pairedDevices = emptyList(),
-          )
-        invalidateExecApprovalRefreshes()
-        resolvedExecApprovalIds.clear()
-        _execApprovals.value = emptyList()
-        _execApprovalsRefreshing.value = false
-        _execApprovalsErrorText.value = null
-        _channelsSummary.value = GatewayChannelsSummary(channels = emptyList())
-        _dreamingSummary.value = GatewayDreamingSummary()
-        _healthLogsSummary.value = GatewayHealthLogsSummary()
+        clearOperatorGatewayState()
         chat.applyMainSessionKey(resolveMainSessionKey())
         chat.onDisconnected(message)
         updateStatus {
@@ -817,6 +808,53 @@ class NodeRuntime private constructor(
       customHeadersProvider = prefs::loadGatewayCustomHeaders,
     )
 
+  private fun clearOperatorGatewayState() {
+    invalidateNodeCapabilityApprovalState()
+    _serverName.value = null
+    _remoteAddress.value = null
+    _gatewayVersion.value = null
+    _gatewayUpdateAvailable.value = null
+    _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
+    _gatewayDefaultAgentId.value = null
+    _gatewayAgents.value = emptyList()
+    _modelCatalog.value = emptyList()
+    _modelAuthProviders.value = emptyList()
+    _modelCatalogRefreshing.value = false
+    _modelCatalogErrorText.value = null
+    _talkSetupReadiness.value = GatewayTalkSetupReadiness.unverified()
+    _cronStatus.value = GatewayCronStatus(enabled = false, jobs = 0, nextWakeAtMs = null)
+    _cronJobs.value = emptyList()
+    _cronRefreshing.value = false
+    _cronErrorText.value = null
+    cronJobDetailRequestGuard.cancel { _cronJobDetailState.value = GatewayCronJobDetailState.Idle }
+    _usageSummary.value = GatewayUsageSummary(updatedAtMs = null, providers = emptyList())
+    _usageRefreshing.value = false
+    _usageErrorText.value = null
+    _skillsSummary.value = GatewaySkillsSummary(skills = emptyList())
+    _skillsRefreshing.value = false
+    _skillsErrorText.value = null
+    _nodesDevicesSummary.value =
+      GatewayNodesDevicesSummary(
+        nodes = emptyList(),
+        pendingDevices = emptyList(),
+        pairedDevices = emptyList(),
+      )
+    invalidateExecApprovalRefreshes()
+    resolvedExecApprovalIds.clear()
+    _execApprovals.value = emptyList()
+    _execApprovalsRefreshing.value = false
+    _execApprovalsErrorText.value = null
+    _channelsSummary.value = GatewayChannelsSummary(channels = emptyList())
+    _channelsRefreshing.value = false
+    _channelsErrorText.value = null
+    _dreamingSummary.value = GatewayDreamingSummary()
+    _dreamingRefreshing.value = false
+    _dreamingErrorText.value = null
+    _healthLogsSummary.value = GatewayHealthLogsSummary()
+    _healthLogsRefreshing.value = false
+    _healthLogsErrorText.value = null
+  }
+
   private suspend fun subscribeOperatorSessionEvents() {
     try {
       operatorSession.request("sessions.subscribe", null)
@@ -831,6 +869,7 @@ class NodeRuntime private constructor(
       identityStore = identityStore,
       deviceAuthStore = deviceAuthStore,
       onConnected = {
+        recordConnectedGateway()
         didAutoRequestCanvasRehydrate = false
         _canvasA2uiHydrated.value = false
         _canvasRehydratePending.value = false
@@ -890,8 +929,10 @@ class NodeRuntime private constructor(
   private val networkMonitor = NetworkMonitor(appContext, ::retryGatewaySessionsAfterNetworkRestore)
 
   private fun retryGatewaySessionsAfterNetworkRestore() {
-    operatorSession.retryAfterNetworkRestore()
-    nodeSession.retryAfterNetworkRestore()
+    launchGatewayLifecycle {
+      operatorSession.retryAfterNetworkRestore()
+      nodeSession.retryAfterNetworkRestore()
+    }
   }
 
   private val notificationOutbox: NotificationNodeEventOutbox by lazy {
@@ -901,7 +942,11 @@ class NodeRuntime private constructor(
       deliveryIntervalMs = ::notificationDeliveryIntervalMs,
       invalidateConnection = nodeSession::reconnect,
       send = { pending ->
-        nodeSession.sendNodeEventWithOutcome(event = pending.event, payloadJson = pending.payloadJson)
+        nodeSession.sendNodeEventWithOutcomeForEndpoint(
+          expectedEndpointStableId = pending.gatewayId,
+          event = pending.event,
+          payloadJson = pending.payloadJson,
+        )
       },
     )
   }
@@ -924,6 +969,7 @@ class NodeRuntime private constructor(
     val packageName = payload["packageName"].asStringOrNull()?.trim().orEmpty()
     if (packageName.isEmpty()) return false
     val policy = prefs.getNotificationForwardingPolicy(appPackageName = appContext.packageName)
+    if (event.gatewayId != null && event.gatewayId != prefs.gatewayRegistry.activeStableId.value) return false
     val eventSessionKey = payload["sessionKey"].asStringOrNull()?.trim()?.ifEmpty { null }
     return policy.enabled &&
       policy.sessionKey == eventSessionKey &&
@@ -935,7 +981,11 @@ class NodeRuntime private constructor(
     scope.launch { notificationOutbox.deliver() }
     DeviceNotificationListenerService.setNodeEventSink { event, payloadJson ->
       notificationOutbox.enqueue(
-        PendingNotificationNodeEvent(event = event, payloadJson = payloadJson),
+        PendingNotificationNodeEvent(
+          event = event,
+          payloadJson = payloadJson,
+          gatewayId = prefs.gatewayRegistry.activeStableId.value,
+        ),
       )
     }
   }
@@ -973,17 +1023,7 @@ class NodeRuntime private constructor(
    */
   private fun chatCacheGatewayId(): String? {
     connectedEndpoint?.stableId?.let { return it }
-    // Chat bootstrap can call this during construction, before the public preference aliases below
-    // initialize. Read their owner directly or onboarding can crash on a null StateFlow field.
-    if (prefs.manualEnabled.value) {
-      val host = prefs.manualHost.value.trim()
-      val port = prefs.manualPort.value
-      if (host.isEmpty() || port !in 1..65535) return null
-      return GatewayEndpoint.manual(host = host, port = port).stableId
-    }
-    return prefs.lastDiscoveredStableId.value
-      .trim()
-      .takeIf { it.isNotEmpty() }
+    return prefs.gatewayRegistry.activeStableId.value
   }
 
   private fun chatCacheScope(): ChatCacheScope? =
@@ -1000,6 +1040,7 @@ class NodeRuntime private constructor(
         scope = scope,
         session = operatorSession,
         isConnected = { gatewayConnectionDisplay.value.isConnected },
+        gatewayStableId = { connectedEndpoint?.stableId },
         onBeforeSpeak = { micCapture.pauseForTts() },
         onAfterSpeak = { micCapture.resumeAfterTts() },
       ).also { speaker ->
@@ -1014,6 +1055,7 @@ class NodeRuntime private constructor(
       context = appContext,
       scope = scope,
       createTranscriptionSession = {
+        val gatewayId = connectedEndpoint?.stableId ?: error("not connected")
         val params =
           buildJsonObject {
             put("mode", JsonPrimitive("transcription"))
@@ -1021,35 +1063,42 @@ class NodeRuntime private constructor(
             put("brain", JsonPrimitive("none"))
           }
         val response =
-          operatorSession.request(
+          operatorSession.requestForEndpoint(
+            gatewayId,
             "talk.session.create",
             params.toString(),
             timeoutMs = 15_000,
           )
-        parseTalkSessionId(response)
+        GatewayTranscriptionSession(
+          id = parseTalkSessionId(response),
+          gatewayId = gatewayId,
+        )
       },
-      appendTranscriptionAudio = { sessionId, audio, onError ->
+      appendTranscriptionAudio = { session, audio, onError ->
         val params =
           buildJsonObject {
-            put("sessionId", JsonPrimitive(sessionId))
+            put("sessionId", JsonPrimitive(session.id))
             put("audioBase64", JsonPrimitive(Base64.encodeToString(audio, Base64.NO_WRAP)))
             put("timestamp", JsonPrimitive(SystemClock.elapsedRealtime()))
           }
-        operatorSession.sendRequestFrame(
+        operatorSession.sendRequestFrameForEndpoint(
+          session.gatewayId,
           "talk.session.appendAudio",
           params.toString(),
           timeoutMs = 8_000,
         ) { error -> onError(error.message) }
       },
-      closeTranscriptionSession = { sessionId ->
-        val params = buildJsonObject { put("sessionId", JsonPrimitive(sessionId)) }
-        operatorSession.request(
+      closeTranscriptionSession = { session ->
+        val params = buildJsonObject { put("sessionId", JsonPrimitive(session.id)) }
+        operatorSession.requestForEndpoint(
+          session.gatewayId,
           "talk.session.close",
           params.toString(),
           timeoutMs = 5_000,
         )
       },
       sendToGateway = { message, onRunIdKnown ->
+        val gatewayId = connectedEndpoint?.stableId ?: error("not connected")
         val idempotencyKey = UUID.randomUUID().toString()
         // Notify MicCaptureManager of the idempotency key *before* the network
         // call so pendingRunId is set before any chat events can arrive.
@@ -1062,7 +1111,7 @@ class NodeRuntime private constructor(
             put("timeoutMs", JsonPrimitive(30_000))
             put("idempotencyKey", JsonPrimitive(idempotencyKey))
           }
-        val response = operatorSession.request("chat.send", params.toString())
+        val response = operatorSession.requestForEndpoint(gatewayId, "chat.send", params.toString())
         val ack = parseChatSendAck(json, response)
         ack.copy(runId = ack.runId ?: idempotencyKey)
       },
@@ -1111,6 +1160,7 @@ class NodeRuntime private constructor(
       scope = scope,
       session = operatorSession,
       isConnected = { gatewayConnectionDisplay.value.isConnected },
+      gatewayStableId = { connectedEndpoint?.stableId },
       onBeforeSpeak = { micCapture.pauseForTts() },
       onAfterSpeak = { micCapture.resumeAfterTts() },
       onStoppedByRelay = { finishTalkModeAfterRelayClose() },
@@ -1329,8 +1379,9 @@ class NodeRuntime private constructor(
     source: String = "manual",
     force: Boolean = true,
   ) {
+    val gatewayId = connectedEndpoint?.stableId
     scope.launch {
-      if (!_nodeConnected.value) {
+      if (gatewayId == null || !_nodeConnected.value) {
         _canvasRehydratePending.value = false
         _canvasRehydrateErrorText.value = "Node offline. Reconnect and retry."
         return@launch
@@ -1347,7 +1398,8 @@ class NodeRuntime private constructor(
           "If existing A2UI state exists, replay it immediately. " +
           "If not, create and render a compact mobile-friendly dashboard in Canvas."
       val sent =
-        nodeSession.sendNodeEvent(
+        nodeSession.sendNodeEventForEndpoint(
+          expectedEndpointStableId = gatewayId,
           event = "agent.request",
           payloadJson =
             buildJsonObject {
@@ -1389,17 +1441,17 @@ class NodeRuntime private constructor(
   val manualHost: StateFlow<String> = prefs.manualHost
   val manualPort: StateFlow<Int> = prefs.manualPort
   val manualTls: StateFlow<Boolean> = prefs.manualTls
-  val gatewayToken: StateFlow<String> = prefs.gatewayToken
   val onboardingCompleted: StateFlow<Boolean> = prefs.onboardingCompleted
 
-  fun setGatewayToken(value: String) = prefs.setGatewayToken(value)
-
-  fun setGatewayBootstrapToken(value: String) = prefs.setGatewayBootstrapToken(value)
-
-  fun setGatewayPassword(value: String) = prefs.setGatewayPassword(value)
-
   /** Clears setup credentials plus paired device tokens for both Android gateway roles. */
-  suspend fun resetGatewaySetupAuth(): Boolean {
+  suspend fun resetGatewaySetupAuth(stableId: String): Boolean =
+    gatewayLifecycleIntentSeq.incrementAndGet().let { intent ->
+      gatewaySwitchMutex.withLock {
+        if (intent != gatewayLifecycleIntentSeq.get()) false else resetGatewaySetupAuthLocked(stableId)
+      }
+    }
+
+  private suspend fun resetGatewaySetupAuthLocked(stableId: String): Boolean {
     val connectOperationsDrained =
       synchronized(gatewayAuthLifecycleLock) {
         if (gatewayAuthResetInProgress) {
@@ -1412,26 +1464,31 @@ class NodeRuntime private constructor(
         ?: return false
     return try {
       connectOperationsDrained.await()
-      // Quiesce authenticated sockets before purging. The controller serializes cache mutations,
-      // so any old write finishes before clear and queued old writes self-reject.
-      disconnectAndJoin()
-      // An old socket callback may have started cache work after prepareDisconnect() advanced the
-      // generation. Advance it again after both terminal callbacks so that work self-rejects.
-      connectAttemptSeq.incrementAndGet()
-      chat.onGatewayScopeChanging()
-      // Purge before destroying credentials. A database failure can abort re-pairing safely while
-      // the old authentication remains recoverable, instead of leaving a half-reset identity.
+      if (connectedEndpoint?.stableId == stableId) {
+        disconnectAndJoin()
+      }
+      if (connectingEndpointStableId == stableId) {
+        connectAttemptSeq.incrementAndGet()
+        connectingEndpointStableId = null
+        _pendingGatewayTrust.value = null
+        chat.onGatewayScopeChanging(retireRunState = true)
+      }
+      drainIdleGatewaySessionTails()
+      // A deliberate disconnect retains reconnect ownership. Authentication replacement does not.
+      chat.onGatewayScopeChanging(retireRunState = true)
+      // Replacing authentication retires the old identity even when the endpoint is unchanged.
+      // Purge only that gateway; ordinary switches retain every gateway's offline state.
       val cacheCleared =
-        runCatching { chat.clearTranscriptCache() }
+        runCatching { chat.clearGatewayCache(stableId) }
           .onFailure { err ->
-            Log.e("OpenClawRuntime", "Failed to purge offline chat cache before auth reset", err)
+            Log.e("OpenClawRuntime", "Failed to purge gateway chat data before auth reset", err)
             setStandaloneGatewayStatus("Failed: couldn't clear offline chat data. Retry sign out.")
           }.isSuccess
       if (!cacheCleared) return false
-      prefs.clearGatewaySetupAuth()
+      prefs.clearGatewayCredentials(stableId)
       val deviceId = identityStore.loadOrCreate().deviceId
-      deviceAuthStore.clearToken(deviceId, "node")
-      deviceAuthStore.clearToken(deviceId, "operator")
+      deviceAuthStore.clearToken(stableId, deviceId, "node")
+      deviceAuthStore.clearToken(stableId, deviceId, "operator")
       true
     } finally {
       synchronized(gatewayAuthLifecycleLock) { gatewayAuthResetInProgress = false }
@@ -1442,6 +1499,8 @@ class NodeRuntime private constructor(
   fun setOnboardingCompleted(value: Boolean) = prefs.setOnboardingCompleted(value)
 
   val lastDiscoveredStableId: StateFlow<String> = prefs.lastDiscoveredStableId
+  val pairedGateways: StateFlow<List<GatewayRegistryEntry>> = prefs.gatewayRegistry.entries
+  val activeGatewayStableId: StateFlow<String?> = prefs.gatewayRegistry.activeStableId
   val canvasDebugStatusEnabled: StateFlow<Boolean> = prefs.canvasDebugStatusEnabled
   val installedAppsSharingEnabled: StateFlow<Boolean> = prefs.installedAppsSharingEnabled
   val notificationForwardingEnabled: StateFlow<Boolean> = prefs.notificationForwardingEnabled
@@ -1481,10 +1540,6 @@ class NodeRuntime private constructor(
   init {
     if (prefs.voiceWakeMode.value != VoiceWakeMode.Off) {
       prefs.setVoiceWakeMode(VoiceWakeMode.Off)
-    }
-
-    scope.launch {
-      prefs.loadGatewayToken()
     }
 
     if (prefs.voiceMicEnabled.value) {
@@ -1539,12 +1594,18 @@ class NodeRuntime private constructor(
     trigger: NodePresenceAliveBeacon.Trigger,
     throttleRecentSuccess: Boolean = false,
   ) {
+    val gatewayId = connectedEndpoint?.stableId ?: return
     scope.launch {
-      sendNodePresenceAliveBeacon(trigger = trigger, throttleRecentSuccess = throttleRecentSuccess)
+      sendNodePresenceAliveBeacon(
+        gatewayId = gatewayId,
+        trigger = trigger,
+        throttleRecentSuccess = throttleRecentSuccess,
+      )
     }
   }
 
   private suspend fun sendNodePresenceAliveBeacon(
+    gatewayId: String,
     trigger: NodePresenceAliveBeacon.Trigger,
     throttleRecentSuccess: Boolean,
   ) {
@@ -1572,7 +1633,8 @@ class NodeRuntime private constructor(
         modelIdentifier = client.modelIdentifier,
       )
     val result =
-      nodeSession.sendNodeEventDetailed(
+      nodeSession.sendNodeEventDetailedForEndpoint(
+        expectedEndpointStableId = gatewayId,
         event = NodePresenceAliveBeacon.EVENT_NAME,
         payloadJson = payloadJson,
       )
@@ -1595,19 +1657,76 @@ class NodeRuntime private constructor(
   }
 
   private fun resolvePreferredGatewayEndpoint(): GatewayEndpoint? {
-    if (manualEnabled.value) {
-      val host = manualHost.value.trim()
-      val port = manualPort.value
-      if (host.isEmpty() || port !in 1..65535) return null
-      return GatewayEndpoint.manual(host = host, port = port)
+    val entry = prefs.gatewayRegistry.activeEntry() ?: return null
+    return when (entry.kind) {
+      GatewayRegistryEntryKind.MANUAL -> {
+        val host = entry.host?.trim().orEmpty()
+        val port = entry.port ?: return null
+        if (host.isEmpty() || port !in 1..65535) return null
+        GatewayEndpoint.manual(host = host, port = port)
+      }
+      GatewayRegistryEntryKind.DISCOVERED -> {
+        val endpoint = gateways.value.firstOrNull { it.stableId == entry.stableId } ?: return null
+        val storedFingerprint = prefs.loadGatewayTlsFingerprint(endpoint.stableId)?.trim().orEmpty()
+        endpoint.takeIf { storedFingerprint.isNotEmpty() }
+      }
     }
+  }
 
-    val targetStableId = lastDiscoveredStableId.value.trim()
-    if (targetStableId.isEmpty()) return null
-    val endpoint = gateways.value.firstOrNull { it.stableId == targetStableId } ?: return null
-    val storedFingerprint = prefs.loadGatewayTlsFingerprint(endpoint.stableId)?.trim().orEmpty()
-    if (storedFingerprint.isEmpty()) return null
-    return endpoint
+  suspend fun switchToGateway(stableId: String): Boolean {
+    val entry =
+      prefs.gatewayRegistry.entries.value
+        .firstOrNull { it.stableId == stableId } ?: return false
+    val endpoint =
+      when (entry.kind) {
+        GatewayRegistryEntryKind.MANUAL -> {
+          val host = entry.host?.trim().orEmpty()
+          val port = entry.port ?: return false
+          if (host.isEmpty() || port !in 1..65535) return false
+          GatewayEndpoint.manual(host, port)
+        }
+        GatewayRegistryEntryKind.DISCOVERED ->
+          gateways.value.firstOrNull { it.stableId == stableId }
+            ?: run {
+              setStandaloneGatewayStatus("Gateway not currently discoverable")
+              return false
+            }
+      }
+    return connectSwitchingGateway(endpoint)
+  }
+
+  suspend fun connectSwitchingGateway(
+    endpoint: GatewayEndpoint,
+    explicitAuth: GatewayConnectAuth? = null,
+  ): Boolean {
+    val intent = gatewayLifecycleIntentSeq.incrementAndGet()
+    return gatewaySwitchMutex.withLock {
+      if (intent != gatewayLifecycleIntentSeq.get()) return@withLock false
+      val currentStableId =
+        connectedEndpoint?.stableId
+          ?: connectingEndpointStableId
+          ?: prefs.gatewayRegistry.activeStableId.value
+      if (currentStableId != null && currentStableId != endpoint.stableId) {
+        disconnectAndJoin()
+      }
+      if (prefs.gatewayRegistry.entries.value
+          .any { it.stableId == endpoint.stableId }
+      ) {
+        prefs.gatewayRegistry.setActive(endpoint.stableId)
+      }
+      val started =
+        synchronized(gatewayLifecycleIntentLock) {
+          if (intent != gatewayLifecycleIntentSeq.get()) {
+            false
+          } else {
+            beginConnect(endpoint, resolveGatewayConnectAuth(endpoint, explicitAuth))
+            true
+          }
+        }
+      if (!started) return@withLock false
+      chat.restoreSelectedGatewayOfflineState()
+      true
+    }
   }
 
   private fun autoConnectIfNeeded() {
@@ -2235,24 +2354,50 @@ class NodeRuntime private constructor(
     }
 
   fun refreshGatewayConnection() {
-    val endpoint = connectedEndpoint
-    if (endpoint == null) {
-      resolvePreferredGatewayEndpoint()?.let(::connect)
-        ?: run {
+    gatewayLifecycleIntentSeq.incrementAndGet()
+    launchGatewayLifecycle {
+      val endpoint = connectedEndpoint
+      if (endpoint == null) {
+        val preferred = resolvePreferredGatewayEndpoint()
+        if (preferred == null) {
           setStandaloneGatewayStatus("Failed: no saved gateway endpoint")
+        } else {
+          prepareGatewayTarget(preferred)
+          beginConnect(preferred, resolveGatewayConnectAuth(preferred))
         }
-      return
+        return@launchGatewayLifecycle
+      }
+      updateStatus {
+        operatorStatusText = "Connecting…"
+        operatorConnectionProblem = null
+      }
+      connectWithAuth(endpoint = endpoint, auth = resolveGatewayConnectAuth(endpoint), reconnect = true)
     }
-    updateStatus {
-      operatorStatusText = "Connecting…"
-      operatorConnectionProblem = null
-    }
-    connectWithAuth(endpoint = endpoint, auth = resolveGatewayConnectAuth(), reconnect = true)
   }
 
   private fun refreshNodeSurfaceAfterSharingChange() {
-    val endpoint = connectedEndpoint ?: return
-    connectWithAuth(endpoint = endpoint, auth = resolveGatewayConnectAuth(), reconnect = true)
+    launchGatewayLifecycle {
+      val endpoint = connectedEndpoint ?: return@launchGatewayLifecycle
+      connectWithAuth(endpoint = endpoint, auth = resolveGatewayConnectAuth(endpoint), reconnect = true)
+    }
+  }
+
+  private fun launchGatewayLifecycle(block: () -> Unit) {
+    val intent = gatewayLifecycleIntentSeq.get()
+    val guardedBlock = {
+      synchronized(gatewayLifecycleIntentLock) {
+        if (intent == gatewayLifecycleIntentSeq.get()) block()
+      }
+    }
+    if (gatewaySwitchMutex.tryLock()) {
+      try {
+        guardedBlock()
+      } finally {
+        gatewaySwitchMutex.unlock()
+      }
+    } else {
+      scope.launch { gatewaySwitchMutex.withLock { guardedBlock() } }
+    }
   }
 
   private fun connectWithAuth(
@@ -2265,7 +2410,7 @@ class NodeRuntime private constructor(
       beforeConnect()
       activeGatewayAuth = auth
       val tls = connectionManager.resolveTlsParams(endpoint)
-      val storedOperatorEntry = loadStoredRoleDeviceAuthEntry("operator")
+      val storedOperatorEntry = loadStoredRoleDeviceAuthEntry(endpoint, "operator")
       refreshGatewayControlPage(endpoint, auth, storedOperatorEntry?.token)
       val usesStoredOperatorDeviceToken =
         operatorSessionUsesStoredDeviceToken(auth, storedOperatorEntry?.token)
@@ -2353,6 +2498,7 @@ class NodeRuntime private constructor(
     notificationOutbox.clear()
     invalidateNodeCapabilityApprovalState()
     val connectAttemptId = connectAttemptSeq.incrementAndGet()
+    connectingEndpointStableId = endpoint.stableId
     chat.onGatewayScopeChanging()
     _pendingGatewayTrust.value = null
     val tls = connectionManager.resolveTlsParams(endpoint)
@@ -2368,6 +2514,7 @@ class NodeRuntime private constructor(
         val fp =
           tlsProbe.fingerprintSha256 ?: run {
             if (expectedFingerprint == null) {
+              connectingEndpointStableId = null
               setStandaloneGatewayStatus(gatewayTlsProbeFailureMessage(tlsProbe.failure))
             } else {
               connectAfterTlsCheck(endpoint = endpoint, auth = auth, connectAttemptId = connectAttemptId)
@@ -2397,7 +2544,7 @@ class NodeRuntime private constructor(
       return
     }
 
-    connectAfterTlsCheck(endpoint = endpoint, auth = auth, connectAttemptId = connectAttemptId)
+    connectAfterTlsCheckLocked(endpoint = endpoint, auth = auth, connectAttemptId = connectAttemptId)
   }
 
   private fun isCurrentConnectAttempt(connectAttemptId: Long): Boolean = connectAttemptSeq.get() == connectAttemptId
@@ -2417,14 +2564,14 @@ class NodeRuntime private constructor(
 
   private fun refreshGatewayControlPage(
     endpoint: GatewayEndpoint? = connectedEndpoint,
-    auth: GatewayConnectAuth = activeGatewayAuth ?: resolveGatewayConnectAuth(),
-    storedOperatorToken: String? = loadStoredRoleDeviceAuthEntry("operator")?.token,
+    auth: GatewayConnectAuth? = activeGatewayAuth,
+    storedOperatorToken: String? = endpoint?.let { loadStoredRoleDeviceAuthEntry(it, "operator")?.token },
   ) {
     if (endpoint == null) {
       _gatewayControlPage.value = null
       return
     }
-    val pageAuth = resolveGatewayControlPageAuth(auth, storedOperatorToken)
+    val pageAuth = resolveGatewayControlPageAuth(auth ?: resolveGatewayConnectAuth(endpoint), storedOperatorToken)
     _gatewayControlPage.value =
       GatewayControlPage(
         baseUrl = gatewayControlPageBaseUrl(endpoint),
@@ -2438,9 +2585,18 @@ class NodeRuntime private constructor(
     auth: GatewayConnectAuth,
     connectAttemptId: Long,
   ) {
+    launchGatewayLifecycle { connectAfterTlsCheckLocked(endpoint, auth, connectAttemptId) }
+  }
+
+  private fun connectAfterTlsCheckLocked(
+    endpoint: GatewayEndpoint,
+    auth: GatewayConnectAuth,
+    connectAttemptId: Long,
+  ) {
     if (!isCurrentConnectAttempt(connectAttemptId)) return
     connectWithAuth(endpoint = endpoint, auth = auth) {
       connectedEndpoint = endpoint
+      connectingEndpointStableId = null
       updateStatus {
         operatorConnectionProblem = null
         nodeConnectionProblem = null
@@ -2451,14 +2607,35 @@ class NodeRuntime private constructor(
   }
 
   fun connect(endpoint: GatewayEndpoint) {
-    beginConnect(endpoint = endpoint, auth = resolveGatewayConnectAuth())
+    gatewayLifecycleIntentSeq.incrementAndGet()
+    launchGatewayLifecycle {
+      prepareGatewayTarget(endpoint)
+      beginConnect(endpoint = endpoint, auth = resolveGatewayConnectAuth(endpoint))
+    }
   }
 
   fun connect(
     endpoint: GatewayEndpoint,
     auth: GatewayConnectAuth,
   ) {
-    beginConnect(endpoint = endpoint, auth = resolveGatewayConnectAuth(auth))
+    gatewayLifecycleIntentSeq.incrementAndGet()
+    launchGatewayLifecycle {
+      prepareGatewayTarget(endpoint)
+      beginConnect(endpoint = endpoint, auth = resolveGatewayConnectAuth(endpoint, auth))
+    }
+  }
+
+  private fun prepareGatewayTarget(endpoint: GatewayEndpoint) {
+    if (connectedEndpoint?.stableId?.let { it != endpoint.stableId } == true) {
+      // Closing both sockets is synchronous; cleanup callbacks may finish later, but no event can
+      // cross the active-pointer change on the old authenticated transport.
+      disconnect(retireRunState = true)
+    }
+    if (prefs.gatewayRegistry.entries.value
+        .any { it.stableId == endpoint.stableId }
+    ) {
+      prefs.gatewayRegistry.setActive(endpoint.stableId)
+    }
   }
 
   /** HTTP(S) origin serving the connected gateway's Control UI pages. */
@@ -2467,24 +2644,38 @@ class NodeRuntime private constructor(
     return "$scheme://${formatGatewayAuthority(endpoint.host, endpoint.port)}"
   }
 
-  internal fun resolveGatewayConnectAuth(explicitAuth: GatewayConnectAuth? = null): GatewayConnectAuth =
+  internal fun resolveGatewayConnectAuth(
+    endpoint: GatewayEndpoint,
+    explicitAuth: GatewayConnectAuth? = null,
+  ): GatewayConnectAuth =
     explicitAuth
-      ?: GatewayConnectAuth(
-        token = prefs.loadGatewayToken(),
-        bootstrapToken = prefs.loadGatewayBootstrapToken(),
-        password = prefs.loadGatewayPassword(),
-      )
+      ?: prefs.loadGatewayCredentials(endpoint.stableId).let { credentials ->
+        GatewayConnectAuth(
+          token = credentials.token,
+          bootstrapToken = credentials.bootstrapToken,
+          password = credentials.password,
+        )
+      }
 
   fun acceptGatewayTrustPrompt() {
     val prompt = _pendingGatewayTrust.value ?: return
-    _pendingGatewayTrust.value = null
-    prefs.saveGatewayTlsFingerprint(prompt.endpoint.stableId, prompt.fingerprintSha256)
-    beginConnect(endpoint = prompt.endpoint, auth = prompt.auth)
+    gatewayLifecycleIntentSeq.incrementAndGet()
+    launchGatewayLifecycle {
+      if (_pendingGatewayTrust.value != prompt) return@launchGatewayLifecycle
+      _pendingGatewayTrust.value = null
+      prefs.saveGatewayTlsFingerprint(prompt.endpoint.stableId, prompt.fingerprintSha256)
+      registerGateway(prompt.endpoint, setActive = true)
+      beginConnect(endpoint = prompt.endpoint, auth = prompt.auth)
+    }
   }
 
   fun declineGatewayTrustPrompt() {
-    _pendingGatewayTrust.value = null
-    setStandaloneGatewayStatus("Offline")
+    gatewayLifecycleIntentSeq.incrementAndGet()
+    launchGatewayLifecycle {
+      _pendingGatewayTrust.value = null
+      connectingEndpointStableId = null
+      setStandaloneGatewayStatus("Offline")
+    }
   }
 
   private fun gatewayTlsProbeFailureMessage(failure: GatewayTlsProbeFailure?): String =
@@ -2513,18 +2704,23 @@ class NodeRuntime private constructor(
     connect(GatewayEndpoint.manual(host = host, port = port))
   }
 
-  private fun loadStoredRoleDeviceAuthEntry(role: String): DeviceAuthEntry? {
+  private fun loadStoredRoleDeviceAuthEntry(
+    endpoint: GatewayEndpoint,
+    role: String,
+  ): DeviceAuthEntry? {
     val deviceId = identityStore.loadOrCreate().deviceId
-    return deviceAuthStore.loadEntry(deviceId, role)
+    return deviceAuthStore.loadEntry(endpoint.stableId, deviceId, role)
   }
 
   private fun maybeStartOperatorSessionAfterNodeConnect(
     endpoint: GatewayEndpoint,
     auth: GatewayConnectAuth,
   ) {
+    val selectedGatewayId = connectedEndpoint?.stableId ?: connectingEndpointStableId
+    if (selectedGatewayId != null && selectedGatewayId != endpoint.stableId) return
     runGatewayConnectOperation {
       if (operatorConnected) return@runGatewayConnectOperation
-      val storedOperatorEntry = loadStoredRoleDeviceAuthEntry("operator")
+      val storedOperatorEntry = loadStoredRoleDeviceAuthEntry(endpoint, "operator")
       val usesStoredOperatorDeviceToken =
         operatorSessionUsesStoredDeviceToken(auth, storedOperatorEntry?.token)
       val operatorAuth =
@@ -2554,13 +2750,119 @@ class NodeRuntime private constructor(
   }
 
   fun disconnect() {
-    prepareDisconnect()
+    synchronized(gatewayLifecycleIntentLock) {
+      gatewayLifecycleIntentSeq.incrementAndGet()
+      disconnect(retireRunState = false)
+    }
+  }
+
+  fun prepareForGatewaySetup() {
+    synchronized(gatewayLifecycleIntentLock) {
+      gatewayLifecycleIntentSeq.incrementAndGet()
+      disconnect(retireRunState = true)
+    }
+  }
+
+  private fun disconnect(retireRunState: Boolean) {
+    prepareDisconnect(retireRunState)
     operatorSession.disconnect()
     nodeSession.disconnect()
   }
 
+  suspend fun forgetGateway(stableId: String): Boolean =
+    gatewayLifecycleIntentSeq.incrementAndGet().let { intent ->
+      gatewaySwitchMutex.withLock {
+        if (intent != gatewayLifecycleIntentSeq.get()) false else forgetGatewayLocked(stableId)
+      }
+    }
+
+  private suspend fun forgetGatewayLocked(stableId: String): Boolean {
+    val normalized = stableId.trim()
+    if (normalized.isEmpty()) return false
+    val wasActive = prefs.gatewayRegistry.activeStableId.value == normalized
+    val connectOperationsDrained =
+      synchronized(gatewayAuthLifecycleLock) {
+        if (gatewayAuthResetInProgress) {
+          null
+        } else {
+          gatewayAuthResetInProgress = true
+          gatewayConnectOperationsDrained
+        }
+      }
+        ?: return false
+    return try {
+      connectOperationsDrained.await()
+      if (connectedEndpoint?.stableId == normalized) {
+        disconnectAndJoin()
+      } else if (connectingEndpointStableId == normalized) {
+        connectAttemptSeq.incrementAndGet()
+        connectingEndpointStableId = null
+        _pendingGatewayTrust.value = null
+        chat.onGatewayScopeChanging(retireRunState = true)
+      } else if (wasActive) {
+        prepareDisconnect(retireRunState = true)
+      }
+      drainIdleGatewaySessionTails()
+      val cacheCleared =
+        runCatching { chat.clearGatewayCache(normalized) }
+          .onFailure { err ->
+            Log.e("OpenClawRuntime", "Failed to purge forgotten gateway chat data", err)
+            setStandaloneGatewayStatus("Failed: couldn't clear offline gateway data. Retry forget.")
+          }.isSuccess
+      if (!cacheCleared) return false
+      val deviceId = identityStore.loadOrCreate().deviceId
+      deviceAuthStore.clearToken(normalized, deviceId, "node")
+      deviceAuthStore.clearToken(normalized, deviceId, "operator")
+      prefs.clearGatewayCredentials(normalized)
+      prefs.clearGatewayCustomHeaders(normalized)
+      prefs.clearGatewayTlsFingerprint(normalized)
+      prefs.clearNotificationForwardingSessionKey(normalized)
+      prefs.gatewayRegistry.remove(normalized)
+      true
+    } finally {
+      synchronized(gatewayAuthLifecycleLock) { gatewayAuthResetInProgress = false }
+    }
+  }
+
+  private fun recordConnectedGateway() {
+    val endpoint = connectedEndpoint ?: return
+    registerGateway(endpoint, setActive = true)
+    prefs.gatewayRegistry.markConnected(endpoint.stableId, System.currentTimeMillis())
+  }
+
+  private fun registerGateway(
+    endpoint: GatewayEndpoint,
+    setActive: Boolean,
+  ) {
+    val existing =
+      prefs.gatewayRegistry.entries.value
+        .firstOrNull { it.stableId == endpoint.stableId }
+    val entry =
+      if (endpoint.stableId.startsWith("manual|")) {
+        GatewayRegistryEntry(
+          stableId = endpoint.stableId,
+          kind = GatewayRegistryEntryKind.MANUAL,
+          name = endpoint.name,
+          host = endpoint.host,
+          port = endpoint.port,
+          tls = existing?.tls ?: manualTls.value,
+          lastConnectedAtMs = existing?.lastConnectedAtMs ?: 0L,
+        )
+      } else {
+        GatewayRegistryEntry(
+          stableId = endpoint.stableId,
+          kind = GatewayRegistryEntryKind.DISCOVERED,
+          name = endpoint.name,
+          tls = true,
+          lastConnectedAtMs = existing?.lastConnectedAtMs ?: 0L,
+        )
+      }
+    prefs.gatewayRegistry.upsert(entry)
+    if (setActive) prefs.gatewayRegistry.setActive(endpoint.stableId)
+  }
+
   private suspend fun disconnectAndJoin() {
-    prepareDisconnect()
+    prepareDisconnect(retireRunState = true)
     // Both sockets close before either reconnect loop is joined, so no authenticated role stays
     // live while reset waits for the other role's terminal callback.
     coroutineScope {
@@ -2569,16 +2871,43 @@ class NodeRuntime private constructor(
     }
   }
 
-  private fun prepareDisconnect() {
+  private suspend fun drainIdleGatewaySessionTails() {
+    if (connectedEndpoint != null || connectingEndpointStableId != null) return
+    coroutineScope {
+      launch { operatorSession.disconnectAndJoin() }
+      launch { nodeSession.disconnectAndJoin() }
+    }
+  }
+
+  private fun prepareDisconnect(retireRunState: Boolean) {
     notificationOutbox.clear()
     connectAttemptSeq.incrementAndGet()
-    chat.onGatewayScopeChanging()
+    synchronized(gatewayDataScopeLock) {
+      gatewayDataGeneration += 1
+      clearOperatorGatewayState()
+    }
+    chat.onGatewayScopeChanging(retireRunState)
     stopMessageSpeech()
+    micCapture.onGatewayScopeChanging()
     stopActiveVoiceSession()
+    talkMode.onGatewayScopeChanging()
+    if (voiceReplySpeakerLazy.isInitialized()) {
+      voiceReplySpeaker.onGatewayScopeChanging()
+    }
+    if (retireRunState) {
+      val defaultMainSessionKey = resolveNodeMainSessionKey()
+      _mainSessionKey.value = defaultMainSessionKey
+      talkMode.setMainSessionKey(defaultMainSessionKey)
+    }
     connectedEndpoint = null
+    connectingEndpointStableId = null
     _gatewayControlPage.value = null
     activeGatewayAuth = null
     updateStatus {
+      operatorConnected = false
+      _nodeConnected.value = false
+      operatorStatusText = "Offline"
+      nodeStatusText = "Offline"
       operatorConnectionProblem = null
       nodeConnectionProblem = null
     }
@@ -2586,6 +2915,7 @@ class NodeRuntime private constructor(
   }
 
   fun handleCanvasA2UIActionFromWebView(payloadJson: String) {
+    val gatewayId = connectedEndpoint?.stableId
     scope.launch {
       val trimmed = payloadJson.trim()
       if (trimmed.isEmpty()) return@launch
@@ -2634,9 +2964,10 @@ class NodeRuntime private constructor(
 
       val connected = _nodeConnected.value
       var error: String? = null
-      if (connected) {
+      if (connected && gatewayId != null) {
         val sent =
-          nodeSession.sendNodeEvent(
+          nodeSession.sendNodeEventForEndpoint(
+            expectedEndpointStableId = gatewayId,
             event = "agent.request",
             payloadJson =
               buildJsonObject {
@@ -2841,19 +3172,54 @@ class NodeRuntime private constructor(
     return sessionId
   }
 
+  private fun captureGatewayDataScope(): GatewayDataScope? =
+    synchronized(gatewayDataScopeLock) {
+      connectedEndpoint?.stableId?.let { GatewayDataScope(it, gatewayDataGeneration) }
+    }
+
+  private suspend fun requestGatewayData(
+    gatewayScope: GatewayDataScope,
+    method: String,
+    paramsJson: String?,
+  ): String {
+    val response = operatorSession.requestForEndpoint(gatewayScope.stableId, method, paramsJson)
+    if (!isGatewayDataScopeCurrent(gatewayScope)) throw CancellationException("gateway scope changed")
+    return response
+  }
+
+  private fun isGatewayDataScopeCurrent(gatewayScope: GatewayDataScope): Boolean =
+    synchronized(gatewayDataScopeLock) {
+      gatewayScope.generation == gatewayDataGeneration && connectedEndpoint?.stableId == gatewayScope.stableId
+    }
+
+  private inline fun publishGatewayData(
+    gatewayScope: GatewayDataScope,
+    publish: () -> Unit,
+  ): Boolean =
+    synchronized(gatewayDataScopeLock) {
+      if (gatewayScope.generation != gatewayDataGeneration || connectedEndpoint?.stableId != gatewayScope.stableId) {
+        false
+      } else {
+        publish()
+        true
+      }
+    }
+
   private suspend fun refreshBrandingFromGateway() {
+    val gatewayScope = captureGatewayDataScope() ?: return
     if (!gatewayConnectionDisplay.value.isConnected) return
     try {
-      val res = operatorSession.request("config.get", "{}")
+      val res = requestGatewayData(gatewayScope, "config.get", "{}")
       val root = json.parseToJsonElement(res).asObjectOrNull()
       val config = root?.get("config").asObjectOrNull()
       val ui = config?.get("ui").asObjectOrNull()
       val raw = ui?.get("seamColor").asStringOrNull()?.trim()
-      syncMainSessionKey(gatewayDefaultAgentId.value)
-
       val parsed = parseHexColorArgb(raw)
-      _seamColorArgb.value = parsed ?: DEFAULT_SEAM_COLOR_ARGB
-      updateHomeCanvasState()
+      publishGatewayData(gatewayScope) {
+        syncMainSessionKey(gatewayDefaultAgentId.value)
+        _seamColorArgb.value = parsed ?: DEFAULT_SEAM_COLOR_ARGB
+        updateHomeCanvasState()
+      }
     } catch (_: Throwable) {
       // ignore
     }
@@ -2890,9 +3256,10 @@ class NodeRuntime private constructor(
   private fun workspaceAgentId(): String = resolveActiveAgentId().ifEmpty { "main" }
 
   private suspend fun refreshAgentsFromGateway() {
+    val gatewayScope = captureGatewayDataScope() ?: return
     if (!operatorConnected) return
     try {
-      val res = operatorSession.request("agents.list", "{}")
+      val res = requestGatewayData(gatewayScope, "agents.list", "{}")
       val root = json.parseToJsonElement(res).asObjectOrNull() ?: return
       val defaultAgentId = root["defaultId"].asStringOrNull()?.trim().orEmpty()
       val mainKey = normalizeMainKey(root["mainKey"].asStringOrNull())
@@ -2916,18 +3283,23 @@ class NodeRuntime private constructor(
           )
         } ?: emptyList()
 
-      _gatewayDefaultAgentId.value = defaultAgentId.ifEmpty { null }
-      _gatewayAgents.value = agents
-      syncMainSessionKey(resolveAgentIdFromMainSessionKey(mainKey) ?: gatewayDefaultAgentId.value)
-      updateHomeCanvasState()
+      publishGatewayData(gatewayScope) {
+        _gatewayDefaultAgentId.value = defaultAgentId.ifEmpty { null }
+        _gatewayAgents.value = agents
+        syncMainSessionKey(resolveAgentIdFromMainSessionKey(mainKey) ?: gatewayDefaultAgentId.value)
+        updateHomeCanvasState()
+      }
     } catch (_: Throwable) {
       // ignore
     }
   }
 
   private suspend fun refreshModelCatalogFromGateway() {
-    _modelCatalogRefreshing.value = true
-    _modelCatalogErrorText.value = null
+    val gatewayScope = captureGatewayDataScope() ?: return
+    publishGatewayData(gatewayScope) {
+      _modelCatalogRefreshing.value = true
+      _modelCatalogErrorText.value = null
+    }
     if (!operatorConnected) {
       _modelCatalog.value = emptyList()
       _modelAuthProviders.value = emptyList()
@@ -2935,37 +3307,45 @@ class NodeRuntime private constructor(
       return
     }
     try {
-      val modelsRes = operatorSession.request("models.list", "{}")
+      val modelsRes = requestGatewayData(gatewayScope, "models.list", "{}")
       val modelsRoot = json.parseToJsonElement(modelsRes).asObjectOrNull()
-      _modelCatalog.value = parseGatewayModels(modelsRoot?.get("models") as? JsonArray)
-
-      val authRes = operatorSession.request("models.authStatus", "{}")
+      val models = parseGatewayModels(modelsRoot?.get("models") as? JsonArray)
+      val authRes = requestGatewayData(gatewayScope, "models.authStatus", "{}")
       val authRoot = json.parseToJsonElement(authRes).asObjectOrNull()
-      _modelAuthProviders.value = parseGatewayModelProviders(authRoot?.get("providers") as? JsonArray)
+      val providers = parseGatewayModelProviders(authRoot?.get("providers") as? JsonArray)
+      publishGatewayData(gatewayScope) {
+        _modelCatalog.value = models
+        _modelAuthProviders.value = providers
+      }
     } catch (_: Throwable) {
-      _modelCatalogErrorText.value = "Could not load provider catalog."
+      publishGatewayData(gatewayScope) { _modelCatalogErrorText.value = "Could not load provider catalog." }
     } finally {
-      _modelCatalogRefreshing.value = false
+      publishGatewayData(gatewayScope) { _modelCatalogRefreshing.value = false }
     }
   }
 
   private suspend fun refreshTalkSetupReadinessFromGateway() {
+    val gatewayScope = captureGatewayDataScope() ?: return
     if (!operatorConnected) {
       _talkSetupReadiness.value = GatewayTalkSetupReadiness.unverified()
       return
     }
-    _talkSetupReadiness.value =
+    val readiness =
       try {
-        val response = operatorSession.request("talk.catalog", "{}")
+        val response = requestGatewayData(gatewayScope, "talk.catalog", "{}")
         parseGatewayTalkSetupReadiness(json.parseToJsonElement(response).asObjectOrNull())
       } catch (_: Throwable) {
         GatewayTalkSetupReadiness.unverified(GatewayTalkSetupIssue.CatalogLoadFailed)
       }
+    publishGatewayData(gatewayScope) { _talkSetupReadiness.value = readiness }
   }
 
   private suspend fun refreshCronFromGateway() {
-    _cronRefreshing.value = true
-    _cronErrorText.value = null
+    val gatewayScope = captureGatewayDataScope() ?: return
+    publishGatewayData(gatewayScope) {
+      _cronRefreshing.value = true
+      _cronErrorText.value = null
+    }
     if (!operatorConnected) {
       _cronStatus.value = GatewayCronStatus(enabled = false, jobs = 0, nextWakeAtMs = null)
       _cronJobs.value = emptyList()
@@ -2973,26 +3353,31 @@ class NodeRuntime private constructor(
       return
     }
     try {
-      val statusRes = operatorSession.request("cron.status", "{}")
+      val statusRes = requestGatewayData(gatewayScope, "cron.status", "{}")
       val statusRoot = json.parseToJsonElement(statusRes).asObjectOrNull()
-      _cronStatus.value =
+      val status =
         GatewayCronStatus(
           enabled = statusRoot.boolean("enabled"),
           jobs = statusRoot.long("jobs")?.toInt() ?: 0,
           nextWakeAtMs = statusRoot.long("nextWakeAtMs"),
         )
 
-      val listRes = operatorSession.request("cron.list", """{"includeDisabled":true,"limit":20,"sortBy":"nextRunAtMs","sortDir":"asc"}""")
+      val listRes = requestGatewayData(gatewayScope, "cron.list", """{"includeDisabled":true,"limit":20,"sortBy":"nextRunAtMs","sortDir":"asc"}""")
       val listRoot = json.parseToJsonElement(listRes).asObjectOrNull()
-      _cronJobs.value = parseCronJobs(listRoot?.get("jobs") as? JsonArray)
+      val jobs = parseCronJobs(listRoot?.get("jobs") as? JsonArray)
+      publishGatewayData(gatewayScope) {
+        _cronStatus.value = status
+        _cronJobs.value = jobs
+      }
     } catch (_: Throwable) {
-      _cronErrorText.value = "Could not load cron jobs."
+      publishGatewayData(gatewayScope) { _cronErrorText.value = "Could not load cron jobs." }
     } finally {
-      _cronRefreshing.value = false
+      publishGatewayData(gatewayScope) { _cronRefreshing.value = false }
     }
   }
 
   private suspend fun loadCronJobDetailFromGateway(request: CronJobDetailRequest) {
+    val gatewayScope = captureGatewayDataScope() ?: return
     if (!operatorConnected) {
       cronJobDetailRequestGuard.publishIfCurrent(request) {
         _cronJobDetailState.value = GatewayCronJobDetailState.Error(request.id, "Connect the gateway to inspect cron jobs.")
@@ -3000,7 +3385,7 @@ class NodeRuntime private constructor(
       return
     }
     try {
-      val res = operatorSession.request("cron.get", cronJobGetParams(request.id))
+      val res = requestGatewayData(gatewayScope, "cron.get", cronJobGetParams(request.id))
       val root = json.parseToJsonElement(res).asObjectOrNull()
       cronJobDetailRequestGuard.publishIfCurrent(request) {
         _cronJobDetailState.value =
@@ -3015,40 +3400,47 @@ class NodeRuntime private constructor(
   }
 
   private suspend fun refreshUsageFromGateway() {
-    _usageRefreshing.value = true
-    _usageErrorText.value = null
+    val gatewayScope = captureGatewayDataScope() ?: return
+    publishGatewayData(gatewayScope) {
+      _usageRefreshing.value = true
+      _usageErrorText.value = null
+    }
     if (!operatorConnected) {
       _usageSummary.value = GatewayUsageSummary(updatedAtMs = null, providers = emptyList())
       _usageRefreshing.value = false
       return
     }
     try {
-      val res = operatorSession.request("usage.status", "{}")
+      val res = requestGatewayData(gatewayScope, "usage.status", "{}")
       val root = json.parseToJsonElement(res).asObjectOrNull()
-      _usageSummary.value =
+      val summary =
         GatewayUsageSummary(
           updatedAtMs = root.long("updatedAt"),
           providers = parseUsageProviders(root?.get("providers") as? JsonArray),
         )
+      publishGatewayData(gatewayScope) { _usageSummary.value = summary }
     } catch (_: Throwable) {
-      _usageErrorText.value = "Could not load usage."
+      publishGatewayData(gatewayScope) { _usageErrorText.value = "Could not load usage." }
     } finally {
-      _usageRefreshing.value = false
+      publishGatewayData(gatewayScope) { _usageRefreshing.value = false }
     }
   }
 
   private suspend fun refreshSkillsFromGateway() {
-    _skillsRefreshing.value = true
-    _skillsErrorText.value = null
+    val gatewayScope = captureGatewayDataScope() ?: return
+    publishGatewayData(gatewayScope) {
+      _skillsRefreshing.value = true
+      _skillsErrorText.value = null
+    }
     if (!operatorConnected) {
       _skillsSummary.value = GatewaySkillsSummary(skills = emptyList())
       _skillsRefreshing.value = false
       return
     }
     try {
-      val res = operatorSession.request("skills.status", "{}")
+      val res = requestGatewayData(gatewayScope, "skills.status", "{}")
       val root = json.parseToJsonElement(res).asObjectOrNull()
-      _skillsSummary.value =
+      val summary =
         GatewaySkillsSummary(
           managedSkillsDirAvailable =
             root
@@ -3058,46 +3450,54 @@ class NodeRuntime private constructor(
               ?.isNotEmpty() == true,
           skills = parseSkillSummaries(root?.get("skills") as? JsonArray),
         )
+      publishGatewayData(gatewayScope) { _skillsSummary.value = summary }
     } catch (_: Throwable) {
-      _skillsErrorText.value = "Could not load skills."
+      publishGatewayData(gatewayScope) { _skillsErrorText.value = "Could not load skills." }
     } finally {
-      _skillsRefreshing.value = false
+      publishGatewayData(gatewayScope) { _skillsRefreshing.value = false }
     }
   }
 
   private suspend fun refreshNodesDevicesFromGateway() {
+    val gatewayScope = captureGatewayDataScope() ?: return
     val refreshGeneration = nodeApprovalRefreshGuard.begin()
-    val refreshStarted =
-      nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
-        _nodesDevicesRefreshing.value = true
-        _nodesDevicesErrorText.value = null
-        _nodesDevicesSummary.value = _nodesDevicesSummary.value.withoutExactApprovalRequestIds()
-        val pendingFallback = _nodeCapabilityApproval.value.withoutExactRequestId()
-        if (pendingFallback != null) {
-          _nodeCapabilityApproval.value = pendingFallback
-        } else if (
-          _nodeCapabilityApproval.value !is GatewayNodeCapabilityApproval.PendingApproval &&
-          _nodeCapabilityApproval.value !is GatewayNodeCapabilityApproval.PendingReapproval
-        ) {
-          _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Loading
-        }
+    var refreshStarted = false
+    val currentScope =
+      publishGatewayData(gatewayScope) {
+        refreshStarted =
+          nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
+            _nodesDevicesRefreshing.value = true
+            _nodesDevicesErrorText.value = null
+            _nodesDevicesSummary.value = _nodesDevicesSummary.value.withoutExactApprovalRequestIds()
+            val pendingFallback = _nodeCapabilityApproval.value.withoutExactRequestId()
+            if (pendingFallback != null) {
+              _nodeCapabilityApproval.value = pendingFallback
+            } else if (
+              _nodeCapabilityApproval.value !is GatewayNodeCapabilityApproval.PendingApproval &&
+              _nodeCapabilityApproval.value !is GatewayNodeCapabilityApproval.PendingReapproval
+            ) {
+              _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Loading
+            }
+          }
       }
-    if (!refreshStarted) return
+    if (!currentScope || !refreshStarted) return
     if (!operatorConnected) {
-      nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
-        _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Loading
-        _nodesDevicesSummary.value =
-          GatewayNodesDevicesSummary(
-            nodes = emptyList(),
-            pendingDevices = emptyList(),
-            pairedDevices = emptyList(),
-          )
-        _nodesDevicesRefreshing.value = false
+      publishGatewayData(gatewayScope) {
+        nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
+          _nodeCapabilityApproval.value = GatewayNodeCapabilityApproval.Loading
+          _nodesDevicesSummary.value =
+            GatewayNodesDevicesSummary(
+              nodes = emptyList(),
+              pendingDevices = emptyList(),
+              pairedDevices = emptyList(),
+            )
+          _nodesDevicesRefreshing.value = false
+        }
       }
       return
     }
     try {
-      val nodesRes = operatorSession.request("node.list", "{}")
+      val nodesRes = requestGatewayData(gatewayScope, "node.list", "{}")
       val nodesRoot = json.parseToJsonElement(nodesRes).asObjectOrNull()
       val nodes = parseGatewayNodeList(nodesRoot)
       val selfNodeId = identityStore.loadOrCreate().deviceId
@@ -3107,49 +3507,62 @@ class NodeRuntime private constructor(
           selfNodeId = selfNodeId,
         )
       val selfNodeConnected = nodes.firstOrNull { it.id == selfNodeId }?.connected == true
-      val publishedApproval =
-        nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
-          _nodeCapabilityApproval.value = approval
+      var approvalPublished = false
+      val scopePublished =
+        publishGatewayData(gatewayScope) {
+          approvalPublished =
+            nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
+              _nodeCapabilityApproval.value = approval
+            }
         }
-      if (!publishedApproval) {
+      if (!scopePublished || !approvalPublished) {
         return
       }
-      if (selfNodeConnected && !_nodeConnected.value) {
-        updateStatus {
-          nodeConnectionProblem = null
-          _nodeConnected.value = true
-          nodeStatusText = "Connected"
+      publishGatewayData(gatewayScope) {
+        if (selfNodeConnected && !_nodeConnected.value) {
+          updateStatus {
+            nodeConnectionProblem = null
+            _nodeConnected.value = true
+            nodeStatusText = "Connected"
+          }
         }
       }
-      scheduleNodeApprovalCommandRefresh(refreshGeneration, approval)
+      scheduleNodeApprovalCommandRefresh(gatewayScope, refreshGeneration, approval)
       val devicesRoot =
         try {
-          val devicesRes = operatorSession.request("device.pair.list", "{}")
+          val devicesRes = requestGatewayData(gatewayScope, "device.pair.list", "{}")
           json.parseToJsonElement(devicesRes).asObjectOrNull()
         } catch (_: Throwable) {
           null
         }
-      nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
-        _nodesDevicesSummary.value =
-          GatewayNodesDevicesSummary(
-            nodes = nodes,
-            pendingDevices = parsePendingDevices(devicesRoot?.get("pending") as? JsonArray),
-            pairedDevices = parsePairedDevices(devicesRoot?.get("paired") as? JsonArray),
-            devicePairingAvailable = devicesRoot != null,
-          )
+      publishGatewayData(gatewayScope) {
+        nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
+          _nodesDevicesSummary.value =
+            GatewayNodesDevicesSummary(
+              nodes = nodes,
+              pendingDevices = parsePendingDevices(devicesRoot?.get("pending") as? JsonArray),
+              pairedDevices = parsePairedDevices(devicesRoot?.get("paired") as? JsonArray),
+              devicePairingAvailable = devicesRoot != null,
+            )
+        }
       }
     } catch (_: Throwable) {
-      nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
-        _nodesDevicesErrorText.value = "Could not load nodes and devices."
+      publishGatewayData(gatewayScope) {
+        nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
+          _nodesDevicesErrorText.value = "Could not load nodes and devices."
+        }
       }
     } finally {
-      nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
-        _nodesDevicesRefreshing.value = false
+      publishGatewayData(gatewayScope) {
+        nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
+          _nodesDevicesRefreshing.value = false
+        }
       }
     }
   }
 
   private fun scheduleNodeApprovalCommandRefresh(
+    gatewayScope: GatewayDataScope,
     refreshGeneration: Long,
     approval: GatewayNodeCapabilityApproval,
   ) {
@@ -3158,30 +3571,39 @@ class NodeRuntime private constructor(
       delay(NODE_APPROVAL_COMMAND_FRESH_MS)
       // Pairing request IDs expire on the Gateway. Age out cached commands before rechecking so
       // recovery never leaves an old exact ID visible when a refresh fails or races disconnect.
-      val shouldRefresh =
-        nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
-          _nodeCapabilityApproval.value = fallback
-          _nodesDevicesSummary.value = _nodesDevicesSummary.value.withoutExactApprovalRequestIds()
+      var approvalPublished = false
+      val scopePublished =
+        publishGatewayData(gatewayScope) {
+          approvalPublished =
+            nodeApprovalRefreshGuard.publishIfCurrent(refreshGeneration) {
+              _nodeCapabilityApproval.value = fallback
+              _nodesDevicesSummary.value = _nodesDevicesSummary.value.withoutExactApprovalRequestIds()
+            }
         }
-      if (shouldRefresh && operatorConnected) {
+      if (scopePublished && approvalPublished && operatorConnected) {
         refreshNodesDevicesFromGateway()
       }
     }
   }
 
   private suspend fun refreshExecApprovalsFromGateway() {
+    val gatewayScope = captureGatewayDataScope() ?: return
     val refreshGeneration = execApprovalsRefreshSeq.incrementAndGet()
-    _execApprovalsRefreshing.value = true
-    _execApprovalsErrorText.value = null
+    publishGatewayData(gatewayScope) {
+      _execApprovalsRefreshing.value = true
+      _execApprovalsErrorText.value = null
+    }
     if (!operatorConnected) {
-      if (execApprovalsRefreshSeq.get() == refreshGeneration) {
-        _execApprovals.value = emptyList()
-        _execApprovalsRefreshing.value = false
+      publishGatewayData(gatewayScope) {
+        if (execApprovalsRefreshSeq.get() == refreshGeneration) {
+          _execApprovals.value = emptyList()
+          _execApprovalsRefreshing.value = false
+        }
       }
       return
     }
     try {
-      val res = operatorSession.request("exec.approval.list", "{}")
+      val res = requestGatewayData(gatewayScope, "exec.approval.list", "{}")
       val existing = _execApprovals.value.associateBy { it.id }
       val rows =
         parseGatewayExecApprovalListPayload(res, json)
@@ -3190,6 +3612,7 @@ class NodeRuntime private constructor(
             val hydrated =
               try {
                 fetchExecApprovalDetailFromGateway(
+                  gatewayScope = gatewayScope,
                   id = row.id,
                   createdAtMs = row.createdAtMs ?: System.currentTimeMillis(),
                 )
@@ -3206,42 +3629,54 @@ class NodeRuntime private constructor(
               )
             }
           }
-      publishExecApprovalsIfCurrent(refreshGeneration, rows)
+      publishExecApprovalsIfCurrent(gatewayScope, refreshGeneration, rows)
     } catch (_: Throwable) {
-      if (execApprovalsRefreshSeq.get() == refreshGeneration) {
-        _execApprovalsErrorText.value = "Could not load approvals."
+      publishGatewayData(gatewayScope) {
+        if (execApprovalsRefreshSeq.get() == refreshGeneration) {
+          _execApprovalsErrorText.value = "Could not load approvals."
+        }
       }
     } finally {
-      if (execApprovalsRefreshSeq.get() == refreshGeneration) {
-        _execApprovalsRefreshing.value = false
+      publishGatewayData(gatewayScope) {
+        if (execApprovalsRefreshSeq.get() == refreshGeneration) {
+          _execApprovalsRefreshing.value = false
+        }
       }
     }
   }
 
   private suspend fun refreshExecApprovalFromGateway(id: String) {
+    val gatewayScope = captureGatewayDataScope() ?: return
     if (!operatorConnected) return
     if (id in resolvedExecApprovalIds) return
     try {
       val current = _execApprovals.value.firstOrNull { it.id == id }
       val row =
         fetchExecApprovalDetailFromGateway(
+          gatewayScope = gatewayScope,
           id = id,
           createdAtMs = current?.createdAtMs ?: System.currentTimeMillis(),
         ) ?: return
-      if (id in resolvedExecApprovalIds) return
-      invalidateExecApprovalRefreshes()
-      upsertExecApproval(row)
+      publishGatewayData(gatewayScope) {
+        if (id !in resolvedExecApprovalIds) {
+          invalidateExecApprovalRefreshes()
+          upsertExecApproval(row)
+        }
+      }
     } catch (_: Throwable) {
-      refreshExecApprovalsFromGateway()
+      if (isGatewayDataScopeCurrent(gatewayScope)) {
+        refreshExecApprovalsFromGateway()
+      }
     }
   }
 
   private suspend fun fetchExecApprovalDetailFromGateway(
+    gatewayScope: GatewayDataScope,
     id: String,
     createdAtMs: Long,
   ): GatewayExecApprovalSummary? {
     val params = buildJsonObject { put("id", JsonPrimitive(id)) }.toString()
-    val res = operatorSession.request("exec.approval.get", params)
+    val res = requestGatewayData(gatewayScope, "exec.approval.get", params)
     val root = json.parseToJsonElement(res).asObjectOrNull() ?: return null
     return parseGatewayExecApprovalDetail(root, createdAtMs = createdAtMs)
   }
@@ -3250,35 +3685,44 @@ class NodeRuntime private constructor(
     id: String,
     decision: String,
   ) {
-    synchronized(execApprovalsStateLock) {
-      if (!operatorConnected || id in resolvedExecApprovalIds) return
-      val currentRows = _execApprovals.value
-      if (currentRows.none { it.id == id }) return
-      invalidateExecApprovalRefreshes()
-      _execApprovals.value =
-        currentRows.map { row ->
-          if (row.id == id) row.copy(resolvingDecision = decision, errorText = null) else row
+    val gatewayScope = captureGatewayDataScope() ?: return
+    var markedResolving = false
+    val currentScope =
+      publishGatewayData(gatewayScope) {
+        synchronized(execApprovalsStateLock) {
+          if (!operatorConnected || id in resolvedExecApprovalIds) return@synchronized
+          val currentRows = _execApprovals.value
+          if (currentRows.none { it.id == id }) return@synchronized
+          invalidateExecApprovalRefreshes()
+          _execApprovals.value =
+            currentRows.map { row ->
+              if (row.id == id) row.copy(resolvingDecision = decision, errorText = null) else row
+            }
+          markedResolving = true
         }
-    }
+      }
+    if (!currentScope || !markedResolving) return
     try {
       val params =
         buildJsonObject {
           put("id", JsonPrimitive(id))
           put("decision", JsonPrimitive(decision))
         }.toString()
-      operatorSession.request("exec.approval.resolve", params)
-      markExecApprovalResolved(id)
+      requestGatewayData(gatewayScope, "exec.approval.resolve", params)
+      publishGatewayData(gatewayScope) { markExecApprovalResolved(id) }
     } catch (_: Throwable) {
-      synchronized(execApprovalsStateLock) {
-        if (!operatorConnected || id in resolvedExecApprovalIds) return
-        _execApprovals.value =
-          _execApprovals.value.map { row ->
-            if (row.id == id) {
-              row.copy(resolvingDecision = null, errorText = "Could not resolve approval. Refresh and try again.")
-            } else {
-              row
+      publishGatewayData(gatewayScope) {
+        synchronized(execApprovalsStateLock) {
+          if (!operatorConnected || id in resolvedExecApprovalIds) return@synchronized
+          _execApprovals.value =
+            _execApprovals.value.map { row ->
+              if (row.id == id) {
+                row.copy(resolvingDecision = null, errorText = "Could not resolve approval. Refresh and try again.")
+              } else {
+                row
+              }
             }
-          }
+        }
       }
     }
   }
@@ -3326,14 +3770,17 @@ class NodeRuntime private constructor(
   }
 
   private fun publishExecApprovalsIfCurrent(
+    gatewayScope: GatewayDataScope,
     refreshGeneration: Long,
     rows: List<GatewayExecApprovalSummary>,
   ) {
-    synchronized(execApprovalsStateLock) {
-      if (execApprovalsRefreshSeq.get() == refreshGeneration && operatorConnected) {
-        val nextRows = rows.filterNot { it.id in resolvedExecApprovalIds }.filterActiveExecApprovals()
-        _execApprovals.value = nextRows
-        scheduleExecApprovalExpiryPrune(nextRows)
+    publishGatewayData(gatewayScope) {
+      synchronized(execApprovalsStateLock) {
+        if (execApprovalsRefreshSeq.get() == refreshGeneration && operatorConnected) {
+          val nextRows = rows.filterNot { it.id in resolvedExecApprovalIds }.filterActiveExecApprovals()
+          _execApprovals.value = nextRows
+          scheduleExecApprovalExpiryPrune(nextRows)
+        }
       }
     }
   }
@@ -3369,69 +3816,80 @@ class NodeRuntime private constructor(
   }
 
   private suspend fun refreshChannelsFromGateway() {
-    _channelsRefreshing.value = true
-    _channelsErrorText.value = null
+    val gatewayScope = captureGatewayDataScope() ?: return
+    publishGatewayData(gatewayScope) {
+      _channelsRefreshing.value = true
+      _channelsErrorText.value = null
+    }
     if (!operatorConnected) {
       _channelsSummary.value = GatewayChannelsSummary(channels = emptyList())
       _channelsRefreshing.value = false
       return
     }
     try {
-      val res = operatorSession.request("channels.status", """{"probe":false,"timeoutMs":8000}""")
+      val res = requestGatewayData(gatewayScope, "channels.status", """{"probe":false,"timeoutMs":8000}""")
       val root = json.parseToJsonElement(res).asObjectOrNull()
-      _channelsSummary.value =
+      val summary =
         GatewayChannelsSummary(
           updatedAtMs = root.long("ts"),
           partial = root.boolean("partial"),
           warnings = parseStringArray(root?.get("warnings") as? JsonArray),
           channels = parseChannelSummaries(root),
         )
+      publishGatewayData(gatewayScope) { _channelsSummary.value = summary }
     } catch (_: Throwable) {
-      _channelsErrorText.value = "Could not load channels."
+      publishGatewayData(gatewayScope) { _channelsErrorText.value = "Could not load channels." }
     } finally {
-      _channelsRefreshing.value = false
+      publishGatewayData(gatewayScope) { _channelsRefreshing.value = false }
     }
   }
 
   private suspend fun refreshDreamingFromGateway() {
-    _dreamingRefreshing.value = true
-    _dreamingErrorText.value = null
+    val gatewayScope = captureGatewayDataScope() ?: return
+    publishGatewayData(gatewayScope) {
+      _dreamingRefreshing.value = true
+      _dreamingErrorText.value = null
+    }
     if (!operatorConnected) {
       _dreamingSummary.value = GatewayDreamingSummary()
       _dreamingRefreshing.value = false
       return
     }
     try {
-      val statusRes = operatorSession.request("doctor.memory.status", "{}")
+      val statusRes = requestGatewayData(gatewayScope, "doctor.memory.status", "{}")
       val statusRoot = json.parseToJsonElement(statusRes).asObjectOrNull()
-      val diaryRes = operatorSession.request("doctor.memory.dreamDiary", "{}")
+      val diaryRes = requestGatewayData(gatewayScope, "doctor.memory.dreamDiary", "{}")
       val diaryRoot = json.parseToJsonElement(diaryRes).asObjectOrNull()
       val dreaming = statusRoot?.get("dreaming").asObjectOrNull()
-      _dreamingSummary.value =
+      val summary =
         parseDreamingSummary(
           dreaming = dreaming,
           diary = diaryRoot,
         )
+      publishGatewayData(gatewayScope) { _dreamingSummary.value = summary }
     } catch (_: Throwable) {
-      _dreamingErrorText.value = "Could not load dreaming."
+      publishGatewayData(gatewayScope) { _dreamingErrorText.value = "Could not load dreaming." }
     } finally {
-      _dreamingRefreshing.value = false
+      publishGatewayData(gatewayScope) { _dreamingRefreshing.value = false }
     }
   }
 
   private suspend fun refreshHealthLogsFromGateway() {
-    _healthLogsRefreshing.value = true
-    _healthLogsErrorText.value = null
+    val gatewayScope = captureGatewayDataScope() ?: return
+    publishGatewayData(gatewayScope) {
+      _healthLogsRefreshing.value = true
+      _healthLogsErrorText.value = null
+    }
     if (!operatorConnected) {
       _healthLogsSummary.value = GatewayHealthLogsSummary()
       _healthLogsRefreshing.value = false
       return
     }
     try {
-      val res = operatorSession.request("logs.tail", """{"limit":40,"maxBytes":65536}""")
+      val res = requestGatewayData(gatewayScope, "logs.tail", """{"limit":40,"maxBytes":65536}""")
       val root = json.parseToJsonElement(res).asObjectOrNull()
       val lines = (root?.get("lines") as? JsonArray)?.mapNotNull { it.asStringOrNull() }.orEmpty()
-      _healthLogsSummary.value =
+      val summary =
         GatewayHealthLogsSummary(
           fileName =
             root
@@ -3445,10 +3903,11 @@ class NodeRuntime private constructor(
           truncated = root.boolean("truncated"),
           entries = lines.map { parseGatewayLogEntry(it) },
         )
+      publishGatewayData(gatewayScope) { _healthLogsSummary.value = summary }
     } catch (_: Throwable) {
-      _healthLogsErrorText.value = "Could not load gateway logs."
+      publishGatewayData(gatewayScope) { _healthLogsErrorText.value = "Could not load gateway logs." }
     } finally {
-      _healthLogsRefreshing.value = false
+      publishGatewayData(gatewayScope) { _healthLogsRefreshing.value = false }
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -3,6 +3,8 @@
 package ai.openclaw.app
 
 import ai.openclaw.app.gateway.GatewayCustomHeaders
+import ai.openclaw.app.gateway.GatewayRegistryStore
+import ai.openclaw.app.gateway.GatewayStoreMigration
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
@@ -10,12 +12,27 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 import java.util.UUID
+
+@Serializable
+data class GatewayCredentials(
+  val token: String? = null,
+  val bootstrapToken: String? = null,
+  val password: String? = null,
+) {
+  internal fun normalized(): GatewayCredentials =
+    copy(
+      token = token?.trim()?.takeIf { it.isNotEmpty() },
+      bootstrapToken = bootstrapToken?.trim()?.takeIf { it.isNotEmpty() },
+      password = password?.trim()?.takeIf { it.isNotEmpty() },
+    )
+}
 
 /**
  * Reactive settings facade for Android node preferences and encrypted gateway credentials.
@@ -41,7 +58,7 @@ class SecurePrefs(
     private const val notificationsForwardingQuietEndKey = "notifications.forwarding.quietEnd"
     private const val notificationsForwardingMaxEventsPerMinuteKey =
       "notifications.forwarding.maxEventsPerMinute"
-    private const val notificationsForwardingSessionKeyKey = "notifications.forwarding.sessionKey"
+    private const val notificationsForwardingSessionKeyPrefix = "notifications.forwarding.sessionKey"
     private const val installedAppsSharingEnabledKey = "device.apps.sharing.enabled"
     private const val cameraEnabledKey = "camera.enabled"
     private const val voiceMicEnabledKey = "voice.micEnabled"
@@ -71,6 +88,14 @@ class SecurePrefs(
 
   private val _instanceId = MutableStateFlow(loadOrCreateInstanceId())
   val instanceId: StateFlow<String> = _instanceId
+
+  // Lazy so plain-preference reads never touch the encrypted store (Robolectric
+  // has no AndroidKeyStore); the one-time legacy migration runs before the first
+  // gateway-state read, which is the earliest the registry can be observed.
+  val gatewayRegistry: GatewayRegistryStore by lazy {
+    GatewayStoreMigration(this).run()
+    GatewayRegistryStore(this, ::handleActiveGatewayChanged)
+  }
 
   private val _displayName =
     MutableStateFlow(loadOrMigrateDisplayName(context = context))
@@ -104,12 +129,6 @@ class SecurePrefs(
   private val _manualTls =
     MutableStateFlow(plainPrefs.getBoolean("gateway.manual.tls", true))
   val manualTls: StateFlow<Boolean> = _manualTls
-
-  private val _gatewayToken = MutableStateFlow("")
-  val gatewayToken: StateFlow<String> = _gatewayToken
-
-  private val _gatewayBootstrapToken = MutableStateFlow("")
-  val gatewayBootstrapToken: StateFlow<String> = _gatewayBootstrapToken
 
   private val _onboardingCompleted =
     MutableStateFlow(plainPrefs.getBoolean("onboarding.completed", false))
@@ -169,14 +188,10 @@ class SecurePrefs(
     MutableStateFlow(plainPrefs.getInt(notificationsForwardingMaxEventsPerMinuteKey, 20).coerceAtLeast(1))
   val notificationForwardingMaxEventsPerMinute: StateFlow<Int> = _notificationForwardingMaxEventsPerMinute
 
-  private val _notificationForwardingSessionKey =
-    MutableStateFlow(
-      plainPrefs
-        .getString(notificationsForwardingSessionKeyKey, "")
-        ?.trim()
-        ?.takeIf { it.isNotEmpty() },
-    )
-  val notificationForwardingSessionKey: StateFlow<String?> = _notificationForwardingSessionKey
+  private val _notificationForwardingSessionKey by lazy {
+    MutableStateFlow(loadNotificationForwardingSessionKey(gatewayRegistry.activeStableId.value))
+  }
+  val notificationForwardingSessionKey: StateFlow<String?> get() = _notificationForwardingSessionKey
 
   private val _wakeWords = MutableStateFlow(loadWakeWords())
   val wakeWords: StateFlow<List<String>> = _wakeWords
@@ -253,20 +268,6 @@ class SecurePrefs(
     _manualTls.value = value
   }
 
-  fun setGatewayToken(value: String) {
-    val trimmed = value.trim()
-    securePrefs.edit { putString("gateway.manual.token", trimmed) }
-    _gatewayToken.value = trimmed
-  }
-
-  fun setGatewayPassword(value: String) {
-    saveGatewayPassword(value)
-  }
-
-  fun setGatewayBootstrapToken(value: String) {
-    saveGatewayBootstrapToken(value)
-  }
-
   fun setOnboardingCompleted(value: Boolean) {
     plainPrefs.edit { putBoolean("onboarding.completed", value) }
     _onboardingCompleted.value = value
@@ -305,11 +306,9 @@ class SecurePrefs(
     val quietEnd =
       normalizeLocalHourMinute(plainPrefs.getString(notificationsForwardingQuietEndKey, "07:00").orEmpty())
         ?: "07:00"
-    val sessionKey =
-      plainPrefs
-        .getString(notificationsForwardingSessionKeyKey, "")
-        ?.trim()
-        ?.takeIf { it.isNotEmpty() }
+    // NotificationListenerService owns a separate SecurePrefs facade, so resolve the persisted
+    // pointer per event rather than trusting that facade's process-local registry flow.
+    val sessionKey = loadNotificationForwardingSessionKey(gatewayRegistry.storedActiveStableId())
 
     val quietHoursEnabled =
       plainPrefs.getBoolean(notificationsForwardingQuietHoursEnabledKey, false) &&
@@ -386,72 +385,42 @@ class SecurePrefs(
   }
 
   internal fun setNotificationForwardingSessionKey(value: String?) {
+    val stableId = gatewayRegistry.activeStableId.value ?: return
     val normalized = value?.trim()?.takeIf { it.isNotEmpty() }
     plainPrefs.edit {
-      putString(notificationsForwardingSessionKeyKey, normalized.orEmpty())
+      putString(notificationForwardingSessionKeyKey(stableId), normalized.orEmpty())
     }
     _notificationForwardingSessionKey.value = normalized
   }
 
-  /** Loads manual or instance-scoped gateway token material from encrypted preferences. */
-  fun loadGatewayToken(): String? {
-    val manual =
-      _gatewayToken.value.trim().ifEmpty {
-        val stored = securePrefs.getString("gateway.manual.token", null)?.trim().orEmpty()
-        if (stored.isNotEmpty()) _gatewayToken.value = stored
-        stored
-      }
-    if (manual.isNotEmpty()) return manual
-    // Per-instance tokens keep reused Android installs from sharing stale gateway auth.
-    val key = "gateway.token.${_instanceId.value}"
-    val stored = securePrefs.getString(key, null)?.trim()
-    return stored?.takeIf { it.isNotEmpty() }
+  fun loadGatewayCredentials(stableId: String): GatewayCredentials {
+    // Credential reads are gateway state; force the lazy registry so the one-time
+    // legacy migration has run before the first per-gateway bundle is resolved.
+    gatewayRegistry
+    val raw = securePrefs.getString(gatewayCredentialsKey(stableId), null) ?: return GatewayCredentials()
+    return runCatching { json.decodeFromString<GatewayCredentials>(raw).normalized() }.getOrDefault(GatewayCredentials())
   }
 
-  /** Loads the bootstrap token used during gateway setup and device-token handoff. */
-  fun loadGatewayBootstrapToken(): String? {
-    val key = "gateway.bootstrapToken.${_instanceId.value}"
-    val stored =
-      _gatewayBootstrapToken.value.trim().ifEmpty {
-        val persisted = securePrefs.getString(key, null)?.trim().orEmpty()
-        if (persisted.isNotEmpty()) {
-          _gatewayBootstrapToken.value = persisted
-        }
-        persisted
-      }
-    return stored.takeIf { it.isNotEmpty() }
-  }
-
-  fun saveGatewayBootstrapToken(token: String) {
-    val key = "gateway.bootstrapToken.${_instanceId.value}"
-    val trimmed = token.trim()
-    securePrefs.edit { putString(key, trimmed) }
-    _gatewayBootstrapToken.value = trimmed
-  }
-
-  fun loadGatewayPassword(): String? {
-    val key = "gateway.password.${_instanceId.value}"
-    val stored = securePrefs.getString(key, null)?.trim()
-    return stored?.takeIf { it.isNotEmpty() }
-  }
-
-  fun saveGatewayPassword(password: String) {
-    val key = "gateway.password.${_instanceId.value}"
-    securePrefs.edit { putString(key, password.trim()) }
-  }
-
-  /** Clears manual/setup credentials without removing persisted role-specific device tokens. */
-  fun clearGatewaySetupAuth() {
-    val instanceId = _instanceId.value
+  fun saveGatewayCredentials(
+    stableId: String,
+    credentials: GatewayCredentials,
+  ) {
     securePrefs.edit {
-      // Clear both current manual credentials and instance-scoped setup credentials after pairing/reset.
-      remove("gateway.manual.token")
-      remove("gateway.token.$instanceId")
-      remove("gateway.bootstrapToken.$instanceId")
-      remove("gateway.password.$instanceId")
+      putString(gatewayCredentialsKey(stableId), json.encodeToString(credentials.normalized()))
     }
-    _gatewayToken.value = ""
-    _gatewayBootstrapToken.value = ""
+  }
+
+  fun saveGatewayCredentials(
+    stableId: String,
+    token: String? = null,
+    bootstrapToken: String? = null,
+    password: String? = null,
+  ) {
+    saveGatewayCredentials(stableId, GatewayCredentials(token, bootstrapToken, password))
+  }
+
+  fun clearGatewayCredentials(stableId: String) {
+    securePrefs.edit { remove(gatewayCredentialsKey(stableId)) }
   }
 
   /**
@@ -479,13 +448,9 @@ class SecurePrefs(
     securePrefs.edit { putString(key, json.encodeToString(sanitized)) }
   }
 
-  /** Forgets every gateway's proxy credentials during an explicit sign-out/re-pair action. */
-  fun clearGatewayCustomHeaders() {
-    val keys = securePrefs.all.keys.filter { it.startsWith(gatewayCustomHeadersKeyPrefix) }
-    if (keys.isEmpty()) return
-    securePrefs.edit {
-      for (key in keys) remove(key)
-    }
+  /** Forgets one gateway's proxy credentials; forgetting a gateway is the removal boundary. */
+  fun clearGatewayCustomHeaders(stableId: String) {
+    securePrefs.edit { remove(gatewayCustomHeadersKey(stableId)) }
   }
 
   private fun gatewayCustomHeadersKey(stableId: String) = "$gatewayCustomHeadersKeyPrefix${stableId.trim()}"
@@ -505,6 +470,17 @@ class SecurePrefs(
     plainPrefs.edit { putString(key, fingerprint.trim()) }
   }
 
+  fun clearGatewayTlsFingerprint(stableId: String) {
+    plainPrefs.edit { remove("gateway.tls.$stableId") }
+  }
+
+  fun clearNotificationForwardingSessionKey(stableId: String) {
+    plainPrefs.edit { remove(notificationForwardingSessionKeyKey(stableId)) }
+    if (gatewayRegistry.activeStableId.value == stableId) {
+      _notificationForwardingSessionKey.value = null
+    }
+  }
+
   fun getString(key: String): String? = securePrefs.getString(key, null)
 
   fun putString(
@@ -516,6 +492,78 @@ class SecurePrefs(
 
   fun remove(key: String) {
     securePrefs.edit { remove(key) }
+  }
+
+  internal fun containsSecureKey(key: String): Boolean = securePrefs.contains(key)
+
+  internal fun secureKeys(): Set<String> = securePrefs.all.keys
+
+  internal fun removeSecureKeys(keys: List<String>) {
+    securePrefs.edit { keys.forEach { remove(it) } }
+  }
+
+  internal fun moveSecureString(
+    sourceKey: String,
+    destinationKey: String?,
+  ) {
+    val value = securePrefs.getString(sourceKey, null)
+    securePrefs.edit {
+      if (destinationKey != null && value != null) putString(destinationKey, value)
+      remove(sourceKey)
+    }
+  }
+
+  internal fun getPlainString(key: String): String? = plainPrefs.getString(key, null)
+
+  internal fun getPlainBoolean(
+    key: String,
+    defaultValue: Boolean,
+  ): Boolean = plainPrefs.getBoolean(key, defaultValue)
+
+  internal fun getPlainInt(
+    key: String,
+    defaultValue: Int,
+  ): Int = plainPrefs.getInt(key, defaultValue)
+
+  internal fun putPlainString(
+    key: String,
+    value: String,
+  ) {
+    plainPrefs.edit { putString(key, value) }
+  }
+
+  internal fun removePlainKey(key: String) {
+    plainPrefs.edit { remove(key) }
+  }
+
+  internal fun movePlainString(
+    sourceKey: String,
+    destinationKey: String?,
+  ) {
+    val value = plainPrefs.getString(sourceKey, null)?.trim()?.takeIf { it.isNotEmpty() }
+    plainPrefs.edit(commit = true) {
+      if (destinationKey != null && value != null) putString(destinationKey, value)
+      remove(sourceKey)
+    }
+  }
+
+  private fun gatewayCredentialsKey(stableId: String): String {
+    val normalized = stableId.trim()
+    require(normalized.isNotEmpty()) { "Gateway stable id cannot be empty" }
+    return "gateway.credentials.$normalized"
+  }
+
+  private fun notificationForwardingSessionKeyKey(stableId: String): String = "$notificationsForwardingSessionKeyPrefix.$stableId"
+
+  private fun loadNotificationForwardingSessionKey(stableId: String?): String? =
+    stableId
+      ?.let(::notificationForwardingSessionKeyKey)
+      ?.let { plainPrefs.getString(it, null) }
+      ?.trim()
+      ?.takeIf { it.isNotEmpty() }
+
+  private fun handleActiveGatewayChanged(stableId: String?) {
+    _notificationForwardingSessionKey.value = loadNotificationForwardingSessionKey(stableId)
   }
 
   private fun createSecurePrefs(

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatCommandOutbox.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatCommandOutbox.kt
@@ -110,6 +110,9 @@ interface ChatCommandOutbox {
     sessionKey: String,
   )
 
+  /** Drops every queued command owned by one gateway identity. */
+  suspend fun clearGateway(gatewayId: String)
+
   /** Crash safety: rows stuck in 'sending' from a killed process become 'queued' again. */
   suspend fun requeueSendingAfterRestart()
 
@@ -195,6 +198,9 @@ internal interface ChatOutboxDao {
     gatewayId: String,
     sessionKey: String,
   )
+
+  @Query("DELETE FROM outbox_commands WHERE gatewayId = :gatewayId")
+  suspend fun deleteGateway(gatewayId: String)
 
   @Query("DELETE FROM outbox_commands")
   suspend fun deleteAll()
@@ -305,6 +311,11 @@ class RoomChatCommandOutbox internal constructor(
     val gateway = scopedGatewayId(gatewayId) ?: return
     val key = sessionKey.trim().takeIf { it.isNotEmpty() } ?: return
     database.outboxDao().deleteForSession(gateway, key)
+  }
+
+  override suspend fun clearGateway(gatewayId: String) {
+    val gateway = scopedGatewayId(gatewayId) ?: return
+    database.outboxDao().deleteGateway(gateway)
   }
 
   override suspend fun requeueSendingAfterRestart() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -41,6 +41,8 @@ class ChatController internal constructor(
   private val scope: CoroutineScope,
   private val json: Json,
   private val requestGateway: suspend (method: String, paramsJson: String?) -> String,
+  private val requestGatewayForGateway: suspend (gatewayId: String, method: String, paramsJson: String?) -> String =
+    { _, method, paramsJson -> requestGateway(method, paramsJson) },
   private val transcriptCache: ChatTranscriptCache? = null,
   private val cacheScope: () -> ChatCacheScope? = { null },
   private val commandOutbox: ChatCommandOutbox? = null,
@@ -58,6 +60,9 @@ class ChatController internal constructor(
     scope = scope,
     json = json,
     requestGateway = { method, paramsJson -> session.request(method, paramsJson) },
+    requestGatewayForGateway = { gatewayId, method, paramsJson ->
+      session.requestForEndpoint(gatewayId, method, paramsJson)
+    },
     transcriptCache = transcriptCache,
     cacheScope = cacheScope,
     commandOutbox = commandOutbox,
@@ -235,10 +240,18 @@ class ChatController internal constructor(
   }
 
   /** Invalidates and clears gateway-bound UI state before a target switch can race old responses. */
-  fun onGatewayScopeChanging() {
+  fun onGatewayScopeChanging(retireRunState: Boolean = false) {
     synchronized(gatewayScopeApplyLock) {
+      if (retireRunState) {
+        restoreRunStateOnReconnect = false
+        clearPendingRuns()
+        pendingToolCallsById.clear()
+        publishPendingToolCalls()
+        _streamingAssistantText.value = null
+      }
+      appliedMainSessionKey = "main"
       beginHistoryLoad(
-        key = normalizeRequestedSessionKey(_sessionKey.value),
+        key = "main",
         clearMessages = true,
         markLoading = false,
       )
@@ -247,9 +260,20 @@ class ChatController internal constructor(
       sessionsListArchived = false
       unreadPatchSessionKey = null
       unreadPatchRequested = false
+      _commands.value = emptyList()
+      _modelCatalog.value = emptyList()
+      chatMetadataAgentId = null
+      chatMetadataLoadState = ChatMetadataLoadState.Unloaded
+      lastHealthPollAtMs = null
       // Outbox rows are gateway-scoped too; the next publish repopulates them for the new scope.
       _outboxItems.value = emptyList()
     }
+  }
+
+  /** Restores the selected gateway's local state without waiting for transport availability. */
+  fun restoreSelectedGatewayOfflineState() {
+    refresh()
+    scope.launch { publishOutbox() }
   }
 
   /** Purges cached transcripts and queued sends after old-scope writes finish. */
@@ -258,6 +282,14 @@ class ChatController internal constructor(
     cacheMutationMutex.withLock {
       cache.clearAll()
       commandOutbox?.clearAll()
+    }
+  }
+
+  /** Purges cached transcripts and queued sends for one retired authentication scope. */
+  internal suspend fun clearGatewayCache(gatewayId: String) {
+    cacheMutationMutex.withLock {
+      transcriptCache?.clearGateway(gatewayId)
+      commandOutbox?.clearGateway(gatewayId)
     }
   }
 
@@ -404,6 +436,7 @@ class ChatController internal constructor(
 
   /** Starts a fresh chat and returns whether the gateway created the session. */
   suspend fun startNewChatAwait(worktree: Boolean = false): Boolean {
+    val createGatewayId = currentCacheScope()?.gatewayId
     val parentKey = normalizeRequestedSessionKey(_sessionKey.value)
     if (parentKey.isEmpty()) return false
     if (_pendingRunCount.value > 0) {
@@ -429,7 +462,7 @@ class ChatController internal constructor(
           put("label", JsonPrimitive(label))
           if (worktree) put("worktree", JsonPrimitive(true))
         }
-      val res = requestGateway("sessions.create", params.toString())
+      val res = requestGatewayBound(createGatewayId, "sessions.create", params.toString())
       if (!isCurrentHistoryLoad(parentKey, _sessionKey.value, requestGeneration, historyLoadGeneration.get())) {
         return false
       }
@@ -614,6 +647,8 @@ class ChatController internal constructor(
     thinkingLevel: String,
     attachments: List<OutgoingAttachment>,
   ): Boolean {
+    val sendCacheScope = currentCacheScope()
+    val sendGatewayId = sendCacheScope?.gatewayId
     val trimmed = message.trim()
     if (trimmed.isEmpty() && attachments.isEmpty()) return false
     val sessionKey = _sessionKey.value
@@ -698,7 +733,8 @@ class ChatController internal constructor(
             )
           }
         }
-      val res = requestGateway("chat.send", params.toString())
+      val res = requestGatewayBound(sendGatewayId, "chat.send", params.toString())
+      if (sendCacheScope != currentCacheScope()) return true
       val ack = parseChatSendAck(json, res)
       val actualRunId = ack.runId ?: runId
       if (actualRunId != runId) {
@@ -727,12 +763,14 @@ class ChatController internal constructor(
     } catch (err: CancellationException) {
       throw err
     } catch (err: GatewayRequestDefinitiveFailure) {
+      if (sendCacheScope != currentCacheScope()) return true
       clearPendingRun(runId)
       removeOptimisticMessage(runId)
       unresolvedRepliesByRunId.remove(runId)
       updateErrorText(err.message)
       false
     } catch (_: GatewayRequestOutcomeUnknown) {
+      if (sendCacheScope != currentCacheScope()) return true
       // A transport failure cannot distinguish rejection from an accepted send whose
       // ACK was lost. Keep the idempotency-key-backed row to prevent a duplicate retry.
       unknownOutcomeRunIds.add(runId)
@@ -741,6 +779,7 @@ class ChatController internal constructor(
       }
       true
     } catch (err: Throwable) {
+      if (sendCacheScope != currentCacheScope()) return true
       clearPendingRun(runId)
       removeOptimisticMessage(runId)
       unresolvedRepliesByRunId.remove(runId)
@@ -751,6 +790,7 @@ class ChatController internal constructor(
 
   /** Sends best-effort abort requests for every currently pending gateway run. */
   fun abort() {
+    val abortGatewayId = currentCacheScope()?.gatewayId
     val runIds =
       synchronized(pendingRuns) {
         pendingRuns.toList()
@@ -764,7 +804,7 @@ class ChatController internal constructor(
               put("sessionKey", JsonPrimitive(_sessionKey.value))
               put("runId", JsonPrimitive(runId))
             }
-          requestGateway("chat.abort", params.toString())
+          requestGatewayBound(abortGatewayId, "chat.abort", params.toString())
         } catch (_: Throwable) {
           // best-effort
         }
@@ -926,7 +966,8 @@ class ChatController internal constructor(
     val history =
       try {
         val historyJson =
-          requestGateway(
+          requestGatewayBound(
+            requestCacheScope?.gatewayId,
             "chat.history",
             buildJsonObject { put("sessionKey", JsonPrimitive(sessionKey)) }.toString(),
           )
@@ -1145,34 +1186,39 @@ class ChatController internal constructor(
   }
 
   private suspend fun fetchChatMetadata() {
+    val requestCacheScope = currentCacheScope()
     val agentId = resolveAgentIdForSessionKey(_sessionKey.value)
     try {
       val params =
         buildJsonObject {
           put("agentId", JsonPrimitive(agentId))
         }
-      val res = requestGateway("chat.metadata", params.toString())
-      if (agentId == resolveAgentIdForSessionKey(_sessionKey.value)) {
-        _commands.value = parseChatCommands(json, res)
-        val root = json.parseToJsonElement(res).asObjectOrNull()
-        val models = parseGatewayModels(root?.get("models") as? JsonArray)
-        _modelCatalog.value = models
-        // chat.metadata cannot distinguish a valid empty catalog from its timeout fallback.
-        // Retry one empty response, then accept empty so health events cannot poll forever.
-        chatMetadataLoadState =
-          when {
-            models.isNotEmpty() -> ChatMetadataLoadState.Loaded
-            chatMetadataLoadState == ChatMetadataLoadState.RetryEmptyCatalog -> ChatMetadataLoadState.Loaded
-            else -> ChatMetadataLoadState.RetryEmptyCatalog
-          }
-        chatMetadataAgentId = agentId
+      val res = requestGatewayBound(requestCacheScope?.gatewayId, "chat.metadata", params.toString())
+      synchronized(gatewayScopeApplyLock) {
+        if (requestCacheScope == currentCacheScope() && agentId == resolveAgentIdForSessionKey(_sessionKey.value)) {
+          _commands.value = parseChatCommands(json, res)
+          val root = json.parseToJsonElement(res).asObjectOrNull()
+          val models = parseGatewayModels(root?.get("models") as? JsonArray)
+          _modelCatalog.value = models
+          // chat.metadata cannot distinguish a valid empty catalog from its timeout fallback.
+          // Retry one empty response, then accept empty so health events cannot poll forever.
+          chatMetadataLoadState =
+            when {
+              models.isNotEmpty() -> ChatMetadataLoadState.Loaded
+              chatMetadataLoadState == ChatMetadataLoadState.RetryEmptyCatalog -> ChatMetadataLoadState.Loaded
+              else -> ChatMetadataLoadState.RetryEmptyCatalog
+            }
+          chatMetadataAgentId = agentId
+        }
       }
     } catch (_: Throwable) {
-      if (agentId == resolveAgentIdForSessionKey(_sessionKey.value)) {
-        _commands.value = emptyList()
-        _modelCatalog.value = emptyList()
-        chatMetadataAgentId = null
-        chatMetadataLoadState = ChatMetadataLoadState.Unloaded
+      synchronized(gatewayScopeApplyLock) {
+        if (requestCacheScope == currentCacheScope() && agentId == resolveAgentIdForSessionKey(_sessionKey.value)) {
+          _commands.value = emptyList()
+          _modelCatalog.value = emptyList()
+          chatMetadataAgentId = null
+          chatMetadataLoadState = ChatMetadataLoadState.Unloaded
+        }
       }
     }
   }
@@ -1188,18 +1234,22 @@ class ChatController internal constructor(
   }
 
   private suspend fun pollHealthIfNeeded(force: Boolean) {
+    val requestCacheScope = currentCacheScope()
     val now = System.currentTimeMillis()
     val last = lastHealthPollAtMs
     if (!force && last != null && now - last < 10_000) return
     lastHealthPollAtMs = now
     try {
-      requestGateway("health", null)
+      requestGatewayBound(requestCacheScope?.gatewayId, "health", null)
+      if (requestCacheScope != currentCacheScope()) return
       markHealthOk()
       if (!hasCurrentChatMetadata()) {
         fetchChatMetadata()
       }
     } catch (_: Throwable) {
-      _healthOk.value = false
+      if (requestCacheScope == currentCacheScope()) {
+        _healthOk.value = false
+      }
     }
   }
 
@@ -1365,7 +1415,7 @@ class ChatController internal constructor(
     var attempts = item.retryCount
     while (true) {
       val error =
-        when (val result = attemptOutboxSend(item)) {
+        when (val result = attemptOutboxSend(item, flushScope.gatewayId)) {
           OutboxSendResult.Accepted -> {
             // Ack received: delete the row so the flushed history copy is the only bubble left.
             runCatching { outbox.delete(item.id) }
@@ -1423,7 +1473,10 @@ class ChatController internal constructor(
     return OutboxSendOutcome.Stop
   }
 
-  private suspend fun attemptOutboxSend(item: ChatOutboxItem): OutboxSendResult =
+  private suspend fun attemptOutboxSend(
+    item: ChatOutboxItem,
+    gatewayId: String,
+  ): OutboxSendResult =
     try {
       val params =
         buildJsonObject {
@@ -1438,7 +1491,7 @@ class ChatController internal constructor(
           // acked-but-crashed item harmless.
           put("idempotencyKey", JsonPrimitive(item.id))
         }
-      val ack = parseChatSendAck(json, requestGateway("chat.send", params.toString()))
+      val ack = parseChatSendAck(json, requestGatewayBound(gatewayId, "chat.send", params.toString()))
       if (ack.isTerminalFailure) {
         OutboxSendResult.Rejected("Chat failed before the run started")
       } else {
@@ -2097,6 +2150,17 @@ class ChatController internal constructor(
       publishOutbox()
     }
   }
+
+  private suspend fun requestGatewayBound(
+    gatewayId: String?,
+    method: String,
+    paramsJson: String?,
+  ): String =
+    if (gatewayId == null) {
+      requestGateway(method, paramsJson)
+    } else {
+      requestGatewayForGateway(gatewayId, method, paramsJson)
+    }
 
   private fun currentCacheScope(): ChatCacheScope? {
     val scope = cacheScope() ?: return null

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
@@ -83,6 +83,9 @@ interface ChatTranscriptCache {
     sessionKey: String,
   )
 
+  /** Removes every cached transcript row owned by one gateway identity. */
+  suspend fun clearGateway(gatewayId: String)
+
   /** Purges every cached row for all gateways; used when pairing/auth state is reset. */
   suspend fun clearAll()
 }
@@ -140,6 +143,9 @@ internal interface ChatCacheDao {
 
   @Query("DELETE FROM cached_sessions WHERE gatewayId = :gatewayId")
   suspend fun deleteSessions(gatewayId: String)
+
+  @Query("DELETE FROM cached_messages WHERE gatewayId = :gatewayId")
+  suspend fun deleteMessages(gatewayId: String)
 
   @Query("DELETE FROM cached_sessions")
   suspend fun deleteAllSessions()
@@ -342,6 +348,15 @@ class RoomChatTranscriptCache internal constructor(
     database.withTransaction {
       dao.deleteAllSessions()
       dao.deleteAllMessages()
+    }
+  }
+
+  override suspend fun clearGateway(gatewayId: String) {
+    val gateway = scopedGatewayId(gatewayId) ?: return
+    val dao = database.dao()
+    database.withTransaction {
+      dao.deleteMessages(gateway)
+      dao.deleteSessions(gateway)
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/DeviceAuthStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/DeviceAuthStore.kt
@@ -5,7 +5,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-/** Stored gateway device-token material scoped by device id and role. */
+/** Stored gateway device-token material scoped by gateway, device id, and role. */
 data class DeviceAuthEntry(
   val token: String,
   val role: String,
@@ -23,18 +23,21 @@ private data class PersistedDeviceAuthMetadata(
 interface DeviceAuthTokenStore {
   /** Loads the stored token plus metadata for one device/role pair. */
   fun loadEntry(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ): DeviceAuthEntry?
 
   /** Loads only the bearer token when callers do not need scope metadata. */
   fun loadToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
-  ): String? = loadEntry(deviceId, role)?.token
+  ): String? = loadEntry(gatewayId, deviceId, role)?.token
 
   /** Persists a role token and deterministic scope metadata under normalized keys. */
   fun saveToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
     token: String,
@@ -43,6 +46,7 @@ interface DeviceAuthTokenStore {
 
   /** Removes both token and metadata for the normalized device/role pair. */
   fun clearToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
   )
@@ -55,15 +59,16 @@ class DeviceAuthStore(
   private val json = Json { ignoreUnknownKeys = true }
 
   override fun loadEntry(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ): DeviceAuthEntry? {
-    val key = tokenKey(deviceId, role)
+    val key = tokenKey(gatewayId, deviceId, role)
     val token = prefs.getString(key)?.trim()?.takeIf { it.isNotEmpty() } ?: return null
     val normalizedRole = normalizeRole(role)
     val metadata =
       prefs
-        .getString(metadataKey(deviceId, role))
+        .getString(metadataKey(gatewayId, deviceId, role))
         ?.let { raw ->
           runCatching { json.decodeFromString<PersistedDeviceAuthMetadata>(raw) }.getOrNull()
         }
@@ -76,16 +81,17 @@ class DeviceAuthStore(
   }
 
   override fun saveToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
     token: String,
     scopes: List<String>,
   ) {
     val normalizedScopes = normalizeScopes(scopes)
-    val key = tokenKey(deviceId, role)
+    val key = tokenKey(gatewayId, deviceId, role)
     prefs.putString(key, token.trim())
     prefs.putString(
-      metadataKey(deviceId, role),
+      metadataKey(gatewayId, deviceId, role),
       json.encodeToString(
         PersistedDeviceAuthMetadata(
           scopes = normalizedScopes,
@@ -96,33 +102,40 @@ class DeviceAuthStore(
   }
 
   override fun clearToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ) {
-    val key = tokenKey(deviceId, role)
+    val key = tokenKey(gatewayId, deviceId, role)
     prefs.remove(key)
-    prefs.remove(metadataKey(deviceId, role))
+    prefs.remove(metadataKey(gatewayId, deviceId, role))
   }
 
   private fun tokenKey(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ): String {
+    val normalizedGateway = normalizeGatewayId(gatewayId)
     val normalizedDevice = normalizeDeviceId(deviceId)
     val normalizedRole = normalizeRole(role)
     // Keep key normalization shared with metadata keys so token and metadata
     // are added/removed as one logical auth entry.
-    return "gateway.deviceToken.$normalizedDevice.$normalizedRole"
+    return "gateway.deviceToken.$normalizedGateway.$normalizedDevice.$normalizedRole"
   }
 
   private fun metadataKey(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ): String {
+    val normalizedGateway = normalizeGatewayId(gatewayId)
     val normalizedDevice = normalizeDeviceId(deviceId)
     val normalizedRole = normalizeRole(role)
-    return "gateway.deviceTokenMeta.$normalizedDevice.$normalizedRole"
+    return "gateway.deviceTokenMeta.$normalizedGateway.$normalizedDevice.$normalizedRole"
   }
+
+  private fun normalizeGatewayId(gatewayId: String): String = gatewayId.trim().also { require(it.isNotEmpty()) }
 
   /** Normalizes device ids before they become encrypted preference key segments. */
   private fun normalizeDeviceId(deviceId: String): String = deviceId.trim().lowercase()

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayRegistry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayRegistry.kt
@@ -1,0 +1,135 @@
+package ai.openclaw.app.gateway
+
+import ai.openclaw.app.SecurePrefs
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+@Serializable
+enum class GatewayRegistryEntryKind {
+  @SerialName("manual")
+  MANUAL,
+
+  @SerialName("discovered")
+  DISCOVERED,
+}
+
+@Serializable
+data class GatewayRegistryEntry(
+  val stableId: String,
+  val kind: GatewayRegistryEntryKind,
+  val name: String,
+  val host: String? = null,
+  val port: Int? = null,
+  val tls: Boolean = true,
+  val lastConnectedAtMs: Long = 0L,
+)
+
+@Serializable
+internal data class PersistedGatewayRegistry(
+  val version: Int = 1,
+  val activeStableId: String? = null,
+  val entries: List<GatewayRegistryEntry> = emptyList(),
+)
+
+class GatewayRegistryStore(
+  private val prefs: SecurePrefs,
+  private val onActiveChanged: ((String?) -> Unit)? = null,
+) {
+  companion object {
+    internal const val STORAGE_KEY = "gateway.registry"
+  }
+
+  private val json =
+    Json {
+      ignoreUnknownKeys = true
+      encodeDefaults = true
+    }
+  private val mutationLock = Any()
+  private val initial = decode(prefs.getString(STORAGE_KEY))
+  private val _entries = MutableStateFlow(initial.entries.sortedForStorage())
+  val entries: StateFlow<List<GatewayRegistryEntry>> = _entries.asStateFlow()
+  private val _activeStableId = MutableStateFlow(initial.activeStableId)
+  val activeStableId: StateFlow<String?> = _activeStableId.asStateFlow()
+
+  fun upsert(entry: GatewayRegistryEntry): Unit =
+    synchronized(mutationLock) {
+      val stableId = entry.stableId.trim()
+      require(stableId.isNotEmpty()) { "Gateway stable id cannot be empty" }
+      val existing = _entries.value.firstOrNull { it.stableId == stableId }
+      val normalized =
+        entry.copy(
+          stableId = stableId,
+          name = entry.name.trim().ifEmpty { stableId },
+          host = entry.host?.trim()?.takeIf { it.isNotEmpty() },
+          lastConnectedAtMs =
+            if (entry.lastConnectedAtMs == 0L) {
+              existing?.lastConnectedAtMs ?: 0L
+            } else {
+              entry.lastConnectedAtMs
+            },
+        )
+      _entries.value = (_entries.value.filterNot { it.stableId == stableId } + normalized).sortedForStorage()
+      persist()
+    }
+
+  fun setActive(stableId: String?): Unit =
+    synchronized(mutationLock) {
+      val normalized = stableId?.trim()?.takeIf { it.isNotEmpty() }
+      require(normalized == null || _entries.value.any { it.stableId == normalized }) {
+        "Active gateway must exist in the registry"
+      }
+      _activeStableId.value = normalized
+      persist()
+      onActiveChanged?.invoke(normalized)
+    }
+
+  fun markConnected(
+    stableId: String,
+    atMs: Long,
+  ): Unit =
+    synchronized(mutationLock) {
+      val existing = _entries.value.firstOrNull { it.stableId == stableId } ?: return
+      upsert(existing.copy(lastConnectedAtMs = atMs))
+    }
+
+  fun remove(stableId: String): Unit =
+    synchronized(mutationLock) {
+      val normalized = stableId.trim()
+      _entries.value = _entries.value.filterNot { it.stableId == normalized }
+      if (_activeStableId.value == normalized) {
+        _activeStableId.value = null
+        onActiveChanged?.invoke(null)
+      }
+      persist()
+    }
+
+  fun activeEntry(): GatewayRegistryEntry? =
+    synchronized(mutationLock) {
+      val activeId = _activeStableId.value ?: return@synchronized null
+      _entries.value.firstOrNull { it.stableId == activeId }
+    }
+
+  internal fun storedActiveStableId(): String? = decode(prefs.getString(STORAGE_KEY)).activeStableId
+
+  private fun persist() {
+    val registry =
+      PersistedGatewayRegistry(
+        activeStableId = _activeStableId.value,
+        entries = _entries.value.sortedForStorage(),
+      )
+    prefs.putString(STORAGE_KEY, json.encodeToString(registry))
+  }
+
+  private fun decode(raw: String?): PersistedGatewayRegistry =
+    raw
+      ?.let { runCatching { json.decodeFromString<PersistedGatewayRegistry>(it) }.getOrNull() }
+      ?.takeIf { it.version == 1 }
+      ?: PersistedGatewayRegistry()
+}
+
+internal fun List<GatewayRegistryEntry>.sortedForStorage(): List<GatewayRegistryEntry> = sortedWith(compareBy<GatewayRegistryEntry>({ it.name.lowercase() }, { it.stableId }))

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -358,11 +358,25 @@ class GatewaySession(
     payloadJson: String?,
   ): Boolean = sendNodeEventWithOutcome(event, payloadJson) == NodeEventSendOutcome.COMPLETED
 
+  internal suspend fun sendNodeEventForEndpoint(
+    expectedEndpointStableId: String?,
+    event: String,
+    payloadJson: String?,
+  ): Boolean =
+    sendNodeEventWithOutcomeForEndpoint(expectedEndpointStableId, event, payloadJson) ==
+      NodeEventSendOutcome.COMPLETED
+
   internal suspend fun sendNodeEventWithOutcome(
     event: String,
     payloadJson: String?,
+  ): NodeEventSendOutcome = sendNodeEventWithOutcomeForEndpoint(expectedEndpointStableId = null, event, payloadJson)
+
+  internal suspend fun sendNodeEventWithOutcomeForEndpoint(
+    expectedEndpointStableId: String?,
+    event: String,
+    payloadJson: String?,
   ): NodeEventSendOutcome {
-    val conn = readyConnection() ?: return NodeEventSendOutcome.DISCONNECTED
+    val conn = readyConnection(expectedEndpointStableId) ?: return NodeEventSendOutcome.DISCONNECTED
     return try {
       conn.request(
         "node.event",
@@ -383,9 +397,16 @@ class GatewaySession(
     event: String,
     payloadJson: String?,
     timeoutMs: Long = 8_000,
+  ): RpcResult = sendNodeEventDetailedForEndpoint(null, event, payloadJson, timeoutMs)
+
+  internal suspend fun sendNodeEventDetailedForEndpoint(
+    expectedEndpointStableId: String?,
+    event: String,
+    payloadJson: String?,
+    timeoutMs: Long = 8_000,
   ): RpcResult {
     val conn =
-      readyConnection()
+      readyConnection(expectedEndpointStableId)
         ?: return RpcResult(
           ok = false,
           payloadJson = null,
@@ -426,13 +447,31 @@ class GatewaySession(
     throw GatewayRequestRejected(res.error ?: ErrorShape("UNAVAILABLE", "request failed"))
   }
 
+  internal suspend fun requestForEndpoint(
+    expectedEndpointStableId: String,
+    method: String,
+    paramsJson: String?,
+    timeoutMs: Long = 15_000,
+  ): String {
+    val res = requestDetailed(expectedEndpointStableId, method, paramsJson, timeoutMs)
+    if (res.ok) return res.payloadJson ?: ""
+    throw GatewayRequestRejected(res.error ?: ErrorShape("UNAVAILABLE", "request failed"))
+  }
+
   /** Sends an RPC request and returns the structured success/error payload. */
   suspend fun requestDetailed(
     method: String,
     paramsJson: String?,
     timeoutMs: Long = 15_000,
+  ): RpcResult = requestDetailed(expectedEndpointStableId = null, method, paramsJson, timeoutMs)
+
+  private suspend fun requestDetailed(
+    expectedEndpointStableId: String?,
+    method: String,
+    paramsJson: String?,
+    timeoutMs: Long,
   ): RpcResult {
-    val conn = readyConnection() ?: throw GatewayRequestNotEnqueued("not connected")
+    val conn = readyConnection(expectedEndpointStableId) ?: throw GatewayRequestNotEnqueued("not connected")
     val params =
       if (paramsJson.isNullOrBlank()) {
         null
@@ -443,14 +482,27 @@ class GatewaySession(
     return RpcResult(ok = res.ok, payloadJson = res.payloadJson, error = res.error)
   }
 
+  private fun readyConnection(expectedEndpointStableId: String?): Connection? =
+    readyConnection()?.takeIf { connection ->
+      expectedEndpointStableId == null || connection.endpoint.stableId == expectedEndpointStableId
+    }
+
   /** Sends an RPC request frame and reports errors asynchronously through [onError]. */
   suspend fun sendRequestFrame(
     method: String,
     paramsJson: String?,
     timeoutMs: Long = 15_000,
     onError: (ErrorShape) -> Unit = {},
+  ) = sendRequestFrameForEndpoint(null, method, paramsJson, timeoutMs, onError)
+
+  internal suspend fun sendRequestFrameForEndpoint(
+    expectedEndpointStableId: String?,
+    method: String,
+    paramsJson: String?,
+    timeoutMs: Long = 15_000,
+    onError: (ErrorShape) -> Unit = {},
   ) {
-    val conn = readyConnection() ?: throw IllegalStateException("not connected")
+    val conn = readyConnection(expectedEndpointStableId) ?: throw IllegalStateException("not connected")
     val params =
       if (paramsJson.isNullOrBlank()) {
         null
@@ -767,7 +819,7 @@ class GatewaySession(
 
     private suspend fun sendConnect(connectNonce: String) {
       val identity = identityStore.loadOrCreate()
-      val storedEntry = deviceAuthStore.loadEntry(identity.deviceId, options.role)
+      val storedEntry = deviceAuthStore.loadEntry(endpoint.stableId, identity.deviceId, options.role)
       val storedToken = storedEntry?.token?.trim()
       val selectedAuth =
         selectConnectAuth(
@@ -808,7 +860,7 @@ class GatewaySession(
           selectedAuth.attemptedDeviceTokenRetry &&
           shouldClearStoredDeviceTokenAfterRetry(error)
         ) {
-          deviceAuthStore.clearToken(identity.deviceId, options.role)
+          deviceAuthStore.clearToken(endpoint.stableId, identity.deviceId, options.role)
         }
         throw GatewayConnectFailure(error)
       }
@@ -848,7 +900,7 @@ class GatewaySession(
       scopes: List<String>,
     ) {
       val filteredScopes = filteredBootstrapHandoffScopes(role, scopes) ?: return
-      deviceAuthStore.saveToken(deviceId, role, token, filteredScopes)
+      deviceAuthStore.saveToken(endpoint.stableId, deviceId, role, token, filteredScopes)
     }
 
     private fun persistIssuedDeviceToken(
@@ -863,7 +915,7 @@ class GatewaySession(
         persistBootstrapHandoffToken(deviceId, role, token, scopes)
         return
       }
-      deviceAuthStore.saveToken(deviceId, role, token, scopes)
+      deviceAuthStore.saveToken(endpoint.stableId, deviceId, role, token, scopes)
     }
 
     private fun parseConnectSuccess(

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayStoreMigration.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayStoreMigration.kt
@@ -1,0 +1,102 @@
+package ai.openclaw.app.gateway
+
+import ai.openclaw.app.GatewayCredentials
+import ai.openclaw.app.SecurePrefs
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal class GatewayStoreMigration(
+  private val prefs: SecurePrefs,
+) {
+  private val json = Json { encodeDefaults = true }
+
+  fun run() {
+    if (prefs.containsSecureKey(GatewayRegistryStore.STORAGE_KEY)) return
+
+    val activeEntry = legacyActiveEntry()
+    migrateCredentials(activeEntry?.stableId)
+    migrateDeviceTokens(activeEntry?.stableId)
+    migrateNotificationSessionKey(activeEntry?.stableId)
+    prefs.putString(
+      GatewayRegistryStore.STORAGE_KEY,
+      json.encodeToString(
+        PersistedGatewayRegistry(
+          activeStableId = activeEntry?.stableId,
+          entries = listOfNotNull(activeEntry),
+        ),
+      ),
+    )
+  }
+
+  private fun legacyActiveEntry(): GatewayRegistryEntry? {
+    if (prefs.getPlainBoolean("gateway.manual.enabled", false)) {
+      val host = prefs.getPlainString("gateway.manual.host").orEmpty().trim()
+      val port = prefs.getPlainInt("gateway.manual.port", 18789)
+      if (host.isNotEmpty() && port in 1..65535) {
+        val endpoint = GatewayEndpoint.manual(host, port)
+        return GatewayRegistryEntry(
+          stableId = endpoint.stableId,
+          kind = GatewayRegistryEntryKind.MANUAL,
+          name = "$host:$port",
+          host = host,
+          port = port,
+          tls = prefs.getPlainBoolean("gateway.manual.tls", true),
+        )
+      }
+    }
+
+    val stableId = prefs.getPlainString("gateway.lastDiscoveredStableID").orEmpty().trim()
+    return stableId
+      .takeIf { it.isNotEmpty() }
+      ?.let {
+        GatewayRegistryEntry(
+          stableId = it,
+          kind = GatewayRegistryEntryKind.DISCOVERED,
+          name = it,
+        )
+      }
+  }
+
+  private fun migrateCredentials(activeStableId: String?) {
+    val instanceId = prefs.instanceId.value
+    val legacyKeys =
+      listOf(
+        "gateway.manual.token",
+        "gateway.token.$instanceId",
+        "gateway.bootstrapToken.$instanceId",
+        "gateway.password.$instanceId",
+      )
+    if (activeStableId != null) {
+      val legacyToken =
+        sequenceOf(prefs.getString(legacyKeys[0]), prefs.getString(legacyKeys[1]))
+          .mapNotNull { it?.trim()?.takeIf(String::isNotEmpty) }
+          .firstOrNull()
+      val credentials =
+        GatewayCredentials(
+          token = legacyToken,
+          bootstrapToken = prefs.getString(legacyKeys[2]),
+          password = prefs.getString(legacyKeys[3]),
+        ).normalized()
+      if (credentials != GatewayCredentials()) {
+        prefs.saveGatewayCredentials(activeStableId, credentials)
+      }
+    }
+    prefs.removeSecureKeys(legacyKeys)
+  }
+
+  private fun migrateDeviceTokens(activeStableId: String?) {
+    val legacyPrefixes = listOf("gateway.deviceToken.", "gateway.deviceTokenMeta.")
+    val keys = prefs.secureKeys()
+    for (key in keys) {
+      val prefix = legacyPrefixes.firstOrNull(key::startsWith) ?: continue
+      val suffix = key.removePrefix(prefix)
+      if (suffix.split('.').size != 2) continue
+      prefs.moveSecureString(key, activeStableId?.let { "$prefix$it.$suffix" })
+    }
+  }
+
+  private fun migrateNotificationSessionKey(activeStableId: String?) {
+    val legacyKey = "notifications.forwarding.sessionKey"
+    prefs.movePlainString(legacyKey, activeStableId?.let { "$legacyKey.$it" })
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
@@ -29,7 +29,7 @@ class ConnectionManager(
   private val photosAvailable: () -> Boolean,
   private val hasRecordAudioPermission: () -> Boolean,
   private val installedAppsSharingEnabled: () -> Boolean,
-  private val manualTls: () -> Boolean,
+  private val manualTls: (GatewayEndpoint) -> Boolean,
 ) {
   companion object {
     internal val legacyOperatorScopes: List<String> =
@@ -230,6 +230,6 @@ class ConnectionManager(
   /** Resolves persisted TLS pin policy for a concrete gateway endpoint. */
   fun resolveTlsParams(endpoint: GatewayEndpoint): GatewayTlsParams? {
     val stored = prefs.loadGatewayTlsFingerprint(endpoint.stableId)
-    return resolveTlsParamsForEndpoint(endpoint, storedFingerprint = stored, manualTlsEnabled = manualTls())
+    return resolveTlsParamsForEndpoint(endpoint, storedFingerprint = stored, manualTlsEnabled = manualTls(endpoint))
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.ContentCopy
@@ -32,9 +33,12 @@ import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.PowerSettingsNew
+import androidx.compose.material.icons.filled.SwapHoriz
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -81,14 +85,16 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
   val manualEnabled by viewModel.manualEnabled.collectAsState()
-  val gatewayToken by viewModel.gatewayToken.collectAsState()
   val pendingTrust by viewModel.pendingGatewayTrust.collectAsState()
+  val pairedGateways by viewModel.pairedGateways.collectAsState()
+  val activeGatewayStableId by viewModel.activeGatewayStableId.collectAsState()
 
   var advancedOpen by rememberSaveable { mutableStateOf(false) }
+  var gatewaySwitcherOpen by remember { mutableStateOf(false) }
   var inputMode by
-    remember(manualEnabled, manualHost, gatewayToken) {
+    remember(manualEnabled, manualHost) {
       mutableStateOf(
-        if (manualEnabled || manualHost.isNotBlank() || gatewayToken.trim().isNotEmpty()) {
+        if (manualEnabled || manualHost.isNotBlank()) {
           ConnectInputMode.Manual
         } else {
           ConnectInputMode.SetupCode
@@ -232,6 +238,57 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
           Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
             Text(stringResource(R.string.status), style = mobileCaption1.copy(fontWeight = FontWeight.SemiBold), color = mobileTextSecondary)
             Text(statusText, style = mobileBody, color = if (isConnected) mobileSuccess else mobileText)
+          }
+        }
+      }
+    }
+
+    if (pairedGateways.size > 1) {
+      Box(modifier = Modifier.fillMaxWidth()) {
+        Surface(
+          modifier = Modifier.fillMaxWidth(),
+          shape = RoundedCornerShape(14.dp),
+          color = mobileCardSurface,
+          border = BorderStroke(1.dp, mobileBorder),
+          onClick = { gatewaySwitcherOpen = true },
+        ) {
+          Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+          ) {
+            Icon(Icons.Default.SwapHoriz, contentDescription = null, tint = mobileAccent)
+            Column(modifier = Modifier.weight(1f)) {
+              Text(stringResource(R.string.switch_gateway), style = mobileCaption1, color = mobileTextSecondary)
+              Text(
+                pairedGateways.firstOrNull { it.stableId == activeGatewayStableId }?.name
+                  ?: stringResource(R.string.select_gateway),
+                style = mobileHeadline,
+                color = mobileText,
+              )
+            }
+            Icon(Icons.Default.ExpandMore, contentDescription = null, tint = mobileTextSecondary)
+          }
+        }
+        DropdownMenu(
+          expanded = gatewaySwitcherOpen,
+          onDismissRequest = { gatewaySwitcherOpen = false },
+        ) {
+          pairedGateways.forEach { entry ->
+            DropdownMenuItem(
+              text = { Text(entry.name) },
+              leadingIcon = {
+                if (entry.stableId == activeGatewayStableId) {
+                  Icon(Icons.Default.Check, contentDescription = stringResource(R.string.active_gateway))
+                }
+              },
+              onClick = {
+                gatewaySwitcherOpen = false
+                if (entry.stableId != activeGatewayStableId) {
+                  viewModel.switchToGateway(entry.stableId)
+                }
+              },
+            )
           }
         }
       }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -285,7 +285,6 @@ fun OnboardingFlow(
     val nodesDevicesRefreshing by viewModel.nodesDevicesRefreshing.collectAsState()
     val serverName by viewModel.serverName.collectAsState()
     val gateways by viewModel.gateways.collectAsState()
-    val savedToken by viewModel.gatewayToken.collectAsState()
     val savedManualHost by viewModel.manualHost.collectAsState()
     val savedManualPort by viewModel.manualPort.collectAsState()
     val savedManualTls by viewModel.manualTls.collectAsState()
@@ -303,7 +302,7 @@ fun OnboardingFlow(
     var manualHost by rememberSaveable { mutableStateOf("") }
     var manualPort by rememberSaveable { mutableStateOf("18789") }
     var manualTls by rememberSaveable { mutableStateOf(false) }
-    var token by rememberSaveable { mutableStateOf(savedToken) }
+    var token by rememberSaveable { mutableStateOf("") }
     var password by rememberSaveable { mutableStateOf("") }
     var setupError by rememberSaveable { mutableStateOf<String?>(null) }
     var setupScanError by rememberSaveable { mutableStateOf<String?>(null) }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -18,6 +18,7 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NotificationPackageFilterMode
 import ai.openclaw.app.SensitiveFeatureConfig
 import ai.openclaw.app.chat.ChatPendingToolCall
+import ai.openclaw.app.gateway.GatewayRegistryEntryKind
 import ai.openclaw.app.gatewayTalkSetupDescription
 import ai.openclaw.app.gatewayTalkSetupStatusText
 import ai.openclaw.app.hasPhotoReadPermission
@@ -89,6 +90,7 @@ import androidx.compose.material.icons.automirrored.filled.ScreenShare
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.GraphicEq
@@ -1141,6 +1143,8 @@ private fun GatewaySettingsScreen(
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
+  val pairedGateways by viewModel.pairedGateways.collectAsState()
+  val activeGatewayStableId by viewModel.activeGatewayStableId.collectAsState()
   var setupCode by remember { mutableStateOf("") }
   var hostInput by remember(manualHost) { mutableStateOf(manualHost.ifBlank { "127.0.0.1" }) }
   var portInput by remember(manualPort) { mutableStateOf(manualPort.toString()) }
@@ -1151,6 +1155,7 @@ private fun GatewaySettingsScreen(
   var validationText by remember { mutableStateOf<String?>(null) }
   var showSetupCodeHelp by remember { mutableStateOf(false) }
   var pendingSetupResetPlan by remember { mutableStateOf<GatewayConnectPlan?>(null) }
+  var pendingForgetStableId by remember { mutableStateOf<String?>(null) }
 
   fun saveAndConnect(plan: GatewayConnectPlan) {
     validationText = null
@@ -1187,6 +1192,29 @@ private fun GatewaySettingsScreen(
     )
   }
 
+  pendingForgetStableId?.let { stableId ->
+    val entry = pairedGateways.firstOrNull { it.stableId == stableId }
+    AlertDialog(
+      onDismissRequest = { pendingForgetStableId = null },
+      title = { Text("Forget gateway?") },
+      text = { Text("Remove ${entry?.name ?: "this gateway"} and its saved credentials from this phone?") },
+      confirmButton = {
+        TextButton(
+          onClick = {
+            pendingForgetStableId = null
+            viewModel.forgetGateway(stableId)
+          },
+        ) {
+          Text("Forget")
+        }
+      },
+      dismissButton = {
+        TextButton(onClick = { pendingForgetStableId = null }) { Text("Cancel") }
+      },
+      containerColor = ClawTheme.colors.surface,
+    )
+  }
+
   SettingsDetailFrame(title = "Gateway", subtitle = "Connection between this phone and OpenClaw.", icon = Icons.Default.Cloud, onBack = onBack) {
     SettingsMetricPanel(
       rows =
@@ -1206,17 +1234,61 @@ private fun GatewaySettingsScreen(
       ClawSecondaryButton(text = "Disconnect", onClick = viewModel::disconnect, modifier = Modifier.weight(1f))
     }
     ClawPanel {
+      Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(text = "Gateways", style = ClawTheme.type.section, color = ClawTheme.colors.text)
+        if (pairedGateways.isEmpty()) {
+          Text(text = "No paired gateways.", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+        } else {
+          pairedGateways.forEachIndexed { index, entry ->
+            if (index > 0) HorizontalDivider(color = ClawTheme.colors.border)
+            ClawListItem(
+              title = entry.name,
+              subtitle =
+                when (entry.kind) {
+                  GatewayRegistryEntryKind.MANUAL -> "${entry.host}:${entry.port}"
+                  GatewayRegistryEntryKind.DISCOVERED -> entry.stableId
+                },
+              leading = {
+                if (entry.stableId == activeGatewayStableId) {
+                  ClawIconBadge(Icons.Default.Check)
+                } else {
+                  ClawIconBadge(Icons.Default.Cloud)
+                }
+              },
+              trailing = {
+                TextButton(onClick = { pendingForgetStableId = entry.stableId }) {
+                  Text("Forget")
+                }
+              },
+              onClick =
+                if (entry.stableId == activeGatewayStableId) {
+                  null
+                } else {
+                  { viewModel.switchToGateway(entry.stableId) }
+                },
+            )
+          }
+        }
+        ClawSecondaryButton(
+          text = "Add gateway",
+          onClick = viewModel::pairNewGateway,
+          modifier = Modifier.fillMaxWidth(),
+          icon = Icons.Default.QrCode2,
+        )
+      }
+    }
+    ClawPanel {
       Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        Text(text = "Pair New Gateway", style = ClawTheme.type.section, color = ClawTheme.colors.text)
+        Text(text = "Gateway setup", style = ClawTheme.type.section, color = ClawTheme.colors.text)
         Text(
-          text = "Clear this phone's saved gateway access and scan a fresh setup code.",
+          text = "Scan or paste a setup code to add another gateway.",
           style = ClawTheme.type.body,
           color = ClawTheme.colors.textMuted,
           maxLines = 2,
           overflow = TextOverflow.Ellipsis,
         )
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-          ClawSecondaryButton(text = "Pair New Gateway", onClick = viewModel::pairNewGateway, modifier = Modifier.fillMaxWidth(), icon = Icons.Default.QrCode2)
+          ClawSecondaryButton(text = "Add gateway", onClick = viewModel::pairNewGateway, modifier = Modifier.fillMaxWidth(), icon = Icons.Default.QrCode2)
           ClawSecondaryButton(text = "Setup Code", onClick = { showSetupCodeHelp = !showSetupCodeHelp }, modifier = Modifier.fillMaxWidth(), icon = Icons.Default.Info)
         }
         if (showSetupCodeHelp) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -40,17 +40,22 @@ data class VoiceConversationEntry(
   val isStreaming: Boolean = false,
 )
 
+internal data class GatewayTranscriptionSession(
+  val id: String,
+  val gatewayId: String,
+)
+
 /** Coordinates live mic transcription, queued sends, and assistant audio replies. */
 internal class MicCaptureManager(
   private val context: Context,
   private val scope: CoroutineScope,
-  private val createTranscriptionSession: suspend () -> String,
+  private val createTranscriptionSession: suspend () -> GatewayTranscriptionSession,
   private val appendTranscriptionAudio: suspend (
-    sessionId: String,
+    session: GatewayTranscriptionSession,
     audio: ByteArray,
     onError: (String) -> Unit,
   ) -> Unit,
-  private val closeTranscriptionSession: suspend (sessionId: String) -> Unit,
+  private val closeTranscriptionSession: suspend (session: GatewayTranscriptionSession) -> Unit,
   /**
    * Send [message] to the gateway and return the full chat.send ACK.
    * [onRunIdKnown] is called with the idempotency key *before* the network
@@ -108,14 +113,16 @@ internal class MicCaptureManager(
   private var pendingRunId: String? = null
   private var pendingAssistantEntryId: String? = null
   private var gatewayConnected = false
+  private var gatewayGeneration = 0L
 
-  @Volatile private var transcriptionSessionId: String? = null
+  @Volatile private var transcriptionSession: GatewayTranscriptionSession? = null
   private var transcriptionStartJob: Job? = null
   private var transcriptionCaptureJob: Job? = null
   private var transcriptionAppendJob: Job? = null
   private var transcriptionDrainJob: Job? = null
   private var transcriptFlushJob: Job? = null
   private var pendingRunTimeoutJob: Job? = null
+  private var sendJob: Job? = null
   private var stopRequested = false
   private val ttsPauseLock = Any()
   private var ttsPauseDepth = 0
@@ -210,7 +217,7 @@ internal class MicCaptureManager(
         ttsPauseDepth += 1
         if (ttsPauseDepth > 1) return@synchronized false
         resumeMicAfterTts = _micEnabled.value
-        val active = resumeMicAfterTts || transcriptionSessionId != null || _isListening.value
+        val active = resumeMicAfterTts || transcriptionSession != null || _isListening.value
         if (!active) return@synchronized false
         stopRequested = true
         transcriptFlushJob?.cancel()
@@ -255,7 +262,7 @@ internal class MicCaptureManager(
   fun onGatewayConnectionChanged(connected: Boolean) {
     gatewayConnected = connected
     if (connected) {
-      if (_micEnabled.value && transcriptionSessionId == null) {
+      if (_micEnabled.value && transcriptionSession == null) {
         start()
       }
       sendQueuedIfIdle()
@@ -271,6 +278,33 @@ internal class MicCaptureManager(
     if (hasQueuedMessages()) {
       _statusText.value = queuedWaitingStatus()
     }
+  }
+
+  /** Retires voice data owned by the old gateway before another gateway can connect. */
+  fun onGatewayScopeChanging() {
+    gatewayGeneration += 1
+    gatewayConnected = false
+    transcriptionDrainJob?.cancel()
+    transcriptionDrainJob = null
+    transcriptFlushJob?.cancel()
+    transcriptFlushJob = null
+    transcriptionStartJob?.cancel()
+    transcriptionStartJob = null
+    sendJob?.cancel()
+    sendJob = null
+    pendingRunTimeoutJob?.cancel()
+    pendingRunTimeoutJob = null
+    pendingRunId = null
+    pendingAssistantEntryId = null
+    synchronized(messageQueueLock) { messageQueue.clear() }
+    publishQueue()
+    _conversation.value = emptyList()
+    _liveTranscript.value = null
+    flushedPartialTranscript = null
+    _isSending.value = false
+    stopRequested = true
+    stopTranscription(preserveStatus = true)
+    _statusText.value = if (_micEnabled.value) "Mic on · waiting for gateway" else "Mic off"
   }
 
   internal fun submitTranscribedMessage(text: String) {
@@ -352,22 +386,22 @@ internal class MicCaptureManager(
       _statusText.value = "Mic on · waiting for gateway"
       return
     }
-    if (transcriptionSessionId != null || transcriptionStartJob?.isActive == true) return
+    if (transcriptionSession != null || transcriptionStartJob?.isActive == true) return
 
     val startJob =
       scope.launch {
         var restartAfterCancellation = false
         try {
-          val sessionId = createTranscriptionSession()
+          val session = createTranscriptionSession()
           if (stopRequested || !_micEnabled.value) {
-            closeTranscriptionSession(sessionId)
+            closeTranscriptionSession(session)
             return@launch
           }
-          transcriptionSessionId = sessionId
+          transcriptionSession = session
           _isListening.value = true
           _statusText.value = listeningStatus()
-          startTranscriptionCapture(sessionId)
-          Log.d(tag, "transcription session started sessionId=$sessionId")
+          startTranscriptionCapture(session)
+          Log.d(tag, "transcription session started sessionId=${session.id}")
         } catch (err: Throwable) {
           if (err is CancellationException) {
             restartAfterCancellation = _micEnabled.value && gatewayConnected && !stopRequested
@@ -395,9 +429,9 @@ internal class MicCaptureManager(
 
   private fun stopTranscription(preserveStatus: Boolean = false) {
     val status = _statusText.value
-    val sessionId = transcriptionSessionId
-    transcriptionSessionId = null
-    if (sessionId != null) {
+    val session = transcriptionSession
+    transcriptionSession = null
+    if (session != null) {
       transcriptionStartJob?.cancel()
       transcriptionStartJob = null
     } else if (transcriptionStartJob?.isActive != true) {
@@ -416,10 +450,10 @@ internal class MicCaptureManager(
     } else {
       _statusText.value = status
     }
-    if (!sessionId.isNullOrBlank()) {
+    if (session != null) {
       scope.launch {
         try {
-          closeTranscriptionSession(sessionId)
+          closeTranscriptionSession(session)
         } catch (err: Throwable) {
           if (err !is CancellationException) {
             Log.d(tag, "transcription close ignored: ${err.message ?: err::class.simpleName}")
@@ -480,47 +514,59 @@ internal class MicCaptureManager(
     pendingRunTimeoutJob = null
     _statusText.value = if (_micEnabled.value) "Listening · sending queued voice" else "Sending queued voice"
 
-    scope.launch {
-      try {
-        val ack =
-          sendToGateway(next) { earlyRunId ->
-            // Called with the idempotency key before chat.send fires so that
-            // pendingRunId is populated before any chat events can arrive.
-            pendingRunId = earlyRunId
+    val sendGeneration = gatewayGeneration
+    sendJob =
+      scope.launch {
+        try {
+          val ack =
+            sendToGateway(next) { earlyRunId ->
+              // Called with the idempotency key before chat.send fires so that
+              // pendingRunId is populated before any chat events can arrive.
+              if (sendGeneration == gatewayGeneration) {
+                pendingRunId = earlyRunId
+              }
+            }
+          if (sendGeneration != gatewayGeneration) return@launch
+          val runId = ack.runId
+          // Update to the real runId if the gateway returned a different one.
+          if (runId != null && runId != pendingRunId) pendingRunId = runId
+          when {
+            ack.isTerminalSuccess -> {
+              completePendingTurn()
+              refreshAfterTerminalSuccess()
+            }
+            ack.isTerminalFailure -> {
+              completePendingTurn()
+              _statusText.value = "Send failed: Chat failed before the run started; try again."
+            }
+            runId == null -> {
+              completePendingTurn()
+            }
+            else -> {
+              armPendingRunTimeout(runId)
+            }
           }
-        val runId = ack.runId
-        // Update to the real runId if the gateway returned a different one.
-        if (runId != null && runId != pendingRunId) pendingRunId = runId
-        when {
-          ack.isTerminalSuccess -> {
-            completePendingTurn()
-            refreshAfterTerminalSuccess()
-          }
-          ack.isTerminalFailure -> {
-            completePendingTurn()
-            _statusText.value = "Send failed: Chat failed before the run started; try again."
-          }
-          runId == null -> {
-            completePendingTurn()
-          }
-          else -> {
-            armPendingRunTimeout(runId)
+        } catch (err: CancellationException) {
+          throw err
+        } catch (err: Throwable) {
+          if (sendGeneration != gatewayGeneration) return@launch
+          pendingRunTimeoutJob?.cancel()
+          pendingRunTimeoutJob = null
+          _isSending.value = false
+          pendingRunId = null
+          pendingAssistantEntryId = null
+          _statusText.value =
+            if (!gatewayConnected) {
+              queuedWaitingStatus()
+            } else {
+              "Send failed: ${err.message ?: err::class.simpleName}"
+            }
+        } finally {
+          if (sendGeneration == gatewayGeneration) {
+            sendJob = null
           }
         }
-      } catch (err: Throwable) {
-        pendingRunTimeoutJob?.cancel()
-        pendingRunTimeoutJob = null
-        _isSending.value = false
-        pendingRunId = null
-        pendingAssistantEntryId = null
-        _statusText.value =
-          if (!gatewayConnected) {
-            queuedWaitingStatus()
-          } else {
-            "Send failed: ${err.message ?: err::class.simpleName}"
-          }
       }
-    }
   }
 
   private fun armPendingRunTimeout(runId: String) {
@@ -621,7 +667,7 @@ internal class MicCaptureManager(
   }
 
   @SuppressLint("MissingPermission")
-  private fun startTranscriptionCapture(sessionId: String) {
+  private fun startTranscriptionCapture(session: GatewayTranscriptionSession) {
     transcriptionCaptureJob?.cancel()
     transcriptionAppendJob?.cancel()
     val audioFrames =
@@ -634,14 +680,14 @@ internal class MicCaptureManager(
     transcriptionAppendJob =
       scope.launch(Dispatchers.IO) {
         for (frame in audioFrames) {
-          if (transcriptionSessionId != sessionId) continue
+          if (transcriptionSession != session) continue
           try {
-            appendTranscriptionAudio(sessionId, pcm16ToPcmu(frame)) { message ->
-              failTranscription(sessionId, message)
+            appendTranscriptionAudio(session, pcm16ToPcmu(frame)) { message ->
+              failTranscription(session, message)
             }
           } catch (err: Throwable) {
             if (err is CancellationException) throw err
-            failTranscription(sessionId, err.message ?: err::class.simpleName ?: "request failed")
+            failTranscription(session, err.message ?: err::class.simpleName ?: "request failed")
           }
         }
       }
@@ -653,7 +699,7 @@ internal class MicCaptureManager(
           audioInput = AndroidAudioInputSession.open(context, transcriptionSampleRateHz, frameBytes)
           val buffer = ByteArray(frameBytes)
           audioInput.startRecording()
-          while (coroutineContext.isActive && _micEnabled.value && transcriptionSessionId == sessionId) {
+          while (coroutineContext.isActive && _micEnabled.value && transcriptionSession == session) {
             val read = audioInput.read(buffer, 0, buffer.size)
             if (read <= 0) continue
             _inputLevel.value = pcm16Level(buffer, read)
@@ -661,7 +707,7 @@ internal class MicCaptureManager(
           }
         } catch (err: Throwable) {
           if (err is CancellationException) throw err
-          failTranscription(sessionId, err.message ?: err::class.simpleName ?: "capture failed")
+          failTranscription(session, err.message ?: err::class.simpleName ?: "capture failed")
         } finally {
           audioFrames.close()
           audioInput?.close()
@@ -678,8 +724,8 @@ internal class MicCaptureManager(
         null
       } ?: return
     val sessionId = obj["transcriptionSessionId"].asStringOrNull() ?: obj["sessionId"].asStringOrNull()
-    val currentSessionId = transcriptionSessionId
-    if (currentSessionId == null || sessionId != currentSessionId) return
+    val currentSession = transcriptionSession
+    if (currentSession == null || sessionId != currentSession.id) return
 
     when (obj["type"].asStringOrNull()) {
       "ready", "inputAudio", "speechStart" -> {
@@ -713,7 +759,7 @@ internal class MicCaptureManager(
             ?.trim()
             .orEmpty()
             .ifEmpty { "transcription failed" }
-        failTranscription(currentSessionId, message)
+        failTranscription(currentSession, message)
       }
       "close" -> {
         _micEnabled.value = false
@@ -723,10 +769,10 @@ internal class MicCaptureManager(
   }
 
   private fun failTranscription(
-    sessionId: String,
+    session: GatewayTranscriptionSession,
     message: String,
   ) {
-    if (transcriptionSessionId != sessionId) return
+    if (transcriptionSession != session) return
     _statusText.value = "Transcription failed: $message"
     _micEnabled.value = false
     stopTranscription(preserveStatus = true)

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.BufferOverflow
@@ -142,6 +143,7 @@ class TalkModeManager internal constructor(
   private val scope: CoroutineScope,
   private val session: GatewaySession,
   private val isConnected: () -> Boolean,
+  private val gatewayStableId: () -> String? = { null },
   private val onBeforeSpeak: suspend () -> Unit = {},
   private val onAfterSpeak: suspend () -> Unit = {},
   private val onStoppedByRelay: () -> Unit = {},
@@ -161,6 +163,14 @@ class TalkModeManager internal constructor(
   }
 
   private val mainHandler = Handler(Looper.getMainLooper())
+  private var gatewayWorkJob = SupervisorJob()
+  private var gatewayWorkScope = CoroutineScope(scope.coroutineContext + gatewayWorkJob)
+  private val gatewayGeneration = AtomicLong()
+
+  init {
+    scope.coroutineContext[Job]?.invokeOnCompletion { gatewayWorkJob.cancel() }
+  }
+
   private val json = Json { ignoreUnknownKeys = true }
   private val _isEnabled = MutableStateFlow(false)
   val isEnabled: StateFlow<Boolean> = _isEnabled
@@ -300,6 +310,46 @@ class TalkModeManager internal constructor(
   fun stopAllCapture() {
     _isEnabled.value = false
     stop()
+  }
+
+  /** Cancels work carrying voice/session data before a replacement gateway can connect. */
+  fun onGatewayScopeChanging() {
+    gatewayGeneration.incrementAndGet()
+    gatewayWorkJob.cancel()
+    gatewayWorkJob = SupervisorJob()
+    gatewayWorkScope = CoroutineScope(scope.coroutineContext + gatewayWorkJob)
+    _conversation.value = emptyList()
+    _lastAssistantText.value = null
+    configLoaded = false
+    silenceWindowMs = TalkDefaults.defaultSilenceTimeoutMs
+    interruptOnSpeech = false
+  }
+
+  private suspend fun requestGateway(
+    method: String,
+    paramsJson: String?,
+    timeoutMs: Long = 15_000,
+  ): String {
+    val gatewayId = gatewayStableId()?.trim()?.takeIf { it.isNotEmpty() }
+    return if (gatewayId == null) {
+      session.request(method, paramsJson, timeoutMs)
+    } else {
+      session.requestForEndpoint(gatewayId, method, paramsJson, timeoutMs)
+    }
+  }
+
+  private suspend fun sendGatewayRequestFrame(
+    method: String,
+    paramsJson: String?,
+    timeoutMs: Long,
+    onError: (GatewaySession.ErrorShape) -> Unit,
+  ) {
+    val gatewayId = gatewayStableId()?.trim()?.takeIf { it.isNotEmpty() }
+    if (gatewayId == null) {
+      session.sendRequestFrame(method, paramsJson, timeoutMs, onError)
+    } else {
+      session.sendRequestFrameForEndpoint(gatewayId, method, paramsJson, timeoutMs, onError)
+    }
   }
 
   internal val activePushToTalkCaptureId: String?
@@ -455,7 +505,7 @@ class TalkModeManager internal constructor(
           // background stop can run between capture startup and job registration.
           startSilenceMonitor(captureId)
           pttTimeoutJob =
-            scope.launch {
+            gatewayWorkScope.launch {
               delay(autoStopAfterMs)
               if (pttAutoStopEnabled) {
                 endPushToTalk(captureId)
@@ -506,7 +556,9 @@ class TalkModeManager internal constructor(
       _statusText.value = "Thinking…"
       lateinit var finishingJob: Job
       finishingJob =
-        scope.launch(start = CoroutineStart.LAZY) {
+        // Gateway-scoped so a switch drops the stale finalize; the NonCancellable
+        // finally still resumes capture when the scope cancels this job.
+        gatewayWorkScope.launch(start = CoroutineStart.LAZY) {
           try {
             finalizeTranscript(transcript)
           } finally {
@@ -617,7 +669,7 @@ class TalkModeManager internal constructor(
     command: String,
     onComplete: () -> Unit,
   ) {
-    scope.launch {
+    gatewayWorkScope.launch {
       try {
         reloadConfig()
         val startedAt = System.currentTimeMillis().toDouble() / 1000.0
@@ -661,7 +713,7 @@ class TalkModeManager internal constructor(
   fun playTtsForText(text: String) {
     val playbackToken = playbackGeneration.incrementAndGet()
     cancelActivePlayback()
-    scope.launch {
+    gatewayWorkScope.launch {
       reloadConfig()
       runPlaybackSession(playbackToken) {
         playAssistant(text, playbackToken)
@@ -786,11 +838,12 @@ class TalkModeManager internal constructor(
 
   private fun start() {
     if (realtimeSessionId != null || realtimeCaptureJob?.isActive == true) return
+    if (scope.coroutineContext[Job]?.isActive == false) return
     val generation = startGeneration.incrementAndGet()
     stopRequested = false
     listeningMode = true
     Log.d(tag, "start")
-    scope.launch {
+    gatewayWorkScope.launch {
       try {
         ensureConfigLoaded()
         if (generation != startGeneration.get() || !_isEnabled.value || stopRequested) return@launch
@@ -895,7 +948,7 @@ class TalkModeManager internal constructor(
         put("transport", JsonPrimitive("gateway-relay"))
         put("brain", JsonPrimitive("agent-consult"))
       }
-    val payload = session.request("talk.session.create", params.toString(), timeoutMs = 15_000)
+    val payload = requestGateway("talk.session.create", params.toString(), timeoutMs = 15_000)
     val root = json.parseToJsonElement(payload).asObjectOrNull()
     val relaySession = root?.get("relaySessionId").asStringOrNull()
     val sessionId = relaySession ?: root?.get("sessionId").asStringOrNull()
@@ -967,7 +1020,7 @@ class TalkModeManager internal constructor(
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
       )
     realtimeAppendJob =
-      scope.launch(realtimeCaptureDispatcher) {
+      gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         for (frame in audioFrames) {
           if (realtimeSessionId != sessionId) continue
           if (isRealtimePlaybackActive()) continue
@@ -979,7 +1032,7 @@ class TalkModeManager internal constructor(
               put("timestamp", JsonPrimitive(SystemClock.elapsedRealtime()))
             }
           try {
-            session.sendRequestFrame(
+            sendGatewayRequestFrame(
               "talk.session.appendAudio",
               params.toString(),
               timeoutMs = 8_000,
@@ -995,7 +1048,7 @@ class TalkModeManager internal constructor(
         }
       }
     realtimeCaptureJob =
-      scope.launch(realtimeCaptureDispatcher) {
+      gatewayWorkScope.launch(realtimeCaptureDispatcher) {
         var audioInput: AndroidAudioInputSession? = null
         try {
           val frameBytes = realtimeSampleRateHz * 2 * realtimeAudioFrameMs / 1000
@@ -1153,7 +1206,7 @@ class TalkModeManager internal constructor(
         ?: Channel<ByteArray>(Channel.UNLIMITED).also { queue ->
           realtimeAudioQueue = queue
           realtimeAudioWriterJob =
-            scope.launch(Dispatchers.IO) {
+            gatewayWorkScope.launch(Dispatchers.IO) {
               for (chunk in queue) {
                 if (!playbackEnabled || realtimeOutputSuppressed || realtimeSessionId == null) continue
                 try {
@@ -1232,7 +1285,7 @@ class TalkModeManager internal constructor(
     realtimePlaybackIdleJob?.cancel()
     val delayMs = maxOf(0L, realtimePlaybackEndsAtMs - SystemClock.elapsedRealtime())
     realtimePlaybackIdleJob =
-      scope.launch {
+      gatewayWorkScope.launch {
         delay(delayMs)
         val idle =
           synchronized(realtimePlaybackLock) {
@@ -1315,7 +1368,7 @@ class TalkModeManager internal constructor(
     }
     _isListening.value = false
     if (closeSession && !sessionId.isNullOrBlank()) {
-      scope.launch {
+      gatewayWorkScope.launch {
         closeRealtimeSession(sessionId)
       }
     }
@@ -1401,7 +1454,7 @@ class TalkModeManager internal constructor(
   private suspend fun closeRealtimeSession(sessionId: String) {
     try {
       val params = buildJsonObject { put("sessionId", JsonPrimitive(sessionId)) }
-      session.request("talk.session.close", params.toString(), timeoutMs = 5_000)
+      requestGateway("talk.session.close", params.toString(), timeoutMs = 5_000)
     } catch (err: Throwable) {
       if (err !is CancellationException) {
         Log.d(tag, "realtime close ignored: ${err.message ?: err::class.simpleName}")
@@ -1419,7 +1472,7 @@ class TalkModeManager internal constructor(
     synchronized(realtimeToolLock) {
       pendingRealtimeToolCalls.add(callId)
     }
-    scope.launch {
+    gatewayWorkScope.launch {
       try {
         if (name == REALTIME_AGENT_CONTROL_TOOL) {
           submitRealtimeAgentControl(callId = callId, relaySessionId = relaySessionId, args = args)
@@ -1437,7 +1490,7 @@ class TalkModeManager internal constructor(
             if (args != null) put("args", args)
           }
         val response =
-          session.request("talk.client.toolCall", params.toString(), timeoutMs = 15_000)
+          requestGateway("talk.client.toolCall", params.toString(), timeoutMs = 15_000)
         val runId = parseRunId(response)
         if (!runId.isNullOrBlank()) {
           when (val registration = registerRealtimeToolRun(runId, callId, relaySessionId)) {
@@ -1528,7 +1581,7 @@ class TalkModeManager internal constructor(
       "final" -> {
         val text = extractTextFromChatEventMessage(dispatch.messageEl).orEmpty()
         val toolRun = dispatch.toolRun
-        scope.launch {
+        gatewayWorkScope.launch {
           submitRealtimeToolResult(
             callId = toolRun.callId,
             result = buildJsonObject { put("text", JsonPrimitive(text)) },
@@ -1539,7 +1592,7 @@ class TalkModeManager internal constructor(
       "aborted", "error" -> {
         val toolRun = dispatch.toolRun
         val state = dispatch.state
-        scope.launch {
+        gatewayWorkScope.launch {
           submitRealtimeToolError(toolRun.callId, state, toolRun.relaySessionId)
         }
       }
@@ -1573,7 +1626,7 @@ class TalkModeManager internal constructor(
         if (options != null) put("options", options)
       }
     try {
-      session.request("talk.session.submitToolResult", params.toString(), timeoutMs = 15_000)
+      requestGateway("talk.session.submitToolResult", params.toString(), timeoutMs = 15_000)
     } catch (err: Throwable) {
       if (err is CancellationException) throw err
       Log.w(tag, "realtime submitToolResult failed: ${err.message ?: err::class.simpleName}")
@@ -1626,7 +1679,7 @@ class TalkModeManager internal constructor(
         put("text", JsonPrimitive(text.ifEmpty { "status" }))
         if (!mode.isNullOrEmpty()) put("mode", JsonPrimitive(mode))
       }
-    val response = session.request("talk.session.steer", params.toString(), timeoutMs = 15_000)
+    val response = requestGateway("talk.session.steer", params.toString(), timeoutMs = 15_000)
     val result = json.parseToJsonElement(response).asObjectOrNull()
     if (result != null) {
       submitRealtimeToolResult(callId = callId, result = result, sessionId = relaySessionId)
@@ -1883,7 +1936,7 @@ class TalkModeManager internal constructor(
     if (stopRequested) return
     restartJob?.cancel()
     restartJob =
-      scope.launch {
+      gatewayWorkScope.launch {
         delay(delayMs)
         mainHandler.post {
           if (stopRequested) return@post
@@ -1930,7 +1983,7 @@ class TalkModeManager internal constructor(
   private fun startSilenceMonitor(captureId: String) {
     silenceJob?.cancel()
     silenceJob =
-      scope.launch {
+      gatewayWorkScope.launch {
         while (_isEnabled.value || pttAutoStopEnabled) {
           delay(200)
           checkSilence(captureId)
@@ -1947,13 +2000,13 @@ class TalkModeManager internal constructor(
     if (elapsed < silenceWindowMs) return
     if (activePttCaptureId != null) {
       if (pttAutoStopEnabled) {
-        scope.launch { endPushToTalk(captureId) }
+        gatewayWorkScope.launch { endPushToTalk(captureId) }
       }
       return
     }
     if (finalizeInFlight) return
     finalizeInFlight = true
-    scope.launch {
+    gatewayWorkScope.launch {
       try {
         finalizeTranscript(transcript)
       } finally {
@@ -2107,7 +2160,7 @@ class TalkModeManager internal constructor(
         put("idempotencyKey", JsonPrimitive(runId))
       }
     try {
-      val res = session.request("chat.send", params.toString())
+      val res = requestGateway("chat.send", params.toString())
       val parsed = parseChatSendAck(json, res)
       val actualRunId = parsed.runId ?: runId
       if (actualRunId != runId) {
@@ -2214,7 +2267,7 @@ class TalkModeManager internal constructor(
     sinceSeconds: Double? = null,
   ): String? {
     val key = mainSessionKey.ifBlank { "main" }
-    val res = session.request("chat.history", "{\"sessionKey\":\"$key\"}")
+    val res = requestGateway("chat.history", "{\"sessionKey\":\"$key\"}")
     val root = json.parseToJsonElement(res).asObjectOrNull() ?: return null
     val messages = root["messages"] as? JsonArray ?: return null
     for (item in messages.reversed()) {
@@ -2455,7 +2508,7 @@ class TalkModeManager internal constructor(
             put("sessionId", JsonPrimitive(sessionId))
             put("reason", JsonPrimitive(reason))
           }
-        session.request("talk.session.cancelOutput", params.toString(), timeoutMs = 5_000)
+        requestGateway("talk.session.cancelOutput", params.toString(), timeoutMs = 5_000)
         // The response confirms provider cancellation; clear confirms that the
         // old playback boundary reached Android before capture can resume.
         withTimeout(2_000) { clear.await() }
@@ -2634,14 +2687,17 @@ class TalkModeManager internal constructor(
   }
 
   private suspend fun reloadConfig() {
+    val generation = gatewayGeneration.get()
     try {
-      val res = session.request("talk.config", "{}")
+      val res = requestGateway("talk.config", "{}")
       val root = json.parseToJsonElement(res).asObjectOrNull()
       val parsed = TalkModeGatewayConfigParser.parse(root?.get("config").asObjectOrNull())
+      if (generation != gatewayGeneration.get()) return
       silenceWindowMs = parsed.silenceTimeoutMs
       parsed.interruptOnSpeech?.let { interruptOnSpeech = it }
       configLoaded = true
     } catch (_: Throwable) {
+      if (generation != gatewayGeneration.get()) return
       silenceWindowMs = TalkDefaults.defaultSilenceTimeoutMs
       configLoaded = false
     }

--- a/apps/android/app/src/main/res/values-ar/strings.xml
+++ b/apps/android/app/src/main/res/values-ar/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">نقطة النهاية التي تم حلها</string>
     <string name="gateway_trust_first_seen">تحقق من بصمة الشهادة قبل الوثوق بهذه البوابة.\n\n%1$s</string>
     <string name="gateway_trust_changed">تم تغيير شهادة البوابة. تابع فقط إذا كنت تتوقع هذا التغيير.\n\nSHA-256 القديم:\n%1$s\n\nSHA-256 الجديد:\n%2$s</string>
+    <string name="switch_gateway">تبديل Gateway</string>
+    <string name="select_gateway">تحديد Gateway</string>
+    <string name="active_gateway">Gateway النشط</string>
 </resources>

--- a/apps/android/app/src/main/res/values-de/strings.xml
+++ b/apps/android/app/src/main/res/values-de/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Aufgelöster Endpunkt</string>
     <string name="gateway_trust_first_seen">Überprüfen Sie den Zertifikatfingerabdruck, bevor Sie diesem Gateway vertrauen.\n\n%1$s</string>
     <string name="gateway_trust_changed">Das Gateway-Zertifikat wurde geändert. Fahren Sie nur fort, wenn Sie diese Änderung erwartet haben.\n\nAlter SHA-256-Wert:\n%1$s\n\nNeuer SHA-256-Wert:\n%2$s</string>
+    <string name="switch_gateway">Gateway wechseln</string>
+    <string name="select_gateway">Gateway auswählen</string>
+    <string name="active_gateway">Aktives Gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-es/strings.xml
+++ b/apps/android/app/src/main/res/values-es/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Endpoint resuelto</string>
     <string name="gateway_trust_first_seen">Verifica la huella digital del certificado antes de confiar en este gateway.\n\n%1$s</string>
     <string name="gateway_trust_changed">El certificado del gateway cambió. Continúa solo si esperabas este cambio.\n\nSHA-256 anterior:\n%1$s\n\nSHA-256 nuevo:\n%2$s</string>
+    <string name="switch_gateway">Cambiar de gateway</string>
+    <string name="select_gateway">Seleccionar gateway</string>
+    <string name="active_gateway">Gateway activo</string>
 </resources>

--- a/apps/android/app/src/main/res/values-fa/strings.xml
+++ b/apps/android/app/src/main/res/values-fa/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">نقطه پایانی حل‌شده</string>
     <string name="gateway_trust_first_seen">پیش از اعتماد به این دروازه، اثر انگشت گواهی را تأیید کنید.\n\n%1$s</string>
     <string name="gateway_trust_changed">گواهی دروازه تغییر کرده است. فقط در صورتی ادامه دهید که انتظار این تغییر را داشتید.\n\nSHA-256 قدیمی:\n%1$s\n\nSHA-256 جدید:\n%2$s</string>
+    <string name="switch_gateway">تغییر Gateway</string>
+    <string name="select_gateway">انتخاب Gateway</string>
+    <string name="active_gateway">Gateway فعال</string>
 </resources>

--- a/apps/android/app/src/main/res/values-fr/strings.xml
+++ b/apps/android/app/src/main/res/values-fr/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Point de terminaison résolu</string>
     <string name="gateway_trust_first_seen">Vérifiez l’empreinte du certificat avant d’accorder votre confiance à cette passerelle.\n\n%1$s</string>
     <string name="gateway_trust_changed">Le certificat de la passerelle a changé. Continuez uniquement si vous vous attendiez à ce changement.\n\nAncien SHA-256 :\n%1$s\n\nNouveau SHA-256 :\n%2$s</string>
+    <string name="switch_gateway">Changer de Gateway</string>
+    <string name="select_gateway">Sélectionner un Gateway</string>
+    <string name="active_gateway">Gateway actif</string>
 </resources>

--- a/apps/android/app/src/main/res/values-hi/strings.xml
+++ b/apps/android/app/src/main/res/values-hi/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">रिज़ॉल्व किया गया एंडपॉइंट</string>
     <string name="gateway_trust_first_seen">इस गेटवे पर भरोसा करने से पहले प्रमाणपत्र फ़िंगरप्रिंट सत्यापित करें।\n\n%1$s</string>
     <string name="gateway_trust_changed">गेटवे प्रमाणपत्र बदल गया है। केवल तभी जारी रखें जब आपको इस बदलाव की अपेक्षा थी।\n\nपुराना SHA-256:\n%1$s\n\nनया SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Gateway बदलें</string>
+    <string name="select_gateway">Gateway चुनें</string>
+    <string name="active_gateway">सक्रिय gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-in/strings.xml
+++ b/apps/android/app/src/main/res/values-in/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Endpoint yang diselesaikan</string>
     <string name="gateway_trust_first_seen">Verifikasi sidik jari sertifikat sebelum memercayai gateway ini.\n\n%1$s</string>
     <string name="gateway_trust_changed">Sertifikat gateway berubah. Lanjutkan hanya jika Anda mengharapkan perubahan ini.\n\nSHA-256 lama:\n%1$s\n\nSHA-256 baru:\n%2$s</string>
+    <string name="switch_gateway">Ganti gateway</string>
+    <string name="select_gateway">Pilih gateway</string>
+    <string name="active_gateway">Gateway aktif</string>
 </resources>

--- a/apps/android/app/src/main/res/values-it/strings.xml
+++ b/apps/android/app/src/main/res/values-it/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Endpoint risolto</string>
     <string name="gateway_trust_first_seen">Verifica l’impronta digitale del certificato prima di considerare attendibile questo gateway.\n\n%1$s</string>
     <string name="gateway_trust_changed">Il certificato del gateway è cambiato. Continua solo se ti aspettavi questa modifica.\n\nSHA-256 precedente:\n%1$s\n\nNuovo SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Cambia gateway</string>
+    <string name="select_gateway">Seleziona gateway</string>
+    <string name="active_gateway">Gateway attivo</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ja/strings.xml
+++ b/apps/android/app/src/main/res/values-ja/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">解決済みエンドポイント</string>
     <string name="gateway_trust_first_seen">このゲートウェイを信頼する前に、証明書のフィンガープリントを確認してください。\n\n%1$s</string>
     <string name="gateway_trust_changed">ゲートウェイの証明書が変更されました。想定した変更である場合のみ続行してください。\n\n以前の SHA-256:\n%1$s\n\n新しい SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Gatewayを切り替え</string>
+    <string name="select_gateway">Gatewayを選択</string>
+    <string name="active_gateway">アクティブなGateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ko/strings.xml
+++ b/apps/android/app/src/main/res/values-ko/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">확인된 엔드포인트</string>
     <string name="gateway_trust_first_seen">이 게이트웨이를 신뢰하기 전에 인증서 지문을 확인하세요.\n\n%1$s</string>
     <string name="gateway_trust_changed">게이트웨이 인증서가 변경되었습니다. 예상한 변경인 경우에만 계속하세요.\n\n이전 SHA-256:\n%1$s\n\n새 SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Gateway 전환</string>
+    <string name="select_gateway">Gateway 선택</string>
+    <string name="active_gateway">활성 Gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-nl/strings.xml
+++ b/apps/android/app/src/main/res/values-nl/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Opgelost endpoint</string>
     <string name="gateway_trust_first_seen">Controleer de certificaatvingerafdruk voordat je deze gateway vertrouwt.\n\n%1$s</string>
     <string name="gateway_trust_changed">Het gatewaycertificaat is gewijzigd. Ga alleen door als je deze wijziging verwachtte.\n\nOude SHA-256:\n%1$s\n\nNieuwe SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Van gateway wisselen</string>
+    <string name="select_gateway">Gateway selecteren</string>
+    <string name="active_gateway">Actieve gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pl/strings.xml
+++ b/apps/android/app/src/main/res/values-pl/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Rozpoznany punkt końcowy</string>
     <string name="gateway_trust_first_seen">Sprawdź odcisk certyfikatu, zanim zaufasz tej bramie.\n\n%1$s</string>
     <string name="gateway_trust_changed">Certyfikat bramy uległ zmianie. Kontynuuj tylko wtedy, gdy oczekujesz tej zmiany.\n\nStary SHA-256:\n%1$s\n\nNowy SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Przełącz Gateway</string>
+    <string name="select_gateway">Wybierz Gateway</string>
+    <string name="active_gateway">Aktywne Gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-pt-rBR/strings.xml
+++ b/apps/android/app/src/main/res/values-pt-rBR/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Endpoint resolvido</string>
     <string name="gateway_trust_first_seen">Verifique a impressão digital do certificado antes de confiar neste gateway.\n\n%1$s</string>
     <string name="gateway_trust_changed">O certificado do gateway foi alterado. Continue somente se você esperava essa alteração.\n\nSHA-256 antigo:\n%1$s\n\nSHA-256 novo:\n%2$s</string>
+    <string name="switch_gateway">Trocar Gateway</string>
+    <string name="select_gateway">Selecionar Gateway</string>
+    <string name="active_gateway">Gateway ativo</string>
 </resources>

--- a/apps/android/app/src/main/res/values-ru/strings.xml
+++ b/apps/android/app/src/main/res/values-ru/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Разрешенная конечная точка</string>
     <string name="gateway_trust_first_seen">Проверьте отпечаток сертификата, прежде чем доверять этому шлюзу.\n\n%1$s</string>
     <string name="gateway_trust_changed">Сертификат шлюза изменился. Продолжайте, только если вы ожидали это изменение.\n\nСтарый SHA-256:\n%1$s\n\nНовый SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Переключить gateway</string>
+    <string name="select_gateway">Выбрать gateway</string>
+    <string name="active_gateway">Активный gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-sv/strings.xml
+++ b/apps/android/app/src/main/res/values-sv/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Löst slutpunkt</string>
     <string name="gateway_trust_first_seen">Verifiera certifikatets fingeravtryck innan du litar på denna gateway.\n\n%1$s</string>
     <string name="gateway_trust_changed">Gateway-certifikatet har ändrats. Fortsätt bara om du förväntade dig denna ändring.\n\nTidigare SHA-256:\n%1$s\n\nNy SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Byt Gateway</string>
+    <string name="select_gateway">Välj Gateway</string>
+    <string name="active_gateway">Aktiv Gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-th/strings.xml
+++ b/apps/android/app/src/main/res/values-th/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">เอนด์พอยต์ที่แก้ไขแล้ว</string>
     <string name="gateway_trust_first_seen">ตรวจสอบลายนิ้วมือของใบรับรองก่อนเชื่อถือเกตเวย์นี้\n\n%1$s</string>
     <string name="gateway_trust_changed">ใบรับรองของเกตเวย์มีการเปลี่ยนแปลง ดำเนินการต่อเมื่อคุณคาดว่าจะมีการเปลี่ยนแปลงนี้เท่านั้น\n\nSHA-256 เดิม:\n%1$s\n\nSHA-256 ใหม่:\n%2$s</string>
+    <string name="switch_gateway">สลับ Gateway</string>
+    <string name="select_gateway">เลือก Gateway</string>
+    <string name="active_gateway">Gateway ที่ใช้งานอยู่</string>
 </resources>

--- a/apps/android/app/src/main/res/values-tr/strings.xml
+++ b/apps/android/app/src/main/res/values-tr/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Çözümlenen uç nokta</string>
     <string name="gateway_trust_first_seen">Bu ağ geçidine güvenmeden önce sertifika parmak izini doğrulayın.\n\n%1$s</string>
     <string name="gateway_trust_changed">Ağ geçidi sertifikası değişti. Yalnızca bu değişikliği bekliyorsanız devam edin.\n\nEski SHA-256:\n%1$s\n\nYeni SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Gateway değiştir</string>
+    <string name="select_gateway">Gateway seç</string>
+    <string name="active_gateway">Etkin Gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-uk/strings.xml
+++ b/apps/android/app/src/main/res/values-uk/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Визначена кінцева точка</string>
     <string name="gateway_trust_first_seen">Перевірте відбиток сертифіката, перш ніж довіряти цьому шлюзу.\n\n%1$s</string>
     <string name="gateway_trust_changed">Сертифікат шлюзу змінився. Продовжуйте, лише якщо ви очікували цю зміну.\n\nСтарий SHA-256:\n%1$s\n\nНовий SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Перемкнути gateway</string>
+    <string name="select_gateway">Виберіть gateway</string>
+    <string name="active_gateway">Активний gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-vi/strings.xml
+++ b/apps/android/app/src/main/res/values-vi/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Điểm cuối đã phân giải</string>
     <string name="gateway_trust_first_seen">Xác minh dấu vân tay chứng chỉ trước khi tin cậy cổng này.\n\n%1$s</string>
     <string name="gateway_trust_changed">Chứng chỉ cổng đã thay đổi. Chỉ tiếp tục nếu bạn mong đợi thay đổi này.\n\nSHA-256 cũ:\n%1$s\n\nSHA-256 mới:\n%2$s</string>
+    <string name="switch_gateway">Chuyển Gateway</string>
+    <string name="select_gateway">Chọn Gateway</string>
+    <string name="active_gateway">Gateway đang hoạt động</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">已解析的端点</string>
     <string name="gateway_trust_first_seen">验证证书指纹后再信任此网关。\n\n%1$s</string>
     <string name="gateway_trust_changed">网关证书已更改。仅当这是您预期的更改时才继续。\n\n旧 SHA-256：\n%1$s\n\n新 SHA-256：\n%2$s</string>
+    <string name="switch_gateway">切换 Gateway</string>
+    <string name="select_gateway">选择 Gateway</string>
+    <string name="active_gateway">当前 Gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values-zh-rTW/strings.xml
+++ b/apps/android/app/src/main/res/values-zh-rTW/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">已解析的端點</string>
     <string name="gateway_trust_first_seen">請先驗證憑證指紋，再信任此閘道。\n\n%1$s</string>
     <string name="gateway_trust_changed">閘道憑證已變更。僅在這是您預期的變更時繼續。\n\n舊 SHA-256：\n%1$s\n\n新 SHA-256：\n%2$s</string>
+    <string name="switch_gateway">切換 gateway</string>
+    <string name="select_gateway">選取 gateway</string>
+    <string name="active_gateway">使用中的 gateway</string>
 </resources>

--- a/apps/android/app/src/main/res/values/strings.xml
+++ b/apps/android/app/src/main/res/values/strings.xml
@@ -31,4 +31,7 @@
     <string name="resolved_endpoint">Resolved endpoint</string>
     <string name="gateway_trust_first_seen">Verify the certificate fingerprint before trusting this gateway.\n\n%1$s</string>
     <string name="gateway_trust_changed">The gateway certificate changed. Continue only if you expected this.\n\nOld SHA-256:\n%1$s\n\nNew SHA-256:\n%2$s</string>
+    <string name="switch_gateway">Switch gateway</string>
+    <string name="select_gateway">Select gateway</string>
+    <string name="active_gateway">Active gateway</string>
 </resources>

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -1,16 +1,11 @@
 package ai.openclaw.app
 
-import ai.openclaw.app.chat.ChatMessage
-import ai.openclaw.app.chat.ChatMessageContent
-import ai.openclaw.app.chat.ChatOutboxEnqueueResult
-import ai.openclaw.app.chat.ChatSessionEntry
-import ai.openclaw.app.chat.ChatTranscriptCache
-import ai.openclaw.app.chat.RoomChatCommandOutbox
-import ai.openclaw.app.chat.RoomChatTranscriptCache
 import ai.openclaw.app.gateway.DeviceAuthStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewayConnectErrorDetails
 import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.gateway.GatewayRegistryEntry
+import ai.openclaw.app.gateway.GatewayRegistryEntryKind
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.GatewayTlsProbeFailure
 import ai.openclaw.app.gateway.GatewayTlsProbeResult
@@ -27,7 +22,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
-import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
@@ -52,90 +46,12 @@ import java.util.UUID
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicLong
 
-private class FailingClearTranscriptCache : ChatTranscriptCache {
-  override suspend fun loadSessions(gatewayId: String): List<ChatSessionEntry> = emptyList()
-
-  override suspend fun loadTranscript(
-    gatewayId: String,
-    sessionKey: String,
-  ): List<ChatMessage> = emptyList()
-
-  override suspend fun saveSessions(
-    gatewayId: String,
-    sessions: List<ChatSessionEntry>,
-    retainedSessionKey: String?,
-  ) = Unit
-
-  override suspend fun saveTranscript(
-    gatewayId: String,
-    sessionKey: String,
-    messages: List<ChatMessage>,
-  ) = Unit
-
-  override suspend fun deleteSession(
-    gatewayId: String,
-    sessionKey: String,
-  ) = Unit
-
-  override suspend fun clearAll(): Unit = error("cache unavailable")
-}
-
-private class BlockingClearTranscriptCache : ChatTranscriptCache {
-  val clearStarted = CompletableDeferred<Unit>()
-  val allowClear = CompletableDeferred<Unit>()
-
-  override suspend fun loadSessions(gatewayId: String): List<ChatSessionEntry> = emptyList()
-
-  override suspend fun loadTranscript(
-    gatewayId: String,
-    sessionKey: String,
-  ): List<ChatMessage> = emptyList()
-
-  override suspend fun saveSessions(
-    gatewayId: String,
-    sessions: List<ChatSessionEntry>,
-    retainedSessionKey: String?,
-  ) = Unit
-
-  override suspend fun saveTranscript(
-    gatewayId: String,
-    sessionKey: String,
-    messages: List<ChatMessage>,
-  ) = Unit
-
-  override suspend fun deleteSession(
-    gatewayId: String,
-    sessionKey: String,
-  ) = Unit
-
-  override suspend fun clearAll() {
-    clearStarted.complete(Unit)
-    allowClear.await()
-  }
-}
-
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class GatewayBootstrapAuthTest {
   @Test
-  fun recreatedViewModelResetsProcessOwnedRuntime() {
-    val app = RuntimeEnvironment.getApplication() as NodeApp
-    val runtime = app.ensureRuntime()
-    writeField(runtime, "connectedEndpoint", GatewayEndpoint.manual("old-gateway.example", 18789))
-    val viewModel = MainViewModel(app)
-    viewModel.pairNewGateway()
-    runBlocking {
-      withTimeout(5_000) {
-        while (readField<GatewayEndpoint?>(runtime, "connectedEndpoint") != null) delay(10)
-      }
-    }
-
-    assertNull(readField<GatewayEndpoint?>(runtime, "connectedEndpoint"))
-  }
-
-  @Test
   fun standaloneStatusPreservesLiveOperatorConnection() {
-    val runtime = NodeRuntime(RuntimeEnvironment.getApplication())
+    val runtime = createTestRuntime(RuntimeEnvironment.getApplication())
     writeField(runtime, "operatorConnected", true)
     val method = runtime.javaClass.getDeclaredMethod("setStandaloneGatewayStatus", String::class.java)
     method.isAccessible = true
@@ -149,7 +65,7 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun unstructuredRetryClearsEarlierOperatorAuthProblem() {
-    val runtime = NodeRuntime(RuntimeEnvironment.getApplication())
+    val runtime = createTestRuntime(RuntimeEnvironment.getApplication())
     val session = readField<GatewaySession>(runtime, "operatorSession")
     val onDisconnected = readField<(String) -> Unit>(session, "onDisconnected")
     val onConnectFailure = readField<(GatewaySession.ErrorShape, Boolean) -> Unit>(session, "onConnectFailure")
@@ -187,7 +103,7 @@ class GatewayBootstrapAuthTest {
 
   @Test
   fun retryableNodePairingProblemSurvivesReconnectStatus() {
-    val runtime = NodeRuntime(RuntimeEnvironment.getApplication())
+    val runtime = createTestRuntime(RuntimeEnvironment.getApplication())
     val session = readField<GatewaySession>(runtime, "nodeSession")
     val onDisconnected = readField<(String) -> Unit>(session, "onDisconnected")
     val onConnectFailure = readField<(GatewaySession.ErrorShape, Boolean) -> Unit>(session, "onConnectFailure")
@@ -439,12 +355,13 @@ class GatewayBootstrapAuthTest {
     val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
     val runtime = NodeRuntime(app, prefs)
     val deviceId = DeviceIdentityStore(app).loadOrCreate().deviceId
-    DeviceAuthStore(prefs).saveToken(deviceId, "operator", "bootstrap-operator-token")
+    val endpoint = GatewayEndpoint.manual(host = "127.0.0.1", port = 18789)
+    DeviceAuthStore(prefs).saveToken(endpoint.stableId, deviceId, "operator", "bootstrap-operator-token")
 
     writeField(runtime, "operatorStatusText", "Connecting…")
     invokeMaybeStartOperatorSessionAfterNodeConnect(
       runtime = runtime,
-      endpoint = GatewayEndpoint.manual(host = "127.0.0.1", port = 18789),
+      endpoint = endpoint,
       auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "setup-bootstrap-token", password = null),
     )
 
@@ -462,13 +379,13 @@ class GatewayBootstrapAuthTest {
         android.content.Context.MODE_PRIVATE,
       )
     val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-    prefs.setGatewayToken("stale-shared-token")
-    prefs.setGatewayBootstrapToken("")
-    prefs.setGatewayPassword("stale-password")
+    val endpoint = GatewayEndpoint.manual("gateway.example", 18789)
+    prefs.saveGatewayCredentials(endpoint.stableId, token = "stale-shared-token", password = "stale-password")
     val runtime = NodeRuntime(app, prefs)
 
     val auth =
       runtime.resolveGatewayConnectAuth(
+        endpoint,
         NodeRuntime.GatewayConnectAuth(
           token = null,
           bootstrapToken = "setup-bootstrap-token",
@@ -491,16 +408,14 @@ class GatewayBootstrapAuthTest {
           android.content.Context.MODE_PRIVATE,
         )
       val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-      prefs.setGatewayToken("stale-shared-token")
-      prefs.setGatewayBootstrapToken("")
-      prefs.setGatewayPassword("stale-password")
+      val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
+      prefs.saveGatewayCredentials(endpoint.stableId, token = "stale-shared-token", password = "stale-password")
       val runtime =
         NodeRuntime(
           app,
           prefs,
           tlsFingerprintProbe = { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = "fp:1") },
         )
-      val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
       val explicitAuth =
         NodeRuntime.GatewayConnectAuth(
           token = null,
@@ -614,6 +529,54 @@ class GatewayBootstrapAuthTest {
     }
 
   @Test
+  fun forgetGatewayCancelsInFlightTlsProbeBeforePurgingAuth() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      val securePrefs =
+        app.getSharedPreferences(
+          "openclaw.node.secure.test.${UUID.randomUUID()}",
+          android.content.Context.MODE_PRIVATE,
+        )
+      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+      val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
+      val probeStarted = CompletableDeferred<Unit>()
+      val probeResult = CompletableDeferred<GatewayTlsProbeResult>()
+      val runtime =
+        NodeRuntime(
+          app,
+          prefs,
+          tlsFingerprintProbe = { _, _ ->
+            probeStarted.complete(Unit)
+            probeResult.await()
+          },
+        )
+      prefs.gatewayRegistry.upsert(
+        GatewayRegistryEntry(
+          stableId = endpoint.stableId,
+          kind = GatewayRegistryEntryKind.MANUAL,
+          name = endpoint.name,
+          host = endpoint.host,
+          port = endpoint.port,
+        ),
+      )
+      prefs.saveGatewayCredentials(endpoint.stableId, token = "shared-token")
+
+      runtime.connect(endpoint)
+      probeStarted.await()
+      assertTrue(runtime.forgetGateway(endpoint.stableId))
+      probeResult.complete(GatewayTlsProbeResult(fingerprintSha256 = "aaaaaaaa"))
+      yield()
+
+      assertNull(
+        prefs.gatewayRegistry.entries.value
+          .firstOrNull { it.stableId == endpoint.stableId },
+      )
+      assertEquals(GatewayCredentials(), prefs.loadGatewayCredentials(endpoint.stableId))
+      assertNull(runtime.pendingGatewayTrust.value)
+      assertNull(desiredConnection(runtime, "nodeSession"))
+    }
+
+  @Test
   fun refreshGatewayConnection_reconnectsSavedManualEndpointAfterDisconnect() {
     val app = RuntimeEnvironment.getApplication()
     val securePrefs =
@@ -626,7 +589,19 @@ class GatewayBootstrapAuthTest {
     prefs.setManualHost("127.0.0.1")
     prefs.setManualPort(18789)
     prefs.setManualTls(false)
-    prefs.setGatewayToken("shared-token")
+    val savedEndpoint = GatewayEndpoint.manual(host = "127.0.0.1", port = 18789)
+    prefs.gatewayRegistry.upsert(
+      GatewayRegistryEntry(
+        stableId = savedEndpoint.stableId,
+        kind = GatewayRegistryEntryKind.MANUAL,
+        name = savedEndpoint.name,
+        host = savedEndpoint.host,
+        port = savedEndpoint.port,
+        tls = false,
+      ),
+    )
+    prefs.gatewayRegistry.setActive(savedEndpoint.stableId)
+    prefs.saveGatewayCredentials(savedEndpoint.stableId, token = "shared-token")
     val runtime = NodeRuntime(app, prefs)
 
     runtime.connect(
@@ -651,6 +626,10 @@ class GatewayBootstrapAuthTest {
     val runtime =
       NodeRuntime(
         app,
+        SecurePrefs(
+          app,
+          app.getSharedPreferences("openclaw.node.secure.test.${UUID.randomUUID()}", android.content.Context.MODE_PRIVATE),
+        ),
         tlsFingerprintProbe = { _, _ ->
           GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.TLS_UNAVAILABLE)
         },
@@ -674,6 +653,10 @@ class GatewayBootstrapAuthTest {
     val runtime =
       NodeRuntime(
         app,
+        SecurePrefs(
+          app,
+          app.getSharedPreferences("openclaw.node.secure.test.${UUID.randomUUID()}", android.content.Context.MODE_PRIVATE),
+        ),
         tlsFingerprintProbe = { _, _ ->
           GatewayTlsProbeResult(failure = GatewayTlsProbeFailure.TLS_HANDSHAKE_TIMEOUT)
         },
@@ -692,7 +675,7 @@ class GatewayBootstrapAuthTest {
   }
 
   @Test
-  fun resetGatewaySetupAuth_clearsStoredGatewayAndDeviceTokens() =
+  fun resetGatewaySetupAuth_clearsOnlyTargetGatewayCredentialsAndDeviceTokens() =
     runBlocking {
       val app = RuntimeEnvironment.getApplication()
       val securePrefs =
@@ -704,134 +687,59 @@ class GatewayBootstrapAuthTest {
       val runtime = NodeRuntime(app, prefs)
       val deviceId = DeviceIdentityStore(app).loadOrCreate().deviceId
       val authStore = DeviceAuthStore(prefs)
-      val transcriptCache = readField<RoomChatTranscriptCache>(runtime, "chatTranscriptCache")
-      val commandOutbox = readField<RoomChatCommandOutbox>(runtime, "chatCommandOutbox")
-      val cacheGatewayId = "gateway-${UUID.randomUUID()}"
-      prefs.setGatewayToken("stale-shared-token")
-      prefs.setGatewayBootstrapToken("stale-bootstrap-token")
-      prefs.setGatewayPassword("stale-password")
-      authStore.saveToken(deviceId, "node", "stale-node-token")
-      authStore.saveToken(deviceId, "operator", "stale-operator-token")
-      writeField(runtime, "connectedEndpoint", GatewayEndpoint.manual("old-gateway.example", 18789))
-      transcriptCache.saveTranscript(
-        gatewayId = cacheGatewayId,
-        sessionKey = "main",
-        messages =
-          listOf(
-            ChatMessage(
-              id = "cached",
-              role = "assistant",
-              content = listOf(ChatMessageContent(type = "text", text = "stale transcript")),
-              timestampMs = 1L,
-            ),
-          ),
+      val target = GatewayEndpoint.manual("target.example", 18789).stableId
+      val other = GatewayEndpoint.manual("other.example", 18789).stableId
+      prefs.saveGatewayCredentials(target, token = "target-token")
+      prefs.saveGatewayCredentials(other, token = "other-token")
+      authStore.saveToken(target, deviceId, "node", "target-node-token")
+      authStore.saveToken(other, deviceId, "node", "other-node-token")
+
+      assertTrue(runtime.resetGatewaySetupAuth(target))
+
+      assertEquals(GatewayCredentials(), prefs.loadGatewayCredentials(target))
+      assertEquals("other-token", prefs.loadGatewayCredentials(other).token)
+      assertNull(authStore.loadToken(target, deviceId, "node"))
+      assertEquals("other-node-token", authStore.loadToken(other, deviceId, "node"))
+    }
+
+  @Test
+  fun switchToUndiscoveredGatewayKeepsCurrentConnectionAndActiveGateway() {
+    val app = RuntimeEnvironment.getApplication()
+    val securePrefs =
+      app.getSharedPreferences(
+        "openclaw.node.secure.test.${UUID.randomUUID()}",
+        android.content.Context.MODE_PRIVATE,
       )
-      assertTrue(
-        commandOutbox.enqueue(
-          gatewayId = cacheGatewayId,
-          sessionKey = "main",
-          text = "stale queued command",
-          thinkingLevel = "off",
-          nowMs = 1L,
-        ) is ChatOutboxEnqueueResult.Queued,
-      )
-      val connectionGeneration = readField<AtomicLong>(runtime, "connectAttemptSeq")
-      val generationBeforeReset = connectionGeneration.get()
+    val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+    val runtime = NodeRuntime(app, prefs)
+    val current = GatewayEndpoint.manual("127.0.0.1", 18789)
+    val missingStableId = "bonjour-missing"
+    prefs.gatewayRegistry.upsert(
+      GatewayRegistryEntry(
+        stableId = current.stableId,
+        kind = GatewayRegistryEntryKind.MANUAL,
+        name = current.name,
+        host = current.host,
+        port = current.port,
+        tls = false,
+      ),
+    )
+    prefs.gatewayRegistry.upsert(
+      GatewayRegistryEntry(
+        stableId = missingStableId,
+        kind = GatewayRegistryEntryKind.DISCOVERED,
+        name = "Missing gateway",
+      ),
+    )
+    prefs.gatewayRegistry.setActive(current.stableId)
+    writeField(runtime, "connectedEndpoint", current)
 
-      assertTrue(runtime.resetGatewaySetupAuth())
+    assertFalse(runBlocking { runtime.switchToGateway(missingStableId) })
 
-      assertNull(prefs.loadGatewayToken())
-      assertNull(prefs.loadGatewayBootstrapToken())
-      assertNull(prefs.loadGatewayPassword())
-      assertNull(authStore.loadToken(deviceId, "node"))
-      assertNull(authStore.loadToken(deviceId, "operator"))
-      assertNull(readField<GatewayEndpoint?>(runtime, "connectedEndpoint"))
-      assertTrue(transcriptCache.loadTranscript(cacheGatewayId, "main").isEmpty())
-      assertTrue(commandOutbox.load(cacheGatewayId).isEmpty())
-      assertEquals(generationBeforeReset + 2, connectionGeneration.get())
-    }
-
-  @Test
-  fun resetGatewaySetupAuth_preservesCredentialsWhenCachePurgeFails() =
-    runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-      val runtime = NodeRuntime(app, prefs, FailingClearTranscriptCache())
-      val deviceId = DeviceIdentityStore(app).loadOrCreate().deviceId
-      val authStore = DeviceAuthStore(prefs)
-      prefs.setGatewayToken("stale-shared-token")
-      authStore.saveToken(deviceId, "operator", "stale-operator-token")
-      assertFalse(runtime.resetGatewaySetupAuth())
-
-      assertEquals("stale-shared-token", prefs.loadGatewayToken())
-      assertEquals("stale-operator-token", authStore.loadToken(deviceId, "operator"))
-      assertEquals("Failed: couldn't clear offline chat data. Retry sign out.", runtime.statusText.value)
-    }
-
-  @Test
-  fun resetGatewaySetupAuthRejectsReplacementConnectionUntilResetCompletes() =
-    runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-      val transcriptCache = BlockingClearTranscriptCache()
-      val runtime = NodeRuntime(app, prefs, transcriptCache)
-      val reset = async { runtime.resetGatewaySetupAuth() }
-      withTimeout(5_000) { transcriptCache.clearStarted.await() }
-
-      runtime.connect(GatewayEndpoint.manual("replacement.example", 18789))
-
-      val nodeSession = readField<GatewaySession>(runtime, "nodeSession")
-      assertNull(readField<Any?>(nodeSession, "desired"))
-      transcriptCache.allowClear.complete(Unit)
-      assertTrue(withTimeout(5_000) { reset.await() })
-      assertNull(readField<Any?>(nodeSession, "desired"))
-    }
-
-  @Test
-  fun resetGatewaySetupAuthRejectsTlsTrustPromptPublication() =
-    runBlocking {
-      val app = RuntimeEnvironment.getApplication()
-      val securePrefs =
-        app.getSharedPreferences(
-          "openclaw.node.secure.test.${UUID.randomUUID()}",
-          android.content.Context.MODE_PRIVATE,
-        )
-      val transcriptCache = BlockingClearTranscriptCache()
-      val runtime = NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs), transcriptCache)
-      val reset = async { runtime.resetGatewaySetupAuth() }
-      withTimeout(5_000) { transcriptCache.clearStarted.await() }
-      val connectAttemptId = readField<AtomicLong>(runtime, "connectAttemptSeq").get()
-      val staleAuth = NodeRuntime.GatewayConnectAuth(token = "stale-token", bootstrapToken = null, password = null)
-      val prompt =
-        NodeRuntime.GatewayTrustPrompt(
-          endpoint = GatewayEndpoint.manual("stale.example", 18789),
-          fingerprintSha256 = "AA:BB",
-          auth = staleAuth,
-        )
-      val method =
-        runtime.javaClass.getDeclaredMethod(
-          "publishGatewayTrustPromptIfCurrent",
-          Long::class.javaPrimitiveType,
-          NodeRuntime.GatewayTrustPrompt::class.java,
-        )
-      method.isAccessible = true
-
-      assertFalse(method.invoke(runtime, connectAttemptId, prompt) as Boolean)
-      assertNull(runtime.pendingGatewayTrust.value)
-      transcriptCache.allowClear.complete(Unit)
-      assertTrue(withTimeout(5_000) { reset.await() })
-      assertNull(runtime.pendingGatewayTrust.value)
-    }
+    assertEquals(current, readField<GatewayEndpoint?>(runtime, "connectedEndpoint"))
+    assertEquals(current.stableId, prefs.gatewayRegistry.activeStableId.value)
+    assertEquals("Gateway not currently discoverable", runtime.statusText.value)
+  }
 
   @Test
   fun gatewayConnectDoesNotHoldAuthMonitorWhileWaitingForSessionLifecycle() =
@@ -894,9 +802,7 @@ class GatewayBootstrapAuthTest {
         } finally {
           lifecycleDispatcher.close()
           runtime.disconnect()
-          withTimeout(5_000) {
-            readField<CoroutineScope>(runtime, "scope").coroutineContext[Job]?.cancelAndJoin()
-          }
+          readField<CoroutineScope>(runtime, "scope").coroutineContext[Job]?.cancel()
         }
       }
       Unit

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsNotificationForwardingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsNotificationForwardingTest.kt
@@ -1,5 +1,8 @@
 package ai.openclaw.app
 
+import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.gateway.GatewayRegistryEntry
+import ai.openclaw.app.gateway.GatewayRegistryEntryKind
 import android.content.Context
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -8,16 +11,23 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class SecurePrefsNotificationForwardingTest {
+  private fun testPrefs(context: android.app.Application): SecurePrefs =
+    SecurePrefs(
+      context,
+      context.getSharedPreferences("notification-prefs-${UUID.randomUUID()}", Context.MODE_PRIVATE),
+    )
+
   @Test
   fun setNotificationForwardingQuietHours_rejectsInvalidDraftsWithoutMutatingStoredValues() {
     val context = RuntimeEnvironment.getApplication()
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
 
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
 
     assertTrue(
       prefs.setNotificationForwardingQuietHours(
@@ -50,7 +60,7 @@ class SecurePrefsNotificationForwardingTest {
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
 
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
 
     assertTrue(
       prefs.setNotificationForwardingQuietHours(
@@ -71,7 +81,7 @@ class SecurePrefsNotificationForwardingTest {
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
 
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
     assertTrue(
       prefs.setNotificationForwardingQuietHours(
         enabled = true,
@@ -99,7 +109,7 @@ class SecurePrefsNotificationForwardingTest {
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
 
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
     assertTrue(
       prefs.setNotificationForwardingQuietHours(
         enabled = true,
@@ -121,7 +131,7 @@ class SecurePrefsNotificationForwardingTest {
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
 
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
     val policy = prefs.getNotificationForwardingPolicy(appPackageName = "ai.openclaw.app")
 
     assertFalse(prefs.notificationForwardingEnabled.value)
@@ -135,7 +145,7 @@ class SecurePrefsNotificationForwardingTest {
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
 
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
     prefs.setNotificationForwardingMode(NotificationPackageFilterMode.Allowlist)
     prefs.setNotificationForwardingPackages(listOf("ai.openclaw.app", "com.whatsapp", "com.other.app"))
 
@@ -144,5 +154,40 @@ class SecurePrefsNotificationForwardingTest {
     assertFalse(policy.allowsPackage("ai.openclaw.app"))
     assertFalse(policy.allowsPackage("com.whatsapp"))
     assertTrue(policy.allowsPackage("com.other.app"))
+  }
+
+  @Test
+  fun notificationSessionKeyFollowsActiveGateway() {
+    val context = RuntimeEnvironment.getApplication()
+    context
+      .getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+      .edit()
+      .clear()
+      .commit()
+    val secure = context.getSharedPreferences("notification-gateways-${UUID.randomUUID()}", Context.MODE_PRIVATE)
+    val prefs = SecurePrefs(context, secure)
+    val gatewayA = GatewayEndpoint.manual("a.example", 18789)
+    val gatewayB = GatewayEndpoint.manual("b.example", 18789)
+    listOf(gatewayA, gatewayB).forEach { endpoint ->
+      prefs.gatewayRegistry.upsert(
+        GatewayRegistryEntry(
+          stableId = endpoint.stableId,
+          kind = GatewayRegistryEntryKind.MANUAL,
+          name = endpoint.name,
+          host = endpoint.host,
+          port = endpoint.port,
+        ),
+      )
+    }
+
+    prefs.gatewayRegistry.setActive(gatewayA.stableId)
+    prefs.setNotificationForwardingSessionKey("session-a")
+    prefs.gatewayRegistry.setActive(gatewayB.stableId)
+    prefs.setNotificationForwardingSessionKey("session-b")
+
+    prefs.gatewayRegistry.setActive(gatewayA.stableId)
+    assertEquals("session-a", prefs.getNotificationForwardingPolicy("ai.openclaw.app").sessionKey)
+    prefs.gatewayRegistry.setActive(gatewayB.stableId)
+    assertEquals("session-b", prefs.getNotificationForwardingPolicy("ai.openclaw.app").sessionKey)
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -3,15 +3,21 @@ package ai.openclaw.app
 import android.content.Context
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class SecurePrefsTest {
+  private fun testPrefs(context: android.app.Application): SecurePrefs =
+    SecurePrefs(
+      context,
+      context.getSharedPreferences("secure-prefs-test-${UUID.randomUUID()}", Context.MODE_PRIVATE),
+    )
+
   @Test
   fun backgroundSettingsResolutionRequiresBothPermissionLevels() {
     assertEquals(
@@ -38,7 +44,7 @@ class SecurePrefsTest {
       .putString("location.enabledMode", "always")
       .commit()
 
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
 
     val expected =
       if (SensitiveFeatureConfig.backgroundLocationEnabled) LocationMode.Always else LocationMode.WhileUsing
@@ -56,7 +62,7 @@ class SecurePrefsTest {
       .putBoolean("talk.enabled", true)
       .commit()
 
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
 
     assertFalse(prefs.voiceMicEnabled.value)
     assertFalse(plainPrefs.contains("voice.micEnabled"))
@@ -71,7 +77,7 @@ class SecurePrefsTest {
       .clear()
       .putBoolean("talk.enabled", false)
       .commit()
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
 
     prefs.setVoiceMicEnabled(true)
 
@@ -85,7 +91,7 @@ class SecurePrefsTest {
     val context = RuntimeEnvironment.getApplication()
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
 
     assertFalse(prefs.installedAppsSharingEnabled.value)
 
@@ -100,7 +106,7 @@ class SecurePrefsTest {
     val context = RuntimeEnvironment.getApplication()
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
 
     assertFalse(prefs.cameraEnabled.value)
     assertFalse(plainPrefs.getBoolean("camera.enabled", true))
@@ -120,7 +126,7 @@ class SecurePrefsTest {
       .clear()
       .putString("node.instanceId", "existing-node")
       .commit()
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
 
     assertTrue(prefs.cameraEnabled.value)
     assertTrue(plainPrefs.getBoolean("camera.enabled", false))
@@ -131,7 +137,7 @@ class SecurePrefsTest {
     val context = RuntimeEnvironment.getApplication()
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
-    val prefs = SecurePrefs(context)
+    val prefs = testPrefs(context)
 
     assertEquals(AppearanceThemeMode.Dark, prefs.appearanceThemeMode.value)
     assertFalse(plainPrefs.contains("appearance.themeMode"))
@@ -142,48 +148,44 @@ class SecurePrefsTest {
     val context = RuntimeEnvironment.getApplication()
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
-    val prefs = SecurePrefs(context)
+    val securePrefs = context.getSharedPreferences("secure-prefs-test-${UUID.randomUUID()}", Context.MODE_PRIVATE)
+    val prefs = SecurePrefs(context, securePrefs)
 
     prefs.setAppearanceThemeMode(AppearanceThemeMode.Light)
 
     assertEquals(AppearanceThemeMode.Light, prefs.appearanceThemeMode.value)
     assertEquals("light", plainPrefs.getString("appearance.themeMode", null))
-    assertEquals(AppearanceThemeMode.Light, SecurePrefs(context).appearanceThemeMode.value)
+    assertEquals(AppearanceThemeMode.Light, SecurePrefs(context, securePrefs).appearanceThemeMode.value)
   }
 
   @Test
-  fun saveGatewayBootstrapToken_persistsSeparatelyFromSharedToken() {
+  fun gatewayCredentials_areIndependentAcrossGateways() {
     val context = RuntimeEnvironment.getApplication()
     val securePrefs = context.getSharedPreferences("openclaw.node.secure.test", Context.MODE_PRIVATE)
     securePrefs.edit().clear().commit()
     val prefs = SecurePrefs(context, securePrefsOverride = securePrefs)
 
-    prefs.setGatewayToken("shared-token")
-    prefs.setGatewayBootstrapToken("bootstrap-token")
+    prefs.saveGatewayCredentials("gateway-a", token = " shared-token ", bootstrapToken = "bootstrap-token")
+    prefs.saveGatewayCredentials("gateway-b", password = "password-token")
 
-    assertEquals("shared-token", prefs.loadGatewayToken())
-    assertEquals("bootstrap-token", prefs.loadGatewayBootstrapToken())
-    assertEquals("bootstrap-token", prefs.gatewayBootstrapToken.value)
+    assertEquals(GatewayCredentials(token = "shared-token", bootstrapToken = "bootstrap-token"), prefs.loadGatewayCredentials("gateway-a"))
+    assertEquals(GatewayCredentials(password = "password-token"), prefs.loadGatewayCredentials("gateway-b"))
   }
 
   @Test
-  fun clearGatewaySetupAuth_removesStoredGatewayAuth() {
+  fun clearGatewayCredentials_removesOnlyTargetGateway() {
     val context = RuntimeEnvironment.getApplication()
     val securePrefs = context.getSharedPreferences("openclaw.node.secure.test.clear", Context.MODE_PRIVATE)
     securePrefs.edit().clear().commit()
     val prefs = SecurePrefs(context, securePrefsOverride = securePrefs)
 
-    prefs.setGatewayToken("shared-token")
-    prefs.setGatewayBootstrapToken("bootstrap-token")
-    prefs.setGatewayPassword("password-token")
+    prefs.saveGatewayCredentials("gateway-a", token = "shared-token", bootstrapToken = "bootstrap-token")
+    prefs.saveGatewayCredentials("gateway-b", password = "password-token")
 
-    prefs.clearGatewaySetupAuth()
+    prefs.clearGatewayCredentials("gateway-a")
 
-    assertEquals("", prefs.gatewayToken.value)
-    assertEquals("", prefs.gatewayBootstrapToken.value)
-    assertNull(prefs.loadGatewayToken())
-    assertNull(prefs.loadGatewayBootstrapToken())
-    assertNull(prefs.loadGatewayPassword())
+    assertEquals(GatewayCredentials(), prefs.loadGatewayCredentials("gateway-a"))
+    assertEquals(GatewayCredentials(password = "password-token"), prefs.loadGatewayCredentials("gateway-b"))
   }
 
   @Test
@@ -288,10 +290,10 @@ class SecurePrefsTest {
     prefs.saveGatewayCustomHeaders("manual|two.example|443", mapOf("X-Two" to "secret-two"))
     prefs.putString("unrelated.secret", "keep")
 
-    prefs.clearGatewayCustomHeaders()
+    prefs.clearGatewayCustomHeaders("manual|one.example|443")
 
     assertTrue(prefs.loadGatewayCustomHeaders("manual|one.example|443").isEmpty())
-    assertTrue(prefs.loadGatewayCustomHeaders("manual|two.example|443").isEmpty())
+    assertEquals(mapOf("X-Two" to "secret-two"), prefs.loadGatewayCustomHeaders("manual|two.example|443"))
     assertEquals("keep", prefs.getString("unrelated.secret"))
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Assert.assertEquals
@@ -170,6 +171,52 @@ class ChatControllerCommandControlsTest {
       val commandRequests = requests.filter { it.first == "chat.metadata" }
       assertTrue(commandRequests.any { it.second.orEmpty().contains("\"agentId\":\"main\"") })
       assertTrue(commandRequests.any { it.second.orEmpty().contains("\"agentId\":\"ops\"") })
+    }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun delayedCommandListFromPreviousGatewayCannotReplaceCurrentCommands() =
+    runTest {
+      var cacheScope = ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 1)
+      val gatewayAResponse = CompletableDeferred<String>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { _, _ -> error("gateway-bound request expected") },
+          requestGatewayForGateway = { gatewayId, method, _ ->
+            require(method == "chat.metadata")
+            if (gatewayId == "gateway-a") {
+              gatewayAResponse.await()
+            } else {
+              commandResponse("gateway-b")
+            }
+          },
+          cacheScope = { cacheScope },
+        )
+
+      controller.refreshCommands()
+      runCurrent()
+      cacheScope = ChatCacheScope(gatewayId = "gateway-b", connectionGeneration = 2)
+      controller.onGatewayScopeChanging()
+      controller.refreshCommands()
+      runCurrent()
+      assertEquals(
+        "gateway-b",
+        controller.commands.value
+          .single()
+          .name,
+      )
+
+      gatewayAResponse.complete(commandResponse("gateway-a"))
+      advanceUntilIdle()
+
+      assertEquals(
+        "gateway-b",
+        controller.commands.value
+          .single()
+          .name,
+      )
     }
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -736,4 +783,6 @@ class ChatControllerCommandControlsTest {
       assertEquals("other-session", controller.sessionId.value)
       assertTrue(requests.any { it.first == "sessions.create" })
     }
+
+  private fun commandResponse(name: String): String = """{"commands":[{"name":"$name","textAliases":["/$name"],"acceptsArgs":false}]}"""
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
@@ -24,15 +24,20 @@ class ChatControllerOutboxTest {
     private val capacity: Int = OUTBOX_MAX_QUEUED,
   ) : ChatCommandOutbox {
     val rows = LinkedHashMap<String, ChatOutboxItem>()
+    val gatewayIds = mutableMapOf<String, String>()
     val deletedSessions = mutableListOf<String>()
     private var nextCreatedAt = 0L
 
-    fun seed(item: ChatOutboxItem) {
+    fun seed(
+      item: ChatOutboxItem,
+      gatewayId: String = "gateway-test",
+    ) {
       rows[item.id] = item
+      gatewayIds[item.id] = gatewayId
       nextCreatedAt = maxOf(nextCreatedAt, item.createdAtMs + 1)
     }
 
-    override suspend fun load(gatewayId: String): List<ChatOutboxItem> = rows.values.sortedWith(compareBy({ it.createdAtMs }, { it.id }))
+    override suspend fun load(gatewayId: String): List<ChatOutboxItem> = rows.values.filter { gatewayIds[it.id] == gatewayId }.sortedWith(compareBy({ it.createdAtMs }, { it.id }))
 
     override suspend fun enqueue(
       gatewayId: String,
@@ -41,7 +46,7 @@ class ChatControllerOutboxTest {
       thinkingLevel: String,
       nowMs: Long,
     ): ChatOutboxEnqueueResult {
-      if (rows.size >= capacity) return ChatOutboxEnqueueResult.QueueFull
+      if (gatewayIds.values.count { it == gatewayId } >= capacity) return ChatOutboxEnqueueResult.QueueFull
       val createdAt = maxOf(nowMs, nextCreatedAt)
       nextCreatedAt = createdAt + 1
       val item =
@@ -56,6 +61,7 @@ class ChatControllerOutboxTest {
           lastError = null,
         )
       rows[item.id] = item
+      gatewayIds[item.id] = gatewayId
       return ChatOutboxEnqueueResult.Queued(item)
     }
 
@@ -76,6 +82,7 @@ class ChatControllerOutboxTest {
       nowMs: Long,
     ) {
       val current = rows[id] ?: return
+      if (gatewayIds[id] != gatewayId) return
       val createdAt = maxOf(nowMs, nextCreatedAt)
       nextCreatedAt = createdAt + 1
       rows[id] = current.copy(status = ChatOutboxStatus.Queued, retryCount = 0, lastError = null, createdAtMs = createdAt)
@@ -83,6 +90,7 @@ class ChatControllerOutboxTest {
 
     override suspend fun delete(id: String) {
       rows.remove(id)
+      gatewayIds.remove(id)
     }
 
     override suspend fun deleteForSession(
@@ -90,7 +98,19 @@ class ChatControllerOutboxTest {
       sessionKey: String,
     ) {
       deletedSessions += sessionKey
-      rows.values.removeAll { it.sessionKey == sessionKey }
+      val ids = rows.values.filter { gatewayIds[it.id] == gatewayId && it.sessionKey == sessionKey }.map { it.id }
+      ids.forEach {
+        rows.remove(it)
+        gatewayIds.remove(it)
+      }
+    }
+
+    override suspend fun clearGateway(gatewayId: String) {
+      val ids = gatewayIds.filterValues { it == gatewayId }.keys.toList()
+      ids.forEach {
+        rows.remove(it)
+        gatewayIds.remove(it)
+      }
     }
 
     override suspend fun requeueSendingAfterRestart() {
@@ -106,7 +126,7 @@ class ChatControllerOutboxTest {
       nowMs: Long,
     ) {
       for ((id, item) in rows) {
-        if (item.status == ChatOutboxStatus.Queued && item.createdAtMs <= nowMs - OUTBOX_EXPIRY_MS) {
+        if (gatewayIds[id] == gatewayId && item.status == ChatOutboxStatus.Queued && item.createdAtMs <= nowMs - OUTBOX_EXPIRY_MS) {
           rows[id] = item.copy(status = ChatOutboxStatus.Failed, lastError = OUTBOX_EXPIRED_ERROR)
         }
       }
@@ -114,6 +134,7 @@ class ChatControllerOutboxTest {
 
     override suspend fun clearAll() {
       rows.clear()
+      gatewayIds.clear()
     }
   }
 
@@ -315,6 +336,48 @@ class ChatControllerOutboxTest {
       val row = outbox.rows.values.single()
       assertEquals(ChatOutboxStatus.Queued, row.status)
       assertEquals(1, row.retryCount)
+    }
+
+  @Test
+  fun queuedRowsStayWithTheirGatewayAcrossSwitchAndFlushAfterSwitchBack() =
+    runTest {
+      val gateway = FakeGateway()
+      val outbox = FakeCommandOutbox()
+      var activeScope = ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 1L)
+      val chat =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = gateway::request,
+          cacheScope = { activeScope },
+          commandOutbox = outbox,
+        )
+      chat.load("main")
+      advanceUntilIdle()
+      chat.sendMessageAwaitAcceptance(message = "gateway A queued", thinkingLevel = "off", attachments = emptyList())
+      val queuedId =
+        chat.outboxItems.value
+          .single()
+          .id
+
+      activeScope = ChatCacheScope(gatewayId = "gateway-b", connectionGeneration = 2L)
+      chat.onGatewayScopeChanging()
+      chat.onDisconnected("Offline")
+      gateway.online = true
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+      assertTrue(gateway.sentMessages.isEmpty())
+      assertTrue(chat.outboxItems.value.isEmpty())
+      assertEquals(listOf(queuedId), outbox.load("gateway-a").map { it.id })
+      assertTrue(outbox.load("gateway-b").isEmpty())
+
+      activeScope = ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 3L)
+      chat.onGatewayScopeChanging()
+      chat.onDisconnected("Offline")
+      chat.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+      assertEquals(listOf("gateway A queued"), gateway.sentMessages)
+      assertTrue(outbox.load("gateway-a").isEmpty())
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerTranscriptCacheTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerTranscriptCacheTest.kt
@@ -18,12 +18,13 @@ class ChatControllerTranscriptCacheTest {
   private class FakeTranscriptCache : ChatTranscriptCache {
     val transcripts = mutableMapOf<Pair<String, String>, List<ChatMessage>>()
     var sessions: List<ChatSessionEntry> = emptyList()
+    val sessionsByGateway = mutableMapOf<String, List<ChatSessionEntry>>()
     val savedTranscripts = mutableListOf<Triple<String, String, List<ChatMessage>>>()
     val savedSessions = mutableListOf<Pair<String, List<ChatSessionEntry>>>()
     val retainedSessionKeys = mutableListOf<String?>()
     val deletedSessions = mutableListOf<Pair<String, String>>()
 
-    override suspend fun loadSessions(gatewayId: String): List<ChatSessionEntry> = sessions
+    override suspend fun loadSessions(gatewayId: String): List<ChatSessionEntry> = sessionsByGateway[gatewayId] ?: sessions
 
     override suspend fun loadTranscript(
       gatewayId: String,
@@ -52,6 +53,12 @@ class ChatControllerTranscriptCacheTest {
       sessionKey: String,
     ) {
       deletedSessions += gatewayId to sessionKey
+    }
+
+    override suspend fun clearGateway(gatewayId: String) {
+      transcripts.keys.removeAll { it.first == gatewayId }
+      savedTranscripts.removeAll { it.first == gatewayId }
+      savedSessions.removeAll { it.first == gatewayId }
     }
 
     override suspend fun clearAll() {
@@ -465,5 +472,43 @@ class ChatControllerTranscriptCacheTest {
 
       assertTrue(controller.sessions.value.isEmpty())
       assertTrue(cache.savedSessions.isEmpty())
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun switchingGatewayScopeIsolatesCachedTranscriptAndSessionsThenRestoresThem() =
+    runTest {
+      val cache = FakeTranscriptCache()
+      cache.transcripts["gateway-a" to "main"] = listOf(cachedMessage("gateway A transcript"))
+      cache.sessionsByGateway["gateway-a"] = listOf(ChatSessionEntry(key = "main", updatedAtMs = 1L, displayName = "Gateway A"))
+      cache.sessionsByGateway["gateway-b"] = emptyList()
+      var currentScope = ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 1)
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { _, _ -> throw IllegalStateException("offline") },
+          transcriptCache = cache,
+          cacheScope = { currentScope },
+        )
+
+      controller.load("main")
+      advanceUntilIdle()
+      assertEquals(listOf("gateway A transcript"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("Gateway A"), controller.sessions.value.mapNotNull { it.displayName })
+
+      currentScope = ChatCacheScope(gatewayId = "gateway-b", connectionGeneration = 2)
+      controller.onGatewayScopeChanging()
+      controller.load("main")
+      advanceUntilIdle()
+      assertTrue(controller.messages.value.isEmpty())
+      assertTrue(controller.sessions.value.isEmpty())
+
+      currentScope = ChatCacheScope(gatewayId = "gateway-a", connectionGeneration = 3)
+      controller.onGatewayScopeChanging()
+      controller.load("main")
+      advanceUntilIdle()
+      assertEquals(listOf("gateway A transcript"), controller.messages.value.map { it.content.single().text })
+      assertEquals(listOf("Gateway A"), controller.sessions.value.mapNotNull { it.displayName })
     }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/DeviceAuthStoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/DeviceAuthStoreTest.kt
@@ -27,13 +27,14 @@ class DeviceAuthStoreTest {
     val store = DeviceAuthStore(prefs)
 
     store.saveToken(
+      gatewayId = "gateway-a",
       deviceId = " Device-1 ",
       role = " Operator ",
       token = " operator-token ",
       scopes = listOf("operator.write", "operator.read", "operator.write", " "),
     )
 
-    val entry = store.loadEntry("device-1", "operator")
+    val entry = store.loadEntry("gateway-a", "device-1", "operator")
     assertNotNull(entry)
     assertEquals("operator-token", entry?.token)
     assertEquals("operator", entry?.role)
@@ -42,7 +43,7 @@ class DeviceAuthStoreTest {
   }
 
   @Test
-  fun loadEntryReadsLegacyTokenWithoutMetadata() {
+  fun gatewayIdsIsolateSameDeviceAndRole() {
     val app = RuntimeEnvironment.getApplication()
     val securePrefs =
       app.getSharedPreferences(
@@ -50,14 +51,16 @@ class DeviceAuthStoreTest {
         Context.MODE_PRIVATE,
       )
     val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
-    prefs.putString("gateway.deviceToken.device-1.operator", "legacy-token")
     val store = DeviceAuthStore(prefs)
+    store.saveToken("gateway-a", "device-1", "operator", "token-a")
+    store.saveToken("gateway-b", "device-1", "operator", "token-b")
 
-    val entry = store.loadEntry("device-1", "operator")
-    assertNotNull(entry)
-    assertEquals("legacy-token", entry?.token)
-    assertEquals("operator", entry?.role)
-    assertEquals(emptyList<String>(), entry?.scopes)
-    assertEquals(0L, entry?.updatedAtMs)
+    assertEquals("token-a", store.loadToken("gateway-a", "device-1", "operator"))
+    assertEquals("token-b", store.loadToken("gateway-b", "device-1", "operator"))
+
+    store.clearToken("gateway-a", "device-1", "operator")
+
+    assertEquals(null, store.loadToken("gateway-a", "device-1", "operator"))
+    assertEquals("token-b", store.loadToken("gateway-b", "device-1", "operator"))
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayRegistryStoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayRegistryStoreTest.kt
@@ -1,0 +1,86 @@
+package ai.openclaw.app.gateway
+
+import ai.openclaw.app.SecurePrefs
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class GatewayRegistryStoreTest {
+  @Test
+  fun roundTripUpsertActiveAndRemove() {
+    val (prefs, securePrefs) = freshPrefs()
+    val store = prefs.gatewayRegistry
+    val alpha = manualEntry("alpha", "alpha.example")
+    val beta = manualEntry("Beta", "beta.example")
+
+    store.upsert(beta)
+    store.upsert(alpha)
+    store.setActive(alpha.stableId)
+    store.markConnected(alpha.stableId, 42L)
+
+    val restored = GatewayRegistryStore(SecurePrefs(RuntimeEnvironment.getApplication(), securePrefs))
+    assertEquals(listOf("alpha", "Beta"), restored.entries.value.map { it.name })
+    assertEquals(alpha.stableId, restored.activeStableId.value)
+    assertEquals(42L, restored.activeEntry()?.lastConnectedAtMs)
+
+    restored.remove(alpha.stableId)
+    assertNull(restored.activeStableId.value)
+    assertEquals(listOf(beta.stableId), restored.entries.value.map { it.stableId })
+  }
+
+  @Test
+  fun serializationIsDeterministicAndPreservesConnectedTimestampOnMetadataUpdate() {
+    val (prefs, securePrefs) = freshPrefs()
+    val store = prefs.gatewayRegistry
+    val alpha = manualEntry("alpha", "alpha.example")
+    val beta = manualEntry("Beta", "beta.example")
+
+    store.upsert(beta.copy(lastConnectedAtMs = 7L))
+    store.upsert(alpha)
+    val first = securePrefs.getString(GatewayRegistryStore.STORAGE_KEY, null)
+    store.upsert(beta.copy(name = "Beta renamed"))
+    assertEquals(
+      7L,
+      store.entries.value
+        .first { it.stableId == beta.stableId }
+        .lastConnectedAtMs,
+    )
+    store.upsert(beta)
+    val second = securePrefs.getString(GatewayRegistryStore.STORAGE_KEY, null)
+
+    assertEquals(first, second)
+  }
+
+  private fun freshPrefs(): Pair<SecurePrefs, android.content.SharedPreferences> {
+    val context = RuntimeEnvironment.getApplication()
+    context
+      .getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+      .edit()
+      .clear()
+      .commit()
+    val securePrefs =
+      context.getSharedPreferences("gateway-registry-${UUID.randomUUID()}", Context.MODE_PRIVATE)
+    securePrefs.edit().clear().commit()
+    return SecurePrefs(context, securePrefs) to securePrefs
+  }
+
+  private fun manualEntry(
+    name: String,
+    host: String,
+  ): GatewayRegistryEntry {
+    val endpoint = GatewayEndpoint.manual(host, 18789)
+    return GatewayRegistryEntry(
+      stableId = endpoint.stableId,
+      kind = GatewayRegistryEntryKind.MANUAL,
+      name = name,
+      host = host,
+      port = 18789,
+    )
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
@@ -37,11 +37,13 @@ private const val CONNECT_CHALLENGE_FRAME =
 
 private class NoopDeviceAuthStore : DeviceAuthTokenStore {
   override fun loadEntry(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ): DeviceAuthEntry? = null
 
   override fun saveToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
     token: String,
@@ -49,6 +51,7 @@ private class NoopDeviceAuthStore : DeviceAuthTokenStore {
   ) = Unit
 
   override fun clearToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ) = Unit

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -45,17 +45,19 @@ private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
   private val tokens = mutableMapOf<String, DeviceAuthEntry>()
 
   override fun loadEntry(
+    gatewayId: String,
     deviceId: String,
     role: String,
-  ): DeviceAuthEntry? = tokens["${deviceId.trim()}|${role.trim()}"]
+  ): DeviceAuthEntry? = tokens["${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}"]
 
   override fun saveToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
     token: String,
     scopes: List<String>,
   ) {
-    tokens["${deviceId.trim()}|${role.trim()}"] =
+    tokens["${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}"] =
       DeviceAuthEntry(
         token = token.trim(),
         role = role.trim(),
@@ -65,10 +67,11 @@ private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
   }
 
   override fun clearToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ) {
-    tokens.remove("${deviceId.trim()}|${role.trim()}")
+    tokens.remove("${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}")
   }
 }
 
@@ -365,7 +368,7 @@ class GatewaySessionInvokeTest {
 
       try {
         val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
-        harness.deviceAuthStore.saveToken(deviceId, "node", "device-token")
+        harness.deviceAuthStore.saveToken(gatewayIdForPort(server.port), deviceId, "node", "device-token")
 
         connectNodeSession(
           session = harness.session,
@@ -410,6 +413,7 @@ class GatewaySessionInvokeTest {
       try {
         val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
         harness.deviceAuthStore.saveToken(
+          gatewayId = gatewayIdForPort(server.port),
           deviceId = deviceId,
           role = "operator",
           token = "operator-device-token",
@@ -548,7 +552,7 @@ class GatewaySessionInvokeTest {
 
       try {
         val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
-        harness.deviceAuthStore.saveToken(deviceId, "node", "stored-device-token")
+        harness.deviceAuthStore.saveToken(gatewayIdForPort(server.port), deviceId, "node", "stored-device-token")
 
         connectNodeSession(
           session = harness.session,
@@ -606,8 +610,8 @@ class GatewaySessionInvokeTest {
         awaitConnectedOrThrow(connected, lastDisconnect, server)
 
         val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
-        assertEquals("shared-node-token", harness.deviceAuthStore.loadToken(deviceId, "node"))
-        assertNull(harness.deviceAuthStore.loadToken(deviceId, "operator"))
+        assertEquals("shared-node-token", harness.deviceAuthStore.loadToken(gatewayIdForPort(server.port), deviceId, "node"))
+        assertNull(harness.deviceAuthStore.loadToken(gatewayIdForPort(server.port), deviceId, "operator"))
       } finally {
         shutdownHarness(harness, server)
       }
@@ -651,8 +655,8 @@ class GatewaySessionInvokeTest {
         awaitConnectedOrThrow(connected, lastDisconnect, server)
 
         val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
-        val nodeEntry = harness.deviceAuthStore.loadEntry(deviceId, "node")
-        val operatorEntry = harness.deviceAuthStore.loadEntry(deviceId, "operator")
+        val nodeEntry = harness.deviceAuthStore.loadEntry(gatewayIdForPort(server.port), deviceId, "node")
+        val operatorEntry = harness.deviceAuthStore.loadEntry(gatewayIdForPort(server.port), deviceId, "operator")
         assertEquals("bootstrap-node-token", nodeEntry?.token)
         assertEquals(emptyList<String>(), nodeEntry?.scopes)
         assertEquals("bootstrap-operator-token", operatorEntry?.token)
@@ -703,8 +707,8 @@ class GatewaySessionInvokeTest {
         awaitConnectedOrThrow(connected, lastDisconnect, server)
 
         val deviceId = DeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
-        assertEquals("shared-node-token", harness.deviceAuthStore.loadToken(deviceId, "node"))
-        assertNull(harness.deviceAuthStore.loadToken(deviceId, "operator"))
+        assertEquals("shared-node-token", harness.deviceAuthStore.loadToken(gatewayIdForPort(server.port), deviceId, "node"))
+        assertNull(harness.deviceAuthStore.loadToken(gatewayIdForPort(server.port), deviceId, "operator"))
       } finally {
         shutdownHarness(harness, server)
       }
@@ -1076,7 +1080,7 @@ class GatewaySessionInvokeTest {
     session.connect(
       endpoint =
         GatewayEndpoint(
-          stableId = "manual|127.0.0.1|$port",
+          stableId = gatewayIdForPort(port),
           name = "test",
           host = "127.0.0.1",
           port = port,
@@ -1107,6 +1111,8 @@ class GatewaySessionInvokeTest {
       tls = null,
     )
   }
+
+  private fun gatewayIdForPort(port: Int): String = "manual|127.0.0.1|$port"
 
   private suspend fun awaitConnectedOrThrow(
     connected: CompletableDeferred<Unit>,

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -48,11 +48,13 @@ private const val LIFECYCLE_CONNECT_CHALLENGE_FRAME =
 
 private class ReconnectDeviceAuthStore : DeviceAuthTokenStore {
   override fun loadEntry(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ): DeviceAuthEntry? = null
 
   override fun saveToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
     token: String,
@@ -60,6 +62,7 @@ private class ReconnectDeviceAuthStore : DeviceAuthTokenStore {
   ) = Unit
 
   override fun clearToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ) = Unit
@@ -70,11 +73,13 @@ private class BlockingSaveDeviceAuthStore : DeviceAuthTokenStore {
   val allowSave = CountDownLatch(1)
 
   override fun loadEntry(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ): DeviceAuthEntry? = null
 
   override fun saveToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
     token: String,
@@ -85,6 +90,7 @@ private class BlockingSaveDeviceAuthStore : DeviceAuthTokenStore {
   }
 
   override fun clearToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ) = Unit
@@ -94,11 +100,13 @@ private class RecordingDeviceAuthStore : DeviceAuthTokenStore {
   val savedToken = CompletableDeferred<String>()
 
   override fun loadEntry(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ): DeviceAuthEntry? = null
 
   override fun saveToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
     token: String,
@@ -108,6 +116,7 @@ private class RecordingDeviceAuthStore : DeviceAuthTokenStore {
   }
 
   override fun clearToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ) = Unit

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayStoreMigrationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayStoreMigrationTest.kt
@@ -1,0 +1,172 @@
+package ai.openclaw.app.gateway
+
+import ai.openclaw.app.GatewayCredentials
+import ai.openclaw.app.SecurePrefs
+import android.content.Context
+import android.content.SharedPreferences
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+class GatewayStoreMigrationTest {
+  @Test
+  fun manualStateMigratesCredentialsDeviceTokensAndNotificationKey() {
+    val fixture = fixture()
+    fixture.plain
+      .edit()
+      .putString("node.instanceId", "install-1")
+      .putBoolean("gateway.manual.enabled", true)
+      .putString("gateway.manual.host", "Example.COM")
+      .putInt("gateway.manual.port", 18789)
+      .putBoolean("gateway.manual.tls", false)
+      .putString("notifications.forwarding.sessionKey", " notify-main ")
+      .commit()
+    fixture.secure
+      .edit()
+      .putString("gateway.manual.token", "manual-token")
+      .putString("gateway.token.install-1", "fallback-token")
+      .putString("gateway.bootstrapToken.install-1", "bootstrap-token")
+      .putString("gateway.password.install-1", "password")
+      .putString("gateway.deviceToken.device-1.operator", "device-token")
+      .putString("gateway.deviceTokenMeta.device-1.operator", "{\"scopes\":[\"operator.read\"]}")
+      .commit()
+
+    val prefs = SecurePrefs(fixture.context, fixture.secure)
+    val stableId = GatewayEndpoint.manual("Example.COM", 18789).stableId
+
+    assertEquals(stableId, prefs.gatewayRegistry.activeStableId.value)
+    assertEquals(GatewayRegistryEntryKind.MANUAL, prefs.gatewayRegistry.activeEntry()?.kind)
+    assertEquals("Example.COM:18789", prefs.gatewayRegistry.activeEntry()?.name)
+    assertEquals(false, prefs.gatewayRegistry.activeEntry()?.tls)
+    assertEquals(
+      GatewayCredentials("manual-token", "bootstrap-token", "password"),
+      prefs.loadGatewayCredentials(stableId),
+    )
+    assertEquals("device-token", fixture.secure.getString("gateway.deviceToken.$stableId.device-1.operator", null))
+    assertTrue(fixture.secure.contains("gateway.deviceTokenMeta.$stableId.device-1.operator"))
+    assertFalse(fixture.secure.contains("gateway.manual.token"))
+    assertFalse(fixture.secure.contains("gateway.token.install-1"))
+    assertFalse(fixture.secure.contains("gateway.bootstrapToken.install-1"))
+    assertFalse(fixture.secure.contains("gateway.password.install-1"))
+    assertFalse(fixture.plain.contains("notifications.forwarding.sessionKey"))
+    assertEquals("notify-main", fixture.plain.getString("notifications.forwarding.sessionKey.$stableId", null))
+    assertTrue(fixture.plain.getBoolean("gateway.manual.enabled", false))
+  }
+
+  @Test
+  fun discoveredOnlyStateBecomesActivePlaceholderEntry() {
+    val fixture = fixture()
+    fixture.plain
+      .edit()
+      .putString("gateway.lastDiscoveredStableID", "bonjour-gateway")
+      .commit()
+
+    val prefs = SecurePrefs(fixture.context, fixture.secure)
+
+    assertEquals("bonjour-gateway", prefs.gatewayRegistry.activeStableId.value)
+    assertEquals(
+      GatewayRegistryEntry(
+        stableId = "bonjour-gateway",
+        kind = GatewayRegistryEntryKind.DISCOVERED,
+        name = "bonjour-gateway",
+      ),
+      prefs.gatewayRegistry.activeEntry(),
+    )
+  }
+
+  @Test
+  fun blankManualTokenFallsBackToInstanceScopedToken() {
+    val fixture = fixture()
+    fixture.plain
+      .edit()
+      .putString("node.instanceId", "install-1")
+      .putBoolean("gateway.manual.enabled", true)
+      .putString("gateway.manual.host", "gateway.example")
+      .putInt("gateway.manual.port", 18789)
+      .commit()
+    fixture.secure
+      .edit()
+      .putString("gateway.manual.token", "  ")
+      .putString("gateway.token.install-1", "fallback-token")
+      .commit()
+
+    val prefs = SecurePrefs(fixture.context, fixture.secure)
+    val stableId = GatewayEndpoint.manual("gateway.example", 18789).stableId
+
+    assertEquals("fallback-token", prefs.loadGatewayCredentials(stableId).token)
+    assertFalse(fixture.secure.contains("gateway.manual.token"))
+    assertFalse(fixture.secure.contains("gateway.token.install-1"))
+  }
+
+  @Test
+  fun emptyLegacyStateWritesEmptyRegistryAndDeletesOwnerlessDeviceTokens() {
+    val fixture = fixture()
+    fixture.secure
+      .edit()
+      .putString("gateway.deviceToken.device-1.node", "orphan")
+      .putString("gateway.deviceTokenMeta.device-1.node", "{}")
+      .commit()
+
+    val prefs = SecurePrefs(fixture.context, fixture.secure)
+
+    // Migration runs on first gateway-state access, not at construction.
+    assertTrue(
+      prefs.gatewayRegistry.entries.value
+        .isEmpty(),
+    )
+    assertTrue(fixture.secure.contains(GatewayRegistryStore.STORAGE_KEY))
+    assertNull(prefs.gatewayRegistry.activeStableId.value)
+    assertFalse(fixture.secure.contains("gateway.deviceToken.device-1.node"))
+    assertFalse(fixture.secure.contains("gateway.deviceTokenMeta.device-1.node"))
+  }
+
+  @Test
+  fun secondMigrationRunIsNoOp() {
+    val fixture = fixture()
+    fixture.plain
+      .edit()
+      .putBoolean("gateway.manual.enabled", true)
+      .putString("gateway.manual.host", "first.example")
+      .putInt("gateway.manual.port", 18789)
+      .commit()
+    val prefs = SecurePrefs(fixture.context, fixture.secure)
+    // First gateway-state access performs the one-time migration.
+    prefs.gatewayRegistry.activeStableId.value
+    val registryBefore = fixture.secure.getString(GatewayRegistryStore.STORAGE_KEY, null)
+    fixture.plain
+      .edit()
+      .putString("gateway.manual.host", "changed.example")
+      .commit()
+    fixture.secure
+      .edit()
+      .putString("gateway.manual.token", "late-legacy-token")
+      .commit()
+
+    GatewayStoreMigration(prefs).run()
+
+    assertEquals(registryBefore, fixture.secure.getString(GatewayRegistryStore.STORAGE_KEY, null))
+    assertEquals("late-legacy-token", fixture.secure.getString("gateway.manual.token", null))
+  }
+
+  private fun fixture(): Fixture {
+    val context = RuntimeEnvironment.getApplication()
+    val plain = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
+    plain.edit().clear().commit()
+    val secure = context.getSharedPreferences("gateway-migration-${UUID.randomUUID()}", Context.MODE_PRIVATE)
+    secure.edit().clear().commit()
+    return Fixture(context, plain, secure)
+  }
+
+  private data class Fixture(
+    val context: android.app.Application,
+    val plain: SharedPreferences,
+    val secure: SharedPreferences,
+  )
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/MicCaptureManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/MicCaptureManagerTest.kt
@@ -39,7 +39,7 @@ class MicCaptureManagerTest {
           },
         )
 
-      setPrivateField(manager, "transcriptionSessionId", "transcription-1")
+      setTranscriptionSession(manager, "transcription-1")
       manager.onGatewayConnectionChanged(true)
       manager.handleGatewayEvent(
         "talk.event",
@@ -64,7 +64,7 @@ class MicCaptureManagerTest {
   fun transcriptionErrorDisablesMic() {
     val manager = createManager()
 
-    setPrivateField(manager, "transcriptionSessionId", "transcription-1")
+    setTranscriptionSession(manager, "transcription-1")
     manager.handleGatewayEvent(
       "talk.event",
       """{"transcriptionSessionId":"transcription-1","type":"error","message":"provider unavailable"}""",
@@ -89,7 +89,7 @@ class MicCaptureManagerTest {
           },
         )
 
-      setPrivateField(manager, "transcriptionSessionId", "transcription-1")
+      setTranscriptionSession(manager, "transcription-1")
       manager.onGatewayConnectionChanged(true)
       manager.handleGatewayEvent(
         "talk.event",
@@ -260,7 +260,7 @@ class MicCaptureManagerTest {
       val manager = createManager(scope = this)
 
       setPrivateMutableStateFlowValue(manager, "_micEnabled", true)
-      setPrivateField(manager, "transcriptionSessionId", "transcription-1")
+      setTranscriptionSession(manager, "transcription-1")
       manager.setMicEnabled(false)
       manager.handleGatewayEvent(
         "talk.event",
@@ -274,8 +274,35 @@ class MicCaptureManagerTest {
           .single()
           .text,
       )
-      assertEquals("transcription-1", privateField<String?>(manager, "transcriptionSessionId"))
+      assertEquals("transcription-1", privateField<GatewayTranscriptionSession?>(manager, "transcriptionSession")?.id)
       privateField<Job?>(manager, "transcriptionDrainJob")?.cancel()
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun gatewayScopeChangeDropsQueuedVoiceBeforeReconnect() =
+    runTest {
+      val sentMessages = mutableListOf<String>()
+      val manager =
+        createManager(
+          scope = this,
+          sendToGateway = { message, onRunIdKnown ->
+            sentMessages += message
+            onRunIdKnown("run-b")
+            ChatSendAck(runId = "run-b", status = "started")
+          },
+        )
+
+      manager.submitTranscribedMessage("gateway A only")
+      assertEquals(listOf("gateway A only"), manager.queuedMessages.value)
+
+      manager.onGatewayScopeChanging()
+      manager.onGatewayConnectionChanged(true)
+      runCurrent()
+
+      assertEquals(emptyList<String>(), manager.queuedMessages.value)
+      assertEquals(emptyList<String>(), sentMessages)
+      assertEquals(emptyList<VoiceConversationEntry>(), manager.conversation.value)
     }
 
   @Test
@@ -325,12 +352,28 @@ class MicCaptureManagerTest {
           shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
         },
       scope = scope,
-      createTranscriptionSession = createTranscriptionSession,
+      createTranscriptionSession = {
+        GatewayTranscriptionSession(
+          id = createTranscriptionSession(),
+          gatewayId = "gateway-a",
+        )
+      },
       appendTranscriptionAudio = { _, _, _ -> },
-      closeTranscriptionSession = closeTranscriptionSession,
+      closeTranscriptionSession = { session -> closeTranscriptionSession(session.id) },
       sendToGateway = sendToGateway,
       refreshAfterTerminalSuccess = refreshAfterTerminalSuccess,
     )
+
+  private fun setTranscriptionSession(
+    manager: MicCaptureManager,
+    id: String,
+  ) {
+    setPrivateField(
+      manager,
+      "transcriptionSession",
+      GatewayTranscriptionSession(id = id, gatewayId = "gateway-a"),
+    )
+  }
 
   private fun setPrivateField(
     target: Any,

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -1047,11 +1047,13 @@ private class FakeTalkAudioPlayer : TalkAudioPlaying {
 
 private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
   override fun loadEntry(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ): DeviceAuthEntry? = null
 
   override fun saveToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
     token: String,
@@ -1059,6 +1061,7 @@ private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
   ) = Unit
 
   override fun clearToken(
+    gatewayId: String,
     deviceId: String,
     role: String,
   ) = Unit

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -4861,6 +4861,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H3: 2. Verify discovery (optional)
   - H4: Cross-network discovery via unicast DNS-SD
   - H3: 3. Connect from Android
+  - H3: Multiple gateways
   - H3: Presence alive beacons
   - H3: 4. Approve pairing (CLI)
   - H3: 5. Verify the node is connected

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -192,7 +192,16 @@ In the Android app:
 - Use **Setup Code** or **Manual** mode.
 - If discovery is blocked, use manual host/port in **Advanced controls**. For private LAN hosts, `ws://` still works. For Tailscale/public hosts, turn on TLS and use a `wss://` / Tailscale Serve endpoint.
 
-After the first successful pairing, Android auto-reconnects on launch: the manual endpoint (if enabled), otherwise the last discovered gateway (best-effort).
+After the first successful pairing, Android auto-reconnects on launch to the active paired gateway (best-effort for discovered gateways, which must be visible on the network).
+
+### Multiple gateways
+
+The app keeps a registry of every gateway it has paired with, so you can switch between them without pairing again:
+
+- **Settings -> Gateways** lists paired gateways with the active one marked. Tap an entry to switch; the app tears down the current sessions and reconnects to the selected gateway.
+- The **Connect** tab shows a quick switcher when more than one gateway is paired.
+- Credentials, device tokens, TLS trust, chat history, and queued offline messages are stored per gateway. Switching never mixes state between gateways, and messages queued while offline are delivered only to the gateway they were written for.
+- **Forget** removes a gateway's registry entry together with its credentials, device tokens, TLS pin, and cached chats.
 
 ### Presence alive beacons
 


### PR DESCRIPTION
Related: #100700

## What Problem This Solves

The Android app can hold exactly one paired gateway. Anyone running more than one gateway (home machine plus a server, personal plus work) has to re-enter the endpoint and credentials every time they want to talk to a different one, losing trust-on-first-use decisions along the way and risking pointing stored credentials at the wrong gateway.

## Why This Change Was Made

Adds first-class multi-gateway support, app-side only (no protocol changes):

- **Paired-gateway registry** (`GatewayRegistryStore`): a versioned, encrypted-preferences record of every paired gateway plus the active selection, keyed by the existing stable endpoint identity that already scopes TLS pinning and the Room chat cache.
- **Per-gateway credentials**: setup credentials become one atomic encrypted bundle per gateway (`gateway.credentials.<stableId>`), and gateway-issued device tokens in `DeviceAuthStore` are now keyed by gateway as well, so tokens from two gateways can no longer overwrite each other.
- **One-time migration** (`GatewayStoreMigration`): folds the legacy single-slot manual endpoint config, instance-scoped credentials, unscoped device tokens, and the global notification-forwarding session key into the new per-gateway shape, then deletes the legacy keys. Runtime reads only the canonical shape; there are no fallback readers.
- **Switching and forgetting**: `NodeRuntime.switchToGateway` / `forgetGateway` serialize gateway lifecycle operations, tear down sessions through the existing connect path, and scope-guard late RPC responses and voice/talk/chat callbacks so state from the previous gateway can never populate the next one. Forget removes the entry, credentials, device tokens, TLS pin, notification key, and cached chat data for that gateway only.
- **UI**: a Gateways list in Settings (active marker, tap to switch, confirmed forget) and a compact quick switcher on the Connect tab when more than one gateway is paired.
- Notification forwarding events are stamped with the gateway they were captured for and only deliver to that gateway.

## User Impact

Users can pair the app with any number of gateways and jump between them from Settings or the Connect tab without pairing again. Chat history, queued offline messages, credentials, TLS trust, and notification routing stay strictly per gateway across switches; forgetting a gateway removes all of its stored state.

## Evidence

- Blacksmith Testbox `tbx_01kww72qj3gptwk301k0dy2m5b`: forced exact-tree `node scripts/run-android-gradle.mjs :app:testPlayDebugUnitTest --rerun-tasks` passed all 948 tests after the final rebase and locale update.
- New coverage: registry round-trip/mutations; one-time migration; per-gateway credentials, device tokens, TLS, notification keys, cache, outbox, and model metadata; destructive reset/forget supersession; stale voice/chat/workspace responses; and endpoint-bound RPC rejection.
- `node --import tsx scripts/android-app-i18n.ts check`, `node --import tsx scripts/native-app-i18n.ts check`, docs map, and `git diff --check` pass. All 21 Android locales contain the new gateway labels.
- Touched Kotlin ktlint is clean. The repository-wide task still reports only two current-main `ShellScreen.kt` layout violations outside this PR.
- Fresh project-local structured review (Codex, gpt-5.5) after every accepted repair: no actionable findings.
- A separately suffixed proof APK and two temporary TLS gateways were prepared on a connected Pixel 10a. Visual switch/forget capture was blocked by the device PIN; the installed production app and its data were not replaced or modified.
- Docs updated: `docs/platforms/android.md`; Android app changelog entry added.
