### PR TITLE
fix: pace delivery recovery after startup outages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
+- **Delivery recovery pacing:** pace eligible outbound and restart-continuation replays after gateway startup so outage backlogs do not burst into channel rate limits, while preserving the wall-clock recovery budget. (#101118, #101058) Thanks @ZengWen-DT.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.
 - **LM Studio embedding preload:** honor model- and provider-level context-window limits when preloading embedding models, preventing avoidable GPU out-of-memory failures. (#100750) Thanks @zak-li, @ZOOWH, and @hxz398.

--- a/src/infra/delivery-recovery.shared.ts
+++ b/src/infra/delivery-recovery.shared.ts
@@ -32,20 +32,43 @@ export function releaseRecoveryEntry(entriesInProgress: Set<string>, entryId: st
   entriesInProgress.delete(entryId);
 }
 
-// Startup recovery can find many already-eligible entries after an outage.
-// Pace only between real replay attempts and keep the wait inside the existing
-// wall-clock budget so a large backlog cannot prolong startup work indefinitely.
-export async function waitForRecoveryReplayPace(params: {
-  hasAttemptedReplay: boolean;
-  deadlineMs: number;
-}): Promise<"ready" | "deadline-exceeded"> {
-  if (!params.hasAttemptedReplay) {
-    return "ready";
-  }
-  if (Date.now() >= params.deadlineMs) {
-    return "deadline-exceeded";
-  }
-  const remainingBudgetMs = Math.max(0, params.deadlineMs - Date.now());
-  await sleep(Math.min(RECOVERY_REPLAY_SPACING_MS, remainingBudgetMs));
-  return Date.now() >= params.deadlineMs ? "deadline-exceeded" : "ready";
+export function createRecoveryReplayPacer(): {
+  wait(deadlineMs?: number): Promise<"ready" | "deadline-exceeded">;
+} {
+  let lastReplayStartedAt = 0;
+  let waitQueue = Promise.resolve();
+
+  return {
+    async wait(deadlineMs) {
+      let releaseWaiter: () => void = () => {};
+      const previousWaiter = waitQueue;
+      waitQueue = new Promise<void>((resolve) => {
+        releaseWaiter = resolve;
+      });
+      await previousWaiter;
+
+      try {
+        const now = Date.now();
+        if (deadlineMs !== undefined && now >= deadlineMs) {
+          return "deadline-exceeded";
+        }
+        // Clock rollback starts a fresh pacing epoch. Otherwise concurrent startup
+        // and reconnect drains serialize here so neither can bypass the spacing floor.
+        const elapsedMs = now - lastReplayStartedAt;
+        const waitMs = elapsedMs < 0 ? 0 : Math.max(0, RECOVERY_REPLAY_SPACING_MS - elapsedMs);
+        if (waitMs > 0) {
+          const remainingBudgetMs =
+            deadlineMs === undefined ? waitMs : Math.max(0, deadlineMs - now);
+          await sleep(Math.min(waitMs, remainingBudgetMs));
+        }
+        if (deadlineMs !== undefined && Date.now() >= deadlineMs) {
+          return "deadline-exceeded";
+        }
+        lastReplayStartedAt = Date.now();
+        return "ready";
+      } finally {
+        releaseWaiter();
+      }
+    },
+  };
 }

--- a/src/infra/delivery-recovery.shared.ts
+++ b/src/infra/delivery-recovery.shared.ts
@@ -37,18 +37,20 @@ export function releaseRecoveryEntry(entriesInProgress: Set<string>, entryId: st
 }
 
 // Startup recovery can find many already-eligible entries after an outage.
-// Pace only between real replay attempts; backoff/max-retry skips must not spend this budget.
+// Pace only between real replay attempts; the pacing sleep itself must not consume
+// the recovery budget and strand an otherwise eligible backlog tail.
 export async function waitForRecoveryReplayPace(params: {
   attemptedReplayCount: number;
   deadlineMs: number;
-}): Promise<"ready" | "deadline-exceeded"> {
+  pacedDelayMs: number;
+}): Promise<{ status: "ready"; sleptMs: number } | { status: "deadline-exceeded" }> {
   if (params.attemptedReplayCount <= 0) {
-    return "ready";
+    return { status: "ready", sleptMs: 0 };
   }
-  const remainingMs = params.deadlineMs - Date.now();
-  if (remainingMs <= 0) {
-    return "deadline-exceeded";
+  if (Date.now() >= params.deadlineMs + params.pacedDelayMs) {
+    return { status: "deadline-exceeded" };
   }
-  await sleep(Math.min(RECOVERY_REPLAY_SPACING_MS, remainingMs));
-  return Date.now() >= params.deadlineMs ? "deadline-exceeded" : "ready";
+  const sleepStartedAt = Date.now();
+  await sleep(RECOVERY_REPLAY_SPACING_MS);
+  return { status: "ready", sleptMs: Math.max(0, Date.now() - sleepStartedAt) };
 }

--- a/src/infra/delivery-recovery.shared.ts
+++ b/src/infra/delivery-recovery.shared.ts
@@ -1,4 +1,11 @@
 const RECOVERY_BACKOFF_MS: readonly number[] = [5_000, 25_000, 120_000, 600_000];
+export const RECOVERY_REPLAY_SPACING_MS = 250;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
 
 export function computeBackoffMs(retryCount: number): number {
   if (retryCount <= 0) {
@@ -27,4 +34,21 @@ export function claimRecoveryEntry(entriesInProgress: Set<string>, entryId: stri
 
 export function releaseRecoveryEntry(entriesInProgress: Set<string>, entryId: string): void {
   entriesInProgress.delete(entryId);
+}
+
+// Startup recovery can find many already-eligible entries after an outage.
+// Pace only between real replay attempts; backoff/max-retry skips must not spend this budget.
+export async function waitForRecoveryReplayPace(params: {
+  attemptedReplayCount: number;
+  deadlineMs: number;
+}): Promise<"ready" | "deadline-exceeded"> {
+  if (params.attemptedReplayCount <= 0) {
+    return "ready";
+  }
+  const remainingMs = params.deadlineMs - Date.now();
+  if (remainingMs <= 0) {
+    return "deadline-exceeded";
+  }
+  await sleep(Math.min(RECOVERY_REPLAY_SPACING_MS, remainingMs));
+  return Date.now() >= params.deadlineMs ? "deadline-exceeded" : "ready";
 }

--- a/src/infra/delivery-recovery.shared.ts
+++ b/src/infra/delivery-recovery.shared.ts
@@ -1,11 +1,7 @@
+import { sleep } from "../utils/sleep.js";
+
 const RECOVERY_BACKOFF_MS: readonly number[] = [5_000, 25_000, 120_000, 600_000];
 export const RECOVERY_REPLAY_SPACING_MS = 250;
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
 
 export function computeBackoffMs(retryCount: number): number {
   if (retryCount <= 0) {
@@ -37,20 +33,19 @@ export function releaseRecoveryEntry(entriesInProgress: Set<string>, entryId: st
 }
 
 // Startup recovery can find many already-eligible entries after an outage.
-// Pace only between real replay attempts; the pacing sleep itself must not consume
-// the recovery budget and strand an otherwise eligible backlog tail.
+// Pace only between real replay attempts and keep the wait inside the existing
+// wall-clock budget so a large backlog cannot prolong startup work indefinitely.
 export async function waitForRecoveryReplayPace(params: {
-  attemptedReplayCount: number;
+  hasAttemptedReplay: boolean;
   deadlineMs: number;
-  pacedDelayMs: number;
-}): Promise<{ status: "ready"; sleptMs: number } | { status: "deadline-exceeded" }> {
-  if (params.attemptedReplayCount <= 0) {
-    return { status: "ready", sleptMs: 0 };
+}): Promise<"ready" | "deadline-exceeded"> {
+  if (!params.hasAttemptedReplay) {
+    return "ready";
   }
-  if (Date.now() >= params.deadlineMs + params.pacedDelayMs) {
-    return { status: "deadline-exceeded" };
+  if (Date.now() >= params.deadlineMs) {
+    return "deadline-exceeded";
   }
-  const sleepStartedAt = Date.now();
-  await sleep(RECOVERY_REPLAY_SPACING_MS);
-  return { status: "ready", sleptMs: Math.max(0, Date.now() - sleepStartedAt) };
+  const remainingBudgetMs = Math.max(0, params.deadlineMs - Date.now());
+  await sleep(Math.min(RECOVERY_REPLAY_SPACING_MS, remainingBudgetMs));
+  return Date.now() >= params.deadlineMs ? "deadline-exceeded" : "ready";
 }

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -739,12 +739,11 @@ export async function recoverPendingDeliveries(opts: {
 
   const deadline = resolveRecoveryDeadlineMs(opts.maxRecoveryMs);
   const summary = createEmptyRecoverySummary();
-  let attemptedReplayCount = 0;
-  let pacedDelayMs = 0;
+  let hasAttemptedReplay = false;
 
   for (const entry of pending) {
     const now = Date.now();
-    if (now >= deadline + pacedDelayMs) {
+    if (now >= deadline) {
       opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next startup`);
       // Budget deferral is not a delivery attempt. Keep entries pending without
       // consuming retry budget; attempted failures still flow through failDelivery.
@@ -782,15 +781,13 @@ export async function recoverPendingDeliveries(opts: {
       }
 
       const paceResult = await waitForRecoveryReplayPace({
-        attemptedReplayCount,
+        hasAttemptedReplay,
         deadlineMs: deadline,
-        pacedDelayMs,
       });
-      if (paceResult.status === "deadline-exceeded") {
+      if (paceResult === "deadline-exceeded") {
         opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next startup`);
         break;
       }
-      pacedDelayMs += paceResult.sleptMs;
 
       const result = await drainQueuedEntry({
         entry: currentEntry,
@@ -813,7 +810,7 @@ export async function recoverPendingDeliveries(opts: {
           opts.log.warn(`Retry failed for delivery ${failedEntry.id}: ${errMsg}`);
         },
       });
-      attemptedReplayCount += 1;
+      hasAttemptedReplay = true;
       if (result === "moved-to-failed") {
         continue;
       }

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -12,9 +12,9 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   claimRecoveryEntry as claimSharedRecoveryEntry,
   computeBackoffMs,
+  createRecoveryReplayPacer,
   getErrnoCode,
   releaseRecoveryEntry as releaseSharedRecoveryEntry,
-  waitForRecoveryReplayPace,
 } from "../delivery-recovery.shared.js";
 import { formatErrorMessage } from "../errors.js";
 import { resolveOutboundChannelMessageAdapter } from "./channel-resolution.js";
@@ -94,6 +94,7 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
 
 const drainInProgress = new Map<string, boolean>();
 const entriesInProgress = new Set<string>();
+const recoveryReplayPacer = createRecoveryReplayPacer();
 
 function resolveRecoveryDeadlineMs(maxRecoveryMs: number | undefined): number {
   const durationMs =
@@ -687,6 +688,8 @@ export async function drainPendingDeliveries(opts: {
           }
         }
 
+        await recoveryReplayPacer.wait();
+
         const result = await drainQueuedEntry({
           entry: currentEntry,
           cfg: opts.cfg,
@@ -739,7 +742,6 @@ export async function recoverPendingDeliveries(opts: {
 
   const deadline = resolveRecoveryDeadlineMs(opts.maxRecoveryMs);
   const summary = createEmptyRecoverySummary();
-  let hasAttemptedReplay = false;
 
   for (const entry of pending) {
     const now = Date.now();
@@ -780,10 +782,7 @@ export async function recoverPendingDeliveries(opts: {
         continue;
       }
 
-      const paceResult = await waitForRecoveryReplayPace({
-        hasAttemptedReplay,
-        deadlineMs: deadline,
-      });
+      const paceResult = await recoveryReplayPacer.wait(deadline);
       if (paceResult === "deadline-exceeded") {
         opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next startup`);
         break;
@@ -810,7 +809,6 @@ export async function recoverPendingDeliveries(opts: {
           opts.log.warn(`Retry failed for delivery ${failedEntry.id}: ${errMsg}`);
         },
       });
-      hasAttemptedReplay = true;
       if (result === "moved-to-failed") {
         continue;
       }

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -740,10 +740,11 @@ export async function recoverPendingDeliveries(opts: {
   const deadline = resolveRecoveryDeadlineMs(opts.maxRecoveryMs);
   const summary = createEmptyRecoverySummary();
   let attemptedReplayCount = 0;
+  let pacedDelayMs = 0;
 
   for (const entry of pending) {
     const now = Date.now();
-    if (now >= deadline) {
+    if (now >= deadline + pacedDelayMs) {
       opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next startup`);
       // Budget deferral is not a delivery attempt. Keep entries pending without
       // consuming retry budget; attempted failures still flow through failDelivery.
@@ -783,11 +784,13 @@ export async function recoverPendingDeliveries(opts: {
       const paceResult = await waitForRecoveryReplayPace({
         attemptedReplayCount,
         deadlineMs: deadline,
+        pacedDelayMs,
       });
-      if (paceResult === "deadline-exceeded") {
+      if (paceResult.status === "deadline-exceeded") {
         opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next startup`);
         break;
       }
+      pacedDelayMs += paceResult.sleptMs;
 
       const result = await drainQueuedEntry({
         entry: currentEntry,

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -14,6 +14,7 @@ import {
   computeBackoffMs,
   getErrnoCode,
   releaseRecoveryEntry as releaseSharedRecoveryEntry,
+  waitForRecoveryReplayPace,
 } from "../delivery-recovery.shared.js";
 import { formatErrorMessage } from "../errors.js";
 import { resolveOutboundChannelMessageAdapter } from "./channel-resolution.js";
@@ -738,6 +739,7 @@ export async function recoverPendingDeliveries(opts: {
 
   const deadline = resolveRecoveryDeadlineMs(opts.maxRecoveryMs);
   const summary = createEmptyRecoverySummary();
+  let attemptedReplayCount = 0;
 
   for (const entry of pending) {
     const now = Date.now();
@@ -778,6 +780,15 @@ export async function recoverPendingDeliveries(opts: {
         continue;
       }
 
+      const paceResult = await waitForRecoveryReplayPace({
+        attemptedReplayCount,
+        deadlineMs: deadline,
+      });
+      if (paceResult === "deadline-exceeded") {
+        opts.log.warn(`Recovery time budget exceeded — remaining entries deferred to next startup`);
+        break;
+      }
+
       const result = await drainQueuedEntry({
         entry: currentEntry,
         cfg: opts.cfg,
@@ -799,6 +810,7 @@ export async function recoverPendingDeliveries(opts: {
           opts.log.warn(`Retry failed for delivery ${failedEntry.id}: ${errMsg}`);
         },
       });
+      attemptedReplayCount += 1;
       if (result === "moved-to-failed") {
         continue;
       }

--- a/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
+++ b/src/infra/outbound/delivery-queue.reconnect-drain.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { RECOVERY_REPLAY_SPACING_MS } from "../delivery-recovery.shared.js";
 import {
   type DeliverFn,
   drainPendingDeliveries,
@@ -300,6 +301,62 @@ describe("drainPendingDeliveries for reconnect", () => {
 
     resolveDeliver!();
     await startupRecovery;
+  });
+
+  it("shares replay pacing between reconnect and startup drains", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-04-23T00:00:00.000Z");
+    vi.setSystemTime(startedAt);
+    try {
+      const log = createRecoveryLog();
+      const startupLog = createRecoveryLog();
+      let firstStarted!: () => void;
+      const firstStartedPromise = new Promise<void>((resolve) => {
+        firstStarted = resolve;
+      });
+      let releaseFirst!: () => void;
+      const firstBlocked = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const deliveryTimes: number[] = [];
+      const deliver = vi.fn<DeliverFn>(async () => {
+        deliveryTimes.push(Date.now());
+        if (deliveryTimes.length === 1) {
+          firstStarted();
+          await firstBlocked;
+        }
+      });
+
+      for (const to of ["+1000", "+2000"]) {
+        await enqueueDelivery(
+          { channel: "directchat", to, payloads: [{ text: "hi" }], accountId: "acct1" },
+          tmpDir,
+        );
+      }
+
+      const reconnectDrain = drainAcct1DirectChatReconnect({ deliver, log, stateDir: tmpDir });
+      await firstStartedPromise;
+      const startupRecovery = recoverPendingDeliveries({
+        cfg: stubCfg,
+        deliver,
+        log: startupLog,
+        stateDir: tmpDir,
+      });
+      releaseFirst();
+
+      await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS - 1);
+      expect(deliver).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.all([reconnectDrain, startupRecovery]);
+
+      expect(deliver).toHaveBeenCalledTimes(2);
+      expect(deliveryTimes).toEqual([
+        startedAt.getTime(),
+        startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS,
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not re-deliver a stale startup snapshot after reconnect already acked it", async () => {

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -3,6 +3,7 @@
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { RECOVERY_REPLAY_SPACING_MS } from "../delivery-recovery.shared.js";
 import { OutboundDeliveryError, type OutboundPayloadDeliveryOutcome } from "./deliver-types.js";
 import { attachOutboundDeliveryCommitHook } from "./delivery-commit-hooks.js";
 import {
@@ -115,6 +116,43 @@ describe("delivery-queue recovery", () => {
     });
 
     expect(await loadPendingDeliveries(tmpDir())).toHaveLength(0);
+  });
+
+  it("paces startup replay instead of draining eligible entries back-to-back", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-04-23T00:00:00.000Z");
+    vi.setSystemTime(startedAt);
+    try {
+      await enqueueCrashRecoveryEntries();
+      let firstDelivered!: () => void;
+      const firstDeliveredPromise = new Promise<void>((resolve) => {
+        firstDelivered = resolve;
+      });
+      const deliveryTimes: number[] = [];
+      const deliver = vi.fn(async () => {
+        deliveryTimes.push(Date.now());
+        if (deliveryTimes.length === 1) {
+          firstDelivered();
+        }
+        return [];
+      });
+
+      const recovery = runRecovery({ deliver, maxRecoveryMs: 60_000 });
+      await firstDeliveredPromise;
+      expect(deliver).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS - 1);
+      expect(deliver).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      const { result } = await recovery;
+
+      expect(deliver).toHaveBeenCalledTimes(2);
+      expect(deliveryTimes[1]).toBe(startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS);
+      expect(result).toMatchObject({ recovered: 2, deferredBackoff: 0 });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("moves entries that exceeded max retries to failed/", async () => {

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -155,6 +155,50 @@ describe("delivery-queue recovery", () => {
     }
   });
 
+  it("does not let replay pacing consume the recovery budget for eligible backlog tails", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-04-23T00:00:00.000Z");
+    vi.setSystemTime(startedAt);
+    try {
+      await enqueueCrashRecoveryEntries();
+      await enqueueDelivery(
+        { channel: "demo-channel-c", to: "#c", payloads: [{ text: "c" }] },
+        tmpDir(),
+      );
+      let firstDelivered!: () => void;
+      const firstDeliveredPromise = new Promise<void>((resolve) => {
+        firstDelivered = resolve;
+      });
+      const deliveryTimes: number[] = [];
+      const deliver = vi.fn(async () => {
+        deliveryTimes.push(Date.now());
+        if (deliveryTimes.length === 1) {
+          firstDelivered();
+        }
+        return [];
+      });
+
+      const recovery = runRecovery({ deliver, maxRecoveryMs: 1 });
+      await firstDeliveredPromise;
+
+      await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS);
+      expect(deliver).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS);
+      const { result } = await recovery;
+
+      expect(deliver).toHaveBeenCalledTimes(3);
+      expect(deliveryTimes).toEqual([
+        startedAt.getTime(),
+        startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS,
+        startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS * 2,
+      ]);
+      expect(result).toMatchObject({ recovered: 3, deferredBackoff: 0 });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("moves entries that exceeded max retries to failed/", async () => {
     const id = await enqueueDelivery(
       { channel: "demo-channel-a", to: "+1", payloads: [{ text: "a" }] },

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -155,7 +155,7 @@ describe("delivery-queue recovery", () => {
     }
   });
 
-  it("does not let replay pacing consume the recovery budget for eligible backlog tails", async () => {
+  it("counts replay pacing against the recovery budget and defers the backlog tail", async () => {
     vi.useFakeTimers();
     const startedAt = new Date("2026-04-23T00:00:00.000Z");
     vi.setSystemTime(startedAt);
@@ -181,19 +181,13 @@ describe("delivery-queue recovery", () => {
       const recovery = runRecovery({ deliver, maxRecoveryMs: 1 });
       await firstDeliveredPromise;
 
-      await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS);
-      expect(deliver).toHaveBeenCalledTimes(2);
-
-      await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS);
+      await vi.advanceTimersByTimeAsync(1);
       const { result } = await recovery;
 
-      expect(deliver).toHaveBeenCalledTimes(3);
-      expect(deliveryTimes).toEqual([
-        startedAt.getTime(),
-        startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS,
-        startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS * 2,
-      ]);
-      expect(result).toMatchObject({ recovered: 3, deferredBackoff: 0 });
+      expect(deliver).toHaveBeenCalledTimes(1);
+      expect(deliveryTimes).toEqual([startedAt.getTime()]);
+      expect(result).toMatchObject({ recovered: 1, deferredBackoff: 0 });
+      expect(await loadPendingDeliveries(tmpDir())).toHaveLength(2);
     } finally {
       vi.useRealTimers();
     }

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -214,11 +214,10 @@ export async function recoverPendingSessionDeliveries(opts: {
   pending.sort((a, b) => a.enqueuedAt - b.enqueuedAt);
   const summary = createEmptyRecoverySummary();
   const deadline = resolveSessionDeliveryRecoveryDeadlineMs(opts.maxRecoveryMs);
-  let attemptedReplayCount = 0;
-  let pacedDelayMs = 0;
+  let hasAttemptedReplay = false;
 
   for (const entry of pending) {
-    if (Date.now() >= deadline + pacedDelayMs) {
+    if (Date.now() >= deadline) {
       opts.log.warn("Session delivery recovery time budget exceeded — remaining entries deferred");
       break;
     }
@@ -253,17 +252,15 @@ export async function recoverPendingSessionDeliveries(opts: {
       }
 
       const paceResult = await waitForRecoveryReplayPace({
-        attemptedReplayCount,
+        hasAttemptedReplay,
         deadlineMs: deadline,
-        pacedDelayMs,
       });
-      if (paceResult.status === "deadline-exceeded") {
+      if (paceResult === "deadline-exceeded") {
         opts.log.warn(
           "Session delivery recovery time budget exceeded — remaining entries deferred",
         );
         break;
       }
-      pacedDelayMs += paceResult.sleptMs;
 
       const result = await drainQueuedEntry({
         entry: currentEntry,
@@ -277,7 +274,7 @@ export async function recoverPendingSessionDeliveries(opts: {
           opts.log.warn(`Session delivery retry failed: ${errMsg}`);
         },
       });
-      attemptedReplayCount += 1;
+      hasAttemptedReplay = true;
       if (result === "recovered") {
         opts.log.info(`Recovered session delivery ${currentEntry.id}`);
       }

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -7,9 +7,9 @@ import {
 import {
   claimRecoveryEntry as claimSharedRecoveryEntry,
   computeBackoffMs,
+  createRecoveryReplayPacer,
   getErrnoCode,
   releaseRecoveryEntry as releaseSharedRecoveryEntry,
-  waitForRecoveryReplayPace,
 } from "./delivery-recovery.shared.js";
 import { formatErrorMessage } from "./errors.js";
 import {
@@ -47,6 +47,7 @@ const MAX_SESSION_DELIVERY_RETRIES = 5;
 
 const drainInProgress = new Map<string, boolean>();
 const entriesInProgress = new Set<string>();
+const recoveryReplayPacer = createRecoveryReplayPacer();
 
 function createEmptyRecoverySummary(): SessionDeliveryRecoverySummary {
   return {
@@ -214,7 +215,6 @@ export async function recoverPendingSessionDeliveries(opts: {
   pending.sort((a, b) => a.enqueuedAt - b.enqueuedAt);
   const summary = createEmptyRecoverySummary();
   const deadline = resolveSessionDeliveryRecoveryDeadlineMs(opts.maxRecoveryMs);
-  let hasAttemptedReplay = false;
 
   for (const entry of pending) {
     if (Date.now() >= deadline) {
@@ -251,10 +251,7 @@ export async function recoverPendingSessionDeliveries(opts: {
         continue;
       }
 
-      const paceResult = await waitForRecoveryReplayPace({
-        hasAttemptedReplay,
-        deadlineMs: deadline,
-      });
+      const paceResult = await recoveryReplayPacer.wait(deadline);
       if (paceResult === "deadline-exceeded") {
         opts.log.warn(
           "Session delivery recovery time budget exceeded — remaining entries deferred",
@@ -274,7 +271,6 @@ export async function recoverPendingSessionDeliveries(opts: {
           opts.log.warn(`Session delivery retry failed: ${errMsg}`);
         },
       });
-      hasAttemptedReplay = true;
       if (result === "recovered") {
         opts.log.info(`Recovered session delivery ${currentEntry.id}`);
       }

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -9,6 +9,7 @@ import {
   computeBackoffMs,
   getErrnoCode,
   releaseRecoveryEntry as releaseSharedRecoveryEntry,
+  waitForRecoveryReplayPace,
 } from "./delivery-recovery.shared.js";
 import { formatErrorMessage } from "./errors.js";
 import {
@@ -213,6 +214,7 @@ export async function recoverPendingSessionDeliveries(opts: {
   pending.sort((a, b) => a.enqueuedAt - b.enqueuedAt);
   const summary = createEmptyRecoverySummary();
   const deadline = resolveSessionDeliveryRecoveryDeadlineMs(opts.maxRecoveryMs);
+  let attemptedReplayCount = 0;
 
   for (const entry of pending) {
     if (Date.now() >= deadline) {
@@ -249,6 +251,17 @@ export async function recoverPendingSessionDeliveries(opts: {
         continue;
       }
 
+      const paceResult = await waitForRecoveryReplayPace({
+        attemptedReplayCount,
+        deadlineMs: deadline,
+      });
+      if (paceResult === "deadline-exceeded") {
+        opts.log.warn(
+          "Session delivery recovery time budget exceeded — remaining entries deferred",
+        );
+        break;
+      }
+
       const result = await drainQueuedEntry({
         entry: currentEntry,
         deliver: opts.deliver,
@@ -261,6 +274,7 @@ export async function recoverPendingSessionDeliveries(opts: {
           opts.log.warn(`Session delivery retry failed: ${errMsg}`);
         },
       });
+      attemptedReplayCount += 1;
       if (result === "recovered") {
         opts.log.info(`Recovered session delivery ${currentEntry.id}`);
       }

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -215,9 +215,10 @@ export async function recoverPendingSessionDeliveries(opts: {
   const summary = createEmptyRecoverySummary();
   const deadline = resolveSessionDeliveryRecoveryDeadlineMs(opts.maxRecoveryMs);
   let attemptedReplayCount = 0;
+  let pacedDelayMs = 0;
 
   for (const entry of pending) {
-    if (Date.now() >= deadline) {
+    if (Date.now() >= deadline + pacedDelayMs) {
       opts.log.warn("Session delivery recovery time budget exceeded — remaining entries deferred");
       break;
     }
@@ -254,13 +255,15 @@ export async function recoverPendingSessionDeliveries(opts: {
       const paceResult = await waitForRecoveryReplayPace({
         attemptedReplayCount,
         deadlineMs: deadline,
+        pacedDelayMs,
       });
-      if (paceResult === "deadline-exceeded") {
+      if (paceResult.status === "deadline-exceeded") {
         opts.log.warn(
           "Session delivery recovery time budget exceeded — remaining entries deferred",
         );
         break;
       }
+      pacedDelayMs += paceResult.sleptMs;
 
       const result = await drainQueuedEntry({
         entry: currentEntry,

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -2,6 +2,7 @@
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
+import { RECOVERY_REPLAY_SPACING_MS } from "./delivery-recovery.shared.js";
 import {
   drainPendingSessionDeliveries,
   enqueueSessionDelivery,
@@ -38,6 +39,68 @@ describe("session-delivery queue recovery", () => {
       expect(summary.recovered).toBe(1);
       expect(await loadPendingSessionDeliveries(tempDir)).toStrictEqual([]);
     });
+  });
+
+  it("paces startup replay for multiple eligible session deliveries", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-04-23T00:00:00.000Z");
+    vi.setSystemTime(startedAt);
+    try {
+      await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+        await enqueueSessionDelivery(
+          {
+            kind: "systemEvent",
+            sessionKey: "agent:main:main",
+            text: "first",
+          },
+          tempDir,
+        );
+        await enqueueSessionDelivery(
+          {
+            kind: "systemEvent",
+            sessionKey: "agent:main:main",
+            text: "second",
+          },
+          tempDir,
+        );
+
+        let firstDelivered!: () => void;
+        const firstDeliveredPromise = new Promise<void>((resolve) => {
+          firstDelivered = resolve;
+        });
+        const deliveryTimes: number[] = [];
+        const deliver = vi.fn(async () => {
+          deliveryTimes.push(Date.now());
+          if (deliveryTimes.length === 1) {
+            firstDelivered();
+          }
+        });
+
+        const recovery = recoverPendingSessionDeliveries({
+          deliver,
+          stateDir: tempDir,
+          log: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+          },
+        });
+        await firstDeliveredPromise;
+        expect(deliver).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS - 1);
+        expect(deliver).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1);
+        const summary = await recovery;
+
+        expect(deliver).toHaveBeenCalledTimes(2);
+        expect(deliveryTimes[1]).toBe(startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS);
+        expect(summary.recovered).toBe(2);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("defers recovery when the recovery budget would exceed the date range", async () => {

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -103,7 +103,7 @@ describe("session-delivery queue recovery", () => {
     }
   });
 
-  it("does not let replay pacing consume the session recovery budget", async () => {
+  it("counts replay pacing against the session recovery budget", async () => {
     vi.useFakeTimers();
     const startedAt = new Date("2026-04-23T00:00:00.000Z");
     vi.setSystemTime(startedAt);
@@ -144,19 +144,13 @@ describe("session-delivery queue recovery", () => {
         });
         await firstDeliveredPromise;
 
-        await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS);
-        expect(deliver).toHaveBeenCalledTimes(2);
-
-        await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS);
+        await vi.advanceTimersByTimeAsync(1);
         const summary = await recovery;
 
-        expect(deliver).toHaveBeenCalledTimes(3);
-        expect(deliveryTimes).toEqual([
-          startedAt.getTime(),
-          startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS,
-          startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS * 2,
-        ]);
-        expect(summary.recovered).toBe(3);
+        expect(deliver).toHaveBeenCalledTimes(1);
+        expect(deliveryTimes).toEqual([startedAt.getTime()]);
+        expect(summary.recovered).toBe(1);
+        expect(await loadPendingSessionDeliveries(tempDir)).toHaveLength(2);
       });
     } finally {
       vi.useRealTimers();

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -103,6 +103,66 @@ describe("session-delivery queue recovery", () => {
     }
   });
 
+  it("does not let replay pacing consume the session recovery budget", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-04-23T00:00:00.000Z");
+    vi.setSystemTime(startedAt);
+    try {
+      await withTempDir({ prefix: "openclaw-session-delivery-" }, async (tempDir) => {
+        for (const text of ["first", "second", "third"]) {
+          await enqueueSessionDelivery(
+            {
+              kind: "systemEvent",
+              sessionKey: "agent:main:main",
+              text,
+            },
+            tempDir,
+          );
+        }
+
+        let firstDelivered!: () => void;
+        const firstDeliveredPromise = new Promise<void>((resolve) => {
+          firstDelivered = resolve;
+        });
+        const deliveryTimes: number[] = [];
+        const deliver = vi.fn(async () => {
+          deliveryTimes.push(Date.now());
+          if (deliveryTimes.length === 1) {
+            firstDelivered();
+          }
+        });
+
+        const recovery = recoverPendingSessionDeliveries({
+          deliver,
+          stateDir: tempDir,
+          maxRecoveryMs: 1,
+          log: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+          },
+        });
+        await firstDeliveredPromise;
+
+        await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS);
+        expect(deliver).toHaveBeenCalledTimes(2);
+
+        await vi.advanceTimersByTimeAsync(RECOVERY_REPLAY_SPACING_MS);
+        const summary = await recovery;
+
+        expect(deliver).toHaveBeenCalledTimes(3);
+        expect(deliveryTimes).toEqual([
+          startedAt.getTime(),
+          startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS,
+          startedAt.getTime() + RECOVERY_REPLAY_SPACING_MS * 2,
+        ]);
+        expect(summary.recovered).toBe(3);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("defers recovery when the recovery budget would exceed the date range", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(MAX_DATE_TIMESTAMP_MS));


### PR DESCRIPTION
Closes #101058

## What Problem This Solves

Startup delivery recovery could replay a large eligible backlog in a tight sequential burst after an outage or restart. Reconnect-triggered drains could run at the same time and bypass any startup-only pacing, concentrating sends against channel and provider rate limits.

## Why This Change Was Made

Outbound startup recovery and reconnect drains now share one replay pacer; session-delivery startup recovery uses the same pacing primitive with its own owner. The coordinator grants replay starts at least 250ms apart, lets the first replay start immediately, and serializes concurrent callers without holding delivery execution behind a global lock.

Pacing remains inside the existing recovery deadline. Each sleep is capped to the remaining budget, so a small budget defers the backlog tail instead of overrunning the 60-second startup ceiling. Backoff skips, max-retry moves, active-entry claims, and retry counters keep their existing semantics.

## User Impact

Queued messages recovered after a restart or reconnect are replayed more gently instead of all eligible entries being sent back-to-back. This reduces avoidable rate-limit bursts while preserving the bounded startup path and reconnect behavior.

## Evidence

Before: both startup recovery loops sorted eligible SQLite queue entries and immediately iterated them; reconnect drains were independently callable. There was no shared pacing owner between those entry points.

After: focused regressions cover:

- outbound and session startup replay spacing;
- deadline-bound tail deferral with a 1ms recovery budget;
- concurrent outbound startup and reconnect drains sharing the same pacing floor;
- existing reconnect selection, retry/backoff, active-claim, queue-policy, and session recovery behavior.

Local focused proof on the reviewed patch lineage:

```text
src/infra/outbound/delivery-queue.recovery.test.ts
src/infra/outbound/delivery-queue.reconnect-drain.test.ts
src/infra/outbound/delivery-queue.policy.test.ts
src/infra/session-delivery-queue.recovery.test.ts

Test Files 4 passed
Tests 79 passed
```

Real SQLite queue proof observed a 252ms interval between two eligible recovered deliveries with zero failures. Fresh autoreview completed clean after addressing three findings: retain the recovery deadline, cap pacing sleep to remaining budget, and share outbound pacing with reconnect drains.

Exact-head hosted CI and the additional remote-proof disposition are recorded in the maintainer verification comment before merge.

AI-assisted: implementation and review were AI-assisted; the evidence above was independently exercised against the queue and test surfaces.
