### PR TITLE
fix(qa): keep smoke profile on one channel

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -110,6 +110,7 @@ import { loadNonYamlScenarioRefs } from "./live-transports/shared/live-transport
 import { runQaTelegramCommand } from "./live-transports/telegram/cli.runtime.js";
 import { defaultQaModelForMode as defaultQaProviderModelForMode } from "./model-selection.js";
 import type { QaProviderModeInput } from "./run-config.js";
+import { readQaScenarioPack } from "./scenario-catalog.js";
 
 function mockFirstObjectArg(mock: unknown): Record<string, unknown> {
   const calls = (mock as { mock?: { calls?: Array<Array<unknown>> } }).mock?.calls ?? [];
@@ -566,7 +567,7 @@ describe("qa cli runtime", () => {
     expectWriteContains(stdoutWrite, "QA run profile: all; categories: 1; scenarios:");
   });
 
-  it("filters QA-channel-pinned scenarios from the Crabline smoke profile", async () => {
+  it("keeps the automatic Crabline smoke profile on its default channel", async () => {
     runQaSuite.mockImplementationOnce(async () => {
       await fs.writeFile(suiteEvidencePath, JSON.stringify(makeQaEvidence()), "utf8");
       return flowSuiteRuntimeResult({
@@ -583,6 +584,17 @@ describe("qa cli runtime", () => {
     const suiteArgs = mockFirstObjectArg(runQaSuite);
     expect(suiteArgs.channelDriver).toBe("crabline");
     expect(suiteArgs.scenarioIds).toEqual(expect.arrayContaining(["dm-chat-baseline"]));
+    const scenarioChannelById = new Map(
+      readQaScenarioPack().scenarios.map((scenario) => [scenario.id, scenario.execution.channel]),
+    );
+    const selectedChannels = [
+      ...new Set(
+        (suiteArgs.scenarioIds as string[])
+          .map((scenarioId) => scenarioChannelById.get(scenarioId))
+          .filter((channel): channel is string => Boolean(channel)),
+      ),
+    ];
+    expect(selectedChannels).toEqual(["telegram"]);
     expect(suiteArgs.scenarioIds).not.toEqual(
       expect.arrayContaining([
         "instruction-followthrough-repo-contract",
@@ -611,6 +623,21 @@ describe("qa cli runtime", () => {
         "config-apply-restart-wakeup",
       ]),
     );
+  });
+
+  it("keeps an explicitly requested non-default Crabline channel scenario", async () => {
+    await runQaProfileCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      profile: "smoke-ci",
+      scenarioIds: ["slack-restart-resume"],
+    });
+
+    const suiteArgs = mockFirstObjectArg(runQaSuite);
+    expect(suiteArgs.scenarioIds).toEqual(["slack-restart-resume"]);
+    expect(suiteArgs.channelDriverSelection).toMatchObject({
+      channel: "slack",
+      channelDriver: "crabline",
+    });
   });
 
   it("rejects qa profile runs that do not match taxonomy categories", async () => {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -734,14 +734,26 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
   const providerMode = opts.providerMode ?? defaultQaRunProfileProviderMode(profile);
   const normalizedProviderMode = normalizeQaProviderMode(providerMode);
   const primaryModel = opts.primaryModel?.trim() || defaultQaModelForMode(normalizedProviderMode);
-  const scenarios = taxonomyScenarios.filter((scenario) =>
-    scenarioMatchesQaProviderLane({
-      scenario,
-      providerMode: normalizedProviderMode,
-      primaryModel,
-      channelDriver: profileReport.channelDriver,
-    }),
-  );
+  // Automatic Crabline profiles share one driver instance, so keep unpinned scenarios plus the
+  // default channel. Explicit scenario requests still infer their declared execution channel.
+  const automaticProfileChannel =
+    requestedScenarioIds.length === 0 && profileReport.channelDriver === "crabline"
+      ? OPENCLAW_CRABLINE_DEFAULT_CHANNEL
+      : undefined;
+  const scenarios = taxonomyScenarios.filter((scenario) => {
+    const scenarioChannel = scenario.execution.channel?.trim().toLowerCase();
+    const matchesProfileChannel =
+      !automaticProfileChannel || !scenarioChannel || scenarioChannel === automaticProfileChannel;
+    return (
+      matchesProfileChannel &&
+      scenarioMatchesQaProviderLane({
+        scenario,
+        providerMode: normalizedProviderMode,
+        primaryModel,
+        channelDriver: profileReport.channelDriver,
+      })
+    );
+  });
   if (scenarios.length === 0) {
     throw new Error(
       `qa run --qa-profile ${profile} did not resolve any executable QA scenarios for provider mode ${normalizedProviderMode}.`,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the `smoke-ci` QA profile selected Telegram, Matrix, Slack, and WhatsApp scenarios together, causing CI to fail before scenario execution because one QA suite run supports only one channel driver instance.

## Why This Change Was Made

Automatic Crabline profile selection now keeps channel-unpinned scenarios plus Crabline's default Telegram scenarios. Explicitly requested non-default scenarios still infer and use their declared channel, and the suite's mixed-channel rejection remains unchanged.

## User Impact

QA Smoke CI can start its deterministic scenario run instead of failing during planning when the shared catalog contains scenarios for several channels. Explicit channel-focused QA commands retain their existing behavior.

## Evidence

- Original failure: CI run `28818865466`, job `85465286235` selected Telegram, Matrix, Slack, and WhatsApp and exited before any scenario execution.
- Current-main repro before the fix on Blacksmith Testbox `tbx_01kwwgg5zsdwddrngk045s9dd7`: the smoke profile selected 92 scenarios and failed with the same four-channel planning error.
- Regression test before the fix: 90 passed / 1 failed with the same planning error; explicit Slack scenario selection passed.
- After the fix on the same Testbox: `extensions/qa-lab/src/cli.runtime.test.ts` passed 91/91.
- Targeted oxlint passed with 0 warnings and 0 errors.
- Scoped changed checks passed repository guards, then extension typecheck was blocked by the known Testbox sparse-sync omission of tracked `extensions/qa-lab/src/mantis/**`; exact-head hosted CI is the typecheck authority.
- Fresh structured Codex autoreview: `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output --prompt '<scoped qa-smoke-selector review>'` completed clean with no accepted/actionable findings (`patch is correct`, confidence `0.86`).

AI-assisted change; implementation and evidence were reviewed and validated as described above.
