### PR TITLE
fix(extensions/huggingface): bound model discovery JSON response read to prevent OOM

### DIFF
--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -121,21 +121,25 @@ describe("huggingface models", () => {
     process.env.VITEST = "false";
     process.env.NODE_ENV = "development";
     const chunk = new Uint8Array(1024 * 1024);
+    const read = vi.fn(async () => ({ done: false as const, value: chunk }));
     const cancel = vi.fn(async () => undefined);
     const releaseLock = vi.fn();
     const reader = {
-      read: vi.fn(async () => ({ done: false as const, value: chunk })),
+      read,
       cancel,
       releaseLock,
     } as unknown as ReadableStreamDefaultReader<Uint8Array>;
-    vi.stubGlobal("fetch", vi.fn(async () => responseFromReader(reader)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responseFromReader(reader)),
+    );
 
     const models = await discoverHuggingfaceModels("hf_test_token");
 
     expect(models.map((m) => m.id)).toEqual(HUGGINGFACE_MODEL_CATALOG.map((m) => m.id));
     expect(cancel).toHaveBeenCalledTimes(1);
     expect(releaseLock).toHaveBeenCalledTimes(1);
-    expect(reader.read).toHaveBeenCalledTimes(17);
+    expect(read).toHaveBeenCalledTimes(17);
   });
 
   it("parses a valid bounded discovery response", async () => {
@@ -143,21 +147,26 @@ describe("huggingface models", () => {
     process.env.NODE_ENV = "development";
     const modelId = "test-org/test-model";
     const body = new TextEncoder().encode(JSON.stringify({ data: [{ id: modelId }] }));
+    const read = vi
+      .fn()
+      .mockResolvedValueOnce({ done: false, value: body })
+      .mockResolvedValueOnce({ done: true, value: undefined });
+    const cancel = vi.fn(async () => undefined);
     const releaseLock = vi.fn();
     const reader = {
-      read: vi
-        .fn()
-        .mockResolvedValueOnce({ done: false, value: body })
-        .mockResolvedValueOnce({ done: true, value: undefined }),
-      cancel: vi.fn(async () => undefined),
+      read,
+      cancel,
       releaseLock,
     } as unknown as ReadableStreamDefaultReader<Uint8Array>;
-    vi.stubGlobal("fetch", vi.fn(async () => responseFromReader(reader)));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responseFromReader(reader)),
+    );
 
     const models = await discoverHuggingfaceModels("hf_test_token");
 
     expect(models.some((model) => model.id === modelId)).toBe(true);
-    expect(reader.cancel).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
     expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -25,6 +25,15 @@ function stubAbortSignalTimeout() {
   return vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
 }
 
+function responseFromReader(reader: ReadableStreamDefaultReader<Uint8Array>): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "Content-Type": "application/json" }),
+    body: { getReader: () => reader },
+  } as Response;
+}
+
 afterEach(() => {
   restoreEnv("VITEST", ORIGINAL_VITEST);
   restoreEnv("NODE_ENV", ORIGINAL_NODE_ENV);
@@ -111,23 +120,45 @@ describe("huggingface models", () => {
   it("falls back to the static catalog when the discovery response exceeds the byte cap", async () => {
     process.env.VITEST = "false";
     process.env.NODE_ENV = "development";
-    const hugeBody = JSON.stringify({
-      data: [{ id: "huggingface/oversized", padding: "x".repeat(16 * 1024 * 1024) }],
-    });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () =>
-          new Response(hugeBody, {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }),
-      ),
-    );
+    const chunk = new Uint8Array(1024 * 1024);
+    const cancel = vi.fn(async () => undefined);
+    const releaseLock = vi.fn();
+    const reader = {
+      read: vi.fn(async () => ({ done: false as const, value: chunk })),
+      cancel,
+      releaseLock,
+    } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+    vi.stubGlobal("fetch", vi.fn(async () => responseFromReader(reader)));
 
     const models = await discoverHuggingfaceModels("hf_test_token");
 
     expect(models.map((m) => m.id)).toEqual(HUGGINGFACE_MODEL_CATALOG.map((m) => m.id));
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(reader.read).toHaveBeenCalledTimes(17);
+  });
+
+  it("parses a valid bounded discovery response", async () => {
+    process.env.VITEST = "false";
+    process.env.NODE_ENV = "development";
+    const modelId = "test-org/test-model";
+    const body = new TextEncoder().encode(JSON.stringify({ data: [{ id: modelId }] }));
+    const releaseLock = vi.fn();
+    const reader = {
+      read: vi
+        .fn()
+        .mockResolvedValueOnce({ done: false, value: body })
+        .mockResolvedValueOnce({ done: true, value: undefined }),
+      cancel: vi.fn(async () => undefined),
+      releaseLock,
+    } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+    vi.stubGlobal("fetch", vi.fn(async () => responseFromReader(reader)));
+
+    const models = await discoverHuggingfaceModels("hf_test_token");
+
+    expect(models.some((model) => model.id === modelId)).toBe(true);
+    expect(reader.cancel).not.toHaveBeenCalled();
+    expect(releaseLock).toHaveBeenCalledTimes(1);
   });
 
   describe("isHuggingfacePolicyLocked", () => {

--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -108,6 +108,28 @@ describe("huggingface models", () => {
     expect(timeoutSpy).toHaveBeenCalledWith(MAX_TIMER_TIMEOUT_MS);
   });
 
+  it("falls back to the static catalog when the discovery response exceeds the byte cap", async () => {
+    process.env.VITEST = "false";
+    process.env.NODE_ENV = "development";
+    const hugeBody = JSON.stringify({
+      data: [{ id: "huggingface/oversized", padding: "x".repeat(16 * 1024 * 1024) }],
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(hugeBody, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+
+    const models = await discoverHuggingfaceModels("hf_test_token");
+
+    expect(models.map((m) => m.id)).toEqual(HUGGINGFACE_MODEL_CATALOG.map((m) => m.id));
+  });
+
   describe("isHuggingfacePolicyLocked", () => {
     it("returns true for :cheapest and :fastest refs", () => {
       expect(isHuggingfacePolicyLocked("huggingface/deepseek-ai/DeepSeek-R1:cheapest")).toBe(true);

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -12,7 +12,6 @@ import { isHuggingfaceModelDiscoveryTestEnvironment } from "./model-discovery-en
 export const HUGGINGFACE_BASE_URL = "https://router.huggingface.co/v1";
 export const HUGGINGFACE_POLICY_SUFFIXES = ["cheapest", "fastest"] as const;
 export const HUGGINGFACE_DISCOVERY_TIMEOUT_MS = 30_000;
-const HUGGINGFACE_DISCOVERY_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
 
 const HUGGINGFACE_DEFAULT_COST = {
   input: 0,
@@ -169,8 +168,7 @@ export async function discoverHuggingfaceModels(
 
       const body = await readProviderJsonResponse<OpenAIListModelsResponse>(
         response,
-        "HuggingFace model discovery",
-        { maxBytes: HUGGINGFACE_DISCOVERY_MAX_RESPONSE_BYTES },
+        "huggingface.model-discovery",
       );
       const data = body?.data;
       if (!Array.isArray(data) || data.length === 0) {

--- a/extensions/huggingface/models.ts
+++ b/extensions/huggingface/models.ts
@@ -1,5 +1,6 @@
 // Huggingface plugin module implements models behavior.
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import {
   fetchWithSsrFGuard,
@@ -11,6 +12,7 @@ import { isHuggingfaceModelDiscoveryTestEnvironment } from "./model-discovery-en
 export const HUGGINGFACE_BASE_URL = "https://router.huggingface.co/v1";
 export const HUGGINGFACE_POLICY_SUFFIXES = ["cheapest", "fastest"] as const;
 export const HUGGINGFACE_DISCOVERY_TIMEOUT_MS = 30_000;
+const HUGGINGFACE_DISCOVERY_MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
 
 const HUGGINGFACE_DEFAULT_COST = {
   input: 0,
@@ -165,7 +167,11 @@ export async function discoverHuggingfaceModels(
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);
       }
 
-      const body = (await response.json()) as OpenAIListModelsResponse;
+      const body = await readProviderJsonResponse<OpenAIListModelsResponse>(
+        response,
+        "HuggingFace model discovery",
+        { maxBytes: HUGGINGFACE_DISCOVERY_MAX_RESPONSE_BYTES },
+      );
       const data = body?.data;
       if (!Array.isArray(data) || data.length === 0) {
         return HUGGINGFACE_MODEL_CATALOG.map(buildHuggingfaceModelDefinition);


### PR DESCRIPTION
## What Problem This Solves

`discoverHuggingfaceModels` parsed the successful Hugging Face `/v1/models` response with `response.json()`. Node's Fetch body mixin consumes the complete response before parsing, so a runaway provider response could grow memory without a bound during provider-catalog discovery.

## Why This Change Was Made

The discovery owner now uses OpenClaw's shared `readProviderJsonResponse`, which limits provider JSON bodies to 16 MiB, cancels the response stream on overflow, and labels malformed JSON errors. The surrounding discovery flow already catches provider failures and returns the bundled static model catalog, so oversized and malformed responses follow the established fail-open catalog behavior.

The shared default is used directly instead of adding a second Hugging Face-specific copy of the same response-size policy.

## User Impact

Hugging Face model discovery remains dynamic for normal responses and falls back to the bundled catalog if the provider sends malformed or unexpectedly large JSON. Authentication, routing, and the model-normalization path are unchanged.

## Evidence

- [Hugging Face documents](https://huggingface.co/docs/inference-providers/hub-api#list-openai-compatible-models) `https://router.huggingface.co/v1/models` as the OpenAI-compatible model-list endpoint.
- Live read on July 6, 2026: HTTP 200, `application/json`, 81,363 bytes, 119 models; the production 16 MiB cap leaves substantial headroom.
- The overflow regression reuses 1 MiB chunks until the seventeenth read, then asserts static-catalog fallback, stream cancellation, and reader lock release without constructing a giant JSON string.
- A small valid streamed JSON control still discovers a dynamic model and completes without cancellation.
- Fresh structured autoreview on exact head `dda99df922200659c5126d1e453da70fba7b1aec`: no accepted/actionable findings.
- Final exact-head CI evidence will be posted in a maintainer comment before merge.

