### PR TITLE
fix(usage): preserve provider-billed zero costs

### DIFF
--- a/extensions/deepseek/provider-policy-api.test.ts
+++ b/extensions/deepseek/provider-policy-api.test.ts
@@ -156,6 +156,29 @@ describe("deepseek provider-policy-api", () => {
     expect(model.contextWindow).toBe(1_000_000);
   });
 
+  it("preserves explicit all-zero user cost override", () => {
+    const userCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+    const providerConfig: ModelProviderConfig = {
+      baseUrl: "https://api.deepseek.com",
+      api: "openai-completions",
+      models: [
+        {
+          id: "deepseek-v4-flash",
+          name: "DeepSeek V4 Flash",
+          reasoning: true,
+          input: ["text"],
+          cost: userCost,
+        } as never,
+      ],
+    };
+
+    const result = normalizeConfig({ provider: "deepseek", providerConfig });
+    const model = result.models[0];
+    expect(model.cost).toEqual(userCost);
+    expect(model.contextWindow).toBe(1_000_000);
+    expect(model.maxTokens).toBe(384_000);
+  });
+
   it("preserves explicit user maxTokens override", () => {
     const providerConfig: ModelProviderConfig = {
       baseUrl: "https://api.deepseek.com",

--- a/extensions/deepseek/provider-policy-api.ts
+++ b/extensions/deepseek/provider-policy-api.ts
@@ -77,7 +77,7 @@ export function normalizeConfig(params: {
       modelMutated = true;
     }
 
-    // Hydrate cost from catalog when missing or when all fields are zero/absent.
+    // Hydrate cost from catalog only when the model has no explicit numeric cost fields.
     if (!hasCostValues(raw.cost) && hasCostValues(catalogEntry.cost)) {
       patched.cost = catalogEntry.cost;
       modelMutated = true;

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -851,6 +851,49 @@ describe("openrouter provider hooks", () => {
     }
   });
 
+  it("reconciles OpenRouter zero generation metadata cost", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe("https://openrouter.ai/api/v1/generation?id=gen-free-1");
+      return new Response(JSON.stringify({ data: { total_cost: 0 } }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const baseStreamFn = vi.fn(() =>
+      createOpenRouterDoneStream({ responseId: "gen-free-1", totalCost: 0.001 }),
+    );
+
+    try {
+      const wrapped = provider.wrapStreamFn?.({
+        provider: "openrouter",
+        modelId: "openrouter/auto",
+        streamFn: baseStreamFn,
+      } as never);
+      if (!wrapped) {
+        throw new Error("expected OpenRouter wrapper");
+      }
+      const stream = await wrapped(
+        {
+          provider: "openrouter",
+          api: "openai-completions",
+          id: "openrouter/auto",
+          baseUrl: "https://openrouter.ai/api/v1",
+          compat: {},
+        } as never,
+        { messages: [] } as never,
+        { apiKey: "or-test-key" } as never,
+      );
+      const message = await stream.result();
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(message.usage.cost.total).toBe(0);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("falls back to streamed cost estimate when generation metadata response is oversized", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
     // Body exceeds the 16 MiB cap; readProviderJsonResponse must reject it and

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -449,6 +449,130 @@ describe("session cost usage", () => {
     }
   });
 
+  it("preserves provider-billed zero totals with all-zero cost components", async () => {
+    const root = await makeSessionCostRoot("cost-provider-billed-all-zero-total");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-openrouter-billed-zero.jsonl");
+    const entry = {
+      type: "message",
+      timestamp: "2026-02-05T12:00:00.000Z",
+      message: {
+        role: "assistant",
+        provider: "openrouter",
+        model: "openai/gpt-5.5",
+        content: "billed-free OpenRouter answer",
+        usage: {
+          input: 10_000,
+          output: 5_000,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 15_000,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+    await fs.writeFile(sessionFile, transcriptText("sess-openrouter-billed-zero", entry), "utf-8");
+
+    const config = {
+      models: {
+        providers: {
+          openrouter: {
+            models: [
+              {
+                id: "openai/gpt-5.5",
+                cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    clearGatewayModelPricingCacheState();
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({
+        startMs: Date.UTC(2026, 1, 5),
+        endMs: Date.UTC(2026, 1, 5, 23, 59, 59, 999),
+        config,
+      });
+      expect(summary.totals.totalTokens).toBe(15_000);
+      expect(summary.totals.totalCost).toBe(0);
+      expect(summary.totals.missingCostEntries).toBe(0);
+
+      await refreshCostUsageCache({ config, sessionFiles: [sessionFile] });
+      const cached = await loadCostUsageSummaryFromCache({
+        startMs: Date.UTC(2026, 1, 5),
+        endMs: Date.UTC(2026, 1, 5, 23, 59, 59, 999),
+        config,
+        requestRefresh: false,
+      });
+      expect(cached.totals.totalCost).toBe(0);
+      expect(cached.totals.missingCostEntries).toBe(0);
+
+      const logs = await loadSessionLogs({ sessionFile, config });
+      expect(logs?.[0]?.tokens).toBe(15_000);
+      expect(logs?.[0]?.cost).toBe(0);
+    });
+  });
+
+  it("keeps zero-token recorded zero costs at zero even when pricing is known", async () => {
+    const root = await makeSessionCostRoot("cost-known-pricing-zero-token");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-zero-tokens.jsonl");
+    const entry = {
+      type: "message",
+      timestamp: "2026-02-05T12:00:00.000Z",
+      message: {
+        role: "assistant",
+        provider: "deepseek",
+        model: "deepseek-v4-flash",
+        content: "empty DeepSeek accounting row",
+        usage: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 0,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+      },
+    };
+    await fs.writeFile(sessionFile, transcriptText("sess-zero-tokens", entry), "utf-8");
+
+    const config = {
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              {
+                id: "deepseek-v4-flash",
+                cost: { input: 0.14, output: 0.28, cacheRead: 0.028, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    clearGatewayModelPricingCacheState();
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({
+        startMs: Date.UTC(2026, 1, 5),
+        endMs: Date.UTC(2026, 1, 5, 23, 59, 59, 999),
+        config,
+      });
+      expect(summary.totals.totalTokens).toBe(0);
+      expect(summary.totals.totalCost).toBe(0);
+      expect(summary.totals.missingCostEntries).toBe(0);
+
+      const logs = await loadSessionLogs({ sessionFile, config });
+      expect(logs?.[0]?.tokens).toBe(0);
+      expect(logs?.[0]?.cost).toBe(0);
+    });
+  });
+
   it("uses top-level transcript provider and model when recomputing session-log cost", async () => {
     const root = await makeSessionCostRoot("cost-known-pricing-top-level-metadata");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
@@ -529,7 +653,7 @@ describe("session cost usage", () => {
       await refreshCostUsageCache({ sessionFiles: [sessionFile] });
       const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
       const cache = JSON.parse(await fs.readFile(cachePath, "utf-8")) as { version: number };
-      cache.version = 5;
+      cache.version = 6;
       await fs.writeFile(cachePath, `${JSON.stringify(cache)}\n`, "utf-8");
 
       // The pre-upgrade cache must be treated as stale (not served), forcing a rebuild

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -76,7 +76,7 @@ export type {
 
 // Bump when the durable cache schema or the meaning of cached totals changes, so
 // older builds are rebuilt instead of served stale.
-const USAGE_COST_CACHE_VERSION = 6;
+const USAGE_COST_CACHE_VERSION = 7;
 const USAGE_COST_CACHE_FILE = ".usage-cost-cache.json";
 const USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS = 10_000;
 const USAGE_COST_CACHE_TEMP_FILE_GRACE_MS = USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS;
@@ -1139,6 +1139,18 @@ const isModelPricingKnown = (cost: ReturnType<typeof resolveModelCostConfig>): b
   return cost.input > 0 || cost.output > 0 || cost.cacheRead > 0 || cost.cacheWrite > 0;
 };
 
+const DEEPSEEK_V4_MODEL_IDS = new Set(["deepseek-v4-flash", "deepseek-v4-pro"]);
+
+const isDirectDeepSeekV4ModelRef = (params: { provider?: string; model?: string }): boolean => {
+  const provider = normalizeOptionalString(params.provider)?.toLowerCase();
+  const model = normalizeOptionalString(params.model);
+  if (provider !== "deepseek" || !model) {
+    return false;
+  }
+  const modelId = (model.split("/").at(-1) ?? model).toLowerCase();
+  return DEEPSEEK_V4_MODEL_IDS.has(modelId);
+};
+
 const shouldPreserveRecordedZeroCost = (costBreakdown: CostBreakdown | undefined): boolean =>
   costBreakdown?.total === 0 &&
   [
@@ -1152,9 +1164,12 @@ const shouldRecomputeRecordedZeroCost = (params: {
   cost: ReturnType<typeof resolveModelCostConfig>;
   costBreakdown: CostBreakdown | undefined;
   costTotal: number | undefined;
+  model?: string;
+  provider?: string;
   usage: NormalizedUsage;
 }): boolean =>
   params.costTotal === 0 &&
+  isDirectDeepSeekV4ModelRef(params) &&
   !shouldPreserveRecordedZeroCost(params.costBreakdown) &&
   isModelPricingKnown(params.cost) &&
   computeUsageTokenTotals(params.usage).totalTokens > 0;
@@ -1289,11 +1304,13 @@ async function scanTranscriptFile(params: {
           cost,
           costBreakdown: entry.costBreakdown,
           costTotal: entry.costTotal,
+          provider: entry.provider,
+          model: entry.model,
         })
       ) {
         // Fill in missing estimates and override fabricated API-provided zeros
-        // for known-priced models such as DeepSeek V4. Providers that reconcile
-        // only the total keep their authoritative zero when components are nonzero.
+        // only for direct DeepSeek V4 transcripts. Other known-priced providers
+        // can report a real billed zero, so keep their recorded total authoritative.
         entry.costTotal = estimateUsageCost({ usage: entry.usage, cost });
         entry.costBreakdown = undefined;
       }
@@ -2758,14 +2775,13 @@ export async function loadSessionLogs(params: {
               (usage.cacheRead ?? 0) +
               (usage.cacheWrite ?? 0);
           const breakdown = extractCostBreakdown(usageRaw);
-          const costConfig = resolveCost({
-            provider:
-              (typeof message.provider === "string" ? message.provider : undefined) ??
-              (typeof parsed.provider === "string" ? parsed.provider : undefined),
-            model:
-              (typeof message.model === "string" ? message.model : undefined) ??
-              (typeof parsed.model === "string" ? parsed.model : undefined),
-          });
+          const provider =
+            (typeof message.provider === "string" ? message.provider : undefined) ??
+            (typeof parsed.provider === "string" ? parsed.provider : undefined);
+          const model =
+            (typeof message.model === "string" ? message.model : undefined) ??
+            (typeof parsed.model === "string" ? parsed.model : undefined);
+          const costConfig = resolveCost({ provider, model });
           if (
             breakdown?.total !== undefined &&
             !shouldRecomputeRecordedZeroCost({
@@ -2773,6 +2789,8 @@ export async function loadSessionLogs(params: {
               cost: costConfig,
               costBreakdown: breakdown,
               costTotal: breakdown.total,
+              provider,
+              model,
             })
           ) {
             cost = breakdown.total;


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #97047 after the direct DeepSeek V4 spend fix landed on `main`.

The shipped main fix recomputes known-priced transcript rows whose recorded `usage.cost.total` is zero. That covers the direct DeepSeek V4 placeholder-zero bug, but it can also overwrite a legitimate provider-billed free/zero total for other providers when their cost components are all zero.

OpenRouter is the concrete compatibility case: its generation metadata endpoint can return `total_cost: 0`, and the OpenRouter wrapper treats that as authoritative provider billing data. If a later usage-cost scan recomputes that row only because catalog pricing is known, the UI can show local estimated spend for a provider-billed free route.

## Why This Change Was Made

This patch keeps the DeepSeek V4 workaround but narrows recorded-zero recomputation to the direct DeepSeek V4 case that actually had the placeholder-zero bug:

- `provider: "deepseek"`
- `deepseek-v4-flash` / `deepseek-v4-pro`
- nonzero tokens
- known positive pricing
- recorded `usage.cost.total === 0`

For other known-priced providers, a recorded zero total remains authoritative unless the row is otherwise unpriced/missing under existing usage-cost rules.

## What Changed

- Limit recorded-zero recomputation to direct DeepSeek V4 transcript rows only.
- Preserve provider-billed zero totals for other known-priced providers, including all-zero component rows.
- Add OpenRouter proof that generation metadata can authoritatively reconcile a streamed estimate to `total_cost: 0`.
- Keep DeepSeek provider-policy compatibility explicit: missing `cost` hydrates from the bundled catalog, while explicit all-zero user overrides remain zero-cost overrides.
- Bump the durable usage-cost cache version from 6 to 7 because cached known-priced recorded-zero semantics changed.

## Evidence

Regression coverage added/updated:

- `src/infra/session-cost-usage.test.ts`
  - direct DeepSeek V4 recorded zero with nonzero tokens is estimated
  - OpenRouter known-priced all-zero billed total remains zero in summary, durable cache, and session logs
  - zero-token recorded zero rows remain zero
  - version-6 durable cache entries are treated as stale after the semantics change
- `extensions/openrouter/index.test.ts`
  - OpenRouter generation metadata `total_cost: 0` overwrites the streamed estimate to an authoritative zero total
- `extensions/deepseek/provider-policy-api.test.ts`
  - explicit all-zero DeepSeek user cost override is preserved

Local targeted validation on the pushed head:

- `git diff --check -- src/infra/session-cost-usage.ts src/infra/session-cost-usage.test.ts extensions/deepseek/provider-policy-api.ts extensions/deepseek/provider-policy-api.test.ts extensions/openrouter/index.test.ts`
- `CI=1 NO_COLOR=1 node scripts/run-vitest.mjs run src/infra/session-cost-usage.test.ts extensions/deepseek/provider-policy-api.test.ts extensions/openrouter/index.test.ts`
  - `src/infra/session-cost-usage.test.ts`: 67 passed
  - `extensions/openrouter/index.test.ts` + `extensions/deepseek/provider-policy-api.test.ts`: 58 passed

## Conflict Resolution

This replaces the closed #97134 branch work because GitHub refused reopening #97134 after the head branch was force-pushed/recreated.

The replacement branch is based on current `openclaw/openclaw@3accc99b43` and is mergeable against `main`.

## Risk

Low-to-moderate behavior risk, limited to spend accounting for transcript rows that carry `usage.cost.total: 0`.

Expected behavior after this change:

- Direct DeepSeek V4 placeholder zero + nonzero token usage: recompute from catalog pricing.
- OpenRouter/provider-billed zero total: preserve the recorded total as authoritative.
- Unknown/all-zero pricing with nonzero tokens: still counted as missing cost instead of confident zero.
- Zero-token rows: remain zero.

No workflow, dependency, lockfile, secret, or release artifact changes.