### PR TITLE
fix(infra): wrap sha256File stream errors with context instead of leaking raw rejects

### DIFF
--- a/src/infra/crypto-digest.test.ts
+++ b/src/infra/crypto-digest.test.ts
@@ -43,4 +43,15 @@ describe("crypto digest helpers", () => {
       await expect(sha256File(filePath)).resolves.toBe(HOSTILE_BYTES_SHA256);
     });
   });
+
+  it("throws a wrapped error when the file stream fails mid-read", async () => {
+    await withTempDir({ prefix: "openclaw-crypto-digest-" }, async (dir) => {
+      const filePath = path.join(dir, "not-a-file");
+      await fs.mkdir(filePath);
+
+      await expect(sha256File(filePath)).rejects.toThrow(
+        /EISDIR|is a directory|Failed to hash file/,
+      );
+    });
+  });
 });

--- a/src/infra/crypto-digest.test.ts
+++ b/src/infra/crypto-digest.test.ts
@@ -44,14 +44,14 @@ describe("crypto digest helpers", () => {
     });
   });
 
-  it("throws a wrapped error when the file stream fails mid-read", async () => {
+  it("preserves stream failure context when hashing a file", async () => {
     await withTempDir({ prefix: "openclaw-crypto-digest-" }, async (dir) => {
-      const filePath = path.join(dir, "not-a-file");
-      await fs.mkdir(filePath);
+      const filePath = path.join(dir, "missing.bin");
 
-      await expect(sha256File(filePath)).rejects.toThrow(
-        /EISDIR|is a directory|Failed to hash file/,
-      );
+      await expect(sha256File(filePath)).rejects.toMatchObject({
+        message: expect.stringContaining(`Failed to hash file ${filePath}:`),
+        cause: expect.objectContaining({ code: "ENOENT" }),
+      });
     });
   });
 });

--- a/src/infra/crypto-digest.ts
+++ b/src/infra/crypto-digest.ts
@@ -25,8 +25,15 @@ export function sha256HexPrefix(input: DigestInput, length: number): string {
 
 export async function sha256File(filePath: string): Promise<string> {
   const digest = createHash("sha256");
-  for await (const chunk of createReadStream(filePath)) {
-    digest.update(chunk);
+  try {
+    for await (const chunk of createReadStream(filePath)) {
+      digest.update(chunk);
+    }
+  } catch (err) {
+    throw new Error(
+      `Failed to hash file ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
   }
   return digest.digest("hex");
 }


### PR DESCRIPTION
## What Problem This Solves

`sha256File` previously forwarded raw `fs.createReadStream` failures. Callers
validating skill archives and uploads could see an error code without knowing which
file failed to hash.

## Why This Change Was Made

The shared digest helper now wraps stream iteration failures with the target path and
preserves the original error as `cause`. Successful digest behavior and all caller
control flow remain unchanged.

## User Impact

Hash failures during skill archive validation or upload commit identify the affected
file while retaining the original system error for diagnostics.

## Evidence

- `node scripts/run-vitest.mjs src/infra/crypto-digest.test.ts`
  - 5 tests passed.
- The regression uses a deterministic missing-file failure and asserts:
  - the message contains `Failed to hash file <path>:`
  - the preserved cause has code `ENOENT`
- `node_modules/.bin/oxfmt --check src/infra/crypto-digest.ts src/infra/crypto-digest.test.ts`
- `git diff --check origin/main...HEAD`
- Fresh GPT-5.5 autoreview: no accepted or actionable findings.
