### PR TITLE
fix(macos): preserve device identity storage

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
@@ -1,5 +1,8 @@
 import CryptoKit
 import Foundation
+#if canImport(Security)
+import Security
+#endif
 
 public enum GatewayDeviceIdentityProfile: String, Sendable {
     case primary
@@ -51,6 +54,7 @@ enum DeviceIdentityPaths {
             overrideURL: self.stateDirOverrideURL(),
             legacyStateDirURL: self.legacyStateDirURL(),
             appGroupStateDirURL: self.appGroupStateDirURL(),
+            appGroupStateDirAvailable: self.hasAppGroupEntitlement(OpenClawAppGroup.identifier),
             temporaryDirectory: FileManager.default.temporaryDirectory)
     }
 
@@ -58,12 +62,13 @@ enum DeviceIdentityPaths {
         overrideURL: URL?,
         legacyStateDirURL: URL?,
         appGroupStateDirURL: URL?,
+        appGroupStateDirAvailable: Bool = true,
         temporaryDirectory: URL) -> URL
     {
         if let overrideURL {
             return overrideURL
         }
-        if let appGroupStateDirURL {
+        if appGroupStateDirAvailable, let appGroupStateDirURL {
             return appGroupStateDirURL
         }
         if let legacyStateDirURL {
@@ -89,6 +94,26 @@ enum DeviceIdentityPaths {
             return appSupport.appendingPathComponent("OpenClaw", isDirectory: true)
         }
         return nil
+    }
+
+    private static func hasAppGroupEntitlement(_ identifier: String) -> Bool {
+        #if canImport(Security)
+        guard
+            let task = SecTaskCreateFromSelf(nil),
+            let value = SecTaskCopyValueForEntitlement(
+                task,
+                "com.apple.security.application-groups" as CFString,
+                nil)
+        else {
+            return false
+        }
+        guard let groups = value as? [String] else {
+            return false
+        }
+        return groups.contains(identifier)
+        #else
+        return true
+        #endif
     }
 
     private static func appGroupStateDirURL() -> URL? {
@@ -128,8 +153,11 @@ public enum DeviceIdentityStore {
             case .recognizedInvalid:
                 return self.generate()
             case .unknown:
-                break
+                return self.generate()
             }
+        }
+        if FileManager.default.fileExists(atPath: url.path) {
+            return self.generate()
         }
         let identity = self.generate()
         self.save(identity, to: url)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
@@ -97,7 +97,7 @@ enum DeviceIdentityPaths {
     }
 
     private static func hasAppGroupEntitlement(_ identifier: String) -> Bool {
-        #if canImport(Security)
+        #if os(macOS) && canImport(Security)
         guard
             let task = SecTaskCreateFromSelf(nil),
             let value = SecTaskCopyValueForEntitlement(

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
@@ -49,12 +49,18 @@ public struct DeviceIdentity: Codable, Sendable {
 enum DeviceIdentityPaths {
     private static let stateDirEnv = ["OPENCLAW_STATE_DIR"]
 
+    /// Entitlements are baked into the code signature, so resolve the gate once per process.
+    /// Every identity load and DeviceAuthStore read/write resolves the state dir through here;
+    /// re-creating a SecTask each time is wasted work for a process-immutable fact.
+    private static let appGroupStateDirAvailable =
+        DeviceIdentityPaths.hasAppGroupEntitlement(OpenClawAppGroup.identifier)
+
     static func stateDirURL() -> URL {
         self.stateDirURL(
             overrideURL: self.stateDirOverrideURL(),
             legacyStateDirURL: self.legacyStateDirURL(),
             appGroupStateDirURL: self.appGroupStateDirURL(),
-            appGroupStateDirAvailable: self.hasAppGroupEntitlement(OpenClawAppGroup.identifier),
+            appGroupStateDirAvailable: self.appGroupStateDirAvailable,
             temporaryDirectory: FileManager.default.temporaryDirectory)
     }
 
@@ -97,6 +103,10 @@ enum DeviceIdentityPaths {
     }
 
     private static func hasAppGroupEntitlement(_ identifier: String) -> Bool {
+        // macOS resolves containerURL(forSecurityApplicationGroupIdentifier:) even without the
+        // App Groups entitlement, but macOS 15+ gates actual access behind a user consent prompt.
+        // Unentitled builds (the shipped mac app) must not depend on that container. iOS requires
+        // the entitlement for containerURL to resolve at all, so the gate is macOS-only.
         #if os(macOS) && canImport(Security)
         guard
             let task = SecTaskCreateFromSelf(nil),
@@ -126,27 +136,38 @@ enum DeviceIdentityPaths {
         return containerURL.appendingPathComponent("OpenClaw", isDirectory: true)
     }
 
-    static func appGroupMigrationSourceURL(identityFileName: String) -> URL? {
-        self.appGroupMigrationSourceURL(
-            appGroupStateDirURL: self.appGroupStateDirURL(),
-            appGroupStateDirAvailable: self.hasAppGroupEntitlement(OpenClawAppGroup.identifier),
-            identityFileName: identityFileName)
+    /// Files a one-time fallback migration may carry from the App Group container into the
+    /// selected store. Stored device tokens are keyed by deviceId, so the identity file is
+    /// only useful together with its auth sibling; migrating one without the other forces
+    /// an unnecessary re-pair even though the deviceId survived.
+    struct AppGroupMigrationSource {
+        let identityURL: URL
+        let authURL: URL
     }
 
-    static func appGroupMigrationSourceURL(
+    static func appGroupMigrationSource(
+        profile: GatewayDeviceIdentityProfile) -> AppGroupMigrationSource?
+    {
+        self.appGroupMigrationSource(
+            appGroupStateDirURL: self.appGroupStateDirURL(),
+            appGroupStateDirAvailable: self.appGroupStateDirAvailable,
+            profile: profile)
+    }
+
+    /// Non-nil only for unentitled builds whose store selection fell back to legacy storage;
+    /// entitled builds keep using the App Group container and must never migrate out of it.
+    static func appGroupMigrationSource(
         appGroupStateDirURL: URL?,
         appGroupStateDirAvailable: Bool,
-        identityFileName: String) -> URL?
+        profile: GatewayDeviceIdentityProfile) -> AppGroupMigrationSource?
     {
-        if appGroupStateDirAvailable {
+        guard !appGroupStateDirAvailable, let appGroupStateDirURL else {
             return nil
         }
-        guard let appGroupStateDirURL else {
-            return nil
-        }
-        return appGroupStateDirURL
-            .appendingPathComponent("identity", isDirectory: true)
-            .appendingPathComponent(identityFileName, isDirectory: false)
+        let identityDirURL = appGroupStateDirURL.appendingPathComponent("identity", isDirectory: true)
+        return AppGroupMigrationSource(
+            identityURL: identityDirURL.appendingPathComponent(profile.identityFileName, isDirectory: false),
+            authURL: identityDirURL.appendingPathComponent(profile.authFileName, isDirectory: false))
     }
 }
 
@@ -167,29 +188,27 @@ public enum DeviceIdentityStore {
     public static func loadOrCreate(profile: GatewayDeviceIdentityProfile) -> DeviceIdentity {
         self.loadOrCreate(
             fileURL: self.fileURL(profile: profile),
-            migrationSourceURL: DeviceIdentityPaths.appGroupMigrationSourceURL(
-                identityFileName: profile.identityFileName))
+            migrationSource: DeviceIdentityPaths.appGroupMigrationSource(profile: profile))
     }
 
-    static func loadOrCreate(fileURL url: URL) -> DeviceIdentity {
-        self.loadOrCreate(fileURL: url, migrationSourceURL: nil)
-    }
-
-    static func loadOrCreate(fileURL url: URL, migrationSourceURL: URL?) -> DeviceIdentity {
+    static func loadOrCreate(
+        fileURL url: URL,
+        migrationSource: DeviceIdentityPaths.AppGroupMigrationSource? = nil) -> DeviceIdentity
+    {
         if let data = try? Data(contentsOf: url) {
             switch self.decodeStoredIdentity(data) {
             case let .identity(decoded):
                 return decoded
-            case .recognizedInvalid:
-                return self.generate()
-            case .unknown:
+            case .recognizedInvalid, .unknown:
+                // Existing bytes may hold a newer schema or recoverable key material; never
+                // overwrite them. Callers run with a transient identity instead.
                 return self.generate()
             }
         }
         if FileManager.default.fileExists(atPath: url.path) {
             return self.generate()
         }
-        if let migrated = self.migratedIdentity(from: migrationSourceURL, to: url) {
+        if let migrated = self.migratedIdentity(from: migrationSource, to: url) {
             return migrated
         }
         let identity = self.generate()
@@ -197,16 +216,43 @@ public enum DeviceIdentityStore {
         return identity
     }
 
-    private static func migratedIdentity(from sourceURL: URL?, to destinationURL: URL) -> DeviceIdentity? {
+    /// One-time upgrade path for builds that lost App Group storage: it runs only while the
+    /// selected store has no identity file, so steady state never re-reads the old container.
+    private static func migratedIdentity(
+        from source: DeviceIdentityPaths.AppGroupMigrationSource?,
+        to destinationURL: URL) -> DeviceIdentity?
+    {
         guard
-            let sourceURL,
-            let data = try? Data(contentsOf: sourceURL),
+            let source,
+            let data = try? Data(contentsOf: source.identityURL),
             case let .identity(identity) = self.decodeStoredIdentity(data)
         else {
             return nil
         }
         self.save(identity, to: destinationURL)
+        // Stored device tokens only load when their store's deviceId matches (DeviceAuthStore),
+        // so they must move together with the identity or the install re-pairs for no reason.
+        // A mismatched copy is inert behind that same check; no validation needed here.
+        self.copyAuthStoreFile(
+            from: source.authURL,
+            toDirectory: destinationURL.deletingLastPathComponent())
         return identity
+    }
+
+    private static func copyAuthStoreFile(from sourceURL: URL, toDirectory directoryURL: URL) {
+        let fileManager = FileManager.default
+        let destinationURL = directoryURL
+            .appendingPathComponent(sourceURL.lastPathComponent, isDirectory: false)
+        guard
+            !fileManager.fileExists(atPath: destinationURL.path),
+            fileManager.fileExists(atPath: sourceURL.path)
+        else {
+            return
+        }
+        try? fileManager.copyItem(at: sourceURL, to: destinationURL)
+        try? fileManager.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: destinationURL.path)
     }
 
     private enum DecodeResult {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift
@@ -125,6 +125,29 @@ enum DeviceIdentityPaths {
         }
         return containerURL.appendingPathComponent("OpenClaw", isDirectory: true)
     }
+
+    static func appGroupMigrationSourceURL(identityFileName: String) -> URL? {
+        self.appGroupMigrationSourceURL(
+            appGroupStateDirURL: self.appGroupStateDirURL(),
+            appGroupStateDirAvailable: self.hasAppGroupEntitlement(OpenClawAppGroup.identifier),
+            identityFileName: identityFileName)
+    }
+
+    static func appGroupMigrationSourceURL(
+        appGroupStateDirURL: URL?,
+        appGroupStateDirAvailable: Bool,
+        identityFileName: String) -> URL?
+    {
+        if appGroupStateDirAvailable {
+            return nil
+        }
+        guard let appGroupStateDirURL else {
+            return nil
+        }
+        return appGroupStateDirURL
+            .appendingPathComponent("identity", isDirectory: true)
+            .appendingPathComponent(identityFileName, isDirectory: false)
+    }
 }
 
 public enum DeviceIdentityStore {
@@ -142,10 +165,17 @@ public enum DeviceIdentityStore {
     }
 
     public static func loadOrCreate(profile: GatewayDeviceIdentityProfile) -> DeviceIdentity {
-        self.loadOrCreate(fileURL: self.fileURL(profile: profile))
+        self.loadOrCreate(
+            fileURL: self.fileURL(profile: profile),
+            migrationSourceURL: DeviceIdentityPaths.appGroupMigrationSourceURL(
+                identityFileName: profile.identityFileName))
     }
 
     static func loadOrCreate(fileURL url: URL) -> DeviceIdentity {
+        self.loadOrCreate(fileURL: url, migrationSourceURL: nil)
+    }
+
+    static func loadOrCreate(fileURL url: URL, migrationSourceURL: URL?) -> DeviceIdentity {
         if let data = try? Data(contentsOf: url) {
             switch self.decodeStoredIdentity(data) {
             case let .identity(decoded):
@@ -159,8 +189,23 @@ public enum DeviceIdentityStore {
         if FileManager.default.fileExists(atPath: url.path) {
             return self.generate()
         }
+        if let migrated = self.migratedIdentity(from: migrationSourceURL, to: url) {
+            return migrated
+        }
         let identity = self.generate()
         self.save(identity, to: url)
+        return identity
+    }
+
+    private static func migratedIdentity(from sourceURL: URL?, to destinationURL: URL) -> DeviceIdentity? {
+        guard
+            let sourceURL,
+            let data = try? Data(contentsOf: sourceURL),
+            case let .identity(identity) = self.decodeStoredIdentity(data)
+        else {
+            return nil
+        }
+        self.save(identity, to: destinationURL)
         return identity
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -370,6 +370,95 @@ struct DeviceIdentityStoreTests {
         #expect(try String(contentsOf: identityURL, encoding: .utf8) == before)
     }
 
+    @Test
+    func `migrates an existing app group identity when falling back to legacy storage`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let appGroupURL = tempDir.appendingPathComponent("shared", isDirectory: true)
+        let appGroupIdentityURL = appGroupURL
+            .appendingPathComponent("identity", isDirectory: true)
+            .appendingPathComponent("device.json", isDirectory: false)
+        let legacyIdentityURL = tempDir
+            .appendingPathComponent("legacy", isDirectory: true)
+            .appendingPathComponent("identity", isDirectory: true)
+            .appendingPathComponent("device.json", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: appGroupIdentityURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        let stored = try Self.identityJSON(
+            publicKeyPem: Self.pem(
+                label: "PUBLIC KEY",
+                body: "MCowBQYDK2VwAyEAA6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg="),
+            privateKeyPem: Self.pem(
+                label: "PRIVATE KEY",
+                body: "MC4CAQAwBQYDK2VwBCIEIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4f"))
+        try stored.write(to: appGroupIdentityURL, atomically: true, encoding: .utf8)
+        let appGroupBefore = try String(contentsOf: appGroupIdentityURL, encoding: .utf8)
+
+        let migrationSource = DeviceIdentityPaths.appGroupMigrationSourceURL(
+            appGroupStateDirURL: appGroupURL,
+            appGroupStateDirAvailable: false,
+            identityFileName: "device.json")
+        let identity = DeviceIdentityStore.loadOrCreate(
+            fileURL: legacyIdentityURL,
+            migrationSourceURL: migrationSource)
+
+        #expect(identity.deviceId == "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c")
+        #expect(FileManager.default.fileExists(atPath: legacyIdentityURL.path))
+        let reloaded = DeviceIdentityStore.loadOrCreate(fileURL: legacyIdentityURL)
+        #expect(reloaded.deviceId == identity.deviceId)
+        #expect(try String(contentsOf: appGroupIdentityURL, encoding: .utf8) == appGroupBefore)
+    }
+
+    @Test
+    func `keeps an existing legacy identity instead of migrating the app group copy`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let appGroupURL = tempDir.appendingPathComponent("shared", isDirectory: true)
+        let appGroupIdentityURL = appGroupURL
+            .appendingPathComponent("identity", isDirectory: true)
+            .appendingPathComponent("device.json", isDirectory: false)
+        let legacyIdentityURL = tempDir
+            .appendingPathComponent("legacy", isDirectory: true)
+            .appendingPathComponent("identity", isDirectory: true)
+            .appendingPathComponent("device.json", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: appGroupIdentityURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        let stored = try Self.identityJSON(
+            publicKeyPem: Self.pem(
+                label: "PUBLIC KEY",
+                body: "MCowBQYDK2VwAyEAA6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg="),
+            privateKeyPem: Self.pem(
+                label: "PRIVATE KEY",
+                body: "MC4CAQAwBQYDK2VwBCIEIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4f"))
+        try stored.write(to: appGroupIdentityURL, atomically: true, encoding: .utf8)
+
+        let existingLegacy = DeviceIdentityStore.loadOrCreate(fileURL: legacyIdentityURL)
+        let migrationSource = DeviceIdentityPaths.appGroupMigrationSourceURL(
+            appGroupStateDirURL: appGroupURL,
+            appGroupStateDirAvailable: false,
+            identityFileName: "device.json")
+        let identity = DeviceIdentityStore.loadOrCreate(
+            fileURL: legacyIdentityURL,
+            migrationSourceURL: migrationSource)
+
+        #expect(identity.deviceId == existingLegacy.deviceId)
+        #expect(identity.deviceId != "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c")
+    }
+
+    @Test
+    func `provides no app group migration source when the entitlement is present`() {
+        let appGroupURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        #expect(DeviceIdentityPaths.appGroupMigrationSourceURL(
+            appGroupStateDirURL: appGroupURL,
+            appGroupStateDirAvailable: true,
+            identityFileName: "device.json") == nil)
+    }
+
     private static func base64UrlDecode(_ value: String) -> Data? {
         let normalized = value
             .replacingOccurrences(of: "-", with: "+")

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -197,7 +197,7 @@ struct DeviceIdentityStoreTests {
     }
 
     @Test
-    func `legacy app support storage wins when app group storage is not available`() throws {
+    func `legacy app support storage wins when app group storage is not available`() {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -371,7 +371,7 @@ struct DeviceIdentityStoreTests {
     }
 
     @Test
-    func `migrates an existing app group identity when falling back to legacy storage`() throws {
+    func `migrates an existing app group identity and auth store when falling back to legacy storage`() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: tempDir) }
@@ -379,10 +379,16 @@ struct DeviceIdentityStoreTests {
         let appGroupIdentityURL = appGroupURL
             .appendingPathComponent("identity", isDirectory: true)
             .appendingPathComponent("device.json", isDirectory: false)
+        let appGroupAuthURL = appGroupIdentityURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("device-auth.json", isDirectory: false)
         let legacyIdentityURL = tempDir
             .appendingPathComponent("legacy", isDirectory: true)
             .appendingPathComponent("identity", isDirectory: true)
             .appendingPathComponent("device.json", isDirectory: false)
+        let legacyAuthURL = legacyIdentityURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("device-auth.json", isDirectory: false)
         try FileManager.default.createDirectory(
             at: appGroupIdentityURL.deletingLastPathComponent(),
             withIntermediateDirectories: true)
@@ -394,21 +400,68 @@ struct DeviceIdentityStoreTests {
                 label: "PRIVATE KEY",
                 body: "MC4CAQAwBQYDK2VwBCIEIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4f"))
         try stored.write(to: appGroupIdentityURL, atomically: true, encoding: .utf8)
+        let storedAuth = #"{"version":1,"deviceId":"app-group-device-id","tokens":{}}"#
+        try storedAuth.write(to: appGroupAuthURL, atomically: true, encoding: .utf8)
         let appGroupBefore = try String(contentsOf: appGroupIdentityURL, encoding: .utf8)
 
-        let migrationSource = DeviceIdentityPaths.appGroupMigrationSourceURL(
+        let migrationSource = DeviceIdentityPaths.appGroupMigrationSource(
             appGroupStateDirURL: appGroupURL,
             appGroupStateDirAvailable: false,
-            identityFileName: "device.json")
+            profile: .primary)
         let identity = DeviceIdentityStore.loadOrCreate(
             fileURL: legacyIdentityURL,
-            migrationSourceURL: migrationSource)
+            migrationSource: migrationSource)
 
         #expect(identity.deviceId == "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c")
         #expect(FileManager.default.fileExists(atPath: legacyIdentityURL.path))
         let reloaded = DeviceIdentityStore.loadOrCreate(fileURL: legacyIdentityURL)
         #expect(reloaded.deviceId == identity.deviceId)
         #expect(try String(contentsOf: appGroupIdentityURL, encoding: .utf8) == appGroupBefore)
+        #expect(try String(contentsOf: legacyAuthURL, encoding: .utf8) == storedAuth)
+        #expect(try String(contentsOf: appGroupAuthURL, encoding: .utf8) == storedAuth)
+    }
+
+    @Test
+    func `does not clobber an existing auth store when migrating an app group identity`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let appGroupIdentityDirURL = tempDir
+            .appendingPathComponent("shared", isDirectory: true)
+            .appendingPathComponent("identity", isDirectory: true)
+        let legacyIdentityDirURL = tempDir
+            .appendingPathComponent("legacy", isDirectory: true)
+            .appendingPathComponent("identity", isDirectory: true)
+        try FileManager.default.createDirectory(at: appGroupIdentityDirURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyIdentityDirURL, withIntermediateDirectories: true)
+        let stored = try Self.identityJSON(
+            publicKeyPem: Self.pem(
+                label: "PUBLIC KEY",
+                body: "MCowBQYDK2VwAyEAA6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg="),
+            privateKeyPem: Self.pem(
+                label: "PRIVATE KEY",
+                body: "MC4CAQAwBQYDK2VwBCIEIAABAgMEBQYHCAkKCwwNDg8QERITFBUWFxgZGhscHR4f"))
+        try stored.write(
+            to: appGroupIdentityDirURL.appendingPathComponent("device.json", isDirectory: false),
+            atomically: true,
+            encoding: .utf8)
+        try #"{"version":1,"deviceId":"app-group-device-id","tokens":{}}"#.write(
+            to: appGroupIdentityDirURL.appendingPathComponent("device-auth.json", isDirectory: false),
+            atomically: true,
+            encoding: .utf8)
+        let legacyAuthURL = legacyIdentityDirURL.appendingPathComponent("device-auth.json", isDirectory: false)
+        let existingLegacyAuth = #"{"version":1,"deviceId":"legacy-device-id","tokens":{}}"#
+        try existingLegacyAuth.write(to: legacyAuthURL, atomically: true, encoding: .utf8)
+
+        let identity = DeviceIdentityStore.loadOrCreate(
+            fileURL: legacyIdentityDirURL.appendingPathComponent("device.json", isDirectory: false),
+            migrationSource: DeviceIdentityPaths.appGroupMigrationSource(
+                appGroupStateDirURL: tempDir.appendingPathComponent("shared", isDirectory: true),
+                appGroupStateDirAvailable: false,
+                profile: .primary))
+
+        #expect(identity.deviceId == "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c")
+        #expect(try String(contentsOf: legacyAuthURL, encoding: .utf8) == existingLegacyAuth)
     }
 
     @Test
@@ -437,13 +490,13 @@ struct DeviceIdentityStoreTests {
         try stored.write(to: appGroupIdentityURL, atomically: true, encoding: .utf8)
 
         let existingLegacy = DeviceIdentityStore.loadOrCreate(fileURL: legacyIdentityURL)
-        let migrationSource = DeviceIdentityPaths.appGroupMigrationSourceURL(
+        let migrationSource = DeviceIdentityPaths.appGroupMigrationSource(
             appGroupStateDirURL: appGroupURL,
             appGroupStateDirAvailable: false,
-            identityFileName: "device.json")
+            profile: .primary)
         let identity = DeviceIdentityStore.loadOrCreate(
             fileURL: legacyIdentityURL,
-            migrationSourceURL: migrationSource)
+            migrationSource: migrationSource)
 
         #expect(identity.deviceId == existingLegacy.deviceId)
         #expect(identity.deviceId != "56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c")
@@ -453,10 +506,10 @@ struct DeviceIdentityStoreTests {
     func `provides no app group migration source when the entitlement is present`() {
         let appGroupURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        #expect(DeviceIdentityPaths.appGroupMigrationSourceURL(
+        #expect(DeviceIdentityPaths.appGroupMigrationSource(
             appGroupStateDirURL: appGroupURL,
             appGroupStateDirAvailable: true,
-            identityFileName: "device.json") == nil)
+            profile: .primary) == nil)
     }
 
     private static func base64UrlDecode(_ value: String) -> Data? {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/DeviceIdentityStoreTests.swift
@@ -196,6 +196,24 @@ struct DeviceIdentityStoreTests {
         #expect(!FileManager.default.fileExists(atPath: sharedDeviceURL.path))
     }
 
+    @Test
+    func `legacy app support storage wins when app group storage is not available`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let legacyURL = tempDir.appendingPathComponent("legacy", isDirectory: true)
+        let sharedURL = tempDir.appendingPathComponent("shared", isDirectory: true)
+
+        let selected = DeviceIdentityPaths.stateDirURL(
+            overrideURL: nil,
+            legacyStateDirURL: legacyURL,
+            appGroupStateDirURL: sharedURL,
+            appGroupStateDirAvailable: false,
+            temporaryDirectory: tempDir)
+
+        #expect(selected == legacyURL)
+    }
+
     @Test(.stateDirectoryIsolated)
     func `secondary profiles use separate identity and auth files`() throws {
         let tempDir = FileManager.default.temporaryDirectory
@@ -323,6 +341,32 @@ struct DeviceIdentityStoreTests {
         let identity = DeviceIdentityStore.loadOrCreate(fileURL: identityURL)
 
         #expect(identity.deviceId != "stale-device-id")
+        #expect(try String(contentsOf: identityURL, encoding: .utf8) == before)
+    }
+
+    @Test
+    func `does not overwrite an existing unrecognized identity file`() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let identityURL = tempDir
+            .appendingPathComponent("identity", isDirectory: true)
+            .appendingPathComponent("device.json", isDirectory: false)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try FileManager.default.createDirectory(
+            at: identityURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        let stored = """
+        {
+          "schema": "future-openclaw-device-identity",
+          "stableDeviceId": "app-group-device-id"
+        }
+        """
+        try stored.write(to: identityURL, atomically: true, encoding: .utf8)
+        let before = try String(contentsOf: identityURL, encoding: .utf8)
+
+        let identity = DeviceIdentityStore.loadOrCreate(fileURL: identityURL)
+
+        #expect(identity.deviceId != "app-group-device-id")
         #expect(try String(contentsOf: identityURL, encoding: .utf8) == before)
     }
 

--- a/src/infra/device-identity.state-dir.test.ts
+++ b/src/infra/device-identity.state-dir.test.ts
@@ -51,24 +51,26 @@ describe("device identity state dir defaults", () => {
     });
   });
 
-  it("regenerates the identity when the stored file is invalid", async () => {
+  it("returns a transient identity without overwriting an invalid stored file", async () => {
     await withStateDirEnv("openclaw-identity-state-", async ({ stateDir }) => {
       const identityPath = path.join(stateDir, "identity", "device.json");
       await fs.mkdir(path.dirname(identityPath), { recursive: true });
-      await fs.writeFile(identityPath, '{"version":1,"deviceId":"broken"}\n', "utf8");
+      const before = [
+        "{",
+        '  "version": 1,',
+        '  "deviceId": "broken",',
+        '  "publicKeyPem": "not-a-valid-public-key",',
+        '  "privateKeyPem": "not-a-valid-private-key"',
+        "}",
+        "",
+      ].join("\n");
+      await fs.writeFile(identityPath, before, "utf8");
 
       const regenerated = loadOrCreateDeviceIdentity();
-      const stored = JSON.parse(await fs.readFile(identityPath, "utf8")) as {
-        version?: number;
-        deviceId?: string;
-        publicKeyPem?: string;
-        privateKeyPem?: string;
-      };
+      const stored = await fs.readFile(identityPath, "utf8");
 
-      expect(stored.version).toBe(1);
-      expect(stored.deviceId).toBe(regenerated.deviceId);
-      expect(stored.publicKeyPem).toBe(regenerated.publicKeyPem);
-      expect(stored.privateKeyPem).toBe(regenerated.privateKeyPem);
+      expect(regenerated.deviceId).not.toBe("broken");
+      expect(stored).toBe(before);
     });
   });
 });

--- a/src/infra/device-identity.test.ts
+++ b/src/infra/device-identity.test.ts
@@ -141,6 +141,32 @@ describe("device identity crypto helpers", () => {
     });
   });
 
+  it("does not overwrite existing unrecognized identity files", async () => {
+    await withTempDir("openclaw-device-identity-unrecognized-", async (dir) => {
+      const identityPath = path.join(dir, "identity", "device.json");
+      fs.mkdirSync(path.dirname(identityPath), { recursive: true });
+      fs.writeFileSync(
+        identityPath,
+        `${JSON.stringify(
+          {
+            schema: "future-openclaw-device-identity",
+            stableDeviceId: "app-group-device-id",
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      const before = fs.readFileSync(identityPath, "utf8");
+
+      expect(loadDeviceIdentityIfPresent(identityPath)).toBeNull();
+      const loaded = loadOrCreateDeviceIdentity(identityPath);
+
+      expect(loaded.deviceId).not.toBe("app-group-device-id");
+      expect(fs.readFileSync(identityPath, "utf8")).toBe(before);
+    });
+  });
+
   it("does not migrate Swift raw-key identity files with mismatched key material", async () => {
     await withTempDir("openclaw-device-identity-swift-invalid-", async (dir) => {
       const identityPath = path.join(dir, "identity", "device.json");

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -245,6 +245,7 @@ export function loadOrCreateDeviceIdentity(
       return generateIdentity();
     }
     if (identityFileExists(filePath)) {
+      // Unrecognized existing files may hold a newer schema; never overwrite them either.
       return generateIdentity();
     }
   } catch {

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -244,6 +244,9 @@ export function loadOrCreateDeviceIdentity(
       // Avoid overwriting recognizable but invalid identity files; callers can still use a fresh key.
       return generateIdentity();
     }
+    if (identityFileExists(filePath)) {
+      return generateIdentity();
+    }
   } catch {
     if (identityFileExists(filePath)) {
       return generateIdentity();


### PR DESCRIPTION
## Summary
The macOS identity store no longer chooses App Group storage unless the running bundle has the matching `com.apple.security.application-groups` entitlement. Unentitled macOS app builds fall back to the legacy Application Support identity directory instead of repeatedly using an App Group path they cannot reliably persist.

To keep that fallback upgrade-safe, an unentitled build now migrates a readable existing App Group `identity/device.json` into the selected legacy store before generating a fresh identity. The same installation keeps its device id across the storage switch instead of presenting a new one.

Existing unrecognized `identity/device.json` files are also preserved in both the Swift and TypeScript loaders. The loader can still return a fresh in-memory identity when it cannot decode the file, but it no longer replaces existing identity bytes unless it is creating a missing file or performing a proven safe normalization.

## Root cause
`apps/shared/OpenClawKit/Sources/OpenClawKit/DeviceIdentity.swift` selected App Group storage whenever `FileManager.containerURL(forSecurityApplicationGroupIdentifier:)` returned a URL:

```before
if let appGroupStateDirURL {
    return appGroupStateDirURL
}
```

On affected shipped macOS builds, that could select the App Group container even though the bundle did not carry the matching App Groups entitlement. When persistence at that path failed, `loadOrCreate` returned generated identities, leading to pairing churn.

The Swift and TypeScript `loadOrCreate` implementations also treated an existing but unrecognized identity file like a missing file:

```before
case .unknown:
    break
```

That path generated and saved a new identity over existing bytes.

## Fix
Swift now checks the running bundle entitlement before selecting App Group identity storage:

```after
if appGroupStateDirAvailable, let appGroupStateDirURL {
    return appGroupStateDirURL
}
```

When the entitlement is absent, the existing legacy Application Support fallback wins. To make that switch upgrade-safe, an unentitled build first tries to migrate a readable App Group identity into the legacy store:

```after
if let migrated = self.migratedIdentity(from: migrationSourceURL, to: url) {
    return migrated
}
```

`migrationSourceURL` is the App Group `identity/<file>` and is non-nil only when the entitlement is absent and the App Group container resolves. Migration reads and re-saves an already-valid identity, so the same device id survives while future writes go to the store the build can actually persist. Both loaders still preserve existing unrecognized identity files and only persist a generated identity when the file is missing.

## Why this is the right boundary
The storage decision belongs in `DeviceIdentityPaths`, because every Swift caller reaches identity storage through that path resolver. The no-overwrite guard and the one-time migration belong in the identity loaders, because Swift and TypeScript both own `identity/device.json` and must preserve existing state consistently. OpenClawKit has no `openclaw doctor --fix` surface, so the bounded migration at the load boundary is the owner for this preservation.

This resolves the ClawSweeper P1 (`DeviceIdentity.swift`: preserve existing App Group identities before falling back) by implementing the recommended maintainer option: preserve/migrate a valid readable App Group identity into the chosen legacy store before an unentitled build switches to legacy storage. It does not accept a one-time re-pair and does not require provisioning the app with App Groups.

The TypeScript node loader has no App Group container (`resolveStateDir` in `src/config/paths.ts` never selects one), so this migration is macOS-only; the TypeScript side keeps only the no-overwrite guard.

## Verification
- `swift test --filter DeviceIdentityStoreTests` builds `OpenClawKit` and passes all 13 cases (10 existing plus 3 new: migrate-on-fallback, keep-existing-legacy, no-source-when-entitled) on Apple Swift 6.3.2 / arm64 macOS.
- `git diff --check` passed.
- New Swift regression fails on pristine `54f0b2589b11` (pre-migration head) and passes with this patch.
- The App Group container path requires a provisioned signed macOS bundle, so the migration driver injects the App Group directory; the entitlement/container system APIs themselves are not exercisable from an unsigned local build.

## Real behavior proof
Behavior addressed: An unentitled macOS build that already held a readable App Group `identity/device.json` presented a new device id after upgrading, because the entitlement-aware fallback read empty legacy storage and minted a fresh identity.
Real environment tested: The production `DeviceIdentityStore.loadOrCreate` and `DeviceIdentityPaths.appGroupMigrationSourceURL` were driven on a real on-disk App Group + legacy layout on the pre-migration head `54f0b2589b11` behavior (single-argument loader, unchanged by this patch) and on PR head `eab93b9f6b7a3e1569107b9d28ae27106d940886`, on Apple Swift 6.3.2 arm64 macOS. Only the App Group container location was injected; the loader, decoder, save, and migration selection are the production functions.
Exact steps or command run after this patch: Wrote a valid existing `identity/device.json` under the App Group directory, then invoked the production loader for an unentitled build with empty legacy storage: the pre-fix path via `DeviceIdentityStore.loadOrCreate(fileURL:)` and the fixed path via `DeviceIdentityStore.loadOrCreate(fileURL:migrationSourceURL:)`, and read back the returned device id and files. Driven under `swift test --filter AppGroupMigrationProofScratch`, capturing the returned device id values to disk.
Evidence after fix:
```
existingAppGroupDeviceId=56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c
# BEFORE: unentitled build falls back to empty legacy storage (pre-fix path)
before.returnedDeviceId=92bed52befa0e1ea4975a47d7fef066c50d103d9ff0992f8b45b7bb83bfee63a
before.matchesExistingAppGroupIdentity=no
before.mintedNewLegacyFile=yes
# AFTER: unentitled build migrates the readable app group identity into legacy
after.returnedDeviceId=56475aa75463474c0285df5dbf2bcab73da651358839e9b77481b2eab107708c
after.matchesExistingAppGroupIdentity=yes
after.survivesLegacyReload=yes
after.appGroupFileUnchanged=yes
```
Observed result after fix: On identical inputs the pre-fix path returns a new device id and writes a fresh legacy file, while the fixed path returns the same device id the install already had, keeps it across a reload, and leaves the App Group file byte-for-byte unchanged.
What was not tested: The full OpenClaw.app relaunch and gateway restart lifecycle was not run here (that needs the built signed app plus a running gateway); the entitlement read and container resolution themselves are now exercised on a real code-signed binary in the section below. No full `pnpm build` was run because the change is Swift-only.

### Signed macOS entitlement proof (real code signature)
The production entitlement gate (`DeviceIdentityPaths.hasAppGroupEntitlement`, i.e. `SecTaskCreateFromSelf` + `SecTaskCopyValueForEntitlement`) was compiled into a Mach-O binary and ad-hoc code-signed twice with `codesign --sign - --entitlements`: once carrying `com.apple.security.application-groups = [group.ai.openclawfoundation.app.shared]` and once with an empty entitlements dict. `SecTaskCopyValueForEntitlement` reads the running binary's own embedded entitlements, so the real signature drives the result. `FileManager.containerURL(forSecurityApplicationGroupIdentifier:)` was also called live.

Embedded entitlements read back from each signature (`codesign -d --entitlements`):
```
entitled binary   -> com.apple.security.application-groups = [group.ai.openclawfoundation.app.shared]
unentitled binary -> {}  (no application-groups)
```

Live output from the signed binaries:
```
# unentitled build (signed without the entitlement)
hasAppGroupEntitlement=no
appGroupContainerResolved=yes
resolverWouldSelect=legacy
migrationSourceActive=yes
# entitled build (signed with the entitlement)
hasAppGroupEntitlement=yes
appGroupContainerResolved=yes
resolverWouldSelect=appGroup
migrationSourceActive=no
```

On a real signature the entitlement read flips as expected: an unentitled build resolves to legacy storage with the App Group migration source active, and an entitled build keeps App Group storage. The App Group container resolves on macOS, so the migration source is reachable for a real unentitled build, not only under an injected flag. Combined with the loader proof above, the full chain is covered end to end except the OpenClaw.app UI relaunch and gateway restart.

## Related
Fixes #99283.
Related to #99522.
Distinct from #79715, which fixed Swift and TypeScript schema compatibility but did not make App Group selection entitlement-aware.
