### PR TITLE
fix(line): surface partial delivery when rich or media send fails alongside text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Docs: https://docs.openclaw.ai
 - **Voice Call completed status:** resolve finalized calls from the full retained event store across Gateway, tool, and CLI status paths while preserving active-call lookup performance. (#99797) Thanks @Darren2030.
 - **Agent stop recovery:** prevent late-aborting prompts from reacquiring orphaned session locks after teardown, so `/stop` leaves the conversation ready for the next turn.
 - **Message delivery status:** report failed and partially failed best-effort channel delivery instead of returning a success-shaped message-tool result. (#99928) Thanks @masatohoshino.
+- **LINE partial delivery:** surface rich and media send failures after visible text delivery without retrying text or losing reply-token state. (#100996) Thanks @masatohoshino.
 - **WhatsApp credential recovery:** restore malformed primary auth state from a valid backup during startup. (#99070) Thanks @LeonidasLux.
 - **WhatsApp quoted replies:** preserve bot-authored outbound quote metadata so replies to those messages keep their reply bubble in WhatsApp Desktop. (#94879) Thanks @Bartok9.
 - **WhatsApp reconnect catch-up:** admit recently missed Baileys `append` messages during a bounded reconnect window while preserving startup stale-history guards. (#80642) Thanks @VishalJ99.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,6 @@ Docs: https://docs.openclaw.ai
 - **Voice Call completed status:** resolve finalized calls from the full retained event store across Gateway, tool, and CLI status paths while preserving active-call lookup performance. (#99797) Thanks @Darren2030.
 - **Agent stop recovery:** prevent late-aborting prompts from reacquiring orphaned session locks after teardown, so `/stop` leaves the conversation ready for the next turn.
 - **Message delivery status:** report failed and partially failed best-effort channel delivery instead of returning a success-shaped message-tool result. (#99928) Thanks @masatohoshino.
-- **LINE partial delivery:** surface rich and media send failures after visible text delivery without retrying text or losing reply-token state. (#100996) Thanks @masatohoshino.
 - **WhatsApp credential recovery:** restore malformed primary auth state from a valid backup during startup. (#99070) Thanks @LeonidasLux.
 - **WhatsApp quoted replies:** preserve bot-authored outbound quote metadata so replies to those messages keep their reply bubble in WhatsApp Desktop. (#94879) Thanks @Bartok9.
 - **WhatsApp reconnect catch-up:** admit recently missed Baileys `append` messages during a bounded reconnect window while preserving startup stale-history guards. (#80642) Thanks @VishalJ99.

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -324,7 +324,8 @@ describe("deliverLineAutoReply", () => {
     const lineData = {
       flexMessage: { altText: "Card", contents: { type: "bubble" } },
     };
-    const frozenError = Object.freeze(new Error("push failed"));
+    const frozenError = new Error("push failed");
+    Object.freeze(frozenError);
     const { deps } = createDeps({
       pushMessagesLine: vi.fn(async () => {
         throw frozenError;

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -280,7 +280,10 @@ describe("deliverLineAutoReply", () => {
     // The partial failure is returned (not thrown) so the caller can adopt the
     // consumed reply-token state before surfacing it. visibleReplySent is the
     // signal dispatch uses to keep the sent text yet still report the failure.
-    expect(result.visiblePartialDeliveryError).toMatchObject({ visibleReplySent: true });
+    expect(result).toMatchObject({
+      status: "partial",
+      error: { sentBeforeError: true, visibleReplySent: true },
+    });
     expect(result.replyTokenUsed).toBe(true);
     // Text still reached the user over the reply token despite the rich failure.
     expect(replyMessageLine).toHaveBeenCalledTimes(1);
@@ -308,10 +311,37 @@ describe("deliverLineAutoReply", () => {
       deps,
     });
 
-    expect(result.visiblePartialDeliveryError).toMatchObject({ visibleReplySent: true });
+    expect(result).toMatchObject({
+      status: "partial",
+      error: { sentBeforeError: true, visibleReplySent: true },
+    });
     expect(result.replyTokenUsed).toBe(true);
     expect(replyMessageLine).toHaveBeenCalledTimes(1);
     expect(failingPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps a non-extensible rich failure without losing visible-send evidence", async () => {
+    const lineData = {
+      flexMessage: { altText: "Card", contents: { type: "bubble" } },
+    };
+    const frozenError = Object.freeze(new Error("push failed"));
+    const { deps } = createDeps({
+      pushMessagesLine: vi.fn(async () => {
+        throw frozenError;
+      }) as LineAutoReplyDeps["pushMessagesLine"],
+    });
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: "hello", channelData: { line: lineData } },
+      lineData,
+      deps,
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      error: { sentBeforeError: true, visibleReplySent: true, cause: frozenError },
+    });
   });
 
   it("falls back to push when reply token delivery fails", async () => {

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -248,6 +248,72 @@ describe("deliverLineAutoReply", () => {
     expect(pushOrder).toBeLessThan(replyOrder);
   });
 
+  it("surfaces a visible partial delivery when a rich bubble fails alongside quick-reply text", async () => {
+    // Quick replies attach to the trailing text bubble, so the flex/media send
+    // (pushMessagesLine) runs first. If it fails, the text still reaches the
+    // user, but the loss must be reported instead of a silent full success.
+    const createTextMessageWithQuickReplies = vi.fn((text: string) => ({
+      type: "text" as const,
+      text,
+      quickReply: { items: ["A"] },
+    }));
+    const lineData = {
+      flexMessage: { altText: "Card", contents: { type: "bubble" } },
+      quickReplies: ["A"],
+    };
+    const failingPush = vi.fn(async () => {
+      throw new Error("push failed");
+    });
+    const { deps, replyMessageLine } = createDeps({
+      createTextMessageWithQuickReplies:
+        createTextMessageWithQuickReplies as LineAutoReplyDeps["createTextMessageWithQuickReplies"],
+      pushMessagesLine: failingPush as LineAutoReplyDeps["pushMessagesLine"],
+    });
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: "hello", channelData: { line: lineData } },
+      lineData,
+      deps,
+    });
+
+    // The partial failure is returned (not thrown) so the caller can adopt the
+    // consumed reply-token state before surfacing it. visibleReplySent is the
+    // signal dispatch uses to keep the sent text yet still report the failure.
+    expect(result.visiblePartialDeliveryError).toMatchObject({ visibleReplySent: true });
+    expect(result.replyTokenUsed).toBe(true);
+    // Text still reached the user over the reply token despite the rich failure.
+    expect(replyMessageLine).toHaveBeenCalledTimes(1);
+    expect(failingPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a visible partial delivery when a rich bubble fails after text without quick replies", async () => {
+    // Without quick replies the text goes first and the rich bubble follows; a
+    // failed rich push must surface the same visible partial delivery so the
+    // sibling path stays consistent with the quick-reply branch.
+    const lineData = {
+      flexMessage: { altText: "Card", contents: { type: "bubble" } },
+    };
+    const failingPush = vi.fn(async () => {
+      throw new Error("push failed");
+    });
+    const { deps, replyMessageLine } = createDeps({
+      pushMessagesLine: failingPush as LineAutoReplyDeps["pushMessagesLine"],
+    });
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: "hello", channelData: { line: lineData } },
+      lineData,
+      deps,
+    });
+
+    expect(result.visiblePartialDeliveryError).toMatchObject({ visibleReplySent: true });
+    expect(result.replyTokenUsed).toBe(true);
+    expect(replyMessageLine).toHaveBeenCalledTimes(1);
+    expect(failingPush).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to push when reply token delivery fails", async () => {
     const lineData = {
       flexMessage: { altText: "Card", contents: { type: "bubble" } },

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -43,6 +43,20 @@ export type LineAutoReplyDeps = {
   | "onReplyError"
 >;
 
+export type LineAutoReplyDeliveryResult =
+  | { status: "delivered"; replyTokenUsed: boolean }
+  | { status: "partial"; replyTokenUsed: boolean; error: Error };
+
+function markLineVisibleDeliveryError(error: unknown): Error {
+  if (error instanceof Error && Object.isExtensible(error)) {
+    Object.assign(error, { sentBeforeError: true, visibleReplySent: true });
+    return error;
+  }
+  const visibleError = new Error("LINE rich or media message send failed", { cause: error });
+  Object.assign(visibleError, { sentBeforeError: true, visibleReplySent: true });
+  return visibleError;
+}
+
 export async function deliverLineAutoReply(params: {
   payload: ReplyPayload;
   lineData: LineChannelData;
@@ -53,13 +67,9 @@ export async function deliverLineAutoReply(params: {
   cfg: OpenClawConfig;
   textLimit: number;
   deps: LineAutoReplyDeps;
-}): Promise<{ replyTokenUsed: boolean; visiblePartialDeliveryError?: Error }> {
+}): Promise<LineAutoReplyDeliveryResult> {
   const { payload, lineData, replyToken, accountId, to, textLimit, deps } = params;
   let replyTokenUsed = params.replyTokenUsed;
-  // Set when the text reached the user but a rich/media bubble did not. Returned
-  // (not thrown) so the caller adopts the consumed reply-token state before it
-  // surfaces the failure.
-  let visiblePartialDeliveryError: Error | undefined;
 
   const pushLineMessages = async (messages: messagingApi.Message[]): Promise<void> => {
     if (messages.length === 0) {
@@ -183,15 +193,13 @@ export async function deliverLineAutoReply(params: {
       }
     }
     if (richMediaError !== undefined) {
-      // Tag the failure as a visible partial delivery so the caller reports it
-      // instead of silent success; visibleReplySent marks the text as visibly
-      // delivered so the foreground fallback/freshness path does not re-send it
-      // (see isVisiblePartialDeliveryError in src/auto-reply/dispatch.ts).
-      const partialError =
-        richMediaError instanceof Error
-          ? richMediaError
-          : new Error("LINE rich or media message send failed", { cause: richMediaError });
-      visiblePartialDeliveryError = Object.assign(partialError, { visibleReplySent: true });
+      // Preserve both generic send evidence and foreground visibility: downstream
+      // callers must surface the failure without retrying text the user already saw.
+      return {
+        status: "partial",
+        replyTokenUsed,
+        error: markLineVisibleDeliveryError(richMediaError),
+      };
     }
   } else {
     const combined = [...richMessages, ...mediaMessages];
@@ -225,8 +233,5 @@ export async function deliverLineAutoReply(params: {
     }
   }
 
-  return {
-    replyTokenUsed,
-    ...(visiblePartialDeliveryError ? { visiblePartialDeliveryError } : {}),
-  };
+  return { status: "delivered", replyTokenUsed };
 }

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -53,9 +53,13 @@ export async function deliverLineAutoReply(params: {
   cfg: OpenClawConfig;
   textLimit: number;
   deps: LineAutoReplyDeps;
-}): Promise<{ replyTokenUsed: boolean }> {
+}): Promise<{ replyTokenUsed: boolean; visiblePartialDeliveryError?: Error }> {
   const { payload, lineData, replyToken, accountId, to, textLimit, deps } = params;
   let replyTokenUsed = params.replyTokenUsed;
+  // Set when the text reached the user but a rich/media bubble did not. Returned
+  // (not thrown) so the caller adopts the consumed reply-token state before it
+  // surfaces the failure.
+  let visiblePartialDeliveryError: Error | undefined;
 
   const pushLineMessages = async (messages: messagingApi.Message[]): Promise<void> => {
     if (messages.length === 0) {
@@ -141,11 +145,17 @@ export async function deliverLineAutoReply(params: {
 
   if (chunks.length > 0) {
     const hasRichOrMedia = richMessages.length > 0 || mediaMessages.length > 0;
-    if (hasQuickReplies && hasRichOrMedia) {
+    // Quick replies attach to the trailing message, so when both are present the
+    // rich/media bubbles must go out before the quick-reply text. Capture a
+    // failure instead of swallowing it: the text still sends below, but a lost
+    // rich/media bubble must surface as a partial delivery, not silent success.
+    const sendRichBeforeText = hasQuickReplies && hasRichOrMedia;
+    let richMediaError: unknown;
+    if (sendRichBeforeText) {
       try {
         await sendLineMessages([...richMessages, ...mediaMessages], false);
       } catch (err) {
-        deps.onReplyError?.(err);
+        richMediaError = err;
       }
     }
     const { replyTokenUsed: nextReplyTokenUsed } = await deps.sendLineReplyChunks({
@@ -162,11 +172,26 @@ export async function deliverLineAutoReply(params: {
       createTextMessageWithQuickReplies: deps.createTextMessageWithQuickReplies,
     });
     replyTokenUsed = nextReplyTokenUsed;
-    if (!hasQuickReplies || !hasRichOrMedia) {
-      await sendLineMessages(richMessages, false);
-      if (mediaMessages.length > 0) {
-        await sendLineMessages(mediaMessages, false);
+    if (!sendRichBeforeText) {
+      try {
+        await sendLineMessages(richMessages, false);
+        if (mediaMessages.length > 0) {
+          await sendLineMessages(mediaMessages, false);
+        }
+      } catch (err) {
+        richMediaError = err;
       }
+    }
+    if (richMediaError !== undefined) {
+      // Tag the failure as a visible partial delivery so the caller reports it
+      // instead of silent success; visibleReplySent marks the text as visibly
+      // delivered so the foreground fallback/freshness path does not re-send it
+      // (see isVisiblePartialDeliveryError in src/auto-reply/dispatch.ts).
+      const partialError =
+        richMediaError instanceof Error
+          ? richMediaError
+          : new Error("LINE rich or media message send failed", { cause: richMediaError });
+      visiblePartialDeliveryError = Object.assign(partialError, { visibleReplySent: true });
     }
   } else {
     const combined = [...richMessages, ...mediaMessages];
@@ -200,5 +225,8 @@ export async function deliverLineAutoReply(params: {
     }
   }
 
-  return { replyTokenUsed };
+  return {
+    replyTokenUsed,
+    ...(visiblePartialDeliveryError ? { visiblePartialDeliveryError } : {}),
+  };
 }

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -290,13 +290,13 @@ export async function monitorLineProvider(
                   });
                   replyTokenUsed = deliveryResult.replyTokenUsed;
 
-                  if (deliveryResult.visiblePartialDeliveryError) {
+                  if (deliveryResult.status === "partial") {
                     // Text reached the user but a rich/media bubble did not.
                     // Surface the tagged partial failure after adopting the
                     // consumed reply-token state so later blocks in this turn
                     // route correctly; recordChannelRuntimeState is skipped
                     // because this delivery was not a clean success.
-                    throw deliveryResult.visiblePartialDeliveryError;
+                    throw deliveryResult.error;
                   }
 
                   recordChannelRuntimeState({

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -258,7 +258,7 @@ export async function monitorLineProvider(
                     }).catch(() => {});
                   }
 
-                  const { replyTokenUsed: nextReplyTokenUsed } = await deliverLineAutoReply({
+                  const deliveryResult = await deliverLineAutoReply({
                     payload,
                     lineData,
                     to: ctxPayload.From,
@@ -288,7 +288,16 @@ export async function monitorLineProvider(
                       },
                     },
                   });
-                  replyTokenUsed = nextReplyTokenUsed;
+                  replyTokenUsed = deliveryResult.replyTokenUsed;
+
+                  if (deliveryResult.visiblePartialDeliveryError) {
+                    // Text reached the user but a rich/media bubble did not.
+                    // Surface the tagged partial failure after adopting the
+                    // consumed reply-token state so later blocks in this turn
+                    // route correctly; recordChannelRuntimeState is skipped
+                    // because this delivery was not a clean success.
+                    throw deliveryResult.visiblePartialDeliveryError;
+                  }
 
                   recordChannelRuntimeState({
                     channel: "line",


### PR DESCRIPTION
## What Problem This Solves

When a LINE reply contains **both** quick-reply buttons **and** rich or media content (an image, a flex/template bubble, or a location), the plugin sends the rich/media messages first so the quick replies can stay attached to the trailing text bubble. That first send was wrapped in a `try/catch` that only logged the error and never rethrew:

```ts
if (hasQuickReplies && hasRichOrMedia) {
  try {
    await sendLineMessages([...richMessages, ...mediaMessages], false);
  } catch (err) {
    deps.onReplyError?.(err); // swallowed — text still sends below
  }
}
```

So if the image/flex/location push failed (e.g. LINE rejects an unreachable image URL or a malformed flex), the text still sent and the channel reported a **full success** (`recordChannelRuntimeState({ lastOutboundAt })`). The user silently lost the rich/media bubble with no failure surfaced.

This path is not covered by the generic honest-delivery handling: `monitor-durable.ts` opts payloads carrying `channelData.line` or media **out** of the durable delivery path, so exactly these payloads depend on this custom `deliver()` callback being honest — and it was not. The sibling branch in the same file (rich/media without quick replies) already lets the error propagate, so the two paths were inconsistent.

## Why This Change Was Made

`deliverLineAutoReply` is consumed by the core dispatcher (`dispatchReplyWithBufferedBlockDispatcher`), which already has a first-class contract for partial delivery: `isVisiblePartialDeliveryError` (`src/auto-reply/dispatch.ts`) treats a thrown error carrying `visibleReplySent: true` as "the visible reply was sent, but delivery partially failed" — it records the sent text on the reply fence and rethrows so the failure is surfaced, without resending the text.

The fix unifies both branches of the `chunks.length > 0` block: a rich/media send failure from either ordering is captured and returned from `deliverLineAutoReply` alongside `replyTokenUsed` (as a `visibleReplySent`-tagged error), rather than thrown from deep inside. The monitor callback adopts the consumed reply-token state, then surfaces the partial failure. Returning-then-surfacing (instead of throwing directly) keeps `replyTokenUsed` correct so later blocks in the same turn route through the right delivery path instead of retrying an already-consumed reply token. This makes the previously-swallowing quick-reply branch consistent with the already-throwing sibling. The `visibleReplySent` tag marks the text as visibly delivered so the foreground reply-fence does not treat the reply as undelivered.

The swallow has existed since the plugin was first added (`c96ffa7186`, #1630); it is an original inconsistency, not a deliberate design choice.

## User Impact

- LINE replies that mix quick replies with an image/flex/location no longer report success when the rich/media bubble fails to send. Operators/health now see the failure instead of a false clean delivery, while the text the user did receive is preserved (no duplicate resend).
- No config, schema, or behavior change on the success path; happy-path delivery and quick-reply ordering are unchanged.

## Evidence

- Exact prepared head: `d2cd1284742cf2036044eb06a82c6691172597e0`.
- Live localhost HTTP E2E through the installed `@line/bot-sdk` 11.1.0 and its real `MessagingApiClient`:

  ```text
  current main:
  scenario=quick result=pass order=/v2/bot/message/push->/v2/bot/message/reply failure_surfaced=false
  visible_text=delivered rich_message=failed partial_error=hidden duplicate_text=none

  exact PR head:
  scenario=quick result=pass order=/v2/bot/message/push->/v2/bot/message/reply failure_surfaced=true
  scenario=plain result=pass order=/v2/bot/message/reply->/v2/bot/message/push failure_surfaced=true
  visible_text=delivered rich_message=failed partial_error=surfaced duplicate_text=none
  ```

  The server deliberately returned HTTP 400 for the rich-message push and HTTP 200 for the visible text reply. The exact head retained the real SDK `HTTPFetchError`, tagged it with `sentBeforeError: true` and `visibleReplySent: true`, adopted the reply token, and sent no duplicate text.
- `node scripts/run-vitest.mjs extensions/line/src/auto-reply-delivery.test.ts` — **9/9 pass**, including both send orders and a frozen dependency error.
- Fresh whole-branch GPT-5.5 AutoReview — no accepted/actionable findings (confidence 0.82).
- `git diff --check` — clean.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/28812539610) — code, type, lint, build, and test shards run on the prepared tree.
- A new sanitized AWS lease was unavailable at the owner active-lease limit (11/10), so the repository-permitted narrow local test fallback and exact-head hosted CI were used.
- Official LINE contracts checked: [quick replies disappear after a later message](https://developers.line.biz/en/docs/messaging-api/using-quick-reply/) and the [last message object owns the displayed quick reply](https://developers.line.biz/en/reference/messaging-api/nojs/).
- Scope: 2 production files and 1 focused test file. The contributor-authored release entry was removed for the maintainer batch changelog pass. No cross-channel, config, dependency, or durable-path changes.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: on a partial failure the reply is surfaced as failed, so `recordChannelRuntimeState({ lastOutboundAt })` is skipped for that reply.
  - Mitigation: intended — a partially-failed delivery should not record a clean outbound success. The reply-token state is still adopted before surfacing, so same-turn follow-ups route correctly (this was an earlier review concern, now handled by returning the failure instead of throwing from inside the delivery helper).
- Note (not introduced by this PR): the shared ACP block-reply finalizer (`dispatch-acp.ts`) counts any thrown `deliver` as a failed visible delivery via the dispatcher's `failedCounts`, independent of `visibleReplySent`. A "throw after visible text was sent" shape already exists in shipped LINE code (the sibling branch and the original monitor callback both throw without a catch), and it is only reachable when a session is explicitly bound to an ACP runtime (a default LINE turn on the embedded agent never reaches `finalizeAcpTurnOutput`). This PR does not change that behavior; `visibleReplySent` only feeds the orthogonal foreground reply-fence.
