### PR TITLE
fix(clawhub): bound archive download bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **ClawHub archive downloads:** cap package, ClawPack, skill, resolver, and GitHub-source archive reads at 256 MiB, rejecting declared oversize responses before buffering them. (#101176, supersedes #100999) Thanks @hugenshen.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **ClawHub archive downloads:** cap package, ClawPack, skill, resolver, and GitHub-source archive reads at 256 MiB, rejecting declared oversize responses before buffering them. (#101176, supersedes #100999) Thanks @hugenshen.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/src/infra/clawhub.test.ts
+++ b/src/infra/clawhub.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import {
+  downloadClawHubGitHubSkillArchive,
   downloadClawHubPackageArchive,
   downloadClawHubSkillArchive,
   downloadClawHubSkillArchiveUrl,
@@ -68,6 +69,92 @@ function createStalledBodyResponse(params: {
     cancel,
   };
 }
+
+function createOversizedArchiveResponse(
+  params: {
+    headers?: HeadersInit;
+  } = {},
+): {
+  response: Response;
+  cancel: ReturnType<typeof vi.fn>;
+} {
+  const cancel = vi.fn();
+  const body = new ReadableStream<Uint8Array>({
+    cancel() {
+      cancel();
+    },
+  });
+  const headers = new Headers(params.headers);
+  headers.set("content-type", headers.get("content-type") ?? "application/zip");
+  headers.set("content-length", String(256 * 1024 * 1024 + 512 * 1024));
+  return {
+    response: new Response(body, {
+      status: 200,
+      headers,
+    }),
+    cancel,
+  };
+}
+
+const oversizedArchiveCases: Array<{
+  name: string;
+  headers?: HeadersInit;
+  download: (response: Response) => Promise<unknown>;
+  expectedResource: string;
+}> = [
+  {
+    name: "package archive",
+    download: (response) =>
+      downloadClawHubPackageArchive({
+        name: "@hyf/zai-external-alpha",
+        version: "0.0.1",
+        fetchImpl: async () => response,
+      }),
+    expectedResource: "package archive download for @hyf/zai-external-alpha",
+  },
+  {
+    name: "ClawPack artifact",
+    headers: { "content-type": "application/octet-stream" },
+    download: (response) =>
+      downloadClawHubPackageArchive({
+        name: "demo",
+        version: "1.2.3",
+        artifact: "clawpack",
+        fetchImpl: async () => response,
+      }),
+    expectedResource: "ClawPack download for demo@1.2.3",
+  },
+  {
+    name: "skill archive",
+    download: (response) =>
+      downloadClawHubSkillArchive({
+        slug: "agentreceipt",
+        version: "1.0.0",
+        fetchImpl: async () => response,
+      }),
+    expectedResource: "skill archive download for agentreceipt",
+  },
+  {
+    name: "resolver URL archive",
+    download: (response) =>
+      downloadClawHubSkillArchiveUrl({
+        baseUrl: "https://clawhub.ai",
+        url: "https://downloads.example.com/skill.zip",
+        fetchImpl: async () => response,
+      }),
+    expectedResource: "skill archive download at /skill.zip",
+  },
+  {
+    name: "GitHub source archive",
+    download: (response) =>
+      downloadClawHubGitHubSkillArchive({
+        repo: "owner/repo",
+        commit: "abc123",
+        fetchImpl: async () => response,
+      }),
+    expectedResource: "GitHub source archive for owner/repo@abc123",
+  },
+];
 
 describe("clawhub helpers", () => {
   const originalEnv = captureEnv(["HOME", "XDG_CONFIG_HOME"]);
@@ -844,6 +931,40 @@ describe("clawhub helpers", () => {
           }),
       }),
     ).rejects.toThrow(/declared sha256/);
+  });
+
+  it.each(oversizedArchiveCases)(
+    "rejects and cancels oversized $name downloads",
+    async ({ headers, download, expectedResource }) => {
+      const oversized = createOversizedArchiveResponse({ headers });
+
+      await expect(download(oversized.response)).rejects.toThrow(
+        `ClawHub ${expectedResource} exceeded 268435456 bytes (268959744 bytes declared)`,
+      );
+      expect(oversized.cancel).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("uses decoded stream bytes instead of encoded content length", async () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const archive = await downloadClawHubPackageArchive({
+      name: "encoded-package",
+      version: "1.0.0",
+      fetchImpl: async () =>
+        new Response(bytes, {
+          status: 200,
+          headers: {
+            "content-encoding": "gzip",
+            "content-length": String(256 * 1024 * 1024 + 1),
+            "content-type": "application/zip",
+          },
+        }),
+    });
+    try {
+      await expect(fs.readFile(archive.archivePath)).resolves.toEqual(Buffer.from(bytes));
+    } finally {
+      await archive.cleanup();
+    }
   });
 
   it("annotates 429 errors with the reset hint and a sign-in hint when unauthenticated", async () => {

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -817,8 +817,8 @@ async function readClawHubResponseBytes(params: {
   }
   return await readResponseWithLimit(params.response, maxBytes, {
     chunkTimeoutMs: timeoutMs,
-    onOverflow: ({ size, maxBytes }) =>
-      createClawHubBodyLimitError(params.resourceLabel, size, maxBytes),
+    onOverflow: ({ size, maxBytes: limitBytes }) =>
+      createClawHubBodyLimitError(params.resourceLabel, size, limitBytes),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`ClawHub ${params.resourceLabel} body stalled after ${chunkTimeoutMs}ms`),
   });

--- a/src/infra/clawhub.ts
+++ b/src/infra/clawhub.ts
@@ -11,7 +11,10 @@ import {
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import { sha256Base64, sha256Hex as digestSha256Hex } from "./crypto-digest.js";
 import { readResponseTextSnippet, readResponseWithLimit } from "./http-body.js";
-import { parseStrictPositiveInteger } from "./parse-finite-number.js";
+import {
+  parseStrictNonNegativeInteger,
+  parseStrictPositiveInteger,
+} from "./parse-finite-number.js";
 import { isAtLeast, parseSemver } from "./runtime-guard.js";
 import { compareComparableSemver, parseComparableSemver } from "./semver-compare.js";
 import { createTempDownloadTarget } from "./temp-download.js";
@@ -21,6 +24,8 @@ const DEFAULT_CLAWHUB_URL = "https://clawhub.ai";
 const DEFAULT_GITHUB_CODELOAD_URL = "https://codeload.github.com";
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
 const SKILL_CARD_MAX_BYTES = 256 * 1024;
+// Align with marketplace archive downloads (src/plugins/marketplace.ts).
+const CLAWHUB_ARCHIVE_MAX_BYTES = 256 * 1024 * 1024;
 // ClawHub is an external marketplace: bound untrusted JSON and error bodies so
 // a hostile or malfunctioning host cannot exhaust memory with an endless stream.
 const CLAWHUB_JSON_MAX_BYTES = 16 * 1024 * 1024;
@@ -798,15 +803,36 @@ async function readClawHubResponseBytes(params: {
   resourceLabel: string;
 }): Promise<Uint8Array> {
   const timeoutMs = resolveClawHubRequestTimeoutMs(params.timeoutMs);
-  return await readResponseWithLimit(params.response, params.maxBytes ?? Number.MAX_SAFE_INTEGER, {
+  const maxBytes = params.maxBytes ?? CLAWHUB_ARCHIVE_MAX_BYTES;
+  const contentEncoding = normalizeOptionalString(params.response.headers.get("content-encoding"));
+  const declaredSize =
+    !contentEncoding || contentEncoding.toLowerCase() === "identity"
+      ? parseStrictNonNegativeInteger(params.response.headers.get("content-length"))
+      : undefined;
+  if (declaredSize !== undefined && declaredSize > maxBytes) {
+    // Fetch may decode encoded bodies while retaining their wire length, so
+    // only identity lengths can safely short-circuit the decoded stream cap.
+    await params.response.body?.cancel().catch(() => undefined);
+    throw createClawHubBodyLimitError(params.resourceLabel, declaredSize, maxBytes, "declared");
+  }
+  return await readResponseWithLimit(params.response, maxBytes, {
     chunkTimeoutMs: timeoutMs,
     onOverflow: ({ size, maxBytes }) =>
-      new Error(
-        `ClawHub ${params.resourceLabel} exceeded ${maxBytes} bytes (${size} bytes received)`,
-      ),
+      createClawHubBodyLimitError(params.resourceLabel, size, maxBytes),
     onIdleTimeout: ({ chunkTimeoutMs }) =>
       new Error(`ClawHub ${params.resourceLabel} body stalled after ${chunkTimeoutMs}ms`),
   });
+}
+
+function createClawHubBodyLimitError(
+  resourceLabel: string,
+  size: number,
+  maxBytes: number,
+  measurement: "declared" | "received" = "received",
+): Error {
+  return new Error(
+    `ClawHub ${resourceLabel} exceeded ${maxBytes} bytes (${size} bytes ${measurement})`,
+  );
 }
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## What Problem This Solves

ClawHub package, ClawPack, skill, resolver, and GitHub-source archive paths all omitted a practical body limit; the shared reader defaulted to `Number.MAX_SAFE_INTEGER`. A hostile or broken registry could therefore grow gateway memory until the process failed.

Supersedes #100999 because its conflicting branch was converged into a clean maintainer rewrite. Contributor authorship is preserved in the squashed commit.

## Why This Change Was Made

- Give the shared ClawHub byte reader the same 256 MiB archive ceiling already used by marketplace downloads.
- Preserve the explicit 256 KiB skill-card limit.
- Reject trustworthy identity `Content-Length` declarations before buffering while measuring encoded responses from their decoded stream bytes.
- Exercise every archive entry point, declared-oversize cancellation, and encoded-body behavior while retaining the shared reader's streamed overflow guard.

## User Impact

ClawHub installs now fail with a bounded, resource-specific error instead of allowing oversized archive responses to exhaust gateway memory. Normal archives and skill cards keep their existing behavior.

## Evidence

- Targeted `oxfmt --check`: passed.
- `git diff --check`: passed.
- Fresh exact-head high-reasoning autoreview at `1afa5b3f8d28587d88dea57376de7b01743d862b`: clean, correctness confidence 0.94.
- Sanitized public-network AWS `run_e3f0cbbdf59e` on the behavior-equivalent pre-rebase head: 66 focused ClawHub tests passed, 2 skipped; no Tailscale, IAM role, credential hydration, or secret forwarding.
- Sanitized public-network AWS `run_1201348c8070`: real `openclaw skills install @steipete/github --global` completed against live ClawHub in an isolated home.
- Sanitized public-network AWS `run_fd976cd2cc27` on the behavior-equivalent pre-rebase head: the live `weather` archive downloaded through `downloadClawHubSkillArchive` (2,013 bytes, 64-character SHA-256) and cleaned up.
- Sanitized public-network AWS `run_bdd373538e73` on the behavior-equivalent pre-rebase head: Node 24 retained a 39-byte gzip `Content-Length` while returning 4,096 decoded bytes, proving encoded wire length cannot enforce the decoded-body cap.
- Exact-head release gate [28827137909](https://github.com/openclaw/openclaw/actions/runs/28827137909): all 109 substantive jobs passed.
- No screenshot: this is a non-UI download-boundary change.
