### PR TITLE
improve(android): align command palette row affordances

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -963,7 +963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 208,
+      "line": 206,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -971,7 +971,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 262,
+      "line": 246,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Open session",
       "surface": "android",
@@ -979,7 +979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 297,
+      "line": 304,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Connect Gateway to view providers",
       "surface": "android",
@@ -987,7 +987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 299,
+      "line": 306,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "$readyProviderCount providers ready",
       "surface": "android",
@@ -995,7 +995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 300,
+      "line": 307,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "No ready providers",
       "surface": "android",
@@ -1003,7 +1003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 304,
+      "line": 311,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt",
       "source": "Main session",
       "surface": "android",

--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -10,6 +10,8 @@ Android notification forwarding now excludes native WhatsApp, Telegram, Telegram
 
 Assistant messages now offer a long-press Listen action with gateway TTS playback, on-device fallback, and tap-to-stop status.
 
+Android command-palette rows now align icon and navigation affordances consistently and truncate long session details cleanly. Thanks @IWhatsskill.
+
 The Settings About screen now shows the animated mascot with the app tagline plus Website, Docs, GitHub, and Discord links.
 
 Adds a read-only Files browser for agent workspaces with directory navigation, text and image previews, and system share export.

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
@@ -198,17 +198,12 @@ private fun CommandActionRow(row: CommandItem) {
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(9.dp),
     ) {
-      Icon(imageVector = row.icon, contentDescription = null, modifier = Modifier.size(19.dp), tint = ClawTheme.colors.text)
+      CommandRowIcon(icon = row.icon)
       Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
         Text(text = row.title, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
         Text(text = row.subtitle, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
       }
-      Icon(
-        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-        contentDescription = "Open ${row.title}",
-        modifier = Modifier.size(17.dp),
-        tint = ClawTheme.colors.textMuted,
-      )
+      CommandRowChevron(contentDescription = "Open ${row.title}")
     }
   }
 }
@@ -242,28 +237,40 @@ private fun CommandSessionListRow(
       verticalAlignment = Alignment.CenterVertically,
       horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-      Surface(
-        modifier = Modifier.size(30.dp),
-        shape = CircleShape,
-        color = ClawTheme.colors.canvas,
-        border = BorderStroke(1.dp, ClawTheme.colors.borderStrong),
-      ) {
-        Box(contentAlignment = Alignment.Center) {
-          Icon(imageVector = Icons.Outlined.ChatBubbleOutline, contentDescription = null, modifier = Modifier.size(15.dp), tint = ClawTheme.colors.text)
-        }
-      }
+      CommandRowIcon(icon = Icons.Outlined.ChatBubbleOutline)
       Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(1.dp)) {
-        Text(text = row.title, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1)
-        Text(text = row.subtitle, style = ClawTheme.type.caption, color = ClawTheme.colors.textSubtle, maxLines = 1)
+        Text(text = row.title, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Text(text = row.subtitle, style = ClawTheme.type.caption, color = ClawTheme.colors.textSubtle, maxLines = 1, overflow = TextOverflow.Ellipsis)
       }
-      Text(text = row.metadata, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted)
-      Icon(
-        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-        contentDescription = "Open session",
-        modifier = Modifier.size(17.dp),
-        tint = ClawTheme.colors.textMuted,
-      )
+      Text(text = row.metadata, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
+      CommandRowChevron(contentDescription = "Open session")
     }
+  }
+}
+
+@Composable
+private fun CommandRowIcon(icon: ImageVector) {
+  Surface(
+    modifier = Modifier.size(30.dp),
+    shape = CircleShape,
+    color = ClawTheme.colors.canvas,
+    border = BorderStroke(1.dp, ClawTheme.colors.borderStrong),
+  ) {
+    Box(contentAlignment = Alignment.Center) {
+      Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(15.dp), tint = ClawTheme.colors.text)
+    }
+  }
+}
+
+@Composable
+private fun CommandRowChevron(contentDescription: String) {
+  Box(modifier = Modifier.size(24.dp), contentAlignment = Alignment.Center) {
+    Icon(
+      imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+      contentDescription = contentDescription,
+      modifier = Modifier.size(17.dp),
+      tint = ClawTheme.colors.textMuted,
+    )
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Android command palette mixed bare quick-action icons with boxed session-row icons and loose trailing chevrons. That made the list rows feel uneven even though they are part of the same command surface.

## Why This Change Was Made

This normalizes the command palette row structure by sharing fixed leading icon boxes and fixed trailing chevron boxes across action and session rows. It also keeps session row labels constrained to one line with ellipsis and refreshes native i18n source-line metadata for existing strings.

## User Impact

Command Palette rows now scan more consistently, with steadier leading/trailing affordance spacing and no change to navigation, copy, Gateway behavior, or session behavior.

## Evidence

- `git diff --check` passed.
- `PNPM_CONFIG_OFFLINE=true pnpm native:i18n:check` passed.
- `PNPM_CONFIG_OFFLINE=true pnpm android:i18n:check` passed.
- `PNPM_CONFIG_OFFLINE=true pnpm apple:i18n:check` passed.
- `node scripts/ensure-cli-startup-build.mjs` passed.
- `PNPM_CONFIG_OFFLINE=true pnpm android:assemble` passed with `:app:assemblePlayDebug` / `BUILD SUCCESSFUL`.
- Real Android emulator proof paired the app with the Gateway, verified paired devices `1`, paired nodes `1`, pending devices `0`, and pending nodes `0`.

**Before screenshot**

<img width="360" alt="before-command-palette-screenshot" src="https://github.com/user-attachments/assets/b48b0e2b-7964-4d3a-bff5-ef41ea0de01b" />

**Before video**

https://github.com/user-attachments/assets/b00bc03b-5087-4bee-84f9-dcee01c5ffdb

**After screenshot**

<img width="360" alt="after-command-palette-screenshot" src="https://github.com/user-attachments/assets/0a3fb2c1-1ef9-4dea-9adf-02048ca11f7e" />

**After video**

https://github.com/user-attachments/assets/be59d59d-a0d3-4fd5-9c4d-2086807a65b4

- Video proof was checked with `ffprobe`: before `720x1280`, `5.257933s`, `98` frames; after `720x1280`, `5.015867s`, `90` frames.
