### PR TITLE
feat(gateway): let write-scope operators manage chat session organization

### DIFF
--- a/src/agents/subagent-spawn.runtime.ts
+++ b/src/agents/subagent-spawn.runtime.ts
@@ -22,7 +22,10 @@ export {
   dispatchGatewayMethodInProcess,
   hasInProcessGatewayContext,
 } from "../gateway/server-plugins.js";
-export { ADMIN_SCOPE, isAdminOnlyMethod } from "../gateway/method-scopes.js";
+export {
+  ADMIN_SCOPE,
+  resolveLeastPrivilegeOperatorScopesForMethod,
+} from "../gateway/method-scopes.js";
 export { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
 export {
   pruneLegacyStoreKeys,

--- a/src/agents/subagent-spawn.test-helpers.ts
+++ b/src/agents/subagent-spawn.test-helpers.ts
@@ -3,6 +3,7 @@
 import os from "node:os";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { expect, vi } from "vitest";
+import { resolveLeastPrivilegeOperatorScopesForMethod } from "../gateway/method-scopes.js";
 import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
 
 type MockFn = (...args: unknown[]) => unknown;
@@ -303,8 +304,9 @@ export async function loadSubagentSpawnModuleForTest(params: {
         await mutator(store);
         return store;
       }),
-    isAdminOnlyMethod: (method: string) =>
-      method === "sessions.patch" || method === "sessions.delete",
+    // Real scope resolver: spawn's admin-tier pinning depends on params-aware
+    // sessions.patch policy, so a stub here would hide policy regressions.
+    resolveLeastPrivilegeOperatorScopesForMethod,
     pruneLegacyStoreKeys: (...args: unknown[]) => params.pruneLegacyStoreKeysMock?.(...args),
     getSessionBindingService:
       params.getSessionBindingService ??

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -106,7 +106,7 @@ import {
   resolveMainSessionAlias,
   resolveSandboxRuntimeStatus,
   updateSessionStore,
-  isAdminOnlyMethod,
+  resolveLeastPrivilegeOperatorScopesForMethod,
 } from "./subagent-spawn.runtime.js";
 import type {
   SpawnSubagentContextMode,
@@ -242,9 +242,15 @@ async function callSubagentGateway(
   // scope-upgrade handshake that headless gateway-client connections cannot
   // complete interactively, causing close(1008) "pairing required" (#59428).
   //
-  // Only admin-only methods are pinned to ADMIN_SCOPE; other methods (e.g.
-  // "agent" -> write) keep their least-privilege scope.
-  const scopes = params.scopes ?? (isAdminOnlyMethod(params.method) ? [ADMIN_SCOPE] : undefined);
+  // Only admin-requiring calls are pinned to ADMIN_SCOPE; other methods (e.g.
+  // "agent" -> write) keep their least-privilege scope. The params-aware
+  // resolver keeps spawn-metadata sessions.patch calls on the admin tier.
+  const leastPrivilegeScopes = resolveLeastPrivilegeOperatorScopesForMethod(
+    params.method,
+    params.params,
+  );
+  const scopes =
+    params.scopes ?? (leastPrivilegeScopes.includes(ADMIN_SCOPE) ? [ADMIN_SCOPE] : undefined);
   const request = {
     ...params,
     ...(scopes != null ? { scopes } : {}),

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -181,6 +181,68 @@ describe("method scope resolution", () => {
     ).toEqual({ allowed: false, missingScope: "operator.approvals" });
   });
 
+  it("resolves sessions.patch to write scope for chat-organization fields only", () => {
+    expect(
+      resolveLeastPrivilegeOperatorScopesForMethod("sessions.patch", {
+        key: "agent:main:ios-1",
+        label: "Trip planning",
+        pinned: true,
+        archived: false,
+      }),
+    ).toEqual(["operator.write"]);
+    expect(
+      resolveLeastPrivilegeOperatorScopesForMethod("sessions.patch", {
+        key: "agent:main:ios-1",
+        agentId: "main",
+        category: "Travel",
+        unread: true,
+      }),
+    ).toEqual(["operator.write"]);
+    expect(isGatewayMethodClassified("sessions.patch")).toBe(true);
+  });
+
+  it.each([
+    ["model", { key: "agent:main:ios-1", model: "anthropic/claude-sonnet-5" }],
+    ["sendPolicy", { key: "agent:main:ios-1", sendPolicy: "deny" }],
+    ["inheritedToolAllow", { key: "agent:main:ios-1", inheritedToolAllow: ["exec"] }],
+    ["spawnedBy", { key: "agent:main:ios-1", spawnedBy: "agent:main:main" }],
+    ["mixed with safe fields", { key: "agent:main:ios-1", label: "x", execHost: "node-1" }],
+    ["unknown fields", { key: "agent:main:ios-1", futureField: true }],
+  ])("keeps sessions.patch admin-only when params include %s", (_name, params) => {
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("sessions.patch", params)).toEqual([
+      "operator.admin",
+    ]);
+    expect(authorizeOperatorScopesForMethod("sessions.patch", ["operator.write"], params)).toEqual({
+      allowed: false,
+      missingScope: "operator.admin",
+    });
+    expect(authorizeOperatorScopesForMethod("sessions.patch", ["operator.admin"], params)).toEqual({
+      allowed: true,
+    });
+  });
+
+  it("authorizes write-scoped sessions.patch for chat-organization fields and denies read scope", () => {
+    const params = { key: "agent:main:ios-1", label: "Trip planning", pinned: true };
+    expect(authorizeOperatorScopesForMethod("sessions.patch", ["operator.write"], params)).toEqual({
+      allowed: true,
+    });
+    expect(authorizeOperatorScopesForMethod("sessions.patch", ["operator.read"], params)).toEqual({
+      allowed: false,
+      missingScope: "operator.write",
+    });
+  });
+
+  it("lets malformed sessions.patch params through to handler validation at write scope", () => {
+    // Malformed params cannot mutate anything; the handler rejects them with a
+    // precise validation error instead of a misleading missing-scope error.
+    expect(authorizeOperatorScopesForMethod("sessions.patch", ["operator.write"])).toEqual({
+      allowed: true,
+    });
+    expect(resolveLeastPrivilegeOperatorScopesForMethod("sessions.patch")).toEqual([
+      "operator.write",
+    ]);
+  });
+
   it("falls back to broad operator scopes when a dynamic session action is not locally registered", () => {
     expect(
       resolveLeastPrivilegeOperatorScopesForMethod("plugins.sessionAction", {

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -78,6 +78,31 @@ export function resolveRequiredOperatorScopeForMethod(method: string): OperatorS
   return resolveScopedMethod(method);
 }
 
+/**
+ * sessions.patch fields a write-scoped operator may mutate: user-level chat
+ * organization only. Any other field (model, sendPolicy, tool inheritance,
+ * exec routing, ...) keeps requiring operator.admin — fail closed on unknowns.
+ */
+const SESSIONS_PATCH_WRITE_SCOPE_FIELDS: ReadonlySet<string> = new Set([
+  "key",
+  "agentId",
+  "label",
+  "category",
+  "pinned",
+  "archived",
+  "unread",
+]);
+
+function resolveSessionsPatchRequiredScopes(params: unknown): OperatorScope[] {
+  if (!params || typeof params !== "object" || Array.isArray(params)) {
+    // Malformed params cannot mutate anything; let the handler return the
+    // precise validation error instead of a misleading missing-scope error.
+    return [WRITE_SCOPE];
+  }
+  const safeOnly = Object.keys(params).every((key) => SESSIONS_PATCH_WRITE_SCOPE_FIELDS.has(key));
+  return safeOnly ? [WRITE_SCOPE] : [ADMIN_SCOPE];
+}
+
 function resolveSessionActionRegisteredScopes(params: unknown): OperatorScope[] | undefined {
   if (!params || typeof params !== "object" || Array.isArray(params)) {
     return undefined;
@@ -127,7 +152,19 @@ function resolveDynamicLeastPrivilegeOperatorScopesForMethod(
   if (method === "plugins.sessionAction") {
     return resolveSessionActionLeastPrivilegeScopes(params);
   }
+  if (method === "sessions.patch") {
+    return resolveSessionsPatchRequiredScopes(params);
+  }
   return [WRITE_SCOPE];
+}
+
+function findMissingOperatorScope(
+  requiredScopes: readonly OperatorScope[],
+  scopes: readonly string[],
+): OperatorScope | undefined {
+  return requiredScopes.find((scope) => {
+    return !scopes.includes(scope) && !(scope === READ_SCOPE && scopes.includes(WRITE_SCOPE));
+  });
 }
 
 /** Returns the narrowest known operator scopes needed to call a gateway method. */
@@ -156,6 +193,13 @@ export function authorizeOperatorScopesForMethod(
     return { allowed: true };
   }
   if (isDynamicOperatorGatewayMethod(method)) {
+    if (method === "sessions.patch") {
+      const missingScope = findMissingOperatorScope(
+        resolveSessionsPatchRequiredScopes(params),
+        scopes,
+      );
+      return missingScope ? { allowed: false, missingScope } : { allowed: true };
+    }
     const registeredScopes = resolveSessionActionRegisteredScopes(params);
     if (!registeredScopes && params && typeof params === "object" && !Array.isArray(params)) {
       const pluginId = normalizeSessionActionParam((params as { pluginId?: unknown }).pluginId);
@@ -168,10 +212,7 @@ export function authorizeOperatorScopesForMethod(
           : { allowed: false, missingScope: WRITE_SCOPE };
       }
     }
-    const requiredScopes = registeredScopes ?? [WRITE_SCOPE];
-    const missingScope = requiredScopes.find((scope) => {
-      return !scopes.includes(scope) && !(scope === READ_SCOPE && scopes.includes(WRITE_SCOPE));
-    });
+    const missingScope = findMissingOperatorScope(registeredScopes ?? [WRITE_SCOPE], scopes);
     return missingScope ? { allowed: false, missingScope } : { allowed: true };
   }
   const requiredScope = resolveRequiredOperatorScopeForMethod(method) ?? ADMIN_SCOPE;

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -162,7 +162,10 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "sessions.create", scope: "operator.write", startup: true },
   { name: "sessions.send", scope: "operator.write", startup: true },
   { name: "sessions.abort", scope: "operator.write", startup: true },
-  { name: "sessions.patch", scope: "operator.admin" },
+  // Params-aware: write scope may mutate chat-organization fields
+  // (label/category/pinned/archived/unread); every other patch field stays
+  // admin-only. Policy lives in method-scopes.ts.
+  { name: "sessions.patch", scope: "dynamic" },
   { name: "sessions.pluginPatch", scope: "operator.admin" },
   { name: "sessions.cleanup", scope: "operator.admin" },
   { name: "sessions.reset", scope: "operator.admin" },

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -673,3 +673,123 @@ test("sessions.list hides phantom agent store placeholder rows", async () => {
   expect(listed.ok).toBe(true);
   expect(listed.payload?.sessions.map((session) => session.key)).toEqual(["agent:main:main"]);
 });
+
+test("write-scoped operators manage chat organization but not admin session settings", async () => {
+  await createSessionStoreDir();
+  const now = Date.now();
+  await writeSessionStore({
+    entries: {
+      main: { sessionId: "sess-main", updatedAt: now },
+      "topic-a": {
+        sessionId: "sess-topic-a",
+        updatedAt: now - 60_000,
+        // Stored channel-derived name; a user rename (label) must beat it.
+        displayName: "channel topic",
+      },
+      "topic-b": { sessionId: "sess-topic-b", updatedAt: now - 30_000 },
+    },
+  });
+
+  const { ws } = await openClient({ scopes: ["operator.read", "operator.write"] });
+  try {
+    const renamed = await rpcReq<{ ok: true; entry: { label?: string } }>(ws, "sessions.patch", {
+      key: "agent:main:topic-a",
+      label: "Trip planning",
+    });
+    expect(renamed.ok).toBe(true);
+    expect(renamed.payload?.entry.label).toBe("Trip planning");
+
+    const pinned = await rpcReq<{ ok: true; entry: { pinnedAt?: number } }>(ws, "sessions.patch", {
+      key: "agent:main:topic-a",
+      pinned: true,
+    });
+    expect(pinned.ok).toBe(true);
+    expect(pinned.payload?.entry.pinnedAt).toEqual(expect.any(Number));
+
+    const organized = await rpcReq<{
+      ok: true;
+      entry: { category?: string; markedUnreadAt?: number };
+    }>(ws, "sessions.patch", {
+      key: "agent:main:topic-a",
+      category: "Travel",
+      unread: true,
+    });
+    expect(organized.ok).toBe(true);
+    expect(organized.payload?.entry.category).toBe("Travel");
+
+    const archived = await rpcReq<{ ok: true; entry: { archivedAt?: number } }>(
+      ws,
+      "sessions.patch",
+      { key: "agent:main:topic-b", archived: true },
+    );
+    expect(archived.ok).toBe(true);
+    expect(archived.payload?.entry.archivedAt).toEqual(expect.any(Number));
+
+    const searched = await rpcReq<{
+      sessions: Array<{ key: string; pinned?: boolean; displayName?: string }>;
+    }>(ws, "sessions.list", { search: "trip plan" });
+    expect(searched.ok).toBe(true);
+    expect(searched.payload?.sessions.map((session) => session.key)).toEqual([
+      "agent:main:topic-a",
+    ]);
+    expect(searched.payload?.sessions[0]?.displayName).toBe("Trip planning");
+
+    const archivedList = await rpcReq<{ sessions: Array<{ key: string }> }>(ws, "sessions.list", {
+      archived: true,
+    });
+    expect(archivedList.ok).toBe(true);
+    expect(archivedList.payload?.sessions.map((session) => session.key)).toEqual([
+      "agent:main:topic-b",
+    ]);
+
+    const adminFieldDenied = await rpcReq(ws, "sessions.patch", {
+      key: "agent:main:topic-a",
+      sendPolicy: "deny",
+    });
+    expect(adminFieldDenied.ok).toBe(false);
+    expect(adminFieldDenied.error?.message).toContain("missing scope: operator.admin");
+
+    const mixedFieldsDenied = await rpcReq(ws, "sessions.patch", {
+      key: "agent:main:topic-a",
+      label: "Sneaky",
+      model: "anthropic/claude-sonnet-5",
+    });
+    expect(mixedFieldsDenied.ok).toBe(false);
+    expect(mixedFieldsDenied.error?.message).toContain("missing scope: operator.admin");
+  } finally {
+    ws.close();
+  }
+});
+
+test("sessions.list breaks timestamp ties by key for stable paging", async () => {
+  await createSessionStoreDir();
+  const updatedAt = Date.now() - 5_000;
+  await writeSessionStore({
+    entries: {
+      main: { sessionId: "sess-main", updatedAt },
+      "tie-c": { sessionId: "sess-tie-c", updatedAt },
+      "tie-a": { sessionId: "sess-tie-a", updatedAt },
+      "tie-b": { sessionId: "sess-tie-b", updatedAt },
+    },
+  });
+
+  const expectedOrder = [
+    "agent:main:main",
+    "agent:main:tie-a",
+    "agent:main:tie-b",
+    "agent:main:tie-c",
+  ];
+  const listed = await directSessionHandlerReq<{ sessions: Array<{ key: string }> }>(
+    "sessions.list",
+    { includeGlobal: false, includeUnknown: false },
+  );
+  expect(listed.ok).toBe(true);
+  expect(listed.payload?.sessions.map((session) => session.key)).toEqual(expectedOrder);
+
+  const paged = await directSessionHandlerReq<{ sessions: Array<{ key: string }> }>(
+    "sessions.list",
+    { includeGlobal: false, includeUnknown: false, limit: 2, offset: 2 },
+  );
+  expect(paged.ok).toBe(true);
+  expect(paged.payload?.sessions.map((session) => session.key)).toEqual(expectedOrder.slice(2));
+});

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1898,7 +1898,10 @@ export function buildGatewaySessionRow(params: {
   const origin = entry?.origin;
   const originLabel = origin?.label;
   const isGroupSession = isGroupOrChannelDisplaySession(entry, parsed);
+  // A user-assigned label is an explicit rename; it must win over stored
+  // channel-derived display names or renames silently vanish on refresh.
   const displayName =
+    entry?.label ??
     entry?.displayName ??
     (isGroupSession && channel
       ? buildGroupDisplayName({
@@ -1910,7 +1913,6 @@ export function buildGatewaySessionRow(params: {
           key,
         })
       : undefined) ??
-    entry?.label ??
     originLabel;
   const deliveryFields = normalizeSessionDeliveryFields(entry);
   const parsedAgent = parseAgentSessionKey(key);
@@ -2458,7 +2460,13 @@ function compareSessionEntryPairs(a: SessionEntryPair, b: SessionEntryPair): num
   if (aPinnedAt !== bPinnedAt) {
     return bPinnedAt - aPinnedAt;
   }
-  return (b[1]?.updatedAt ?? 0) - (a[1]?.updatedAt ?? 0);
+  const byUpdatedAt = (b[1]?.updatedAt ?? 0) - (a[1]?.updatedAt ?? 0);
+  if (byUpdatedAt !== 0) {
+    return byUpdatedAt;
+  }
+  // Timestamp ties fall back to the key so list order (and offset paging) stays
+  // deterministic across calls; locale-independent code-unit comparison.
+  return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
 }
 
 function resolveSessionsListLimit(


### PR DESCRIPTION
## What Problem This Solves

The session controls shipped in #100814 (rename, pin, archive, mark unread, move to group) mutate sessions through `sessions.patch`, which requires the `operator.admin` scope. The Android app deliberately connects as a bounded operator without admin (`nativeClientOperatorScopes` in `apps/android/.../node/ConnectionManager.kt`), so every one of those controls fails authorization with `missing scope: operator.admin` on Android. More broadly, user-level chat organization should not require admin rights on any client.

Two smaller gaps in the same surface: session list ordering had no tiebreaker for equal timestamps (unstable offset paging), and a stored channel-derived `displayName` beat a user-assigned `label` in the row projection, so renames of channel-named sessions vanished on the next refresh.

Tracking issue: #100712

## Why This Change Was Made

- `sessions.patch` becomes a params-aware dynamic-scope method (same mechanism as `plugins.sessionAction`): `operator.write` authorizes patches touching only user-level chat-organization fields — `label`, `category`, `pinned`, `archived`, `unread` (plus `key`/`agentId` targeting). Any other field, mixed patches, or unknown keys keep requiring `operator.admin`, fail closed. Write scope can already create sessions, send messages, and abort runs, so chat organization is not an escalation; the admin-only fields (`sendPolicy`, tool inheritance, exec routing, model, spawn metadata, …) stay admin-only. Existing handler guards are unchanged (no archiving active runs or an agent's main session; webchat mutations stay rejected).
- A dedicated write-scoped RPC was rejected: it would duplicate the existing mutation path for the same fields and add protocol/codegen surface for no behavioral gain. Granting mobile clients admin was rejected; the Android operator session is least-privilege by design.
- `compareSessionEntryPairs` gains a locale-independent key tiebreaker after `pinnedAt`/`updatedAt`, so list order and offset paging are deterministic across calls.
- The row projection now prefers `label` over stored `displayName`: an explicit user rename must win over channel-derived names.
- Subagent spawn pinned admin scopes via the static `isAdminOnlyMethod` check; with `sessions.patch` now dynamic it uses the params-aware least-privilege resolver, so spawn-metadata patches still pin to admin (preserves the #59428 no-scope-upgrade contract). `isAdminOnlyMethod` had no other callers outside its own module.

No protocol schema changes: `sessions.patch` params and `sessions.list` `search`/`archived` already exist; `pnpm protocol:check` is clean.

## User Impact

Android (and any non-admin operator client) can now rename, pin, archive, categorize, and mark sessions unread. Session lists page deterministically, and renames of channel-named sessions stick. Admin-gated session mutations are unchanged for admin clients.

## Evidence

- New scope-policy tests in `src/gateway/method-scopes.test.ts`: write scope allowed for organization-field patches (incl. `category`/`unread`), denied for admin fields, mixed patches, and unknown keys; read scope denied; malformed params fall through to handler validation.
- New WS-level test in `src/gateway/server.sessions.store-rpc.test.ts`: a client connected with `["operator.read", "operator.write"]` renames/pins/archives/categorizes via `sessions.patch`, filters archived lists, server-searches by the renamed label (asserting `displayName` reflects the label over a stored channel name), and gets `missing scope: operator.admin` for `sendPolicy`/mixed patches. Plus a tie-ordering/paging test.
- Hosted Testbox runs (Blacksmith): `pnpm test src/gateway/method-scopes.test.ts src/gateway/server.sessions.store-rpc.test.ts src/gateway/session-utils.test.ts src/gateway/session-utils.search.test.ts src/gateway/sessions-patch.test.ts src/gateway/server.sessions.list-changed.test.ts src/agents/subagent-spawn.test.ts` → 20 files, 1200 tests passed (+ 25 in the spawn shard); `pnpm tsgo:core` and `pnpm tsgo:core:test` green; oxlint/oxfmt clean on touched files.
- Autoreview (Codex, gpt-5.5) run to a clean result on the combined change; review findings (label-vs-displayName precedence, cancellation handling in the client half) were verified and fixed before splitting.

Client follow-ups (stacked): iOS/shared and Android PRs add server-backed session search UI on top of this.
