### PR TITLE
improve(ci): raise Node shard parallelism to 28

### DIFF
--- a/.agents/skills/openclaw-ci-limits/SKILL.md
+++ b/.agents/skills/openclaw-ci-limits/SKILL.md
@@ -132,7 +132,7 @@ These are intentionally guarded by `test/scripts/ci-workflow-guards.test.ts`:
 - `runner-admission` on `ubuntu-24.04` with
   `OPENCLAW_MAIN_CI_DEBOUNCE_SECONDS=90`.
 - `preflight` and `security-fast` needing `runner-admission`.
-- CI matrix caps: fast/check lanes at 12, Node test shards at 24, Windows and
+- CI matrix caps: fast/check lanes at 12, Node test shards at 28, Windows and
   Android at 2.
 - `build-artifacts` on `blacksmith-16vcpu-ubuntu-2404`.
 - lower-weight Node/check shards on `blacksmith-4vcpu-ubuntu-2404`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1033,7 +1033,7 @@ jobs:
       fail-fast: false
       # The canonical main path waits for the admission debounce above, so
       # widen this large matrix within the current runner-registration budget.
-      max-parallel: 24
+      max-parallel: 28
       matrix: ${{ fromJson(needs.preflight.outputs.checks_node_core_nondist_matrix) }}
     steps:
       - *linux_node_checkout_step

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -101,7 +101,7 @@ The slowest Node test families are split or balanced so each job stays small wit
 - `check-additional-*` stripes the supplemental boundary guard list (`scripts/run-additional-boundary-checks.mjs`) into one prompt-heavy shard (`check-additional-boundaries-a`, which includes the Codex prompt snapshot drift check) and one combined shard for the remaining stripes (`check-additional-boundaries-bcd`), each running independent guards concurrently and printing per-check timings. Package-boundary compile/canary work stays together, and runtime topology architecture runs separately from the gateway watch coverage embedded in `build-artifacts`.
 - Gateway watch, channel tests, and the core support-boundary shard run concurrently inside `build-artifacts` after `dist/` and `dist-runtime/` are already built.
 
-Once admitted, canonical Linux CI permits up to 24 concurrent Node test jobs and
+Once admitted, canonical Linux CI permits up to 28 concurrent Node test jobs and
 12 for the smaller fast/check lanes; Windows and Android stay at two because
 those runner pools are narrower. Compact whole-config batches run with a
 120-minute batch timeout, while include-pattern groups share the same bounded

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -274,7 +274,7 @@ describe("ci workflow guards", () => {
       "github.event_name == 'pull_request'",
     );
     expect(workflow.jobs["checks-fast-core"].strategy["max-parallel"]).toBe(12);
-    expect(workflow.jobs["checks-node-core-test-nondist-shard"].strategy["max-parallel"]).toBe(24);
+    expect(workflow.jobs["checks-node-core-test-nondist-shard"].strategy["max-parallel"]).toBe(28);
     expect(workflow.jobs["checks-fast-plugin-contracts-shard"].strategy["max-parallel"]).toBe(12);
     expect(workflow.jobs["checks-fast-channel-contracts-shard"].strategy["max-parallel"]).toBe(12);
     expect(workflow.jobs["check-shard"].strategy["max-parallel"]).toBe(12);


### PR DESCRIPTION
## What Problem This Solves

OpenClaw CI can leave Node nondistribution shards waiting for runner admission even when the organization runner-registration bucket has ample headroom. A sampled busy run showed job queue waits up to 194 seconds while the live registration bucket remained unused.

## Why This Change Was Made

Raise only the large Linux Node test matrix from 24 to 28 concurrent rows. The matrix row count, fast/check lane caps, Windows and Android caps, and main-push debounce remain unchanged.

The live `actions_runner_registration` bucket was 0 used of 10,000 on July 6, 2026. This change permits at most four additional simultaneous registrations per active run, well inside the 6,000-registration operating target.

## User Impact

PR and `main` CI can start four more Node shard jobs concurrently during busy periods, reducing avoidable queue latency without adding test jobs or changing coverage.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` - 34 tests passed
- `node scripts/check-workflows.mjs` - passed
- `node scripts/docs-list.js` - passed
- `oxfmt --check` on all changed files - passed
- `git diff --check` - passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` - clean, no actionable findings
- Hosted Workflow Sanity `actionlint` and `no-tabs` checks - passed on commit `667f89463c`
- Live registration budget: 0 used / 10,000
- Sampled CI run: p95 start delay 55 seconds; longest job queue wait 194 seconds
