### PR TITLE
fix(test): preflight targeted UI e2e

### DIFF
--- a/scripts/test-projects.mjs
+++ b/scripts/test-projects.mjs
@@ -25,6 +25,7 @@ import {
   applyDefaultVitestNoOutputTimeout,
   applyParallelVitestCachePaths,
   buildFullSuiteVitestRunPlans,
+  createVitestPreflightPnpmArgs,
   createVitestRunSpecs,
   findUnmatchedExplicitTestTargets,
   formatFailedShardDigest,
@@ -84,16 +85,13 @@ function cleanupVitestRunSpec(spec) {
   }
 }
 
-function runVitestSpec(spec) {
-  if (spec.includeFilePath && spec.includePatterns) {
-    writeVitestIncludeFile(spec.includeFilePath, spec.includePatterns);
-  }
+function runPnpmSpecCommand(spec, pnpmArgs, label) {
   let noOutputTimedOut = false;
   return new Promise((resolve, reject) => {
     const { child, getForwardedSignal, teardown } = spawnWatchedVitestProcess({
-      pnpmArgs: spec.pnpmArgs,
+      pnpmArgs,
       env: spec.env,
-      label: spec.config,
+      label,
       onNoOutputTimeout: () => {
         noOutputTimedOut = true;
       },
@@ -105,7 +103,6 @@ function runVitestSpec(spec) {
 
     child.on("exit", (code, signal) => {
       teardown();
-      cleanupVitestRunSpec(spec);
       const forwardedSignal = getForwardedSignal();
       if (forwardedSignal) {
         forceKillVitestProcessGroup(child);
@@ -117,10 +114,31 @@ function runVitestSpec(spec) {
 
     child.on("error", (error) => {
       teardown();
-      cleanupVitestRunSpec(spec);
-      reject(error);
+      reject(error instanceof Error ? error : new Error(String(error)));
     });
   });
+}
+
+async function runVitestSpec(spec) {
+  if (spec.includeFilePath && spec.includePatterns) {
+    writeVitestIncludeFile(spec.includeFilePath, spec.includePatterns);
+  }
+  try {
+    if (spec.preflightPnpmArgs) {
+      console.error(`[test] preflight ${spec.config}`);
+      const preflightResult = await runPnpmSpecCommand(
+        spec,
+        spec.preflightPnpmArgs,
+        `${spec.config}:preflight`,
+      );
+      if (preflightResult.code !== 0 || preflightResult.signal) {
+        return preflightResult;
+      }
+    }
+    return await runPnpmSpecCommand(spec, spec.pnpmArgs, spec.config);
+  } finally {
+    cleanupVitestRunSpec(spec);
+  }
 }
 
 function applyDefaultParallelVitestWorkerBudget(specs, env) {
@@ -270,6 +288,7 @@ async function main() {
             plan.config,
             ...plan.forwardedArgs,
           ],
+          preflightPnpmArgs: createVitestPreflightPnpmArgs(plan.config),
           watchMode: plan.watchMode,
         }))
       : createVitestRunSpecs(args, {

--- a/scripts/test-projects.test-support.mjs
+++ b/scripts/test-projects.test-support.mjs
@@ -3729,6 +3729,13 @@ function createVitestArgs(params) {
   ];
 }
 
+export function createVitestPreflightPnpmArgs(config) {
+  if (config !== UI_E2E_VITEST_CONFIG) {
+    return null;
+  }
+  return ["exec", "node", "scripts/ensure-playwright-chromium.mjs"];
+}
+
 export function parseTestProjectsArgs(args, cwd = process.cwd()) {
   const forwardedArgs = [];
   const targetArgs = [];
@@ -4254,6 +4261,7 @@ export function createVitestRunSpecs(args, params = {}) {
       includeFilePath,
       includePatterns: plan.includePatterns,
       pnpmArgs: createVitestArgs(plan),
+      preflightPnpmArgs: createVitestPreflightPnpmArgs(plan.config),
       watchMode: plan.watchMode,
     };
   });

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -3386,6 +3386,19 @@ describe("scripts/test-projects changed-target routing", () => {
     expect(spec?.includeFilePath).not.toMatch(new RegExp(`${process.pid}-\\d+-0\\.json$`, "u"));
   });
 
+  it("preflights targeted UI E2E specs with Playwright browser assets", () => {
+    const [spec] = createVitestRunSpecs(["ui/src/pages/tasks/tasks.e2e.test.ts"], {
+      baseEnv: {},
+    });
+
+    expect(spec?.config).toBe("test/vitest/vitest.ui-e2e.config.ts");
+    expect(spec?.preflightPnpmArgs).toEqual([
+      "exec",
+      "node",
+      "scripts/ensure-playwright-chromium.mjs",
+    ]);
+  });
+
   it("routes explicit commands light tests to the lighter commands lane", () => {
     const plans = buildVitestRunPlans(["src/commands/status-json-runtime.test.ts"], process.cwd());
 


### PR DESCRIPTION
Summary
- Add a UI E2E preflight step to targeted `test-projects` specs so `pnpm test:serial <ui-e2e-file>` installs Playwright Chromium/ffmpeg before running Vitest.
- Preserve include-file cleanup across preflight and Vitest execution.
- Cover the targeted UI E2E preflight spec generation in `test-projects` tests.

Verification
- `git diff --check`
- Testbox `tbx_01kwvxgpgyqbxrrnmdr3dme3jv`, Actions run `28799345158`: `pnpm test:serial test/scripts/test-projects.test.ts ui/src/pages/tasks/tasks.e2e.test.ts` passed, including ffmpeg install and the previously failing tasks UI E2E.
- Testbox `tbx_01kwvxgqq7xxw0985eehhgzawm`, Actions run `28799346360`: `pnpm exec oxfmt --check scripts/test-projects.mjs scripts/test-projects.test-support.mjs test/scripts/test-projects.test.ts` passed.
- Testbox `tbx_01kwvy20wtfs7cb9eky9hwj13c`, Actions run `28799968719`: `pnpm test:serial ui/src/pages/tasks/tasks.e2e.test.ts` passed after rebase onto `5733fb0e193`.
- Testbox `tbx_01kwvy1xr60va26j6k9zqwb0v6`, Actions run `28799964897`: `pnpm check:changed` passed after rebase onto `5733fb0e193`.
- Autoreview on `d60ef683f85`: clean, no accepted/actionable findings.

Notes
- During the sweep, native/i18n/android verification also passed on Testbox `tbx_01kwvx5p5ww7fpy951m9bq3hp5`; cleanup reported the box was already stopped.
