### PR TITLE
fix(infra): terminate ssh config reads on stdout errors

### DIFF
--- a/src/infra/ssh-config.test.ts
+++ b/src/infra/ssh-config.test.ts
@@ -139,6 +139,21 @@ describe("ssh-config", () => {
     await expect(resolveSshConfig({ user: "me", host: "bad-host", port: 22 })).resolves.toBeNull();
   });
 
+  it("returns null and terminates ssh when stdout emits an error", async () => {
+    let capturedChild: MockSpawnChild | undefined;
+    spawnMock.mockImplementationOnce(
+      (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
+        const { child, stdout } = createMockSpawnChild();
+        capturedChild = child;
+        process.nextTick(() => stdout?.emit("error", new Error("stdout boom")));
+        return child as unknown as ChildProcess;
+      },
+    );
+
+    await expect(resolveSshConfig({ user: "me", host: "bad-host", port: 22 })).resolves.toBeNull();
+    expect(capturedChild?.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
   it("rejects oversized ssh -G output while preserving the parser contract", () => {
     expect(appendSshConfigOutput("user bob", "\nhostname example.com", 128)).toEqual({
       ok: true,

--- a/src/infra/ssh-config.ts
+++ b/src/infra/ssh-config.ts
@@ -106,14 +106,15 @@ export async function resolveSshConfig(
     });
 
     const timeoutMs = Math.max(200, opts.timeoutMs ?? 800);
-    const timer = setTimeout(() => {
-      try {
-        child.kill("SIGKILL");
-      } finally {
-        resolve(null);
-      }
-    }, timeoutMs);
+    let timer: ReturnType<typeof setTimeout>;
+    const terminate = () => {
+      clearTimeout(timer);
+      child.kill("SIGKILL");
+      resolve(null);
+    };
+    timer = setTimeout(terminate, timeoutMs);
 
+    child.stdout?.on("error", terminate);
     child.once("error", () => {
       clearTimeout(timer);
       resolve(null);

--- a/src/infra/ssh-config.ts
+++ b/src/infra/ssh-config.ts
@@ -106,13 +106,12 @@ export async function resolveSshConfig(
     });
 
     const timeoutMs = Math.max(200, opts.timeoutMs ?? 800);
-    let timer: ReturnType<typeof setTimeout>;
-    const terminate = () => {
+    const timer = setTimeout(terminate, timeoutMs);
+    function terminate() {
       clearTimeout(timer);
       child.kill("SIGKILL");
       resolve(null);
-    };
-    timer = setTimeout(terminate, timeoutMs);
+    }
 
     child.stdout?.on("error", terminate);
     child.once("error", () => {


### PR DESCRIPTION
## What Problem This Solves

`resolveSshConfig` handled process-level failures and timeouts, but an `error` emitted by the spawned `ssh -G` stdout stream remained unhandled. Node treats an unhandled `error` event as fatal, so local gateway discovery could crash instead of treating SSH configuration as unavailable.

This is the maintainer replacement for #101021, which the repository queue policy auto-closed. It preserves @cxbAsDev's contribution and co-author credit.

## Why This Change Was Made

The stdout stream is owned at this spawn boundary. A single termination helper now owns the timeout and stdout-error cleanup path: clear the timer, kill the child, and resolve `null`. The regression lives with the existing SSH config tests; the standalone proof artifact and root changelog edit were intentionally omitted.

## User Impact

Gateway status discovery degrades to unavailable SSH configuration when `ssh -G` stdout fails instead of risking a process crash or leaving the child alive.

## Evidence

- Source and caller review: `src/infra/ssh-config.ts`, `src/commands/gateway-status/discovery.ts`, and adjacent parser/spawn tests.
- Exact head `d757a01002338ec4357a59dd682f4321f01c988b` on Blacksmith Testbox `tbx_01kwwe4bnj8tdzyt7xvnm2zwjq`: `pnpm test src/infra/ssh-config.test.ts` — 9/9 pass.
- Same Testbox: a real long-lived Node child received an injected stdout failure and exited by `SIGKILL` while the parent remained healthy.
- Canonical `oxfmt --check` passed for both touched files.
- Fresh Codex AutoReview clean, confidence 0.88.
- Root changelog entry deferred to the release-owned maintainer batch.

Closes #101021.
