### PR TITLE
fix(infra): contain SSH config probe stream failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **SSH config stream failures:** terminate `ssh -G` and continue with the configured target when stdout fails or exceeds its bound, preventing local Gateway discovery crashes and hangs. (#101021) Thanks @cxbAsDev.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **SSH config stream failures:** terminate `ssh -G` and continue with the configured target when stdout fails or exceeds its bound, preventing local Gateway discovery crashes and hangs. (#101021) Thanks @cxbAsDev.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/src/infra/ssh-config.test.ts
+++ b/src/infra/ssh-config.test.ts
@@ -10,8 +10,8 @@ type MockSpawnChild = EventEmitter & {
 
 function createMockSpawnChild() {
   const child = new EventEmitter() as MockSpawnChild;
-  const stdout = new EventEmitter() as MockSpawnChild["stdout"];
-  stdout!.setEncoding = vi.fn();
+  const stdout = new EventEmitter() as NonNullable<MockSpawnChild["stdout"]>;
+  stdout.setEncoding = vi.fn();
   child.stdout = stdout;
   child.kill = vi.fn();
   return { child, stdout };
@@ -58,11 +58,13 @@ function requireSpawnArgs(index: number): string[] {
 let parseSshConfigOutput: typeof import("./ssh-config.js").parseSshConfigOutput;
 let resolveSshConfig: typeof import("./ssh-config.js").resolveSshConfig;
 let appendSshConfigOutput: typeof import("./ssh-config.js").appendSshConfigOutput;
+let sshConfigOutputMaxChars: number;
 
 describe("ssh-config", () => {
   beforeAll(async () => {
-    ({ appendSshConfigOutput, parseSshConfigOutput, resolveSshConfig } =
-      await import("./ssh-config.js"));
+    const sshConfig = await import("./ssh-config.js");
+    ({ appendSshConfigOutput, parseSshConfigOutput, resolveSshConfig } = sshConfig);
+    sshConfigOutputMaxChars = sshConfig.SSH_CONFIG_OUTPUT_MAX_CHARS;
   });
 
   it("parses ssh -G output", () => {
@@ -132,6 +134,45 @@ describe("ssh-config", () => {
         process.nextTick(() => {
           child.emit("error", new Error("spawn boom"));
         });
+        return child as unknown as ChildProcess;
+      },
+    );
+
+    await expect(resolveSshConfig({ user: "me", host: "bad-host", port: 22 })).resolves.toBeNull();
+  });
+
+  it.each([
+    {
+      name: "stdout emits an error",
+      emit: (stdout: EventEmitter) => stdout.emit("error", new Error("stdout boom")),
+    },
+    {
+      name: "stdout exceeds the output limit",
+      emit: (stdout: EventEmitter) => stdout.emit("data", "x".repeat(sshConfigOutputMaxChars + 1)),
+    },
+  ])("returns null and terminates ssh when $name", async ({ emit }) => {
+    let capturedChild: MockSpawnChild | undefined;
+    spawnMock.mockImplementationOnce(
+      (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
+        const { child, stdout } = createMockSpawnChild();
+        capturedChild = child;
+        process.nextTick(() => emit(stdout));
+        return child as unknown as ChildProcess;
+      },
+    );
+
+    await expect(resolveSshConfig({ user: "me", host: "bad-host", port: 22 })).resolves.toBeNull();
+    expect(capturedChild?.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("returns null when terminating ssh throws", async () => {
+    spawnMock.mockImplementationOnce(
+      (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
+        const { child, stdout } = createMockSpawnChild();
+        child.kill = vi.fn(() => {
+          throw new Error("kill failed");
+        });
+        process.nextTick(() => stdout?.emit("error", new Error("stdout boom")));
         return child as unknown as ChildProcess;
       },
     );

--- a/src/infra/ssh-config.ts
+++ b/src/infra/ssh-config.ts
@@ -94,7 +94,6 @@ export async function resolveSshConfig(
     });
     let stdout = "";
     let settled = false;
-    let timer: ReturnType<typeof setTimeout>;
     const settle = (result: SshResolvedConfig | null, options?: { terminate?: boolean }) => {
       if (settled) {
         return;
@@ -112,7 +111,7 @@ export async function resolveSshConfig(
     };
 
     const timeoutMs = Math.max(200, opts.timeoutMs ?? 800);
-    timer = setTimeout(() => settle(null, { terminate: true }), timeoutMs);
+    const timer = setTimeout(() => settle(null, { terminate: true }), timeoutMs);
 
     child.stdout?.setEncoding("utf8");
     child.stdout?.on("data", (chunk) => {

--- a/src/infra/ssh-config.ts
+++ b/src/infra/ssh-config.ts
@@ -93,38 +93,44 @@ export async function resolveSshConfig(
       stdio: ["ignore", "pipe", "ignore"],
     });
     let stdout = "";
-    let outputTooLarge = false;
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const settle = (result: SshResolvedConfig | null, options?: { terminate?: boolean }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if (options?.terminate) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // A failed best-effort kill must not strand gateway discovery.
+        }
+      }
+      resolve(result);
+    };
+
+    const timeoutMs = Math.max(200, opts.timeoutMs ?? 800);
+    timer = setTimeout(() => settle(null, { terminate: true }), timeoutMs);
+
     child.stdout?.setEncoding("utf8");
     child.stdout?.on("data", (chunk) => {
       const appended = appendSshConfigOutput(stdout, chunk);
       if (!appended.ok) {
-        outputTooLarge = true;
-        child.kill("SIGKILL");
+        settle(null, { terminate: true });
         return;
       }
       stdout = appended.value;
     });
-
-    const timeoutMs = Math.max(200, opts.timeoutMs ?? 800);
-    const timer = setTimeout(() => {
-      try {
-        child.kill("SIGKILL");
-      } finally {
-        resolve(null);
-      }
-    }, timeoutMs);
-
-    child.once("error", () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
+    child.stdout?.on("error", () => settle(null, { terminate: true }));
+    child.once("error", () => settle(null));
     child.once("exit", (code) => {
-      clearTimeout(timer);
-      if (outputTooLarge || code !== 0 || !stdout.trim()) {
-        resolve(null);
+      if (code !== 0 || !stdout.trim()) {
+        settle(null);
         return;
       }
-      resolve(parseSshConfigOutput(stdout));
+      settle(parseSshConfigOutput(stdout));
     });
   });
 }


### PR DESCRIPTION
Related: #101021

## What Problem This Solves

Fixes an issue where local Gateway discovery could crash or hang when the stdout pipe from its bounded `ssh -G` config probe failed.

The contributor PR carrying this fix was automatically closed only because its author exceeded the repository's open-PR limit. This maintainer-owned replacement preserves the contributor's authorship and the reviewed rewrite.

## Why This Change Was Made

All probe terminal paths now use one idempotent settle owner. Stdout failures, output overflow, and timeout terminate `ssh -G` best-effort and resolve to the existing unavailable-config result; child errors and exits retain their prior fallback behavior. A failed kill cannot strand Gateway discovery.

## User Impact

Remote Gateway status discovery continues with the configured SSH target when effective-config probing fails, instead of risking an unhandled stream error or waiting on a probe that should already be abandoned.

## Evidence

- Regression coverage for stdout errors, bounded-output overflow, and kill failures.
- Focused `oxfmt --check`: passed.
- `git diff --check`: passed.
- Fresh high-reasoning autoreview: no actionable findings (correctness confidence 0.86).
- Current head `db3ed0bfca43c9d3b7bbaaca04120c85d99b0410`; focused head `9c72167c4294b6ae8e8430d8f742dccc025ac405` on Blacksmith Testbox `tbx_01kwwe4bnj8tdzyt7xvnm2zwjq`: `pnpm test src/infra/ssh-config.test.ts` — 11/11 passed. Current runtime/test blobs are identical after the base-only rebase.
- Same Testbox: a real long-lived child received an injected stdout failure and exited by `SIGKILL` while the parent remained healthy.
- Exact-head hosted CI is running on the post-QA-fix `main` base.

AI-assisted maintainer repair. I reviewed the full SSH probe lifecycle, its Gateway discovery caller and fallback, existing parser/boundary tests, and sibling child-process cleanup implementations.
