### PR TITLE
fix(extensions/browser): bound successful JSON response reads in client fetch

### DIFF
--- a/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
+++ b/extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts
@@ -59,7 +59,11 @@ describe("fetchHttpJson error body boundary", () => {
         return;
       }
 
-      res.writeHead(500, { "Content-Type": "text/plain" });
+      const targetBytes =
+        req.url === "/huge-json" ? STREAM_BODY_BYTES + STREAM_CHUNK.byteLength : STREAM_BODY_BYTES;
+      res.writeHead(req.url === "/huge-json" ? 200 : 500, {
+        "Content-Type": req.url === "/huge-json" ? "application/json" : "text/plain",
+      });
       let written = 0;
       let closed = false;
       res.once("close", () => {
@@ -70,7 +74,7 @@ describe("fetchHttpJson error body boundary", () => {
         if (closed) {
           return;
         }
-        if (written >= STREAM_BODY_BYTES) {
+        if (written >= targetBytes) {
           streamCompleted = true;
           res.end();
           return;
@@ -119,5 +123,15 @@ describe("fetchHttpJson error body boundary", () => {
       message: "session expired",
     });
     await expect(smallConnectionClosed).resolves.toBeUndefined();
+  });
+
+  it("rejects an oversized successful JSON body", async () => {
+    const error = await fetchBrowserJson(`${baseUrl}/huge-json`).catch((err: unknown) => err);
+
+    expect(error).toMatchObject({
+      name: "BrowserServiceError",
+      message: "browser control JSON response exceeded size limit",
+    });
+    await expect(streamClosed).resolves.toBeUndefined();
   });
 });

--- a/extensions/browser/src/browser/client-fetch.ts
+++ b/extensions/browser/src/browser/client-fetch.ts
@@ -106,6 +106,7 @@ const BROWSER_TOOL_MODEL_HINT =
   "Use an alternative approach or inform the user that the browser is currently unavailable.";
 
 const BROWSER_ERROR_BODY_LIMIT_BYTES = 16 * 1024;
+const BROWSER_JSON_BODY_LIMIT_BYTES = 1024 * 1024;
 
 function isRateLimitStatus(status: number): boolean {
   return status === 429;
@@ -277,7 +278,19 @@ async function fetchHttpJson<T>(
       const text = body ? new TextDecoder().decode(body) : "";
       throw new BrowserServiceError(text || `HTTP ${res.status}`);
     }
-    return (await res.json()) as T;
+    const body = await readResponseWithLimit(res, BROWSER_JSON_BODY_LIMIT_BYTES).catch(
+      () => undefined,
+    );
+    if (!body) {
+      throw new BrowserServiceError("browser control JSON response exceeded size limit");
+    }
+    let json: unknown;
+    try {
+      json = JSON.parse(body.toString("utf-8"));
+    } catch {
+      throw new BrowserServiceError("browser control returned malformed JSON");
+    }
+    return json as T;
   } finally {
     clearTimeout(t);
     await release?.();


### PR DESCRIPTION
## What Problem This Solves

`fetchHttpJson` in the browser control client called `res.json()` directly on successful responses, buffering the entire body without a size cap. A misbehaving or compromised browser control endpoint could return a huge JSON-like payload and OOM the agent.

## Why This Change Was Made

Use the already-imported `readResponseWithLimit` helper to cap successful JSON bodies at 1 MiB. If the body exceeds the cap, the request fails with a `BrowserServiceError`. Malformed JSON is also surfaced as a `BrowserServiceError` instead of a raw parse exception.

## User Impact

Browser tool JSON fetches are protected from runaway response bodies.

## Evidence

- Regression test added in `extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts`: streams a >1 MiB 200 response and asserts `fetchBrowserJson` throws a size-limit error.
- Local verification:
  - `node scripts/run-vitest.mjs extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts` passes.
  - `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs extensions/browser/src/browser/client-fetch.ts extensions/browser/src/browser/client-fetch.error-body-boundary.test.ts` passes.
