### PR TITLE
feat(macos): redesign chat window as native shell with sessions sidebar, toolbar pickers, slash commands, and context usage

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22027,7 +22027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 596,
+      "line": 591,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
@@ -22035,7 +22035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 642,
+      "line": 637,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
@@ -22043,7 +22043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 642,
+      "line": 637,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
@@ -22051,7 +22051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 675,
+      "line": 670,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -22059,7 +22059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 675,
+      "line": 670,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -22099,7 +22099,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 944,
+      "line": 1024,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -22107,7 +22107,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 969,
+      "line": 1049,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -22115,7 +22115,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 984,
+      "line": 1064,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -22123,7 +22123,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1118,
+      "line": 1198,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -22131,11 +22131,27 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1118,
+      "line": 1198,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",
       "id": "native.apple.898849eb2bcb0b53"
+    },
+    {
+      "kind": "ui-call",
+      "line": 115,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "\\(percent)%",
+      "surface": "apple",
+      "id": "native.apple.e8fba80e238f4283"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 122,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift",
+      "source": "Context usage",
+      "surface": "apple",
+      "id": "native.apple.a902d7f653b46010"
     },
     {
       "kind": "ui-named-argument",
@@ -22298,6 +22314,14 @@
       "id": "native.apple.7c99becc26501014"
     },
     {
+      "kind": "ui-named-argument",
+      "line": 37,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift",
+      "source": "Pinned",
+      "surface": "apple",
+      "id": "native.apple.63320b6d5138c0db"
+    },
+    {
       "kind": "conditional-branch",
       "line": 16,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSheets.swift",
@@ -22427,7 +22451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 436,
+      "line": 440,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -22435,7 +22459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 450,
+      "line": 454,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -22443,7 +22467,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 481,
+      "line": 485,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -22451,7 +22475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 484,
+      "line": 488,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -22459,7 +22483,15 @@
     },
     {
       "kind": "ui-call",
-      "line": 557,
+      "line": 535,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
+      "source": "Copy Message",
+      "surface": "apple",
+      "id": "native.apple.fe9f30f12f1dcfaf"
+    },
+    {
+      "kind": "ui-call",
+      "line": 594,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
@@ -22467,7 +22499,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 568,
+      "line": 605,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -22475,7 +22507,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 588,
+      "line": 625,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -22483,7 +22515,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1013,
+      "line": 1050,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -22491,7 +22523,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1093,
+      "line": 1130,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -22523,7 +22555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1462,
+      "line": 1516,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -22531,7 +22563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1462,
+      "line": 1516,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -22539,7 +22571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1686,
+      "line": 1740,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -22547,11 +22579,251 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1742,
+      "line": 1796,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",
       "id": "native.apple.d93e6fe16ec1b0e5"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 39,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Clear this session's history?",
+      "surface": "apple",
+      "id": "native.apple.87ba543b42696b92"
+    },
+    {
+      "kind": "ui-call",
+      "line": 43,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Clear History",
+      "surface": "apple",
+      "id": "native.apple.6192578088f1b100"
+    },
+    {
+      "kind": "ui-call",
+      "line": 47,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "This resets the conversation for \\(self.activeSessionTitle). The session key stays the same.",
+      "surface": "apple",
+      "id": "native.apple.ca701776b3d9ce70"
+    },
+    {
+      "kind": "ui-call",
+      "line": 74,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Export Transcript",
+      "surface": "apple",
+      "id": "native.apple.2ee7858b00a47c42"
+    },
+    {
+      "kind": "ui-call",
+      "line": 137,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Thinking",
+      "surface": "apple",
+      "id": "native.apple.b1f10b5e9113881d"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 148,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Thinking level",
+      "surface": "apple",
+      "id": "native.apple.48dde5fe65b841a3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 153,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Model",
+      "surface": "apple",
+      "id": "native.apple.273aa7b9194a8d0d"
+    },
+    {
+      "kind": "ui-call",
+      "line": 165,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Pinned",
+      "surface": "apple",
+      "id": "native.apple.17ea1ddec4a7b7a8"
+    },
+    {
+      "kind": "ui-call",
+      "line": 168,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Recent",
+      "surface": "apple",
+      "id": "native.apple.f5bbceea34d12623"
+    },
+    {
+      "kind": "ui-call",
+      "line": 171,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Models",
+      "surface": "apple",
+      "id": "native.apple.f41f892742244520"
+    },
+    {
+      "kind": "ui-call",
+      "line": 198,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Refresh",
+      "surface": "apple",
+      "id": "native.apple.5361129a24118af6"
+    },
+    {
+      "kind": "ui-call",
+      "line": 213,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Export Transcript…",
+      "surface": "apple",
+      "id": "native.apple.9b2ad72143b931bf"
+    },
+    {
+      "kind": "ui-call",
+      "line": 230,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Clear History…",
+      "surface": "apple",
+      "id": "native.apple.4b24d792545e5086"
+    },
+    {
+      "kind": "ui-call",
+      "line": 233,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Session",
+      "surface": "apple",
+      "id": "native.apple.920fe8a7a33f9e92"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 236,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Session actions",
+      "surface": "apple",
+      "id": "native.apple.185a401f78328b0f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 268,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Session cost \\(ChatContextUsageFormatter.cost(cost))",
+      "surface": "apple",
+      "id": "native.apple.547fe762a61d08a6"
+    },
+    {
+      "kind": "ui-call",
+      "line": 271,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Compact Session",
+      "surface": "apple",
+      "id": "native.apple.f0a4720df5f5f403"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 321,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "No Results",
+      "surface": "apple",
+      "id": "native.apple.f10d5ccfd0530fec"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 321,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "No Sessions",
+      "surface": "apple",
+      "id": "native.apple.42b0ee4c8b3326b6"
+    },
+    {
+      "kind": "ui-call",
+      "line": 333,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "New Session",
+      "surface": "apple",
+      "id": "native.apple.eb58552e43c8dde2"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 335,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "New session",
+      "surface": "apple",
+      "id": "native.apple.247771e4350c006f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 350,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Delete Session",
+      "surface": "apple",
+      "id": "native.apple.d9a72d07e8d95d35"
+    },
+    {
+      "kind": "ui-call",
+      "line": 357,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "The session and its transcript are removed from the gateway.",
+      "surface": "apple",
+      "id": "native.apple.499537ec30a28ae0"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 407,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Unread",
+      "surface": "apple",
+      "id": "native.apple.1bd1b747fd161df5"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 414,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Pin",
+      "surface": "apple",
+      "id": "native.apple.a8a2f4b248663f97"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 414,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Unpin",
+      "surface": "apple",
+      "id": "native.apple.8768f9ed198edc54"
+    },
+    {
+      "kind": "ui-call",
+      "line": 417,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Copy Session Key",
+      "surface": "apple",
+      "id": "native.apple.27ddbe5e4643b60f"
+    },
+    {
+      "kind": "ui-call",
+      "line": 426,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Delete Session…",
+      "surface": "apple",
+      "id": "native.apple.a994d072ab35cb35"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 446,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Connecting…",
+      "surface": "apple",
+      "id": "native.apple.22d5ce71e22a7f73"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 446,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift",
+      "source": "Gateway connected",
+      "surface": "apple",
+      "id": "native.apple.8d0606ab1a2c0f44"
     },
     {
       "kind": "ui-modifier",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22555,7 +22555,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1516,
+      "line": 1481,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -22563,7 +22563,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1516,
+      "line": 1481,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -22571,7 +22571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1740,
+      "line": 1705,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -22579,7 +22579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1796,
+      "line": 1761,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -42,7 +42,10 @@ final class WebChatManager {
     func show(sessionKey: String) {
         self.closePanel()
         if let controller = self.windowController {
-            if self.windowSessionKey == sessionKey {
+            // The window shell can switch sessions in place (sidebar), so an
+            // existing window already showing the requested session must not
+            // be torn down and re-bootstrapped.
+            if self.windowSessionKey == sessionKey || self.currentChatSessionKey == sessionKey {
                 controller.show()
                 return
             }

--- a/apps/macos/Sources/OpenClaw/WebChatManager.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatManager.swift
@@ -42,10 +42,10 @@ final class WebChatManager {
     func show(sessionKey: String) {
         self.closePanel()
         if let controller = self.windowController {
-            // The window shell can switch sessions in place (sidebar), so an
-            // existing window already showing the requested session must not
-            // be torn down and re-bootstrapped.
-            if self.windowSessionKey == sessionKey || self.currentChatSessionKey == sessionKey {
+            // The window shell switches sessions in place (sidebar, /new);
+            // windowSessionKey tracks those switches, so a window already on
+            // the requested session must not be torn down and re-bootstrapped.
+            if self.windowSessionKey == sessionKey {
                 controller.show()
                 return
             }
@@ -57,6 +57,10 @@ final class WebChatManager {
         let controller = WebChatSwiftUIWindowController(sessionKey: sessionKey, presentation: .window)
         controller.onVisibilityChanged = { [weak self] visible in
             self?.onPanelVisibilityChanged?(visible)
+        }
+        controller.onSessionKeyChanged = { [weak self] key in
+            self?.windowSessionKey = key
+            self?.currentChatSessionKey = key
         }
         self.windowController = controller
         self.windowSessionKey = sessionKey
@@ -88,6 +92,10 @@ final class WebChatManager {
         }
         controller.onVisibilityChanged = { [weak self] visible in
             self?.onPanelVisibilityChanged?(visible)
+        }
+        controller.onSessionKeyChanged = { [weak self] key in
+            self?.panelSessionKey = key
+            self?.currentChatSessionKey = key
         }
         self.panelController = controller
         self.panelSessionKey = sessionKey

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -20,9 +20,21 @@ private enum WebChatSwiftUILayout {
 
 struct MacGatewayChatTransport: OpenClawChatTransport {
     private let outboxGatewayID: String?
+    private let defaultGlobalAgentID: String?
 
-    init(outboxGatewayID: String? = nil) {
+    init(outboxGatewayID: String? = nil, defaultGlobalAgentID: String? = nil) {
         self.outboxGatewayID = outboxGatewayID
+        let normalized = defaultGlobalAgentID?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        self.defaultGlobalAgentID = normalized?.isEmpty == false ? normalized : nil
+    }
+
+    /// Bare alias keys ("global") do not name their owner; the gateway
+    /// resolves an omitted agentId to the default agent, so scope them to the
+    /// window's agent explicitly, mirroring the iOS transport.
+    private func selectedGlobalAgentID(for sessionKey: String) -> String? {
+        sessionKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "global"
+            ? self.defaultGlobalAgentID
+            : nil
     }
 
     var outboxRequiresSessionRoutingContract: Bool {
@@ -266,7 +278,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             "scope": AnyCodable("text"),
             "includeArgs": AnyCodable(true),
         ]
-        if let agentID = Self.agentID(fromSessionKey: sessionKey) {
+        if let agentID = Self.agentID(fromSessionKey: sessionKey) ?? self.defaultGlobalAgentID {
             params["agentId"] = AnyCodable(agentID)
         }
         let data = try await GatewayConnection.shared.request(
@@ -288,6 +300,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         ]
         if let agentID = Self.agentID(fromSessionKey: key)
             ?? parentSessionKey.flatMap(Self.agentID(fromSessionKey:))
+            ?? self.defaultGlobalAgentID
         {
             params["agentId"] = AnyCodable(agentID)
         }
@@ -318,6 +331,9 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         var params: [String: AnyCodable] = [
             "key": AnyCodable(key),
         ]
+        if let agentID = self.selectedGlobalAgentID(for: key) {
+            params["agentId"] = AnyCodable(agentID)
+        }
         if let label {
             params["label"] = label.map(AnyCodable.init) ?? AnyCodable(NSNull())
         }
@@ -340,12 +356,16 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func deleteSession(key: String) async throws {
+        var params: [String: AnyCodable] = [
+            "key": AnyCodable(key),
+            "deleteTranscript": AnyCodable(true),
+        ]
+        if let agentID = self.selectedGlobalAgentID(for: key) {
+            params["agentId"] = AnyCodable(agentID)
+        }
         _ = try await GatewayConnection.shared.request(
             method: "sessions.delete",
-            params: [
-                "key": AnyCodable(key),
-                "deleteTranscript": AnyCodable(true),
-            ],
+            params: params,
             timeoutMs: 15000)
     }
 
@@ -541,7 +561,9 @@ final class WebChatSwiftUIWindowController {
         self.init(
             sessionKey: sessionKey,
             presentation: presentation,
-            transport: MacGatewayChatTransport(outboxGatewayID: store?.gatewayID),
+            transport: MacGatewayChatTransport(
+                outboxGatewayID: store?.gatewayID,
+                defaultGlobalAgentID: context?.routingIdentity?.defaultAgentID),
             initialActiveAgentID: context?.routingIdentity?.defaultAgentID,
             initialSessionRoutingContract: context?.routingIdentity?.contract,
             transcriptCache: store,

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -19,6 +19,11 @@ private enum WebChatSwiftUILayout {
 }
 
 struct MacGatewayChatTransport: OpenClawChatTransport {
+    struct SessionTarget: Equatable {
+        let sessionKey: String
+        let agentID: String?
+    }
+
     private let outboxGatewayID: String?
     private let defaultGlobalAgentID: String?
 
@@ -37,12 +42,30 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             : nil
     }
 
+    func sessionTarget(for sessionKey: String) -> SessionTarget {
+        SessionTarget(
+            sessionKey: sessionKey,
+            agentID: self.selectedGlobalAgentID(for: sessionKey))
+    }
+
+    private func sessionParams(for sessionKey: String, key: String = "key") -> [String: AnyCodable] {
+        let target = self.sessionTarget(for: sessionKey)
+        var params = [key: AnyCodable(target.sessionKey)]
+        if let agentID = target.agentID {
+            params["agentId"] = AnyCodable(agentID)
+        }
+        return params
+    }
+
     var outboxRequiresSessionRoutingContract: Bool {
         true
     }
 
     func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
-        try await GatewayConnection.shared.chatHistory(sessionKey: sessionKey)
+        let target = self.sessionTarget(for: sessionKey)
+        return try await GatewayConnection.shared.chatHistory(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID)
     }
 
     func listModels() async throws -> [OpenClawChatModelChoice] {
@@ -61,12 +84,11 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func abortRun(sessionKey: String, runId: String) async throws {
+        var params = self.sessionParams(for: sessionKey, key: "sessionKey")
+        params["runId"] = AnyCodable(runId)
         _ = try await GatewayConnection.shared.request(
             method: "chat.abort",
-            params: [
-                "sessionKey": AnyCodable(sessionKey),
-                "runId": AnyCodable(runId),
-            ],
+            params: params,
             timeoutMs: 10000)
     }
 
@@ -117,9 +139,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func setSessionModel(sessionKey: String, model: String?) async throws {
-        var params: [String: AnyCodable] = [
-            "key": AnyCodable(sessionKey),
-        ]
+        var params = self.sessionParams(for: sessionKey)
         params["model"] = model.map(AnyCodable.init) ?? AnyCodable(NSNull())
         _ = try await GatewayConnection.shared.request(
             method: "sessions.patch",
@@ -128,10 +148,8 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func setSessionThinking(sessionKey: String, thinkingLevel: String) async throws {
-        let params: [String: AnyCodable] = [
-            "key": AnyCodable(sessionKey),
-            "thinkingLevel": AnyCodable(thinkingLevel),
-        ]
+        var params = self.sessionParams(for: sessionKey)
+        params["thinkingLevel"] = AnyCodable(thinkingLevel)
         _ = try await GatewayConnection.shared.request(
             method: "sessions.patch",
             params: params,
@@ -178,8 +196,10 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         idempotencyKey: String,
         attachments: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
     {
-        try await GatewayConnection.shared.chatSend(
-            sessionKey: sessionKey,
+        let target = self.sessionTarget(for: sessionKey)
+        return try await GatewayConnection.shared.chatSend(
+            sessionKey: target.sessionKey,
+            agentID: target.agentID,
             message: message,
             thinking: thinking,
             idempotencyKey: idempotencyKey,
@@ -195,6 +215,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         idempotencyKey: String,
         attachments: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
     {
+        let target = self.sessionTarget(for: sessionKey)
         if let outboxGatewayID {
             try await Self.requireGateway(outboxGatewayID)
         }
@@ -210,8 +231,8 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             expectedSessionRoutingContract,
             serverSupportsGuard: supportsRoutingContract)
         return try await GatewayConnection.shared.chatSend(
-            sessionKey: sessionKey,
-            agentID: agentID,
+            sessionKey: target.sessionKey,
+            agentID: agentID ?? target.agentID,
             expectedSessionRoutingContract: guardedContract,
             message: message,
             thinking: thinking,
@@ -328,12 +349,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         archived: Bool?,
         unread: Bool?) async throws
     {
-        var params: [String: AnyCodable] = [
-            "key": AnyCodable(key),
-        ]
-        if let agentID = self.selectedGlobalAgentID(for: key) {
-            params["agentId"] = AnyCodable(agentID)
-        }
+        var params = self.sessionParams(for: key)
         if let label {
             params["label"] = label.map(AnyCodable.init) ?? AnyCodable(NSNull())
         }
@@ -356,13 +372,8 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     }
 
     func deleteSession(key: String) async throws {
-        var params: [String: AnyCodable] = [
-            "key": AnyCodable(key),
-            "deleteTranscript": AnyCodable(true),
-        ]
-        if let agentID = self.selectedGlobalAgentID(for: key) {
-            params["agentId"] = AnyCodable(agentID)
-        }
+        var params = self.sessionParams(for: key)
+        params["deleteTranscript"] = AnyCodable(true)
         _ = try await GatewayConnection.shared.request(
             method: "sessions.delete",
             params: params,
@@ -376,14 +387,14 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     func resetSession(sessionKey: String) async throws {
         _ = try await GatewayConnection.shared.request(
             method: "sessions.reset",
-            params: ["key": AnyCodable(sessionKey)],
+            params: self.sessionParams(for: sessionKey),
             timeoutMs: 10000)
     }
 
     func compactSession(sessionKey: String) async throws {
         let response = try await GatewayConnection.shared.request(
             method: "sessions.compact",
-            params: ["key": AnyCodable(sessionKey)],
+            params: self.sessionParams(for: sessionKey),
             timeoutMs: 0,
             retryTransportFailures: false)
         try OpenClawSessionsCompactResponse.requireSuccess(from: response)
@@ -395,7 +406,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         }
         _ = try await GatewayConnection.shared.request(
             method: "sessions.messages.subscribe",
-            params: ["key": AnyCodable(sessionKey)],
+            params: self.sessionParams(for: sessionKey),
             timeoutMs: 10000)
     }
 

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -509,15 +509,27 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
 
 // MARK: - Window controller
 
+/// Bridges the view model's session switches out of the controller. The view
+/// model is constructed before `self`, so the closure targets this box and the
+/// controller re-points it after initialization.
+@MainActor
+private final class WebChatSessionKeyRelay {
+    var onChange: ((String) -> Void)?
+}
+
 @MainActor
 final class WebChatSwiftUIWindowController {
     private let presentation: WebChatPresentation
     private let sessionKey: String
     private let contentController: NSViewController
+    private let sessionKeyRelay: WebChatSessionKeyRelay
     private var window: NSWindow?
     private var dismissMonitor: Any?
     var onClosed: (() -> Void)?
     var onVisibilityChanged: ((Bool) -> Void)?
+    /// Fires when the hosted chat switches sessions in place (sidebar,
+    /// composer picker, /new) so the owner can track what this surface shows.
+    var onSessionKeyChanged: ((String) -> Void)?
 
     convenience init(sessionKey: String, presentation: WebChatPresentation) {
         // Connection-mode changes tear chat windows down via resetTunnels(),
@@ -547,6 +559,8 @@ final class WebChatSwiftUIWindowController {
     {
         self.sessionKey = sessionKey
         self.presentation = presentation
+        let sessionKeyRelay = WebChatSessionKeyRelay()
+        self.sessionKeyRelay = sessionKeyRelay
         let vm = OpenClawChatViewModel(
             sessionKey: sessionKey,
             transport: transport,
@@ -555,6 +569,9 @@ final class WebChatSwiftUIWindowController {
             transcriptCache: transcriptCache,
             outbox: outbox,
             initialThinkingLevel: Self.persistedThinkingLevel(),
+            onSessionChanged: { key in
+                sessionKeyRelay.onChange?(key)
+            },
             onThinkingLevelChanged: { level in
                 UserDefaults.standard.set(level, forKey: webChatThinkingLevelDefaultsKey)
             })
@@ -603,6 +620,9 @@ final class WebChatSwiftUIWindowController {
             self.contentController = Self.makePanelContentController(hosting: hosting)
         }
         self.window = Self.makeWindow(for: presentation, contentViewController: self.contentController)
+        sessionKeyRelay.onChange = { [weak self] key in
+            self?.onSessionKeyChanged?(key)
+        }
     }
 
     deinit {}

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -19,18 +19,47 @@ private enum WebChatSwiftUILayout {
 }
 
 struct MacGatewayChatTransport: OpenClawChatTransport {
+    /// Shared across transport value copies so the live view model and its
+    /// snapshot observer cannot diverge on the owner of the bare global alias.
+    private final class RoutingIdentity: @unchecked Sendable {
+        private let lock = NSLock()
+        private var defaultGlobalAgentID: String?
+
+        init(defaultGlobalAgentID: String?) {
+            self.defaultGlobalAgentID = Self.normalized(defaultGlobalAgentID)
+        }
+
+        func update(defaultGlobalAgentID: String?) {
+            self.lock.withLock {
+                self.defaultGlobalAgentID = Self.normalized(defaultGlobalAgentID)
+            }
+        }
+
+        func currentAgentID() -> String? {
+            self.lock.withLock { self.defaultGlobalAgentID }
+        }
+
+        private static func normalized(_ agentID: String?) -> String? {
+            let normalized = agentID?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            return normalized?.isEmpty == false ? normalized : nil
+        }
+    }
+
     struct SessionTarget: Equatable {
         let sessionKey: String
         let agentID: String?
     }
 
     private let outboxGatewayID: String?
-    private let defaultGlobalAgentID: String?
+    private let routingIdentity: RoutingIdentity
 
     init(outboxGatewayID: String? = nil, defaultGlobalAgentID: String? = nil) {
         self.outboxGatewayID = outboxGatewayID
-        let normalized = defaultGlobalAgentID?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        self.defaultGlobalAgentID = normalized?.isEmpty == false ? normalized : nil
+        self.routingIdentity = RoutingIdentity(defaultGlobalAgentID: defaultGlobalAgentID)
+    }
+
+    func updateDefaultGlobalAgentID(_ agentID: String?) {
+        self.routingIdentity.update(defaultGlobalAgentID: agentID)
     }
 
     /// Bare alias keys ("global") do not name their owner; the gateway
@@ -38,7 +67,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
     /// window's agent explicitly, mirroring the iOS transport.
     private func selectedGlobalAgentID(for sessionKey: String) -> String? {
         sessionKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "global"
-            ? self.defaultGlobalAgentID
+            ? self.routingIdentity.currentAgentID()
             : nil
     }
 
@@ -299,7 +328,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             "scope": AnyCodable("text"),
             "includeArgs": AnyCodable(true),
         ]
-        if let agentID = Self.agentID(fromSessionKey: sessionKey) ?? self.defaultGlobalAgentID {
+        if let agentID = Self.agentID(fromSessionKey: sessionKey) ?? self.routingIdentity.currentAgentID() {
             params["agentId"] = AnyCodable(agentID)
         }
         let data = try await GatewayConnection.shared.request(
@@ -321,7 +350,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         ]
         if let agentID = Self.agentID(fromSessionKey: key)
             ?? parentSessionKey.flatMap(Self.agentID(fromSessionKey:))
-            ?? self.defaultGlobalAgentID
+            ?? self.routingIdentity.currentAgentID()
         {
             params["agentId"] = AnyCodable(agentID)
         }
@@ -621,6 +650,8 @@ final class WebChatSwiftUIWindowController {
                     nil
                 }
                 if let routingIdentity {
+                    (transport as? MacGatewayChatTransport)?
+                        .updateDefaultGlobalAgentID(routingIdentity.defaultAgentID)
                     if let store = transcriptCache as? OpenClawChatSQLiteTranscriptCache,
                        store.gatewayID == MacChatTranscriptCache.currentGatewayID(),
                        let persistedIdentity = OpenClawChatSessionRoutingIdentity(

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -185,39 +185,6 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             timeoutMs: 15000)
     }
 
-    func patchSession(
-        key: String,
-        label: String??,
-        category: String??,
-        pinned: Bool?,
-        archived: Bool?,
-        unread: Bool?) async throws
-    {
-        var params: [String: AnyCodable] = [
-            "key": AnyCodable(key),
-        ]
-        // Double-optionals: .some(nil) clears the field server-side (JSON null).
-        if let label {
-            params["label"] = label.map(AnyCodable.init) ?? AnyCodable(NSNull())
-        }
-        if let category {
-            params["category"] = category.map(AnyCodable.init) ?? AnyCodable(NSNull())
-        }
-        if let pinned {
-            params["pinned"] = AnyCodable(pinned)
-        }
-        if let archived {
-            params["archived"] = AnyCodable(archived)
-        }
-        if let unread {
-            params["unread"] = AnyCodable(unread)
-        }
-        _ = try await GatewayConnection.shared.request(
-            method: "sessions.patch",
-            params: params,
-            timeoutMs: 15000)
-    }
-
     func sendMessage(
         sessionKey: String,
         message: String,

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -11,9 +11,10 @@ private let webChatSwiftLogger = Logger(subsystem: "ai.openclaw", category: "Web
 private let webChatThinkingLevelDefaultsKey = "openclaw.webchat.thinkingLevel"
 
 private enum WebChatSwiftUILayout {
-    static let windowSize = NSSize(width: 500, height: 840)
+    static let windowSize = NSSize(width: 960, height: 700)
     static let panelSize = NSSize(width: 480, height: 640)
-    static let windowMinSize = NSSize(width: 480, height: 360)
+    static let windowMinSize = NSSize(width: 640, height: 420)
+    static let windowFrameAutosaveName = "OpenClawChatWindow"
     static let anchorPadding: CGFloat = 8
 }
 
@@ -256,6 +257,98 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
         }
     }
 
+    var supportsSlashCommandCatalog: Bool {
+        true
+    }
+
+    func listCommands(sessionKey: String) async throws -> [OpenClawChatCommandChoice] {
+        var params: [String: AnyCodable] = [
+            "scope": AnyCodable("text"),
+            "includeArgs": AnyCodable(true),
+        ]
+        if let agentID = Self.agentID(fromSessionKey: sessionKey) {
+            params["agentId"] = AnyCodable(agentID)
+        }
+        let data = try await GatewayConnection.shared.request(
+            method: "commands.list",
+            params: params,
+            timeoutMs: 15000)
+        let decoded = try JSONDecoder().decode(CommandsListResult.self, from: data)
+        return decoded.commands.map(Self.mapCommandChoice)
+    }
+
+    func createSession(
+        key: String,
+        label: String?,
+        parentSessionKey: String?,
+        worktree: Bool?) async throws -> OpenClawChatCreateSessionResponse
+    {
+        var params: [String: AnyCodable] = [
+            "key": AnyCodable(key),
+        ]
+        if let agentID = Self.agentID(fromSessionKey: key)
+            ?? parentSessionKey.flatMap(Self.agentID(fromSessionKey:))
+        {
+            params["agentId"] = AnyCodable(agentID)
+        }
+        if let label {
+            params["label"] = AnyCodable(label)
+        }
+        if let parentSessionKey {
+            params["parentSessionKey"] = AnyCodable(parentSessionKey)
+        }
+        if let worktree {
+            params["worktree"] = AnyCodable(worktree)
+        }
+        let data = try await GatewayConnection.shared.request(
+            method: "sessions.create",
+            params: params,
+            timeoutMs: 15000)
+        return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: data)
+    }
+
+    func patchSession(
+        key: String,
+        label: String??,
+        category: String??,
+        pinned: Bool?,
+        archived: Bool?,
+        unread: Bool?) async throws
+    {
+        var params: [String: AnyCodable] = [
+            "key": AnyCodable(key),
+        ]
+        if let label {
+            params["label"] = label.map(AnyCodable.init) ?? AnyCodable(NSNull())
+        }
+        if let category {
+            params["category"] = category.map(AnyCodable.init) ?? AnyCodable(NSNull())
+        }
+        if let pinned {
+            params["pinned"] = AnyCodable(pinned)
+        }
+        if let archived {
+            params["archived"] = AnyCodable(archived)
+        }
+        if let unread {
+            params["unread"] = AnyCodable(unread)
+        }
+        _ = try await GatewayConnection.shared.request(
+            method: "sessions.patch",
+            params: params,
+            timeoutMs: 15000)
+    }
+
+    func deleteSession(key: String) async throws {
+        _ = try await GatewayConnection.shared.request(
+            method: "sessions.delete",
+            params: [
+                "key": AnyCodable(key),
+                "deleteTranscript": AnyCodable(true),
+            ],
+            timeoutMs: 15000)
+    }
+
     func requestHealth(timeoutMs: Int) async throws -> Bool {
         try await GatewayConnection.shared.healthOK(timeoutMs: timeoutMs)
     }
@@ -372,6 +465,46 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             contextWindow: model.contextwindow,
             reasoning: model.reasoning)
     }
+
+    static func agentID(fromSessionKey sessionKey: String) -> String? {
+        let parts = sessionKey
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: ":", omittingEmptySubsequences: false)
+        guard parts.count >= 3, parts[0].lowercased() == "agent" else { return nil }
+        let agentID = String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return agentID.isEmpty ? nil : agentID
+    }
+
+    private static func mapCommandChoice(_ entry: CommandEntry) -> OpenClawChatCommandChoice {
+        let sourceValue = (entry.source.value as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let source: OpenClawChatCommandChoice.Source = switch sourceValue {
+        case "native":
+            .command
+        case "skill":
+            .skill
+        case "plugin":
+            .plugin
+        default:
+            .unknown
+        }
+        let aliases = (entry.textaliases ?? [])
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let id = [
+            source.rawValue,
+            entry.name.trimmingCharacters(in: .whitespacesAndNewlines),
+            aliases.first ?? "",
+        ].joined(separator: ":")
+        return OpenClawChatCommandChoice(
+            id: id,
+            name: entry.name,
+            textAliases: aliases,
+            description: entry.description,
+            source: source,
+            acceptsArgs: entry.acceptsargs)
+    }
 }
 
 // MARK: - Window controller
@@ -380,7 +513,6 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
 final class WebChatSwiftUIWindowController {
     private let presentation: WebChatPresentation
     private let sessionKey: String
-    private let hosting: NSHostingController<OpenClawChatView>
     private let contentController: NSViewController
     private var window: NSWindow?
     private var dismissMonitor: Any?
@@ -453,11 +585,23 @@ final class WebChatSwiftUIWindowController {
             }
         }
         let accent = Self.color(fromHex: AppStateStore.shared.seamColorHex)
-        self.hosting = NSHostingController(rootView: OpenClawChatView(
-            viewModel: vm,
-            showsSessionSwitcher: true,
-            userAccent: accent))
-        self.contentController = Self.makeContentController(for: presentation, hosting: self.hosting)
+        switch presentation {
+        case .window:
+            // Full window: native split-view shell with sessions sidebar and
+            // toolbar pickers bridged into the NSToolbar.
+            let hosting = NSHostingController(rootView: OpenClawChatWindowShell(
+                viewModel: vm,
+                userAccent: accent))
+            hosting.sceneBridgingOptions = [.toolbars, .title]
+            self.contentController = hosting
+        case .panel:
+            // Anchored quick-chat panel: compact single-column chat.
+            let hosting = NSHostingController(rootView: OpenClawChatView(
+                viewModel: vm,
+                showsSessionSwitcher: true,
+                userAccent: accent))
+            self.contentController = Self.makePanelContentController(hosting: hosting)
+        }
         self.window = Self.makeWindow(for: presentation, contentViewController: self.contentController)
     }
 
@@ -568,21 +712,18 @@ final class WebChatSwiftUIWindowController {
         case .window:
             let window = NSWindow(
                 contentRect: NSRect(origin: .zero, size: WebChatSwiftUILayout.windowSize),
-                styleMask: [.titled, .closable, .resizable, .miniaturizable],
+                styleMask: [.titled, .closable, .resizable, .miniaturizable, .fullSizeContentView],
                 backing: .buffered,
                 defer: false)
             window.title = "OpenClaw Chat"
             window.contentViewController = contentViewController
             window.isReleasedWhenClosed = false
             window.titleVisibility = .visible
-            window.titlebarAppearsTransparent = false
-            window.backgroundColor = .clear
-            window.isOpaque = false
+            window.toolbarStyle = .unified
             window.center()
+            window.setFrameAutosaveName(WebChatSwiftUILayout.windowFrameAutosaveName)
             WindowPlacement.ensureOnScreen(window: window, defaultSize: WebChatSwiftUILayout.windowSize)
             window.minSize = WebChatSwiftUILayout.windowMinSize
-            window.contentView?.wantsLayer = true
-            window.contentView?.layer?.backgroundColor = NSColor.clear.cgColor
             return window
         case .panel:
             let panel = WebChatPanel(
@@ -612,28 +753,17 @@ final class WebChatSwiftUIWindowController {
         }
     }
 
-    private static func makeContentController(
-        for presentation: WebChatPresentation,
+    private static func makePanelContentController(
         hosting: NSHostingController<OpenClawChatView>) -> NSViewController
     {
         let controller = NSViewController()
         let effectView = NSVisualEffectView()
         effectView.material = .sidebar
-        effectView.blendingMode = switch presentation {
-        case .panel:
-            .withinWindow
-        case .window:
-            .behindWindow
-        }
+        effectView.blendingMode = .withinWindow
         effectView.state = .active
         effectView.wantsLayer = true
         effectView.layer?.cornerCurve = .continuous
-        let cornerRadius: CGFloat = switch presentation {
-        case .panel:
-            16
-        case .window:
-            0
-        }
+        let cornerRadius: CGFloat = 16
         effectView.layer?.cornerRadius = cornerRadius
         effectView.layer?.masksToBounds = true
         effectView.layer?.backgroundColor = NSColor.clear.cgColor

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
@@ -16,6 +16,12 @@ struct MacGatewayChatTransportMappingTests {
         #expect(transport.sessionTarget(for: "main") == .init(
             sessionKey: "main",
             agentID: nil))
+
+        let snapshotObserverTransport = transport
+        snapshotObserverTransport.updateDefaultGlobalAgentID("Agent-B")
+        #expect(transport.sessionTarget(for: "global") == .init(
+            sessionKey: "global",
+            agentID: "agent-b"))
     }
 
     @Test func `bare global session target tolerates missing selected agent`() {

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
@@ -4,6 +4,28 @@ import Testing
 @testable import OpenClaw
 
 struct MacGatewayChatTransportMappingTests {
+    @Test func `bare global session target carries normalized selected agent`() {
+        let transport = MacGatewayChatTransport(defaultGlobalAgentID: "  Agent-A  ")
+
+        #expect(transport.sessionTarget(for: " GLOBAL ") == .init(
+            sessionKey: " GLOBAL ",
+            agentID: "agent-a"))
+        #expect(transport.sessionTarget(for: "agent:agent-a:main") == .init(
+            sessionKey: "agent:agent-a:main",
+            agentID: nil))
+        #expect(transport.sessionTarget(for: "main") == .init(
+            sessionKey: "main",
+            agentID: nil))
+    }
+
+    @Test func `bare global session target tolerates missing selected agent`() {
+        let transport = MacGatewayChatTransport()
+
+        #expect(transport.sessionTarget(for: "global") == .init(
+            sessionKey: "global",
+            agentID: nil))
+    }
+
     @Test func `snapshot maps to health`() {
         let snapshot = Snapshot(
             presence: [],

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -64,14 +64,12 @@ private struct CleanChatComposerSurface: ViewModifier {
     }
 }
 
-#if !os(macOS)
 private struct SlashPanelHeightKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())
     }
 }
-#endif
 
 @MainActor
 struct OpenClawChatComposer: View {
@@ -89,11 +87,12 @@ struct OpenClawChatComposer: View {
     let talkControl: OpenClawChatTalkControl?
     let voiceNoteControl: OpenClawChatVoiceNoteControl?
 
-    #if !os(macOS)
-    @State private var pickerItems: [PhotosPickerItem] = []
     @State private var isSlashPopoverPresented = false
     @State private var suppressNextSlashPopoverUpdate = false
     @State private var slashPanelHeight: CGFloat = 0
+    @State private var slashHighlightIndex = 0
+    #if !os(macOS)
+    @State private var pickerItems: [PhotosPickerItem] = []
     @FocusState private var isFocused: Bool
     #else
     @State private var shouldFocusTextView = false
@@ -157,6 +156,7 @@ struct OpenClawChatComposer: View {
         }
         .onAppear {
             self.shouldFocusTextView = true
+            self.viewModel.loadSlashCommandsIfNeeded()
         }
         #else
         .onChange(of: self.isComposerEnabled) { _, isEnabled in
@@ -471,11 +471,7 @@ struct OpenClawChatComposer: View {
         }
     }
 
-    @ViewBuilder
     private var editor: some View {
-        #if os(macOS)
-        self.editorContent
-        #else
         self.editorContent
             .overlay(alignment: .top) {
                 if self.isSlashPopoverPresented {
@@ -493,7 +489,6 @@ struct OpenClawChatComposer: View {
             .onPreferenceChange(SlashPanelHeightKey.self) { newHeight in
                 self.slashPanelHeight = newHeight
             }
-        #endif
     }
 
     @ViewBuilder
@@ -722,10 +717,16 @@ struct OpenClawChatComposer: View {
                 onPasteImageAttachment: { data, fileName, mimeType in
                     guard self.isAttachmentInputEnabled else { return }
                     self.viewModel.addImageAttachment(data: data, fileName: fileName, mimeType: mimeType)
+                },
+                onKeyCommand: { command in
+                    self.handleComposerKeyCommand(command)
                 })
                 .frame(minHeight: self.textMinHeight, idealHeight: self.textMinHeight, maxHeight: self.textMaxHeight)
                 .padding(.horizontal, 4)
                 .padding(.vertical, 3)
+                .onChange(of: self.viewModel.input) { _, _ in
+                    self.updateSlashPopoverPresentation()
+                }
             #else
             TextField(
                 "",
@@ -757,7 +758,6 @@ struct OpenClawChatComposer: View {
         }
     }
 
-    #if !os(macOS)
     private var slashQuery: String? {
         let text = self.viewModel.input.trimmingCharacters(in: .whitespacesAndNewlines)
         guard text.hasPrefix("/"), !text.hasPrefix("//") else { return nil }
@@ -814,19 +814,32 @@ struct OpenClawChatComposer: View {
                     .foregroundStyle(.secondary)
                     .frame(maxWidth: .infinity, minHeight: 96)
             } else {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 2) {
-                        ForEach(matches) { command in
-                            Button {
-                                self.selectSlashCommand(command)
-                            } label: {
-                                self.slashCommandRow(command)
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 2) {
+                            ForEach(Array(matches.enumerated()), id: \.element.id) { index, command in
+                                Button {
+                                    self.selectSlashCommand(command)
+                                } label: {
+                                    self.slashCommandRow(
+                                        command,
+                                        isHighlighted: index == self.slashHighlightIndex)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel(command.displayInvocation)
+                                .id(index)
+                                .onHover { hovering in
+                                    if hovering {
+                                        self.slashHighlightIndex = index
+                                    }
+                                }
                             }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel(command.displayInvocation)
                         }
+                        .padding(8)
                     }
-                    .padding(8)
+                    .onChange(of: self.slashHighlightIndex) { _, index in
+                        proxy.scrollTo(index)
+                    }
                 }
                 .frame(maxHeight: .infinity)
                 .overlay(alignment: .bottom) {
@@ -847,7 +860,10 @@ struct OpenClawChatComposer: View {
         .shadow(color: .black.opacity(0.12), radius: 12, y: 4)
     }
 
-    private func slashCommandRow(_ command: OpenClawChatCommandChoice) -> some View {
+    private func slashCommandRow(
+        _ command: OpenClawChatCommandChoice,
+        isHighlighted: Bool) -> some View
+    {
         HStack(alignment: .top, spacing: 0) {
             VStack(alignment: .leading, spacing: 3) {
                 Text(command.displayInvocation)
@@ -869,6 +885,9 @@ struct OpenClawChatComposer: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 8)
         .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(isHighlighted ? AnyShapeStyle(.selection) : AnyShapeStyle(.clear)))
     }
 
     private var slashCommandScrollAffordance: some View {
@@ -896,13 +915,30 @@ struct OpenClawChatComposer: View {
         self.suppressNextSlashPopoverUpdate = true
         self.viewModel.applySlashCommandSelection(command)
         self.setSlashPanelPresented(false)
+        #if os(macOS)
+        self.shouldFocusTextView = true
+        #else
         self.isFocused = true
+        #endif
     }
 
     private func setSlashPanelPresented(_ presented: Bool) {
         withAnimation(.easeInOut(duration: 0.18)) {
             self.isSlashPopoverPresented = presented
         }
+        if presented {
+            self.slashHighlightIndex = 0
+        }
+    }
+
+    private var slashPanelCanPresent: Bool {
+        // macOS input is an NSTextView outside SwiftUI focus tracking; it is
+        // the composer's only editable field, so enablement is the gate.
+        #if os(macOS)
+        self.isComposerEnabled
+        #else
+        self.isComposerEnabled && self.isFocused
+        #endif
     }
 
     private func updateSlashPopoverPresentation() {
@@ -910,12 +946,42 @@ struct OpenClawChatComposer: View {
             self.suppressNextSlashPopoverUpdate = false
             return
         }
-        let shouldShow = self.isComposerEnabled && self.isFocused && self.slashQuery != nil
+        let shouldShow = self.slashPanelCanPresent && self.slashQuery != nil
         if shouldShow {
             self.viewModel.loadSlashCommandsIfNeeded()
+            self.slashHighlightIndex = 0
         }
         if shouldShow != self.isSlashPopoverPresented {
             self.setSlashPanelPresented(shouldShow)
+        }
+    }
+
+    #if os(macOS)
+    /// Keyboard routing while the slash panel is open: arrows move the
+    /// highlight, Tab/Return accept, Escape dismisses. Returning false hands
+    /// the key back to the text view (typing, send-on-return).
+    private func handleComposerKeyCommand(_ command: ChatComposerKeyCommand) -> Bool {
+        guard self.isSlashPopoverPresented else { return false }
+        let matches = self.viewModel.slashCommandMatches(query: self.slashQuery ?? "", filter: .all)
+        switch command {
+        case .escape:
+            self.setSlashPanelPresented(false)
+            return true
+        case .moveUp:
+            guard !matches.isEmpty else { return true }
+            self.slashHighlightIndex = (self.slashHighlightIndex - 1 + matches.count) % matches.count
+            return true
+        case .moveDown:
+            guard !matches.isEmpty else { return true }
+            self.slashHighlightIndex = (self.slashHighlightIndex + 1) % matches.count
+            return true
+        case .tab, .returnKey:
+            guard matches.indices.contains(self.slashHighlightIndex) else {
+                self.setSlashPanelPresented(false)
+                return command == .tab
+            }
+            self.selectSlashCommand(matches[self.slashHighlightIndex])
+            return true
         }
     }
     #endif
@@ -1189,12 +1255,46 @@ struct OpenClawChatComposer: View {
 import AppKit
 import UniformTypeIdentifiers
 
+/// Navigation keys the composer intercepts while UI like the slash-command
+/// panel is open. The handler returns true when it consumed the key.
+enum ChatComposerKeyCommand: Equatable {
+    case moveUp
+    case moveDown
+    case tab
+    case escape
+    case returnKey
+}
+
+enum ChatComposerKeyRouting {
+    /// Maps a key event to an interceptable command. Modified keys (except
+    /// plain Shift on arrows) stay with the text view so shortcuts keep
+    /// working; marked text (IME composition) is never intercepted.
+    static func command(
+        keyCode: UInt16,
+        modifierFlags: NSEvent.ModifierFlags,
+        hasMarkedText: Bool) -> ChatComposerKeyCommand?
+    {
+        guard !hasMarkedText else { return nil }
+        let disallowed: NSEvent.ModifierFlags = [.command, .option, .control, .shift]
+        guard modifierFlags.intersection(disallowed).isEmpty else { return nil }
+        switch keyCode {
+        case 126: return .moveUp
+        case 125: return .moveDown
+        case 48: return .tab
+        case 53: return .escape
+        case 36: return .returnKey
+        default: return nil
+        }
+    }
+}
+
 private struct ChatComposerTextView: NSViewRepresentable {
     @Binding var text: String
     @Binding var shouldFocus: Bool
     var isEnabled: Bool
     var onSend: () -> Void
     var onPasteImageAttachment: (_ data: Data, _ fileName: String, _ mimeType: String) -> Void
+    var onKeyCommand: (_ command: ChatComposerKeyCommand) -> Bool = { _ in false }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
@@ -1213,6 +1313,7 @@ private struct ChatComposerTextView: NSViewRepresentable {
             self.onSend()
         }
         composerTextView.onPasteImageAttachment = self.onPasteImageAttachment
+        composerTextView.onKeyCommand = self.onKeyCommand
 
         let scroll = NSScrollView()
         scroll.drawsBackground = false
@@ -1228,6 +1329,7 @@ private struct ChatComposerTextView: NSViewRepresentable {
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = scrollView.documentView as? ChatComposerNSTextView else { return }
         textView.onPasteImageAttachment = self.onPasteImageAttachment
+        textView.onKeyCommand = self.onKeyCommand
         textView.isEditable = self.isEnabled
         textView.isSelectable = self.isEnabled
 
@@ -1301,6 +1403,7 @@ enum ChatComposerTextViewFactory {
 private final class ChatComposerNSTextView: NSTextView {
     var onSend: (() -> Void)?
     var onPasteImageAttachment: ((_ data: Data, _ fileName: String, _ mimeType: String) -> Void)?
+    var onKeyCommand: ((_ command: ChatComposerKeyCommand) -> Bool)?
 
     override var readablePasteboardTypes: [NSPasteboard.PasteboardType] {
         var types = super.readablePasteboardTypes
@@ -1311,6 +1414,14 @@ private final class ChatComposerNSTextView: NSTextView {
     }
 
     override func keyDown(with event: NSEvent) {
+        if let command = ChatComposerKeyRouting.command(
+            keyCode: event.keyCode,
+            modifierFlags: event.modifierFlags,
+            hasMarkedText: hasMarkedText()),
+            self.onKeyCommand?(command) == true
+        {
+            return
+        }
         let isReturn = event.keyCode == 36
         if isReturn {
             if hasMarkedText() {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -1357,21 +1357,28 @@ private struct ChatComposerTextView: NSViewRepresentable {
 
         let isEditing = scrollView.window?.firstResponder == textView
 
-        // Always allow clearing the text (e.g. after send), even while editing.
-        // Only skip other updates while editing to avoid cursor jumps.
-        let shouldClear = self.text.isEmpty && !textView.string.isEmpty
-        if isEditing, !shouldClear { return }
+        // While the user is typing, binding updates just echo textDidChange;
+        // rewriting the view then would jump the cursor. A binding value the
+        // coordinator never reported is programmatic (send-clear, slash
+        // completion) and must reach the view even mid-edit.
+        let isEcho = context.coordinator.lastReportedText == self.text
+        if isEditing, isEcho { return }
 
         if textView.string != self.text {
             context.coordinator.isProgrammaticUpdate = true
             defer { context.coordinator.isProgrammaticUpdate = false }
             textView.string = self.text
+            if isEditing {
+                textView.setSelectedRange(NSRange(location: (self.text as NSString).length, length: 0))
+            }
         }
+        context.coordinator.lastReportedText = self.text
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: ChatComposerTextView
         var isProgrammaticUpdate = false
+        var lastReportedText: String?
 
         init(_ parent: ChatComposerTextView) {
             self.parent = parent
@@ -1381,6 +1388,7 @@ private struct ChatComposerTextView: NSViewRepresentable {
             guard !self.isProgrammaticUpdate else { return }
             guard let view = notification.object as? NSTextView else { return }
             guard view.window?.firstResponder === view else { return }
+            self.lastReportedText = view.string
             self.parent.text = view.string
         }
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -823,7 +823,8 @@ struct OpenClawChatComposer: View {
                                 } label: {
                                     self.slashCommandRow(
                                         command,
-                                        isHighlighted: index == self.slashHighlightIndex)
+                                        isHighlighted: self.usesSlashKeyboardHighlight
+                                            && index == self.slashHighlightIndex)
                                 }
                                 .buttonStyle(.plain)
                                 .accessibilityLabel(command.displayInvocation)
@@ -932,12 +933,25 @@ struct OpenClawChatComposer: View {
     }
 
     private var slashPanelCanPresent: Bool {
+        // Transports without a command catalog (e.g. onboarding) get no panel
+        // instead of an empty "No matching commands" box.
+        guard self.viewModel.transport.supportsSlashCommandCatalog else { return false }
         // macOS input is an NSTextView outside SwiftUI focus tracking; it is
         // the composer's only editable field, so enablement is the gate.
         #if os(macOS)
-        self.isComposerEnabled
+        return self.isComposerEnabled
         #else
-        self.isComposerEnabled && self.isFocused
+        return self.isComposerEnabled && self.isFocused
+        #endif
+    }
+
+    /// Keyboard-driven row highlight is macOS-only; on touch platforms a
+    /// persistent highlight on row 0 would read as a stray selection.
+    private var usesSlashKeyboardHighlight: Bool {
+        #if os(macOS)
+        true
+        #else
+        false
         #endif
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
@@ -71,7 +71,10 @@ enum ChatContextUsageCalculator {
 
 extension OpenClawChatViewModel {
     public var contextUsage: OpenClawChatContextUsage? {
-        let entry = self.sessions.first { $0.key == self.sessionKey }
+        let entry = self.sessions.first { $0.key == self.sessionKey } ??
+            self.sessions.first {
+                self.matchesCurrentSessionKey(incoming: $0.key, current: self.sessionKey)
+            }
         return ChatContextUsageCalculator.usage(
             messages: self.messages,
             sessionEntry: entry,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
@@ -20,14 +20,15 @@ public struct OpenClawChatContextUsage: Equatable, Sendable {
 
 enum ChatContextUsageCalculator {
     /// Prefers the newest per-run usage (fresh after every reply) and falls
-    /// back to the server-side session totals when no message carries usage.
+    /// back to fresh server-side session totals when no message carries usage.
     static func usage(
         messages: [OpenClawChatMessage],
         sessionEntry: OpenClawChatSessionEntry?,
         defaults: OpenClawChatSessionsDefaults?,
         modelContextWindow: Int?) -> OpenClawChatContextUsage?
     {
-        let usedTokens = self.latestRunTokens(in: messages) ?? sessionEntry?.totalTokens
+        let sessionTokens = sessionEntry?.totalTokensFresh == false ? nil : sessionEntry?.totalTokens
+        let usedTokens = self.latestRunTokens(in: messages) ?? sessionTokens
         guard let usedTokens, usedTokens > 0 else { return nil }
         let contextWindow = self.positive(sessionEntry?.contextTokens)
             ?? self.positive(defaults?.contextTokens)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatContextUsage.swift
@@ -1,0 +1,152 @@
+import Foundation
+import SwiftUI
+
+/// Snapshot of how full the active session's context window is, derived from
+/// the newest usage-bearing message plus session/model metadata.
+public struct OpenClawChatContextUsage: Equatable, Sendable {
+    public let usedTokens: Int
+    public let contextWindowTokens: Int?
+    public let totalCost: Double?
+
+    public var fractionUsed: Double? {
+        guard let contextWindowTokens, contextWindowTokens > 0 else { return nil }
+        return min(1, max(0, Double(self.usedTokens) / Double(contextWindowTokens)))
+    }
+
+    public var percentUsed: Int? {
+        self.fractionUsed.map { Int(($0 * 100).rounded()) }
+    }
+}
+
+enum ChatContextUsageCalculator {
+    /// Prefers the newest per-run usage (fresh after every reply) and falls
+    /// back to the server-side session totals when no message carries usage.
+    static func usage(
+        messages: [OpenClawChatMessage],
+        sessionEntry: OpenClawChatSessionEntry?,
+        defaults: OpenClawChatSessionsDefaults?,
+        modelContextWindow: Int?) -> OpenClawChatContextUsage?
+    {
+        let usedTokens = self.latestRunTokens(in: messages) ?? sessionEntry?.totalTokens
+        guard let usedTokens, usedTokens > 0 else { return nil }
+        let contextWindow = self.positive(sessionEntry?.contextTokens)
+            ?? self.positive(defaults?.contextTokens)
+            ?? self.positive(modelContextWindow)
+        return OpenClawChatContextUsage(
+            usedTokens: usedTokens,
+            contextWindowTokens: contextWindow,
+            totalCost: self.totalCost(in: messages))
+    }
+
+    /// Context pressure comes from the latest run: its usage already counts
+    /// the whole conversation the model saw, so runs are not summed.
+    private static func latestRunTokens(in messages: [OpenClawChatMessage]) -> Int? {
+        for message in messages.reversed() {
+            guard let usage = message.usage else { continue }
+            if let total = usage.total, total > 0 {
+                return total
+            }
+            let summed = [usage.input, usage.cacheRead, usage.cacheWrite, usage.output]
+                .compactMap(\.self)
+                .reduce(0, +)
+            if summed > 0 {
+                return summed
+            }
+        }
+        return nil
+    }
+
+    private static func totalCost(in messages: [OpenClawChatMessage]) -> Double? {
+        let costs = messages.compactMap { $0.usage?.cost?.total }
+        guard !costs.isEmpty else { return nil }
+        return costs.reduce(0, +)
+    }
+
+    private static func positive(_ value: Int?) -> Int? {
+        guard let value, value > 0 else { return nil }
+        return value
+    }
+}
+
+extension OpenClawChatViewModel {
+    public var contextUsage: OpenClawChatContextUsage? {
+        let entry = self.sessions.first { $0.key == self.sessionKey }
+        return ChatContextUsageCalculator.usage(
+            messages: self.messages,
+            sessionEntry: entry,
+            defaults: self.sessionDefaults,
+            modelContextWindow: self.selectedModelContextWindow(sessionEntry: entry))
+    }
+
+    private func selectedModelContextWindow(sessionEntry: OpenClawChatSessionEntry?) -> Int? {
+        let selection = self.modelSelectionID != Self.defaultModelSelectionID
+            ? self.modelSelectionID
+            : (sessionEntry?.model ?? self.sessionDefaults?.model)
+        guard let selection else { return nil }
+        return self.modelChoices.first {
+            $0.selectionID == selection || $0.modelID == selection
+        }?.contextWindow
+    }
+}
+
+#if os(macOS)
+/// Compact token ring for the window toolbar, mirroring the web UI's context
+/// gauge: ring fill and tint track pressure, the menu carries the details.
+struct ChatContextUsageIndicator: View {
+    let usage: OpenClawChatContextUsage
+
+    var body: some View {
+        HStack(spacing: 5) {
+            ZStack {
+                Circle()
+                    .stroke(Color.secondary.opacity(0.25), lineWidth: 2.5)
+                Circle()
+                    .trim(from: 0, to: max(0.02, self.usage.fractionUsed ?? 0))
+                    .stroke(self.tint, style: StrokeStyle(lineWidth: 2.5, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+            }
+            .frame(width: 13, height: 13)
+
+            if let percent = self.usage.percentUsed {
+                Text("\(percent)%")
+                    .font(OpenClawChatTypography.captionSemiBold)
+                    .monospacedDigit()
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Context usage")
+        .accessibilityValue(self.accessibilityValue)
+    }
+
+    private var tint: Color {
+        guard let percent = usage.percentUsed else { return .secondary }
+        if percent >= 90 { return Color(nsColor: .systemRed) }
+        if percent >= 75 { return Color(nsColor: .systemOrange) }
+        return Color(nsColor: .systemGreen)
+    }
+
+    private var accessibilityValue: String {
+        if let percent = self.usage.percentUsed {
+            return "\(percent) percent of the context window used"
+        }
+        return "\(self.usage.usedTokens) tokens used"
+    }
+}
+
+enum ChatContextUsageFormatter {
+    static func tokens(_ value: Int) -> String {
+        if value >= 1_000_000 {
+            return String(format: "%.1fM", Double(value) / 1_000_000)
+        }
+        if value >= 1000 {
+            return String(format: "%.1fk", Double(value) / 1000)
+        }
+        return "\(value)"
+    }
+
+    static func cost(_ value: Double) -> String {
+        String(format: "$%.2f", value)
+    }
+}
+#endif

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -132,7 +132,7 @@ enum ChatSessionSidebarModel {
             if selectedIsResolvedAlias, entry.key.lowercased() == normalizedCurrent {
                 return false
             }
-            entry.key == selectedSessionKey ||
+            return entry.key == selectedSessionKey ||
                 (!self.isHiddenInternalSession(entry.key) && entry.archived != true)
         }
         if !entries.contains(where: { $0.key == selectedSessionKey }),

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -69,6 +69,23 @@ enum ChatSessionSidebarModel {
         mainSessionKey: String,
         activeAgentID: String?) -> String
     {
+        let normalizedCurrent = currentSessionKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedAgent = activeAgentID?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let preferredAliasKey = if normalizedCurrent == "global",
+                                   let normalizedAgent,
+                                   !normalizedAgent.isEmpty
+        {
+            "agent:\(normalizedAgent):global"
+        } else if normalizedCurrent == "main" {
+            mainSessionKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        } else {
+            ""
+        }
+        // The selected wrapper is the active session even when archived;
+        // active rows stay visible until the user leaves them.
+        if let preferred = sessions.first(where: { $0.key.lowercased() == preferredAliasKey }) {
+            return preferred.key
+        }
         if sessions.contains(where: { $0.key == currentSessionKey }) {
             return currentSessionKey
         }
@@ -108,7 +125,13 @@ enum ChatSessionSidebarModel {
             currentSessionKey: currentSessionKey,
             mainSessionKey: mainSessionKey,
             activeAgentID: activeAgentID)
+        let normalizedCurrent = currentSessionKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let selectedIsResolvedAlias = (normalizedCurrent == "main" || normalizedCurrent == "global") &&
+            selectedSessionKey.lowercased() != normalizedCurrent
         var entries = sessions.filter { entry in
+            if selectedIsResolvedAlias, entry.key.lowercased() == normalizedCurrent {
+                return false
+            }
             entry.key == selectedSessionKey ||
                 (!self.isHiddenInternalSession(entry.key) && entry.archived != true)
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -15,6 +15,7 @@ enum ChatSessionSidebarModel {
         return trimmed == "onboarding" || trimmed.hasSuffix(":onboarding")
     }
 
+    @MainActor
     static func sections(
         sessions: [OpenClawChatSessionEntry],
         currentSessionKey: String,
@@ -61,6 +62,7 @@ enum ChatSessionSidebarModel {
         return normalized != "main" && normalized != "global" && normalized != normalizedMain
     }
 
+    @MainActor
     static func selectedSessionKey(
         sessions: [OpenClawChatSessionEntry],
         currentSessionKey: String,
@@ -93,6 +95,7 @@ enum ChatSessionSidebarModel {
         return agent == "main" || agent.isEmpty ? session : "\(session) (\(agent))"
     }
 
+    @MainActor
     private static func visibleSessions(
         sessions: [OpenClawChatSessionEntry],
         currentSessionKey: String,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -51,6 +51,12 @@ enum ChatSessionSidebarModel {
         return self.displayName(forKey: session.key)
     }
 
+    static func canDeleteSession(key: String, mainSessionKey: String) -> Bool {
+        let normalized = key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedMain = mainSessionKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized != "main" && normalized != "global" && normalized != normalizedMain
+    }
+
     /// Session keys read as routing ids ("agent:main:main"); show the human
     /// part and keep the owning agent as a suffix only when it disambiguates.
     static func displayName(forKey key: String) -> String {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// Pure grouping/filtering for the macOS sessions sidebar. Kept UI-free so the
+/// pin/search/ordering rules stay unit-testable.
+enum ChatSessionSidebarModel {
+    struct Section: Identifiable, Equatable {
+        let id: String
+        let title: String?
+        let sessions: [OpenClawChatSessionEntry]
+    }
+
+    static func isHiddenInternalSession(_ key: String) -> Bool {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return trimmed == "onboarding" || trimmed.hasSuffix(":onboarding")
+    }
+
+    static func sections(
+        sessions: [OpenClawChatSessionEntry],
+        currentSessionKey: String,
+        query: String) -> [Section]
+    {
+        let visible = self.visibleSessions(
+            sessions: sessions,
+            currentSessionKey: currentSessionKey,
+            query: query)
+        let pinned = visible.filter { $0.pinned == true }
+        let recent = visible.filter { $0.pinned != true }
+
+        var result: [Section] = []
+        if !pinned.isEmpty {
+            result.append(Section(id: "pinned", title: "Pinned", sessions: pinned))
+        }
+        if !recent.isEmpty {
+            result.append(Section(
+                id: "recent",
+                title: pinned.isEmpty ? nil : "Recent",
+                sessions: recent))
+        }
+        return result
+    }
+
+    static func displayName(for session: OpenClawChatSessionEntry) -> String {
+        for candidate in [session.displayName, session.label] {
+            if let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !trimmed.isEmpty
+            {
+                return trimmed
+            }
+        }
+        return self.displayName(forKey: session.key)
+    }
+
+    /// Session keys read as routing ids ("agent:main:main"); show the human
+    /// part and keep the owning agent as a suffix only when it disambiguates.
+    static func displayName(forKey key: String) -> String {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = trimmed.split(separator: ":", maxSplits: 2, omittingEmptySubsequences: false)
+        guard parts.count == 3, parts[0] == "agent" else {
+            return trimmed.isEmpty ? key : trimmed
+        }
+        let agent = String(parts[1])
+        let session = String(parts[2])
+        if session.isEmpty { return trimmed }
+        return agent == "main" || agent.isEmpty ? session : "\(session) (\(agent))"
+    }
+
+    private static func visibleSessions(
+        sessions: [OpenClawChatSessionEntry],
+        currentSessionKey: String,
+        query: String) -> [OpenClawChatSessionEntry]
+    {
+        var entries = sessions.filter { entry in
+            entry.key == currentSessionKey ||
+                (!self.isHiddenInternalSession(entry.key) && entry.archived != true)
+        }
+        if !entries.contains(where: { $0.key == currentSessionKey }),
+           !currentSessionKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            // Sessions can lag behind a fresh switch/new-session; keep the
+            // active row selectable instead of showing an empty selection.
+            entries.append(self.placeholder(key: currentSessionKey))
+        }
+        entries.sort { (($0.updatedAt ?? $0.lastActivityAt) ?? 0) > (($1.updatedAt ?? $1.lastActivityAt) ?? 0) }
+
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else { return entries }
+        return entries.filter { entry in
+            self.displayName(for: entry).lowercased().contains(needle) ||
+                entry.key.lowercased().contains(needle)
+        }
+    }
+
+    private static func placeholder(key: String) -> OpenClawChatSessionEntry {
+        OpenClawChatSessionEntry(
+            key: key,
+            kind: nil,
+            displayName: nil,
+            surface: nil,
+            subject: nil,
+            room: nil,
+            space: nil,
+            updatedAt: nil,
+            sessionId: nil,
+            systemSent: nil,
+            abortedLastRun: nil,
+            thinkingLevel: nil,
+            verboseLevel: nil,
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: nil,
+            modelProvider: nil,
+            model: nil,
+            contextTokens: nil)
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessionSidebarModel.swift
@@ -18,11 +18,15 @@ enum ChatSessionSidebarModel {
     static func sections(
         sessions: [OpenClawChatSessionEntry],
         currentSessionKey: String,
+        mainSessionKey: String = "main",
+        activeAgentID: String? = nil,
         query: String) -> [Section]
     {
         let visible = self.visibleSessions(
             sessions: sessions,
             currentSessionKey: currentSessionKey,
+            mainSessionKey: mainSessionKey,
+            activeAgentID: activeAgentID,
             query: query)
         let pinned = visible.filter { $0.pinned == true }
         let recent = visible.filter { $0.pinned != true }
@@ -57,6 +61,24 @@ enum ChatSessionSidebarModel {
         return normalized != "main" && normalized != "global" && normalized != normalizedMain
     }
 
+    static func selectedSessionKey(
+        sessions: [OpenClawChatSessionEntry],
+        currentSessionKey: String,
+        mainSessionKey: String,
+        activeAgentID: String?) -> String
+    {
+        if sessions.contains(where: { $0.key == currentSessionKey }) {
+            return currentSessionKey
+        }
+        return sessions.first(where: {
+            OpenClawChatViewModel.matchesCurrentSessionKey(
+                incoming: $0.key,
+                current: currentSessionKey,
+                mainSessionKey: mainSessionKey,
+                activeAgentId: activeAgentID)
+        })?.key ?? currentSessionKey
+    }
+
     /// Session keys read as routing ids ("agent:main:main"); show the human
     /// part and keep the owning agent as a suffix only when it disambiguates.
     static func displayName(forKey key: String) -> String {
@@ -74,13 +96,20 @@ enum ChatSessionSidebarModel {
     private static func visibleSessions(
         sessions: [OpenClawChatSessionEntry],
         currentSessionKey: String,
+        mainSessionKey: String,
+        activeAgentID: String?,
         query: String) -> [OpenClawChatSessionEntry]
     {
+        let selectedSessionKey = self.selectedSessionKey(
+            sessions: sessions,
+            currentSessionKey: currentSessionKey,
+            mainSessionKey: mainSessionKey,
+            activeAgentID: activeAgentID)
         var entries = sessions.filter { entry in
-            entry.key == currentSessionKey ||
+            entry.key == selectedSessionKey ||
                 (!self.isHiddenInternalSession(entry.key) && entry.archived != true)
         }
-        if !entries.contains(where: { $0.key == currentSessionKey }),
+        if !entries.contains(where: { $0.key == selectedSessionKey }),
            !currentSessionKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
             // Sessions can lag behind a fresh switch/new-session; keep the

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
@@ -77,35 +77,10 @@ enum OpenClawChatTheme {
     @ViewBuilder
     static var background: some View {
         #if os(macOS)
-        ZStack {
-            Rectangle()
-                .fill(.ultraThinMaterial)
-            LinearGradient(
-                colors: [
-                    Color.white.opacity(0.12),
-                    Color(nsColor: .windowBackgroundColor).opacity(0.35),
-                    Color.black.opacity(0.35),
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing)
-            RadialGradient(
-                colors: [
-                    Color(nsColor: .systemOrange).opacity(0.14),
-                    .clear,
-                ],
-                center: .topLeading,
-                startRadius: 40,
-                endRadius: 320)
-            RadialGradient(
-                colors: [
-                    Color(nsColor: .systemTeal).opacity(0.12),
-                    .clear,
-                ],
-                center: .topTrailing,
-                startRadius: 40,
-                endRadius: 280)
-            Color.black.opacity(0.08)
-        }
+        // Plain material so the chat reads as a native surface; the window
+        // (or the anchored panel's effect view) supplies the vibrancy.
+        Rectangle()
+            .fill(.ultraThinMaterial)
         #else
         ZStack {
             LinearGradient(
@@ -144,7 +119,9 @@ enum OpenClawChatTheme {
 
     static var userBubble: Color {
         #if os(macOS)
-        Color(red: 127 / 255.0, green: 184 / 255.0, blue: 212 / 255.0)
+        // Follow the user's system accent; hosts can still override per-view
+        // with `userAccent` (e.g. the seam color in the desktop app).
+        Color(nsColor: .controlAccentColor)
         #else
         self.adaptiveColor(
             light: IOSPalette.lightAccent,

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -549,6 +549,7 @@ public struct OpenClawChatView: View {
         UIPasteboard.general.string = text
         #endif
     }
+
     private var visibleMessages: [OpenClawChatMessage] {
         let base: [OpenClawChatMessage]
         if self.style == .onboarding {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if os(macOS)
+import AppKit
+#endif
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -428,6 +431,7 @@ public struct OpenClawChatView: View {
             }
             .frame(maxWidth: .infinity, alignment: .trailing)
             .contextMenu {
+                self.copyMessageButton(for: msg)
                 if outboxState.isFailed {
                     Button {
                         self.viewModel.retryOutboxMessage(msg.id)
@@ -490,7 +494,14 @@ public struct OpenClawChatView: View {
                 }
             }
         } else {
+            #if os(macOS)
             bubble
+                .contextMenu {
+                    self.copyMessageButton(for: msg)
+                }
+            #else
+            bubble
+            #endif
         }
     }
 
@@ -513,6 +524,31 @@ public struct OpenClawChatView: View {
         }
     }
 
+    @ViewBuilder
+    private func copyMessageButton(for message: OpenClawChatMessage) -> some View {
+        let text = self.primaryText(in: message)
+        if !text.isEmpty {
+            Button {
+                Self.copyToClipboard(text)
+            } label: {
+                Label {
+                    Text("Copy Message")
+                        .font(OpenClawChatTypography.body)
+                } icon: {
+                    Image(systemName: "doc.on.doc")
+                }
+            }
+        }
+    }
+
+    private static func copyToClipboard(_ text: String) {
+        #if os(macOS)
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+        #else
+        UIPasteboard.general.string = text
+        #endif
+    }
     private var visibleMessages: [OpenClawChatMessage] {
         let base: [OpenClawChatMessage]
         if self.style == .onboarding {
@@ -685,7 +721,7 @@ public struct OpenClawChatView: View {
 
     private var emptyStateTitle: String {
         #if os(macOS)
-        "Web Chat"
+        "Start a Conversation"
         #else
         "Chat"
         #endif
@@ -693,7 +729,7 @@ public struct OpenClawChatView: View {
 
     private var emptyStateMessage: String {
         #if os(macOS)
-        "Type a message below to start.\nReturn sends • Shift-Return adds a line break."
+        "Message your agent to get started.\nReturn sends • Shift-Return adds a line break • / shows commands."
         #else
         "Type a message below to start."
         #endif

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension OpenClawChatViewModel {
+    public func refreshSessions(limit: Int? = nil) {
+        let context = self.currentSessionSnapshot()
+        Task { await self.fetchSessions(limit: limit, sessionSnapshot: context) }
+    }
+
+    public func startNewSession(worktree: Bool = false) async {
+        await self.performStartNewSession(worktree: worktree)
+    }
+
+    public func requestSessionReset() {
+        Task { await self.performReset() }
+    }
+
+    public func requestSessionCompact() {
+        Task { await self.performCompact() }
+    }
+
+    public func setSessionPinned(_ sessionKey: String, pinned: Bool) {
+        Task {
+            do {
+                try await self.transport.patchSession(
+                    key: sessionKey,
+                    label: nil,
+                    category: nil,
+                    pinned: pinned,
+                    archived: nil,
+                    unread: nil)
+            } catch {
+                self.errorText = error.localizedDescription
+                return
+            }
+            await self.fetchSessions(limit: nil, sessionSnapshot: self.currentSessionSnapshot())
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -45,7 +45,8 @@ extension OpenClawChatViewModel {
 
         for entry in sorted {
             guard !included.contains(entry.key) else { continue }
-            guard entry.key == sessionKey || !Self.isHiddenInternalSession(entry.key) else { continue }
+            guard entry.key == sessionKey || !ChatSessionSidebarModel.isHiddenInternalSession(entry.key)
+            else { continue }
             // Pinned sessions stay reachable regardless of recency.
             guard (entry.updatedAt ?? 0) >= cutoff || entry.isPinned else { continue }
             result.append(entry)
@@ -61,12 +62,6 @@ extension OpenClawChatViewModel {
         }
 
         return result
-    }
-
-    private static func isHiddenInternalSession(_ key: String) -> Bool {
-        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return false }
-        return trimmed == "onboarding" || trimmed.hasSuffix(":onboarding")
     }
 
     func matchesCurrentSessionKey(incoming: String, current: String) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -413,7 +413,7 @@ public final class OpenClawChatViewModel {
                 return
             }
             self.sessions.removeAll { $0.key == sessionKey }
-            if sessionKey == self.sessionKey {
+            if self.matchesCurrentSessionKey(incoming: sessionKey, current: self.sessionKey) {
                 // The active transcript just disappeared server-side; fall
                 // back to the main session instead of a dead key.
                 let fallback = self.resolvedMainSessionKey

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -416,7 +416,17 @@ public final class OpenClawChatViewModel {
             if sessionKey == self.sessionKey {
                 // The active transcript just disappeared server-side; fall
                 // back to the main session instead of a dead key.
-                self.applySessionSwitch(to: self.resolvedMainSessionKey, intent: .userInitiated)
+                let fallback = self.resolvedMainSessionKey
+                if fallback != self.sessionKey {
+                    self.applySessionSwitch(to: fallback, intent: .userInitiated)
+                } else {
+                    // Deleting the active main session: the key stays the
+                    // address, so clear local state and re-bootstrap in place.
+                    self.advanceSessionGeneration()
+                    self.clearSessionOwnedState()
+                    self.errorText = nil
+                    self.startBootstrap()
+                }
             }
             await self.fetchSessions(limit: nil, sessionSnapshot: self.currentSessionSnapshot())
         }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -378,6 +378,50 @@ public final class OpenClawChatViewModel {
         await self.performStartNewSession(worktree: worktree)
     }
 
+    public func requestSessionReset() {
+        Task { await self.performReset() }
+    }
+
+    public func requestSessionCompact() {
+        Task { await self.performCompact() }
+    }
+
+    public func setSessionPinned(_ sessionKey: String, pinned: Bool) {
+        Task {
+            do {
+                try await self.transport.patchSession(
+                    key: sessionKey,
+                    label: nil,
+                    category: nil,
+                    pinned: pinned,
+                    archived: nil,
+                    unread: nil)
+            } catch {
+                self.errorText = error.localizedDescription
+                return
+            }
+            await self.fetchSessions(limit: nil, sessionSnapshot: self.currentSessionSnapshot())
+        }
+    }
+
+    public func deleteSession(_ sessionKey: String) {
+        Task {
+            do {
+                try await self.transport.deleteSession(key: sessionKey)
+            } catch {
+                self.errorText = error.localizedDescription
+                return
+            }
+            self.sessions.removeAll { $0.key == sessionKey }
+            if sessionKey == self.sessionKey {
+                // The active transcript just disappeared server-side; fall
+                // back to the main session instead of a dead key.
+                self.applySessionSwitch(to: self.resolvedMainSessionKey, intent: .userInitiated)
+            }
+            await self.fetchSessions(limit: nil, sessionSnapshot: self.currentSessionSnapshot())
+        }
+    }
+
     public func switchSession(to sessionKey: String) {
         self.applySessionSwitch(to: sessionKey, intent: .userInitiated)
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -369,41 +369,6 @@ public final class OpenClawChatViewModel {
         Task { await self.performAbort() }
     }
 
-    public func refreshSessions(limit: Int? = nil) {
-        let context = self.currentSessionSnapshot()
-        Task { await self.fetchSessions(limit: limit, sessionSnapshot: context) }
-    }
-
-    public func startNewSession(worktree: Bool = false) async {
-        await self.performStartNewSession(worktree: worktree)
-    }
-
-    public func requestSessionReset() {
-        Task { await self.performReset() }
-    }
-
-    public func requestSessionCompact() {
-        Task { await self.performCompact() }
-    }
-
-    public func setSessionPinned(_ sessionKey: String, pinned: Bool) {
-        Task {
-            do {
-                try await self.transport.patchSession(
-                    key: sessionKey,
-                    label: nil,
-                    category: nil,
-                    pinned: pinned,
-                    archived: nil,
-                    unread: nil)
-            } catch {
-                self.errorText = error.localizedDescription
-                return
-            }
-            await self.fetchSessions(limit: nil, sessionSnapshot: self.currentSessionSnapshot())
-        }
-    }
-
     public func deleteSession(_ sessionKey: String) {
         Task {
             do {
@@ -1565,7 +1530,7 @@ public final class OpenClawChatViewModel {
         }
     }
 
-    private func fetchSessions(limit: Int?, sessionSnapshot: SessionSnapshot? = nil) async {
+    func fetchSessions(limit: Int?, sessionSnapshot: SessionSnapshot? = nil) async {
         do {
             let res = try await transport.listSessions(limit: limit, search: nil, archived: false)
             if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
@@ -1765,7 +1730,7 @@ public final class OpenClawChatViewModel {
         self.applySessionSwitch(to: sessionKey, intent: .externalSync)
     }
 
-    private func performStartNewSession(worktree: Bool) async {
+    func performStartNewSession(worktree: Bool) async {
         guard !self.blocksAttachmentOwnerChange else {
             self.errorText = String(
                 localized: "Remove attachments or wait for delivery to resolve before starting a new chat.")
@@ -1828,7 +1793,7 @@ public final class OpenClawChatViewModel {
             && nsError.localizedDescription == "sessions.create not supported by this transport"
     }
 
-    private func performReset() async {
+    func performReset() async {
         self.isLoading = true
         self.errorText = nil
 
@@ -1846,7 +1811,7 @@ public final class OpenClawChatViewModel {
         self.startBootstrap()
     }
 
-    private func performCompact() async {
+    func performCompact() async {
         guard !self.isCompacting else { return }
         guard !self.isSending, self.pendingRuns.isEmpty, !self.isAborting else {
             self.errorText = "Wait for the current response before compacting the session."

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
@@ -34,6 +34,7 @@ public struct OpenClawChatWindowShell: View {
                 .navigationTitle(self.activeSessionTitle)
                 .navigationSubtitle(self.subtitle)
                 .toolbar { self.detailToolbar }
+                .background(self.keyboardShortcutHandlers)
         }
         .confirmationDialog(
             "Clear this session's history?",
@@ -52,6 +53,33 @@ public struct OpenClawChatWindowShell: View {
                     self.viewModel.refreshSessions(limit: 200)
                 }
             }
+    }
+
+    /// Key equivalents only fire for installed views; buttons inside a closed
+    /// toolbar Menu are not built yet, so the shortcuts live here and the menu
+    /// items carry matching labels for discoverability.
+    private var keyboardShortcutHandlers: some View {
+        Group {
+            Button("New Session") {
+                Task { await self.viewModel.startNewSession() }
+            }
+            .keyboardShortcut("n", modifiers: [.command])
+
+            Button("Refresh") {
+                self.viewModel.refresh()
+                self.viewModel.refreshSessions(limit: 200)
+            }
+            .keyboardShortcut("r", modifiers: [.command])
+
+            Button("Export Transcript") {
+                self.exportTranscript()
+            }
+            .keyboardShortcut("e", modifiers: [.command, .shift])
+            .disabled(self.viewModel.messages.isEmpty)
+        }
+        .opacity(0)
+        .frame(width: 0, height: 0)
+        .accessibilityHidden(true)
     }
 
     private var activeSessionTitle: String {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
@@ -410,9 +410,14 @@ private struct ChatSessionSidebar: View {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(session.key, forType: .string)
             }
-            Divider()
-            Button("Delete Session…", role: .destructive) {
-                self.sessionPendingDeletion = session
+            if ChatSessionSidebarModel.canDeleteSession(
+                key: session.key,
+                mainSessionKey: self.viewModel.resolvedMainSessionKey)
+            {
+                Divider()
+                Button("Delete Session…", role: .destructive) {
+                    self.sessionPendingDeletion = session
+                }
             }
         }
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
@@ -295,6 +295,8 @@ private struct ChatSessionSidebar: View {
         let sections = ChatSessionSidebarModel.sections(
             sessions: self.viewModel.sessions,
             currentSessionKey: self.viewModel.sessionKey,
+            mainSessionKey: self.viewModel.resolvedMainSessionKey,
+            activeAgentID: self.viewModel.activeAgentId,
             query: self.query)
         List(selection: self.selectionBinding) {
             ForEach(sections) { section in
@@ -369,7 +371,13 @@ private struct ChatSessionSidebar: View {
 
     private var selectionBinding: Binding<String?> {
         Binding(
-            get: { self.viewModel.sessionKey },
+            get: {
+                ChatSessionSidebarModel.selectedSessionKey(
+                    sessions: self.viewModel.sessions,
+                    currentSessionKey: self.viewModel.sessionKey,
+                    mainSessionKey: self.viewModel.resolvedMainSessionKey,
+                    activeAgentID: self.viewModel.activeAgentId)
+            },
             set: { next in
                 guard let next, next != self.viewModel.sessionKey else { return }
                 self.viewModel.switchSession(to: next)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
@@ -1,0 +1,413 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// Native macOS chat window: sessions sidebar + transcript detail with the
+/// pickers promoted into the unified window toolbar. The compact menu-bar
+/// panel keeps using `OpenClawChatView` directly; this shell is the full
+/// window experience.
+@MainActor
+public struct OpenClawChatWindowShell: View {
+    @State private var viewModel: OpenClawChatViewModel
+    @State private var sessionQuery = ""
+    @State private var isConfirmingClearHistory = false
+    private let userAccent: Color?
+
+    public init(viewModel: OpenClawChatViewModel, userAccent: Color? = nil) {
+        _viewModel = State(initialValue: viewModel)
+        self.userAccent = userAccent
+    }
+
+    public var body: some View {
+        NavigationSplitView {
+            ChatSessionSidebar(
+                viewModel: self.viewModel,
+                query: self.$sessionQuery)
+                .navigationSplitViewColumnWidth(min: 200, ideal: 240, max: 340)
+        } detail: {
+            OpenClawChatView(
+                viewModel: self.viewModel,
+                drawsBackground: false,
+                userAccent: self.userAccent,
+                composerChrome: .clean)
+                .navigationTitle(self.activeSessionTitle)
+                .navigationSubtitle(self.subtitle)
+                .toolbar { self.detailToolbar }
+        }
+        .confirmationDialog(
+            "Clear this session's history?",
+            isPresented: self.$isConfirmingClearHistory)
+        {
+            Button("Clear History", role: .destructive) {
+                self.viewModel.requestSessionReset()
+            }
+        } message: {
+            Text("This resets the conversation for \(self.activeSessionTitle). The session key stays the same.")
+        }
+        .onChange(of: self.viewModel.pendingRunCount) { previous, current in
+                // Run completion changes timestamps/token totals; pull them once
+                // per run instead of polling.
+                if previous > 0, current == 0 {
+                    self.viewModel.refreshSessions(limit: 200)
+                }
+            }
+    }
+
+    private var activeSessionTitle: String {
+        let entry = self.viewModel.sessions.first { $0.key == self.viewModel.sessionKey }
+        if let entry {
+            return ChatSessionSidebarModel.displayName(for: entry)
+        }
+        return ChatSessionSidebarModel.displayName(forKey: self.viewModel.sessionKey)
+    }
+
+    private var subtitle: String {
+        let model = self.currentModelLabel
+        guard let usage = self.viewModel.contextUsage, let cost = usage.totalCost else {
+            return model
+        }
+        let costLabel = ChatContextUsageFormatter.cost(cost)
+        return model.isEmpty ? costLabel : "\(model) · \(costLabel)"
+    }
+
+    private var currentModelLabel: String {
+        if self.viewModel.modelSelectionID != OpenClawChatViewModel.defaultModelSelectionID {
+            return self.viewModel.modelSelectionID
+        }
+        let entry = self.viewModel.sessions.first { $0.key == self.viewModel.sessionKey }
+        for candidate in [entry?.model, self.viewModel.sessionDefaults?.model] {
+            if let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+        return ""
+    }
+
+    @ToolbarContentBuilder
+    private var detailToolbar: some ToolbarContent {
+        ToolbarItemGroup(placement: .primaryAction) {
+            if let usage = self.viewModel.contextUsage {
+                ChatContextUsageMenu(usage: usage) {
+                    self.viewModel.requestSessionCompact()
+                }
+            }
+
+            if self.viewModel.showsThinkingPicker {
+                self.thinkingPicker
+            }
+
+            if self.viewModel.showsModelPicker {
+                self.modelPicker
+            }
+
+            self.sessionActionsMenu
+        }
+    }
+
+    private var thinkingPicker: some View {
+        Picker(
+            "Thinking",
+            selection: Binding(
+                get: { self.viewModel.thinkingLevel },
+                set: { self.viewModel.selectThinkingLevel($0) }))
+        {
+            ForEach(self.viewModel.thinkingLevelOptions) { option in
+                Text(option.label).tag(option.id)
+            }
+        }
+        .pickerStyle(.menu)
+        .help("Thinking level")
+    }
+
+    private var modelPicker: some View {
+        let sections = self.viewModel.modelPickerSections
+        return Picker(
+            "Model",
+            selection: Binding(
+                get: { self.viewModel.modelSelectionID },
+                set: { self.viewModel.selectModel($0) }))
+        {
+            Text(self.viewModel.defaultModelLabel)
+                .tag(OpenClawChatViewModel.defaultModelSelectionID)
+            if sections.pinned.isEmpty, sections.recent.isEmpty {
+                self.modelOptions(sections.remaining)
+            } else {
+                if !sections.pinned.isEmpty {
+                    Section("Pinned") { self.modelOptions(sections.pinned) }
+                }
+                if !sections.recent.isEmpty {
+                    Section("Recent") { self.modelOptions(sections.recent) }
+                }
+                if !sections.remaining.isEmpty {
+                    Section("Models") { self.modelOptions(sections.remaining) }
+                }
+            }
+        }
+        .pickerStyle(.menu)
+        .help("Model")
+    }
+
+    private func modelOptions(_ models: [OpenClawChatModelChoice]) -> some View {
+        ForEach(models) { model in
+            Text(model.displayLabel).tag(model.selectionID)
+        }
+    }
+
+    private var sessionActionsMenu: some View {
+        Menu {
+            Button {
+                Task { await self.viewModel.startNewSession() }
+            } label: {
+                Label("New Session", systemImage: "square.and.pencil")
+            }
+            .keyboardShortcut("n", modifiers: [.command])
+
+            Button {
+                self.viewModel.refresh()
+                self.viewModel.refreshSessions(limit: 200)
+            } label: {
+                Label("Refresh", systemImage: "arrow.clockwise")
+            }
+            .keyboardShortcut("r", modifiers: [.command])
+
+            Divider()
+
+            Button {
+                self.copyToPasteboard(self.viewModel.sessionKey)
+            } label: {
+                Label("Copy Session Key", systemImage: "doc.on.doc")
+            }
+
+            Button {
+                self.exportTranscript()
+            } label: {
+                Label("Export Transcript…", systemImage: "square.and.arrow.up")
+            }
+            .keyboardShortcut("e", modifiers: [.command, .shift])
+            .disabled(self.viewModel.messages.isEmpty)
+
+            Divider()
+
+            Button {
+                self.viewModel.requestSessionCompact()
+            } label: {
+                Label("Compact Session", systemImage: "arrow.down.right.and.arrow.up.left")
+            }
+            .disabled(self.viewModel.pendingRunCount > 0)
+
+            Button(role: .destructive) {
+                self.isConfirmingClearHistory = true
+            } label: {
+                Label("Clear History…", systemImage: "trash")
+            }
+        } label: {
+            Label("Session", systemImage: "ellipsis.circle")
+        }
+        .menuIndicator(.hidden)
+        .help("Session actions")
+    }
+
+    private func copyToPasteboard(_ string: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(string, forType: .string)
+    }
+
+    private func exportTranscript() {
+        let markdown = self.viewModel.exportTranscriptMarkdown()
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "md") ?? .plainText]
+        panel.nameFieldStringValue = ChatTranscriptExporter.filename(
+            sessionTitle: self.activeSessionTitle,
+            sessionKey: self.viewModel.sessionKey)
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            try? markdown.write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+}
+
+/// Toolbar gauge + dropdown with token/cost details, mirroring the web UI's
+/// context ring.
+private struct ChatContextUsageMenu: View {
+    let usage: OpenClawChatContextUsage
+    let onCompact: () -> Void
+
+    var body: some View {
+        Menu {
+            Text(self.tokensLine)
+            if let cost = self.usage.totalCost {
+                Text("Session cost \(ChatContextUsageFormatter.cost(cost))")
+            }
+            Divider()
+            Button("Compact Session", action: self.onCompact)
+        } label: {
+            ChatContextUsageIndicator(usage: self.usage)
+        }
+        .menuIndicator(.hidden)
+        .help(self.tokensLine)
+    }
+
+    private var tokensLine: String {
+        let used = ChatContextUsageFormatter.tokens(self.usage.usedTokens)
+        guard let window = self.usage.contextWindowTokens else {
+            return "\(used) tokens used"
+        }
+        return "\(used) of \(ChatContextUsageFormatter.tokens(window)) tokens used"
+    }
+}
+
+@MainActor
+private struct ChatSessionSidebar: View {
+    @Bindable var viewModel: OpenClawChatViewModel
+    @Binding var query: String
+    @State private var sessionPendingDeletion: OpenClawChatSessionEntry?
+
+    var body: some View {
+        let sections = ChatSessionSidebarModel.sections(
+            sessions: self.viewModel.sessions,
+            currentSessionKey: self.viewModel.sessionKey,
+            query: self.query)
+        List(selection: self.selectionBinding) {
+            ForEach(sections) { section in
+                if let title = section.title {
+                    Section(title) {
+                        ForEach(section.sessions) { session in
+                            self.row(for: session)
+                        }
+                    }
+                } else {
+                    ForEach(section.sessions) { session in
+                        self.row(for: session)
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .searchable(text: self.$query, placement: .sidebar, prompt: "Search sessions")
+        .overlay {
+            if sections.isEmpty {
+                ContentUnavailableView(
+                    self.query.isEmpty ? "No Sessions" : "No Results",
+                    systemImage: "bubble.left.and.bubble.right")
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            self.connectionFooter
+        }
+        .toolbar {
+            ToolbarItem {
+                Button {
+                    Task { await self.viewModel.startNewSession() }
+                } label: {
+                    Label("New Session", systemImage: "square.and.pencil")
+                }
+                .help("New session")
+            }
+        }
+        .task {
+            self.viewModel.refreshSessions(limit: 200)
+        }
+        .onChange(of: self.viewModel.healthOK) { previous, current in
+            if !previous, current {
+                self.viewModel.refreshSessions(limit: 200)
+            }
+        }
+        .confirmationDialog(
+            self.deleteDialogTitle,
+            isPresented: self.isPresentingDeleteDialog)
+        {
+            Button("Delete Session", role: .destructive) {
+                if let session = self.sessionPendingDeletion {
+                    self.viewModel.deleteSession(session.key)
+                }
+                self.sessionPendingDeletion = nil
+            }
+        } message: {
+            Text("The session and its transcript are removed from the gateway.")
+        }
+    }
+
+    private var deleteDialogTitle: String {
+        let name = self.sessionPendingDeletion.map(ChatSessionSidebarModel.displayName(for:)) ?? ""
+        return "Delete “\(name)”?"
+    }
+
+    private var isPresentingDeleteDialog: Binding<Bool> {
+        Binding(
+            get: { self.sessionPendingDeletion != nil },
+            set: { if !$0 { self.sessionPendingDeletion = nil } })
+    }
+
+    private var selectionBinding: Binding<String?> {
+        Binding(
+            get: { self.viewModel.sessionKey },
+            set: { next in
+                guard let next, next != self.viewModel.sessionKey else { return }
+                self.viewModel.switchSession(to: next)
+            })
+    }
+
+    private func row(for session: OpenClawChatSessionEntry) -> some View {
+        HStack(spacing: 6) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(ChatSessionSidebarModel.displayName(for: session))
+                    .font(OpenClawChatTypography.body(size: 13, weight: .medium, relativeTo: .body))
+                    .lineLimit(1)
+                if let subtitle = self.rowSubtitle(for: session) {
+                    Text(subtitle)
+                        .font(OpenClawChatTypography.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if session.unread == true, session.key != self.viewModel.sessionKey {
+                Circle()
+                    .fill(.tint)
+                    .frame(width: 7, height: 7)
+                    .accessibilityLabel("Unread")
+            }
+        }
+        .tag(session.key)
+        .contextMenu {
+            Button(session.pinned == true ? "Unpin" : "Pin") {
+                self.viewModel.setSessionPinned(session.key, pinned: session.pinned != true)
+            }
+            Button("Copy Session Key") {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(session.key, forType: .string)
+            }
+            Divider()
+            Button("Delete Session…", role: .destructive) {
+                self.sessionPendingDeletion = session
+            }
+        }
+    }
+
+    private func rowSubtitle(for session: OpenClawChatSessionEntry) -> String? {
+        guard let updatedAt = session.updatedAt ?? session.lastActivityAt, updatedAt > 0 else {
+            return nil
+        }
+        let date = Date(timeIntervalSince1970: updatedAt / 1000)
+        return date.formatted(.relative(presentation: .named))
+    }
+
+    private var connectionFooter: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(self.viewModel.healthOK ? .green : .orange)
+                .frame(width: 7, height: 7)
+            Text(self.viewModel.healthOK ? "Gateway connected" : "Connecting…")
+                .font(OpenClawChatTypography.caption)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+}
+#endif

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWindowShell.swift
@@ -399,7 +399,9 @@ private struct ChatSessionSidebar: View {
                     .accessibilityLabel("Unread")
             }
         }
-        .tag(session.key)
+        // The tag type must equal the List selection type (String?) exactly;
+        // a plain String tag silently breaks selection highlighting/clicks.
+        .tag(Optional(session.key))
         .contextMenu {
             Button(session.pinned == true ? "Unpin" : "Pin") {
                 self.viewModel.setSessionPinned(session.key, pinned: session.pinned != true)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewTests.swift
@@ -12,4 +12,24 @@ struct ChatComposerTextViewTests {
         #expect(textView.allowsUndo)
     }
 }
+
+@Suite
+struct ChatComposerKeyRoutingTests {
+    @Test func mapsInterceptableNavigationKeys() {
+        #expect(ChatComposerKeyRouting.command(keyCode: 126, modifierFlags: [], hasMarkedText: false) == .moveUp)
+        #expect(ChatComposerKeyRouting.command(keyCode: 125, modifierFlags: [], hasMarkedText: false) == .moveDown)
+        #expect(ChatComposerKeyRouting.command(keyCode: 48, modifierFlags: [], hasMarkedText: false) == .tab)
+        #expect(ChatComposerKeyRouting.command(keyCode: 53, modifierFlags: [], hasMarkedText: false) == .escape)
+        #expect(ChatComposerKeyRouting.command(keyCode: 36, modifierFlags: [], hasMarkedText: false) == .returnKey)
+    }
+
+    @Test func ignoresModifiedKeysAndIMEComposition() {
+        // Shift-Return must stay a newline and Cmd-arrows must stay text
+        // navigation; IME composition owns Return while marked text exists.
+        #expect(ChatComposerKeyRouting.command(keyCode: 36, modifierFlags: [.shift], hasMarkedText: false) == nil)
+        #expect(ChatComposerKeyRouting.command(keyCode: 126, modifierFlags: [.command], hasMarkedText: false) == nil)
+        #expect(ChatComposerKeyRouting.command(keyCode: 36, modifierFlags: [], hasMarkedText: true) == nil)
+        #expect(ChatComposerKeyRouting.command(keyCode: 0, modifierFlags: [], hasMarkedText: false) == nil)
+    }
+}
 #endif

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatContextUsageTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatContextUsageTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import Testing
 @testable import OpenClawChatUI
 
-@Suite
 struct ChatContextUsageTests {
     private func message(
         role: String = "assistant",
@@ -105,6 +104,37 @@ struct ChatContextUsageTests {
         #expect(result?.usedTokens == 5000)
         #expect(result?.contextWindowTokens == 10000)
         #expect(result?.percentUsed == 50)
+    }
+
+    @Test func `ignores stale session totals without message usage`() {
+        let entry = OpenClawChatSessionEntry(
+            key: "main",
+            kind: nil,
+            displayName: nil,
+            surface: nil,
+            subject: nil,
+            room: nil,
+            space: nil,
+            updatedAt: nil,
+            sessionId: nil,
+            systemSent: nil,
+            abortedLastRun: nil,
+            thinkingLevel: nil,
+            verboseLevel: nil,
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: 5000,
+            modelProvider: nil,
+            model: nil,
+            contextTokens: 10000,
+            totalTokensFresh: false)
+        let result = ChatContextUsageCalculator.usage(
+            messages: [self.message()],
+            sessionEntry: entry,
+            defaults: nil,
+            modelContextWindow: nil)
+
+        #expect(result == nil)
     }
 
     @Test func `sums cost across all runs`() throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatContextUsageTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatContextUsageTests.swift
@@ -2,6 +2,32 @@ import Foundation
 import Testing
 @testable import OpenClawChatUI
 
+private final class ContextUsageTestTransport: @unchecked Sendable, OpenClawChatTransport {
+    func requestHistory(sessionKey _: String) async throws -> OpenClawChatHistoryPayload {
+        throw CancellationError()
+    }
+
+    func sendMessage(
+        sessionKey _: String,
+        message _: String,
+        thinking _: String,
+        idempotencyKey _: String,
+        attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+    {
+        throw CancellationError()
+    }
+
+    func requestHealth(timeoutMs _: Int) async throws -> Bool {
+        false
+    }
+
+    func events() -> AsyncStream<OpenClawChatTransportEvent> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
+    }
+}
+
 struct ChatContextUsageTests {
     private func message(
         role: String = "assistant",
@@ -159,5 +185,35 @@ struct ChatContextUsageTests {
             modelContextWindow: 4000)
 
         #expect(result == nil)
+    }
+
+    @Test @MainActor func `view model resolves context totals through a selected global alias`() {
+        let vm = OpenClawChatViewModel(
+            sessionKey: "global",
+            activeAgentId: "ops",
+            transport: ContextUsageTestTransport())
+        vm.sessions = [OpenClawChatSessionEntry(
+            key: "agent:ops:global",
+            kind: nil,
+            displayName: nil,
+            surface: nil,
+            subject: nil,
+            room: nil,
+            space: nil,
+            updatedAt: nil,
+            sessionId: nil,
+            systemSent: nil,
+            abortedLastRun: nil,
+            thinkingLevel: nil,
+            verboseLevel: nil,
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: 5000,
+            modelProvider: nil,
+            model: nil,
+            contextTokens: 10000)]
+
+        #expect(vm.contextUsage?.usedTokens == 5000)
+        #expect(vm.contextUsage?.contextWindowTokens == 10000)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatContextUsageTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatContextUsageTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import OpenClawChatUI
+
+@Suite
+struct ChatContextUsageTests {
+    private func message(
+        role: String = "assistant",
+        usage: OpenClawChatUsage? = nil) -> OpenClawChatMessage
+    {
+        OpenClawChatMessage(
+            id: UUID(),
+            role: role,
+            content: [OpenClawChatMessageContent(
+                type: "text",
+                text: "hi",
+                thinking: nil,
+                thinkingSignature: nil,
+                mimeType: nil,
+                fileName: nil,
+                content: nil,
+                id: nil,
+                name: nil,
+                arguments: nil)],
+            timestamp: nil,
+            usage: usage)
+    }
+
+    private func usage(
+        input: Int? = nil,
+        output: Int? = nil,
+        cacheRead: Int? = nil,
+        total: Int? = nil,
+        costTotal: Double? = nil) throws -> OpenClawChatUsage
+    {
+        var payload: [String: Any] = [:]
+        payload["input"] = input
+        payload["output"] = output
+        payload["cacheRead"] = cacheRead
+        payload["total"] = total
+        if let costTotal {
+            payload["cost"] = ["total": costTotal]
+        }
+        let data = try JSONSerialization.data(withJSONObject: payload.compactMapValues { $0 })
+        return try JSONDecoder().decode(OpenClawChatUsage.self, from: data)
+    }
+
+    @Test func `uses newest usage-bearing message, not a sum of runs`() throws {
+        let messages = try [
+            self.message(usage: self.usage(total: 900)),
+            self.message(role: "user"),
+            self.message(usage: self.usage(total: 1200)),
+        ]
+        let result = ChatContextUsageCalculator.usage(
+            messages: messages,
+            sessionEntry: nil,
+            defaults: nil,
+            modelContextWindow: 4000)
+
+        #expect(result?.usedTokens == 1200)
+        #expect(result?.contextWindowTokens == 4000)
+        #expect(result?.percentUsed == 30)
+    }
+
+    @Test func `sums usage components when total is missing`() throws {
+        let messages = try [self.message(usage: self.usage(input: 700, output: 100, cacheRead: 200))]
+        let result = ChatContextUsageCalculator.usage(
+            messages: messages,
+            sessionEntry: nil,
+            defaults: nil,
+            modelContextWindow: nil)
+
+        #expect(result?.usedTokens == 1000)
+        #expect(result?.contextWindowTokens == nil)
+        #expect(result?.fractionUsed == nil)
+    }
+
+    @Test func `falls back to session totals without message usage`() {
+        let entry = OpenClawChatSessionEntry(
+            key: "main",
+            kind: nil,
+            displayName: nil,
+            surface: nil,
+            subject: nil,
+            room: nil,
+            space: nil,
+            updatedAt: nil,
+            sessionId: nil,
+            systemSent: nil,
+            abortedLastRun: nil,
+            thinkingLevel: nil,
+            verboseLevel: nil,
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: 5000,
+            modelProvider: nil,
+            model: nil,
+            contextTokens: 10000)
+        let result = ChatContextUsageCalculator.usage(
+            messages: [self.message()],
+            sessionEntry: entry,
+            defaults: nil,
+            modelContextWindow: nil)
+
+        #expect(result?.usedTokens == 5000)
+        #expect(result?.contextWindowTokens == 10000)
+        #expect(result?.percentUsed == 50)
+    }
+
+    @Test func `sums cost across all runs`() throws {
+        let messages = try [
+            self.message(usage: self.usage(total: 100, costTotal: 0.25)),
+            self.message(usage: self.usage(total: 200, costTotal: 0.5)),
+        ]
+        let result = ChatContextUsageCalculator.usage(
+            messages: messages,
+            sessionEntry: nil,
+            defaults: nil,
+            modelContextWindow: nil)
+
+        #expect(result?.totalCost == 0.75)
+    }
+
+    @Test func `no usage anywhere yields nil`() {
+        let result = ChatContextUsageCalculator.usage(
+            messages: [self.message()],
+            sessionEntry: nil,
+            defaults: nil,
+            modelContextWindow: 4000)
+
+        #expect(result == nil)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -101,7 +101,10 @@ struct ChatSessionSidebarModelTests {
     }
 
     @Test func `global aliases select their agent wrapped row`() {
-        let sessions = [self.entry(key: "agent:ops:global", updatedAt: 100)]
+        let sessions = [
+            self.entry(key: "global", updatedAt: 200),
+            self.entry(key: "agent:ops:global", updatedAt: 100, archived: true),
+        ]
         let sections = ChatSessionSidebarModel.sections(
             sessions: sessions,
             currentSessionKey: "global",
@@ -109,6 +112,11 @@ struct ChatSessionSidebarModelTests {
             activeAgentID: "ops",
             query: "")
 
+        #expect(ChatSessionSidebarModel.selectedSessionKey(
+            sessions: sessions,
+            currentSessionKey: "global",
+            mainSessionKey: "agent:main:main",
+            activeAgentID: "ops") == "agent:ops:global")
         #expect(sections.flatMap(\.sessions).map(\.key) == ["agent:ops:global"])
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -82,6 +82,35 @@ struct ChatSessionSidebarModelTests {
         #expect(sections.flatMap(\.sessions).map(\.key) == ["agent:main:main"])
     }
 
+    @Test func `main aliases select the resolved row without adding a placeholder`() {
+        let sessions = [self.entry(key: "agent:default:main", updatedAt: 100)]
+        let sections = ChatSessionSidebarModel.sections(
+            sessions: sessions,
+            currentSessionKey: "main",
+            mainSessionKey: "agent:default:main",
+            activeAgentID: "default",
+            query: "")
+
+        #expect(sections.flatMap(\.sessions).map(\.key) == ["agent:default:main"])
+        #expect(ChatSessionSidebarModel.selectedSessionKey(
+            sessions: sessions,
+            currentSessionKey: "main",
+            mainSessionKey: "agent:default:main",
+            activeAgentID: "default") == "agent:default:main")
+    }
+
+    @Test func `global aliases select their agent wrapped row`() {
+        let sessions = [self.entry(key: "agent:ops:global", updatedAt: 100)]
+        let sections = ChatSessionSidebarModel.sections(
+            sessions: sessions,
+            currentSessionKey: "global",
+            mainSessionKey: "agent:main:main",
+            activeAgentID: "ops",
+            query: "")
+
+        #expect(sections.flatMap(\.sessions).map(\.key) == ["agent:ops:global"])
+    }
+
     @Test func `query filters on display name and key`() {
         let sections = ChatSessionSidebarModel.sections(
             sessions: [

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import OpenClawChatUI
 
+@MainActor
 struct ChatSessionSidebarModelTests {
     private func entry(
         key: String,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import OpenClawChatUI
+
+@Suite
+struct ChatSessionSidebarModelTests {
+    private func entry(
+        key: String,
+        displayName: String? = nil,
+        updatedAt: Double? = nil,
+        pinned: Bool? = nil,
+        archived: Bool? = nil) -> OpenClawChatSessionEntry
+    {
+        OpenClawChatSessionEntry(
+            key: key,
+            kind: nil,
+            displayName: displayName,
+            surface: nil,
+            subject: nil,
+            room: nil,
+            space: nil,
+            updatedAt: updatedAt,
+            sessionId: nil,
+            systemSent: nil,
+            abortedLastRun: nil,
+            thinkingLevel: nil,
+            verboseLevel: nil,
+            inputTokens: nil,
+            outputTokens: nil,
+            totalTokens: nil,
+            modelProvider: nil,
+            model: nil,
+            contextTokens: nil,
+            pinned: pinned,
+            archived: archived)
+    }
+
+    @Test func `pinned sessions get their own section, rest sorted by recency`() {
+        let sections = ChatSessionSidebarModel.sections(
+            sessions: [
+                self.entry(key: "a", updatedAt: 100),
+                self.entry(key: "b", updatedAt: 300, pinned: true),
+                self.entry(key: "c", updatedAt: 200),
+            ],
+            currentSessionKey: "a",
+            query: "")
+
+        #expect(sections.map(\.id) == ["pinned", "recent"])
+        #expect(sections[0].sessions.map(\.key) == ["b"])
+        #expect(sections[1].sessions.map(\.key) == ["c", "a"])
+        #expect(sections[1].title == "Recent")
+    }
+
+    @Test func `single unpinned section carries no title`() {
+        let sections = ChatSessionSidebarModel.sections(
+            sessions: [self.entry(key: "a", updatedAt: 100)],
+            currentSessionKey: "a",
+            query: "")
+
+        #expect(sections.count == 1)
+        #expect(sections[0].title == nil)
+    }
+
+    @Test func `hides onboarding and archived sessions, keeps the active one`() {
+        let sections = ChatSessionSidebarModel.sections(
+            sessions: [
+                self.entry(key: "agent:main:onboarding", updatedAt: 500),
+                self.entry(key: "gone", updatedAt: 400, archived: true),
+                self.entry(key: "main", updatedAt: 300),
+            ],
+            currentSessionKey: "main",
+            query: "")
+
+        #expect(sections.flatMap(\.sessions).map(\.key) == ["main"])
+    }
+
+    @Test func `active session gets a placeholder row before lists load`() {
+        let sections = ChatSessionSidebarModel.sections(
+            sessions: [],
+            currentSessionKey: "agent:main:main",
+            query: "")
+
+        #expect(sections.flatMap(\.sessions).map(\.key) == ["agent:main:main"])
+    }
+
+    @Test func `query filters on display name and key`() {
+        let sections = ChatSessionSidebarModel.sections(
+            sessions: [
+                self.entry(key: "agent:main:research", displayName: "Deep Research", updatedAt: 200),
+                self.entry(key: "agent:main:main", updatedAt: 100),
+            ],
+            currentSessionKey: "agent:main:main",
+            query: "research")
+
+        #expect(sections.flatMap(\.sessions).map(\.key) == ["agent:main:research"])
+    }
+
+    @Test func `session keys render as human names`() {
+        #expect(ChatSessionSidebarModel.displayName(forKey: "agent:main:main") == "main")
+        #expect(ChatSessionSidebarModel.displayName(forKey: "agent:ops:standup") == "standup (ops)")
+        #expect(ChatSessionSidebarModel.displayName(forKey: "global") == "global")
+    }
+
+    @Test func `display name prefers explicit names over key prettifying`() {
+        let named = self.entry(key: "agent:main:x", displayName: "  Weekly Sync  ")
+        #expect(ChatSessionSidebarModel.displayName(for: named) == "Weekly Sync")
+
+        let unnamed = self.entry(key: "agent:main:x")
+        #expect(ChatSessionSidebarModel.displayName(for: unnamed) == "x")
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatSessionSidebarModelTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import Testing
 @testable import OpenClawChatUI
 
-@Suite
 struct ChatSessionSidebarModelTests {
     private func entry(
         key: String,
@@ -107,5 +106,17 @@ struct ChatSessionSidebarModelTests {
 
         let unnamed = self.entry(key: "agent:main:x")
         #expect(ChatSessionSidebarModel.displayName(for: unnamed) == "x")
+    }
+
+    @Test func `delete excludes main aliases and allows ordinary or selected global sessions`() {
+        let mainKey = "agent:default:main"
+
+        #expect(!ChatSessionSidebarModel.canDeleteSession(key: "main", mainSessionKey: mainKey))
+        #expect(!ChatSessionSidebarModel.canDeleteSession(key: "GLOBAL", mainSessionKey: mainKey))
+        #expect(!ChatSessionSidebarModel.canDeleteSession(key: mainKey, mainSessionKey: mainKey))
+        #expect(ChatSessionSidebarModel.canDeleteSession(key: "scratch", mainSessionKey: mainKey))
+        #expect(ChatSessionSidebarModel.canDeleteSession(
+            key: "agent:other:global",
+            mainSessionKey: mainKey))
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionDeletionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionDeletionTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+@testable import OpenClawChatUI
+
+/// Minimal transport for delete-session flows; unrelated protocol methods keep
+/// their throwing defaults.
+private final class DeleteSessionTestTransport: @unchecked Sendable, OpenClawChatTransport {
+    private let lock = NSLock()
+    private var deletedKeysStorage: [String] = []
+    private var historyRequestsStorage: [String] = []
+
+    var deletedKeys: [String] {
+        self.lock.withLock { self.deletedKeysStorage }
+    }
+
+    var historyRequests: [String] {
+        self.lock.withLock { self.historyRequestsStorage }
+    }
+
+    func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload {
+        self.lock.withLock { self.historyRequestsStorage.append(sessionKey) }
+        let json = """
+        {"sessionKey":"\(sessionKey)","sessionId":null,"messages":[],"thinkingLevel":"off"}
+        """
+        return try JSONDecoder().decode(OpenClawChatHistoryPayload.self, from: Data(json.utf8))
+    }
+
+    func sendMessage(
+        sessionKey _: String,
+        message _: String,
+        thinking _: String,
+        idempotencyKey _: String,
+        attachments _: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
+    {
+        let json = """
+        {"runId":"\(UUID().uuidString)","status":"ok"}
+        """
+        return try JSONDecoder().decode(OpenClawChatSendResponse.self, from: Data(json.utf8))
+    }
+
+    func requestHealth(timeoutMs _: Int) async throws -> Bool {
+        true
+    }
+
+    func events() -> AsyncStream<OpenClawChatTransportEvent> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
+    }
+
+    func deleteSession(key: String) async throws {
+        self.lock.withLock { self.deletedKeysStorage.append(key) }
+    }
+}
+
+@Suite
+@MainActor
+struct ChatViewModelSessionDeletionTests {
+    @Test func `deleting the active main session re-bootstraps in place`() async throws {
+        let transport = DeleteSessionTestTransport()
+        let vm = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        vm.load()
+        try await waitUntil("initial bootstrap history") {
+            await MainActor.run { transport.historyRequests.contains("main") }
+        }
+
+        let historyCountBeforeDelete = transport.historyRequests.count
+        vm.deleteSession("main")
+
+        try await waitUntil("delete reaches transport") {
+            await MainActor.run { transport.deletedKeys == ["main"] }
+        }
+        // The main key stays the address after deletion, so the view model
+        // must re-bootstrap it rather than silently keeping dead state.
+        try await waitUntil("post-delete re-bootstrap") {
+            await MainActor.run { transport.historyRequests.count > historyCountBeforeDelete }
+        }
+        #expect(vm.sessionKey == "main")
+    }
+
+    @Test func `deleting the active non-main session switches to main`() async throws {
+        let transport = DeleteSessionTestTransport()
+        let vm = OpenClawChatViewModel(sessionKey: "scratch", transport: transport)
+        vm.load()
+        try await waitUntil("initial bootstrap history") {
+            await MainActor.run { transport.historyRequests.contains("scratch") }
+        }
+
+        vm.deleteSession("scratch")
+
+        try await waitUntil("delete reaches transport") {
+            await MainActor.run { transport.deletedKeys == ["scratch"] }
+        }
+        try await waitUntil("fallback switch to main") {
+            await MainActor.run { vm.sessionKey == "main" }
+        }
+    }
+
+    @Test func `deleting an inactive session keeps the active one`() async throws {
+        let transport = DeleteSessionTestTransport()
+        let vm = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+        vm.load()
+        try await waitUntil("initial bootstrap history") {
+            await MainActor.run { transport.historyRequests.contains("main") }
+        }
+
+        vm.deleteSession("scratch")
+
+        try await waitUntil("delete reaches transport") {
+            await MainActor.run { transport.deletedKeys == ["scratch"] }
+        }
+        #expect(vm.sessionKey == "main")
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionDeletionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionDeletionTests.swift
@@ -53,7 +53,6 @@ private final class DeleteSessionTestTransport: @unchecked Sendable, OpenClawCha
     }
 }
 
-@Suite
 @MainActor
 struct ChatViewModelSessionDeletionTests {
     @Test func `deleting the active main session re-bootstraps in place`() async throws {
@@ -92,6 +91,27 @@ struct ChatViewModelSessionDeletionTests {
             await MainActor.run { transport.deletedKeys == ["scratch"] }
         }
         try await waitUntil("fallback switch to main") {
+            await MainActor.run { vm.sessionKey == "main" }
+        }
+    }
+
+    @Test func `deleting the canonical selected global row treats its alias as active`() async throws {
+        let transport = DeleteSessionTestTransport()
+        let vm = OpenClawChatViewModel(
+            sessionKey: "global",
+            activeAgentId: "ops",
+            transport: transport)
+        vm.load()
+        try await waitUntil("initial bootstrap history") {
+            await MainActor.run { transport.historyRequests.contains("global") }
+        }
+
+        vm.deleteSession("agent:ops:global")
+
+        try await waitUntil("delete reaches transport") {
+            await MainActor.run { transport.deletedKeys == ["agent:ops:global"] }
+        }
+        try await waitUntil("alias fallback switch to main") {
             await MainActor.run { vm.sessionKey == "main" }
         }
     }

--- a/docs/platforms/mac/webchat.md
+++ b/docs/platforms/mac/webchat.md
@@ -5,7 +5,15 @@ read_when:
 title: "WebChat (macOS)"
 ---
 
-The macOS menu bar app embeds the WebChat UI as a native SwiftUI view. It connects to the Gateway and defaults to the primary session for the selected agent (`main`, or `global` when `session.scope` is `global`), with a session switcher for other sessions.
+The macOS menu bar app embeds the WebChat UI as a native SwiftUI view. It connects to the Gateway and defaults to the primary session for the selected agent (`main`, or `global` when `session.scope` is `global`).
+
+The full chat window is a native split view:
+
+- **Sessions sidebar**: searchable session list with pinned and recent sections, unread indicators, and context menus for pin/unpin, copy session key, and delete. A toolbar button (or Cmd-N) creates a real new session via `sessions.create`.
+- **Window toolbar**: context-usage ring (tokens and session cost, with a compact action), thinking-level picker, model picker, and a session actions menu (new session, refresh, copy session key, export transcript, compact, clear history).
+- **Transcript and composer**: assistant messages render as plain text with an avatar, user messages as accent bubbles. Typing `/` opens slash-command autocomplete backed by `commands.list`, with arrow/Tab/Return/Escape keyboard navigation. Right-click a message to copy it.
+
+The anchored quick-chat panel from the menu bar keeps the compact single-column layout with inline pickers.
 
 - **Local mode**: connects directly to the local Gateway WebSocket.
 - **Remote mode**: forwards the Gateway control port over SSH and uses that tunnel as the data plane.


### PR DESCRIPTION
Closes #101086

## What Problem This Solves

The native macOS chat window lagged far behind the web Control UI. It was a single fixed column in a bare `NSWindow` with a dated gradient background: sessions were only reachable through a cramped dropdown of raw routing keys (`agent:main:main`), session/thinking/model pickers were squeezed into a strip above the composer, and the surface had no slash-command autocomplete, no context-window/token/cost visibility, no message copy actions, no transcript export, and no compact/clear-history affordances. "New session" silently fell back to `sessions.reset` because the Mac transport never implemented `sessions.create`, so starting a fresh session actually wiped the current one.

## Why This Change Was Made

Rebuilds the chat window as a native macOS shell (`OpenClawChatWindowShell` in `OpenClawChatUI`, macOS-only): a `NavigationSplitView` with a searchable sessions sidebar (pinned/recent sections, unread dots, relative timestamps, pin/copy-key/delete context menus, connection footer) and a unified toolbar carrying the context-usage ring (tokens/cost with a compact action), thinking picker, model picker (pinned/recent/all sections), and a session actions menu (new ⌘N, refresh ⌘R, copy session key, export transcript ⇧⌘E, compact, clear history with confirmation). The transcript uses clean chrome: assistant messages render as plain flowing text with an avatar, user messages in accent bubbles that follow the system accent (host override preserved for the seam color). The shared slash-command panel is enabled on macOS with full keyboard navigation (↑/↓/Tab/Return/Esc) routed through the composer NSTextView, and the Mac gateway transport now implements `commands.list`, `sessions.create`, `sessions.patch`, and `sessions.delete`. The compact menu-bar panel keeps the existing single-column presentation. Full web parity (split panes, checkpoints, workspace rail, thread search, in-window talk mode) is intentionally out of scope and tracked in #101086.

## User Impact

macOS users get a first-class chat window: browse/search/switch/pin/delete sessions in a sidebar, create real new sessions, see context pressure and session cost at a glance, autocomplete slash commands with the keyboard, copy messages via right-click, export transcripts, and compact or clear a session from the toolbar — all in native window chrome with frame persistence. iOS behavior is unchanged aside from the slash panel no longer appearing for transports without a command catalog.

## Evidence

- `swift test --parallel` in `apps/shared/OpenClawKit`: 531 tests green (15 new: context-usage calculator, sidebar section/filter/display-name model, composer key routing). One pre-existing wall-clock-timeout test (`definitive live-send rejection restores draft without queueing`) flakes under heavy parallel host load and passes in isolation and on rerun.
- `swift test --parallel` in `apps/macos`: 653 tests green (includes window/panel controller smoke tests running the new shell).
- `swift build --product OpenClaw` release-style build green; `OpenClawChatUI` also built for `generic/platform=iOS Simulator` to prove the shared-package changes compile for iOS.
- `swiftlint` (repo config) clean on touched files; `swiftformat --lint` clean for `apps/macos/Sources` and the new shared sources.
- Live verification against a real gateway on macOS: session switching from the sidebar (title/subtitle/model/cost update per session), slash panel with gateway `commands.list` catalog, keyboard completion (`/` → ↓ → Tab inserts `/commands`), context ring showing 9%/3% per session, connection footer, message context menu. Screenshots were captured during live verification; the Crabbox artifact broker is not configured on this host, so they are held locally rather than attached (available on request).
