### PR TITLE
fix(android): keep chat model selection synchronized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Android chat model picker:** choose a model in chat, pin favorites, and reuse recent selections while keeping session state synchronized with the Gateway. (#100798)
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Android chat model picker:** choose a model in chat, pin favorites, and reuse recent selections while keeping session state synchronized with the Gateway. (#100798)
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -203,7 +203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2469,
+      "line": 2470,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: this host requires wss:// or Tailscale Serve. No TLS endpoint detected.",
       "surface": "android",
@@ -211,7 +211,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2471,
+      "line": 2472,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: secure endpoint reached, but TLS fingerprint verification timed out. Check Tailscale Serve or gateway TLS and retry.",
       "surface": "android",
@@ -219,7 +219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2473,
+      "line": 2474,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt",
       "source": "Failed: couldn't reach the secure gateway endpoint for this host.",
       "surface": "android",
@@ -5899,7 +5899,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 272,
+      "line": 266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -5907,7 +5907,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 430,
+      "line": 424,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -5915,7 +5915,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 488,
+      "line": 482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -5923,7 +5923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 509,
+      "line": 503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -5931,7 +5931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 514,
+      "line": 508,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "More new chat options",
       "surface": "android",
@@ -5939,7 +5939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 529,
+      "line": 523,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -5947,7 +5947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 532,
+      "line": 526,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -5955,7 +5955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 674,
+      "line": 668,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -5963,7 +5963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 701,
+      "line": 695,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -5971,7 +5971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 721,
+      "line": 715,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -5979,7 +5979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 752,
+      "line": 746,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -5987,7 +5987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 753,
+      "line": 747,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -5995,7 +5995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 904,
+      "line": 898,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -6003,7 +6003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 906,
+      "line": 900,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -6011,7 +6011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 909,
+      "line": 903,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -6019,7 +6019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 919,
+      "line": 913,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -6027,7 +6027,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 920,
+      "line": 914,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -6035,7 +6035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1054,
+      "line": 1048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -6043,7 +6043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1120,
+      "line": 1114,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -6051,7 +6051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1186,
+      "line": 1180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -6059,7 +6059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1186,
+      "line": 1180,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -6067,7 +6067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1203,
+      "line": 1197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -6075,7 +6075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1265,
+      "line": 1259,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -6083,7 +6083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1355,
+      "line": 1349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -6091,7 +6091,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1370,
+      "line": 1364,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -6099,7 +6099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1385,
+      "line": 1379,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Voice",
       "surface": "android",
@@ -6107,7 +6107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1423,
+      "line": 1417,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -6115,7 +6115,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1444,
+      "line": 1438,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -6123,7 +6123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1500,
+      "line": 1494,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -6131,7 +6131,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1539,
+      "line": 1533,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -223,6 +223,7 @@ class MainViewModel(
   val chatHealthOk: StateFlow<Boolean> = runtimeState(initial = false) { it.chatHealthOk }
   val chatThinkingLevel: StateFlow<String> = runtimeState(initial = "off") { it.chatThinkingLevel }
   val chatSelectedModelRef: StateFlow<String?> = runtimeState(initial = null) { it.chatSelectedModelRef }
+  val chatModelCatalog: StateFlow<List<GatewayModelSummary>> = runtimeState(initial = emptyList()) { it.chatModelCatalog }
   val chatStreamingAssistantText: StateFlow<String?> = runtimeState(initial = null) { it.chatStreamingAssistantText }
   val chatPendingToolCalls: StateFlow<List<ChatPendingToolCall>> = runtimeState(initial = emptyList()) { it.chatPendingToolCalls }
   val chatSessions: StateFlow<List<ChatSessionEntry>> = runtimeState(initial = emptyList()) { it.chatSessions }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1445,6 +1445,7 @@ class NodeRuntime private constructor(
   val chatHealthOk: StateFlow<Boolean> = chat.healthOk
   val chatThinkingLevel: StateFlow<String> = chat.thinkingLevel
   val chatSelectedModelRef: StateFlow<String?> = chat.selectedModelRef
+  val chatModelCatalog: StateFlow<List<GatewayModelSummary>> = chat.modelCatalog
   val chatStreamingAssistantText: StateFlow<String?> = chat.streamingAssistantText
   val chatPendingToolCalls: StateFlow<List<ChatPendingToolCall>> = chat.pendingToolCalls
   val chatSessions: StateFlow<List<ChatSessionEntry>> = chat.sessions
@@ -3385,27 +3386,6 @@ class NodeRuntime private constructor(
     }
   }
 
-  private fun parseGatewayModels(models: JsonArray?): List<GatewayModelSummary> =
-    models
-      ?.mapNotNull { item ->
-        val obj = item.asObjectOrNull() ?: return@mapNotNull null
-        val id = obj["id"].asStringOrNull()?.trim().orEmpty()
-        if (id.isEmpty()) return@mapNotNull null
-        val provider = obj["provider"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: id.substringBefore('/', "default")
-        val inputTypes = (obj["input"] as? JsonArray)?.mapNotNull { it.asStringOrNull()?.trim()?.lowercase() }?.toSet().orEmpty()
-        GatewayModelSummary(
-          id = id,
-          name = obj["name"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: id,
-          provider = provider,
-          available = obj.optionalBoolean("available"),
-          supportsVision = "image" in inputTypes,
-          supportsAudio = "audio" in inputTypes,
-          supportsDocuments = "document" in inputTypes,
-          supportsReasoning = obj["reasoning"].toString().trim() == "true",
-          contextTokens = obj["contextWindow"].toString().toLongOrNull() ?: obj["contextTokens"].toString().toLongOrNull(),
-        )
-      }.orEmpty()
-
   private fun parseGatewayLogEntry(line: String): GatewayLogEntry {
     val sanitizedLine = sanitizeGatewayLogText(line)
     val root =
@@ -4050,6 +4030,27 @@ data class GatewayModelSummary(
   val supportsReasoning: Boolean,
   val contextTokens: Long?,
 )
+
+internal fun parseGatewayModels(models: JsonArray?): List<GatewayModelSummary> =
+  models
+    ?.mapNotNull { item ->
+      val obj = item.asObjectOrNull() ?: return@mapNotNull null
+      val id = obj["id"].asStringOrNull()?.trim().orEmpty()
+      if (id.isEmpty()) return@mapNotNull null
+      val provider = obj["provider"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: id.substringBefore('/', "default")
+      val inputTypes = (obj["input"] as? JsonArray)?.mapNotNull { it.asStringOrNull()?.trim()?.lowercase() }?.toSet().orEmpty()
+      GatewayModelSummary(
+        id = id,
+        name = obj["name"].asStringOrNull()?.trim()?.takeIf { it.isNotEmpty() } ?: id,
+        provider = provider,
+        available = obj.optionalBoolean("available"),
+        supportsVision = "image" in inputTypes,
+        supportsAudio = "audio" in inputTypes,
+        supportsDocuments = "document" in inputTypes,
+        supportsReasoning = obj["reasoning"].toString().trim() == "true",
+        contextTokens = obj["contextWindow"].toString().toLongOrNull() ?: obj["contextTokens"].toString().toLongOrNull(),
+      )
+    }.orEmpty()
 
 data class GatewayModelProviderSummary(
   val id: String,

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -145,6 +145,7 @@ class ChatController internal constructor(
 
   private var lastHealthPollAtMs: Long? = null
   private var chatMetadataAgentId: String? = null
+  private var chatMetadataLoadState = ChatMetadataLoadState.Unloaded
   private var sessionsListArchived = false
 
   // One acknowledgement per unread episode: the pending flag clears when the
@@ -195,6 +196,7 @@ class ChatController internal constructor(
     _commands.value = emptyList()
     _modelCatalog.value = emptyList()
     chatMetadataAgentId = null
+    chatMetadataLoadState = ChatMetadataLoadState.Unloaded
     synchronized(pendingRuns) {
       disconnectedPendingRunIds.addAll(pendingRuns)
     }
@@ -526,6 +528,7 @@ class ChatController internal constructor(
       _commands.value = emptyList()
       _modelCatalog.value = emptyList()
       chatMetadataAgentId = null
+      chatMetadataLoadState = ChatMetadataLoadState.Unloaded
     }
     updateErrorText(null)
     _healthOk.value = false
@@ -1109,7 +1112,16 @@ class ChatController internal constructor(
       if (agentId == resolveAgentIdForSessionKey(_sessionKey.value)) {
         _commands.value = parseChatCommands(json, res)
         val root = json.parseToJsonElement(res).asObjectOrNull()
-        _modelCatalog.value = parseGatewayModels(root?.get("models") as? JsonArray)
+        val models = parseGatewayModels(root?.get("models") as? JsonArray)
+        _modelCatalog.value = models
+        // chat.metadata cannot distinguish a valid empty catalog from its timeout fallback.
+        // Retry one empty response, then accept empty so health events cannot poll forever.
+        chatMetadataLoadState =
+          when {
+            models.isNotEmpty() -> ChatMetadataLoadState.Loaded
+            chatMetadataLoadState == ChatMetadataLoadState.RetryEmptyCatalog -> ChatMetadataLoadState.Loaded
+            else -> ChatMetadataLoadState.RetryEmptyCatalog
+          }
         chatMetadataAgentId = agentId
       }
     } catch (_: Throwable) {
@@ -1117,6 +1129,7 @@ class ChatController internal constructor(
         _commands.value = emptyList()
         _modelCatalog.value = emptyList()
         chatMetadataAgentId = null
+        chatMetadataLoadState = ChatMetadataLoadState.Unloaded
       }
     }
   }
@@ -1139,7 +1152,7 @@ class ChatController internal constructor(
     try {
       requestGateway("health", null)
       markHealthOk()
-      if (_commands.value.isEmpty() || chatMetadataAgentId != resolveAgentIdForSessionKey(_sessionKey.value)) {
+      if (!hasCurrentChatMetadata()) {
         fetchChatMetadata()
       }
     } catch (_: Throwable) {
@@ -1157,8 +1170,12 @@ class ChatController internal constructor(
     }
   }
 
+  private fun hasCurrentChatMetadata(): Boolean =
+    chatMetadataLoadState == ChatMetadataLoadState.Loaded &&
+      chatMetadataAgentId == resolveAgentIdForSessionKey(_sessionKey.value)
+
   private fun refreshCommandsAfterReconnect() {
-    if (_commands.value.isNotEmpty() && chatMetadataAgentId == resolveAgentIdForSessionKey(_sessionKey.value)) return
+    if (hasCurrentChatMetadata()) return
     scope.launch { fetchChatMetadata() }
   }
 
@@ -2051,6 +2068,12 @@ class ChatController internal constructor(
       "high" -> "high"
       else -> "off"
     }
+}
+
+private enum class ChatMetadataLoadState {
+  Unloaded,
+  RetryEmptyCatalog,
+  Loaded,
 }
 
 private const val NEW_CHAT_SESSION_LABEL = "New chat"

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -1,13 +1,16 @@
 package ai.openclaw.app.chat
 
+import ai.openclaw.app.GatewayModelSummary
 import ai.openclaw.app.gateway.GatewayRequestDefinitiveFailure
 import ai.openclaw.app.gateway.GatewayRequestOutcomeUnknown
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.parseChatSendAck
+import ai.openclaw.app.parseGatewayModels
 import ai.openclaw.app.resolveAgentIdFromMainSessionKey
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -64,6 +67,7 @@ class ChatController internal constructor(
   private var appliedMainSessionKey = "main"
   private val cacheMutationMutex = Mutex()
   private val modelSelectionMutex = Mutex()
+  private val pendingModelSelections = ConcurrentHashMap<String, CompletableDeferred<Boolean>>()
   private val _sessionKey = MutableStateFlow("main")
   val sessionKey: StateFlow<String> = _sessionKey.asStateFlow()
 
@@ -91,6 +95,9 @@ class ChatController internal constructor(
 
   private val _selectedModelRef = MutableStateFlow<String?>(null)
   val selectedModelRef: StateFlow<String?> = _selectedModelRef.asStateFlow()
+
+  private val _modelCatalog = MutableStateFlow<List<GatewayModelSummary>>(emptyList())
+  val modelCatalog: StateFlow<List<GatewayModelSummary>> = _modelCatalog.asStateFlow()
 
   private val _pendingRunCount = MutableStateFlow(0)
   val pendingRunCount: StateFlow<Int> = _pendingRunCount.asStateFlow()
@@ -137,7 +144,7 @@ class ChatController internal constructor(
   private val newChatCreateInFlight = AtomicBoolean(false)
 
   private var lastHealthPollAtMs: Long? = null
-  private var commandsAgentId: String? = null
+  private var chatMetadataAgentId: String? = null
   private var sessionsListArchived = false
 
   // One acknowledgement per unread episode: the pending flag clears when the
@@ -186,7 +193,8 @@ class ChatController internal constructor(
     _healthOk.value = false
     updateErrorText(null)
     _commands.value = emptyList()
-    commandsAgentId = null
+    _modelCatalog.value = emptyList()
+    chatMetadataAgentId = null
     synchronized(pendingRuns) {
       disconnectedPendingRunIds.addAll(pendingRuns)
     }
@@ -425,7 +433,7 @@ class ChatController internal constructor(
 
   /** Refreshes the available text slash commands for the current gateway. */
   fun refreshCommands() {
-    scope.launch { fetchCommands() }
+    scope.launch { fetchChatMetadata() }
   }
 
   /** Persists the normalized thinking level used for subsequent chat sends. */
@@ -450,30 +458,43 @@ class ChatController internal constructor(
   internal suspend fun setSessionModelAwait(
     sessionKey: String,
     modelRef: String?,
-  ): Boolean =
-    modelSelectionMutex.withLock {
-      val key = normalizeRequestedSessionKey(sessionKey)
-      val normalizedModelRef = modelRef?.trim()?.takeIf { it.isNotEmpty() }
-      updateErrorText(null)
-      try {
-        val params =
-          buildJsonObject {
-            put("key", JsonPrimitive(key))
-            put("model", normalizedModelRef?.let(::JsonPrimitive) ?: JsonNull)
+  ): Boolean {
+    val key = normalizeRequestedSessionKey(sessionKey)
+    val normalizedModelRef = modelRef?.trim()?.takeIf { it.isNotEmpty() }
+    val pendingSelection = CompletableDeferred<Boolean>()
+    pendingModelSelections[key] = pendingSelection
+    return try {
+      val succeeded =
+        modelSelectionMutex.withLock {
+          updateErrorText(null)
+          try {
+            val params =
+              buildJsonObject {
+                put("key", JsonPrimitive(key))
+                put("model", normalizedModelRef?.let(::JsonPrimitive) ?: JsonNull)
+              }
+            requestGateway("sessions.patch", params.toString())
+            normalizedModelRef?.let(recordModelRecent)
+            if (_sessionKey.value == key) {
+              _selectedModelRef.value = normalizedModelRef
+            }
+            true
+          } catch (err: CancellationException) {
+            throw err
+          } catch (err: Throwable) {
+            updateErrorText(err.message ?: "Could not update model.")
+            false
           }
-        requestGateway("sessions.patch", params.toString())
-        normalizedModelRef?.let(recordModelRecent)
-        if (_sessionKey.value == key) {
-          _selectedModelRef.value = normalizedModelRef
         }
-        true
-      } catch (err: CancellationException) {
-        throw err
-      } catch (err: Throwable) {
-        updateErrorText(err.message ?: "Could not update model.")
-        false
-      }
+      pendingSelection.complete(succeeded)
+      succeeded
+    } catch (err: CancellationException) {
+      pendingSelection.complete(false)
+      throw err
+    } finally {
+      pendingModelSelections.remove(key, pendingSelection)
     }
+  }
 
   /** Switches to another gateway chat session and starts a fresh history load. */
   fun switchSession(sessionKey: String) {
@@ -501,9 +522,10 @@ class ChatController internal constructor(
     _selectedModelRef.value = null
     lastHandledTerminalRunId = null
     val nextAgentId = resolveAgentIdForSessionKey(key)
-    if (commandsAgentId != nextAgentId) {
+    if (chatMetadataAgentId != nextAgentId) {
       _commands.value = emptyList()
-      commandsAgentId = null
+      _modelCatalog.value = emptyList()
+      chatMetadataAgentId = null
     }
     updateErrorText(null)
     _healthOk.value = false
@@ -552,9 +574,12 @@ class ChatController internal constructor(
   ): Boolean {
     val trimmed = message.trim()
     if (trimmed.isEmpty() && attachments.isEmpty()) return false
+    val sessionKey = _sessionKey.value
     // Model patches and sends share one ordering boundary; the first post-selection turn
     // must not leave on the previous model while sessions.patch is still in flight.
-    modelSelectionMutex.withLock {}
+    val pendingSelection = pendingModelSelections[sessionKey]
+    if (pendingSelection != null && !pendingSelection.await()) return false
+    if (_sessionKey.value != sessionKey) return false
     if (!_healthOk.value) {
       // Offline capture: text-only commands become durable outbox rows and flush on reconnect.
       // Attachments stay blocked (text-only v1) so large payloads never sit in the database.
@@ -567,7 +592,6 @@ class ChatController internal constructor(
 
     val runId = UUID.randomUUID().toString()
     val text = if (trimmed.isEmpty() && attachments.isNotEmpty()) "See attached." else trimmed
-    val sessionKey = _sessionKey.value
     val thinking = normalizeThinking(thinkingLevel)
 
     // Optimistic user message keeps the composer responsive while chat.send and history refresh complete.
@@ -888,6 +912,7 @@ class ChatController internal constructor(
         latestAppliedHistoryRequest = requestSequence
         if (updateSessionInfo) {
           updateSessionFromHistory(history)
+          _selectedModelRef.value = history.sessionInfo?.providerQualifiedModelRef()
         }
         transferLostAckOwnershipFromHistory(history)
         resolvePersistedReplies(history.messages)
@@ -1073,24 +1098,25 @@ class ChatController internal constructor(
     }
   }
 
-  private suspend fun fetchCommands() {
+  private suspend fun fetchChatMetadata() {
     val agentId = resolveAgentIdForSessionKey(_sessionKey.value)
     try {
       val params =
         buildJsonObject {
           put("agentId", JsonPrimitive(agentId))
-          put("scope", JsonPrimitive("text"))
-          put("includeArgs", JsonPrimitive(true))
         }
-      val res = requestGateway("commands.list", params.toString())
+      val res = requestGateway("chat.metadata", params.toString())
       if (agentId == resolveAgentIdForSessionKey(_sessionKey.value)) {
         _commands.value = parseChatCommands(json, res)
-        commandsAgentId = agentId
+        val root = json.parseToJsonElement(res).asObjectOrNull()
+        _modelCatalog.value = parseGatewayModels(root?.get("models") as? JsonArray)
+        chatMetadataAgentId = agentId
       }
     } catch (_: Throwable) {
       if (agentId == resolveAgentIdForSessionKey(_sessionKey.value)) {
         _commands.value = emptyList()
-        commandsAgentId = null
+        _modelCatalog.value = emptyList()
+        chatMetadataAgentId = null
       }
     }
   }
@@ -1113,8 +1139,8 @@ class ChatController internal constructor(
     try {
       requestGateway("health", null)
       markHealthOk()
-      if (_commands.value.isEmpty() || commandsAgentId != resolveAgentIdForSessionKey(_sessionKey.value)) {
-        fetchCommands()
+      if (_commands.value.isEmpty() || chatMetadataAgentId != resolveAgentIdForSessionKey(_sessionKey.value)) {
+        fetchChatMetadata()
       }
     } catch (_: Throwable) {
       _healthOk.value = false
@@ -1132,8 +1158,8 @@ class ChatController internal constructor(
   }
 
   private fun refreshCommandsAfterReconnect() {
-    if (_commands.value.isNotEmpty() && commandsAgentId == resolveAgentIdForSessionKey(_sessionKey.value)) return
-    scope.launch { fetchCommands() }
+    if (_commands.value.isNotEmpty() && chatMetadataAgentId == resolveAgentIdForSessionKey(_sessionKey.value)) return
+    scope.launch { fetchChatMetadata() }
   }
 
   private suspend fun enqueueOfflineCommand(
@@ -1919,6 +1945,8 @@ class ChatController internal constructor(
       lastActivityAt = obj["lastActivityAt"].asLongOrNull(),
       totalTokens = obj["totalTokens"].asLongOrNull(),
       totalTokensFresh = obj["totalTokensFresh"].asBooleanOrNull(),
+      modelProvider = obj["modelProvider"].asStringOrNull()?.trim(),
+      model = obj["model"].asStringOrNull()?.trim(),
       contextTokens = obj["contextTokens"].asLongOrNull(),
       hasContextUsageMetadata =
         "totalTokens" in obj ||
@@ -2328,6 +2356,8 @@ internal fun mergeChatSessionEntry(
         next.hasContextUsageMetadata -> next.totalTokensFresh
         else -> null
       },
+    modelProvider = next.modelProvider ?: existing.modelProvider,
+    model = next.model ?: existing.model,
     contextTokens =
       when {
         preserveExistingContextUsage -> next.contextTokens ?: existing.contextTokens
@@ -2340,4 +2370,10 @@ internal fun mergeChatSessionEntry(
         else -> next.hasContextUsageMetadata
       },
   )
+}
+
+private fun ChatSessionEntry.providerQualifiedModelRef(): String? {
+  val model = model?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+  val provider = modelProvider?.trim()?.takeIf { it.isNotEmpty() } ?: return model
+  return if (model.startsWith("$provider/")) model else "$provider/$model"
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -135,6 +135,7 @@ class ChatController internal constructor(
   // Drops stale history responses after session switches or refresh races.
   private val historyLoadGeneration = AtomicLong(0)
   private val historyRequestSequence = AtomicLong(0)
+  private val modelSelectionGeneration = AtomicLong(0)
   private val sessionsRequestSequence = AtomicLong(0)
   private val gatewayScopeApplyLock = Any()
   private var latestAppliedHistoryRequest = 0L
@@ -478,6 +479,7 @@ class ChatController internal constructor(
             requestGateway("sessions.patch", params.toString())
             normalizedModelRef?.let(recordModelRecent)
             if (_sessionKey.value == key) {
+              modelSelectionGeneration.incrementAndGet()
               _selectedModelRef.value = normalizedModelRef
             }
             true
@@ -882,6 +884,7 @@ class ChatController internal constructor(
     runIdsToReconcile: Set<String> = emptySet(),
   ): Boolean {
     val requestSequence = historyRequestSequence.incrementAndGet()
+    val requestModelSelectionGeneration = modelSelectionGeneration.get()
     val requestCacheScope = currentCacheScope()
     val history =
       try {
@@ -915,7 +918,9 @@ class ChatController internal constructor(
         latestAppliedHistoryRequest = requestSequence
         if (updateSessionInfo) {
           updateSessionFromHistory(history)
-          _selectedModelRef.value = history.sessionInfo?.providerQualifiedModelRef()
+          if (requestModelSelectionGeneration == modelSelectionGeneration.get()) {
+            _selectedModelRef.value = history.sessionInfo?.providerQualifiedModelRef()
+          }
         }
         transferLostAckOwnershipFromHistory(history)
         resolvePersistedReplies(history.messages)

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -60,6 +60,8 @@ data class ChatSessionEntry(
   val lastActivityAt: Long? = null,
   val totalTokens: Long? = null,
   val totalTokensFresh: Boolean? = null,
+  val modelProvider: String? = null,
+  val model: String? = null,
   val contextTokens: Long? = null,
   val hasContextUsageMetadata: Boolean = totalTokens != null || totalTokensFresh != null || contextTokens != null,
 )

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -129,7 +129,7 @@ fun ChatScreen(
   val manualHost by viewModel.manualHost.collectAsState()
   val manualPort by viewModel.manualPort.collectAsState()
   val manualTls by viewModel.manualTls.collectAsState()
-  val modelCatalog by viewModel.modelCatalog.collectAsState()
+  val modelCatalog by viewModel.chatModelCatalog.collectAsState()
   val modelFavorites by viewModel.modelFavorites.collectAsState()
   val modelRecents by viewModel.modelRecents.collectAsState()
   val selectedModelRef by viewModel.chatSelectedModelRef.collectAsState()
@@ -204,12 +204,6 @@ fun ChatScreen(
   LaunchedEffect(chatDraft) {
     input = mergeChatDraft(chatDraft, input) ?: return@LaunchedEffect
     viewModel.clearChatDraft()
-  }
-
-  LaunchedEffect(showModelPicker) {
-    if (showModelPicker && modelCatalog.isEmpty()) {
-      viewModel.refreshModelCatalog()
-    }
   }
 
   LaunchedEffect(gatewayConnectionDisplay.isConnected) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt
@@ -61,7 +61,7 @@ class ChatControllerCommandControlsTest {
           requestGateway = { method, paramsJson ->
             requests += method to paramsJson
             when (method) {
-              "commands.list" ->
+              "chat.metadata" ->
                 """
                 {
                   "commands": [
@@ -99,7 +99,7 @@ class ChatControllerCommandControlsTest {
           .single()
           .textAliases,
       )
-      assertEquals(2, requests.count { it.first == "commands.list" })
+      assertEquals(2, requests.count { it.first == "chat.metadata" })
     }
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -114,7 +114,7 @@ class ChatControllerCommandControlsTest {
           requestGateway = { method, paramsJson ->
             requests += method to paramsJson
             when (method) {
-              "commands.list" ->
+              "chat.metadata" ->
                 if (paramsJson.orEmpty().contains("\"agentId\":\"ops\"")) {
                   """
                   {
@@ -167,7 +167,7 @@ class ChatControllerCommandControlsTest {
           .textAliases,
       )
 
-      val commandRequests = requests.filter { it.first == "commands.list" }
+      val commandRequests = requests.filter { it.first == "chat.metadata" }
       assertTrue(commandRequests.any { it.second.orEmpty().contains("\"agentId\":\"main\"") })
       assertTrue(commandRequests.any { it.second.orEmpty().contains("\"agentId\":\"ops\"") })
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
@@ -175,6 +175,40 @@ class ChatControllerModelSelectionTest {
 
   @Test
   @OptIn(ExperimentalCoroutinesApi::class)
+  fun staleHistoryDoesNotOverwriteAcceptedModelSelection() =
+    runTest {
+      val historyStarted = CompletableDeferred<Unit>()
+      val releaseHistory = CompletableDeferred<Unit>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, _ ->
+            when (method) {
+              "chat.history" -> {
+                historyStarted.complete(Unit)
+                releaseHistory.await()
+                """{"messages":[],"sessionInfo":{"key":"main","modelProvider":"anthropic","model":"claude-opus-4"}}"""
+              }
+              "sessions.list" -> """{"sessions":[]}"""
+              "chat.metadata" -> """{"commands":[],"models":[]}"""
+              else -> "{}"
+            }
+          },
+        )
+
+      controller.load("main")
+      historyStarted.await()
+      assertTrue(controller.setSessionModelAwait("main", "openai/gpt-5"))
+
+      releaseHistory.complete(Unit)
+      advanceUntilIdle()
+
+      assertEquals("openai/gpt-5", controller.selectedModelRef.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
   fun historyHydratesSelectedModelAndAgentScopedCatalog() =
     runTest {
       val requests = mutableListOf<Pair<String, String?>>()

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
@@ -231,4 +231,72 @@ class ChatControllerModelSelectionTest {
       val metadataRequest = requests.single { it.first == "chat.metadata" }
       assertTrue(metadataRequest.second.orEmpty().contains("\"agentId\":\"ops\""))
     }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun emptyModelCatalogIsRetriedOnNextHealthEvent() =
+    runTest {
+      var metadataRequests = 0
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, _ ->
+            when (method) {
+              "chat.metadata" -> {
+                metadataRequests += 1
+                if (metadataRequests == 1) {
+                  """{"commands":[{"name":"new","textAliases":["/new"]}],"models":[]}"""
+                } else {
+                  """{"commands":[{"name":"new","textAliases":["/new"]}],"models":[{"id":"gpt-5","provider":"openai","input":["text"]}]}"""
+                }
+              }
+              else -> "{}"
+            }
+          },
+        )
+
+      controller.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+      assertTrue(controller.modelCatalog.value.isEmpty())
+
+      controller.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertEquals(2, metadataRequests)
+      assertEquals(
+        "gpt-5",
+        controller.modelCatalog.value
+          .single()
+          .id,
+      )
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun validEmptyModelCatalogStopsAfterOneRetry() =
+    runTest {
+      var metadataRequests = 0
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, _ ->
+            if (method == "chat.metadata") {
+              metadataRequests += 1
+              """{"commands":[],"models":[]}"""
+            } else {
+              "{}"
+            }
+          },
+        )
+
+      repeat(3) {
+        controller.handleGatewayEvent("health", null)
+        advanceUntilIdle()
+      }
+
+      assertEquals(2, metadataRequests)
+      assertTrue(controller.modelCatalog.value.isEmpty())
+    }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerModelSelectionTest.kt
@@ -1,7 +1,9 @@
 package ai.openclaw.app.chat
 
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlinx.serialization.json.Json
@@ -126,5 +128,107 @@ class ChatControllerModelSelectionTest {
         listOf("sessions.patch", "chat.send"),
         requests.filter { it == "sessions.patch" || it == "chat.send" },
       )
+    }
+
+  @Test
+  fun immediateSendStopsWhenPendingModelSelectionFails() =
+    runTest {
+      val patchStarted = CompletableDeferred<Unit>()
+      val releasePatch = CompletableDeferred<Unit>()
+      val requests = mutableListOf<String>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, _ ->
+            requests += method
+            when (method) {
+              "sessions.patch" -> {
+                patchStarted.complete(Unit)
+                releasePatch.await()
+                error("patch failed")
+              }
+              "chat.send" -> """{"runId":"run-unexpected","status":"ok"}"""
+              else -> "{}"
+            }
+          },
+        )
+      controller.handleGatewayEvent("health", null)
+
+      controller.setSessionModel("main", "openai/gpt-5")
+      patchStarted.await()
+      val send =
+        async {
+          controller.sendMessageAwaitAcceptance(
+            message = "hello",
+            thinkingLevel = "off",
+            attachments = emptyList(),
+          )
+        }
+      yield()
+
+      releasePatch.complete(Unit)
+      assertFalse(send.await())
+      assertEquals("patch failed", controller.errorText.value)
+      assertFalse("chat.send" in requests)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun historyHydratesSelectedModelAndAgentScopedCatalog() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "chat.history" ->
+                """
+                {
+                  "sessionId": "session-ops",
+                  "messages": [],
+                  "sessionInfo": {
+                    "key": "agent:ops:main",
+                    "modelProvider": "anthropic",
+                    "model": "claude-opus-4"
+                  }
+                }
+                """.trimIndent()
+              "chat.metadata" ->
+                """
+                {
+                  "commands": [],
+                  "models": [
+                    {
+                      "id": "claude-opus-4",
+                      "name": "Claude Opus 4",
+                      "provider": "anthropic",
+                      "available": true,
+                      "input": ["text"]
+                    }
+                  ]
+                }
+                """.trimIndent()
+              "sessions.list" -> """{"sessions":[]}"""
+              else -> "{}"
+            }
+          },
+        )
+
+      controller.load("agent:ops:main")
+      advanceUntilIdle()
+
+      assertEquals("anthropic/claude-opus-4", controller.selectedModelRef.value)
+      assertEquals(
+        "claude-opus-4",
+        controller.modelCatalog.value
+          .single()
+          .id,
+      )
+      val metadataRequest = requests.single { it.first == "chat.metadata" }
+      assertTrue(metadataRequest.second.orEmpty().contains("\"agentId\":\"ops\""))
     }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerReconnectRestoreTest.kt
@@ -86,7 +86,7 @@ class ChatControllerReconnectRestoreTest {
       controller.load("main")
       runCurrent()
       val historyCallsAfterLoad = gateway.callCount("chat.history")
-      val commandCallsAfterLoad = gateway.callCount("commands.list")
+      val metadataCallsAfterLoad = gateway.callCount("chat.metadata")
 
       controller.onDisconnected("Offline")
       controller.onGatewayConnected()
@@ -94,7 +94,7 @@ class ChatControllerReconnectRestoreTest {
 
       // Reconnect refetched history once and restored nothing.
       assertEquals(historyCallsAfterLoad + 1, gateway.callCount("chat.history"))
-      assertEquals(commandCallsAfterLoad + 1, gateway.callCount("commands.list"))
+      assertEquals(metadataCallsAfterLoad + 1, gateway.callCount("chat.metadata"))
       assertEquals(0, controller.pendingRunCount.value)
       assertNull(controller.streamingAssistantText.value)
       assertNull(controller.errorText.value)

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
@@ -33,7 +33,7 @@ internal class ScriptedGateway(
   init {
     // Benign defaults so bootstrap/health/commands side requests never fail a scenario.
     respondWith("health", "{}")
-    respondWith("commands.list", """{"commands":[]}""")
+    respondWith("chat.metadata", """{"commands":[],"models":[]}""")
     respondWith("sessions.list", """{"sessions":[]}""")
   }
 


### PR DESCRIPTION
Related: #100798
Related: #100699

## What Problem This Solves

Fixes issues where Android users selecting a chat model could send on the previous model after a failed patch, see an accepted selection overwritten by stale history, or receive the default agent's model catalog while chatting with another agent. It also prevents a temporarily empty model catalog from remaining empty for the session.

## Why This Change Was Made

The chat controller now owns the active agent's combined command/model metadata, treats model patch acceptance as the send-ordering boundary, hydrates the selected model from canonical session history, and rejects stale history model state after a newer local selection. Empty catalog metadata gets one bounded retry so timeout fallbacks recover without polling forever for a legitimately empty catalog.

## User Impact

Android's in-chat model picker stays aligned with the active session and agent. Immediate sends wait for a successful model change; failed changes remain visible and do not send on the wrong model.

## Evidence

- Blacksmith Testbox `tbx_01kwvyq0f7630vtfpjeeqwxt2d`: focused Play-debug unit tests passed for model selection, command metadata, reconnect restoration, picker ordering, secure preferences, connection management, and bootstrap auth.
- Regression coverage includes patch-failure send suppression, agent-scoped catalogs, history hydration, bounded empty-catalog retry, and stale-history ordering.
- Fresh Codex autoreview: no accepted/actionable findings.
- `git diff --check`: clean.
- Full Android ktlint remains blocked by pre-existing findings in `CronJobDetailTest.kt`, `InvokeErrorParserTest.kt`, and `NodeUtilsTest.kt`; no touched file was reported.
- Device UI proof gap: the connected Pixel remained keyguard-locked, so no screenshot or manual interaction proof was uploaded.
