### PR TITLE
fix: keep compaction summaries when token telemetry is invalid

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import { createAssistantMessageEventStream } from "../../llm.js";
-import type { AssistantMessage, Model, StreamFn } from "../../llm.js";
+import type { AssistantMessage, Model, StreamFn, Usage } from "../../llm.js";
 import {
   calculateContextTokens,
   compact,
   estimateContextTokens,
   generateSummary,
+  getLastAssistantUsage,
 } from "./compaction.js";
 import { createFileOps } from "./utils.js";
 
@@ -40,6 +41,21 @@ describe("calculateContextTokens", () => {
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
       }),
     ).toBe(927_907);
+  });
+
+  it("normalizes non-canonical token totals without producing NaN", () => {
+    expect(calculateContextTokens({ input: 10, output: 5, total: 15 } as unknown as Usage)).toBe(
+      15,
+    );
+    expect(
+      calculateContextTokens({
+        input: 10,
+        output: 5,
+        totalTokens: 0,
+        cache: { read: 3, write: 2 },
+      } as unknown as Usage),
+    ).toBe(20);
+    expect(calculateContextTokens({ input: 0, output: 0 } as unknown as Usage)).toBe(0);
   });
 
   it("estimates the transcript instead of using aggregate billing when context is unavailable", () => {
@@ -120,6 +136,93 @@ describe("calculateContextTokens", () => {
     expect(estimate.tokens).toBeGreaterThan(149_874);
     expect(estimate.tokens).toBeLessThan(927_907);
     expect(estimate.lastUsageIndex).toBe(0);
+  });
+
+  it("skips transcript-only delivery mirrors when sampling assistant usage", () => {
+    const realUsage: Usage = {
+      input: 100,
+      output: 25,
+      cacheRead: 50,
+      cacheWrite: 0,
+      contextUsage: {
+        state: "available",
+        promptTokens: 150,
+        totalTokens: 175,
+      },
+      totalTokens: 175,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    };
+    const estimate = estimateContextTokens([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real assistant" }],
+        api: "anthropic-messages",
+        provider: "anthropic",
+        model: "claude-fable-5",
+        usage: realUsage,
+        stopReason: "stop",
+        timestamp: 0,
+      },
+      { role: "user", content: "follow-up", timestamp: 1 },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real assistant" }],
+        api: "openclaw-transcript",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        usage: {
+          input: 0,
+          output: 0,
+          total: 0,
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          total_tokens: 0,
+          cache: { read: 0, write: 0 },
+        } as unknown as Usage,
+        stopReason: "stop",
+        timestamp: 2,
+      },
+    ]);
+
+    expect(estimate.usageTokens).toBe(175);
+    expect(estimate.tokens).toBeGreaterThan(175);
+    expect(estimate.lastUsageIndex).toBe(0);
+    expect(
+      getLastAssistantUsage([
+        {
+          type: "message",
+          id: "real",
+          parentId: null,
+          timestamp: "2026-07-06T00:00:00.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "real assistant" }],
+            api: "anthropic-messages",
+            provider: "anthropic",
+            model: "claude-fable-5",
+            usage: realUsage,
+            stopReason: "stop",
+            timestamp: 0,
+          },
+        },
+        {
+          type: "message",
+          id: "mirror",
+          parentId: "real",
+          timestamp: "2026-07-06T00:00:01.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "real assistant" }],
+            api: "openclaw-transcript",
+            provider: "openclaw",
+            model: "delivery-mirror",
+            usage: { input: 0, output: 0 } as unknown as Usage,
+            stopReason: "stop",
+            timestamp: 1,
+          },
+        },
+      ]),
+    ).toBe(realUsage);
   });
 });
 

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -146,13 +146,76 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
   keepRecentTokens: 20000,
 };
 
