### PR TITLE
fix(extensions/openai): bound ChatGPT OAuth token response reads to prevent OOM

### DIFF
--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts
@@ -143,6 +143,26 @@ describe("OpenAI Codex OAuth flow", () => {
     });
   });
 
+  it("fails token exchange when the JSON response exceeds the byte cap", async () => {
+    const hugeBody = JSON.stringify({
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      expires_in: 3600,
+      padding: "x".repeat(1024 * 1024),
+    });
+    mockTokenResponseText(hugeBody);
+
+    const result = await testing.exchangeAuthorizationCode(
+      "code",
+      "verifier",
+      testing.resolveRedirectUri("localhost"),
+      { timeoutMs: 5 },
+    );
+
+    expect(result.type).toBe("failed");
+    expect(result.message).toMatch(/exceeds\s+\d+\s+bytes/);
+  });
+
   it("times out token refresh requests", async () => {
     ssrfMocks.fetchWithSsrFGuard.mockRejectedValueOnce(timeoutError());
 

--- a/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
+++ b/extensions/openai/openai-chatgpt-oauth-flow.runtime.ts
@@ -7,6 +7,10 @@
 
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import {
+  readProviderJsonResponse,
+  readResponseTextLimited,
+} from "openclaw/plugin-sdk/provider-http";
+import {
   parseOAuthAuthorizationInput,
   resolveOAuthTokenExpiresAt,
   resolveOAuthTokenLifetimeMs,
@@ -38,6 +42,8 @@ const CALLBACK_HOST = resolveCallbackHost();
 const REDIRECT_URI = resolveRedirectUri(CALLBACK_HOST);
 const MANUAL_PROMPT_FALLBACK_MS = 15_000;
 const TOKEN_REQUEST_TIMEOUT_MS = 30_000;
+const TOKEN_BODY_LIMIT_BYTES = 1024 * 1024;
+const TOKEN_ERROR_BODY_LIMIT_BYTES = 8 * 1024;
 const SCOPE = "openid profile email offline_access";
 
 type TokenSuccess = { type: "success"; access: string; refresh: string; expires: number };
@@ -178,8 +184,22 @@ async function postTokenForm(
     auditContext: "openai-chatgpt-oauth-token",
   });
   try {
-    const responseBody = await response.arrayBuffer();
-    return new Response(responseBody, {
+    if (response.ok) {
+      const json = await readProviderJsonResponse<TokenResponseJson>(
+        response,
+        "OpenAI Codex token exchange",
+        { maxBytes: TOKEN_BODY_LIMIT_BYTES },
+      );
+      return new Response(JSON.stringify(json), {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    }
+    const text = await readResponseTextLimited(response, TOKEN_ERROR_BODY_LIMIT_BYTES).catch(
+      () => "",
+    );
+    return new Response(text, {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,

--- a/scripts/proof/openai-chatgpt-oauth-json-bound.mts
+++ b/scripts/proof/openai-chatgpt-oauth-json-bound.mts
@@ -1,0 +1,99 @@
+// Real behavior proof: OpenAI ChatGPT OAuth token response read is bounded.
+//
+// exchangeAuthorizationCode and refreshAccessToken previously buffered the entire
+// response body with response.json(). The fix uses readProviderJsonResponse with
+// a 1 MiB cap so a runaway token endpoint cannot OOM the CLI login flow.
+//
+// This proof starts a local HTTP server, feeds it an oversized JSON body, and
+// shows readProviderJsonResponse rejects before buffering the whole payload.
+
+import http from "node:http";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+const { readProviderJsonResponse } = await import(
+  path.join(repoRoot, "src/plugin-sdk/provider-http.js")
+);
+
+const PORT = 0;
+const HUGE_SIZE = 8 * 1024 * 1024;
+let sendOversized = false;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  if (sendOversized) {
+    res.write('{"access_token":"a","refresh_token":"r","expires_in":3600,"padding":"');
+    const chunk = "x".repeat(64 * 1024);
+    let sent = 0;
+    function sendChunk(): void {
+      if (sent >= HUGE_SIZE) {
+        res.end('"}');
+        return;
+      }
+      res.write(chunk);
+      sent += chunk.length;
+      setImmediate(sendChunk);
+    }
+    sendChunk();
+  } else {
+    res.end(JSON.stringify({ access_token: "a", refresh_token: "r", expires_in: 3600 }));
+  }
+});
+
+await new Promise<void>((resolve) => {
+  server.listen(PORT, "127.0.0.1", () => {
+    resolve();
+  });
+});
+const address = server.address();
+const port = address && typeof address === "object" ? address.port : 0;
+
+console.log("=== Proof: OpenAI ChatGPT OAuth token JSON bound ===\n");
+console.log(`Local token server listening on port ${port}\n`);
+
+// Normal path: small token JSON parses fine.
+const normalResp = await fetch(`http://127.0.0.1:${port}/token`);
+const normalData = await readProviderJsonResponse<{
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+}>(normalResp, "OpenAI Codex token exchange", { maxBytes: 1024 * 1024 });
+console.log(`Normal token response: access_token=${normalData.access_token.slice(0, 8)}...`);
+
+// Oversized path: bounded read rejects before buffering everything.
+sendOversized = true;
+const oversizedResp = await fetch(`http://127.0.0.1:${port}/token-oversized`);
+const startMem = process.memoryUsage.rss();
+const start = performance.now();
+
+try {
+  await readProviderJsonResponse<Record<string, unknown>>(
+    oversizedResp,
+    "OpenAI Codex token exchange",
+    { maxBytes: 1024 * 1024 },
+  );
+  console.log("\nFAIL: oversized token body should have been rejected.");
+  process.exitCode = 1;
+} catch (err) {
+  const duration = performance.now() - start;
+  const endMem = process.memoryUsage.rss();
+  const message = err instanceof Error ? err.message : String(err);
+  console.log(`\nOversized token body rejected: ${message}`);
+  console.log(`Duration: ${duration.toFixed(1)} ms`);
+  console.log(`RSS delta: ${((endMem - startMem) / 1024 / 1024).toFixed(1)} MB`);
+
+  if (message.includes("JSON response exceeds") && duration < 5000 && endMem - startMem < 64 * 1024 * 1024) {
+    console.log("\nPASS: OAuth token JSON read is bounded; oversized bodies fail fast without OOM.");
+  } else {
+    console.log("\nFAIL: did not fail fast or consumed too much memory.");
+    process.exitCode = 1;
+  }
+} finally {
+  server.close();
+  await new Promise<void>((resolve) => {
+    server.once("close", () => {
+      resolve();
+    });
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

`postTokenForm` in the OpenAI Codex OAuth flow buffered the entire token exchange / refresh response into an `arrayBuffer` before re-wrapping it as a `Response`. A malicious or misbehaving token endpoint could stream an unbounded JSON payload and force the CLI to buffer it all, leading to OOM.

## Why This Change Was Made

Use the repo's existing bounded provider HTTP helpers (`readProviderJsonResponse` / `readResponseTextLimited`) to cap the successful token JSON body at 1 MiB and error diagnostic bodies at 8 KiB. This mirrors the already-landed fixes for OpenRouter OAuth (#98645), Google OAuth (#97587), and QA bus JSON responses (#99169).

## User Impact

`openclaw auth openai` (ChatGPT OAuth) is protected against runaway token endpoint responses.

## Evidence

- Regression test added in `extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts`: it feeds a >1 MiB JSON payload to `exchangeAuthorizationCode` and asserts the result is a bounded `failed` response.
- Added a real behavior proof script at `scripts/proof/openai-chatgpt-oauth-json-bound.mts` that serves an 8 MiB JSON body from a local HTTP server and verifies `readProviderJsonResponse` rejects at the 1 MiB cap before buffering everything.
- Local verification:
  - `node scripts/run-vitest.mjs extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts` passes.
  - `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs extensions/openai/openai-chatgpt-oauth-flow.runtime.ts extensions/openai/openai-chatgpt-oauth-flow.runtime.test.ts scripts/proof/openai-chatgpt-oauth-json-bound.mts` passes.
  - `node --import tsx scripts/proof/openai-chatgpt-oauth-json-bound.mts` passes.

### Proof output

```
=== Proof: OpenAI ChatGPT OAuth token JSON bound ===

Local token server listening on port 43211

Normal token response: access_token=a...

Oversized token body rejected: OpenAI Codex token exchange: JSON response exceeds 1048576 bytes
Duration: 17.4 ms
RSS delta: 11.6 MB

PASS: OAuth token JSON read is bounded; oversized bodies fail fast without OOM.
```