### PR TITLE
feat(android): richer Settings About screen with mascot hero and project links

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -2923,7 +2923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 215,
+      "line": 218,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits and quota health.",
       "surface": "android",
@@ -2931,7 +2931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 215,
+      "line": 218,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Usage",
       "surface": "android",
@@ -2939,7 +2939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 235,
+      "line": 238,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load usage.",
       "surface": "android",
@@ -2947,7 +2947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 240,
+      "line": 243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No usage data yet.",
       "surface": "android",
@@ -2955,7 +2955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 241,
+      "line": 244,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Provider limits will appear here when your gateway reports them.",
       "surface": "android",
@@ -2963,7 +2963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 276,
+      "line": 279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron Jobs",
       "surface": "android",
@@ -2971,7 +2971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 276,
+      "line": 279,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Scheduled OpenClaw work from your gateway.",
       "surface": "android",
@@ -2979,7 +2979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 287,
+      "line": 290,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android shows scheduled work status. Create and edit schedules from the desktop app.",
       "surface": "android",
@@ -2987,7 +2987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 297,
+      "line": 300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load cron jobs.",
       "surface": "android",
@@ -2995,7 +2995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 302,
+      "line": 305,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No scheduled jobs.",
       "surface": "android",
@@ -3003,7 +3003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 303,
+      "line": 306,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Create recurring OpenClaw work from the desktop app.",
       "surface": "android",
@@ -3011,7 +3011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 338,
+      "line": 341,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Inspect scheduled gateway work.",
       "surface": "android",
@@ -3019,7 +3019,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 352,
+      "line": 355,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to inspect cron jobs.",
       "surface": "android",
@@ -3027,7 +3027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 360,
+      "line": 363,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cron job not loaded.",
       "surface": "android",
@@ -3035,7 +3035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 360,
+      "line": 363,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Loading cron job…",
       "surface": "android",
@@ -3043,7 +3043,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 382,
+      "line": 385,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agents",
       "surface": "android",
@@ -3051,7 +3051,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 382,
+      "line": 385,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose and inspect the assistants available on this gateway.",
       "surface": "android",
@@ -3059,7 +3059,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 393,
+      "line": 396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load agents.",
       "surface": "android",
@@ -3067,7 +3067,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 397,
+      "line": 400,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No agents loaded yet.",
       "surface": "android",
@@ -3075,7 +3075,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 423,
+      "line": 426,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Approvals",
       "surface": "android",
@@ -3083,7 +3083,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 423,
+      "line": 426,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review actions that need your attention.",
       "surface": "android",
@@ -3091,7 +3091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 434,
+      "line": 437,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refresh",
       "surface": "android",
@@ -3099,7 +3099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 434,
+      "line": 437,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Refreshing",
       "surface": "android",
@@ -3107,7 +3107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 447,
+      "line": 450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway disconnected.",
       "surface": "android",
@@ -3115,7 +3115,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 448,
+      "line": 451,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connect the gateway to load approval requests in the app.",
       "surface": "android",
@@ -3123,7 +3123,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 454,
+      "line": 457,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No gateway approvals.",
       "surface": "android",
@@ -3131,7 +3131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 455,
+      "line": 458,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Exec approval requests will appear here while this phone is connected.",
       "surface": "android",
@@ -3139,7 +3139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 462,
+      "line": 465,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Session activity",
       "surface": "android",
@@ -3147,7 +3147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 463,
+      "line": 466,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Chat tool calls waiting in the active session remain visible here.",
       "surface": "android",
@@ -3155,7 +3155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 477,
+      "line": 480,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "How this phone appears to OpenClaw.",
       "surface": "android",
@@ -3163,7 +3163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 477,
+      "line": 480,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Profile",
       "surface": "android",
@@ -3171,7 +3171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 480,
+      "line": 483,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Device name",
       "surface": "android",
@@ -3179,7 +3179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 481,
+      "line": 484,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save Profile",
       "surface": "android",
@@ -3187,7 +3187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 500,
+      "line": 503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Configure voice, transport, and playback.",
       "surface": "android",
@@ -3195,7 +3195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 500,
+      "line": 503,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Talk Provider Setup",
       "surface": "android",
@@ -3203,7 +3203,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 503,
+      "line": 506,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Audio Test",
       "surface": "android",
@@ -3211,7 +3211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 504,
+      "line": 507,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check that OpenClaw can speak clearly on this phone.",
       "surface": "android",
@@ -3219,7 +3219,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 507,
+      "line": 510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enable speaker",
       "surface": "android",
