### PR TITLE
fix(android): prevent native notification cross-session replies

### DIFF
--- a/apps/android/CHANGELOG.md
+++ b/apps/android/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Android notification forwarding now excludes native WhatsApp, Telegram, Telegram X, Discord, and Signal channel apps to prevent duplicate cross-session replies. (#48516)
+
 Assistant messages now offer a long-press Listen action with gateway TTS playback, on-device fallback, and tap-to-stop status.
 
 The Settings About screen now shows the animated mascot with the app tagline plus Website, Docs, GitHub, and Discord links.

--- a/apps/android/app/src/main/java/ai/openclaw/app/NotificationForwardingPolicy.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NotificationForwardingPolicy.kt
@@ -3,6 +3,17 @@ package ai.openclaw.app
 import java.time.Instant
 import java.time.ZoneId
 
+private val nativeChannelNotificationPackages =
+  setOf(
+    "com.discord",
+    "com.whatsapp",
+    "com.whatsapp.w4b",
+    "org.telegram.messenger",
+    "org.telegram.messenger.web",
+    "org.thunderdog.challegram",
+    "org.thoughtcrime.securesms",
+  )
+
 /** Package-filter mode used before notification events are forwarded to the gateway. */
 enum class NotificationPackageFilterMode(
   val rawValue: String,
@@ -38,6 +49,11 @@ internal fun NotificationForwardingPolicy.allowsPackage(packageName: String): Bo
   }
   val self = selfPackageName.trim()
   if (self.isNotEmpty() && normalized == self) {
+    return false
+  }
+  // Native channel sessions own these messages. Forwarding their notifications creates an
+  // unbound duplicate that can be answered from the wrong conversation.
+  if (normalized in nativeChannelNotificationPackages) {
     return false
   }
   return when (mode) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/NotificationForwardingPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NotificationForwardingPolicyTest.kt
@@ -97,6 +97,45 @@ class NotificationForwardingPolicyTest {
   }
 
   @Test
+  fun allowsPackage_neverForwardsNativeChannelPackages() {
+    val nativeChannelPackages =
+      setOf(
+        "com.discord",
+        "com.whatsapp",
+        "com.whatsapp.w4b",
+        "org.telegram.messenger",
+        "org.telegram.messenger.web",
+        "org.thunderdog.challegram",
+        "org.thoughtcrime.securesms",
+      )
+    val policies =
+      NotificationPackageFilterMode.entries.map { mode ->
+        NotificationForwardingPolicy(
+          enabled = true,
+          mode = mode,
+          packages =
+            if (mode == NotificationPackageFilterMode.Allowlist) {
+              nativeChannelPackages + "com.other.app"
+            } else {
+              nativeChannelPackages
+            },
+          quietHoursEnabled = false,
+          quietStart = "22:00",
+          quietEnd = "07:00",
+          maxEventsPerMinute = 20,
+          sessionKey = null,
+        )
+      }
+
+    policies.forEach { policy ->
+      nativeChannelPackages.forEach { packageName ->
+        assertFalse("$packageName must be owned by its native channel", policy.allowsPackage(packageName))
+      }
+      assertTrue(policy.allowsPackage("com.other.app"))
+    }
+  }
+
+  @Test
   fun isWithinQuietHours_handlesWindowCrossingMidnight() {
     val policy =
       NotificationForwardingPolicy(

--- a/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsNotificationForwardingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SecurePrefsNotificationForwardingTest.kt
@@ -130,18 +130,19 @@ class SecurePrefsNotificationForwardingTest {
   }
 
   @Test
-  fun getNotificationForwardingPolicy_blocksSelfPackageInAllowlistMode() {
+  fun getNotificationForwardingPolicy_blocksOwnedPackagesInAllowlistMode() {
     val context = RuntimeEnvironment.getApplication()
     val plainPrefs = context.getSharedPreferences("openclaw.node", Context.MODE_PRIVATE)
     plainPrefs.edit().clear().commit()
 
     val prefs = SecurePrefs(context)
     prefs.setNotificationForwardingMode(NotificationPackageFilterMode.Allowlist)
-    prefs.setNotificationForwardingPackages(listOf("ai.openclaw.app", "com.other.app"))
+    prefs.setNotificationForwardingPackages(listOf("ai.openclaw.app", "com.whatsapp", "com.other.app"))
 
     val policy = prefs.getNotificationForwardingPolicy(appPackageName = "ai.openclaw.app")
 
     assertFalse(policy.allowsPackage("ai.openclaw.app"))
+    assertFalse(policy.allowsPackage("com.whatsapp"))
     assertTrue(policy.allowsPackage("com.other.app"))
   }
 }

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -320,6 +320,8 @@ Android can forward device notifications to the gateway as `node.event` items. T
 Notification forwarding requires the Android Notification Listener permission. The app prompts for this during setup.
 </Note>
 
+WhatsApp, WhatsApp Business, Telegram, Telegram X, Discord, and Signal notifications are always excluded. Their messages are already owned by native OpenClaw channel sessions; forwarding the Android notification as a separate node event could route a reply through the wrong conversation.
+
 ## Related
 
 - [iOS app](/platforms/ios)


### PR DESCRIPTION
Closes #48516

## What Problem This Solves

Fixes an issue where users with Android notification forwarding enabled could have a WhatsApp, Telegram, Discord, or Signal notification enter a generic node session and trigger a duplicate reply in the wrong conversation.

## Why This Change Was Made

Native channel sessions already own messages from these apps. Android now rejects their package families before either Allowlist or Blocklist evaluation, and the existing send-time policy recheck also drops already-queued events after an update. This keeps the fix at the Android notification-owner boundary without changing gateway session, heartbeat, or provider behavior.

## User Impact

WhatsApp, WhatsApp Business, Telegram (Play and direct distributions), Telegram X, Discord, and Signal notifications can no longer be forwarded as generic Android node events, even when an old Allowlist explicitly contains them. Notifications from other selected apps continue to follow the configured filter, quiet-hours, and rate-limit policy.

## Evidence

- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/28816153706
- `cd apps/android && ./gradlew :app:ktlintCheck :app:testPlayDebugUnitTest --tests ai.openclaw.app.NotificationForwardingPolicyTest --tests ai.openclaw.app.SecurePrefsNotificationForwardingTest :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.NotificationForwardingPolicyTest --tests ai.openclaw.app.SecurePrefsNotificationForwardingTest :app:assemblePlayDebug :app:assembleThirdPartyDebug`
  - `BUILD SUCCESSFUL`; 114 tasks; focused tests pass for both flavors; both debug APKs assemble.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`
  - First pass found missing official Telegram direct/Telegram X package variants; accepted and fixed.
  - Final pass: `autoreview clean: no accepted/actionable findings reported`.
- Source-blind live validation reached a connected Pixel 10a with WhatsApp and Telegram installed, but Android rejected the exact Testbox APK because the existing OpenClaw install has a different signing identity (`INSTALL_FAILED_UPDATE_INCOMPATIBLE`). The existing app was not uninstalled because that would destroy device state; live notification round-trip proof remains the known gap.
