### PR TITLE
fix(cron): keep implicit announcements when disabling best-effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Cron edit delivery:** preserve each job's implicit delivery mode when applying partial delivery updates, so disabling best-effort delivery no longer turns detached job announcements off. (#100846) Thanks @machine3at.
 - **Control UI session creation:** keep newly created sessions at the front of the stable sidebar order after selecting another session. Thanks @shakkernerd.
 - **FTS-only memory startup:** skip plugin capability discovery when `memorySearch.provider` is explicitly `none`, avoiding an unnecessary cold-start scan.
 - **Control UI agent model labels:** show each selected agent's effective model in the Default picker option instead of the global model. (#100719, #77690, #77440) Thanks @hyspacex.

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -1,6 +1,6 @@
 // Cron job patch tests cover applying partial updates to scheduled jobs.
 import { describe, expect, it } from "vitest";
-import { resolveFailureDestination } from "../delivery-plan.js";
+import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
 import type { CronJob } from "../types.js";
 import { applyJobPatch } from "./jobs.js";
 
@@ -76,6 +76,32 @@ describe("applyJobPatch delivery merge", () => {
     });
 
     expect(job.delivery).toBeUndefined();
+  });
+
+  it("preserves implicit detached delivery when patching best-effort", () => {
+    const job = makeJob({ delivery: undefined });
+
+    applyJobPatch(job, {
+      delivery: { bestEffort: false },
+    });
+
+    expect(job.delivery).toEqual({ mode: "announce", bestEffort: false });
+    expect(resolveCronDeliveryPlan(job).mode).toBe("announce");
+  });
+
+  it("preserves implicit main-session delivery when patching best-effort", () => {
+    const job = makeJob({
+      sessionTarget: "main",
+      payload: { kind: "systemEvent", text: "tick" },
+      delivery: undefined,
+    });
+
+    applyJobPatch(job, {
+      delivery: { bestEffort: false },
+    });
+
+    expect(job.delivery).toBeUndefined();
+    expect(resolveCronDeliveryPlan(job).mode).toBe("none");
   });
 
   it("clears nullable failure destination fields", () => {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalThreadValue,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { resolveCronDeliveryPlan } from "../delivery-plan.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import {
   coerceFiniteScheduleNumber,
@@ -959,7 +960,8 @@ export function applyJobPatch(
     job.payload = mergeCronPayload(job.payload, patch.payload);
   }
   if (patch.delivery) {
-    job.delivery = mergeCronDelivery(job.delivery, patch.delivery);
+    const implicitMode = resolveCronDeliveryPlan(job).mode;
+    job.delivery = mergeCronDelivery(job.delivery, patch.delivery, implicitMode);
   }
   if ("failureAlert" in patch) {
     job.failureAlert = mergeCronFailureAlert(job.failureAlert, patch.failureAlert);
@@ -1231,10 +1233,11 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
 function mergeCronDelivery(
   existing: CronDelivery | undefined,
   patch: CronDeliveryPatch,
+  implicitMode: CronDelivery["mode"],
 ): CronDelivery | undefined {
   const hasCompletionDestinationPatch = "completionDestination" in patch;
   const next: CronDelivery = {
-    mode: existing?.mode ?? "none",
+    mode: existing?.mode ?? implicitMode,
     channel: existing?.channel,
     to: existing?.to,
     threadId: existing?.threadId,
@@ -1338,7 +1341,6 @@ function mergeCronDelivery(
   if (
     existing === undefined &&
     !("mode" in patch) &&
-    next.mode === "none" &&
     next.channel === undefined &&
     next.to === undefined &&
     next.threadId === undefined &&


### PR DESCRIPTION
Related: #100846

## What Problem This Solves

Fixes an issue where users disabling best-effort delivery on an older detached cron job could silently disable the job's completion announcement when that job had no stored delivery override.

## Why This Change Was Made

Partial delivery updates now preserve the job's already-resolved implicit delivery mode before materializing a delivery object. Clear-only updates remain absent, and main-session jobs retain their non-delivering default. This fixes the same invariant for every partial delivery patch instead of teaching the CLI another copy of cron delivery policy.

## User Impact

`openclaw cron edit <id> --no-best-effort-deliver`, including when combined with a message edit, no longer turns implicit detached-job announcements off. Enabling best-effort still retains its documented announce compatibility behavior.

## Evidence

- Blacksmith Testbox: 135 focused cron service and CLI tests passed.
- Source-blind CLI/Gateway contract: isolated and main jobs, combined message edit, and both best-effort directions exercised against an ephemeral Gateway.
- Fresh GPT-5.5 autoreview: no accepted or actionable findings.
- `git diff --check` and targeted oxfmt passed.

AI-assisted: implementation and review performed with Codex. No transcript attached because the working session also contains unrelated maintainer operations.
