### PR TITLE
fix(sessions): handle mid-stream read errors in transcript streaming

### DIFF
--- a/scripts/proof/transcript-stream-readline-errors.mts
+++ b/scripts/proof/transcript-stream-readline-errors.mts
@@ -1,0 +1,44 @@
+// Real behavior proof: streamSessionTranscriptLines handles mid-stream read errors
+// without crashing the caller's async iteration.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const { streamSessionTranscriptLines } = await import(
+  path.join(repoRoot, "src/config/sessions/transcript-stream.js")
+);
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-proof-transcript-stream-"));
+const transcriptPath = path.join(tmpDir, "session.jsonl");
+fs.writeFileSync(transcriptPath, "one\ntwo\nthree\n", "utf-8");
+
+// Force a mid-stream read error by truncating the file after the stream starts.
+const originalCreateReadStream = fs.createReadStream;
+fs.createReadStream = ((...args: unknown[]) => {
+  const stream = originalCreateReadStream.apply(fs, args as never);
+  setTimeout(() => {
+    fs.truncateSync(args[0] as string, 0);
+    stream.destroy(new Error("forced read error"));
+  }, 10);
+  return stream;
+}) as typeof fs.createReadStream;
+
+console.log("=== Proof: transcript stream mid-read error handling ===\n");
+
+try {
+  const lines: string[] = [];
+  for await (const line of streamSessionTranscriptLines(transcriptPath)) {
+    lines.push(line);
+  }
+  console.log(`PASS: streamSessionTranscriptLines completed without crashing (got ${lines.length} lines).`);
+} catch (err) {
+  console.error("FAIL: streamSessionTranscriptLines rejected with:");
+  console.error(err);
+  process.exitCode = 1;
+} finally {
+  fs.createReadStream = originalCreateReadStream;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}

--- a/src/config/sessions/transcript-stream.test.ts
+++ b/src/config/sessions/transcript-stream.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   streamSessionTranscriptLines,
   streamSessionTranscriptLinesReverse,
@@ -94,6 +94,24 @@ describe("streamSessionTranscriptLines", () => {
     const lines = await collect(streamSessionTranscriptLines(transcriptPath));
 
     expect(lines).toEqual([longLine, "short"]);
+  });
+
+  it("does not crash when the read stream emits an error mid-read", async () => {
+    fs.writeFileSync(transcriptPath, "one\ntwo\n", "utf-8");
+
+    const originalCreateReadStream = fs.createReadStream;
+    vi.spyOn(fs, "createReadStream").mockImplementationOnce((...args: unknown[]) => {
+      const created = originalCreateReadStream.apply(fs, args as never);
+      process.nextTick(() => {
+        created.emit("error", new Error("stream read failed"));
+      });
+      return created;
+    });
+
+    const lines = await collect(streamSessionTranscriptLines(transcriptPath));
+
+    vi.restoreAllMocks();
+    expect(lines).toEqual([]);
   });
 });
 

--- a/src/config/sessions/transcript-stream.ts
+++ b/src/config/sessions/transcript-stream.ts
@@ -62,6 +62,9 @@ export async function* streamSessionTranscriptLines(
       }
       yield trimmed;
     }
+  } catch {
+    // Mid-stream read errors are swallowed so callers see a truncated but
+    // stable iterator, matching the behavior for missing/empty files.
   } finally {
     rl.close();
     stream.destroy();


### PR DESCRIPTION
## What Problem This Solves

`streamSessionTranscriptLines` reads session transcripts through a `readline` interface over a file stream. If the file stream emits an error mid-read, the error propagates out of the async generator and can crash the caller.

## Why This Change Was Made

Add a catch block around the async iteration so mid-stream read errors are swallowed, returning a truncated but stable iterator. This matches the existing behavior for missing or empty transcript files.

## User Impact

Transcript streaming is more resilient to transient file-system read failures.

## Evidence

- Added regression test in `src/config/sessions/transcript-stream.test.ts` covering a mid-stream read error.
- Added real behavior proof at `scripts/proof/transcript-stream-readline-errors.mts`.
- Local run:
  - `node scripts/run-vitest.mjs src/config/sessions/transcript-stream.test.ts` passed
  - `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs src/config/sessions/transcript-stream.ts src/config/sessions/transcript-stream.test.ts scripts/proof/transcript-stream-readline-errors.mts` passed
