### PR TITLE
Let owner-operated Codex agents use connected account apps

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5421,6 +5421,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: How native plugin setup works
   - H2: V1 support boundary
   - H2: App inventory and ownership
+  - H2: Connected account apps
   - H2: Thread app config
   - H2: Destructive action policy
   - H2: Troubleshooting

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -296,6 +296,10 @@ conversation bindings, or any non-Codex harness.
               },
             },
           },
+          accountApps: {
+            mode: "all",
+            allow_destructive_actions: false,
+          },
         },
       },
     },
@@ -340,6 +344,15 @@ host-specific.
 asynchronously when stale. Codex thread app config is computed at Codex harness
 session establishment, not on every turn; use `/new`, `/reset`, or a gateway
 restart after changing native plugin config.
+
+`plugins.entries.codex.config.accountApps` is a separate, explicit opt-in for
+apps already connected to the authenticated Codex account. Set `mode: "all"`
+to snapshot every currently accessible app into each new native Codex thread.
+The setting does not install plugins or apps, and inaccessible apps stay
+excluded. `allow_destructive_actions` accepts the same `true`, `false`,
+`"auto"`, or `"ask"` policies as `codexPlugins` and defaults to `false`.
+Explicit `codexPlugins` entries take precedence when the same app is present in
+both policies. If `app/list` cannot be read, account-wide exposure fails closed.
 
 - `plugins.entries.firecrawl.config.webFetch`: Firecrawl web-fetch provider settings.
   - `apiKey`: Optional Firecrawl API key for higher limits (accepts SecretRef). Falls back to `plugins.entries.firecrawl.config.webSearch.apiKey`, legacy `tools.web.fetch.firecrawl.apiKey`, or `FIRECRAWL_API_KEY` env var.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -286,7 +286,8 @@ conversation bindings, or any non-Codex harness.
         config: {
           codexPlugins: {
             enabled: true,
-            allow_destructive_actions: true,
+            allow_all_plugins: true,
+            allow_destructive_actions: "auto",
             plugins: {
               "google-calendar": {
                 enabled: true,
@@ -295,10 +296,6 @@ conversation bindings, or any non-Codex harness.
                 allow_destructive_actions: false,
               },
             },
-          },
-          accountApps: {
-            mode: "all",
-            allow_destructive_actions: false,
           },
         },
       },
@@ -309,6 +306,9 @@ conversation bindings, or any non-Codex harness.
 
 - `plugins.entries.codex.config.codexPlugins.enabled`: enables native Codex
   plugin/app support for the Codex harness. Default: `false`.
+- `plugins.entries.codex.config.codexPlugins.allow_all_plugins`: exposes every
+  currently accessible app connected to the authenticated Codex account in
+  each new native Codex thread. Default: `false`.
 - `plugins.entries.codex.config.codexPlugins.allow_destructive_actions`:
   default destructive-action policy for migrated plugin app elicitations.
   Use `true` to accept safe Codex approval schemas without prompting, `false`
@@ -345,14 +345,12 @@ asynchronously when stale. Codex thread app config is computed at Codex harness
 session establishment, not on every turn; use `/new`, `/reset`, or a gateway
 restart after changing native plugin config.
 
-`plugins.entries.codex.config.accountApps` is a separate, explicit opt-in for
-apps already connected to the authenticated Codex account. Set `mode: "all"`
-to snapshot every currently accessible app into each new native Codex thread.
-The setting does not install plugins or apps, and inaccessible apps stay
-excluded. `allow_destructive_actions` accepts the same `true`, `false`,
-`"auto"`, or `"ask"` policies as `codexPlugins` and defaults to `false`.
-Explicit `codexPlugins` entries take precedence when the same app is present in
-both policies. If `app/list` cannot be read, account-wide exposure fails closed.
+`codexPlugins.allow_all_plugins` snapshots every currently accessible account
+app into each new native Codex thread. It does not install plugins or apps, and
+inaccessible apps stay excluded. Account apps use the global
+`codexPlugins.allow_destructive_actions` policy. Explicit plugin entries take
+precedence when the same app is present in both paths. If `app/list` cannot be
+read, account-wide exposure fails closed.
 
 - `plugins.entries.firecrawl.config.webFetch`: Firecrawl web-fetch provider settings.
   - `apiKey`: Optional Firecrawl API key for higher limits (accepts SecretRef). Falls back to `plugins.entries.firecrawl.config.webSearch.apiKey`, legacy `tools.web.fetch.firecrawl.apiKey`, or `FIRECRAWL_API_KEY` env var.

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -38,14 +38,14 @@ All Codex harness settings live under `plugins.entries.codex.config`.
 
 Top-level fields:
 
-| Field                      | Default                  | Meaning                                                                                                                                                                            |
-| -------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `discovery`                | enabled                  | Model discovery settings for Codex app-server `model/list`.                                                                                                                        |
-| `appServer`                | managed stdio app-server | Transport, command, auth, approval, sandbox, and timeout settings.                                                                                                                 |
-| `codexDynamicToolsLoading` | `"searchable"`           | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context.                                                                                           |
-| `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                                                                        |
+| Field                      | Default                  | Meaning                                                                                                                                        |
+| -------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `discovery`                | enabled                  | Model discovery settings for Codex app-server `model/list`.                                                                                    |
+| `appServer`                | managed stdio app-server | Transport, command, auth, approval, sandbox, and timeout settings.                                                                             |
+| `codexDynamicToolsLoading` | `"searchable"`           | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context.                                                       |
+| `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                                    |
 | `codexPlugins`             | disabled                 | Native Codex plugin/app support, including opt-in access to connected account apps. See [Native Codex plugins](/plugins/codex-native-plugins). |
-| `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                                                                   |
+| `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                               |
 
 ## App-server transport
 

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -45,6 +45,7 @@ Top-level fields:
 | `codexDynamicToolsLoading` | `"searchable"`           | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context.                                                  |
 | `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                               |
 | `codexPlugins`             | disabled                 | Native Codex plugin/app support for migrated source-installed curated plugins. See [Native Codex plugins](/plugins/codex-native-plugins). |
+| `accountApps`              | disabled                 | Explicit opt-in to all currently accessible apps connected to the authenticated Codex account. See [Connected account apps](/plugins/codex-native-plugins#connected-account-apps). |
 | `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                          |
 
 ## App-server transport

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -44,8 +44,7 @@ Top-level fields:
 | `appServer`                | managed stdio app-server | Transport, command, auth, approval, sandbox, and timeout settings.                                                                                                                 |
 | `codexDynamicToolsLoading` | `"searchable"`           | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context.                                                                                           |
 | `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                                                                        |
-| `codexPlugins`             | disabled                 | Native Codex plugin/app support for migrated source-installed curated plugins. See [Native Codex plugins](/plugins/codex-native-plugins).                                          |
-| `accountApps`              | disabled                 | Explicit opt-in to all currently accessible apps connected to the authenticated Codex account. See [Connected account apps](/plugins/codex-native-plugins#connected-account-apps). |
+| `codexPlugins`             | disabled                 | Native Codex plugin/app support, including opt-in access to connected account apps. See [Native Codex plugins](/plugins/codex-native-plugins). |
 | `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                                                                   |
 
 ## App-server transport

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -38,15 +38,15 @@ All Codex harness settings live under `plugins.entries.codex.config`.
 
 Top-level fields:
 
-| Field                      | Default                  | Meaning                                                                                                                                   |
-| -------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `discovery`                | enabled                  | Model discovery settings for Codex app-server `model/list`.                                                                               |
-| `appServer`                | managed stdio app-server | Transport, command, auth, approval, sandbox, and timeout settings.                                                                        |
-| `codexDynamicToolsLoading` | `"searchable"`           | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context.                                                  |
-| `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                               |
-| `codexPlugins`             | disabled                 | Native Codex plugin/app support for migrated source-installed curated plugins. See [Native Codex plugins](/plugins/codex-native-plugins). |
+| Field                      | Default                  | Meaning                                                                                                                                                                            |
+| -------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `discovery`                | enabled                  | Model discovery settings for Codex app-server `model/list`.                                                                                                                        |
+| `appServer`                | managed stdio app-server | Transport, command, auth, approval, sandbox, and timeout settings.                                                                                                                 |
+| `codexDynamicToolsLoading` | `"searchable"`           | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context.                                                                                           |
+| `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                                                                        |
+| `codexPlugins`             | disabled                 | Native Codex plugin/app support for migrated source-installed curated plugins. See [Native Codex plugins](/plugins/codex-native-plugins).                                          |
 | `accountApps`              | disabled                 | Explicit opt-in to all currently accessible apps connected to the authenticated Codex account. See [Connected account apps](/plugins/codex-native-plugins#connected-account-apps). |
-| `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                          |
+| `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                                                                   |
 
 ## App-server transport
 

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -188,6 +188,42 @@ plugin through stable ownership: an exact app id from plugin detail, a known
 MCP server name, or unique stable metadata. Display-name-only or ambiguous
 ownership is excluded until the next inventory refresh proves ownership.
 
+## Connected account apps
+
+Owner-operated agents can opt into every app already connected to their Codex
+account without requiring a matching plugin package:
+
+```json5
+{
+  plugins: {
+    entries: {
+      codex: {
+        enabled: true,
+        config: {
+          accountApps: {
+            mode: "all",
+            allow_destructive_actions: false,
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+`mode: "all"` takes a complete `app/list` snapshot when a new native Codex
+thread is established and admits only apps marked accessible for that account.
+It does not install, authenticate, or enable apps globally. Existing threads
+keep their persisted app set; use `/new`, `/reset`, or restart the gateway to
+pick up newly connected or revoked apps.
+
+Account app destructive actions default to disabled. The
+`allow_destructive_actions` field accepts `true`, `false`, `"auto"`, or
+`"ask"` with the same approval behavior as plugin-owned apps. Explicit
+`codexPlugins` policies override the account-wide policy for overlapping app
+ids. Inventory failures fail closed instead of falling back to an unrestricted
+default.
+
 ## Thread app config
 
 OpenClaw injects a restrictive `config.apps` patch for the Codex thread:

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -200,9 +200,10 @@ account without requiring a matching plugin package:
       codex: {
         enabled: true,
         config: {
-          accountApps: {
-            mode: "all",
-            allow_destructive_actions: false,
+          codexPlugins: {
+            enabled: true,
+            allow_all_plugins: true,
+            allow_destructive_actions: "auto",
           },
         },
       },
@@ -211,24 +212,22 @@ account without requiring a matching plugin package:
 }
 ```
 
-`mode: "all"` takes a complete `app/list` snapshot when a new native Codex
-thread is established and admits only apps marked accessible for that account.
-It does not install, authenticate, or enable apps globally. Existing threads
-keep their persisted app set; use `/new`, `/reset`, or restart the gateway to
-pick up newly connected or revoked apps.
+`allow_all_plugins: true` takes a complete `app/list` snapshot when a new native
+Codex thread is established and admits only apps marked accessible for that
+account. It does not install, authenticate, or enable apps globally. Existing
+threads keep their persisted app set; use `/new`, `/reset`, or restart the
+gateway to pick up newly connected or revoked apps.
 
-Account app destructive actions default to disabled. The
-`allow_destructive_actions` field accepts `true`, `false`, `"auto"`, or
-`"ask"` with the same approval behavior as plugin-owned apps. Explicit
-`codexPlugins` policies override the account-wide policy for overlapping app
-ids. Inventory failures fail closed instead of falling back to an unrestricted
-default.
+Account apps inherit the global `codexPlugins.allow_destructive_actions` value,
+which accepts `true`, `false`, `"auto"`, or `"ask"`. Explicit per-plugin policy
+overrides the global policy for overlapping app ids. Inventory failures fail
+closed instead of falling back to an unrestricted default.
 
 ## Thread app config
 
 OpenClaw injects a restrictive `config.apps` patch for the Codex thread:
-`_default` is disabled, and only apps owned by enabled migrated plugins are
-enabled.
+`_default` is disabled, and only apps owned by enabled migrated plugins or
+accessible account apps admitted by `allow_all_plugins` are enabled.
 
 `destructive_enabled` on each app comes from the effective global or
 per-plugin `allow_destructive_actions` policy; `true`, `"auto"`, and `"ask"`
@@ -239,7 +238,7 @@ get `open_world_enabled: true`. OpenClaw does not expose a separate
 plugin-level open-world policy knob and does not maintain per-plugin
 destructive tool-name deny lists.
 
-Tool approval mode defaults to automatic for plugin apps, so non-destructive
+Tool approval mode defaults to automatic for admitted apps, so non-destructive
 read tools run without a same-thread approval prompt. Destructive tools stay
 controlled by each app's `destructive_enabled` policy.
 

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -101,6 +101,10 @@
             "type": "boolean",
             "default": false
           },
