### PR TITLE
feat: add commands list and inspect inventory

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -1,0 +1,77 @@
+---
+summary: "List and inspect the command surfaces known to OpenClaw"
+read_when:
+  - Building command inventory, compliance, diagnostics, or documentation tooling
+  - Inspecting command provenance and effect data
+title: "Commands"
+---
+
+# `openclaw tools commands`
+
+`openclaw tools commands` provides a read-only inventory of command information OpenClaw already
+owns. It does not execute commands, grant permission, or enforce policy.
+
+## List commands
+
+```bash
+openclaw tools commands list
+openclaw tools commands list --json
+openclaw tools commands list --markdown
+openclaw tools commands list --json --plugin-descriptors
+```
+
+The inventory joins these command-owned sources:
+
+- static core and sub-CLI descriptors
+- routed command paths and their operation metadata
+- commands registered in the current CLI invocation
+- plugin CLI descriptors when `--plugin-descriptors` is supplied
+
+Human output is Markdown by default. Use `--json` for the versioned machine-readable shape.
+`--json` and `--markdown` cannot be combined.
+
+Plugin descriptor discovery is opt-in because it activates plugin registration. When requested,
+loader failures and error-level plugin diagnostics fail the command instead of returning an
+apparently complete partial inventory. Plugin warnings remain visible on stderr.
+
+## Inspect one path
+
+```bash
+openclaw tools commands inspect gateway
+openclaw tools commands inspect nodes run --json
+openclaw tools commands inspect memory --json --plugin-descriptors
+```
+
+`inspect` hydrates the requested lazy core or sub-CLI group, resolves runtime aliases, and returns
+the records that match that exact command path. The result includes `found`, the requested and
+resolved paths, and matching descriptors, routes, routed operations, runtime registrations, plugin
+registrations, and caller-supplied node records.
+
+An unknown path returns `found: false` in JSON or `No matching command was found` in Markdown.
+
+## Inventory semantics
+
+The JSON result includes `schemaVersion: 1`, source identity, discovery mode, visibility, and effect
+metadata where the owning registry provides it. Missing effect metadata is not a safety claim.
+Callers should not infer that an unannotated command is read-only or low risk.
+
+The current runtime command scope is the command tree registered for this invocation. Plugin
+commands appear only with `--plugin-descriptors`. Node command records are supported by the catalog
+model but this CLI does not fetch live paired-node commands.
+
+The existing Gateway `commands.list` RPC remains the agent-facing chat, native, skill, and plugin
+inventory. This CLI is an operator and developer view and does not replace that RPC.
+
+## Options
+
+| Flag                   | Meaning                                                      |
+| ---------------------- | ------------------------------------------------------------ |
+| `--json`               | Emit the versioned JSON inventory.                           |
+| `--markdown`           | Emit Markdown explicitly; this is the default human format.  |
+| `--plugin-descriptors` | Load plugin CLI descriptors and include their command shape. |
+
+## Related
+
+- [CLI reference](/cli)
+- [Plugin SDK](/plugins/sdk-overview)
+- [`openclaw nodes`](/cli/nodes)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -9,6 +9,8 @@ title: "CLI reference"
 `openclaw` is the main CLI entry point. Each core command has a dedicated
 reference page or is documented with the command it aliases; this index lists
 the commands, global flags, and output styling rules that apply across the CLI.
+For a machine-readable inventory of command descriptors, routes, runtime registrations, and
+opt-in plugin descriptors, see [`openclaw tools commands`](/cli/commands).
 
 Setup commands by intent:
 
@@ -126,6 +128,8 @@ openclaw [--dev] [--profile <name>] <command>
     wizard
     status
     repair
+  tools
+    commands list|inspect
   channels
     list
     status

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -9,6 +9,8 @@ title: "CLI reference"
 `openclaw` is the main CLI entry point. Each core command has a dedicated
 reference page or is documented with the command it aliases. This index lists
 the commands, global flags, and output styling rules that apply across the CLI.
+For a machine-readable inventory of command descriptors, routes, runtime registrations, and
+opt-in plugin descriptors, see [`openclaw tools commands`](/cli/commands).
 
 Setup commands by intent:
 
@@ -180,6 +182,8 @@ openclaw [--dev] [--profile <name>] <command>
     wizard
     status
     repair
+  tools
+    commands list|inspect
   channels
     list
     status

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1856,6 +1856,7 @@
                     "pages": [
                       "cli/approvals",
                       "cli/browser",
+                      "cli/commands",
                       "cli/cron",
                       "cli/flows",
                       "cli/node",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2853,6 +2853,7 @@
                     "pages": [
                       "cli/approvals",
                       "cli/browser",
+                      "cli/commands",
                       "cli/cron",
                       "cli/connect",
                       "cli/devices",

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -254,7 +254,9 @@ CLI registration:
   `registerCli(registrar, { parentPath: ["nodes"], ... })`).
 - For other nested plugin commands, add `parentPath` and register commands
   on the `program` object passed to the registrar; OpenClaw resolves it to
-  the parent command before calling the plugin.
+  the parent command before calling the plugin. Use only documented
+  plugin-extensible parents; `openclaw tools` is core-owned inventory and is
+  not a plugin command parent.
 - For channel plugins, register CLI descriptors from `registerCliMetadata`
   and keep `registerFull` focused on runtime-only work.
 - If `registerFull` also registers gateway RPC methods, keep them on a

--- a/docs/plugins/sdk-entrypoints/define-channel-plugin-entry.md
+++ b/docs/plugins/sdk-entrypoints/define-channel-plugin-entry.md
@@ -106,7 +106,9 @@ CLI registration:
   `registerCli(registrar, { parentPath: ["nodes"], ... })`).
 - For other nested plugin commands, add `parentPath` and register commands
   on the `program` object passed to the registrar; OpenClaw resolves it to
-  the parent command before calling the plugin.
+  the parent command before calling the plugin. Use only documented
+  plugin-extensible parents; `openclaw tools` is core-owned inventory and is
+  not a plugin command parent.
 - For channel plugins, register CLI descriptors from `registerCliMetadata`
   and keep `registerFull` focused on runtime-only work.
 - If `registerFull` also registers gateway RPC methods, keep them on a

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -507,7 +507,7 @@ own trust.
 
 ### CLI registration metadata
 
-`api.registerCli(registrar, opts?)` accepts two kinds of command metadata:
+`api.registerCli(registrar, opts?)` accepts command ownership data:
 
 - `commands`: explicit command names owned by the registrar
 - `descriptors`: parse-time command descriptors used for CLI help,
@@ -523,6 +523,9 @@ For paired-node features, prefer
 If you want a plugin command to stay lazy-loaded in the normal root CLI path,
 provide `descriptors` that cover every top-level command root exposed by that
 registrar.
+
+Descriptors describe parse-time command shape only. They do not declare effect
+risk, grant permission, enforce policy, or hide commands from inventory.
 
 ```typescript
 api.registerCli(

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -515,6 +515,10 @@ own trust.
 - `parentPath`: optional parent command path for nested command groups, such as
   `["nodes"]`
 
+Nested plugin CLI registrations are only for extension points that core
+documents as plugin-extensible. The `tools` root is reserved for OpenClaw's
+read-only inventory commands and does not load plugin-owned child commands.
+
 For paired-node features, prefer
 `api.registerNodeCliFeature(registrar, opts?)`. It is a small wrapper around
 `api.registerCli(..., { parentPath: ["nodes"] })` and makes commands such as

--- a/docs/plugins/sdk-overview/cli-and-discovery.md
+++ b/docs/plugins/sdk-overview/cli-and-discovery.md
@@ -56,6 +56,10 @@ helper; see [retained SDK contracts](/plugins/sdk-migration/compatibility-policy
 - `parentPath`: optional parent command path for nested command groups, such as
   `["nodes"]`
 
+Nested plugin CLI registrations are only for extension points that core
+documents as plugin-extensible. The `tools` root is reserved for OpenClaw's
+read-only inventory commands and does not load plugin-owned child commands.
+
 For paired-node features, prefer
 `api.registerNodeCliFeature(registrar, opts?)`. It is a small wrapper around
 `api.registerCli(..., { parentPath: ["nodes"] })` and makes commands such as

--- a/src/cli-catalog-overlay/inspect.test.ts
+++ b/src/cli-catalog-overlay/inspect.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { inspectCommand, renderCommandInspectionMarkdown } from "./inspect.js";
+import { buildCatalogList } from "./list.js";
+
+describe("command inventory inspect", () => {
+  it("joins records for an exact command path", () => {
+    const inspection = inspectCommand(buildCatalogList(), ["gateway", "status"]);
+
+    expect(inspection.found).toBe(true);
+    expect(inspection.routes.map((route) => route.commandPath)).toEqual([
+      ["gateway"],
+      ["gateway", "status"],
+    ]);
+    expect(inspection.routedOperations.map((operation) => operation.id)).toContain(
+      "gateway-status",
+    );
+  });
+
+  it("inspects supplied node commands", () => {
+    const list = buildCatalogList({
+      nodeCommands: [
+        {
+          id: "node:demo:filesystem.read",
+          command: "filesystem.read",
+          title: "Read a file",
+          description: "Read a file from the paired node",
+          argumentHints: ["path"],
+          invocationHint: "filesystem.read path=<path>",
+          availability: "approved",
+          approvalKind: "pairing",
+          risk: "low",
+          confirmationRequired: false,
+          effectMode: "read",
+          effects: ["filesystem.read"],
+          trustBoundary: "paired-node",
+          sourceKind: "node-pairing",
+          sourceId: "demo:filesystem.read",
+          discoveryMode: "paired-node-declaration",
+          visibility: ["audit", "operator"],
+        },
+      ],
+    });
+
+    expect(inspectCommand(list, ["filesystem.read"]).nodeCommands).toHaveLength(1);
+  });
+
+  it("reports unknown command paths without fuzzy matching", () => {
+    const inspection = inspectCommand(buildCatalogList(), ["missing"]);
+
+    expect(inspection.found).toBe(false);
+    expect(renderCommandInspectionMarkdown(inspection)).toContain("No matching command was found.");
+  });
+
+  it("does not treat an inherited route policy as command existence", () => {
+    const inspection = inspectCommand(buildCatalogList(), ["gateway", "missing"]);
+
+    expect(inspection.found).toBe(false);
+    expect(inspection.routes.map((route) => route.commandPath)).toEqual([["gateway"]]);
+  });
+
+  it("includes inherited operations without treating them as command existence", () => {
+    const inspection = inspectCommand(buildCatalogList(), ["tasks", "missing"]);
+
+    expect(inspection.found).toBe(false);
+    expect(inspection.routedOperations.map((operation) => operation.id)).toContain("tasks-list");
+  });
+
+  it("resolves runtime aliases before joining command records", () => {
+    const list = buildCatalogList({
+      runtimeCommands: [
+        {
+          commandPath: ["infer"],
+          parentPath: [],
+          depth: 1,
+          name: "infer",
+          aliases: ["capability"],
+          description: "Run inference",
+          hasSubcommands: false,
+          visibleSubcommandCount: 0,
+          hidden: false,
+          sourceKind: "runtime",
+          sourceId: "infer",
+          discoveryMode: "runtime-registered",
+          visibility: ["operator"],
+        },
+      ],
+    });
+
+    const inspection = inspectCommand(list, ["capability"]);
+    expect(inspection.found).toBe(true);
+    expect(inspection.resolvedCommandPath).toEqual(["infer"]);
+    expect(inspection.runtimeCommands).toHaveLength(1);
+  });
+
+  it("uses a Markdown fence longer than plugin-controlled content", () => {
+    const list = buildCatalogList({
+      pluginCommands: [
+        {
+          pluginId: "example",
+          commandPath: ["example"],
+          parentPath: [],
+          depth: 1,
+          name: "example",
+          descriptorName: "example",
+          description: "contains ``` fence",
+          hasSubcommands: false,
+          commandHints: ["example"],
+          sourceKind: "plugin",
+          sourceId: "example:example",
+          discoveryMode: "plugin-descriptor",
+        },
+      ],
+    });
+
+    expect(renderCommandInspectionMarkdown(inspectCommand(list, ["example"]))).toContain(
+      "````json",
+    );
+  });
+});

