### PR TITLE
fix: sanitize streamed assistant payload text

### DIFF
--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -40,6 +40,14 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expect(payloads).toStrictEqual([]);
   });
 
+  it("strips provider reasoning close tags from streamed assistant payload text", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["</mm:think>Scan complete. No new actionable inbox items."],
+    });
+
+    expectSinglePayloadText(payloads, "Scan complete. No new actionable inbox items.");
+  });
+
   it("falls back to final-answer assistant text when streamed text is unavailable", () => {
     const payloads = buildPayloads({
       lastAssistant: {

--- a/src/agents/embedded-agent-runner/run/payloads.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.test.ts
@@ -48,6 +48,40 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSinglePayloadText(payloads, "Scan complete. No new actionable inbox items.");
   });
 
+  it("suppresses streamed text that only contains hidden reasoning", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["<mm:think>private reasoning</mm:think>"],
+    });
+
+    expect(payloads).toStrictEqual([]);
+  });
+
+  it("sanitizes every streamed text while preserving multiple visible answers", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [
+        '<tool_call>{"name":"exec","arguments":{"command":"secret"}}</tool_call>',
+        "</mm:think>First visible answer.",
+        "Second visible answer.",
+      ],
+    });
+
+    expect(payloads.map((payload) => payload.text)).toStrictEqual([
+      "First visible answer.",
+      "Second visible answer.",
+    ]);
+  });
+
+  it("keeps media directives while sanitizing streamed assistant text", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["</mm:think>MEDIA:/tmp/reply-image.png\nAttached image"],
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Attached image");
+    expect(payloads[0]?.mediaUrl).toBe("/tmp/reply-image.png");
+    expect(payloads[0]?.mediaUrls).toEqual(["/tmp/reply-image.png"]);
+  });
+
   it("falls back to final-answer assistant text when streamed text is unavailable", () => {
     const payloads = buildPayloads({
       lastAssistant: {

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -651,7 +651,9 @@ export function buildEmbeddedRunPayloads(params: {
     params.didSendDeterministicApprovalPrompt === true ||
     (params.sourceReplyDeliveryMode === "message_tool_only" && hasSourceReplyPayload) ||
     deliveredSourceReplyViaMessageTool;
-  const nonEmptyAssistantTexts = params.assistantTexts.filter((text) => text.trim().length > 0);
+  const nonEmptyAssistantTexts = params.assistantTexts
+    .map((text) => sanitizeAssistantVisibleText(text))
+    .filter((text) => text.trim().length > 0);
   const currentAssistant = params.currentAssistant ?? undefined;
   const assistantForPayload =
     currentAssistant ?? (nonEmptyAssistantTexts.length === 1 ? undefined : params.lastAssistant);

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -47,6 +47,7 @@ import type { ToolResultFormat } from "../../embedded-agent-subscribe.shared-typ
 import {
   extractAssistantThinking,
   extractAssistantVisibleText,
+  sanitizeAssistantVisibleStreamText,
 } from "../../embedded-agent-utils.js";
 import { isExecLikeToolName, type ToolErrorSummary } from "../../tool-error-summary.js";
 import { isLikelyMutatingToolName } from "../../tool-mutation.js";
@@ -652,7 +653,7 @@ export function buildEmbeddedRunPayloads(params: {
     (params.sourceReplyDeliveryMode === "message_tool_only" && hasSourceReplyPayload) ||
     deliveredSourceReplyViaMessageTool;
   const nonEmptyAssistantTexts = params.assistantTexts
-    .map((text) => sanitizeAssistantVisibleText(text))
+    .map((text) => sanitizeAssistantVisibleStreamText(text))
     .filter((text) => text.trim().length > 0);
   const currentAssistant = params.currentAssistant ?? undefined;
   const assistantForPayload =


### PR DESCRIPTION
## What Problem This Solves

DeepInfra MiniMax can emit provider-hidden reasoning markers such as `</mm:think>` as ordinary assistant text. Streamed assistant text then reaches embedded-run payload construction without the canonical visible-text sanitizer, so cron summaries or channel reply payloads can expose those markers to users.

## Why This Change Was Made

OpenClaw already has a canonical assistant visible-text sanitizer that strips reasoning tags, tool scaffolding, and internal markers. This change applies that sanitizer to streamed `assistantTexts` before they are selected for embedded-run reply payloads, so the payload path matches the existing final-assistant extraction path.

## User Impact

Users should no longer see MiniMax-style `</mm:think>` markers in cron output, Teams/Slack replies, or other embedded-run payload replies when a provider leaks those markers as plain text. Silent replies and empty sanitized text remain suppressed.

## Evidence

- Added regression coverage for streamed assistant text starting with `</mm:think>`.
- Verified locally with:
  - `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/payloads.test.ts`
  - Result: `42 passed`
- Redacted Teams verification:
  - Before: leaked provider reasoning close tag rendered in a visible assistant reply.
  - After: visible reply no longer includes the reasoning close tag.

![Before: reasoning close tag leaked in Teams](https://raw.githubusercontent.com/velanir-ai-manager/openclaw/c0a720f0c0f5540b46be4d3f19e0c6a507114200/pr-evidence/101036/teams-mm-think-leak-before.png)

![After: clean Teams response](https://raw.githubusercontent.com/velanir-ai-manager/openclaw/c0a720f0c0f5540b46be4d3f19e0c6a507114200/pr-evidence/101036/teams-clean-response-after.png)