+const OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER = "openclaw";
+const TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS = new Set(["delivery-mirror", "gateway-injected"]);
+
+function readFiniteTokenCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, value) : undefined;
+}
+
+function readPositiveTokenCount(value: unknown): number | undefined {
+  const count = readFiniteTokenCount(value);
+  return count !== undefined && count > 0 ? count : undefined;
+}
+
+function sumTokenCounts(values: readonly (number | undefined)[]): number | undefined {
+  if (values.every((value) => value === undefined)) {
+    return undefined;
+  }
+  return values.reduce<number>((sum, value) => sum + (value ?? 0), 0);
+}
+
+function isTranscriptOnlyOpenClawAssistant(msg: AgentMessage): boolean {
+  return (
+    msg.role === "assistant" &&
+    msg.provider === OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER &&
+    TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS.has(msg.model)
+  );
+}
+
 /** Calculate total context tokens from provider usage. */
 export function calculateContextTokens(usage: Usage): number {
   if (usage.contextUsage?.state === "available") {
     return usage.contextUsage.totalTokens;
   }
-  return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+  const usageRecord = usage as unknown as {
+    input?: unknown;
+    output?: unknown;
+    cacheRead?: unknown;
+    cacheWrite?: unknown;
+    total?: unknown;
+    totalTokens?: unknown;
+    total_tokens?: unknown;
+    prompt_tokens?: unknown;
+    completion_tokens?: unknown;
+    input_tokens?: unknown;
+    output_tokens?: unknown;
+    cache?: { read?: unknown; write?: unknown };
+  };
+  return (
+    readPositiveTokenCount(usageRecord.totalTokens) ??
+    readPositiveTokenCount(usageRecord.total) ??
+    readPositiveTokenCount(usageRecord.total_tokens) ??
+    sumTokenCounts([
+      readFiniteTokenCount(usageRecord.input) ??
+        readFiniteTokenCount(usageRecord.prompt_tokens) ??
+        readFiniteTokenCount(usageRecord.input_tokens),
+      readFiniteTokenCount(usageRecord.output) ??
+        readFiniteTokenCount(usageRecord.completion_tokens) ??
+        readFiniteTokenCount(usageRecord.output_tokens),
+      readFiniteTokenCount(usageRecord.cacheRead) ?? readFiniteTokenCount(usageRecord.cache?.read),
+      readFiniteTokenCount(usageRecord.cacheWrite) ??
+        readFiniteTokenCount(usageRecord.cache?.write),
+    ]) ??
+    0
+  );
 }
