### PR TITLE
fix(tasks): harden recent task state updates

### DIFF
--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTaskRecord as createTaskRecordOrNull,
+  finalizeTaskRunByRunId,
   getTaskById,
   markTaskTerminalById,
   recordTaskProgressByRunId,
@@ -199,6 +200,49 @@ describe("tasks gateway handlers", () => {
     expect(ids?.indexOf(oldButJustFinished.taskId)).toBeLessThan(
       ids?.indexOf(newerQuietTask.taskId) ?? -1,
     );
+  });
+
+  it("orders endedAt-only terminal finalizers by their completion time", async () => {
+    const first = createTaskRecord({
+      runtime: "cli",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      runId: "run-first-finished",
+      task: "Finished first",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      lastEventAt: 100,
+    });
+    const second = createTaskRecord({
+      runtime: "cli",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      runId: "run-second-finished",
+      task: "Finished second",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      lastEventAt: 200,
+    });
+
+    finalizeTaskRunByRunId({
+      runId: first.runId!,
+      runtime: "cli",
+      status: "succeeded",
+      endedAt: 1_000,
+    });
+    finalizeTaskRunByRunId({
+      runId: second.runId!,
+      runtime: "cli",
+      status: "succeeded",
+      endedAt: 500,
+    });
+
+    const { payload } = await runTaskHandler("tasks.list", {});
+
+    expect(payload?.tasks?.map((task) => task.id)).toEqual([first.taskId, second.taskId]);
+    expect(payload?.tasks?.[0]?.updatedAt).toBe(1_000);
   });
 
   it("treats explicit task agentId as authoritative over the session-key fallback", async () => {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -810,6 +810,39 @@ describe("task-registry", () => {
     });
   });
 