--- a/src/cli-catalog-overlay/inspect.ts
+++ b/src/cli-catalog-overlay/inspect.ts
@@ -1,0 +1,119 @@
+import { matchesCommandPath } from "../cli/command-path-matches.js";
+import type { CliCatalogList } from "./list.js";
+
+type CliCommandInspection = {
+  readonly schemaVersion: 1;
+  readonly generatedFrom: "command-inventory-inspect";
+  readonly commandPath: readonly string[];
+  readonly resolvedCommandPath: readonly string[];
+  readonly found: boolean;
+  readonly descriptors: CliCatalogList["cli"]["descriptors"];
+  readonly routes: CliCatalogList["cli"]["commandRoutes"];
+  readonly routedOperations: CliCatalogList["cli"]["routedOperations"];
+  readonly runtimeCommands: CliCatalogList["cli"]["runtimeCommands"];
+  readonly pluginCommands: CliCatalogList["cli"]["pluginCommands"];
+  readonly nodeCommands: CliCatalogList["cli"]["nodeCommands"];
+};
+
+function samePath(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((part, index) => part === right[index]);
+}
+
+function resolveRuntimeCommandPath(
+  commands: CliCatalogList["cli"]["runtimeCommands"],
+  commandPath: readonly string[],
+): readonly string[] {
+  const resolved: string[] = [];
+  for (const segment of commandPath) {
+    const match = commands.find(
+      (command) =>
+        samePath(command.parentPath, resolved) &&
+        (command.name === segment || command.aliases.includes(segment)),
+    );
+    if (!match) {
+      return commandPath;
+    }
+    resolved.push(match.name);
+  }
+  return resolved;
+}
+
+export function inspectCommand(
+  list: CliCatalogList,
+  commandPath: readonly string[],
+): CliCommandInspection {
+  const resolvedCommandPath = resolveRuntimeCommandPath(list.cli.runtimeCommands, commandPath);
+  const descriptors =
+    resolvedCommandPath.length === 1
+      ? list.cli.descriptors.filter((descriptor) => descriptor.name === resolvedCommandPath[0])
+      : [];
+  const routes = list.cli.commandRoutes.filter((route) =>
+    matchesCommandPath([...resolvedCommandPath], route.commandPath, { exact: route.exact }),
+  );
+  const hasExactRoute = routes.some((route) => samePath(route.commandPath, resolvedCommandPath));
+  const matchedRouteIds = new Set<string>(
+    routes.flatMap((route) => (route.routeId ? [route.routeId] : [])),
+  );
+  const routedOperations = list.cli.routedOperations.filter((operation) =>
+    matchedRouteIds.has(operation.id),
+  );
+  const hasExactRoutedOperation = routedOperations.some((operation) =>
+    operation.commandPaths.some((path) => samePath(path, resolvedCommandPath)),
+  );
+  const runtimeCommands = list.cli.runtimeCommands.filter((command) =>
+    samePath(command.commandPath, resolvedCommandPath),
+  );
+  const pluginCommands = list.cli.pluginCommands.filter((command) =>
+    samePath(command.commandPath, resolvedCommandPath),
+  );
+  const nodeCommands = list.cli.nodeCommands.filter(
+    (command) => command.command === resolvedCommandPath.join(" "),
+  );
+  const found =
+    descriptors.length +
+      Number(hasExactRoute) +
+      Number(hasExactRoutedOperation) +
+      runtimeCommands.length +
+      pluginCommands.length +
+      nodeCommands.length >
+    0;
+
+  return {
+    schemaVersion: 1,
+    generatedFrom: "command-inventory-inspect",
+    commandPath,
+    resolvedCommandPath,
+    found,
+    descriptors,
+    routes,
+    routedOperations,
+    runtimeCommands,
+    pluginCommands,
+    nodeCommands,
+  };
+}
+
+export function renderCommandInspectionMarkdown(inspection: CliCommandInspection): string {
+  const path = inspection.commandPath.join(" ");
+  if (!inspection.found) {
+    return `# Command: ${path}\n\nNo matching command was found.\n`;
+  }
+  const json = JSON.stringify(inspection, null, 2);
+  const longestFence = Math.max(0, ...Array.from(json.matchAll(/`+/g), (match) => match[0].length));
+  const fence = "`".repeat(Math.max(3, longestFence + 1));
+  return [
+    `# Command: ${path}`,
+    "",
+    `- Descriptors: ${inspection.descriptors.length}`,
+    `- Routes: ${inspection.routes.length}`,
+    `- Routed operations: ${inspection.routedOperations.length}`,
+    `- Runtime registrations: ${inspection.runtimeCommands.length}`,
+    `- Plugin registrations: ${inspection.pluginCommands.length}`,
+    `- Node commands: ${inspection.nodeCommands.length}`,
+    "",
+    `${fence}json`,
+    json,
+    fence,
+    "",
+  ].join("\n");
+}

--- a/src/cli-catalog-overlay/list.test.ts
+++ b/src/cli-catalog-overlay/list.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { buildCatalogList, renderCatalogListMarkdown } from "./list.js";
+import type { CliCatalogNodeCommand } from "./node-commands.js";
+
+const sampleNodeCommands: readonly CliCatalogNodeCommand[] = [
+  {
+    id: "node:demo-filesystem:filesystem.read",
+    command: "filesystem.read",
+    title: "Read file through paired node",
+    nodeId: "demo-filesystem",
+    nodeName: "Demo filesystem node",
+    cap: "filesystem",
+    description: "Read a file through a paired node command declaration.",
+    argumentHints: ["path"],
+    invocationHint:
+      'openclaw nodes invoke --node demo-filesystem --command filesystem.read --params {"path":"..."}',
+    availability: "approved",
+    approvalKind: "pairing",
+    risk: "medium",
+    confirmationRequired: true,
+    effectMode: "read",
+    effects: ["filesystem.read"],
+    trustBoundary: "paired-node",
+    sourceKind: "node-pairing",
+    sourceId: "demo-filesystem:filesystem.read",
+    discoveryMode: "paired-node-declaration",
+    visibility: ["docs", "audit", "operator", "policy"],
+  },
+];
+
+describe("command inventory list", () => {
+  it("builds a read-only programmatic list", () => {
+    const list = buildCatalogList();
+
+    expect(list).toMatchObject({
+      schemaVersion: 1,
+      generatedFrom: "command-inventory",
+      counts: {
+        runtimeCommands: 0,
+        nodeCommands: 0,
+      },
+    });
+    expect(list.cli.runtimeCommandScope).toBe("current-invocation-registered-tree");
+    expect(list.cli.nodeCommandScope).toBe("caller-supplied");
+    expect(list.collection).toEqual({
+      descriptors: "complete",
+      commandRoutes: "complete",
+      runtimeCommands: "not-requested",
+      pluginCommands: "not-requested",
+      nodeCommands: "not-requested",
+    });
+    expect(list.cli.descriptors.map((descriptor) => descriptor.name)).not.toContain("crestodian");
+    expect(list.cli.descriptors.find((descriptor) => descriptor.name === "gateway")).toMatchObject({
+      source: "subcli",
+      hasSubcommands: true,
+    });
+    expect(
+      list.cli.routedOperations.find((operation) => operation.id === "gateway-status"),
+    ).toMatchObject({ commandPaths: [["gateway", "status"]] });
+    expect(
+      list.cli.routedOperations.find((operation) => operation.id === "config-unset"),
+    ).toMatchObject({
+      risk: "medium",
+      confirmationRequired: true,
+      effectMode: "mutating",
+    });
+    expect(list.counts.commandDescriptors).toBeGreaterThan(50);
+    expect(list.counts.commandRoutes).toBeGreaterThan(90);
+    expect(list.counts.routedOperations).toBeGreaterThan(10);
+  });
+
+  it("preserves unknown routed-operation effects", () => {
+    const operation = buildCatalogList().cli.routedOperations.find(
+      (entry) => entry.id === "agents-list",
+    );
+
+    expect(operation).toBeDefined();
+    expect(operation).not.toHaveProperty("risk");
+    expect(operation).not.toHaveProperty("confirmationRequired");
+    expect(operation).not.toHaveProperty("effectMode");
+  });
+
+  it("carries supplied node/operator commands through the list contract", () => {
+    const list = buildCatalogList({ nodeCommands: sampleNodeCommands });
+
+    expect(list.counts.nodeCommands).toBe(1);
+    expect(list.cli.nodeCommands[0]).toMatchObject({
+      id: "node:demo-filesystem:filesystem.read",
+      command: "filesystem.read",
+      availability: "approved",
+      approvalKind: "pairing",
+      trustBoundary: "paired-node",
+    });
+  });
+
+  it("renders a Markdown command inventory", () => {
+    const markdown = renderCatalogListMarkdown();
+
+    expect(markdown).toContain("# OpenClaw Commands");
+    expect(markdown).toContain("- CLI descriptors:");
+    expect(markdown).toContain("- Command routes:");
+    expect(markdown).toContain("- Runtime command scope: current-invocation-registered-tree");
+    expect(markdown).toContain("- Supplied node commands: 0");
+    expect(markdown).toContain("- Node command scope: caller-supplied");
+    expect(markdown).toContain(
+      "| `gateway-status` | `unknown` | `unknown` | unknown | `gateway status` |",
+    );
+    expect(markdown).not.toContain("Agent/tool surfaces");
+  });
+
+  it("renders node/operator command rows when supplied", () => {
+    const markdown = renderCatalogListMarkdown({ nodeCommands: sampleNodeCommands });
+
+    expect(markdown).toContain("## Node/operator commands");
+    expect(markdown).toContain(
+      "| `filesystem.read` | Demo filesystem node | `approved` | `pairing` |",
+    );
+  });
+
+  it("keeps supplied node metadata inside its Markdown table cells", () => {
+    const command = {
+      ...sampleNodeCommands[0]!,
+      command: "filesystem.`read`|raw",
+      nodeName: "Build | prod\nprimary",
+      invocationHint: "nodes invoke `filesystem.read` | inspect\nnext",
+    };
+
+    const markdown = renderCatalogListMarkdown({ nodeCommands: [command] });
+
+    expect(markdown).toContain(
+      "| `` filesystem.`read`\\|raw `` | Build \\| prod primary | `approved` | `pairing` |",
+    );
+    expect(markdown).toContain("`` nodes invoke `filesystem.read` \\| inspect next ``");
+    expect(markdown).not.toContain("Build | prod\nprimary");
+  });
+});

--- a/src/cli-catalog-overlay/list.test.ts
+++ b/src/cli-catalog-overlay/list.test.ts
@@ -61,7 +61,7 @@ describe("command inventory list", () => {
       list.cli.routedOperations.find((operation) => operation.id === "config-unset"),
     ).toMatchObject({
       risk: "medium",
-      confirmationRequired: true,
+      confirmationRequired: false,
       effectMode: "mutating",
     });
     expect(list.counts.commandDescriptors).toBeGreaterThan(50);
@@ -102,6 +102,10 @@ describe("command inventory list", () => {
     expect(markdown).toContain("- Runtime command scope: current-invocation-registered-tree");
     expect(markdown).toContain("- Supplied node commands: 0");
     expect(markdown).toContain("- Node command scope: caller-supplied");
+    expect(markdown).toContain("## CLI descriptors");
+    expect(markdown).toContain("| `gateway` | `subcli` | yes |");
+    expect(markdown).toContain("## Command routes");
+    expect(markdown).toContain("| `gateway status` | yes | `gateway-status` |");
     expect(markdown).toContain(
       "| `gateway-status` | `unknown` | `unknown` | unknown | `gateway status` |",
     );

--- a/src/cli-catalog-overlay/list.ts
+++ b/src/cli-catalog-overlay/list.ts
@@ -1,0 +1,315 @@
+import {
+  normalizeCommandEffectProfile,
+  normalizeCommandExposure,
+  type CliCatalogVisibility,
+} from "../cli/catalog-metadata.js";
+import { cliCommandCatalog, type CliCommandCatalogEntry } from "../cli/command-catalog.js";
+import { getCoreCliCommandDescriptors } from "../cli/program/core-command-descriptors.js";
+import { getSubCliEntries } from "../cli/program/subcli-descriptors.js";
+import { buildNodeCommandCatalog, type CliCatalogNodeCommand } from "./node-commands.js";
+import type { CliCatalogPluginCommand } from "./plugin-commands.js";
+import type { CliCatalogRuntimeCommand } from "./runtime-commands.js";
+
+function markdownTableCell(value: string): string {
+  return value.replace(/\r\n?|\n/g, " ").replace(/\|/g, "\\|");
+}
+
+function markdownCodeCell(value: string): string {
+  const cell = markdownTableCell(value);
+  const longestFence = Math.max(0, ...Array.from(cell.matchAll(/`+/g), (match) => match[0].length));
+  const fence = "`".repeat(longestFence + 1);
+  return longestFence > 0 ? `${fence} ${cell} ${fence}` : `${fence}${cell}${fence}`;
+}
+
+type CliCatalogListDescriptor = {
+  readonly name: string;
+  readonly description: string;
+  readonly hasSubcommands: boolean;
+  readonly parentDefaultHelp: boolean;
+  readonly source: "core" | "subcli";
+  readonly sourceKind: "core" | "subcli";
+  readonly sourceId: string;
+  readonly discoveryMode: "static-descriptor";
+  readonly visibility: readonly CliCatalogVisibility[];
+  readonly effectProfile?: {
+    readonly effectMode: string;
+    readonly confirmationRequired?: boolean;
+    readonly risk?: string;
+  };
+  readonly exposureTier?: "public" | "internal";
+};
+
+type CliCatalogListCommandRoute = {
+  readonly commandPath: readonly string[];
+  readonly exact: boolean;
+  readonly routeId?: NonNullable<CliCommandCatalogEntry["route"]>["id"];
+  readonly policyKeys: readonly string[];
+  readonly sourceKind: "route-policy";
+  readonly sourceId: string;
+  readonly discoveryMode: "route-policy";
+  readonly visibility: readonly CliCatalogVisibility[];
+};
+
+type CliCatalogListRoutedOperation = {
+  readonly id: string;
+  readonly commandPaths: readonly (readonly string[])[];
+  readonly risk?: string;
+  readonly confirmationRequired?: boolean;
+  readonly effectMode?: string;
+  readonly sourceKind: "route-policy";
+  readonly discoveryMode: "route-policy";
+  readonly visibility: readonly CliCatalogVisibility[];
+};
+
+type CliCatalogRuntimeCommandScope = "current-invocation-registered-tree";
+type CliCatalogNodeCommandScope = "caller-supplied";
+
+const RUNTIME_COMMAND_SCOPE: CliCatalogRuntimeCommandScope = "current-invocation-registered-tree";
+const NODE_COMMAND_SCOPE: CliCatalogNodeCommandScope = "caller-supplied";
+
+export type CliCatalogList = {
+  readonly schemaVersion: 1;
+  readonly generatedFrom: "command-inventory";
+  readonly counts: {
+    readonly commandDescriptors: number;
+    readonly commandRoutes: number;
+    readonly routedOperations: number;
+    readonly runtimeCommands: number;
+    readonly pluginCommands: number;
+    readonly nodeCommands: number;
+  };
+  readonly collection: {
+    readonly descriptors: "complete";
+    readonly commandRoutes: "complete";
+    readonly runtimeCommands: "collected" | "not-requested";
+    readonly pluginCommands: "collected" | "not-requested";
+    readonly nodeCommands: "caller-supplied" | "not-requested";
+  };
+  readonly cli: {
+    readonly descriptors: readonly CliCatalogListDescriptor[];
+    readonly commandRoutes: readonly CliCatalogListCommandRoute[];
+    readonly routedOperations: readonly CliCatalogListRoutedOperation[];
+    readonly runtimeCommandScope: CliCatalogRuntimeCommandScope;
+    readonly nodeCommandScope: CliCatalogNodeCommandScope;
+    readonly runtimeCommands: readonly CliCatalogRuntimeCommand[];
+    readonly pluginCommands: readonly CliCatalogPluginCommand[];
+    readonly nodeCommands: readonly CliCatalogNodeCommand[];
+  };
+};
+
+function mapDescriptor(
+  descriptor: ReturnType<typeof getCoreCliCommandDescriptors>[number],
+  source: "core" | "subcli",
+): CliCatalogListDescriptor {
+  const commandExposure = normalizeCommandExposure(descriptor.commandExposure);
+  const effectProfile = normalizeCommandEffectProfile(descriptor.effectProfile);
+  return {
+    name: descriptor.name,
+    description: descriptor.description,
+    hasSubcommands: descriptor.hasSubcommands,
+    parentDefaultHelp: Boolean(descriptor.parentDefaultHelp),
+    source,
+    sourceKind: source,
+    sourceId: descriptor.name,
+    discoveryMode: "static-descriptor",
+    visibility:
+      commandExposure?.tier === "internal"
+        ? ["audit", "operator", "policy"]
+        : ["docs", "audit", "operator", "policy"],
+    ...(effectProfile ? { effectProfile } : {}),
+    ...(commandExposure?.tier ? { exposureTier: commandExposure.tier } : {}),
+  };
+}
+
+function buildDescriptors(): readonly CliCatalogListDescriptor[] {
+  const core = getCoreCliCommandDescriptors()
+    .filter((descriptor) => descriptor.hidden !== true)
+    .map((descriptor) => mapDescriptor(descriptor, "core"));
+  const subcli = getSubCliEntries()
+    .filter((descriptor) => descriptor.hidden !== true)
+    .map((descriptor) => mapDescriptor(descriptor, "subcli"));
+  return [...core, ...subcli];
+}
+
+function buildCommandRoutes(): readonly CliCatalogListCommandRoute[] {
+  return cliCommandCatalog.map((entry) => {
+    const route: CliCatalogListCommandRoute = {
+      commandPath: entry.commandPath,
+      exact: Boolean(entry.exact),
+      policyKeys: entry.policy ? Object.keys(entry.policy).toSorted() : [],
+      sourceKind: "route-policy",
+      sourceId: entry.commandPath.join(" "),
+      discoveryMode: "route-policy",
+      visibility: ["audit", "operator", "policy"],
+    };
+    if (entry.route) {
+      Object.assign(route, { routeId: entry.route.id });
+    }
+    return route;
+  });
+}
+
+function buildRoutedOperations(
+  routes = buildCommandRoutes(),
+): readonly CliCatalogListRoutedOperation[] {
+  const effectProfiles = new Map(
+    cliCommandCatalog.flatMap((entry) => {
+      const effectProfile = normalizeCommandEffectProfile(entry.route?.effectProfile);
+      return entry.route && effectProfile ? [[entry.route.id, effectProfile] as const] : [];
+    }),
+  );
+  return [...new Set(routes.flatMap((route) => (route.routeId ? [route.routeId] : [])))]
+    .toSorted()
+    .map((id) => {
+      const effectProfile = effectProfiles.get(id);
+      const operation: CliCatalogListRoutedOperation = {
+        id,
+        sourceKind: "route-policy" as const,
+        discoveryMode: "route-policy" as const,
+        visibility: ["audit", "operator", "policy"] as const,
+        commandPaths: routes
+          .filter((route) => route.routeId === id)
+          .map((route) => route.commandPath),
+      };
+      if (effectProfile?.risk) {
+        Object.assign(operation, { risk: effectProfile.risk });
+      }
+      if (effectProfile?.confirmationRequired !== undefined) {
+        Object.assign(operation, {
+          confirmationRequired: effectProfile.confirmationRequired,
+        });
+      }
+      if (effectProfile?.effectMode) {
+        Object.assign(operation, { effectMode: effectProfile.effectMode });
+      }
+      return operation;
+    });
+}
+
+export function buildCatalogList(
+  params: {
+    runtimeCommands?: readonly CliCatalogRuntimeCommand[];
+    pluginCommands?: readonly CliCatalogPluginCommand[];
+    nodeCommands?: readonly CliCatalogNodeCommand[];
+  } = {},
+): CliCatalogList {
+  const descriptors = buildDescriptors();
+  const commandRoutes = buildCommandRoutes();
+  const routedOperations = buildRoutedOperations(commandRoutes);
+  const runtimeCommands = params.runtimeCommands ?? [];
+  const pluginCommands = params.pluginCommands ?? [];
+  const nodeCommands = buildNodeCommandCatalog(params.nodeCommands);
+  return {
+    schemaVersion: 1,
+    generatedFrom: "command-inventory",
+    counts: {
+      commandDescriptors: descriptors.length,
+      commandRoutes: commandRoutes.length,
+      routedOperations: routedOperations.length,
+      runtimeCommands: runtimeCommands.length,
+      pluginCommands: pluginCommands.length,
+      nodeCommands: nodeCommands.length,
+    },
+    collection: {
+      descriptors: "complete",
+      commandRoutes: "complete",
+      runtimeCommands: params.runtimeCommands === undefined ? "not-requested" : "collected",
+      pluginCommands: params.pluginCommands === undefined ? "not-requested" : "collected",
+      nodeCommands: params.nodeCommands === undefined ? "not-requested" : "caller-supplied",
+    },
+    cli: {
+      descriptors,
+      commandRoutes,
+      routedOperations,
+      runtimeCommandScope: RUNTIME_COMMAND_SCOPE,
+      nodeCommandScope: NODE_COMMAND_SCOPE,
+      runtimeCommands,
+      pluginCommands,
+      nodeCommands,
+    },
+  };
+}
+
+export function renderCatalogListMarkdown(
+  params: {
+    runtimeCommands?: readonly CliCatalogRuntimeCommand[];
+    pluginCommands?: readonly CliCatalogPluginCommand[];
+    nodeCommands?: readonly CliCatalogNodeCommand[];
+  } = {},
+): string {
+  const list = buildCatalogList(params);
+  const lines = [
+    "# OpenClaw Commands",
+    "",
+    "Read-only inventory of OpenClaw CLI, routed, runtime, plugin, and node commands.",
+    "",
+    "## Counts",
+    "",
+    `- CLI descriptors: ${list.counts.commandDescriptors}`,
+    `- Command routes: ${list.counts.commandRoutes}`,
+    `- Routed operations: ${list.counts.routedOperations}`,
+    `- Runtime commands: ${list.counts.runtimeCommands}`,
+    `- Runtime command scope: ${list.cli.runtimeCommandScope}`,
+    `- Plugin descriptor commands: ${list.counts.pluginCommands}`,
+    `- Supplied node commands: ${list.counts.nodeCommands}`,
+    `- Node command scope: ${list.cli.nodeCommandScope}`,
+    "",
+    "## Routed operations",
+    "",
+    "| Operation | Risk | Effect mode | Confirmation | Command paths |",
+    "| --- | --- | --- | --- | --- |",
+  ];
+  for (const operation of list.cli.routedOperations) {
+    const paths = operation.commandPaths.map((path) => markdownCodeCell(path.join(" "))).join(", ");
+    lines.push(
+      `| ${markdownCodeCell(operation.id)} | ${markdownCodeCell(operation.risk ?? "unknown")} | ${markdownCodeCell(operation.effectMode ?? "unknown")} | ${operation.confirmationRequired === undefined ? "unknown" : operation.confirmationRequired ? "yes" : "no"} | ${paths || "None"} |`,
+    );
+  }
+  if (list.cli.pluginCommands.length > 0) {
+    lines.push(
+      "",
+      "## Plugin descriptor commands",
+      "",
+      "| Command path | Parent | Depth | Plugin | Description |",
+      "| --- | --- | --- | --- | --- |",
+    );
+    for (const command of list.cli.pluginCommands) {
+      lines.push(
+        `| ${markdownCodeCell(command.commandPath.join(" "))} | ${command.parentPath.length > 0 ? markdownCodeCell(command.parentPath.join(" ")) : "None"} | ${command.depth} | ${markdownCodeCell(command.pluginId)} | ${markdownTableCell(command.description || "None")} |`,
+      );
+    }
+  }
+
+  if (list.cli.runtimeCommands.length > 0) {
+    lines.push(
+      "",
+      "## Runtime registered commands",
+      "",
+      "| Command path | Parent | Depth | Visible subcommands | Description |",
+      "| --- | --- | --- | --- | --- |",
+    );
+    for (const command of list.cli.runtimeCommands) {
+      lines.push(
+        `| ${markdownCodeCell(command.commandPath.join(" "))} | ${command.parentPath.length > 0 ? markdownCodeCell(command.parentPath.join(" ")) : "None"} | ${command.depth} | ${command.visibleSubcommandCount} | ${markdownTableCell(command.description || "None")} |`,
+      );
+    }
+  }
+
+  if (list.cli.nodeCommands.length > 0) {
+    lines.push(
+      "",
+      "## Node/operator commands",
+      "",
+      "| Command | Node | Availability | Approval | Risk | Effect mode | Invocation |",
+      "| --- | --- | --- | --- | --- | --- | --- |",
+    );
+    for (const command of list.cli.nodeCommands) {
+      lines.push(
+        `| ${markdownCodeCell(command.command)} | ${markdownTableCell(command.nodeName ?? command.nodeId ?? "Any")} | ${markdownCodeCell(command.availability ?? "unknown")} | ${markdownCodeCell(command.approvalKind ?? "unknown")} | ${markdownCodeCell(command.risk ?? "unknown")} | ${markdownCodeCell(command.effectMode ?? "unknown")} | ${command.invocationHint ? markdownCodeCell(command.invocationHint) : "None"} |`,
+      );
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}

--- a/src/cli-catalog-overlay/list.ts
+++ b/src/cli-catalog-overlay/list.ts
@@ -5,7 +5,7 @@ import {
 } from "../cli/catalog-metadata.js";
 import { cliCommandCatalog, type CliCommandCatalogEntry } from "../cli/command-catalog.js";
 import { getCoreCliCommandDescriptors } from "../cli/program/core-command-descriptors.js";
-import { getSubCliEntries } from "../cli/program/subcli-descriptors.js";
+import { getSubCliEntriesCore } from "../cli/program/subcli-descriptors.js";
 import { buildNodeCommandCatalog, type CliCatalogNodeCommand } from "./node-commands.js";
 import type { CliCatalogPluginCommand } from "./plugin-commands.js";
 import type { CliCatalogRuntimeCommand } from "./runtime-commands.js";
@@ -125,7 +125,7 @@ function buildDescriptors(): readonly CliCatalogListDescriptor[] {
   const core = getCoreCliCommandDescriptors()
     .filter((descriptor) => descriptor.hidden !== true)
     .map((descriptor) => mapDescriptor(descriptor, "core"));
-  const subcli = getSubCliEntries()
+  const subcli = getSubCliEntriesCore()
     .filter((descriptor) => descriptor.hidden !== true)
     .map((descriptor) => mapDescriptor(descriptor, "subcli"));
   return [...core, ...subcli];
@@ -254,11 +254,35 @@ export function renderCatalogListMarkdown(
     `- Supplied node commands: ${list.counts.nodeCommands}`,
     `- Node command scope: ${list.cli.nodeCommandScope}`,
     "",
+    "## CLI descriptors",
+    "",
+    "| Command | Source | Subcommands | Description |",
+    "| --- | --- | --- | --- |",
+  ];
+  for (const descriptor of list.cli.descriptors) {
+    lines.push(
+      `| ${markdownCodeCell(descriptor.name)} | ${markdownCodeCell(descriptor.source)} | ${descriptor.hasSubcommands ? "yes" : "no"} | ${markdownTableCell(descriptor.description)} |`,
+    );
+  }
+  lines.push(
+    "",
+    "## Command routes",
+    "",
+    "| Command path | Exact | Route | Policy keys |",
+    "| --- | --- | --- | --- |",
+  );
+  for (const route of list.cli.commandRoutes) {
+    lines.push(
+      `| ${markdownCodeCell(route.commandPath.join(" "))} | ${route.exact ? "yes" : "no"} | ${route.routeId ? markdownCodeCell(route.routeId) : "None"} | ${route.policyKeys.length > 0 ? route.policyKeys.map(markdownCodeCell).join(", ") : "None"} |`,
+    );
+  }
+  lines.push(
+    "",
     "## Routed operations",
     "",
     "| Operation | Risk | Effect mode | Confirmation | Command paths |",
     "| --- | --- | --- | --- | --- |",
-  ];
+  );
   for (const operation of list.cli.routedOperations) {
     const paths = operation.commandPaths.map((path) => markdownCodeCell(path.join(" "))).join(", ");
     lines.push(

--- a/src/cli-catalog-overlay/node-commands.ts
+++ b/src/cli-catalog-overlay/node-commands.ts
@@ -1,0 +1,63 @@
+import type {
+  CliCatalogEffectMode,
+  CliCatalogRisk,
+  CliCatalogVisibility,
+} from "../cli/catalog-metadata.js";
+
+type CliCatalogNodeCommandSourceKind = "node-pairing" | "node-host-command" | "node-runtime";
+
+type CliCatalogNodeCommandDiscoveryMode =
+  | "paired-node-declaration"
+  | "node-host-registry"
+  | "runtime-node-query";
+
+type CliCatalogNodeCommandAvailability =
+  | "approved"
+  | "pending-approval"
+  | "available"
+  | "unavailable";
+
+type CliCatalogNodeCommandApprovalKind =
+  | "pairing"
+  | "gateway-allowlist"
+  | "operator-confirmation"
+  | "none";
+
+export type CliCatalogNodeCommand = {
+  readonly id: string;
+  readonly command: string;
+  readonly title: string;
+  readonly nodeId?: string;
+  readonly nodeName?: string;
+  readonly cap?: string;
+  readonly description?: string;
+  readonly argumentHints: readonly string[];
+  readonly invocationHint?: string;
+  readonly availability?: CliCatalogNodeCommandAvailability;
+  readonly approvalKind?: CliCatalogNodeCommandApprovalKind;
+  readonly risk?: CliCatalogRisk;
+  readonly confirmationRequired?: boolean;
+  readonly effectMode?: CliCatalogEffectMode;
+  readonly effects: readonly string[];
+  readonly trustBoundary: "local-node-host" | "paired-node" | "remote-node";
+  readonly sourceKind: CliCatalogNodeCommandSourceKind;
+  readonly sourceId: string;
+  readonly discoveryMode: CliCatalogNodeCommandDiscoveryMode;
+  readonly visibility: readonly CliCatalogVisibility[];
+};
+
+const DEFAULT_NODE_COMMAND_VISIBILITY: readonly CliCatalogVisibility[] = ["audit", "operator"];
+
+export function buildNodeCommandCatalog(
+  commands: readonly CliCatalogNodeCommand[] = [],
+): readonly CliCatalogNodeCommand[] {
+  return commands
+    .filter((command) => command.id.trim() && command.command.trim())
+    .map((command) =>
+      Object.assign({}, command, {
+        visibility:
+          command.visibility.length > 0 ? command.visibility : DEFAULT_NODE_COMMAND_VISIBILITY,
+      }),
+    )
+    .toSorted((left, right) => left.id.localeCompare(right.id));
+}

--- a/src/cli-catalog-overlay/plugin-commands.test.ts
+++ b/src/cli-catalog-overlay/plugin-commands.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { buildCatalogList, renderCatalogListMarkdown } from "./list.js";
+import { buildPluginCatalogCommands } from "./plugin-commands.js";
+
+describe("plugin command catalog", () => {
+  it("projects plugin CLI descriptors into source-labeled catalog entries", () => {
+    const pluginCommands = buildPluginCatalogCommands([
+      {
+        pluginId: "example-plugin",
+        parentPath: ["nodes"],
+        commands: ["camera"],
+        descriptors: [
+          { name: "camera", description: "Camera controls", hasSubcommands: true },
+          {
+            name: "status",
+            description: "Internal camera status",
+            hasSubcommands: false,
+          },
+        ],
+      },
+    ]);
+
+    expect(pluginCommands).toEqual([
+      expect.objectContaining({
+        pluginId: "example-plugin",
+        commandPath: ["nodes", "camera"],
+        parentPath: ["nodes"],
+        depth: 2,
+        descriptorName: "camera",
+        sourceKind: "plugin",
+        sourceId: "example-plugin:nodes camera",
+        discoveryMode: "plugin-descriptor",
+      }),
+      expect.objectContaining({
+        sourceId: "example-plugin:nodes status",
+      }),
+    ]);
+    expect(pluginCommands[0]).not.toHaveProperty("risk");
+    expect(pluginCommands[0]).not.toHaveProperty("effectMode");
+    expect(pluginCommands[0]).not.toHaveProperty("confirmationRequired");
+    expect(buildCatalogList({ pluginCommands }).counts.pluginCommands).toBe(2);
+  });
+
+  it("omits plugin CLI command registrations without descriptors", () => {
+    const pluginCommands = buildPluginCatalogCommands([
+      {
+        pluginId: "voice-plugin",
+        parentPath: [],
+        commands: ["voicecall"],
+        descriptors: [],
+      },
+    ]);
+
+    expect(pluginCommands).toEqual([]);
+    expect(buildCatalogList({ pluginCommands }).counts.pluginCommands).toBe(0);
+  });
+
+  it("keeps plugin descriptions inside their Markdown table cells", () => {
+    const pluginCommands = buildPluginCatalogCommands([
+      {
+        pluginId: "example-plugin",
+        parentPath: [],
+        commands: ["camera"],
+        descriptors: [
+          {
+            name: "camera",
+            description: "Camera | controls\nfor operators",
+            hasSubcommands: true,
+          },
+        ],
+      },
+    ]);
+
+    expect(renderCatalogListMarkdown({ pluginCommands })).toContain(
+      "| `camera` | None | 1 | `example-plugin` | Camera \\| controls for operators |",
+    );
+  });
+});

--- a/src/cli-catalog-overlay/plugin-commands.test.ts
+++ b/src/cli-catalog-overlay/plugin-commands.test.ts
@@ -55,6 +55,32 @@ describe("plugin command catalog", () => {
     expect(buildCatalogList({ pluginCommands }).counts.pluginCommands).toBe(0);
   });
 
+  it("omits plugin descriptors under reserved core command roots", () => {
+    const pluginCommands = buildPluginCatalogCommands([
+      {
+        pluginId: "tools-plugin",
+        parentPath: ["tools"],
+        commands: ["sync"],
+        descriptors: [{ name: "sync", description: "Sync tools", hasSubcommands: false }],
+      },
+      {
+        pluginId: "auth-plugin",
+        parentPath: [],
+        commands: ["auth"],
+        descriptors: [{ name: "auth", description: "Auth replacement", hasSubcommands: false }],
+      },
+      {
+        pluginId: "node-plugin",
+        parentPath: ["nodes"],
+        commands: ["camera"],
+        descriptors: [{ name: "camera", description: "Camera controls", hasSubcommands: false }],
+      },
+    ]);
+
+    expect(pluginCommands.map((command) => command.commandPath)).toEqual([["nodes", "camera"]]);
+    expect(buildCatalogList({ pluginCommands }).counts.pluginCommands).toBe(1);
+  });
+
   it("keeps plugin descriptions inside their Markdown table cells", () => {
     const pluginCommands = buildPluginCatalogCommands([
       {

--- a/src/cli-catalog-overlay/plugin-commands.ts
+++ b/src/cli-catalog-overlay/plugin-commands.ts
@@ -1,3 +1,4 @@
+import { isReservedNonPluginCommandRoot } from "../cli/command-registration-policy.js";
 import type { PluginCliDescriptorEntry } from "../plugins/cli-registry-loader.js";
 
 export type CliCatalogPluginCommand = {
@@ -19,22 +20,27 @@ export function buildPluginCatalogCommands(
   entries: readonly PluginCliDescriptorEntry[],
 ): readonly CliCatalogPluginCommand[] {
   return entries.flatMap((entry) => {
-    return entry.descriptors.map((descriptor) => {
+    return entry.descriptors.flatMap((descriptor): CliCatalogPluginCommand[] => {
       const commandPath = [...entry.parentPath, descriptor.name];
-      return {
-        pluginId: entry.pluginId,
-        commandPath,
-        parentPath: entry.parentPath,
-        depth: commandPath.length,
-        name: descriptor.name,
-        descriptorName: descriptor.name,
-        description: descriptor.description,
-        hasSubcommands: descriptor.hasSubcommands,
-        commandHints: [commandPath.join(" ")],
-        sourceKind: "plugin" as const,
-        sourceId: `${entry.pluginId}:${commandPath.join(" ")}`,
-        discoveryMode: "plugin-descriptor" as const,
-      };
+      if (isReservedNonPluginCommandRoot(commandPath[0])) {
+        return [];
+      }
+      return [
+        {
+          pluginId: entry.pluginId,
+          commandPath,
+          parentPath: entry.parentPath,
+          depth: commandPath.length,
+          name: descriptor.name,
+          descriptorName: descriptor.name,
+          description: descriptor.description,
+          hasSubcommands: descriptor.hasSubcommands,
+          commandHints: [commandPath.join(" ")],
+          sourceKind: "plugin" as const,
+          sourceId: `${entry.pluginId}:${commandPath.join(" ")}`,
+          discoveryMode: "plugin-descriptor" as const,
+        },
+      ];
     });
   });
 }

--- a/src/cli-catalog-overlay/plugin-commands.ts
+++ b/src/cli-catalog-overlay/plugin-commands.ts
@@ -1,0 +1,40 @@
+import type { PluginCliDescriptorEntry } from "../plugins/cli-registry-loader.js";
+
+export type CliCatalogPluginCommand = {
+  readonly pluginId: string;
+  readonly commandPath: readonly string[];
+  readonly parentPath: readonly string[];
+  readonly depth: number;
+  readonly name: string;
+  readonly descriptorName: string;
+  readonly description: string;
+  readonly hasSubcommands: boolean;
+  readonly commandHints: readonly string[];
+  readonly sourceKind: "plugin";
+  readonly sourceId: string;
+  readonly discoveryMode: "plugin-descriptor";
+};
+
+export function buildPluginCatalogCommands(
+  entries: readonly PluginCliDescriptorEntry[],
+): readonly CliCatalogPluginCommand[] {
+  return entries.flatMap((entry) => {
+    return entry.descriptors.map((descriptor) => {
+      const commandPath = [...entry.parentPath, descriptor.name];
+      return {
+        pluginId: entry.pluginId,
+        commandPath,
+        parentPath: entry.parentPath,
+        depth: commandPath.length,
+        name: descriptor.name,
+        descriptorName: descriptor.name,
+        description: descriptor.description,
+        hasSubcommands: descriptor.hasSubcommands,
+        commandHints: [commandPath.join(" ")],
+        sourceKind: "plugin" as const,
+        sourceId: `${entry.pluginId}:${commandPath.join(" ")}`,
+        discoveryMode: "plugin-descriptor" as const,
+      };
+    });
+  });
+}

--- a/src/cli-catalog-overlay/runtime-commands.test.ts
+++ b/src/cli-catalog-overlay/runtime-commands.test.ts
@@ -1,0 +1,63 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { buildCatalogList, renderCatalogListMarkdown } from "./list.js";
+import { collectRuntimeCommandTree } from "./runtime-commands.js";
+
+describe("runtime command catalog", () => {
+  it("enumerates the currently registered Commander tree", () => {
+    const program = new Command();
+    program.command("alpha").description("Alpha command").alias("a");
+    program
+      .command("beta")
+      .description("Beta command")
+      .command("child")
+      .description("Nested child");
+    program
+      .command("secret", { hidden: true })
+      .description("Hidden command")
+      .command("child")
+      .description("Hidden child");
+
+    const runtimeCommands = collectRuntimeCommandTree(program);
+
+    expect(runtimeCommands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          commandPath: ["alpha"],
+          parentPath: [],
+          depth: 1,
+          aliases: ["a"],
+          visibleSubcommandCount: 0,
+          hidden: false,
+          discoveryMode: "runtime-registered",
+          sourceKind: "runtime",
+        }),
+        expect.objectContaining({
+          commandPath: ["beta"],
+          hasSubcommands: true,
+          visibleSubcommandCount: 1,
+        }),
+        expect.objectContaining({ commandPath: ["beta", "child"], parentPath: ["beta"], depth: 2 }),
+      ]),
+    );
+    expect(runtimeCommands.map((command) => command.commandPath)).not.toContainEqual(["secret"]);
+    expect(runtimeCommands.map((command) => command.commandPath)).not.toContainEqual([
+      "secret",
+      "child",
+    ]);
+    expect(
+      runtimeCommands.find((command) => command.commandPath[0] === "secret-visible-parent"),
+    ).toBeUndefined();
+    expect(buildCatalogList({ runtimeCommands }).counts.runtimeCommands).toBe(3);
+  });
+
+  it("keeps runtime descriptions inside their Markdown table cells", () => {
+    const program = new Command();
+    program.command("alpha").description("Alpha | command\nfor operators");
+    const runtimeCommands = collectRuntimeCommandTree(program);
+
+    expect(renderCatalogListMarkdown({ runtimeCommands })).toContain(
+      "| `alpha` | None | 1 | 0 | Alpha \\| command for operators |",
+    );
+  });
+});

--- a/src/cli-catalog-overlay/runtime-commands.ts
+++ b/src/cli-catalog-overlay/runtime-commands.ts
@@ -1,0 +1,62 @@
+import type { Command } from "commander";
+import type { CliCatalogVisibility } from "../cli/catalog-metadata.js";
+
+export type CliCatalogRuntimeCommand = {
+  readonly commandPath: readonly string[];
+  readonly parentPath: readonly string[];
+  readonly depth: number;
+  readonly name: string;
+  readonly aliases: readonly string[];
+  readonly description: string;
+  readonly hasSubcommands: boolean;
+  readonly visibleSubcommandCount: number;
+  readonly hidden: false;
+  readonly sourceKind: "runtime";
+  readonly sourceId: string;
+  readonly discoveryMode: "runtime-registered";
+  readonly visibility: readonly CliCatalogVisibility[];
+};
+
+function commandDescription(command: Command): string {
+  return command.description().trim();
+}
+
+function isHiddenCommand(command: Command): boolean {
+  return Reflect.get(command, "_hidden") === true;
+}
+
+function visibleChildren(command: Command): readonly Command[] {
+  return command.commands.filter((child) => !isHiddenCommand(child));
+}
+
+function collectChildren(
+  command: Command,
+  parentPath: readonly string[],
+): CliCatalogRuntimeCommand[] {
+  const result: CliCatalogRuntimeCommand[] = [];
+  for (const child of visibleChildren(command)) {
+    const commandPath = [...parentPath, child.name()];
+    const childCommands = visibleChildren(child);
+    const entry: CliCatalogRuntimeCommand = {
+      commandPath,
+      parentPath,
+      depth: commandPath.length,
+      name: child.name(),
+      aliases: child.aliases(),
+      description: commandDescription(child),
+      hasSubcommands: childCommands.length > 0,
+      visibleSubcommandCount: childCommands.length,
+      hidden: false,
+      sourceKind: "runtime",
+      sourceId: commandPath.join(" "),
+      discoveryMode: "runtime-registered",
+      visibility: ["audit", "operator", "policy"],
+    };
+    result.push(entry, ...collectChildren(child, commandPath));
+  }
+  return result;
+}
+
+export function collectRuntimeCommandTree(program: Command): readonly CliCatalogRuntimeCommand[] {
+  return collectChildren(program, []);
+}

--- a/src/cli/catalog-cli.test.ts
+++ b/src/cli/catalog-cli.test.ts
@@ -1,0 +1,219 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loggingState } from "../logging/state.js";
+import { registerCommandsCli } from "./catalog-cli.js";
+
+const loadPluginCliDescriptorEntriesMock = vi.hoisted(() =>
+  vi.fn<typeof import("../plugins/cli-registry-loader.js").loadPluginCliDescriptorEntries>(
+    async () => [],
+  ),
+);
+
+vi.mock("../plugins/cli-registry-loader.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../plugins/cli-registry-loader.js")>();
+  return {
+    ...original,
+    loadPluginCliDescriptorEntries: loadPluginCliDescriptorEntriesMock,
+  };
+});
+
+function createProgram(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: (text) => process.stdout.write(text),
+    writeErr: (text) => process.stderr.write(text),
+  });
+  registerCommandsCli(program.command("tools"));
+  return program;
+}
+
+async function captureStdout(run: () => Promise<void> | void): Promise<string> {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    await run();
+    return chunks.join("");
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+describe("tools commands cli", () => {
+  afterEach(() => {
+    loadPluginCliDescriptorEntriesMock.mockReset();
+    loadPluginCliDescriptorEntriesMock.mockResolvedValue([]);
+    loggingState.forceConsoleToStderr = false;
+    loggingState.earlyConsoleRoutingRestore = null;
+  });
+
+  it("prints parent help for a bare tools commands invocation", async () => {
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync(["node", "openclaw", "tools", "commands"]);
+    });
+
+    expect(output).toContain("list");
+    expect(output).toContain("inspect");
+    expect(output).not.toContain("audit");
+  });
+
+  it("prints command inventory JSON", async () => {
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync(["node", "openclaw", "tools", "commands", "list", "--json"]);
+    });
+    const parsed = JSON.parse(output) as {
+      counts: { commandDescriptors: number; routedOperations: number; runtimeCommands: number };
+    };
+
+    expect(parsed.counts.commandDescriptors).toBeGreaterThan(50);
+    expect(parsed.counts.routedOperations).toBeGreaterThan(10);
+    expect(parsed.counts.runtimeCommands).toBeGreaterThan(0);
+  });
+
+  it("inspects an exact nested command path", async () => {
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "inspect",
+        "gateway",
+        "status",
+        "--json",
+      ]);
+    });
+    const parsed = JSON.parse(output) as {
+      found: boolean;
+      commandPath: string[];
+      routes: unknown[];
+    };
+
+    expect(parsed.found).toBe(true);
+    expect(parsed.commandPath).toEqual(["gateway", "status"]);
+    expect(parsed.routes).toHaveLength(2);
+  });
+
+  it("loads a lazy sub-CLI before inspecting a nested command", async () => {
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "inspect",
+        "models",
+        "aliases",
+        "list",
+        "--json",
+      ]);
+    });
+    const parsed = JSON.parse(output) as { found: boolean; runtimeCommands: unknown[] };
+
+    expect(parsed.found).toBe(true);
+    expect(parsed.runtimeCommands).toHaveLength(1);
+  });
+
+  it("loads a lazy core command group before inspection", async () => {
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "inspect",
+        "message",
+        "send",
+        "--json",
+      ]);
+    });
+    const parsed = JSON.parse(output) as { found: boolean; runtimeCommands: unknown[] };
+
+    expect(parsed.found).toBe(true);
+    expect(parsed.runtimeCommands).toHaveLength(1);
+  });
+
+  it("loads plugin descriptors only when requested and keeps JSON clean", async () => {
+    const forceStderrSnapshots: boolean[] = [];
+    loadPluginCliDescriptorEntriesMock.mockImplementationOnce(async () => {
+      forceStderrSnapshots.push(loggingState.forceConsoleToStderr);
+      return [
+        {
+          pluginId: "example-plugin",
+          parentPath: [],
+          commands: ["example"],
+          descriptors: [
+            { name: "example", description: "Example plugin command", hasSubcommands: false },
+          ],
+        },
+      ];
+    });
+
+    const output = await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "inspect",
+        "example",
+        "--json",
+        "--plugin-descriptors",
+      ]);
+    });
+
+    expect(forceStderrSnapshots).toEqual([true]);
+    expect(JSON.parse(output).pluginCommands).toHaveLength(1);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
+  it("routes plugin logs away from Markdown output", async () => {
+    const forceStderrSnapshots: boolean[] = [];
+    loadPluginCliDescriptorEntriesMock.mockImplementationOnce(async () => {
+      forceStderrSnapshots.push(loggingState.forceConsoleToStderr);
+      return [];
+    });
+
+    await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "list",
+        "--markdown",
+        "--plugin-descriptors",
+      ]);
+    });
+
+    expect(forceStderrSnapshots).toEqual([true]);
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+
+  it("fails instead of emitting an incomplete inventory when plugin loading fails", async () => {
+    loadPluginCliDescriptorEntriesMock.mockRejectedValueOnce(
+      new Error("Failed to load plugin CLI descriptor metadata: example-plugin: register failed"),
+    );
+
+    const output = await captureStdout(async () => {
+      await expect(
+        createProgram().parseAsync([
+          "node",
+          "openclaw",
+          "tools",
+          "commands",
+          "list",
+          "--json",
+          "--plugin-descriptors",
+        ]),
+      ).rejects.toThrow("Failed to load plugin CLI descriptor metadata");
+    });
+
+    expect(output).toBe("");
+    expect(loggingState.forceConsoleToStderr).toBe(false);
+  });
+});

