### PR TITLE
feat(ios): context-window usage indicator in the chat composer

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -21698,8 +21698,16 @@
       "id": "native.apple.d4f7cdeb3737a201"
     },
     {
+      "kind": "ui-modifier",
+      "line": 214,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
+      "source": "Context \\(percentage)% used",
+      "surface": "apple",
+      "id": "native.apple.38a8e96962b1a93d"
+    },
+    {
       "kind": "ui-call",
-      "line": 198,
+      "line": 218,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -21707,7 +21715,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 219,
+      "line": 239,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Model",
       "surface": "apple",
@@ -21715,7 +21723,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 236,
+      "line": 256,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -21723,7 +21731,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 244,
+      "line": 264,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Recent",
       "surface": "apple",
@@ -21731,7 +21739,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 252,
+      "line": 272,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Models",
       "surface": "apple",
@@ -21739,7 +21747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 281,
+      "line": 301,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pin model",
       "surface": "apple",
@@ -21747,7 +21755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 281,
+      "line": 301,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Unpin model",
       "surface": "apple",
@@ -21755,7 +21763,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 285,
+      "line": 305,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Session",
       "surface": "apple",
@@ -21763,7 +21771,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 349,
+      "line": 369,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Add Image",
       "surface": "apple",
@@ -21771,7 +21779,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 350,
+      "line": 370,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Attachments",
       "surface": "apple",
@@ -21779,7 +21787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 520,
+      "line": 540,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
@@ -21787,7 +21795,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 566,
+      "line": 586,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
@@ -21795,7 +21803,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 566,
+      "line": 586,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
@@ -21803,7 +21811,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 599,
+      "line": 619,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -21811,7 +21819,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 599,
+      "line": 619,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -21819,7 +21827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 709,
+      "line": 729,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -21827,7 +21835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 718,
+      "line": 738,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -21835,7 +21843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 727,
+      "line": 747,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -21843,7 +21851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 736,
+      "line": 756,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -21851,7 +21859,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 868,
+      "line": 888,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -21859,7 +21867,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 893,
+      "line": 913,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -21867,7 +21875,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 908,
+      "line": 928,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -21875,7 +21883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1018,
+      "line": 1038,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -21883,7 +21891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1018,
+      "line": 1038,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",
@@ -22139,7 +22147,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1350,
+      "line": 1360,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -22147,7 +22155,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1350,
+      "line": 1360,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -186,12 +186,32 @@ struct OpenClawChatComposer: View {
 
             Spacer(minLength: 4)
 
+            if let fraction = self.viewModel.contextUsageFraction {
+                self.contextUsageIndicator(fraction)
+            }
+
             if self.style == .standard {
                 self.refreshButton
                 self.attachmentPicker
             }
         }
         .padding(.horizontal, 10)
+    }
+
+    private func contextUsageIndicator(_ fraction: Double) -> some View {
+        let percentage = Int((fraction * 100).rounded())
+        let color = fraction >= 0.8 ? OpenClawChatTheme.warning : OpenClawChatTheme.muted
+        return ZStack {
+            Circle()
+                .stroke(OpenClawChatTheme.muted.opacity(0.2), lineWidth: 2)
+            Circle()
+                .trim(from: 0, to: fraction)
+                .stroke(color, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+        }
+        .frame(width: 14, height: 14)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Context \(percentage)% used")
     }
 
     private var thinkingPicker: some View {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatSessions.swift
@@ -109,6 +109,7 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
     public let inputTokens: Int?
     public let outputTokens: Int?
     public let totalTokens: Int?
+    public let totalTokensFresh: Bool?
 
     public let modelProvider: String?
     public let model: String?
@@ -134,6 +135,7 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
         inputTokens: Int?,
         outputTokens: Int?,
         totalTokens: Int?,
+        totalTokensFresh: Bool? = nil,
         modelProvider: String?,
         model: String?,
         contextTokens: Int?,
@@ -171,6 +173,7 @@ public struct OpenClawChatSessionEntry: Codable, Identifiable, Sendable, Hashabl
         self.inputTokens = inputTokens
         self.outputTokens = outputTokens
         self.totalTokens = totalTokens
+        self.totalTokensFresh = totalTokensFresh
         self.modelProvider = modelProvider
         self.model = model
         self.contextTokens = contextTokens

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTheme.swift
@@ -164,6 +164,18 @@ enum OpenClawChatTheme {
         #endif
     }
 
+    static var muted: Color {
+        .secondary
+    }
+
+    static var warning: Color {
+        #if os(macOS)
+        Color(nsColor: .systemOrange)
+        #else
+        Color(uiColor: .systemOrange)
+        #endif
+    }
+
     static var assistantBubble: Color {
         #if os(macOS)
         Color(nsColor: self.assistantBubbleDynamicNSColor)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionKeys.swift
@@ -1,6 +1,30 @@
 import Foundation
 
 extension OpenClawChatViewModel {
+    nonisolated static func chatContextUsageFraction(for session: OpenClawChatSessionEntry?) -> Double? {
+        guard session?.totalTokensFresh != false,
+              let totalTokens = session?.totalTokens,
+              totalTokens >= 0,
+              let contextTokens = session?.contextTokens,
+              contextTokens > 0
+        else {
+            return nil
+        }
+        return min(max(Double(totalTokens) / Double(contextTokens), 0), 1)
+    }
+
+    func syncContextUsageFraction() {
+        let mainSessionKey = self.resolvedMainSessionKey
+        let activeSessionKey = self.sessionKey == "main" && mainSessionKey != "main"
+            ? mainSessionKey
+            : self.sessionKey
+        let currentSession = self.sessions.first(where: { $0.key == activeSessionKey }) ??
+            self.sessions.first(where: {
+                self.matchesCurrentSessionKey(incoming: $0.key, current: self.sessionKey)
+            })
+        self.contextUsageFraction = Self.chatContextUsageFraction(for: currentSession)
+    }
+
     public var sessionChoices: [OpenClawChatSessionEntry] {
         let now = Date().timeIntervalSince1970 * 1000
         let cutoff = now - (24 * 60 * 60 * 1000)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -53,7 +53,10 @@ public final class OpenClawChatViewModel {
 
     public private(set) var pendingRunCount: Int = 0
 
-    public private(set) var sessionKey: String
+    public private(set) var sessionKey: String {
+        didSet { self.syncContextUsageFraction() }
+    }
+
     public private(set) var sessionId: String?
     public private(set) var streamingAssistantText: String?
 
@@ -61,7 +64,11 @@ public final class OpenClawChatViewModel {
 
     private(set) var timelineRevision: UInt64 = 0
     /// Setter is module-internal for the transcript-cache extension only.
-    public internal(set) var sessions: [OpenClawChatSessionEntry] = []
+    public internal(set) var sessions: [OpenClawChatSessionEntry] = [] {
+        didSet { self.syncContextUsageFraction() }
+    }
+
+    public internal(set) var contextUsageFraction: Double?
     /// True while the visible transcript came from the offline cache and no
     /// live history response has replaced it yet (possibly stale).
     public internal(set) var isShowingCachedTranscript = false
@@ -114,7 +121,10 @@ public final class OpenClawChatViewModel {
     var pendingCacheWriteTask: Task<Void, Never>?
     private(set) var activeAgentId: String?
     private(set) var sessionRoutingContract: String?
-    var sessionDefaults: OpenClawChatSessionsDefaults?
+    var sessionDefaults: OpenClawChatSessionsDefaults? {
+        didSet { self.syncContextUsageFraction() }
+    }
+
     private let prefersExplicitThinkingLevel: Bool
     private let onSessionChanged: (@MainActor (String) -> Void)?
     private let onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)?
@@ -1810,6 +1820,7 @@ public final class OpenClawChatViewModel {
             inputTokens: current.inputTokens,
             outputTokens: current.outputTokens,
             totalTokens: current.totalTokens,
+            totalTokensFresh: current.totalTokensFresh,
             modelProvider: current.modelProvider,
             model: current.model,
             contextTokens: current.contextTokens,
@@ -1856,6 +1867,7 @@ public final class OpenClawChatViewModel {
                 inputTokens: current.inputTokens,
                 outputTokens: current.outputTokens,
                 totalTokens: current.totalTokens,
+                totalTokensFresh: current.totalTokensFresh,
                 modelProvider: modelProvider,
                 model: modelID,
                 contextTokens: current.contextTokens,
@@ -1889,6 +1901,7 @@ public final class OpenClawChatViewModel {
                     inputTokens: placeholder.inputTokens,
                     outputTokens: placeholder.outputTokens,
                     totalTokens: placeholder.totalTokens,
+                    totalTokensFresh: placeholder.totalTokensFresh,
                     modelProvider: modelProvider,
                     model: modelID,
                     contextTokens: placeholder.contextTokens))

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -83,7 +83,13 @@ private func historyPayload(
         inFlightRun: inFlightRun)
 }
 
-private func sessionEntry(key: String, updatedAt: Double) -> OpenClawChatSessionEntry {
+private func sessionEntry(
+    key: String,
+    updatedAt: Double,
+    totalTokens: Int? = nil,
+    totalTokensFresh: Bool? = nil,
+    contextTokens: Int? = nil) -> OpenClawChatSessionEntry
+{
     OpenClawChatSessionEntry(
         key: key,
         kind: nil,
@@ -100,10 +106,11 @@ private func sessionEntry(key: String, updatedAt: Double) -> OpenClawChatSession
         verboseLevel: nil,
         inputTokens: nil,
         outputTokens: nil,
-        totalTokens: nil,
+        totalTokens: totalTokens,
+        totalTokensFresh: totalTokensFresh,
         modelProvider: nil,
         model: nil,
-        contextTokens: nil)
+        contextTokens: contextTokens)
 }
 
 private func thinkingOption(_ id: String, label: String? = nil) -> OpenClawChatThinkingLevelOption {
@@ -867,6 +874,27 @@ extension TestChatTransportState {
 
 @Suite(.serialized)
 struct ChatViewModelTests {
+    @Test func `context usage fraction validates freshness and token bounds`() {
+        func fraction(total: Int?, fresh: Bool? = true, context: Int?) -> Double? {
+            OpenClawChatViewModel.chatContextUsageFraction(
+                for: sessionEntry(
+                    key: "main",
+                    updatedAt: 1,
+                    totalTokens: total,
+                    totalTokensFresh: fresh,
+                    contextTokens: context))
+        }
+
+        #expect(fraction(total: nil, context: 100) == nil)
+        #expect(fraction(total: 25, context: nil) == nil)
+        #expect(fraction(total: 25, context: 0) == nil)
+        #expect(fraction(total: 25, context: -100) == nil)
+        #expect(fraction(total: -1, context: 100) == nil)
+        #expect(fraction(total: 25, fresh: false, context: 100) == nil)
+        #expect(fraction(total: 150, context: 100) == 1)
+        #expect(fraction(total: 25, fresh: nil, context: 100) == 0.25)
+    }
+
     @Test @MainActor func `event listener does not retain discarded view model`() async throws {
         let transport = TestChatTransport(historyResponses: [historyPayload()])
         var viewModel: OpenClawChatViewModel? = OpenClawChatViewModel(
@@ -4293,6 +4321,44 @@ struct ChatViewModelTests {
         #expect(keys == ["main", "recent-1", "recent-2"])
     }
 
+    @Test func `context usage follows active session switches`() async throws {
+        let sessions = OpenClawChatSessionsListResponse(
+            ts: 1,
+            path: nil,
+            count: 2,
+            defaults: nil,
+            sessions: [
+                sessionEntry(
+                    key: "main",
+                    updatedAt: 2,
+                    totalTokens: 20,
+                    totalTokensFresh: true,
+                    contextTokens: 100),
+                sessionEntry(
+                    key: "other",
+                    updatedAt: 1,
+                    totalTokens: 80,
+                    totalTokensFresh: true,
+                    contextTokens: 100),
+            ])
+        let (_, vm) = await makeViewModel(
+            historyResponses: [
+                historyPayload(sessionKey: "main", sessionId: "sess-main"),
+                historyPayload(sessionKey: "other", sessionId: "sess-other"),
+            ],
+            sessionsResponses: [sessions, sessions])
+
+        await MainActor.run { vm.load() }
+        try await waitUntil("main context usage loaded") {
+            await MainActor.run { vm.contextUsageFraction == 0.2 }
+        }
+
+        await MainActor.run { vm.switchSession(to: "other") }
+        try await waitUntil("other context usage selected") {
+            await MainActor.run { vm.contextUsageFraction == 0.8 }
+        }
+    }
+
     @Test func `session choices include current when missing`() async throws {
         let now = Date().timeIntervalSince1970 * 1000
         let recent = now - (30 * 60 * 1000)
@@ -6497,6 +6563,9 @@ struct ChatViewModelTests {
               "key": "main",
               "modelProvider": "openrouter",
               "model": "deepseek/deepseek-v4",
+              "totalTokens": 25000,
+              "totalTokensFresh": false,
+              "contextTokens": 100000,
               "thinkingLevel": "max",
               "thinkingLevels": [
                 { "id": "off", "label": "off" },
@@ -6520,6 +6589,7 @@ struct ChatViewModelTests {
         #expect(decoded.defaults?.thinkingDefault == "adaptive")
         #expect(decoded.sessions.first?.thinkingLevels?.map(\.id) == ["off", "xhigh", "max"])
         #expect(decoded.sessions.first?.thinkingDefault == "max")
+        #expect(decoded.sessions.first?.totalTokensFresh == false)
     }
 
     @Test func `session thinking levels drive picker options`() async throws {


### PR DESCRIPTION
Related: #100699

## What Problem This Solves

iOS/macOS chat users have no visibility into how full the session context window is — long sessions hit compaction or truncation without warning. Android already ships a context meter; iOS had nothing.

## Why This Change Was Made

Adds a subtle 14pt progress ring at the trailing edge of the composer toolbar showing tokens-used vs. the model context window. No server changes: the gateway's session rows already carry `totalTokens`/`totalTokensFresh`/`contextTokens` (Android's meter reads the same fields); this PR adds the missing optional `totalTokensFresh` decode to the iOS session entry and mirrors Android's semantics exactly — the indicator hides entirely when data is missing, context size is unknown, or the total is marked stale, and the fraction clamps to 0…1. The ring turns to the warning tone at ≥80%. Accessibility reads "Context NN% used". Active-session resolution honors the main-session-key alias, and the fraction resyncs via `didSet` observers on session state (single owner).

## User Impact

iOS and macOS users can see at a glance when a session is approaching its context limit, matching the Android experience. No visual noise when the gateway doesn't provide usage data.

## Evidence

- `swift test --package-path apps/shared/OpenClawKit` — full suite green (465 Swift Testing / 40 suites + 21 XCTest); new coverage: missing fields, zero/negative context, stale freshness flag, clamping, normal fraction, session-switch follow, decode of the new optional field.
- `swiftformat --lint` via the iOS filelist — clean.
- `corepack pnpm native:i18n:sync` run for the accessibility string.
- Structured review (codex) — clean at head.
- Known gap: no on-device VoiceOver/visual pass in this environment; the existing render-smoke suite does not cover the composer.
- Flake note (honest record): under heavy multi-session machine load, `ChatViewModelTests` shows nondeterministic timing failures (different convergence-wait tests each run, 3-4x slower runs). Verified environmental: a detached `origin/main` baseline flakes identically under the same load and both trees pass when rerun. Not introduced by this diff.
