### PR TITLE
fix(agents): bound tool_search_code stderr accumulation

### DIFF
--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -7,6 +7,7 @@ import {
   isToolWrappedWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
 } from "./agent-tools.before-tool-call.js";
+import { SESSION_TOOL_STDERR_TAIL_BYTES } from "./sessions/tools/limits.js";
 import {
   testing,
   addClientToolsToToolSearchCatalog,
@@ -1725,5 +1726,19 @@ describe("Tool Search", () => {
       sessionId,
     });
     expect(second.catalogReused).toBe(false);
+  });
+
+  it("bounds tool_search_code stderr accumulation to the session tool tail limit", () => {
+    let stderrTail = "";
+    stderrTail = testing.appendToolSearchCodeStderrTail(
+      stderrTail,
+      `HEAD_OVERFLOW_${"x".repeat(SESSION_TOOL_STDERR_TAIL_BYTES + 10_000)}TAIL`,
+    );
+
+    expect(stderrTail).not.toContain("HEAD_OVERFLOW_");
+    expect(stderrTail.endsWith("TAIL")).toBe(true);
+    expect(Buffer.byteLength(stderrTail, "utf8")).toBeLessThanOrEqual(
+      SESSION_TOOL_STDERR_TAIL_BYTES,
+    );
   });
 });

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -21,6 +21,7 @@ import {
 } from "./agent-tools.before-tool-call.js";
 import type { AgentMessage, AgentToolResult, AgentToolUpdateCallback } from "./runtime/index.js";
 import type { ToolDefinition } from "./sessions/index.js";
+import { appendBoundedTextTail, SESSION_TOOL_STDERR_TAIL_BYTES } from "./sessions/tools/limits.js";
 import { asToolParamsRecord, jsonResult, ToolInputError } from "./tools/common.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -2093,6 +2094,10 @@ async function runCodeModeBridgeRequest(
   throw new ToolInputError("Unsupported tool_search_code bridge method.");
 }
 
+function appendToolSearchCodeStderrTail(current: string, chunk: string): string {
+  return appendBoundedTextTail(current, chunk, SESSION_TOOL_STDERR_TAIL_BYTES);
+}
+
 function runCodeModeChild(params: {
   code: string;
   config: ToolSearchConfig;
@@ -2108,7 +2113,7 @@ function runCodeModeChild(params: {
       env: {},
       stdio: ["ignore", "pipe", "pipe", "ipc"],
     });
-    const stderr: string[] = [];
+    let stderrTail = "";
     let settled = false;
     let timedOut = false;
     let exitRejectionTimer: ReturnType<typeof setTimeout> | undefined;
@@ -2147,7 +2152,7 @@ function runCodeModeChild(params: {
 
     child.stderr?.setEncoding("utf8");
     child.stderr?.on("data", (chunk: string) => {
-      stderr.push(chunk);
+      stderrTail = appendToolSearchCodeStderrTail(stderrTail, chunk);
     });
 
     child.on("error", (error) => {
@@ -2158,7 +2163,7 @@ function runCodeModeChild(params: {
         return;
       }
       const rejectOnExit = () => {
-        const suffix = stderr.join("").trim();
+        const suffix = stderrTail.trim();
         const detail = suffix ? `: ${suffix.slice(0, 500)}` : "";
         settle(() =>
           reject(
@@ -2351,5 +2356,6 @@ export const testing = {
   },
   applyToolSearchCatalog,
   addClientToolsToToolSearchCatalog,
+  appendToolSearchCodeStderrTail,
 };
 export { testing as __testing };

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -2164,7 +2164,7 @@ function runCodeModeChild(params: {
       }
       const rejectOnExit = () => {
         const suffix = stderrTail.trim();
-        const detail = suffix ? `: ${suffix.slice(0, 500)}` : "";
+        const detail = suffix ? `: ${suffix.slice(-500)}` : "";
         settle(() =>
           reject(
             new Error(


### PR DESCRIPTION
## What Problem This Solves

`tool_search_code` accumulated child stderr with unbounded `stderr.push(chunk)` in `src/agents/tool-search.ts`. A noisy or runaway code-mode subprocess could grow gateway memory even though only the first 500 characters are surfaced in exit errors.

## Why This Change Was Made

Reuse the existing session-tool stderr tail helper (`appendBoundedTextTail`, 64 KiB) already used by grep/find. Child stderr is now retained as a bounded UTF-8-safe tail instead of an ever-growing string array.

## User Impact

Normal code-mode runs are unchanged. Pathological stderr floods no longer accumulate unbounded memory in the gateway process.

## Evidence

Focused test:

```text
node scripts/run-vitest.mjs src/agents/tool-search.test.ts --run -t "bounds tool_search_code stderr"
```

Result: **passed** — new regression verifies early overflow prefix is dropped and retained bytes stay within `SESSION_TOOL_STDERR_TAIL_BYTES`.

## Real behavior proof

- **Behavior or issue addressed:** Unbounded `stderr.push(chunk)` growth during `tool_search_code` child execution.
- **Real environment tested:** macOS (Darwin), Node.js v22.22.0.
- **Exact steps or command run after this patch:**
  1. Direct helper probe via `node --import tsx`
  2. `node scripts/run-vitest.mjs src/agents/tool-search.test.ts --run -t "bounds tool_search_code stderr"`
- **Evidence after fix:**

```text
$ node --import tsx -e "…testing.appendToolSearchCodeStderrTail(…)"
bytes retained: 65536
includes HEAD: false
ends with TAIL: true
within cap: true
```

```text
$ node scripts/run-vitest.mjs src/agents/tool-search.test.ts --run -t "bounds tool_search_code stderr"

 Test Files  2 passed (2)
      Tests  2 passed | 96 skipped (98)
   Duration  2.05s
```

- **Observed result after fix:** A synthetic stderr flood of `HEAD_OVERFLOW_ + 74KiB + TAIL` retains only the 64 KiB tail (`65536` bytes), drops the early prefix, and keeps the trailing marker.
- **What was not tested:** Live code-mode subprocess stderr flood end-to-end; proof exercises the production helper used by the stderr `data` handler.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/tool-search.test.ts --run -t "bounds tool_search_code stderr"`
- Regression test added in `src/agents/tool-search.test.ts`

## Risk checklist

- Did user-visible behavior change? Only for failure diagnostics — stderr detail in child-exit errors now reflects the bounded tail rather than the full stream prefix.
- Did config, environment, or migration behavior change? No
- Did security, auth, secrets, network, or tool execution behavior change? Yes — code-mode stderr buffering is now bounded.
- Highest-risk area: `tool_search_code` child exit error messages when stderr is very large.
- Mitigation: Matches grep/find session-tool stderr policy (`SESSION_TOOL_STDERR_TAIL_BYTES = 64 KiB`); surfaced detail was already truncated to 500 chars.

## Current review state

- Next action: awaiting maintainer review
- Bot comments addressed: none yet

## AI-assisted disclosure

- [x] AI-assisted (Cursor agent)
- [x] Human-run Real behavior proof from local setup
