### PR TITLE
feat(android): server-backed session search with offline fallback

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -2635,7 +2635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 133,
+      "line": 154,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Sessions",
       "surface": "android",
@@ -2643,15 +2643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 134,
-      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
-      "source": "Search sessions",
-      "surface": "android",
-      "id": "native.android.b9cf34c137e4cf03"
-    },
-    {
-      "kind": "ui-named-argument",
-      "line": 135,
+      "line": 156,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Reverse session sort",
       "surface": "android",
@@ -2659,7 +2651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 141,
+      "line": 162,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Recent",
       "surface": "android",
@@ -2667,7 +2659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 142,
+      "line": 163,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -2675,15 +2667,23 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 143,
+      "line": 164,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Archived",
       "surface": "android",
       "id": "native.android.78654c0f198c6df2"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 173,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Search sessions",
+      "surface": "android",
+      "id": "native.android.b9cf34c137e4cf03"
+    },
+    {
       "kind": "conditional-branch",
-      "line": 158,
+      "line": 189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Newest",
       "surface": "android",
@@ -2691,7 +2691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 158,
+      "line": 189,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Oldest",
       "surface": "android",
@@ -2699,7 +2699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 161,
+      "line": 192,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Toggle session layout",
       "surface": "android",
@@ -2707,7 +2707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 166,
+      "line": 197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Layout: Compact",
       "surface": "android",
@@ -2715,7 +2715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 166,
+      "line": 197,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Layout: Detailed",
       "surface": "android",
@@ -2723,7 +2723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 178,
+      "line": 209,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -2731,7 +2731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 199,
+      "line": 230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Current session",
       "surface": "android",
@@ -2739,7 +2739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 199,
+      "line": 230,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "OpenClaw session",
       "surface": "android",
@@ -2747,7 +2747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 244,
+      "line": 275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Rename session",
       "surface": "android",
@@ -2755,7 +2755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 247,
+      "line": 278,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Rename",
       "surface": "android",
@@ -2763,7 +2763,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 266,
+      "line": 297,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "New group",
       "surface": "android",
@@ -2771,7 +2771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 269,
+      "line": 300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Create",
       "surface": "android",
@@ -2779,7 +2779,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 283,
+      "line": 314,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Delete session?",
       "surface": "android",
@@ -2787,7 +2787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 284,
+      "line": 315,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "This permanently deletes the session and its transcript.",
       "surface": "android",
@@ -2795,7 +2795,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 292,
+      "line": 323,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Delete",
       "surface": "android",
@@ -2803,7 +2803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 413,
+      "line": 444,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Pinned",
       "surface": "android",
@@ -2811,7 +2811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 419,
+      "line": 450,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Workspace",
       "surface": "android",
@@ -2819,7 +2819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 420,
+      "line": 451,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -2827,7 +2827,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 470,
+      "line": 501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Pin",
       "surface": "android",
@@ -2835,7 +2835,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 470,
+      "line": 501,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Unpin",
       "surface": "android",
@@ -2843,7 +2843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 474,
+      "line": 505,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Mark as read",
       "surface": "android",
@@ -2851,7 +2851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 474,
+      "line": 505,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Mark as unread",
       "surface": "android",
@@ -2859,7 +2859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 533,
+      "line": 564,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Group name",
       "surface": "android",
@@ -2867,7 +2867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 533,
+      "line": 564,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Name",
       "surface": "android",
@@ -2875,7 +2875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 543,
+      "line": 574,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Cancel",
       "surface": "android",
@@ -2883,7 +2883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 616,
+      "line": 647,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No sessions yet",
       "surface": "android",
@@ -2891,7 +2891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 617,
+      "line": 648,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No current session",
       "surface": "android",
@@ -2899,7 +2899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 618,
+      "line": 649,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No archived sessions",
       "surface": "android",
@@ -2907,7 +2907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 624,
+      "line": 655,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Start a new conversation and it will show up here.",
       "surface": "android",
@@ -2915,7 +2915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 625,
+      "line": 656,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Open Chat to start or resume the current session.",
       "surface": "android",
@@ -2923,7 +2923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 626,
+      "line": 657,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Archived sessions will show up here.",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -719,6 +719,11 @@ class MainViewModel(
     ensureRuntime().switchChatSession(sessionKey)
   }
 
