### PR TITLE
feat(provider): add Featherless AI integration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -378,6 +378,11 @@
       - any-glob-to-any-file:
           - "extensions/deepinfra/**"
           - "docs/providers/deepinfra.md"
+"extensions: featherless":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/featherless/**"
+          - "docs/providers/featherless.md"
 "extensions: gmi":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Featherless AI provider:** add an official external provider plugin with API-key onboarding, a tool-capable Qwen3 default, and support for arbitrary Featherless model ids.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Featherless AI provider:** add an official external provider plugin with API-key onboarding, a tool-capable Qwen3 default, and support for arbitrary Featherless model ids.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)
 - **Slack progress indicators:** use Slack's native assistant thread status and rotating loading messages by default while keeping acknowledgement reactions static; lifecycle reaction updates now require `messages.statusReactions.enabled: true`.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -288,6 +288,7 @@ messages and normalizes `stats.cached` into `cacheRead`; legacy
 | Cohere                                  | `cohere`                         | `COHERE_API_KEY`                                     | `cohere/command-a-03-2025`                                 |
 | DeepInfra                               | `deepinfra`                      | `DEEPINFRA_API_KEY`                                  | `deepinfra/deepseek-ai/DeepSeek-V4-Flash`                  |
 | DeepSeek                                | `deepseek`                       | `DEEPSEEK_API_KEY`                                   | `deepseek/deepseek-v4-flash`                               |
+| Featherless AI                          | `featherless`                    | `FEATHERLESS_API_KEY`                                | `featherless/Qwen/Qwen3-32B`                               |
 | GitHub Copilot                          | `github-copilot`                 | `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` / `GITHUB_TOKEN` | -                                                          |
 | GMI Cloud                               | `gmi`                            | `GMI_API_KEY`                                        | `gmi/google/gemini-3.1-flash-lite`                         |
 | Groq                                    | `groq`                           | `GROQ_API_KEY`                                       | `groq/llama-3.3-70b-versatile`                             |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1469,6 +1469,7 @@
                   "providers/ds4",
                   "providers/elevenlabs",
                   "providers/fal",
+                  "providers/featherless",
                   "providers/fireworks",
                   "providers/github-copilot",
                   "providers/gmi",

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -6062,6 +6062,15 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Surface
   - H2: Related docs
 
+## plugins/reference/featherless.md
+
+- Route: /plugins/reference/featherless
+- Headings:
+  - H1: Featherless plugin
+  - H2: Distribution
+  - H2: Surface
+  - H2: Related docs
+
 ## plugins/reference/feishu.md
 
 - Route: /plugins/reference/feishu
@@ -7434,6 +7443,16 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: Image generation
   - H2: Video generation
   - H2: Music generation
+  - H2: Related
+
+## providers/featherless.md
+
+- Route: /providers/featherless
+- Headings:
+  - H2: Setup
+  - H2: Default model
+  - H2: Other Featherless models
+  - H2: Troubleshooting
   - H2: Related
 
 ## providers/fireworks.md

--- a/docs/plugins/plugin-inventory.md
+++ b/docs/plugins/plugin-inventory.md
@@ -177,7 +177,7 @@ Each entry lists the package, distribution route, and description.
 
 ## Official external packages
 
-69 plugins
+70 plugins
 
 - **[acpx](/plugins/reference/acpx)** (`@openclaw/acpx`) - npm; ClawHub. OpenClaw ACP runtime backend with plugin-owned session and transport management.
 
@@ -218,6 +218,8 @@ Each entry lists the package, distribution route, and description.
 - **[discord](/plugins/reference/discord)** (`@openclaw/discord`) - npm; ClawHub. OpenClaw Discord channel plugin for channels, DMs, commands, and app events.
 
 - **[exa](/plugins/reference/exa)** (`@openclaw/exa-plugin`) - npm; ClawHub: `clawhub:@openclaw/exa-plugin`. Adds web search provider support.
+
+- **[featherless](/plugins/reference/featherless)** (`@openclaw/featherless-provider`) - npm; ClawHub: `clawhub:@openclaw/featherless-provider`. OpenClaw Featherless AI provider plugin.
 
 - **[feishu](/plugins/reference/feishu)** (`@openclaw/feishu`) - npm; ClawHub. OpenClaw Feishu/Lark channel plugin for chats and workplace tools (community maintained by @m1heng).
 
@@ -295,7 +297,7 @@ Each entry lists the package, distribution route, and description.
 
 - **[tavily](/plugins/reference/tavily)** (`@openclaw/tavily-plugin`) - npm; ClawHub: `clawhub:@openclaw/tavily-plugin`. Adds agent-callable tools. Adds web search provider support.
 
-- **[tencent](/plugins/reference/tencent)** (`@openclaw/tencent-provider`) - npm; ClawHub: `clawhub:@openclaw/tencent-provider`. Adds Tencent TokenHub and TokenPlan model provider support to OpenClaw.
+- **[tencent](/plugins/reference/tencent)** (`@openclaw/tencent-provider`) - npm; ClawHub: `clawhub:@openclaw/tencent-provider`. Adds Tencent TokenHub, Tencent Tokenplan model provider support to OpenClaw.
 
 - **[tlon](/plugins/reference/tlon)** (`@openclaw/tlon`) - npm; ClawHub. OpenClaw Tlon/Urbit channel plugin for chat workflows.
 

--- a/docs/plugins/reference.md
+++ b/docs/plugins/reference.md
@@ -15,5 +15,5 @@ This page is generated from `extensions/*/package.json` and
 pnpm plugins:inventory:gen
 ```
 
-Use [Plugin inventory](/plugins/plugin-inventory) to browse all 132
+Use [Plugin inventory](/plugins/plugin-inventory) to browse all 133
 generated plugin reference pages by distribution, package, and description.

--- a/docs/plugins/reference/anthropic.md
+++ b/docs/plugins/reference/anthropic.md
@@ -16,7 +16,7 @@ Adds Anthropic model provider support to OpenClaw.
 
 ## Surface
 
-providers: anthropic; contracts: mediaUnderstandingProviders
+providers: anthropic; contracts: mediaUnderstandingProviders, usageProviders
 
 ## Related docs
 

--- a/docs/plugins/reference/clawrouter.md
+++ b/docs/plugins/reference/clawrouter.md
@@ -16,7 +16,7 @@ Adds ClawRouter model provider support to OpenClaw.
 
 ## Surface
 
-providers: clawrouter
+providers: clawrouter; contracts: usageProviders
 
 ## Related docs
 

