### PR TITLE
fix(msteams): bound Bot Framework User Token JSON response read

### DIFF
--- a/extensions/msteams/src/monitor-handler.sso.test.ts
+++ b/extensions/msteams/src/monitor-handler.sso.test.ts
@@ -116,6 +116,44 @@ describe("handleSigninTokenExchangeInvoke", () => {
     expect(stored?.expiresAt).toBe("2030-01-01T00:00:00Z");
   });
 
+  it("returns a service error when the User Token response exceeds the byte cap", async () => {
+    const hugeBody = JSON.stringify({
+      channelId: "msteams",
+      connectionName: "GraphConnection",
+      token: "delegated-graph-token",
+      expiration: "2030-01-01T00:00:00Z",
+      padding: "x".repeat(128 * 1024),
+    });
+    const fetchImpl: MSTeamsSsoFetch = async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(hugeBody));
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    const { sso, tokenStore } = createSsoDeps({ fetchImpl });
+
+    const result = await handleSigninTokenExchangeInvoke({
+      value: { id: "flow-1", connectionName: "GraphConnection", token: "exchangeable-token" },
+      user: { userId: "aad-user-guid", channelId: "msteams" },
+      deps: sso,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("unexpected_response");
+      expect(result.message).toMatch(/invalid JSON/i);
+    }
+    const stored = await tokenStore.get({
+      connectionName: "GraphConnection",
+      userId: "aad-user-guid",
+    });
+    expect(stored).toBeNull();
+  });
+
   it("returns a service error when the User Token service rejects the exchange", async () => {
     const { fetchImpl } = createFakeFetch([
       () => ({ ok: false, status: 502, body: "bad gateway" }),

--- a/extensions/msteams/src/sso.ts
+++ b/extensions/msteams/src/sso.ts
@@ -24,6 +24,7 @@
  * that ack; these helpers encapsulate token exchange and persistence.
  */
 
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import { readMSTeamsHttpErrorDetail } from "./http-error.js";
 import type { MSTeamsSsoTokenStore } from "./sso-token-store.js";
@@ -34,6 +35,9 @@ const BOT_FRAMEWORK_TOKEN_SCOPE = "https://api.botframework.com/.default";
 
 /** Bot Framework User Token service base URL. */
 const BOT_FRAMEWORK_USER_TOKEN_BASE_URL = "https://token.botframework.com";
+
+/** Max bytes to read from the User Token service JSON response. */
+const USER_TOKEN_RESPONSE_MAX_BYTES = 64 * 1024;
 
 /**
  * Response shape returned by the Bot Framework User Token service for
@@ -130,7 +134,9 @@ async function callUserTokenService(
   }
   let parsed: unknown;
   try {
-    parsed = await response.json();
+    parsed = await readProviderJsonResponse<unknown>(response, "Bot Framework User Token service", {
+      maxBytes: USER_TOKEN_RESPONSE_MAX_BYTES,
+    });
   } catch {
     return { error: "invalid JSON from User Token service", status: response.status };
   }

--- a/scripts/proof/msteams-sso-json-bound.mts
+++ b/scripts/proof/msteams-sso-json-bound.mts
@@ -1,0 +1,69 @@
+// Real behavior proof: MSTeams SSO token exchange bounds the User Token
+// service JSON response so an oversized body cannot OOM the runtime.
+//
+// The proof runs a local HTTP server that returns a User Token response
+// larger than the 64 KiB cap. With the fix the handler rejects with an
+// "invalid JSON" service error; without the bound the runtime would buffer
+// the entire oversized body before parsing.
+
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { handleSigninTokenExchangeInvoke } from "../../extensions/msteams/src/sso.js";
+
+const hugeBody = JSON.stringify({
+  channelId: "msteams",
+  connectionName: "GraphConnection",
+  token: "delegated-graph-token",
+  expiration: "2030-01-01T00:00:00Z",
+  padding: "x".repeat(128 * 1024),
+});
+
+const server = createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(hugeBody);
+});
+
+await new Promise<void>((resolve, reject) => {
+  server.listen(0, "127.0.0.1", () => {
+    resolve();
+  });
+  server.on("error", reject);
+});
+const { port } = server.address() as AddressInfo;
+
+console.log("=== Proof: MSTeams SSO JSON response bound ===\n");
+
+try {
+  const result = await handleSigninTokenExchangeInvoke({
+    value: { id: "flow-1", connectionName: "GraphConnection", token: "exchangeable-token" },
+    user: { userId: "aad-user-guid", channelId: "msteams" },
+    deps: {
+      userTokenBaseUrl: `http://127.0.0.1:${port}`,
+      connectionName: "GraphConnection",
+      tokenProvider: {
+        getAccessToken: async () => "bf-service-token",
+      },
+      tokenStore: {
+        async get() {
+          return null;
+        },
+        async save() {},
+        async remove() {
+          return true;
+        },
+      },
+    },
+  });
+
+  if (!result.ok && result.code === "unexpected_response" && /invalid JSON/i.test(result.message)) {
+    console.log("PASS: oversized User Token JSON response was rejected without OOM.");
+  } else {
+    console.log("FAIL: unexpected result:", result);
+    process.exitCode = 1;
+  }
+} catch (err) {
+  console.error("FAIL: handler threw:", err);
+  process.exitCode = 1;
+} finally {
+  server.close();
+}


### PR DESCRIPTION
## What Problem This Solves

`callUserTokenService` in the MSTeams SSO handler called `response.json()` directly on the Bot Framework User Token service response. An oversized or malicious JSON body could be buffered without limit, leading to OOM during token exchange.

## Why This Change Was Made

Replace the bare `response.json()` with `readProviderJsonResponse` capped at 64 KiB. The existing catch path already returns `{ error: "invalid JSON from User Token service", status: response.status }`, so the handler now treats an oversized body as an invalid response instead of crashing.

## User Impact

Teams SSO token exchanges are resilient to unexpectedly large User Token service responses.

## Evidence

- Added regression test in `extensions/msteams/src/monitor-handler.sso.test.ts` asserting the handler returns an `unexpected_response` error when the JSON body exceeds the cap.
- Added real behavior proof at `scripts/proof/msteams-sso-json-bound.mts` that serves an oversized User Token JSON response from a local HTTP server and verifies the handler rejects cleanly.
- Local run:
  - `pnpm test extensions/msteams/src/monitor-handler.sso.test.ts` passed
  - `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs extensions/msteams/src/sso.ts extensions/msteams/src/monitor-handler.sso.test.ts scripts/proof/msteams-sso-json-bound.mts` passed
  - `node --import tsx scripts/proof/msteams-sso-json-bound.mts`:

```
=== Proof: MSTeams SSO JSON response bound ===

PASS: oversized User Token JSON response was rejected without OOM.
```
