### PR TITLE
fix(android): stabilize chat refresh loading

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -4595,7 +4595,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 416,
+      "line": 425,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
@@ -4603,7 +4603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 461,
+      "line": 470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent sessions",
       "surface": "android",
@@ -4611,7 +4611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 462,
+      "line": 471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start a chat and your active OpenClaw conversations will appear here.",
       "surface": "android",
@@ -4619,7 +4619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 463,
+      "line": 472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -4771,7 +4771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 954,
+      "line": 960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
@@ -4779,7 +4779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 954,
+      "line": 960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
@@ -4787,7 +4787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 986,
+      "line": 992,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
@@ -4795,7 +4795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 993,
+      "line": 999,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Browse",
       "surface": "android",
@@ -4803,7 +4803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 993,
+      "line": 999,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -4811,7 +4811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1045,
+      "line": 1051,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active ${pluralize(\"run\", pendingRunCount)}",
       "surface": "android",
@@ -4819,7 +4819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1166,
+      "line": 1172,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -4827,7 +4827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1231,
+      "line": 1237,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -4835,7 +4835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1305,
+      "line": 1327,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open session",
       "surface": "android",
@@ -4843,7 +4843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1417,
+      "line": 1439,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back",
       "surface": "android",
@@ -4851,7 +4851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1420,
+      "line": 1442,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
@@ -4859,7 +4859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1423,
+      "line": 1445,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
@@ -4867,7 +4867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1447,
+      "line": 1469,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$readyProviderCount ready",
       "surface": "android",
@@ -4875,7 +4875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1447,
+      "line": 1469,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review readiness",
       "surface": "android",
@@ -4883,7 +4883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1458,
+      "line": 1480,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
@@ -4891,7 +4891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1458,
+      "line": 1480,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
@@ -4899,7 +4899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1460,
+      "line": 1482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -4907,7 +4907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1460,
+      "line": 1482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
@@ -4915,7 +4915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1461,
+      "line": 1483,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
@@ -4923,7 +4923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1461,
+      "line": 1483,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
@@ -4931,7 +4931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1503,
+      "line": 1525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
@@ -4939,7 +4939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1506,
+      "line": 1528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
@@ -4947,7 +4947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1506,
+      "line": 1528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -4955,7 +4955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1538,
+      "line": 1560,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
@@ -4963,7 +4963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1539,
+      "line": 1561,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
@@ -4971,7 +4971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1540,
+      "line": 1562,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
@@ -4979,7 +4979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1546,
+      "line": 1568,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$ready/${skills.size} ready",
       "surface": "android",
@@ -4987,7 +4987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1546,
+      "line": 1568,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No skills",
       "surface": "android",
@@ -4995,7 +4995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1724,
+      "line": 1746,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
@@ -5003,7 +5003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1728,
+      "line": 1750,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
@@ -5011,7 +5011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1813,
+      "line": 1835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main session",
       "surface": "android",
@@ -5843,7 +5843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 121,
+      "line": 122,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5851,7 +5851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 142,
+      "line": 143,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5859,7 +5859,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 162,
+      "line": 163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt",
       "source": "No messages yet",
       "surface": "android",
@@ -6067,7 +6067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 715,
+      "line": 721,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -6075,7 +6075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 746,
+      "line": 752,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -6083,7 +6083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 747,
+      "line": 753,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -6091,7 +6091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 898,
+      "line": 904,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -6099,7 +6099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 900,
+      "line": 906,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -6107,7 +6107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 903,
+      "line": 909,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -6115,7 +6115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 913,
+      "line": 919,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -6123,7 +6123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 914,
+      "line": 920,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -6131,7 +6131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1048,
+      "line": 1054,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -6139,7 +6139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1114,
+      "line": 1120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -6147,7 +6147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1180,
+      "line": 1186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -6155,7 +6155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1180,
+      "line": 1186,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -6163,7 +6163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1197,
+      "line": 1203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -6171,7 +6171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1259,
+      "line": 1265,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -6179,7 +6179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1349,
+      "line": 1355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -6187,7 +6187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1364,
+      "line": 1370,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -6195,7 +6195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1379,
+      "line": 1385,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -6203,7 +6203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1417,
+      "line": 1423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -6211,7 +6211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1438,
+      "line": 1444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -6219,7 +6219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1494,
+      "line": 1500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -6227,7 +6227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1533,
+      "line": 1539,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",
@@ -6235,7 +6235,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 270,
+      "line": 273,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt",
       "source": "CHAT ERROR",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -81,6 +81,15 @@ class ChatController internal constructor(
   private val _messagesFromCache = MutableStateFlow(false)
   val messagesFromCache: StateFlow<Boolean> = _messagesFromCache.asStateFlow()
 
+  private data class LiveHistoryMarker(
+    val sessionKey: String,
+    val sessionId: String?,
+    val generation: Long,
+  )
+
+  @Volatile
+  private var liveHistoryMarker: LiveHistoryMarker? = null
+
   private val _historyLoading = MutableStateFlow(false)
   val historyLoading: StateFlow<Boolean> = _historyLoading.asStateFlow()
 
@@ -198,6 +207,7 @@ class ChatController internal constructor(
     _modelCatalog.value = emptyList()
     chatMetadataAgentId = null
     chatMetadataLoadState = ChatMetadataLoadState.Unloaded
+    clearLiveHistoryMarker()
     synchronized(pendingRuns) {
       disconnectedPendingRunIds.addAll(pendingRuns)
     }
@@ -232,6 +242,7 @@ class ChatController internal constructor(
         clearMessages = true,
         markLoading = false,
       )
+      clearLiveHistoryMarker()
       _sessions.value = emptyList()
       sessionsListArchived = false
       unreadPatchSessionKey = null
@@ -254,6 +265,7 @@ class ChatController internal constructor(
   fun load(sessionKey: String) {
     val key = normalizeRequestedSessionKey(sessionKey)
     if (key == _sessionKey.value) {
+      if (hasCurrentLiveHistory(key)) return
       refresh()
       return
     }
@@ -534,6 +546,7 @@ class ChatController internal constructor(
     }
     updateErrorText(null)
     _healthOk.value = false
+    clearLiveHistoryMarker()
     clearPendingRuns()
     pendingToolCallsById.clear()
     publishPendingToolCalls()
@@ -545,6 +558,30 @@ class ChatController internal constructor(
       _messagesFromCache.value = false
     }
     return generation
+  }
+
+  private fun clearLiveHistoryMarker() {
+    liveHistoryMarker = null
+  }
+
+  private fun markLiveHistoryApplied(
+    sessionKey: String,
+    sessionId: String?,
+    generation: Long,
+  ) {
+    liveHistoryMarker = LiveHistoryMarker(sessionKey = sessionKey, sessionId = sessionId, generation = generation)
+  }
+
+  private fun hasCurrentLiveHistory(sessionKey: String): Boolean {
+    val marker = liveHistoryMarker ?: return false
+    // Same-session load may skip refresh only for the exact live snapshot that
+    // applied in the active generation. Cached or stale lifecycle state must refetch.
+    return marker.sessionKey == sessionKey &&
+      marker.generation == historyLoadGeneration.get() &&
+      marker.sessionId == _sessionId.value &&
+      !_messagesFromCache.value &&
+      _errorText.value == null &&
+      _healthOk.value
   }
 
   private fun normalizeRequestedSessionKey(sessionKey: String): String {
@@ -950,6 +987,7 @@ class ChatController internal constructor(
         _messagesFromCache.value = false
         _messages.value = mergeOptimisticMessages(incoming = history.messages, optimistic = optimisticMessagesByRunId.values)
         _sessionId.value = history.sessionId
+        markLiveHistoryApplied(sessionKey = sessionKey, sessionId = history.sessionId, generation = generation)
         _historyLoading.value = false
         if (historyLoadErrorGeneration == generation) {
           updateErrorText(null)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -13,6 +13,7 @@ import ai.openclaw.app.HomeDestination
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NodeRuntime
 import ai.openclaw.app.R
+import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.ui.chat.ChatScreen
 import ai.openclaw.app.ui.design.ClawBottomNav
 import ai.openclaw.app.ui.design.ClawDesignTheme
@@ -92,6 +93,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -128,6 +130,7 @@ private val shellContentInsets: WindowInsets
 private val overviewMetricTileMinHeight = 96.dp
 private val overviewTalkPanelMinHeight = 72.dp
 private val overviewListRowMinHeight = 54.dp
+private const val overviewRecentSessionLimit = 50
 
 internal fun shellBottomNavVisible(
   keyboardVisible: Boolean,
@@ -380,13 +383,19 @@ private fun OverviewScreen(
   val headerRoute = overviewHeaderRoute(attentionRows)
   val activeAgentName = overviewAgentName(agents = agents, defaultAgentId = defaultAgentId)
   val activeAgentBadge = overviewAgentBadgeText(agents = agents, defaultAgentId = defaultAgentId)
+  val overviewSessions = overviewRecentSessions(sessions)
+  val overviewSessionCount = overviewSessions.size
+  val recentRows =
+    remember(overviewSessions, channelsSummary) {
+      overviewRecentSessionRows(sessions = overviewSessions, channelsSummary = channelsSummary)
+    }
   val metricCards =
     overviewMetricCards(
       isConnected = isConnected,
       hasAttention = attentionRows.isNotEmpty(),
       nodesDevicesSummary = nodesDevicesSummary,
       pendingApprovals = pendingApprovalsCount,
-      sessionCount = sessions.size,
+      sessionCount = overviewSessionCount,
     )
 
   LaunchedEffect(isConnected) {
@@ -426,7 +435,7 @@ private fun OverviewScreen(
             statusText = gatewaySummary(gatewayConnectionDisplay),
             isConnected = gatewayConnectionDisplay.isConnected,
             pendingRunCount = pendingRunCount,
-            sessionCount = sessions.size,
+            sessionCount = overviewSessionCount,
             cronJobCount = cronStatus.jobs,
             onOpenChat = { onSelectTab(Tab.Chat) },
             onOpenVoice = { onSelectTab(Tab.Voice) },
@@ -455,7 +464,7 @@ private fun OverviewScreen(
 
         item { RecentSessionsHeader(onOpenSessions = { onSelectTab(Tab.Sessions) }) }
 
-        if (sessions.isEmpty()) {
+        if (recentRows.isEmpty()) {
           item {
             ClawEmptyState(
               title = "No recent sessions",
@@ -466,16 +475,7 @@ private fun OverviewScreen(
         } else {
           item {
             RecentSessionList(
-              rows =
-                sessions.take(3).map { session ->
-                  val title = displaySessionTitle(session.displayName)
-                  RecentSessionListItem(
-                    key = session.key,
-                    title = title,
-                    source = sessionSourceLabel(session.key, channelsSummary),
-                    metadata = session.updatedAtMs?.let(::relativeSessionTime) ?: "",
-                  )
-                },
+              rows = recentRows,
               onOpen = { sessionKey ->
                 viewModel.switchChatSession(sessionKey)
                 onSelectTab(Tab.Chat)
@@ -860,6 +860,12 @@ internal fun overviewHeaderState(
 
 internal fun overviewHeaderRoute(attentionRows: List<HomeAttentionRow>): SettingsRoute = attentionRows.firstNotNullOfOrNull { it.settingsRoute } ?: SettingsRoute.Gateway
 
+internal fun overviewRecentSessionCount(sessions: List<ChatSessionEntry>): Int =
+  overviewRecentSessions(sessions).size
+
+internal fun overviewRecentSessions(sessions: List<ChatSessionEntry>): List<ChatSessionEntry> =
+  sessions.take(overviewRecentSessionLimit).distinctBy { session -> session.key }
+
 internal data class OverviewMetricCard(
   val title: String,
   val value: String,
@@ -1242,6 +1248,22 @@ private data class RecentSessionListItem(
   val source: String,
   val metadata: String,
 )
+
+private fun overviewRecentSessionRows(
+  sessions: List<ChatSessionEntry>,
+  channelsSummary: GatewayChannelsSummary,
+): List<RecentSessionListItem> =
+  sessions
+    .take(3)
+    .map { session ->
+      val title = displaySessionTitle(session.displayName)
+      RecentSessionListItem(
+        key = session.key,
+        title = title,
+        source = sessionSourceLabel(session.key, channelsSummary),
+        metadata = session.updatedAtMs?.let(::relativeSessionTime) ?: "",
+      )
+    }
 
 /** Recent sessions panel that preserves the session key behind display labels. */
 @Composable

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMessageListCard.kt
@@ -42,6 +42,7 @@ fun ChatMessageListCard(
   pendingToolCalls: List<ChatPendingToolCall>,
   streamingAssistantText: String?,
   healthOk: Boolean,
+  gatewayOffline: Boolean,
   modifier: Modifier = Modifier,
   outboxItems: List<ChatOutboxItem> = emptyList(),
   onRetryOutbox: (String) -> Unit = {},
@@ -96,7 +97,7 @@ fun ChatMessageListCard(
     }
 
     if (timeline.items.isEmpty()) {
-      if (historyLoading) {
+      if (showChatLoadingPlaceholder(historyLoading = historyLoading, healthOk = healthOk, gatewayOffline = gatewayOffline)) {
         LoadingChatHint(modifier = Modifier.align(Alignment.Center))
       } else {
         EmptyChatHint(modifier = Modifier.align(Alignment.Center), healthOk = healthOk)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -664,7 +664,7 @@ private fun ChatMessageList(
     }
 
     if (timeline.items.isEmpty()) {
-      if (historyLoading) {
+      if (showChatLoadingPlaceholder(historyLoading = historyLoading, healthOk = healthOk, gatewayOffline = gatewayOffline)) {
         ClawLoadingState(title = "Loading session", modifier = Modifier.align(Alignment.Center))
       } else {
         EmptyChatHint(
@@ -698,6 +698,12 @@ private fun ChatMessageList(
     }
   }
 }
+
+internal fun showChatLoadingPlaceholder(
+  historyLoading: Boolean,
+  healthOk: Boolean,
+  gatewayOffline: Boolean,
+): Boolean = historyLoading && !healthOk && !gatewayOffline
 
 @Composable
 private fun EmptyChatHint(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatSheetContent.kt
@@ -87,6 +87,8 @@ fun ChatSheetContent(viewModel: MainViewModel) {
   val pendingAssistantAutoSend by viewModel.pendingAssistantAutoSend.collectAsState()
   val assistantAutoSendInFlight by viewModel.assistantAutoSendInFlight.collectAsState()
   val outboxItems by viewModel.chatOutboxItems.collectAsState()
+  val gatewayConnectionDisplay by viewModel.gatewayConnectionDisplay.collectAsState()
+  val gatewayOffline = !gatewayConnectionDisplay.isConnected
 
   LaunchedEffect(Unit) {
     val loadSessionKey = resolveInitialChatLoadSessionKey(sessionKey, mainSessionKey)
@@ -164,6 +166,7 @@ fun ChatSheetContent(viewModel: MainViewModel) {
       pendingToolCalls = pendingToolCalls,
       streamingAssistantText = streamingAssistantText,
       healthOk = healthOk,
+      gatewayOffline = gatewayOffline,
       modifier = Modifier.weight(1f, fill = true),
       outboxItems =
         outboxItemsForSession(

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerStreamReplayTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerStreamReplayTest.kt
@@ -357,6 +357,93 @@ class ChatControllerStreamReplayTest {
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
+  fun loadOfCurrentLiveSessionDoesNotRefreshOrMarkHistoryLoading() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val controller = newController(gateway)
+
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("assistant", "main transcript", 1_000)),
+        ),
+      )
+      controller.load("main")
+      advanceUntilIdle()
+      val historyCallsAfterLiveLoad = gateway.callCount("chat.history")
+      assertFalse(controller.historyLoading.value)
+      assertEquals(listOf("assistant" to "main transcript"), transcript(controller))
+
+      controller.load("main")
+
+      assertEquals(historyCallsAfterLiveLoad, gateway.callCount("chat.history"))
+      assertFalse(controller.historyLoading.value)
+      assertEquals(listOf("assistant" to "main transcript"), transcript(controller))
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun explicitRefreshFetchesAfterSameSessionLoadGate() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val controller = newController(gateway)
+
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("assistant", "main transcript", 1_000)),
+        ),
+      )
+      controller.load("main")
+      advanceUntilIdle()
+      val historyCallsAfterLiveLoad = gateway.callCount("chat.history")
+
+      controller.load("main")
+      assertEquals(historyCallsAfterLiveLoad, gateway.callCount("chat.history"))
+
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("assistant", "refreshed transcript", 2_000)),
+        ),
+      )
+      controller.refresh()
+      advanceUntilIdle()
+
+      assertEquals(historyCallsAfterLiveLoad + 1, gateway.callCount("chat.history"))
+      assertEquals(listOf("assistant" to "refreshed transcript"), transcript(controller))
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun loadOfCurrentUnhealthyLiveSessionRefreshesToRecoverHealth() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      val controller = newController(gateway)
+      gateway.respond("health") { error("gateway down") }
+      gateway.respondWith(
+        "chat.history",
+        historyResponse(
+          sessionId = "session-main",
+          messages = listOf(ReplayHistoryMessage("assistant", "main transcript", 1_000)),
+        ),
+      )
+
+      controller.load("main")
+      advanceUntilIdle()
+      assertFalse(controller.healthOk.value)
+      assertFalse(controller.historyLoading.value)
+
+      controller.load("main")
+
+      assertTrue(controller.historyLoading.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun unknownTerminalRefreshesIdleTranscript() =
     runTest {
       val gateway = ScriptedGateway(json)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -10,6 +10,7 @@ import ai.openclaw.app.GatewayNodeApprovalState
 import ai.openclaw.app.GatewayNodeSummary
 import ai.openclaw.app.GatewayNodesDevicesSummary
 import ai.openclaw.app.GatewayPendingDeviceSummary
+import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.ui.design.ClawStatus
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
@@ -317,6 +318,31 @@ class ShellScreenLogicTest {
     assertEquals("4", cards.single { it.title == "Sessions" }.value)
     assertEquals("Browse", cards.single { it.title == "Files" }.value)
     assertEquals(Tab.Files, cards.single { it.title == "Files" }.tab)
+  }
+
+  @Test
+  fun overviewRecentSessionCountIgnoresRetainedRowsOutsideTheRecentWindow() {
+    val sessions =
+      (1..51).map { index ->
+        ChatSessionEntry(key = "session-$index", updatedAtMs = index.toLong())
+      }
+
+    assertEquals(50, overviewRecentSessionCount(sessions))
+    assertEquals((1..50).map { "session-$it" }, overviewRecentSessions(sessions).map { it.key })
+  }
+
+  @Test
+  fun overviewRecentSessionsDeduplicateWithinTheRecentWindow() {
+    assertEquals(
+      listOf("main", "cron"),
+      overviewRecentSessions(
+        listOf(
+          ChatSessionEntry(key = "main", updatedAtMs = 3),
+          ChatSessionEntry(key = "cron", updatedAtMs = 2),
+          ChatSessionEntry(key = "main", updatedAtMs = 1),
+        ),
+      ).map { session -> session.key },
+    )
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatSheetContentTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatSheetContentTest.kt
@@ -1,7 +1,9 @@
 package ai.openclaw.app.ui.chat
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ChatSheetContentTest {
@@ -48,6 +50,24 @@ class ChatSheetContentTest {
       resolveInitialChatLoadSessionKey(
         sessionKey = "session:history",
         mainSessionKey = "agent:ops:device",
+      ),
+    )
+  }
+
+  @Test
+  fun healthyEmptyChatShowsStarterStateInsteadOfLoadingPlaceholder() {
+    assertFalse(
+      showChatLoadingPlaceholder(
+        historyLoading = true,
+        healthOk = true,
+        gatewayOffline = false,
+      ),
+    )
+    assertTrue(
+      showChatLoadingPlaceholder(
+        historyLoading = true,
+        healthOk = false,
+        gatewayOffline = false,
       ),
     )
   }


### PR DESCRIPTION
## What Problem This Solves

Android could visibly flicker during automatic refreshes in two places:

- Re-entering the already-loaded Chat tab called `ChatController.load(currentSession)` and immediately forced another history refresh, which toggled `historyLoading` and could flash `Loading session` even when the chat was already ready.
- Overview rendered raw recent-session rows/counts from the gateway list, so retained/duplicate rows outside the intended recent window could churn the Recent Sessions panel and session count.

Regression provenance:

- Chat same-session refresh behavior came from #100551 (`2b48e98148405441b3aa7812ca643a114228dace`, merged 2026-07-06T02:50:09Z): `load(current)` started routing to `refresh()`.
- Overview raw recent-session rendering came from #95557 (`5e342c774d8db4b8d311bdca980837d10d1a8781`, merged 2026-06-22T23:57:34Z): Overview used `sessions.size` and `sessions.take(3)` directly.

## Why This Change Was Made

This keeps automatic refreshes from replacing stable UI with loading/empty states when the current data is already live and healthy:

- Track the session key whose live history has applied, and skip same-session `load()` only when that history is live, not cache-backed, error-free, and chat health is OK.
- Keep refreshing when chat health is false so tab entry can recover a failed health poll.
- Gate the full Chat screen and legacy Chat sheet loading placeholders behind the same helper so healthy empty chat shows the starter state instead of `Loading session`.
- Normalize Overview recent sessions through a 50-row deduped window before deriving counts and the three visible rows, while preserving gateway recency ordering.

## User Impact

Switching back to Chat should stay visually stable instead of flashing `Loading session` for an already-loaded healthy session. Overview Recent Sessions should avoid duplicate/retained-row count churn without freezing stale ordering.

No typography/design-token changes are included in this PR.

## Risk Mitigation

The same-session load gate now uses a live-history marker tied to the applied history generation and session id, not just a session key. Same-session `load()` skips refresh only when that marker still matches the active controller state, the transcript is not cache-backed, there is no error, and chat health is OK. Explicit refresh remains a fresh fetch path and is covered by `explicitRefreshFetchesAfterSameSessionLoadGate`.

## Evidence

Regression proof on unpatched `origin/main` with only the new controller test applied:

```bash
./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.chat.ChatControllerStreamReplayTest.loadOfCurrentLiveSessionDoesNotRefreshOrMarkHistoryLoading
```

Result: failed at `ChatControllerStreamReplayTest.kt:361` because `load(current)` triggered another refresh/history-loading path.

Visual proof captured on emulator `emulator-5554` against the same gateway/app data:

![Before and after Android chat refresh proof](https://github.com/Solvely-Colin/openclaw/releases/download/_attachments/openclaw-before-after-side-by-side.gif)

Left: unpatched `origin/main`; right: this PR.

- Before (`origin/main`): Home -> Chat second entry shows `Ready` in the header while the body flashes `Loading session`.
- After (`codex/android-refresh-flicker-fix`): Home -> Chat second entry stays on the ready starter state without the `Loading session` flash.

Fixed branch proof:

```bash
./gradlew :app:testPlayDebugUnitTest \
  --tests ai.openclaw.app.chat.ChatControllerStreamReplayTest \
  --tests ai.openclaw.app.chat.ChatControllerModelSelectionTest \
  --tests ai.openclaw.app.chat.ChatControllerReconnectRestoreTest \
  --tests ai.openclaw.app.ui.ShellScreenLogicTest \
  --tests ai.openclaw.app.ui.chat.ChatSheetContentTest
./gradlew :app:runKtlintCheckOverMainSourceSet :app:runKtlintCheckOverTestSourceSet
pnpm native:i18n:check
pnpm android:i18n:check
git diff --check
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

Results:

- Focused Android unit tests: passed, including chat stream replay, chat model selection, reconnect/session recovery, Overview session logic, and chat sheet placeholder coverage.
- Android ktlint main/test source sets: passed.
- Native i18n inventory check: passed after syncing `apps/.i18n/native-source.json`.
- Android i18n resources check: passed.
- `git diff --check`: passed.
- Autoreview: clean, no accepted/actionable findings.