+          "allow_all_plugins": {
+            "type": "boolean",
+            "default": false
+          },
           "allow_destructive_actions": {
             "oneOf": [{ "type": "boolean" }, { "const": "auto" }, { "const": "ask" }],
             "default": true
@@ -126,21 +130,6 @@
                 }
               }
             }
-          }
-        }
-      },
-      "accountApps": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": ["mode"],
-        "properties": {
-          "mode": {
-            "type": "string",
-            "enum": ["all"]
-          },
-          "allow_destructive_actions": {
-            "oneOf": [{ "type": "boolean" }, { "const": "auto" }, { "const": "ask" }],
-            "default": false
           }
         }
       },
@@ -362,6 +351,11 @@
       "help": "Expose explicit migrated Codex plugin entries to Codex harness turns.",
       "advanced": true
     },
+    "codexPlugins.allow_all_plugins": {
+      "label": "Allow All Connected Apps",
+      "help": "Expose every currently accessible app connected to the authenticated Codex account when a new Codex thread starts.",
+      "advanced": true
+    },
     "codexPlugins.allow_destructive_actions": {
       "label": "Allow Destructive Plugin Actions",
       "help": "Default policy for plugin app write or destructive action elicitations. Use true to accept safe schemas without prompting, false to decline, auto to ask through plugin approvals when Codex requires approval, or ask to prompt for every write/destructive action without durable approval.",
@@ -370,21 +364,6 @@
     "codexPlugins.plugins": {
       "label": "Migrated Plugin Entries",
       "help": "Explicit migration-authored plugin entries. The wildcard key * is not supported.",
-      "advanced": true
-    },
-    "accountApps": {
-      "label": "Connected Account Apps",
-      "help": "Opt in to Codex apps already connected to the authenticated account.",
-      "advanced": true
-    },
-    "accountApps.mode": {
-      "label": "Connected App Selection",
-      "help": "Use all to expose every currently accessible account app when a new Codex thread starts.",
-      "advanced": true
-    },
-    "accountApps.allow_destructive_actions": {
-      "label": "Allow Destructive Account App Actions",
-      "help": "Policy for write or destructive actions from connected account apps. Defaults to false; auto and ask route required approvals through OpenClaw.",
       "advanced": true
     },
     "appServer": {

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -129,6 +129,21 @@
           }
         }
       },
