### PR TITLE
[codex] Keep Telegram model summary text-only

### DIFF
--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -21,6 +21,9 @@ const modelsCommandMock = vi.hoisted(() => ({
   delegateToActual: false,
   resolveModelsCommandReply: vi.fn(),
 }));
+const channelPluginMock = vi.hoisted(() => ({
+  getChannelPlugin: vi.fn(),
+}));
 
 function defaultModelsCommandReply() {
   return {
@@ -91,6 +94,10 @@ vi.mock("./commands-models.js", () => ({
     }
     return defaultModelsCommandReply();
   },
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: (surface: string) => channelPluginMock.getChannelPlugin(surface),
 }));
 
 vi.mock("./directive-handling.auth.js", () => ({
@@ -421,6 +428,7 @@ beforeEach(() => {
     .mockReset()
     .mockResolvedValue(defaultModelsCommandReply());
   modelsCommandMock.delegateToActual = false;
+  channelPluginMock.getChannelPlugin.mockReset();
   clearRuntimeAuthProfileStoreSnapshots();
   replaceRuntimeAuthProfileStoreSnapshots([
     {
@@ -605,6 +613,38 @@ describe("/model chat UX", () => {
     expect(reply?.text).toContain("Current:");
     expect(reply?.text).toContain("Browse: /models");
     expect(reply?.text).toContain("Switch: /model <provider/model>");
+  });
+
+  it("uses channel model browse data for non-Telegram summary replies", async () => {
+    channelPluginMock.getChannelPlugin.mockReturnValue({
+      commands: {
+        buildModelBrowseChannelData: () => ({ custom: { picker: true } }),
+      },
+    });
+
+    const reply = await resolveModelInfoReply({
+      surface: "custom",
+    });
+
+    expect(channelPluginMock.getChannelPlugin).toHaveBeenCalledWith("custom");
+    expect(reply?.text).toContain("Tap below to browse models");
+    expect(reply?.channelData).toEqual({ custom: { picker: true } });
+  });
+
+  it("does not attach Telegram channel model browse data to summary replies", async () => {
+    channelPluginMock.getChannelPlugin.mockReturnValue({
+      commands: {
+        buildModelBrowseChannelData: () => ({ telegram: { buttons: [[{ text: "Browse" }]] } }),
+      },
+    });
+
+    const reply = await resolveModelInfoReply({
+      surface: "telegram",
+    });
+
+    expect(channelPluginMock.getChannelPlugin).not.toHaveBeenCalled();
+    expect(reply?.text).toContain("Browse: /models");
+    expect(reply?.channelData).toBeUndefined();
   });
 
   it("treats /model list as a models browser alias, not a model id", async () => {

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -394,7 +394,8 @@ export async function maybeHandleModelDirectiveInfo(params: {
     const activeRuntimeLine = modelRefs.activeDiffers
       ? `Active: ${modelRefs.active.label} (runtime)`
       : null;
-    const commandPlugin = params.surface ? getChannelPlugin(params.surface) : null;
+    const commandPlugin =
+      params.surface && params.surface !== "telegram" ? getChannelPlugin(params.surface) : null;
     const channelData = commandPlugin?.commands?.buildModelBrowseChannelData?.();
     if (channelData) {
       return {


### PR DESCRIPTION
## Summary
- keep Telegram `/model` summary replies on the plain-text fallback instead of attaching channel model-picker data
- preserve channel model-picker payloads for non-Telegram surfaces
- add regression coverage for both behaviors

## Root Cause
Telegram direct-message `/model` summary handling could attach `channelData` from the channel plugin. In runtimes where Telegram rich/model-picker payloads are not supported or are disabled, that can produce unsupported rich-message output instead of a usable slash-command response.

## Validation
- `pnpm test src/auto-reply/reply/directive-handling.model.test.ts`