### PR TITLE
refactor(ui): localize internal type exports

### DIFF
--- a/ui/src/app/agent-selection.ts
+++ b/ui/src/app/agent-selection.ts
@@ -9,7 +9,7 @@ type AgentSelectionGateway = {
   subscribe: (listener: (snapshot: AgentSelectionGateway["snapshot"]) => void) => () => void;
 };
 
-export type AgentSelectionState = {
+type AgentSelectionState = {
   selectedId: string | null;
 };
 

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -17,7 +17,7 @@ import type {
 } from "./context.ts";
 import { loadSettings, patchSettings } from "./settings.ts";
 
-export type GatewayClientFactory = (opts: GatewayBrowserClientOptions) => GatewayBrowserClient;
+type GatewayClientFactory = (opts: GatewayBrowserClientOptions) => GatewayBrowserClient;
 
 const defaultClientFactory: GatewayClientFactory = (opts) => new GatewayBrowserClient(opts);
 

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -26,7 +26,7 @@ import {
 } from "./exec-approval.ts";
 import type { ApplicationGateway } from "./gateway.ts";
 
-export type ApplicationStatusBanner = {
+type ApplicationStatusBanner = {
   tone: "danger" | "warn" | "info";
   text: string;
 };

--- a/ui/src/app/public-assets.ts
+++ b/ui/src/app/public-assets.ts
@@ -1,7 +1,7 @@
 // Control UI module implements public assets behavior.
 import { inferBasePathFromPathname, normalizeBasePath } from "../app-route-paths.ts";
 
-export type ControlUiPublicAsset =
+type ControlUiPublicAsset =
   | "apple-touch-icon.png"
   | "favicon-32.png"
   | "favicon.ico"

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -136,7 +136,7 @@ function isAvatarUrl(value: string): boolean {
   return trimmed.startsWith("blob:") || isRenderableControlUiAvatarUrl(trimmed);
 }
 
-export type ChatAvatarHost = {
+type ChatAvatarHost = {
   assistantAgentId?: string | null;
   agentsList?: { defaultId?: string | null } | null;
   basePath: string;

--- a/ui/src/pages/chat/components/chat-controls.ts
+++ b/ui/src/pages/chat/components/chat-controls.ts
@@ -22,7 +22,7 @@ import {
 } from "../../../lib/sessions/session-key.ts";
 import { renderChatModelControls, type ChatModelControlsProps } from "./chat-model-controls.ts";
 
-export type ChatControlsProps = {
+type ChatControlsProps = {
   paneId: string;
   agentsList: AgentsListResult | null;
   connected: boolean;

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -66,7 +66,7 @@ type ChatThreadState = {
   historyRenderAnchorFrame: number | null;
 };
 
-export type ChatThreadProps = {
+type ChatThreadProps = {
   paneId: string;
   sessionKey: string;
   loading: boolean;

--- a/ui/src/pages/chat/components/chat-welcome.ts
+++ b/ui/src/pages/chat/components/chat-welcome.ts
@@ -7,7 +7,7 @@ import {
 } from "../../../lib/agents/display.ts";
 import { resolveChatAvatarRenderUrl } from "../../../lib/avatar.ts";
 
-export type ChatWelcomeProps = {
+type ChatWelcomeProps = {
   assistantName: string;
   assistantAvatar: string | null;
   assistantAvatarUrl?: string | null;

--- a/ui/src/pages/cron/quick-create.ts
+++ b/ui/src/pages/cron/quick-create.ts
@@ -13,7 +13,7 @@ import type { CronFormState } from "../../lib/cron/index.ts";
 
 // ── Types ──
 
-export type CronQuickCreateProps = {
+type CronQuickCreateProps = {
   open: boolean;
   step: CronQuickCreateStep;
   draft: CronQuickCreateDraft;

--- a/ui/src/pages/nodes/view-shared.ts
+++ b/ui/src/pages/nodes/view-shared.ts
@@ -6,7 +6,7 @@ export type NodeTargetOption = {
   label: string;
 };
 
-export type ConfigAgentOption = {
+type ConfigAgentOption = {
   id: string;
   name?: string;
   isDefault: boolean;

--- a/ui/src/pages/overview/cards.ts
+++ b/ui/src/pages/overview/cards.ts
@@ -23,7 +23,7 @@ import {
 } from "../../lib/provider-quota-summary.ts";
 import { resolveSessionDisplayName } from "../../lib/session-display.ts";
 
-export type OverviewCardsProps = {
+type OverviewCardsProps = {
   usageResult: SessionsUsageResult | null;
   sessionsResult: SessionsListResult | null;
   skillsReport: SkillStatusReport | null;

--- a/ui/src/pages/usage/cache-status.ts
+++ b/ui/src/pages/usage/cache-status.ts
@@ -2,7 +2,7 @@
 import { t } from "../../i18n/index.ts";
 import type { SessionsUsageResult } from "./data-types.ts";
 
-export type UsageCacheStatus = SessionsUsageResult["cacheStatus"];
+type UsageCacheStatus = SessionsUsageResult["cacheStatus"];
 
 export function mergeUsageCacheStatus(
   sessionsStatus: UsageCacheStatus,

--- a/ui/src/pages/usage/helpers.ts
+++ b/ui/src/pages/usage/helpers.ts
@@ -1,7 +1,7 @@
 // Control UI module implements usage helpers behavior.
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 
-export type UsageQueryTerm = {
+type UsageQueryTerm = {
   key?: string;
   value: string;
   raw: string;

--- a/ui/src/pages/usage/query.ts
+++ b/ui/src/pages/usage/query.ts
@@ -260,7 +260,6 @@ const setQueryTokensForKey = (query: string, key: string, values: string[]): str
   return next.length ? `${next.join(" ")} ` : "";
 };
 
-export type { QuerySuggestion };
 export {
   addQueryToken,
   applySuggestionToQuery,


### PR DESCRIPTION
## What Problem This Solves

The Control UI exports 14 structural types that are only consumed inside their defining modules. These unused exports enlarge the internal TypeScript surface and keep recurring in the repository deadcode report.

## Why This Change Was Made

Localize the 14 types while leaving every exported function, capability, and runtime path unchanged. Fresh MCP inbound-edge queries, repository-wide source search, and the CI deadcode artifact all agree that the types have no external consumers.

## User Impact

No user-visible behavior changes. Developers get a smaller, more accurate Control UI module surface and 14 fewer deadcode findings.

## Evidence

- `pnpm check:changed` passed on the exact rebased head using Blacksmith Testbox `tbx_01kwwdwt5sjwmj2tp4shbx97ew`.
- Regenerated `deadcode:report:ci:ts-unused` on Testbox `tbx_01kwwdnw01zbdnpjg4c9789gfw`; all 14 targeted findings are absent and the report fell from 3,702 to 3,688 lines.
- Focused UI test run: 83 tests passed across six suites. Four additional suites were blocked before collection by the stale shared install missing `@openclaw/uirouter`; the clean Testbox typecheck and lint lanes passed.
- `oxfmt --check` passed for all 14 changed files.
- Fresh branch autoreview reported no accepted/actionable findings, confidence 0.92.
