### PR TITLE
fix(acp): preserve runtime option clears

### DIFF
--- a/src/acp/control-plane/runtime-options.test.ts
+++ b/src/acp/control-plane/runtime-options.test.ts
@@ -1,6 +1,55 @@
 /** Tests runtime config-option serialization against advertised backend keys. */
 import { describe, expect, it } from "vitest";
-import { buildRuntimeConfigOptionPairs } from "./runtime-options.js";
+import type { AcpSessionRuntimeOptions } from "../../config/sessions/types.js";
+import { buildRuntimeConfigOptionPairs, mergeRuntimeOptions } from "./runtime-options.js";
+
+describe("mergeRuntimeOptions", () => {
+  it("clears top-level options when a patch explicitly sets them to undefined", () => {
+    const patch = {
+      runtimeMode: undefined,
+      model: undefined,
+      thinking: undefined,
+      cwd: undefined,
+      permissionProfile: undefined,
+      timeoutSeconds: undefined,
+    } as Partial<AcpSessionRuntimeOptions>;
+
+    expect(
+      mergeRuntimeOptions({
+        current: {
+          runtimeMode: "plan",
+          model: "claude-sonnet-4.6",
+          thinking: "high",
+          cwd: "/tmp/project",
+          permissionProfile: "trusted",
+          timeoutSeconds: 120,
+        },
+        patch,
+      }),
+    ).toEqual({});
+  });
+
+  it("clears backend extras when a patch explicitly clears them", () => {
+    expect(
+      mergeRuntimeOptions({
+        current: {
+          model: "claude-sonnet-4.6",
+          backendExtras: { provider: "anthropic", profile: "work" },
+        },
+        patch: { backendExtras: undefined } as Partial<AcpSessionRuntimeOptions>,
+      }),
+    ).toEqual({ model: "claude-sonnet-4.6" });
+  });
+
+  it("keeps merging backend extras when a patch provides new entries", () => {
+    expect(
+      mergeRuntimeOptions({
+        current: { backendExtras: { provider: "anthropic" } },
+        patch: { backendExtras: { profile: "work" } },
+      }),
+    ).toEqual({ backendExtras: { provider: "anthropic", profile: "work" } });
+  });
+});
 
 describe("buildRuntimeConfigOptionPairs timeout advertisement", () => {
   it("omits the timeout pair when advertised keys exclude every timeout alias", () => {

--- a/src/acp/control-plane/runtime-options.ts
+++ b/src/acp/control-plane/runtime-options.ts
@@ -21,6 +21,16 @@ const MAX_BACKEND_EXTRAS = 32;
 
 const SAFE_OPTION_KEY_RE = /^[a-z0-9][a-z0-9._:-]*$/i;
 // User-facing config aliases accepted by ACP clients and normalized to session runtime options.
+const RUNTIME_OPTION_KEYS = [
+  "runtimeMode",
+  "model",
+  "thinking",
+  "cwd",
+  "permissionProfile",
+  "timeoutSeconds",
+  "backendExtras",
+] as const;
+
 const RUNTIME_CONFIG_OPTION_ALIASES = {
   model: ["model"],
   thinking: ["thinking", "effort", "reasoning_effort", "thought_level"],
@@ -160,15 +170,7 @@ export function validateRuntimeOptionPatch(
     return {};
   }
   const rawPatch = patch as Record<string, unknown>;
-  const allowedKeys = new Set([
-    "runtimeMode",
-    "model",
-    "thinking",
-    "cwd",
-    "permissionProfile",
-    "timeoutSeconds",
-    "backendExtras",
-  ]);
+  const allowedKeys = new Set<string>(RUNTIME_OPTION_KEYS);
   for (const key of Object.keys(rawPatch)) {
     if (!allowedKeys.has(key)) {
       failInvalidOption(`Unknown runtime option "${key}".`);
@@ -277,16 +279,30 @@ export function mergeRuntimeOptions(params: {
   patch?: Partial<AcpSessionRuntimeOptions>;
 }): AcpSessionRuntimeOptions {
   const current = normalizeRuntimeOptions(params.current);
-  const patch = normalizeRuntimeOptions(validateRuntimeOptionPatch(params.patch));
-  const mergedExtras = {
-    ...current.backendExtras,
-    ...patch.backendExtras,
-  };
-  return normalizeRuntimeOptions({
+  const patch = validateRuntimeOptionPatch(params.patch);
+  const normalizedPatch = normalizeRuntimeOptions(patch);
+  const merged: Partial<AcpSessionRuntimeOptions> = {
     ...current,
-    ...patch,
-    ...(Object.keys(mergedExtras).length > 0 ? { backendExtras: mergedExtras } : {}),
-  });
+    ...normalizedPatch,
+  };
+
+  if (Object.hasOwn(patch, "backendExtras") && patch.backendExtras !== undefined) {
+    const mergedExtras = {
+      ...current.backendExtras,
+      ...normalizedPatch.backendExtras,
+    };
+    if (Object.keys(mergedExtras).length > 0) {
+      merged.backendExtras = mergedExtras;
+    }
+  }
+
+  for (const key of RUNTIME_OPTION_KEYS) {
+    if (Object.hasOwn(patch, key) && patch[key] === undefined) {
+      delete merged[key];
+    }
+  }
+
+  return normalizeRuntimeOptions(merged);
 }
 
 export function resolveRuntimeOptionsFromMeta(meta: SessionAcpMeta): AcpSessionRuntimeOptions {

--- a/src/acp/control-plane/runtime-options.ts
+++ b/src/acp/control-plane/runtime-options.ts
@@ -21,16 +21,6 @@ const MAX_BACKEND_EXTRAS = 32;
 
 const SAFE_OPTION_KEY_RE = /^[a-z0-9][a-z0-9._:-]*$/i;
 // User-facing config aliases accepted by ACP clients and normalized to session runtime options.
-const RUNTIME_OPTION_KEYS = [
-  "runtimeMode",
-  "model",
-  "thinking",
-  "cwd",
-  "permissionProfile",
-  "timeoutSeconds",
-  "backendExtras",
-] as const;
-
 const RUNTIME_CONFIG_OPTION_ALIASES = {
   model: ["model"],
   thinking: ["thinking", "effort", "reasoning_effort", "thought_level"],
@@ -170,7 +160,15 @@ export function validateRuntimeOptionPatch(
     return {};
   }
   const rawPatch = patch as Record<string, unknown>;
-  const allowedKeys = new Set<string>(RUNTIME_OPTION_KEYS);
+  const allowedKeys = new Set([
+    "runtimeMode",
+    "model",
+    "thinking",
+    "cwd",
+    "permissionProfile",
+    "timeoutSeconds",
+    "backendExtras",
+  ]);
   for (const key of Object.keys(rawPatch)) {
     if (!allowedKeys.has(key)) {
       failInvalidOption(`Unknown runtime option "${key}".`);
@@ -280,29 +278,13 @@ export function mergeRuntimeOptions(params: {
 }): AcpSessionRuntimeOptions {
   const current = normalizeRuntimeOptions(params.current);
   const patch = validateRuntimeOptionPatch(params.patch);
-  const normalizedPatch = normalizeRuntimeOptions(patch);
-  const merged: Partial<AcpSessionRuntimeOptions> = {
+  return normalizeRuntimeOptions({
     ...current,
-    ...normalizedPatch,
-  };
-
-  if (Object.hasOwn(patch, "backendExtras") && patch.backendExtras !== undefined) {
-    const mergedExtras = {
-      ...current.backendExtras,
-      ...normalizedPatch.backendExtras,
-    };
-    if (Object.keys(mergedExtras).length > 0) {
-      merged.backendExtras = mergedExtras;
-    }
-  }
-
-  for (const key of RUNTIME_OPTION_KEYS) {
-    if (Object.hasOwn(patch, key) && patch[key] === undefined) {
-      delete merged[key];
-    }
-  }
-
-  return normalizeRuntimeOptions(merged);
+    ...patch,
+    ...(patch.backendExtras
+      ? { backendExtras: { ...current.backendExtras, ...patch.backendExtras } }
+      : {}),
+  });
 }
 
 export function resolveRuntimeOptionsFromMeta(meta: SessionAcpMeta): AcpSessionRuntimeOptions {


### PR DESCRIPTION
## Summary

- Preserve explicit `undefined` runtime option patch fields through `mergeRuntimeOptions` so they clear existing persisted values.
- Add regression coverage for clearing scalar runtime options, clearing backend extras, and preserving backend-extra partial merges.

## What Problem This Solves

`validateRuntimeOptionPatch()` already treats own properties set to `undefined` as clear requests, but `mergeRuntimeOptions()` normalized that validated patch before merging. Normalization drops `undefined` fields, so the merge step lost the clear request and kept the previous runtime options.

## User Impact

ACP clients or runtime-control callers that clear model, thinking, cwd, permission profile, timeout, runtime mode, or backend extras can observe stale settings persist into later runtime option state. For example, clearing a model override with `{ model: undefined }` still leaves the old model selected before this patch.

## Origin / follow-up

Follows #23580, which introduced the ACP runtime session control surface and `mergeRuntimeOptions()` helper. This PR fills a clear-semantics gap in that same helper: validated patch own-keys that mean “clear this option” must survive until the merge step instead of being normalized away.

## Competition / linked PR analysis

No open PR found for this exact `mergeRuntimeOptions` clear-semantics issue.

Related open PR scan: checked adjacent open PRs touching `src/acp/control-plane/runtime-options.ts` and runtime option semantics. None covers explicit `undefined` patch clears in `mergeRuntimeOptions()`.

Checked adjacent open PRs touching `src/acp/control-plane/runtime-options.ts`:

- #80193 by @yxjsxy: rejects fractional runtime timeouts; it does not change patch clearing or merge semantics.
- #90968 by @moeedahmed: strips chat options for Claude ACP startup sessions and adds applied-baseline retention; it does not fix explicit `undefined` patch clears.
- #82148 by @jai: adds fast mode runtime overrides; it does not fix existing option clear behavior.

## Real behavior proof

- **Behavior or issue addressed:** `mergeRuntimeOptions()` should honor explicit `undefined` patch fields as clear requests instead of retaining stale current runtime options.
- **Real environment tested:** Linux task worktree at `c437f4af9d303ec1a4918942d1561e4eea1dac14` plus this patch, using Node v22.22.0 and `node --import tsx` to import the production `src/acp/control-plane/runtime-options.ts` module.
- **Exact steps or command run after this patch:** `OPENCLAW_REPO=/media/vdb/code/ai/aispace/openclaw-worktrees/followup-23580 EXPECTED_RESULT=after-fixed PROOF_LABEL="patched worktree after fix" node --import tsx /media/vdb/code/ai/aispace/openclaw-followup-23580-evidence/runtime-options-clear-proof.ts`; `node scripts/run-vitest.mjs src/acp/control-plane/runtime-options.test.ts`.
- **Evidence after fix:** `/media/vdb/code/ai/aispace/openclaw-followup-23580-evidence/after-runtime-options-clear.txt` shows the patched production function returns `{}` with no retained keys for explicit `undefined` clears. `/media/vdb/code/ai/aispace/openclaw-followup-23580-evidence/runtime-options-vitest.txt` shows `src/acp/control-plane/runtime-options.test.ts` passed with 8 tests.
- **Observed result after fix:** The same proof script against `origin/main` in `/media/vdb/code/ai/aispace/openclaw-followup-23580-evidence/before-runtime-options-clear.txt` retained `runtimeMode`, `model`, `thinking`, `cwd`, `permissionProfile`, `timeoutSeconds`, and `backendExtras`; after this patch the retained key list is empty.
- **What was not tested:** Full remote `pnpm check:changed` delegation was unavailable locally because the Crabbox binary failed its basic sanity check; targeted runtime-options Vitest and production-function before/after proof were completed locally.
- **Fix classification:** Root cause fix

## Review findings addressed

N/A — new focused follow-up PR with no prior review findings.

## Regression Test Plan

- **Target test file:** `src/acp/control-plane/runtime-options.test.ts`.
- **Scenario locked in:** Regression test covers the exact state transition where `current` has scalar runtime options or backend extras and the patch owns the same keys with `undefined`, plus a control case where concrete backend extras still merge incrementally.
- **Why this is the smallest reliable guardrail:** The exported helper is pure and deterministic, so a focused unit regression plus before/after production-function proof locks the root behavior without needing a gateway, provider account, or broader ACP session harness.
- `node --import tsx /media/vdb/code/ai/aispace/openclaw-followup-23580-evidence/runtime-options-clear-proof.ts` against an `origin/main` snapshot confirmed the old behavior retained stale runtime options.
- `node --import tsx /media/vdb/code/ai/aispace/openclaw-followup-23580-evidence/runtime-options-clear-proof.ts` against this patch confirmed explicit `undefined` fields clear all supplied runtime options.
- `node scripts/run-vitest.mjs src/acp/control-plane/runtime-options.test.ts` passed with 8 tests.

## Merge risk

- **Why it matters / User impact:** Stale runtime control values can remain active after a caller explicitly clears them, so later ACP turns can keep using an old model, thinking level, cwd, permission profile, timeout, runtime mode, or backend-extra value.
- **Risk labels considered:** `merge-risk: compatibility`, `merge-risk: session-state`, `merge-risk: message-delivery`, `merge-risk: security-boundary`.
- **Risk explanation:** The patch only changes the in-memory merge result for own patch keys whose validated value is `undefined`; it does not alter validation, persistence schema, authorization, transports, or delivery paths.
- **Why acceptable:** `validateRuntimeOptionPatch()` already preserves explicit `undefined` values as the clear signal. This patch carries that existing signal through the merge boundary and keeps concrete backend-extra partial merges unchanged.
- **Maintainer-ready confidence:** High for this focused helper-level root cause because before/after production-function proof covers the exact exported function and the regression test covers scalar clears, backend-extra clears, and backend-extra merges.
- **Patch quality notes:** Two source files changed, no unrelated cleanup, no schema or public dependency changes.
- **Target test file:** `src/acp/control-plane/runtime-options.test.ts`.

## Risk / Compatibility

Low risk. This only changes how `mergeRuntimeOptions()` handles own patch keys that `validateRuntimeOptionPatch()` already accepts as explicit clear requests. Existing non-clear merges are preserved, including partial `backendExtras` merging when a patch provides new backend-extra entries.

## What was not changed

- **What did NOT change:** This PR does not change runtime option validation limits, accepted value shapes, ACP transport, session storage, provider selection, authorization, message delivery, or concrete backend-extra partial merge behavior.
- No changes to runtime option validation limits or accepted value shapes.
- No changes to ACP transport, session storage, provider selection, authorization, or message delivery.
- No change to backend-extra partial merge behavior when concrete backend-extra entries are provided.

## Root Cause

- **Root cause:** The root cause is in the `mergeRuntimeOptions()` merge boundary because it called `normalizeRuntimeOptions(validateRuntimeOptionPatch(params.patch))` before merging. `normalizeRuntimeOptions()` removes `undefined` fields, so it erased the own-key clear signal that `validateRuntimeOptionPatch()` preserved.
- **Architecture / source-of-truth check:** `validateRuntimeOptionPatch()` is the source-of-truth validator for patch intent; it already preserves own keys with `undefined` as clear requests. `mergeRuntimeOptions()` is the canonical place that combines current state with that validated patch, so the fix belongs at this merge boundary rather than in downstream ACP runtime consumers.
- **Why this is root-cause fix:** The patch keeps the validated patch separate from its normalized values because the validated patch owns the clear-signal contract. It merges normalized concrete values, then deletes keys that were explicitly present with `undefined`, preserving the source-of-truth clear signal through the merge boundary instead of adding a downstream workaround.