+
+function calculateUsableContextTokens(usage: Usage): number | undefined {
+  const tokens = calculateContextTokens(usage);
+  return tokens > 0 && Number.isFinite(tokens) ? tokens : undefined;
+}
+
 function getAssistantUsage(msg: AgentMessage): Usage | undefined {
   if (msg.role === "assistant" && "usage" in msg) {
     const assistantMsg = msg;
@@ -171,6 +234,9 @@ function getAssistantUsage(msg: AgentMessage): Usage | undefined {
 export function getLastAssistantUsage(entries: SessionTreeEntry[]): Usage | undefined {
   for (const entry of entries.toReversed()) {
     if (entry.type === "message") {
+      if (isTranscriptOnlyOpenClawAssistant(entry.message)) {
+        continue;
+      }
       const usage = getAssistantUsage(entry.message);
       if (usage) {
         return usage;
@@ -200,8 +266,15 @@ function getLastAssistantUsageInfo(
     if (!message) {
       continue;
     }
+    if (isTranscriptOnlyOpenClawAssistant(message)) {
+      continue;
+    }
     const usage = getAssistantUsage(message);
-    if (usage && usage.contextUsage?.state !== "unavailable") {
+    if (
+      usage &&
+      usage.contextUsage?.state !== "unavailable" &&
+      calculateUsableContextTokens(usage) !== undefined
+    ) {
       return { usage, index: i };
     }
   }
@@ -225,7 +298,19 @@ export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEst
     };
   }
 
-  const usageTokens = calculateContextTokens(usageInfo.usage);
+  const usageTokens = calculateUsableContextTokens(usageInfo.usage);
+  if (usageTokens === undefined) {
+    let estimated = 0;
+    for (const message of messages) {
+      estimated += estimateTokens(message);
+    }
+    return {
+      tokens: estimated,
+      usageTokens: 0,
+      trailingTokens: estimated,
+      lastUsageIndex: null,
+    };
+  }
   let trailingTokens = 0;
   for (const message of messages.slice(usageInfo.index + 1)) {
     trailingTokens += estimateTokens(message);

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -24,6 +24,10 @@ import type {
 } from "../types.js";
 import { SessionError } from "../types.js";
 
+function normalizeCompactionTokensBefore(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
 /** Build model context from the active session branch and its latest state markers. */
 export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionContext {
   let thinkingLevel = "off";
@@ -201,7 +205,7 @@ export class Session<TMetadata extends SessionMetadata = SessionMetadata> {
       timestamp: new Date().toISOString(),
       summary,
       firstKeptEntryId,
-      tokensBefore,
+      tokensBefore: normalizeCompactionTokensBefore(tokensBefore),
       details,
       fromHook,
     } satisfies CompactionEntry);

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -565,6 +565,56 @@ describe("readTranscriptFileState", () => {
     ]);
   });
 
+  it("keeps compaction summaries when persisted tokensBefore telemetry is null", async () => {
+    const root = await makeRoot("openclaw-transcript-state-compaction-null-tokens-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "old turn" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "kept reply" }] },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "compact-1",
+          parentId: "assistant-1",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          summary: "summary",
+          firstKeptEntryId: "assistant-1",
+          tokensBefore: null,
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const compaction = state.getEntries().find((entry) => entry.type === "compaction");
+
+    expect(compaction).toMatchObject({ id: "compact-1", tokensBefore: 0 });
+    expect(state.buildSessionContext().messages).toMatchObject([
+      { role: "compactionSummary", summary: "summary", tokensBefore: 0 },
+      { role: "assistant", content: [{ type: "text", text: "kept reply" }] },
+    ]);
+  });
+
   it("relinks valid current rows past malformed parents", async () => {
     const root = await makeRoot("openclaw-transcript-state-current-suffix-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -171,6 +171,10 @@ function isOptionalBoolean(value: unknown): boolean {
   return value === undefined || typeof value === "boolean";
 }
 
+function normalizeCompactionTokensBefore(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
 function isBashExecutionMessage(value: Record<string, unknown>): boolean {
   return (
     isString(value.command) &&
@@ -242,11 +246,11 @@ function isSessionEntry(entry: FileEntry): entry is SessionEntry {
         summary?: unknown;
         tokensBefore?: unknown;
       };
-      return (
-        isString(candidate.firstKeptEntryId) &&
-        typeof candidate.summary === "string" &&
-        typeof candidate.tokensBefore === "number"
-      );
+      if (!isString(candidate.firstKeptEntryId) || typeof candidate.summary !== "string") {
+        return false;
+      }
+      candidate.tokensBefore = normalizeCompactionTokensBefore(candidate.tokensBefore);
+      return true;
     }
     case "custom":
       return isString((entry as { customType?: unknown }).customType);
@@ -813,7 +817,7 @@ export class TranscriptFileState {
       timestamp: new Date().toISOString(),
       summary,
       firstKeptEntryId,
-      tokensBefore,
+      tokensBefore: normalizeCompactionTokensBefore(tokensBefore),
       details,
       fromHook,
     });

--- a/src/agents/sessions/session-manager-entries.ts
+++ b/src/agents/sessions/session-manager-entries.ts
@@ -25,6 +25,10 @@ import type {
   ThinkingLevelChangeEntry,
 } from "./session-manager-types.js";
 
+function normalizeCompactionTokensBefore(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
 export class SessionManagerEntries extends SessionManagerPersistence {
   protected appendEntry(entry: SessionEntry, options?: AppendPersistenceOptions): void {
     if (
@@ -98,7 +102,7 @@ export class SessionManagerEntries extends SessionManagerPersistence {
       timestamp: new Date().toISOString(),
       summary,
       firstKeptEntryId,
-      tokensBefore,
+      tokensBefore: normalizeCompactionTokensBefore(tokensBefore),
       details,
       fromHook,
     };


### PR DESCRIPTION
Closes #100982

## What Problem This Solves

Fixes an issue where users resuming a compacted agent session could lose the compaction summary boundary when transcript-only assistant mirror rows carried token telemetry that did not match OpenClaw's normalized usage shape.

When that telemetry produced an invalid `tokensBefore` value, the persisted compaction entry could later be treated as malformed and skipped, leaving the resumed context without the summary that should have replaced earlier history.

## Why This Change Was Made

The compaction estimator now ignores transcript-only OpenClaw assistant mirror rows when sampling provider usage, normalizes OpenAI-shaped token fields without producing `NaN`, and falls back to content estimation when no usable provider usage remains. Compaction persistence and transcript loading also clamp invalid `tokensBefore` telemetry to `0` while still requiring the compaction summary and retained entry id, so bad telemetry cannot invalidate the semantic compaction entry.

This is scoped to compaction telemetry and transcript-only mirror rows; it does not change provider-owned usage accounting or accept compaction rows without the required summary boundary.

## User Impact

Users can resume compacted sessions without losing the compaction summary just because token telemetry was missing, null, or shaped differently by a transcript mirror. Future compaction entries also persist finite `tokensBefore` values instead of leaking invalid numbers into session state.

## Evidence

Before premise on the old calculation shape:

```text
$ node --input-type=module -e 'const usage={input:0,output:0,total:0,prompt_tokens:0,completion_tokens:0,cache:{read:0,write:0}}; const old=usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite; console.log({oldTokensBefore: old, oldIsNaN: Number.isNaN(old)});'
{ oldTokensBefore: NaN, oldIsNaN: true }
```

After proof against the current source:

```text
$ node --import tsx --input-type=module -e 'import { calculateContextTokens } from "./packages/agent-core/src/harness/compaction/compaction.ts"; const usage={input:0,output:0,total:0,prompt_tokens:0,completion_tokens:0,cache:{read:0,write:0}}; const current=calculateContextTokens(usage); console.log({currentTokensBefore: current, currentIsFinite: Number.isFinite(current)});'
{ currentTokensBefore: 0, currentIsFinite: true }
```

Invalid-telemetry replay proof against the changed loader/context path:

```text
$ node --import tsx --input-type=module <<'EOF'
# The script writes a redacted session.jsonl with a compaction row whose
# firstKeptEntryId is assistant-kept and whose persisted tokensBefore is null,
# then reads it through readTranscriptFileState() and prints buildSessionContext().
EOF
{
  "loadedEntryIds": [
    "user-old",
    "assistant-kept",
    "compact-invalid-telemetry"
  ],
  "compaction": {
    "id": "compact-invalid-telemetry",
    "firstKeptEntryId": "assistant-kept",
    "tokensBefore": 0
  },
  "contextMessages": [
    {
      "role": "compactionSummary",
      "summary": "redacted summary of the compacted prefix",
      "tokensBefore": 0
    },
    {
      "role": "assistant",
      "content": [
        {
          "type": "text",
          "text": "kept reply after summary boundary"
        }
      ]
    }
  ]
}
```

Focused validation:

```text
$ node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts src/agents/embedded-agent-runner/transcript-file-state.test.ts
[test] passed 2 Vitest shards in 11.22s

$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
# passed

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
# passed

$ OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs packages/agent-core/src/harness/compaction/compaction.ts packages/agent-core/src/harness/compaction/compaction.test.ts packages/agent-core/src/harness/session/session.ts src/agents/embedded-agent-runner/transcript-file-state.ts src/agents/embedded-agent-runner/transcript-file-state.test.ts src/agents/sessions/session-manager.ts
# passed

$ git diff --check upstream/main...HEAD
# passed

$ node scripts/build-all.mjs
[build-all] phase timings: total 133.5s; slowest tsdown 117.0s; write-cli-startup-metadata 9.86s; plugins:assets:build 2.89s; ui:build 1.57s
```

Real agent behavior proof using an isolated local config/state directory and an environment-sourced DeepSeek API key:

```text
$ node scripts/run-node.mjs agent --local --session-key agent:main:issue100982-live-proof --model deepseek/deepseek-v4-pro --message 'Reply exactly: ISSUE100982_DEEPSEEK_OK' --timeout 180 --json
```

Observed result: the run exited 0, the provider request completed with `provider=deepseek`, `model=deepseek-v4-pro`, `status=200`, `executionTrace.attempts[0].result=success`, and `payloads[0].text=ISSUE100982_DEEPSEEK_OK`.

Pre-commit review:

```text
$ .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.75)
```

AI-assisted.

