### PR TITLE
feat(apple): session search, archived browsing, and sheet management actions

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -7027,7 +7027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 318,
+      "line": 339,
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
       "source": "\\\"\\(trimmed)\\\"",
       "surface": "apple",
@@ -7035,7 +7035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 318,
+      "line": 339,
       "path": "apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift",
       "source": "that request",
       "surface": "apple",
@@ -22170,12 +22170,132 @@
       "id": "native.apple.7c99becc26501014"
     },
     {
+      "kind": "conditional-branch",
+      "line": 16,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Active",
+      "surface": "apple",
+      "id": "native.apple.0d9f7c1e0e65a820"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 17,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Archived",
+      "surface": "apple",
+      "id": "native.apple.3c71a4c13836cc75"
+    },
+    {
+      "kind": "ui-call",
+      "line": 65,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Scope",
+      "surface": "apple",
+      "id": "native.apple.0489ad746c8d35c2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 77,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Search sessions",
+      "surface": "apple",
+      "id": "native.apple.2c37581c7b88f741"
+    },
+    {
       "kind": "ui-modifier",
-      "line": 30,
+      "line": 78,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
       "source": "Sessions",
       "surface": "apple",
       "id": "native.apple.43be8a2336e42faf"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 102,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Rename Session",
+      "surface": "apple",
+      "id": "native.apple.0b379cdfcbd3247f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 108,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Session name",
+      "surface": "apple",
+      "id": "native.apple.54b6fbd9e41db009"
+    },
+    {
+      "kind": "ui-call",
+      "line": 116,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.833fe2915430c89d"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 145,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "No archived sessions",
+      "surface": "apple",
+      "id": "native.apple.b67eaecec1b423ac"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 145,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "No sessions found",
+      "surface": "apple",
+      "id": "native.apple.b2435a79abf0c794"
+    },
+    {
+      "kind": "ui-call",
+      "line": 186,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Pinned",
+      "surface": "apple",
+      "id": "native.apple.05cb1fecc5844b69"
+    },
+    {
+      "kind": "ui-call",
+      "line": 219,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Rename",
+      "surface": "apple",
+      "id": "native.apple.080fce25e4a9bb61"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 227,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Pin",
+      "surface": "apple",
+      "id": "native.apple.d148288258094aa6"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 227,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Unpin",
+      "surface": "apple",
+      "id": "native.apple.3c62aaf44e6ab4d4"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 236,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Archive",
+      "surface": "apple",
+      "id": "native.apple.666ba6eb696e649f"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 236,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
+      "source": "Unarchive",
+      "surface": "apple",
+      "id": "native.apple.34b910911a05110e"
     },
     {
       "kind": "ui-call",
@@ -22259,7 +22379,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1360,
+      "line": 1361,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -22267,7 +22387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1360,
+      "line": 1361,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",

--- a/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
+++ b/apps/ios/Sources/Chat/AppleReviewDemoChatTransport.swift
@@ -168,8 +168,25 @@ struct LocalFixtureChatTransport: OpenClawChatTransport {
 
     func abortRun(sessionKey _: String, runId _: String) async throws {}
 
-    func listSessions(limit _: Int?) async throws -> OpenClawChatSessionsListResponse {
-        try await self.store.sessions()
+    func listSessions(
+        limit _: Int?,
+        search: String?,
+        archived: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
+        let response = try await self.store.sessions()
+        var sessions = response.sessions
+        if archived {
+            sessions = []
+        }
+        if let search {
+            sessions = OpenClawChatSessionListOrganizer.filter(sessions, search: search)
+        }
+        return OpenClawChatSessionsListResponse(
+            ts: response.ts,
+            path: response.path,
+            count: sessions.count,
+            defaults: response.defaults,
+            sessions: sessions)
     }
 
     func setSessionModel(sessionKey _: String, model _: String?) async throws {}
@@ -243,8 +260,12 @@ struct AppleReviewDemoChatTransport: OpenClawChatTransport {
         try await self.transport.abortRun(sessionKey: sessionKey, runId: runId)
     }
 
-    func listSessions(limit: Int?) async throws -> OpenClawChatSessionsListResponse {
-        try await self.transport.listSessions(limit: limit)
+    func listSessions(
+        limit: Int?,
+        search: String?,
+        archived: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
+        try await self.transport.listSessions(limit: limit, search: search, archived: archived)
     }
 
     func setSessionModel(sessionKey: String, model: String?) async throws {

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -34,6 +34,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         var includeGlobal: Bool
         var includeUnknown: Bool
         var limit: Int?
+        var search: String?
         var archived: Bool?
     }
 
@@ -205,11 +206,17 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         max(1, Int(ceil(Double(timeoutMs) / 1000.0)) + 5)
     }
 
-    static func makeListSessionsParamsJSON(limit: Int?, archived: Bool = false) throws -> String {
-        try self.encodeParams(ListSessionsParams(
+    static func makeListSessionsParamsJSON(
+        limit: Int?,
+        search: String? = nil,
+        archived: Bool = false) throws -> String
+    {
+        let normalizedSearch = search?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return try self.encodeParams(ListSessionsParams(
             includeGlobal: true,
             includeUnknown: false,
             limit: limit,
+            search: normalizedSearch?.isEmpty == false ? normalizedSearch : nil,
             archived: archived ? true : nil))
     }
 
@@ -444,12 +451,12 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         _ = try await self.gateway.request(method: "chat.abort", paramsJSON: json, timeoutSeconds: 10)
     }
 
-    func listSessions(limit: Int?) async throws -> OpenClawChatSessionsListResponse {
-        try await self.listSessions(limit: limit, archived: false)
-    }
-
-    func listSessions(limit: Int?, archived: Bool) async throws -> OpenClawChatSessionsListResponse {
-        let json = try Self.makeListSessionsParamsJSON(limit: limit, archived: archived)
+    func listSessions(
+        limit: Int?,
+        search: String?,
+        archived: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
+        let json = try Self.makeListSessionsParamsJSON(limit: limit, search: search, archived: archived)
         let res = try await self.gateway.request(method: "sessions.list", paramsJSON: json, timeoutSeconds: 15)
         return try JSONDecoder().decode(OpenClawChatSessionsListResponse.self, from: res)
     }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -57,13 +57,24 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             timeoutMs: 10000)
     }
 
-    func listSessions(limit: Int?) async throws -> OpenClawChatSessionsListResponse {
+    func listSessions(
+        limit: Int?,
+        search: String?,
+        archived: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
         var params: [String: AnyCodable] = [
             "includeGlobal": AnyCodable(true),
             "includeUnknown": AnyCodable(false),
         ]
         if let limit {
             params["limit"] = AnyCodable(limit)
+        }
+        let normalizedSearch = search?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let normalizedSearch, !normalizedSearch.isEmpty {
+            params["search"] = AnyCodable(normalizedSearch)
+        }
+        if archived {
+            params["archived"] = AnyCodable(true)
         }
         let data = try await GatewayConnection.shared.request(
             method: "sessions.list",
@@ -108,6 +119,39 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             "key": AnyCodable(sessionKey),
             "thinkingLevel": AnyCodable(thinkingLevel),
         ]
+        _ = try await GatewayConnection.shared.request(
+            method: "sessions.patch",
+            params: params,
+            timeoutMs: 15000)
+    }
+
+    func patchSession(
+        key: String,
+        label: String??,
+        category: String??,
+        pinned: Bool?,
+        archived: Bool?,
+        unread: Bool?) async throws
+    {
+        var params: [String: AnyCodable] = [
+            "key": AnyCodable(key),
+        ]
+        // Double-optionals: .some(nil) clears the field server-side (JSON null).
+        if let label {
+            params["label"] = label.map(AnyCodable.init) ?? AnyCodable(NSNull())
+        }
+        if let category {
+            params["category"] = category.map(AnyCodable.init) ?? AnyCodable(NSNull())
+        }
+        if let pinned {
+            params["pinned"] = AnyCodable(pinned)
+        }
+        if let archived {
+            params["archived"] = AnyCodable(archived)
+        }
+        if let unread {
+            params["unread"] = AnyCodable(unread)
+        }
         _ = try await GatewayConnection.shared.request(
             method: "sessions.patch",
             params: params,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -84,39 +84,41 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
         self.key
     }
 
-    public let key: String
-    public let kind: String?
-    public let displayName: String?
-    public let label: String?
-    public let category: String?
-    public let pinned: Bool?
-    public let archived: Bool?
-    public let unread: Bool?
-    public let surface: String?
-    public let subject: String?
-    public let room: String?
-    public let space: String?
-    public let updatedAt: Double?
-    public let lastReadAt: Double?
-    public let lastActivityAt: Double?
-    public let sessionId: String?
+    public var key: String
+    public var kind: String?
+    public var displayName: String?
+    public var label: String?
+    public var category: String?
+    public var pinned: Bool?
+    public var pinnedAt: Double?
+    public var archived: Bool?
+    public var archivedAt: Double?
+    public var unread: Bool?
+    public var surface: String?
+    public var subject: String?
+    public var room: String?
+    public var space: String?
+    public var updatedAt: Double?
+    public var lastReadAt: Double?
+    public var lastActivityAt: Double?
+    public var sessionId: String?
 
-    public let systemSent: Bool?
-    public let abortedLastRun: Bool?
-    public let thinkingLevel: String?
-    public let verboseLevel: String?
+    public var systemSent: Bool?
+    public var abortedLastRun: Bool?
+    public var thinkingLevel: String?
+    public var verboseLevel: String?
 
-    public let inputTokens: Int?
-    public let outputTokens: Int?
-    public let totalTokens: Int?
-    public let totalTokensFresh: Bool?
+    public var inputTokens: Int?
+    public var outputTokens: Int?
+    public var totalTokens: Int?
+    public var totalTokensFresh: Bool?
 
-    public let modelProvider: String?
-    public let model: String?
-    public let contextTokens: Int?
-    public let thinkingLevels: [OpenClawChatThinkingLevelOption]?
-    public let thinkingOptions: [String]?
-    public let thinkingDefault: String?
+    public var modelProvider: String?
+    public var model: String?
+    public var contextTokens: Int?
+    public var thinkingLevels: [OpenClawChatThinkingLevelOption]?
+    public var thinkingOptions: [String]?
+    public var thinkingDefault: String?
 
     public init(
         key: String,
@@ -145,7 +147,9 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
         label: String? = nil,
         category: String? = nil,
         pinned: Bool? = nil,
+        pinnedAt: Double? = nil,
         archived: Bool? = nil,
+        archivedAt: Double? = nil,
         unread: Bool? = nil,
         lastReadAt: Double? = nil,
         lastActivityAt: Double? = nil)
@@ -156,7 +160,9 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
         self.label = label
         self.category = category
         self.pinned = pinned
+        self.pinnedAt = pinnedAt
         self.archived = archived
+        self.archivedAt = archivedAt
         self.unread = unread
         self.surface = surface
         self.subject = subject
@@ -180,6 +186,53 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
         self.thinkingLevels = thinkingLevels
         self.thinkingOptions = thinkingOptions
         self.thinkingDefault = thinkingDefault
+    }
+
+    public var isPinned: Bool {
+        self.pinned == true
+    }
+
+    public var isArchived: Bool {
+        self.archived == true
+    }
+}
+
+/// Client-side session list policy shared by every session list surface.
+/// Ordering mirrors the gateway (`pinnedAt` desc, `updatedAt` desc, key) so
+/// cached/offline lists render in the same order as server responses.
+public enum OpenClawChatSessionListOrganizer {
+    public static func organize(_ sessions: [OpenClawChatSessionEntry]) -> [OpenClawChatSessionEntry] {
+        sessions.sorted { lhs, rhs in
+            let lhsPinnedAt = lhs.pinnedAt ?? (lhs.isPinned ? .greatestFiniteMagnitude : 0)
+            let rhsPinnedAt = rhs.pinnedAt ?? (rhs.isPinned ? .greatestFiniteMagnitude : 0)
+            if lhsPinnedAt != rhsPinnedAt {
+                return lhsPinnedAt > rhsPinnedAt
+            }
+            let lhsUpdatedAt = lhs.updatedAt ?? 0
+            let rhsUpdatedAt = rhs.updatedAt ?? 0
+            if lhsUpdatedAt != rhsUpdatedAt {
+                return lhsUpdatedAt > rhsUpdatedAt
+            }
+            return lhs.key < rhs.key
+        }
+    }
+
+    /// Local fallback for the server-side `sessions.list` search when the
+    /// gateway is unreachable and only cached entries are available.
+    public static func filter(
+        _ sessions: [OpenClawChatSessionEntry],
+        search: String) -> [OpenClawChatSessionEntry]
+    {
+        let query = search.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else { return sessions }
+        return sessions.filter { session in
+            for field in [session.displayName, session.label, session.subject, session.sessionId, session.key] {
+                if let field, field.lowercased().contains(query) {
+                    return true
+                }
+            }
+            return false
+        }
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift
@@ -3,67 +3,269 @@ import SwiftUI
 
 @MainActor
 struct ChatSessionsSheet: View {
+    private enum SessionScope: String, CaseIterable, Identifiable {
+        case active
+        case archived
+
+        var id: String {
+            self.rawValue
+        }
+
+        var title: String {
+            switch self {
+            case .active: "Active"
+            case .archived: "Archived"
+            }
+        }
+    }
+
     @Bindable var viewModel: OpenClawChatViewModel
     @Environment(\.dismiss) private var dismiss
+    @State private var searchText = ""
+    @State private var scope: SessionScope = .active
+    @State private var scopedSessions: [OpenClawChatSessionEntry] = []
+    @State private var isLoadingScoped = false
+    @State private var renameTarget: OpenClawChatSessionEntry?
+    @State private var renameText = ""
+
+    /// Live view-model sessions serve the default active list; search and the
+    /// archived scope fetch one-shot lists (server-side search with local
+    /// cached fallback inside the view model).
+    private var usesScopedFetch: Bool {
+        self.scope == .archived || !self.trimmedSearchText.isEmpty
+    }
+
+    private var trimmedSearchText: String {
+        self.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var displayedSessions: [OpenClawChatSessionEntry] {
+        self.usesScopedFetch ? self.scopedSessions : self.viewModel.sessions
+    }
+
+    private var scopedFetchID: String {
+        "\(self.scope.rawValue)|\(self.trimmedSearchText.lowercased())"
+    }
 
     var body: some View {
         NavigationStack {
-            List(self.viewModel.sessions) { session in
-                Button {
-                    self.viewModel.switchSession(to: session.key)
-                    self.dismiss()
-                } label: {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(session.displayName ?? session.key)
-                            .font(OpenClawChatTypography.mono(size: 17, relativeTo: .body))
-                            .lineLimit(1)
-                        if let updatedAt = session.updatedAt, updatedAt > 0 {
-                            Text(Date(timeIntervalSince1970: updatedAt / 1000).formatted(
-                                date: .abbreviated,
-                                time: .shortened))
-                                .font(OpenClawChatTypography.caption)
-                                .foregroundStyle(.secondary)
-                        }
+            List {
+                Section {
+                    ForEach(self.displayedSessions) { session in
+                        self.sessionRow(session)
                     }
+                } header: {
+                    Picker(selection: self.$scope) {
+                        ForEach(SessionScope.allCases) { scope in
+                            Text(scope.title)
+                                .font(OpenClawChatTypography.caption)
+                                .tag(scope)
+                        }
+                    } label: {
+                        Text("Scope")
+                            .font(OpenClawChatTypography.caption)
+                    }
+                    .pickerStyle(.segmented)
+                    .textCase(nil)
                 }
             }
+            .overlay {
+                if self.displayedSessions.isEmpty {
+                    self.emptyState
+                }
+            }
+            .searchable(text: self.$searchText, prompt: Text("Search sessions"))
             .navigationTitle("Sessions")
             .toolbar {
                 #if os(macOS)
                 ToolbarItem(placement: .automatic) {
-                    Button {
-                        self.viewModel.refreshSessions(limit: 200)
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                    }
+                    self.refreshButton
                 }
                 ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        self.dismiss()
-                    } label: {
-                        Image(systemName: "xmark")
-                    }
+                    self.closeButton
                 }
                 #else
                 ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        self.viewModel.refreshSessions(limit: 200)
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                    }
+                    self.refreshButton
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        self.dismiss()
-                    } label: {
-                        Image(systemName: "xmark")
-                    }
+                    self.closeButton
                 }
                 #endif
             }
-            .onAppear {
-                self.viewModel.refreshSessions(limit: 200)
+            .task(id: self.scopedFetchID) {
+                await self.refreshScopedSessionsIfNeeded(debounce: !self.trimmedSearchText.isEmpty)
             }
+            .onAppear {
+                self.viewModel.refreshSessions(limit: OpenClawChatViewModel.sessionListFetchLimit)
+            }
+            .alert(
+                "Rename Session",
+                isPresented: Binding(
+                    get: { self.renameTarget != nil },
+                    set: { if !$0 { self.renameTarget = nil } }))
+            {
+                TextField("Session name", text: self.$renameText)
+                Button("Rename") {
+                    if let target = self.renameTarget {
+                        self.viewModel.renameSession(key: target.key, label: self.renameText)
+                        self.refreshScopedSessionsSoon()
+                    }
+                    self.renameTarget = nil
+                }
+                Button("Cancel", role: .cancel) {
+                    self.renameTarget = nil
+                }
+            }
+        }
+    }
+
+    private var refreshButton: some View {
+        Button {
+            self.viewModel.refreshSessions(limit: OpenClawChatViewModel.sessionListFetchLimit)
+            self.refreshScopedSessionsSoon()
+        } label: {
+            Image(systemName: "arrow.clockwise")
+        }
+    }
+
+    private var closeButton: some View {
+        Button {
+            self.dismiss()
+        } label: {
+            Image(systemName: "xmark")
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            if self.isLoadingScoped {
+                ProgressView()
+            } else {
+                Text(self.scope == .archived ? "No archived sessions" : "No sessions found")
+                    .font(OpenClawChatTypography.body)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func sessionRow(_ session: OpenClawChatSessionEntry) -> some View {
+        Button {
+            if session.isArchived {
+                // Archived sessions reject new sends; opening one restores it
+                // first and only switches on success so the composer never
+                // points at a still-archived session.
+                Task {
+                    guard await self.viewModel.restoreSession(key: session.key) else { return }
+                    self.viewModel.switchSession(to: session.key)
+                    self.dismiss()
+                }
+            } else {
+                self.viewModel.switchSession(to: session.key)
+                self.dismiss()
+            }
+        } label: {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(session.displayName ?? session.key)
+                        .font(OpenClawChatTypography.mono(size: 17, relativeTo: .body))
+                        .lineLimit(1)
+                    if let updatedAt = session.updatedAt, updatedAt > 0 {
+                        Text(Date(timeIntervalSince1970: updatedAt / 1000).formatted(
+                            date: .abbreviated,
+                            time: .shortened))
+                            .font(OpenClawChatTypography.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 0)
+                if session.isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .accessibilityLabel(Text("Pinned"))
+                }
+            }
+        }
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            if !session.isArchived {
+                Button {
+                    self.viewModel.setSessionPinned(key: session.key, pinned: !session.isPinned)
+                    self.refreshScopedSessionsSoon()
+                } label: {
+                    Label(
+                        session.isPinned ? "Unpin" : "Pin",
+                        systemImage: session.isPinned ? "pin.slash" : "pin")
+                }
+                .tint(OpenClawChatTheme.accent)
+            }
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button {
+                self.viewModel.setSessionArchived(key: session.key, archived: !session.isArchived)
+                self.refreshScopedSessionsSoon()
+            } label: {
+                Label(
+                    session.isArchived ? "Unarchive" : "Archive",
+                    systemImage: session.isArchived ? "tray.and.arrow.up" : "archivebox")
+            }
+            .tint(session.isArchived ? OpenClawChatTheme.accent : OpenClawChatTheme.danger)
+        }
+        .contextMenu {
+            Button {
+                self.renameText = session.displayName ?? ""
+                self.renameTarget = session
+            } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+            if !session.isArchived {
+                Button {
+                    self.viewModel.setSessionPinned(key: session.key, pinned: !session.isPinned)
+                    self.refreshScopedSessionsSoon()
+                } label: {
+                    Label(
+                        session.isPinned ? "Unpin" : "Pin",
+                        systemImage: session.isPinned ? "pin.slash" : "pin")
+                }
+            }
+            Button {
+                self.viewModel.setSessionArchived(key: session.key, archived: !session.isArchived)
+                self.refreshScopedSessionsSoon()
+            } label: {
+                Label(
+                    session.isArchived ? "Unarchive" : "Archive",
+                    systemImage: session.isArchived ? "tray.and.arrow.up" : "archivebox")
+            }
+        }
+    }
+
+    private func refreshScopedSessionsIfNeeded(debounce: Bool) async {
+        guard self.usesScopedFetch else {
+            self.scopedSessions = []
+            return
+        }
+        if debounce {
+            // Debounce keystrokes; .task(id:) cancels superseded fetches.
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            guard !Task.isCancelled else { return }
+        }
+        self.isLoadingScoped = true
+        defer { self.isLoadingScoped = false }
+        let query = self.trimmedSearchText
+        let rows = await self.viewModel.fetchSessionList(
+            search: query.isEmpty ? nil : query,
+            archived: self.scope == .archived)
+        // A superseded task must not repaint stale rows over the newer query.
+        guard !Task.isCancelled else { return }
+        self.scopedSessions = rows
+    }
+
+    /// Mutations refresh the scoped list after the optimistic patch settles.
+    private func refreshScopedSessionsSoon() {
+        guard self.usesScopedFetch else { return }
+        Task {
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            await self.refreshScopedSessionsIfNeeded(debounce: false)
         }
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -132,8 +132,10 @@ public protocol OpenClawChatTransport: Sendable {
     var outboxRequiresSessionRoutingContract: Bool { get }
 
     func abortRun(sessionKey: String, runId: String) async throws
-    func listSessions(limit: Int?) async throws -> OpenClawChatSessionsListResponse
-    func listSessions(limit: Int?, archived: Bool) async throws -> OpenClawChatSessionsListResponse
+    func listSessions(
+        limit: Int?,
+        search: String?,
+        archived: Bool) async throws -> OpenClawChatSessionsListResponse
     func patchSession(
         key: String,
         label: String??,
@@ -232,21 +234,27 @@ extension OpenClawChatTransport {
             userInfo: [NSLocalizedDescriptionKey: "chat.abort not supported by this transport"])
     }
 
-    public func listSessions(limit _: Int?) async throws -> OpenClawChatSessionsListResponse {
+    public func listSessions(
+        limit _: Int?,
+        search _: String?,
+        archived _: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
         throw NSError(
             domain: "OpenClawChatTransport",
             code: 0,
             userInfo: [NSLocalizedDescriptionKey: "sessions.list not supported by this transport"])
     }
 
+    /// Conveniences for callers that only page a list. Transports must
+    /// implement the canonical `listSessions(limit:search:archived:)`
+    /// requirement; same-name methods on a conformer are shadowed by these
+    /// sugars and never called through the protocol.
+    public func listSessions(limit: Int?) async throws -> OpenClawChatSessionsListResponse {
+        try await self.listSessions(limit: limit, search: nil, archived: false)
+    }
+
     public func listSessions(limit: Int?, archived: Bool) async throws -> OpenClawChatSessionsListResponse {
-        guard !archived else {
-            throw NSError(
-                domain: "OpenClawChatTransport",
-                code: 0,
-                userInfo: [NSLocalizedDescriptionKey: "archived sessions.list not supported by this transport"])
-        }
-        return try await self.listSessions(limit: limit)
+        try await self.listSessions(limit: limit, search: nil, archived: archived)
     }
 
     public func patchSession(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView+Previews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView+Previews.swift
@@ -91,7 +91,11 @@ private struct OpenClawChatPreviewTransport: OpenClawChatTransport {
         OpenClawChatSendResponse(runId: idempotencyKey, status: "ok")
     }
 
-    func listSessions(limit _: Int?) async throws -> OpenClawChatSessionsListResponse {
+    func listSessions(
+        limit _: Int?,
+        search _: String?,
+        archived _: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
         OpenClawChatSessionsListResponse(
             ts: 0,
             path: nil,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -28,7 +28,7 @@ extension OpenClawChatViewModel {
     public var sessionChoices: [OpenClawChatSessionEntry] {
         let now = Date().timeIntervalSince1970 * 1000
         let cutoff = now - (24 * 60 * 60 * 1000)
-        let sorted = sessions.sorted { ($0.updatedAt ?? 0) > ($1.updatedAt ?? 0) }
+        let sorted = OpenClawChatSessionListOrganizer.organize(sessions)
         let mainSessionKey = resolvedMainSessionKey
 
         var result: [OpenClawChatSessionEntry] = []
@@ -46,7 +46,8 @@ extension OpenClawChatViewModel {
         for entry in sorted {
             guard !included.contains(entry.key) else { continue }
             guard entry.key == sessionKey || !Self.isHiddenInternalSession(entry.key) else { continue }
-            guard (entry.updatedAt ?? 0) >= cutoff else { continue }
+            // Pinned sessions stay reachable regardless of recency.
+            guard (entry.updatedAt ?? 0) >= cutoff || entry.isPinned else { continue }
             result.append(entry)
             included.insert(entry.key)
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TranscriptCache.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+TranscriptCache.swift
@@ -61,7 +61,7 @@ extension OpenClawChatViewModel {
                 // A live sessions response (even an empty one) is authoritative;
                 // a slow cache read must never repaint over it.
                 guard self.sessions.isEmpty, !self.hasAppliedLiveSessions else { return }
-                self.sessions = cached
+                self.sessions = OpenClawChatSessionListOrganizer.organize(cached)
             }
         }
         guard messages.isEmpty, !hasAppliedLiveHistory else { return }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -11,6 +11,7 @@ private let chatUILogger = Logger(subsystem: "ai.openclaw", category: "OpenClawC
 public final class OpenClawChatViewModel {
     public nonisolated static let defaultModelSelectionID = "__default__"
     static let maxAttachmentBytes = 5_000_000
+    static let sessionListFetchLimit = 200
 
     public internal(set) var messages: [OpenClawChatMessage] = []
 
@@ -1402,16 +1403,147 @@ public final class OpenClawChatViewModel {
 
     private func fetchSessions(limit: Int?, sessionSnapshot: SessionSnapshot? = nil) async {
         do {
-            let res = try await transport.listSessions(limit: limit)
+            let res = try await transport.listSessions(limit: limit, search: nil, archived: false)
             if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
-            self.sessions = res.sessions
+            let organized = OpenClawChatSessionListOrganizer.organize(res.sessions)
+            self.sessions = organized
             self.sessionDefaults = res.defaults
             self.hasAppliedLiveSessions = true
             self.syncSelectedModel()
             syncThinkingLevelOptions()
-            persistSessionsToCache(res.sessions)
+            persistSessionsToCache(organized)
         } catch {
             // Best-effort.
+        }
+    }
+
+    /// One-shot session list fetch for search and archived browsing. Falls back
+    /// to locally filtering the cached active list when the gateway is
+    /// unreachable; archived rows exist only server-side, so archived mode
+    /// returns empty offline.
+    public func fetchSessionList(search: String?, archived: Bool) async -> [OpenClawChatSessionEntry] {
+        let normalizedSearch = search?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let query = normalizedSearch?.isEmpty == false ? normalizedSearch : nil
+        do {
+            let res = try await self.transport.listSessions(
+                limit: Self.sessionListFetchLimit,
+                search: query,
+                archived: archived)
+            return OpenClawChatSessionListOrganizer.organize(res.sessions)
+        } catch {
+            // A superseded (cancelled) fetch must not produce fallback rows;
+            // the newer task owns the scoped list. Callers also guard on
+            // Task.isCancelled before applying results.
+            guard !(error is CancellationError), !Task.isCancelled else { return [] }
+            guard !archived else { return [] }
+            guard let query else { return self.sessions }
+            return OpenClawChatSessionListOrganizer.filter(self.sessions, search: query)
+        }
+    }
+
+    public func renameSession(key: String, label: String) {
+        let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let previous = self.sessions
+        if let index = self.sessions.firstIndex(where: { $0.key == key }) {
+            self.sessions[index].label = trimmed
+            self.sessions[index].displayName = trimmed
+        }
+        Task {
+            do {
+                try await self.transport.patchSession(
+                    key: key,
+                    label: trimmed,
+                    category: nil,
+                    pinned: nil,
+                    archived: nil,
+                    unread: nil)
+                self.refreshSessions()
+            } catch {
+                self.sessions = previous
+                self.errorText = error.localizedDescription
+                chatUILogger.error(
+                    "sessions.patch(label) failed \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    public func setSessionPinned(key: String, pinned: Bool) {
+        let previous = self.sessions
+        if let index = self.sessions.firstIndex(where: { $0.key == key }) {
+            self.sessions[index].pinned = pinned
+            self.sessions[index].pinnedAt = pinned ? Date().timeIntervalSince1970 * 1000 : nil
+            self.sessions = OpenClawChatSessionListOrganizer.organize(self.sessions)
+        }
+        Task {
+            do {
+                try await self.transport.patchSession(
+                    key: key,
+                    label: nil,
+                    category: nil,
+                    pinned: pinned,
+                    archived: nil,
+                    unread: nil)
+                self.refreshSessions()
+            } catch {
+                self.sessions = previous
+                self.errorText = error.localizedDescription
+                chatUILogger.error(
+                    "sessions.patch(pinned) failed \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    public func setSessionArchived(key: String, archived: Bool) {
+        guard archived else {
+            Task { await self.restoreSession(key: key) }
+            return
+        }
+        let previous = self.sessions
+        self.sessions.removeAll { $0.key == key }
+        Task {
+            do {
+                try await self.transport.patchSession(
+                    key: key,
+                    label: nil,
+                    category: nil,
+                    pinned: nil,
+                    archived: true,
+                    unread: nil)
+                if key == self.sessionKey {
+                    // The archived session rejects new sends; move the user back
+                    // to the main session instead of leaving a dead composer.
+                    self.switchSession(to: self.resolvedMainSessionKey)
+                }
+                self.refreshSessions()
+            } catch {
+                self.sessions = previous
+                self.errorText = error.localizedDescription
+                chatUILogger.error(
+                    "sessions.patch(archived) failed \(error.localizedDescription, privacy: .public)")
+            }
+        }
+    }
+
+    /// Restores an archived session. Returns false (with `errorText` set) on
+    /// failure so open-flows can avoid switching into a still-archived session.
+    @discardableResult
+    public func restoreSession(key: String) async -> Bool {
+        do {
+            try await self.transport.patchSession(
+                key: key,
+                label: nil,
+                category: nil,
+                pinned: nil,
+                archived: false,
+                unread: nil)
+            self.refreshSessions()
+            return true
+        } catch {
+            self.errorText = error.localizedDescription
+            chatUILogger.error(
+                "sessions.patch(archived=false) failed \(error.localizedDescription, privacy: .public)")
+            return false
         }
     }
 
@@ -1802,38 +1934,7 @@ public final class OpenClawChatViewModel {
 
     private func updateCurrentSessionThinkingLevel(_ thinkingLevel: String?, sessionKey: String) {
         guard let index = sessions.firstIndex(where: { $0.key == sessionKey }) else { return }
-        let current = self.sessions[index]
-        self.sessions[index] = OpenClawChatSessionEntry(
-            key: current.key,
-            kind: current.kind,
-            displayName: current.displayName,
-            surface: current.surface,
-            subject: current.subject,
-            room: current.room,
-            space: current.space,
-            updatedAt: current.updatedAt,
-            sessionId: current.sessionId,
-            systemSent: current.systemSent,
-            abortedLastRun: current.abortedLastRun,
-            thinkingLevel: thinkingLevel,
-            verboseLevel: current.verboseLevel,
-            inputTokens: current.inputTokens,
-            outputTokens: current.outputTokens,
-            totalTokens: current.totalTokens,
-            totalTokensFresh: current.totalTokensFresh,
-            modelProvider: current.modelProvider,
-            model: current.model,
-            contextTokens: current.contextTokens,
-            thinkingLevels: current.thinkingLevels,
-            thinkingOptions: current.thinkingOptions,
-            thinkingDefault: current.thinkingDefault,
-            label: current.label,
-            category: current.category,
-            pinned: current.pinned,
-            archived: current.archived,
-            unread: current.unread,
-            lastReadAt: current.lastReadAt,
-            lastActivityAt: current.lastActivityAt)
+        self.sessions[index].thinkingLevel = thinkingLevel
     }
 
     private func updateCurrentSessionModel(
@@ -1842,69 +1943,25 @@ public final class OpenClawChatViewModel {
         sessionKey: String,
         syncSelection: Bool)
     {
+        var updated = self.sessions.first(where: { $0.key == sessionKey })
+            ?? self.placeholderSession(key: sessionKey)
+        // Thinking metadata follows model identity; stale options must not survive a model change.
+        let preservesThinkingMetadata =
+            Self.normalizedModelIdentityComponent(updated.model) ==
+            Self.normalizedModelIdentityComponent(modelID) &&
+            Self.normalizedModelIdentityComponent(updated.modelProvider) ==
+            Self.normalizedModelIdentityComponent(modelProvider)
+        updated.modelProvider = modelProvider
+        updated.model = modelID
+        if !preservesThinkingMetadata {
+            updated.thinkingLevels = nil
+            updated.thinkingOptions = nil
+            updated.thinkingDefault = nil
+        }
         if let index = sessions.firstIndex(where: { $0.key == sessionKey }) {
-            let current = self.sessions[index]
-            let preservesThinkingMetadata =
-                Self.normalizedModelIdentityComponent(current.model) ==
-                Self.normalizedModelIdentityComponent(modelID) &&
-                Self.normalizedModelIdentityComponent(current.modelProvider) ==
-                Self.normalizedModelIdentityComponent(modelProvider)
-            // Thinking metadata follows model identity; stale options must not survive a model change.
-            self.sessions[index] = OpenClawChatSessionEntry(
-                key: current.key,
-                kind: current.kind,
-                displayName: current.displayName,
-                surface: current.surface,
-                subject: current.subject,
-                room: current.room,
-                space: current.space,
-                updatedAt: current.updatedAt,
-                sessionId: current.sessionId,
-                systemSent: current.systemSent,
-                abortedLastRun: current.abortedLastRun,
-                thinkingLevel: current.thinkingLevel,
-                verboseLevel: current.verboseLevel,
-                inputTokens: current.inputTokens,
-                outputTokens: current.outputTokens,
-                totalTokens: current.totalTokens,
-                totalTokensFresh: current.totalTokensFresh,
-                modelProvider: modelProvider,
-                model: modelID,
-                contextTokens: current.contextTokens,
-                thinkingLevels: preservesThinkingMetadata ? current.thinkingLevels : nil,
-                thinkingOptions: preservesThinkingMetadata ? current.thinkingOptions : nil,
-                thinkingDefault: preservesThinkingMetadata ? current.thinkingDefault : nil,
-                label: current.label,
-                category: current.category,
-                pinned: current.pinned,
-                archived: current.archived,
-                unread: current.unread,
-                lastReadAt: current.lastReadAt,
-                lastActivityAt: current.lastActivityAt)
+            self.sessions[index] = updated
         } else {
-            let placeholder = self.placeholderSession(key: sessionKey)
-            self.sessions.append(
-                OpenClawChatSessionEntry(
-                    key: placeholder.key,
-                    kind: placeholder.kind,
-                    displayName: placeholder.displayName,
-                    surface: placeholder.surface,
-                    subject: placeholder.subject,
-                    room: placeholder.room,
-                    space: placeholder.space,
-                    updatedAt: placeholder.updatedAt,
-                    sessionId: placeholder.sessionId,
-                    systemSent: placeholder.systemSent,
-                    abortedLastRun: placeholder.abortedLastRun,
-                    thinkingLevel: placeholder.thinkingLevel,
-                    verboseLevel: placeholder.verboseLevel,
-                    inputTokens: placeholder.inputTokens,
-                    outputTokens: placeholder.outputTokens,
-                    totalTokens: placeholder.totalTokens,
-                    totalTokensFresh: placeholder.totalTokensFresh,
-                    modelProvider: modelProvider,
-                    model: modelID,
-                    contextTokens: placeholder.contextTokens))
+            self.sessions.append(updated)
         }
         if syncSelection {
             self.syncSelectedModel()

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamReplayTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatStreamReplayTests.swift
@@ -93,7 +93,11 @@ private final class ScriptedChatTransport: @unchecked Sendable, OpenClawChatTran
         []
     }
 
-    func listSessions(limit _: Int?) async throws -> OpenClawChatSessionsListResponse {
+    func listSessions(
+        limit _: Int?,
+        search _: String?,
+        archived _: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
         OpenClawChatSessionsListResponse(ts: nil, path: nil, count: 0, defaults: nil, sessions: [])
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
@@ -368,7 +368,11 @@ private final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransp
         _ = await iterator.next()
     }
 
-    func listSessions(limit _: Int?) async throws -> OpenClawChatSessionsListResponse {
+    func listSessions(
+        limit _: Int?,
+        search _: String?,
+        archived _: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
         OpenClawChatSessionsListResponse(
             ts: nil,
             path: nil,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -86,6 +86,11 @@ private func historyPayload(
 private func sessionEntry(
     key: String,
     updatedAt: Double,
+    displayName: String? = nil,
+    label: String? = nil,
+    pinned: Bool = false,
+    pinnedAt: Double? = nil,
+    archived: Bool = false,
     totalTokens: Int? = nil,
     totalTokensFresh: Bool? = nil,
     contextTokens: Int? = nil) -> OpenClawChatSessionEntry
@@ -93,7 +98,7 @@ private func sessionEntry(
     OpenClawChatSessionEntry(
         key: key,
         kind: nil,
-        displayName: nil,
+        displayName: displayName,
         surface: nil,
         subject: nil,
         room: nil,
@@ -110,7 +115,21 @@ private func sessionEntry(
         totalTokensFresh: totalTokensFresh,
         modelProvider: nil,
         model: nil,
-        contextTokens: contextTokens)
+        contextTokens: contextTokens,
+        label: label,
+        pinned: pinned ? true : nil,
+        pinnedAt: pinnedAt ?? (pinned ? updatedAt : nil),
+        archived: archived ? true : nil,
+        archivedAt: archived ? updatedAt : nil)
+}
+
+private func sessionsListResponse(_ sessions: [OpenClawChatSessionEntry]) -> OpenClawChatSessionsListResponse {
+    OpenClawChatSessionsListResponse(
+        ts: nil,
+        path: nil,
+        count: sessions.count,
+        defaults: nil,
+        sessions: sessions)
 }
 
 private func thinkingOption(_ id: String, label: String? = nil) -> OpenClawChatThinkingLevelOption {
@@ -211,6 +230,11 @@ private func makeViewModel(
     compactSessionHook: (@Sendable (String) async throws -> Void)? = nil,
     setSessionModelHook: (@Sendable (String?) async throws -> Void)? = nil,
     setSessionThinkingHook: (@Sendable (String) async throws -> Void)? = nil,
+    renameSessionHook: (@Sendable (String, String) async throws -> Void)? = nil,
+    setSessionPinnedHook: (@Sendable (String, Bool) async throws -> Void)? = nil,
+    setSessionArchivedHook: (@Sendable (String, Bool) async throws -> Void)? = nil,
+    listSessionsHook: (
+        @Sendable (TestSessionListQuery) async throws -> OpenClawChatSessionsListResponse?)? = nil,
     sendMessageHook: (@Sendable (String) async throws -> OpenClawChatSendResponse)? = nil,
     sendMessageStatus: String = "ok",
     waitForRunCompletionHook: (@Sendable (String, Int) async -> Bool)? = nil,
@@ -240,6 +264,10 @@ private func makeViewModel(
         compactSessionHook: compactSessionHook,
         setSessionModelHook: setSessionModelHook,
         setSessionThinkingHook: setSessionThinkingHook,
+        renameSessionHook: renameSessionHook,
+        setSessionPinnedHook: setSessionPinnedHook,
+        setSessionArchivedHook: setSessionArchivedHook,
+        listSessionsHook: listSessionsHook,
         sendMessageHook: sendMessageHook,
         sendMessageStatus: sendMessageStatus,
         waitForRunCompletionHook: waitForRunCompletionHook,
@@ -453,6 +481,12 @@ private func weakReference<Value: AnyObject>(to value: Value?) throws -> WeakRef
     return WeakReference(value)
 }
 
+struct TestSessionListQuery: Equatable, Sendable {
+    var limit: Int?
+    var search: String?
+    var archived: Bool
+}
+
 private actor TestChatTransportState {
     var historyCallCount: Int = 0
     var sessionsCallCount: Int = 0
@@ -475,6 +509,10 @@ private actor TestChatTransportState {
     var waitCompletionRunIds: [String] = []
     var patchedModels: [String?] = []
     var patchedThinkingLevels: [String] = []
+    var listSessionsQueries: [TestSessionListQuery] = []
+    var renamedLabelsByKey: [(key: String, label: String)] = []
+    var pinnedChanges: [(key: String, pinned: Bool)] = []
+    var archivedChanges: [(key: String, archived: Bool)] = []
 }
 
 private final class TestChatTransport: @unchecked Sendable, OpenClawChatTransport {
@@ -492,6 +530,11 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
     private let compactSessionHook: (@Sendable (String) async throws -> Void)?
     private let setSessionModelHook: (@Sendable (String?) async throws -> Void)?
     private let setSessionThinkingHook: (@Sendable (String) async throws -> Void)?
+    private let renameSessionHook: (@Sendable (String, String) async throws -> Void)?
+    private let setSessionPinnedHook: (@Sendable (String, Bool) async throws -> Void)?
+    private let setSessionArchivedHook: (@Sendable (String, Bool) async throws -> Void)?
+    private let listSessionsHook:
+        (@Sendable (TestSessionListQuery) async throws -> OpenClawChatSessionsListResponse?)?
     private let sendMessageHook: (@Sendable (String) async throws -> OpenClawChatSendResponse)?
     private let sendMessageStatus: String
     private let waitForRunCompletionHook: (@Sendable (String, Int) async -> Bool)?
@@ -513,6 +556,11 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         compactSessionHook: (@Sendable (String) async throws -> Void)? = nil,
         setSessionModelHook: (@Sendable (String?) async throws -> Void)? = nil,
         setSessionThinkingHook: (@Sendable (String) async throws -> Void)? = nil,
+        renameSessionHook: (@Sendable (String, String) async throws -> Void)? = nil,
+        setSessionPinnedHook: (@Sendable (String, Bool) async throws -> Void)? = nil,
+        setSessionArchivedHook: (@Sendable (String, Bool) async throws -> Void)? = nil,
+        listSessionsHook: (
+            @Sendable (TestSessionListQuery) async throws -> OpenClawChatSessionsListResponse?)? = nil,
         sendMessageHook: (@Sendable (String) async throws -> OpenClawChatSendResponse)? = nil,
         sendMessageStatus: String = "ok",
         waitForRunCompletionHook: (@Sendable (String, Int) async -> Bool)? = nil,
@@ -530,6 +578,10 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         self.compactSessionHook = compactSessionHook
         self.setSessionModelHook = setSessionModelHook
         self.setSessionThinkingHook = setSessionThinkingHook
+        self.renameSessionHook = renameSessionHook
+        self.setSessionPinnedHook = setSessionPinnedHook
+        self.setSessionArchivedHook = setSessionArchivedHook
+        self.listSessionsHook = listSessionsHook
         self.sendMessageHook = sendMessageHook
         self.sendMessageStatus = sendMessageStatus
         self.waitForRunCompletionHook = waitForRunCompletionHook
@@ -627,8 +679,18 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         await self.state.abortedRunIdsAppend(runId)
     }
 
-    func listSessions(limit _: Int?) async throws -> OpenClawChatSessionsListResponse {
-        let idx = await state.nextSessionsCallIndex()
+    func listSessions(
+        limit: Int?,
+        search: String?,
+        archived: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
+        let query = TestSessionListQuery(limit: limit, search: search, archived: archived)
+        // Single actor hop: bootstrap assertions in older tests race the
+        // post-health sync, so this fake must not add suspension points.
+        let idx = await state.recordSessionsCall(query)
+        if let listSessionsHook, let response = try await listSessionsHook(query) {
+            return response
+        }
         if idx < self.sessionsResponses.count {
             return self.sessionsResponses[idx]
         }
@@ -638,6 +700,34 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
             count: 0,
             defaults: nil,
             sessions: [])
+    }
+
+    func patchSession(
+        key: String,
+        label: String??,
+        category _: String??,
+        pinned: Bool?,
+        archived: Bool?,
+        unread _: Bool?) async throws
+    {
+        if let label, let label {
+            await self.state.renamedLabelsAppend(key: key, label: label)
+            if let renameSessionHook {
+                try await renameSessionHook(key, label)
+            }
+        }
+        if let pinned {
+            await self.state.pinnedChangesAppend(key: key, pinned: pinned)
+            if let setSessionPinnedHook {
+                try await setSessionPinnedHook(key, pinned)
+            }
+        }
+        if let archived {
+            await self.state.archivedChangesAppend(key: key, archived: archived)
+            if let setSessionArchivedHook {
+                try await setSessionArchivedHook(key, archived)
+            }
+        }
     }
 
     func listModels() async throws -> [OpenClawChatModelChoice] {
@@ -779,6 +869,22 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
     func createdParentSessionKeys() async -> [String?] {
         await self.state.createdParentSessionKeys
     }
+
+    func listSessionsQueries() async -> [TestSessionListQuery] {
+        await self.state.listSessionsQueries
+    }
+
+    func renamedLabels() async -> [(key: String, label: String)] {
+        await self.state.renamedLabelsByKey
+    }
+
+    func pinnedChanges() async -> [(key: String, pinned: Bool)] {
+        await self.state.pinnedChanges
+    }
+
+    func archivedChanges() async -> [(key: String, archived: Bool)] {
+        await self.state.archivedChanges
+    }
 }
 
 extension TestChatTransportState {
@@ -790,6 +896,11 @@ extension TestChatTransportState {
     fileprivate func nextSessionsCallIndex() -> Int {
         defer { self.sessionsCallCount += 1 }
         return self.sessionsCallCount
+    }
+
+    fileprivate func recordSessionsCall(_ query: TestSessionListQuery) -> Int {
+        self.listSessionsQueries.append(query)
+        return self.nextSessionsCallIndex()
     }
 
     fileprivate func nextModelsCallIndex() -> Int {
@@ -869,6 +980,19 @@ extension TestChatTransportState {
 
     fileprivate func sentMessagesAppend(_ v: String) {
         self.sentMessages.append(v)
+    }
+
+
+    fileprivate func renamedLabelsAppend(key: String, label: String) {
+        self.renamedLabelsByKey.append((key: key, label: label))
+    }
+
+    fileprivate func pinnedChangesAppend(key: String, pinned: Bool) {
+        self.pinnedChanges.append((key: key, pinned: pinned))
+    }
+
+    fileprivate func archivedChangesAppend(key: String, archived: Bool) {
+        self.archivedChanges.append((key: key, archived: archived))
     }
 }
 
@@ -7332,5 +7456,196 @@ struct ChatViewModelTests {
                     errorMessage: nil)))
 
         try await waitUntil("pending run clears") { await MainActor.run { vm.pendingRunCount == 0 } }
+    }
+}
+
+@Suite(.serialized)
+struct ChatViewModelSessionManagementTests {
+    @Test @MainActor func `session list organizer orders pinned first with key tiebreak`() {
+        let organized = OpenClawChatSessionListOrganizer.organize([
+            sessionEntry(key: "c-tie", updatedAt: 100),
+            sessionEntry(key: "a-tie", updatedAt: 100),
+            sessionEntry(key: "recent", updatedAt: 500),
+            sessionEntry(key: "pinned-old", updatedAt: 10, pinned: true, pinnedAt: 1),
+            sessionEntry(key: "pinned-new", updatedAt: 5, pinned: true, pinnedAt: 2),
+        ])
+        #expect(organized.map(\.key) == ["pinned-new", "pinned-old", "recent", "a-tie", "c-tie"])
+    }
+
+    @Test @MainActor func `session list organizer filters across display fields`() {
+        let sessions = [
+            sessionEntry(key: "agent:main:topic-a", updatedAt: 2, displayName: "Trip planning"),
+            sessionEntry(key: "agent:main:topic-b", updatedAt: 1, displayName: "Groceries"),
+            sessionEntry(key: "agent:main:trip-notes", updatedAt: 3, displayName: "Notes"),
+        ]
+        let matched = OpenClawChatSessionListOrganizer.filter(sessions, search: "TRIP")
+        #expect(matched.map(\.key) == ["agent:main:topic-a", "agent:main:trip-notes"])
+        #expect(OpenClawChatSessionListOrganizer.filter(sessions, search: "  ") == sessions)
+    }
+
+    @Test func `pin patches transport and reorders optimistically`() async throws {
+        let initial = sessionsListResponse([
+            sessionEntry(key: "agent:main:topic-a", updatedAt: 200),
+            sessionEntry(key: "agent:main:topic-b", updatedAt: 100),
+        ])
+        let pinned = sessionsListResponse([
+            sessionEntry(key: "agent:main:topic-b", updatedAt: 100, pinned: true, pinnedAt: 300),
+            sessionEntry(key: "agent:main:topic-a", updatedAt: 200),
+        ])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sessionsResponses: [initial, pinned])
+
+        await MainActor.run { vm.refreshSessions() }
+        try await waitUntil("initial sessions applied") {
+            await MainActor.run { vm.sessions.map(\.key) == ["agent:main:topic-a", "agent:main:topic-b"] }
+        }
+
+        await MainActor.run { vm.setSessionPinned(key: "agent:main:topic-b", pinned: true) }
+        // Optimistic reorder happens before the transport call settles.
+        #expect(await MainActor.run { vm.sessions.first?.key } == "agent:main:topic-b")
+
+        try await waitUntil("pin patch sent") {
+            let changes = await transport.pinnedChanges()
+            return changes.count == 1 && changes[0].key == "agent:main:topic-b" && changes[0].pinned
+        }
+        try await waitUntil("refresh keeps pinned order") {
+            await MainActor.run { vm.sessions.first?.isPinned == true }
+        }
+    }
+
+    @Test func `rename patches label optimistically and reverts on failure`() async throws {
+        let initial = sessionsListResponse([
+            sessionEntry(key: "agent:main:topic-a", updatedAt: 200, displayName: "Old name"),
+        ])
+        // The post-rename refresh must return the renamed row; otherwise the
+        // refetch legitimately repaints the old name and races the assertions.
+        let renamed = sessionsListResponse([
+            sessionEntry(
+                key: "agent:main:topic-a",
+                updatedAt: 200,
+                displayName: "Trip planning",
+                label: "Trip planning"),
+        ])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sessionsResponses: [initial, renamed],
+            renameSessionHook: { _, label in
+                if label == "Bad name" {
+                    throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "rename failed"])
+                }
+            })
+
+        await MainActor.run { vm.refreshSessions() }
+        try await waitUntil("initial sessions applied") {
+            await MainActor.run { !vm.sessions.isEmpty }
+        }
+
+        await MainActor.run { vm.renameSession(key: "agent:main:topic-a", label: " Trip planning ") }
+        #expect(await MainActor.run { vm.sessions.first?.displayName } == "Trip planning")
+        try await waitUntil("rename sent trimmed label") {
+            let renames = await transport.renamedLabels()
+            return renames.count == 1 && renames[0].label == "Trip planning"
+        }
+        // Let the post-rename refresh settle so the failing rename below
+        // captures a deterministic pre-mutation snapshot to revert to.
+        try await waitUntil("post-rename refresh applied") {
+            await transport.listSessionsQueries().count >= 2
+        }
+
+        await MainActor.run { vm.renameSession(key: "agent:main:topic-a", label: "Bad name") }
+        try await waitUntil("failed rename reverts") {
+            await MainActor.run {
+                vm.sessions.first?.displayName == "Trip planning" && vm.errorText == "rename failed"
+            }
+        }
+    }
+
+    @Test func `archive removes the session from the active list`() async throws {
+        let initial = sessionsListResponse([
+            sessionEntry(key: "agent:main:topic-a", updatedAt: 200),
+            sessionEntry(key: "agent:main:topic-b", updatedAt: 100),
+        ])
+        let afterArchive = sessionsListResponse([
+            sessionEntry(key: "agent:main:topic-a", updatedAt: 200),
+        ])
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sessionsResponses: [initial, afterArchive])
+
+        await MainActor.run { vm.refreshSessions() }
+        try await waitUntil("initial sessions applied") {
+            await MainActor.run { vm.sessions.count == 2 }
+        }
+
+        await MainActor.run { vm.setSessionArchived(key: "agent:main:topic-b", archived: true) }
+        #expect(await MainActor.run { vm.sessions.map(\.key) } == ["agent:main:topic-a"])
+        try await waitUntil("archive patch sent") {
+            let changes = await transport.archivedChanges()
+            return changes.count == 1 && changes[0].key == "agent:main:topic-b" && changes[0].archived
+        }
+    }
+
+    @Test func `fetchSessionList sends search and archived to the server`() async throws {
+        let archivedEntry = sessionEntry(key: "agent:main:old", updatedAt: 10, archived: true)
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            listSessionsHook: { query in
+                query.archived == true ? sessionsListResponse([archivedEntry]) : nil
+            })
+
+        let archivedRows = await vm.fetchSessionList(search: nil, archived: true)
+        #expect(archivedRows.map(\.key) == ["agent:main:old"])
+
+        _ = await vm.fetchSessionList(search: "  trip  ", archived: false)
+        let queries = await transport.listSessionsQueries()
+        #expect(queries.contains(TestSessionListQuery(limit: 200, search: nil, archived: true)))
+        #expect(queries.contains(TestSessionListQuery(limit: 200, search: "trip", archived: false)))
+    }
+
+    @Test func `restore session only reports success when the patch lands`() async throws {
+        let (transport, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            setSessionArchivedHook: { key, archived in
+                if !archived, key == "agent:main:broken" {
+                    throw NSError(domain: "test", code: 9, userInfo: [NSLocalizedDescriptionKey: "restore failed"])
+                }
+            })
+
+        let restored = await vm.restoreSession(key: "agent:main:old")
+        #expect(restored)
+        let failed = await vm.restoreSession(key: "agent:main:broken")
+        #expect(!failed)
+        #expect(await MainActor.run { vm.errorText } == "restore failed")
+        let changes = await transport.archivedChanges()
+        #expect(changes.map(\.key) == ["agent:main:old", "agent:main:broken"])
+        #expect(changes.allSatisfy { !$0.archived })
+    }
+
+    @Test func `fetchSessionList falls back to local filtering when the server is unreachable`() async throws {
+        let cached = sessionsListResponse([
+            sessionEntry(key: "agent:main:topic-a", updatedAt: 2, displayName: "Trip planning"),
+            sessionEntry(key: "agent:main:topic-b", updatedAt: 1, displayName: "Groceries"),
+        ])
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            sessionsResponses: [cached],
+            listSessionsHook: { query in
+                if query.search != nil || query.archived == true {
+                    throw NSError(domain: "test", code: 7, userInfo: [NSLocalizedDescriptionKey: "offline"])
+                }
+                return nil
+            })
+
+        await MainActor.run { vm.refreshSessions() }
+        try await waitUntil("cached sessions applied") {
+            await MainActor.run { vm.sessions.count == 2 }
+        }
+
+        let filtered = await vm.fetchSessionList(search: "trip", archived: false)
+        #expect(filtered.map(\.key) == ["agent:main:topic-a"])
+        // Archived rows only exist server-side; offline archived mode is empty.
+        let archivedRows = await vm.fetchSessionList(search: nil, archived: true)
+        #expect(archivedRows.isEmpty)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTranscriptCacheTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTranscriptCacheTests.swift
@@ -151,7 +151,11 @@ private final class GatedHistoryChatTransport: @unchecked Sendable, OpenClawChat
         OpenClawChatSendResponse(runId: idempotencyKey, status: "accepted")
     }
 
-    func listSessions(limit _: Int?) async throws -> OpenClawChatSessionsListResponse {
+    func listSessions(
+        limit _: Int?,
+        search _: String?,
+        archived _: Bool) async throws -> OpenClawChatSessionsListResponse
+    {
         OpenClawChatSessionsListResponse(ts: nil, path: nil, count: 0, defaults: nil, sessions: [])
     }
 


### PR DESCRIPTION
## What Problem This Solves

The gateway has supported server-side session search (`sessions.list` `search`) for a while, but no Apple client exposes it — finding a session on a gateway with dozens of sessions means scrolling. The in-chat session switcher sheet (`ChatSessionsSheet`, shared by iOS chat and the macOS webchat window) also remained a bare recency list after #100814 shipped full session controls in the iOS Command Center: no search, no archived access, no pin/rename/archive, and the macOS webchat transport never implemented `patchSession`, so no session management existed on macOS at all.

Tracking issue: #100712 (stacked on #100964, which grants `operator.write` clients the needed `sessions.patch` access).

## Why This Change Was Made

- `OpenClawChatTransport` consolidates the two list requirements from #100814 into one canonical `listSessions(limit:search:archived:)` (unreleased internal API, so no compat shim), with `(limit:)`/`(limit:archived:)` sugars so existing call sites stay put. All conformers updated: iOS gateway transport (search param in `sessions.list`), local-fixture/demo transports (local filtering), previews, macOS webchat (search + archived params), and test fakes.
- `OpenClawChatSessionEntry` properties become `var` and gain `pinnedAt`/`archivedAt` (already in the gateway row). This deletes the two error-prone full-init rebuild blocks in `ChatViewModel` (the pattern that silently dropped new fields — the #100814-era model-change rebuild preserved thinking metadata only because a reviewer caught it) in favor of copy-mutation; the model-identity/thinking-metadata semantics from main are preserved.
- A shared `OpenClawChatSessionListOrganizer` mirrors gateway ordering (`pinnedAt` desc, `updatedAt` desc, key) for cached/offline lists and provides the local search fallback.
- `OpenClawChatViewModel` gains `fetchSessionList(search:archived:)` (server search with cancellation-safe offline fallback — a superseded fetch never repaints stale rows), plus `renameSession`/`setSessionPinned`/`setSessionArchived` built on the #100814 `patchSession` API with optimistic updates and failure rollback. Archiving the open session switches back to the main session so the composer never points at a session that rejects sends.
- `ChatSessionsSheet` gets a search field (250 ms debounce, `.task(id:)` cancellation), an Active/Archived scope picker, swipe actions and a context menu (pin/unpin, archive/unarchive, rename with alert), pin indicators, and restore-on-open for archived rows.
- macOS webchat implements `patchSession`, so the shared sheet's controls work there too.
- Pinned sessions survive the 24 h recency cutoff in `sessionChoices` and float first in the Command Center recent lists.

## User Impact

iOS and macOS webchat users can search sessions server-side (with a local fallback when offline), browse and restore archived sessions, and pin/rename/archive directly from the in-chat session switcher. macOS webchat gains session management for the first time.

## Evidence

- New `ChatViewModelSessionManagementTests` scripted-transport suite: organizer ordering/tiebreak, local filter fields, optimistic pin reorder + patch call, rename trim/optimistic/rollback-on-failure, archive removal, search/archived request params, and offline local-filter fallback (archived mode empty offline).
- Full OpenClawKit suite green via `swift test` on the rebased branch (macOS host; Linux Testbox cannot run Swift).
- `swiftformat --lint` clean on touched files; OpenClawKit and macOS app packages build clean.
- Autoreview (Codex, gpt-5.5) ran to a clean result on the pre-rebase change set; its findings (label-precedence, archived-row dead composer, cancellation-swallowing fallback) are all incorporated here.