@@ -3227,7 +3227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 507,
+      "line": 510,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Mute speaker",
       "surface": "android",
@@ -3235,7 +3235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 508,
+      "line": 511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Assistant speech muted",
       "surface": "android",
@@ -3243,7 +3243,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 508,
+      "line": 511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replies play aloud",
       "surface": "android",
@@ -3251,7 +3251,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 510,
+      "line": 513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Muted",
       "surface": "android",
@@ -3259,7 +3259,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 510,
+      "line": 513,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "On",
       "surface": "android",
@@ -3267,7 +3267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 514,
+      "line": 517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Done",
       "surface": "android",
@@ -3275,7 +3275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 524,
+      "line": 527,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Realtime Talk",
       "surface": "android",
@@ -3283,7 +3283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 525,
+      "line": 528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Dictation",
       "surface": "android",
@@ -3291,7 +3291,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 653,
+      "line": 656,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowlist",
       "surface": "android",
@@ -3299,7 +3299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 653,
+      "line": 656,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Blocklist",
       "surface": "android",
@@ -3307,7 +3307,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 686,
+      "line": 689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what reaches OpenClaw.",
       "surface": "android",
@@ -3315,7 +3315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 686,
+      "line": 689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Notifications",
       "surface": "android",
@@ -3323,7 +3323,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 690,
+      "line": 693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Alerts stay on this phone.",
       "surface": "android",
@@ -3331,7 +3331,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 690,
+      "line": 693,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can receive selected alerts.",
       "surface": "android",
@@ -3339,7 +3339,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 702,
+      "line": 705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Granted",
       "surface": "android",
@@ -3347,7 +3347,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 702,
+      "line": 705,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup",
       "surface": "android",
@@ -3355,7 +3355,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 707,
+      "line": 710,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check Access",
       "surface": "android",
@@ -3363,7 +3363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 707,
+      "line": 710,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open System Access",
       "surface": "android",
@@ -3371,7 +3371,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 717,
+      "line": 720,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Forwarding Mode",
       "surface": "android",
@@ -3379,7 +3379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 766,
+      "line": 769,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App Filter",
       "surface": "android",
@@ -3387,7 +3387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 773,
+      "line": 776,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Close App Picker",
       "surface": "android",
@@ -3395,7 +3395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 773,
+      "line": 776,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open App Picker",
       "surface": "android",
@@ -3403,7 +3403,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 778,
+      "line": 781,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Search apps",
       "surface": "android",
@@ -3411,7 +3411,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 781,
+      "line": 784,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Show System Apps",
       "surface": "android",
@@ -3419,7 +3419,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 782,
+      "line": 785,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Include Android and background packages.",
       "surface": "android",
@@ -3427,7 +3427,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 789,
+      "line": 792,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No matching apps.",
       "surface": "android",
@@ -3435,7 +3435,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 800,
+      "line": 803,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Showing ${visibleApps.size} of ${apps.size}. Refine search for more.",
       "surface": "android",
@@ -3443,7 +3443,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1039,
+      "line": 1042,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Choose what this phone can share.",
       "surface": "android",
@@ -3451,7 +3451,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1039,
+      "line": 1042,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Phone Capabilities",
       "surface": "android",
@@ -3459,7 +3459,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1048,
+      "line": 1051,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow photo library access.",
       "surface": "android",
@@ -3467,7 +3467,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1048,
+      "line": 1051,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Selected or full photo access granted.",
       "surface": "android",
@@ -3475,7 +3475,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1058,
+      "line": 1061,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "App list stays on this phone.",
       "surface": "android",
@@ -3483,7 +3483,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1058,
+      "line": 1061,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw can list launcher-visible apps.",
       "surface": "android",
@@ -3491,7 +3491,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1069,
+      "line": 1072,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Location",
       "surface": "android",
@@ -3499,7 +3499,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1077,
+      "line": 1080,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always allows requested location checks while OpenClaw is in the background; Android shows this in the persistent node notification.",
       "surface": "android",
@@ -3507,7 +3507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1102,
+      "line": 1105,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow background location?",
       "surface": "android",
@@ -3515,7 +3515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1104,
+      "line": 1107,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw only checks location when your paired Gateway requests it. ",
       "surface": "android",
@@ -3523,7 +3523,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1117,
+      "line": 1120,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open Settings",
       "surface": "android",
@@ -3531,7 +3531,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1122,
+      "line": 1125,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not Now",
       "surface": "android",
