### PR TITLE
fix(signal): retry inbound messages on reply session initialization conflict (#100944)

### DIFF
--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -2050,16 +2050,20 @@ describe("signal createSignalEventHandler inbound context", () => {
         }),
       );
 
-      // 1 initial + 3 retries = 4 attempts total, then stops
+      // Trigger initial debounce flush (timer at 0ms with debounceMs=0).
+      await vi.advanceTimersByTimeAsync(1);
+
+      // 1 initial + 3 retries = 4 attempts total, then stops.
+      // Each retry cycle: 1 000ms retry delay + debounce flush tick.
       for (let attempt = 1; attempt <= 4; attempt += 1) {
-        await vi.advanceTimersByTimeAsync(1);
-        await vi.advanceTimersByTimeAsync(10);
         expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(attempt);
+        if (attempt < 4) {
+          await vi.advanceTimersByTimeAsync(1_001);
+        }
       }
 
       // 5th attempt should NOT happen (max 3 retries = 4 total)
-      await vi.advanceTimersByTimeAsync(1_000);
-      await vi.advanceTimersByTimeAsync(10);
+      await vi.advanceTimersByTimeAsync(1_001);
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
     } finally {
       vi.useRealTimers();

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -1977,4 +1977,92 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(capture.ctx).toBeUndefined();
     expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
   });
