### PR TITLE
fix(msteams): bound Bot Framework attachmentInfo JSON response read

### DIFF
--- a/extensions/msteams/src/attachments/bot-framework.test.ts
+++ b/extensions/msteams/src/attachments/bot-framework.test.ts
@@ -514,6 +514,49 @@ describe("downloadMSTeamsBotFrameworkAttachment", () => {
         { status: 500 },
       ]);
     });
+
+    it("logs a warning when the attachmentInfo JSON response exceeds the byte cap", async () => {
+      const warn = vi.fn();
+      const hugeBody = JSON.stringify({
+        name: "doc.pdf",
+        type: "application/pdf",
+        views: [{ viewId: "original", size: 10 }],
+        padding: "x".repeat(128 * 1024),
+      });
+      const fetchFn: typeof fetch = (async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+        if (url.endsWith("/v3/attachments/att-1")) {
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                controller.enqueue(new TextEncoder().encode(hugeBody));
+                controller.close();
+              },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response("not found", { status: 404 });
+      }) as typeof fetch;
+
+      const media = await downloadMSTeamsBotFrameworkAttachment({
+        serviceUrl: "https://smba.trafficmanager.net/amer",
+        attachmentId: "att-1",
+        tokenProvider: buildTokenProvider(),
+        maxBytes: 10_000_000,
+        fetchFn,
+        fetchFnSupportsDispatcher: true,
+        resolveFn: resolvePublicHost,
+        logger: { warn },
+      });
+
+      expect(media).toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(firstMockCall(warn, "logger.warn")[0]).toBe(
+        "msteams botFramework attachmentInfo parse failed",
+      );
+    });
   });
 });
 

