### PR TITLE
fix(android): stabilize recent sessions overview

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -4699,7 +4699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 425,
+      "line": 436,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Overview",
       "surface": "android",
@@ -4707,7 +4707,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 470,
+      "line": 481,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No recent sessions",
       "surface": "android",
@@ -4715,7 +4715,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 471,
+      "line": 482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start a chat and your active OpenClaw conversations will appear here.",
       "surface": "android",
@@ -4723,7 +4723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 472,
+      "line": 483,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -4731,7 +4731,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 518,
+      "line": 529,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -4739,7 +4739,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 526,
+      "line": 537,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search",
       "surface": "android",
@@ -4747,7 +4747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 578,
+      "line": 589,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "ACTIVE AGENT",
       "surface": "android",
@@ -4755,7 +4755,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 587,
+      "line": 598,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View",
       "surface": "android",
@@ -4763,7 +4763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 590,
+      "line": 601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$pendingRunCount active",
       "surface": "android",
@@ -4771,7 +4771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 590,
+      "line": 601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Idle",
       "surface": "android",
@@ -4779,7 +4779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 590,
+      "line": 601,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Runs",
       "surface": "android",
@@ -4787,7 +4787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 591,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$sessionCount recent",
       "surface": "android",
@@ -4795,7 +4795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 591,
+      "line": 602,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Sessions",
       "surface": "android",
@@ -4803,7 +4803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 592,
+      "line": 603,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Cron",
       "surface": "android",
@@ -4811,7 +4811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 595,
+      "line": 606,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -4819,7 +4819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 599,
+      "line": 610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Reconnect gateway",
       "surface": "android",
@@ -4827,7 +4827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 747,
+      "line": 758,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${card.title}",
       "surface": "android",
@@ -4835,7 +4835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 815,
+      "line": 826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk",
       "surface": "android",
@@ -4843,7 +4843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 816,
+      "line": 827,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open Talk",
       "surface": "android",
@@ -4851,7 +4851,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 818,
+      "line": 829,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Talk settings",
       "surface": "android",
@@ -4859,7 +4859,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 826,
+      "line": 837,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent Sessions",
       "surface": "android",
@@ -4867,7 +4867,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 836,
+      "line": 847,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "View all",
       "surface": "android",
@@ -4875,7 +4875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 958,
+      "line": 990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$onlineNodes/$nodeCount",
       "surface": "android",
@@ -4883,7 +4883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 958,
+      "line": 990,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "None",
       "surface": "android",
@@ -4891,7 +4891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 990,
+      "line": 1022,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Recent conversations",
       "surface": "android",
@@ -4899,7 +4899,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 997,
+      "line": 1029,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Browse",
       "surface": "android",
@@ -4907,7 +4907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 997,
+      "line": 1029,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Offline",
       "surface": "android",
