### PR TITLE
fix(browser): keep CDP discovery on the configured host

### DIFF
--- a/extensions/browser/src/browser/cdp-reachability-policy.ts
+++ b/extensions/browser/src/browser/cdp-reachability-policy.ts
@@ -4,22 +4,32 @@
  * CDP control-plane probes may target loopback even when page navigation policy
  * is stricter, so this module scopes the exception to browser control only.
  */
-import { isPrivateNetworkAllowedByPolicy, type SsrFPolicy } from "../infra/net/ssrf.js";
+import type { SsrFPolicy } from "../infra/net/ssrf.js";
+import { matchesHostnameAllowlist, normalizeHostname } from "../sdk-security-runtime.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { getBrowserProfileCapabilities } from "./profile-capabilities.js";
-import { withAllowedHostname } from "./ssrf-policy-helpers.js";
+import { withExactHostnamePolicy } from "./ssrf-policy-helpers.js";
 
-function withCdpHostnameAllowed(
+function withCdpControlHostname(
   profile: ResolvedBrowserProfile,
   ssrfPolicy?: SsrFPolicy,
+  requireAllowlistMatch = false,
 ): SsrFPolicy | undefined {
-  if (!ssrfPolicy || !profile.cdpHost) {
+  const cdpHost = normalizeHostname(profile.cdpHost);
+  if (!ssrfPolicy || !cdpHost) {
     return ssrfPolicy;
   }
-  if (isPrivateNetworkAllowedByPolicy(ssrfPolicy)) {
+  const hostnameAllowlist = (ssrfPolicy.hostnameAllowlist ?? [])
+    .map((pattern) => normalizeHostname(pattern))
+    .filter((pattern) => pattern && pattern !== "*" && pattern !== "*.");
+  if (
+    requireAllowlistMatch &&
+    hostnameAllowlist.length > 0 &&
+    !matchesHostnameAllowlist(cdpHost, hostnameAllowlist)
+  ) {
     return ssrfPolicy;
   }
-  return withAllowedHostname(ssrfPolicy, profile.cdpHost);
+  return withExactHostnamePolicy(ssrfPolicy, cdpHost);
 }
 
 export function resolveCdpReachabilityPolicy(
@@ -33,7 +43,10 @@ export function resolveCdpReachabilityPolicy(
   if (!capabilities.isRemote && profile.cdpIsLoopback && profile.driver === "openclaw") {
     return undefined;
   }
-  return withCdpHostnameAllowed(profile, ssrfPolicy);
+  // Configured local relays are control-plane endpoints even when page policy
+  // excludes loopback. Remote CDP hosts must still satisfy an explicit
+  // hostnameAllowlist before their control policy is narrowed.
+  return withCdpControlHostname(profile, ssrfPolicy, capabilities.isRemote);
 }
 
 /** Alias used by callers that treat reachability and control as one CDP policy. */

--- a/extensions/browser/src/browser/cdp.helpers.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.test.ts
@@ -102,6 +102,29 @@ describe("cdp helpers", () => {
     ).rejects.toThrow("browser endpoint blocked by policy");
   });
 
+  it("does not let a returned loopback URL replace an exact remote CDP host", async () => {
+    await expect(
+      assertCdpEndpointAllowed(
+        "ws://127.0.0.1:9222/devtools/browser/remote",
+        {
+          allowPrivateNetwork: true,
+          allowedHostnames: ["browserless.example.com"],
+          hostnameAllowlist: ["browserless.example.com"],
+        },
+        { source: "discovered" },
+      ),
+    ).rejects.toThrow("browser endpoint blocked by policy");
+  });
+
+  it("still grants configured loopback for same-shaped strict navigation policy", async () => {
+    await expect(
+      assertCdpEndpointAllowed("http://127.0.0.1:9222/json/version", {
+        allowedHostnames: ["api.example.com"],
+        hostnameAllowlist: ["api.example.com"],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
   it("releases guarded CDP fetches for bodyless requests", async () => {
     const release = vi.fn(async () => {});
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
@@ -143,6 +166,7 @@ describe("cdp helpers", () => {
     expect(request?.policy).toEqual({
       dangerouslyAllowPrivateNetwork: false,
       allowedHostnames: ["127.0.0.1"],
+      hostnameAllowlist: ["127.0.0.1"],
     });
     expect(release).toHaveBeenCalledTimes(1);
   });
@@ -191,7 +215,7 @@ describe("cdp helpers", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves hostname allowlist while allowing exact loopback CDP fetches", async () => {
+  it("replaces navigation grants with the exact loopback CDP host", async () => {
     const release = vi.fn(async () => {});
     fetchWithSsrFGuardMock.mockResolvedValueOnce({
       response: {
@@ -212,7 +236,7 @@ describe("cdp helpers", () => {
     expect(request?.url).toBe("http://127.0.0.1:9222/json/version");
     expect(request?.policy).toEqual({
       dangerouslyAllowPrivateNetwork: false,
-      hostnameAllowlist: ["*.corp.example", "127.0.0.1"],
+      hostnameAllowlist: ["127.0.0.1"],
       allowedHostnames: ["127.0.0.1"],
     });
     expect(release).toHaveBeenCalledTimes(1);
@@ -317,6 +341,7 @@ describe("CDP reachability policy", () => {
 
     expect(resolveCdpReachabilityPolicy(profile, browserPolicy)).toEqual({
       allowedHostnames: ["172.29.128.1"],
+      hostnameAllowlist: ["172.29.128.1"],
     });
     expect(browserPolicy).toStrictEqual({});
     await expect(
@@ -327,7 +352,7 @@ describe("CDP reachability policy", () => {
     ).rejects.toThrow(/private\/internal\/special-use ip address/i);
   });
 
-  it("merges the selected remote profile CDP host with existing CDP policy hostnames", () => {
+  it("restricts remote CDP policy to the selected profile host", () => {
     const profile = createProfile({});
 
     expect(
@@ -335,18 +360,36 @@ describe("CDP reachability policy", () => {
         allowedHostnames: ["metadata.internal"],
       }),
     ).toEqual({
-      allowedHostnames: ["metadata.internal", "172.29.128.1"],
+      allowedHostnames: ["172.29.128.1"],
+      hostnameAllowlist: ["172.29.128.1"],
     });
   });
 
-  it("merges the selected remote profile CDP host without widening navigation", async () => {
+  it("narrows permissive private-network policy to the selected CDP host", () => {
+    const profile = createProfile({});
+    const browserPolicy = {
+      allowPrivateNetwork: true,
+      allowedHostnames: ["metadata.internal"],
+      allowedOrigins: ["https://navigation.example"],
+    };
+
+    expect(resolveCdpReachabilityPolicy(profile, browserPolicy)).toEqual({
+      allowPrivateNetwork: true,
+      allowedHostnames: ["172.29.128.1"],
+      hostnameAllowlist: ["172.29.128.1"],
+    });
+    expect(browserPolicy).toStrictEqual({
+      allowPrivateNetwork: true,
+      allowedHostnames: ["metadata.internal"],
+      allowedOrigins: ["https://navigation.example"],
+    });
+  });
+
+  it("preserves a restrictive hostname allowlist that rejects the remote CDP host", async () => {
     const profile = createProfile({});
     const browserPolicy = { hostnameAllowlist: ["browserless.example.com"] };
 
-    expect(resolveCdpReachabilityPolicy(profile, browserPolicy)).toEqual({
-      hostnameAllowlist: ["browserless.example.com", "172.29.128.1"],
-      allowedHostnames: ["172.29.128.1"],
-    });
+    expect(resolveCdpReachabilityPolicy(profile, browserPolicy)).toBe(browserPolicy);
     expect(browserPolicy).toStrictEqual({ hostnameAllowlist: ["browserless.example.com"] });
     await expect(
       assertBrowserNavigationAllowed({
@@ -354,6 +397,48 @@ describe("CDP reachability policy", () => {
         ssrfPolicy: browserPolicy,
       }),
     ).rejects.toThrow(/not in allowlist/i);
+  });
+
+  it("narrows an allowlisted remote CDP host to that exact control host", () => {
+    const profile = createProfile({});
+
+    expect(
+      resolveCdpReachabilityPolicy(profile, {
+        hostnameAllowlist: ["browserless.example.com", "172.29.128.1"],
+        allowedOrigins: ["https://navigation.example"],
+      }),
+    ).toEqual({
+      hostnameAllowlist: ["172.29.128.1"],
+      allowedHostnames: ["172.29.128.1"],
+    });
+  });
+
+  it("normalizes the selected CDP host before narrowing wildcard policy", () => {
+    const profile = createProfile({
+      cdpUrl: "https://browser.corp.example.:9222",
+      cdpHost: "browser.corp.example.",
+    });
+
+    expect(
+      resolveCdpReachabilityPolicy(profile, {
+        hostnameAllowlist: ["*.corp.example"],
+      }),
+    ).toEqual({
+      hostnameAllowlist: ["browser.corp.example"],
+      allowedHostnames: ["browser.corp.example"],
+    });
+  });
+
+  it.each(["*", "*."])("narrows the global %s allowlist to the selected CDP host", (pattern) => {
+    const profile = createProfile({
+      cdpUrl: "https://browser.example:9222",
+      cdpHost: "browser.example",
+    });
+
+    expect(resolveCdpReachabilityPolicy(profile, { hostnameAllowlist: [pattern] })).toEqual({
+      hostnameAllowlist: ["browser.example"],
+      allowedHostnames: ["browser.example"],
+    });
   });
 
   it("keeps local managed loopback CDP control outside browser SSRF policy", () => {
@@ -364,5 +449,23 @@ describe("CDP reachability policy", () => {
     });
 
     expect(resolveCdpReachabilityPolicy(profile, {})).toBeUndefined();
+  });
+
+  it("narrows configured extension loopback outside navigation allowlist", () => {
+    const profile = createProfile({
+      cdpUrl: "http://127.0.0.1:18792",
+      cdpHost: "127.0.0.1",
+      cdpIsLoopback: true,
+      driver: "extension",
+    });
+
+    expect(
+      resolveCdpReachabilityPolicy(profile, {
+        hostnameAllowlist: ["*.corp.example"],
+      }),
+    ).toEqual({
+      hostnameAllowlist: ["127.0.0.1"],
+      allowedHostnames: ["127.0.0.1"],
+    });
   });
 });

--- a/extensions/browser/src/browser/cdp.helpers.ts
+++ b/extensions/browser/src/browser/cdp.helpers.ts
@@ -23,7 +23,7 @@ import {
 import { CDP_HTTP_REQUEST_TIMEOUT_MS, CDP_WS_HANDSHAKE_TIMEOUT_MS } from "./cdp-timeouts.js";
 import { BrowserCdpEndpointBlockedError } from "./errors.js";
 import { resolveBrowserRateLimitMessage } from "./rate-limit-message.js";
-import { withAllowedHostname } from "./ssrf-policy-helpers.js";
+import { withExactHostnamePolicy } from "./ssrf-policy-helpers.js";
 import { normalizeBrowserTimerDelayMs } from "./timer-delay.js";
 
 export { isLoopbackHost };
@@ -77,6 +77,7 @@ export function isDirectCdpWebSocketEndpoint(url: string): boolean {
 export async function assertCdpEndpointAllowed(
   cdpUrl: string,
   ssrfPolicy?: SsrFPolicy,
+  options?: { source?: "configured" | "discovered" },
 ): Promise<void> {
   if (!ssrfPolicy) {
     return;
@@ -86,9 +87,13 @@ export async function assertCdpEndpointAllowed(
     throw new Error(`Invalid CDP URL protocol: ${parsed.protocol.replace(":", "")}`);
   }
   try {
-    const policy = isLoopbackHost(parsed.hostname)
-      ? withAllowedHostname(ssrfPolicy, parsed.hostname)
-      : ssrfPolicy;
+    // Configured loopback CDP is a local control plane. Discovered endpoints
+    // must remain within the caller's selected-host policy and cannot claim a
+    // new loopback exception through returned JSON.
+    const policy =
+      isLoopbackHost(parsed.hostname) && options?.source !== "discovered"
+        ? withExactHostnamePolicy(ssrfPolicy, parsed.hostname)
+        : ssrfPolicy;
     await resolvePinnedHostnameWithPolicy(parsed.hostname, {
       policy,
     });
@@ -352,7 +357,7 @@ export async function fetchCdpChecked(
         // Loopback CDP is an OpenClaw control plane, not page navigation. Allow
         // its exact host while preserving the caller's policy for remote hosts.
         const policy = isLoopbackHost(parsedUrl.hostname)
-          ? withAllowedHostname(ssrfPolicy, parsedUrl.hostname)
+          ? withExactHostnamePolicy(ssrfPolicy, parsedUrl.hostname)
           : (ssrfPolicy ?? { allowPrivateNetwork: true });
         const guarded = await fetchWithSsrFGuard({
           url: fetchUrl,

--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -248,7 +248,9 @@ export async function createTargetViaCdp(opts: {
   let lastError: unknown;
   for (const candidateWsUrl of candidateWsUrls) {
     try {
-      await assertCdpEndpointAllowed(candidateWsUrl, opts.ssrfPolicy);
+      await assertCdpEndpointAllowed(candidateWsUrl, opts.ssrfPolicy, {
+        source: candidateWsUrl === opts.cdpUrl ? "configured" : "discovered",
+      });
       return await withCdpSocket(
         candidateWsUrl,
         async (send) => {

--- a/extensions/browser/src/browser/chrome.diagnostics.ts
+++ b/extensions/browser/src/browser/chrome.diagnostics.ts
@@ -400,7 +400,7 @@ export async function diagnoseChromeCdp(
   }
   const wsUrl = normalizeCdpWsUrl(wsUrlRaw, discoveryUrl);
   try {
-    await assertCdpEndpointAllowed(wsUrl, ssrfPolicy);
+    await assertCdpEndpointAllowed(wsUrl, ssrfPolicy, { source: "discovered" });
   } catch (err) {
     return failureDiagnostic({
       cdpUrl,

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -881,7 +881,7 @@ export async function getChromeWebSocketUrl(
     return null;
   }
   const normalizedWsUrl = normalizeCdpWsUrl(wsUrl, discoveryUrl);
-  await assertCdpEndpointAllowed(normalizedWsUrl, ssrfPolicy);
+  await assertCdpEndpointAllowed(normalizedWsUrl, ssrfPolicy, { source: "discovered" });
   return normalizedWsUrl;
 }
 

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -1669,7 +1669,7 @@ async function tryTerminateExecutionViaCdp(opts: {
     return;
   }
   const wsUrl = normalizeCdpWsUrl(wsUrlRaw, cdpHttpBase);
-  await assertCdpEndpointAllowed(wsUrl, opts.ssrfPolicy);
+  await assertCdpEndpointAllowed(wsUrl, opts.ssrfPolicy, { source: "discovered" });
   const needsAttach = cdpSocketNeedsAttach(wsUrl);
 
   const runWithTimeout = async <T>(work: Promise<T>, ms: number): Promise<T> => {
@@ -1911,6 +1911,7 @@ export async function createPageViaPlaywright(
   opts: {
     cdpUrl: string;
     url: string;
+    cdpPolicy?: SsrFPolicy;
   } & BrowserNavigationPolicyOptions,
 ): Promise<{
   targetId: string;
@@ -1918,7 +1919,7 @@ export async function createPageViaPlaywright(
   url: string;
   type: string;
 }> {
-  const { browser } = await connectBrowser(opts.cdpUrl, opts.ssrfPolicy);
+  const { browser } = await connectBrowser(opts.cdpUrl, opts.cdpPolicy ?? opts.ssrfPolicy);
   const context = browser.contexts()[0] ?? (await browser.newContext());
   ensureContextState(context);
 

--- a/extensions/browser/src/browser/routes/permissions.test.ts
+++ b/extensions/browser/src/browser/routes/permissions.test.ts
@@ -40,11 +40,15 @@ vi.mock("../cdp.helpers.js", () => ({
 
 const { registerBrowserPermissionRoutes, testing } = await import("./permissions.js");
 
-function createProfileContext() {
+function createProfileContext(overrides: Record<string, unknown> = {}) {
   return {
     profile: {
       name: "openclaw",
       cdpUrl: "http://127.0.0.1:18800",
+      cdpHost: "127.0.0.1",
+      cdpIsLoopback: true,
+      driver: "openclaw",
+      ...overrides,
     },
     ensureBrowserAvailable: vi.fn(async () => {}),
     ensureTabAvailable: vi.fn(),
@@ -61,9 +65,12 @@ function createProfileContext() {
   };
 }
 
-function createRouteContext(profileCtx: ReturnType<typeof createProfileContext>) {
+function createRouteContext(
+  profileCtx: ReturnType<typeof createProfileContext>,
+  ssrfPolicy: Record<string, unknown> = { allowPrivateNetwork: false },
+) {
   return {
-    state: () => ({ resolved: { ssrfPolicy: { allowPrivateNetwork: false } } }),
+    state: () => ({ resolved: { ssrfPolicy } }),
     forProfile: () => profileCtx,
     listProfiles: vi.fn(async () => []),
     mapTabError: vi.fn(() => null),
@@ -71,10 +78,16 @@ function createRouteContext(profileCtx: ReturnType<typeof createProfileContext>)
   };
 }
 
-async function callGrant(body: Record<string, unknown>) {
+async function callGrant(
+  body: Record<string, unknown>,
+  options: {
+    profile?: Record<string, unknown>;
+    ssrfPolicy?: Record<string, unknown>;
+  } = {},
+) {
   const { app, postHandlers } = createBrowserRouteApp();
-  const profileCtx = createProfileContext();
-  registerBrowserPermissionRoutes(app, createRouteContext(profileCtx) as never);
+  const profileCtx = createProfileContext(options.profile);
+  registerBrowserPermissionRoutes(app, createRouteContext(profileCtx, options.ssrfPolicy) as never);
   const handler = postHandlers.get("/permissions/grant");
   expect(handler).toBeTypeOf("function");
 
@@ -118,7 +131,7 @@ describe("browser permission routes", () => {
     expect(pwMocks.getPageForTargetId).toHaveBeenCalledWith({
       cdpUrl: "http://127.0.0.1:18800",
       targetId: "meet-tab",
-      ssrfPolicy: { allowPrivateNetwork: false },
+      ssrfPolicy: undefined,
     });
     expect(pwMocks.grantPermissions).toHaveBeenCalledWith(["microphone", "camera"], {
       origin: "https://meet.google.com",
@@ -143,9 +156,11 @@ describe("browser permission routes", () => {
       grantMethod: "cdp",
     });
     expect(profileCtx.ensureBrowserAvailable).toHaveBeenCalled();
-    expect(cdpMocks.getChromeWebSocketUrl).toHaveBeenCalledWith("http://127.0.0.1:18800", 1234, {
-      allowPrivateNetwork: false,
-    });
+    expect(cdpMocks.getChromeWebSocketUrl).toHaveBeenCalledWith(
+      "http://127.0.0.1:18800",
+      1234,
+      undefined,
+    );
     expect(cdpMocks.send).toHaveBeenCalledWith("Browser.grantPermissions", {
       origin: "https://meet.google.com",
       permissions: ["audioCapture", "videoCapture", "speakerSelection"],
@@ -174,9 +189,43 @@ describe("browser permission routes", () => {
     });
 
     expect(response.statusCode).toBe(200);
-    expect(cdpMocks.getChromeWebSocketUrl).toHaveBeenCalledWith("http://127.0.0.1:18800", 1000, {
-      allowPrivateNetwork: false,
-    });
+    expect(cdpMocks.getChromeWebSocketUrl).toHaveBeenCalledWith(
+      "http://127.0.0.1:18800",
+      1000,
+      undefined,
+    );
+  });
+
+  it("uses exact remote CDP control policy for permission discovery", async () => {
+    const { response } = await callGrant(
+      {
+        origin: "https://meet.google.com",
+        permissions: ["audioCapture"],
+      },
+      {
+        profile: {
+          name: "remote",
+          cdpUrl: "https://browser.example:9222",
+          cdpHost: "browser.example",
+          cdpIsLoopback: false,
+        },
+        ssrfPolicy: {
+          allowPrivateNetwork: true,
+          allowedOrigins: ["https://navigation.example"],
+        },
+      },
+    );
+
+    expect(response.statusCode).toBe(200);
+    expect(cdpMocks.getChromeWebSocketUrl).toHaveBeenCalledWith(
+      "https://browser.example:9222",
+      5000,
+      {
+        allowPrivateNetwork: true,
+        allowedHostnames: ["browser.example"],
+        hostnameAllowlist: ["browser.example"],
+      },
+    );
   });
 
   it("keeps required permissions when an optional permission is unsupported", async () => {

--- a/extensions/browser/src/browser/routes/permissions.ts
+++ b/extensions/browser/src/browser/routes/permissions.ts
@@ -7,6 +7,7 @@
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
+import { resolveCdpControlPolicy } from "../cdp-reachability-policy.js";
 import { withCdpSocket } from "../cdp.helpers.js";
 import { getChromeWebSocketUrl } from "../chrome.js";
 import { getPwAiModule } from "../pw-ai-module.js";
@@ -178,11 +179,11 @@ export function registerBrowserPermissionRoutes(
 
       try {
         await profileCtx.ensureBrowserAvailable();
-        const wsUrl = await getChromeWebSocketUrl(
-          profileCtx.profile.cdpUrl,
-          timeoutMs,
+        const cdpPolicy = resolveCdpControlPolicy(
+          profileCtx.profile,
           ctx.state().resolved.ssrfPolicy,
         );
+        const wsUrl = await getChromeWebSocketUrl(profileCtx.profile.cdpUrl, timeoutMs, cdpPolicy);
         if (!wsUrl) {
           return jsonError(res, 409, "browser CDP WebSocket unavailable");
         }
@@ -194,7 +195,7 @@ export function registerBrowserPermissionRoutes(
           requiredPermissions,
           optionalPermissions,
           timeoutMs,
-          ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+          ssrfPolicy: cdpPolicy,
         });
         return res.json({ ok: true, origin, ...granted });
       } catch (error) {

--- a/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
+++ b/extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts
@@ -29,6 +29,12 @@ async function expectBlockedCdpEndpoint(promise: Promise<unknown>) {
   throw new Error("expected blocked browser CDP endpoint");
 }
 
+const permissiveRemoteCdpPolicy = {
+  allowPrivateNetwork: true,
+  allowedHostnames: ["1.1.1.1"],
+  hostnameAllowlist: ["1.1.1.1"],
+};
+
 describe("browser remote profile tab ops via Playwright", () => {
   it("uses Playwright tab operations when available", async () => {
     const listPagesViaPlaywright = vi.fn(async () => [
@@ -54,7 +60,7 @@ describe("browser remote profile tab ops via Playwright", () => {
     expect(tabs.map((t) => t.targetId)).toEqual(["T1"]);
     expect(listPagesViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: "https://1.1.1.1:9222/chrome?token=abc",
-      ssrfPolicy: { allowPrivateNetwork: true },
+      ssrfPolicy: permissiveRemoteCdpPolicy,
       timeoutMs: 3000,
     });
 
@@ -64,6 +70,7 @@ describe("browser remote profile tab ops via Playwright", () => {
     expect(createPageViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: "https://1.1.1.1:9222/chrome?token=abc",
       url: "http://127.0.0.1:3000",
+      cdpPolicy: permissiveRemoteCdpPolicy,
       ssrfPolicy: { allowPrivateNetwork: true },
     });
 
@@ -71,7 +78,7 @@ describe("browser remote profile tab ops via Playwright", () => {
     expect(closePageByTargetIdViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: "https://1.1.1.1:9222/chrome?token=abc",
       targetId: "T1",
-      ssrfPolicy: { allowPrivateNetwork: true },
+      ssrfPolicy: permissiveRemoteCdpPolicy,
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });
@@ -245,6 +252,7 @@ describe("browser remote profile tab ops via Playwright", () => {
     expect(createPageViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: "https://1.1.1.1:9222/chrome?token=abc",
       url: "about:blank",
+      cdpPolicy: permissiveRemoteCdpPolicy,
       ssrfPolicy: { allowPrivateNetwork: true },
     });
   });
@@ -290,7 +298,7 @@ describe("browser remote profile tab ops via Playwright", () => {
     expect(focusPageByTargetIdViaPlaywright).toHaveBeenCalledWith({
       cdpUrl: "https://1.1.1.1:9222/chrome?token=abc",
       targetId: "T1",
-      ssrfPolicy: { allowPrivateNetwork: true },
+      ssrfPolicy: permissiveRemoteCdpPolicy,
     });
     expect(fetchMock).not.toHaveBeenCalled();
     expect(state.profiles.get("remote")?.lastTargetId).toBe("T1");

--- a/extensions/browser/src/browser/server-context.tab-ops.ts
+++ b/extensions/browser/src/browser/server-context.tab-ops.ts
@@ -254,7 +254,7 @@ export function createProfileTabOps({
         continue;
       }
       if (tab.wsUrl) {
-        await assertCdpEndpointAllowed(tab.wsUrl, cdpControlPolicy);
+        await assertCdpEndpointAllowed(tab.wsUrl, cdpControlPolicy, { source: "discovered" });
       }
       tabs.push(tab);
     }
@@ -323,6 +323,7 @@ export function createProfileTabOps({
         const page = await createPageViaPlaywright({
           cdpUrl: profile.cdpUrl,
           url,
+          cdpPolicy: getCdpControlPolicy(),
           ...ssrfPolicyOpts,
         });
         const profileState = getProfileState();
@@ -421,7 +422,7 @@ export function createProfileTabOps({
     await assertBrowserNavigationResultAllowed({ url: resolvedUrl, ...ssrfPolicyOpts });
     const wsUrl = normalizeWsUrl(created.webSocketDebuggerUrl, profile.cdpUrl);
     if (wsUrl) {
-      await assertCdpEndpointAllowed(wsUrl, getCdpControlPolicy());
+      await assertCdpEndpointAllowed(wsUrl, getCdpControlPolicy(), { source: "discovered" });
     }
     triggerManagedTabLimit(created.id);
     return assignTabAlias({

--- a/extensions/browser/src/browser/ssrf-policy-helpers.ts
+++ b/extensions/browser/src/browser/ssrf-policy-helpers.ts
@@ -1,20 +1,17 @@
 /**
  * SSRF policy helpers for Browser routes that need one-off hostname grants.
  */
-import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 
-/** Returns an SSRF policy with the hostname added to exact-host allowlists. */
-export function withAllowedHostname(
+/** Returns an SSRF policy restricted to one exact control-plane hostname. */
+export function withExactHostnamePolicy(
   ssrfPolicy: SsrFPolicy | undefined,
   hostname: string,
 ): SsrFPolicy {
-  const hostnameAllowlist = ssrfPolicy?.hostnameAllowlist?.length
-    ? uniqueStrings([...ssrfPolicy.hostnameAllowlist, hostname])
-    : undefined;
+  const { allowedOrigins: _allowedOrigins, ...basePolicy } = ssrfPolicy ?? {};
   return {
-    ...ssrfPolicy,
-    allowedHostnames: uniqueStrings([...(ssrfPolicy?.allowedHostnames ?? []), hostname]),
-    ...(hostnameAllowlist ? { hostnameAllowlist } : {}),
+    ...basePolicy,
+    allowedHostnames: [hostname],
+    hostnameAllowlist: [hostname],
   };
 }


### PR DESCRIPTION
Related: #100819
Follow-up to #100986

AI-assisted: Codex implemented and reviewed this change; the maintainer verified the trust-boundary decisions and live proof.

## What Problem This Solves

Fixes an issue where browser users with permissive or multi-host navigation policy could let CDP discovery follow a returned debugger WebSocket to a host other than the configured browser endpoint. The same page policy also leaked into persistent Playwright tab creation and permission grants, while strict local-relay configurations could block legitimate loopback control.

## Why This Change Was Made

CDP control now gets a dedicated exact-host policy after preserving the existing remote `hostnameAllowlist` gate. Configured local relays keep their loopback control exception, discovered endpoints cannot claim one, and Playwright plus permission routes use the control policy only for CDP connections while retaining the page policy for navigation.

## User Impact

Browser automation keeps working for managed and extension loopback profiles under strict navigation rules. Explicitly allowed remote CDP profiles still work, excluded remote hosts remain blocked, and discovery cannot pivot control traffic or CDP URL credentials to another navigation-allowed host.

## Evidence

- Fresh `autoreview` against current `main`: clean after all actionable findings were fixed.
- Targeted `oxfmt --check` across all 12 changed files: pass.
- Added strict, permissive, wildcard, trailing-dot, extension-loopback, discovered-endpoint, persistent Playwright, and permission-route regressions.
- Exact rebased head `5a33fe8d345b493dc0345bcc898192e53901e316`, sanitized AWS Crabbox `cbx_72d43a28c47b` (`m7i.xlarge`, public network, no Tailscale or instance role).
- `pnpm test extensions/browser/src/browser/cdp.helpers.test.ts extensions/browser/src/browser/cdp.helpers.internal.test.ts extensions/browser/src/browser/cdp.test.ts extensions/browser/src/browser/chrome.test.ts extensions/browser/src/browser/chrome.internal.test.ts extensions/browser/src/browser/pw-session.connections.test.ts extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts extensions/browser/src/browser/server-context.remote-profile-tab-ops.playwright.test.ts extensions/browser/src/browser/routes/permissions.test.ts`: 9 files, 236 tests passed.
- Live run `run_087175c3f407`: real Chrome 150, Gateway, and `openai/gpt-5.4` agent. CDP open/list worked under a restrictive navigation allowlist; direct and agent navigation to `openai.com` were policy-blocked; the existing tab remained on `example.com`; agent summary recorded 3 tool calls including browser with zero failures.
