### PR TITLE
fix: acknowledge native task starts

### DIFF
--- a/src/tasks/task-executor-policy.test.ts
+++ b/src/tasks/task-executor-policy.test.ts
@@ -182,6 +182,26 @@ describe("task-executor-policy", () => {
       shouldAutoDeliverTaskStateChange(
         createTask({
           status: "running",
+          notifyPolicy: "done_only",
+          deliveryStatus: "pending",
+        }),
+        { at: 10, kind: "running" },
+      ),
+    ).toBe(true);
+    expect(
+      shouldAutoDeliverTaskStateChange(
+        createTask({
+          status: "running",
+          notifyPolicy: "done_only",
+          deliveryStatus: "pending",
+        }),
+        { at: 11, kind: "progress", summary: "Still working." },
+      ),
+    ).toBe(false);
+    expect(
+      shouldAutoDeliverTaskStateChange(
+        createTask({
+          status: "running",
           notifyPolicy: "state_changes",
           deliveryStatus: "pending",
         }),

--- a/src/tasks/task-executor-policy.ts
+++ b/src/tasks/task-executor-policy.ts
@@ -137,12 +137,17 @@ export function shouldAutoDeliverTaskTerminalUpdate(task: TaskRecord): boolean {
   return task.deliveryStatus === "pending";
 }
 
-export function shouldAutoDeliverTaskStateChange(task: TaskRecord): boolean {
-  return (
-    task.notifyPolicy === "state_changes" &&
-    task.deliveryStatus === "pending" &&
-    !isTerminalTaskStatus(task.status)
-  );
+export function shouldAutoDeliverTaskStateChange(
+  task: TaskRecord,
+  event?: TaskEventRecord,
+): boolean {
+  if (task.notifyPolicy === "silent") {
+    return false;
+  }
+  if (task.deliveryStatus !== "pending" || isTerminalTaskStatus(task.status)) {
+    return false;
+  }
+  return event?.kind === "running" || task.notifyPolicy === "state_changes";
 }
 
 export function shouldSuppressDuplicateTerminalDelivery(params: {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -4370,6 +4370,55 @@ describe("task-registry", () => {
     });
   });
 
+  it("delivers bound Discord thread start ack directly instead of queuing it on the parent session", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const runId = "run-bound-discord-thread-start-ack";
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "discord",
+        to: "channel:parent-channel",
+        via: "direct",
+      });
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:discord:guild-123:channel-parent-channel",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "discord",
+          to: "channel:parent-channel",
+          threadId: "thread-84022",
+        },
+        childSessionKey: "agent:main:acp:child",
+        runId,
+        task: "Investigate thread-bound ACP delivery",
+        status: "queued",
+        deliveryStatus: "pending",
+        notifyPolicy: "done_only",
+      });
+
+      markTaskRunningByRunId({
+        runId,
+        startedAt: 100,
+        lastEventAt: 100,
+      });
+
+      await waitForAssertion(() =>
+        expectRecordFields(sentMessageCall(), {
+          channel: "discord",
+          to: "channel:parent-channel",
+          threadId: "thread-84022",
+          content: "Background task started: ACP background task.",
+          idempotencyKey: expect.stringMatching(/^task-start:/),
+        }),
+      );
+      expect(peekSystemEvents("agent:main:discord:guild-123:channel-parent-channel")).toStrictEqual(
+        [],
+      );
+    });
+  });
+
   it("suppresses native start ack for silent tasks and tasks without requester origin", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1848,6 +1848,13 @@ describe("task-registry", () => {
         startedAt: 100,
       });
 
+      await waitForAssertion(() =>
+        expectRecordFields(sentMessageCall(), {
+          content: "Background task started: ACP background task.",
+        }),
+      );
+      hoisted.sendMessageMock.mockClear();
+
       emitAgentEvent({
         runId: "run-delivery",
         stream: "lifecycle",
@@ -1864,9 +1871,11 @@ describe("task-registry", () => {
         }),
       );
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-      expect(peekSystemEvents("agent:main:main")).toEqual([
-        expect.stringContaining("Background task ready for review: ACP background task"),
-      ]);
+      await waitForAssertion(() =>
+        expect(peekSystemEvents("agent:main:main")).toEqual([
+          expect.stringContaining("Background task ready for review: ACP background task"),
+        ]),
+      );
     });
   });
 
