### PR TITLE
feat(android): support opt-in background location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Android background location:** let third-party builds opt into `Always` location through Android settings, keep requested background checks visible in the persistent node notification, and keep the Play flavor foreground-only. (#68581) Thanks @ioridev.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Android background location:** let third-party builds opt into `Always` location through Android settings, keep requested background checks visible in the persistent node notification, and keep the Play flavor foreground-only. (#68581) Thanks @ioridev.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -163,7 +163,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 113,
+      "line": 116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Connected",
       "surface": "android",
@@ -171,7 +171,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 113,
+      "line": 116,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": "Talk mode active",
       "surface": "android",
@@ -179,7 +179,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 239,
+      "line": 278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Listening",
       "surface": "android",
@@ -187,7 +187,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 239,
+      "line": 278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt",
       "source": " · Mic: Pending",
       "surface": "android",
@@ -195,7 +195,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 577,
+      "line": 579,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Offline",
       "surface": "android",
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2467,
+      "line": 2469,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2469,
+      "line": 2471,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2471,
+      "line": 2473,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -2923,7 +2923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 214,
+      "line": 215,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
@@ -2931,7 +2931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 214,
+      "line": 215,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -2939,7 +2939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 234,
+      "line": 235,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -2947,7 +2947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 239,
+      "line": 240,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -2955,7 +2955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 240,
+      "line": 241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -2963,7 +2963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 275,
+      "line": 276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron Jobs",
       "surface": "android",
@@ -2971,7 +2971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 275,
+      "line": 276,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
@@ -2979,7 +2979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 286,
+      "line": 287,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android shows scheduled work status. Create and edit schedules from the desktop app.",
       "surface": "android",
@@ -2987,7 +2987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 296,
+      "line": 297,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load cron jobs.",
       "surface": "android",
@@ -2995,7 +2995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 301,
+      "line": 302,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No scheduled jobs.",
       "surface": "android",
@@ -3003,7 +3003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 302,
+      "line": 303,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Create recurring OpenClaw work from the desktop app.",
       "surface": "android",
@@ -3011,7 +3011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 337,
+      "line": 338,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect scheduled gateway work.",
       "surface": "android",
@@ -3019,7 +3019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 351,
+      "line": 352,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect cron jobs.",
       "surface": "android",
@@ -3027,7 +3027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 359,
+      "line": 360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron job not loaded.",
       "surface": "android",
@@ -3035,7 +3035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 359,
+      "line": 360,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading cron job…",
       "surface": "android",
@@ -3043,7 +3043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 381,
+      "line": 382,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -3051,7 +3051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 381,
+      "line": 382,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
@@ -3059,7 +3059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 392,
+      "line": 393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -3067,7 +3067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 396,
+      "line": 397,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -3075,7 +3075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 422,
+      "line": 423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -3083,7 +3083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 422,
+      "line": 423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
@@ -3091,7 +3091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 433,
+      "line": 434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -3099,7 +3099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 433,
+      "line": 434,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -3107,7 +3107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 446,
+      "line": 447,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -3115,7 +3115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 447,
+      "line": 448,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -3123,7 +3123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 453,
+      "line": 454,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -3131,7 +3131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 454,
+      "line": 455,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -3139,7 +3139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 461,
+      "line": 462,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session activity",
       "surface": "android",
@@ -3147,7 +3147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 462,
+      "line": 463,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active session remain visible here.",
       "surface": "android",
@@ -3155,7 +3155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 476,
+      "line": 477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
@@ -3163,7 +3163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 476,
+      "line": 477,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -3171,7 +3171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 479,
+      "line": 480,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -3179,7 +3179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 480,
+      "line": 481,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -3187,7 +3187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 499,
+      "line": 500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure voice, transport, and playback.",
       "surface": "android",
@@ -3195,7 +3195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 499,
+      "line": 500,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -3203,7 +3203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 502,
+      "line": 503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -3211,7 +3211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 503,
+      "line": 504,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -3219,7 +3219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 506,
+      "line": 507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -3227,7 +3227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 506,
+      "line": 507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -3235,7 +3235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 507,
+      "line": 508,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -3243,7 +3243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 507,
+      "line": 508,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -3251,7 +3251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 509,
+      "line": 510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -3259,7 +3259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 509,
+      "line": 510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -3267,7 +3267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 513,
+      "line": 514,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -3275,7 +3275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 523,
+      "line": 524,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -3283,7 +3283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 524,
+      "line": 525,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
@@ -3291,7 +3291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 652,
+      "line": 653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -3299,7 +3299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 652,
+      "line": 653,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -3307,7 +3307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 685,
+      "line": 686,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
@@ -3315,7 +3315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 685,
+      "line": 686,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -3323,7 +3323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 689,
+      "line": 690,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -3331,7 +3331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 689,
+      "line": 690,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -3339,7 +3339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 701,
+      "line": 702,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -3347,7 +3347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 701,
+      "line": 702,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -3355,7 +3355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 706,
+      "line": 707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -3363,7 +3363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 706,
+      "line": 707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -3371,7 +3371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 716,
+      "line": 717,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -3379,7 +3379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 765,
+      "line": 766,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -3387,7 +3387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 772,
+      "line": 773,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -3395,7 +3395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 772,
+      "line": 773,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -3403,7 +3403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 777,
+      "line": 778,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -3411,7 +3411,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 780,
+      "line": 781,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -3419,7 +3419,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 781,
+      "line": 782,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
@@ -3427,7 +3427,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 788,
+      "line": 789,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -3435,7 +3435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 799,
+      "line": 800,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -3443,7 +3443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 934,
+      "line": 1039,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
@@ -3451,7 +3451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 934,
+      "line": 1039,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -3459,7 +3459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 943,
+      "line": 1048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -3467,7 +3467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 943,
+      "line": 1048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -3475,7 +3475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 953,
+      "line": 1058,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -3483,7 +3483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 953,
+      "line": 1058,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -3491,23 +3491,55 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 964,
+      "line": 1069,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
       "id": "native.android.4ea310efb1f0e7ff"
     },
     {
-      "kind": "conditional-branch",
-      "line": 967,
+      "kind": "ui-named-argument",
+      "line": 1077,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
-      "source": "While Using",
+      "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
-      "id": "native.android.53928793ec65d766"
+      "id": "native.android.58549715b04997cc"
     },
     {
       "kind": "ui-call",
-      "line": 1006,
+      "line": 1102,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Allow background location?",
+      "surface": "android",
+      "id": "native.android.d5a8d7f97a7971b1"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1104,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "OpenClaw only checks location when your paired Gateway requests it. ",
+      "surface": "android",
+      "id": "native.android.9d149d1ad66e42f9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1117,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Open Settings",
+      "surface": "android",
+      "id": "native.android.c48805f3de1d72ca"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1122,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Not Now",
+      "surface": "android",
+      "id": "native.android.fd97640418602532"
+    },
+    {
+      "kind": "ui-call",
+      "line": 1160,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -3515,7 +3547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1021,
+      "line": 1175,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -3523,7 +3555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1026,
+      "line": 1180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -3531,7 +3563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1033,
+      "line": 1187,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -3539,7 +3571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1037,
+      "line": 1191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -3547,7 +3579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1037,
+      "line": 1191,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -3555,7 +3587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1038,
+      "line": 1192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -3563,7 +3595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1038,
+      "line": 1192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -3571,7 +3603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1048,
+      "line": 1202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -3579,7 +3611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1049,
+      "line": 1203,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -3587,7 +3619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1055,
+      "line": 1209,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
       "surface": "android",
@@ -3595,7 +3627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1062,
+      "line": 1216,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pair New Gateway",
       "surface": "android",
@@ -3603,7 +3635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1063,
+      "line": 1217,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
@@ -3611,7 +3643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1067,
+      "line": 1221,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -3619,7 +3651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1076,
+      "line": 1230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
@@ -3627,7 +3659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1077,
+      "line": 1231,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -3635,7 +3667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1079,
+      "line": 1233,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -3643,7 +3675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1080,
+      "line": 1234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -3651,7 +3683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1084,
+      "line": 1238,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Local",
       "surface": "android",
@@ -3659,7 +3691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1088,
+      "line": 1242,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -3667,7 +3699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1089,
+      "line": 1243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -3675,7 +3707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1091,
+      "line": 1245,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -3683,7 +3715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1096,
+      "line": 1250,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -3691,7 +3723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1113,
+      "line": 1267,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -3699,7 +3731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1136,
+      "line": 1290,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "A calm, high-contrast OpenClaw interface.",
       "surface": "android",
@@ -3707,7 +3739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1136,
+      "line": 1290,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -3715,7 +3747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1147,
+      "line": 1301,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -3723,7 +3755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1170,
+      "line": 1346,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -3731,7 +3763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1199,
+      "line": 1375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -3739,7 +3771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1199,
+      "line": 1375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -3747,7 +3779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1211,
+      "line": 1387,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -3755,7 +3787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1213,
+      "line": 1389,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -3763,7 +3795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1216,
+      "line": 1392,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -3771,7 +3803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1246,
+      "line": 1422,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -3779,7 +3811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1247,
+      "line": 1423,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -3787,7 +3819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1256,
+      "line": 1432,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -3795,7 +3827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1282,
+      "line": 1458,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -3803,7 +3835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1317,
+      "line": 1493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -3811,7 +3843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1350,
+      "line": 1526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -3819,7 +3851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1424,
+      "line": 1600,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -3827,7 +3859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1433,
+      "line": 1609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -3835,7 +3867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1433,
+      "line": 1609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowing",
       "surface": "android",
@@ -3843,7 +3875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1441,
+      "line": 1617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -3851,7 +3883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1441,
+      "line": 1617,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving",
       "surface": "android",
@@ -3859,7 +3891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1449,
+      "line": 1625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -3867,7 +3899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1449,
+      "line": 1625,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Denying",
       "surface": "android",
@@ -3875,7 +3907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1474,
+      "line": 1650,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -3883,7 +3915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1502,
+      "line": 1678,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -3891,7 +3923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1532,
+      "line": 1708,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -3899,7 +3931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1546,
+      "line": 1722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -3907,7 +3939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1546,
+      "line": 1722,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -3915,7 +3947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1564,
+      "line": 1740,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -3923,7 +3955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1567,
+      "line": 1743,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -3931,7 +3963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1606,
+      "line": 1782,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -3939,7 +3971,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1621,
+      "line": 1797,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -3947,7 +3979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1659,
+      "line": 1835,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -3955,7 +3987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1661,
+      "line": 1837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -3963,7 +3995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1717,
+      "line": 1893,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -3971,7 +4003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1720,
+      "line": 1896,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -3979,7 +4011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1720,
+      "line": 1896,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -3987,7 +4019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1748,
+      "line": 1924,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -3995,7 +4027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1755,
+      "line": 1931,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -4003,7 +4035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1786,
+      "line": 1962,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -4011,7 +4043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1807,
+      "line": 1983,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -4019,7 +4051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1808,
+      "line": 1984,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -4027,7 +4059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1809,
+      "line": 1985,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -4035,7 +4067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1810,
+      "line": 1986,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Android onboarding now completes after permission-triggered node approval and keeps Back navigation from cycling between permissions and approval.
 
+Third-party Android builds can now opt into Always location through Android settings, with requested background checks disclosed in the persistent node notification while Play builds remain foreground-only. (#68581) Thanks @ioridev.
+
 Android system notifications now open OpenClaw when tapped without accepting arbitrary external deeplinks.
 
 Android chat history now excludes internal, reasoning, and tool-result rows from rendered messages and the offline transcript cache.

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -240,6 +240,9 @@ More details: `docs/platforms/android.md`.
 - Discovery:
   - Android 13+ (`API 33+`): `NEARBY_WIFI_DEVICES`
   - Android 12 and below: `ACCESS_FINE_LOCATION` (required for NSD scanning)
+- Location:
+  - Both flavors: `ACCESS_FINE_LOCATION` / `ACCESS_COARSE_LOCATION` for foreground checks.
+  - Third-party flavor only: `ACCESS_BACKGROUND_LOCATION` plus `FOREGROUND_SERVICE_LOCATION` for user-enabled `Always` checks.
 - Foreground service notification (Android 13+): `POST_NOTIFICATIONS`
 - Camera:
   - `CAMERA` for `camera.snap` and `camera.clip`
@@ -265,9 +268,9 @@ Current OpenClaw Android implication:
 - APK / sideload build can keep SMS, Call Log, and recent-photo features.
 - Google Play build excludes SMS send/search, Call Log search, and recent-photo access unless the product is intentionally positioned and approved under the relevant policy exception.
 - The repo now ships this split as Android product flavors:
-  - `play`: removes `READ_SMS`, `SEND_SMS`, `READ_CALL_LOG`, `READ_MEDIA_IMAGES`, `READ_MEDIA_VISUAL_USER_SELECTED`, and `READ_EXTERNAL_STORAGE`; hides SMS, Call Log, and Photos surfaces in onboarding, settings, and advertised node capabilities.
+  - `play`: removes `READ_SMS`, `SEND_SMS`, `READ_CALL_LOG`, `READ_MEDIA_IMAGES`, `READ_MEDIA_VISUAL_USER_SELECTED`, `READ_EXTERNAL_STORAGE`, and background location; hides SMS, Call Log, Photos, and `Always` location surfaces.
   - Installed-app listing is user controlled. `device.apps` is advertised only after the user enables **Settings > Phone Capabilities > Installed Apps**. The command defaults to launcher-visible apps and does not require `QUERY_ALL_PACKAGES`.
-  - `thirdParty`: keeps the full permission set and the existing SMS / Call Log / Photos functionality.
+  - `thirdParty`: keeps the full permission set and the existing SMS / Call Log / Photos functionality, and offers explicit `Always` location opt-in through Android settings.
 
 Policy links:
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/LocationMode.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/LocationMode.kt
@@ -8,15 +8,27 @@ enum class LocationMode(
 ) {
   Off("off"),
   WhileUsing("whileUsing"),
+  Always("always"),
   ;
 
   companion object {
-    /** Parses persisted location mode text while migrating old always-on configs to while-using. */
+    /** Parses persisted location mode text. */
     fun fromRawValue(raw: String?): LocationMode {
       val normalized = raw?.trim()?.lowercase()
-      // Older configs used "always"; Android node currently exposes while-using location only.
-      if (normalized == "always") return WhileUsing
       return entries.firstOrNull { it.rawValue.lowercase() == normalized } ?: Off
     }
   }
 }
+
+/** Resolves the in-app mode after Android's external background-location settings return. */
+internal fun locationModeAfterBackgroundSettings(
+  previousMode: LocationMode,
+  foregroundGranted: Boolean,
+  backgroundGranted: Boolean,
+): LocationMode =
+  when {
+    foregroundGranted && backgroundGranted -> LocationMode.Always
+    !foregroundGranted -> LocationMode.Off
+    previousMode == LocationMode.Always -> LocationMode.WhileUsing
+    else -> previousMode
+  }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeForegroundService.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app
 
+import android.Manifest
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -7,6 +8,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import androidx.core.app.NotificationCompat
 import androidx.core.app.ServiceCompat
@@ -45,7 +47,8 @@ class NodeForegroundService : Service() {
             runtime.gatewayConnectionDisplay,
             runtime.serverName,
             runtime.voiceCaptureMode,
-          ) { connection, server, mode ->
+            runtime.locationMode,
+          ) { connection, server, mode, _ ->
             VoiceNotificationBase(
               status = connection.statusText,
               server = server,
@@ -146,6 +149,7 @@ class NodeForegroundService : Service() {
     text: String,
   ): Notification {
     val launchPending = mainActivityPendingIntent(this, requestCode = 1)
+    val visibleText = text + backgroundLocationNotificationSuffix(isBackgroundLocationActive())
 
     val stopIntent = Intent(this, NodeForegroundService::class.java).setAction(ACTION_STOP)
     val stopPending =
@@ -160,7 +164,7 @@ class NodeForegroundService : Service() {
       .Builder(this, CHANNEL_ID)
       .setSmallIcon(R.mipmap.ic_launcher)
       .setContentTitle(title)
-      .setContentText(text)
+      .setContentText(visibleText)
       .setContentIntent(launchPending)
       .setOngoing(true)
       .setOnlyAlertOnce(true)
@@ -170,8 +174,27 @@ class NodeForegroundService : Service() {
   }
 
   private fun startForegroundWithTypes(notification: Notification) {
-    val serviceTypes = foregroundServiceTypesForVoiceMode(voiceCaptureMode)
+    val serviceTypes =
+      foregroundServiceTypes(
+        voiceMode = voiceCaptureMode,
+        backgroundLocationActive = isBackgroundLocationActive(),
+      )
     ServiceCompat.startForeground(this, NOTIFICATION_ID, notification, serviceTypes)
+  }
+
+  private fun isBackgroundLocationActive(): Boolean {
+    if (!SensitiveFeatureConfig.backgroundLocationEnabled) return false
+    if ((application as NodeApp).prefs.locationMode.value != LocationMode.Always) return false
+    val fineGranted =
+      ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED
+    val coarseGranted =
+      ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED
+    val backgroundGranted =
+      ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
+        PackageManager.PERMISSION_GRANTED
+    return (fineGranted || coarseGranted) && backgroundGranted
   }
 
   companion object {
@@ -210,15 +233,31 @@ class NodeForegroundService : Service() {
   }
 }
 
-internal fun foregroundServiceTypesForVoiceMode(mode: VoiceCaptureMode): Int {
+internal fun foregroundServiceTypes(
+  voiceMode: VoiceCaptureMode,
+  backgroundLocationActive: Boolean,
+): Int {
   val base = ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-  return when (mode) {
-    VoiceCaptureMode.Off -> base
-    VoiceCaptureMode.ManualMic,
-    VoiceCaptureMode.TalkMode,
-    -> base or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+  val voiceTypes =
+    when (voiceMode) {
+      VoiceCaptureMode.Off -> base
+      VoiceCaptureMode.ManualMic,
+      VoiceCaptureMode.TalkMode,
+      -> base or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+    }
+  return if (backgroundLocationActive) {
+    voiceTypes or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+  } else {
+    voiceTypes
   }
 }
+
+internal fun backgroundLocationNotificationSuffix(active: Boolean): String =
+  if (active) {
+    " · Location: Always"
+  } else {
+    ""
+  }
 
 internal fun voiceNotificationSuffix(
   mode: VoiceCaptureMode,

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -420,6 +420,8 @@ class NodeRuntime private constructor(
       location = location,
       json = json,
       isForeground = { _isForeground.value },
+      locationMode = { locationMode.value },
+      backgroundLocationEnabled = { SensitiveFeatureConfig.backgroundLocationEnabled },
       locationPreciseEnabled = { locationPreciseEnabled.value },
     )
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -605,9 +605,14 @@ class SecurePrefs(
 
   private fun loadLocationMode(): LocationMode {
     val raw = plainPrefs.getString(locationModeKey, "off")
-    val resolved = LocationMode.fromRawValue(raw)
-    if (raw?.trim()?.lowercase() == "always") {
-      // Migrate old "always" configs to the current while-using contract.
+    val stored = LocationMode.fromRawValue(raw)
+    val resolved =
+      if (stored == LocationMode.Always && !SensitiveFeatureConfig.backgroundLocationEnabled) {
+        LocationMode.WhileUsing
+      } else {
+        stored
+      }
+    if (resolved != stored) {
       plainPrefs.edit { putString(locationModeKey, resolved.rawValue) }
     }
     return resolved

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/LocationHandler.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.node
 
+import ai.openclaw.app.LocationMode
 import ai.openclaw.app.gateway.GatewaySession
 import android.Manifest
 import android.content.Context
@@ -18,6 +19,8 @@ internal interface LocationDataSource {
 
   fun hasCoarsePermission(context: Context): Boolean
 
+  fun hasBackgroundPermission(context: Context): Boolean
+
   suspend fun fetchLocation(
     desiredProviders: List<String>,
     maxAgeMs: Long?,
@@ -35,6 +38,10 @@ private class DefaultLocationDataSource(
 
   override fun hasCoarsePermission(context: Context): Boolean =
     ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) ==
+      PackageManager.PERMISSION_GRANTED
+
+  override fun hasBackgroundPermission(context: Context): Boolean =
+    ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) ==
       PackageManager.PERMISSION_GRANTED
 
   override suspend fun fetchLocation(
@@ -56,6 +63,8 @@ class LocationHandler private constructor(
   private val dataSource: LocationDataSource,
   private val json: Json,
   private val isForeground: () -> Boolean,
+  private val locationMode: () -> LocationMode,
+  private val backgroundLocationEnabled: () -> Boolean,
   private val locationPreciseEnabled: () -> Boolean,
 ) {
   constructor(
@@ -63,12 +72,16 @@ class LocationHandler private constructor(
     location: LocationCaptureManager,
     json: Json,
     isForeground: () -> Boolean,
+    locationMode: () -> LocationMode,
+    backgroundLocationEnabled: () -> Boolean,
     locationPreciseEnabled: () -> Boolean,
   ) : this(
     appContext = appContext,
     dataSource = DefaultLocationDataSource(location),
     json = json,
     isForeground = isForeground,
+    locationMode = locationMode,
+    backgroundLocationEnabled = backgroundLocationEnabled,
     locationPreciseEnabled = locationPreciseEnabled,
   )
 
@@ -85,6 +98,8 @@ class LocationHandler private constructor(
       dataSource: LocationDataSource,
       json: Json = Json { ignoreUnknownKeys = true },
       isForeground: () -> Boolean = { true },
+      locationMode: () -> LocationMode = { LocationMode.WhileUsing },
+      backgroundLocationEnabled: () -> Boolean = { false },
       locationPreciseEnabled: () -> Boolean = { true },
     ): LocationHandler =
       LocationHandler(
@@ -92,17 +107,20 @@ class LocationHandler private constructor(
         dataSource = dataSource,
         json = json,
         isForeground = isForeground,
+        locationMode = locationMode,
+        backgroundLocationEnabled = backgroundLocationEnabled,
         locationPreciseEnabled = locationPreciseEnabled,
       )
   }
 
   /** Handles location.get with foreground, permission, and user precision gates applied. */
   suspend fun handleLocationGet(paramsJson: String?): GatewaySession.InvokeResult {
-    if (!isForeground()) {
+    if (!isForeground() && !allowsBackgroundLocation()) {
       // Android foreground restrictions and user expectation keep live location tied to the visible app.
       return GatewaySession.InvokeResult.error(
         code = "LOCATION_BACKGROUND_UNAVAILABLE",
-        message = "LOCATION_BACKGROUND_UNAVAILABLE: location requires OpenClaw to stay open",
+        message =
+          "LOCATION_BACKGROUND_UNAVAILABLE: choose Always and grant background location access",
       )
     }
     if (!dataSource.hasFinePermission(appContext) && !dataSource.hasCoarsePermission(appContext)) {
@@ -147,6 +165,11 @@ class LocationHandler private constructor(
       return GatewaySession.InvokeResult.error(code = "LOCATION_UNAVAILABLE", message = message)
     }
   }
+
+  private fun allowsBackgroundLocation(): Boolean =
+    backgroundLocationEnabled() &&
+      locationMode() == LocationMode.Always &&
+      dataSource.hasBackgroundPermission(appContext)
 
   private fun parseLocationParams(paramsJson: String?): Triple<Long?, Long, String?> {
     if (paramsJson.isNullOrBlank()) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -23,6 +23,7 @@ import ai.openclaw.app.gatewayTalkSetupStatusText
 import ai.openclaw.app.hasPhotoReadPermission
 import ai.openclaw.app.isReady
 import ai.openclaw.app.loadAndroidLicenseNotices
+import ai.openclaw.app.locationModeAfterBackgroundSettings
 import ai.openclaw.app.node.DeviceNotificationListenerService
 import ai.openclaw.app.photoReadPermissionsForRequest
 import ai.openclaw.app.ui.design.ClawDetailRow
@@ -858,28 +859,98 @@ private fun PhoneCapabilitiesScreen(
   val canvasDebugStatusEnabled by viewModel.canvasDebugStatusEnabled.collectAsState()
   val installedAppsSharingEnabled by viewModel.installedAppsSharingEnabled.collectAsState()
   val photosAvailable = remember { SensitiveFeatureConfig.photosEnabled }
+  val backgroundLocationAvailable = remember { SensitiveFeatureConfig.backgroundLocationEnabled }
   val photoPermissions = remember { photoReadPermissionsForRequest() }
   var photosGranted by remember { mutableStateOf(photosAvailable && hasPhotoReadPermission(context)) }
+  var pendingLocationModeRaw by rememberSaveable { mutableStateOf<String?>(null) }
+  var pendingAlwaysPreviousModeRaw by rememberSaveable { mutableStateOf<String?>(null) }
+  var awaitingBackgroundSettings by rememberSaveable { mutableStateOf(false) }
+  var showBackgroundLocationExplanation by rememberSaveable { mutableStateOf(false) }
+  var pendingPreciseLocation by rememberSaveable { mutableStateOf(false) }
+  val backgroundPermissionLabel =
+    remember(context) {
+      context.packageManager.backgroundPermissionOptionLabel.toString().trim().ifEmpty {
+        "Allow all the time"
+      }
+    }
   val cameraPermissionLauncher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
       viewModel.setCameraEnabled(granted)
     }
   val locationPermissionLauncher =
-    rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { grants ->
-      val granted = grants[Manifest.permission.ACCESS_FINE_LOCATION] == true || grants[Manifest.permission.ACCESS_COARSE_LOCATION] == true
-      viewModel.setLocationMode(if (granted) LocationMode.WhileUsing else LocationMode.Off)
-      viewModel.setLocationPreciseEnabled(grants[Manifest.permission.ACCESS_FINE_LOCATION] == true)
+    rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { _ ->
+      val foregroundGranted = hasLocationPermission(context)
+      val fineGranted = hasPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)
+      if (pendingPreciseLocation) {
+        pendingPreciseLocation = false
+        viewModel.setLocationPreciseEnabled(fineGranted)
+        if (foregroundGranted && locationMode == LocationMode.Off) {
+          viewModel.setLocationMode(LocationMode.WhileUsing)
+        }
+        return@rememberLauncherForActivityResult
+      }
+
+      val requestedMode = LocationMode.fromRawValue(pendingLocationModeRaw)
+      pendingLocationModeRaw = null
+      when (requestedMode) {
+        LocationMode.WhileUsing ->
+          viewModel.setLocationMode(
+            if (foregroundGranted) LocationMode.WhileUsing else LocationMode.Off,
+          )
+        LocationMode.Always -> {
+          if (foregroundGranted) {
+            viewModel.setLocationMode(LocationMode.WhileUsing)
+            showBackgroundLocationExplanation = true
+          } else {
+            viewModel.setLocationMode(LocationMode.Off)
+            pendingAlwaysPreviousModeRaw = null
+          }
+        }
+        LocationMode.Off -> Unit
+      }
+      viewModel.setLocationPreciseEnabled(fineGranted)
     }
   val photoPermissionLauncher =
     rememberLauncherForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
       photosGranted = photosAvailable && hasPhotoReadPermission(context)
     }
 
-  DisposableEffect(lifecycleOwner, context, photosAvailable) {
+  DisposableEffect(
+    lifecycleOwner,
+    context,
+    photosAvailable,
+    backgroundLocationAvailable,
+    locationMode,
+    awaitingBackgroundSettings,
+    pendingAlwaysPreviousModeRaw,
+  ) {
     val observer =
       LifecycleEventObserver { _, event ->
         if (event == Lifecycle.Event.ON_RESUME) {
           photosGranted = photosAvailable && hasPhotoReadPermission(context)
+          val foregroundGranted = hasLocationPermission(context)
+          val backgroundGranted = hasBackgroundLocationPermission(context)
+          if (awaitingBackgroundSettings && pendingAlwaysPreviousModeRaw != null) {
+            val previousMode = LocationMode.fromRawValue(pendingAlwaysPreviousModeRaw)
+            viewModel.setLocationMode(
+              locationModeAfterBackgroundSettings(
+                previousMode = previousMode,
+                foregroundGranted = foregroundGranted,
+                backgroundGranted = backgroundGranted,
+              ),
+            )
+            awaitingBackgroundSettings = false
+            pendingAlwaysPreviousModeRaw = null
+          } else if (
+            locationMode == LocationMode.Always &&
+            (!backgroundLocationAvailable || !foregroundGranted || !backgroundGranted)
+          ) {
+            viewModel.setLocationMode(
+              if (foregroundGranted) LocationMode.WhileUsing else LocationMode.Off,
+            )
+          } else if (locationMode == LocationMode.WhileUsing && !foregroundGranted) {
+            viewModel.setLocationMode(LocationMode.Off)
+          }
         }
       }
     lifecycleOwner.lifecycle.addObserver(observer)
@@ -899,14 +970,40 @@ private fun PhoneCapabilitiesScreen(
   }
 
   fun setLocationAccess(mode: LocationMode) {
-    if (mode == LocationMode.Off) {
-      viewModel.setLocationMode(LocationMode.Off)
-      return
-    }
-    if (hasLocationPermission(context)) {
-      viewModel.setLocationMode(LocationMode.WhileUsing)
-    } else {
-      locationPermissionLauncher.launch(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION))
+    when (mode) {
+      LocationMode.Off -> viewModel.setLocationMode(LocationMode.Off)
+      LocationMode.WhileUsing -> {
+        if (hasLocationPermission(context)) {
+          viewModel.setLocationMode(LocationMode.WhileUsing)
+        } else {
+          pendingLocationModeRaw = mode.rawValue
+          locationPermissionLauncher.launch(
+            arrayOf(
+              Manifest.permission.ACCESS_FINE_LOCATION,
+              Manifest.permission.ACCESS_COARSE_LOCATION,
+            ),
+          )
+        }
+      }
+      LocationMode.Always -> {
+        if (!backgroundLocationAvailable) return
+        if (hasLocationPermission(context) && hasBackgroundLocationPermission(context)) {
+          viewModel.setLocationMode(LocationMode.Always)
+          return
+        }
+        pendingAlwaysPreviousModeRaw = locationMode.rawValue
+        if (hasLocationPermission(context)) {
+          showBackgroundLocationExplanation = true
+        } else {
+          pendingLocationModeRaw = mode.rawValue
+          locationPermissionLauncher.launch(
+            arrayOf(
+              Manifest.permission.ACCESS_FINE_LOCATION,
+              Manifest.permission.ACCESS_COARSE_LOCATION,
+            ),
+          )
+        }
+      }
     }
   }
 
@@ -917,9 +1014,17 @@ private fun PhoneCapabilitiesScreen(
     }
     if (hasPermission(context, Manifest.permission.ACCESS_FINE_LOCATION)) {
       viewModel.setLocationPreciseEnabled(true)
-      viewModel.setLocationMode(LocationMode.WhileUsing)
+      if (locationMode == LocationMode.Off) {
+        viewModel.setLocationMode(LocationMode.WhileUsing)
+      }
     } else {
-      locationPermissionLauncher.launch(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION))
+      pendingPreciseLocation = true
+      locationPermissionLauncher.launch(
+        arrayOf(
+          Manifest.permission.ACCESS_FINE_LOCATION,
+          Manifest.permission.ACCESS_COARSE_LOCATION,
+        ),
+      )
     }
   }
 
@@ -963,12 +1068,61 @@ private fun PhoneCapabilitiesScreen(
       Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(text = "Location", style = ClawTheme.type.section, color = ClawTheme.colors.text)
         ClawSegmentedControl(
-          options = listOf("Off", "While Using"),
-          selected = if (locationMode == LocationMode.WhileUsing) "While Using" else "Off",
-          onSelect = { selected -> setLocationAccess(if (selected == "While Using") LocationMode.WhileUsing else LocationMode.Off) },
+          options = locationModeLabels(backgroundLocationAvailable),
+          selected = locationMode.displayLabel,
+          onSelect = { selected -> setLocationAccess(locationModeForLabel(selected)) },
         )
+        if (backgroundLocationAvailable) {
+          Text(
+            text = "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
+            style = ClawTheme.type.caption,
+            color = ClawTheme.colors.textMuted,
+          )
+        }
       }
     }
+  }
+
+  if (showBackgroundLocationExplanation) {
+    fun cancelBackgroundLocationRequest() {
+      val previousMode = LocationMode.fromRawValue(pendingAlwaysPreviousModeRaw)
+      viewModel.setLocationMode(
+        locationModeAfterBackgroundSettings(
+          previousMode = previousMode,
+          foregroundGranted = hasLocationPermission(context),
+          backgroundGranted = hasBackgroundLocationPermission(context),
+        ),
+      )
+      pendingAlwaysPreviousModeRaw = null
+      showBackgroundLocationExplanation = false
+    }
+
+    AlertDialog(
+      onDismissRequest = ::cancelBackgroundLocationRequest,
+      title = { Text("Allow background location?") },
+      text = {
+        Text(
+          "OpenClaw only checks location when your paired Gateway requests it. " +
+            "On the next Android screen, choose $backgroundPermissionLabel to allow checks while the app is in the background.",
+        )
+      },
+      confirmButton = {
+        TextButton(
+          onClick = {
+            showBackgroundLocationExplanation = false
+            awaitingBackgroundSettings = true
+            openAppPermissionSettings(context)
+          },
+        ) {
+          Text("Open Settings")
+        }
+      },
+      dismissButton = {
+        TextButton(onClick = ::cancelBackgroundLocationRequest) {
+          Text("Not Now")
+        }
+      },
+    )
   }
 }
 
@@ -1160,6 +1314,28 @@ internal fun appearanceThemeSummary(mode: AppearanceThemeMode): String = mode.di
 internal fun appearanceThemeOptions(): List<String> = AppearanceThemeMode.entries.map { it.displayLabel }
 
 internal fun appearanceThemeModeForLabel(label: String): AppearanceThemeMode = AppearanceThemeMode.fromDisplayLabel(label)
+
+internal fun locationModeLabels(backgroundLocationAvailable: Boolean): List<String> =
+  if (backgroundLocationAvailable) {
+    listOf("Off", "While Using", "Always")
+  } else {
+    listOf("Off", "While Using")
+  }
+
+internal fun locationModeForLabel(label: String): LocationMode =
+  when (label) {
+    "While Using" -> LocationMode.WhileUsing
+    "Always" -> LocationMode.Always
+    else -> LocationMode.Off
+  }
+
+private val LocationMode.displayLabel: String
+  get() =
+    when (this) {
+      LocationMode.Off -> "Off"
+      LocationMode.WhileUsing -> "While Using"
+      LocationMode.Always -> "Always"
+    }
 
 /** Converts raw gateway connection text into stable settings metric labels. */
 internal fun gatewayStatusLabel(
@@ -1972,6 +2148,8 @@ private fun hasPermission(
 private fun hasLocationPermission(context: Context): Boolean =
   hasPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) ||
     hasPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
+
+private fun hasBackgroundLocationPermission(context: Context): Boolean = hasPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
 
 private fun openNotificationListenerSettings(context: Context) {
   val intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/apps/android/app/src/play/java/ai/openclaw/app/SensitiveFeatureConfig.kt
+++ b/apps/android/app/src/play/java/ai/openclaw/app/SensitiveFeatureConfig.kt
@@ -4,4 +4,5 @@ object SensitiveFeatureConfig {
   const val smsEnabled: Boolean = false
   const val callLogEnabled: Boolean = false
   const val photosEnabled: Boolean = false
+  const val backgroundLocationEnabled: Boolean = false
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -32,19 +32,27 @@ class NodeForegroundServiceTest {
   }
 
   @Test
-  fun foregroundServiceTypesForVoiceMode_addsMicrophoneForActiveCaptureModes() {
+  fun foregroundServiceTypes_addsOnlyActiveSensitiveTypes() {
     assertEquals(
       ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
-      foregroundServiceTypesForVoiceMode(VoiceCaptureMode.Off),
+      foregroundServiceTypes(VoiceCaptureMode.Off, backgroundLocationActive = false),
     )
     assertEquals(
       ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
-      foregroundServiceTypesForVoiceMode(VoiceCaptureMode.ManualMic),
+      foregroundServiceTypes(VoiceCaptureMode.ManualMic, backgroundLocationActive = false),
     )
     assertEquals(
-      ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE,
-      foregroundServiceTypesForVoiceMode(VoiceCaptureMode.TalkMode),
+      ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE or
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE or
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION,
+      foregroundServiceTypes(VoiceCaptureMode.TalkMode, backgroundLocationActive = true),
     )
+  }
+
+  @Test
+  fun backgroundLocationNotificationSuffix_disclosesActiveAlwaysMode() {
+    assertEquals("", backgroundLocationNotificationSuffix(active = false))
+    assertEquals(" · Location: Always", backgroundLocationNotificationSuffix(active = true))
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsTest.kt
@@ -13,7 +13,23 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class SecurePrefsTest {
   @Test
-  fun loadLocationMode_migratesLegacyAlwaysValue() {
+  fun backgroundSettingsResolutionRequiresBothPermissionLevels() {
+    assertEquals(
+      LocationMode.Always,
+      locationModeAfterBackgroundSettings(LocationMode.Off, foregroundGranted = true, backgroundGranted = true),
+    )
+    assertEquals(
+      LocationMode.Off,
+      locationModeAfterBackgroundSettings(LocationMode.Off, foregroundGranted = true, backgroundGranted = false),
+    )
+    assertEquals(
+      LocationMode.WhileUsing,
+      locationModeAfterBackgroundSettings(LocationMode.Always, foregroundGranted = true, backgroundGranted = false),
+    )
+  }
+
+  @Test
+  fun loadLocationMode_enforcesFlavorAvailabilityForAlwaysValue() {
     val context = RuntimeEnvironment.getApplication()
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs
@@ -24,8 +40,10 @@ class SecurePrefsTest {
 
     val prefs = SecurePrefs(context)
 
-    assertEquals(LocationMode.WhileUsing, prefs.locationMode.value)
-    assertEquals("whileUsing", plainPrefs.getString("location.enabledMode", null))
+    val expected =
+      if (SensitiveFeatureConfig.backgroundLocationEnabled) LocationMode.Always else LocationMode.WhileUsing
+    assertEquals(expected, prefs.locationMode.value)
+    assertEquals(expected.rawValue, plainPrefs.getString("location.enabledMode", null))
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
@@ -355,6 +355,8 @@ private class InvokeDispatcherFakeLocationDataSource : LocationDataSource {
 
   override fun hasCoarsePermission(context: Context): Boolean = false
 
+  override fun hasBackgroundPermission(context: Context): Boolean = false
+
   override suspend fun fetchLocation(
     desiredProviders: List<String>,
     maxAgeMs: Long?,

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/LocationHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/LocationHandlerTest.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.node
 
+import ai.openclaw.app.LocationMode
 import android.content.Context
 import android.location.LocationManager
 import kotlinx.coroutines.test.runTest
@@ -41,6 +42,53 @@ class LocationHandlerTest : NodeHandlerRobolectricTest() {
               coarseGranted = true,
             ),
           isForeground = { false },
+        )
+
+      val result = handler.handleLocationGet(null)
+
+      assertFalse(result.ok)
+      assertEquals("LOCATION_BACKGROUND_UNAVAILABLE", result.error?.code)
+    }
+
+  @Test
+  fun handleLocationGet_allowsBackgroundWhenThirdPartyAlwaysGrantIsEffective() =
+    runTest {
+      val source =
+        FakeLocationDataSource(
+          fineGranted = false,
+          coarseGranted = true,
+          backgroundGranted = true,
+          payload = LocationCaptureManager.Payload("""{"ok":true}"""),
+        )
+      val handler =
+        LocationHandler.forTesting(
+          appContext = appContext(),
+          dataSource = source,
+          isForeground = { false },
+          locationMode = { LocationMode.Always },
+          backgroundLocationEnabled = { true },
+        )
+
+      val result = handler.handleLocationGet(null)
+
+      assertTrue(result.ok)
+    }
+
+  @Test
+  fun handleLocationGet_deniesBackgroundWhenFlavorDisablesAlwaysMode() =
+    runTest {
+      val handler =
+        LocationHandler.forTesting(
+          appContext = appContext(),
+          dataSource =
+            FakeLocationDataSource(
+              fineGranted = true,
+              coarseGranted = true,
+              backgroundGranted = true,
+            ),
+          isForeground = { false },
+          locationMode = { LocationMode.Always },
+          backgroundLocationEnabled = { false },
         )
 
       val result = handler.handleLocationGet(null)
@@ -162,6 +210,7 @@ class LocationHandlerTest : NodeHandlerRobolectricTest() {
 private class FakeLocationDataSource(
   private val fineGranted: Boolean,
   private val coarseGranted: Boolean,
+  private val backgroundGranted: Boolean = false,
   private val payload: LocationCaptureManager.Payload? = null,
   private val failure: Throwable? = null,
   private val timeout: Boolean = false,
@@ -174,6 +223,8 @@ private class FakeLocationDataSource(
   override fun hasFinePermission(context: Context): Boolean = fineGranted
 
   override fun hasCoarsePermission(context: Context): Boolean = coarseGranted
+
+  override fun hasBackgroundPermission(context: Context): Boolean = backgroundGranted
 
   override suspend fun fetchLocation(
     desiredProviders: List<String>,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensTest.kt
@@ -2,10 +2,21 @@ package ai.openclaw.app.ui
 
 import ai.openclaw.app.GatewayConnectionProblem
 import ai.openclaw.app.GatewayNodeCapabilityApproval
+import ai.openclaw.app.LocationMode
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class SettingsScreensTest {
+  @Test
+  fun locationModes_hideAlwaysFromPlayAndMapThirdPartySelection() {
+    assertEquals(listOf("Off", "While Using"), locationModeLabels(backgroundLocationAvailable = false))
+    assertEquals(
+      listOf("Off", "While Using", "Always"),
+      locationModeLabels(backgroundLocationAvailable = true),
+    )
+    assertEquals(LocationMode.Always, locationModeForLabel("Always"))
+  }
+
   @Test
   fun androidDistributionChannelUsesBuildFlavorLabels() {
     assertEquals("Play", androidDistributionChannel("play"))

--- a/apps/android/app/src/thirdParty/AndroidManifest.xml
+++ b/apps/android/app/src/thirdParty/AndroidManifest.xml
@@ -1,8 +1,17 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-feature
         android:name="android.hardware.telephony"
         android:required="false" />
+    <application>
+        <service
+            android:name=".NodeForegroundService"
+            android:foregroundServiceType="connectedDevice|microphone|location"
+            tools:replace="android:foregroundServiceType" />
+    </application>
 </manifest>

--- a/apps/android/app/src/thirdParty/java/ai/openclaw/app/SensitiveFeatureConfig.kt
+++ b/apps/android/app/src/thirdParty/java/ai/openclaw/app/SensitiveFeatureConfig.kt
@@ -4,4 +4,5 @@ object SensitiveFeatureConfig {
   const val smsEnabled: Boolean = true
   const val callLogEnabled: Boolean = true
   const val photosEnabled: Boolean = true
+  const val backgroundLocationEnabled: Boolean = true
 }

--- a/docs/nodes/location-command.md
+++ b/docs/nodes/location-command.md
@@ -10,23 +10,25 @@ title: "Location command"
 
 - `location.get` is a node command, invoked via `node.invoke` or `openclaw nodes location get`.
 - Off by default.
-- Android app settings use a selector: Off / While Using.
+- Android third-party builds use a selector: Off / While Using / Always. Play builds remain Off / While Using.
 - Precise Location is a separate toggle.
 
 ## Why a selector (not just a switch)
 
-OS location permissions are multi-level (iOS/macOS expose While Using vs Always; Android currently supports foreground-only). Precise location is a separate OS grant too (iOS 14+ "Precise", Android "fine" vs "coarse"). The in-app selector drives the requested mode, but the OS still decides the actual grant.
+OS location permissions are multi-level. Precise location is a separate OS grant too (iOS 14+ "Precise", Android "fine" vs "coarse"). The in-app selector drives the requested mode, but the OS still decides the actual grant.
 
 ## Settings model
 
 Per node device:
 
-- `location.enabledMode`: `off | whileUsing`
+- `location.enabledMode`: `off | whileUsing | always`
 - `location.preciseEnabled`: bool
 
 UI behavior:
 
 - Selecting `whileUsing` requests foreground permission.
+- Selecting `always` in the Android third-party build first requests foreground permission, explains the background access, then opens Android app settings for the separate **Allow all the time** grant.
+- Android Play builds do not declare background location permission or show `always`.
 - If the OS denies the requested level, the app reverts to the highest granted level and shows status.
 
 ## Permissions mapping (node.permissions)
@@ -80,7 +82,8 @@ Errors (stable codes):
 
 ## Background behavior
 
-- The Android app denies `location.get` while backgrounded; keep OpenClaw open when requesting location on Android.
+- Android third-party builds accept background `location.get` only when the user selected `Always` and Android granted background location. The existing persistent node service adds the `location` service type and discloses `Location: Always` while active.
+- Android Play builds and `While Using` mode deny `location.get` while backgrounded.
 - Other node platforms may differ.
 
 ## Model/tooling integration
@@ -93,6 +96,7 @@ Errors (stable codes):
 
 - Off: "Location sharing is disabled."
 - While Using: "Only when OpenClaw is open."
+- Always: "Allow requested location checks while OpenClaw is in the background."
 - Precise: "Use precise GPS location. Toggle off to share approximate location."
 
 ## Related


### PR DESCRIPTION
Closes #68581

## What Problem This Solves

Android nodes reject `location.get` whenever the app is backgrounded, even when a sideloaded build's user explicitly wants background location access.

## Why This Change Was Made

Third-party builds now offer an explicit `Always` mode using Android's incremental foreground-then-background permission flow and the existing persistent node service. The Play flavor remains foreground-only and does not declare background location; this carries forward the useful design work from #61232 while tightening flavor, grant, notification, and service-type gates.

## User Impact

Users of third-party Android builds can choose **Settings → Phone Capabilities → Location → Always**, review why access is needed, and grant **Allow all the time** in Android settings. Background checks remain request-driven, appear as `Location: Always` in the persistent node notification, and stop working immediately when the mode or Android grant is removed.

## Evidence

- Blacksmith Testbox `tbx_01kwvy3yr4res531vj34bqvwj5`:
  - `./gradlew :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest :app:assemblePlayDebug :app:assembleThirdPartyDebug`
  - both unit suites and both debug builds passed
  - merged-manifest assertions proved Play excludes `ACCESS_BACKGROUND_LOCATION` / `FOREGROUND_SERVICE_LOCATION` while third-party includes both and the `location` service type
- `node --import tsx scripts/native-app-i18n.ts check` — clean, 2702 entries
- scoped `:app:ktlintCheck` report — all touched Kotlin files clean; the full task still reports unrelated formatting debt already present on `main`
- two fresh Codex autoreviews — no accepted/actionable findings
- Android 16 Pixel: isolated third-party validation APK installed successfully and package inspection confirmed both location declarations. The device remained PIN-locked, so no tap-through screenshot or live Gateway invocation is claimed here.

Contributor credit is preserved in the implementation commit for @ioridev's earlier work in #61232.
