### PR TITLE
fix(discord): handle ffmpeg stderr stream errors in voice playback

### DIFF
--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -1,11 +1,43 @@
 // Discord tests cover audio plugin behavior.
-import { Readable } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { PassThrough, Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: spawnMock,
+}));
+// resolveFfmpegBin requires a real ffmpeg on PATH; stub only that lookup so the
+// playback stream construction reaches the stdio stream-error wiring under test.
+vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>()),
+  resolveFfmpegBin: () => "ffmpeg",
+}));
+
 import {
   createDiscordOpusEncodeStream,
+  createDiscordOpusPlaybackStream,
   decodeOpusStream,
   decodeOpusStreamChunks,
 } from "./audio.js";
+
+// Mirrors the ffmpeg child's stdio shape so we can emit stream `error` events.
+// On a raw stream an unhandled `error` throws synchronously (the real gateway
+// uncaughtException crash path).
+function createFakeFfmpeg() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough;
+    stderr: PassThrough;
+    stdin: PassThrough;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = new PassThrough();
+  child.kill = vi.fn();
+  return child;
+}
 
 async function collectBuffers(stream: Readable): Promise<Buffer[]> {
   const chunks: Buffer[] = [];
@@ -75,4 +107,26 @@ describe("discord voice opus codec", () => {
 
     expect(onError).toHaveBeenCalledWith(err);
   });
+});
+
+describe("createDiscordOpusPlaybackStream child stream errors", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it.each(["stdout", "stderr"] as const)(
+    "routes a %s stream error to the playback stream instead of crashing",
+    async (streamName) => {
+      const ffmpeg = createFakeFfmpeg();
+      spawnMock.mockReturnValue(ffmpeg);
+
+      const playback = createDiscordOpusPlaybackStream("input.mp3");
+      const errorSeen = new Promise<Error>((resolve) => playback.once("error", resolve));
+
+      const streamError = new Error(`${streamName} broke`);
+      expect(() => ffmpeg[streamName].emit("error", streamError)).not.toThrow();
+
+      await expect(errorSeen).resolves.toBe(streamError);
+    },
+  );
 });

--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -8,8 +8,6 @@ vi.mock("node:child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:child_process")>()),
   spawn: spawnMock,
 }));
-// resolveFfmpegBin requires a real ffmpeg on PATH; stub only that lookup so the
-// playback stream construction reaches the stdio stream-error wiring under test.
 vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>()),
   resolveFfmpegBin: () => "ffmpeg",
@@ -22,9 +20,6 @@ import {
   decodeOpusStreamChunks,
 } from "./audio.js";
 
-// Mirrors the ffmpeg child's stdio shape so we can emit stream `error` events.
-// On a raw stream an unhandled `error` throws synchronously (the real gateway
-// uncaughtException crash path).
 function createFakeFfmpeg() {
   const child = new EventEmitter() as EventEmitter & {
     stdout: PassThrough;
@@ -121,7 +116,9 @@ describe("createDiscordOpusPlaybackStream child stream errors", () => {
       spawnMock.mockReturnValue(ffmpeg);
 
       const playback = createDiscordOpusPlaybackStream("input.mp3");
-      const errorSeen = new Promise<Error>((resolve) => playback.once("error", resolve));
+      const errorSeen = new Promise<Error>((resolve) => {
+        playback.once("error", resolve);
+      });
 
       const streamError = new Error(`${streamName} broke`);
       expect(() => ffmpeg[streamName].emit("error", streamError)).not.toThrow();

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -134,6 +134,10 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
   });
 
   ffmpeg.stdout.on("error", (err) => opusStream.destroy(err));
+  // A raw stream `error` without a listener is process-fatal (uncaughtException).
+  // stderr content is diagnostic-only, but its stream can still emit `error`, so
+  // surface it through the playback stream like stdout instead of crashing.
+  ffmpeg.stderr.on("error", (err) => opusStream.destroy(err));
   ffmpeg.stdin.on("error", (err) => {
     if ((err as NodeJS.ErrnoException).code !== "EPIPE") {
       opusStream.destroy(err);

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -133,11 +133,10 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
     }
   });
 
-  ffmpeg.stdout.on("error", (err) => opusStream.destroy(err));
-  // A raw stream `error` without a listener is process-fatal (uncaughtException).
-  // stderr content is diagnostic-only, but its stream can still emit `error`, so
-  // surface it through the playback stream like stdout instead of crashing.
-  ffmpeg.stderr.on("error", (err) => opusStream.destroy(err));
+  // Both readable child pipes need listeners; an unhandled stream error terminates Node.
+  for (const readable of [ffmpeg.stdout, ffmpeg.stderr]) {
+    readable.on("error", (err) => opusStream.destroy(err));
+  }
   ffmpeg.stdin.on("error", (err) => {
     if ((err as NodeJS.ErrnoException).code !== "EPIPE") {
       opusStream.destroy(err);


### PR DESCRIPTION
## What Problem This Solves

`createDiscordOpusPlaybackStream` guarded ffmpeg's stdout stream but left stderr's own `error` event unhandled. Node rethrows an unhandled EventEmitter `error`, so a broken stderr pipe could terminate the gateway instead of failing only the Discord voice playback stream.

## Why This Change Was Made

Both readable child pipes have the same lifecycle contract. This change installs the same error forwarding on stdout and stderr in one loop, while preserving stderr data capture for ffmpeg diagnostics. The existing stdin `EPIPE` handling remains separate because it intentionally suppresses write-side shutdown noise.

## User Impact

A broken ffmpeg stdout or stderr pipe during Discord voice playback now destroys the playback stream with the original error instead of risking an uncaught process-level exception. Normal decoding and playback are unchanged.

## Evidence

- Parameterized regression test covers both readable child pipes and proves their errors surface on the playback stream without a synchronous throw.
- Focused Discord voice suite: 6/6 passed on the contributor head; the maintained refactor changes only listener construction and test lint shape.
- `oxfmt --check` and `git diff --check`: clean.
- Fresh full-branch autoreview: no findings, confidence 0.98.
- Exact maintained head: `258f6fb073b55976ed502e31d68e10a34964374a`.
- Exact-head GitHub CI: https://github.com/openclaw/openclaw/actions/runs/28814134465
- Node's EventEmitter contract documents that emitting `error` without a listener throws and exits the process: https://nodejs.org/api/events.html#error-events

Direct sanitized AWS Crabbox proof was attempted twice, but the coordinator reset during its own deployment before a lease or PR execution began. Secretless exact-head GitHub CI therefore remains the execution proof.
