### PR TITLE
fix(discord): terminate ffmpeg on stream errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Discord voice ffmpeg failures:** surface stdout/stderr stream errors through playback and terminate the transcoder, preventing Gateway crashes and orphaned ffmpeg processes. (#101088, #101124) Thanks @masatohoshino.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Discord voice ffmpeg failures:** surface stdout/stderr stream errors through playback and terminate the transcoder, preventing Gateway crashes and orphaned ffmpeg processes. (#101088, #101124) Thanks @masatohoshino.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -130,6 +130,7 @@ describe("createDiscordOpusPlaybackStream child stream errors", () => {
 
       await expect(errorSeen).resolves.toBe(streamError);
       expect(ffmpeg.kill).toHaveBeenCalledOnce();
+      expect(ffmpeg.kill).toHaveBeenCalledWith("SIGKILL");
     },
   );
 });

--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -25,12 +25,17 @@ function createFakeFfmpeg() {
     stdout: PassThrough;
     stderr: PassThrough;
     stdin: PassThrough;
+    killed: boolean;
     kill: ReturnType<typeof vi.fn>;
   };
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
   child.stdin = new PassThrough();
-  child.kill = vi.fn();
+  child.killed = false;
+  child.kill = vi.fn(() => {
+    child.killed = true;
+    return true;
+  });
   return child;
 }
 
@@ -124,6 +129,7 @@ describe("createDiscordOpusPlaybackStream child stream errors", () => {
       expect(() => ffmpeg[streamName].emit("error", streamError)).not.toThrow();
 
       await expect(errorSeen).resolves.toBe(streamError);
+      expect(ffmpeg.kill).toHaveBeenCalledOnce();
     },
   );
 });

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -110,6 +110,11 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
   const opusStream = createDiscordOpusEncodeStream();
   let stderr = "";
   let ffmpegClosed = false;
+  const killFfmpeg = () => {
+    if (!ffmpegClosed && !ffmpeg.killed) {
+      ffmpeg.kill();
+    }
+  };
 
   ffmpeg.stderr.setEncoding("utf8");
   ffmpeg.stderr.on("data", (chunk: string) => {
@@ -135,7 +140,10 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
 
   // Both readable child pipes need listeners; an unhandled stream error terminates Node.
   for (const readable of [ffmpeg.stdout, ffmpeg.stderr]) {
-    readable.on("error", (err) => opusStream.destroy(err));
+    readable.on("error", (err) => {
+      killFfmpeg();
+      opusStream.destroy(err);
+    });
   }
   ffmpeg.stdin.on("error", (err) => {
     if ((err as NodeJS.ErrnoException).code !== "EPIPE") {
@@ -144,8 +152,8 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
   });
   ffmpeg.stdout.pipe(opusStream);
   opusStream.once("close", () => {
-    if (!ffmpegClosed && !opusStream.readableEnded) {
-      ffmpeg.kill();
+    if (!opusStream.readableEnded) {
+      killFfmpeg();
     }
   });
   if (typeof input !== "string") {

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -110,9 +110,9 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
   const opusStream = createDiscordOpusEncodeStream();
   let stderr = "";
   let ffmpegClosed = false;
-  const killFfmpeg = () => {
+  const killFfmpeg = (signal: NodeJS.Signals = "SIGTERM") => {
     if (!ffmpegClosed && !ffmpeg.killed) {
-      ffmpeg.kill();
+      ffmpeg.kill(signal);
     }
   };
 
@@ -141,7 +141,9 @@ export function createDiscordOpusPlaybackStream(input: Readable | string): Reada
   // Both readable child pipes need listeners; an unhandled stream error terminates Node.
   for (const readable of [ffmpeg.stdout, ffmpeg.stderr]) {
     readable.on("error", (err) => {
-      killFfmpeg();
+      // A broken output pipe cannot drain usefully; force termination so a
+      // blocked ffmpeg process cannot outlive the failed playback stream.
+      killFfmpeg("SIGKILL");
       opusStream.destroy(err);
     });
   }


### PR DESCRIPTION
Related: #101088

## What Problem This Solves

Fixes an issue where Discord voice playback could leave an ffmpeg subprocess running after its stdout or stderr stream failed.

## Why This Change Was Made

The readable-pipe error path uses one lifecycle-owned termination helper and force-stops ffmpeg because a broken output pipe cannot drain successfully. Ordinary playback closure keeps graceful termination.

## User Impact

Discord voice playback no longer crashes the Gateway or leaks a transcoder process when an ffmpeg output stream fails.

## Evidence

- Current head `4f1fc0ab589903743ddb2fafcb35a8a70352b6d0`; focused head `6493e8be122fbdc42f0d13677dcc276f907da4e2` on Blacksmith Testbox `tbx_01kwwe4bnj8tdzyt7xvnm2zwjq`:
  - `pnpm test extensions/discord/src/voice/audio.test.ts` — 6/6 passed.
  - Real ffmpeg 6.1.1 normal WAV-to-Opus playback — 5 packets.
  - Injected stdout and stderr failures — original errors surfaced, both ffmpeg children exited within 2 seconds, parent process stayed alive; current runtime/test blobs match the live-proven blobs after the base-only rebase.
- Fresh Codex AutoReview: clean, confidence 0.86.