@@ -2796,7 +2805,7 @@ describe("task-registry", () => {
       const second = maybeDeliverTaskTerminalUpdate(task.taskId);
       await Promise.all([first, second]);
 
-      expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1);
+      await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1));
       const message = sentMessageCall();
       expectRecordFields(message, {
         idempotencyKey: `task-terminal:${task.taskId}:succeeded:blocked`,
@@ -2804,9 +2813,11 @@ describe("task-registry", () => {
       expectRecordFields(message.mirror, {
         idempotencyKey: `task-terminal:${task.taskId}:succeeded:blocked`,
       });
-      expectRecordFields(requireTaskByRunId("run-racing-delivery"), {
-        deliveryStatus: "delivered",
-      });
+      await waitForAssertion(() =>
+        expectRecordFields(requireTaskByRunId("run-racing-delivery"), {
+          deliveryStatus: "delivered",
+        }),
+      );
     });
   });
 
@@ -4248,7 +4259,159 @@ describe("task-registry", () => {
     });
   });
 
-  it("delivers concise state-change updates only when notify policy requests them", async () => {
+  it("delivers native start ack once before terminal delivery for running tasks", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+      let resolveStartDelivery: () => void = () => {};
+      hoisted.sendMessageMock
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveStartDelivery = () =>
+                resolve({
+                  channel: "notifychat",
+                  to: "notifychat:123",
+                  via: "direct",
+                });
+            }),
+        )
+        .mockResolvedValueOnce({
+          channel: "notifychat",
+          to: "notifychat:123",
+          via: "direct",
+        });
+
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "notifychat",
+          to: "notifychat:123",
+        },
+        runId: "run-start-ack-on-create",
+        task: "Investigate issue",
+        status: "running",
+        deliveryStatus: "pending",
+        startedAt: 100,
+        notifyPolicy: "done_only",
+      });
+
+      await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1));
+      expectRecordFields(sentMessageCall(0), {
+        content: "Background task started: ACP background task.",
+        idempotencyKey: `task-start:${task.taskId}`,
+      });
+
+      markTaskRunningByRunId({
+        runId: "run-start-ack-on-create",
+        startedAt: 100,
+        lastEventAt: 150,
+        eventSummary: "Started.",
+      });
+      finalizeTaskRunByRunId({
+        runId: "run-start-ack-on-create",
+        runtime: "acp",
+        status: "succeeded",
+        endedAt: 250,
+        terminalSummary: "Done.",
+      });
+      await flushAsyncWork();
+      expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(1);
+
+      resolveStartDelivery();
+      await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(2));
+      expectRecordFields(sentMessageCall(1), {
+        content: "Background task done: ACP background task (run run-star). Done.",
+      });
+      expect(sentMessageCall(0).content).toBe("Background task started: ACP background task.");
+    });
+  });
+
+  it("delivers native start ack when a queued task transitions to running", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "notifychat",
+        to: "notifychat:123",
+        via: "direct",
+      });
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "notifychat",
+          to: "notifychat:123",
+        },
+        runId: "run-start-ack-from-queued",
+        task: "Investigate issue",
+        status: "queued",
+        deliveryStatus: "pending",
+        notifyPolicy: "done_only",
+      });
+
+      await flushAsyncWork();
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+
+      markTaskRunningByRunId({
+        runId: "run-start-ack-from-queued",
+        startedAt: 100,
+        lastEventAt: 100,
+      });
+
+      await waitForAssertion(() =>
+        expectRecordFields(sentMessageCall(), {
+          content: "Background task started: ACP background task.",
+          idempotencyKey: expect.stringMatching(/^task-start:/),
+        }),
+      );
+    });
+  });
+
+  it("suppresses native start ack for silent tasks and tasks without requester origin", async () => {
+    await withTaskRegistryTempDir(async () => {
+      resetTaskRegistryMemoryForTest();
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "notifychat",
+        to: "notifychat:123",
+        via: "direct",
+      });
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "notifychat",
+          to: "notifychat:123",
+        },
+        runId: "run-start-ack-silent",
+        task: "Silent task",
+        status: "running",
+        deliveryStatus: "pending",
+        notifyPolicy: "silent",
+      });
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: "run-start-ack-no-origin",
+        task: "No origin task",
+        status: "running",
+        deliveryStatus: "pending",
+        notifyPolicy: "done_only",
+      });
+
+      await flushAsyncWork();
+
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+      expect(peekSystemEvents("agent:main:main")).toStrictEqual([]);
+    });
+  });
+
+  it("delivers concise progress updates only when notify policy requests them", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockResolvedValue({
@@ -4274,9 +4437,15 @@ describe("task-registry", () => {
 
       markTaskRunningByRunId({
         runId: "run-state-change",
-        eventSummary: "Started.",
+        startedAt: 100,
+        lastEventAt: 100,
       });
-      await waitForAssertion(() => expect(hoisted.sendMessageMock).not.toHaveBeenCalled());
+      await waitForAssertion(() =>
+        expectRecordFields(sentMessageCall(), {
+          content: "Background task started: ACP background task.",
+        }),
+      );
+      hoisted.sendMessageMock.mockClear();
 
       updateTaskNotifyPolicyById({
         taskId: task.taskId,
@@ -4284,6 +4453,7 @@ describe("task-registry", () => {
       });
       recordTaskProgressByRunId({
         runId: "run-state-change",
+        lastEventAt: 200,
         eventSummary: "No output for 60s. It may be waiting for input.",
       });
 
@@ -4301,7 +4471,7 @@ describe("task-registry", () => {
     });
   });
 
-  it("keeps background ACP progress off the foreground lane and only sends a terminal notify", async () => {
+  it("keeps background ACP chatter off the foreground lane after native start ack", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
       resetSystemEventsForTest();
@@ -4326,6 +4496,12 @@ describe("task-registry", () => {
         status: "running",
         deliveryStatus: "pending",
       });
+
+      await flushAsyncWork();
+      expectRecordFields(sentMessageCall(), {
+        content: "Background task started: ACP background task.",
+      });
+      hoisted.sendMessageMock.mockClear();
 
       const relay = startAcpSpawnParentStreamRelay({
         runId: "run-quiet-terminal",
@@ -4362,15 +4538,17 @@ describe("task-registry", () => {
       await flushAsyncWork();
 
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
-      expect(peekSystemEvents("agent:main:main")).toEqual([
-        "Background task ready for review: ACP background task (run run-quie). Next: parent will review/verify before calling it done.",
-      ]);
+      await waitForAssertion(() =>
+        expect(peekSystemEvents("agent:main:main")).toEqual([
+          "Background task ready for review: ACP background task (run run-quie). Next: parent will review/verify before calling it done.",
+        ]),
+      );
       relay.dispose();
       vi.useRealTimers();
     });
   });
 
-  it("delivers a concise terminal failure message without internal ACP chatter", async () => {
+  it("delivers a concise terminal failure message after native start ack", async () => {
     await withTaskRegistryTempDir(async () => {
       resetTaskRegistryMemoryForTest();
       resetSystemEventsForTest();
@@ -4396,6 +4574,12 @@ describe("task-registry", () => {
         progressSummary:
           "I am loading session context and checking helper availability before writing the file.",
       });
+
+      await flushAsyncWork();
+      expectRecordFields(sentMessageCall(), {
+        content: "Background task started: ACP background task.",
+      });
+      hoisted.sendMessageMock.mockClear();
 
       emitAgentEvent({
         runId: "run-failure-terminal",
@@ -4445,6 +4629,12 @@ describe("task-registry", () => {
         notifyPolicy: "state_changes",
       });
 
+      await flushAsyncWork();
+      expectRecordFields(sentMessageCall(), {
+        content: "Background task started: ACP background task.",
+      });
+      hoisted.sendMessageMock.mockClear();
+
       const relay = startAcpSpawnParentStreamRelay({
         runId: "run-state-stream",
         parentSessionKey: "agent:main:main",
@@ -4458,11 +4648,8 @@ describe("task-registry", () => {
 
       relay.notifyStarted();
       await flushAsyncWork();
-      expectRecordFields(sentMessageCall(), {
-        content: "Background task update: ACP background task. Started.",
-      });
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
 
-      hoisted.sendMessageMock.mockClear();
       vi.advanceTimersByTime(1_500);
       await flushAsyncWork();
       expectRecordFields(sentMessageCall(), {
@@ -4521,6 +4708,13 @@ describe("task-registry", () => {
         status: "running",
         deliveryStatus: "pending",
       });
+
+      await waitForAssertion(() =>
+        expectRecordFields(sentMessageCall(), {
+          content: "Background task started: ACP background task.",
+        }),
+      );
+      hoisted.sendMessageMock.mockClear();
 
       const result = await cancelTaskById({
         cfg: {} as never,
@@ -4593,6 +4787,14 @@ describe("task-registry", () => {
         status: "running",
         deliveryStatus: "pending",
       });
+      await waitForAssertion(() => expect(hoisted.sendMessageMock).toHaveBeenCalledTimes(2));
+      expectRecordFields(sentMessageCall(0), {
+        content: "Background task started: Subagent task.",
+      });
+      expectRecordFields(sentMessageCall(1), {
+        content: "Background task started: Subagent task.",
+      });
+      hoisted.sendMessageMock.mockClear();
       hoisted.killSubagentRunAdminMock.mockImplementationOnce(async () => {
         finalizeTaskRunByRunId({
           runId: task.runId!,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1413,10 +1413,7 @@ function canDeliverToRequesterOrigin(origin: TaskDeliveryState["requesterOrigin"
   return Boolean(channel && to && isDeliverableMessageChannel(channel));
 }
 
-function canDeliverParentReviewTaskToBoundDiscordThread(task: TaskRecord): boolean {
-  if (!shouldUseParentReviewTaskTerminalMessage(task)) {
-    return false;
-  }
+function hasBoundDiscordRequesterThread(task: TaskRecord): boolean {
   const owner = resolveTaskDeliveryOwner(task);
   const origin = owner.requesterOrigin;
   const channel = origin?.channel?.trim().toLowerCase();
@@ -1429,6 +1426,18 @@ function canDeliverParentReviewTaskToBoundDiscordThread(task: TaskRecord): boole
     to?.startsWith("channel:") &&
     threadId &&
     canDeliverToRequesterOrigin(origin),
+  );
+}
+
+function canDeliverParentReviewTaskToBoundDiscordThread(task: TaskRecord): boolean {
+  return shouldUseParentReviewTaskTerminalMessage(task) && hasBoundDiscordRequesterThread(task);
+}
+
+function canDeliverTaskStateChangeToBoundDiscordThread(task: TaskRecord): boolean {
+  return (
+    task.runtime === "acp" &&
+    Boolean(task.childSessionKey?.trim()) &&
+    hasBoundDiscordRequesterThread(task)
   );
 }
 
@@ -1703,7 +1712,8 @@ async function maybeDeliverTaskStateChangeUpdateUnderAdmission(
         lastEventAt: Date.now(),
       });
     }
-    if (!canDeliverTaskOwnerToRequesterOrigin(owner)) {
+    const shouldDeliverParentReviewDirect = canDeliverTaskStateChangeToBoundDiscordThread(current);
+    if (!canDeliverTaskOwnerToRequesterOrigin(owner) && !shouldDeliverParentReviewDirect) {
       queueTaskSystemEvent(current, eventText);
       upsertTaskDeliveryState({
         taskId,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -85,6 +85,7 @@ const taskIdsByOwnerKey = taskRegistryProcessState.taskIdsByOwnerKey;
 const taskIdsByParentFlowId = taskRegistryProcessState.taskIdsByParentFlowId;
 const taskIdsByRelatedSessionKey = taskRegistryProcessState.taskIdsByRelatedSessionKey;
 const tasksWithPendingDelivery = taskRegistryProcessState.tasksWithPendingDelivery;
+const pendingTaskStateChangeDeliveries = new Map<string, Promise<void>>();
 let listenerStarted = false;
 let listenerStop: (() => void) | null = null;
 type TaskRegistryRestoreState =
@@ -136,6 +137,10 @@ type TaskDeliveryOwner = {
   sessionKey?: string;
   requesterOrigin?: TaskDeliveryState["requesterOrigin"];
   flowId?: string;
+};
+
+type TaskStateChangeDeliveryOptions = {
+  requireRequesterDeliveryContext?: boolean;
 };
 
 type ParentFlowLinkErrorCode =
@@ -390,6 +395,7 @@ function tryPersistTaskDeliveryStateUpsert(state: TaskDeliveryState): boolean {
 
 function clearTaskRegistryMemory(): void {
   clearTaskFlowSyncRetries();
+  pendingTaskStateChangeDeliveries.clear();
   tasks.clear();
   taskDeliveryStates.clear();
   taskIdsByRunId.clear();
@@ -609,6 +615,39 @@ function appendTaskEvent(event: {
     kind: event.kind,
     ...(summary ? { summary } : {}),
   };
+}
+
+function buildTaskRunningEvent(task: Pick<TaskRecord, "createdAt" | "startedAt" | "lastEventAt">) {
+  return appendTaskEvent({
+    at: task.startedAt ?? task.lastEventAt ?? task.createdAt,
+    kind: "running",
+  });
+}
+
+function scheduleTaskStateChangeDelivery(
+  taskId: string,
+  latestEvent?: TaskEventRecord,
+  options?: TaskStateChangeDeliveryOptions,
+): void {
+  if (!latestEvent) {
+    return;
+  }
+  const previous = pendingTaskStateChangeDeliveries.get(taskId);
+  const delivery = (async () => {
+    await previous;
+    await maybeDeliverTaskStateChangeUpdate(taskId, latestEvent, options);
+  })().catch((error: unknown) => {
+    log.warn("Failed to deliver background task state change", {
+      taskId,
+      error,
+    });
+  });
+  pendingTaskStateChangeDeliveries.set(taskId, delivery);
+  void delivery.finally(() => {
+    if (pendingTaskStateChangeDeliveries.get(taskId) === delivery) {
+      pendingTaskStateChangeDeliveries.delete(taskId);
+    }
+  });
 }
 
 function loadTaskRegistryDeliveryRuntime() {
@@ -1020,6 +1059,9 @@ function resolveTaskStateChangeIdempotencyKey(params: {
   latestEvent: TaskEventRecord;
   owner: TaskDeliveryOwner;
 }): string {
+  if (params.latestEvent.kind === "running") {
+    return `task-start:${params.task.taskId}`;
+  }
   if (params.owner.flowId) {
     return `flow-event:${params.owner.flowId}:${params.task.taskId}:${params.latestEvent.at}:${params.latestEvent.kind}`;
   }
@@ -1349,10 +1391,20 @@ function getTaskDeliveryState(taskId: string): TaskDeliveryState | undefined {
 
 function canDeliverTaskToRequesterOrigin(task: TaskRecord): boolean {
   const owner = resolveTaskDeliveryOwner(task);
+  return canDeliverTaskOwnerToRequesterOrigin(owner);
+}
+
+function canDeliverTaskOwnerToRequesterOrigin(owner: TaskDeliveryOwner): boolean {
   if (shouldRouteCompletionThroughRequesterSession(owner.sessionKey)) {
     return false;
   }
   return canDeliverToRequesterOrigin(owner.requesterOrigin);
+}
+
+function hasRequesterDeliveryContext(origin: TaskDeliveryState["requesterOrigin"]): boolean {
+  const channel = origin?.channel?.trim();
+  const to = origin?.to?.trim();
+  return Boolean(channel && to);
 }
 
 function canDeliverToRequesterOrigin(origin: TaskDeliveryState["requesterOrigin"]): boolean {
@@ -1471,6 +1523,7 @@ async function maybeDeliverTaskTerminalUpdateUnderAdmission(
   }
   tasksWithPendingDelivery.add(taskId);
   try {
+    await pendingTaskStateChangeDeliveries.get(taskId);
     const latest = tasks.get(taskId);
     if (!latest || !shouldAutoDeliverTaskTerminalUpdate(latest)) {
       return latest ? cloneTaskRecord(latest) : null;
@@ -1620,10 +1673,11 @@ async function maybeDeliverTaskStateChangeUpdate(
 async function maybeDeliverTaskStateChangeUpdateUnderAdmission(
   taskId: string,
   latestEvent?: TaskEventRecord,
+  options: TaskStateChangeDeliveryOptions = {},
 ): Promise<TaskRecord | null> {
   ensureTaskRegistryReady();
   const current = tasks.get(taskId);
-  if (!current || !shouldAutoDeliverTaskStateChange(current)) {
+  if (!current || !shouldAutoDeliverTaskStateChange(current, latestEvent)) {
     return current ? cloneTaskRecord(current) : null;
   }
   const deliveryState = getTaskDeliveryState(taskId);
@@ -1636,6 +1690,12 @@ async function maybeDeliverTaskStateChangeUpdateUnderAdmission(
   }
   try {
     const owner = resolveTaskDeliveryOwner(current);
+    if (
+      options.requireRequesterDeliveryContext &&
+      !hasRequesterDeliveryContext(owner.requesterOrigin)
+    ) {
+      return cloneTaskRecord(current);
+    }
     const ownerSessionKey = owner.sessionKey?.trim();
     if (!ownerSessionKey) {
       return updateTask(taskId, {
@@ -1643,7 +1703,7 @@ async function maybeDeliverTaskStateChangeUpdateUnderAdmission(
         lastEventAt: Date.now(),
       });
     }
-    if (!canDeliverTaskToRequesterOrigin(current)) {
+    if (!canDeliverTaskOwnerToRequesterOrigin(owner)) {
       queueTaskSystemEvent(current, eventText);
       upsertTaskDeliveryState({
         taskId,
@@ -1877,7 +1937,9 @@ function ensureListener() {
           : undefined;
       const updated = updateTask(current.taskId, patch);
       if (updated) {
-        void maybeDeliverTaskStateChangeUpdate(current.taskId, stateChangeEvent);
+        scheduleTaskStateChangeDelivery(current.taskId, stateChangeEvent, {
+          requireRequesterDeliveryContext: stateChangeEvent?.kind === "running",
+        });
         void maybeDeliverTaskTerminalUpdate(current.taskId);
       }
     }
@@ -2029,6 +2091,11 @@ export function createTaskRecord(params: {
     kind: "upserted",
     task: cloneTaskRecord(record),
   }));
+  if (record.status === "running") {
+    scheduleTaskStateChangeDelivery(taskId, buildTaskRunningEvent(record), {
+      requireRequesterDeliveryContext: true,
+    });
+  }
   if (isTerminalTaskStatus(record.status)) {
     void maybeDeliverTaskTerminalUpdate(taskId);
   }
@@ -2151,7 +2218,9 @@ function updateTaskStateByRunId(params: {
     if (task) {
       updated.push(task);
       if (!params.suppressDelivery) {
-        void maybeDeliverTaskStateChangeUpdate(task.taskId, nextEvent);
+        scheduleTaskStateChangeDelivery(task.taskId, nextEvent, {
+          requireRequesterDeliveryContext: nextEvent?.kind === "running",
+        });
         void maybeDeliverTaskTerminalUpdate(task.taskId);
       }
     }


### PR DESCRIPTION
## Summary
- send a visible `Background task started: ...` update when native/background task records enter the running state with a requester delivery context
- keep progress-only updates quiet for `done_only` tasks while still allowing the initial start acknowledgement
- avoid emitting start notices for task rows without a requester delivery route, so internal/session-only tasks stay quiet

## What Problem This Solves
Long-running native tasks could be accepted and tracked without an immediate requester-visible start acknowledgement. If the parent session later failed before closure, users saw recovery artefacts or silence instead of a normal "work started" signal.

## Test
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tasks.config.ts src/tasks/task-executor-policy.test.ts src/tasks/task-registry.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`

## Evidence
Contributor-authored evidence for the external PR proof gate.

Behavior addressed: native/background tasks now auto-deliver an initial started update when they have a requester delivery context.

Source validation:
- Local OpenClaw source worktree on `origin/main` plus this one patch commit.
- Targeted task policy/registry tests passed: 115 task tests.
- Core production typecheck exited successfully.

Live requester-visible proof:
- Local OpenClaw 2026.6.11 gateway was temporarily hotfixed with the same task-registry behaviour as this PR, then restarted.
- Gateway health after restart: RPC healthy, Telegram channel connected, plugin errors empty.
- A real Telegram-originated background task was started from a group topic.
- Requester-visible Telegram transcript showed exactly one start acknowledgement before completion:
  - `2026-07-06 22:00:23 GMT+1` — `Background task started: PR 101126 live proof background task.`
  - `2026-07-06 22:00:43 GMT+1` — task completed with `PR 101126 live proof task complete.`
- The tracked task record then showed `status=succeeded`, `deliveryStatus=delivered`, and `notifyPolicy=done_only`.

Observed result after fix: `running` task events generate a single requester-visible start acknowledgement while later progress remains suppressed unless the task requested state-change notifications, and terminal delivery occurs after the start acknowledgement has been emitted.

