### PR TITLE
Instrument native hook relay timings

### DIFF
--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -219,6 +219,7 @@ const NATIVE_HOOK_BRIDGE_RETRY_INTERVAL_MS = 25;
 const NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS = 250;
 const NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR =
   "native hook relay bridge stale registration";
+const NATIVE_HOOK_RELAY_SLOW_WARN_MS = 250;
 const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
 
@@ -1367,16 +1368,39 @@ async function processNativeHookRelayInvocation(params: {
   invocation: NativeHookRelayInvocation;
   adapter: NativeHookRelayProviderAdapter;
 }): Promise<NativeHookRelayProcessResponse> {
-  if (params.invocation.event === "pre_tool_use") {
-    return runNativeHookRelayPreToolUse(params);
+  const startedAt = Date.now();
+  let outcome: "ok" | "error" = "ok";
+  try {
+    if (params.invocation.event === "pre_tool_use") {
+      return await runNativeHookRelayPreToolUse(params);
+    }
+    if (params.invocation.event === "post_tool_use") {
+      return await runNativeHookRelayPostToolUse(params);
+    }
+    if (params.invocation.event === "before_agent_finalize") {
+      return await runNativeHookRelayBeforeAgentFinalize(params);
+    }
+    return await runNativeHookRelayPermissionRequest(params);
+  } catch (error) {
+    outcome = "error";
+    throw error;
+  } finally {
+    const durationMs = Date.now() - startedAt;
+    const details = {
+      event: params.invocation.event,
+      durationMs,
+      outcome,
+      runId: params.registration.runId,
+      ...(params.registration.agentId ? { agentId: params.registration.agentId } : {}),
+      ...(params.registration.sessionKey ? { sessionKey: params.registration.sessionKey } : {}),
+      relayId: `${params.registration.relayId.slice(0, 16)}...`,
+    };
+    if (durationMs >= NATIVE_HOOK_RELAY_SLOW_WARN_MS) {
+      log.warn("native hook relay invocation slow", details);
+    } else {
+      log.debug("native hook relay invocation completed", details);
+    }
   }
-  if (params.invocation.event === "post_tool_use") {
-    return runNativeHookRelayPostToolUse(params);
-  }
-  if (params.invocation.event === "before_agent_finalize") {
-    return runNativeHookRelayBeforeAgentFinalize(params);
-  }
-  return runNativeHookRelayPermissionRequest(params);
 }
 
 async function runNativeHookRelayPreToolUse(params: {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -589,6 +589,23 @@ export function createHookRunner(
     }
   };
 
+  const HOOK_HANDLER_SLOW_WARN_MS = 250;
+
+  const recordHookHandlerDuration = (params: {
+    hookName: PluginHookName;
+    pluginId: string;
+    durationMs: number;
+    mode: "parallel" | "sequential";
+    outcome: "ok" | "error";
+  }): void => {
+    const details = `hook=${params.hookName} plugin=${params.pluginId} durationMs=${params.durationMs} mode=${params.mode} outcome=${params.outcome}`;
+    if (params.durationMs >= HOOK_HANDLER_SLOW_WARN_MS) {
+      logger?.warn?.(`[hooks] slow handler ${details}`);
+    } else {
+      logger?.debug?.(`[hooks] handler completed ${details}`);
+    }
+  };
+
   const runSyncHookHandler = <K extends SyncHookName>(
     hook: PluginHookRegistration<K>,
     event: SyncHookEvent<K>,
@@ -616,6 +633,8 @@ export function createHookRunner(
     logger?.debug?.(`[hooks] running ${hookName} (${hooks.length} handlers)`);
 
     const promises = hooks.map(async (hook) => {
+      const startedAt = Date.now();
+      let outcome: "ok" | "error" = "ok";
       try {
         const promise = Promise.resolve(
           (hook.handler as (event: unknown, ctx: unknown) => Promise<void> | void)(event, ctx),
@@ -627,7 +646,16 @@ export function createHookRunner(
           await promise;
         }
       } catch (err) {
+        outcome = "error";
         handleHookError({ hookName, pluginId: hook.pluginId, error: err });
+      } finally {
+        recordHookHandlerDuration({
+          hookName,
+          pluginId: hook.pluginId,
+          durationMs: Date.now() - startedAt,
+          mode: "parallel",
+          outcome,
+        });
       }
     });
 
@@ -654,6 +682,8 @@ export function createHookRunner(
     let result: TResult | undefined;
 
     for (const hook of hooks) {
+      const startedAt = Date.now();
+      let outcome: "ok" | "error" = "ok";
       try {
         const handler = hook.handler as (event: unknown, ctx: unknown) => Promise<TResult>;
         const promise = Promise.resolve(handler(event, ctx));
@@ -679,7 +709,16 @@ export function createHookRunner(
           }
         }
       } catch (err) {
+        outcome = "error";
         handleHookError({ hookName, pluginId: hook.pluginId, error: err });
+      } finally {
+        recordHookHandlerDuration({
+          hookName,
+          pluginId: hook.pluginId,
+          durationMs: Date.now() - startedAt,
+          mode: "sequential",
+          outcome,
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
- add duration logging around native hook relay invocation dispatch
- add per-plugin hook handler duration logging for parallel void hooks and sequential modifying hooks
- warn only when handlers/relay invocations take at least 250ms; debug-log faster completions

## Notes
- instrumentation only: no payload logging, no secret logging, no behavior change
- intended to support the hook CPU burst investigation by identifying expensive relay events and hook handlers before changing concurrency or event routing

## Verification
- `pnpm format:check src/agents/harness/native-hook-relay.ts src/plugins/hooks.ts`
- `TMPDIR="$(mktemp -d)" node scripts/test-projects.mjs src/agents/harness/native-hook-relay.test.ts src/cli/native-hook-relay-cli.test.ts src/plugins/hooks.sync-only.test.ts src/plugins/loader.hook-runner-live-view.test.ts src/plugins/hooks.before-tool-call.test.ts src/plugins/hooks.before-agent-finalize.test.ts`
- `pnpm tsgo:core`