### PR TITLE
refactor(ui): localize internal type exports

### DIFF
--- a/ui/src/app/config.ts
+++ b/ui/src/app/config.ts
@@ -28,7 +28,7 @@ const SEAM_COLOR_CSS_VARIABLES = [
   "--focus-glow",
 ] as const;
 
-export type ApplicationConfig = {
+type ApplicationConfig = {
   assistantIdentity: {
     agentId: string | null;
     name: string;

--- a/ui/src/app/context.ts
+++ b/ui/src/app/context.ts
@@ -44,7 +44,7 @@ export type ApplicationNavigationPreferences = {
 
 export type ApplicationNavigationOptions = Partial<Pick<RouteLocation, "search" | "hash">>;
 
-export type SkillWorkshopRevisionHandoff = {
+type SkillWorkshopRevisionHandoff = {
   sessionKey: string;
   instructions: string;
   proposalId: string;

--- a/ui/src/app/router-outlet.ts
+++ b/ui/src/app/router-outlet.ts
@@ -11,19 +11,15 @@ type RenderableModule<TData> = {
   render: (data: TData | undefined) => unknown;
 };
 
-export type RouterOutletOptions<TLoadContext = unknown> = {
+type RouterOutletOptions<TLoadContext = unknown> = {
   retryContext?: TLoadContext;
 };
 
-export type RouterOutletBoundaryOptions = {
+type RouterOutletBoundaryOptions = {
   onNotFound?: () => void;
 };
 
-export type RouterOutletSelection<
-  TRouteId extends string = string,
-  TModule = unknown,
-  TData = unknown,
-> = {
+type RouterOutletSelection<TRouteId extends string = string, TModule = unknown, TData = unknown> = {
   status: RouterState<TRouteId, TModule, TData>["status"];
   active: RouteMatch<TRouteId, TModule, TData> | undefined;
   pending: RouteMatch<TRouteId, TModule, TData> | undefined;

--- a/ui/src/components/config-form.node.ts
+++ b/ui/src/components/config-form.node.ts
@@ -163,7 +163,7 @@ type SensitiveRenderState = {
   canReveal: boolean;
 };
 
-export type ConfigSearchCriteria = {
+type ConfigSearchCriteria = {
   text: string;
   tags: string[];
 };

--- a/ui/src/lib/open-external-url.ts
+++ b/ui/src/lib/open-external-url.ts
@@ -24,7 +24,7 @@ function isAllowedDataImageUrl(url: string): boolean {
   return !BLOCKED_DATA_IMAGE_MIME_TYPES.has(mimeType);
 }
 
-export type ResolveSafeExternalUrlOptions = {
+type ResolveSafeExternalUrlOptions = {
   allowDataImage?: boolean;
 };
 

--- a/ui/src/pages/activity/tool-activity.ts
+++ b/ui/src/pages/activity/tool-activity.ts
@@ -28,7 +28,7 @@ const ACTIVITY_STATUS_SUMMARY_LABELS: Record<ActivityStatus, string> = {
   error: "failed",
 };
 
-export type ToolActivityEvent = {
+type ToolActivityEvent = {
   runId: string;
   ts: number;
   receivedAt: number;

--- a/ui/src/pages/agents/files.ts
+++ b/ui/src/pages/agents/files.ts
@@ -7,7 +7,7 @@ import type {
   AgentsFilesSetResult,
 } from "../../api/types.ts";
 
-export type AgentFilesState = {
+type AgentFilesState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
   agentFilesLoading: boolean;

--- a/ui/src/pages/agents/skills.ts
+++ b/ui/src/pages/agents/skills.ts
@@ -3,7 +3,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { SkillStatusReport } from "../../api/types.ts";
 import { loadSkillStatusReport } from "../../lib/skills/index.ts";
 
-export type AgentSkillsState = {
+type AgentSkillsState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
   agentSkillsLoading: boolean;


### PR DESCRIPTION
## What Problem This Solves

The Control UI exports ten type aliases and interfaces that have no external consumers. Keeping them public adds noise to dead-code reports and expands module API surfaces without a caller.

## Why This Change Was Made

Localize the unused types in their owning modules. The types remain available to the same internal code, while the public module surface reflects actual consumers.

## User Impact

No runtime or UI behavior changes. This is a type-only API cleanup across eight Control UI files.

## Evidence

- Focused UI validation: 3 suites, 24 tests passed.
- `oxfmt --check` passed on all 8 changed files.
- Testbox `tbx_01kwwymmwart3qcryz73btgmap`: `check:changed` passed for `core, coreTests`.
- Exact unused-export scan: 3,685 report lines; all 10 localized type names absent.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: clean, no actionable findings.
- Production diff: 8 files, `+10/-14`.

