### PR TITLE
fix(clawhub): cap archive and clawpack download size at 256 MiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **ClawHub archive downloads:** cap package, ClawPack, skill, resolver, and GitHub-source archive reads at 256 MiB, rejecting declared oversize responses before buffering them. (#100999) Thanks @hugenshen.
 - **Control UI session creation:** keep newly created sessions at the front of the stable sidebar order after selecting another session. Thanks @shakkernerd.
 - **FTS-only memory startup:** skip plugin capability discovery when `memorySearch.provider` is explicitly `none`, avoiding an unnecessary cold-start scan.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -69,6 +69,40 @@ function createStalledBodyResponse(params: {
   };
 }
 
+function createOversizedArchiveBodyResponse(
+  params: {
+    headers?: HeadersInit;
+  } = {},
+): {
+  response: Response;
+  cancel: ReturnType<typeof vi.fn>;
+} {
+  const cancel = vi.fn();
+  const chunk = new Uint8Array(512 * 1024).fill(0);
+  const overshootChunks = 512 + 1; // 256 MiB + 512 KiB > CLAWHUB_ARCHIVE_MAX_BYTES
+  let emitted = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (emitted >= overshootChunks) {
+        controller.close();
+        return;
+      }
+      emitted += 1;
+      controller.enqueue(chunk);
+    },
+    cancel() {
+      cancel();
+    },
+  });
+  return {
+    response: new Response(body, {
+      status: 200,
+      headers: params.headers ?? { "content-type": "application/zip" },
+    }),
+    cancel,
+  };
+}
+
 describe("clawhub helpers", () => {
   const originalEnv = captureEnv(["HOME", "XDG_CONFIG_HOME"]);
 
@@ -844,6 +878,51 @@ describe("clawhub helpers", () => {
           }),
       }),
     ).rejects.toThrow(/declared sha256/);
