### PR TITLE
fix(acp): exec approvals target the matching concurrent prompt

### DIFF
--- a/src/acp/permission-relay.test.ts
+++ b/src/acp/permission-relay.test.ts
@@ -99,12 +99,14 @@ describe("ACP permission relay helpers", () => {
           command: "echo raw",
           host: "gateway",
           sessionKey: "agent:main:main",
+          toolCallId: "tool-raw",
         },
       }),
     ).toEqual({
       approvalId: "approval-raw",
       command: "echo raw",
       host: "gateway",
+      toolCallId: "tool-raw",
     });
 
     expect(parseGatewayExecApprovalRequestEventPayload({ id: "approval-raw" })).toBeNull();

--- a/src/acp/permission-relay.ts
+++ b/src/acp/permission-relay.ts
@@ -109,6 +109,7 @@ export function parseGatewayExecApprovalRequestEventPayload(
     command:
       readNonEmptyString(requestRecord.command) ?? readNonEmptyString(requestRecord.commandPreview),
     host: readNonEmptyString(requestRecord.host),
+    toolCallId: readNonEmptyString(requestRecord.toolCallId),
   };
 }
 

--- a/src/acp/translator.permission-relay.test.ts
+++ b/src/acp/translator.permission-relay.test.ts
@@ -58,6 +58,7 @@ function createApprovalRequestEvent(params: {
   approvalId?: string;
   sessionKey?: string;
   command?: string;
+  toolCallId?: string;
 }): EventFrame {
   return {
     type: "event",
@@ -70,6 +71,30 @@ function createApprovalRequestEvent(params: {
         command: params.command ?? "echo raw",
         host: "gateway",
         sessionKey: params.sessionKey ?? SESSION_KEY,
+        toolCallId: params.toolCallId,
+      },
+    },
+  } as EventFrame;
+}
+
+function createToolStartEvent(params: {
+  runId: string;
+  toolCallId: string;
+  name: string;
+  command?: string;
+}): EventFrame {
+  return {
+    type: "event",
+    event: "agent",
+    payload: {
+      runId: params.runId,
+      sessionKey: SESSION_KEY,
+      stream: "tool",
+      data: {
+        phase: "start",
+        name: params.name,
+        toolCallId: params.toolCallId,
+        args: params.command ? { command: params.command } : {},
       },
     },
   } as EventFrame;
@@ -256,7 +281,7 @@ describe("ACP translator permission relay", () => {
     await cleanupHarness(harness);
   });
 
-  it("does not bind session-only approval events when multiple prompts share the session key", async () => {
+  it("correlates concurrent approvals by a unique execute tool call and fails closed otherwise", async () => {
     const runIds: string[] = [];
     const request = vi.fn(async (method: string, requestParams?: Record<string, unknown>) => {
       if (method === "chat.send") {
@@ -297,17 +322,23 @@ describe("ACP translator permission relay", () => {
       expect(runIds).toHaveLength(2);
     });
 
-    const approvalId = "approval-shared";
-    await agent.handleGatewayEvent(createApprovalRequestEvent({ approvalId }));
+    await agent.handleGatewayEvent(
+      createApprovalRequestEvent({ approvalId: "approval-without-tool-id" }),
+    );
 
     expect(requestPermission).not.toHaveBeenCalled();
     expect(approvalResolveCalls(request)).toHaveLength(0);
 
     await agent.handleGatewayEvent(
-      createApprovalEvent({
+      createToolStartEvent({
         runId: expectDefined(runIds[1], "runIds[1] test invariant"),
-        approvalId,
+        toolCallId: "tool-second",
+        name: "exec",
+        command: "echo second",
       }),
+    );
+    await agent.handleGatewayEvent(
+      createApprovalRequestEvent({ approvalId: "approval-shared", toolCallId: "tool-second" }),
     );
 
     await vi.waitFor(() => {
@@ -315,11 +346,42 @@ describe("ACP translator permission relay", () => {
       expect(approvalResolveCalls(request)).toHaveLength(1);
     });
 
-    expect(firstCallArg(requestPermission).sessionId).toBe(SECOND_SESSION_ID);
+    const permission = requestPermissionPayload(requestPermission);
+    expect(permission.payload.sessionId).toBe(SECOND_SESSION_ID);
+    expect(permission.toolCall.toolCallId).toBe("tool-second");
+    expect(permission.toolCall.title).toContain("echo second");
     expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
-      id: approvalId,
+      id: "approval-shared",
       decision: "allow-once",
     });
+
+    await agent.handleGatewayEvent(
+      createApprovalRequestEvent({ approvalId: "approval-mismatch", toolCallId: "tool-missing" }),
+    );
+    for (const runId of runIds) {
+      await agent.handleGatewayEvent(
+        createToolStartEvent({ runId, toolCallId: "tool-duplicate", name: "exec" }),
+      );
+    }
+    await agent.handleGatewayEvent(
+      createApprovalRequestEvent({
+        approvalId: "approval-duplicate",
+        toolCallId: "tool-duplicate",
+      }),
+    );
+    await agent.handleGatewayEvent(
+      createToolStartEvent({
+        runId: expectDefined(runIds[0], "runIds[0] test invariant"),
+        toolCallId: "tool-read",
+        name: "read",
+      }),
+    );
+    await agent.handleGatewayEvent(
+      createApprovalRequestEvent({ approvalId: "approval-read", toolCallId: "tool-read" }),
+    );
+
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+    expect(approvalResolveCalls(request)).toHaveLength(1);
 
     await agent.cancel({ sessionId: SESSION_ID } as CancelNotification);
     await agent.cancel({ sessionId: SECOND_SESSION_ID } as CancelNotification);

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -976,12 +976,17 @@ export class AcpGatewayAgent implements Agent {
       return;
     }
 
-    const pending = params.runId
-      ? this.findPendingBySessionKey(params.sessionKey, params.runId)
-      : this.findUniquePendingBySessionKey(params.sessionKey);
+    const pending = this.findPendingForApproval(params);
     if (!pending) {
       return;
     }
+    const pendingToolCall = approvalEvent.toolCallId
+      ? pending.toolCalls?.get(approvalEvent.toolCallId)
+      : undefined;
+    const correlatedApprovalEvent =
+      !approvalEvent.title && pendingToolCall?.kind === "execute"
+        ? { ...approvalEvent, title: pendingToolCall.title }
+        : approvalEvent;
 
     const relay: PendingApprovalRelay = {
       approvalId: approvalEvent.approvalId,
@@ -991,7 +996,36 @@ export class AcpGatewayAgent implements Agent {
       state: "active",
     };
     this.approvalRelays.set(relay.approvalId, relay);
-    void this.runApprovalRelay(relay, approvalEvent);
+    void this.runApprovalRelay(relay, correlatedApprovalEvent);
+  }
+
+  private findPendingForApproval(params: {
+    sessionKey: string;
+    runId?: string;
+    approvalEvent: GatewayExecApprovalEvent;
+  }): PendingPrompt | undefined {
+    if (params.runId) {
+      return this.findPendingBySessionKey(params.sessionKey, params.runId);
+    }
+    const toolCallId = params.approvalEvent.toolCallId;
+    if (!toolCallId) {
+      return this.findUniquePendingBySessionKey(params.sessionKey);
+    }
+
+    let match: PendingPrompt | undefined;
+    for (const pending of this.pendingPrompts.values()) {
+      if (
+        pending.sessionKey !== params.sessionKey ||
+        pending.toolCalls?.get(toolCallId)?.kind !== "execute"
+      ) {
+        continue;
+      }
+      if (match) {
+        return undefined;
+      }
+      match = pending;
+    }
+    return match;
   }
 
   private async runApprovalRelay(

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -637,6 +637,7 @@ describe("executeNodeHostCommand", () => {
 
     const result = await executeNodeHostCommand({
       command: "bun ./script.ts",
+      toolCallId: "tool-node",
       workdir: "/tmp/work",
       env: {},
       security: "full",
@@ -653,7 +654,10 @@ describe("executeNodeHostCommand", () => {
     });
 
     expect(result.details?.status).toBe("approval-pending");
-    expect(requireRegisteredApprovalRequest().systemRunPlan).toEqual(preparedPlan);
+    expect(requireRegisteredApprovalRequest()).toMatchObject({
+      systemRunPlan: preparedPlan,
+      toolCallId: "tool-node",
+    });
 
     await vi.waitFor(() => {
       expect(callGatewayToolMock).toHaveBeenCalledTimes(3);

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -255,6 +255,7 @@ export async function executeNodeHostCommand(
       workdir: prepared.cwd,
       host: "node",
       nodeId: target.nodeId,
+      toolCallId: params.toolCallId,
       security: hostSecurity,
       ask: hostAsk,
       ...unavailableDecisionRequestParams,

--- a/src/agents/bash-tools.exec-host-node.types.ts
+++ b/src/agents/bash-tools.exec-host-node.types.ts
@@ -10,6 +10,7 @@ import type { ExecElevatedDefaults } from "./bash-tools.exec-types.js";
 /** Full parameter bundle for Node-hosted exec command execution. */
 export type ExecuteNodeHostCommandParams = {
   command: string;
+  toolCallId?: string;
   workdir: string | undefined;
   env: Record<string, string>;
   requestedEnv?: Record<string, string>;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1883,6 +1883,7 @@ export function createExecTool(
         if (host === "node") {
           return executeNodeHostCommand({
             command: params.command,
+            toolCallId,
             workdir,
             env,
             requestedEnv,


### PR DESCRIPTION
## What Problem This Solves

ACP clients can run concurrent prompts that share one Gateway session. Structured `exec.approval.requested` events already carry the originating `toolCallId`, but the ACP parser discarded it and selected a target only by session uniqueness. That could drop an approval when two prompts shared a session, or associate an explicit but unmatched identifier with the wrong prompt through a session-only fallback.

Follows #79337.

## Why This Change Was Made

The fix stays inside the existing contract:

- parse the already-supported `toolCallId` from structured Gateway approval requests;
- treat a present identifier as authoritative and relay only to one pending `execute` call with the same session and tool-call id;
- fail closed for missing, duplicate, unmatched, or non-execute matches;
- keep the legacy unique-session fallback only when the event omits `toolCallId`;
- derive the ACP approval title from the matched pending tool call instead of adding another Gateway protocol field;
- forward the existing tool-call id through the node-host exec approval path, matching the gateway-host path.

This replaces the earlier 20-file protocol-expansion approach. Current main already carries `toolCallId` through the public exec caller, Gateway schema, manager, and broadcast, so no schema or generated-client change is required.

## User Impact

Concurrent ACP prompts sharing a session receive exec approval requests only when the request matches their pending execute call. Contradictory identifiers do not silently degrade to another prompt, while older events without identifiers retain their sole-pending compatibility behavior.

## Evidence

- `node scripts/run-vitest.mjs src/acp/permission-relay.test.ts src/acp/translator.permission-relay.test.ts src/agents/bash-tools.exec-host-node.test.ts` — 80 tests passed.
- `node scripts/check-changed.mjs -- src/acp/permission-relay.test.ts src/acp/permission-relay.ts src/acp/translator.permission-relay.test.ts src/acp/translator.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.exec-host-node.ts src/agents/bash-tools.exec-host-node.types.ts src/agents/bash-tools.exec.ts` — passed on Blacksmith Testbox run 29813269932.
- AutoReview on the complete uncommitted bundle — clean, confidence 0.89.
- `git diff --check` — passed.

The focused ACP coverage exercises unique concurrent matching, omitted-id compatibility fallback, explicit mismatch rejection, duplicate ambiguity, and non-execute collision rejection. The node-host test proves the public tool-call identifier reaches approval registration.

## Maintainer Decision Needed

This remains an authorization-routing boundary. An ACP/exec-approval owner should explicitly approve the rule that a present `toolCallId` is authoritative and contradictory or ambiguous events fail closed. Until then, the branch is repaired and proven but should not be merged.
