### PR TITLE
fix(cli-runner): assemble context engine before prompt on generic CLI hosts

### DIFF
--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1837,7 +1837,48 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     }
   });
 
-  it("rejects CLI runs for context engines that require pre-prompt assembly", async () => {
+  it("folds the context engine systemPromptAddition into the CLI system prompt in the same turn", async () => {
+    const { dir, sessionFile } = createSessionFile();
+    const engineId = `cli-assemble-engine-${Date.now().toString(36)}`;
+    const sentinel = `CARRYOVER_SLOT_${engineId}`;
+    const assemble = vi.fn(async ({ messages }) => ({
+      messages,
+      estimatedTokens: 0,
+      systemPromptAddition: sentinel,
+    }));
+    registerContextEngine(engineId, (): ContextEngine => {
+      return {
+        info: { id: engineId, name: "CLI assemble engine" },
+        ingest: vi.fn(async () => ({ ingested: true })),
+        assemble,
+        compact: vi.fn(async () => ({ ok: true, compacted: false })),
+      };
+    });
+
+    try {
+      const context = await prepareCliRunContext({
+        sessionId: "session-test",
+        sessionFile,
+        workspaceDir: dir,
+        prompt: "latest ask",
+        provider: "test-cli",
+        model: "test-model",
+        timeoutMs: 1_000,
+        runId: "run-test-context-engine-assemble",
+        config: {
+          ...createCliBackendConfig(),
+          plugins: { slots: { contextEngine: engineId } },
+        },
+      });
+
+      expect(assemble).toHaveBeenCalledOnce();
+      expect(context.systemPrompt).toContain(sentinel);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects CLI runs for context engines that require an unsupported capability", async () => {
     const { dir, sessionFile } = createSessionFile();
     const engineId = `cli-unsupported-engine-${Date.now().toString(36)}`;
     registerContextEngine(engineId, (): ContextEngine => {
@@ -1847,7 +1888,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
           name: "CLI unsupported engine",
           hostRequirements: {
             "agent-run": {
-              requiredCapabilities: ["assemble-before-prompt"],
+              requiredCapabilities: ["runtime-llm-complete"],
               unsupportedMessage: "Use the native Codex or OpenClaw embedded runtime.",
             },
           },

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -77,9 +77,11 @@ import {
   mapSandboxSkillEntriesForPrompt,
   resolveSandboxSkillRuntimeInputs,
 } from "../embedded-agent-runner/sandbox-skills.js";
+import { assembleHarnessContextEngine } from "../harness/context-engine-lifecycle.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
+import type { AgentMessage } from "../runtime/index.js";
 import { ensureSandboxWorkspaceForSession } from "../sandbox.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
 import { appendModelIdentitySystemPrompt, buildModelIdentityPromptLine } from "../system-prompt.js";
@@ -1059,14 +1061,51 @@ export async function prepareCliRunContext(
     const contextEngine =
       resolvedContextEngine.info.id !== "legacy" ? resolvedContextEngine : undefined;
     if (contextEngine) {
+      const cliContextEngineHost = buildGenericCliContextEngineHostSupport({
+        backendId: backendResolved.id,
+        capabilities: backendResolved.contextEngineHostCapabilities,
+      });
       assertContextEngineHostSupport({
         contextEngine,
         operation: "agent-run",
-        host: buildGenericCliContextEngineHostSupport({
-          backendId: backendResolved.id,
-          capabilities: backendResolved.contextEngineHostCapabilities,
-        }),
+        host: cliContextEngineHost,
       });
+      // Parity with the embedded/codex runners: when the host advertises
+      // pre-prompt assembly, run assemble() now and fold the returned
+      // systemPromptAddition into this turn's system prompt. The generic CLI
+      // runner otherwise never calls assemble(), so engine slots that depend on
+      // it (e.g. the post-reset carry-over) would only surface a turn late.
+      // Ephemeral per-turn injection: no sessionFile mutation, no accumulation.
+      if (cliContextEngineHost.capabilities.includes("assemble-before-prompt")) {
+        try {
+          const assembled = await assembleHarnessContextEngine({
+            contextEngine,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+            messages: (await loadCliSessionHistoryMessages({
+              sessionId: params.sessionId,
+              sessionFile: params.sessionFile,
+              sessionKey: params.sessionKey,
+              agentId: params.agentId,
+              config: contextEngineConfig,
+            })) as AgentMessage[],
+            modelId,
+            contextEngineHostSupport: cliContextEngineHost,
+            providerId: params.provider,
+            ...(preparedPrompt !== undefined ? { prompt: preparedPrompt } : {}),
+          });
+          if (assembled?.systemPromptAddition) {
+            systemPrompt = prependSystemPromptAddition({
+              systemPrompt: ensureSystemPromptCacheBoundary(systemPrompt),
+              systemPromptAddition: assembled.systemPromptAddition,
+            });
+          }
+        } catch (assembleErr) {
+          cliBackendLog.warn(
+            `cli context engine assemble failed, continuing without system prompt addition: ${String(assembleErr)}`,
+          );
+        }
+      }
     }
     const hadSessionFile = await hasCliSessionTranscript({
       sessionId: params.sessionId,

--- a/src/commands/doctor/shared/context-engine-host-compat.test.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.test.ts
@@ -122,7 +122,7 @@ describe("doctor context-engine host compatibility", () => {
   });
 
   it("repairs an incompatible context engine by switching the global slot to legacy", async () => {
-    const engineId = registerEngine(["assemble-before-prompt"]);
+    const engineId = registerEngine(["runtime-llm-complete"]);
     const result = await maybeRepairContextEngineHostCompatibility({
       cfg: configWithEngine(engineId, {
         agents: {
@@ -164,7 +164,7 @@ describe("doctor context-engine host compatibility", () => {
   });
 
   it("warns but does not auto-repair mixed compatible and incompatible runtimes", async () => {
-    const engineId = registerEngine(["assemble-before-prompt"]);
+    const engineId = registerEngine(["runtime-llm-complete"]);
     const cfg = configWithEngine(engineId, {
       agents: {
         defaults: {

--- a/src/context-engine/host-compat.test.ts
+++ b/src/context-engine/host-compat.test.ts
@@ -43,10 +43,18 @@ describe("context engine host compatibility", () => {
     });
   });
 
-  it("rejects generic CLI hosts when an engine requires pre-prompt assembly", () => {
+  it("allows generic CLI hosts to satisfy pre-prompt assembly", () => {
+    assertContextEngineHostSupport({
+      contextEngine: createEngine(["assemble-before-prompt"]),
+      operation: "agent-run",
+      host: buildGenericCliContextEngineHostSupport({ backendId: "claude-cli" }),
+    });
+  });
+
+  it("rejects generic CLI hosts when an engine requires a capability they lack", () => {
     expect(() =>
       assertContextEngineHostSupport({
-        contextEngine: createEngine(["assemble-before-prompt"]),
+        contextEngine: createEngine(["runtime-llm-complete"]),
         operation: "agent-run",
         host: buildGenericCliContextEngineHostSupport({ backendId: "claude-cli" }),
       }),
@@ -57,14 +65,14 @@ describe("context engine host compatibility", () => {
 
   it("evaluates missing capabilities without throwing", () => {
     const evaluation = evaluateContextEngineHostSupport({
-      contextEngineInfo: createEngine(["assemble-before-prompt"]).info,
+      contextEngineInfo: createEngine(["runtime-llm-complete"]).info,
       operation: "agent-run",
       host: buildGenericCliContextEngineHostSupport({ backendId: "claude-cli" }),
     });
 
     expect(evaluation).toMatchObject({
       ok: false,
-      missingCapabilities: ["assemble-before-prompt"],
+      missingCapabilities: ["runtime-llm-complete"],
     });
   });
 

--- a/src/context-engine/host-compat.ts
+++ b/src/context-engine/host-compat.ts
@@ -15,6 +15,7 @@ export type ContextEngineHostSupport = {
 
 export const GENERIC_CLI_CONTEXT_ENGINE_HOST_CAPABILITIES = [
   "bootstrap",
+  "assemble-before-prompt",
   "after-turn",
   "maintain",
 ] as const satisfies readonly ContextEngineHostCapability[];


### PR DESCRIPTION
## Problem

The generic CLI runner (`prepareCliRunContext`) resolves the active context engine and asserts host support, but **never calls `assemble()`**. It freezes the system prompt before any assemble step. Every other host — the OpenClaw embedded runner (`attempt.ts`) and the Codex app-server harness — calls `assemble()` before building the prompt and folds the returned `systemPromptAddition` into the system prompt. The generic CLI host did not, and `GENERIC_CLI_CONTEXT_ENGINE_HOST_CAPABILITIES` omitted `"assemble-before-prompt"` to match.

Consequence: any context engine that injects context via `systemPromptAddition` (e.g. a post-reset "carry-over" slot that re-seeds the tail of a just-reset conversation) only surfaces **a turn late** on CLI backends like `claude-cli` — the seed lands via bootstrap next-turn instead of the current turn.

## Fix

- Add `"assemble-before-prompt"` to `GENERIC_CLI_CONTEXT_ENGINE_HOST_CAPABILITIES`.
- In `prepareCliRunContext`, after resolving the engine and asserting host support, when the host advertises `assemble-before-prompt`, run `assembleHarnessContextEngine(...)` and fold the returned `systemPromptAddition` into the system prompt for the **same** turn — parity with the embedded/Codex runners (`attempt.ts` `prependSystemPromptAddition` path).
- The current session's messages are loaded and passed so engines can gate on session thinness (self-erasing slots that only fire while a session is fresh).

Injection is **ephemeral per-turn**: no session-file mutation, no accumulation. It is guarded by the host-capability check and a `try/catch` that degrades to the unmodified prompt on assemble failure (same failure posture as the embedded runner).

## Tests

- `prepare.test.ts`: new case asserts a context engine's `systemPromptAddition` lands in `context.systemPrompt` within the same `prepareCliRunContext` run (verified red without the change: `assemble` is called 0 times).
- `host-compat.test.ts` / doctor `context-engine-host-compat.test.ts`: updated to reflect the generic CLI host now satisfying pre-prompt assembly; rejection coverage retargeted to a capability the generic CLI host still lacks (`runtime-llm-complete`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)