### PR TITLE
chore: add zak-li to ensureLogins in clawtributors map

### DIFF
--- a/scripts/clawtributors-map.json
+++ b/scripts/clawtributors-map.json
@@ -16,7 +16,8 @@
     "atalovesyou",
     "0xJonHoldsCrypto",
     "hougangdev",
-    "jiulingyun"
+    "jiulingyun",
+    "zak-li"
   ],
   "seedCommit": "d6863f87",
   "displayName": {


### PR DESCRIPTION
## Summary
Adds `zak-li` to the `ensureLogins` list in `scripts/clawtributors-map.json` so that the clawtributors wall in the README includes my avatar on the next update.

## Context
My contribution to the LM Studio embedding preload context fix was merged as a co-author in commit b3e68a093c812ae089ad7b38b115a83166627a10 (PR #100750). Because the `update-clawtributors` script resolves contributors from `git log` author fields and the GitHub Contributors API, co-authored-by credits are not picked up automatically. Adding my login to `ensureLogins` is the documented way to ensure co-authors appear in the contributor wall.

Ref: #100750, #99613

## Proof of contribution

### 1. Co-authored-by credit on merged commit

Commit [`b3e68a093c81`](https://github.com/openclaw/openclaw/commit/b3e68a093c812ae089ad7b38b115a83166627a10) message:

```
fix(lmstudio): honor embedding preload context (#100750)

Co-authored-by: Zakaria Rahali <zakariarahali288@gmail.com>
Co-authored-by: 徐闻涵0668001344 <xu.wenhan1@xydigit.com>
```

### 2. GitHub contributions API confirms attribution

```json
// gh api search/commits?q=repo:openclaw/openclaw+zakariarahali288@gmail.com
{
  "total_count": 1,
  "items": [{
    "sha": "b3e68a093c812ae089ad7b38b115a83166627a10",
    "commit": "fix(lmstudio): honor embedding preload context (#100750)\n\nCo-authored-by: Zakaria Rahali <zakariarahali288@gmail.com>..."
  }]
}
```

### 3. GitHub user `zak-li` resolves correctly

```json
// gh api users/zak-li
{
  "login": "zak-li",
  "id": 119002492,
  "name": "Zakaria Rahali",
  "avatar_url": "https://avatars.githubusercontent.com/u/119002492?v=4",
  "html_url": "https://github.com/zak-li"
}
```

### 4. Expected README entry after `update-clawtributors` runs

The script's `ensureLogins` path calls `fetchUser(login)` to resolve the avatar, then renders a standard contributor wall entry. The expected output for `zak-li` would be:

```markdown
[![zak-li](https://avatars.githubusercontent.com/u/119002492?v=4&s=48)](https://github.com/zak-li)
```

Preview:

[![zak-li](https://avatars.githubusercontent.com/u/119002492?v=4&s=48)](https://github.com/zak-li)

### 5. User does not use a default avatar

The avatar URL `https://avatars.githubusercontent.com/u/119002492?v=4` is a custom avatar (not GitHub's default identicon), so `zak-li` would appear in the visible wall, not in the `clawtributors:hidden` block.