+  suspend fun fetchChatSessionList(
+    search: String?,
+    archived: Boolean,
+  ): List<ChatSessionEntry> = ensureRuntime().fetchChatSessionList(search = search, archived = archived)
+
   fun abortChat() {
     ensureRuntime().abortChat()
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -2730,6 +2730,11 @@ class NodeRuntime private constructor(
     chat.switchSession(sessionKey)
   }
 
+  suspend fun fetchChatSessionList(
+    search: String?,
+    archived: Boolean,
+  ): List<ChatSessionEntry> = chat.fetchSessionList(search = search, archived = archived)
+
   fun abortChat() {
     chat.abort()
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -31,6 +31,9 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
+// Bounds one-shot search list fetches like the primary session list.
+internal const val SESSION_LIST_FETCH_LIMIT = 200
+
 // Capture before suspend points; both fields must still match before gateway data reaches UI state.
 internal data class ChatCacheScope(
   val gatewayId: String,
@@ -394,6 +397,39 @@ class ChatController internal constructor(
     } catch (err: Throwable) {
       updateErrorText(err.message)
       null
+    }
+  }
+
+  /**
+   * One-shot session list for the search UI; does not touch the live list
+   * state. Falls back to locally filtering the cached active list when the
+   * gateway is unreachable; archived rows exist only server-side, so archived
+   * search is empty offline.
+   */
+  suspend fun fetchSessionList(
+    search: String?,
+    archived: Boolean,
+  ): List<ChatSessionEntry> {
+    val query = search?.trim()?.takeIf { it.isNotEmpty() }
+    return try {
+      val params =
+        buildJsonObject {
+          put("includeGlobal", JsonPrimitive(true))
+          put("includeUnknown", JsonPrimitive(false))
+          put("limit", JsonPrimitive(SESSION_LIST_FETCH_LIMIT))
+          if (query != null) put("search", JsonPrimitive(query))
+          if (archived) put("archived", JsonPrimitive(true))
+        }
+      parseSessions(requestGateway("sessions.list", params.toString())).sessions
+    } catch (err: CancellationException) {
+      // A superseded search owns the results now; never repaint stale fallback rows.
+      throw err
+    } catch (_: Throwable) {
+      when {
+        archived -> emptyList()
+        query == null -> _sessions.value
+        else -> filterSessionEntries(_sessions.value, query)
+      }
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatModels.kt
@@ -66,6 +66,19 @@ data class ChatSessionEntry(
   val hasContextUsageMetadata: Boolean = totalTokens != null || totalTokensFresh != null || contextTokens != null,
 )
 
+/** Local fallback for server-side `sessions.list` search over cached entries. */
+fun filterSessionEntries(
+  sessions: List<ChatSessionEntry>,
+  search: String,
+): List<ChatSessionEntry> {
+  val query = search.trim().lowercase()
+  if (query.isEmpty()) return sessions
+  return sessions.filter { session ->
+    listOfNotNull(session.displayName, session.label, session.key)
+      .any { it.lowercase().contains(query) }
+  }
+}
+
 /**
  * Slash command metadata exposed by the gateway for text-surface chat clients.
  */

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
@@ -66,6 +66,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /** Session browser for active, current, and archived chat sessions. */
@@ -85,8 +86,11 @@ internal fun SessionsScreen(
   var renameSessionKey by rememberSaveable { mutableStateOf<String?>(null) }
   var groupSessionKey by rememberSaveable { mutableStateOf<String?>(null) }
   var deleteSessionKey by rememberSaveable { mutableStateOf<String?>(null) }
+  var searchText by rememberSaveable { mutableStateOf("") }
+  var searchResults by remember { mutableStateOf<List<ChatSessionEntry>>(emptyList()) }
+  val searchQuery = searchText.trim()
   val visibleSessions =
-    sessions
+    (if (searchQuery.isEmpty()) sessions else searchResults)
       .let { rows ->
         when (filter) {
           SessionFilter.Recent -> rows.filter { it.archived != true }
@@ -113,6 +117,23 @@ internal fun SessionsScreen(
     if (isConnected) {
       viewModel.refreshChatSessions(limit = 200, archived = filter == SessionFilter.Archived)
     }
+  }
+
+  // Keyed on the live session list too: row actions (pin/rename/archive/delete)
+  // refresh live state, which re-runs the search so results never go stale.
+  LaunchedEffect(searchQuery, filter, sessions) {
+    if (searchQuery.isEmpty()) {
+      searchResults = emptyList()
+      return@LaunchedEffect
+    }
+    // Debounce keystrokes; the key change cancels superseded fetches, and the
+    // controller falls back to local filtering when the gateway is unreachable.
+    delay(250)
+    searchResults =
+      viewModel.fetchChatSessionList(
+        search = searchQuery,
+        archived = filter == SessionFilter.Archived,
+      )
   }
 
   ClawScaffold(
@@ -142,6 +163,16 @@ internal fun SessionsScreen(
           FilterPill(text = "Current", icon = Icons.Outlined.MicNone, active = filter == SessionFilter.Current, showDot = sessions.any { it.key == chatSessionKey }, onClick = { filter = SessionFilter.Current })
           FilterPill(text = "Archived", icon = Icons.Outlined.Archive, active = filter == SessionFilter.Archived, onClick = { filter = SessionFilter.Archived })
         }
+      }
+
+      item {
+        OutlinedTextField(
+          value = searchText,
+          onValueChange = { searchText = it },
+          modifier = Modifier.fillMaxWidth(),
+          placeholder = { Text(text = "Search sessions", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted) },
+          singleLine = true,
+        )
       }
 
       item {

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionSearchTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerSessionSearchTest.kt
@@ -1,0 +1,123 @@
+package ai.openclaw.app.chat
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChatControllerSessionSearchTest {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun TestScope.newController(gateway: ScriptedGateway): ChatController = ChatController(scope = this, json = json, requestGateway = gateway::request)
+
+  private fun sessionRowJson(
+    key: String,
+    updatedAt: Long,
+    displayName: String? = null,
+    archived: Boolean = false,
+  ) = buildJsonObject {
+    put("key", JsonPrimitive(key))
+    put("updatedAt", JsonPrimitive(updatedAt))
+    if (displayName != null) put("displayName", JsonPrimitive(displayName))
+    if (archived) put("archived", JsonPrimitive(true))
+  }
+
+  private fun sessionsListJson(vararg rows: kotlinx.serialization.json.JsonObject): String = buildJsonObject { put("sessions", JsonArray(rows.toList())) }.toString()
+
+  private fun paramField(
+    paramsJson: String?,
+    field: String,
+  ): String? =
+    paramsJson
+      ?.let { json.parseToJsonElement(it).jsonObject[field] }
+      ?.jsonPrimitive
+      ?.content
+
+  @Test
+  fun filterSessionEntriesMatchesDisplayNameLabelAndKey() {
+    val sessions =
+      listOf(
+        ChatSessionEntry(key = "agent:main:topic-a", updatedAtMs = 2, displayName = "Trip planning"),
+        ChatSessionEntry(key = "agent:main:topic-b", updatedAtMs = 1, displayName = "Groceries"),
+        ChatSessionEntry(key = "agent:main:trip-notes", updatedAtMs = 3, displayName = "Notes"),
+      )
+    assertEquals(
+      listOf("agent:main:topic-a", "agent:main:trip-notes"),
+      filterSessionEntries(sessions, "TRIP").map { it.key },
+    )
+    assertEquals(sessions, filterSessionEntries(sessions, "  "))
+  }
+
+  @Test
+  fun fetchSessionListSendsSearchAndArchivedParams() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.list") { paramsJson ->
+        val params = json.parseToJsonElement(paramsJson.orEmpty()).jsonObject
+        if (params["archived"]?.jsonPrimitive?.content == "true") {
+          sessionsListJson(sessionRowJson(key = "agent:main:old", updatedAt = 10, archived = true))
+        } else {
+          sessionsListJson(sessionRowJson(key = "agent:main:topic-a", updatedAt = 100))
+        }
+      }
+      val controller = newController(gateway)
+
+      val archivedRows = controller.fetchSessionList(search = null, archived = true)
+      assertEquals(listOf("agent:main:old"), archivedRows.map { it.key })
+      assertTrue(archivedRows.single().archived == true)
+
+      controller.fetchSessionList(search = "  trip  ", archived = false)
+      val searchCall = gateway.calls.last { it.method == "sessions.list" }
+      assertEquals("trip", paramField(searchCall.paramsJson, "search"))
+      assertEquals("200", paramField(searchCall.paramsJson, "limit"))
+    }
+
+  @Test
+  fun fetchSessionListFallsBackToLocalFilterWhenOffline() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.list") { paramsJson ->
+        val params = json.parseToJsonElement(paramsJson.orEmpty()).jsonObject
+        if ("search" in params || "archived" in params) error("offline")
+        sessionsListJson(
+          sessionRowJson(key = "agent:main:topic-a", updatedAt = 2, displayName = "Trip planning"),
+          sessionRowJson(key = "agent:main:topic-b", updatedAt = 1, displayName = "Groceries"),
+        )
+      }
+      val controller = newController(gateway)
+      controller.refreshSessions()
+      advanceUntilIdle()
+
+      val filtered = controller.fetchSessionList(search = "trip", archived = false)
+      assertEquals(listOf("agent:main:topic-a"), filtered.map { it.key })
+      // Archived rows exist only server-side, so offline archived search is empty.
+      assertTrue(controller.fetchSessionList(search = null, archived = true).isEmpty())
+    }
+
+  @Test
+  fun fetchSessionListRethrowsCancellationInsteadOfFallingBack() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respond("sessions.list") { _ -> throw CancellationException("superseded") }
+      val controller = newController(gateway)
+
+      try {
+        controller.fetchSessionList(search = "trip", archived = false)
+        fail("expected CancellationException to propagate")
+      } catch (_: CancellationException) {
+        // A superseded search must cancel, not repaint stale fallback rows.
+      }
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

The Android sessions screen gained full management controls in #100814 (pin, rename, archive, groups, unread), but there is still no way to *find* a session: no search field, and the gateway's server-side `sessions.list` search stays unused on Android. On gateways with many sessions the grouped list is scroll-only.

Tracking issue: #100712 (stacked on #100964, which grants `operator.write` clients the `sessions.patch` access the shipped Android controls rely on).

## Why This Change Was Made

- `ChatController.fetchSessionList(search:archived:)` performs a one-shot server-side search (`sessions.list` with `search`/`archived`/bounded `limit`) without touching the live list state. When the gateway is unreachable it falls back to locally filtering the cached active list (`filterSessionEntries` over display name/label/key); archived rows exist only server-side, so archived search is empty offline. `CancellationException` is rethrown before the fallback so a superseded search can never repaint stale rows over a newer query.
- `SessionsScreen` gets a search field under the filter pills, debounced 250 ms via `LaunchedEffect` keyed on the query and filter (key changes cancel superseded fetches). Search results flow through the existing filter/sort/grouping pipeline, so pinned/grouped rendering and the Archived filter behave identically while searching.
- `NodeRuntime`/`MainViewModel` gain the matching pass-through, mirroring the existing session control plumbing.

## User Impact

Android users can search sessions by name/label/key with server-side matching (covering sessions beyond the fetched window) in Recent and Archived scopes, with a graceful cached-list fallback while offline.

## Evidence

- New `ChatControllerSessionSearchTest` (ScriptedGateway seam): search/archived/limit request params, offline local-filter fallback, archived-empty-offline, and cancellation rethrow (no stale fallback repaint).
- `pnpm android:test` green on a Blacksmith Testbox (33 Gradle tasks, includes the new suite); `pnpm android:lint` reports no violations in touched files.
- `apps/.i18n/native-source.json` regenerated via `native-app-i18n sync` for the new "Search sessions" string.
