### PR TITLE
refactor(ui): localize view prop types

### DIFF
--- a/ui/src/pages/activity/view.test.ts
+++ b/ui/src/pages/activity/view.test.ts
@@ -4,7 +4,9 @@ import { render } from "lit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import type { ActivityEntry, ActivityStatus } from "./tool-activity.ts";
-import { renderActivity, type ActivityProps } from "./view.ts";
+import { renderActivity } from "./view.ts";
+
+type ActivityProps = Parameters<typeof renderActivity>[0];
 
 function createEntry(overrides: Partial<ActivityEntry> = {}): ActivityEntry {
   return {

--- a/ui/src/pages/activity/view.ts
+++ b/ui/src/pages/activity/view.ts
@@ -8,7 +8,7 @@ import type { ActivityEntry, ActivityStatus } from "./tool-activity.ts";
 
 const STATUS_ORDER: ActivityStatus[] = ["running", "done", "error"];
 
-export type ActivityProps = {
+type ActivityProps = {
   entries: ActivityEntry[];
   filterText: string;
   statusFilters: Record<ActivityStatus, boolean>;

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 import { i18n, t } from "../../i18n/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { renderAgentFiles } from "./panels-status-files.ts";
-import { renderAgents, type AgentsProps } from "./view.ts";
+import { renderAgents } from "./view.ts";
+
+type AgentsProps = Parameters<typeof renderAgents>[0];
 
 function createSkill() {
   return {

--- a/ui/src/pages/agents/view.ts
+++ b/ui/src/pages/agents/view.ts
@@ -24,28 +24,28 @@ import { renderAgentOverview } from "./panels-overview.ts";
 import { renderAgentFiles, renderAgentChannels, renderAgentCron } from "./panels-status-files.ts";
 import { renderAgentTools, renderAgentSkills } from "./panels-tools-skills.ts";
 
-export type ConfigState = {
+type ConfigState = {
   form: Record<string, unknown> | null;
   loading: boolean;
   saving: boolean;
   dirty: boolean;
 };
 
-export type ChannelsState = {
+type ChannelsState = {
   snapshot: ChannelsStatusSnapshot | null;
   loading: boolean;
   error: string | null;
   lastSuccess: number | null;
 };
 
-export type CronState = {
+type CronState = {
   status: CronStatus | null;
   jobs: CronJob[];
   loading: boolean;
   error: string | null;
 };
 
-export type AgentFilesState = {
+type AgentFilesState = {
   list: AgentsFilesListResult | null;
   loading: boolean;
   error: string | null;
@@ -55,7 +55,7 @@ export type AgentFilesState = {
   saving: boolean;
 };
 
-export type AgentSkillsState = {
+type AgentSkillsState = {
   report: SkillStatusReport | null;
   loading: boolean;
   error: string | null;
@@ -69,13 +69,13 @@ type ToolsCatalogState = {
   result: ToolsCatalogResult | null;
 };
 
-export type ToolsEffectiveState = {
+type ToolsEffectiveState = {
   loading: boolean;
   error: string | null;
   result: ToolsEffectiveResult | null;
 };
 
-export type AgentsProps = {
+type AgentsProps = {
   basePath: string;
   loading: boolean;
   error: string | null;

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 import type { CronJob } from "../../api/types.ts";
 import { DEFAULT_CRON_FORM } from "../../lib/cron/index.ts";
 import { createDefaultDraft, renderCronQuickCreate } from "./quick-create.ts";
-import { renderCron, type CronProps } from "./view.ts";
+import { renderCron } from "./view.ts";
+
+type CronProps = Parameters<typeof renderCron>[0];
 
 function createJob(id: string): CronJob {
   return {

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -38,7 +38,7 @@ import { formatCronSchedule, formatNextRun } from "../../lib/presenter.ts";
 import { searchForSession } from "../../lib/sessions/index.ts";
 import { normalizeStringEntries, uniqueStrings } from "../../lib/string-coerce.ts";
 
-export type CronProps = {
+type CronProps = {
   basePath: string;
   loading: boolean;
   jobsLoadingMore: boolean;

--- a/ui/src/pages/debug/view.test.ts
+++ b/ui/src/pages/debug/view.test.ts
@@ -3,7 +3,9 @@ import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
-import { renderDebug, type DebugProps } from "./view.ts";
+import { renderDebug } from "./view.ts";
+
+type DebugProps = Parameters<typeof renderDebug>[0];
 
 function createProps(overrides: Partial<DebugProps> = {}): DebugProps {
   return {

--- a/ui/src/pages/debug/view.ts
+++ b/ui/src/pages/debug/view.ts
@@ -5,7 +5,7 @@ import { t } from "../../i18n/index.ts";
 import { formatTimeMs } from "../../lib/format.ts";
 import { formatEventPayload } from "../../lib/presenter.ts";
 
-export type DebugProps = {
+type DebugProps = {
   loading: boolean;
   status: Record<string, unknown> | null;
   health: Record<string, unknown> | null;

--- a/ui/src/pages/dreams/view.test.ts
+++ b/ui/src/pages/dreams/view.test.ts
@@ -2,12 +2,9 @@
 
 import { render } from "lit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createDreamingViewState,
-  renderDreaming,
-  type DreamingProps,
-  type DreamingViewState,
-} from "./view.ts";
+import { createDreamingViewState, renderDreaming, type DreamingViewState } from "./view.ts";
+
+type DreamingProps = Parameters<typeof renderDreaming>[0];
 
 let viewState = createDreamingViewState();
 

--- a/ui/src/pages/dreams/view.ts
+++ b/ui/src/pages/dreams/view.ts
@@ -94,7 +94,7 @@ type DreamingAgentOption = {
   label: string;
 };
 
-export type DreamingProps = {
+type DreamingProps = {
   viewState: DreamingViewState;
   active: boolean;
   selectedAgentId: string;

--- a/ui/src/pages/logs/view.test.ts
+++ b/ui/src/pages/logs/view.test.ts
@@ -5,7 +5,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import { pt_BR } from "../../i18n/locales/pt-BR.ts";
 import type { LogLevel } from "./log-lines.ts";
-import { renderLogs, type LogsProps } from "./view.ts";
+import { renderLogs } from "./view.ts";
+
+type LogsProps = Parameters<typeof renderLogs>[0];
 
 function createLevelFilters(overrides: Partial<Record<LogLevel, boolean>> = {}) {
   return {

--- a/ui/src/pages/logs/view.ts
+++ b/ui/src/pages/logs/view.ts
@@ -7,7 +7,7 @@ import type { LogEntry, LogLevel } from "./log-lines.ts";
 const LEVELS: LogLevel[] = ["trace", "debug", "info", "warn", "error", "fatal"];
 type ExportFileLabel = "filtered" | "visible";
 
-export type LogsProps = {
+type LogsProps = {
   loading: boolean;
   error: string | null;
   file: string | null;

--- a/ui/src/pages/overview/view.render.test.ts
+++ b/ui/src/pages/overview/view.render.test.ts
@@ -4,7 +4,9 @@ import { render } from "lit";
 import { describe, expect, it } from "vitest";
 import { i18n } from "../../i18n/index.ts";
 import { getSafeLocalStorage } from "../../local-storage.ts";
-import { renderOverview, type OverviewProps } from "./view.ts";
+import { renderOverview } from "./view.ts";
+
+type OverviewProps = Parameters<typeof renderOverview>[0];
 
 function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewProps {
   return {

--- a/ui/src/pages/overview/view.ts
+++ b/ui/src/pages/overview/view.ts
@@ -22,7 +22,7 @@ import { renderOverviewCards } from "./cards.ts";
 import { renderOverviewEventLog } from "./event-log.ts";
 import { renderOverviewLogTail } from "./log-tail.ts";
 
-export type OverviewProps = {
+type OverviewProps = {
   connected: boolean;
   hello: GatewayHelloOk | null;
   settings: UiSettings;

--- a/ui/src/pages/skills/view.test.ts
+++ b/ui/src/pages/skills/view.test.ts
@@ -3,7 +3,9 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentsListResult, SkillStatusEntry, SkillStatusReport } from "../../api/types.ts";
-import { renderSkills, type SkillsProps } from "./view.ts";
+import { renderSkills } from "./view.ts";
+
+type SkillsProps = Parameters<typeof renderSkills>[0];
 
 const dialogRestores: Array<() => void> = [];
 

--- a/ui/src/pages/skills/view.ts
+++ b/ui/src/pages/skills/view.ts
@@ -49,7 +49,7 @@ function showDialogWhenClosed(el?: Element) {
 export type SkillsStatusFilter = "all" | "ready" | "needs-setup" | "disabled";
 export type SkillDetailTab = "overview" | "card";
 
-export type SkillsProps = {
+type SkillsProps = {
   connected: boolean;
   loading: boolean;
   report: SkillStatusReport | null;

--- a/ui/src/pages/tasks/view.ts
+++ b/ui/src/pages/tasks/view.ts
@@ -6,7 +6,7 @@ import { formatMs, formatRelativeTimestamp } from "../../lib/format.ts";
 import { searchForSession } from "../../lib/sessions/index.ts";
 import { partitionTasks, taskTimestampMs, type TaskStatus, type TaskSummary } from "./data.ts";
 
-export type TasksProps = {
+type TasksProps = {
   basePath: string;
   connected: boolean;
   canCancel: boolean;


### PR DESCRIPTION
## What Problem This Solves

The Control UI exposes 15 view prop/state aliases that are not production API. Eight are exported only for colocated tests, and the rest have no cross-file consumers. These accidental exports add noise to the TypeScript surface and exact-head deadcode reports.

Fixes #101011.

## Why This Change Was Made

- Keep the 15 implementation-only aliases local to their view modules.
- Derive test input types from the exported render functions with `Parameters<typeof renderX>[0]`, matching the existing Workboard test pattern.
- Preserve the render functions, runtime signatures, and all UI behavior.

## User Impact

None. This is a type-visibility refactor with no emitted JavaScript or rendered behavior change.

## Evidence

- Fresh full codebase-memory graph: 274,167 nodes, 1,097,764 edges, 20,766 files.
- Exact-head `ts-unused-exports` artifact from CI run `28804283923`.
- Graph ingress queries showed only defining-file edges for the nine view prop aliases.
- Repository-wide searches found no production import of the removed aliases.
- Focused UI proof on Testbox `tbx_01kww2x4ttkn7qdyrc81958gyz`: 8 files, 62 tests passed.
- The same Testbox passed `pnpm check:changed`, including production/test typechecks, core/UI lint, database/storage guards, and zero runtime import cycles.
- Fresh post-rebase Codex autoreview: no actionable findings, confidence 0.89.
- `git diff --check` passed.