--- a/docs/plugins/reference/deepseek.md
+++ b/docs/plugins/reference/deepseek.md
@@ -16,7 +16,7 @@ Adds DeepSeek model provider support to OpenClaw.
 
 ## Surface
 
-providers: deepseek
+providers: deepseek; contracts: usageProviders
 
 ## Related docs
 

--- a/docs/plugins/reference/featherless.md
+++ b/docs/plugins/reference/featherless.md
@@ -1,0 +1,23 @@
+---
+summary: "OpenClaw Featherless AI provider plugin."
+read_when:
+  - You are installing, configuring, or auditing the featherless plugin
+title: "Featherless plugin"
+---
+
+# Featherless plugin
+
+OpenClaw Featherless AI provider plugin.
+
+## Distribution
+
+- Package: `@openclaw/featherless-provider`
+- Install route: npm; ClawHub: `clawhub:@openclaw/featherless-provider`
+
+## Surface
+
+providers: featherless
+
+## Related docs
+
+- [featherless](/providers/featherless)

--- a/docs/plugins/reference/github-copilot.md
+++ b/docs/plugins/reference/github-copilot.md
@@ -16,7 +16,7 @@ Adds GitHub Copilot model provider support to OpenClaw.
 
 ## Surface
 
-providers: github-copilot; contracts: memoryEmbeddingProviders
+providers: github-copilot; contracts: memoryEmbeddingProviders, usageProviders
 
 ## Related docs
 

--- a/docs/plugins/reference/google.md
+++ b/docs/plugins/reference/google.md
@@ -16,7 +16,7 @@ Adds Google, Google Gemini CLI, Google Vertex model provider support to OpenClaw
 
 ## Surface
 
-providers: google, google-gemini-cli, google-vertex; contracts: imageGenerationProviders, mediaUnderstandingProviders, memoryEmbeddingProviders, musicGenerationProviders, realtimeVoiceProviders, speechProviders, videoGenerationProviders, webSearchProviders
+providers: google, google-gemini-cli, google-vertex; contracts: imageGenerationProviders, mediaUnderstandingProviders, memoryEmbeddingProviders, musicGenerationProviders, realtimeVoiceProviders, speechProviders, usageProviders, videoGenerationProviders, webSearchProviders
 
 ## Related docs
 

--- a/docs/plugins/reference/minimax.md
+++ b/docs/plugins/reference/minimax.md
@@ -16,7 +16,7 @@ Adds MiniMax, MiniMax Portal model provider support to OpenClaw.
 
 ## Surface
 
-providers: minimax, minimax-portal; contracts: imageGenerationProviders, mediaUnderstandingProviders, musicGenerationProviders, speechProviders, videoGenerationProviders, webSearchProviders
+providers: minimax, minimax-portal; contracts: imageGenerationProviders, mediaUnderstandingProviders, musicGenerationProviders, speechProviders, usageProviders, videoGenerationProviders, webSearchProviders
 
 ## Related docs
 

--- a/docs/plugins/reference/openai.md
+++ b/docs/plugins/reference/openai.md
@@ -16,7 +16,7 @@ Adds OpenAI model provider support to OpenClaw.
 
 ## Surface
 
-providers: openai; contracts: imageGenerationProviders, mediaUnderstandingProviders, memoryEmbeddingProviders, realtimeTranscriptionProviders, realtimeVoiceProviders, speechProviders, videoGenerationProviders
+providers: openai; contracts: imageGenerationProviders, mediaUnderstandingProviders, memoryEmbeddingProviders, realtimeTranscriptionProviders, realtimeVoiceProviders, speechProviders, usageProviders, videoGenerationProviders
 
 ## Related docs
 

--- a/docs/plugins/reference/openrouter.md
+++ b/docs/plugins/reference/openrouter.md
@@ -16,7 +16,7 @@ Adds OpenRouter model provider support to OpenClaw.
 
 ## Surface
 
-providers: openrouter; contracts: imageGenerationProviders, mediaUnderstandingProviders, musicGenerationProviders, speechProviders, videoGenerationProviders
+providers: openrouter; contracts: imageGenerationProviders, mediaUnderstandingProviders, musicGenerationProviders, speechProviders, usageProviders, videoGenerationProviders
 
 ## Related docs
 

--- a/docs/plugins/reference/tencent.md
+++ b/docs/plugins/reference/tencent.md
@@ -1,5 +1,5 @@
 ---
-summary: "Adds Tencent Hy3 model provider support (TokenHub and TokenPlan) to OpenClaw."
+summary: "Adds Tencent TokenHub, Tencent Tokenplan model provider support to OpenClaw."
 read_when:
   - You are installing, configuring, or auditing the tencent plugin
 title: "Tencent plugin"
@@ -7,7 +7,7 @@ title: "Tencent plugin"
 
 # Tencent plugin
 
-Adds Tencent TokenHub and TokenPlan model provider support to OpenClaw.
+Adds Tencent TokenHub, Tencent Tokenplan model provider support to OpenClaw.
 
 ## Distribution
 

--- a/docs/plugins/reference/venice.md
+++ b/docs/plugins/reference/venice.md
@@ -16,7 +16,7 @@ Adds Venice model provider support to OpenClaw.
 
 ## Surface
 
-providers: venice
+providers: venice; contracts: usageProviders
 
 ## Related docs
 

--- a/docs/plugins/reference/xiaomi.md
+++ b/docs/plugins/reference/xiaomi.md
@@ -16,7 +16,7 @@ Adds Xiaomi, Xiaomi Token Plan model provider support to OpenClaw.
 
 ## Surface
 
-providers: xiaomi, xiaomi-token-plan; contracts: speechProviders
+providers: xiaomi, xiaomi-token-plan; contracts: speechProviders, usageProviders
 
 ## Related docs
 

--- a/docs/plugins/reference/zai.md
+++ b/docs/plugins/reference/zai.md
@@ -16,7 +16,7 @@ Adds Z.AI model provider support to OpenClaw.
 
 ## Surface
 
-providers: zai; contracts: mediaUnderstandingProviders
+providers: zai; contracts: mediaUnderstandingProviders, usageProviders
 
 ## Related docs
 

