### PR TITLE
Discord gateway-metadata response bound

### DIFF
--- a/extensions/discord/src/monitor/gateway-metadata.test.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.test.ts
@@ -1,10 +1,15 @@
 // Discord tests cover gateway metadata plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   fetchDiscordGatewayInfo,
+  fetchDiscordGatewayMetadataGuarded,
   resolveDiscordGatewayInfoTimeoutMs,
   resolveGatewayInfoWithFallback,
 } from "./gateway-metadata.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("Discord gateway metadata", () => {
   it("resolves gateway info timeouts from strict integer config and env values", () => {
@@ -51,5 +56,16 @@ describe("Discord gateway metadata", () => {
     expect(logs).toBe(
       "discord: gateway metadata lookup failed transiently; using default gateway url (Failed to get gateway information from Discord: fetch failed | Discord API /gateway/bot failed (429): Error 1015 rate limited)",
     );
+  });
+
+  it("rejects oversized gateway metadata responses before buffering them", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("x".repeat(2 * 1024 * 1024))),
+    );
+
+    await expect(
+      fetchDiscordGatewayMetadataGuarded("https://discord.com/api/v10/gateway/bot"),
+    ).rejects.toThrow(/Discord gateway metadata response exceeds/);
   });
 });

--- a/extensions/discord/src/monitor/gateway-metadata.ts
+++ b/extensions/discord/src/monitor/gateway-metadata.ts
@@ -3,6 +3,7 @@ import type { APIGatewayBotInfo } from "discord-api-types/v10";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { captureHttpExchange } from "openclaw/plugin-sdk/proxy-capture";
+import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { Type } from "typebox";
@@ -12,6 +13,7 @@ import { withAbortTimeout } from "./timeouts.js";
 
 const DISCORD_GATEWAY_BOT_URL = "https://discord.com/api/v10/gateway/bot";
 const DISCORD_API_HOST = "discord.com";
+const MAX_DISCORD_GATEWAY_METADATA_RESPONSE_BYTES = 1024 * 1024;
 const DEFAULT_DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/";
 const DEFAULT_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 30_000;
 const MAX_DISCORD_GATEWAY_INFO_TIMEOUT_MS = 120_000;
@@ -57,7 +59,10 @@ function resolveFetchInputUrl(input: RequestInfo | URL): string {
 }
 
 async function materializeGuardedResponse(response: Response): Promise<Response> {
-  const body = await response.arrayBuffer();
+  const body = await readResponseWithLimit(response, MAX_DISCORD_GATEWAY_METADATA_RESPONSE_BYTES, {
+    onOverflow: ({ size, maxBytes }) =>
+      new Error(`Discord gateway metadata response exceeds ${maxBytes} bytes (${size} bytes)`),
+  });
   return new Response(body, {
     status: response.status,
     statusText: response.statusText,

--- a/scripts/proof/discord-gateway-metadata-response-bound.mts
+++ b/scripts/proof/discord-gateway-metadata-response-bound.mts
@@ -1,0 +1,74 @@
+// Real behavior proof: Discord gateway metadata fetch rejects an oversized
+// response body instead of buffering it unbounded.
+//
+// A local HTTP server returns a 20 MiB payload. The script routes the mocked
+// global fetch for the Discord metadata URL to that server, then calls
+// fetchDiscordGatewayMetadataGuarded. The bounded read in materializeGuardedResponse
+// rejects before the full body is consumed.
+
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const { fetchDiscordGatewayMetadataGuarded } = await import(
+  path.join(repoRoot, "extensions/discord/src/monitor/gateway-metadata.js")
+);
+
+const OVERSIZED_BYTES = 20 * 1024 * 1024;
+const DISCORD_GATEWAY_BOT_URL = "https://discord.com/api/v10/gateway/bot";
+
+const server = http.createServer((_req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end("x".repeat(OVERSIZED_BYTES));
+});
+
+await new Promise<void>((resolve) => {
+  server.listen(0, "127.0.0.1", () => resolve());
+});
+const address = server.address();
+const localUrl =
+  typeof address === "object" && address !== null
+    ? `http://127.0.0.1:${address.port}`
+    : null;
+if (!localUrl) {
+  throw new Error("Failed to start local server");
+}
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = Object.assign(
+  async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    if (url === DISCORD_GATEWAY_BOT_URL) {
+      return originalFetch(localUrl);
+    }
+    return originalFetch(input, init);
+  },
+  { mock: {} },
+);
+
+console.log("=== Proof: discord gateway metadata response bound ===\n");
+console.log(`Local server returning ${OVERSIZED_BYTES} bytes at ${localUrl}`);
+
+try {
+  await fetchDiscordGatewayMetadataGuarded(DISCORD_GATEWAY_BOT_URL);
+  console.log("\nFAIL: fetchDiscordGatewayMetadataGuarded did not reject.");
+  process.exitCode = 1;
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.log(`\nCaught expected error: ${message}`);
+  if (message.includes("Discord gateway metadata response exceeds")) {
+    console.log("\nPASS: oversized response was rejected before OOM.");
+  } else {
+    console.log("\nFAIL: error did not mention the response size bound.");
+    process.exitCode = 1;
+  }
+} finally {
+  server.close();
+}


### PR DESCRIPTION
## What Problem This Solves

`fetchDiscordGatewayMetadataGuarded` in `extensions/discord/src/monitor/gateway-metadata.ts` buffered the entire Discord `/gateway/bot` response with `response.arrayBuffer()` before re-wrapping it as a `Response`. A malicious or buggy endpoint that returned a huge body could force the process to allocate an unbounded amount of memory.

## Why This Change Was Made

The response body is now read through `readResponseWithLimit` (via `openclaw/plugin-sdk/response-limit-runtime`) with a 1 MiB cap. When the cap is exceeded the helper throws a clear error before the full body is buffered, matching the bounded-read pattern already used across provider transports.

## User Impact

Discord gateway metadata lookups now fail safely on unexpectedly large responses instead of risking an out-of-memory crash.

## Evidence

- Regression test added in `extensions/discord/src/monitor/gateway-metadata.test.ts` mocks an oversized response and asserts that `fetchDiscordGatewayMetadataGuarded` rejects with the size-bound error.
- Real behavior proof script in `scripts/proof/discord-gateway-metadata-response-bound.mts` starts a local HTTP server returning a 20 MiB body and shows the bounded read rejecting before OOM.

### Local verification commands

```bash
pnpm test extensions/discord/src/monitor/gateway-metadata.test.ts
OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs \
  extensions/discord/src/monitor/gateway-metadata.ts \
  extensions/discord/src/monitor/gateway-metadata.test.ts \
  scripts/proof/discord-gateway-metadata-response-bound.mts
node --import tsx scripts/proof/discord-gateway-metadata-response-bound.mts
```

### Proof script output

```
=== Proof: discord gateway metadata response bound ===

Local server returning 20971520 bytes at http://127.0.0.1:42409

Caught expected error: Discord gateway metadata response exceeds 1048576 bytes (1111652 bytes)

PASS: oversized response was rejected before OOM.
```
