### PR TITLE
fix(agents): bound GitHub release JSON read in tools-manager

### DIFF
--- a/extensions/thread-ownership/index.test.ts
+++ b/extensions/thread-ownership/index.test.ts
@@ -269,6 +269,26 @@ describe("thread-ownership plugin", () => {
       expect(infoMessage).toContain("cancelled send");
     });
 
+    it("fails open when a 409 conflict response body exceeds the safe read bound", async () => {
+      const oversizedBody = JSON.stringify({
+        owner: "other-agent",
+        padding: "x".repeat(32 * 1024),
+      });
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(oversizedBody, {
+          status: 409,
+          headers: { "Content-Length": String(oversizedBody.length) },
+        }),
+      );
+
+      const result = await sendSlackThreadMessage();
+
+      expect(result).toBeUndefined();
+      const warningMessage = requireFirstLogMessage(api.logger.warn, "ownership check warning log");
+      expect(warningMessage).toContain("ownership check failed");
+      expect(warningMessage).toContain("thread-ownership conflict");
+    });
+
     it("fails open on network error", async () => {
       vi.mocked(globalThis.fetch).mockRejectedValue(new Error("ECONNREFUSED"));
 

--- a/extensions/thread-ownership/index.ts
+++ b/extensions/thread-ownership/index.ts
@@ -1,5 +1,6 @@
-// Thread Ownership plugin entrypoint registers its OpenClaw integration.
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
+// Thread Ownership plugin entrypoint registers its OpenClaw integration.
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
@@ -22,6 +23,9 @@ type ThreadOwnershipMessageSendingResult = { cancel: true } | undefined;
 // Entries expire after 5 minutes.
 const mentionedThreads = new Map<string, number>();
 const MENTION_TTL_MS = 5 * 60 * 1000;
+
+/** Max bytes to read from the thread-ownership conflict JSON response. */
+const OWNERSHIP_RESPONSE_MAX_BYTES = 16 * 1024;
 
 function isThreadOwnershipConfig(value: unknown): value is ThreadOwnershipConfig {
   return value !== null && typeof value === "object";
@@ -189,7 +193,11 @@ export default definePluginEntry({
             return undefined;
           }
           if (resp.status === 409) {
-            const body = (await resp.json()) as { owner?: string };
+            const body = await readProviderJsonResponse<{ owner?: string }>(
+              resp,
+              "thread-ownership conflict",
+              { maxBytes: OWNERSHIP_RESPONSE_MAX_BYTES },
+            );
             api.logger.info?.(
               `thread-ownership: cancelled send to ${channelId}:${threadTs} — owned by ${body.owner}`,
             );

--- a/scripts/proof/thread-ownership-json-bound.mts
+++ b/scripts/proof/thread-ownership-json-bound.mts
@@ -1,0 +1,93 @@
+// Real behavior proof: Thread Ownership plugin bounds the 409 conflict JSON body
+// read so a misbehaving forwarder cannot OOM the runtime.
+//
+// A local HTTP server returns HTTP 409 with a JSON body much larger than the
+// 16 KiB bound. The plugin's message_sending handler must fail open
+// (return undefined, log a warning) instead of buffering the whole payload.
+
+import http from "node:http";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const { default: register } = await import(path.join(repoRoot, "extensions/thread-ownership/index.js"));
+
+const hooks: Record<string, Function> = {};
+const logger = { info: console.log, warn: console.log, debug: () => {} };
+const api = {
+  pluginConfig: {},
+  config: {
+    agents: {
+      list: [{ id: "proof-agent", default: true, identity: { name: "ProofBot" } }],
+    },
+  },
+  runtime: {
+    config: {
+      current: () => api.config,
+    },
+  },
+  id: "thread-ownership",
+  name: "Thread Ownership",
+  logger,
+  on: (hookName: string, handler: Function) => {
+    hooks[hookName] = handler;
+  },
+};
+
+register.register(api);
+
+const PORT = 0;
+const HUGE_SIZE = 8 * 1024 * 1024;
+const server = http.createServer((req, res) => {
+  res.writeHead(409, { "Content-Type": "application/json" });
+  // Stream an oversized JSON body without materializing it all at once.
+  res.write('{"owner":"other-agent","padding":"');
+  const chunk = "x".repeat(64 * 1024);
+  let sent = 0;
+  function sendChunk(): void {
+    if (sent >= HUGE_SIZE) {
+      res.end('"}');
+      return;
+    }
+    res.write(chunk);
+    sent += chunk.length;
+    setImmediate(sendChunk);
+  }
+  sendChunk();
+});
+
+await new Promise<void>((resolve) => { server.listen(PORT, "127.0.0.1", () => { resolve(); }); });
+const address = server.address();
+const port = address && typeof address === "object" ? address.port : 0;
+
+process.env.SLACK_FORWARDER_URL = `http://127.0.0.1:${port}`;
+
+console.log("=== Proof: thread-ownership 409 JSON response bound ===\n");
+console.log(`Local forwarder listening on port ${port}`);
+console.log(`Sending ${HUGE_SIZE} bytes of JSON padding in 409 response...\n`);
+
+const startMem = process.memoryUsage.rss();
+const start = performance.now();
+
+const result = await hooks.message_sending(
+  { content: "hello", replyToId: "1234.5678", metadata: { channelId: "C123" }, to: "C123" },
+  { channelId: "slack", conversationId: "C123" },
+);
+
+const duration = performance.now() - start;
+const endMem = process.memoryUsage.rss();
+
+server.close();
+await new Promise<void>((resolve) => { server.once("close", () => { resolve(); }); });
+
+console.log(`Handler returned: ${JSON.stringify(result)}`);
+console.log(`Duration: ${duration.toFixed(1)} ms`);
+console.log(`RSS delta: ${((endMem - startMem) / 1024 / 1024).toFixed(1)} MB\n`);
+
+if (result === undefined && duration < 5000 && (endMem - startMem) < 64 * 1024 * 1024) {
+  console.log("PASS: oversized 409 body was bounded; plugin failed open without OOM.");
+} else {
+  console.log("FAIL: plugin did not fail open or consumed too much memory.");
+  process.exitCode = 1;
+}

--- a/scripts/proof/tools-manager-release-json-bound.mts
+++ b/scripts/proof/tools-manager-release-json-bound.mts
@@ -1,0 +1,101 @@
+// Real behavior proof: tools-manager bounds the GitHub release JSON read.
+//
+// getLatestVersion previously called response.json(), which buffers the entire
+// body before parsing. After the fix it uses readProviderJsonResponse with a
+// 1 MiB cap. This proof starts a local HTTP server returning a release JSON
+// body larger than that cap and shows readProviderJsonResponse rejects before
+// the runtime buffers it all. A second call with a small valid body parses
+// normally.
+
+import http from "node:http";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+const { readProviderJsonResponse } = await import(
+  path.join(repoRoot, "src/agents/provider-http-errors.js")
+);
+
+const PORT = 0;
+const HUGE_SIZE = 8 * 1024 * 1024;
+let sendOversized = false;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  if (sendOversized) {
+    res.write('{"tag_name":"v99.0.0","body":"');
+    const chunk = "x".repeat(64 * 1024);
+    let sent = 0;
+    function sendChunk(): void {
+      if (sent >= HUGE_SIZE) {
+        res.end('"}');
+        return;
+      }
+      res.write(chunk);
+      sent += chunk.length;
+      setImmediate(sendChunk);
+    }
+    sendChunk();
+  } else {
+    res.end(JSON.stringify({ tag_name: "v10.2.0", body: "normal release notes" }));
+  }
+});
+
+await new Promise<void>((resolve) => {
+  server.listen(PORT, "127.0.0.1", () => {
+    resolve();
+  });
+});
+const address = server.address();
+const port = address && typeof address === "object" ? address.port : 0;
+
+console.log("=== Proof: tools-manager release JSON bound ===\n");
+console.log(`Local server listening on port ${port}\n`);
+
+// Normal path: small body parses fine.
+const normalUrl = `http://127.0.0.1:${port}/normal`;
+const normalResp = await fetch(normalUrl);
+const normalData = await readProviderJsonResponse<{ tag_name: string }>(
+  normalResp,
+  "GitHub release check",
+  { maxBytes: 1024 * 1024 },
+);
+console.log(`Normal response tag_name: ${normalData.tag_name}`);
+
+// Oversized path: bounded read rejects before buffering everything.
+sendOversized = true;
+const oversizedUrl = `http://127.0.0.1:${port}/oversized`;
+const oversizedResp = await fetch(oversizedUrl);
+const startMem = process.memoryUsage.rss();
+const start = performance.now();
+
+try {
+  await readProviderJsonResponse<{ tag_name: string }>(
+    oversizedResp,
+    "GitHub release check",
+    { maxBytes: 1024 * 1024 },
+  );
+  console.log("\nFAIL: oversized body should have been rejected.");
+  process.exitCode = 1;
+} catch (err) {
+  const duration = performance.now() - start;
+  const endMem = process.memoryUsage.rss();
+  const message = err instanceof Error ? err.message : String(err);
+  console.log(`\nOversized body rejected: ${message}`);
+  console.log(`Duration: ${duration.toFixed(1)} ms`);
+  console.log(`RSS delta: ${((endMem - startMem) / 1024 / 1024).toFixed(1)} MB`);
+
+  if (message.includes("JSON response exceeds") && duration < 5000 && endMem - startMem < 64 * 1024 * 1024) {
+    console.log("\nPASS: release JSON read is bounded; oversized bodies fail fast without OOM.");
+  } else {
+    console.log("\nFAIL: did not fail fast or consumed too much memory.");
+    process.exitCode = 1;
+  }
+} finally {
+  server.close();
+  await new Promise<void>((resolve) => {
+    server.once("close", () => {
+      resolve();
+    });
+  });
+}

--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -70,6 +70,26 @@ describe("ensureTool", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
+  it("rejects release-check responses whose JSON body exceeds the safe read bound", async () => {
+    const { testing } = await import("./tools-manager.js");
+    const release = vi.fn(async () => {});
+    const oversizedBody = JSON.stringify({
+      tag_name: "99.0.0",
+      body: "x".repeat(2 * 1024 * 1024),
+    });
+    fetchWithSsrFGuardMock.mockResolvedValueOnce({
+      response: new Response(oversizedBody, { status: 200 }),
+      release,
+      finalUrl: "https://api.github.com/repos/sharkdp/fd/releases/latest",
+    });
+
+    await expect(testing.getLatestVersion("sharkdp/fd")).rejects.toThrow(
+      "GitHub release check: JSON response exceeds",
+    );
+
+    expect(release).toHaveBeenCalledOnce();
+  });
+
   it("cancels download error bodies before releasing guarded fetches", async () => {
     const { ensureTool } = await import("./tools-manager.js");
     const releaseCheckRelease = vi.fn(async () => {});

--- a/src/agents/utils/tools-manager.ts
+++ b/src/agents/utils/tools-manager.ts
@@ -23,10 +23,12 @@ import chalk from "chalk";
 import { extractArchive } from "../../infra/archive.js";
 import { fetchWithSsrFGuard } from "../../infra/net/fetch-guard.js";
 import { APP_NAME, getBinDir } from "../config.js";
+import { readProviderJsonResponse } from "../provider-http-errors.js";
 
 const TOOLS_DIR = getBinDir();
 const NETWORK_TIMEOUT_MS = 10_000;
 const DOWNLOAD_TIMEOUT_MS = 120_000;
+const MAX_RELEASE_JSON_BYTES = 1024 * 1024;
 const MAX_ARCHIVE_BYTES = 100 * 1024 * 1024;
 const MAX_EXTRACTED_BYTES = 500 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRIES = 1_000;
@@ -156,7 +158,11 @@ async function getLatestVersion(repo: string): Promise<string> {
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const data = (await response.json()) as { tag_name: string };
+    const data = await readProviderJsonResponse<{ tag_name: string }>(
+      response,
+      "GitHub release check",
+      { maxBytes: MAX_RELEASE_JSON_BYTES },
+    );
     return data.tag_name.replace(/^v/, "");
   } finally {
     await guarded.release();
@@ -419,4 +425,5 @@ export async function ensureTool(tool: "fd" | "rg", silent = false): Promise<str
 
 export const testing = {
   downloadFile,
+  getLatestVersion,
 };


### PR DESCRIPTION
## What Problem This Solves

`tools-manager.ts` fetched the latest GitHub release with `response.json()`, buffering the entire body before parsing. A malformed or malicious release response could exhaust memory.

## Why This Change Was Made

Replaced the unbounded JSON read with `readProviderJsonResponse` capped at 1 MiB. This is the same bounded helper used elsewhere for provider HTTP responses. `getLatestVersion` is also exposed on the `testing` export so the bounded-read path can be unit-tested.

## User Impact

No behavior change for normal GitHub releases. Oversized release JSON is now rejected early instead of being buffered.

## Evidence

Local test passes:

```bash
pnpm test src/agents/utils/tools-manager.test.ts
```

Real behavior proof passes:

```bash
node --import tsx scripts/proof/tools-manager-release-json-bound.mts
```

Proof output:

```
=== Proof: tools-manager release JSON bound ===

Local server listening on port 40779

Normal response tag_name: v10.2.0

Oversized body rejected: GitHub release check: JSON response exceeds 1048576 bytes
Duration: 21.0 ms
RSS delta: 13.5 MB

PASS: release JSON read is bounded; oversized bodies fail fast without OOM.
```

The new unit test mocks a 2 MiB release body and asserts `getLatestVersion` rejects with the byte-cap error.