--- a/docs/providers/featherless.md
+++ b/docs/providers/featherless.md
@@ -1,0 +1,139 @@
+---
+summary: "Featherless AI setup, model selection, and tool calling"
+title: "Featherless AI"
+read_when:
+  - You want to use Featherless AI with OpenClaw
+  - You need the Featherless API key env var or model ref format
+---
+
+[Featherless AI](https://featherless.ai) serves open models through an
+OpenAI-compatible API. OpenClaw installs Featherless as an official external
+provider plugin and keeps the built-in catalog small while accepting exact
+model ids from Featherless at runtime.
+
+| Property        | Value                                    |
+| --------------- | ---------------------------------------- |
+| Provider id     | `featherless`                            |
+| Package         | `@openclaw/featherless-provider`         |
+| Auth env var    | `FEATHERLESS_API_KEY`                    |
+| Onboarding flag | `--auth-choice featherless-api-key`      |
+| Direct CLI flag | `--featherless-api-key <key>`            |
+| API             | OpenAI-compatible (`openai-completions`) |
+| Base URL        | `https://api.featherless.ai/v1`          |
+| Default model   | `featherless/Qwen/Qwen3-32B`             |
+
+## Setup
+
+Install the plugin and restart the Gateway:
+
+```bash
+openclaw plugins install @openclaw/featherless-provider
+openclaw gateway restart
+```
+
+Run onboarding:
+
+```bash
+openclaw onboard --auth-choice featherless-api-key
+```
+
+For non-interactive setup:
+
+```bash
+openclaw onboard --non-interactive \
+  --mode local \
+  --auth-choice featherless-api-key \
+  --featherless-api-key "$FEATHERLESS_API_KEY"
+```
+
+Or expose the key to the Gateway process:
+
+```bash
+export FEATHERLESS_API_KEY="<your-featherless-api-key>" # pragma: allowlist secret
+```
+
+Verify the provider:
+
+```bash
+openclaw models list --provider featherless
+```
+
+## Default model
+
+The plugin uses `Qwen/Qwen3-32B` as the setup default because Featherless
+documents native tool calling for the Qwen 3 family. OpenClaw configures its
+32,768-token context window, a conservative 4,096-token output limit, and
+Qwen chat-template thinking controls.
+
+The catalog cost fields are zero because Featherless supports multiple billing
+modes and OpenClaw does not embed account-specific plan or request-pricing
+rates.
+
+## Other Featherless models
+
+Use the exact Featherless model id after the `featherless/` provider prefix:
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: {
+        primary: "featherless/moonshotai/Kimi-K2-Instruct",
+      },
+    },
+  },
+}
+```
+
+OpenClaw deliberately does not copy Featherless's full public model index into
+the picker. The index is large and does not expose enough structured capability
+metadata to classify every text, vision, embedding, and reasoning model safely.
+Unknown ids therefore resolve with conservative text-only, non-reasoning
+defaults: a 4,096-token context window and 1,024-token output limit.
+
+Add an explicit provider model entry when a model needs different metadata:
+
+```json5
+{
+  models: {
+    mode: "merge",
+    providers: {
+      featherless: {
+        baseUrl: "https://api.featherless.ai/v1",
+        apiKey: "${FEATHERLESS_API_KEY}",
+        api: "openai-completions",
+        models: [
+          {
+            id: "google/gemma-3-27b-it",
+            name: "Gemma 3 27B",
+            input: ["text", "image"],
+            reasoning: false,
+            contextWindow: 32768,
+            maxTokens: 4096,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+Check Featherless's model catalog for current model availability and capability
+tags before adding custom metadata.
+
+## Troubleshooting
+
+- `401` or `403`: confirm `FEATHERLESS_API_KEY` is visible to the Gateway
+  process, or run onboarding again.
+- Unknown model: use the exact case-sensitive id from Featherless after the
+  `featherless/` prefix.
+- Tool calls returned as text: choose a model family Featherless documents for
+  native function calling, such as Qwen 3.
+- Managed Gateway cannot see the key: put it in `~/.openclaw/.env` or another
+  environment source loaded by the service, then restart the Gateway.
+
+## Related
+
+- [Model providers](/concepts/model-providers)
+- [All providers](/providers/index)
+- [Thinking modes](/tools/thinking)

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -41,6 +41,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [ds4 (local DeepSeek V4)](/providers/ds4)
 - [ElevenLabs](/providers/elevenlabs)
 - [fal](/providers/fal)
+- [Featherless AI](/providers/featherless)
 - [Fireworks](/providers/fireworks)
 - [GitHub Copilot](/providers/github-copilot)
 - [GMI Cloud](/providers/gmi)

--- a/extensions/featherless/README.md
+++ b/extensions/featherless/README.md
@@ -1,0 +1,12 @@
+# OpenClaw Featherless AI Provider
+
+Official OpenClaw provider plugin for Featherless AI's OpenAI-compatible API.
+
+Install from OpenClaw:
+
+```bash
+openclaw plugins install @openclaw/featherless-provider
+openclaw gateway restart
+```
+
+See <https://docs.openclaw.ai/providers/featherless> for setup and configuration.

--- a/extensions/featherless/api.ts
+++ b/extensions/featherless/api.ts
@@ -1,0 +1,14 @@
+// Public Featherless provider plugin API exports.
+export {
+  FEATHERLESS_BASE_URL,
+  FEATHERLESS_DEFAULT_CONTEXT_WINDOW,
+  FEATHERLESS_DEFAULT_MAX_TOKENS,
+  FEATHERLESS_DEFAULT_MODEL_ID,
+  FEATHERLESS_DEFAULT_MODEL_REF,
+  FEATHERLESS_DYNAMIC_CONTEXT_WINDOW,
+  FEATHERLESS_DYNAMIC_MAX_TOKENS,
+  buildFeatherlessCatalogModels,
+  isFeatherlessCatalogModelId,
+} from "./models.js";
+export { applyFeatherlessConfig } from "./onboard.js";
+export { buildFeatherlessProvider } from "./provider-catalog.js";

--- a/extensions/featherless/featherless.live.test.ts
+++ b/extensions/featherless/featherless.live.test.ts
@@ -1,0 +1,114 @@
+// Featherless live tests prove text generation and a complete tool-call round trip.
+import {
+  completeSimple,
+  type AssistantMessage,
+  type Model,
+  type Tool,
+} from "openclaw/plugin-sdk/llm";
+import { extractNonEmptyAssistantText, isLiveTestEnabled } from "openclaw/plugin-sdk/test-env";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { FEATHERLESS_DEFAULT_MODEL_ID } from "./models.js";
+import { buildFeatherlessProvider } from "./provider-catalog.js";
+
+const FEATHERLESS_API_KEY = process.env.FEATHERLESS_API_KEY?.trim() ?? "";
+const LIVE = isLiveTestEnabled(["FEATHERLESS_LIVE_TEST"]) && FEATHERLESS_API_KEY.length > 0;
+const describeLive = LIVE ? describe : describe.skip;
+
+function resolveLiveModel(): Model<"openai-completions"> {
+  const provider = buildFeatherlessProvider();
+  const model = provider.models?.find((entry) => entry.id === FEATHERLESS_DEFAULT_MODEL_ID);
+  if (!model) {
+    throw new Error(`Featherless catalog does not include ${FEATHERLESS_DEFAULT_MODEL_ID}`);
+  }
+  return {
+    provider: "featherless",
+    baseUrl: provider.baseUrl,
+    ...model,
+    api: "openai-completions",
+  } as Model<"openai-completions">;
+}
+
+function liveEchoTool(): Tool {
+  return {
+    name: "live_echo",
+    description: "Return the supplied value.",
+    parameters: Type.Object(
+      {
+        value: Type.String(),
+      },
+      { additionalProperties: false },
+    ),
+  };
+}
+
+function requireToolCall(message: AssistantMessage) {
+  const toolCall = message.content.find((block) => block.type === "toolCall");
+  if (toolCall?.type !== "toolCall") {
+    throw new Error(`Featherless live model did not call a tool: ${message.stopReason}`);
+  }
+  return toolCall;
+}
+
+describeLive("featherless plugin live", () => {
+  it("completes a tool-call round trip with the default model", async () => {
+    const model = resolveLiveModel();
+    const tool = liveEchoTool();
+    const userPrompt = {
+      role: "user" as const,
+      content: "Call live_echo with value featherless. Do not answer directly.",
+      timestamp: Date.now() - 3,
+    };
+    const first = await completeSimple(
+      model,
+      {
+        messages: [userPrompt],
+        tools: [tool],
+      },
+      {
+        apiKey: FEATHERLESS_API_KEY,
+        maxTokens: 256,
+      },
+    );
+
+    if (first.stopReason === "error") {
+      throw new Error(first.errorMessage || "Featherless first turn returned an error");
+    }
+    const toolCall = requireToolCall(first);
+    expect(toolCall.name).toBe("live_echo");
+    expect(toolCall.arguments).toEqual({ value: "featherless" });
+
+    const second = await completeSimple(
+      model,
+      {
+        messages: [
+          userPrompt,
+          first,
+          {
+            role: "toolResult",
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            content: [{ type: "text", text: "ok" }],
+            isError: false,
+            timestamp: Date.now() - 1,
+          },
+          {
+            role: "user",
+            content: "Reply with exactly: ok",
+            timestamp: Date.now(),
+          },
+        ],
+        tools: [tool],
+      },
+      {
+        apiKey: FEATHERLESS_API_KEY,
+        maxTokens: 64,
+      },
+    );
+
+    if (second.stopReason === "error") {
+      throw new Error(second.errorMessage || "Featherless second turn returned an error");
+    }
+    expect(extractNonEmptyAssistantText(second.content)).toMatch(/^ok[.!]?$/i);
+  }, 120_000);
+});

--- a/extensions/featherless/index.test.ts
+++ b/extensions/featherless/index.test.ts
@@ -1,0 +1,147 @@
+// Featherless tests cover provider registration, catalog, and dynamic model behavior.
+import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  registerSingleProviderPlugin,
+  resolveProviderPluginChoice,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
+import { describe, expect, it } from "vitest";
+import { createProviderDynamicModelContext } from "../test-support/provider-model-test-helpers.js";
+import featherlessPlugin from "./index.js";
+import {
+  FEATHERLESS_BASE_URL,
+  FEATHERLESS_DEFAULT_CONTEXT_WINDOW,
+  FEATHERLESS_DEFAULT_MAX_TOKENS,
+  FEATHERLESS_DEFAULT_MODEL_ID,
+  FEATHERLESS_DEFAULT_MODEL_REF,
+  FEATHERLESS_DYNAMIC_COMPAT,
+  FEATHERLESS_DYNAMIC_CONTEXT_WINDOW,
+  FEATHERLESS_DYNAMIC_MAX_TOKENS,
+} from "./models.js";
+import { applyFeatherlessConfig } from "./onboard.js";
+
+function createDefaultRuntimeModel(): ProviderRuntimeModel {
+  return {
+    id: FEATHERLESS_DEFAULT_MODEL_ID,
+    name: "Qwen3 32B",
+    provider: "featherless",
+    api: "openai-completions",
+    baseUrl: FEATHERLESS_BASE_URL,
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: FEATHERLESS_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: FEATHERLESS_DEFAULT_MAX_TOKENS,
+    compat: { thinkingFormat: "qwen-chat-template" },
+  };
+}
+
+describe("featherless provider plugin", () => {
+  it("registers Featherless AI with api-key auth metadata", async () => {
+    const provider = await registerSingleProviderPlugin(featherlessPlugin);
+    const resolved = resolveProviderPluginChoice({
+      providers: [provider],
+      choice: "featherless-api-key",
+    });
+
+    expect(provider.id).toBe("featherless");
+    expect(provider.label).toBe("Featherless AI");
+    expect(provider.envVars).toEqual(["FEATHERLESS_API_KEY"]);
+    expect(provider.auth).toHaveLength(1);
+    expect(provider.normalizeToolSchemas).toEqual(expect.any(Function));
+    expect(resolved?.provider.id).toBe("featherless");
+    expect(resolved?.method.id).toBe("api-key");
+  });
+
+  it("applies the curated default during onboarding", () => {
+    const config = applyFeatherlessConfig({});
+
+    expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
+      FEATHERLESS_DEFAULT_MODEL_REF,
+    );
+    expect(config.agents?.defaults?.models?.[FEATHERLESS_DEFAULT_MODEL_REF]?.alias).toBe(
+      "Qwen3 32B",
+    );
+  });
+
+  it("builds the curated Featherless catalog", async () => {
+    const provider = await registerSingleProviderPlugin(featherlessPlugin);
+    const result = await provider.staticCatalog?.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({}),
+    } as never);
+    if (!result || !("provider" in result)) {
+      throw new Error("expected Featherless static catalog");
+    }
+
+    expect(result.provider.baseUrl).toBe(FEATHERLESS_BASE_URL);
+    expect(result.provider.api).toBe("openai-completions");
+    expect(result.provider.models).toEqual([
+      expect.objectContaining({
+        id: FEATHERLESS_DEFAULT_MODEL_ID,
+        reasoning: true,
+        input: ["text"],
+        contextWindow: FEATHERLESS_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: FEATHERLESS_DEFAULT_MAX_TOKENS,
+        compat: expect.objectContaining({
+          maxTokensField: "max_tokens",
+          thinkingFormat: "qwen-chat-template",
+        }),
+      }),
+    ]);
+  });
+
+  it("resolves arbitrary Featherless model ids from conservative text defaults", async () => {
+    const provider = await registerSingleProviderPlugin(featherlessPlugin);
+    const resolved = provider.resolveDynamicModel?.(
+      createProviderDynamicModelContext({
+        provider: "featherless",
+        modelId: "moonshotai/Kimi-K2-Instruct",
+        models: [createDefaultRuntimeModel()],
+      }),
+    );
+
+    expect(resolved).toMatchObject({
+      id: "moonshotai/Kimi-K2-Instruct",
+      provider: "featherless",
+      api: "openai-completions",
+      baseUrl: FEATHERLESS_BASE_URL,
+      reasoning: false,
+      input: ["text"],
+      contextWindow: FEATHERLESS_DYNAMIC_CONTEXT_WINDOW,
+      maxTokens: FEATHERLESS_DYNAMIC_MAX_TOKENS,
+      compat: FEATHERLESS_DYNAMIC_COMPAT,
+    });
+  });
+
+  it("defers the curated model to static catalog resolution", async () => {
+    const provider = await registerSingleProviderPlugin(featherlessPlugin);
+    const resolved = provider.resolveDynamicModel?.(
+      createProviderDynamicModelContext({
+        provider: "featherless",
+        modelId: FEATHERLESS_DEFAULT_MODEL_ID,
+        models: [createDefaultRuntimeModel()],
+      }),
+    );
+
+    expect(resolved).toBeUndefined();
+  });
+
+  it("uses the shared OpenAI-compatible replay policy", async () => {
+    const provider = await registerSingleProviderPlugin(featherlessPlugin);
+    const policy = provider.buildReplayPolicy?.({
+      provider: "featherless",
+      modelApi: "openai-completions",
+      modelId: FEATHERLESS_DEFAULT_MODEL_ID,
+    });
+
+    expect(policy).toMatchObject({
+      sanitizeToolCallIds: true,
+      applyAssistantFirstOrderingFix: true,
+      validateGeminiTurns: true,
+      validateAnthropicTurns: true,
+    });
+    expect(policy).not.toHaveProperty("dropReasoningFromHistory");
+  });
+});

--- a/extensions/featherless/index.test.ts
+++ b/extensions/featherless/index.test.ts
@@ -115,6 +115,29 @@ describe("featherless provider plugin", () => {
     });
   });
 
+  it("applies provider compat to configured models without overriding explicit values", async () => {
+    const provider = await registerSingleProviderPlugin(featherlessPlugin);
+    const normalized = provider.normalizeResolvedModel?.({
+      provider: "featherless",
+      modelId: "google/gemma-3-27b-it",
+      model: {
+        ...createDefaultRuntimeModel(),
+        id: "google/gemma-3-27b-it",
+        name: "Gemma 3 27B",
+        compat: {
+          supportsStore: true,
+          thinkingFormat: "deepseek",
+        },
+      },
+    });
+
+    expect(normalized?.compat).toMatchObject({
+      ...FEATHERLESS_DYNAMIC_COMPAT,
+      supportsStore: true,
+      thinkingFormat: "deepseek",
+    });
+  });
+
   it("defers the curated model to static catalog resolution", async () => {
     const provider = await registerSingleProviderPlugin(featherlessPlugin);
     const resolved = provider.resolveDynamicModel?.(

--- a/extensions/featherless/index.ts
+++ b/extensions/featherless/index.ts
@@ -1,0 +1,105 @@
+// Featherless plugin entrypoint registers its OpenClaw integration.
+import type { ProviderResolveDynamicModelContext } from "openclaw/plugin-sdk/plugin-entry";
+import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import {
+  buildProviderReplayFamilyHooks,
+  cloneFirstTemplateModel,
+  normalizeModelCompat,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
+import { applyFeatherlessConfig, FEATHERLESS_DEFAULT_MODEL_REF } from "./onboard.js";
+import {
+  buildFeatherlessProvider,
+  FEATHERLESS_BASE_URL,
+  FEATHERLESS_DEFAULT_MODEL_ID,
+  FEATHERLESS_DYNAMIC_COMPAT,
+  FEATHERLESS_DYNAMIC_CONTEXT_WINDOW,
+  FEATHERLESS_DYNAMIC_MAX_TOKENS,
+  isFeatherlessCatalogModelId,
+} from "./provider-catalog.js";
+
+const PROVIDER_ID = "featherless";
+
+function resolveFeatherlessDynamicModel(ctx: ProviderResolveDynamicModelContext) {
+  const modelId = ctx.modelId.trim();
+  if (!modelId || isFeatherlessCatalogModelId(modelId)) {
+    return undefined;
+  }
+
+  return (
+    cloneFirstTemplateModel({
+      providerId: PROVIDER_ID,
+      modelId,
+      templateIds: [FEATHERLESS_DEFAULT_MODEL_ID],
+      ctx,
+      patch: {
+        provider: PROVIDER_ID,
+        reasoning: false,
+        input: ["text"],
+        contextWindow: FEATHERLESS_DYNAMIC_CONTEXT_WINDOW,
+        maxTokens: FEATHERLESS_DYNAMIC_MAX_TOKENS,
+        compat: FEATHERLESS_DYNAMIC_COMPAT,
+      },
+    }) ??
+    normalizeModelCompat({
+      id: modelId,
+      name: modelId,
+      provider: PROVIDER_ID,
+      api: "openai-completions",
+      baseUrl: FEATHERLESS_BASE_URL,
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: FEATHERLESS_DYNAMIC_CONTEXT_WINDOW,
+      maxTokens: FEATHERLESS_DYNAMIC_MAX_TOKENS,
+      compat: FEATHERLESS_DYNAMIC_COMPAT,
+    })
+  );
+}
+
+export default defineSingleProviderPluginEntry({
+  id: PROVIDER_ID,
+  name: "Featherless AI Provider",
+  description: "Featherless AI provider plugin",
+  provider: {
+    label: "Featherless AI",
+    docsPath: "/providers/featherless",
+    envVars: ["FEATHERLESS_API_KEY"],
+    auth: [
+      {
+        methodId: "api-key",
+        label: "Featherless AI API key",
+        hint: "OpenAI-compatible access to open models",
+        optionKey: "featherlessApiKey",
+        flagName: "--featherless-api-key",
+        envVar: "FEATHERLESS_API_KEY",
+        promptMessage: "Enter Featherless AI API key",
+        defaultModel: FEATHERLESS_DEFAULT_MODEL_REF,
+        applyConfig: (cfg) => applyFeatherlessConfig(cfg),
+        noteTitle: "Featherless AI",
+        noteMessage: [
+          "Featherless AI serves open models through an OpenAI-compatible API.",
+          "Create an API key at: https://featherless.ai/account/api-keys",
+        ].join("\n"),
+      },
+    ],
+    catalog: {
+      buildProvider: buildFeatherlessProvider,
+      buildStaticProvider: buildFeatherlessProvider,
+      allowExplicitBaseUrl: true,
+    },
+    augmentModelCatalog: ({ config }) =>
+      readConfiguredProviderCatalogEntries({
+        config,
+        providerId: PROVIDER_ID,
+      }),
+    ...buildProviderReplayFamilyHooks({
+      family: "openai-compatible",
+      dropReasoningFromHistory: false,
+    }),
+    ...buildProviderToolCompatFamilyHooks("openai"),
+    resolveDynamicModel: (ctx) => resolveFeatherlessDynamicModel(ctx),
+    isModernModelRef: () => true,
+  },
+});

--- a/extensions/featherless/index.ts
+++ b/extensions/featherless/index.ts
@@ -1,5 +1,8 @@
 // Featherless plugin entrypoint registers its OpenClaw integration.
-import type { ProviderResolveDynamicModelContext } from "openclaw/plugin-sdk/plugin-entry";
+import type {
+  ProviderResolveDynamicModelContext,
+  ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/plugin-entry";
 import { readConfiguredProviderCatalogEntries } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import {
@@ -58,6 +61,16 @@ function resolveFeatherlessDynamicModel(ctx: ProviderResolveDynamicModelContext)
   );
 }
 
+function normalizeFeatherlessResolvedModel(model: ProviderRuntimeModel): ProviderRuntimeModel {
+  return {
+    ...model,
+    compat: {
+      ...FEATHERLESS_DYNAMIC_COMPAT,
+      ...model.compat,
+    },
+  };
+}
+
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "Featherless AI Provider",
@@ -94,6 +107,7 @@ export default defineSingleProviderPluginEntry({
         config,
         providerId: PROVIDER_ID,
       }),
+    normalizeResolvedModel: ({ model }) => normalizeFeatherlessResolvedModel(model),
     ...buildProviderReplayFamilyHooks({
       family: "openai-compatible",
       dropReasoningFromHistory: false,

--- a/extensions/featherless/models.ts
+++ b/extensions/featherless/models.ts
@@ -1,0 +1,40 @@
+// Featherless model catalog helpers derive their values from the plugin manifest.
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+const FEATHERLESS_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
+  providerId: "featherless",
+  catalog: manifest.modelCatalog.providers.featherless,
+});
+
+export const FEATHERLESS_BASE_URL = FEATHERLESS_MANIFEST_PROVIDER.baseUrl;
+export const FEATHERLESS_DEFAULT_MODEL_ID = "Qwen/Qwen3-32B";
+export const FEATHERLESS_DEFAULT_MODEL_REF = `featherless/${FEATHERLESS_DEFAULT_MODEL_ID}` as const;
+export const FEATHERLESS_DYNAMIC_CONTEXT_WINDOW = 4096;
+export const FEATHERLESS_DYNAMIC_MAX_TOKENS = 1024;
+
+function requireFeatherlessManifestModel(id: string): ModelDefinitionConfig {
+  const model = FEATHERLESS_MANIFEST_PROVIDER.models.find((entry) => entry.id === id);
+  if (!model) {
+    throw new Error(`Missing Featherless modelCatalog row ${id}`);
+  }
+  return model;
+}
+
+const FEATHERLESS_DEFAULT_MODEL = requireFeatherlessManifestModel(FEATHERLESS_DEFAULT_MODEL_ID);
+
+export const FEATHERLESS_DEFAULT_CONTEXT_WINDOW = FEATHERLESS_DEFAULT_MODEL.contextWindow;
+export const FEATHERLESS_DEFAULT_MAX_TOKENS = FEATHERLESS_DEFAULT_MODEL.maxTokens;
+export const FEATHERLESS_DYNAMIC_COMPAT = {
+  ...FEATHERLESS_DEFAULT_MODEL.compat,
+  thinkingFormat: "openai",
+} as const;
+
+export function isFeatherlessCatalogModelId(modelId: string): boolean {
+  return FEATHERLESS_MANIFEST_PROVIDER.models.some((model) => model.id === modelId);
+}
+
+export function buildFeatherlessCatalogModels(): ModelDefinitionConfig[] {
+  return FEATHERLESS_MANIFEST_PROVIDER.models.map((model) => structuredClone(model));
+}

--- a/extensions/featherless/models.ts
+++ b/extensions/featherless/models.ts
@@ -1,6 +1,9 @@
 // Featherless model catalog helpers derive their values from the plugin manifest.
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
-import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import type {
+  ModelCompatConfig,
+  ModelDefinitionConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const FEATHERLESS_MANIFEST_PROVIDER = buildManifestModelProviderConfig({
@@ -26,10 +29,10 @@ const FEATHERLESS_DEFAULT_MODEL = requireFeatherlessManifestModel(FEATHERLESS_DE
 
 export const FEATHERLESS_DEFAULT_CONTEXT_WINDOW = FEATHERLESS_DEFAULT_MODEL.contextWindow;
 export const FEATHERLESS_DEFAULT_MAX_TOKENS = FEATHERLESS_DEFAULT_MODEL.maxTokens;
-export const FEATHERLESS_DYNAMIC_COMPAT = {
+export const FEATHERLESS_DYNAMIC_COMPAT: ModelCompatConfig = {
   ...FEATHERLESS_DEFAULT_MODEL.compat,
   thinkingFormat: "openai",
-} as const;
+};
 
 export function isFeatherlessCatalogModelId(modelId: string): boolean {
   return FEATHERLESS_MANIFEST_PROVIDER.models.some((model) => model.id === modelId);

--- a/extensions/featherless/npm-shrinkwrap.json
+++ b/extensions/featherless/npm-shrinkwrap.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/featherless-provider",
+  "version": "2026.6.11",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@openclaw/featherless-provider",
+      "version": "2026.6.11"
+    }
+  }
+}

--- a/extensions/featherless/onboard.ts
+++ b/extensions/featherless/onboard.ts
@@ -1,0 +1,27 @@
+// Featherless onboarding applies the curated model catalog and default.
+import {
+  createModelCatalogPresetAppliers,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import {
+  buildFeatherlessCatalogModels,
+  FEATHERLESS_BASE_URL,
+  FEATHERLESS_DEFAULT_MODEL_REF,
+} from "./models.js";
+
+export { FEATHERLESS_DEFAULT_MODEL_REF } from "./models.js";
+
+const featherlessPresetAppliers = createModelCatalogPresetAppliers({
+  primaryModelRef: FEATHERLESS_DEFAULT_MODEL_REF,
+  resolveParams: (_cfg: OpenClawConfig) => ({
+    providerId: "featherless",
+    api: "openai-completions",
+    baseUrl: FEATHERLESS_BASE_URL,
+    catalogModels: buildFeatherlessCatalogModels(),
+    aliases: [{ modelRef: FEATHERLESS_DEFAULT_MODEL_REF, alias: "Qwen3 32B" }],
+  }),
+});
+
+export function applyFeatherlessConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return featherlessPresetAppliers.applyConfig(cfg);
+}

--- a/extensions/featherless/openclaw.plugin.json
+++ b/extensions/featherless/openclaw.plugin.json
@@ -1,0 +1,82 @@
+{
+  "id": "featherless",
+  "name": "Featherless AI",
+  "description": "OpenClaw Featherless AI provider plugin.",
+  "activation": {
+    "onStartup": false
+  },
+  "enabledByDefault": true,
+  "providers": ["featherless"],
+  "providerRequest": {
+    "providers": {
+      "featherless": {
+        "family": "featherless"
+      }
+    }
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "featherless",
+        "envVars": ["FEATHERLESS_API_KEY"]
+      }
+    ]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "featherless",
+      "method": "api-key",
+      "choiceId": "featherless-api-key",
+      "choiceLabel": "Featherless AI API key",
+      "choiceHint": "OpenAI-compatible access to open models",
+      "groupId": "featherless",
+      "groupLabel": "Featherless AI",
+      "groupHint": "OpenAI-compatible access to open models",
+      "optionKey": "featherlessApiKey",
+      "cliFlag": "--featherless-api-key",
+      "cliOption": "--featherless-api-key <key>",
+      "cliDescription": "Featherless AI API key"
+    }
+  ],
+  "modelCatalog": {
+    "providers": {
+      "featherless": {
+        "baseUrl": "https://api.featherless.ai/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "Qwen/Qwen3-32B",
+            "name": "Qwen3 32B",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 32768,
+            "maxTokens": 4096,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsReasoningEffort": false,
+              "supportsUsageInStreaming": false,
+              "maxTokensField": "max_tokens",
+              "thinkingFormat": "qwen-chat-template",
+              "supportsStrictMode": false
+            }
+          }
+        ]
+      }
+    },
+    "discovery": {
+      "featherless": "static"
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/featherless/openclaw.plugin.json
+++ b/extensions/featherless/openclaw.plugin.json
@@ -27,6 +27,7 @@
       "provider": "featherless",
       "method": "api-key",
       "choiceId": "featherless-api-key",
+      "appGuidedSecret": true,
       "choiceLabel": "Featherless AI API key",
       "choiceHint": "OpenAI-compatible access to open models",
       "groupId": "featherless",

--- a/extensions/featherless/package.json
+++ b/extensions/featherless/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@openclaw/featherless-provider",
+  "version": "2026.6.11",
+  "description": "OpenClaw Featherless AI provider plugin.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/openclaw"
+  },
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "clawhubSpec": "clawhub:@openclaw/featherless-provider",
+      "npmSpec": "@openclaw/featherless-provider",
+      "defaultChoice": "npm",
+      "minHostVersion": ">=2026.6.11"
+    },
+    "compat": {
+      "pluginApi": ">=2026.6.11"
+    },
+    "build": {
+      "openclawVersion": "2026.6.11",
+      "bundledDist": false
+    },
+    "release": {
+      "publishToClawHub": true,
+      "publishToNpm": true
+    }
+  }
+}

