### PR TITLE
refactor(ui): trim unused type surface

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -100,7 +100,7 @@ export type WhatsAppStatus = {
   lastError?: string | null;
 };
 
-export type TelegramBot = {
+type TelegramBot = {
   id?: number | null;
   username?: string | null;
 };
@@ -110,7 +110,7 @@ type TelegramWebhook = {
   hasCustomCert?: boolean | null;
 };
 
-export type TelegramProbe = {
+type TelegramProbe = {
   ok: boolean;
   status?: number | null;
   error?: string | null;
@@ -136,7 +136,7 @@ type DiscordBot = {
   username?: string | null;
 };
 
-export type DiscordProbe = {
+type DiscordProbe = {
   ok: boolean;
   status?: number | null;
   error?: string | null;
@@ -187,7 +187,7 @@ type SlackTeam = {
   name?: string | null;
 };
 
-export type SlackProbe = {
+type SlackProbe = {
   ok: boolean;
   status?: number | null;
   error?: string | null;
@@ -208,7 +208,7 @@ export type SlackStatus = {
   lastProbeAt?: number | null;
 };
 
-export type SignalProbe = {
+type SignalProbe = {
   ok: boolean;
   status?: number | null;
   error?: string | null;
@@ -227,7 +227,7 @@ export type SignalStatus = {
   lastProbeAt?: number | null;
 };
 
-export type IMessageProbe = {
+type IMessageProbe = {
   ok: boolean;
   error?: string | null;
 };
@@ -430,9 +430,9 @@ export type ArtifactDownloadResult = {
 };
 
 export type SessionRunStatus = "running" | "done" | "failed" | "killed" | "timeout";
-export type SubagentRunState = "active" | "interrupted" | "historical";
+type SubagentRunState = "active" | "interrupted" | "historical";
 
-export type SessionCompactionCheckpointReason =
+type SessionCompactionCheckpointReason =
   | "manual"
   | "auto-threshold"
   | "overflow-retry"
@@ -459,7 +459,7 @@ export type SessionCompactionCheckpoint = {
   postCompaction: SessionCompactionTranscriptReference;
 };
 
-export type SessionCompactionCheckpointPreview = Pick<
+type SessionCompactionCheckpointPreview = Pick<
   SessionCompactionCheckpoint,
   "checkpointId" | "createdAt" | "reason"
 >;
@@ -531,12 +531,6 @@ export type SessionsCompactionListResult = {
   checkpoints: SessionCompactionCheckpoint[];
 };
 
-export type SessionsCompactionGetResult = {
-  ok: true;
-  key: string;
-  checkpoint: SessionCompactionCheckpoint;
-};
-
 export type SessionsCompactionBranchResult = {
   ok: true;
   sourceKey: string;
@@ -595,14 +589,14 @@ export type CronRunsStatusValue = CronRunStatus;
 export type CronRunsStatusFilter = "all" | CronRunStatus;
 export type CronSortDir = "asc" | "desc";
 
-export type CronSchedule =
+type CronSchedule =
   | { kind: "at"; at: string }
   | { kind: "every"; everyMs: number; anchorMs?: number }
   | { kind: "cron"; expr: string; tz?: string; staggerMs?: number }
   | { kind: "on-exit"; command: string; cwd?: string };
 
-export type CronSessionTarget = "main" | "isolated" | "current" | `session:${string}`;
-export type CronWakeMode = "next-heartbeat" | "now";
+type CronSessionTarget = "main" | "isolated" | "current" | `session:${string}`;
+type CronWakeMode = "next-heartbeat" | "now";
 
 export type CronPayload =
   | { kind: "systemEvent"; text: string }
@@ -640,14 +634,14 @@ export type CronDelivery = {
   failureDestination?: CronFailureDestination;
 };
 
-export type CronFailureDestination = {
+type CronFailureDestination = {
   channel?: string;
   to?: string;
   mode?: "announce" | "webhook";
   accountId?: string;
 };
 
-export type CronFailureAlert = {
+type CronFailureAlert = {
   after?: number;
   channel?: string;
   to?: string;
@@ -656,7 +650,7 @@ export type CronFailureAlert = {
   accountId?: string;
 };
 
-export type CronJobState = {
+type CronJobState = {
   nextRunAtMs?: number;
   runningAtMs?: number;
   lastRunAtMs?: number;
@@ -742,7 +736,7 @@ type SkillsStatusConfigCheck = {
   satisfied: boolean;
 };
 
-export type SkillInstallOption = {
+type SkillInstallOption = {
   id: string;
   kind: "brew" | "node" | "go" | "uv" | "download";
   label: string;
@@ -828,25 +822,6 @@ export type StatusSummary = Record<string, unknown>;
 
 export type HealthSnapshot = Record<string, unknown>;
 
-/** Strongly-typed health response from the gateway (richer than HealthSnapshot). */
-export type HealthSummary = {
-  ok: boolean;
-  ts: number;
-  durationMs: number;
-  heartbeatSeconds: number;
-  defaultAgentId: string;
-  agents: Array<{ id: string; name?: string }>;
-  sessions: {
-    path: string;
-    count: number;
-    recent: Array<{
-      key: string;
-      updatedAt: number | null;
-      age: number | null;
-    }>;
-  };
-};
-
 /** A model entry returned by the gateway model-catalog endpoint. */
 export type ModelCatalogEntry = {
   id: string;
@@ -860,23 +835,13 @@ export type ModelCatalogEntry = {
 
 export type ToolCatalogProfile =
   import("../../../packages/gateway-protocol/src/schema.js").ToolCatalogProfile;
-export type ToolCatalogEntry =
-  import("../../../packages/gateway-protocol/src/schema.js").ToolCatalogEntry;
-export type ToolCatalogGroup =
-  import("../../../packages/gateway-protocol/src/schema.js").ToolCatalogGroup;
 export type ToolsCatalogResult =
   import("../../../packages/gateway-protocol/src/schema.js").ToolsCatalogResult;
 export type ToolsEffectiveEntry =
   import("../../../packages/gateway-protocol/src/schema.js").ToolsEffectiveEntry;
-export type ToolsEffectiveGroup =
-  import("../../../packages/gateway-protocol/src/schema.js").ToolsEffectiveGroup;
 export type ToolsEffectiveResult =
   import("../../../packages/gateway-protocol/src/schema.js").ToolsEffectiveResult;
 
-export type ModelAuthExpiry =
-  import("../../../src/gateway/server-methods/models-auth-status.js").ModelAuthExpiry;
-export type ModelAuthStatusProfile =
-  import("../../../src/gateway/server-methods/models-auth-status.js").ModelAuthStatusProfile;
 export type ModelAuthStatusProvider =
   import("../../../src/gateway/server-methods/models-auth-status.js").ModelAuthStatusProvider;
 export type ModelAuthStatusResult =

--- a/ui/src/app/exec-approval.ts
+++ b/ui/src/app/exec-approval.ts
@@ -31,7 +31,7 @@ export type ExecApprovalRequest = {
   expiresAtMs: number;
 };
 
-export type ExecApprovalResolved = {
+type ExecApprovalResolved = {
   id: string;
   decision?: string | null;
   resolvedBy?: string | null;

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -487,7 +487,7 @@ export function getHiddenCommandCount(): number {
   return SLASH_COMMANDS.filter((cmd) => (cmd.tier ?? "standard") === "power").length;
 }
 
-export type ParsedSlashCommand = {
+type ParsedSlashCommand = {
   command: SlashCommandDef;
   args: string;
 };

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -492,7 +492,7 @@ export async function applyConfig(state: ConfigState): Promise<boolean> {
   });
 }
 
-export async function patchConfig(
+async function patchConfig(
   state: ConfigGatewayState,
   options: ConfigPatchOptions,
 ): Promise<boolean> {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -72,7 +72,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object");
 }
 
-export function isCronPayload(value: unknown): value is CronPayload {
+function isCronPayload(value: unknown): value is CronPayload {
   if (!isRecord(value)) {
     return false;
   }

--- a/ui/src/lib/nodes/index.ts
+++ b/ui/src/lib/nodes/index.ts
@@ -76,7 +76,7 @@ export type ExecApprovalsAllowlistEntry = {
   lastResolvedPath?: string;
 };
 
-export type ExecApprovalsAgent = ExecApprovalsDefaults & {
+type ExecApprovalsAgent = ExecApprovalsDefaults & {
   allowlist?: ExecApprovalsAllowlistEntry[];
 };
 

--- a/ui/src/lib/select-options.ts
+++ b/ui/src/lib/select-options.ts
@@ -1,7 +1,7 @@
 // Control UI module implements select options behavior.
 import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 
-export type SelectOption = {
+type SelectOption = {
   value: string;
   label: string;
 };

--- a/ui/src/lib/session-display.ts
+++ b/ui/src/lib/session-display.ts
@@ -36,7 +36,7 @@ function capitalize(s: string): string {
  * Parse a session key to extract type information and a human-readable
  * fallback display name. Exported for testing.
  */
-export function parseSessionKey(key: string): SessionKeyInfo {
+function parseSessionKey(key: string): SessionKeyInfo {
   const normalized = normalizeLowercaseStringOrEmpty(key);
 
   // Main session.

--- a/ui/src/lib/sessions/session-key.ts
+++ b/ui/src/lib/sessions/session-key.ts
@@ -5,7 +5,7 @@ import {
   normalizeOptionalString,
 } from "../string-coerce.ts";
 
-export type ParsedAgentSessionKey = {
+type ParsedAgentSessionKey = {
   agentId: string;
   rest: string;
 };

--- a/ui/src/lib/string-coerce.ts
+++ b/ui/src/lib/string-coerce.ts
@@ -3,7 +3,6 @@ export {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
-  normalizeStringifiedOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 export {
   normalizeStringEntries,

--- a/ui/src/lib/workboard/index.ts
+++ b/ui/src/lib/workboard/index.ts
@@ -154,7 +154,7 @@ export type WorkboardStaleState = {
   reason: string;
 };
 
-export type WorkboardClaim = {
+type WorkboardClaim = {
   ownerId: string;
   token?: string;
   claimedAt: number;

--- a/ui/src/pages/chat/chat-send.ts
+++ b/ui/src/pages/chat/chat-send.ts
@@ -168,7 +168,7 @@ function formatTerminalChatSendAckError(
   return "The run ended before the message was accepted.";
 }
 
-export type ChatSendOptions = {
+type ChatSendOptions = {
   confirmReset?: boolean;
   restoreDraft?: boolean;
   skillWorkshopRevision?: ChatQueueSkillWorkshopRevision;

--- a/ui/src/pages/tasks/data.ts
+++ b/ui/src/pages/tasks/data.ts
@@ -22,7 +22,7 @@ export type TaskSummary = {
   error?: string;
 };
 
-export type TaskEventPayload =
+type TaskEventPayload =
   | { action: "upserted"; task: TaskSummary }
   | { action: "deleted"; taskId: string }
   | { action: "restored" };
@@ -169,7 +169,7 @@ export function mergeTaskLists(...lists: readonly (readonly TaskSummary[])[]): T
   return sortTasks([...byId.values()]);
 }
 
-export type TasksCancelResult = {
+type TasksCancelResult = {
   found: boolean;
   cancelled: boolean;
   reason?: string;


### PR DESCRIPTION
## What Problem This Solves

The Control UI exposed aliases that are only consumed inside their defining module and retained stale type declarations with no consumers. That made the UI TypeScript surface larger than the code actually supports.

Fixes #100951

## Why This Change Was Made

- remove eight declaration-only aliases and one unused normalization re-export
- make 28 internal-only aliases and helpers module-private
- keep runtime behavior and gateway protocol handling unchanged

## User Impact

No user-visible behavior changes. This narrows internal TypeScript ownership and removes dead declarations.

## Evidence

- full codebase-memory graph: 273,851 nodes / 1,090,961 edges; zero cross-file ingress for localized symbols
- `node scripts/run-vitest.mjs ui/src/app/exec-approval.test.ts ui/src/lib/chat/commands.browser-import.test.ts ui/src/lib/chat/commands.test.ts ui/src/lib/config/index.test.ts ui/src/lib/cron/index.test.ts ui/src/pages/tasks/data.test.ts` (130 tests passed)
- `node_modules/.bin/oxfmt --check` on all 13 changed files
- Blacksmith Testbox `tbx_01kwvxqcrzhphfm321q4s1ww7e`: `pnpm check:changed` passed
- Actions run: https://github.com/openclaw/openclaw/actions/runs/28799590806
- fresh autoreview: no actionable findings