@@ -3539,7 +3539,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1160,
+      "line": 1163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace gateway setup?",
       "surface": "android",
@@ -3547,7 +3547,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1175,
+      "line": 1178,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Replace setup",
       "surface": "android",
@@ -3555,7 +3555,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1180,
+      "line": 1183,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Cancel",
       "surface": "android",
@@ -3563,7 +3563,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1187,
+      "line": 1190,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection between this phone and OpenClaw.",
       "surface": "android",
@@ -3571,7 +3571,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1191,
+      "line": 1194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connected",
       "surface": "android",
@@ -3579,7 +3579,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1191,
+      "line": 1194,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Offline",
       "surface": "android",
@@ -3587,7 +3587,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1192,
+      "line": 1195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Not paired",
       "surface": "android",
@@ -3595,7 +3595,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1192,
+      "line": 1195,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Online",
       "surface": "android",
@@ -3603,7 +3603,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1202,
+      "line": 1205,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Reconnect",
       "surface": "android",
@@ -3611,7 +3611,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1203,
+      "line": 1206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Disconnect",
       "surface": "android",
@@ -3619,7 +3619,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1209,
+      "line": 1212,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Clear this phone's saved gateway access and scan a fresh setup code.",
       "surface": "android",
@@ -3627,7 +3627,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1216,
+      "line": 1219,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Pair New Gateway",
       "surface": "android",
@@ -3635,7 +3635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1217,
+      "line": 1220,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup Code",
       "surface": "android",
@@ -3643,7 +3643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1221,
+      "line": 1224,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Android can scan or paste an existing setup code, but this gateway does not expose setup-code generation to the app yet. Generate the QR/code on the gateway host with openclaw qr, then scan it here or paste the setup code below.",
       "surface": "android",
@@ -3651,7 +3651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1230,
+      "line": 1233,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Connection Setup",
       "surface": "android",
@@ -3659,7 +3659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1231,
+      "line": 1234,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Setup code",
       "surface": "android",
@@ -3667,7 +3667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1233,
+      "line": 1236,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Host",
       "surface": "android",
@@ -3675,7 +3675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1234,
+      "line": 1237,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Port",
       "surface": "android",
@@ -3683,7 +3683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1238,
+      "line": 1241,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Local",
       "surface": "android",
@@ -3691,7 +3691,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1242,
+      "line": 1245,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Token",
       "surface": "android",
@@ -3699,7 +3699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1243,
+      "line": 1246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Bootstrap",
       "surface": "android",
@@ -3707,7 +3707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1245,
+      "line": 1248,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Password",
       "surface": "android",
@@ -3715,7 +3715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1250,
+      "line": 1253,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Save & Connect",
       "surface": "android",
@@ -3723,7 +3723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1267,
+      "line": 1270,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enter a valid setup code or gateway address.",
       "surface": "android",
@@ -3731,7 +3731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1290,
+      "line": 1293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "A calm, high-contrast OpenClaw interface.",
       "surface": "android",
@@ -3739,7 +3739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1290,
+      "line": 1293,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Appearance",
       "surface": "android",
@@ -3747,7 +3747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1301,
+      "line": 1304,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Theme",
       "surface": "android",
@@ -3755,7 +3755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1346,
+      "line": 1349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Ready",
       "surface": "android",
@@ -3763,7 +3763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1375,
+      "line": 1378,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "About",
       "surface": "android",
@@ -3771,7 +3771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1375,
+      "line": 1378,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw for Android.",
       "surface": "android",
@@ -3779,7 +3779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1387,
+      "line": 1391,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Gateway",
       "surface": "android",
@@ -3787,7 +3787,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1389,
+      "line": 1393,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Runtime",
       "surface": "android",
@@ -3795,7 +3795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1392,
+      "line": 1396,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Update",
       "surface": "android",
@@ -3803,7 +3803,39 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1422,
+      "line": 1407,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "© 2026 OpenClaw Foundation — MIT License.",
+      "surface": "android",
+      "id": "native.android.aac3310699b496c8"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1424,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "OpenClaw logo",
+      "surface": "android",
+      "id": "native.android.a157bbb606e9b398"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1426,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "OpenClaw",
+      "surface": "android",
+      "id": "native.android.7b78b4869baf2160"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1427,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
+      "source": "Personal AI on your devices",
+      "surface": "android",
+      "id": "native.android.ad4c14835d1b71ca"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 1486,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Licenses",
       "surface": "android",
@@ -3811,7 +3843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1423,
+      "line": 1487,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "OpenClaw appreciates its partners in the open-source community.",
       "surface": "android",