+
+  it("retries debounced direct messages on reply session initialization conflict", async () => {
+    vi.useFakeTimers();
+    try {
+      dispatchInboundMessageMock.mockRejectedValueOnce(
+        new Error("Signal dispatch failed", {
+          cause: new Error(
+            "reply session initialization conflicted for agent:main:signal:direct:+15550002222",
+          ),
+        }),
+      );
+      const handler = createSignalEventHandler(
+        createBaseSignalEventHandlerDeps({
+          cfg: {
+            messages: { inbound: { debounceMs: 10 } },
+            channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+          } as any,
+          historyLimit: 0,
+        }),
+      );
+
+      await handler(
+        createSignalReceiveEvent({
+          sourceNumber: "+15550002222",
+          sourceName: "Bob",
+          timestamp: 1700000000001,
+          dataMessage: { message: "follow-up", attachments: [] },
+        }),
+      );
+      expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+
+      // Debounce timer fires → dispatch fails with conflict → retry scheduled
+      await vi.advanceTimersByTimeAsync(10);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+
+      // Retry delay (1s) + debounce (10ms) → retry fires
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops retrying session init conflicts after max attempts", async () => {
+    vi.useFakeTimers();
+    try {
+      for (let i = 0; i < 5; i += 1) {
+        dispatchInboundMessageMock.mockRejectedValueOnce(
+          new Error(
+            "reply session initialization conflicted for agent:main:signal:direct:+15550002222",
+          ),
+        );
+      }
+      const handler = createSignalEventHandler(
+        createBaseSignalEventHandlerDeps({
+          cfg: {
+            messages: { inbound: { debounceMs: 0 } },
+            channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+          } as any,
+          historyLimit: 0,
+        }),
+      );
+
+      await handler(
+        createSignalReceiveEvent({
+          sourceNumber: "+15550002222",
+          sourceName: "Bob",
+          timestamp: 1700000000001,
+          dataMessage: { message: "follow-up", attachments: [] },
+        }),
+      );
+
+      // 1 initial + 3 retries = 4 attempts total, then stops
+      for (let attempt = 1; attempt <= 4; attempt += 1) {
+        await vi.advanceTimersByTimeAsync(1);
+        await vi.advanceTimersByTimeAsync(10);
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(attempt);
+      }
+
+      // 5th attempt should NOT happen (max 3 retries = 4 total)
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(10);
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -643,9 +643,13 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   }
 
   function buildSignalDebounceKey(entry?: SignalInboundEntry): string | null {
-    if (!entry) return null;
+    if (!entry) {
+      return null;
+    }
     const conversationId = entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId;
-    if (!conversationId || !entry.senderPeerId) return null;
+    if (!conversationId || !entry.senderPeerId) {
+      return null;
+    }
     return `signal:${deps.accountId}:${conversationId}:${entry.senderPeerId}`;
   }
 
@@ -708,7 +712,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             .filter(Boolean)
             .join("\\n");
           if (!combinedText.trim()) {
-            if (conflictKey) retryAttemptsByKey.delete(conflictKey);
+            if (conflictKey) {
+              retryAttemptsByKey.delete(conflictKey);
+            }
             return;
           }
           await handleSignalInboundMessage({

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -633,16 +633,55 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     });
   }
 
+  const RETRYABLE_FLUSH_MAX_ATTEMPTS = 3;
+  const RETRYABLE_FLUSH_RETRY_DELAY_MS = 1_000;
+  const REPLY_SESSION_INIT_CONFLICT_RE = /reply session initialization conflicted for \S+/u;
+  const retryAttemptsByKey = new Map<string, number>();
+
+  function isRetryableSignalInboundError(error: unknown): boolean {
+    return REPLY_SESSION_INIT_CONFLICT_RE.test(String(error));
+  }
+
+  function buildSignalDebounceKey(entry?: SignalInboundEntry): string | null {
+    if (!entry) return null;
+    const conversationId = entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId;
+    if (!conversationId || !entry.senderPeerId) return null;
+    return `signal:${deps.accountId}:${conversationId}:${entry.senderPeerId}`;
+  }
+
+  /** Retry transient session-init conflicts with bounded backoff, matching
+   *  the Slack (#99647) and Telegram retry patterns. Re-enqueues entries via
+   *  `inboundDebouncer` after a delay. Returns `true` when a retry was
+   *  scheduled, `false` when the error is not retryable or retries exhausted. */
+  function retrySignalFlushError(entries: SignalInboundEntry[], sourceError: unknown): boolean {
+    if (!isRetryableSignalInboundError(sourceError)) {
+      return false;
+    }
+    const conflictKey = buildSignalDebounceKey(entries[0]);
+    if (!conflictKey) {
+      return false;
+    }
+    const attempts = (retryAttemptsByKey.get(conflictKey) ?? 0) + 1;
+    if (attempts > RETRYABLE_FLUSH_MAX_ATTEMPTS) {
+      retryAttemptsByKey.delete(conflictKey);
+      return false;
+    }
+    retryAttemptsByKey.set(conflictKey, attempts);
+    const timer = setTimeout(() => {
+      for (const entry of entries) {
+        void inboundDebouncer.enqueue(entry).catch((err: unknown) => {
+          deps.runtime.error?.(`signal retry enqueue failed: ${String(err)}`);
+        });
+      }
+    }, RETRYABLE_FLUSH_RETRY_DELAY_MS);
+    timer.unref?.();
+    return true;
+  }
+
   const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
     cfg: deps.cfg,
     channel: "signal",
-    buildKey: (entry) => {
-      const conversationId = entry.isGroup ? (entry.groupId ?? "unknown") : entry.senderPeerId;
-      if (!conversationId || !entry.senderPeerId) {
-        return null;
-      }
-      return `signal:${deps.accountId}:${conversationId}:${entry.senderPeerId}`;
-    },
+    buildKey: buildSignalDebounceKey,
     shouldDebounce: (entry) => {
       return shouldDebounceTextInbound({
         text: entry.commandBody,
@@ -651,34 +690,45 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       });
     },
     onFlush: async (entries) => {
-      const last = entries.at(-1);
-      if (!last) {
-        return;
+      try {
+        const conflictKey = buildSignalDebounceKey(entries[0]);
+        const last = entries.at(-1);
+        if (!last) {
+          return;
+        }
+        if (entries.length === 1) {
+          await handleSignalInboundMessage(last);
+        } else {
+          const combinedText = entries
+            .map((entry) => entry.bodyText)
+            .filter(Boolean)
+            .join("\\n");
+          const combinedCommandBody = entries
+            .map((entry) => entry.commandBody)
+            .filter(Boolean)
+            .join("\\n");
+          if (!combinedText.trim()) {
+            if (conflictKey) retryAttemptsByKey.delete(conflictKey);
+            return;
+          }
+          await handleSignalInboundMessage({
+            ...last,
+            bodyText: combinedText,
+            commandBody: combinedCommandBody,
+            mediaPath: undefined,
+            mediaType: undefined,
+            mediaPaths: undefined,
+            mediaTypes: undefined,
+          });
+        }
+        if (conflictKey) {
+          retryAttemptsByKey.delete(conflictKey);
+        }
+      } catch (err) {
+        if (!retrySignalFlushError(entries, err)) {
+          throw err;
+        }
       }
-      if (entries.length === 1) {
-        await handleSignalInboundMessage(last);
-        return;
-      }
-      const combinedText = entries
-        .map((entry) => entry.bodyText)
-        .filter(Boolean)
-        .join("\\n");
-      const combinedCommandBody = entries
-        .map((entry) => entry.commandBody)
-        .filter(Boolean)
-        .join("\\n");
-      if (!combinedText.trim()) {
-        return;
-      }
-      await handleSignalInboundMessage({
-        ...last,
-        bodyText: combinedText,
-        commandBody: combinedCommandBody,
-        mediaPath: undefined,
-        mediaType: undefined,
-        mediaPaths: undefined,
-        mediaTypes: undefined,
-      });
     },
     onError: (err) => {
       deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -33,6 +33,7 @@ import {
 } from "openclaw/plugin-sdk/channel-policy";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-auth-native";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
+import { collectErrorGraphCandidates, formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   createInternalHookEvent,
   fireAndForgetHook,
@@ -639,7 +640,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   const retryAttemptsByKey = new Map<string, number>();
 
   function isRetryableSignalInboundError(error: unknown): boolean {
-    return REPLY_SESSION_INIT_CONFLICT_RE.test(String(error));
+    return collectErrorGraphCandidates(error, (current) => [current.cause, current.error]).some(
+      (candidate) => REPLY_SESSION_INIT_CONFLICT_RE.test(formatErrorMessage(candidate)),
+    );
   }
 
   function buildSignalDebounceKey(entry?: SignalInboundEntry): string | null {


### PR DESCRIPTION
Fixes #100944

## What Problem This Solves

On Signal, a DM sent shortly after a previous reply completes can be silently dropped. The debounce flush hits `reply session initialization conflicted` and the `onError` handler only logs the error — no retry, no user feedback.

Slack (#99647) and Telegram already have bounded retry-with-backoff for this exact error. Signal was the only channel missing it.

## Why This Change Was Made

Ported the Slack/Telegram retry pattern to Signal's debounce flush handler:

- `isRetryableSignalInboundError()` — traverses nested `cause`/`error` chains via `collectErrorGraphCandidates` from `openclaw/plugin-sdk/error-runtime`, matching Slack's error-graph pattern in `message-handler.ts:78-84`. This handles wrapped errors like `new Error("Signal dispatch failed", { cause: new Error("reply session initialization conflicted...") })` where `String(error)` would only see the outer message.
- `retrySignalFlushError()` — standalone function that re-enqueues entries via `inboundDebouncer.enqueue()` after a 1s delay, up to 3 attempts per debounce key
- `retryAttemptsByKey` — per-conversation retry counter, cleared on success
- Pattern matches `extensions/slack/src/monitor/message-handler.ts:68-158`

## User Impact

Signal DMs arriving shortly after a reply completion are now retried up to 3 times instead of silently dropped. Non-retryable errors still propagate to `onError`.

## Evidence

### Proof 1 — Error graph traversal (Slack parity):
`isRetryableSignalInboundError` now uses the same `collectErrorGraphCandidates` + `formatErrorMessage` pattern as Slack:
```
extensions/slack/src/monitor/message-handler.ts:78-84:
  collectErrorGraphCandidates(error, (current) => [current.cause, current.error])
    .some((candidate) => REPLY_SESSION_INIT_CONFLICT_RE.test(formatErrorMessage(candidate)))

extensions/signal/src/monitor/event-handler.ts:642-645:
  collectErrorGraphCandidates(error, (current) => [current.cause, current.error])
    .some((candidate) => REPLY_SESSION_INIT_CONFLICT_RE.test(formatErrorMessage(candidate)))
```
Both use the public `openclaw/plugin-sdk/error-runtime` export (re-exports from `src/infra/errors.ts`).

### Proof 2 — Wrapped error retry test:
```
pnpm test extensions/signal → 30 files, 424 tests passed
```
Including the focused regression test: wrapped `Signal dispatch failed` with nested `reply session initialization conflicted` cause correctly triggers re-enqueue (was silently dropped before the fix).

### Proof 3 — Module verification:
```
node --import tsx → module loads cleanly
```

### Proof 4 — Pre-submit:
```
oxfmt --check → clean
git diff --check → clean
autoreview → patch is correct
```