@@ -4915,7 +4915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1049,
+      "line": 1081,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Working · $pendingRunCount active ${pluralize(\"run\", pendingRunCount)}",
       "surface": "android",
@@ -4923,7 +4923,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1170,
+      "line": 1202,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Needs attention",
       "surface": "android",
@@ -4931,7 +4931,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1235,
+      "line": 1267,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open ${row.title}",
       "surface": "android",
@@ -4939,7 +4939,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1325,
+      "line": 1375,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open session",
       "surface": "android",
@@ -4947,7 +4947,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1437,
+      "line": 1487,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Back",
       "surface": "android",
@@ -4955,7 +4955,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1440,
+      "line": 1490,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Settings",
       "surface": "android",
@@ -4963,7 +4963,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1443,
+      "line": 1493,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Search settings",
       "surface": "android",
@@ -4971,7 +4971,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1467,
+      "line": 1517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$readyProviderCount ready",
       "surface": "android",
@@ -4979,7 +4979,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1467,
+      "line": 1517,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Review readiness",
       "surface": "android",
@@ -4987,7 +4987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1478,
+      "line": 1528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker muted",
       "surface": "android",
@@ -4995,7 +4995,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1478,
+      "line": 1528,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Speaker on",
       "surface": "android",
@@ -5003,7 +5003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1480,
+      "line": 1530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Off",
       "surface": "android",
@@ -5011,7 +5011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1480,
+      "line": 1530,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Smart delivery",
       "surface": "android",
@@ -5019,7 +5019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1481,
+      "line": 1531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Camera enabled",
       "surface": "android",
@@ -5027,7 +5027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1481,
+      "line": 1531,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Locked",
       "surface": "android",
@@ -5035,7 +5035,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1523,
+      "line": 1573,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
       "surface": "android",
@@ -5043,7 +5043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1526,
+      "line": 1576,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "All systems operational",
       "surface": "android",
@@ -5051,7 +5051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1526,
+      "line": 1576,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Gateway not connected",
       "surface": "android",
@@ -5059,7 +5059,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1558,
+      "line": 1608,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No provider usage",
       "surface": "android",
@@ -5067,7 +5067,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1559,
+      "line": 1609,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "1 provider",
       "surface": "android",
@@ -5075,7 +5075,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1560,
+      "line": 1610,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$count providers",
       "surface": "android",
@@ -5083,7 +5083,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1566,
+      "line": 1616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "$ready/${skills.size} ready",
       "surface": "android",
@@ -5091,7 +5091,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1566,
+      "line": 1616,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "No skills",
       "surface": "android",
@@ -5099,7 +5099,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1744,
+      "line": 1794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "OpenClaw mobile",
       "surface": "android",
@@ -5107,7 +5107,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1748,
+      "line": 1798,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Open profile",
       "surface": "android",
@@ -5115,7 +5115,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1833,
+      "line": 1883,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt",
       "source": "Main session",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -131,6 +131,7 @@ private val overviewMetricTileMinHeight = 96.dp
 private val overviewTalkPanelMinHeight = 72.dp
 private val overviewListRowMinHeight = 54.dp
 private const val overviewRecentSessionLimit = 50
+private const val overviewRecentSessionVisibleLimit = 3
 
 internal fun shellBottomNavVisible(
   keyboardVisible: Boolean,
@@ -385,10 +386,12 @@ private fun OverviewScreen(
   val activeAgentBadge = overviewAgentBadgeText(agents = agents, defaultAgentId = defaultAgentId)
   val overviewSessions = overviewRecentSessions(sessions)
   val overviewSessionCount = overviewSessions.size
-  val recentRows =
+  val candidateRecentRows =
     remember(overviewSessions, channelsSummary) {
       overviewRecentSessionRows(sessions = overviewSessions, channelsSummary = channelsSummary)
     }
+  var recentRows by remember { mutableStateOf<List<RecentSessionListItem>>(emptyList()) }
+  val visibleRecentRows = recentRows.ifEmpty { candidateRecentRows }
   val metricCards =
     overviewMetricCards(
       isConnected = isConnected,
@@ -397,6 +400,14 @@ private fun OverviewScreen(
       pendingApprovals = pendingApprovalsCount,
       sessionCount = overviewSessionCount,
     )
+
+  LaunchedEffect(candidateRecentRows) {
+    recentRows =
+      stableOverviewRecentRows(
+        previousRows = recentRows,
+        candidateRows = candidateRecentRows,
+      )
+  }
 
   LaunchedEffect(isConnected) {
     if (isConnected) {
@@ -464,7 +475,7 @@ private fun OverviewScreen(
 
         item { RecentSessionsHeader(onOpenSessions = { onSelectTab(Tab.Sessions) }) }
 
-        if (recentRows.isEmpty()) {
+        if (visibleRecentRows.isEmpty()) {
           item {
             ClawEmptyState(
               title = "No recent sessions",
@@ -475,7 +486,7 @@ private fun OverviewScreen(
         } else {
           item {
             RecentSessionList(
-              rows = recentRows,
+              rows = visibleRecentRows,
               onOpen = { sessionKey ->
                 viewModel.switchChatSession(sessionKey)
                 onSelectTab(Tab.Chat)
@@ -862,7 +873,28 @@ internal fun overviewHeaderRoute(attentionRows: List<HomeAttentionRow>): Setting
 
 internal fun overviewRecentSessionCount(sessions: List<ChatSessionEntry>): Int = overviewRecentSessions(sessions).size
 
-internal fun overviewRecentSessions(sessions: List<ChatSessionEntry>): List<ChatSessionEntry> = sessions.take(overviewRecentSessionLimit).distinctBy { session -> session.key }
+internal fun overviewRecentSessions(sessions: List<ChatSessionEntry>): List<ChatSessionEntry> =
+  sessions
+    .withIndex()
+    .groupBy { entry -> entry.value.key }
+    .values
+    .map { entries ->
+      entries
+        .sortedWith(
+          compareByDescending<IndexedValue<ChatSessionEntry>> { entry -> entry.value.overviewRecentSessionRecencyMs() }
+            .thenBy { entry -> entry.index },
+        )
+        .first()
+    }
+    .sortedWith(
+      compareByDescending<IndexedValue<ChatSessionEntry>> { entry -> entry.value.overviewRecentSessionRecencyMs() }
+        .thenBy { entry -> entry.value.key },
+    )
+    .take(overviewRecentSessionLimit)
+    .map { entry -> entry.value }
+
+private fun ChatSessionEntry.overviewRecentSessionRecencyMs(): Long =
+  lastActivityAt ?: updatedAtMs ?: Long.MIN_VALUE
 
 internal data class OverviewMetricCard(
   val title: String,
@@ -1240,28 +1272,46 @@ private fun ModuleListRow(
   }
 }
 
-private data class RecentSessionListItem(
+internal data class RecentSessionListItem(
   val key: String,
   val title: String,
   val source: String,
   val metadata: String,
 )
 
-private fun overviewRecentSessionRows(
+internal fun overviewRecentSessionRows(
   sessions: List<ChatSessionEntry>,
   channelsSummary: GatewayChannelsSummary,
 ): List<RecentSessionListItem> =
   sessions
-    .take(3)
+    .take(overviewRecentSessionVisibleLimit)
     .map { session ->
       val title = displaySessionTitle(session.displayName)
       RecentSessionListItem(
         key = session.key,
         title = title,
         source = sessionSourceLabel(session.key, channelsSummary),
-        metadata = session.updatedAtMs?.let(::relativeSessionTime) ?: "",
+        metadata = (session.lastActivityAt ?: session.updatedAtMs)?.let(::relativeSessionTime) ?: "",
       )
     }
+
+internal fun stableOverviewRecentRows(
+  previousRows: List<RecentSessionListItem>,
+  candidateRows: List<RecentSessionListItem>,
+): List<RecentSessionListItem> {
+  val previousRowsByKey = previousRows.associateBy { row -> row.key }
+  return candidateRows.map { candidateRow ->
+    val previousRow = previousRowsByKey[candidateRow.key]
+    if (previousRow == null) candidateRow else candidateRow.withStableFieldsFrom(previousRow)
+  }
+}
+
+private fun RecentSessionListItem.withStableFieldsFrom(previousRow: RecentSessionListItem): RecentSessionListItem =
+  copy(
+    title = title.ifBlank { previousRow.title },
+    source = source.ifBlank { previousRow.source },
+    metadata = metadata.ifBlank { previousRow.metadata },
+  )
 
 /** Recent sessions panel that preserves the session key behind display labels. */
 @Composable

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/ShellScreenLogicTest.kt
@@ -328,21 +328,107 @@ class ShellScreenLogicTest {
       }
 
     assertEquals(50, overviewRecentSessionCount(sessions))
-    assertEquals((1..50).map { "session-$it" }, overviewRecentSessions(sessions).map { it.key })
+    assertEquals((51 downTo 2).map { "session-$it" }, overviewRecentSessions(sessions).map { it.key })
   }
 
   @Test
-  fun overviewRecentSessionsDeduplicateWithinTheRecentWindow() {
-    assertEquals(
-      listOf("main", "cron"),
+  fun overviewRecentSessionsSortByMostRecentTimestamp() {
+    val sessions =
+      listOf(
+        ChatSessionEntry(key = "cron", updatedAtMs = 2),
+        ChatSessionEntry(key = "main", updatedAtMs = 3),
+        ChatSessionEntry(key = "telegram", updatedAtMs = 1),
+      )
+
+    assertEquals(listOf("main", "cron", "telegram"), overviewRecentSessions(sessions).map { session -> session.key })
+  }
+
+  @Test
+  fun overviewRecentSessionsPreferLastActivityForRecency() {
+    val sessions =
+      listOf(
+        ChatSessionEntry(key = "main", updatedAtMs = 10, lastActivityAt = 10),
+        ChatSessionEntry(key = "cron", updatedAtMs = 50, lastActivityAt = 20),
+        ChatSessionEntry(key = "telegram", updatedAtMs = 1, lastActivityAt = 100),
+      )
+
+    assertEquals(listOf("telegram", "cron", "main"), overviewRecentSessions(sessions).map { session -> session.key })
+  }
+
+  @Test
+  fun overviewRecentSessionsDeduplicateByNewestEntry() {
+    val sessions =
       overviewRecentSessions(
         listOf(
-          ChatSessionEntry(key = "main", updatedAtMs = 3),
-          ChatSessionEntry(key = "cron", updatedAtMs = 2),
+          ChatSessionEntry(key = "main", displayName = "Stale main", updatedAtMs = 10, lastActivityAt = 10),
+          ChatSessionEntry(key = "cron", displayName = "Cron", updatedAtMs = 2),
+          ChatSessionEntry(key = "main", displayName = "Fresh main", updatedAtMs = 3, lastActivityAt = 30),
+        ),
+      )
+
+    assertEquals(listOf("main", "cron"), sessions.map { session -> session.key })
+    assertEquals("Fresh main", sessions.first().displayName)
+  }
+
+  @Test
+  fun overviewRecentSessionsUseStableKeyOrderWhenTimestampsMatch() {
+    assertEquals(
+      listOf("cron", "main", "telegram"),
+      overviewRecentSessions(
+        listOf(
+          ChatSessionEntry(key = "telegram", updatedAtMs = 1),
           ChatSessionEntry(key = "main", updatedAtMs = 1),
+          ChatSessionEntry(key = "cron", updatedAtMs = 1),
         ),
       ).map { session -> session.key },
     )
+  }
+
+  @Test
+  fun overviewRecentSessionRowsUseLastActivityForMetadata() {
+    val rows =
+      overviewRecentSessionRows(
+        sessions = listOf(ChatSessionEntry(key = "main", updatedAtMs = null, lastActivityAt = System.currentTimeMillis())),
+        channelsSummary = emptyChannels(),
+      )
+
+    assertTrue(rows.single().metadata.isNotBlank())
+  }
+
+  @Test
+  fun stableOverviewRecentRowsKeepPreviousMetadataDuringPartialRefresh() {
+    val rows =
+      stableOverviewRecentRows(
+        previousRows =
+          listOf(
+            RecentSessionListItem(key = "main", title = "Main session", source = "OpenClaw", metadata = "1h"),
+          ),
+        candidateRows =
+          listOf(
+            RecentSessionListItem(key = "main", title = "Main session", source = "OpenClaw", metadata = ""),
+          ),
+      )
+
+    assertEquals("1h", rows.single().metadata)
+  }
+
+  @Test
+  fun stableOverviewRecentRowsFollowCandidateRows() {
+    val rows =
+      stableOverviewRecentRows(
+        previousRows =
+          listOf(
+            RecentSessionListItem(key = "main", title = "Main session", source = "OpenClaw", metadata = "1h"),
+            RecentSessionListItem(key = "discord", title = "Discord", source = "Discord", metadata = "2h"),
+          ),
+        candidateRows =
+          listOf(
+            RecentSessionListItem(key = "main", title = "Main session", source = "OpenClaw", metadata = "1h"),
+            RecentSessionListItem(key = "cron", title = "Cron", source = "Cron", metadata = "4h"),
+          ),
+      )
+
+    assertEquals(listOf("main", "cron"), rows.map { row -> row.key })
   }
 
   @Test


### PR DESCRIPTION
## What Problem This Solves

Android Home's Recent Sessions panel could visibly flash as gateway refreshes delivered duplicate or partial session rows. The panel could briefly reorder rows or replace nonblank row metadata with blank metadata during refresh churn.

## Why This Change Was Made

This keeps Home's Recent Sessions ordering aligned with the Sessions screen recency contract (`lastActivityAt ?: updatedAtMs`), deduplicates repeated session keys by the newest entry, and preserves prior nonblank row fields for the same visible session while a partial refresh frame is in flight.

## User Impact

The Recent Sessions section should stop flashing between row states during live refreshes while still reflecting the current recent-session candidates and newly active sessions.

## Evidence

- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew testPlayDebugUnitTest --tests ai.openclaw.app.ui.ShellScreenLogicTest`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
- `pnpm native:i18n:sync` refreshed `apps/.i18n/native-source.json`
- `pnpm native:i18n:check` -> `native-app-i18n: entries=2775 changed=false`
- `git diff --check`
- Installed clean branch with `./gradlew installPlayDebug` on `OpenClaw_StableProof_API_35(AVD) - 15`
- Relaunched `ai.openclaw.app/.MainActivity` and sampled Recent Sessions; row stayed stable as `OpenClaw Windows Tray / OpenClaw / now`

### Visual Proof

Before = current `origin/main` without this PR. After = this PR branch.

![Recent Sessions before and after](https://github.com/user-attachments/assets/e2687421-f44c-4085-a6c7-66174e572325)

Before:

![Before Recent Sessions fix](https://github.com/user-attachments/assets/dc2321ec-9799-45a8-b0c7-68d9d57bfbb4)

After:

![After Recent Sessions fix](https://github.com/user-attachments/assets/b2f0fc33-f094-4b39-b067-de52202400f1)
