### PR TITLE
fix: keep newly created sidebar sessions visible after switching chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI session creation:** keep newly created sessions at the front of the stable sidebar order after selecting another session. Thanks @shakkernerd.
 - **FTS-only memory startup:** skip plugin capability discovery when `memorySearch.provider` is explicitly `none`, avoiding an unnecessary cold-start scan.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.
 - **Control UI inbound image previews:** render canonical inbound media references through the authenticated ticket route after chat-history reloads. (#100725, #90172, #89591) Thanks @sweetcornna.

--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -133,6 +133,7 @@ export class AppSidebar extends LitElement {
   @state() private sessionsLoading = false;
 
   private stopSessionsSubscription: (() => void) | undefined;
+  private stopSessionCreatedSubscription: (() => void) | undefined;
   private stopAgentsSubscription: (() => void) | undefined;
   private stopAgentSelectionSubscription: (() => void) | undefined;
   private stopGatewaySubscription: (() => void) | undefined;
@@ -159,6 +160,8 @@ export class AppSidebar extends LitElement {
     this.closeSessionSortMenu();
     this.stopSessionsSubscription?.();
     this.stopSessionsSubscription = undefined;
+    this.stopSessionCreatedSubscription?.();
+    this.stopSessionCreatedSubscription = undefined;
     this.stopAgentsSubscription?.();
     this.stopAgentsSubscription = undefined;
     this.stopAgentSelectionSubscription?.();
@@ -178,6 +181,7 @@ export class AppSidebar extends LitElement {
     if (
       !context ||
       this.stopSessionsSubscription ||
+      this.stopSessionCreatedSubscription ||
       this.stopAgentsSubscription ||
       this.stopAgentSelectionSubscription ||
       this.stopGatewaySubscription
@@ -188,6 +192,9 @@ export class AppSidebar extends LitElement {
     this.updateSessions(context.sessions.state);
     this.stopSessionsSubscription = context.sessions.subscribe((snapshot) => {
       this.updateSessions(snapshot);
+    });
+    this.stopSessionCreatedSubscription = context.sessions.subscribeCreated((key) => {
+      this.promoteCreatedSession(key);
     });
     this.stopAgentsSubscription = context.agents.subscribe(() => {
       this.requestUpdate();
@@ -254,6 +261,20 @@ export class AppSidebar extends LitElement {
       (this.sessionCreatedOrder.get(b.key) ?? Number.MAX_SAFE_INTEGER)
     );
   };
+
+  private promoteCreatedSession(sessionKey: string) {
+    const currentOrder = this.sessionCreatedOrder.get(sessionKey);
+    if (currentOrder === 0) {
+      return;
+    }
+    for (const [key, order] of this.sessionCreatedOrder) {
+      if (key !== sessionKey && (currentOrder === undefined || order < currentOrder)) {
+        this.sessionCreatedOrder.set(key, order + 1);
+      }
+    }
+    this.sessionCreatedOrder.set(sessionKey, 0);
+    this.requestUpdate();
+  }
 
   private getSessionNavigationState() {
     const context = this.context;

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -183,6 +183,7 @@ export type SessionCapability = {
     checkpointId: string,
     options?: { agentId?: string | null },
   ) => Promise<SessionsCompactionRestoreResult>;
+  subscribeCreated: (listener: (key: string) => void) => () => void;
   subscribe: (listener: (state: SessionState) => void) => () => void;
   dispose: () => void;
 };
@@ -496,6 +497,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   let subscribedClient: GatewayBrowserClient | null = null;
   let lastListOptions: SessionListOptions = {};
   const listeners = new Set<(next: SessionState) => void>();
+  const createdListeners = new Set<(key: string) => void>();
 
   const requestList = async (
     options: SessionListOptions = {},
@@ -648,6 +650,11 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
         return null;
       }
       await refresh({ agentId: params.agentId, force: true });
+      // Creation can originate outside the sidebar. Notify presentation owners
+      // after refresh so they can reconcile the new row without guessing from list churn.
+      for (const listener of createdListeners) {
+        listener(key);
+      }
       return key;
     } catch (error) {
       publish({ ...state, error: String(error) });
@@ -1019,6 +1026,10 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     listCheckpoints,
     branchCheckpoint,
     restoreCheckpoint,
+    subscribeCreated(listener) {
+      createdListeners.add(listener);
+      return () => createdListeners.delete(listener);
+    },
     subscribe(listener) {
       listeners.add(listener);
       return () => listeners.delete(listener);
@@ -1027,6 +1038,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       disposed = true;
       stopGateway();
       stopEvents();
+      createdListeners.clear();
       listeners.clear();
       inFlight = null;
       queuedRefresh = null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where newly created sessions initially appeared first in the Control UI sidebar but disappeared or lost their position after the user selected another session.

## Why This Change Was Made

The shared session capability now notifies UI consumers after a successful creation and list refresh. The sidebar uses that notification to promote the created session in its stable ordering without changing Gateway ordering, the session limit, or the existing sorting controls.

## User Impact

Newly created sessions remain at the front of the sidebar after switching between chats, without requiring a page refresh.

## Evidence

- Manually reproduced the failure on current `main`.
- Live verification confirmed that creating a session and selecting another session keeps the new session first.
- `git diff --check`
- Autoreview: no accepted or actionable findings.