+  it("uses endedAt as terminal activity time when run finalizers omit lastEventAt", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+
+      createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-ended-at-activity",
+        task: "Finish after progress",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+        lastEventAt: 150,
+      });
+
+      finalizeTaskRunByRunId({
+        runId: "run-ended-at-activity",
+        runtime: "cli",
+        status: "succeeded",
+        endedAt: 300,
+        terminalSummary: "completed",
+      });
+
+      expectRecordFields(requireTaskByRunId("run-ended-at-activity"), {
+        status: "succeeded",
+        endedAt: 300,
+        lastEventAt: 300,
+      });
+    });
+  });
+
   it("uses shared agent terminal precedence for lifecycle task projection", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1989,6 +1989,8 @@ function updateTaskStateByRunId(params: {
     }
     if (params.lastEventAt != null) {
       patch.lastEventAt = params.lastEventAt;
+    } else if (params.endedAt != null && isTerminalTaskStatus(nextStatus)) {
+      patch.lastEventAt = Math.max(params.endedAt, current.lastEventAt ?? params.endedAt);
     }
     if (
       current.status === "cancelled" &&

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -157,12 +157,11 @@ class TasksPage extends LitElement {
       }
       this.error = formatTaskError(error, t("tasksPage.cancelFailed"));
     } finally {
-      if (client !== this.client) {
-        return;
+      if (client === this.client) {
+        const next = new Set(this.cancellingTaskIds);
+        next.delete(taskId);
+        this.cancellingTaskIds = next;
       }
-      const next = new Set(this.cancellingTaskIds);
-      next.delete(taskId);
-      this.cancellingTaskIds = next;
     }
   }
 

--- a/ui/src/pages/tasks/tasks-page.ts
+++ b/ui/src/pages/tasks/tasks-page.ts
@@ -104,7 +104,10 @@ class TasksPage extends LitElement {
       // long-running task can hide behind newer terminal records on page one.
       const [activePayload, recentPayload] = await Promise.all([
         client.request("tasks.list", { status: ["queued", "running"], limit: 500 }),
-        client.request("tasks.list", { limit: 200 }),
+        client.request("tasks.list", {
+          status: ["completed", "failed", "timed_out", "cancelled"],
+          limit: 200,
+        }),
       ]);
       const active = normalizeTasksListResult(activePayload);
       const recent = normalizeTasksListResult(recentPayload);
@@ -131,10 +134,14 @@ class TasksPage extends LitElement {
     if (!this.connected || !client || this.cancellingTaskIds.has(taskId)) {
       return;
     }
+    const generation = this.loadGeneration;
     this.cancellingTaskIds = new Set([...this.cancellingTaskIds, taskId]);
     this.error = null;
     try {
       const payload = await client.request("tasks.cancel", { taskId });
+      if (generation !== this.loadGeneration || client !== this.client) {
+        return;
+      }
       const result = normalizeTasksCancelResult(payload);
       if (result?.task) {
         this.tasks = applyTaskEvent(this.tasks, { action: "upserted", task: result.task }).tasks;
@@ -145,8 +152,14 @@ class TasksPage extends LitElement {
         this.error = result?.reason?.trim() || t("tasksPage.cancelFailed");
       }
     } catch (error) {
+      if (generation !== this.loadGeneration || client !== this.client) {
+        return;
+      }
       this.error = formatTaskError(error, t("tasksPage.cancelFailed"));
     } finally {
+      if (client !== this.client) {
+        return;
+      }
       const next = new Set(this.cancellingTaskIds);
       next.delete(taskId);
       this.cancellingTaskIds = next;

--- a/ui/src/pages/tasks/tasks.e2e.test.ts
+++ b/ui/src/pages/tasks/tasks.e2e.test.ts
@@ -68,6 +68,18 @@ const failedTask = {
   error: "Worker exited",
 };
 
+const cancelledTask = {
+  id: "task-cancelled",
+  taskId: "task-cancelled",
+  kind: "cli",
+  runtime: "cli",
+  status: "cancelled",
+  title: "Cancelled old task",
+  createdAt: baseTime - 50_000,
+  updatedAt: baseTime - 40_000,
+  error: "Stopped by operator",
+};
+
 let server: ControlUiE2eServer;
 let browser: Browser;
 
@@ -104,7 +116,16 @@ describeControlUiE2e("Control UI Tasks mocked Gateway E2E", () => {
       const gateway = await installMockGateway(page, {
         methodResponses: {
           "tasks.list": {
-            tasks: [runningTask, queuedTask, completedTask, failedTask],
+            cases: [
+              {
+                match: { status: ["queued", "running"], limit: 500 },
+                response: { tasks: [runningTask, queuedTask] },
+              },
+              {
+                match: { status: ["completed", "failed", "timed_out", "cancelled"], limit: 200 },
+                response: { tasks: [completedTask, failedTask] },
+              },
+            ],
           },
           "tasks.cancel": {
             found: true,
@@ -118,6 +139,17 @@ describeControlUiE2e("Control UI Tasks mocked Gateway E2E", () => {
       expect(response?.status()).toBe(200);
       const active = page.locator('[data-task-section="active"]');
       const recent = page.locator('[data-task-section="recent"]');
+      await expect
+        .poll(async () => {
+          const requests = await gateway.getRequests("tasks.list");
+          return requests.map((request) => request.params);
+        })
+        .toEqual(
+          expect.arrayContaining([
+            { status: ["queued", "running"], limit: 500 },
+            { status: ["completed", "failed", "timed_out", "cancelled"], limit: 200 },
+          ]),
+        );
       await active.locator('[data-task-id="task-running"]').waitFor({ state: "visible" });
       await active.locator('[data-task-id="task-queued"]').waitFor({ state: "visible" });
       await recent.locator('[data-task-id="task-completed"]').waitFor({ state: "visible" });
@@ -158,6 +190,62 @@ describeControlUiE2e("Control UI Tasks mocked Gateway E2E", () => {
         await copyFile(await video.path(), path.join(artifactDir, "tasks-flow.webm"));
       }
       await rm(rawVideoDir, { force: true, recursive: true });
+    }
+  });
+
+  it("ignores stale cancel task snapshots after a newer refresh wins", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { width: 1440, height: 900 },
+    });
+    const page = await context.newPage();
+    try {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["tasks.cancel"],
+        methodResponses: {
+          "tasks.list": {
+            cases: [
+              {
+                match: { status: ["queued", "running"], limit: 500 },
+                response: { tasks: [runningTask, queuedTask] },
+              },
+              {
+                match: { status: ["completed", "failed", "timed_out", "cancelled"], limit: 200 },
+                response: { tasks: [cancelledTask] },
+              },
+            ],
+          },
+        },
+      });
+
+      const response = await page.goto(`${server.baseUrl}tasks`);
+      expect(response?.status()).toBe(200);
+      const active = page.locator('[data-task-section="active"]');
+      const recent = page.locator('[data-task-section="recent"]');
+      await active.locator('[data-task-id="task-queued"]').waitFor({ state: "visible" });
+
+      await active
+        .locator('[data-task-id="task-queued"]')
+        .getByRole("button", { name: "Cancel Nightly cleanup" })
+        .click();
+      await gateway.waitForRequest("tasks.cancel");
+      await page.getByRole("button", { name: "Refresh" }).click();
+      await expect
+        .poll(async () => (await gateway.getRequests("tasks.list")).length)
+        .toBeGreaterThanOrEqual(4);
+      await recent.locator('[data-task-id="task-cancelled"]').waitFor({ state: "visible" });
+
+      await gateway.resolveDeferred("tasks.cancel", {
+        found: true,
+        cancelled: true,
+        task: { ...queuedTask, status: "cancelled", updatedAt: baseTime + 5_000 },
+      });
+
+      expect(await recent.locator('[data-task-id="task-queued"]').count()).toBe(0);
+      await active.locator('[data-task-id="task-queued"]').waitFor({ state: "visible" });
+    } finally {
+      await context.close();
     }
   });
 });


### PR DESCRIPTION
Related: #100911

## What Problem This Solves

Fixes an issue where users viewing the Control UI Tasks page could see recently finished tasks rank by stale progress time, have the Recent section starved by large active-task pages, or receive a stale cancellation snapshot after a newer gateway refresh won.

This is a partial fix for #100911. It intentionally does not redesign `tasks.list` cursor stability because the mutable-ordering + offset-cursor behavior still needs the maintainer/product decision called out on the issue.

## Why This Change Was Made

Terminal run finalizers now advance task activity time from `endedAt` when they do not provide `lastEventAt`, keeping gateway summaries and list ordering aligned with completion time. The Tasks page now fetches Active and Recent with explicit status filters, and the cancel path uses the same client/generation guard pattern as refresh before applying returned task snapshots.

No gateway protocol/schema changes are included, and `tasks.list` parameters/response shape stay unchanged.

## User Impact

Tasks that just completed are less likely to appear stale or out of order in the Tasks page. Recent terminal rows remain visible even when many queued/running tasks exist, and stale cancel responses from a previous gateway state no longer overwrite the fresher Tasks page state.

## Evidence

Current head: `f6d55ef81e09b827d73f2d00d48694360ba0f794`.

- Claim proved: endedAt-only terminal finalizers update task activity time and order correctly.
  - `node scripts/run-vitest.mjs src/gateway/server-methods/tasks.test.ts src/tasks/task-registry.test.ts`
  - Result: passed 2 Vitest shards; gateway shard 16 tests passed, tasks shard 108 tests passed.
- Claim proved: Tasks page requests terminal-only Recent rows and ignores stale cancel snapshots after a newer refresh.
  - `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=C:\Users\86158\AppData\Local\ms-playwright\chromium_headless_shell-1228\chrome-headless-shell-win64\chrome-headless-shell.exe node scripts/run-vitest.mjs ui/src/pages/tasks/tasks.e2e.test.ts`
  - Result: passed 1 Vitest shard; 2 tests passed.
- CI failure repair: removed the unsafe `return` from `finally` in the cancel cleanup path that failed `check-lint` with `eslint(no-unsafe-finally)`.
  - `node_modules\.bin\oxlint.CMD --tsconfig config/tsconfig/oxlint.core.json ui/src/pages/tasks/tasks-page.ts`
  - Result: passed.
- Hygiene:
  - `git diff --check`
  - Result: passed.
- Current-head CI proof:
  - GitHub `Real behavior proof`: success on head `f6d55ef81e09b827d73f2d00d48694360ba0f794`.
  - GitHub CI/check lanes shown in the PR rollup were green for the current head when this Evidence section was refreshed.
