### PR TITLE
fix(feishu): WebSocket encryptKey SecretRefs are ignored at runtime

### DIFF
--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -291,23 +291,31 @@ describe("resolveFeishuCredentials", () => {
     });
   });
 
-  it("does not resolve encryptKey SecretRefs outside webhook mode", () => {
-    const creds = resolveFeishuCredentials(
-      asConfig({
-        connectionMode: "websocket",
-        appId: "cli_123",
-        appSecret: "secret_456",
-        encryptKey: { source: "file", provider: "default", id: "path/to/secret" } as never,
-      }),
-    );
+  it("resolves env encryptKey SecretRefs in websocket mode when unresolved refs are allowed", () => {
+    const key = "FEISHU_WEBSOCKET_ENCRYPT_KEY_TEST";
+    const restore = setTestEnvValue(key, " websocket_encrypt_key ");
 
-    expect(creds).toEqual({
-      appId: "cli_123",
-      appSecret: "secret_456", // pragma: allowlist secret
-      encryptKey: undefined,
-      verificationToken: undefined,
-      domain: "feishu",
-    });
+    try {
+      const creds = resolveFeishuCredentials(
+        asConfig({
+          connectionMode: "websocket",
+          appId: "cli_123",
+          appSecret: "secret_456",
+          encryptKey: { source: "env", provider: "default", id: key } as never,
+        }),
+        { allowUnresolvedSecretRef: true },
+      );
+
+      expect(creds).toEqual({
+        appId: "cli_123",
+        appSecret: "secret_456", // pragma: allowlist secret
+        encryptKey: "websocket_encrypt_key",
+        verificationToken: undefined,
+        domain: "feishu",
+      });
+    } finally {
+      restore();
+    }
   });
 
   it("keeps required credentials when optional event SecretRefs are unresolved in inspect mode", () => {

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -122,15 +122,12 @@ function resolveFeishuEventSecrets(
   verificationToken?: string;
 } {
   return {
-    encryptKey:
-      (cfg?.connectionMode ?? "websocket") === "webhook"
-        ? resolveFeishuSecretLike({
-            value: cfg?.encryptKey,
-            path: "channels.feishu.encryptKey",
-            mode,
-            allowEnvSecretRefRead: true,
-          })
-        : normalizeString(cfg?.encryptKey),
+    encryptKey: resolveFeishuSecretLike({
+      value: cfg?.encryptKey,
+      path: "channels.feishu.encryptKey",
+      mode,
+      allowEnvSecretRefRead: true,
+    }),
     verificationToken: resolveFeishuSecretLike({
       value: cfg?.verificationToken,
       path: "channels.feishu.verificationToken",

--- a/extensions/feishu/src/secret-contract.test.ts
+++ b/extensions/feishu/src/secret-contract.test.ts
@@ -1,8 +1,39 @@
 // Feishu tests cover secret contract plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { createResolverContext } from "openclaw/plugin-sdk/secret-ref-runtime";
+import {
+  applyResolvedAssignments,
+  createResolverContext,
+  resolveSecretRefValues,
+} from "openclaw/plugin-sdk/secret-ref-runtime";
 import { describe, expect, it } from "vitest";
 import { collectRuntimeConfigAssignments } from "./secret-contract.js";
+
+async function resolveFeishuSecretAssignments(
+  sourceConfig: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): Promise<OpenClawConfig> {
+  const resolvedConfig: OpenClawConfig = structuredClone(sourceConfig);
+  const context = createResolverContext({ sourceConfig, env });
+
+  collectRuntimeConfigAssignments({
+    config: resolvedConfig,
+    defaults: sourceConfig.secrets?.defaults,
+    context,
+  });
+
+  const resolved = await resolveSecretRefValues(
+    context.assignments.map((assignment) => assignment.ref),
+    {
+      config: sourceConfig,
+      env: context.env,
+      cache: context.cache,
+    },
+  );
+  applyResolvedAssignments({ assignments: context.assignments, resolved });
+
+  expect(context.warnings).toStrictEqual([]);
+  return resolvedConfig;
+}
 
 describe("feishu secret contract", () => {
   it("assigns an enabled accountless appSecret to the default owner without a configured appId", () => {
@@ -67,5 +98,54 @@ describe("feishu secret contract", () => {
 
     expect(context.assignments).toStrictEqual([]);
     expect(context.warnings).toMatchObject([{ path: "channels.feishu.appSecret" }]);
+  });
+
+  it("resolves top-level websocket encryptKey SecretRefs when explicitly configured", async () => {
+    const resolvedConfig = await resolveFeishuSecretAssignments(
+      {
+        channels: {
+          feishu: {
+            enabled: true,
+            connectionMode: "websocket",
+            appId: "cli_123",
+            appSecret: "secret_456",
+            encryptKey: { source: "env", provider: "default", id: "FEISHU_WS_ENCRYPT_KEY" },
+          },
+        },
+      } as OpenClawConfig,
+      { FEISHU_WS_ENCRYPT_KEY: "resolved-ws-encrypt-key" },
+    );
+
+    expect(resolvedConfig.channels?.feishu?.encryptKey).toBe("resolved-ws-encrypt-key");
+  });
+
+  it("resolves account websocket encryptKey SecretRefs when explicitly configured", async () => {
+    const resolvedConfig = await resolveFeishuSecretAssignments(
+      {
+        channels: {
+          feishu: {
+            enabled: true,
+            connectionMode: "websocket",
+            accounts: {
+              main: {
+                enabled: true,
+                appId: "cli_123",
+                appSecret: "secret_456",
+                encryptKey: {
+                  source: "env",
+                  provider: "default",
+                  id: "FEISHU_ACCOUNT_WS_ENCRYPT_KEY",
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      { FEISHU_ACCOUNT_WS_ENCRYPT_KEY: "resolved-account-ws-encrypt-key" },
+    );
+
+    expect(resolvedConfig.channels?.feishu?.accounts?.main?.encryptKey).toBe(
+      "resolved-account-ws-encrypt-key",
+    );
   });
 });

--- a/extensions/feishu/src/secret-contract.ts
+++ b/extensions/feishu/src/secret-contract.ts
@@ -63,6 +63,7 @@ export function collectRuntimeConfigAssignments(params: {
     hasOwnProperty(account, "connectionMode")
       ? normalizeSecretStringValue(account.connectionMode)
       : baseConnectionMode;
+  const topLevelEncryptKeyConfigured = hasOwnProperty(feishu, "encryptKey");
   collectConditionalChannelFieldAssignments({
     channelKey: "feishu",
     field: "encryptKey",
@@ -70,14 +71,14 @@ export function collectRuntimeConfigAssignments(params: {
     surface,
     defaults: params.defaults,
     context: params.context,
-    topLevelActiveWithoutAccounts: baseConnectionMode === "webhook",
+    topLevelActiveWithoutAccounts: baseConnectionMode === "webhook" || topLevelEncryptKeyConfigured,
     topLevelInheritedAccountActive: ({ account, enabled }) =>
       enabled &&
       !hasOwnProperty(account, "encryptKey") &&
-      resolveAccountMode(account) === "webhook",
-    accountActive: ({ account, enabled }) => enabled && resolveAccountMode(account) === "webhook",
-    topInactiveReason: "no enabled Feishu webhook-mode surface inherits this top-level encryptKey.",
-    accountInactiveReason: "Feishu account is disabled or not running in webhook mode.",
+      (resolveAccountMode(account) === "webhook" || topLevelEncryptKeyConfigured),
+    accountActive: ({ enabled }) => enabled,
+    topInactiveReason: "no enabled Feishu account inherits this top-level encryptKey.",
+    accountInactiveReason: "Feishu account is disabled.",
   });
   collectConditionalChannelFieldAssignments({
     channelKey: "feishu",


### PR DESCRIPTION
## What Problem This Solves

When `channels.feishu.encryptKey` was configured as a SecretRef and `connectionMode` was `websocket`, the Feishu account resolver treated the field as a plain string before runtime secret resolution. The SecretRef was therefore discarded instead of being resolved and passed on. Plain-string values were unaffected.

## Why This Change Was Made

This change sends `encryptKey` through the existing SecretRef-aware resolver for both webhook and WebSocket account resolution. It also registers explicitly configured top-level and enabled account-level `encryptKey` values for runtime SecretRef assignment.

The change does not add a configuration surface or change Feishu event transport behavior. It is limited to OpenClaw configuration resolution and delivery of an explicitly configured value to the Feishu SDK dispatcher.

## User Impact

Feishu configurations that explicitly provide `encryptKey` through a supported SecretRef can now resolve that value in WebSocket mode instead of silently dropping it before dispatcher construction. Existing plain-string configuration and configurations that omit `encryptKey` keep their current behavior.

This does not claim that Feishu persistent WebSocket delivery uses encrypted event envelopes. Whether Feishu sends encrypted events on that transport remains a vendor protocol question outside the scope of this resolver fix.

## Evidence

- `extensions/feishu/src/accounts.ts` replaces the WebSocket-only string normalization with the existing SecretRef-aware resolution path for `encryptKey`.
- `extensions/feishu/src/secret-contract.ts` registers explicitly configured top-level and enabled account-level `encryptKey` SecretRefs for runtime resolution.
- Added regression coverage verifies environment-backed SecretRefs resolve in WebSocket mode and that top-level and account-level assignments reach the resolved runtime configuration.
- `@larksuiteoapi/node-sdk@1.68.0` declares `EventDispatcher` with an optional `encryptKey` constructor parameter; this change supplies the resolved configuration value to that existing SDK surface.
- No real encrypted Feishu persistent-WebSocket event was used as end-to-end evidence. The tests cover OpenClaw SecretRef resolution and SDK parameter delivery only.