### PR TITLE
fix(agents): handle find subprocess stream failures

### DIFF
--- a/src/agents/sessions/tools/find.fd.test.ts
+++ b/src/agents/sessions/tools/find.fd.test.ts
@@ -17,19 +17,25 @@ vi.mock("../../utils/tools-manager.js", () => ({
 }));
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-type MockChild = ChildProcessWithoutNullStreams & { stdout: PassThrough; stderr: PassThrough };
+type MockChild = ChildProcessWithoutNullStreams & {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  killMock: ReturnType<typeof vi.fn>;
+};
 
 afterEach(() => {
   vi.clearAllMocks();
 });
 
 function createChild(): MockChild {
+  const kill = vi.fn(() => true);
   return Object.assign(new EventEmitter(), {
     stdin: new PassThrough(),
     stdout: new PassThrough(),
     stderr: new PassThrough(),
     killed: false,
-    kill: vi.fn(() => true),
+    kill,
+    killMock: kill,
   }) as unknown as MockChild;
 }
 
@@ -47,6 +53,23 @@ it("rejects partial fd output when fd exits with an error", async () => {
 
   await expect(result).rejects.toThrow("fd failed while reading subtree");
 });
+
+it.each(["stdout", "stderr"] as const)(
+  "rejects and stops fd when %s emits an error",
+  async (stream) => {
+    const child = createChild();
+    vi.mocked(spawn).mockReturnValue(child);
+    vi.mocked(ensureTool).mockResolvedValue("fd");
+
+    const tool = createFindToolDefinition("/workspace");
+    const result = tool.execute("call-1", { pattern: "*.ts" }, undefined, undefined, {} as never);
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalledOnce());
+    child[stream].emit("error", new Error(`${stream} EPIPE`));
+
+    await expect(result).rejects.toThrow(`${stream} EPIPE`);
+    expect(child.killMock).toHaveBeenCalledOnce();
+  },
+);
 
 it.each([
   { name: "inside a repository", gitBoundary: true, expected: false },

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -291,10 +291,23 @@ export function createFindToolDefinition(
             const cleanup = () => {
               rl.close();
             };
+            const onStreamError = (stream: "stdout" | "stderr", error: Error) => {
+              if (settled) {
+                return;
+              }
+              stopChild?.();
+              cleanup();
+              settle(() => reject(new Error(`fd ${stream} error: ${error.message}`)));
+            };
 
             child.stderr?.on("data", (chunk) => {
               stderr = appendBoundedTextTail(stderr, chunk);
             });
+            // Readline re-emits input failures, while the stream listener also catches
+            // implementations that do not. settle() keeps the shared failure path one-shot.
+            rl.on("error", (error) => onStreamError("stdout", error));
+            child.stdout?.on("error", (error) => onStreamError("stdout", error));
+            child.stderr?.on("error", (error) => onStreamError("stderr", error));
 
             rl.on("line", (line) => {
               lines.push(line);


### PR DESCRIPTION
Related: #101020

## What Problem This Solves

Fixes an issue where agent runs using the `find` tool could crash and leave `fd` running when its stdout or stderr stream failed.

The contributor PR carrying this fix was automatically closed only because its author exceeded the repository's open-PR limit. This maintainer-owned replacement preserves the contributor's authorship and reviewed implementation.

## Why This Change Was Made

The `fd` subprocess now has one idempotent stream-failure path shared by readline, stdout, and stderr. That path stops the child, closes readline, removes abort handling through the existing settle owner, and rejects exactly once even though Node forwards an input error through both readline and the raw stream.

## User Impact

The `find` tool now fails the individual tool call cleanly on an OS-level pipe/read failure instead of risking an agent-process crash or orphaned search process. Successful searches, cancellation, result limits, and existing `fd` exit handling are unchanged.

## Evidence

- Node behavior probe confirmed an input-stream failure is emitted first by readline and then by the raw stream; the settled guard keeps cleanup one-shot.
- Focused type-aware `oxlint`: passed.
- Focused `oxfmt --check`: passed.
- `git diff --check`: passed.
- Fresh high-reasoning autoreview: no actionable findings (correctness confidence 0.87).
- Exact-head CI run 28818145434: passed.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 101158`: passed at `cf5000f1de7042a9a0aa8cc7a9344b840aeaa0f6`.

AI-assisted maintainer repair. I reviewed the full `find` subprocess lifecycle, its registration callers, the sibling `grep` implementation, adjacent tests, and Node's readline error contract.
