### PR TITLE
fix: carry 2026.7.1 stability repairs into main

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1329,7 +1329,11 @@ describe("TelegramPollingSession", () => {
     };
     createTelegramBotMock.mockReturnValueOnce(bot);
     let onMessage:
-      | ((message: { type: "poll-success"; finishedAt: number; count: number }) => void)
+      | ((
+          message:
+            | { type: "poll-success"; finishedAt: number; count: number }
+            | { type: "poll-error"; finishedAt: number; message: string },
+        ) => void)
       | undefined;
     let stopWorker: (() => void) | undefined;
     const workerDone = new Promise<void>((resolve) => {
@@ -1359,9 +1363,21 @@ describe("TelegramPollingSession", () => {
 
     const runPromise = session.runUntilAbort();
     await vi.waitFor(() => expect(init).toHaveBeenCalledTimes(1));
-    onMessage?.({ type: "poll-success", finishedAt: Date.now(), count: 0 });
+    onMessage?.({ type: "poll-success", finishedAt: 10_000, count: 0 });
+    onMessage?.({ type: "poll-success", finishedAt: 10_001, count: 0 });
 
     await vi.waitFor(() => expect(drainPendingDeliveriesMock).toHaveBeenCalledTimes(1));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    onMessage?.({ type: "poll-success", finishedAt: 15_000, count: 0 });
+    await vi.waitFor(() => expect(drainPendingDeliveriesMock).toHaveBeenCalledTimes(2));
+    onMessage?.({ type: "poll-error", finishedAt: 15_001, message: "offline" });
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    onMessage?.({ type: "poll-success", finishedAt: 15_002, count: 0 });
+    await vi.waitFor(() => expect(drainPendingDeliveriesMock).toHaveBeenCalledTimes(3));
 
     abort.abort();
     await runPromise;
@@ -4666,7 +4682,7 @@ describe("TelegramPollingSession", () => {
     await runPromise;
   });
 
-  it("drains Telegram delivery queue after each getUpdates success", async () => {
+  it("throttles healthy delivery drains and re-arms after polling errors", async () => {
     const abort = new AbortController();
     const botStop = vi.fn(async () => undefined);
     const runnerStop = vi.fn(async () => undefined);
@@ -4690,6 +4706,27 @@ describe("TelegramPollingSession", () => {
       { offset: 2 },
     );
 
+    await vi.waitFor(() => expect(drainPendingDeliveriesMock).toHaveBeenCalledTimes(1));
+    await apiMiddleware(
+      vi.fn(async () => []),
+      "getUpdates",
+      { offset: 3 },
+    );
+    await vi.waitFor(() => expect(drainPendingDeliveriesMock).toHaveBeenCalledTimes(1));
+    await expect(
+      apiMiddleware(
+        vi.fn(async () => {
+          throw new Error("offline");
+        }),
+        "getUpdates",
+        { offset: 4 },
+      ),
+    ).rejects.toThrow("offline");
+    await apiMiddleware(
+      vi.fn(async () => []),
+      "getUpdates",
+      { offset: 5 },
+    );
     await vi.waitFor(() => expect(drainPendingDeliveriesMock).toHaveBeenCalledTimes(2));
 
     abort.abort();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -128,6 +128,7 @@ const TELEGRAM_GET_UPDATES_CONFLICT_HINT =
 
 const DEFAULT_POLL_STALL_THRESHOLD_MS = 120_000;
 const MIN_POLL_STALL_THRESHOLD_MS = 30_000;
+const TELEGRAM_DELIVERY_DRAIN_INTERVAL_MS = 5_000;
 const MAX_POLL_STALL_THRESHOLD_MS = 600_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
@@ -333,6 +334,7 @@ export class TelegramPollingSession {
   #spooledUpdateHandlerTimeoutMs: number;
   #spooledUpdateHandlerAbortGraceMs: number;
   #deliveryDrainInFlight = false;
+  #nextDeliveryDrainAt = 0;
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
     this.#transportState = new TelegramPollingTransportState({
@@ -471,6 +473,20 @@ export class TelegramPollingSession {
       .finally(() => {
         this.#deliveryDrainInFlight = false;
       });
+  }
+
+  #maybeDrainPendingDeliveries(finishedAt: number) {
+    if (finishedAt < this.#nextDeliveryDrainAt) {
+      return;
+    }
+    // Match the queue's first retry window. This keeps healthy polling useful
+    // as a recovery driver without reopening the drain on every long poll.
+    this.#nextDeliveryDrainAt = finishedAt + TELEGRAM_DELIVERY_DRAIN_INTERVAL_MS;
+    this.#drainPendingDeliveriesAfterReconnect();
+  }
+
+  #rearmPendingDeliveryDrain() {
+    this.#nextDeliveryDrainAt = 0;
   }
 
   async #createPollingBot(): Promise<TelegramBot | undefined> {
@@ -1203,11 +1219,12 @@ export class TelegramPollingSession {
         if (!restartRequested && stalledBacklogKeys.size === 0) {
           this.#status.notePollSuccess(message.finishedAt);
         }
-        this.#drainPendingDeliveriesAfterReconnect();
+        this.#maybeDrainPendingDeliveries(message.finishedAt);
         pollState.outcome = `ok:${message.count}`;
         return;
       }
       if (message.type === "poll-error") {
+        this.#rearmPendingDeliveryDrain();
         liveness.noteGetUpdatesError(new Error(message.message), message.finishedAt);
         liveness.noteGetUpdatesFinished();
         pollState.outcome = "error";
@@ -1455,7 +1472,7 @@ export class TelegramPollingSession {
       onPollSuccess: (finishedAt) => {
         this.#noteHealthyPollingCycle();
         this.#status.notePollSuccess(finishedAt);
-        this.#drainPendingDeliveriesAfterReconnect();
+        this.#maybeDrainPendingDeliveries(finishedAt);
       },
     });
     bot.api.config.use(async (prev, method, payload, signal) => {
@@ -1469,6 +1486,7 @@ export class TelegramPollingSession {
         liveness.noteGetUpdatesSuccess(result);
         return result;
       } catch (err) {
+        this.#rearmPendingDeliveryDrain();
         liveness.noteGetUpdatesError(err);
         throw err;
       } finally {

--- a/scripts/e2e/parallels/linux-smoke.ts
+++ b/scripts/e2e/parallels/linux-smoke.ts
@@ -331,7 +331,7 @@ class LinuxSmoke extends SmokeRunController<LinuxOptions> {
     );
     this.status.freshVersion = await this.extractLastVersion("fresh.install-main");
     await this.phase("fresh.verify-main-version", 90, () => this.verifyTargetVersion());
-    await this.phase("fresh.onboard-ref", 180, () => this.runRefOnboard());
+    await this.phase("fresh.onboard-ref", 420, () => this.runRefOnboard());
     await this.phase("fresh.inject-bad-plugin", 90, () =>
       this.maybeInjectBadPluginFixture("fresh"),
     );
@@ -366,7 +366,7 @@ class LinuxSmoke extends SmokeRunController<LinuxOptions> {
     await this.phase("upgrade.inject-bad-plugin", 90, () =>
       this.maybeInjectBadPluginFixture("upgrade"),
     );
-    await this.phase("upgrade.onboard-ref", 180, () => this.runRefOnboard());
+    await this.phase("upgrade.onboard-ref", 420, () => this.runRefOnboard());
     await this.phase("upgrade.gateway-start", 240, () => this.startGatewayBackground());
     await this.phase("upgrade.bad-plugin-diagnostic", 90, () =>
       this.maybeVerifyBadPluginDiagnostic("upgrade"),
@@ -514,9 +514,7 @@ if command -v curl >/dev/null 2>&1; then
     url,
   )} -o ${shellQuote(outputPath)}
 else
-  wget -q --timeout=10 --read-timeout=120 --tries=3 -O ${shellQuote(outputPath)} ${shellQuote(
-    url,
-  )}
+  wget -q --timeout=10 --read-timeout=120 --tries=3 -O ${shellQuote(outputPath)} ${shellQuote(url)}
 fi`);
   }
 

--- a/scripts/e2e/parallels/npm-update-scripts.ts
+++ b/scripts/e2e/parallels/npm-update-scripts.ts
@@ -275,51 +275,47 @@ ${windowsScopedEnvFunction}
 function Remove-FuturePluginEntries {
   $configPath = Join-Path $env:USERPROFILE '.openclaw\\openclaw.json'
   if (-not (Test-Path $configPath)) { return }
-  try { $config = Get-Content $configPath -Raw | ConvertFrom-Json } catch { return }
-  $plugins = Get-OpenClawJsonProperty $config 'plugins'
-  if ($null -eq $plugins) { return }
-  $entries = Get-OpenClawJsonProperty $plugins 'entries'
-  if ($null -ne $entries) {
-    foreach ($pluginId in @('feishu', 'whatsapp', 'openai')) {
-      Remove-OpenClawJsonProperty $entries $pluginId
+  $nodeScript = @'
+const fs = require("node:fs");
+const configPath = process.argv[2];
+let config;
+try {
+  config = JSON.parse(fs.readFileSync(configPath, "utf8").replace(/^\\uFEFF/u, ""));
+} catch {
+  process.exit(0);
+}
+const plugins = config.plugins;
+if (!plugins || typeof plugins !== "object") {
+  process.exit(0);
+}
+const futurePluginIds = new Set(["feishu", "whatsapp", "openai"]);
+let changed = false;
+if (plugins.entries && typeof plugins.entries === "object") {
+  for (const pluginId of futurePluginIds) {
+    if (Object.hasOwn(plugins.entries, pluginId)) {
+      delete plugins.entries[pluginId];
+      changed = true;
     }
   }
-  $allow = Get-OpenClawJsonProperty $plugins 'allow'
-  if ($null -ne $allow) {
-    Set-OpenClawJsonProperty $plugins 'allow' @($allow | Where-Object { $_ -notin @('feishu', 'whatsapp', 'openai') })
-  }
-  $config | ConvertTo-Json -Depth 100 | Set-Content -Path $configPath -Encoding UTF8
 }
-function Get-OpenClawJsonProperty {
-  param([object]$Object, [string]$Name)
-  if ($null -eq $Object) { return $null }
-  if ($Object -is [System.Collections.IDictionary]) { return $Object[$Name] }
-  $property = $Object.PSObject.Properties[$Name]
-  if ($null -eq $property) { return $null }
-  return $property.Value
+if (Array.isArray(plugins.allow)) {
+  const allow = plugins.allow.filter((pluginId) => !futurePluginIds.has(pluginId));
+  if (allow.length !== plugins.allow.length) {
+    plugins.allow = allow;
+    changed = true;
+  }
 }
-function Set-OpenClawJsonProperty {
-  param([object]$Object, [string]$Name, [object]$Value)
-  if ($Object -is [System.Collections.IDictionary]) {
-    $Object[$Name] = $Value
-    return
-  }
-  $property = $Object.PSObject.Properties[$Name]
-  if ($null -ne $property) {
-    $property.Value = $Value
-    return
-  }
-  $Object | Add-Member -NotePropertyName $Name -NotePropertyValue $Value
+if (changed) {
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + "\\n");
 }
-function Remove-OpenClawJsonProperty {
-  param([object]$Object, [string]$Name)
-  if ($null -eq $Object) { return }
-  if ($Object -is [System.Collections.IDictionary]) {
-    if ($Object.Contains($Name)) { $Object.Remove($Name) }
-    return
-  }
-  if ($null -ne $Object.PSObject.Properties[$Name]) {
-    $Object.PSObject.Properties.Remove($Name)
+'@
+  $nodeScriptPath = Join-Path ([System.IO.Path]::GetTempPath()) ('openclaw-future-plugin-scrub-' + [guid]::NewGuid().ToString('N') + '.cjs')
+  try {
+    $nodeScript | Set-Content -Path $nodeScriptPath -Encoding UTF8
+    & node.exe $nodeScriptPath $configPath
+    if ($LASTEXITCODE -ne 0) { throw "failed to scrub future plugin entries" }
+  } finally {
+    Remove-Item $nodeScriptPath -Force -ErrorAction SilentlyContinue
   }
 }
 function Stop-OpenClawGatewayProcesses {

--- a/scripts/e2e/parallels/npm-update-scripts.ts
+++ b/scripts/e2e/parallels/npm-update-scripts.ts
@@ -285,7 +285,7 @@ function Remove-FuturePluginEntries {
     }
   }
   $allow = Get-OpenClawJsonProperty $plugins 'allow'
-  if ($allow -is [array]) {
+  if ($null -ne $allow) {
     Set-OpenClawJsonProperty $plugins 'allow' @($allow | Where-Object { $_ -notin @('feishu', 'whatsapp', 'openai') })
   }
   $config | ConvertTo-Json -Depth 100 | Set-Content -Path $configPath -Encoding UTF8

--- a/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
+  createContextEngineBootstrapAndAssemble,
+  getHoisted,
+  preloadRunEmbeddedAttemptForTests,
+  resetEmbeddedAttemptHarness,
+} from "./attempt.spawn-workspace.test-support.js";
+
+const hoisted = getHoisted();
+const tempPaths: string[] = [];
+
+describe("runEmbeddedAttempt abort races", () => {
+  beforeAll(async () => {
+    await preloadRunEmbeddedAttemptForTests();
+  });
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness();
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+    tempPaths.length = 0;
+  });
+
+  it("stops before session creation when aborted during eager lock acquisition", async () => {
+    const abortController = new AbortController();
+    const prompt = vi.fn(async () => {});
+    const abortError = new Error("stopped during lock acquisition");
+    abortError.name = "AbortError";
+    let markLockRequested!: () => void;
+    let observedSignal: AbortSignal | undefined;
+    const lockRequested = new Promise<void>((resolve) => {
+      markLockRequested = resolve;
+    });
+    hoisted.acquireSessionWriteLockMock.mockImplementationOnce(async (params) => {
+      observedSignal = params.signal;
+      markLockRequested();
+      await new Promise<void>((resolve) => {
+        params.signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      throw params.signal?.reason;
+    });
+
+    const attempt = createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey: "agent:main:telegram:direct:123",
+      tempPaths,
+      sessionPrompt: prompt,
+      attemptOverrides: {
+        abortSignal: abortController.signal,
+      },
+    });
+    await lockRequested;
+    abortController.abort(abortError);
+
+    await expect(attempt).rejects.toBe(abortError);
+
+    expect(hoisted.createAgentSessionMock).not.toHaveBeenCalled();
+    expect(prompt).not.toHaveBeenCalled();
+    expect(observedSignal).toBe(abortController.signal);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.session-lock.ts
@@ -1176,21 +1176,23 @@ export type EmbeddedAttemptSessionLockController = {
 
 export async function createEmbeddedAttemptSessionLockController(params: {
   acquireSessionWriteLock: AcquireSessionWriteLock;
+  initialAcquireSignal?: AbortSignal;
   lockOptions: LockOptions;
   mergePromptReleasedSessionEntries?: (
     entries: readonly PromptReleasedSessionEntry[],
   ) => Promise<PromptReleasedSessionMergeResult | void> | PromptReleasedSessionMergeResult | void;
   reloadPromptReleasedSessionFile?: () => Promise<void> | void;
 }): Promise<EmbeddedAttemptSessionLockController> {
-  const acquireLock = async (): Promise<SessionLock> =>
+  const acquireLock = async (signal?: AbortSignal): Promise<SessionLock> =>
     await params.acquireSessionWriteLock({
       sessionFile: params.lockOptions.sessionFile,
       timeoutMs: params.lockOptions.timeoutMs,
       staleMs: params.lockOptions.staleMs,
       maxHoldMs: params.lockOptions.maxHoldMs,
+      ...(signal ? { signal } : {}),
     });
 
-  let heldLock: SessionLock | undefined = await acquireLock();
+  let heldLock: SessionLock | undefined = await acquireLock(params.initialAcquireSignal);
   const activeWriteLock = new AsyncLocalStorage<ActiveWriteLockState>();
   let ownedPublicationQueue: Promise<void> = Promise.resolve();
   let fenceFingerprint: SessionFileFingerprint | undefined;

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -2088,6 +2088,7 @@ export async function runEmbeddedAttempt(
     let sessionManager: ReturnType<typeof guardSessionManager> | undefined;
     const sessionLockController = await createEmbeddedAttemptSessionLockController({
       acquireSessionWriteLock,
+      initialAcquireSignal: params.abortSignal,
       lockOptions: {
         sessionFile: params.sessionFile,
         ...sessionWriteLockOptions,
@@ -2123,6 +2124,9 @@ export async function runEmbeddedAttempt(
         sessionLockController.withSessionWriteLock(operation),
       );
     armExternalAbortSignal();
+    // The signal can fire while the eager session lock is being acquired.
+    // Recheck after arming so a stopped run never reaches session creation or provider prompt.
+    await throwIfAttemptAbortSignalFiredAfterPrepCleanup();
 
     let session: Awaited<ReturnType<typeof createAgentSession>>["session"] | undefined;
     let removeToolResultContextGuard: (() => void) | undefined;

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -244,6 +244,29 @@ describe("acquireSessionWriteLock", () => {
     });
   });
 
+  it("cancels a contended infinite acquisition without leaving a lock waiter", async () => {
+    await withTempSessionLockFile(async ({ sessionFile }) => {
+      const heldLock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+      const abortController = new AbortController();
+      const abortError = new Error("stop requested");
+      abortError.name = "AbortError";
+      const pendingLock = acquireSessionWriteLock({
+        sessionFile,
+        timeoutMs: Number.POSITIVE_INFINITY,
+        signal: abortController.signal,
+      });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 20);
+      });
+      abortController.abort(abortError);
+
+      await expect(pendingLock).rejects.toBe(abortError);
+      await heldLock.release();
+      const nextLock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+      await nextLock.release();
+    });
+  });
+
   it("does not reenter locks by default through symlinked session paths", async () => {
     await withSymlinkedSessionPaths(async ({ sessionReal, sessionLink }) => {
       const lock = await acquireSessionWriteLock({ sessionFile: sessionReal, timeoutMs: 500 });

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -50,6 +50,7 @@ const WATCHDOG_STATE_KEY = Symbol.for("openclaw.sessionWriteLockWatchdogState");
 const DEFAULT_SESSION_WRITE_LOCK_STALE_MS = 30 * 60 * 1000;
 const DEFAULT_SESSION_WRITE_LOCK_MAX_HOLD_MS = 5 * 60 * 1000;
 const DEFAULT_SESSION_WRITE_LOCK_ACQUIRE_TIMEOUT_MS = 60_000;
+const ABORTABLE_SESSION_WRITE_LOCK_POLL_MS = 100;
 const DEFAULT_WATCHDOG_INTERVAL_MS = 60_000;
 const DEFAULT_TIMEOUT_GRACE_MS = 2 * 60 * 1000;
 const REPORT_ONLY_STALE_LOCK_REASONS = new Set(["too-old", "hold-exceeded"]);
@@ -888,9 +889,22 @@ export async function acquireSessionWriteLock(params: {
   staleMs?: number;
   maxHoldMs?: number;
   allowReentrant?: boolean;
+  signal?: AbortSignal;
 }): Promise<{
   release: () => Promise<void>;
 }> {
+  const throwIfAborted = () => {
+    if (!params.signal?.aborted) {
+      return;
+    }
+    if (params.signal.reason instanceof Error) {
+      throw params.signal.reason;
+    }
+    const error = new Error("request aborted", { cause: params.signal.reason });
+    error.name = "AbortError";
+    throw error;
+  };
+  throwIfAborted();
   registerCleanupHandlers();
   const allowReentrant = params.allowReentrant ?? false;
   const defaultOptions = resolveSessionWriteLockOptions();
@@ -908,6 +922,7 @@ export async function acquireSessionWriteLock(params: {
   const startedAtMs = Date.now();
 
   while (true) {
+    throwIfAborted();
     const remainingTimeoutMs = resolveRemainingAcquireTimeoutMs(timeoutMs, startedAtMs, Date.now());
     if (remainingTimeoutMs <= 0) {
       const payload = await readLockPayload(lockPath);
@@ -926,9 +941,12 @@ export async function acquireSessionWriteLock(params: {
       throw new SessionWriteLockTimeoutError({ timeoutMs, owner, lockPath });
     }
     try {
+      const acquireAttemptTimeoutMs = params.signal
+        ? Math.min(remainingTimeoutMs, ABORTABLE_SESSION_WRITE_LOCK_POLL_MS)
+        : remainingTimeoutMs;
       const lock = await SESSION_LOCKS.acquire(sessionFile, {
         staleMs,
-        timeoutMs: remainingTimeoutMs,
+        timeoutMs: acquireAttemptTimeoutMs,
         retry: { minTimeout: 50, maxTimeout: 1000, factor: 1 },
         staleRecovery: "remove-if-unchanged",
         allowReentrant,
@@ -992,8 +1010,16 @@ export async function acquireSessionWriteLock(params: {
       });
       return { release: lock.release };
     } catch (err) {
+      throwIfAborted();
       if (!isFileLockError(err, "file_lock_timeout") && !isFileLockError(err, "file_lock_stale")) {
         throw err;
+      }
+      if (
+        params.signal &&
+        isFileLockError(err, "file_lock_timeout") &&
+        resolveRemainingAcquireTimeoutMs(timeoutMs, startedAtMs, Date.now()) > 0
+      ) {
+        continue;
       }
       const errorLockPath = (err as { lockPath?: string }).lockPath ?? lockPath;
       const { payload, missing: lockMissingAtDiagnostics } =

--- a/src/infra/openclaw-root.test.ts
+++ b/src/infra/openclaw-root.test.ts
@@ -149,6 +149,25 @@ describe("resolveOpenClawPackageRoot", () => {
       },
     },
     {
+      name: "prefers a symlink target nested under another openclaw package",
+      setup: () => {
+        const sourceRoot = fx("nested-symlink-scenario");
+        const bin = path.join(sourceRoot, ".artifacts", "prefix", "bin", "openclaw");
+        const installedRoot = path.join(
+          sourceRoot,
+          ".artifacts",
+          "prefix",
+          "lib",
+          "node_modules",
+          "openclaw",
+        );
+        state.realpaths.set(abs(bin), abs(path.join(installedRoot, "openclaw.mjs")));
+        setPackageRoot(sourceRoot);
+        setPackageRoot(installedRoot);
+        return { opts: { argv1: bin }, expected: installedRoot };
+      },
+    },
+    {
       name: "falls back when argv1 realpath throws",
       setup: () => {
         const project = fx("realpath-throw-scenario");

--- a/src/infra/openclaw-root.ts
+++ b/src/infra/openclaw-root.ts
@@ -90,10 +90,11 @@ function candidateDirsFromArgv1(argv1: string): string[] {
     return [...cached];
   }
   const normalized = path.resolve(argv1);
-  const candidates = [path.dirname(normalized)];
+  const candidates: string[] = [];
 
   // Resolve symlinks for version managers (nvm, fnm, n, Homebrew/Linuxbrew)
-  // that create symlinks in bin/ pointing to the real package location.
+  // that create symlinks in bin/ pointing to the real package location. Prefer
+  // the target so a launcher nested under another OpenClaw checkout keeps its own package root.
   try {
     const resolved = openClawRootFsSync.realpathSync(normalized);
     if (resolved !== normalized) {
@@ -102,6 +103,7 @@ function candidateDirsFromArgv1(argv1: string): string[] {
   } catch {
     // realpathSync throws if path doesn't exist; keep original candidates
   }
+  candidates.push(path.dirname(normalized));
 
   const parts = normalized.split(path.sep);
   const binIndex = parts.lastIndexOf(".bin");

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -846,6 +846,11 @@ exit 7
 
   it("scrubs future plugin entries before invoking old same-guest updaters", () => {
     const script = readFileSync(UPDATE_SCRIPTS_PATH, "utf8");
+    const windowsScript = windowsUpdateScript({
+      auth: TEST_AUTH,
+      expectedNeedle: "2026.5.3-beta.2",
+      updateTarget: "2026.5.3-beta.2",
+    });
     const macosScript = macosUpdateScript({
       auth: TEST_AUTH,
       expectedNeedle: "2026.5.3-beta.2",
@@ -856,9 +861,18 @@ exit 7
     expect(script).toContain("scrub_future_plugin_entries");
     expect(script).toContain("delete plugins.entries.feishu");
     expect(script).toContain("delete plugins.entries.whatsapp");
-    expect(script).toContain("if ($null -ne $allow)");
-    expect(script).not.toContain("if ($allow -is [array])");
-    expect(script).toContain("Remove-FuturePluginEntries\nStop-OpenClawGatewayProcesses");
+    expect(windowsScript).toContain(
+      'const futurePluginIds = new Set(["feishu", "whatsapp", "openai"])',
+    );
+    expect(windowsScript).toContain('replace(/^\\uFEFF/u, "")');
+    expect(windowsScript).toContain("if (allow.length !== plugins.allow.length)");
+    expect(windowsScript).toContain('JSON.stringify(config, null, 2) + "\\n"');
+    expect(windowsScript).not.toContain("ConvertTo-Json -Depth 100");
+    expect(windowsScript).toContain("& node.exe $nodeScriptPath $configPath");
+    expect(windowsScript).toContain(
+      "Remove-Item $nodeScriptPath -Force -ErrorAction SilentlyContinue",
+    );
+    expect(windowsScript).toContain("Remove-FuturePluginEntries\nStop-OpenClawGatewayProcesses");
     expect(script).toContain("scrub_future_plugin_entries\nstop_openclaw_gateway_processes");
     expect(script).toContain("Invoke-WithScopedEnv @{ OPENCLAW_DISABLE_BUNDLED_PLUGINS = '1'");
     expect(macosScript).toContain('OPENCLAW_BIN="$(resolve_required_command openclaw)"');

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -856,6 +856,8 @@ exit 7
     expect(script).toContain("scrub_future_plugin_entries");
     expect(script).toContain("delete plugins.entries.feishu");
     expect(script).toContain("delete plugins.entries.whatsapp");
+    expect(script).toContain("if ($null -ne $allow)");
+    expect(script).not.toContain("if ($allow -is [array])");
     expect(script).toContain("Remove-FuturePluginEntries\nStop-OpenClawGatewayProcesses");
     expect(script).toContain("scrub_future_plugin_entries\nstop_openclaw_gateway_processes");
     expect(script).toContain("Invoke-WithScopedEnv @{ OPENCLAW_DISABLE_BUNDLED_PLUGINS = '1'");

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -1403,9 +1403,10 @@ if (isPrlctl) {
     const script = readFileSync(TS_PATHS.npmUpdateScripts, "utf8");
 
     expect(script).not.toContain("ConvertFrom-Json -AsHashtable");
-    expect(script).toContain("function Get-OpenClawJsonProperty");
-    expect(script).toContain("function Remove-OpenClawJsonProperty");
-    expect(script).toContain("Remove-OpenClawJsonProperty $entries $pluginId");
+    expect(script).not.toContain("ConvertTo-Json -Depth 100");
+    expect(script).toContain('replace(/^\\\\uFEFF/u, "")');
+    expect(script).toContain("$nodeScript | Set-Content -Path $nodeScriptPath -Encoding UTF8");
+    expect(script).toContain("& node.exe $nodeScriptPath $configPath");
   });
 
   it("keeps aggregate update guest scripts isolated from the npm-update orchestrator", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where reliability repairs proven during the v2026.7.1 release train existed only on the release branch, so later releases cut from `main` could regress Telegram delivery, aborted agent runs, installed CLI launchers, and Parallels update validation.

## Why This Change Was Made

Forward-ports the six release fixes that remain applicable to `main` as exact cherry-picks, while excluding release-only version/changelog commits and fixes already superseded on `main`.

The changes:

- throttle Telegram reconnect delivery drains so queued updates do not starve normal replies;
- make session-lock acquisition abortable for cancelled agent runs;
- prefer an installed launcher's package root during CLI root discovery;
- allow Linux onboarding enough time to finish in Parallels;
- remove stale single-plugin allowlists from Windows update fixtures;
- preserve the Windows config shape during update validation.

## User Impact

Telegram reconnects no longer monopolize delivery, cancelled runs stop while waiting for a session lock, installed launchers resolve their own package correctly, and the Linux/Windows Parallels release lanes validate realistic upgrades without fixture-induced failures.

## Evidence

- `OPENCLAW_TESTBOX=1 pnpm check:changed` equivalent on Blacksmith Testbox `tbx_01kww6211wc06mve8h0gwb4k9m`: passed all selected typecheck, lint, boundary, import-cycle, database-first, and runtime guards.
- 249 focused tests passed on the same Testbox across Telegram polling, session locking/abort behavior, CLI root discovery, and Parallels Linux/Windows update behavior.
- Branch autoreview against `origin/main`: no actionable findings.
- `git diff --check`: clean.

AI-assisted: yes. The maintainer reviewed the selected release commits and the branch was validated against current `main`.