--- a/extensions/msteams/src/attachments/bot-framework.ts
+++ b/extensions/msteams/src/attachments/bot-framework.ts
@@ -1,5 +1,6 @@
 // Msteams plugin module implements bot framework behavior.
 import { parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { getMSTeamsRuntime } from "../runtime.js";
 import { ensureUserAgentHeader } from "../user-agent.js";
 import {
@@ -23,6 +24,9 @@ import type {
  * the Bot Connector (v3) REST endpoints such as `/v3/attachments/{id}`.
  */
 const BOT_FRAMEWORK_SCOPE = "https://api.botframework.com";
+
+/** Max bytes to read from the Bot Framework attachmentInfo JSON response. */
+const ATTACHMENT_INFO_RESPONSE_MAX_BYTES = 64 * 1024;
 
 /**
  * Detect Bot Framework personal chat ("a:") and MSA orgid ("8:orgid:") conversation
@@ -112,7 +116,11 @@ async function fetchBotFrameworkAttachmentInfo(params: {
     return undefined;
   }
   try {
-    return (await response.json()) as BotFrameworkAttachmentInfo;
+    return await readProviderJsonResponse<BotFrameworkAttachmentInfo>(
+      response,
+      "Bot Framework attachmentInfo",
+      { maxBytes: ATTACHMENT_INFO_RESPONSE_MAX_BYTES },
+    );
   } catch (err) {
     params.logger?.warn?.("msteams botFramework attachmentInfo parse failed", {
       error: err instanceof Error ? err.message : String(err),

--- a/scripts/proof/msteams-bot-framework-json-bound.mts
+++ b/scripts/proof/msteams-bot-framework-json-bound.mts
@@ -1,0 +1,77 @@
+// Real behavior proof: MSTeams Bot Framework attachmentInfo fetch bounds
+// the JSON response so an oversized body cannot OOM the runtime.
+//
+// The proof installs the MSTeams runtime, then calls
+// `downloadMSTeamsBotFrameworkAttachment` with a `fetchFn` that returns an
+// attachmentInfo response larger than the 64 KiB cap. With the fix the
+// function returns undefined and logs a parse warning; without the bound the
+// runtime would buffer the entire oversized body before parsing.
+
+import { setMSTeamsRuntime } from "../../extensions/msteams/src/runtime.js";
+import { downloadMSTeamsBotFrameworkAttachment } from "../../extensions/msteams/src/attachments/bot-framework.js";
+
+const hugeBody = JSON.stringify({
+  name: "doc.pdf",
+  type: "application/pdf",
+  views: [{ viewId: "original", size: 10 }],
+  padding: "x".repeat(128 * 1024),
+});
+
+setMSTeamsRuntime({
+  media: {
+    detectMime: async ({ headerMime }: { headerMime?: string }) => headerMime ?? "application/pdf",
+  },
+  channel: {
+    media: {
+      saveMediaBuffer: async () => ({ path: "/tmp/bf-attachment.bin", contentType: "application/pdf" }),
+      readRemoteMediaBuffer: async () => ({ buffer: Buffer.alloc(0), contentType: undefined }),
+      saveRemoteMedia: async () => ({ path: "/tmp/bf-attachment.bin", contentType: "application/pdf" }),
+      saveResponseMedia: async () => ({
+        path: "/tmp/bf-attachment.bin",
+        contentType: "application/pdf",
+      }),
+    },
+  },
+} as never);
+
+console.log("=== Proof: MSTeams Bot Framework attachmentInfo JSON bound ===\n");
+
+const warnings: string[] = [];
+
+try {
+  const media = await downloadMSTeamsBotFrameworkAttachment({
+    serviceUrl: "https://smba.trafficmanager.net/amer",
+    attachmentId: "att-1",
+    tokenProvider: {
+      getAccessToken: async () => "bf-token",
+    },
+    maxBytes: 10_000_000,
+    fetchFn: async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(hugeBody));
+            controller.close();
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    fetchFnSupportsDispatcher: true,
+    resolveFn: async () => ({ address: "93.184.216.34" }),
+    logger: {
+      warn: (msg: string) => {
+        warnings.push(msg);
+      },
+    },
+  });
+
+  if (media === undefined && warnings.includes("msteams botFramework attachmentInfo parse failed")) {
+    console.log("PASS: oversized attachmentInfo JSON response was rejected without OOM.");
+  } else {
+    console.log("FAIL: unexpected result:", { media, warnings });
+    process.exitCode = 1;
+  }
+} catch (err) {
+  console.error("FAIL: handler threw:", err);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## What Problem This Solves

`fetchBotFrameworkAttachmentInfo` in the MSTeams attachment downloader called `response.json()` directly on the Bot Framework `/v3/attachments/{id}` endpoint. An oversized or malicious JSON body could be buffered without limit, leading to OOM while resolving Teams message attachments.

## Why This Change Was Made

Replace the bare `response.json()` with `readProviderJsonResponse` capped at 64 KiB. The existing catch path already logs a parse warning and returns undefined, so an oversized body is now treated as an unparseable response instead of crashing.

## User Impact

Teams Bot Framework attachment resolution is resilient to unexpectedly large attachmentInfo responses.

## Evidence

- Added regression test in `extensions/msteams/src/attachments/bot-framework.test.ts` asserting the downloader logs a parse warning and returns undefined when the JSON body exceeds the cap.
- Added real behavior proof at `scripts/proof/msteams-bot-framework-json-bound.mts` that feeds an oversized attachmentInfo JSON response through the downloader and verifies it rejects cleanly.
- Local run:
  - `pnpm test extensions/msteams/src/attachments/bot-framework.test.ts` passed
  - `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs extensions/msteams/src/attachments/bot-framework.ts extensions/msteams/src/attachments/bot-framework.test.ts scripts/proof/msteams-bot-framework-json-bound.mts` passed
  - `node --import tsx scripts/proof/msteams-bot-framework-json-bound.mts`:

```
=== Proof: MSTeams Bot Framework attachmentInfo JSON bound ===

PASS: oversized attachmentInfo JSON response was rejected without OOM.
```
