### PR TITLE
fix(crestodian): handle stdout/stderr stream errors in local command probes

### DIFF
--- a/scripts/proof/crestodian-probes-stream-errors.mts
+++ b/scripts/proof/crestodian-probes-stream-errors.mts
@@ -1,0 +1,41 @@
+// Real behavior proof: probeLocalCommand handles stdout/stderr stream errors without crashing.
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const require = createRequire(import.meta.url);
+const childProcess = require("node:child_process") as typeof import("node:child_process");
+const originalSpawn = childProcess.spawn;
+
+// Patch spawn so any local command probe becomes a real process whose stdout and
+// stderr emit errors after probeLocalCommand attaches listeners.
+childProcess.spawn = (...args: Parameters<typeof originalSpawn>) => {
+  const child = originalSpawn.apply(childProcess, args);
+  setTimeout(() => {
+    child.stdout?.emit("error", new Error("probe stdout read failed"));
+    child.stderr?.emit("error", new Error("probe stderr read failed"));
+  }, 100);
+  return child;
+};
+
+const { probeLocalCommand } = await import(path.join(repoRoot, "src/crestodian/probes.js"));
+
+console.log("=== Proof: crestodian probe stream error catch ===\n");
+
+try {
+  const result = await probeLocalCommand(process.execPath, ["-e", "setTimeout(() => {}, 5000)"], {
+    timeoutMs: 1_000,
+  });
+  if (result.error?.includes("probe stdout read failed") || result.error?.includes("probe stderr read failed")) {
+    console.log("PASS: probeLocalCommand resolved with a stream error instead of crashing.");
+  } else {
+    console.log("FAIL: expected stream error in result:", result);
+    process.exitCode = 1;
+  }
+} catch (err) {
+  console.error("FAIL: probeLocalCommand rejected with:");
+  console.error(err);
+  process.exitCode = 1;
+}

--- a/src/crestodian/probes.stream-errors.test.ts
+++ b/src/crestodian/probes.stream-errors.test.ts
@@ -1,0 +1,84 @@
+// Regression tests for stdout/stderr stream errors in probeLocalCommand.
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+type MockSpawnChild = EventEmitter & {
+  stdout?: EventEmitter & { setEncoding?: (enc: string) => void };
+  stderr?: EventEmitter & { setEncoding?: (enc: string) => void };
+  kill?: (signal?: string) => void;
+};
+
+function createMockSpawnChild() {
+  const child = new EventEmitter() as MockSpawnChild;
+  const stdout = new EventEmitter() as MockSpawnChild["stdout"];
+  stdout!.setEncoding = vi.fn();
+  const stderr = new EventEmitter() as MockSpawnChild["stderr"];
+  stderr!.setEncoding = vi.fn();
+  child.stdout = stdout;
+  child.stderr = stderr;
+  child.kill = vi.fn();
+  return { child, stdout, stderr };
+}
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
+  const spawnLocal = vi.fn(
+    (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
+      const { child } = createMockSpawnChild();
+      return child as unknown as ChildProcess;
+    },
+  );
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
+    {
+      spawn: spawnLocal as unknown as typeof import("node:child_process").spawn,
+    },
+  );
+});
+
+const spawnMock = vi.mocked(spawn);
+
+let probeLocalCommand: typeof import("./probes.js").probeLocalCommand;
+
+describe("crestodian probe stream errors", () => {
+  beforeAll(async () => {
+    ({ probeLocalCommand } = await import("./probes.js"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports stdout stream error as probe failure", async () => {
+    spawnMock.mockImplementationOnce(
+      (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
+        const { child, stdout } = createMockSpawnChild();
+        process.nextTick(() => {
+          stdout?.emit("error", new Error("stdout read failed"));
+        });
+        return child as unknown as ChildProcess;
+      },
+    );
+
+    const result = await probeLocalCommand("some-binary", ["--version"], { timeoutMs: 1_000 });
+    expect(result.found).toBe(true);
+    expect(result.error).toContain("stdout read failed");
+  });
+
+  it("reports stderr stream error as probe failure", async () => {
+    spawnMock.mockImplementationOnce(
+      (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
+        const { child, stderr } = createMockSpawnChild();
+        process.nextTick(() => {
+          stderr?.emit("error", new Error("stderr read failed"));
+        });
+        return child as unknown as ChildProcess;
+      },
+    );
+
+    const result = await probeLocalCommand("some-binary", ["--version"], { timeoutMs: 1_000 });
+    expect(result.found).toBe(true);
+    expect(result.error).toContain("stderr read failed");
+  });
+});

--- a/src/crestodian/probes.ts
+++ b/src/crestodian/probes.ts
@@ -79,8 +79,14 @@ export async function probeLocalCommand(
     child.stdout.on("data", (chunk) => {
       stdout = appendBounded(stdout, String(chunk), outputLimit);
     });
+    child.stdout.on("error", (err: NodeJS.ErrnoException) => {
+      finish({ command, found: true, error: err.message });
+    });
     child.stderr.on("data", (chunk) => {
       stderr = appendBounded(stderr, String(chunk), outputLimit);
+    });
+    child.stderr.on("error", (err: NodeJS.ErrnoException) => {
+      finish({ command, found: true, error: err.message });
     });
     child.on("error", (err: NodeJS.ErrnoException) => {
       finish({


### PR DESCRIPTION
## What Problem This Solves

`probeLocalCommand` spawns a command and reads stdout/stderr. If either stream emits an error event, it is not handled and can become an unhandled exception.

## Why This Change Was Made

Add explicit `child.stdout.on("error", ...)` and `child.stderr.on("error", ...)` listeners that finish the probe with the error message, mirroring the existing `child.on("error")` handling.

## User Impact

Crestodian overview probes are more resilient to transient stream failures.

## Evidence

- Added regression tests in `src/crestodian/probes.stream-errors.test.ts` covering both stdout and stderr stream errors.
- Added real behavior proof at `scripts/proof/crestodian-probes-stream-errors.mts`.
- Local run:
  - `node scripts/run-vitest.mjs src/crestodian/probes.stream-errors.test.ts src/crestodian/probes.test.ts` passed
  - `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs src/crestodian/probes.ts src/crestodian/probes.stream-errors.test.ts scripts/proof/crestodian-probes-stream-errors.mts` passed
