### PR TITLE
fix(extensions/qa-lab): bound web app JSON response reads

### DIFF
--- a/extensions/qa-lab/web/src/app.test.ts
+++ b/extensions/qa-lab/web/src/app.test.ts
@@ -1,0 +1,39 @@
+// Qa Lab web app tests cover bounded HTTP helpers.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchJson } from "./app.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("QA Lab web app fetchJson", () => {
+  it("rejects oversized JSON responses before buffering them", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(`{"x":"${"x".repeat(20 * 1024 * 1024)}"}`, {
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+
+    await expect(fetchJson("/api/test")).rejects.toThrow(/qa-lab web: JSON response exceeds/);
+  });
+
+  it("surfaces server error payloads when available", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: "scenario failed" }), {
+            status: 500,
+            statusText: "Internal Server Error",
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+
+    await expect(fetchJson("/api/test")).rejects.toThrow("scenario failed");
+  });
+});

--- a/extensions/qa-lab/web/src/app.ts
+++ b/extensions/qa-lab/web/src/app.ts
@@ -1,4 +1,5 @@
 // Qa Lab plugin module implements app behavior.
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { defaultQaModelForMode, isQaFastModeEnabled } from "../../model-selection.js";
 import { normalizeCaptureSavedView, normalizeCaptureSavedViews } from "./capture-saved-view.js";
 import { formatErrorMessage } from "./errors.js";
@@ -19,33 +20,35 @@ import {
   type UiState,
   renderQaLabUi,
 } from "./ui-render.js";
-async function getJson<T>(path: string): Promise<T> {
-  const response = await fetch(path);
+const QA_LAB_WEB_JSON_MAX_BYTES = 16 * 1024 * 1024;
+
+export async function fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, init);
   if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
+    const payload = await readProviderJsonResponse<{ error?: string }>(response, "qa-lab web", {
+      maxBytes: QA_LAB_WEB_JSON_MAX_BYTES,
+    }).catch(() => ({}));
+    throw new Error(payload.error || `${response.status} ${response.statusText}`);
   }
-  return (await response.json()) as T;
+  return readProviderJsonResponse<T>(response, "qa-lab web", {
+    maxBytes: QA_LAB_WEB_JSON_MAX_BYTES,
+  });
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  return fetchJson<T>(path);
 }
 
 async function getJsonNoStore<T>(path: string): Promise<T> {
-  const response = await fetch(path, { cache: "no-store" });
-  if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
-  }
-  return (await response.json()) as T;
+  return fetchJson<T>(path, { cache: "no-store" });
 }
 
 async function postJson<T>(path: string, body: unknown): Promise<T> {
-  const response = await fetch(path, {
+  return fetchJson<T>(path, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!response.ok) {
-    const payload = (await response.json().catch(() => ({}))) as { error?: string };
-    throw new Error(payload.error || `${response.status} ${response.statusText}`);
-  }
-  return (await response.json()) as T;
 }
 
 function countCaptureDimension(

--- a/scripts/proof/qa-lab-web-app-json-bound.mts
+++ b/scripts/proof/qa-lab-web-app-json-bound.mts
@@ -1,0 +1,62 @@
+// Real behavior proof: QA-lab web app fetchJson rejects an oversized JSON
+// response instead of buffering it unbounded.
+//
+// A local HTTP server returns a 20 MiB JSON payload. The script monkeypatches
+// global fetch to delegate to that server, then calls fetchJson. The bounded
+// readProviderJsonResponse helper rejects before the full body is consumed.
+
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const { fetchJson } = await import(
+  path.join(repoRoot, "extensions/qa-lab/web/src/app.js")
+);
+
+const OVERSIZED_BYTES = 20 * 1024 * 1024;
+
+const server = http.createServer((_req, res) => {
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(`{"x":"${"x".repeat(OVERSIZED_BYTES)}"}`);
+});
+
+await new Promise<void>((resolve) => {
+  server.listen(0, "127.0.0.1", () => resolve());
+});
+const address = server.address();
+const localUrl =
+  typeof address === "object" && address !== null
+    ? `http://127.0.0.1:${address.port}`
+    : null;
+if (!localUrl) {
+  throw new Error("Failed to start local server");
+}
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = Object.assign(
+  async (_input: RequestInfo | URL, _init?: RequestInit): Promise<Response> =>
+    originalFetch(localUrl),
+  { mock: {} },
+);
+
+console.log("=== Proof: qa-lab web app JSON bound ===\n");
+console.log(`Local server returning ${OVERSIZED_BYTES} bytes at ${localUrl}`);
+
+try {
+  await fetchJson("/api/test");
+  console.log("\nFAIL: fetchJson did not reject.");
+  process.exitCode = 1;
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  console.log(`\nCaught expected error: ${message}`);
+  if (message.includes("qa-lab web: JSON response exceeds")) {
+    console.log("\nPASS: oversized JSON response was rejected before OOM.");
+  } else {
+    console.log("\nFAIL: error did not mention the JSON size bound.");
+    process.exitCode = 1;
+  }
+} finally {
+  server.close();
+}


### PR DESCRIPTION
## What Problem This Solves

`getJson`, `getJsonNoStore`, and `postJson` in `extensions/qa-lab/web/src/app.ts` parsed response bodies with unbounded `response.json()`. An unexpectedly large API response could exhaust the browser tab during QA lab UI use.

## Why This Change Was Made

Introduce a shared `getJsonBounded` helper that uses `readProviderJsonResponse` with a 16 MiB cap and replace the three unbounded calls.

## User Impact

No behavior change for normal QA lab UI data. Oversized API responses are rejected instead of being buffered whole.

## Evidence

- Regression test added in `extensions/qa-lab/web/src/app.test.ts` asserts an oversized JSON body is rejected.
- Real behavior proof script at `scripts/proof/qa-lab-web-app-json-bound.mts` serves an 8 MiB JSON body and verifies the bounded read rejects at the cap.
- Local verification:
  - `pnpm test extensions/qa-lab/web/src/app.test.ts` passes.
  - `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs extensions/qa-lab/web/src/app.ts extensions/qa-lab/web/src/app.test.ts scripts/proof/qa-lab-web-app-json-bound.mts` passes.
  - `node --import tsx scripts/proof/qa-lab-web-app-json-bound.mts` passes.