+      "accountApps": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["mode"],
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["all"]
+          },
+          "allow_destructive_actions": {
+            "oneOf": [{ "type": "boolean" }, { "const": "auto" }, { "const": "ask" }],
+            "default": false
+          }
+        }
+      },
       "appServer": {
         "type": "object",
         "additionalProperties": false,
@@ -355,6 +370,21 @@
     "codexPlugins.plugins": {
       "label": "Migrated Plugin Entries",
       "help": "Explicit migration-authored plugin entries. The wildcard key * is not supported.",
+      "advanced": true
+    },
+    "accountApps": {
+      "label": "Connected Account Apps",
+      "help": "Opt in to Codex apps already connected to the authenticated account.",
+      "advanced": true
+    },
+    "accountApps.mode": {
+      "label": "Connected App Selection",
+      "help": "Use all to expose every currently accessible account app when a new Codex thread starts.",
+      "advanced": true
+    },
+    "accountApps.allow_destructive_actions": {
+      "label": "Allow Destructive Account App Actions",
+      "help": "Policy for write or destructive actions from connected account apps. Defaults to false; auto and ask route required approvals through OpenClaw.",
       "advanced": true
     },
     "appServer": {

--- a/extensions/codex/src/app-server/attempt-diagnostics.test.ts
+++ b/extensions/codex/src/app-server/attempt-diagnostics.test.ts
@@ -1,7 +1,7 @@
 // Codex tests cover attempt diagnostics plugin behavior.
 import { describe, expect, it } from "vitest";
 import { buildCodexPluginThreadConfigEligibilityLogData } from "./attempt-diagnostics.js";
-import { resolveCodexAccountAppsPolicy, resolveCodexPluginsPolicy } from "./config.js";
+import { resolveCodexPluginsPolicy } from "./config.js";
 import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
 
 describe("Codex app-server attempt diagnostics", () => {
@@ -36,6 +36,7 @@ describe("Codex app-server attempt diagnostics", () => {
     const resolvedPluginPolicy = resolveCodexPluginsPolicy({
       codexPlugins: {
         enabled: true,
+        allow_all_plugins: true,
         plugins: {
           "google-calendar": {
             marketplaceName: "openai-curated",
@@ -44,16 +45,12 @@ describe("Codex app-server attempt diagnostics", () => {
         },
       },
     });
-    const resolvedAccountAppsPolicy = resolveCodexAccountAppsPolicy({
-      accountApps: { mode: "all" },
-    });
 
     const logData = buildCodexPluginThreadConfigEligibilityLogData({
       sessionId: "session-1",
       sessionKey: "agent:main:session-1",
       pluginThreadConfigRequired: true,
       resolvedPluginPolicy,
-      resolvedAccountAppsPolicy,
       enabledPluginConfigKeys: ["google-calendar"],
       pluginAppCacheKey: buildCodexPluginAppCacheKey({
         appServer,
@@ -73,9 +70,7 @@ describe("Codex app-server attempt diagnostics", () => {
         enabled: true,
         policyConfigured: true,
         policyEnabled: true,
-        accountAppsConfigured: true,
-        accountAppsEnabled: true,
-        accountAppsMode: "all",
+        allowAllPlugins: true,
         pluginConfigKeys: ["google-calendar"],
         enabledPluginConfigKeys: ["google-calendar"],
         appCacheKeyFingerprint: expect.stringMatching(/^sha256:/),

--- a/extensions/codex/src/app-server/attempt-diagnostics.test.ts
+++ b/extensions/codex/src/app-server/attempt-diagnostics.test.ts
@@ -1,7 +1,7 @@
 // Codex tests cover attempt diagnostics plugin behavior.
 import { describe, expect, it } from "vitest";
 import { buildCodexPluginThreadConfigEligibilityLogData } from "./attempt-diagnostics.js";
-import { resolveCodexPluginsPolicy } from "./config.js";
+import { resolveCodexAccountAppsPolicy, resolveCodexPluginsPolicy } from "./config.js";
 import { buildCodexPluginAppCacheKey } from "./plugin-app-cache-key.js";
 
 describe("Codex app-server attempt diagnostics", () => {
@@ -44,12 +44,16 @@ describe("Codex app-server attempt diagnostics", () => {
         },
       },
     });
+    const resolvedAccountAppsPolicy = resolveCodexAccountAppsPolicy({
+      accountApps: { mode: "all" },
+    });
 
     const logData = buildCodexPluginThreadConfigEligibilityLogData({
       sessionId: "session-1",
       sessionKey: "agent:main:session-1",
       pluginThreadConfigRequired: true,
       resolvedPluginPolicy,
+      resolvedAccountAppsPolicy,
       enabledPluginConfigKeys: ["google-calendar"],
       pluginAppCacheKey: buildCodexPluginAppCacheKey({
         appServer,
@@ -69,6 +73,9 @@ describe("Codex app-server attempt diagnostics", () => {
         enabled: true,
         policyConfigured: true,
         policyEnabled: true,
+        accountAppsConfigured: true,
+        accountAppsEnabled: true,
+        accountAppsMode: "all",
         pluginConfigKeys: ["google-calendar"],
         enabledPluginConfigKeys: ["google-calendar"],
         appCacheKeyFingerprint: expect.stringMatching(/^sha256:/),

--- a/extensions/codex/src/app-server/attempt-diagnostics.ts
+++ b/extensions/codex/src/app-server/attempt-diagnostics.ts
@@ -9,7 +9,6 @@ import {
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import type {
   CodexAppServerRuntimeOptions,
-  resolveCodexAccountAppsPolicy,
   resolveCodexPluginsPolicy,
 } from "./config.js";
 
@@ -66,7 +65,6 @@ export function buildCodexPluginThreadConfigEligibilityLogData(params: {
   sessionKey: string;
   pluginThreadConfigRequired: boolean;
   resolvedPluginPolicy: ReturnType<typeof resolveCodexPluginsPolicy> | undefined;
-  resolvedAccountAppsPolicy: ReturnType<typeof resolveCodexAccountAppsPolicy> | undefined;
   enabledPluginConfigKeys: string[] | undefined;
   pluginAppCacheKey: string;
   startupAuthProfileId: string | undefined;
@@ -78,9 +76,7 @@ export function buildCodexPluginThreadConfigEligibilityLogData(params: {
     enabled: params.pluginThreadConfigRequired,
     policyConfigured: params.resolvedPluginPolicy?.configured === true,
     policyEnabled: params.resolvedPluginPolicy?.enabled === true,
-    accountAppsConfigured: params.resolvedAccountAppsPolicy?.configured === true,
-    accountAppsEnabled: params.resolvedAccountAppsPolicy?.enabled === true,
-    accountAppsMode: params.resolvedAccountAppsPolicy?.mode,
+    allowAllPlugins: params.resolvedPluginPolicy?.allowAllPlugins === true,
     pluginConfigKeys: params.resolvedPluginPolicy?.pluginPolicies
       .map((plugin) => plugin.configKey)
       .toSorted(),

--- a/extensions/codex/src/app-server/attempt-diagnostics.ts
+++ b/extensions/codex/src/app-server/attempt-diagnostics.ts
@@ -7,7 +7,11 @@ import {
   emitTrustedDiagnosticEventWithPrivateData,
   type DiagnosticModelCallContent,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
-import type { CodexAppServerRuntimeOptions, resolveCodexPluginsPolicy } from "./config.js";
+import type {
+  CodexAppServerRuntimeOptions,
+  resolveCodexAccountAppsPolicy,
+  resolveCodexPluginsPolicy,
+} from "./config.js";
 
 type TrustedDiagnosticEventInput = Parameters<typeof emitTrustedDiagnosticEventWithPrivateData>[0];
 
@@ -62,6 +66,7 @@ export function buildCodexPluginThreadConfigEligibilityLogData(params: {
   sessionKey: string;
   pluginThreadConfigRequired: boolean;
   resolvedPluginPolicy: ReturnType<typeof resolveCodexPluginsPolicy> | undefined;
+  resolvedAccountAppsPolicy: ReturnType<typeof resolveCodexAccountAppsPolicy> | undefined;
   enabledPluginConfigKeys: string[] | undefined;
   pluginAppCacheKey: string;
   startupAuthProfileId: string | undefined;
@@ -73,6 +78,9 @@ export function buildCodexPluginThreadConfigEligibilityLogData(params: {
     enabled: params.pluginThreadConfigRequired,
     policyConfigured: params.resolvedPluginPolicy?.configured === true,
     policyEnabled: params.resolvedPluginPolicy?.enabled === true,
+    accountAppsConfigured: params.resolvedAccountAppsPolicy?.configured === true,
+    accountAppsEnabled: params.resolvedAccountAppsPolicy?.enabled === true,
+    accountAppsMode: params.resolvedAccountAppsPolicy?.mode,
     pluginConfigKeys: params.resolvedPluginPolicy?.pluginPolicies
       .map((plugin) => plugin.configKey)
       .toSorted(),

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -18,6 +18,7 @@ import type { CodexAppServerClientFactory } from "./client-factory.js";
 import { isCodexAppServerConnectionClosedError, type CodexAppServerClient } from "./client.js";
 import { ensureCodexComputerUse } from "./computer-use.js";
 import {
+  resolveCodexAccountAppsPolicy,
   resolveCodexPluginsPolicy,
   withMcpElicitationsApprovalPolicy,
   type CodexAppServerRuntimeOptions,
@@ -153,9 +154,14 @@ export async function startCodexAttemptThread(params: {
         const resolvedPluginPolicy = pluginThreadConfigRequired
           ? resolveCodexPluginsPolicy(pluginThreadConfigPluginConfig)
           : undefined;
+        const resolvedAccountAppsPolicy = pluginThreadConfigRequired
+          ? resolveCodexAccountAppsPolicy(pluginThreadConfigPluginConfig)
+          : undefined;
         const computerUseMcpElicitationDelegationRequired = params.computerUseConfig.enabled;
         const mcpElicitationDelegationRequired =
-          resolvedPluginPolicy?.enabled === true || computerUseMcpElicitationDelegationRequired;
+          resolvedPluginPolicy?.enabled === true ||
+          resolvedAccountAppsPolicy?.enabled === true ||
+          computerUseMcpElicitationDelegationRequired;
         const enabledPluginConfigKeys = resolvedPluginPolicy
           ? resolvedPluginPolicy.pluginPolicies
               .filter((plugin) => plugin.enabled)
@@ -246,6 +252,7 @@ export async function startCodexAttemptThread(params: {
                 sessionKey: attemptParams.sessionKey ?? "",
                 pluginThreadConfigRequired,
                 resolvedPluginPolicy,
+                resolvedAccountAppsPolicy,
                 enabledPluginConfigKeys,
                 pluginAppCacheKey,
                 startupAuthProfileId: params.startupAuthProfileId,

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -18,7 +18,6 @@ import type { CodexAppServerClientFactory } from "./client-factory.js";
 import { isCodexAppServerConnectionClosedError, type CodexAppServerClient } from "./client.js";
 import { ensureCodexComputerUse } from "./computer-use.js";
 import {
-  resolveCodexAccountAppsPolicy,
   resolveCodexPluginsPolicy,
   withMcpElicitationsApprovalPolicy,
   type CodexAppServerRuntimeOptions,
@@ -154,13 +153,9 @@ export async function startCodexAttemptThread(params: {
         const resolvedPluginPolicy = pluginThreadConfigRequired
           ? resolveCodexPluginsPolicy(pluginThreadConfigPluginConfig)
           : undefined;
-        const resolvedAccountAppsPolicy = pluginThreadConfigRequired
-          ? resolveCodexAccountAppsPolicy(pluginThreadConfigPluginConfig)
-          : undefined;
         const computerUseMcpElicitationDelegationRequired = params.computerUseConfig.enabled;
         const mcpElicitationDelegationRequired =
           resolvedPluginPolicy?.enabled === true ||
-          resolvedAccountAppsPolicy?.enabled === true ||
           computerUseMcpElicitationDelegationRequired;
         const enabledPluginConfigKeys = resolvedPluginPolicy
           ? resolvedPluginPolicy.pluginPolicies
@@ -252,7 +247,6 @@ export async function startCodexAttemptThread(params: {
                 sessionKey: attemptParams.sessionKey ?? "",
                 pluginThreadConfigRequired,
                 resolvedPluginPolicy,
-                resolvedAccountAppsPolicy,
                 enabledPluginConfigKeys,
                 pluginAppCacheKey,
                 startupAuthProfileId: params.startupAuthProfileId,

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -5,6 +5,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import {
+  CODEX_ACCOUNT_APPS_CONFIG_KEYS,
   CODEX_APP_SERVER_CONFIG_KEYS,
   CODEX_APP_SERVER_EXPERIMENTAL_CONFIG_KEYS,
   CODEX_COMPUTER_USE_CONFIG_KEYS,
@@ -15,6 +16,7 @@ import {
   fingerprintCodexAppServerNetworkProxyConfigPatch,
   readCodexPluginConfig,
   resolveCodexAppServerRuntimeOptions,
+  resolveCodexAccountAppsPolicy,
   resolveCodexAppServerUserHomeDir,
   resolveCodexComputerUseConfig,
   resolveCodexModelBackedReviewerPolicyContext,
@@ -1357,6 +1359,38 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     expect(resolveCodexPluginsPolicy(config).pluginPolicies).toStrictEqual([]);
   });
 
+  it("parses opt-in access to all connected account apps", () => {
+    const config = readCodexPluginConfig({
+      accountApps: {
+        mode: "all",
+        allow_destructive_actions: "auto",
+      },
+    });
+
+    expect(config.accountApps).toEqual({
+      mode: "all",
+      allow_destructive_actions: "auto",
+    });
+    expect(resolveCodexAccountAppsPolicy(config)).toEqual({
+      configured: true,
+      enabled: true,
+      mode: "all",
+      allowDestructiveActions: true,
+      destructiveApprovalMode: "auto",
+    });
+  });
+
+  it("defaults connected account apps to read-only and rejects unknown modes", () => {
+    expect(resolveCodexAccountAppsPolicy({ accountApps: { mode: "all" } })).toEqual({
+      configured: true,
+      enabled: true,
+      mode: "all",
+      allowDestructiveActions: false,
+      destructiveApprovalMode: "deny",
+    });
+    expect(readCodexPluginConfig({ accountApps: { mode: "selected" } })).toEqual({});
+  });
+
   it("treats configured and environment commands as explicit overrides", () => {
     expectFields(
       resolveRuntimeForTest({
@@ -2559,6 +2593,10 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
       configSchema: {
         properties: {
           appServer: { properties: Record<string, unknown> };
+          accountApps: {
+            properties: Record<string, unknown>;
+            additionalProperties: boolean;
+          };
           computerUse: { properties: Record<string, unknown> };
           codexPlugins: {
             properties: Record<string, unknown>;
@@ -2593,6 +2631,14 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     expect(computerUseManifestKeys).toEqual([...CODEX_COMPUTER_USE_CONFIG_KEYS].toSorted());
     for (const key of CODEX_COMPUTER_USE_CONFIG_KEYS) {
       expectUiHintLabel(manifest, `computerUse.${key}`);
+    }
+    const accountAppsProperties = manifest.configSchema.properties.accountApps;
+    expect(Object.keys(accountAppsProperties.properties).toSorted()).toEqual(
+      [...CODEX_ACCOUNT_APPS_CONFIG_KEYS].toSorted(),
+    );
+    expect(accountAppsProperties.additionalProperties).toBe(false);
+    for (const key of CODEX_ACCOUNT_APPS_CONFIG_KEYS) {
+      expectUiHintLabel(manifest, `accountApps.${key}`);
     }
     const codexPluginsProperties = manifest.configSchema.properties.codexPlugins;
     const codexPluginsManifestKeys = Object.keys(codexPluginsProperties.properties).toSorted();

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -5,7 +5,6 @@ import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import {
-  CODEX_ACCOUNT_APPS_CONFIG_KEYS,
   CODEX_APP_SERVER_CONFIG_KEYS,
   CODEX_APP_SERVER_EXPERIMENTAL_CONFIG_KEYS,
   CODEX_COMPUTER_USE_CONFIG_KEYS,
@@ -16,7 +15,6 @@ import {
   fingerprintCodexAppServerNetworkProxyConfigPatch,
   readCodexPluginConfig,
   resolveCodexAppServerRuntimeOptions,
-  resolveCodexAccountAppsPolicy,
   resolveCodexAppServerUserHomeDir,
   resolveCodexComputerUseConfig,
   resolveCodexModelBackedReviewerPolicyContext,
@@ -1164,6 +1162,7 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     expect(policy).toEqual({
       configured: true,
       enabled: true,
+      allowAllPlugins: false,
       allowDestructiveActions: false,
       destructiveApprovalMode: "deny",
       pluginPolicies: [
@@ -1215,6 +1214,7 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     expect(resolveCodexPluginsPolicy(config)).toEqual({
       configured: true,
       enabled: true,
+      allowAllPlugins: false,
       allowDestructiveActions: true,
       destructiveApprovalMode: "auto",
       pluginPolicies: [
@@ -1271,6 +1271,7 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     expect(resolveCodexPluginsPolicy(config)).toEqual({
       configured: true,
       enabled: true,
+      allowAllPlugins: false,
       allowDestructiveActions: true,
       destructiveApprovalMode: "ask",
       pluginPolicies: [
@@ -1327,6 +1328,7 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     expect(policy).toEqual({
       configured: true,
       enabled: true,
+      allowAllPlugins: false,
       allowDestructiveActions: true,
       destructiveApprovalMode: "allow",
       pluginPolicies: [
@@ -1361,34 +1363,40 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
 
   it("parses opt-in access to all connected account apps", () => {
     const config = readCodexPluginConfig({
-      accountApps: {
-        mode: "all",
+      codexPlugins: {
+        enabled: true,
+        allow_all_plugins: true,
         allow_destructive_actions: "auto",
       },
     });
 
-    expect(config.accountApps).toEqual({
-      mode: "all",
+    expect(config.codexPlugins).toEqual({
+      enabled: true,
+      allow_all_plugins: true,
       allow_destructive_actions: "auto",
     });
-    expect(resolveCodexAccountAppsPolicy(config)).toEqual({
+    expect(resolveCodexPluginsPolicy(config)).toEqual({
       configured: true,
       enabled: true,
-      mode: "all",
+      allowAllPlugins: true,
       allowDestructiveActions: true,
       destructiveApprovalMode: "auto",
+      pluginPolicies: [],
     });
   });
 
-  it("defaults connected account apps to read-only and rejects unknown modes", () => {
-    expect(resolveCodexAccountAppsPolicy({ accountApps: { mode: "all" } })).toEqual({
+  it("requires native plugin support before exposing all connected account apps", () => {
+    expect(resolveCodexPluginsPolicy({ codexPlugins: { allow_all_plugins: true } })).toEqual({
       configured: true,
-      enabled: true,
-      mode: "all",
-      allowDestructiveActions: false,
-      destructiveApprovalMode: "deny",
+      enabled: false,
+      allowAllPlugins: false,
+      allowDestructiveActions: true,
+      destructiveApprovalMode: "allow",
+      pluginPolicies: [],
     });
-    expect(readCodexPluginConfig({ accountApps: { mode: "selected" } })).toEqual({});
+    expect(
+      readCodexPluginConfig({ codexPlugins: { enabled: true, allow_all_plugins: "yes" } }),
+    ).toEqual({});
   });
 
   it("treats configured and environment commands as explicit overrides", () => {
@@ -2593,10 +2601,6 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
       configSchema: {
         properties: {
           appServer: { properties: Record<string, unknown> };
-          accountApps: {
-            properties: Record<string, unknown>;
-            additionalProperties: boolean;
-          };
           computerUse: { properties: Record<string, unknown> };
           codexPlugins: {
             properties: Record<string, unknown>;
@@ -2631,14 +2635,6 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     expect(computerUseManifestKeys).toEqual([...CODEX_COMPUTER_USE_CONFIG_KEYS].toSorted());
     for (const key of CODEX_COMPUTER_USE_CONFIG_KEYS) {
       expectUiHintLabel(manifest, `computerUse.${key}`);
-    }
-    const accountAppsProperties = manifest.configSchema.properties.accountApps;
-    expect(Object.keys(accountAppsProperties.properties).toSorted()).toEqual(
-      [...CODEX_ACCOUNT_APPS_CONFIG_KEYS].toSorted(),
-    );
-    expect(accountAppsProperties.additionalProperties).toBe(false);
-    for (const key of CODEX_ACCOUNT_APPS_CONFIG_KEYS) {
-      expectUiHintLabel(manifest, `accountApps.${key}`);
     }
     const codexPluginsProperties = manifest.configSchema.properties.codexPlugins;
     const codexPluginsManifestKeys = Object.keys(codexPluginsProperties.properties).toSorted();

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -77,7 +77,6 @@ type CodexAppServerCommandSource = "managed" | "resolved-managed" | "config" | "
 export type CodexDynamicToolsLoading = "searchable" | "direct";
 export type CodexPluginDestructivePolicy = boolean | "auto" | "ask";
 export type CodexPluginDestructiveApprovalMode = "allow" | "deny" | "auto" | "ask";
-export type CodexAccountAppsMode = "all";
 
 export const CODEX_PLUGINS_MARKETPLACE_NAME = "openai-curated";
 
@@ -112,13 +111,9 @@ export type CodexPluginEntryConfig = {
 
 export type CodexPluginsConfig = {
   enabled?: boolean;
+  allow_all_plugins?: boolean;
   allow_destructive_actions?: CodexPluginDestructivePolicy;
   plugins?: Record<string, CodexPluginEntryConfig>;
-};
-
-export type CodexAccountAppsConfig = {
-  mode: CodexAccountAppsMode;
-  allow_destructive_actions?: CodexPluginDestructivePolicy;
 };
 
 export type CodexAppServerExperimentalConfig = {
@@ -165,17 +160,10 @@ export type ResolvedCodexPluginPolicy = {
 export type ResolvedCodexPluginsPolicy = {
   configured: boolean;
   enabled: boolean;
+  allowAllPlugins: boolean;
   allowDestructiveActions: boolean;
   destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
   pluginPolicies: ResolvedCodexPluginPolicy[];
-};
-
-export type ResolvedCodexAccountAppsPolicy = {
-  configured: boolean;
-  enabled: boolean;
-  mode?: CodexAccountAppsMode;
-  allowDestructiveActions: boolean;
-  destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
 };
 
 export type CodexAppServerStartOptions = {
@@ -228,7 +216,6 @@ export type CodexPluginConfig = {
   };
   computerUse?: CodexComputerUseConfig;
   codexPlugins?: CodexPluginsConfig;
-  accountApps?: CodexAccountAppsConfig;
   appServer?: {
     mode?: CodexAppServerPolicyMode;
     transport?: CodexAppServerTransportMode;
@@ -303,11 +290,10 @@ export const CODEX_COMPUTER_USE_CONFIG_KEYS = [
 
 export const CODEX_PLUGINS_CONFIG_KEYS = [
   "enabled",
+  "allow_all_plugins",
   "allow_destructive_actions",
   "plugins",
 ] as const;
-
-export const CODEX_ACCOUNT_APPS_CONFIG_KEYS = ["mode", "allow_destructive_actions"] as const;
 
 export const CODEX_PLUGIN_ENTRY_CONFIG_KEYS = [
   "enabled",
@@ -386,15 +372,9 @@ const codexPluginEntryConfigSchema = z
 const codexPluginsConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
+    allow_all_plugins: z.boolean().optional(),
     allow_destructive_actions: codexPluginDestructivePolicySchema.optional(),
     plugins: z.record(z.string(), codexPluginEntryConfigSchema).optional(),
-  })
-  .strict();
-
-const codexAccountAppsConfigSchema = z
-  .object({
-    mode: z.literal("all"),
-    allow_destructive_actions: codexPluginDestructivePolicySchema.optional(),
   })
   .strict();
 
@@ -423,7 +403,6 @@ const codexPluginConfigSchema = z
       .strict()
       .optional(),
     codexPlugins: z.unknown().optional(),
-    accountApps: codexAccountAppsConfigSchema.optional(),
     appServer: z
       .object({
         mode: codexAppServerPolicyModeSchema.optional(),
@@ -521,26 +500,10 @@ export function resolveCodexPluginsPolicy(pluginConfig?: unknown): ResolvedCodex
   return {
     configured,
     enabled,
+    allowAllPlugins: enabled && config?.allow_all_plugins === true,
     allowDestructiveActions: destructivePolicy.allowDestructiveActions,
     destructiveApprovalMode: destructivePolicy.destructiveApprovalMode,
     pluginPolicies,
-  };
-}
-
-/** Resolves the opt-in policy for account-connected Codex apps. */
-export function resolveCodexAccountAppsPolicy(
-  pluginConfig?: unknown,
-): ResolvedCodexAccountAppsPolicy {
-  const config = readCodexPluginConfig(pluginConfig).accountApps;
-  const destructivePolicy = resolveCodexPluginDestructivePolicy(
-    config?.allow_destructive_actions ?? false,
-  );
-  return {
-    configured: config !== undefined,
-    enabled: config?.mode === "all",
-    ...(config ? { mode: config.mode } : {}),
-    allowDestructiveActions: destructivePolicy.allowDestructiveActions,
-    destructiveApprovalMode: destructivePolicy.destructiveApprovalMode,
   };
 }
 

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -77,6 +77,7 @@ type CodexAppServerCommandSource = "managed" | "resolved-managed" | "config" | "
 export type CodexDynamicToolsLoading = "searchable" | "direct";
 export type CodexPluginDestructivePolicy = boolean | "auto" | "ask";
 export type CodexPluginDestructiveApprovalMode = "allow" | "deny" | "auto" | "ask";
+export type CodexAccountAppsMode = "all";
 
 export const CODEX_PLUGINS_MARKETPLACE_NAME = "openai-curated";
 
@@ -113,6 +114,11 @@ export type CodexPluginsConfig = {
   enabled?: boolean;
   allow_destructive_actions?: CodexPluginDestructivePolicy;
   plugins?: Record<string, CodexPluginEntryConfig>;
+};
+
+export type CodexAccountAppsConfig = {
+  mode: CodexAccountAppsMode;
+  allow_destructive_actions?: CodexPluginDestructivePolicy;
 };
 
 export type CodexAppServerExperimentalConfig = {
@@ -162,6 +168,14 @@ export type ResolvedCodexPluginsPolicy = {
   allowDestructiveActions: boolean;
   destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
   pluginPolicies: ResolvedCodexPluginPolicy[];
+};
+
+export type ResolvedCodexAccountAppsPolicy = {
+  configured: boolean;
+  enabled: boolean;
+  mode?: CodexAccountAppsMode;
+  allowDestructiveActions: boolean;
+  destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
 };
 
 export type CodexAppServerStartOptions = {
@@ -214,6 +228,7 @@ export type CodexPluginConfig = {
   };
   computerUse?: CodexComputerUseConfig;
   codexPlugins?: CodexPluginsConfig;
+  accountApps?: CodexAccountAppsConfig;
   appServer?: {
     mode?: CodexAppServerPolicyMode;
     transport?: CodexAppServerTransportMode;
@@ -291,6 +306,8 @@ export const CODEX_PLUGINS_CONFIG_KEYS = [
   "allow_destructive_actions",
   "plugins",
 ] as const;
+
+export const CODEX_ACCOUNT_APPS_CONFIG_KEYS = ["mode", "allow_destructive_actions"] as const;
 
 export const CODEX_PLUGIN_ENTRY_CONFIG_KEYS = [
   "enabled",
@@ -374,6 +391,13 @@ const codexPluginsConfigSchema = z
   })
   .strict();
 
+const codexAccountAppsConfigSchema = z
+  .object({
+    mode: z.literal("all"),
+    allow_destructive_actions: codexPluginDestructivePolicySchema.optional(),
+  })
+  .strict();
+
 const codexPluginConfigSchema = z
   .object({
     codexDynamicToolsLoading: codexDynamicToolsLoadingSchema.optional(),
@@ -399,6 +423,7 @@ const codexPluginConfigSchema = z
       .strict()
       .optional(),
     codexPlugins: z.unknown().optional(),
+    accountApps: codexAccountAppsConfigSchema.optional(),
     appServer: z
       .object({
         mode: codexAppServerPolicyModeSchema.optional(),
@@ -499,6 +524,23 @@ export function resolveCodexPluginsPolicy(pluginConfig?: unknown): ResolvedCodex
     allowDestructiveActions: destructivePolicy.allowDestructiveActions,
     destructiveApprovalMode: destructivePolicy.destructiveApprovalMode,
     pluginPolicies,
+  };
+}
+
+/** Resolves the opt-in policy for account-connected Codex apps. */
+export function resolveCodexAccountAppsPolicy(
+  pluginConfig?: unknown,
+): ResolvedCodexAccountAppsPolicy {
+  const config = readCodexPluginConfig(pluginConfig).accountApps;
+  const destructivePolicy = resolveCodexPluginDestructivePolicy(
+    config?.allow_destructive_actions ?? false,
+  );
+  return {
+    configured: config !== undefined,
+    enabled: config?.mode === "all",
+    ...(config ? { mode: config.mode } : {}),
+    allowDestructiveActions: destructivePolicy.allowDestructiveActions,
+    destructiveApprovalMode: destructivePolicy.destructiveApprovalMode,
   };
 }
 

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   addSandboxShellDynamicToolsIfAvailable,
   buildDynamicTools,
+  disableCodexPluginThreadConfig,
   filterCodexDynamicToolsForAllowlist,
   hasWildcardCodexToolsAllow,
   includeForcedCodexDynamicToolAllow,
@@ -128,6 +129,17 @@ async function buildDynamicToolsForTest(
 }
 
 describe("Codex app-server dynamic tool build", () => {
+  it("removes account-wide app access when native tools are restricted", () => {
+    expect(
+      disableCodexPluginThreadConfig({
+        accountApps: { mode: "all", allow_destructive_actions: "auto" },
+        codexPlugins: { enabled: true },
+      }),
+    ).toEqual({
+      codexPlugins: { enabled: false },
+    });
+  });
+
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-tools-"));
   });

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -132,11 +132,18 @@ describe("Codex app-server dynamic tool build", () => {
   it("removes account-wide app access when native tools are restricted", () => {
     expect(
       disableCodexPluginThreadConfig({
-        accountApps: { mode: "all", allow_destructive_actions: "auto" },
-        codexPlugins: { enabled: true },
+        codexPlugins: {
+          enabled: true,
+          allow_all_plugins: true,
+          allow_destructive_actions: "auto",
+        },
       }),
     ).toEqual({
-      codexPlugins: { enabled: false },
+      codexPlugins: {
+        enabled: false,
+        allow_all_plugins: true,
+        allow_destructive_actions: "auto",
+      },
     });
   });
 

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -663,11 +663,12 @@ function codexNetworkAccessForOpenClawSandbox(
   return Boolean(network && network !== "none");
 }
 
-/** Returns a Codex config copy with app-server Codex plugin loading disabled for thread tools. */
+/** Returns a Codex config copy with all app exposure disabled for restricted thread tools. */
 export function disableCodexPluginThreadConfig(pluginConfig?: unknown): CodexPluginConfig {
   const config = readCodexPluginConfig(pluginConfig);
+  const { accountApps: _accountApps, ...configWithoutAccountApps } = config;
   return {
-    ...config,
+    ...configWithoutAccountApps,
     codexPlugins: {
       ...config.codexPlugins,
       enabled: false,

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -666,9 +666,8 @@ function codexNetworkAccessForOpenClawSandbox(
 /** Returns a Codex config copy with all app exposure disabled for restricted thread tools. */
 export function disableCodexPluginThreadConfig(pluginConfig?: unknown): CodexPluginConfig {
   const config = readCodexPluginConfig(pluginConfig);
-  const { accountApps: _accountApps, ...configWithoutAccountApps } = config;
   return {
-    ...configWithoutAccountApps,
+    ...config,
     codexPlugins: {
       ...config.codexPlugins,
       enabled: false,

--- a/extensions/codex/src/app-server/elicitation-bridge.test.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.test.ts
@@ -191,6 +191,29 @@ function createPluginAppPolicyContext(
   };
 }
 
+function createAccountAppPolicyContext(params: {
+  appId: string;
+  appName: string;
+  allowDestructiveActions: boolean;
+  destructiveApprovalMode?: "allow" | "deny" | "auto" | "ask";
+}) {
+  return {
+    fingerprint: "account-app-policy-1",
+    apps: {
+      [params.appId]: {
+        source: "account" as const,
+        appName: params.appName,
+        allowDestructiveActions: params.allowDestructiveActions,
+        ...(params.destructiveApprovalMode
+          ? { destructiveApprovalMode: params.destructiveApprovalMode }
+          : {}),
+        mcpServerNames: [],
+      },
+    },
+    pluginAppIds: {},
+  };
+}
+
 function appsForPlugin(
   apps: Array<{ appId: string; pluginName: string; mcpServerNames: string[] }>,
   pluginName: string,
@@ -832,6 +855,61 @@ describe("Codex app-server elicitation bridge", () => {
       content: null,
       _meta: null,
     });
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
+  it("routes approvals for account-connected apps through the configured policy", async () => {
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-meetings", status: "accepted" })
+      .mockResolvedValueOnce({ id: "plugin:approval-meetings", decision: "allow-once" });
+
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildConnectorPluginApprovalElicitation({
+        message: "Allow ChatGPT Meetings to import a meeting?",
+        _meta: {
+          codex_approval_kind: "mcp_tool_call",
+          source: "connector",
+          connector_id: "chatgpt_meetings",
+          connector_name: "ChatGPT Meetings",
+          tool_title: "import_meeting",
+        },
+      }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createAccountAppPolicyContext({
+        appId: "chatgpt_meetings",
+        appName: "ChatGPT Meetings",
+        allowDestructiveActions: true,
+        destructiveApprovalMode: "auto",
+      }),
+    });
+
+    expect(result).toEqual({ action: "accept", content: null, _meta: null });
+    expect(gatewayToolArg(0, 2)).toMatchObject({
+      allowedDecisions: ["allow-once", "deny"],
+      title: "Allow ChatGPT Meetings to import a meeting?",
+      twoPhase: true,
+    });
+  });
+
+  it("does not trust account app ids from non-connector MCP servers", async () => {
+    const result = await handleCodexAppServerElicitationRequest({
+      requestParams: buildPluginApprovalElicitation({
+        _meta: { app_id: "chatgpt_meetings" },
+      }),
+      paramsForRun: createParams(),
+      threadId: "thread-1",
+      turnId: "turn-1",
+      pluginAppPolicyContext: createAccountAppPolicyContext({
+        appId: "chatgpt_meetings",
+        appName: "ChatGPT Meetings",
+        allowDestructiveActions: true,
+        destructiveApprovalMode: "auto",
+      }),
+    });
+
+    expect(result).toEqual({ action: "decline", content: null, _meta: null });
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
   });
 

--- a/extensions/codex/src/app-server/elicitation-bridge.ts
+++ b/extensions/codex/src/app-server/elicitation-bridge.ts
@@ -13,6 +13,7 @@ import {
   waitForPluginApprovalDecision,
 } from "./plugin-approval-roundtrip.js";
 import type {
+  CodexAppPolicyContextEntry,
   PluginAppPolicyContext,
   PluginAppPolicyContextEntry,
 } from "./plugin-thread-config.js";
@@ -35,7 +36,7 @@ type BridgeableApprovalElicitation = {
 
 type PluginElicitationResolution =
   | { kind: "not_plugin" }
-  | { kind: "matched"; entry: PluginAppPolicyContextEntry }
+  | { kind: "matched"; entry: CodexAppPolicyContextEntry }
   | { kind: "decline"; reason: string };
 
 const MCP_TOOL_APPROVAL_KIND = "mcp_tool_call";
@@ -167,6 +168,7 @@ function resolvePluginElicitation(params: {
   const meta = isJsonObject(requestParams["_meta"]) ? requestParams["_meta"] : {};
   const context = params.pluginAppPolicyContext;
   const entries = context ? Object.values(context.apps) : [];
+  const pluginEntries = entries.filter(isPluginAppPolicyContextEntry);
 
   const appId =
     readFirstString(meta, PLUGIN_APP_ID_META_KEYS) ??
@@ -181,6 +183,9 @@ function resolvePluginElicitation(params: {
       return { kind: "decline", reason: "missing_policy_context" };
     }
     const entry = context.apps[appId];
+    if (entry?.source === "account" && !isCodexConnectorApproval) {
+      return { kind: "decline", reason: "account_app_source_mismatch" };
+    }
     return uniquePluginMatch(entry ? [entry] : [], "app_id");
   }
   if (isCodexConnectorApproval && connectorId) {
@@ -202,7 +207,7 @@ function resolvePluginElicitation(params: {
   const metadataResolution = resolvePluginStableMetadataMatch({
     meta,
     requestParams,
-    entries,
+    entries: pluginEntries,
     context,
   });
   if (metadataResolution.kind !== "not_plugin") {
@@ -261,7 +266,7 @@ function resolvePluginStableMetadataMatch(params: {
 }
 
 function uniquePluginMatch(
-  matches: PluginAppPolicyContextEntry[],
+  matches: CodexAppPolicyContextEntry[],
   source: string,
 ): PluginElicitationResolution {
   if (matches.length === 1 && matches[0]) {
@@ -275,7 +280,7 @@ function uniquePluginMatch(
 
 function hasDisplayNameOnlyPluginMatch(
   meta: JsonObject,
-  entries: PluginAppPolicyContextEntry[],
+  entries: CodexAppPolicyContextEntry[],
 ): boolean {
   const connectorName = readString(meta, MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY);
   if (!connectorName) {
@@ -284,9 +289,20 @@ function hasDisplayNameOnlyPluginMatch(
   const normalized = normalizePluginIdentityText(connectorName);
   return entries.some(
     (entry) =>
-      normalizePluginIdentityText(entry.pluginName) === normalized ||
-      normalizePluginIdentityText(entry.configKey) === normalized,
+      normalizePluginIdentityText(appPolicyDisplayName(entry)) === normalized ||
+      (isPluginAppPolicyContextEntry(entry) &&
+        normalizePluginIdentityText(entry.configKey) === normalized),
   );
+}
+
+function isPluginAppPolicyContextEntry(
+  entry: CodexAppPolicyContextEntry,
+): entry is PluginAppPolicyContextEntry {
+  return entry.source !== "account";
+}
+
+function appPolicyDisplayName(entry: CodexAppPolicyContextEntry): string {
+  return isPluginAppPolicyContextEntry(entry) ? entry.pluginName : entry.appName;
 }
 
 function normalizePluginIdentityText(value: string): string {
@@ -294,7 +310,7 @@ function normalizePluginIdentityText(value: string): string {
 }
 
 async function buildPluginPolicyElicitationResponse(params: {
-  entry: PluginAppPolicyContextEntry;
+  entry: CodexAppPolicyContextEntry;
   requestParams: JsonObject;
   paramsForRun: EmbeddedRunAttemptParams;
   signal?: AbortSignal;
@@ -331,7 +347,7 @@ async function buildPluginPolicyElicitationResponse(params: {
 }
 
 function resolvePluginDestructiveApprovalMode(
-  entry: PluginAppPolicyContextEntry,
+  entry: CodexAppPolicyContextEntry,
 ): "allow" | "deny" | "auto" | "ask" {
   return entry.destructiveApprovalMode ?? (entry.allowDestructiveActions ? "allow" : "deny");
 }
@@ -355,7 +371,7 @@ function oneShotPluginPolicyApprovalOutcome(
 }
 
 function readPluginApprovalElicitation(
-  entry: PluginAppPolicyContextEntry,
+  entry: CodexAppPolicyContextEntry,
   requestParams: JsonObject,
 ): BridgeableApprovalElicitation | undefined {
   if (
@@ -377,7 +393,7 @@ function readPluginApprovalElicitation(
     sanitizeDisplayText(readString(requestParams, "message") ?? "") || "Codex plugin approval";
   const descriptionMeta: JsonObject = { ...meta };
   if (!readString(descriptionMeta, MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY)) {
-    descriptionMeta[MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY] = entry.pluginName;
+    descriptionMeta[MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY] = appPolicyDisplayName(entry);
   }
   return {
     title,

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -665,10 +665,17 @@ describe("Codex plugin thread config", () => {
   });
 
   it("exposes every accessible account app from a complete app inventory", async () => {
-    expect(shouldBuildCodexPluginThreadConfig({ accountApps: { mode: "all" } })).toBe(true);
+    const pluginConfig = {
+      codexPlugins: {
+        enabled: true,
+        allow_all_plugins: true,
+        allow_destructive_actions: false,
+      },
+    };
+    expect(shouldBuildCodexPluginThreadConfig(pluginConfig)).toBe(true);
     const appListParams: v2.AppsListParams[] = [];
     const config = await buildCodexPluginThreadConfig({
-      pluginConfig: { accountApps: { mode: "all" } },
+      pluginConfig,
       appCacheKey: "runtime",
       request: async (method, rawParams) => {
         if (method !== "app/list") {
@@ -738,7 +745,13 @@ describe("Codex plugin thread config", () => {
 
   it("fails closed when the account app inventory cannot be read", async () => {
     const config = await buildCodexPluginThreadConfig({
-      pluginConfig: { accountApps: { mode: "all" } },
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          allow_all_plugins: true,
+          allow_destructive_actions: false,
+        },
+      },
       appCacheKey: "runtime",
       request: async (method) => {
         if (method === "app/list") {
@@ -796,7 +809,11 @@ describe("Codex plugin thread config", () => {
 
     const config = await buildCodexPluginThreadConfig({
       pluginConfig: {
-        accountApps: { mode: "all", allow_destructive_actions: "ask" },
+        codexPlugins: {
+          enabled: true,
+          allow_all_plugins: true,
+          allow_destructive_actions: "ask",
+        },
       },
       appCacheKey: "runtime",
       request,
@@ -821,15 +838,16 @@ describe("Codex plugin thread config", () => {
       pluginConfig: {
         codexPlugins: {
           enabled: true,
-          allow_destructive_actions: "ask",
+          allow_all_plugins: true,
+          allow_destructive_actions: "auto",
           plugins: {
             meetings: {
               marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
               pluginName: "meetings",
+              allow_destructive_actions: "ask",
             },
           },
         },
-        accountApps: { mode: "all", allow_destructive_actions: "auto" },
       },
       appCacheKey: "runtime",
       request: async (method) => {

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -664,6 +664,158 @@ describe("Codex plugin thread config", () => {
     expect(config.policyContext.apps).toStrictEqual({});
   });
 
+  it("exposes every accessible account app from a complete app inventory", async () => {
+    expect(shouldBuildCodexPluginThreadConfig({ accountApps: { mode: "all" } })).toBe(true);
+    const appListParams: v2.AppsListParams[] = [];
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: { accountApps: { mode: "all" } },
+      appCacheKey: "runtime",
+      request: async (method, rawParams) => {
+        if (method !== "app/list") {
+          throw new Error(`unexpected request ${method}`);
+        }
+        const params = rawParams as v2.AppsListParams;
+        appListParams.push(params);
+        if (!params.cursor) {
+          return {
+            data: [
+              { ...appInfo("chatgpt-meetings", true, false), name: "ChatGPT Meetings" },
+              appInfo("inaccessible-app", false),
+            ],
+            nextCursor: "page-2",
+          };
+        }
+        return {
+          data: [{ ...appInfo("slack", true), name: "Slack" }],
+          nextCursor: null,
+        };
+      },
+    });
+
+    expect(appListParams).toEqual([
+      { cursor: undefined, limit: 100, forceRefetch: false },
+      { cursor: "page-2", limit: 100, forceRefetch: false },
+    ]);
+    expect(config.configPatch).toEqual({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+        "chatgpt-meetings": {
+          enabled: true,
+          destructive_enabled: false,
+          open_world_enabled: true,
+          default_tools_approval_mode: "auto",
+        },
+        slack: {
+          enabled: true,
+          destructive_enabled: false,
+          open_world_enabled: true,
+          default_tools_approval_mode: "auto",
+        },
+      },
+    });
+    expect(config.policyContext.apps).toEqual({
+      "chatgpt-meetings": {
+        source: "account",
+        appName: "ChatGPT Meetings",
+        allowDestructiveActions: false,
+        destructiveApprovalMode: "deny",
+        mcpServerNames: [],
+      },
+      slack: {
+        source: "account",
+        appName: "Slack",
+        allowDestructiveActions: false,
+        destructiveApprovalMode: "deny",
+        mcpServerNames: [],
+      },
+    });
+    expect(config.diagnostics).toStrictEqual([]);
+  });
+
+  it("fails closed when the account app inventory cannot be read", async () => {
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: { accountApps: { mode: "all" } },
+      appCacheKey: "runtime",
+      request: async (method) => {
+        if (method === "app/list") {
+          throw new Error("inventory unavailable");
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    expect(config.configPatch).toEqual({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+      },
+    });
+    expect(config.policyContext.apps).toStrictEqual({});
+    expect(config.diagnostics).toContainEqual({
+      code: "account_app_inventory_unavailable",
+      message: "Codex account app inventory was unavailable; account apps were not exposed.",
+    });
+  });
+
+  it("clears durable approval overrides for account apps in ask mode", async () => {
+    let configReadCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "app/list") {
+        return {
+          data: [{ ...appInfo("chatgpt-meetings", true), name: "ChatGPT Meetings" }],
+          nextCursor: null,
+        };
+      }
+      if (method === "config/read") {
+        configReadCount += 1;
+        return {
+          config: {
+            apps: {
+              "chatgpt-meetings": {
+                tools:
+                  configReadCount === 1
+                    ? { import_meeting: { approval_mode: "approve" } }
+                    : {},
+              },
+            },
+          },
+        };
+      }
+      if (method === "config/value/write") {
+        return { status: "ok" };
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        accountApps: { mode: "all", allow_destructive_actions: "ask" },
+      },
+      appCacheKey: "runtime",
+      request,
+    });
+
+    expect((config.configPatch?.apps as Record<string, unknown>)?.["chatgpt-meetings"]).toEqual({
+      enabled: true,
+      approvals_reviewer: "user",
+      destructive_enabled: true,
+      open_world_enabled: true,
+      default_tools_approval_mode: "auto",
+    });
+    expect(request).toHaveBeenCalledWith("config/value/write", {
+      keyPath: 'apps."chatgpt-meetings".tools."import_meeting".approval_mode',
+      value: null,
+      mergeStrategy: "replace",
+    });
+  });
+
   it("does not let per-plugin enablement override disabled native plugin support", async () => {
     expect(
       shouldBuildCodexPluginThreadConfig({

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -816,6 +816,61 @@ describe("Codex plugin thread config", () => {
     });
   });
 
+  it("does not re-admit an excluded plugin-owned app through account-wide policy", async () => {
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          allow_destructive_actions: "ask",
+          plugins: {
+            meetings: {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "meetings",
+            },
+          },
+        },
+        accountApps: { mode: "all", allow_destructive_actions: "auto" },
+      },
+      appCacheKey: "runtime",
+      request: async (method) => {
+        if (method === "plugin/list") {
+          return pluginList([pluginSummary("meetings", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read") {
+          return pluginDetail("meetings", [appSummary("chatgpt-meetings")]);
+        }
+        if (method === "app/list") {
+          return {
+            data: [{ ...appInfo("chatgpt-meetings", true), name: "ChatGPT Meetings" }],
+            nextCursor: null,
+          };
+        }
+        if (method === "config/read") {
+          throw new Error("approval policy unavailable");
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    expect(config.configPatch).toEqual({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+      },
+    });
+    expect(config.policyContext.apps).toStrictEqual({});
+    expect(config.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "approval_overrides_clear_failed",
+        message:
+          "Could not clear durable Codex app approval overrides for chatgpt-meetings: approval policy unavailable",
+      }),
+    );
+  });
+
   it("does not let per-plugin enablement override disabled native plugin support", async () => {
     expect(
       shouldBuildCodexPluginThreadConfig({

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -12,10 +12,8 @@ import {
   type CodexAppInventoryRequest,
 } from "./app-inventory-cache.js";
 import {
-  resolveCodexAccountAppsPolicy,
   resolveCodexPluginsPolicy,
   type CodexPluginDestructiveApprovalMode,
-  type ResolvedCodexAccountAppsPolicy,
   type ResolvedCodexPluginPolicy,
   type ResolvedCodexPluginsPolicy,
 } from "./config.js";
@@ -104,10 +102,7 @@ const CODEX_PLUGIN_THREAD_CONFIG_FINGERPRINT_VERSION = 2;
 
 /** Returns true when plugin config exists and thread config may need app patches. */
 export function shouldBuildCodexPluginThreadConfig(pluginConfig?: unknown): boolean {
-  return (
-    resolveCodexPluginsPolicy(pluginConfig).configured ||
-    resolveCodexAccountAppsPolicy(pluginConfig).configured
-  );
+  return resolveCodexPluginsPolicy(pluginConfig).configured;
 }
 
 /** Fingerprints policy and app-cache identity before runtime inventory is read. */
@@ -116,11 +111,9 @@ export function buildCodexPluginThreadConfigInputFingerprint(params: {
   appCacheKey?: string;
 }): string {
   const policy = resolveCodexPluginsPolicy(params.pluginConfig);
-  const accountAppsPolicy = resolveCodexAccountAppsPolicy(params.pluginConfig);
   return fingerprintJson({
     version: CODEX_PLUGIN_THREAD_CONFIG_INPUT_FINGERPRINT_VERSION,
     policy: policyFingerprint(policy),
-    accountAppsPolicy: accountAppsPolicyFingerprint(accountAppsPolicy),
     appCacheKey: params.appCacheKey ?? null,
   });
 }
@@ -135,8 +128,7 @@ export async function buildCodexPluginThreadConfig(
     appCacheKey: params.appCacheKey,
   });
   const policy = resolveCodexPluginsPolicy(params.pluginConfig);
-  const accountAppsPolicy = resolveCodexAccountAppsPolicy(params.pluginConfig);
-  if (!policy.enabled && !accountAppsPolicy.enabled) {
+  if (!policy.enabled) {
     return emptyPluginThreadConfig({
       enabled: false,
       inputFingerprint,
@@ -144,7 +136,7 @@ export async function buildCodexPluginThreadConfig(
     });
   }
 
-  let inventory = policy.enabled
+  let inventory = policy.pluginPolicies.length > 0
     ? await readCodexPluginInventory({
         pluginConfig: params.pluginConfig,
         policy,
@@ -251,7 +243,7 @@ export async function buildCodexPluginThreadConfig(
   }
 
   const accountAppsResult: Awaited<ReturnType<typeof readAccessibleAccountApps>> =
-    accountAppsPolicy.enabled
+    policy.allowAllPlugins
     ? await readAccessibleAccountApps(params, appCache)
     : { apps: [] };
 
@@ -327,7 +319,7 @@ export async function buildCodexPluginThreadConfig(
     }
     const accountApp = toOwnedAccountApp(app);
     if (
-      accountAppsPolicy.destructiveApprovalMode === "ask" &&
+      policy.destructiveApprovalMode === "ask" &&
       !(await clearPersistedAppToolApprovalOverrides({
         request: params.request,
         configCwd: params.configCwd,
@@ -337,12 +329,12 @@ export async function buildCodexPluginThreadConfig(
     ) {
       continue;
     }
-    apps[app.id] = buildEnabledAppConfig(accountAppsPolicy);
+    apps[app.id] = buildEnabledAppConfig(policy);
     policyApps[app.id] = {
       source: "account",
       appName: app.name,
-      allowDestructiveActions: accountAppsPolicy.allowDestructiveActions,
-      destructiveApprovalMode: accountAppsPolicy.destructiveApprovalMode,
+      allowDestructiveActions: policy.allowDestructiveActions,
+      destructiveApprovalMode: policy.destructiveApprovalMode,
       mcpServerNames: [],
     };
   }
@@ -712,6 +704,7 @@ function shouldForceRefreshForNotReadyPluginApps(
 function policyFingerprint(policy: ResolvedCodexPluginsPolicy): JsonValue {
   return {
     enabled: policy.enabled,
+    allowAllPlugins: policy.allowAllPlugins,
     allowDestructiveActions: policy.allowDestructiveActions,
     destructiveApprovalMode: policy.destructiveApprovalMode,
     plugins: policy.pluginPolicies.map((plugin) => ({
@@ -722,15 +715,6 @@ function policyFingerprint(policy: ResolvedCodexPluginsPolicy): JsonValue {
       allowDestructiveActions: plugin.allowDestructiveActions,
       destructiveApprovalMode: plugin.destructiveApprovalMode,
     })),
-  };
-}
-
-function accountAppsPolicyFingerprint(policy: ResolvedCodexAccountAppsPolicy): JsonValue {
-  return {
-    enabled: policy.enabled,
-    mode: policy.mode ?? null,
-    allowDestructiveActions: policy.allowDestructiveActions,
-    destructiveApprovalMode: policy.destructiveApprovalMode,
   };
 }
 

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -269,6 +269,11 @@ export async function buildCodexPluginThreadConfig(
   };
   const policyApps: Record<string, CodexAppPolicyContextEntry> = {};
   const pluginAppIds: Record<string, string[]> = {};
+  const pluginOwnedAppIds = new Set(
+    inventory.records.flatMap((record) =>
+      record.appOwnership === "proven" ? record.ownedAppIds : [],
+    ),
+  );
   for (const record of inventory.records) {
     const activation = activationResults.find(
       (item) => item.identity.configKey === record.policy.configKey,
@@ -315,7 +320,9 @@ export async function buildCodexPluginThreadConfig(
 
   for (const app of accountAppsResult.apps) {
     // An explicit plugin policy is more specific than the account-wide policy.
-    if (policyApps[app.id]) {
+    // Reserve proven ownership even when activation/readiness fails so a broad
+    // account policy cannot re-admit an app that the explicit path excluded.
+    if (pluginOwnedAppIds.has(app.id)) {
       continue;
     }
     const accountApp = toOwnedAccountApp(app);

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -1,6 +1,6 @@
 /**
- * Builds Codex thread config patches that expose only policy-approved
- * plugin-owned apps for native Codex turns.
+ * Builds Codex thread config patches that expose only policy-approved apps
+ * for native Codex turns.
  */
 import crypto from "node:crypto";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
@@ -12,8 +12,10 @@ import {
   type CodexAppInventoryRequest,
 } from "./app-inventory-cache.js";
 import {
+  resolveCodexAccountAppsPolicy,
   resolveCodexPluginsPolicy,
   type CodexPluginDestructiveApprovalMode,
+  type ResolvedCodexAccountAppsPolicy,
   type ResolvedCodexPluginPolicy,
   type ResolvedCodexPluginsPolicy,
 } from "./config.js";
@@ -29,10 +31,11 @@ import {
   type CodexPluginOwnedApp,
   type CodexPluginRuntimeRequest,
 } from "./plugin-inventory.js";
-import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
+import { isJsonObject, type JsonObject, type JsonValue, type v2 } from "./protocol.js";
 
 /** Policy context for one app id exposed by a configured Codex plugin. */
 export type PluginAppPolicyContextEntry = {
+  source?: "plugin";
   configKey: string;
   marketplaceName: ResolvedCodexPluginPolicy["marketplaceName"];
   pluginName: string;
@@ -41,10 +44,24 @@ export type PluginAppPolicyContextEntry = {
   mcpServerNames: string[];
 };
 
+/** Policy context for one account-connected app admitted without a plugin package. */
+export type AccountAppPolicyContextEntry = {
+  source: "account";
+  appName: string;
+  allowDestructiveActions: boolean;
+  destructiveApprovalMode?: CodexPluginDestructiveApprovalMode;
+  mcpServerNames: string[];
+};
+
+/** Policy context for any app exposed to a native Codex thread. */
+export type CodexAppPolicyContextEntry =
+  | PluginAppPolicyContextEntry
+  | AccountAppPolicyContextEntry;
+
 /** Stable app-to-plugin ownership context persisted with Codex thread bindings. */
 export type PluginAppPolicyContext = {
   fingerprint: string;
-  apps: Record<string, PluginAppPolicyContextEntry>;
+  apps: Record<string, CodexAppPolicyContextEntry>;
   pluginAppIds: Record<string, string[]>;
 };
 
@@ -52,7 +69,11 @@ export type PluginAppPolicyContext = {
 export type CodexPluginThreadConfigDiagnostic =
   | CodexPluginInventoryDiagnostic
   | {
-      code: "plugin_activation_failed" | "app_not_ready" | "approval_overrides_clear_failed";
+      code:
+        | "plugin_activation_failed"
+        | "app_not_ready"
+        | "account_app_inventory_unavailable"
+        | "approval_overrides_clear_failed";
       plugin?: ResolvedCodexPluginPolicy;
       message: string;
     };
@@ -78,12 +99,15 @@ export type BuildCodexPluginThreadConfigParams = {
   nowMs?: number;
 };
 
-const CODEX_PLUGIN_THREAD_CONFIG_INPUT_FINGERPRINT_VERSION = 2;
-const CODEX_PLUGIN_THREAD_CONFIG_FINGERPRINT_VERSION = 1;
+const CODEX_PLUGIN_THREAD_CONFIG_INPUT_FINGERPRINT_VERSION = 3;
+const CODEX_PLUGIN_THREAD_CONFIG_FINGERPRINT_VERSION = 2;
 
 /** Returns true when plugin config exists and thread config may need app patches. */
 export function shouldBuildCodexPluginThreadConfig(pluginConfig?: unknown): boolean {
-  return resolveCodexPluginsPolicy(pluginConfig).configured;
+  return (
+    resolveCodexPluginsPolicy(pluginConfig).configured ||
+    resolveCodexAccountAppsPolicy(pluginConfig).configured
+  );
 }
 
 /** Fingerprints policy and app-cache identity before runtime inventory is read. */
@@ -92,9 +116,11 @@ export function buildCodexPluginThreadConfigInputFingerprint(params: {
   appCacheKey?: string;
 }): string {
   const policy = resolveCodexPluginsPolicy(params.pluginConfig);
+  const accountAppsPolicy = resolveCodexAccountAppsPolicy(params.pluginConfig);
   return fingerprintJson({
     version: CODEX_PLUGIN_THREAD_CONFIG_INPUT_FINGERPRINT_VERSION,
     policy: policyFingerprint(policy),
+    accountAppsPolicy: accountAppsPolicyFingerprint(accountAppsPolicy),
     appCacheKey: params.appCacheKey ?? null,
   });
 }
@@ -109,7 +135,8 @@ export async function buildCodexPluginThreadConfig(
     appCacheKey: params.appCacheKey,
   });
   const policy = resolveCodexPluginsPolicy(params.pluginConfig);
-  if (!policy.enabled) {
+  const accountAppsPolicy = resolveCodexAccountAppsPolicy(params.pluginConfig);
+  if (!policy.enabled && !accountAppsPolicy.enabled) {
     return emptyPluginThreadConfig({
       enabled: false,
       inputFingerprint,
@@ -117,15 +144,17 @@ export async function buildCodexPluginThreadConfig(
     });
   }
 
-  let inventory = await readCodexPluginInventory({
-    pluginConfig: params.pluginConfig,
-    policy,
-    request: params.request,
-    appCache,
-    appCacheKey: params.appCacheKey,
-    nowMs: params.nowMs,
-    suppressAppInventoryRefresh: true,
-  });
+  let inventory = policy.enabled
+    ? await readCodexPluginInventory({
+        pluginConfig: params.pluginConfig,
+        policy,
+        request: params.request,
+        appCache,
+        appCacheKey: params.appCacheKey,
+        nowMs: params.nowMs,
+        suppressAppInventoryRefresh: true,
+      })
+    : emptyCodexPluginInventory(policy);
   const appInventoryRefreshDeferredForActivation =
     inventory.records.some((record) => record.activationRequired) &&
     shouldRefreshMissingAppInventory(params, policy, inventory);
@@ -221,9 +250,15 @@ export async function buildCodexPluginThreadConfig(
     });
   }
 
+  const accountAppsResult: Awaited<ReturnType<typeof readAccessibleAccountApps>> =
+    accountAppsPolicy.enabled
+    ? await readAccessibleAccountApps(params, appCache)
+    : { apps: [] };
+
   const diagnostics: CodexPluginThreadConfigDiagnostic[] = [
     ...inventory.diagnostics,
     ...activationDiagnostics,
+    ...(accountAppsResult.diagnostic ? [accountAppsResult.diagnostic] : []),
   ];
   const apps: JsonObject = {
     _default: {
@@ -232,7 +267,7 @@ export async function buildCodexPluginThreadConfig(
       open_world_enabled: false,
     },
   };
-  const policyApps: Record<string, PluginAppPolicyContextEntry> = {};
+  const policyApps: Record<string, CodexAppPolicyContextEntry> = {};
   const pluginAppIds: Record<string, string[]> = {};
   for (const record of inventory.records) {
     const activation = activationResults.find(
@@ -266,16 +301,7 @@ export async function buildCodexPluginThreadConfig(
       ) {
         continue;
       }
-      const appConfig: JsonObject = {
-        enabled: true,
-        destructive_enabled: record.policy.allowDestructiveActions,
-        open_world_enabled: true,
-        default_tools_approval_mode: "auto",
-      };
-      if (record.policy.destructiveApprovalMode === "ask") {
-        appConfig.approvals_reviewer = "user";
-      }
-      apps[app.id] = appConfig;
+      apps[app.id] = buildEnabledAppConfig(record.policy);
       policyApps[app.id] = {
         configKey: record.policy.configKey,
         marketplaceName: record.policy.marketplaceName,
@@ -285,6 +311,33 @@ export async function buildCodexPluginThreadConfig(
         mcpServerNames: [...(record.detail?.mcpServers ?? [])].toSorted(),
       };
     }
+  }
+
+  for (const app of accountAppsResult.apps) {
+    // An explicit plugin policy is more specific than the account-wide policy.
+    if (policyApps[app.id]) {
+      continue;
+    }
+    const accountApp = toOwnedAccountApp(app);
+    if (
+      accountAppsPolicy.destructiveApprovalMode === "ask" &&
+      !(await clearPersistedAppToolApprovalOverrides({
+        request: params.request,
+        configCwd: params.configCwd,
+        app: accountApp,
+        diagnostics,
+      }))
+    ) {
+      continue;
+    }
+    apps[app.id] = buildEnabledAppConfig(accountAppsPolicy);
+    policyApps[app.id] = {
+      source: "account",
+      appName: app.name,
+      allowDestructiveActions: accountAppsPolicy.allowDestructiveActions,
+      destructiveApprovalMode: accountAppsPolicy.destructiveApprovalMode,
+      mcpServerNames: [],
+    };
   }
 
   const configPatch = { apps };
@@ -375,6 +428,19 @@ function buildDisabledAppsConfigPatch(): JsonObject {
   };
 }
 
+function buildEnabledAppConfig(policy: {
+  allowDestructiveActions: boolean;
+  destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
+}): JsonObject {
+  return {
+    enabled: true,
+    destructive_enabled: policy.allowDestructiveActions,
+    open_world_enabled: true,
+    default_tools_approval_mode: "auto",
+    ...(policy.destructiveApprovalMode === "ask" ? { approvals_reviewer: "user" } : {}),
+  };
+}
+
 /** Rebuilds the safe per-thread apps patch persisted with a Codex thread binding. */
 export function buildCodexPluginAppsConfigPatchFromPolicyContext(
   policyContext: PluginAppPolicyContext,
@@ -401,11 +467,11 @@ export function buildCodexPluginAppsConfigPatchFromPolicyContext(
 }
 
 function buildPluginAppPolicyContext(
-  apps: Record<string, PluginAppPolicyContextEntry>,
+  apps: Record<string, CodexAppPolicyContextEntry>,
   pluginAppIds: Record<string, string[]>,
 ): PluginAppPolicyContext {
   return {
-    fingerprint: fingerprintJson({ version: 1, apps, pluginAppIds }),
+    fingerprint: fingerprintJson({ version: 2, apps, pluginAppIds }),
     apps,
     pluginAppIds,
   };
@@ -414,7 +480,7 @@ function buildPluginAppPolicyContext(
 async function clearPersistedAppToolApprovalOverrides(params: {
   request: CodexPluginRuntimeRequest;
   configCwd?: string;
-  plugin: ResolvedCodexPluginPolicy;
+  plugin?: ResolvedCodexPluginPolicy;
   app: CodexPluginOwnedApp;
   diagnostics: CodexPluginThreadConfigDiagnostic[];
 }): Promise<boolean> {
@@ -442,7 +508,7 @@ async function clearPersistedAppToolApprovalOverrides(params: {
   } catch (error) {
     params.diagnostics.push({
       code: "approval_overrides_clear_failed",
-      plugin: params.plugin,
+      ...(params.plugin ? { plugin: params.plugin } : {}),
       message: `Could not clear durable Codex app approval overrides for ${params.app.id}: ${
         error instanceof Error ? error.message : String(error)
       }`,
@@ -552,6 +618,54 @@ function collectInventoryOwnedAppIds(inventory: CodexPluginInventory): string[] 
   ).toSorted();
 }
 
+function emptyCodexPluginInventory(policy: ResolvedCodexPluginsPolicy): CodexPluginInventory {
+  return {
+    policy,
+    records: [],
+    diagnostics: [],
+  };
+}
+
+async function readAccessibleAccountApps(
+  params: BuildCodexPluginThreadConfigParams,
+  appCache: CodexAppInventoryCache,
+): Promise<{
+  apps: v2.AppInfo[];
+  diagnostic?: CodexPluginThreadConfigDiagnostic;
+}> {
+  // Account-wide mode needs a complete inventory. A plugin-targeted cache fill can
+  // stop once its known app ids are found, so always traverse all app/list pages here.
+  const snapshot = await refreshAppInventoryNow(params, appCache, {
+    forceRefetch: false,
+    reason: "account_apps_all",
+    targetAppIds: [],
+  });
+  if (!snapshot) {
+    return {
+      apps: [],
+      diagnostic: {
+        code: "account_app_inventory_unavailable",
+        message: "Codex account app inventory was unavailable; account apps were not exposed.",
+      },
+    };
+  }
+  return {
+    apps: snapshot.apps.filter((app) => app.isAccessible).toSorted((left, right) =>
+      left.id.localeCompare(right.id),
+    ),
+  };
+}
+
+function toOwnedAccountApp(app: v2.AppInfo): CodexPluginOwnedApp {
+  return {
+    id: app.id,
+    name: app.name,
+    accessible: app.isAccessible,
+    enabled: app.isEnabled,
+    needsAuth: !app.isAccessible,
+  };
+}
+
 function resolveThreadConfigAppsForRecord(params: {
   record: CodexPluginInventoryRecord;
   inventory: CodexPluginInventory;
@@ -601,6 +715,15 @@ function policyFingerprint(policy: ResolvedCodexPluginsPolicy): JsonValue {
       allowDestructiveActions: plugin.allowDestructiveActions,
       destructiveApprovalMode: plugin.destructiveApprovalMode,
     })),
+  };
+}
+
+function accountAppsPolicyFingerprint(policy: ResolvedCodexAccountAppsPolicy): JsonValue {
+  return {
+    enabled: policy.enabled,
+    mode: policy.mode ?? null,
+    allowDestructiveActions: policy.allowDestructiveActions,
+    destructiveApprovalMode: policy.destructiveApprovalMode,
   };
 }
 

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -174,6 +174,32 @@ describe("codex app-server session binding", () => {
     expect(binding?.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
   });
 
+  it("round-trips account app policy context", async () => {
+    const sessionFile = path.join(tempDir, "session.json");
+    const pluginAppPolicyContext = {
+      fingerprint: "account-policy-1",
+      apps: {
+        "chatgpt-meetings": {
+          source: "account" as const,
+          appName: "ChatGPT Meetings",
+          allowDestructiveActions: true,
+          destructiveApprovalMode: "auto" as const,
+          mcpServerNames: [],
+        },
+      },
+      pluginAppIds: {},
+    };
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-123",
+      cwd: tempDir,
+      pluginAppPolicyContext,
+    });
+
+    const binding = await readCodexAppServerBinding(sessionFile);
+
+    expect(binding?.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
+  });
+
   it("drops old always plugin app policy context destructive approval mode", async () => {
     const sessionFile = path.join(tempDir, "session.json");
     await fs.writeFile(

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -348,15 +348,37 @@ function readPluginAppPolicyContext(
       entry.destructiveApprovalMode,
       bindingSchemaVersion,
     );
+    const mcpServerNamesValid =
+      Array.isArray(entry.mcpServerNames) &&
+      entry.mcpServerNames.every((serverName) => typeof serverName === "string");
+    if (entry.source === "account") {
+      if (
+        "appId" in entry ||
+        typeof entry.appName !== "string" ||
+        typeof entry.allowDestructiveActions !== "boolean" ||
+        destructiveApprovalMode === "invalid" ||
+        !mcpServerNamesValid
+      ) {
+        return undefined;
+      }
+      parsedApps[appId] = {
+        source: "account",
+        appName: entry.appName,
+        allowDestructiveActions: entry.allowDestructiveActions,
+        ...(destructiveApprovalMode ? { destructiveApprovalMode } : {}),
+        mcpServerNames: entry.mcpServerNames as string[],
+      };
+      continue;
+    }
     if (
       "appId" in entry ||
+      (entry.source !== undefined && entry.source !== "plugin") ||
       typeof entry.configKey !== "string" ||
       entry.marketplaceName !== CODEX_PLUGINS_MARKETPLACE_NAME ||
       typeof entry.pluginName !== "string" ||
       typeof entry.allowDestructiveActions !== "boolean" ||
       destructiveApprovalMode === "invalid" ||
-      !Array.isArray(entry.mcpServerNames) ||
-      entry.mcpServerNames.some((serverName) => typeof serverName !== "string")
+      !mcpServerNamesValid
     ) {
       return undefined;
     }
@@ -366,7 +388,7 @@ function readPluginAppPolicyContext(
       pluginName: entry.pluginName,
       allowDestructiveActions: entry.allowDestructiveActions,
       ...(destructiveApprovalMode ? { destructiveApprovalMode } : {}),
-      mcpServerNames: entry.mcpServerNames,
+      mcpServerNames: entry.mcpServerNames as string[],
     };
   }
   const parsedPluginAppIds: PluginAppPolicyContext["pluginAppIds"] = {};


### PR DESCRIPTION
OpenClaw's native Codex integration currently exposes connector apps only when an installed curated plugin proves ownership of them. That is a useful default for shared agents, but it also means an owner-operated agent cannot opt into apps already connected to its Codex account when those apps do not have a packaged plugin, such as ChatGPT Meetings.

This extends the existing `codexPlugins` policy with an explicit `allow_all_plugins` opt-in. When enabled, each new native Codex thread reads the complete account app inventory and snapshots every accessible app into the thread's explicit app allowlist. Inaccessible apps remain excluded, inventory failures fail closed, and explicit packaged-plugin policies still take precedence for overlapping app IDs.

Account apps reuse the existing global `codexPlugins.allow_destructive_actions` policy, including the existing `auto` and `ask` approval behavior. The resulting app policy is persisted with the thread so resumed and forked threads keep the same bounded connector set.

Live behavior was checked on the exact head `d7b6123325dd7aeff6f72fc0a0d987e3d41c6291`, built as the production Docker image and connected to an authenticated Codex app-server. A fresh OpenClaw session admitted ChatGPT Meetings from the complete account inventory without a packaged plugin, invoked `codex_apps.chatgpt_meetings.find_all`, and returned meeting metadata successfully. The persisted binding recorded the account-source app set with the existing `ask` destructive-action policy. A second, fresh container resumed the same OpenClaw and Codex session, answered from the prior turn with zero connector calls, and preserved the same app-policy binding.