--- a/extensions/featherless/provider-catalog.ts
+++ b/extensions/featherless/provider-catalog.ts
@@ -1,0 +1,22 @@
+// Featherless provider catalog exposes the curated setup model.
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+export {
+  FEATHERLESS_BASE_URL,
+  FEATHERLESS_DEFAULT_CONTEXT_WINDOW,
+  FEATHERLESS_DEFAULT_MAX_TOKENS,
+  FEATHERLESS_DEFAULT_MODEL_ID,
+  FEATHERLESS_DYNAMIC_COMPAT,
+  FEATHERLESS_DYNAMIC_CONTEXT_WINDOW,
+  FEATHERLESS_DYNAMIC_MAX_TOKENS,
+  isFeatherlessCatalogModelId,
+} from "./models.js";
+
+export function buildFeatherlessProvider(): ModelProviderConfig {
+  return buildManifestModelProviderConfig({
+    providerId: "featherless",
+    catalog: manifest.modelCatalog.providers.featherless,
+  });
+}

--- a/extensions/featherless/tsconfig.json
+++ b/extensions/featherless/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../tsconfig.package-boundary.base.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./*.ts", "./src/**/*.ts"],
+  "exclude": [
+    "./**/*.test.ts",
+    "./dist/**",
+    "./node_modules/**",
+    "./src/test-support/**",
+    "./src/**/*test-helpers.ts",
+    "./src/**/*test-harness.ts",
+    "./src/**/*test-support.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "!dist/extensions/discord/**",
     "!dist/extensions/exa/**",
     "!dist/extensions/feishu/**",
+    "!dist/extensions/featherless/**",
     "!dist/extensions/firecrawl/**",
     "!dist/extensions/fireworks/**",
     "!dist/extensions/google-meet/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,6 +783,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/featherless:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/firecrawl:
     dependencies:
       typebox:

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -539,6 +539,56 @@
       }
     },
     {
+      "name": "@openclaw/featherless-provider",
+      "description": "OpenClaw Featherless AI provider plugin.",
+      "source": "official",
+      "kind": "provider",
+      "openclaw": {
+        "plugin": {
+          "id": "featherless",
+          "label": "Featherless AI"
+        },
+        "providers": [
+          {
+            "id": "featherless",
+            "name": "Featherless AI",
+            "docs": "/providers/featherless",
+            "categories": [
+              "cloud",
+              "llm"
+            ],
+            "envVars": [
+              "FEATHERLESS_API_KEY"
+            ],
+            "authChoices": [
+              {
+                "method": "api-key",
+                "choiceId": "featherless-api-key",
+                "choiceLabel": "Featherless AI API key",
+                "choiceHint": "OpenAI-compatible access to open models",
+                "groupId": "featherless",
+                "groupLabel": "Featherless AI",
+                "groupHint": "OpenAI-compatible access to open models",
+                "optionKey": "featherlessApiKey",
+                "cliFlag": "--featherless-api-key",
+                "cliOption": "--featherless-api-key <key>",
+                "cliDescription": "Featherless AI API key",
+                "onboardingScopes": [
+                  "text-inference"
+                ]
+              }
+            ]
+          }
+        ],
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/featherless-provider",
+          "npmSpec": "@openclaw/featherless-provider",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.6.11"
+        }
+      }
+    },
+    {
       "name": "@openclaw/gmi-provider",
       "description": "OpenClaw GMI Cloud provider plugin",
       "source": "official",

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1661,6 +1661,7 @@ describe("official external plugin catalog", () => {
       ["vercel-ai-gateway", "@openclaw/vercel-ai-gateway-provider"],
       ["zai", "@openclaw/zai-provider"],
     ] as const;
+    const currentExternalized = [["featherless", "@openclaw/featherless-provider"]] as const;
 
     for (const [id, npmSpec] of [...providers, ...plugins]) {
       expect(resolveOfficialExternalPluginInstall(expectCatalogEntry(id))).toEqual({
@@ -1676,6 +1677,14 @@ describe("official external plugin catalog", () => {
         npmSpec,
         defaultChoice: "npm",
         minHostVersion: ">=2026.6.9",
+      });
+    }
+    for (const [id, npmSpec] of currentExternalized) {
+      expect(resolveOfficialExternalPluginInstall(expectCatalogEntry(id))).toEqual({
+        clawhubSpec: `clawhub:${npmSpec}`,
+        npmSpec,
+        defaultChoice: "npm",
+        minHostVersion: ">=2026.6.11",
       });
     }
   });
@@ -1827,6 +1836,7 @@ describe("official external plugin catalog", () => {
         CLOUDFLARE_AI_GATEWAY_API_KEY: "cloudflare-key",
         DEEPINFRA_API_KEY: "deepinfra-key",
         DEEPSEEK_API_KEY: "deepseek-key",
+        FEATHERLESS_API_KEY: "featherless-key",
         GROQ_API_KEY: "groq-key",
         LONGCAT_API_KEY: "longcat-key",
         KILOCODE_API_KEY: "kilocode-key",
@@ -1850,6 +1860,7 @@ describe("official external plugin catalog", () => {
       "cloudflare-ai-gateway",
       "deepinfra",
       "deepseek",
+      "featherless",
       "fireworks",
       "groq",
       "kilocode",


### PR DESCRIPTION
## What Problem This Solves

Featherless AI currently requires generic custom-provider configuration in OpenClaw. Users must manually wire the endpoint, key, model ids, and capability metadata, and there is no official install, repair, onboarding, documentation, or package release path.

Closes #101065

Prior art: https://github.com/openclaw/openclaw/pull/37854

## Why This Change Was Made

This adds Featherless as an official external provider plugin instead of adding provider-specific policy to core.

- Registers `featherless` through the existing provider plugin SDK.
- Adds API-key onboarding via `FEATHERLESS_API_KEY` and `--featherless-api-key`.
- Supports app-guided secret setup through manifest metadata.
- Uses Featherless's documented OpenAI-compatible endpoint.
- Keeps one curated tool-capable default, `Qwen/Qwen3-32B`.
- Resolves other exact Featherless model ids with conservative text-only defaults.
- Applies Featherless transport compatibility defaults to configured model rows while preserving explicit user overrides.
- Adds official catalog/install metadata, generated references, provider docs, package build metadata, focused tests, and a live tool-call round-trip test.

The full Featherless catalog is intentionally not mirrored. It changes frequently and does not provide uniform structured capability metadata for every model family.

## User Impact

Users can install `@openclaw/featherless-provider`, onboard with a Featherless API key, select the curated default, or use exact Featherless model ids without hand-writing a complete provider block.

This is additive. Existing providers and generic custom-provider configuration are unchanged.

## Evidence

Exact branch head: `12bff140d442af8c95b6cbfb3804d84940a90ed7`.

- Live Featherless tool-call and tool-result replay passed against `featherless/Qwen/Qwen3-32B`: `pnpm test:live -- extensions/featherless/featherless.live.test.ts` (`1/1`, AWS Crabbox run `run_ef0ba801b3e2`, lease `cbx_31dc1a247f37`).
- Current-head provider, manifest, auth-choice, registry, and official-catalog tests passed (`166/166`) on Blacksmith Testbox `tbx_01kwwhbaea1crhacdndcydd1cj`.
- Current-head external plugin package-boundary compile passed for all 119 plugins on the same Testbox.
- `docs:map:check`, root/plugin shrinkwrap checks, focused formatting, and `git diff --check` passed.
- Full `pnpm check:changed` passed on the preceding rebased source head on Blacksmith Testbox `tbx_01kwwgp2nce2dsgej146a1pcrt`; the only subsequent branch change was the current-main `appGuidedSecret` manifest adaptation covered by the current-head contract suite.
- The npm release check and plan select one unpublished production candidate: `@openclaw/featherless-provider@2026.6.11`.
- Fresh whole-branch autoreview reported no accepted/actionable findings (confidence `0.84`).

## Release Preparation

- Public namespace bootstrap published: `@openclaw/featherless-provider@0.0.0`.
- npm `latest` currently points to `0.0.0`.
- Published tarball SHA-1: `8818efef2bb119d24e518e3cb51702f9ac412d52`.
- Published tarball SHA-256: `9cb729626b07d4746e4d0089a6a31cc08919ae286f31cf87c1e34c22a504d767`.
- npm integrity: `sha512-JXPKke7D3UYEbOXgM9r5v66awf31T2Jrn/6Atd6BKdtuiYqc9gCT40g0SpoqMpDqUA2c2wBs9w6is5pOwM1rog==`.
- Registry metadata, public access, exact tarball contents, checksum match, and isolated install smoke were verified after propagation.
- Trusted publishing is configured for repository `openclaw/openclaw`, workflow `plugin-npm-release.yml`, environment `npm-release`.
- Production plugin releases continue to use OpenClaw's dated package version through the normal release workflow.
