### PR TITLE
test(discord): align proxy WebSocket override type

### DIFF
--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -236,13 +236,10 @@ describe("createDiscordGatewayPlugin", () => {
         new HttpsProxyAgent(proxyUrl) as unknown as import("node:http").Agent,
       webSocketCtor: function WebSocketCtor(
         url: string,
-        options?: { agent?: unknown; handshakeTimeout?: number },
+        options?: { agent?: unknown; handshakeTimeout?: number; maxPayload?: number },
       ) {
         webSocketSpy(url, options);
-      } as unknown as new (
-        url: string,
-        options?: { agent?: unknown; handshakeTimeout?: number },
-      ) => import("ws").WebSocket,
+      } as unknown as typeof import("ws").WebSocket,
       registerClient: async (_plugin: unknown, client: unknown) => {
         baseRegisterClientSpy(client);
       },


### PR DESCRIPTION
## What Problem This Solves

PR #99998 widened the production Discord Gateway test seam to `typeof ws.WebSocket`, but `provider.proxy.test.ts` still returned a narrower constructor cast. `pnpm check:test-types` now fails on `main` and on otherwise-unrelated rebased PRs with `TS2322` at every `createProxyTestingOverrides()` call.

## Why This Change Was Made

The test override now casts to the exact production constructor type and includes the newly asserted `maxPayload` option in its local spy shape. This keeps the test seam aligned without changing runtime code or weakening the production type.

## User Impact

No runtime behavior change. Restores the test-type gate so unrelated PRs can verify and land.

## Evidence

- Reproduced on exact-head CI: https://github.com/openclaw/openclaw/actions/runs/28805903782/job/85421383741
- Failure: `extensions/discord/src/monitor/provider.proxy.test.ts` reports `TS2322` because the narrow constructor is not assignable to `GatewayPluginTestingOptions`.
- `node_modules/.bin/oxfmt --check extensions/discord/src/monitor/provider.proxy.test.ts`
- `git diff --check`
- Fresh autoreview: no accepted/actionable findings.
