### PR TITLE
fix(extensions/thread-ownership): bound 409 conflict JSON response read

### DIFF
--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -269,6 +269,26 @@ describe("thread-ownership plugin", () => {
       expect(infoMessage).toContain("cancelled send");
     });
 
+    it("fails open when a 409 conflict response body exceeds the safe read bound", async () => {
+      const oversizedBody = JSON.stringify({
+        owner: "other-agent",
+        padding: "x".repeat(32 * 1024),
+      });
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(oversizedBody, {
+          status: 409,
+          headers: { "Content-Length": String(oversizedBody.length) },
+        }),
+      );
+
+      const result = await sendSlackThreadMessage();
+
+      expect(result).toBeUndefined();
+      const warningMessage = requireFirstLogMessage(api.logger.warn, "ownership check warning log");
+      expect(warningMessage).toContain("ownership check failed");
+      expect(warningMessage).toContain("thread-ownership conflict");
+    });
+
     it("fails open on network error", async () => {
       vi.mocked(globalThis.fetch).mockRejectedValue(new Error("ECONNREFUSED"));
 

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -1,5 +1,6 @@
-// Thread Ownership plugin entrypoint registers its OpenClaw integration.
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
+// Thread Ownership plugin entrypoint registers its OpenClaw integration.
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -22,6 +23,9 @@ type ThreadOwnershipMessageSendingResult = { cancel: true } | undefined;
 // Entries expire after 5 minutes.
 const mentionedThreads = new Map<string, number>();
 const MENTION_TTL_MS = 5 * 60 * 1000;
+
+/** Max bytes to read from the thread-ownership conflict JSON response. */
+const OWNERSHIP_RESPONSE_MAX_BYTES = 16 * 1024;
 
 function isThreadOwnershipConfig(value: unknown): value is ThreadOwnershipConfig {
   return value !== null && typeof value === "object";
@@ -189,7 +193,11 @@ export default definePluginEntry({
             return undefined;
           }
           if (resp.status === 409) {
-            const body = (await resp.json()) as { owner?: string };
+            const body = await readProviderJsonResponse<{ owner?: string }>(
+              resp,
+              "thread-ownership conflict",
+              { maxBytes: OWNERSHIP_RESPONSE_MAX_BYTES },
+            );
             api.logger.info?.(
               `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
             );

--- a/scripts/proof/thread-ownership-json-bound.mts
+++ b/scripts/proof/thread-ownership-json-bound.mts
@@ -1,0 +1,93 @@
+// Real behavior proof: Thread Ownership plugin bounds the 409 conflict JSON body
+// read so a misbehaving forwarder cannot OOM the runtime.
+//
+// A local HTTP server returns HTTP 409 with a JSON body much larger than the
+// 16 KiB bound. The plugin's message_sending handler must fail open
+// (return undefined, log a warning) instead of buffering the whole payload.
+
+import http from "node:http";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const { default: register } = await import(path.join(repoRoot, "extensions/thread-ownership/index.js"));
+
+const hooks: Record<string, Function> = {};
+const logger = { info: console.log, warn: console.log, debug: () => {} };
+const api = {
+  pluginConfig: {},
+  config: {
+    agents: {
+      list: [{ id: "proof-agent", default: true, identity: { name: "ProofBot" } }],
+    },
+  },
+  runtime: {
+    config: {
+      current: () => api.config,
+    },
+  },
+  id: "thread-ownership",
+  name: "Thread Ownership",
+  logger,
+  on: (hookName: string, handler: Function) => {
+    hooks[hookName] = handler;
+  },
+};
+
+register.register(api);
+
+const PORT = 0;
+const HUGE_SIZE = 8 * 1024 * 1024;
+const server = http.createServer((req, res) => {
+  res.writeHead(409, { "Content-Type": "application/json" });
+  // Stream an oversized JSON body without materializing it all at once.
+  res.write('{"owner":"other-agent","padding":"');
+  const chunk = "x".repeat(64 * 1024);
+  let sent = 0;
+  function sendChunk(): void {
+    if (sent >= HUGE_SIZE) {
+      res.end('"}');
+      return;
+    }
+    res.write(chunk);
+    sent += chunk.length;
+    setImmediate(sendChunk);
+  }
+  sendChunk();
+});
+
+await new Promise<void>((resolve) => { server.listen(PORT, "127.0.0.1", () => { resolve(); }); });
+const address = server.address();
+const port = address && typeof address === "object" ? address.port : 0;
+
+process.env.SLACK_FORWARDER_URL = `http://127.0.0.1:${port}`;
+
+console.log("=== Proof: thread-ownership 409 JSON response bound ===\n");
+console.log(`Local forwarder listening on port ${port}`);
+console.log(`Sending ${HUGE_SIZE} bytes of JSON padding in 409 response...\n`);
+
+const startMem = process.memoryUsage.rss();
+const start = performance.now();
+
+const result = await hooks.message_sending(
+  { content: "hello", replyToId: "1234.5678", metadata: { channelId: "C123" }, to: "C123" },
+  { channelId: "slack", conversationId: "C123" },
+);
+
+const duration = performance.now() - start;
+const endMem = process.memoryUsage.rss();
+
+server.close();
+await new Promise<void>((resolve) => { server.once("close", () => { resolve(); }); });
+
+console.log(`Handler returned: ${JSON.stringify(result)}`);
+console.log(`Duration: ${duration.toFixed(1)} ms`);
+console.log(`RSS delta: ${((endMem - startMem) / 1024 / 1024).toFixed(1)} MB\n`);
+
+if (result === undefined && duration < 5000 && (endMem - startMem) < 64 * 1024 * 1024) {
+  console.log("PASS: oversized 409 body was bounded; plugin failed open without OOM.");
+} else {
+  console.log("FAIL: plugin did not fail open or consumed too much memory.");
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## What Problem This Solves

The Thread Ownership plugin reads the JSON body of a 409 conflict response from the internal Slack forwarder using `resp.json()`. If the forwarder misbehaves and returns an enormous payload, the runtime buffers the entire body before parsing, which can exhaust memory.

## Why This Change Was Made

Replaced the unbounded `resp.json()` call with `readProviderJsonResponse` capped at 16 KiB. This keeps the existing fail-open behavior (the plugin allows the send on any ownership-check failure) while preventing a misbehaving internal service from causing an OOM.

## User Impact

No behavior change for normal forwarders. A buggy or compromised forwarder returning a multi-megabyte 409 body no longer risks crashing the agent.

## Evidence

Local test passes:

```bash
pnpm test extensions/thread-ownership/index.test.ts
```

Real behavior proof passes:

```bash
node --import tsx scripts/proof/thread-ownership-json-bound.mts
```

Proof output:

```
=== Proof: thread-ownership 409 JSON response bound ===

Local forwarder listening on port 36579
Sending 8388608 bytes of JSON padding in 409 response...

thread-ownership: ownership check failed (Error: thread-ownership conflict: JSON response exceeds 16384 bytes), allowing send
Handler returned: undefined
Duration: 296.6 ms
RSS delta: 19.0 MB

PASS: oversized 409 body was bounded; plugin failed open without OOM.
```

The new unit test also exercises the bounded-read path with a 32 KiB 409 body and asserts the plugin returns `undefined` and logs a warning.
