### PR TITLE
feat(browser): pair the Chrome extension directly to a remote gateway

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -9083,7 +9083,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: How it works
   - H2: Install and pair
   - H2: Use it
-  - H2: Remote browser nodes
+  - H2: Remote / cross-machine
   - H2: Diagnostics
   - H2: Security model
 

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -91,20 +91,26 @@ openclaw config set browser.defaultProfile chrome
 - Revoke: click the button again, drag the tab out of the group, or dismiss
   Chrome's debugging banner. The agent loses access to that tab immediately.
 
-## Remote browser nodes
+## Remote / cross-machine
 
-The extension works whether Chrome runs on the Gateway host or on a separate
-[browser node host](/tools/browser#local-vs-remote-control). The relay is always
-loopback-only and runs **on the machine with the browser**:
+Chrome does not have to run on the Gateway host. Three topologies work:
 
-- **Same host** (Gateway + Chrome on one machine): pair on that machine.
-- **Remote node** (Chrome on a node, Gateway elsewhere): run
-  `openclaw browser extension path` / `pair` **on the node**, load and pair the
-  extension there. The Gateway proxies browser actions to the node over its
-  existing authenticated node link; the node's local relay drives the extension.
-  No new inbound port is opened on the node.
+- **Same host** (Gateway + Chrome on one machine): pair on that machine with
+  `openclaw browser extension pair`. The relay is loopback-only.
+- **Direct to a remote Gateway** (Chrome on your laptop, Gateway on a VPS, and
+  **nothing else on the laptop**): on the Gateway, run
+  `openclaw browser extension pair --gateway-url wss://your-gateway.example.com`.
+  It prints a `wss://…/browser/extension#<secret>` string; load and pair the
+  extension on the laptop. The extension connects **straight to the Gateway**
+  over `wss://` — no OpenClaw install, Node, CLI, or open inbound port on the
+  laptop. This is the managed-hosting path.
+- **Via a browser node host** (Chrome on a machine already running an OpenClaw
+  node): run `pair` on the node and pair locally; the Gateway proxies browser
+  actions to the node over its existing authenticated node link.
 
-The pairing token is per host, so each node prints its own string.
+The pairing secret is per host (the Gateway's, in the direct case), validated by
+the Gateway's `/browser/extension` route. For the direct path, serve the Gateway
+over TLS (`wss://`) so the pairing secret and CDP traffic are encrypted.
 
 ## Diagnostics
 

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -111,6 +111,10 @@ Chrome does not have to run on the Gateway host. Three topologies work:
 The pairing secret is per host (the Gateway's, in the direct case), validated by
 the Gateway's `/browser/extension` route. For the direct path, serve the Gateway
 over TLS (`wss://`) so the pairing secret and CDP traffic are encrypted.
+The secret remains in the pairing string's URL fragment and is presented during
+the WebSocket handshake as a subprotocol credential, so normal proxy access
+logs do not receive it in the request URL. Ensure any reverse proxy preserves
+the standard `Sec-WebSocket-Protocol` header.
 
 ## Diagnostics
 
@@ -126,6 +130,8 @@ extension popup shows **Connected**.
 
 - The relay binds loopback only; both WebSocket sides are authenticated with the
   derived token, and the extension side is origin-checked to `chrome-extension://`.
+- Direct Gateway pairing does not accept the relay token in the request URL;
+  the bundled extension carries it in the WebSocket subprotocol list instead.
 - The agent can only see and drive tabs in the **OpenClaw tab group**. Your
   other tabs stay private.
 - Compared with the `user` (Chrome MCP) profile, which exposes your whole

--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -7,7 +7,7 @@
 // consent boundary: only grouped tabs are reported to (and driven by) OpenClaw.
 import {
   OPENCLAW_TAB_GROUP_TITLE,
-  buildRelayWsUrl,
+  buildRelayWsProtocols,
   nearestGroupColor,
   parsePairingString,
   reconnectDelayMs,
@@ -298,7 +298,7 @@ async function connectRelay() {
   setBadge("connecting");
   let ws;
   try {
-    ws = new WebSocket(buildRelayWsUrl(relayUrl, token));
+    ws = new WebSocket(relayUrl, buildRelayWsProtocols(token));
   } catch {
     setBadge("error");
     scheduleReconnect();

--- a/extensions/browser/chrome-extension/modules/relay-core.d.ts
+++ b/extensions/browser/chrome-extension/modules/relay-core.d.ts
@@ -2,12 +2,11 @@
 // it can load unbundled in Chrome). Kept in sync with relay-core.js.
 
 export const OPENCLAW_TAB_GROUP_TITLE: string;
+export const EXTENSION_RELAY_PROTOCOL: string;
 
-export function parsePairingString(
-  raw: unknown,
-): { relayUrl: string; token: string } | null;
+export function parsePairingString(raw: unknown): { relayUrl: string; token: string } | null;
 
-export function buildRelayWsUrl(relayUrl: string, token: string): string;
+export function buildRelayWsProtocols(token: string): string[];
 
 export function reconnectDelayMs(attempt: number): number;
 

--- a/extensions/browser/chrome-extension/modules/relay-core.js
+++ b/extensions/browser/chrome-extension/modules/relay-core.js
@@ -4,6 +4,8 @@
 
 /** Tab group shown to the user; membership == what the agent may touch. */
 export const OPENCLAW_TAB_GROUP_TITLE = "OpenClaw";
+export const EXTENSION_RELAY_PROTOCOL = "openclaw-extension-relay";
+const EXTENSION_RELAY_TOKEN_PROTOCOL_PREFIX = "openclaw-extension-token.";
 
 const CHROME_GROUP_COLORS = {
   grey: [128, 128, 128],
@@ -48,11 +50,9 @@ export function parsePairingString(raw) {
   return { relayUrl, token };
 }
 
-/** Build the authenticated relay WebSocket URL (token travels as query). */
-export function buildRelayWsUrl(relayUrl, token) {
-  const url = new URL(relayUrl);
-  url.searchParams.set("token", token);
-  return url.toString();
+/** Build WebSocket subprotocols without putting the relay secret in the request URL. */
+export function buildRelayWsProtocols(token) {
+  return [EXTENSION_RELAY_PROTOCOL, `${EXTENSION_RELAY_TOKEN_PROTOCOL_PREFIX}${token}`];
 }
 
 /** Exponential reconnect backoff: 1s, 2s, 4s ... capped at 30s. */

--- a/extensions/browser/chrome-extension/modules/relay-core.test.ts
+++ b/extensions/browser/chrome-extension/modules/relay-core.test.ts
@@ -2,7 +2,7 @@
 // extension-browser vitest glob (extensions/browser/**/*.test.ts).
 import { describe, expect, it } from "vitest";
 import {
-  buildRelayWsUrl,
+  buildRelayWsProtocols,
   nearestGroupColor,
   parsePairingString,
   reconnectDelayMs,
@@ -25,9 +25,11 @@ describe("parsePairingString", () => {
     if (!parsed) {
       throw new Error("expected pairing string to parse");
     }
-    expect(buildRelayWsUrl(parsed.relayUrl, parsed.token)).toBe(
-      `ws://127.0.0.1:${port}/extension?token=${token}`,
-    );
+    expect(parsed.relayUrl).toBe(`ws://127.0.0.1:${port}/extension`);
+    expect(buildRelayWsProtocols(parsed.token)).toEqual([
+      "openclaw-extension-relay",
+      `openclaw-extension-token.${token}`,
+    ]);
   });
 
   it("rejects malformed strings", () => {

--- a/extensions/browser/cli-metadata.ts
+++ b/extensions/browser/cli-metadata.ts
@@ -13,7 +13,7 @@ export default definePluginEntry({
     api.registerCli(
       async ({ program }) => {
         const { registerBrowserCli } = await import("./src/cli/browser-cli.js");
-        registerBrowserCli(program);
+        registerBrowserCli(program, process.argv, api.rootDir);
       },
       { commands: ["browser"] },
     );

--- a/extensions/browser/index.test.ts
+++ b/extensions/browser/index.test.ts
@@ -71,6 +71,7 @@ function createApi() {
     id: "browser",
     name: "Browser",
     source: "test",
+    rootDir: "/plugins/browser",
     config: {},
     runtime: {} as OpenClawPluginApi["runtime"],
     registerCli,
@@ -242,7 +243,11 @@ describe("browser plugin", () => {
       ],
     });
     await registrar({ program: {} as never });
-    expect(runtimeApiMocks.registerBrowserCli).toHaveBeenCalledWith({});
+    expect(runtimeApiMocks.registerBrowserCli).toHaveBeenCalledWith(
+      {},
+      process.argv,
+      "/plugins/browser",
+    );
   });
 
   it("registers browser.request as an admin gateway method and lazy-loads handler", async () => {

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -1,8 +1,10 @@
-import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 /**
  * Browser plugin registration helpers. This file keeps registration lazy while
  * advertising Browser tools, services, node-host commands, and audits.
  */
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Duplex } from "node:stream";
+import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type {
   AnyAgentTool,
   OpenClawPluginApi,
@@ -216,5 +218,24 @@ export function registerBrowserPlugin(api: OpenClawPluginApi) {
       scope: BROWSER_REQUEST_GATEWAY_SCOPE,
     },
   );
+  // Remote extension relay: lets the Chrome extension connect directly to this
+  // gateway over wss:// (no node host on the browser machine). auth:"plugin"
+  // with no nodeCapability means the gateway does not pre-enforce token auth;
+  // the handler self-validates the host-local relay secret. Path kept in sync
+  // with GATEWAY_EXTENSION_RELAY_PATH (hardcoded here to stay lazy).
+  api.registerHttpRoute({
+    path: "/browser/extension",
+    auth: "plugin",
+    match: "exact",
+    handler: (_req: IncomingMessage, res: ServerResponse) => {
+      res.writeHead(426, { "Content-Type": "text/plain" });
+      res.end("Upgrade Required: connect the OpenClaw Chrome extension over WebSocket.");
+    },
+    handleUpgrade: async (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+      const { handleGatewayExtensionUpgrade } =
+        await import("./src/browser/extension-relay/gateway-relay-route.js");
+      return await handleGatewayExtensionUpgrade(req, socket, head);
+    },
+  });
   api.registerService(createLazyBrowserPluginService());
 }

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -204,7 +204,7 @@ export function registerBrowserPlugin(api: OpenClawPluginApi) {
   api.registerCli(
     async ({ program }) => {
       const { registerBrowserCli } = await import("./src/cli/browser-cli.js");
-      registerBrowserCli(program);
+      registerBrowserCli(program, process.argv, api.rootDir);
     },
     { commands: ["browser"], descriptors: [BROWSER_CLI_DESCRIPTOR] },
   );

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts
@@ -1,0 +1,150 @@
+// Gateway extension relay upgrade handler: auth + routing decisions.
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const getBrowserControlStateMock = vi.fn();
+vi.mock("../../browser-control-state.js", () => ({
+  getBrowserControlState: () => getBrowserControlStateMock(),
+}));
+
+const ensureExtensionRelayForProfileMock = vi.fn();
+vi.mock("./relay-lifecycle.js", () => ({
+  ensureExtensionRelayForProfile: (...args: unknown[]) =>
+    ensureExtensionRelayForProfileMock(...args),
+}));
+
+const resolveProfileMock = vi.fn();
+vi.mock("../config.js", () => ({
+  resolveProfile: (...args: unknown[]) => resolveProfileMock(...args),
+}));
+
+const attachExtensionWebSocketMock = vi.fn();
+vi.mock("./relay-server.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./relay-server.js")>();
+  return {
+    ...actual,
+    attachExtensionWebSocket: (...args: unknown[]) => attachExtensionWebSocketMock(...args),
+  };
+});
+
+import { handleGatewayExtensionUpgrade } from "./gateway-relay-route.js";
+import { extensionRelayTokenMatches } from "./relay-auth.js";
+
+const TOKEN = "a".repeat(64);
+
+function fakeSocket() {
+  const writes: string[] = [];
+  let destroyed = false;
+  const socket = {
+    write: (chunk: string) => {
+      writes.push(chunk);
+      return true;
+    },
+    destroy: () => {
+      destroyed = true;
+    },
+  } as unknown as Duplex;
+  return { socket, writes, isDestroyed: () => destroyed };
+}
+
+function req(url: string, headers: Record<string, string> = {}): IncomingMessage {
+  return { url, headers: { origin: "chrome-extension://abc", ...headers } } as IncomingMessage;
+}
+
+function stateWithExtensionProfile() {
+  return {
+    resolved: {
+      extensionRelayToken: TOKEN,
+      profiles: { chrome: { driver: "extension" } },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// Default: the requested profile resolves to a valid extension profile.
+function primeProfile() {
+  resolveProfileMock.mockReturnValue({ name: "chrome", driver: "extension" });
+}
+
+describe("handleGatewayExtensionUpgrade", () => {
+  it("ignores non-relay paths", async () => {
+    const { socket } = fakeSocket();
+    const handled = await handleGatewayExtensionUpgrade(req("/other"), socket, Buffer.alloc(0));
+    expect(handled).toBe(false);
+    expect(getBrowserControlStateMock).not.toHaveBeenCalled();
+  });
+
+  it("503s when the browser control service is not running", async () => {
+    getBrowserControlStateMock.mockReturnValue(null);
+    const { socket, writes, isDestroyed } = fakeSocket();
+    const handled = await handleGatewayExtensionUpgrade(
+      req("/browser/extension?token=" + TOKEN),
+      socket,
+      Buffer.alloc(0),
+    );
+    expect(handled).toBe(true);
+    expect(writes.join("")).toContain("503");
+    expect(isDestroyed()).toBe(true);
+  });
+
+  it("403s a non-extension origin", async () => {
+    getBrowserControlStateMock.mockReturnValue(stateWithExtensionProfile());
+    const { socket, writes } = fakeSocket();
+    await handleGatewayExtensionUpgrade(
+      req("/browser/extension?token=" + TOKEN, { origin: "https://evil.example" }),
+      socket,
+      Buffer.alloc(0),
+    );
+    expect(writes.join("")).toContain("403");
+  });
+
+  it("401s a missing or wrong token", async () => {
+    getBrowserControlStateMock.mockReturnValue(stateWithExtensionProfile());
+    primeProfile();
+    const missing = fakeSocket();
+    await handleGatewayExtensionUpgrade(req("/browser/extension"), missing.socket, Buffer.alloc(0));
+    expect(missing.writes.join("")).toContain("401");
+
+    const wrong = fakeSocket();
+    await handleGatewayExtensionUpgrade(
+      req("/browser/extension?token=" + "b".repeat(64)),
+      wrong.socket,
+      Buffer.alloc(0),
+    );
+    expect(wrong.writes.join("")).toContain("401");
+    expect(ensureExtensionRelayForProfileMock).not.toHaveBeenCalled();
+  });
+
+  it("attaches the socket to the bridge on a valid token", async () => {
+    getBrowserControlStateMock.mockReturnValue(stateWithExtensionProfile());
+    primeProfile();
+    const bridge = { id: "bridge" };
+    ensureExtensionRelayForProfileMock.mockResolvedValue({ bridge });
+    // Real handleUpgrade would need a live socket; stub it to fire the callback.
+    const wsMod = await import("ws");
+    const upgradeSpy = vi
+      .spyOn(wsMod.WebSocketServer.prototype, "handleUpgrade")
+      .mockImplementation((_req, _socket, _head, cb) => {
+        (cb as (ws: unknown) => void)({ readyState: 1 });
+      });
+    const { socket } = fakeSocket();
+    const handled = await handleGatewayExtensionUpgrade(
+      req("/browser/extension?token=" + TOKEN),
+      socket,
+      Buffer.alloc(0),
+    );
+    expect(handled).toBe(true);
+    expect(ensureExtensionRelayForProfileMock).toHaveBeenCalledOnce();
+    expect(attachExtensionWebSocketMock).toHaveBeenCalledWith(bridge, { readyState: 1 });
+    upgradeSpy.mockRestore();
+  });
+
+  it("uses the real host-local token matcher (sanity)", () => {
+    expect(extensionRelayTokenMatches(TOKEN, TOKEN)).toBe(true);
+    expect(extensionRelayTokenMatches(TOKEN, "b".repeat(64))).toBe(false);
+  });
+});

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts
@@ -1,11 +1,13 @@
 // Gateway extension relay upgrade handler: auth + routing decisions.
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getBrowserControlStateMock = vi.fn();
-vi.mock("../../browser-control-state.js", () => ({
+const startBrowserControlServiceFromConfigMock = vi.fn();
+vi.mock("../../control-service.js", () => ({
   getBrowserControlState: () => getBrowserControlStateMock(),
+  startBrowserControlServiceFromConfig: () => startBrowserControlServiceFromConfigMock(),
 }));
 
 const ensureExtensionRelayForProfileMock = vi.fn();
@@ -25,6 +27,15 @@ vi.mock("./relay-server.js", async (importOriginal) => {
   return {
     ...actual,
     attachExtensionWebSocket: (...args: unknown[]) => attachExtensionWebSocketMock(...args),
+  };
+});
+
+const readExtensionRelayTokenMock = vi.fn();
+vi.mock("./relay-auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./relay-auth.js")>();
+  return {
+    ...actual,
+    readExtensionRelayToken: () => readExtensionRelayTokenMock(),
   };
 });
 
@@ -52,6 +63,17 @@ function req(url: string, headers: Record<string, string> = {}): IncomingMessage
   return { url, headers: { origin: "chrome-extension://abc", ...headers } } as IncomingMessage;
 }
 
+function relayReq(
+  url: string,
+  token = TOKEN,
+  headers: Record<string, string> = {},
+): IncomingMessage {
+  return req(url, {
+    "sec-websocket-protocol": `openclaw-extension-relay, openclaw-extension-token.${token}`,
+    ...headers,
+  });
+}
+
 function stateWithExtensionProfile() {
   return {
     resolved: {
@@ -61,13 +83,27 @@ function stateWithExtensionProfile() {
   };
 }
 
+beforeEach(() => {
+  readExtensionRelayTokenMock.mockReturnValue(TOKEN);
+});
+
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.clearAllMocks();
 });
 
 // Default: the requested profile resolves to a valid extension profile.
 function primeProfile() {
   resolveProfileMock.mockReturnValue({ name: "chrome", driver: "extension" });
+}
+
+async function mockSuccessfulUpgrade() {
+  const wsMod = await import("ws");
+  vi.spyOn(wsMod.WebSocketServer.prototype, "handleUpgrade").mockImplementation(
+    (_req, _socket, _head, cb) => {
+      (cb as (ws: unknown) => void)({ readyState: 1 });
+    },
+  );
 }
 
 describe("handleGatewayExtensionUpgrade", () => {
@@ -78,24 +114,26 @@ describe("handleGatewayExtensionUpgrade", () => {
     expect(getBrowserControlStateMock).not.toHaveBeenCalled();
   });
 
-  it("503s when the browser control service is not running", async () => {
+  it("503s when authenticated lazy startup cannot enable browser control", async () => {
     getBrowserControlStateMock.mockReturnValue(null);
+    startBrowserControlServiceFromConfigMock.mockResolvedValue(null);
     const { socket, writes, isDestroyed } = fakeSocket();
     const handled = await handleGatewayExtensionUpgrade(
-      req("/browser/extension?token=" + TOKEN),
+      relayReq("/browser/extension"),
       socket,
       Buffer.alloc(0),
     );
     expect(handled).toBe(true);
     expect(writes.join("")).toContain("503");
     expect(isDestroyed()).toBe(true);
+    expect(startBrowserControlServiceFromConfigMock).toHaveBeenCalledOnce();
   });
 
   it("403s a non-extension origin", async () => {
     getBrowserControlStateMock.mockReturnValue(stateWithExtensionProfile());
     const { socket, writes } = fakeSocket();
     await handleGatewayExtensionUpgrade(
-      req("/browser/extension?token=" + TOKEN, { origin: "https://evil.example" }),
+      relayReq("/browser/extension", TOKEN, { origin: "https://evil.example" }),
       socket,
       Buffer.alloc(0),
     );
@@ -111,12 +149,46 @@ describe("handleGatewayExtensionUpgrade", () => {
 
     const wrong = fakeSocket();
     await handleGatewayExtensionUpgrade(
-      req("/browser/extension?token=" + "b".repeat(64)),
+      relayReq("/browser/extension", "b".repeat(64)),
       wrong.socket,
       Buffer.alloc(0),
     );
     expect(wrong.writes.join("")).toContain("401");
     expect(ensureExtensionRelayForProfileMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects relay secrets in the public request URL", async () => {
+    getBrowserControlStateMock.mockReturnValue(stateWithExtensionProfile());
+    const { socket, writes } = fakeSocket();
+    await handleGatewayExtensionUpgrade(
+      req("/browser/extension?token=" + TOKEN),
+      socket,
+      Buffer.alloc(0),
+    );
+    expect(writes.join("")).toContain("401");
+    expect(ensureExtensionRelayForProfileMock).not.toHaveBeenCalled();
+  });
+
+  it("authenticates before lazy-starting browser control on a fresh gateway", async () => {
+    const state = stateWithExtensionProfile();
+    getBrowserControlStateMock.mockReturnValue(null);
+    startBrowserControlServiceFromConfigMock.mockResolvedValue(state);
+    primeProfile();
+    const bridge = { id: "fresh-bridge" };
+    ensureExtensionRelayForProfileMock.mockResolvedValue({ bridge });
+    await mockSuccessfulUpgrade();
+
+    const { socket } = fakeSocket();
+    const handled = await handleGatewayExtensionUpgrade(
+      relayReq("/browser/extension"),
+      socket,
+      Buffer.alloc(0),
+    );
+
+    expect(handled).toBe(true);
+    expect(readExtensionRelayTokenMock).toHaveBeenCalledOnce();
+    expect(startBrowserControlServiceFromConfigMock).toHaveBeenCalledOnce();
+    expect(attachExtensionWebSocketMock).toHaveBeenCalledWith(bridge, { readyState: 1 });
   });
 
   it("attaches the socket to the bridge on a valid token", async () => {
@@ -125,22 +197,16 @@ describe("handleGatewayExtensionUpgrade", () => {
     const bridge = { id: "bridge" };
     ensureExtensionRelayForProfileMock.mockResolvedValue({ bridge });
     // Real handleUpgrade would need a live socket; stub it to fire the callback.
-    const wsMod = await import("ws");
-    const upgradeSpy = vi
-      .spyOn(wsMod.WebSocketServer.prototype, "handleUpgrade")
-      .mockImplementation((_req, _socket, _head, cb) => {
-        (cb as (ws: unknown) => void)({ readyState: 1 });
-      });
+    await mockSuccessfulUpgrade();
     const { socket } = fakeSocket();
     const handled = await handleGatewayExtensionUpgrade(
-      req("/browser/extension?token=" + TOKEN),
+      relayReq("/browser/extension"),
       socket,
       Buffer.alloc(0),
     );
     expect(handled).toBe(true);
     expect(ensureExtensionRelayForProfileMock).toHaveBeenCalledOnce();
     expect(attachExtensionWebSocketMock).toHaveBeenCalledWith(bridge, { readyState: 1 });
-    upgradeSpy.mockRestore();
   });
 
   it("uses the real host-local token matcher (sanity)", () => {

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.ts
@@ -1,0 +1,139 @@
+/**
+ * Gateway-hosted extension relay upgrade handler.
+ *
+ * Lets the OpenClaw Chrome extension connect DIRECTLY to a remote gateway over
+ * `wss://` — no OpenClaw node host on the browser machine. This is the
+ * cross-machine path for #53599: a user installs only the extension and pastes
+ * a `wss://gateway/browser/extension#<secret>` pairing string.
+ *
+ * The gateway route is registered with `auth: "plugin"` and no nodeCapability,
+ * so the gateway does NOT pre-enforce gateway-token auth (browser WebSockets
+ * cannot send an Authorization header anyway). This handler self-validates the
+ * host-local relay secret from the `?token=` query, then attaches the socket to
+ * the same ExtensionRelayBridge the loopback relay uses — so all CDP synthesis,
+ * tab-group scoping, and the in-process Playwright /cdp client are unchanged.
+ */
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { WebSocketServer } from "ws";
+import { getBrowserControlState } from "../../browser-control-state.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolveProfile } from "../config.js";
+import { extensionRelayTokenMatches } from "./relay-auth.js";
+import { ensureExtensionRelayForProfile } from "./relay-lifecycle.js";
+import {
+  attachExtensionWebSocket,
+  EXTENSION_RELAY_MAX_PAYLOAD_BYTES,
+  isAllowedExtensionOrigin,
+  requestToken,
+} from "./relay-server.js";
+
+const log = createSubsystemLogger("browser").child("extension-relay-gateway");
+
+/** Path the browser plugin registers on the gateway (ends in /extension so the pairing parser accepts it). */
+export const GATEWAY_EXTENSION_RELAY_PATH = "/browser/extension";
+
+// Single noServer WebSocketServer for all gateway-hosted extension upgrades.
+let wss: WebSocketServer | null = null;
+function getWss(): WebSocketServer {
+  wss ??= new WebSocketServer({ noServer: true, maxPayload: EXTENSION_RELAY_MAX_PAYLOAD_BYTES });
+  return wss;
+}
+
+function destroy(socket: Duplex, statusLine: string): void {
+  try {
+    socket.write(`HTTP/1.1 ${statusLine}\r\nConnection: close\r\n\r\n`);
+    socket.destroy();
+  } catch {
+    // socket already gone
+  }
+}
+
+function requestedProfileName(req: IncomingMessage, fallback: string): string {
+  try {
+    const value = new URL(req.url ?? "/", "http://127.0.0.1").searchParams.get("profile");
+    return value?.trim() || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/** First extension-driver profile name, defaulting to the built-in `chrome`. */
+function defaultExtensionProfileName(profiles: Record<string, { driver?: string }>): string {
+  for (const [name, profile] of Object.entries(profiles)) {
+    if (profile.driver === "extension") {
+      return name;
+    }
+  }
+  return "chrome";
+}
+
+/**
+ * Handle a gateway upgrade for the extension relay path. Returns true when the
+ * request was claimed (handled or rejected), false to let the gateway continue.
+ */
+export async function handleGatewayExtensionUpgrade(
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+): Promise<boolean> {
+  const path = (req.url ?? "/").split("?")[0];
+  if (path !== GATEWAY_EXTENSION_RELAY_PATH) {
+    return false;
+  }
+
+  const state = getBrowserControlState();
+  if (!state) {
+    destroy(socket, "503 Service Unavailable");
+    return true;
+  }
+
+  // chrome-extension:// origin hygiene (not a security boundary on its own —
+  // the relay secret is the gate — but rejects obvious cross-site sockets).
+  if (!isAllowedExtensionOrigin(req)) {
+    destroy(socket, "403 Forbidden");
+    return true;
+  }
+
+  const profileName = requestedProfileName(
+    req,
+    defaultExtensionProfileName(state.resolved.profiles),
+  );
+  const resolved = resolveProfile(state.resolved, profileName);
+  if (!resolved || resolved.driver !== "extension") {
+    destroy(socket, "404 Not Found");
+    return true;
+  }
+
+  const expectedToken = state.resolved.extensionRelayToken;
+  const candidate = requestToken(req);
+  if (
+    !expectedToken ||
+    candidate.length === 0 ||
+    !extensionRelayTokenMatches(expectedToken, candidate)
+  ) {
+    destroy(socket, "401 Unauthorized");
+    return true;
+  }
+
+  let bridge;
+  try {
+    bridge = (await ensureExtensionRelayForProfile(state, resolved)).bridge;
+  } catch (err) {
+    log.warn(`failed to start relay for profile "${profileName}": ${String(err)}`);
+    destroy(socket, "503 Service Unavailable");
+    return true;
+  }
+
+  getWss().handleUpgrade(req, socket, head, (ws) => {
+    attachExtensionWebSocket(bridge, ws);
+    log.info(`extension connected over gateway for profile "${profileName}"`);
+  });
+  return true;
+}
+
+/** Release the shared WebSocketServer (runtime shutdown / tests). */
+export function disposeGatewayExtensionRelay(): void {
+  wss?.close();
+  wss = null;
+}

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.ts
@@ -9,23 +9,27 @@
  * The gateway route is registered with `auth: "plugin"` and no nodeCapability,
  * so the gateway does NOT pre-enforce gateway-token auth (browser WebSockets
  * cannot send an Authorization header anyway). This handler self-validates the
- * host-local relay secret from the `?token=` query, then attaches the socket to
- * the same ExtensionRelayBridge the loopback relay uses — so all CDP synthesis,
- * tab-group scoping, and the in-process Playwright /cdp client are unchanged.
+ * host-local relay secret from the WebSocket subprotocol list, then attaches
+ * the socket to the same ExtensionRelayBridge the loopback relay uses — so all
+ * CDP synthesis, tab-group scoping, and the in-process Playwright /cdp client
+ * are unchanged.
  */
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { WebSocketServer } from "ws";
-import { getBrowserControlState } from "../../browser-control-state.js";
+import {
+  getBrowserControlState,
+  startBrowserControlServiceFromConfig,
+} from "../../control-service.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveProfile } from "../config.js";
-import { extensionRelayTokenMatches } from "./relay-auth.js";
+import { extensionRelayTokenMatches, readExtensionRelayToken } from "./relay-auth.js";
 import { ensureExtensionRelayForProfile } from "./relay-lifecycle.js";
 import {
   attachExtensionWebSocket,
   EXTENSION_RELAY_MAX_PAYLOAD_BYTES,
   isAllowedExtensionOrigin,
-  requestToken,
+  requestExtensionProtocolToken,
 } from "./relay-server.js";
 
 const log = createSubsystemLogger("browser").child("extension-relay-gateway");
@@ -82,17 +86,37 @@ export async function handleGatewayExtensionUpgrade(
     return false;
   }
 
-  const state = getBrowserControlState();
-  if (!state) {
-    destroy(socket, "503 Service Unavailable");
-    return true;
-  }
-
   // chrome-extension:// origin hygiene (not a security boundary on its own —
   // the relay secret is the gate — but rejects obvious cross-site sockets).
   if (!isAllowedExtensionOrigin(req)) {
     destroy(socket, "403 Forbidden");
     return true;
+  }
+
+  // Authenticate before lazy-starting Browser control. A valid pairing secret
+  // may start the service; an arbitrary public WebSocket request may not.
+  let state = getBrowserControlState();
+  const expectedToken = state?.resolved.extensionRelayToken ?? readExtensionRelayToken();
+  const candidate = requestExtensionProtocolToken(req);
+  if (
+    !expectedToken ||
+    candidate.length === 0 ||
+    !extensionRelayTokenMatches(expectedToken, candidate)
+  ) {
+    destroy(socket, "401 Unauthorized");
+    return true;
+  }
+
+  if (!state) {
+    try {
+      state = await startBrowserControlServiceFromConfig();
+    } catch (err) {
+      log.warn(`failed to start Browser control for extension relay: ${String(err)}`);
+    }
+    if (!state) {
+      destroy(socket, "503 Service Unavailable");
+      return true;
+    }
   }
 
   const profileName = requestedProfileName(
@@ -102,17 +126,6 @@ export async function handleGatewayExtensionUpgrade(
   const resolved = resolveProfile(state.resolved, profileName);
   if (!resolved || resolved.driver !== "extension") {
     destroy(socket, "404 Not Found");
-    return true;
-  }
-
-  const expectedToken = state.resolved.extensionRelayToken;
-  const candidate = requestToken(req);
-  if (
-    !expectedToken ||
-    candidate.length === 0 ||
-    !extensionRelayTokenMatches(expectedToken, candidate)
-  ) {
-    destroy(socket, "401 Unauthorized");
     return true;
   }
 

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -117,8 +117,12 @@ describe("ExtensionRelayBridge", () => {
 
     const attached = client.frames().find((frame) => frame.method === "Target.attachedToTarget");
     expect(attached).toBeTruthy();
-    const params = attached?.params as { targetInfo?: { targetId?: string }; sessionId?: string };
+    const params = attached?.params as {
+      targetInfo?: { targetId?: string; browserContextId?: string };
+      sessionId?: string;
+    };
     expect(params.targetInfo?.targetId).toBe("target-1");
+    expect(params.targetInfo?.browserContextId).toBe("openclaw-extension-context");
     expect(typeof params.sessionId).toBe("string");
   });
 
@@ -154,6 +158,94 @@ describe("ExtensionRelayBridge", () => {
     expect(forwarded).toMatchObject({ tabId: 1, method: "Page.navigate" });
     const response = client.frames().find((frame) => frame.id === 2);
     expect(response?.result).toMatchObject({ ok: true });
+  });
+
+  it("multiplexes Playwright page CDP sessions over the shared tab attachment", async () => {
+    const bridge = new ExtensionRelayBridge();
+    const { socket: extSocket, handlers } = wireExtension(bridge);
+    sendHello(handlers);
+
+    const client = new FakeSocket();
+    const cdp = bridge.attachCdpClientSocket(client);
+    cdp.onMessage(
+      JSON.stringify({ id: 1, method: "Target.setAutoAttach", params: { autoAttach: true } }),
+    );
+    await flush();
+    cdp.onMessage(JSON.stringify({ id: 2, method: "Target.attachToBrowserTarget" }));
+    await flush();
+    const browserSessionId = (
+      client.frames().find((frame) => frame.id === 2)?.result as { sessionId?: string }
+    )?.sessionId;
+    expect(browserSessionId).toBeTruthy();
+
+    cdp.onMessage(
+      JSON.stringify({
+        id: 3,
+        sessionId: browserSessionId,
+        method: "Target.attachToTarget",
+        params: { targetId: "target-1", flatten: true },
+      }),
+    );
+    await flush();
+    const pageSessionId = (
+      client.frames().find((frame) => frame.id === 3)?.result as { sessionId?: string }
+    )?.sessionId;
+    expect(pageSessionId).toBeTruthy();
+    expect(pageSessionId).not.toBe(browserSessionId);
+
+    cdp.onMessage(
+      JSON.stringify({ id: 4, sessionId: pageSessionId, method: "Runtime.evaluate", params: {} }),
+    );
+    await flush();
+    expect(
+      extSocket
+        .frames()
+        .find((frame) => frame.type === "cdp" && frame.method === "Runtime.evaluate"),
+    ).toMatchObject({ tabId: 1, method: "Runtime.evaluate" });
+    expect(client.frames().find((frame) => frame.id === 4)?.result).toMatchObject({ ok: true });
+
+    handlers.onMessage(
+      JSON.stringify({
+        type: "cdpEvent",
+        tabId: 1,
+        method: "Runtime.consoleAPICalled",
+        params: { type: "log" },
+      }),
+    );
+    await flush();
+    expect(
+      client
+        .frames()
+        .find(
+          (frame) =>
+            frame.sessionId === pageSessionId && frame.method === "Runtime.consoleAPICalled",
+        ),
+    ).toMatchObject({ params: { type: "log" } });
+
+    const otherClient = new FakeSocket();
+    const otherCdp = bridge.attachCdpClientSocket(otherClient);
+    otherCdp.onMessage(
+      JSON.stringify({
+        id: 1,
+        method: "Target.detachFromTarget",
+        params: { sessionId: pageSessionId },
+      }),
+    );
+    await flush();
+    expect(otherClient.frames().find((frame) => frame.id === 1)?.error).toMatchObject({
+      code: -32001,
+    });
+
+    cdp.onMessage(
+      JSON.stringify({
+        id: 5,
+        sessionId: browserSessionId,
+        method: "Target.detachFromTarget",
+        params: { sessionId: pageSessionId },
+      }),
+    );
+    await flush();
+    expect(client.frames().find((frame) => frame.id === 5)?.result).toEqual({});
   });
 
   it("creates a tab inside the group and returns its synthetic target", async () => {

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -25,6 +25,8 @@ const EXTENSION_PING_INTERVAL_MS = 20_000;
 
 /** Synthetic targetId for the emulated browser target. */
 const BROWSER_TARGET_ID = "openclaw-extension-relay";
+/** Playwright requires every attached page target to identify its browser context. */
+const BROWSER_CONTEXT_ID = "openclaw-extension-context";
 
 /** Minimal socket seam so tests can drive the bridge without real WebSockets. */
 export type BridgeSocket = {
@@ -59,6 +61,12 @@ type CdpClientState = {
   announcedSessions: Set<string>;
 };
 
+type AuxiliaryTabSession = {
+  tabId: number;
+  parentSessionId: string;
+  client: CdpClientState;
+};
+
 /** Browser identity reported by the paired extension. */
 export type ExtensionIdentity = {
   userAgent: string;
@@ -79,6 +87,10 @@ export class ExtensionRelayBridge {
   private extension: { socket: BridgeSocket; identity: ExtensionIdentity } | null = null;
   private readonly clients = new Set<CdpClientState>();
   private readonly tabs = new Map<number, TabState>();
+  /** Browser-level sessions created by Playwright for page-scoped CDP access. */
+  private readonly browserSessions = new Map<string, CdpClientState>();
+  /** Extra root-page sessions multiplexed over one chrome.debugger attachment. */
+  private readonly auxiliaryTabSessions = new Map<string, AuxiliaryTabSession>();
   /** Child debugger sessions (iframes/workers) mapped to their owning tab. */
   private readonly childSessions = new Map<string, number>();
   private readonly pendingExtension = new Map<number, PendingExtensionCommand>();
@@ -344,6 +356,9 @@ export class ExtensionRelayBridge {
       type: "page",
       title: tab.info.title,
       url: tab.info.url,
+      // connectOverCDP owns this as a persistent default context, but still
+      // asserts that attached page events carry a non-empty context id.
+      browserContextId: BROWSER_CONTEXT_ID,
       attached: true,
       canAccessOpener: false,
     };
@@ -388,6 +403,21 @@ export class ExtensionRelayBridge {
       if (client.announcedSessions.delete(sessionId)) {
         client.socket.send(event);
       }
+    }
+    // Playwright's page-scoped CDP sessions listen on their synthetic parent
+    // browser session, so detach those aliases there when the shared tab goes.
+    for (const [auxiliarySessionId, auxiliary] of this.auxiliaryTabSessions) {
+      if (auxiliary.tabId !== tabId) {
+        continue;
+      }
+      auxiliary.client.socket.send(
+        JSON.stringify({
+          sessionId: auxiliary.parentSessionId,
+          method: "Target.detachedFromTarget",
+          params: { sessionId: auxiliarySessionId, targetId },
+        }),
+      );
+      this.auxiliaryTabSessions.delete(auxiliarySessionId);
     }
     // Reap this tab's child sessions (iframes/workers) by owner tabId. Callers
     // clear tab.attached before/around this, so matching on the root sessionId
@@ -438,6 +468,18 @@ export class ExtensionRelayBridge {
         client.socket.send(frame);
       }
     }
+    if (!childSessionId) {
+      // Page-scoped CDP sessions multiplex the same chrome.debugger root.
+      // Mirror root events so Runtime/Page/Network listeners observe the
+      // domains they enabled through their own synthetic session.
+      for (const [auxiliarySessionId, auxiliary] of this.auxiliaryTabSessions) {
+        if (auxiliary.tabId === tabId) {
+          auxiliary.client.socket.send(
+            JSON.stringify({ sessionId: auxiliarySessionId, method, params }),
+          );
+        }
+      }
+    }
   }
 
   // ---------------------------------------------------------------------
@@ -465,6 +507,16 @@ export class ExtensionRelayBridge {
     };
     const onClose = () => {
       this.clients.delete(client);
+      for (const [sessionId, owner] of this.browserSessions) {
+        if (owner === client) {
+          this.browserSessions.delete(sessionId);
+        }
+      }
+      for (const [sessionId, auxiliary] of this.auxiliaryTabSessions) {
+        if (auxiliary.client === client) {
+          this.auxiliaryTabSessions.delete(sessionId);
+        }
+      }
       this.detachAllWhenIdle();
     };
     return { onMessage, onClose };
@@ -513,6 +565,10 @@ export class ExtensionRelayBridge {
         return { tabId, child: false };
       }
     }
+    const auxiliary = this.auxiliaryTabSessions.get(sessionId);
+    if (auxiliary) {
+      return { tabId: auxiliary.tabId, child: false };
+    }
     const childOwner = this.childSessions.get(sessionId);
     if (childOwner !== undefined) {
       return { tabId: childOwner, child: true };
@@ -532,6 +588,10 @@ export class ExtensionRelayBridge {
   private async handleCdpRequest(client: CdpClientState, request: CdpRequest): Promise<void> {
     try {
       if (request.sessionId) {
+        if (this.browserSessions.get(request.sessionId) === client) {
+          await this.handleBrowserScopedRequest(client, request);
+          return;
+        }
         await this.handleSessionScopedRequest(client, request);
         return;
       }
@@ -546,6 +606,11 @@ export class ExtensionRelayBridge {
     request: CdpRequest,
   ): Promise<void> {
     const sessionId = request.sessionId as string;
+    const auxiliary = this.auxiliaryTabSessions.get(sessionId);
+    if (auxiliary && auxiliary.client !== client) {
+      this.respondError(client, request, `Session not found: ${sessionId}`, -32001);
+      return;
+    }
     const route = this.tabBySessionId(sessionId);
     if (!route) {
       this.respondError(client, request, `Session not found: ${sessionId}`, -32001);
@@ -622,6 +687,12 @@ export class ExtensionRelayBridge {
         this.respond(client, request, { targetInfos });
         return;
       }
+      case "Target.attachToBrowserTarget": {
+        const sessionId = `openclaw-browser-${this.nextSessionOrdinal++}`;
+        this.browserSessions.set(sessionId, client);
+        this.respond(client, request, { sessionId });
+        return;
+      }
       case "Target.setAutoAttach": {
         const autoAttach = request.params?.autoAttach !== false;
         client.autoAttach = autoAttach;
@@ -664,6 +735,19 @@ export class ExtensionRelayBridge {
           return;
         }
         const attached = await this.ensureTabAttached(found.tabId);
+        if (request.sessionId && this.browserSessions.get(request.sessionId) === client) {
+          // Playwright creates a fresh page-scoped session for helpers such as
+          // Target.getTargetInfo and DOM refs. Multiplex it onto the one real
+          // chrome.debugger attachment instead of reusing the auto-attach id.
+          const sessionId = `openclaw-tab-${found.tabId}-${this.nextSessionOrdinal++}`;
+          this.auxiliaryTabSessions.set(sessionId, {
+            tabId: found.tabId,
+            parentSessionId: request.sessionId,
+            client,
+          });
+          this.respond(client, request, { sessionId });
+          return;
+        }
         this.announceAttachedTab(found.tabId, attached.targetId, attached.sessionId, {
           onlyAutoAttach: false,
           onlyClient: client,
@@ -673,6 +757,26 @@ export class ExtensionRelayBridge {
       }
       case "Target.detachFromTarget": {
         const sessionId = request.params?.sessionId as string | undefined;
+        if (sessionId && this.browserSessions.get(sessionId) === client) {
+          this.browserSessions.delete(sessionId);
+          for (const [auxiliarySessionId, auxiliary] of this.auxiliaryTabSessions) {
+            if (auxiliary.parentSessionId === sessionId && auxiliary.client === client) {
+              this.auxiliaryTabSessions.delete(auxiliarySessionId);
+            }
+          }
+          this.respond(client, request, {});
+          return;
+        }
+        const auxiliary = sessionId ? this.auxiliaryTabSessions.get(sessionId) : undefined;
+        if (auxiliary?.client === client) {
+          this.auxiliaryTabSessions.delete(sessionId as string);
+          this.respond(client, request, {});
+          return;
+        }
+        if (auxiliary) {
+          this.respondError(client, request, `Session not found: ${String(sessionId)}`, -32001);
+          return;
+        }
         const route = sessionId ? this.tabBySessionId(sessionId) : null;
         if (route && !route.child) {
           const tab = this.tabs.get(route.tabId);
@@ -773,6 +877,8 @@ export class ExtensionRelayBridge {
       client.socket.close(1001, "relay stopped");
     }
     this.clients.clear();
+    this.browserSessions.clear();
+    this.auxiliaryTabSessions.clear();
     this.tabs.clear();
     this.childSessions.clear();
   }

--- a/extensions/browser/src/browser/extension-relay/relay-server.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.ts
@@ -24,7 +24,12 @@ const log = createSubsystemLogger("browser").child("extension-relay");
  * Cap relay frame size to bound memory from a hostile/buggy peer while leaving
  * headroom for CDP payloads (base64 screenshots, DOM snapshots, network bodies).
  */
-const EXTENSION_RELAY_MAX_PAYLOAD_BYTES = 64 * 1024 * 1024;
+export const EXTENSION_RELAY_MAX_PAYLOAD_BYTES = 64 * 1024 * 1024;
+
+/** Wire an accepted extension WebSocket to a bridge (shared by loopback + gateway paths). */
+export function attachExtensionWebSocket(bridge: ExtensionRelayBridge, ws: WebSocket): void {
+  bindSocket(ws, bridge.attachExtensionSocket(toBridgeSocket(ws)));
+}
 
 /** Running relay server handle owned by the profile runtime state. */
 export type ExtensionRelayHandle = {
@@ -39,7 +44,8 @@ function firstHeader(value: string | string[] | undefined): string {
   return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
 }
 
-function requestToken(req: IncomingMessage): string {
+/** Extract the relay token from a request (Bearer/Basic header or ?token= query). */
+export function requestToken(req: IncomingMessage): string {
   const auth = firstHeader(req.headers.authorization);
   if (auth.startsWith("Bearer ")) {
     return auth.slice("Bearer ".length).trim();
@@ -63,7 +69,7 @@ function isAuthorized(req: IncomingMessage, token: string): boolean {
 }
 
 /** Reject cross-origin websocket upgrades; the extension side must come from Chrome. */
-function isAllowedExtensionOrigin(req: IncomingMessage): boolean {
+export function isAllowedExtensionOrigin(req: IncomingMessage): boolean {
   const origin = firstHeader(req.headers.origin);
   // Chrome MV3 service workers send their chrome-extension:// origin. Absent
   // origin is allowed for non-browser clients such as tests and diagnostics.
@@ -158,7 +164,7 @@ export async function startExtensionRelayServer(params: {
         return;
       }
       wss.handleUpgrade(req, socket, head, (ws) => {
-        bindSocket(ws, bridge.attachExtensionSocket(toBridgeSocket(ws)));
+        attachExtensionWebSocket(bridge, ws);
         log.info("extension connected to relay");
       });
       return;

--- a/extensions/browser/src/browser/extension-relay/relay-server.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.ts
@@ -8,7 +8,7 @@
  *   WS  /extension     -> the Chrome extension's relay transport
  * Both sides authenticate with the derived relay token: CDP clients send it as
  * Basic auth (flows from the profile cdpUrl userinfo via getHeadersWithAuth),
- * the extension sends `Authorization: Bearer` or `?token=`.
+ * the extension sends the token in its WebSocket subprotocol list.
  */
 import http, { type IncomingMessage, type Server } from "node:http";
 import type { Duplex } from "node:stream";
@@ -19,6 +19,8 @@ import { extensionRelayTokenMatches } from "./relay-auth.js";
 import { ExtensionRelayBridge } from "./relay-bridge.js";
 
 const log = createSubsystemLogger("browser").child("extension-relay");
+const EXTENSION_RELAY_PROTOCOL = "openclaw-extension-relay";
+const EXTENSION_RELAY_TOKEN_PROTOCOL_PREFIX = "openclaw-extension-token.";
 
 /**
  * Cap relay frame size to bound memory from a hostile/buggy peer while leaving
@@ -44,7 +46,21 @@ function firstHeader(value: string | string[] | undefined): string {
   return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
 }
 
-/** Extract the relay token from a request (Bearer/Basic header or ?token= query). */
+/** Extract a relay token carried by the extension's WebSocket subprotocol list. */
+export function requestExtensionProtocolToken(req: IncomingMessage): string {
+  const protocols = firstHeader(req.headers["sec-websocket-protocol"])
+    .split(",")
+    .map((value) => value.trim());
+  if (!protocols.includes(EXTENSION_RELAY_PROTOCOL)) {
+    return "";
+  }
+  const tokenProtocol = protocols.find((value) =>
+    value.startsWith(EXTENSION_RELAY_TOKEN_PROTOCOL_PREFIX),
+  );
+  return tokenProtocol?.slice(EXTENSION_RELAY_TOKEN_PROTOCOL_PREFIX.length) ?? "";
+}
+
+/** Extract relay auth from a CDP header, extension subprotocol, or legacy query. */
 export function requestToken(req: IncomingMessage): string {
   const auth = firstHeader(req.headers.authorization);
   if (auth.startsWith("Bearer ")) {
@@ -54,6 +70,10 @@ export function requestToken(req: IncomingMessage): string {
     const decoded = Buffer.from(auth.slice("Basic ".length), "base64").toString("utf8");
     const separator = decoded.indexOf(":");
     return separator >= 0 ? decoded.slice(separator + 1) : decoded;
+  }
+  const protocolToken = requestExtensionProtocolToken(req);
+  if (protocolToken) {
+    return protocolToken;
   }
   try {
     const url = new URL(req.url ?? "/", "http://127.0.0.1");

--- a/extensions/browser/src/browser/runtime-lifecycle.ts
+++ b/extensions/browser/src/browser/runtime-lifecycle.ts
@@ -54,6 +54,9 @@ export async function stopBrowserRuntime(params: {
     if (params.current.extensionRelays?.size) {
       const { stopExtensionRelays } = await getExtensionRelayModule();
       await stopExtensionRelays(params.current);
+      const { disposeGatewayExtensionRelay } =
+        await import("./extension-relay/gateway-relay-route.js");
+      disposeGatewayExtensionRelay();
     }
 
     if (params.closeServer && params.current.server) {

--- a/extensions/browser/src/cli/browser-cli-extension.test.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.test.ts
@@ -1,0 +1,54 @@
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildRemoteGatewayRelayUrl,
+  registerBrowserExtensionCommands,
+} from "./browser-cli-extension.js";
+import { defaultRuntime } from "./core-api.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("buildRemoteGatewayRelayUrl", () => {
+  it("builds the direct relay route and preserves a proxy base path", () => {
+    expect(buildRemoteGatewayRelayUrl("wss://gateway.example.com")).toBe(
+      "wss://gateway.example.com/browser/extension",
+    );
+    expect(buildRemoteGatewayRelayUrl("wss://gateway.example.com/openclaw/")).toBe(
+      "wss://gateway.example.com/openclaw/browser/extension",
+    );
+  });
+
+  it("allows plaintext WebSockets only on loopback", () => {
+    expect(buildRemoteGatewayRelayUrl("ws://127.0.0.1:18789")).toBe(
+      "ws://127.0.0.1:18789/browser/extension",
+    );
+    expect(() => buildRemoteGatewayRelayUrl("ws://gateway.example.com")).toThrow("must use wss://");
+  });
+
+  it("rejects non-WebSocket and ambiguous credential-bearing URLs", () => {
+    expect(() => buildRemoteGatewayRelayUrl("https://gateway.example.com")).toThrow(
+      "must use wss://",
+    );
+    expect(() => buildRemoteGatewayRelayUrl("wss://user@gateway.example.com")).toThrow(
+      "must not include credentials",
+    );
+    expect(() => buildRemoteGatewayRelayUrl("wss://gateway.example.com?token=secret")).toThrow(
+      "must not include credentials",
+    );
+  });
+});
+
+describe("browser extension path", () => {
+  it("resolves the copied extension from the registered plugin root", async () => {
+    const program = new Command();
+    const browser = program.command("browser");
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const pluginRoot = path.join("/opt", "openclaw", "dist", "extensions", "browser");
+    registerBrowserExtensionCommands(browser, () => ({}), pluginRoot);
+
+    await program.parseAsync(["browser", "extension", "path"], { from: "user" });
+
+    expect(log).toHaveBeenCalledWith(path.join(pluginRoot, "chrome-extension"));
+  });
+});

--- a/extensions/browser/src/cli/browser-cli-extension.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.ts
@@ -35,7 +35,14 @@ function firstExtensionProfile(): { name: string; relayPort: number } | null {
   return null;
 }
 
-function buildPairingString(): { pairing: string; relayPort: number } {
+/** Gateway route path for the remote extension relay (see gateway-relay-route.ts). */
+const GATEWAY_EXTENSION_RELAY_PATH = "/browser/extension";
+
+function buildPairingString(gatewayUrl?: string): {
+  pairing: string;
+  relayPort: number;
+  remote: boolean;
+} {
   const cfg = getRuntimeConfig();
   const resolved = resolveBrowserConfig(cfg.browser, cfg);
   // Create the host-local relay secret if this host has not used the extension
@@ -44,9 +51,19 @@ function buildPairingString(): { pairing: string; relayPort: number } {
   const token = ensureExtensionRelayToken();
   const profile = firstExtensionProfile();
   const relayPort = profile?.relayPort ?? resolved.extensionRelayDefaultPort;
+
+  const gateway = gatewayUrl?.trim();
+  if (gateway) {
+    // Remote: the extension connects straight to this gateway over wss:// — no
+    // node host on the browser machine. The gateway route self-validates the
+    // same host-local secret.
+    const base = gateway.replace(/\/+$/, "");
+    return { pairing: `${base}${GATEWAY_EXTENSION_RELAY_PATH}#${token}`, relayPort, remote: true };
+  }
   return {
     pairing: `ws://127.0.0.1:${relayPort}/extension#${token}`,
     relayPort,
+    remote: false,
   };
 }
 
@@ -70,22 +87,35 @@ export function registerBrowserExtensionCommands(
     .command("pair")
     .description("Print the pairing string to paste into the OpenClaw extension popup")
     .option("--json", "Print the pairing string as JSON")
+    .option(
+      "--gateway-url <url>",
+      "Print a remote pairing string for a Chrome on another machine (e.g. wss://gateway.example.com)",
+    )
     .action(async (opts) => {
       await runCommandWithRuntime(
         defaultRuntime,
         async () => {
-          const result = buildPairingString();
+          const result = buildPairingString(opts.gatewayUrl);
           if (opts.json === true) {
             defaultRuntime.log(
-              JSON.stringify({ pairingString: result.pairing, relayPort: result.relayPort }),
+              JSON.stringify({
+                pairingString: result.pairing,
+                relayPort: result.relayPort,
+                remote: result.remote,
+              }),
             );
             return;
           }
+          const setupLine = result.remote
+            ? info(
+                "Remote pairing: load and pair the extension on the machine running Chrome; it connects to this gateway over wss://.",
+              )
+            : info(
+                "Run this on the machine that hosts the browser (gateway host or browser node).",
+              );
           defaultRuntime.log(
             [
-              info(
-                "Run this on the machine that hosts the browser (gateway host or browser node).",
-              ),
+              setupLine,
               info("1. Load the extension: chrome://extensions → Developer mode → Load unpacked →"),
               `   ${resolveChromeExtensionDir()}`,
               info("2. Open the OpenClaw popup and paste this pairing string:"),

--- a/extensions/browser/src/cli/browser-cli-extension.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
 import { ensureExtensionRelayToken } from "../browser/extension-relay/relay-auth.js";
+import { isLoopbackHost } from "../gateway/net.js";
 import type { BrowserParentOpts } from "./browser-cli-shared.js";
 import {
   danger,
@@ -18,7 +19,10 @@ import {
 } from "./core-api.js";
 
 /** Absolute path to the bundled unpacked Chrome extension directory. */
-function resolveChromeExtensionDir(): string {
+function resolveChromeExtensionDir(pluginRoot?: string): string {
+  if (pluginRoot) {
+    return path.join(pluginRoot, "chrome-extension");
+  }
   // extensions/browser/dist/cli/ -> extensions/browser/chrome-extension
   const here = path.dirname(fileURLToPath(import.meta.url));
   return path.resolve(here, "..", "..", "chrome-extension");
@@ -37,6 +41,27 @@ function firstExtensionProfile(): { name: string; relayPort: number } | null {
 
 /** Gateway route path for the remote extension relay (see gateway-relay-route.ts). */
 const GATEWAY_EXTENSION_RELAY_PATH = "/browser/extension";
+
+/** Resolve a safe direct-Gateway relay URL, preserving an optional proxy base path. */
+export function buildRemoteGatewayRelayUrl(raw: string): string {
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    throw new Error("--gateway-url must be a valid ws:// or wss:// URL");
+  }
+  const secure = url.protocol === "wss:";
+  const localPlaintext = url.protocol === "ws:" && isLoopbackHost(url.hostname);
+  if (!secure && !localPlaintext) {
+    throw new Error("--gateway-url must use wss:// (ws:// is allowed only for loopback)");
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("--gateway-url must not include credentials, a query, or a fragment");
+  }
+  const basePath = url.pathname.replace(/\/+$/, "");
+  url.pathname = `${basePath}${GATEWAY_EXTENSION_RELAY_PATH}`;
+  return url.toString();
+}
 
 function buildPairingString(gatewayUrl?: string): {
   pairing: string;
@@ -57,8 +82,11 @@ function buildPairingString(gatewayUrl?: string): {
     // Remote: the extension connects straight to this gateway over wss:// — no
     // node host on the browser machine. The gateway route self-validates the
     // same host-local secret.
-    const base = gateway.replace(/\/+$/, "");
-    return { pairing: `${base}${GATEWAY_EXTENSION_RELAY_PATH}#${token}`, relayPort, remote: true };
+    return {
+      pairing: `${buildRemoteGatewayRelayUrl(gateway)}#${token}`,
+      relayPort,
+      remote: true,
+    };
   }
   return {
     pairing: `ws://127.0.0.1:${relayPort}/extension#${token}`,
@@ -71,6 +99,7 @@ function buildPairingString(gatewayUrl?: string): {
 export function registerBrowserExtensionCommands(
   browser: Command,
   _parentOpts: (cmd: Command) => BrowserParentOpts,
+  pluginRoot?: string,
 ) {
   const extension = browser
     .command("extension")
@@ -80,7 +109,7 @@ export function registerBrowserExtensionCommands(
     .command("path")
     .description("Print the unpacked Chrome extension directory (Load unpacked)")
     .action(() => {
-      defaultRuntime.log(resolveChromeExtensionDir());
+      defaultRuntime.log(resolveChromeExtensionDir(pluginRoot));
     });
 
   extension
@@ -117,7 +146,7 @@ export function registerBrowserExtensionCommands(
             [
               setupLine,
               info("1. Load the extension: chrome://extensions → Developer mode → Load unpacked →"),
-              `   ${resolveChromeExtensionDir()}`,
+              `   ${resolveChromeExtensionDir(pluginRoot)}`,
               info("2. Open the OpenClaw popup and paste this pairing string:"),
               "",
               theme.heading(result.pairing),

--- a/extensions/browser/src/cli/browser-cli.ts
+++ b/extensions/browser/src/cli/browser-cli.ts
@@ -34,7 +34,13 @@ type BrowserCommandGroupDefinition = {
 const ROOT_BOOLEAN_OPTIONS = new Set(["--dev", "--no-color"]);
 const ROOT_VALUE_OPTIONS = new Set(["--profile", "--log-level", "--container"]);
 const BROWSER_BOOLEAN_OPTIONS = new Set(["--json", "--expect-final"]);
-const BROWSER_VALUE_OPTIONS = new Set(["--browser-profile", "--url", "--token", "--timeout"]);
+const BROWSER_VALUE_OPTIONS = new Set([
+  "--browser-profile",
+  "--url",
+  "--token",
+  "--timeout",
+  "--gateway-url",
+]);
 
 const command = (
   name: string,

--- a/extensions/browser/src/cli/browser-cli.ts
+++ b/extensions/browser/src/cli/browser-cli.ts
@@ -24,6 +24,7 @@ import {
 type BrowserCommandRegistrar = (args: {
   browser: Command;
   parentOpts: (cmd: Command) => BrowserParentOpts;
+  pluginRoot?: string;
 }) => Promise<void> | void;
 
 type BrowserCommandGroupDefinition = {
@@ -149,7 +150,7 @@ const browserCommandGroupDefinitions: readonly BrowserCommandGroupDefinition[] =
     placeholders: [command("extension", "Chrome extension load path and pairing")],
     register: async (args) => {
       const module = await import("./browser-cli-extension.js");
-      module.registerBrowserExtensionCommands(args.browser, args.parentOpts);
+      module.registerBrowserExtensionCommands(args.browser, args.parentOpts, args.pluginRoot);
     },
   },
 ];
@@ -157,6 +158,7 @@ const browserCommandGroupDefinitions: readonly BrowserCommandGroupDefinition[] =
 function buildBrowserCommandGroups(params: {
   browser: Command;
   parentOpts: (cmd: Command) => BrowserParentOpts;
+  pluginRoot?: string;
 }): CommandGroupEntry[] {
   return browserCommandGroupDefinitions.map((entry) => ({
     placeholders: entry.placeholders,
@@ -248,9 +250,10 @@ function registerLazyBrowserCommands(
   browser: Command,
   parentOpts: (cmd: Command) => BrowserParentOpts,
   argv: string[],
+  pluginRoot?: string,
 ) {
   const subcommand = resolveBrowserLazySubcommand(argv);
-  registerCommandGroups(browser, buildBrowserCommandGroups({ browser, parentOpts }), {
+  registerCommandGroups(browser, buildBrowserCommandGroups({ browser, parentOpts, pluginRoot }), {
     eager: shouldEagerRegisterSubcommands(),
     primary: subcommand,
     registerPrimaryOnly: subcommand !== null,
@@ -258,7 +261,11 @@ function registerLazyBrowserCommands(
 }
 
 /** Registers the Browser CLI command and its lazy-loaded subcommand groups. */
-export function registerBrowserCli(program: Command, argv: string[] = process.argv) {
+export function registerBrowserCli(
+  program: Command,
+  argv: string[] = process.argv,
+  pluginRoot?: string,
+) {
   const browser = program
     .command("browser")
     .description("Manage OpenClaw's dedicated browser (Chrome/Chromium)")
@@ -287,5 +294,5 @@ export function registerBrowserCli(program: Command, argv: string[] = process.ar
 
   const parentOpts = resolveBrowserParentOpts;
 
-  registerLazyBrowserCommands(browser, parentOpts, argv);
+  registerLazyBrowserCommands(browser, parentOpts, argv, pluginRoot);
 }


### PR DESCRIPTION
Related: #53599

## What Problem This Solves

When Chrome and the Gateway run on different machines, the extension could not connect directly to the Gateway. Users had to install and operate a node host on the browser machine solely to bridge the loopback relay.

## Why This Change Was Made

This adds a direct extension-to-Gateway WebSocket route at `/browser/extension`. The browser machine needs only the unpacked OpenClaw extension; same-host and node-host topologies continue to work.

The implementation keeps the existing trust boundaries:

- The host-local relay secret authenticates the extension before Browser control can be lazy-started.
- The pairing secret remains in the pasted URL fragment and is sent in the WebSocket subprotocol list, not in the request URL or normal proxy access logs.
- Non-loopback pairing requires `wss://`; loopback `ws://` remains available for local proof and development.
- Chrome's visible **OpenClaw** tab group remains the consent boundary. Only grouped tabs are reported or controlled.
- Agent-specific sandbox and tool policy still decides whether an agent may use the globally available Browser plugin.

The relay also implements the browser and auxiliary target sessions required by Playwright's page-scoped CDP API. Those sessions are owner-scoped and multiplexed onto the single real `chrome.debugger` attachment for each shared tab.

## User Impact

On the Gateway:

```bash
openclaw browser extension pair --gateway-url wss://gateway.example.com
```

Paste the emitted pairing string into the extension on the browser machine, then explicitly share tabs through the **OpenClaw** group. Reverse proxies must preserve `Sec-WebSocket-Protocol`; an optional proxy base path in `--gateway-url` is preserved.

No new config or environment surface is added. Direct request-URL tokens are rejected, while the existing loopback relay retains its legacy query-token compatibility for already paired local clients.

## Evidence

- Focused Blacksmith Testbox proof: 6 files, 49/49 tests passed on `tbx_01kwx712dryd24qyksfmmpjh1y`.
- Formatting proof: all 17 changed files passed `pnpm format:check` on `tbx_01kwx9fjbffhmq64j2dfwqzhat` ([Actions run 28839109267](https://github.com/openclaw/openclaw/actions/runs/28839109267)).
- Exact-tree AWS Crabbox proof: `run_b5f5bf2096ba` on `cbx_5aed6eaaae17` (c7a.8xlarge, public networking, no Tailscale).
- The live scenario rebuilt the distribution, started a fresh Gateway, rejected unauthenticated and query-token WebSocket attempts without starting Browser control, loaded the built MV3 extension in Chromium, paired it through the Gateway route, and shared a fixture tab.
- A real `openai/gpt-5.4` agent used Browser profile `chrome`, read the changed marker `DIRECT_EXTENSION_BETA` from that shared tab, and lost access after the tab was removed from the OpenClaw group.
- Fresh autoreview reported no actionable findings.
- Dependency contract checked against Playwright 1.61.1: Chromium target attachment requires `browserContextId`; page-scoped CDP sessions use `Target.attachToBrowserTarget` followed by a fresh `Target.attachToTarget` session. The relay now supplies both behaviors and mirrors root tab events to the owning auxiliary sessions.

The source-blind live validator also caught and drove fixes for the built CLI's extension asset path, missing Playwright browser-context metadata, and missing auxiliary CDP session routing.
