### PR TITLE
fix(signal): retry session init conflicts

### DIFF
--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -1863,6 +1863,102 @@ describe("signal createSignalEventHandler inbound context", () => {
     }
   });
 
+  it("retries debounced direct messages after reply session initialization conflicts", async () => {
+    vi.useFakeTimers();
+    try {
+      const runtimeError = vi.fn();
+      dispatchInboundMessageMock.mockRejectedValueOnce(
+        new Error("Signal dispatch failed", {
+          cause: new Error(
+            "reply session initialization conflicted for agent:main:signal:direct:+15550002222",
+          ),
+        }),
+      );
+      const handler = createSignalEventHandler(
+        createBaseSignalEventHandlerDeps({
+          cfg: {
+            messages: { inbound: { debounceMs: 10 } },
+            channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+          } as any,
+          runtime: { log: () => {}, error: runtimeError } as any,
+          historyLimit: 0,
+        }),
+      );
+
+      await handler(
+        createSignalReceiveEvent({
+          sourceNumber: "+15550002222",
+          sourceName: "Bob",
+          timestamp: 1700000000001,
+          dataMessage: {
+            message: "second request",
+            attachments: [],
+          },
+        }),
+      );
+      expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(10);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+      expect(requireCapturedContext().RawBody).toBe("second request");
+      expect(runtimeError).toHaveBeenCalledWith(
+        expect.stringContaining("signal debounce flush failed: Signal dispatch failed"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops retrying reply session initialization conflicts after the bounded retry limit", async () => {
+    vi.useFakeTimers();
+    try {
+      for (let i = 0; i < 4; i += 1) {
+        dispatchInboundMessageMock.mockRejectedValueOnce(
+          new Error(
+            "reply session initialization conflicted for agent:main:signal:direct:+15550002222",
+          ),
+        );
+      }
+      const handler = createSignalEventHandler(
+        createBaseSignalEventHandlerDeps({
+          cfg: {
+            messages: { inbound: { debounceMs: 0 } },
+            channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+          } as any,
+          historyLimit: 0,
+        }),
+      );
+
+      await handler(
+        createSignalReceiveEvent({
+          sourceNumber: "+15550002222",
+          sourceName: "Bob",
+          timestamp: 1700000000001,
+          dataMessage: {
+            message: "second request",
+            attachments: [],
+          },
+        }),
+      );
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("dispatches failed-media commands without text debounce", async () => {
     const handler = createSignalEventHandler(
       createBaseSignalEventHandlerDeps({

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -33,6 +33,7 @@ import {
 } from "openclaw/plugin-sdk/channel-policy";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-auth-native";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
+import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createInternalHookEvent,
   fireAndForgetHook,
@@ -161,6 +162,16 @@ function resolveSignalStatusReactionEmojis(
   };
 }
 
+const RETRYABLE_FLUSH_MAX_ATTEMPTS = 3;
+const RETRYABLE_FLUSH_RETRY_DELAY_MS = 1_000;
+const REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE = /reply session initialization conflicted for \S+/u;
+
+function isRetryableSignalInboundError(error: unknown): boolean {
+  return collectErrorGraphCandidates(error, (current) => [current.cause, current.error]).some(
+    (candidate) => REPLY_SESSION_INIT_CONFLICT_MESSAGE_RE.test(formatErrorMessage(candidate)),
+  );
+}
+
 async function finalizeSignalStatusReaction(params: {
   controller: StatusReactionController;
   outcome: "done" | "error";
@@ -219,6 +230,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     replyToBody?: string;
     replyToSender?: string;
     replyToIsQuote?: boolean;
+    retryAttempt?: number;
   };
 
   async function handleSignalInboundMessage(entry: SignalInboundEntry) {
@@ -680,8 +692,34 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         mediaTypes: undefined,
       });
     },
-    onError: (err) => {
-      deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
+    onError: (err, entries) => {
+      if (isRetryableSignalInboundError(err)) {
+        const retryEntries = entries
+          .map((entry) => {
+            const retryAttempt = entry.retryAttempt ?? 0;
+            if (retryAttempt >= RETRYABLE_FLUSH_MAX_ATTEMPTS) {
+              return null;
+            }
+            return {
+              ...entry,
+              retryAttempt: retryAttempt + 1,
+            };
+          })
+          .filter((entry) => entry !== null);
+        if (retryEntries.length > 0) {
+          const retryTimer = setTimeout(() => {
+            for (const entry of retryEntries) {
+              void inboundDebouncer.enqueue(entry).catch((retryErr: unknown) => {
+                deps.runtime.error?.(
+                  `signal inbound retry enqueue failed: ${formatErrorMessage(retryErr)}`,
+                );
+              });
+            }
+          }, RETRYABLE_FLUSH_RETRY_DELAY_MS);
+          retryTimer.unref?.();
+        }
+      }
+      deps.runtime.error?.(`signal debounce flush failed: ${formatErrorMessage(err)}`);
     },
   });
 


### PR DESCRIPTION
Closes #100944

## What Problem This Solves

Fixes an issue where Signal direct-message users could send a follow-up shortly after a previous reply and receive no response when the Signal inbound debounce flush hit a reply-session initialization conflict. In that path the shared debouncer reports the flush error to Signal and continues, so Signal's previous log-only error handler could drop the buffered inbound message with no retry or visible user feedback.

## Why This Change Was Made

Signal now treats `reply session initialization conflicted` as a retryable inbound flush failure, re-enqueues the original Signal inbound entries after a short backoff, and stops after a bounded retry limit. This stays inside the Signal plugin boundary and leaves the shared debouncer contract unchanged; risk note: the retry is limited to the same session-init conflict class covered by sibling Slack behavior, with tests proving both retry and retry-limit behavior.

## User Impact

Signal DM follow-ups that collide with reply-session initialization get another chance to dispatch instead of being silently lost after the debounce flush logs an error. Other Signal dispatch failures continue to use the existing error logging path without broad retry.

## Evidence

- Source-level before: on current `upstream/main`, `extensions/signal/src/monitor/event-handler.ts` only logs `signal debounce flush failed` from the inbound debounce `onError`, while `src/auto-reply/inbound-debounce.ts` intentionally swallows flush exceptions after calling `onError` so keyed processing can continue. That matches the issue log shape and explains the silent drop.
- Premise checked: Slack already detects `reply session initialization conflicted` through the error graph and re-enters normal inbound delivery gates in `extensions/slack/src/monitor/message-handler.ts`; Telegram's spooled path releases retryable failed updates for later processing in `extensions/telegram/src/polling-session.ts`.
- Focused tests:

```text
node scripts/run-vitest.mjs extensions/signal/src/monitor/event-handler.inbound-context.test.ts src/auto-reply/inbound.test.ts extensions/slack/src/monitor/message-handler.test.ts
[test] passed 3 Vitest shards in 28.04s
```

- Signal-specific regression proof: the new test first hits a debounced Signal DM flush failure with a nested `reply session initialization conflicted...` cause, then advances the retry/backoff timers and verifies `dispatchInboundMessage` is called again with the original `RawBody`. A second test verifies retries stop after the bounded limit.
- Local embedded OpenClaw turn with `/home/wen/.openclaw/.env` loaded and model override `deepseek/deepseek-v4-pro` returned `ok` with stopReason `stop` over a successful DeepSeek HTTP 200 response. The command was non-delivering and did not exercise a live Signal account.
- Formatting/static sanity: `./node_modules/.bin/oxfmt --write --threads=1 extensions/signal/src/monitor/event-handler.ts extensions/signal/src/monitor/event-handler.inbound-context.test.ts` and `git diff --check` passed.
- Not tested: live Signal container/account round-trip. This change is in the network-before debounce/error-preservation path and is covered by source-level reproduction plus focused handler tests; a real Signal account would still be useful for final channel-visible proof.

AI-assisted: implementation and proof were prepared with AI-assisted coding; focused tests and the local embedded turn were run manually from this checkout.
