### PR TITLE
QA-lab runtime-parity JSON bound

### DIFF
--- a/extensions/qa-lab/src/runtime-parity.test.ts
+++ b/extensions/qa-lab/src/runtime-parity.test.ts
@@ -1,5 +1,5 @@
 // Qa Lab tests cover runtime parity classification behavior.
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __testing,
   isRuntimeParityResultPass,
@@ -8,6 +8,10 @@ import {
   type RuntimeParityCell,
   type RuntimeParityToolCall,
 } from "./runtime-parity.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function makeRuntimeParityCell(
   runtime: RuntimeId,
@@ -162,6 +166,21 @@ describe("runtime parity", () => {
         resultHash: "async-started",
       },
     ]);
+  });
+
+  it("ignores oversized mock debug responses instead of buffering them unbounded", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(`[${"x".repeat(20 * 1024 * 1024)}]`)),
+    );
+
+    const result = await __testing.loadRuntimeParityMockToolCalls(
+      "http://127.0.0.1:9999",
+      "parent prompt",
+    );
+
+    expect(result).toBeNull();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 
   it("scopes process-global mock requests to the parent session prompt", () => {

--- a/extensions/qa-lab/src/runtime-parity.ts
+++ b/extensions/qa-lab/src/runtime-parity.ts
@@ -1,6 +1,7 @@
 // Qa Lab plugin module implements runtime parity behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   asFiniteNumber as readFiniteNumber,
@@ -132,6 +133,7 @@ type RuntimeParityPendingToolCall = RuntimeParityToolCall & {
 };
 
 const DEFAULT_AGENT_ID = "qa";
+const RUNTIME_PARITY_MOCK_RESPONSE_MAX_BYTES = 16 * 1024 * 1024;
 const HEARTBEAT_RESPONSE_TOOL_NAME = "heartbeat_respond";
 const HEARTBEAT_TRANSCRIPT_PROMPT = "[OpenClaw heartbeat poll]";
 const HEARTBEAT_TASK_PROMPT_PREFIX =
@@ -992,7 +994,9 @@ async function loadRuntimeParityMockToolCalls(
       if (!response.ok) {
         return null;
       }
-      payload = await response.json();
+      payload = await readProviderJsonResponse(response, "qa-lab runtime parity mock tool calls", {
+        maxBytes: RUNTIME_PARITY_MOCK_RESPONSE_MAX_BYTES,
+      });
     } finally {
       await release();
     }
@@ -1084,6 +1088,7 @@ export async function runRuntimeParityScenario(params: {
 export const testing = {
   classifyRuntimeParityCells,
   filterMockRequestsForParentPrompt,
+  loadRuntimeParityMockToolCalls,
   resolveRuntimeParityToolCalls,
   resolveToolCallOrderFromMockRequests,
 };

--- a/scripts/proof/qa-lab-runtime-parity-json-bound.mts
+++ b/scripts/proof/qa-lab-runtime-parity-json-bound.mts
@@ -1,0 +1,67 @@
+// Real behavior proof: QA-lab runtime-parity mock debug endpoint does not
+// buffer an oversized JSON body.
+//
+// A local HTTP server returns a 20 MiB JSON-like payload. The script routes the
+// mocked global fetch to that server, then calls loadRuntimeParityMockToolCalls.
+// With the bounded readProviderJsonResponse helper the oversized body is caught
+// and the function returns null instead of forcing the runtime to allocate the
+// whole payload.
+
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const { __testing } = await import(
+  path.join(repoRoot, "extensions/qa-lab/src/runtime-parity.js")
+);
+
+const OVERSIZED_BYTES = 20 * 1024 * 1024;
+const MOCK_BASE_URL = "http://127.0.0.1:9999";
+
+const server = http.createServer((_req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(`[${"x".repeat(OVERSIZED_BYTES)}]`);
+});
+
+await new Promise<void>((resolve) => {
+  server.listen(0, "127.0.0.1", () => resolve());
+});
+const address = server.address();
+const localUrl =
+  typeof address === "object" && address !== null
+    ? `http://127.0.0.1:${address.port}`
+    : null;
+if (!localUrl) {
+  throw new Error("Failed to start local server");
+}
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = Object.assign(
+  async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> =>
+    originalFetch(localUrl),
+  { mock: {} },
+);
+
+console.log("=== Proof: qa-lab runtime-parity JSON bound ===\n");
+console.log(`Local server returning ${OVERSIZED_BYTES} bytes at ${localUrl}`);
+
+try {
+  const result = await __testing.loadRuntimeParityMockToolCalls(
+    MOCK_BASE_URL,
+    "parent prompt",
+  );
+  if (result === null) {
+    console.log("\nPASS: oversized mock debug response was discarded (returned null).");
+  } else {
+    console.log("\nFAIL: expected null but got a result.");
+    process.exitCode = 1;
+  }
+} catch (error) {
+  console.log("\nFAIL: loadRuntimeParityMockToolCalls threw an unexpected error:");
+  console.log(error);
+  process.exitCode = 1;
+} finally {
+  server.close();
+}


### PR DESCRIPTION
## What Problem This Solves

`loadRuntimeParityMockToolCalls` in `extensions/qa-lab/src/runtime-parity.ts` parsed the mock debug endpoint body with unbounded `response.json()`. An oversized response could consume arbitrary memory.

## Why This Change Was Made

The JSON body is now read with `readProviderJsonResponse` from `openclaw/plugin-sdk/provider-http`, which applies a 16 MiB byte cap and cancels the stream on overflow. This aligns the QA-lab runtime-parity path with other provider JSON readers.

## User Impact

Runtime parity comparisons are resilient to unexpectedly large mock debug responses; the runtime no longer buffers an unbounded JSON payload.

## Evidence

- Regression test added in `extensions/qa-lab/src/runtime-parity.test.ts` mocks an oversized JSON response and asserts `loadRuntimeParityMockToolCalls` returns null instead of buffering the body.
- Real behavior proof script in `scripts/proof/qa-lab-runtime-parity-json-bound.mts` starts a local HTTP server returning a 20 MiB JSON-like body and verifies the bounded path discards it safely.

### Local verification commands

```bash
pnpm test extensions/qa-lab/src/runtime-parity.test.ts
OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs \
  extensions/qa-lab/src/runtime-parity.ts \
  extensions/qa-lab/src/runtime-parity.test.ts \
  scripts/proof/qa-lab-runtime-parity-json-bound.mts
node --import tsx scripts/proof/qa-lab-runtime-parity-json-bound.mts
```

### Proof script output

```
=== Proof: qa-lab runtime-parity JSON bound ===

Local server returning 20971520 bytes at http://127.0.0.1:38451

PASS: oversized mock debug response was discarded (returned null).
```
