### PR TITLE
fix(plugins): bound hosted catalog feed reads on non-streaming responses

### DIFF
--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1501,6 +1501,83 @@ describe("official external plugin catalog", () => {
     }
   });
 
+  it("rejects non-streaming hosted feeds before buffering underreported bodies", async () => {
+    const oversized = "x".repeat(8192);
+    const response = new Response(oversized, {
+      status: 200,
+      headers: { "content-length": "1" },
+    });
+    Object.defineProperty(response, "body", { value: null });
+    const arrayBuffer = vi.fn(response.arrayBuffer.bind(response));
+    Object.defineProperty(response, "arrayBuffer", { value: arrayBuffer });
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: null,
+      maxBytes: 4096,
+      fetchImpl: vi.fn(async () => response),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("streaming response body unavailable");
+    }
+    expect(arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-streaming hosted feeds without content-length", async () => {
+    const body = JSON.stringify({
+      schemaVersion: 1,
+      id: "openclaw-official-external-plugins",
+      generatedAt: "2026-06-22T00:00:00.000Z",
+      sequence: 1,
+      entries: [],
+    });
+    const response = new Response(body, { status: 200 });
+    Object.defineProperty(response, "body", { value: null });
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: null,
+      fetchImpl: vi.fn(async () => response),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("streaming response body unavailable");
+    }
+  });
+
+  it("rejects oversized streaming hosted feeds incrementally", async () => {
+    const chunk = new Uint8Array(512 * 1024).fill("x".charCodeAt(0));
+    let emitted = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (emitted >= 3) {
+          controller.close();
+          return;
+        }
+        emitted += 1;
+        controller.enqueue(chunk);
+      },
+    });
+
+    const result = await loadHostedOfficialExternalPluginCatalogEntries({
+      snapshotStore: null,
+      maxBytes: 1024 * 1024,
+      fetchImpl: vi.fn(
+        async () =>
+          new Response(body, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    });
+
+    expect(result.source).toBe("bundled-fallback");
+    if (result.source === "bundled-fallback") {
+      expect(result.error).toContain("exceeds 1048576 bytes");
+    }
+  });
+
   it("prefers feed install candidates before legacy install metadata", () => {
     expect(
       resolveOfficialExternalPluginInstall({

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -7,6 +7,7 @@ import officialExternalPluginCatalog from "../../scripts/lib/official-external-p
 import officialExternalProviderCatalog from "../../scripts/lib/official-external-provider-catalog.json" with { type: "json" };
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { normalizeClawHubSha256Integrity } from "../infra/clawhub.js";
+import { readResponseWithLimit } from "../infra/http-body.js";
 import { isRecord } from "../utils.js";
 import type {
   PluginManifestChannelConfig,
@@ -508,91 +509,25 @@ function parseHostedCatalogContentLength(raw: string | null, maxBytes: number): 
   }
 }
 
-function hasStreamingResponseBody(
-  response: Response,
-): response is Response & { body: ReadableStream<Uint8Array> } {
-  return Boolean(
-    response.body && typeof (response.body as { getReader?: unknown }).getReader === "function",
-  );
-}
-
-async function readHostedCatalogChunkWithTimeout(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  chunkTimeoutMs: number,
-): Promise<Awaited<ReturnType<typeof reader.read>>> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  let timedOut = false;
-  return await new Promise((resolve, reject) => {
-    const clear = () => {
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-        timeoutId = undefined;
-      }
-    };
-    timeoutId = setTimeout(() => {
-      timedOut = true;
-      clear();
-      void reader.cancel().catch(() => undefined);
-      reject(new Error(`hosted catalog feed read timed out after ${chunkTimeoutMs}ms`));
-    }, chunkTimeoutMs);
-    void reader.read().then(
-      (result) => {
-        clear();
-        if (!timedOut) {
-          resolve(result);
-        }
-      },
-      (err: unknown) => {
-        clear();
-        if (!timedOut) {
-          reject(err instanceof Error ? err : new Error(String(err)));
-        }
-      },
-    );
-  });
-}
-
 async function readHostedCatalogResponseText(params: {
   response: Response;
   maxBytes: number;
   chunkTimeoutMs: number;
 }): Promise<string> {
   parseHostedCatalogContentLength(params.response.headers.get("content-length"), params.maxBytes);
-  if (!hasStreamingResponseBody(params.response)) {
-    const text = await params.response.text();
-    if (new TextEncoder().encode(text).byteLength > params.maxBytes) {
-      throw new Error(`hosted catalog feed exceeds ${params.maxBytes} bytes`);
-    }
-    return text;
+  const streamless = !params.response.body || typeof params.response.body.getReader !== "function";
+  // Hosted remote feeds are untrusted input, so fail closed when Fetch cannot
+  // provide a streaming body instead of trusting Content-Length before read.
+  if (streamless) {
+    throw new Error("hosted catalog feed streaming response body unavailable");
   }
-  const reader = params.response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let totalBytes = 0;
-  try {
-    while (true) {
-      const chunk = await readHostedCatalogChunkWithTimeout(reader, params.chunkTimeoutMs);
-      if (chunk.done) {
-        break;
-      }
-      totalBytes += chunk.value.byteLength;
-      if (totalBytes > params.maxBytes) {
-        throw new Error(`hosted catalog feed exceeds ${params.maxBytes} bytes`);
-      }
-      chunks.push(chunk.value);
-    }
-  } catch (err) {
-    await reader.cancel().catch(() => undefined);
-    throw err;
-  } finally {
-    reader.releaseLock();
-  }
-  const body = new Uint8Array(totalBytes);
-  let offset = 0;
-  for (const chunk of chunks) {
-    body.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return new TextDecoder().decode(body);
+  const buffer = await readResponseWithLimit(params.response, params.maxBytes, {
+    chunkTimeoutMs: params.chunkTimeoutMs,
+    onOverflow: ({ maxBytes }) => new Error(`hosted catalog feed exceeds ${maxBytes} bytes`),
+    onIdleTimeout: ({ chunkTimeoutMs }) =>
+      new Error(`hosted catalog feed read timed out after ${chunkTimeoutMs}ms`),
+  });
+  return new TextDecoder().decode(buffer);
 }
 
 function bundledOfficialExternalPluginCatalogEntries(): OfficialExternalPluginCatalogEntry[] {


### PR DESCRIPTION
## What Problem This Solves

`readHostedCatalogResponseText` in `src/plugins/official-external-plugin-catalog.ts` used two read paths: the streaming branch incrementally enforced `maxBytes`, but the non-streaming branch could call `response.text()` / `arrayBuffer()` first and only check byte count afterward. That check-after-allocate pattern could OOM on oversized bodies when the response was not stream-backed or when `Content-Length` was missing or wrong.

**Concrete example:** A hostile feed returns 8 KiB with `Content-Length: 1` and `response.body = null`. The old path could buffer the full body before discovering the mismatch.

## Why This Change Was Made

Route all hosted-catalog response reads through one bounded incremental reader (`readResponseWithLimit`) and fail closed when `response.body` is unavailable instead of falling back to unbounded `text()`/`arrayBuffer()` buffering.

## User Impact

**Before:** Gateway/plugin catalog refresh against hostile or misconfigured hosted feeds could allocate unbounded memory during catalog fetch.

**After:** Oversized or non-streaming bodies reject early with `bundled-fallback` and an explicit error; `arrayBuffer()` is never invoked on the underreported-body case.

## Evidence

- `src/plugins/official-external-plugin-catalog.ts:498–526` — `parseHostedCatalogContentLength`, `readHostedCatalogResponseText`, streaming guard
- `src/plugins/official-external-plugin-catalog.ts:832–834` — all hosted loads use unified reader
- Diff: production change in catalog loader; regressions in `official-external-plugin-catalog.test.ts`

### Behavior proof

#### 1) Node runtime (simulated non-streaming fetch, mirrors Vitest contract)

Replays the Vitest fixture: `body = null`, underreported `Content-Length: 1`, 8192-byte payload, `maxBytes = 4096`:

```text
=== #101000 hosted catalog bound read (simulated non-streaming fetch) ===
Node: v22.22.0
body bytes: 8192 content-length header: 1, response.body: null
result.source: bundled-fallback
error: hosted catalog feed streaming response body unavailable
arrayBuffer not called: true
rejects before buffering: true
```

#### 2) Call-site regression tests (real Vitest stdout)

```text
$ pnpm test src/plugins/official-external-plugin-catalog.test.ts -t "rejects non-streaming|rejects oversized|falls back" --reporter=verbose

 ✓ official external plugin catalog > falls back to the bundled catalog on checksum mismatch and oversized bodies 74ms
 ✓ official external plugin catalog > rejects non-streaming hosted feeds before buffering underreported bodies 1ms
 ✓ official external plugin catalog > rejects non-streaming hosted feeds without content-length 0ms
 ✓ official external plugin catalog > rejects oversized streaming hosted feeds incrementally 1ms

 Test Files  1 passed (1)
      Tests  7 passed | 49 skipped (56)
   Duration  325ms

[test] passed 1 Vitest shard in 3.54s
```

Key regression assertions:

| Test | Proves |
|------|--------|
| `rejects non-streaming hosted feeds before buffering underreported bodies` | 8 KiB body + `content-length: 1` + `body=null` → `bundled-fallback`, `arrayBuffer` **not called** |
| `rejects non-streaming hosted feeds without content-length` | `body=null` without length → same streaming guard |
| `rejects oversized streaming hosted feeds incrementally` | 3×512 KiB chunks with `maxBytes=1 MiB` → `exceeds 1048576 bytes` before full buffer |
| `falls back … on checksum mismatch and oversized bodies` | `maxBytes: 4` + body `"12345"` → `exceeds 4 bytes` |

Full catalog suite still green:

```text
$ pnpm test src/plugins/official-external-plugin-catalog.test.ts --reporter=verbose
 Tests  56 passed (56)
```

**Proof gap:** No live fetch against production ClawHub feed URL in this validation environment; proofs use simulated `fetch` responses matching hostile/misconfigured feed shapes.
