### PR TITLE
fix(google): support GOOGLE_CLOUD_PROJECT_ID for Vertex AI

### DIFF
--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -209,6 +209,16 @@ describe("google provider plugin hooks", () => {
       }),
     ).toBe("gcp-vertex-credentials");
     expect(
+      provider.resolveConfigApiKey?.({
+        provider: "google-vertex",
+        env: {
+          GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
+          GOOGLE_CLOUD_PROJECT_ID: "vertex-project",
+          GOOGLE_CLOUD_LOCATION: "global",
+        },
+      }),
+    ).toBe("gcp-vertex-credentials");
+    expect(
       googleProviderDiscovery.resolveConfigApiKey?.({
         provider: "google-vertex",
         env: {

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -609,7 +609,7 @@
               "${HOME}/.config/gcloud/application_default_credentials.json",
               "${APPDATA}/gcloud/application_default_credentials.json"
             ],
-            "requiresAnyEnv": ["GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT"],
+            "requiresAnyEnv": ["GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GCLOUD_PROJECT"],
             "requiresAllEnv": ["GOOGLE_CLOUD_LOCATION"],
             "credentialMarker": "gcp-vertex-credentials",
             "source": "gcloud adc"

--- a/extensions/google/provider-contract-api.ts
+++ b/extensions/google/provider-contract-api.ts
@@ -37,6 +37,7 @@ export function createGoogleVertexProvider(): ProviderPlugin {
     envVars: [
       "GOOGLE_CLOUD_API_KEY",
       "GOOGLE_CLOUD_PROJECT",
+      "GOOGLE_CLOUD_PROJECT_ID",
       "GCLOUD_PROJECT",
       "GOOGLE_CLOUD_LOCATION",
       "GOOGLE_APPLICATION_CREDENTIALS",

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -1244,6 +1244,48 @@ describe("google transport stream", () => {
     });
   });
 
+  it("prefers GCLOUD_PROJECT over GOOGLE_CLOUD_PROJECT_ID for Google Vertex credential marker requests", async () => {
+    await withTempDir("openclaw-google-vertex-project-precedence-", async (tempDir) => {
+      vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+      vi.stubEnv("HOME", path.join(tempDir, "home"));
+      vi.stubEnv("APPDATA", "");
+      vi.stubEnv("GOOGLE_CLOUD_PROJECT", "");
+      vi.stubEnv("GCLOUD_PROJECT", "gcloud-project");
+      vi.stubEnv("GOOGLE_CLOUD_PROJECT_ID", "vertex-project-id");
+      vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+      googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.transport-token");
+      const tokenFetchMock = vi.fn();
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+          },
+        ]),
+      );
+
+      const streamFn = createGoogleVertexTransportStreamFn();
+      const stream = await Promise.resolve(
+        streamFn(
+          buildGoogleVertexModel(),
+          {
+            messages: [{ role: "user", content: "hello", timestamp: 0 }],
+          } as Parameters<typeof streamFn>[1],
+          {
+            apiKey: "gcp-vertex-credentials",
+            fetch: tokenFetchMock,
+          } as Parameters<typeof streamFn>[2],
+        ),
+      );
+      await stream.result();
+
+      expect(tokenFetchMock).not.toHaveBeenCalled();
+      const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+      expect(guardedCall[0]).toBe(
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/gcloud-project/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse",
+      );
+    });
+  });
+
   it("strips redundant google provider prefixes from Google Vertex model paths", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-google-vertex-prefix-"));
     vi.stubEnv("HOME", path.join(tempDir, "home"));

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { gzipSync } from "node:zlib";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 const {
   buildGuardedModelFetchMock,
@@ -42,6 +43,8 @@ let resolveGoogleGemini3FirstResponseRetryMs: typeof import("./transport-stream.
 let hasGoogleVertexAuthorizedUserAdcSync: typeof import("./vertex-adc.js").hasGoogleVertexAuthorizedUserAdcSync;
 let resolveGoogleVertexAuthorizedUserHeaders: typeof import("./vertex-adc.js").resolveGoogleVertexAuthorizedUserHeaders;
 let resetGoogleVertexAuthorizedUserTokenCacheForTest: typeof import("./vertex-adc.js").resetGoogleVertexAuthorizedUserTokenCacheForTest;
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL = Symbol.for(
   "openclaw.modelProviderRequestTransport",
@@ -1201,6 +1204,45 @@ describe("google transport stream", () => {
       accept: "text/event-stream",
     });
     expect(new Headers(guardedInit.headers).has("x-goog-api-key")).toBe(false);
+  });
+
+  it("uses GOOGLE_CLOUD_PROJECT_ID for Google Vertex credential marker requests", async () => {
+    const tempDir = tempDirs.make("openclaw-google-vertex-project-id-");
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+    vi.stubEnv("HOME", path.join(tempDir, "home"));
+    vi.stubEnv("APPDATA", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT_ID", "vertex-project-id");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.transport-token");
+    const tokenFetchMock = vi.fn();
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleVertexTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGoogleVertexModel(),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "gcp-vertex-credentials",
+          fetch: tokenFetchMock,
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(tokenFetchMock).not.toHaveBeenCalled();
+    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+    expect(guardedCall[0]).toBe(
+      "https://us-central1-aiplatform.googleapis.com/v1/projects/vertex-project-id/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse",
+    );
   });
 
   it("strips redundant google provider prefixes from Google Vertex model paths", async () => {

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -4,8 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
 import type { Model } from "openclaw/plugin-sdk/llm";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 const {
   buildGuardedModelFetchMock,
@@ -43,8 +43,6 @@ let resolveGoogleGemini3FirstResponseRetryMs: typeof import("./transport-stream.
 let hasGoogleVertexAuthorizedUserAdcSync: typeof import("./vertex-adc.js").hasGoogleVertexAuthorizedUserAdcSync;
 let resolveGoogleVertexAuthorizedUserHeaders: typeof import("./vertex-adc.js").resolveGoogleVertexAuthorizedUserHeaders;
 let resetGoogleVertexAuthorizedUserTokenCacheForTest: typeof import("./vertex-adc.js").resetGoogleVertexAuthorizedUserTokenCacheForTest;
-
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const MODEL_PROVIDER_REQUEST_TRANSPORT_SYMBOL = Symbol.for(
   "openclaw.modelProviderRequestTransport",
@@ -1207,42 +1205,43 @@ describe("google transport stream", () => {
   });
 
   it("uses GOOGLE_CLOUD_PROJECT_ID for Google Vertex credential marker requests", async () => {
-    const tempDir = tempDirs.make("openclaw-google-vertex-project-id-");
-    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
-    vi.stubEnv("HOME", path.join(tempDir, "home"));
-    vi.stubEnv("APPDATA", "");
-    vi.stubEnv("GOOGLE_CLOUD_PROJECT_ID", "vertex-project-id");
-    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
-    googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.transport-token");
-    const tokenFetchMock = vi.fn();
-    guardedFetchMock.mockResolvedValueOnce(
-      buildSseResponse([
-        {
-          candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
-        },
-      ]),
-    );
+    await withTempDir("openclaw-google-vertex-project-id-", async (tempDir) => {
+      vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "");
+      vi.stubEnv("HOME", path.join(tempDir, "home"));
+      vi.stubEnv("APPDATA", "");
+      vi.stubEnv("GOOGLE_CLOUD_PROJECT_ID", "vertex-project-id");
+      vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+      googleAuthGetAccessTokenMock.mockResolvedValueOnce("ya29.transport-token");
+      const tokenFetchMock = vi.fn();
+      guardedFetchMock.mockResolvedValueOnce(
+        buildSseResponse([
+          {
+            candidates: [{ content: { parts: [{ text: "ok" }] }, finishReason: "STOP" }],
+          },
+        ]),
+      );
 
-    const streamFn = createGoogleVertexTransportStreamFn();
-    const stream = await Promise.resolve(
-      streamFn(
-        buildGoogleVertexModel(),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as Parameters<typeof streamFn>[1],
-        {
-          apiKey: "gcp-vertex-credentials",
-          fetch: tokenFetchMock,
-        } as Parameters<typeof streamFn>[2],
-      ),
-    );
-    await stream.result();
+      const streamFn = createGoogleVertexTransportStreamFn();
+      const stream = await Promise.resolve(
+        streamFn(
+          buildGoogleVertexModel(),
+          {
+            messages: [{ role: "user", content: "hello", timestamp: 0 }],
+          } as Parameters<typeof streamFn>[1],
+          {
+            apiKey: "gcp-vertex-credentials",
+            fetch: tokenFetchMock,
+          } as Parameters<typeof streamFn>[2],
+        ),
+      );
+      await stream.result();
 
-    expect(tokenFetchMock).not.toHaveBeenCalled();
-    const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
-    expect(guardedCall[0]).toBe(
-      "https://us-central1-aiplatform.googleapis.com/v1/projects/vertex-project-id/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse",
-    );
+      expect(tokenFetchMock).not.toHaveBeenCalled();
+      const guardedCall = requireMockCall(guardedFetchMock, 0, "guarded fetch");
+      expect(guardedCall[0]).toBe(
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/vertex-project-id/locations/us-central1/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse",
+      );
+    });
   });
 
   it("strips redundant google provider prefixes from Google Vertex model paths", async () => {

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -345,10 +345,11 @@ function resolveGoogleVertexProject(options: GoogleTransportOptions | undefined)
   const project =
     normalizeOptionalString((options as { project?: unknown } | undefined)?.project) ||
     normalizeOptionalString(process.env.GOOGLE_CLOUD_PROJECT) ||
+    normalizeOptionalString(process.env.GOOGLE_CLOUD_PROJECT_ID) ||
     normalizeOptionalString(process.env.GCLOUD_PROJECT);
   if (!project) {
     throw new Error(
-      "Vertex AI requires a project ID. Set GOOGLE_CLOUD_PROJECT/GCLOUD_PROJECT or pass project in options.",
+      "Vertex AI requires a project ID. Set GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_PROJECT_ID/GCLOUD_PROJECT or pass project in options.",
     );
   }
   return project;

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -345,8 +345,8 @@ function resolveGoogleVertexProject(options: GoogleTransportOptions | undefined)
   const project =
     normalizeOptionalString((options as { project?: unknown } | undefined)?.project) ||
     normalizeOptionalString(process.env.GOOGLE_CLOUD_PROJECT) ||
-    normalizeOptionalString(process.env.GOOGLE_CLOUD_PROJECT_ID) ||
-    normalizeOptionalString(process.env.GCLOUD_PROJECT);
+    normalizeOptionalString(process.env.GCLOUD_PROJECT) ||
+    normalizeOptionalString(process.env.GOOGLE_CLOUD_PROJECT_ID);
   if (!project) {
     throw new Error(
       "Vertex AI requires a project ID. Set GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_PROJECT_ID/GCLOUD_PROJECT or pass project in options.",

--- a/extensions/google/vertex-adc.ts
+++ b/extensions/google/vertex-adc.ts
@@ -106,6 +106,7 @@ export function isGoogleVertexCredentialsMarker(
 function hasGoogleVertexProjectEnv(env: NodeJS.ProcessEnv): boolean {
   return Boolean(
     normalizeOptionalString(env.GOOGLE_CLOUD_PROJECT) ||
+    normalizeOptionalString(env.GOOGLE_CLOUD_PROJECT_ID) ||
     normalizeOptionalString(env.GCLOUD_PROJECT),
   );
 }

--- a/packages/ai/src/env-api-keys.ts
+++ b/packages/ai/src/env-api-keys.ts
@@ -228,7 +228,9 @@ export function getEnvApiKey(provider: string): string | undefined {
   if (provider === "google-vertex") {
     const hasCredentials = hasVertexAdcCredentials();
     const hasProject = Boolean(
-      getEnvValue("GOOGLE_CLOUD_PROJECT") || getEnvValue("GCLOUD_PROJECT"),
+      getEnvValue("GOOGLE_CLOUD_PROJECT") ||
+      getEnvValue("GOOGLE_CLOUD_PROJECT_ID") ||
+      getEnvValue("GCLOUD_PROJECT"),
     );
     const hasLocation = Boolean(getEnvValue("GOOGLE_CLOUD_LOCATION"));
 

--- a/packages/ai/src/providers/google-vertex.test.ts
+++ b/packages/ai/src/providers/google-vertex.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Context, Model } from "../types.js";
+import { streamGoogleVertex } from "./google-vertex.js";
+
+const { generateContentStreamMock, googleGenAIOptions } = vi.hoisted(() => ({
+  generateContentStreamMock: vi.fn(async function* () {
+    yield {
+      candidates: [
+        {
+          content: { parts: [{ text: "ok" }] },
+          finishReason: "STOP",
+        },
+      ],
+    };
+  }),
+  googleGenAIOptions: [] as unknown[],
+}));
+
+vi.mock("@google/genai", () => ({
+  FinishReason: { STOP: "STOP" },
+  FunctionCallingConfigMode: { ANY: "ANY", AUTO: "AUTO", NONE: "NONE" },
+  GoogleGenAI: vi.fn(function GoogleGenAIMock(options: unknown) {
+    googleGenAIOptions.push(options);
+    return {
+      models: {
+        generateContentStream: generateContentStreamMock,
+      },
+    };
+  }),
+  ResourceScope: { COLLECTION: "COLLECTION" },
+  ThinkingLevel: {
+    HIGH: "HIGH",
+    LOW: "LOW",
+    MEDIUM: "MEDIUM",
+    MINIMAL: "MINIMAL",
+    THINKING_LEVEL_UNSPECIFIED: "THINKING_LEVEL_UNSPECIFIED",
+  },
+}));
+
+const model = {
+  id: "gemini-3.1-pro-preview",
+  name: "Gemini 3.1 Pro Preview",
+  api: "google-vertex",
+  provider: "google",
+  baseUrl: "",
+  reasoning: true,
+  input: ["text"],
+  cost: {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+  },
+  contextWindow: 128_000,
+  maxTokens: 8_192,
+} satisfies Model<"google-vertex">;
+
+const context: Context = {
+  messages: [{ role: "user", content: "hello", timestamp: 0 }],
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  generateContentStreamMock.mockClear();
+  googleGenAIOptions.length = 0;
+});
+
+describe("streamGoogleVertex", () => {
+  it("uses GOOGLE_CLOUD_PROJECT_ID for ADC-backed Vertex clients", async () => {
+    vi.stubEnv("GOOGLE_CLOUD_API_KEY", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "");
+    vi.stubEnv("GCLOUD_PROJECT", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT_ID", "vertex-project-id");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+
+    const stream = streamGoogleVertex(model, context, { apiKey: "gcp-vertex-credentials" });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(googleGenAIOptions[0]).toMatchObject({
+      apiVersion: "v1",
+      location: "us-central1",
+      project: "vertex-project-id",
+      vertexai: true,
+    });
+  });
+});

--- a/packages/ai/src/providers/google-vertex.test.ts
+++ b/packages/ai/src/providers/google-vertex.test.ts
@@ -84,4 +84,23 @@ describe("streamGoogleVertex", () => {
       vertexai: true,
     });
   });
+
+  it("prefers GCLOUD_PROJECT over GOOGLE_CLOUD_PROJECT_ID for ADC-backed Vertex clients", async () => {
+    vi.stubEnv("GOOGLE_CLOUD_API_KEY", "");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT", "");
+    vi.stubEnv("GCLOUD_PROJECT", "gcloud-project");
+    vi.stubEnv("GOOGLE_CLOUD_PROJECT_ID", "vertex-project-id");
+    vi.stubEnv("GOOGLE_CLOUD_LOCATION", "us-central1");
+
+    const stream = streamGoogleVertex(model, context, { apiKey: "gcp-vertex-credentials" });
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("stop");
+    expect(googleGenAIOptions[0]).toMatchObject({
+      apiVersion: "v1",
+      location: "us-central1",
+      project: "gcloud-project",
+      vertexai: true,
+    });
+  });
 });

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -157,10 +157,13 @@ function isPlaceholderApiKey(apiKey: string): boolean {
 
 function resolveProject(options?: GoogleVertexOptions): string {
   const project =
-    options?.project || process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT;
+    options?.project ||
+    process.env.GOOGLE_CLOUD_PROJECT ||
+    process.env.GOOGLE_CLOUD_PROJECT_ID ||
+    process.env.GCLOUD_PROJECT;
   if (!project) {
     throw new Error(
-      "Vertex AI requires a project ID. Set GOOGLE_CLOUD_PROJECT/GCLOUD_PROJECT or pass project in options.",
+      "Vertex AI requires a project ID. Set GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_PROJECT_ID/GCLOUD_PROJECT or pass project in options.",
     );
   }
   return project;

--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -159,8 +159,8 @@ function resolveProject(options?: GoogleVertexOptions): string {
   const project =
     options?.project ||
     process.env.GOOGLE_CLOUD_PROJECT ||
-    process.env.GOOGLE_CLOUD_PROJECT_ID ||
-    process.env.GCLOUD_PROJECT;
+    process.env.GCLOUD_PROJECT ||
+    process.env.GOOGLE_CLOUD_PROJECT_ID;
   if (!project) {
     throw new Error(
       "Vertex AI requires a project ID. Set GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_PROJECT_ID/GCLOUD_PROJECT or pass project in options.",

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -162,7 +162,7 @@ vi.mock("./model-auth-env-vars.js", () => {
             "${HOME}/.config/gcloud/application_default_credentials.json",
             "${APPDATA}/gcloud/application_default_credentials.json",
           ],
-          requiresAnyEnv: ["GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT"],
+          requiresAnyEnv: ["GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GCLOUD_PROJECT"],
           requiresAllEnv: ["GOOGLE_CLOUD_LOCATION"],
           credentialMarker: "gcp-vertex-credentials",
           source: "gcloud adc",
@@ -1396,7 +1396,7 @@ describe("getApiKeyForModel", () => {
     }
   });
 
-  it("resolveEnvApiKey('google-vertex') rejects GOOGLE_CLOUD_PROJECT_ID-only ADC auth evidence", async () => {
+  it("resolveEnvApiKey('google-vertex') accepts GOOGLE_CLOUD_PROJECT_ID-only ADC auth evidence", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-google-adc-project-id-"));
     const credentialsPath = path.join(tempDir, "adc.json");
     await fs.writeFile(credentialsPath, "{}", "utf8");
@@ -1408,7 +1408,8 @@ describe("getApiKeyForModel", () => {
         GOOGLE_CLOUD_PROJECT_ID: "vertex-project",
       } as NodeJS.ProcessEnv);
 
-      expect(resolved).toBeNull();
+      expect(resolved?.apiKey).toBe("gcp-vertex-credentials");
+      expect(resolved?.source).toBe("gcloud adc");
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/src/llm/env-api-keys.test.ts
+++ b/src/llm/env-api-keys.test.ts
@@ -3,12 +3,14 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
 
 const envKeys = [
   "GOOGLE_APPLICATION_CREDENTIALS",
   "GOOGLE_CLOUD_LOCATION",
   "GOOGLE_CLOUD_PROJECT",
+  "GOOGLE_CLOUD_PROJECT_ID",
   "KIMI_API_KEY",
   "KIMICODE_API_KEY",
   "MOONSHOT_API_KEY",
@@ -16,6 +18,7 @@ const envKeys = [
 
 const originalEnv = captureEnv([...envKeys]);
 const tempDirs: string[] = [];
+const autoCleanupTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(async () => {
   vi.unstubAllGlobals();
@@ -46,6 +49,27 @@ describe("getEnvApiKey", () => {
         GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
         GOOGLE_CLOUD_LOCATION: "us-central1",
         GOOGLE_CLOUD_PROJECT: "vertex-project",
+      },
+      async () => {
+        vi.resetModules();
+        const { getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+
+        expect(getEnvApiKey("google-vertex")).toBe("<authenticated>");
+      },
+    );
+  });
+
+  it("detects Google Vertex ADC credentials with GOOGLE_CLOUD_PROJECT_ID only", async () => {
+    const dir = autoCleanupTempDirs.make("openclaw-vertex-adc-project-id-");
+    const credentialsPath = join(dir, "application_default_credentials.json");
+    await writeFile(credentialsPath, "{}", "utf-8");
+    await withEnvAsync(
+      {
+        GOOGLE_APPLICATION_CREDENTIALS: credentialsPath,
+        GOOGLE_CLOUD_LOCATION: "us-central1",
+        GOOGLE_CLOUD_PROJECT: undefined,
+        GOOGLE_CLOUD_PROJECT_ID: "vertex-project-id",
+        GCLOUD_PROJECT: undefined,
       },
       async () => {
         vi.resetModules();


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

## What Problem This Solves

Fixes an issue where Google Vertex AI users who configure their project with only `GOOGLE_CLOUD_PROJECT_ID` would have Vertex project detection treat the project as missing, even though the Google OAuth path already accepts that env name.

## Why This Change Was Made

This aligns the Vertex runtime project resolver, ADC credential-marker eligibility, pre-runtime auth evidence, operator-facing provider env metadata, and the published `@openclaw/ai` built-in Vertex surface with the existing Google OAuth project env support. Without updating the auth evidence contract, `GOOGLE_CLOUD_PROJECT_ID`-only ADC setups could still be classified as unauthenticated before the Vertex transport path runs.

The change keeps the existing env behavior intact for `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, and explicit project options, and does not change credential formats, config schema, migrations, provider selection, or default model routing.

## User Impact

Operators can use `GOOGLE_CLOUD_PROJECT_ID` for Google Vertex AI without duplicating the same value into `GOOGLE_CLOUD_PROJECT` or `GCLOUD_PROJECT`. Existing Vertex setups using the older env names continue to work.

## Evidence

- Real Google Vertex ADC proof from an OpenClaw bundled Google Vertex transport run using only `GOOGLE_CLOUD_PROJECT_ID` for the project env. `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT`, and `GOOGLE_APPLICATION_CREDENTIALS` were unset; local ADC credentials were used from the standard gcloud ADC location. The request reached the project-scoped Vertex `streamGenerateContent` endpoint, and Vertex returned `PERMISSION_DENIED` only because billing is disabled on the proof project.

  ```text
  proof_subject=OpenClaw bundled google-vertex transport ADC request
  GOOGLE_CLOUD_PROJECT=unset
  GCLOUD_PROJECT=unset
  GOOGLE_CLOUD_PROJECT_ID=openclaw-proof-0707-7h9iwv
  GOOGLE_CLOUD_LOCATION=us-central1
  GOOGLE_APPLICATION_CREDENTIALS=unset
  [provider-transport-fetch] [model-fetch] start provider=google-vertex api=google-vertex model=gemini-2.5-flash method=POST url=https://us-central1-aiplatform.googleapis.com/v1/projects/openclaw-proof-0707-7h9iwv/locations/us-central1/publishers/google/models/gemini-2.5-flash:streamGenerateContent timeoutMs=undefined proxy=none policy=default
  [provider-transport-fetch] [model-fetch] response provider=google-vertex api=google-vertex model=gemini-2.5-flash status=403 elapsedMs=2338 contentType=text/event-stream
  request_count=1
  request_1_url=https://oauth2.googleapis.com/token
  openclaw_result_stop_reason=error
  openclaw_result_error=Google Vertex AI API error (403): This API method requires billing to be enabled on project #openclaw-proof-0707-7h9iwv. [code=PERMISSION_DENIED]
  ```

- Regression proof before the fix:
  - `node scripts/run-vitest.mjs run extensions/google/transport-stream.test.ts` failed the new `GOOGLE_CLOUD_PROJECT_ID` Vertex transport case because no guarded Vertex request was emitted.
  - `node scripts/run-vitest.mjs run extensions/google/index.test.ts` failed the new ADC marker case with `expected undefined to be 'gcp-vertex-credentials'`.
  - `node scripts/run-vitest.mjs run src/agents/model-auth.profiles.test.ts` failed the new auth discovery case with `expected undefined to be 'gcp-vertex-credentials'`.
  - `node scripts/run-vitest.mjs run src/llm/env-api-keys.test.ts` failed the new published `@openclaw/ai` env helper case with `expected undefined to be '<authenticated>'`.
  - `node scripts/run-vitest.mjs run packages/ai/src/providers/google-vertex.test.ts` failed the new published `@openclaw/ai` provider adapter case with `expected 'error' to be 'stop'`.

- `node scripts/run-vitest.mjs run extensions/google/transport-stream.test.ts`

  ```text
  Test Files  1 passed (1)
       Tests  85 passed (85)
  [test] passed 1 Vitest shard in 28.45s
  ```

- `node scripts/run-vitest.mjs run src/agents/model-auth.profiles.test.ts`

  ```text
  Test Files  1 passed (1)
       Tests  71 passed (71)
  [test] passed 1 Vitest shard in 24.37s
  ```

- `node scripts/run-vitest.mjs run extensions/google`

  ```text
  Test Files  28 passed (28)
       Tests  389 passed (389)
  ```

- `node scripts/run-vitest.mjs run src/llm/env-api-keys.test.ts`

  ```text
  Test Files  1 passed (1)
       Tests  6 passed (6)
  [test] passed 1 Vitest shard in 12.81s
  ```

- `node scripts/run-vitest.mjs run packages/ai/src/providers/google-vertex.test.ts`

  ```text
  Test Files  1 passed (1)
       Tests  2 passed (2)
  [test] passed 1 Vitest shard in 3.83s
  ```

- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed`

  ```text
  [check:changed] lanes=core, coreTests, extensions, extensionTests
  [check:changed] test temp creation report (warning-only)
  No new test temp-directory migration warnings found.
  Import cycle check: 0 runtime value cycle(s).
  ```

  The default `pnpm check:changed` path attempted to delegate to Crabbox, but the local Crabbox binary failed its self-check before running project checks; the local remote-child mode above ran the changed lanes directly.

- CI red follow-up attribution:
  - The failing `check-additional-boundaries-bcd` job reported `extensions/google/transport-stream.test.ts: Use a documented openclaw/plugin-sdk test subpath instead of repo-only test helper bridges`.
  - The same boundary failure surfaced inside `build-artifacts` through `test/extension-test-boundary.test.ts`.
  - The test now uses `openclaw/plugin-sdk/test-env` for the temp-dir helper instead of importing from `../../test/helpers/temp-dir.js`.

- `node --import tsx scripts/check-no-extension-test-core-imports.ts`

  ```text
  OK: extension test files, support helpers, and plugin test helpers avoid direct core test/internal imports (2244 extension files, 1 plugin helpers checked).
  ```

- `node scripts/run-vitest.mjs run test/extension-test-boundary.test.ts`

  ```text
  Test Files  1 passed (1)
       Tests  11 passed (11)
  [test] passed 1 Vitest shard in 10.58s
  ```