@@ -3819,7 +3851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1432,
+      "line": 1496,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No license notices are packaged in this build.",
       "surface": "android",
@@ -3827,7 +3859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1458,
+      "line": 1522,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Open ${license.title}",
       "surface": "android",
@@ -3835,7 +3867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1493,
+      "line": 1557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Check",
       "surface": "android",
@@ -3843,7 +3875,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1526,
+      "line": 1590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Back",
       "surface": "android",
@@ -3851,7 +3883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1600,
+      "line": 1664,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Sending",
       "surface": "android",
@@ -3859,7 +3891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1609,
+      "line": 1673,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allow Once",
       "surface": "android",
@@ -3867,7 +3899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1609,
+      "line": 1673,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Allowing",
       "surface": "android",
@@ -3875,7 +3907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1617,
+      "line": 1681,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Always",
       "surface": "android",
@@ -3883,7 +3915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1617,
+      "line": 1681,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Saving",
       "surface": "android",
@@ -3891,7 +3923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1625,
+      "line": 1689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Deny",
       "surface": "android",
@@ -3899,7 +3931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1625,
+      "line": 1689,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Denying",
       "surface": "android",
@@ -3907,7 +3939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1650,
+      "line": 1714,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Review",
       "surface": "android",
@@ -3915,7 +3947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1678,
+      "line": 1742,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Issue",
       "surface": "android",
@@ -3923,7 +3955,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1708,
+      "line": 1772,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Enabled",
       "surface": "android",
@@ -3931,7 +3963,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1722,
+      "line": 1786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No",
       "surface": "android",
@@ -3939,7 +3971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1722,
+      "line": 1786,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Yes",
       "surface": "android",
@@ -3947,7 +3979,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1740,
+      "line": 1804,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Last Error",
       "surface": "android",
@@ -3955,7 +3987,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1743,
+      "line": 1807,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Delivery Error",
       "surface": "android",
@@ -3963,7 +3995,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1782,
+      "line": 1846,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Tap to copy",
       "surface": "android",
