### PR TITLE
refactor(packages): localize internal helper types

### DIFF
--- a/packages/agent-core/src/harness/compaction/branch-summarization.ts
+++ b/packages/agent-core/src/harness/compaction/branch-summarization.ts
@@ -32,8 +32,6 @@ export interface BranchSummaryDetails {
   modifiedFiles: string[];
 }
 
-export type { FileOperations } from "./utils.js";
-
 /** Prepared branch content for summarization. */
 export interface BranchPreparation {
   /** Messages selected for the branch summary. */
@@ -69,7 +67,7 @@ export interface CollectBranchPathEntriesResult<TEntry extends BranchPathEntry> 
 }
 
 /** Options for generating a branch summary. */
-export interface GenerateBranchSummaryOptions {
+interface GenerateBranchSummaryOptions {
   /** Model used for summarization. */
   model: Model;
   /** API key forwarded to the provider. */

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -381,7 +381,7 @@ export function findTurnStartIndex(
 }
 
 /** Cut point selected for compaction. */
-export interface CutPointResult {
+interface CutPointResult {
   /** Index of the first entry retained after compaction. */
   firstKeptEntryIndex: number;
   /** Index of the turn-start entry when the cut splits a turn, otherwise -1. */

--- a/packages/ai/src/providers/github-copilot-headers.ts
+++ b/packages/ai/src/providers/github-copilot-headers.ts
@@ -3,7 +3,7 @@ import type { Message } from "../types.js";
 
 // Copilot expects X-Initiator to indicate whether the request is user-initiated
 // or agent-initiated (e.g. follow-up after assistant/tool messages).
-export function inferCopilotInitiator(messages: Message[]): "user" | "agent" {
+function inferCopilotInitiator(messages: Message[]): "user" | "agent" {
   const last = messages[messages.length - 1];
   return last && last.role !== "user" ? "agent" : "user";
 }

--- a/packages/ai/src/providers/openai-responses-tools.ts
+++ b/packages/ai/src/providers/openai-responses-tools.ts
@@ -26,7 +26,7 @@ type ResponsesFunctionTool = {
   strict?: boolean | null;
 };
 
-export type ConvertedResponsesTools = {
+type ConvertedResponsesTools = {
   projection: OpenAIToolProjection;
   tools: OpenAITool[];
 };

--- a/packages/media-core/src/lazy-import.ts
+++ b/packages/media-core/src/lazy-import.ts
@@ -1,11 +1,11 @@
 /** Cached async loader used by runtime boundaries that should import on first use. */
-export type LazyPromiseLoader<T> = {
+type LazyPromiseLoader<T> = {
   load(): Promise<T>;
   clear(): void;
 };
 
 /** Controls whether a failed first import stays cached or is retried later. */
-export type LazyPromiseLoaderOptions = {
+type LazyPromiseLoaderOptions = {
   cacheRejections?: boolean;
 };
 

--- a/packages/tool-call-repair/src/grammar.ts
+++ b/packages/tool-call-repair/src/grammar.ts
@@ -94,7 +94,7 @@ export function findJsonObjectEnd(
 }
 
 /** Consumes one optional line break after a repaired serialized tool-call fragment. */
-export function skipSerializedToolCallTrailingLineBreak(text: string, cursor: number): number {
+function skipSerializedToolCallTrailingLineBreak(text: string, cursor: number): number {
   const afterLineBreak = consumeLineBreak(text, cursor);
   return afterLineBreak ?? cursor;
 }
@@ -174,16 +174,12 @@ export function findHarmonyJsonPayloadStart(text: string): number | null {
 }
 
 /** Case-insensitive marker compare for ASCII protocol tags without locale rules. */
-export function startsWithAsciiMarkerIgnoreCase(
-  text: string,
-  cursor: number,
-  marker: string,
-): boolean {
+function startsWithAsciiMarkerIgnoreCase(text: string, cursor: number, marker: string): boolean {
   return text.slice(cursor, cursor + marker.length).toLowerCase() === marker;
 }
 
 /** Case-insensitive marker search for ASCII protocol tags without allocating regexes. */
-export function indexOfAsciiMarkerIgnoreCase(text: string, marker: string, start: number): number {
+function indexOfAsciiMarkerIgnoreCase(text: string, marker: string, start: number): number {
   let cursor = start;
   while (cursor < text.length) {
     const next = text.indexOf(marker[0] ?? "", cursor);


### PR DESCRIPTION
## What Problem This Solves

Internal package helpers and implementation-only types were still exported even though they are not reachable through package export maps and have no external consumers. This keeps private module surfaces broader than necessary.

Fixes #101040

## Why This Change Was Made

The current dead-code export report identified these declarations, and repository search plus package export-map inspection confirmed they are local implementation details. The change removes only the unnecessary export modifiers and one redundant type re-export; runtime logic is untouched.

## User Impact

No user-visible behavior changes. Package internals expose fewer accidental declarations, making dead-code reports and ownership boundaries clearer.

## Evidence

- head: `14b754f77733fa73820e71f82604f4fcc526f3e3`
- 169 focused tests passed across agent-core compaction, media MIME loading, OpenAI responses tooling, and tool-call repair
- `pnpm check:changed` passed on Testbox `tbx_01kww6eawzww5pkvwsp0jxjnsw`
- repo tsdown build passed on Testbox `tbx_01kww617sx3k092mdhw2wt25b4`
- Codex autoreview: no accepted/actionable findings, confidence 0.86
- latest rebase had no changed-file overlap with this six-file patch