+  });
+
+  it("rejects oversized package archive downloads and cancels the stream", async () => {
+    const oversized = createOversizedArchiveBodyResponse();
+
+    await expect(
+      downloadClawHubPackageArchive({
+        name: "@hyf/zai-external-alpha",
+        version: "0.0.1",
+        fetchImpl: async () => oversized.response,
+      }),
+    ).rejects.toThrow(
+      "ClawHub package archive download for @hyf/zai-external-alpha exceeded 268435456 bytes (268959744 bytes received)",
+    );
+  });
+
+  it("rejects oversized ClawPack artifact downloads and cancels the stream", async () => {
+    const oversized = createOversizedArchiveBodyResponse({
+      headers: { "content-type": "application/octet-stream" },
+    });
+
+    await expect(
+      downloadClawHubPackageArchive({
+        name: "demo",
+        version: "1.2.3",
+        artifact: "clawpack",
+        fetchImpl: async () => oversized.response,
+      }),
+    ).rejects.toThrow(
+      "ClawHub ClawPack download for demo@1.2.3 exceeded 268435456 bytes (268959744 bytes received)",
+    );
+  });
+
+  it("rejects oversized skill archive downloads and cancels the stream", async () => {
+    const oversized = createOversizedArchiveBodyResponse();
+
+    await expect(
+      downloadClawHubSkillArchive({
+        slug: "agentreceipt",
+        version: "1.0.0",
+        fetchImpl: async () => oversized.response,
+      }),
+    ).rejects.toThrow(
+      "ClawHub skill archive download for agentreceipt exceeded 268435456 bytes (268959744 bytes received)",
+    );
   });
 
   it("annotates 429 errors with the reset hint and a sign-in hint when unauthenticated", async () => {

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
+  downloadClawHubGitHubSkillArchive,
   downloadClawHubPackageArchive,
   downloadClawHubSkillArchive,
   downloadClawHubSkillArchiveUrl,
@@ -79,7 +80,7 @@ function createOversizedArchiveBodyResponse(
 } {
   const cancel = vi.fn();
   const chunk = new Uint8Array(512 * 1024).fill(0);
-  const overshootChunks = 512 + 1; // 256 MiB + 512 KiB > CLAWHUB_ARCHIVE_MAX_BYTES
+  const overshootChunks = 512 + 1;
   let emitted = 0;
   const body = new ReadableStream<Uint8Array>({
     pull(controller) {
@@ -102,6 +103,66 @@ function createOversizedArchiveBodyResponse(
     cancel,
   };
 }
+
+const oversizedArchiveCases: Array<{
+  name: string;
+  headers?: HeadersInit;
+  download: (response: Response) => Promise<unknown>;
+  expectedResource: string;
+}> = [
+  {
+    name: "package archive",
+    download: (response) =>
+      downloadClawHubPackageArchive({
+        name: "@hyf/zai-external-alpha",
+        version: "0.0.1",
+        fetchImpl: async () => response,
+      }),
+    expectedResource: "package archive download for @hyf/zai-external-alpha",
+  },
+  {
+    name: "ClawPack artifact",
+    headers: { "content-type": "application/octet-stream" },
+    download: (response) =>
+      downloadClawHubPackageArchive({
+        name: "demo",
+        version: "1.2.3",
+        artifact: "clawpack",
+        fetchImpl: async () => response,
+      }),
+    expectedResource: "ClawPack download for demo@1.2.3",
+  },
+  {
+    name: "skill archive",
+    download: (response) =>
+      downloadClawHubSkillArchive({
+        slug: "agentreceipt",
+        version: "1.0.0",
+        fetchImpl: async () => response,
+      }),
+    expectedResource: "skill archive download for agentreceipt",
+  },
+  {
+    name: "resolver URL archive",
+    download: (response) =>
+      downloadClawHubSkillArchiveUrl({
+        baseUrl: "https://clawhub.ai",
+        url: "https://downloads.example.com/skill.zip",
+        fetchImpl: async () => response,
+      }),
+    expectedResource: "skill archive download at /skill.zip",
+  },
+  {
+    name: "GitHub source archive",
+    download: (response) =>
+      downloadClawHubGitHubSkillArchive({
+        repo: "owner/repo",
+        commit: "abc123",
+        fetchImpl: async () => response,
+      }),
+    expectedResource: "GitHub source archive for owner/repo@abc123",
+  },
+];
 
 describe("clawhub helpers", () => {
   const originalEnv = captureEnv(["HOME", "XDG_CONFIG_HOME"]);
@@ -880,50 +941,17 @@ describe("clawhub helpers", () => {
     ).rejects.toThrow(/declared sha256/);
   });
 
-  it("rejects oversized package archive downloads and cancels the stream", async () => {
-    const oversized = createOversizedArchiveBodyResponse();
+  it.each(oversizedArchiveCases)(
+    "rejects and cancels oversized $name downloads",
+    async ({ headers, download, expectedResource }) => {
+      const oversized = createOversizedArchiveBodyResponse({ headers });
 
-    await expect(
-      downloadClawHubPackageArchive({
-        name: "@hyf/zai-external-alpha",
-        version: "0.0.1",
-        fetchImpl: async () => oversized.response,
-      }),
-    ).rejects.toThrow(
-      "ClawHub package archive download for @hyf/zai-external-alpha exceeded 268435456 bytes (268959744 bytes received)",
-    );
-  });
-
-  it("rejects oversized ClawPack artifact downloads and cancels the stream", async () => {
-    const oversized = createOversizedArchiveBodyResponse({
-      headers: { "content-type": "application/octet-stream" },
-    });
-
-    await expect(
-      downloadClawHubPackageArchive({
-        name: "demo",
-        version: "1.2.3",
-        artifact: "clawpack",
-        fetchImpl: async () => oversized.response,
-      }),
-    ).rejects.toThrow(
-      "ClawHub ClawPack download for demo@1.2.3 exceeded 268435456 bytes (268959744 bytes received)",
-    );
-  });
-
-  it("rejects oversized skill archive downloads and cancels the stream", async () => {
-    const oversized = createOversizedArchiveBodyResponse();
-
-    await expect(
-      downloadClawHubSkillArchive({
-        slug: "agentreceipt",
-        version: "1.0.0",
-        fetchImpl: async () => oversized.response,
-      }),
-    ).rejects.toThrow(
-      "ClawHub skill archive download for agentreceipt exceeded 268435456 bytes (268959744 bytes received)",
-    );
-  });
+      await expect(download(oversized.response)).rejects.toThrow(
+        `ClawHub ${expectedResource} exceeded 268435456 bytes (268959744 bytes received)`,
+      );
+      expect(oversized.cancel).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("annotates 429 errors with the reset hint and a sign-in hint when unauthenticated", async () => {
     process.env.OPENCLAW_CLAWHUB_CONFIG_PATH = path.join(os.tmpdir(), "openclaw-no-clawhub-config");

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -945,6 +945,28 @@ describe("clawhub helpers", () => {
     },
   );
 
+  it("uses decoded stream bytes instead of encoded content length", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const archive = await downloadClawHubPackageArchive({
+      name: "encoded-package",
+      version: "1.0.0",
+      fetchImpl: async () =>
+        new Response(bytes, {
+          status: 200,
+          headers: {
+            "content-encoding": "gzip",
+            "content-length": String(256 * 1024 * 1024 + 1),
+            "content-type": "application/zip",
+          },
+        }),
+    });
+    try {
+      await expect(fs.readFile(archive.archivePath)).resolves.toEqual(Buffer.from(bytes));
+    } finally {
+      await archive.cleanup();
+    }
+  });
+
   it("annotates 429 errors with the reset hint and a sign-in hint when unauthenticated", async () => {
     process.env.OPENCLAW_CLAWHUB_CONFIG_PATH = path.join(os.tmpdir(), "openclaw-no-clawhub-config");
     await expect(

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -70,7 +70,7 @@ function createStalledBodyResponse(params: {
   };
 }
 
-function createOversizedArchiveBodyResponse(
+function createOversizedArchiveResponse(
   params: {
     headers?: HeadersInit;
   } = {},
@@ -79,26 +79,18 @@ function createOversizedArchiveBodyResponse(
   cancel: ReturnType<typeof vi.fn>;
 } {
   const cancel = vi.fn();
-  const chunk = new Uint8Array(512 * 1024).fill(0);
-  const overshootChunks = 512 + 1;
-  let emitted = 0;
   const body = new ReadableStream<Uint8Array>({
-    pull(controller) {
-      if (emitted >= overshootChunks) {
-        controller.close();
-        return;
-      }
-      emitted += 1;
-      controller.enqueue(chunk);
-    },
     cancel() {
       cancel();
     },
   });
+  const headers = new Headers(params.headers);
+  headers.set("content-type", headers.get("content-type") ?? "application/zip");
+  headers.set("content-length", String(256 * 1024 * 1024 + 512 * 1024));
   return {
     response: new Response(body, {
       status: 200,
-      headers: params.headers ?? { "content-type": "application/zip" },
+      headers,
     }),
     cancel,
   };
@@ -944,7 +936,7 @@ describe("clawhub helpers", () => {
   it.each(oversizedArchiveCases)(
     "rejects and cancels oversized $name downloads",
     async ({ headers, download, expectedResource }) => {
-      const oversized = createOversizedArchiveBodyResponse({ headers });
+      const oversized = createOversizedArchiveResponse({ headers });
 
       await expect(download(oversized.response)).rejects.toThrow(
         `ClawHub ${expectedResource} exceeded 268435456 bytes (268959744 bytes received)`,

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -1322,7 +1322,6 @@ export async function downloadClawHubPackageArchive(params: {
     }
     const bytes = await readClawHubResponseBytes({
       response,
-      maxBytes: CLAWHUB_ARCHIVE_MAX_BYTES,
       timeoutMs: params.timeoutMs,
       resourceLabel: `ClawPack download for ${params.name}@${params.version}`,
     });
@@ -1402,7 +1401,6 @@ export async function downloadClawHubPackageArchive(params: {
   }
   const bytes = await readClawHubResponseBytes({
     response,
-    maxBytes: CLAWHUB_ARCHIVE_MAX_BYTES,
     timeoutMs: params.timeoutMs,
     resourceLabel: `package archive download for ${params.name}`,
   });
@@ -1450,7 +1448,6 @@ export async function downloadClawHubSkillArchive(params: {
   }
   const bytes = await readClawHubResponseBytes({
     response,
-    maxBytes: CLAWHUB_ARCHIVE_MAX_BYTES,
     timeoutMs: params.timeoutMs,
     resourceLabel: `skill archive download for ${params.slug}`,
   });
@@ -1494,7 +1491,6 @@ export async function downloadClawHubSkillArchiveUrl(params: {
   }
   const bytes = await readClawHubResponseBytes({
     response,
-    maxBytes: CLAWHUB_ARCHIVE_MAX_BYTES,
     timeoutMs: params.timeoutMs,
     resourceLabel: `skill archive download at ${url.pathname}`,
   });
@@ -1532,7 +1528,6 @@ export async function downloadClawHubGitHubSkillArchive(params: {
   }
   const bytes = await readClawHubResponseBytes({
     response,
-    maxBytes: CLAWHUB_ARCHIVE_MAX_BYTES,
     timeoutMs: params.timeoutMs,
     resourceLabel: `GitHub source archive for ${params.repo}@${params.commit}`,
   });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -11,7 +11,10 @@ import {
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { sha256Base64, sha256Hex as digestSha256Hex } from "./crypto-digest.js";
 import { readResponseTextSnippet, readResponseWithLimit } from "./http-body.js";
-import { parseStrictPositiveInteger } from "./parse-finite-number.js";
+import {
+  parseStrictNonNegativeInteger,
+  parseStrictPositiveInteger,
+} from "./parse-finite-number.js";
 import { isAtLeast, parseSemver } from "./runtime-guard.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
 import { createTempDownloadTarget } from "./temp-download.js";
@@ -801,15 +804,24 @@ async function readClawHubResponseBytes(params: {
 }): Promise<Uint8Array> {
   const timeoutMs = resolveClawHubRequestTimeoutMs(params.timeoutMs);
   const maxBytes = params.maxBytes ?? CLAWHUB_ARCHIVE_MAX_BYTES;
+  const declaredSize = parseStrictNonNegativeInteger(params.response.headers.get("content-length"));
+  if (declaredSize !== undefined && declaredSize > maxBytes) {
+    // Release the transport immediately when the peer already declares an
+    // oversized body; streamed or malformed lengths remain guarded below.
+    await params.response.body?.cancel().catch(() => undefined);
+    throw createClawHubBodyLimitError(params.resourceLabel, declaredSize, maxBytes);
+  }
   return await readResponseWithLimit(params.response, maxBytes, {
     chunkTimeoutMs: timeoutMs,
     onOverflow: ({ size, maxBytes }) =>
-      new Error(
-        `ClawHub ${params.resourceLabel} exceeded ${maxBytes} bytes (${size} bytes received)`,
-      ),
+      createClawHubBodyLimitError(params.resourceLabel, size, maxBytes),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`ClawHub ${params.resourceLabel} body stalled after ${chunkTimeoutMs}ms`),
   });
+}
+
+function createClawHubBodyLimitError(resourceLabel: string, size: number, maxBytes: number): Error {
+  return new Error(`ClawHub ${resourceLabel} exceeded ${maxBytes} bytes (${size} bytes received)`);
 }
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -804,10 +804,14 @@ async function readClawHubResponseBytes(params: {
 }): Promise<Uint8Array> {
   const timeoutMs = resolveClawHubRequestTimeoutMs(params.timeoutMs);
   const maxBytes = params.maxBytes ?? CLAWHUB_ARCHIVE_MAX_BYTES;
-  const declaredSize = parseStrictNonNegativeInteger(params.response.headers.get("content-length"));
+  const contentEncoding = normalizeOptionalString(params.response.headers.get("content-encoding"));
+  const declaredSize =
+    !contentEncoding || contentEncoding.toLowerCase() === "identity"
+      ? parseStrictNonNegativeInteger(params.response.headers.get("content-length"))
+      : undefined;
   if (declaredSize !== undefined && declaredSize > maxBytes) {
-    // Release the transport immediately when the peer already declares an
-    // oversized body; streamed or malformed lengths remain guarded below.
+    // Fetch may decode encoded bodies while retaining their wire length, so
+    // only identity lengths can safely short-circuit the decoded stream cap.
     await params.response.body?.cancel().catch(() => undefined);
     throw createClawHubBodyLimitError(params.resourceLabel, declaredSize, maxBytes);
   }

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -21,6 +21,8 @@ const DEFAULT_CLAWHUB_URL = "https://clawhub.ai";
 const DEFAULT_GITHUB_CODELOAD_URL = "https://codeload.github.com";
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
 const SKILL_CARD_MAX_BYTES = 256 * 1024;
+// Align with marketplace archive downloads (src/plugins/marketplace.ts).
+const CLAWHUB_ARCHIVE_MAX_BYTES = 256 * 1024 * 1024;
 // ClawHub is an external marketplace: bound untrusted JSON and error bodies so
 // a hostile or malfunctioning host cannot exhaust memory with an endless stream.
 const CLAWHUB_JSON_MAX_BYTES = 16 * 1024 * 1024;
@@ -798,15 +800,19 @@ async function readClawHubResponseBytes(params: {
   resourceLabel: string;
 }): Promise<Uint8Array> {
   const timeoutMs = resolveClawHubRequestTimeoutMs(params.timeoutMs);
-  return await readResponseWithLimit(params.response, params.maxBytes ?? Number.MAX_SAFE_INTEGER, {
-    chunkTimeoutMs: timeoutMs,
-    onOverflow: ({ size, maxBytes }) =>
-      new Error(
-        `ClawHub ${params.resourceLabel} exceeded ${maxBytes} bytes (${size} bytes received)`,
-      ),
-    onIdleTimeout: ({ chunkTimeoutMs }) =>
-      new Error(`ClawHub ${params.resourceLabel} body stalled after ${chunkTimeoutMs}ms`),
-  });
+  return await readResponseWithLimit(
+    params.response,
+    params.maxBytes ?? CLAWHUB_ARCHIVE_MAX_BYTES,
+    {
+      chunkTimeoutMs: timeoutMs,
+      onOverflow: ({ size, maxBytes }) =>
+        new Error(
+          `ClawHub ${params.resourceLabel} exceeded ${maxBytes} bytes (${size} bytes received)`,
+        ),
+      onIdleTimeout: ({ chunkTimeoutMs }) =>
+        new Error(`ClawHub ${params.resourceLabel} body stalled after ${chunkTimeoutMs}ms`),
+    },
+  );
 }
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {
@@ -1316,6 +1322,7 @@ export async function downloadClawHubPackageArchive(params: {
     }
     const bytes = await readClawHubResponseBytes({
       response,
+      maxBytes: CLAWHUB_ARCHIVE_MAX_BYTES,
       timeoutMs: params.timeoutMs,
       resourceLabel: `ClawPack download for ${params.name}@${params.version}`,
     });
@@ -1395,6 +1402,7 @@ export async function downloadClawHubPackageArchive(params: {
   }
   const bytes = await readClawHubResponseBytes({
     response,
+    maxBytes: CLAWHUB_ARCHIVE_MAX_BYTES,
     timeoutMs: params.timeoutMs,
     resourceLabel: `package archive download for ${params.name}`,
   });
@@ -1442,6 +1450,7 @@ export async function downloadClawHubSkillArchive(params: {
   }
   const bytes = await readClawHubResponseBytes({
     response,
+    maxBytes: CLAWHUB_ARCHIVE_MAX_BYTES,
     timeoutMs: params.timeoutMs,
     resourceLabel: `skill archive download for ${params.slug}`,
   });
@@ -1485,6 +1494,7 @@ export async function downloadClawHubSkillArchiveUrl(params: {
   }
   const bytes = await readClawHubResponseBytes({
     response,
+    maxBytes: CLAWHUB_ARCHIVE_MAX_BYTES,
     timeoutMs: params.timeoutMs,
     resourceLabel: `skill archive download at ${url.pathname}`,
   });
@@ -1522,6 +1532,7 @@ export async function downloadClawHubGitHubSkillArchive(params: {
   }
   const bytes = await readClawHubResponseBytes({
     response,
+    maxBytes: CLAWHUB_ARCHIVE_MAX_BYTES,
     timeoutMs: params.timeoutMs,
     resourceLabel: `GitHub source archive for ${params.repo}@${params.commit}`,
   });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -800,19 +800,16 @@ async function readClawHubResponseBytes(params: {
   resourceLabel: string;
 }): Promise<Uint8Array> {
   const timeoutMs = resolveClawHubRequestTimeoutMs(params.timeoutMs);
-  return await readResponseWithLimit(
-    params.response,
-    params.maxBytes ?? CLAWHUB_ARCHIVE_MAX_BYTES,
-    {
-      chunkTimeoutMs: timeoutMs,
-      onOverflow: ({ size, maxBytes }) =>
-        new Error(
-          `ClawHub ${params.resourceLabel} exceeded ${maxBytes} bytes (${size} bytes received)`,
-        ),
-      onIdleTimeout: ({ chunkTimeoutMs }) =>
-        new Error(`ClawHub ${params.resourceLabel} body stalled after ${chunkTimeoutMs}ms`),
-    },
-  );
+  const maxBytes = params.maxBytes ?? CLAWHUB_ARCHIVE_MAX_BYTES;
+  return await readResponseWithLimit(params.response, maxBytes, {
+    chunkTimeoutMs: timeoutMs,
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(
+        `ClawHub ${params.resourceLabel} exceeded ${maxBytes} bytes (${size} bytes received)`,
+      ),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`ClawHub ${params.resourceLabel} body stalled after ${chunkTimeoutMs}ms`),
+  });
 }
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## What Problem This Solves

ClawHub already bounds JSON/card responses (16 MiB / 256 KiB), but package/skill **archive and ClawPack downloads** in `src/infra/clawhub.ts` called `readClawHubResponseBytes` without `maxBytes`, defaulting to `Number.MAX_SAFE_INTEGER`. A hostile or misconfigured registry could stream a multi-gigabyte archive into gateway memory before extraction limits ever run.

## Why This Change Was Made

Add `CLAWHUB_ARCHIVE_MAX_BYTES = 256 * 1024 * 1024` (aligned with `MAX_MARKETPLACE_ARCHIVE_BYTES` in `src/plugins/marketplace.ts`) and pass it through every archive download path: ClawPack artifact, package archive, skill archive, resolver URL, and GitHub source archive. `readClawHubResponseBytes` now defaults to this cap instead of an unbounded fallback.

## User Impact

Normal ClawHub installs are unchanged. Oversized archive/clawpack bodies now fail fast with a clear byte-limit error instead of buffering unbounded data into memory.

## Evidence

Focused tests:

```text
node scripts/run-vitest.mjs src/infra/clawhub.test.ts --run --reporter=verbose
```

Result: **65/65 passed**, including three new regressions that stream 256 MiB + 512 KiB and assert early rejection for package archive, ClawPack, and skill archive downloads.

## Real behavior proof

- **Behavior or issue addressed:** Unbounded ClawHub archive download buffering could OOM the gateway when a registry streams an oversized zip/clawpack body.
- **Real environment tested:** macOS (Darwin), Node.js v22.22.0, `node:http` loopback server on `127.0.0.1`.
- **Exact steps or command run after this patch:**
  1. `node --import tsx scripts/proof-clawhub-archive-bound.mjs`
  2. `node scripts/run-vitest.mjs src/infra/clawhub.test.ts --run --reporter=verbose`
- **Evidence after fix:**

```text
$ node --import tsx scripts/proof-clawhub-archive-bound.mjs
  ok: unbounded read pulled the full oversized archive (268959744 bytes)
  ok: rejected oversized ClawHub package archive download
  ok: bounded error message present
  ok: reported received size above cap
  ok: small archive download succeeded

ALL PROOF ASSERTIONS PASSED
```

```text
$ node scripts/run-vitest.mjs src/infra/clawhub.test.ts --run --reporter=verbose
 ✓ rejects oversized package archive downloads and cancels the stream
 ✓ rejects oversized ClawPack artifact downloads and cancels the stream
 ✓ rejects oversized skill archive downloads and cancels the stream

 Test Files  1 passed (1)
      Tests  65 passed (65)
```

- **Observed result after fix:** `downloadClawHubPackageArchive` rejects ~256 MiB+ archive streams at the 256 MiB cap with `ClawHub package archive download for proof-package exceeded 268435456 bytes (... bytes received)`; a 4-byte zip header still downloads successfully; negative control shows unbounded `getReader()` would read the full ~269 MiB body.
- **What was not tested:** Live ClawHub SaaS endpoints; proof used loopback fetch and mocked `fetchImpl` only.

## Tests and validation

- `node --import tsx scripts/proof-clawhub-archive-bound.mjs` (local proof script, not committed)
- `node scripts/run-vitest.mjs src/infra/clawhub.test.ts --run --reporter=verbose`
- Regression tests added in `src/infra/clawhub.test.ts`: oversized package archive, ClawPack artifact, skill archive

## Risk checklist

- Did user-visible behavior change? Yes — archive/clawpack downloads larger than 256 MiB now error instead of attempting unbounded buffering.
- Did config, environment, or migration behavior change? No
- Did security, auth, secrets, network, or tool execution behavior change? Yes — ClawHub archive download reads are now bounded at the shared choke point.
- Highest-risk area: plugin/skill install flows that download large but legitimate archives.
- Mitigation: 256 MiB matches marketplace archive cap; post-download extraction still enforces separate `@openclaw/fs-safe/archive` limits.

## Current review state

- Next action: awaiting maintainer review
- Bot comments addressed: none yet

## AI-assisted disclosure

- [x] AI-assisted (Cursor agent)
- [x] Human-run Real behavior proof from local setup
