### PR TITLE
fix(qa): repair smoke scenario lane selection

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -813,6 +813,8 @@ describe("qa scenario catalog", () => {
 
   it("marks channel-owned access gates with their required channel driver", () => {
     const liveScenarioIds = [
+      "slack-restart-resume",
+      "whatsapp-restart-resume",
       "whatsapp-access-control-dm-disabled",
       "whatsapp-access-control-dm-open",
       "whatsapp-access-control-group-disabled",
@@ -827,6 +829,12 @@ describe("qa scenario catalog", () => {
         | undefined;
       expect(config?.requiredChannelDriver, scenarioId).toBe("live");
     }
+  });
+
+  it("isolates channel baseline silence assertions from shared transport state", () => {
+    const scenario = readQaScenarioById("channel-chat-baseline");
+
+    expect(scenario.execution.suiteIsolation).toBe("isolated");
   });
 
   it("adds a dreaming shadow trial report scenario", () => {

--- a/qa/scenarios/channels/channel-chat-baseline.yaml
+++ b/qa/scenarios/channels/channel-chat-baseline.yaml
@@ -22,6 +22,7 @@ scenario:
     - extensions/qa-lab/src/bus-state.ts
   execution:
     kind: flow
+    suiteIsolation: isolated
     summary: Verify the QA agent can respond correctly in a shared channel and respect mention-driven group semantics.
     config:
       expectedMarker: QA-CHANNEL-BASELINE-OK

--- a/qa/scenarios/channels/slack-restart-resume.yaml
+++ b/qa/scenarios/channels/slack-restart-resume.yaml
@@ -21,6 +21,7 @@ scenario:
     suiteIsolation: isolated
     summary: Exercise normalized restart and continuation delivery.
     config:
+      requiredChannelDriver: live
       conversationKind: group
       conversationId: C0123456789
       senderId: U0123456789

--- a/qa/scenarios/channels/whatsapp-restart-resume.yaml
+++ b/qa/scenarios/channels/whatsapp-restart-resume.yaml
@@ -21,6 +21,7 @@ scenario:
     suiteIsolation: isolated
     summary: Exercise normalized restart and continuation delivery.
     config:
+      requiredChannelDriver: live
       conversationKind: direct
       conversationId: 15550000001@s.whatsapp.net
       senderId: 15550000002@s.whatsapp.net


### PR DESCRIPTION
## What Problem This Solves

The channel-sharded QA Smoke experiment exposed three scenario-contract failures that were previously hidden behind mixed-channel suite planning:

- `channel-chat-baseline` shared transport state with another Telegram scenario, so its silence assertion observed an unrelated outbound marker.
- `slack-restart-resume` was selected for Crabline even though Crabline's Slack admin ingress does not deliver provider HTTP event callbacks into OpenClaw.
- `whatsapp-restart-resume` was selected for Crabline even though WhatsApp requires a linked Baileys auth store and Crabline does not seed linked credentials.

## Why This Change Was Made

- Mark `channel-chat-baseline` isolated so its silence-sensitive assertion owns a fresh transport and gateway.
- Mark the Slack and WhatsApp restart-resume scenarios `requiredChannelDriver: live`; they remain covered by real channel lanes instead of timing out in deterministic Crabline smoke.
- Add catalog regression assertions for both ownership decisions.
- Leave automatic QA Smoke disabled as established by #101185. Restoring CI belongs in the channel-compatible replacement for #101164, not this scenario-only repair.

## User Impact

Deterministic QA no longer schedules channel scenarios on drivers that cannot satisfy their runtime prerequisites, and the Telegram baseline cannot fail from another scenario's outbound traffic. This PR does not re-enable the automatic QA Smoke workflow.

## Evidence

- Preserved CI artifacts from run `28820059322`:
  - Telegram baseline failed after seeing `QA-TELEGRAM-REPLY-CHAIN-OK` from another shared scenario.
  - Slack recorded admin ingress twice but produced no Slack event callback or outbound delivery.
  - WhatsApp never reached a running account and timed out twice waiting for transport readiness.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts extensions/qa-lab/src/suite-planning.test.ts` — 61 tests passed.
- Focused local fallback: `channel-chat-baseline` + `telegram-reply-chain-exact-marker` passed together with concurrency 2 after isolation.
- Static profile check: deterministic smoke excludes Slack and WhatsApp restart scenarios; both remain available to live channel lanes.
- `git diff --check` — passed.
- Fresh autoreview — clean.

Remote Testbox proof was attempted first but Blacksmith remained queued; the focused Telegram repro used the documented local fallback.
