### PR TITLE
fix(agents): handle stdout/stderr stream errors in local bash operations

### DIFF
--- a/scripts/proof/bash-tool-stream-errors.mts
+++ b/scripts/proof/bash-tool-stream-errors.mts
@@ -1,0 +1,75 @@
+// Real behavior proof: local bash operations handle stdout/stderr stream errors
+// without crashing the agent runtime.
+//
+// The proof patches child_process.spawn so the spawned shell is a real process
+// whose stdout/stderr streams emit error events after the bash tool attaches
+// listeners. With the fix the exec promise rejects with the stream error; without
+// stream error handlers the unhandled errors would terminate the process.
+
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process") as typeof import("node:child_process");
+const originalSpawn = childProcess.spawn;
+
+let emitError: ((stream: "stdout" | "stderr") => void) | null = null;
+
+childProcess.spawn = (...args: Parameters<typeof originalSpawn>) => {
+  const child = originalSpawn.apply(childProcess, args);
+  emitError = (stream) => {
+    const target = stream === "stdout" ? child.stdout : child.stderr;
+    target?.emit("error", new Error(`${stream} EPIPE`));
+  };
+  return child;
+};
+
+const { createLocalBashOperations } = await import(
+  path.join(repoRoot, "src/agents/sessions/tools/bash.ts")
+);
+
+function longRunningCommand(): string {
+  return `${process.execPath} -e "setTimeout(() => {}, 5000)"`;
+}
+
+async function runProof(stream: "stdout" | "stderr"): Promise<boolean> {
+  const operations = createLocalBashOperations();
+  const resultPromise = operations.exec(longRunningCommand(), process.cwd(), {
+    onData: () => {},
+  });
+
+  // Wait for listeners to attach, then emit the stream error.
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 100);
+  });
+  emitError?.(stream);
+
+  try {
+    await resultPromise;
+    console.log(`FAIL (${stream}): exec resolved instead of rejecting`);
+    return false;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes("EPIPE")) {
+      console.log(`PASS (${stream}): stream error rejected with "${message}"`);
+      return true;
+    }
+    console.log(`FAIL (${stream}): rejected with unexpected error "${message}"`);
+    return false;
+  }
+}
+
+console.log("=== Proof: bash tool stream error handling ===\n");
+
+let ok = true;
+ok = (await runProof("stdout")) && ok;
+ok = (await runProof("stderr")) && ok;
+
+childProcess.spawn = originalSpawn;
+
+if (!ok) {
+  process.exitCode = 1;
+}

--- a/src/agents/sessions/tools/bash.stream-errors.test.ts
+++ b/src/agents/sessions/tools/bash.stream-errors.test.ts
@@ -1,0 +1,63 @@
+// Bash stream error tests verify that stdout/stderr errors reject the exec promise
+// instead of crashing the agent runtime.
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { createLocalBashOperations } from "./bash.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("../../shell-utils.js", () => ({
+  getBashShellConfig: () => ({ shell: "/bin/sh", args: ["-c"] }),
+  getShellEnv: () => ({}),
+  killProcessTree: vi.fn(),
+}));
+
+const { spawn } = await import("node:child_process");
+const { killProcessTree } = await import("../../shell-utils.js");
+
+function createMockChild() {
+  const child = Object.assign(new EventEmitter(), {
+    pid: 12345,
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+  });
+  return child as EventEmitter & {
+    pid: number;
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+  };
+}
+
+describe("local bash operations stream errors", () => {
+  it("rejects when stdout emits an error", async () => {
+    const child = createMockChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+    const operations = createLocalBashOperations();
+    const resultPromise = operations.exec("echo hello", process.cwd(), {
+      onData: () => {},
+    });
+
+    child.stdout.emit("error", new Error("stdout EPIPE"));
+
+    await expect(resultPromise).rejects.toThrow("stdout EPIPE");
+    expect(killProcessTree).toHaveBeenCalledWith(12345);
+  });
+
+  it("rejects when stderr emits an error", async () => {
+    const child = createMockChild();
+    vi.mocked(spawn).mockReturnValue(child as unknown as ReturnType<typeof spawn>);
+
+    const operations = createLocalBashOperations();
+    const resultPromise = operations.exec("echo hello", process.cwd(), {
+      onData: () => {},
+    });
+
+    child.stderr.emit("error", new Error("stderr EPIPE"));
+
+    await expect(resultPromise).rejects.toThrow("stderr EPIPE");
+    expect(killProcessTree).toHaveBeenCalledWith(12345);
+  });
+});

--- a/src/agents/sessions/tools/bash.ts
+++ b/src/agents/sessions/tools/bash.ts
@@ -80,8 +80,27 @@ export function createLocalBashOperations(options?: { shellPath?: string }): Bas
           }, timeoutMs);
         }
         // Stream stdout and stderr.
+        let streamError: Error | null = null;
+        const handleStreamError = (err: Error) => {
+          if (streamError) {
+            return;
+          }
+          streamError = err;
+          if (timeoutHandle) {
+            clearTimeout(timeoutHandle);
+          }
+          if (signal) {
+            signal.removeEventListener("abort", onAbort);
+          }
+          if (child.pid) {
+            killProcessTree(child.pid);
+          }
+          reject(toErrorObject(err, "bash stream error"));
+        };
         child.stdout?.on("data", onData);
+        child.stdout?.on("error", handleStreamError);
         child.stderr?.on("data", onData);
+        child.stderr?.on("error", handleStreamError);
         // Handle abort signal by killing the entire process tree.
         const onAbort = () => {
           if (child.pid) {


### PR DESCRIPTION
## What Problem This Solves

`createLocalBashOperations.exec` attaches `"data"` listeners to the spawned shell's stdout and stderr but never attaches matching `"error"` listeners. If either output stream emits an error during command execution, the error is unhandled and can crash the agent runtime.

## Why This Change Was Made

Added explicit `"error"` handlers on `child.stdout` and `child.stderr` that kill the process tree, clear the timeout/abort bookkeeping, and reject the exec promise with the stream error. This makes the bash tool self-contained rather than relying on the later `waitForChildProcess` error listener.

## User Impact

User bash tool calls no longer crash on stdout/stderr stream errors; they return a failed result instead.

## Evidence

Regression test:

```bash
pnpm test src/agents/sessions/tools/bash.stream-errors.test.ts
```

```
Test Files  1 passed (1)
     Tests  2 passed (2)
```

## Real behavior proof

```bash
node_modules/.bin/tsx scripts/proof/bash-tool-stream-errors.mts
```

```
=== Proof: bash tool stream error handling ===

PASS (stdout): stream error rejected with "stdout EPIPE"
PASS (stderr): stream error rejected with "stderr EPIPE"
```