--- a/src/cli/catalog-cli.test.ts
+++ b/src/cli/catalog-cli.test.ts
@@ -8,6 +8,7 @@ const loadPluginCliDescriptorEntriesMock = vi.hoisted(() =>
     async () => [],
   ),
 );
+const registerPluginCliCommandsFromValidatedConfigMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../plugins/cli-registry-loader.js", async (importOriginal) => {
   const original = await importOriginal<typeof import("../plugins/cli-registry-loader.js")>();
@@ -16,6 +17,10 @@ vi.mock("../plugins/cli-registry-loader.js", async (importOriginal) => {
     loadPluginCliDescriptorEntries: loadPluginCliDescriptorEntriesMock,
   };
 });
+
+vi.mock("../plugins/cli.js", () => ({
+  registerPluginCliCommandsFromValidatedConfig: registerPluginCliCommandsFromValidatedConfigMock,
+}));
 
 function createProgram(): Command {
   const program = new Command();
@@ -47,6 +52,7 @@ describe("tools commands cli", () => {
   afterEach(() => {
     loadPluginCliDescriptorEntriesMock.mockReset();
     loadPluginCliDescriptorEntriesMock.mockResolvedValue([]);
+    registerPluginCliCommandsFromValidatedConfigMock.mockReset();
     loggingState.forceConsoleToStderr = false;
     loggingState.earlyConsoleRoutingRestore = null;
   });
@@ -112,10 +118,30 @@ describe("tools commands cli", () => {
         "--json",
       ]);
     });
+
     const parsed = JSON.parse(output) as { found: boolean; runtimeCommands: unknown[] };
 
     expect(parsed.found).toBe(true);
     expect(parsed.runtimeCommands).toHaveLength(1);
+  });
+
+  it.each([
+    ["bare nodes", ["nodes"]],
+    ["plugin-owned node path", ["nodes", "canvas"]],
+  ])("inspects %s without activating plugin registrars", async (_label, commandPath) => {
+    await captureStdout(async () => {
+      await createProgram().parseAsync([
+        "node",
+        "openclaw",
+        "tools",
+        "commands",
+        "inspect",
+        ...commandPath,
+        "--json",
+      ]);
+    });
+
+    expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
   });
 
   it("loads a lazy core command group before inspection", async () => {

--- a/src/cli/catalog-cli.ts
+++ b/src/cli/catalog-cli.ts
@@ -1,0 +1,111 @@
+import type { Command } from "commander";
+import { inspectCommand, renderCommandInspectionMarkdown } from "../cli-catalog-overlay/inspect.js";
+import { buildCatalogList, renderCatalogListMarkdown } from "../cli-catalog-overlay/list.js";
+import { buildPluginCatalogCommands } from "../cli-catalog-overlay/plugin-commands.js";
+import { collectRuntimeCommandTree } from "../cli-catalog-overlay/runtime-commands.js";
+import { loadPluginCliDescriptorEntries } from "../plugins/cli-registry-loader.js";
+import { withConsoleLogsRoutedToStderrForJson } from "./json-output-mode.js";
+import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
+
+async function loadPluginCommands() {
+  const entries = await withConsoleLogsRoutedToStderrForJson(
+    ["--json"],
+    async () => await loadPluginCliDescriptorEntries({}),
+  );
+  return buildPluginCatalogCommands(entries);
+}
+
+function validateOutputOptions(
+  opts: { json?: boolean; markdown?: boolean },
+  command: Command,
+): void {
+  if (opts.json && opts.markdown) {
+    command.error("error: --json and --markdown cannot be combined");
+  }
+}
+
+async function loadInspectedCommandGroup(
+  program: Command,
+  commandPath: readonly string[],
+): Promise<void> {
+  const root = commandPath[0];
+  if (!root || root === "tools") {
+    return;
+  }
+  const argv = ["node", "openclaw", ...commandPath];
+  const [{ registerCoreCliByName }, { createProgramContext }, { registerSubCliByName }] =
+    await Promise.all([
+      import("./program/command-registry-core.js"),
+      import("./program/context.js"),
+      import("./program/register.subclis.js"),
+    ]);
+  if (await registerCoreCliByName(program, createProgramContext(), root, argv)) {
+    return;
+  }
+  await registerSubCliByName(program, root, argv);
+}
+
+export function registerCommandsCli(program: Command): void {
+  const inventoryRoot = program.parent ?? program;
+  const commands = program.command("commands").description("List and inspect OpenClaw commands");
+
+  commands
+    .command("list")
+    .description("List CLI, routed, runtime, and opt-in plugin commands")
+    .option("--json", "Output JSON", false)
+    .option("--markdown", "Output Markdown", false)
+    .option("--plugin-descriptors", "Include plugin CLI descriptors", false)
+    .action(
+      async (
+        opts: { json?: boolean; markdown?: boolean; pluginDescriptors?: boolean },
+        command: Command,
+      ) => {
+        validateOutputOptions(opts, command);
+        const runtimeCommands = collectRuntimeCommandTree(inventoryRoot);
+        const pluginCommands = opts.pluginDescriptors ? await loadPluginCommands() : undefined;
+        if (opts.json) {
+          process.stdout.write(
+            `${JSON.stringify(buildCatalogList({ runtimeCommands, ...(pluginCommands ? { pluginCommands } : {}) }), null, 2)}\n`,
+          );
+          return;
+        }
+        process.stdout.write(
+          `${renderCatalogListMarkdown({ runtimeCommands, ...(pluginCommands ? { pluginCommands } : {}) })}\n`,
+        );
+      },
+    );
+
+  commands
+    .command("inspect")
+    .description("Inspect one exact command path")
+    .argument("<command-path...>", "Command path to inspect")
+    .option("--json", "Output JSON", false)
+    .option("--markdown", "Output Markdown", false)
+    .option("--plugin-descriptors", "Include plugin CLI descriptors", false)
+    .action(
+      async (
+        commandPath: string[],
+        opts: { json?: boolean; markdown?: boolean; pluginDescriptors?: boolean },
+        command: Command,
+      ) => {
+        validateOutputOptions(opts, command);
+        await loadInspectedCommandGroup(inventoryRoot, commandPath);
+        const runtimeCommands = collectRuntimeCommandTree(inventoryRoot);
+        const pluginCommands = opts.pluginDescriptors ? await loadPluginCommands() : undefined;
+        const inspection = inspectCommand(
+          buildCatalogList({
+            runtimeCommands,
+            ...(pluginCommands ? { pluginCommands } : {}),
+          }),
+          commandPath,
+        );
+        if (opts.json) {
+          process.stdout.write(`${JSON.stringify(inspection, null, 2)}\n`);
+          return;
+        }
+        process.stdout.write(`${renderCommandInspectionMarkdown(inspection)}\n`);
+      },
+    );
+
+  applyParentDefaultHelpAction(commands);
+}

--- a/src/cli/catalog-cli.ts
+++ b/src/cli/catalog-cli.ts
@@ -39,7 +39,7 @@ async function loadInspectedCommandGroup(
       import("./program/context.js"),
       import("./program/register.subclis.js"),
     ]);
-  if (await registerCoreCliByName(program, createProgramContext(), root, argv)) {
+  if (await registerCoreCliByName(program, createProgramContext(), root)) {
     return;
   }
   await registerSubCliByName(program, root, argv, { purpose: "inspection" });

--- a/src/cli/catalog-cli.ts
+++ b/src/cli/catalog-cli.ts
@@ -42,7 +42,7 @@ async function loadInspectedCommandGroup(
   if (await registerCoreCliByName(program, createProgramContext(), root, argv)) {
     return;
   }
-  await registerSubCliByName(program, root, argv);
+  await registerSubCliByName(program, root, argv, { purpose: "inspection" });
 }
 
 export function registerCommandsCli(program: Command): void {

--- a/src/cli/catalog-metadata.test.ts
+++ b/src/cli/catalog-metadata.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCommandEffectProfile, normalizeCommandExposure } from "./catalog-metadata.js";
+
+describe("catalog metadata normalization", () => {
+  it("preserves valid source-owned metadata", () => {
+    expect(
+      normalizeCommandEffectProfile({
+        effectMode: "mutating",
+        risk: "medium",
+        confirmationRequired: true,
+      }),
+    ).toEqual({
+      effectMode: "mutating",
+      risk: "medium",
+      confirmationRequired: true,
+    });
+    expect(normalizeCommandExposure({ tier: "internal" })).toEqual({ tier: "internal" });
+  });
+
+  it("drops malformed or expanded metadata shapes", () => {
+    expect(normalizeCommandEffectProfile({ effectMode: "write" })).toBeUndefined();
+    expect(
+      normalizeCommandEffectProfile({ effectMode: "read", commandHints: ["not source-owned"] }),
+    ).toBeUndefined();
+    expect(normalizeCommandExposure({ tier: "private" })).toBeUndefined();
+  });
+});

--- a/src/cli/catalog-metadata.ts
+++ b/src/cli/catalog-metadata.ts
@@ -1,0 +1,62 @@
+export type CliCatalogRisk = "low" | "medium" | "high";
+export type CliCatalogEffectMode = "read" | "mutating" | "mixed";
+export type CliCatalogVisibility = "docs" | "audit" | "operator" | "policy";
+type CliCommandExposureTier = "public" | "internal";
+
+export type CommandEffectProfile = {
+  readonly effectMode: CliCatalogEffectMode;
+  readonly confirmationRequired?: boolean;
+  readonly risk?: CliCatalogRisk;
+};
+
+export type CommandExposure = {
+  readonly tier?: CliCommandExposureTier;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function normalizeCommandEffectProfile(value: unknown): CommandEffectProfile | undefined {
+  const record = asRecord(value);
+  if (
+    !record ||
+    Object.keys(record).some(
+      (key) => key !== "effectMode" && key !== "confirmationRequired" && key !== "risk",
+    ) ||
+    (record.effectMode !== "read" &&
+      record.effectMode !== "mutating" &&
+      record.effectMode !== "mixed") ||
+    (record.confirmationRequired !== undefined &&
+      typeof record.confirmationRequired !== "boolean") ||
+    (record.risk !== undefined &&
+      record.risk !== "low" &&
+      record.risk !== "medium" &&
+      record.risk !== "high")
+  ) {
+    return undefined;
+  }
+  return {
+    effectMode: record.effectMode,
+    ...(typeof record.confirmationRequired === "boolean"
+      ? { confirmationRequired: record.confirmationRequired }
+      : {}),
+    ...(record.risk === "low" || record.risk === "medium" || record.risk === "high"
+      ? { risk: record.risk }
+      : {}),
+  };
+}
+
+export function normalizeCommandExposure(value: unknown): CommandExposure | undefined {
+  const record = asRecord(value);
+  if (
+    !record ||
+    Object.keys(record).some((key) => key !== "tier") ||
+    (record.tier !== undefined && record.tier !== "public" && record.tier !== "internal")
+  ) {
+    return undefined;
+  }
+  return record.tier === "public" || record.tier === "internal" ? { tier: record.tier } : {};
+}

--- a/src/cli/catalog-metadata.ts
+++ b/src/cli/catalog-metadata.ts
@@ -1,3 +1,5 @@
+import { isRecord } from "@openclaw/normalization-core";
+
 export type CliCatalogRisk = "low" | "medium" | "high";
 export type CliCatalogEffectMode = "read" | "mutating" | "mixed";
 export type CliCatalogVisibility = "docs" | "audit" | "operator" | "policy";
@@ -13,14 +15,14 @@ export type CommandExposure = {
   readonly tier?: CliCommandExposureTier;
 };
 
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
-}
+export const CONFIG_UNSET_EFFECT_PROFILE = {
+  effectMode: "mutating",
+  confirmationRequired: false,
+  risk: "medium",
+} satisfies CommandEffectProfile;
 
 export function normalizeCommandEffectProfile(value: unknown): CommandEffectProfile | undefined {
-  const record = asRecord(value);
+  const record = isRecord(value) ? value : undefined;
   if (
     !record ||
     Object.keys(record).some(
@@ -50,7 +52,7 @@ export function normalizeCommandEffectProfile(value: unknown): CommandEffectProf
 }
 
 export function normalizeCommandExposure(value: unknown): CommandExposure | undefined {
-  const record = asRecord(value);
+  const record = isRecord(value) ? value : undefined;
   if (
     !record ||
     Object.keys(record).some((key) => key !== "tier") ||

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -1,5 +1,6 @@
 // Declarative CLI command catalog for startup policy and fast-path routing.
 import { getCommandPositionalsWithRootOptions, hasFlag } from "./argv.js";
+import type { CommandEffectProfile } from "./catalog-metadata.js";
 
 export type CliCommandPluginLoadPolicy =
   | "never"
@@ -52,6 +53,7 @@ export type CliCommandCatalogEntry = {
   route?: {
     id: CliRoutedCommandId;
     preloadPlugins?: boolean;
+    effectProfile?: CommandEffectProfile;
   };
 };
 
@@ -296,7 +298,14 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     commandPath: ["config", "unset"],
     exact: true,
     policy: { configGuard: "run", ensureCliPath: false, networkProxy: "bypass" },
-    route: { id: "config-unset" },
+    route: {
+      id: "config-unset",
+      effectProfile: {
+        risk: "medium",
+        confirmationRequired: true,
+        effectMode: "mutating",
+      },
+    },
   },
   {
     commandPath: ["models", "list"],
@@ -314,6 +323,15 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
       networkProxy: ({ argv }) => (hasFlag(argv, "--probe") ? "default" : "bypass"),
     },
     route: { id: "models-status" },
+  },
+  {
+    commandPath: ["tools", "commands"],
+    policy: {
+      configGuard: "skip",
+      ensureCliPath: false,
+      loadPlugins: "never",
+      networkProxy: "bypass",
+    },
   },
   {
     commandPath: ["tasks", "list"],
@@ -354,8 +372,6 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },
   {
-    // This unregistered root is reserved so plugin registration cannot claim it;
-    // the catalog entry preserves its startup policy.
     commandPath: ["tools"],
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -1,6 +1,6 @@
 // Declarative CLI command catalog for startup policy and fast-path routing.
 import { hasFlag } from "./argv.js";
-import type { CommandEffectProfile } from "./catalog-metadata.js";
+import { CONFIG_UNSET_EFFECT_PROFILE, type CommandEffectProfile } from "./catalog-metadata.js";
 
 export type CliCommandPluginLoadPolicy =
   | "never"
@@ -334,14 +334,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     commandPath: ["config", "unset"],
     exact: true,
     policy: { configGuard: "run", ensureCliPath: false, networkProxy: "bypass" },
-    route: {
-      id: "config-unset",
-      effectProfile: {
-        risk: "medium",
-        confirmationRequired: false,
-        effectMode: "mutating",
-      },
-    },
+    route: { id: "config-unset", effectProfile: CONFIG_UNSET_EFFECT_PROFILE },
   },
   {
     commandPath: ["models"],
@@ -376,15 +369,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     },
     route: { id: "models-status" },
   },
-  {
-    commandPath: ["tools", "commands"],
-    policy: {
-      configGuard: "skip",
-      ensureCliPath: false,
-      loadPlugins: "never",
-      networkProxy: "bypass",
-    },
-  },
+  { commandPath: ["tools", "commands"], policy: PASSIVE_STARTUP_POLICY },
   {
     commandPath: ["tasks", "list"],
     exact: true,

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -1,5 +1,5 @@
 // Declarative CLI command catalog for startup policy and fast-path routing.
-import { getCommandPositionalsWithRootOptions, hasFlag } from "./argv.js";
+import { hasFlag } from "./argv.js";
 import type { CommandEffectProfile } from "./catalog-metadata.js";
 
 export type CliCommandPluginLoadPolicy =
@@ -338,7 +338,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
       id: "config-unset",
       effectProfile: {
         risk: "medium",
-        confirmationRequired: true,
+        confirmationRequired: false,
         effectMode: "mutating",
       },
     },

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -1,5 +1,6 @@
 // Declarative CLI command catalog for startup policy and fast-path routing.
-import { hasFlag } from "./argv.js";
+import { getCommandPositionalsWithRootOptions, hasFlag } from "./argv.js";
+import type { CommandEffectProfile } from "./catalog-metadata.js";
 
 export type CliCommandPluginLoadPolicy =
   | "never"
@@ -57,6 +58,8 @@ export type CliCommandCatalogEntry = {
   policy?: Partial<CliCommandPathPolicy>;
   route?: {
     id: CliRoutedCommandId;
+    preloadPlugins?: boolean;
+    effectProfile?: CommandEffectProfile;
   };
 };
 
@@ -331,7 +334,14 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     commandPath: ["config", "unset"],
     exact: true,
     policy: { configGuard: "run", ensureCliPath: false, networkProxy: "bypass" },
-    route: { id: "config-unset" },
+    route: {
+      id: "config-unset",
+      effectProfile: {
+        risk: "medium",
+        confirmationRequired: true,
+        effectMode: "mutating",
+      },
+    },
   },
   {
     commandPath: ["models"],
@@ -365,6 +375,15 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
       networkProxy: ({ argv }) => (hasFlag(argv, "--probe") ? "default" : "bypass"),
     },
     route: { id: "models-status" },
+  },
+  {
+    commandPath: ["tools", "commands"],
+    policy: {
+      configGuard: "skip",
+      ensureCliPath: false,
+      loadPlugins: "never",
+      networkProxy: "bypass",
+    },
   },
   {
     commandPath: ["tasks", "list"],
@@ -405,8 +424,6 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },
   {
-    // This unregistered root is reserved so plugin registration cannot claim it;
-    // the catalog entry preserves its startup policy.
     commandPath: ["tools"],
     policy: { loadPlugins: "never", ensureCliPath: false, networkProxy: "bypass" },
   },

--- a/src/cli/command-registration-policy.test.ts
+++ b/src/cli/command-registration-policy.test.ts
@@ -74,6 +74,13 @@ describe("command-registration-policy", () => {
     ).toBe(true);
     expect(
       shouldSkipPluginCommandRegistration({
+        argv: ["node", "openclaw", "tools", "commands", "list"],
+        primary: "tools",
+        hasBuiltinPrimary: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipPluginCommandRegistration({
         argv: ["node", "openclaw", "googlemeet", "login"],
         primary: "googlemeet",
         hasBuiltinPrimary: false,

--- a/src/cli/command-registration-policy.test.ts
+++ b/src/cli/command-registration-policy.test.ts
@@ -67,9 +67,9 @@ describe("command-registration-policy", () => {
     ).toBe(true);
     expect(
       shouldSkipPluginCommandRegistration({
-        argv: ["node", "openclaw", "tools", "effective"],
+        argv: ["node", "openclaw", "tools", "commands"],
         primary: "tools",
-        hasBuiltinPrimary: false,
+        hasBuiltinPrimary: true,
       }),
     ).toBe(true);
     expect(

--- a/src/cli/command-registration-policy.ts
+++ b/src/cli/command-registration-policy.ts
@@ -2,7 +2,7 @@
 import { isTruthyEnvValue } from "../infra/env.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 
-const RESERVED_NON_PLUGIN_COMMAND_ROOTS = new Set(["auth", "tool", "tools"]);
+const RESERVED_NON_PLUGIN_COMMAND_ROOTS = new Set(["auth", "tool"]);
 
 export function isReservedNonPluginCommandRoot(primary: string | null | undefined): boolean {
   return typeof primary === "string" && RESERVED_NON_PLUGIN_COMMAND_ROOTS.has(primary);

--- a/src/cli/command-registration-policy.ts
+++ b/src/cli/command-registration-policy.ts
@@ -2,7 +2,7 @@
 import { isTruthyEnvValue } from "../infra/env.js";
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
 
-const RESERVED_NON_PLUGIN_COMMAND_ROOTS = new Set(["auth", "tool"]);
+const RESERVED_NON_PLUGIN_COMMAND_ROOTS = new Set(["auth", "tool", "tools"]);
 
 export function isReservedNonPluginCommandRoot(primary: string | null | undefined): boolean {
   return typeof primary === "string" && RESERVED_NON_PLUGIN_COMMAND_ROOTS.has(primary);

--- a/src/cli/nodes-cli.plugin-registration.test.ts
+++ b/src/cli/nodes-cli.plugin-registration.test.ts
@@ -79,6 +79,16 @@ describe("registerNodesCli plugin registration", () => {
     );
   });
 
+  it("can hydrate built-ins without activating plugin registrars", async () => {
+    const program = new Command();
+    await registerNodesCli(program, ["node", "openclaw", "nodes"], {
+      includePluginCommands: false,
+    });
+
+    expect(registerPluginCliCommandsFromValidatedConfig).not.toHaveBeenCalled();
+    expect(program.commands.find((command) => command.name() === "nodes")).toBeDefined();
+  });
+
   it("documents the supported system.which parameter shape", async () => {
     const program = await registerWithArgv(["node", "openclaw", "nodes", "--help"]);
     const nodesCommand = program.commands.find((command) => command.name() === "nodes");

--- a/src/cli/nodes-cli/register.ts
+++ b/src/cli/nodes-cli/register.ts
@@ -17,7 +17,11 @@ import { registerNodesScreenCommands } from "./register.screen.js";
 import { registerNodesStatusCommands } from "./register.status.js";
 
 /** Register the `nodes` command group and lazy plugin-provided node commands. */
-export async function registerNodesCli(program: Command, argv: readonly string[] = process.argv) {
+export async function registerNodesCli(
+  program: Command,
+  argv: readonly string[] = process.argv,
+  options: { includePluginCommands?: boolean } = {},
+) {
   const nodes = program
     .command("nodes")
     .description("Manage gateway-owned nodes (pairing, status, invoke, and media)")
@@ -50,7 +54,7 @@ export async function registerNodesCli(program: Command, argv: readonly string[]
   // path: loading plugin CLI/runtime to resolve them only adds startup cost. Plugin-provided node
   // subcommands (e.g. `nodes canvas`) are not registered above, so only pay the plugin load when
   // the invoked subcommand is not already a built-in.
-  if (!shouldRegisterNodesPluginCommands(nodes, argv)) {
+  if (options.includePluginCommands === false || !shouldRegisterNodesPluginCommands(nodes, argv)) {
     return;
   }
   const { registerPluginCliCommandsFromValidatedConfig } = await import("../../plugins/cli.js");

--- a/src/cli/program/command-group-descriptors.ts
+++ b/src/cli/program/command-group-descriptors.ts
@@ -1,5 +1,6 @@
 // Descriptor-to-lazy-command-group adapters used by core and sub-CLI registration.
 import type { Command } from "commander";
+import type { CommandEffectProfile, CommandExposure } from "../catalog-metadata.js";
 import type { MachineOutputResolver } from "../machine-output-argv.js";
 
 /** Descriptor for one root command placeholder. */
@@ -10,6 +11,8 @@ export type NamedCommandDescriptor = {
   machineOutput?: MachineOutputResolver;
   hidden?: boolean;
   parentDefaultHelp?: boolean;
+  effectProfile?: CommandEffectProfile;
+  commandExposure?: CommandExposure;
 };
 
 /** Group spec that names the placeholders owned by one registrar. */

--- a/src/cli/program/command-group-descriptors.ts
+++ b/src/cli/program/command-group-descriptors.ts
@@ -1,5 +1,6 @@
 // Descriptor-to-lazy-command-group adapters used by core and sub-CLI registration.
 import type { Command } from "commander";
+import type { CommandEffectProfile, CommandExposure } from "../catalog-metadata.js";
 import type { MachineOutputResolver } from "../machine-output-argv.js";
 
 /** Descriptor for one root command placeholder. */
@@ -10,6 +11,8 @@ export type NamedCommandDescriptor = {
   machineOutput?: MachineOutputResolver;
   hidden?: boolean;
   parentDefaultHelp?: boolean;
+  effectProfile?: CommandEffectProfile;
+  commandExposure?: CommandExposure;
 };
 
 /** Command names owned by one lazy registrar. */

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -305,6 +305,11 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
       loadModule: () => import("../update-cli.js"),
       exportName: "registerUpdateCli",
     },
+    {
+      commandNames: ["tools"],
+      loadModule: () => import("../tools-cli.js"),
+      exportName: "registerToolsCli",
+    },
   ]),
 ];
 

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -22,7 +22,7 @@ import {
 import { getSubCliEntriesCore } from "./subcli-descriptors.js";
 
 export type SubCliRegistrationContext = {
-  purpose?: "runtime" | "completion";
+  purpose?: "runtime" | "completion" | "inspection";
 };
 
 type PluginCliModule = typeof import("../../plugins/cli.js");
@@ -105,7 +105,10 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<
   ],
   [
     ["nodes"],
-    async (program, argv) => (await import("../nodes-cli.js")).registerNodesCli(program, argv),
+    async (program, argv, context) =>
+      (await import("../nodes-cli.js")).registerNodesCli(program, argv, {
+        includePluginCommands: context.purpose !== "inspection",
+      }),
   ],
   [["devices"], async (program) => (await import("../devices-cli.js")).registerDevicesCli(program)],
   [["users"], async (program) => (await import("../users-cli.js")).registerUsersCli(program)],

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -190,6 +190,7 @@ const entrySpecs: readonly CommandGroupDescriptorSpec<
   [["secrets"], async (program) => (await import("../secrets-cli.js")).registerSecretsCli(program)],
   [["skills"], async (program) => (await import("../skills-cli.js")).registerSkillsCli(program)],
   [["update"], async (program) => (await import("../update-cli.js")).registerUpdateCli(program)],
+  [["tools"], async (program) => (await import("../tools-cli.js")).registerToolsCli(program)],
 ];
 
 function resolveSubCliCommandGroups(

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -273,12 +273,11 @@ describe("registerSubCliCommands", () => {
     await program.parseAsync(["nodes", "list"], { from: "user" });
 
     expect(registerNodesCli).toHaveBeenCalledTimes(1);
-    expect(registerNodesCli).toHaveBeenCalledWith(expect.any(Command), [
-      "node",
-      "openclaw",
-      "nodes",
-      "list",
-    ]);
+    expect(registerNodesCli).toHaveBeenCalledWith(
+      expect.any(Command),
+      ["node", "openclaw", "nodes", "list"],
+      { includePluginCommands: true },
+    );
     expect(nodesAction).toHaveBeenCalledTimes(1);
   });
 

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -13,7 +13,6 @@ import { getSubCliEntries } from "./subcli-descriptors.js";
 
 const RESERVED_CATALOG_ROOTS = {
   tool: "reserved so plugin registration cannot claim this unregistered root",
-  tools: "reserved so plugin registration cannot claim this unregistered root",
 } as const;
 
 const PLUGIN_CATALOG_PATHS = {
@@ -90,6 +89,8 @@ const JSON_NOT_APPLICABLE = {
       "models auth order",
       "tasks flow",
       "skills workshop",
+      "tools",
+      "tools commands",
     ],
   },
   interactive: {

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -16,7 +16,6 @@ import { getSubCliEntriesCore } from "./subcli-descriptors.js";
 
 const RESERVED_CATALOG_ROOTS = {
   tool: "reserved so plugin registration cannot claim this unregistered root",
-  tools: "reserved so plugin registration cannot claim this unregistered root",
 } as const;
 
 const PLUGIN_CATALOG_PATHS = {
@@ -98,6 +97,8 @@ const JSON_NOT_APPLICABLE = {
       "models auth",
       "models auth order",
       "skills workshop",
+      "tools",
+      "tools commands",
     ],
   },
   interactive: {

--- a/src/cli/program/subcli-descriptors.test.ts
+++ b/src/cli/program/subcli-descriptors.test.ts
@@ -67,6 +67,12 @@ describe("sub-cli descriptors", () => {
     expect(getSubCliParentDefaultHelpCommands()).not.toContain("qa");
   });
 
+  it("does not reserve the commands root for the catalog", async () => {
+    const { SUB_CLI_DESCRIPTORS } = await importSubCliDescriptors();
+
+    expect(SUB_CLI_DESCRIPTORS.map((descriptor) => descriptor.name)).not.toContain("commands");
+  });
+
   it("includes qa in the exported descriptor list when private QA is enabled", async () => {
     process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI = "1";
 

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -21,6 +21,14 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     description: "Run, inspect, and query the WebSocket Gateway",
     hasSubcommands: true,
     machineOutput: ({ argv }) => isGatewayMachineOutput(argv),
+    commandExposure: {
+      tier: "public",
+    },
+    effectProfile: {
+      risk: "medium",
+      confirmationRequired: true,
+      effectMode: "mixed",
+    },
   },
   {
     name: "daemon",
@@ -233,6 +241,12 @@ const subCliCommandCatalog = defineCommandDescriptorCatalog([
     name: "update",
     description: "Update OpenClaw and inspect update channel status",
     hasSubcommands: true,
+  },
+  {
+    name: "tools",
+    description: "Inspect OpenClaw tool and command metadata",
+    hasSubcommands: true,
+    parentDefaultHelp: true,
   },
   {
     name: "completion",

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -20,6 +20,14 @@ const subCliCommandDescriptors = [
     description: "Run, inspect, and query the WebSocket Gateway",
     hasSubcommands: true,
     machineOutput: ({ argv }) => isGatewayMachineOutput(argv),
+    commandExposure: {
+      tier: "public",
+    },
+    effectProfile: {
+      risk: "medium",
+      confirmationRequired: true,
+      effectMode: "mixed",
+    },
   },
   {
     name: "daemon",
@@ -249,6 +257,12 @@ const subCliCommandDescriptors = [
     name: "update",
     description: "Update OpenClaw and inspect update channel status",
     hasSubcommands: true,
+  },
+  {
+    name: "tools",
+    description: "Inspect OpenClaw tool and command metadata",
+    hasSubcommands: true,
+    parentDefaultHelp: true,
   },
   {
     name: "completion",

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2807,7 +2807,6 @@ describe("runCli exit behavior", () => {
   it.each([
     ["auth", ["node", "openclaw", "auth", "--help"]],
     ["tool", ["node", "openclaw", "tool", "image_generate"]],
-    ["tools", ["node", "openclaw", "tools", "effective"]],
   ])("keeps reserved %s command roots out of plugin command discovery", async (_name, argv) => {
     const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
     const program = {
@@ -2821,6 +2820,28 @@ describe("runCli exit behavior", () => {
     expect(startProxyMock).not.toHaveBeenCalled();
     expect(registerSubCliByNameMock.mock.calls).toEqual([[program, argv[2], argv]]);
     expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
+    expect(parseAsync).toHaveBeenCalledWith(argv);
+  });
+
+  it("keeps tools available to plugin command discovery", async () => {
+    const argv = ["node", "openclaw", "tools", "effective"];
+    const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
+    const program = {
+      commands: [],
+      parseAsync,
+    };
+    buildProgramMock.mockReturnValueOnce(program);
+
+    await runCli(argv);
+
+    expect(startProxyMock).not.toHaveBeenCalled();
+    expect(registerSubCliByNameMock.mock.calls).toEqual([[program, "tools", argv]]);
+    expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledWith(
+      program,
+      undefined,
+      undefined,
+      { mode: "lazy", primary: "tools", skipPluginValidation: false },
+    );
     expect(parseAsync).toHaveBeenCalledWith(argv);
   });
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -2823,8 +2823,8 @@ describe("runCli exit behavior", () => {
     expect(parseAsync).toHaveBeenCalledWith(argv);
   });
 
-  it("keeps tools available to plugin command discovery", async () => {
-    const argv = ["node", "openclaw", "tools", "effective"];
+  it("keeps tools commands out of plugin command discovery", async () => {
+    const argv = ["node", "openclaw", "tools", "commands", "list"];
     const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
     const program = {
       commands: [],
@@ -2836,12 +2836,7 @@ describe("runCli exit behavior", () => {
 
     expect(startProxyMock).not.toHaveBeenCalled();
     expect(registerSubCliByNameMock.mock.calls).toEqual([[program, "tools", argv]]);
-    expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledWith(
-      program,
-      undefined,
-      undefined,
-      { mode: "lazy", primary: "tools", skipPluginValidation: false },
-    );
+    expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
     expect(parseAsync).toHaveBeenCalledWith(argv);
   });
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -3182,7 +3182,6 @@ describe("runCli exit behavior", () => {
   it.each([
     ["auth", ["node", "openclaw", "auth", "--help"]],
     ["tool", ["node", "openclaw", "tool", "image_generate"]],
-    ["tools", ["node", "openclaw", "tools", "effective"]],
   ])("keeps reserved %s command roots out of plugin command discovery", async (_name, argv) => {
     const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
     const program = {
@@ -3196,6 +3195,28 @@ describe("runCli exit behavior", () => {
     expect(startProxyMock).not.toHaveBeenCalled();
     expect(registerSubCliByNameMock.mock.calls).toEqual([[program, argv[2], argv]]);
     expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
+    expect(parseAsync).toHaveBeenCalledWith(argv);
+  });
+
+  it("keeps tools available to plugin command discovery", async () => {
+    const argv = ["node", "openclaw", "tools", "effective"];
+    const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
+    const program = {
+      commands: [],
+      parseAsync,
+    };
+    buildProgramMock.mockReturnValueOnce(program);
+
+    await runCli(argv);
+
+    expect(startProxyMock).not.toHaveBeenCalled();
+    expect(registerSubCliByNameMock.mock.calls).toEqual([[program, "tools", argv]]);
+    expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledWith(
+      program,
+      undefined,
+      undefined,
+      { mode: "lazy", primary: "tools", skipPluginValidation: false },
+    );
     expect(parseAsync).toHaveBeenCalledWith(argv);
   });
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -3198,8 +3198,8 @@ describe("runCli exit behavior", () => {
     expect(parseAsync).toHaveBeenCalledWith(argv);
   });
 
-  it("keeps tools available to plugin command discovery", async () => {
-    const argv = ["node", "openclaw", "tools", "effective"];
+  it("keeps tools commands out of plugin command discovery", async () => {
+    const argv = ["node", "openclaw", "tools", "commands", "list"];
     const parseAsync = vi.fn().mockResolvedValueOnce(undefined);
     const program = {
       commands: [],
@@ -3211,12 +3211,7 @@ describe("runCli exit behavior", () => {
 
     expect(startProxyMock).not.toHaveBeenCalled();
     expect(registerSubCliByNameMock.mock.calls).toEqual([[program, "tools", argv]]);
-    expect(registerPluginCliCommandsFromValidatedConfigMock).toHaveBeenCalledWith(
-      program,
-      undefined,
-      undefined,
-      { mode: "lazy", primary: "tools", skipPluginValidation: false },
-    );
+    expect(registerPluginCliCommandsFromValidatedConfigMock).not.toHaveBeenCalled();
     expect(parseAsync).toHaveBeenCalledWith(argv);
   });
 

--- a/src/cli/tools-cli.ts
+++ b/src/cli/tools-cli.ts
@@ -1,0 +1,10 @@
+import type { Command } from "commander";
+import { registerCommandsCli } from "./catalog-cli.js";
+import { applyParentDefaultHelpAction } from "./program/parent-default-help.js";
+
+export function registerToolsCli(program: Command): void {
+  const tools = program.command("tools").description("Inspect OpenClaw tool and command metadata");
+
+  registerCommandsCli(tools);
+  applyParentDefaultHelpAction(tools);
+}

--- a/src/plugins/captured-registration.test.ts
+++ b/src/plugins/captured-registration.test.ts
@@ -131,6 +131,15 @@ describe("captured plugin registration", () => {
           description: "Captured command",
           handler: async () => ({ text: "ok" }),
         });
+        api.registerCli(() => {}, {
+          descriptors: [
+            {
+              name: "captured-cli",
+              description: "Captured CLI",
+              hasSubcommands: false,
+            },
+          ],
+        });
         api.registerAgentToolResultMiddleware(() => undefined, {
           runtimes: ["codex"],
         });
@@ -154,6 +163,13 @@ describe("captured plugin registration", () => {
     expect(captured.textTransforms[0]?.input).toHaveLength(1);
     expect(captured.agentToolResultMiddlewares).toHaveLength(1);
     expect(captured.agentToolResultMiddlewares[0]?.runtimes).toEqual(["codex"]);
+    expect(captured.cliRegistrars.flatMap((entry) => entry.descriptors)).toContainEqual(
+      expect.objectContaining({
+        name: "captured-cli",
+        description: "Captured CLI",
+        hasSubcommands: false,
+      }),
+    );
     expect(captured.api.registerMemoryEmbeddingProvider).toBeTypeOf("function");
   });
 

--- a/src/plugins/captured-registration.test.ts
+++ b/src/plugins/captured-registration.test.ts
@@ -245,6 +245,15 @@ describe("captured plugin registration", () => {
           description: "Captured command",
           handler: async () => ({ text: "ok" }),
         });
+        api.registerCli(() => {}, {
+          descriptors: [
+            {
+              name: "captured-cli",
+              description: "Captured CLI",
+              hasSubcommands: false,
+            },
+          ],
+        });
         api.registerAgentToolResultMiddleware(() => undefined, {
           runtimes: ["codex"],
         });
@@ -269,6 +278,13 @@ describe("captured plugin registration", () => {
     expect(captured.agentToolResultMiddlewares).toHaveLength(1);
     expect(captured.agentToolResultMiddlewares[0]?.runtimes).toEqual(["codex"]);
     expect(captured.api.runtime.version).toEqual(expect.any(String));
+    expect(captured.cliRegistrars.flatMap((entry) => entry.descriptors)).toContainEqual(
+      expect.objectContaining({
+        name: "captured-cli",
+        description: "Captured CLI",
+        hasSubcommands: false,
+      }),
+    );
   });
 
   it("enforces captured middleware runtime and tool scopes", async () => {

--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -46,6 +46,13 @@ export type PluginCliCommandGroupEntry = {
   register: (program: OpenClawPluginCliContext["program"]) => Promise<void>;
 };
 
+export type PluginCliDescriptorEntry = {
+  pluginId: string;
+  parentPath: readonly string[];
+  commands: readonly string[];
+  descriptors: readonly OpenClawPluginCliRootCommandDescriptor[];
+};
+
 /** Creates the default plugin CLI logger shared with runtime loading. */
 export function createPluginCliLogger(): PluginLogger {
   return createPluginRuntimeLoaderLogger();
@@ -241,7 +248,38 @@ export async function loadPluginCliDescriptors(
   }
 }
 
-async function loadPluginCliRegistrationEntries(params: {
+export async function loadPluginCliDescriptorEntries(
+  params: PluginCliPublicLoadParams,
+): Promise<PluginCliDescriptorEntry[]> {
+  const logger = resolvePluginCliLogger(params.logger);
+  const context = resolvePluginCliLoadContext({
+    cfg: params.cfg,
+    env: params.env,
+    logger,
+  });
+  const { registry } = await loadPluginCliMetadataRegistryWithContext(
+    context,
+    { primaryCommand: params.primaryCommand },
+    params.loaderOptions,
+  );
+  const loadErrors = registry.diagnostics.filter((diagnostic) => diagnostic.level === "error");
+  if (loadErrors.length > 0) {
+    const details = loadErrors
+      .map((diagnostic) =>
+        diagnostic.pluginId ? `${diagnostic.pluginId}: ${diagnostic.message}` : diagnostic.message,
+      )
+      .join("; ");
+    throw new Error(`Failed to load plugin CLI descriptor metadata: ${details}`);
+  }
+  return registry.cliRegistrars.map((entry) => ({
+    pluginId: entry.pluginId,
+    parentPath: entry.parentPath ?? [],
+    commands: entry.commands,
+    descriptors: entry.descriptors,
+  }));
+}
+
+export async function loadPluginCliRegistrationEntries(params: {
   cfg?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   loaderOptions?: PluginCliLoaderOptions;

--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -208,6 +208,13 @@ function resolvePreparedPluginCliLoad(params: PluginCliPublicLoadParams): Prepar
   return (params.session ?? createPluginCliLoadSession()).resolve(params);
 }
 
+export type PluginCliDescriptorEntry = {
+  pluginId: string;
+  parentPath: readonly string[];
+  commands: readonly string[];
+  descriptors: readonly OpenClawPluginCliRootCommandDescriptor[];
+};
+
 /** Creates the default plugin CLI logger shared with runtime loading. */
 export function createPluginCliLogger(): PluginLogger {
   return createPluginRuntimeLoaderLogger();
@@ -389,6 +396,32 @@ export async function loadPluginCliDescriptors(
     log.warn(`plugin CLI descriptor load failed: ${String(error)}`);
     return [];
   }
+}
+
+export async function loadPluginCliDescriptorEntries(
+  params: PluginCliPublicLoadParams,
+): Promise<PluginCliDescriptorEntry[]> {
+  const prepared = resolvePreparedPluginCliLoad(params);
+  const registry = await loadPluginCliMetadataRegistryWithContext(
+    prepared,
+    { primaryCommand: params.primaryCommand },
+    params.loaderOptions,
+  );
+  const loadErrors = registry.diagnostics.filter((diagnostic) => diagnostic.level === "error");
+  if (loadErrors.length > 0) {
+    const details = loadErrors
+      .map((diagnostic) =>
+        diagnostic.pluginId ? `${diagnostic.pluginId}: ${diagnostic.message}` : diagnostic.message,
+      )
+      .join("; ");
+    throw new Error(`Failed to load plugin CLI descriptor metadata: ${details}`);
+  }
+  return registry.cliRegistrars.map((entry) => ({
+    pluginId: entry.pluginId,
+    parentPath: entry.parentPath ?? [],
+    commands: entry.commands,
+    descriptors: entry.descriptors,
+  }));
 }
 
 export async function loadPluginCliRegistrationEntriesWithDefaults(

--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -98,6 +98,11 @@ describe("plugin loader CLI metadata", () => {
           description: "Rogue CLI metadata",
           hasSubcommands: true,
         },
+        {
+          name: "other-rogue",
+          description: "Other rogue CLI metadata",
+          hasSubcommands: false,
+        },
       ],
     });
   },
@@ -122,6 +127,9 @@ describe("plugin loader CLI metadata", () => {
 
     expect(warnings).toStrictEqual([]);
     expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain("rogue");
+    expect(registry.cliRegistrars.flatMap((entry) => entry.descriptors)).toContainEqual(
+      expect.objectContaining({ name: "other-rogue" }),
+    );
   });
 
   it("passes validated plugin config into non-activating CLI metadata loads", async () => {

--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -290,6 +290,11 @@ module.exports = { id: "packaged-cli-metadata", register() {} };`,
           description: "Rogue CLI metadata",
           hasSubcommands: true,
         },
+        {
+          name: "other-rogue",
+          description: "Other rogue CLI metadata",
+          hasSubcommands: false,
+        },
       ],
     });
   },
@@ -314,6 +319,9 @@ module.exports = { id: "packaged-cli-metadata", register() {} };`,
 
     expect(warnings).toStrictEqual([]);
     expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain("rogue");
+    expect(registry.cliRegistrars.flatMap((entry) => entry.descriptors)).toContainEqual(
+      expect.objectContaining({ name: "other-rogue" }),
+    );
   });
 
   it("passes validated plugin config into non-activating CLI metadata loads", async () => {

--- a/src/plugins/plugin-registration.types.ts
+++ b/src/plugins/plugin-registration.types.ts
@@ -84,12 +84,12 @@ export type OpenClawPluginCliContext = {
 export type OpenClawPluginCliRegistrar = (ctx: OpenClawPluginCliContext) => void | Promise<void>;
 
 /**
- * Top-level CLI metadata for plugin-owned commands.
+ * CLI descriptor data for plugin-owned commands.
  *
  * Descriptors are the parse-time contract for lazy plugin CLI registration.
  * If you want OpenClaw to keep a plugin command lazy-loaded while still
- * advertising it at the root CLI level, provide descriptors that cover every
- * top-level command root registered by that plugin CLI surface.
+ * advertising it at parse time, provide descriptors that cover every command
+ * root registered by that plugin CLI surface.
  */
 type OpenClawPluginCliCommandDescriptor = {
   name: string;

--- a/src/plugins/plugin-registration.types.ts
+++ b/src/plugins/plugin-registration.types.ts
@@ -145,12 +145,12 @@ export type OpenClawPluginCliContext = {
 export type OpenClawPluginCliRegistrar = (ctx: OpenClawPluginCliContext) => void | Promise<void>;
 
 /**
- * Top-level CLI metadata for plugin-owned commands.
+ * CLI descriptor data for plugin-owned commands.
  *
  * Descriptors are the parse-time contract for lazy plugin CLI registration.
  * If you want OpenClaw to keep a plugin command lazy-loaded while still
- * advertising it at the root CLI level, provide descriptors that cover every
- * top-level command root registered by that plugin CLI surface.
+ * advertising it at parse time, provide descriptors that cover every command
+ * root registered by that plugin CLI surface.
  */
 type OpenClawPluginCliCommandDescriptor = {
   name: string;


### PR DESCRIPTION
## Summary

Adds a read-only operator/developer command inventory through:

```text
openclaw tools commands list [--json|--markdown] [--plugin-descriptors]
openclaw tools commands inspect <command-path...> [--json|--markdown] [--plugin-descriptors]
```

This is the foundation proposed by [Command Catalog RFC #32](https://github.com/openclaw/rfcs/pull/32). It joins existing CLI descriptors, command routes, routed operations, the current Commander tree, and explicitly requested plugin CLI descriptors. It adds no dispatcher, authorization decision, or alternate execution path.

## Contract

- Contributing registries remain the owners of command identity, semantics, registration lifetime, conflicts, and execution.
- `tools` is a built-in sub-CLI root; `commands` is nested under `tools` so the inventory does not consume plugin-owned command space.
- Startup policy targets `tools commands`, skips config/plugins by default, and bypasses network setup for the read-only inventory path.
- JSON reports collection status so omitted runtime, plugin, or node sources cannot look complete.
- Each result is a current-invocation snapshot; a record is not an execution capability or a guarantee that the same runtime registration still exists.
- Missing or failed collection is unknown, not proof that a command was removed or revoked.
- Missing effect, risk, or confirmation metadata remains unknown; it is never defaulted to low-risk or read-only.
- Plugin descriptor collection reports parse-time command shape only: name, description, and whether the descriptor has subcommands.
- Commands-only plugin registrations are not emitted as descriptor-shaped catalog records.
- Plugin descriptors whose first command segment is a reserved non-plugin root (`auth`, `tool`, or `tools`) are omitted, matching normal CLI dispatch.
- Plugin collection is opt-in because enabled trusted modules are imported and executed in restricted metadata-registration mode.
- Plugin loader exceptions and error diagnostics fail collection instead of returning apparently complete output.

Plugin descriptors do not declare effect profile, exposure tier, or hidden inventory semantics in this PR. Gateway `commands.list` remains the narrower agent/provider command view. This CLI does not replace or call that RPC.

## Scope

This PR contains list, exact inspection, normalized records, JSON/Markdown rendering, plugin descriptor collection, plugin descriptor documentation, and the built-in `tools commands` CLI registration. Live node collection, prompt projection, and generated reference docs remain separate draft follow-ups.

## Validation

Current head: `2155498943dd4687d446b59f3df0124bba59ee51`.

WSL Ubuntu validation checkout: `/tmp/openclaw-pr100960-tools-validate`.


Latest restack validation on `2155498943dd4687d446b59f3df0124bba59ee51` after rebasing over upstream/main `dcf7fadf2c03d594f455e140194044a492f1fc6e`:

- `git range-diff 321a1a4fed537f4ca530c8134427a415eefe3bba~4..321a1a4fed537f4ca530c8134427a415eefe3bba upstream/main..HEAD` showed all four commits patch-equivalent.
- `git diff --check upstream/main..HEAD` passed.
- Conflict-marker search over touched files passed.
- Windows checkout dependency materialization is still absent (`node_modules/.bin/vitest` missing), so focused Vitest was not rerun locally on this restacked head; GitHub CI is the package-materialized exact-head proof path.

Previous restack validation on `321a1a4fed537f4ca530c8134427a415eefe3bba` after rebasing over upstream/main `05e3ce11aca70c6896d6a06047a663c90850449c`:

- git range-diff 8e72d20247b3adbd447fd738338ab3a93319ca5f~4..8e72d20247b3adbd447fd738338ab3a93319ca5f upstream/main..HEAD showed all four commits patch-equivalent.
- git diff --check upstream/main..HEAD passed.
- Conflict-marker search over touched files passed.
- Windows checkout dependency materialization was not present (
ode_modules/.bin/vitest missing), so focused Vitest was not rerun locally on this restacked head; GitHub CI is the package-materialized exact-head proof path.
Latest validation after the reserved plugin-root inventory repair on pre-restack patch-equivalent head `8e72d20247b3adbd447fd738338ab3a93319ca5f`:

- `node scripts/run-vitest.mjs run src/cli-catalog-overlay/plugin-commands.test.ts --reporter=verbose --maxWorkers=1` passed: 4 tests.
- `node scripts/run-vitest.mjs run src/cli-catalog-overlay/plugin-commands.test.ts src/cli/catalog-cli.test.ts --reporter=verbose --maxWorkers=1 --testNamePattern "plugin|descriptor|tools commands"` passed: 12 tests across 2 files.
- `pnpm deadcode:exports` passed with 0 entries.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-pr100960-type-fix.tsbuildinfo` passed after the type-stable `flatMap` repair.
- `pnpm exec oxfmt --check src/cli-catalog-overlay/plugin-commands.ts src/cli-catalog-overlay/plugin-commands.test.ts` passed.
- `git diff --check` passed.
- Terminal proof below passed on pre-restack patch-equivalent head `8e72d20247b3adbd447fd738338ab3a93319ca5f` after `run-node.mjs` rebuilt stale dist output; the restack range-diff shows the same four patches on `321a1a4fed537f4ca530c8134427a415eefe3bba`, and the latest restack range-diff shows the same four patches on `2155498943dd4687d446b59f3df0124bba59ee51`.

Earlier validation on prior heads covered the full focused command-catalog set, docs list/map generation, configured plugin descriptor collection, plugin loader failure behavior, compact-shard repair, and the `tools` reserved-root registration policy regression.

Not completed locally:

- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-pr100960-type-fix.tsbuildinfo` exceeded the local timeout and was stopped; GitHub CI should provide the broad test type signal for this two-file change.

## Real behavior proof

Behavior or issue addressed:
`openclaw tools commands` exposes command inventory without occupying the plugin-owned `plugins commands` path, startup policy points at the built-in `tools commands` path, and plugin descriptor inventory no longer advertises commands under reserved non-plugin roots.

Real environment tested:
WSL Ubuntu checkout at `/tmp/openclaw-pr100960-tools-validate`, Node `v24.15.0`, pnpm `11.15.1`, pre-restack patch-equivalent head `8e72d20247b3adbd447fd738338ab3a93319ca5f`.

Exact steps or command run after this patch:

1. `git rev-parse HEAD`
2. `node scripts/run-node.mjs tools commands list --json > .artifacts/pr100960-proof/list.json`
3. `node scripts/run-node.mjs tools commands inspect gateway status --json > .artifacts/pr100960-proof/inspect-gateway-status.json`
4. `node scripts/run-node.mjs tools commands list --json --plugin-descriptors > .artifacts/pr100960-proof/list-plugin-descriptors.json`
5. A Node verifier loaded all three JSON files and asserted the exact head, `schemaVersion: 1`, `generatedFrom: "command-inventory"`, presence of the registered `tools commands` runtime path, successful `gateway status` inspection, and zero plugin descriptor commands whose first path segment is `auth`, `tool`, or `tools`.

Evidence after fix:

```json
{
  "head": "8e72d20247b3adbd447fd738338ab3a93319ca5f",
  "list": {
    "schemaVersion": 1,
    "generatedFrom": "command-inventory",
    "commandDescriptors": 64,
    "runtimeCommands": 27,
    "pluginCommands": 0,
    "hasToolsCommandsRuntime": true
  },
  "inspect": {
    "found": true,
    "commandPath": ["gateway", "status"],
    "routes": 2
  },
  "pluginDescriptors": {
    "pluginCommands": 6,
    "reservedRootLeaks": 0
  }
}
```

Observed result after fix:
The built-in `tools` root and nested `tools commands` runtime path are present in the CLI inventory. Inspecting `gateway status` finds the exact routed operation and runtime command registration. Plugin collection remains `not-requested` unless `--plugin-descriptors` is supplied, commands-only plugin registrations are not projected as descriptor-shaped records, and plugin descriptors under reserved core roots are filtered out of inventory.

What was not tested on this restacked head:
No deployed docs site was rendered. The configured-plugin terminal fixture from the previous head was not rerun beyond the exact-head `--plugin-descriptors` list proof and focused source regression.

## Draft follow-ups

- [#104158](https://github.com/openclaw/openclaw/pull/104158): live paired-node command identifiers
- [#104159](https://github.com/openclaw/openclaw/pull/104159): explicit scoped prompt projection
- [#104160](https://github.com/openclaw/openclaw/pull/104160): generated static command reference






