### PR TITLE
fix(device-pair): mobile pairing rejects local IPv6 cleartext URLs

### DIFF
--- a/extensions/device-pair/index.test.ts
+++ b/extensions/device-pair/index.test.ts
@@ -1039,7 +1039,7 @@ describe("device-pair /pair default setup code", () => {
     expect(requireText(result)).toContain("prefer gateway.tailscale.mode=serve");
   });
 
-  it.each(["ws://[2001:db8::1]:18789", "ws://[fec0::1]:18789"])(
+  it.each(["ws://[2001:db8::1]:18789", "ws://[fe7f::1]:18789", "ws://[fec0::1]:18789"])(
     "rejects non-LAN IPv6 cleartext setup url %s before issuing setup codes",
     async (publicUrl) => {
       const command = registerPairCommand({

--- a/extensions/device-pair/index.test.ts
+++ b/extensions/device-pair/index.test.ts
@@ -847,6 +847,30 @@ describe("device-pair /pair default setup code", () => {
     expect(requireText(result)).toContain("Gateway: ws://192.168.1.20:18789");
   });
 
+  it.each([
+    "ws://[fc00::1]:18789",
+    "ws://[fd7a:115c:a1e0::1]:18789",
+    "ws://[fe80::1]:18789",
+    "ws://[febf::1]:18789",
+  ])("allows IPv6 ULA and link-local cleartext setup url %s", async (publicUrl) => {
+    const command = registerPairCommand({
+      pluginConfig: {
+        publicUrl,
+      },
+    });
+    const result = await command.handler(
+      createCommandContext({
+        channel: "webchat",
+        args: "",
+        commandBody: "/pair",
+        gatewayClientScopes: INTERNAL_SETUP_SCOPES,
+      }),
+    );
+
+    expect(pluginApiMocks.issueDeviceBootstrapToken).toHaveBeenCalledTimes(1);
+    expect(requireText(result)).toContain(`Gateway: ${publicUrl}`);
+  });
+
   it("allows mdns cleartext setup urls", async () => {
     const command = registerPairCommand({
       pluginConfig: {
@@ -1014,6 +1038,30 @@ describe("device-pair /pair default setup code", () => {
     expect(pluginApiMocks.issueDeviceBootstrapToken).not.toHaveBeenCalled();
     expect(requireText(result)).toContain("prefer gateway.tailscale.mode=serve");
   });
+
+  it.each(["ws://[2001:db8::1]:18789", "ws://[fec0::1]:18789"])(
+    "rejects non-LAN IPv6 cleartext setup url %s before issuing setup codes",
+    async (publicUrl) => {
+      const command = registerPairCommand({
+        pluginConfig: {
+          publicUrl,
+        },
+      });
+      const result = await command.handler(
+        createCommandContext({
+          channel: "webchat",
+          args: "",
+          commandBody: "/pair",
+          gatewayClientScopes: INTERNAL_SETUP_SCOPES,
+        }),
+      );
+
+      expect(pluginApiMocks.issueDeviceBootstrapToken).not.toHaveBeenCalled();
+      expect(requireText(result)).toContain(
+        "Tailscale and public mobile pairing require a secure gateway URL",
+      );
+    },
+  );
 
   it("uses Tailscale Serve MagicDNS as a secure setup url", async () => {
     vi.mocked(resolveTailnetHostWithRunner).mockResolvedValueOnce("gateway.tailnet.ts.net");

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -1,5 +1,6 @@
 // Device Pair plugin entrypoint registers its OpenClaw integration.
 import { rm } from "node:fs/promises";
+import { isIP } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
@@ -242,12 +243,24 @@ function isPrivateIPv4(address: string): boolean {
   return false;
 }
 
+function isPrivateLanIPv6(address: string): boolean {
+  if (isIP(address) !== 6) {
+    return false;
+  }
+  const firstHextet = address.split(":", 1)[0] ?? "";
+  if (!/^[0-9a-f]{4}$/.test(firstHextet)) {
+    return false;
+  }
+  const value = Number.parseInt(firstHextet, 16);
+  return (value & 0xfe00) === 0xfc00 || (value & 0xffc0) === 0xfe80;
+}
+
 function isPrivateLanCleartextHost(host: string): boolean {
   const normalized = normalizeHostForIpCheck(host);
   if (normalized.endsWith(".local")) {
     return true;
   }
-  if (isPrivateIPv4(normalized)) {
+  if (isPrivateIPv4(normalized) || isPrivateLanIPv6(normalized)) {
     return true;
   }
   const octets = parseIPv4Octets(normalized);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users pairing a mobile device with a local IPv6 gateway URL would be blocked when the `device-pair` plugin produced cleartext `ws://[fc00::1]`, `ws://[fd7a:115c:a1e0::1]`, or `ws://[fe80::1]` setup URLs. The plugin already allowed `.local`, RFC1918 IPv4, and IPv4 link-local addresses, but treated IPv6 ULA and IPv6 link-local literals as non-local cleartext endpoints and stopped `/pair` before issuing a setup code.

## Why This Change Was Made

The cleartext pairing guard now recognizes normalized IPv6 literals in the local ULA `fc00::/7` and link-local `fe80::/10` ranges. Public IPv6, deprecated site-local-style `fec0::/10` addresses, Tailscale CGNAT cleartext URLs, and public hostnames still fail closed with the existing secure URL guidance.

## User Impact

Operators on IPv6-capable local networks can use local IPv6 LAN/link-local gateway addresses in mobile setup codes without switching to TLS or advertising a different host. Non-local cleartext pairing URLs remain rejected, so public mobile pairing still requires `wss://` or Tailscale Serve/Funnel.

## Evidence

- `pnpm exec vitest run extensions/device-pair/index.test.ts` — passed, 59 tests.
- `pnpm exec vitest run extensions/device-pair/index.test.ts -t 'non-LAN IPv6 cleartext'` — passed, 3 tests covering public IPv6, `fe7f::1` just below `fe80::/10`, and deprecated site-local `fec0::/10` rejection.
- `pnpm exec oxfmt --check --threads=1 extensions/device-pair/index.test.ts` — passed.
- `pnpm exec oxlint extensions/device-pair/index.test.ts` — passed.
- Runtime command proof using the real bundled plugin loader and `/pair` command:

  ```text
  ALLOW ws://[fc00::1]:18789
  ALLOW ws://[fd7a:115c:a1e0::1]:18789
  ALLOW ws://[fe80::1]:18789
  ALLOW ws://[febf::1]:18789
  REJECT ws://[2001:db8::1]:18789
  REJECT ws://[fec0::1]:18789
  ```

- Isolated `pnpm gateway:dev` startup proof loaded the patched `device-pair` plugin and reached ready:

  ```text
  http server listening (9 plugins: acpx, browser, canvas, device-pair, file-transfer, memory-core, ollama, phone-control, talk-voice; 22.3s)
  ready
  ```