@@ -3971,7 +4003,7 @@
     },
     {
       "kind": "ui-toast",
-      "line": 1797,
+      "line": 1861,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "$title copied",
       "surface": "android",
@@ -3979,7 +4011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1835,
+      "line": 1899,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default assistant",
       "surface": "android",
@@ -3987,7 +4019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1837,
+      "line": 1901,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Default",
       "surface": "android",
@@ -3995,7 +4027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1893,
+      "line": 1957,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -4003,7 +4035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1896,
+      "line": 1960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting ${minutes}m",
       "surface": "android",
@@ -4011,7 +4043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1896,
+      "line": 1960,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Waiting for review",
       "surface": "android",
@@ -4019,7 +4051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1924,
+      "line": 1988,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "${job.scheduleLabel} · ${formatCronWake(job.nextRunAtMs)} · ${job.promptPreview}",
       "surface": "android",
@@ -4027,7 +4059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1931,
+      "line": 1995,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "No limits reported",
       "surface": "android",
@@ -4035,7 +4067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1962,
+      "line": 2026,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Off",
       "surface": "android",
@@ -4043,7 +4075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1983,
+      "line": 2047,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "System Event Text",
       "surface": "android",
@@ -4051,7 +4083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1984,
+      "line": 2048,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Agent Prompt",
       "surface": "android",
@@ -4059,7 +4091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1985,
+      "line": 2049,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Command",
       "surface": "android",
@@ -4067,7 +4099,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1986,
+      "line": 2050,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt",
       "source": "Payload Text",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+The Settings About screen now shows the animated mascot with the app tagline plus Website, Docs, GitHub, and Discord links.
+
 Adds a read-only Files browser for agent workspaces with directory navigation, text and image previews, and system share export.
 
 Android onboarding now completes after permission-triggered node approval and keeps Back navigation from cycling between permissions and approval.

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -42,6 +42,7 @@ import ai.openclaw.app.ui.design.ClawStatusPill
 import ai.openclaw.app.ui.design.ClawTextBadge
 import ai.openclaw.app.ui.design.ClawTextField
 import ai.openclaw.app.ui.design.ClawTheme
+import ai.openclaw.app.ui.design.OpenClawMascot
 import android.Manifest
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -83,6 +84,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.automirrored.filled.ScreenShare
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Bolt
@@ -121,6 +123,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -1373,6 +1376,7 @@ private fun AboutSettingsScreen(
   val currentGatewayVersion = updateAvailable?.currentVersion?.takeIf { it.isNotBlank() } ?: gatewayVersion
 
   SettingsDetailFrame(title = "About", subtitle = "OpenClaw for Android.", icon = Icons.Default.Info, onBack = onBack) {
+    AboutHeroPanel()
     SettingsMetricPanel(
       rows =
         listOf(
@@ -1398,6 +1402,66 @@ private fun AboutSettingsScreen(
     ClawPanel {
       Text(text = aboutUpdateText(latestVersion = latestVersion), style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
     }
+    AboutLinksPanel()
+    Text(
+      text = "© 2026 OpenClaw Foundation — MIT License.",
+      style = ClawTheme.type.caption,
+      color = ClawTheme.colors.textSubtle,
+      modifier = Modifier.fillMaxWidth(),
+      textAlign = TextAlign.Center,
+    )
+  }
+}
+
+@Composable
+private fun AboutHeroPanel() {
+  ClawPanel {
+    Column(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+      OpenClawMascot(contentDescription = "OpenClaw logo", modifier = Modifier.size(96.dp))
+      Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(text = "OpenClaw", style = ClawTheme.type.section, color = ClawTheme.colors.text)
+        Text(text = "Personal AI on your devices", style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
+      }
+    }
+  }
+}
+
+/** External project links; static first-party URLs matching the iOS and macOS About screens. */
+private data class AboutLink(
+  val title: String,
+  val subtitle: String,
+  val url: String,
+)
+
+private val aboutLinks =
+  listOf(
+    AboutLink("Website", "openclaw.ai", "https://openclaw.ai"),
+    AboutLink("Docs", "docs.openclaw.ai", "https://docs.openclaw.ai"),
+    AboutLink("GitHub", "github.com/openclaw/openclaw", "https://github.com/openclaw/openclaw"),
+    AboutLink("Discord", "discord.gg/clawd", "https://discord.gg/clawd"),
+  )
+
+@Composable
+private fun AboutLinksPanel() {
+  val uriHandler = LocalUriHandler.current
+  ClawListPanel(items = aboutLinks) { link ->
+    ClawListItem(
+      title = link.title,
+      subtitle = link.subtitle,
+      onClick = { uriHandler.openUri(link.url) },
+      trailing = {
+        Icon(
+          imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+          contentDescription = null,
+          tint = ClawTheme.colors.textSubtle,
+          modifier = Modifier.size(16.dp),
+        )
+      },
+    )
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Android Settings → About screen showed version metrics and gateway status but no product identity and no way to reach the project — no logo, no tagline, no links to the website, docs, repo, or community. The iOS and macOS About screens got this treatment already ([#100531](https://github.com/openclaw/openclaw/pull/100531)); Android was the gap.

## Why This Change Was Made

Adds the same brand treatment using existing components only: an `AboutHeroPanel` with the animated `OpenClawMascot` (already used in onboarding/voice/chat), the App Store tagline ("Personal AI on your devices"), a links panel (Website, Docs, GitHub, Discord) built from `ClawListPanel`/`ClawListItem` rows that open via `LocalUriHandler`, and the OpenClaw Foundation MIT footer matching the other platforms. The existing version metrics, gateway status rows, and update text are unchanged. New user-visible strings are registered in the native i18n inventory.

## User Impact

Android users can now see the app identity (animated mascot + tagline) on the About screen and jump straight to openclaw.ai, docs.openclaw.ai, the GitHub repo, or the Discord community.

## Evidence

- `./gradlew :app:compilePlayDebugKotlin` — BUILD SUCCESSFUL
- `./gradlew :app:ktlintMainSourceSetCheck` — 0 violations in the touched file (`SettingsScreens.kt`); remaining report entries are pre-existing on `main` in untouched files (`ChatController.kt`, `CronJobDetail.kt`, `NetworkMonitor.kt`, `CameraHandler.kt` — local ktlint is stricter than the CI baseline)
- `pnpm native:i18n:check` / `android:i18n:check` / `apple:i18n:check` — all pass after `native:i18n:sync`
- Codex autoreview (gpt-5.5): clean, no actionable findings
- Live emulator verification attempted (play-debug APK installs and the app shell runs on an API 36 emulator), but the emulator's system server repeatedly ANR'd under machine load before the About screen could be captured; a screenshot will be posted as a PR comment if a healthy device run completes. The change reuses only components already rendered elsewhere (`OpenClawMascot` from onboarding/voice/chat, `ClawListPanel`/`ClawListItem` from Licenses), and the same layout was verified live on iOS in #100531.
