### PR TITLE
fix: prevent context-engine wedges after session rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
+- **Session reset transcripts:** create rotated transcript headers before notifying lifecycle consumers, preventing context-engine bootstrap checkpoints from wedging new sessions after automatic rotation.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.
 - **LM Studio embedding preload:** honor model- and provider-level context-window limits when preloading embedding models, preventing avoidable GPU out-of-memory failures. (#100750) Thanks @zak-li, @ZOOWH, and @hxz398.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
-- **Session reset transcripts:** create rotated transcript headers before notifying lifecycle consumers, preventing context-engine bootstrap checkpoints from wedging new sessions after automatic rotation.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.
 - **LM Studio embedding preload:** honor model- and provider-level context-window limits when preloading embedding models, preventing avoidable GPU out-of-memory failures. (#100750) Thanks @zak-li, @ZOOWH, and @hxz398.

--- a/extensions/device-pair/index.test.ts
+++ b/extensions/device-pair/index.test.ts
@@ -847,6 +847,30 @@ describe("device-pair /pair default setup code", () => {
     expect(requireText(result)).toContain("Gateway: ws://192.168.1.20:18789");
   });
 
+  it.each([
+    "ws://[fc00::1]:18789",
+    "ws://[fd7a:115c:a1e0::1]:18789",
+    "ws://[fe80::1]:18789",
+    "ws://[febf::1]:18789",
+  ])("allows IPv6 ULA and link-local cleartext setup url %s", async (publicUrl) => {
+    const command = registerPairCommand({
+      pluginConfig: {
+        publicUrl,
+      },
+    });
+    const result = await command.handler(
+      createCommandContext({
+        channel: "webchat",
+        args: "",
+        commandBody: "/pair",
+        gatewayClientScopes: INTERNAL_SETUP_SCOPES,
+      }),
+    );
+
+    expect(pluginApiMocks.issueDeviceBootstrapToken).toHaveBeenCalledTimes(1);
+    expect(requireText(result)).toContain(`Gateway: ${publicUrl}`);
+  });
+
   it("allows mdns cleartext setup urls", async () => {
     const command = registerPairCommand({
       pluginConfig: {
@@ -1014,6 +1038,30 @@ describe("device-pair /pair default setup code", () => {
     expect(pluginApiMocks.issueDeviceBootstrapToken).not.toHaveBeenCalled();
     expect(requireText(result)).toContain("prefer gateway.tailscale.mode=serve");
   });
+
+  it.each(["ws://[2001:db8::1]:18789", "ws://[fe7f::1]:18789", "ws://[fec0::1]:18789"])(
+    "rejects non-LAN IPv6 cleartext setup url %s before issuing setup codes",
+    async (publicUrl) => {
+      const command = registerPairCommand({
+        pluginConfig: {
+          publicUrl,
+        },
+      });
+      const result = await command.handler(
+        createCommandContext({
+          channel: "webchat",
+          args: "",
+          commandBody: "/pair",
+          gatewayClientScopes: INTERNAL_SETUP_SCOPES,
+        }),
+      );
+
+      expect(pluginApiMocks.issueDeviceBootstrapToken).not.toHaveBeenCalled();
+      expect(requireText(result)).toContain(
+        "Tailscale and public mobile pairing require a secure gateway URL",
+      );
+    },
+  );
 
   it("uses Tailscale Serve MagicDNS as a secure setup url", async () => {
     vi.mocked(resolveTailnetHostWithRunner).mockResolvedValueOnce("gateway.tailnet.ts.net");

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -1,5 +1,6 @@
 // Device Pair plugin entrypoint registers its OpenClaw integration.
 import { rm } from "node:fs/promises";
+import { isIP } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
@@ -242,12 +243,24 @@ function isPrivateIPv4(address: string): boolean {
   return false;
 }
 
+function isPrivateLanIPv6(address: string): boolean {
+  if (isIP(address) !== 6) {
+    return false;
+  }
+  const firstHextet = address.split(":", 1)[0] ?? "";
+  if (!/^[0-9a-f]{4}$/.test(firstHextet)) {
+    return false;
+  }
+  const value = Number.parseInt(firstHextet, 16);
+  return (value & 0xfe00) === 0xfc00 || (value & 0xffc0) === 0xfe80;
+}
+
 function isPrivateLanCleartextHost(host: string): boolean {
   const normalized = normalizeHostForIpCheck(host);
   if (normalized.endsWith(".local")) {
     return true;
   }
-  if (isPrivateIPv4(normalized)) {
+  if (isPrivateIPv4(normalized) || isPrivateLanIPv6(normalized)) {
     return true;
   }
   const octets = parseIPv4Octets(normalized);

--- a/src/config/sessions/store.session-lifecycle-mutation.test.ts
+++ b/src/config/sessions/store.session-lifecycle-mutation.test.ts
@@ -21,9 +21,11 @@ describe("session store lifecycle mutations", () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it("resets an entry while archiving the old transcript and creating the new header", async () => {
+  it("creates the new header before notifying observers and archiving the old transcript", async () => {
     const oldTranscriptPath = path.join(tempDir, "old-session.jsonl");
     const nextTranscriptPath = path.join(tempDir, "next-session.jsonl");
+    let nextTranscriptAtMutation: string | undefined;
+    let oldTranscriptExistsAtMutation = false;
     const now = Date.now();
     fs.writeFileSync(oldTranscriptPath, '{"type":"session","id":"old-session"}\n', "utf-8");
     await saveSessionStore(
@@ -57,16 +59,66 @@ describe("session store lifecycle mutations", () => {
         systemSent: false,
         abortedLastRun: false,
       }),
+      afterEntryMutation: () => {
+        nextTranscriptAtMutation = fs.readFileSync(nextTranscriptPath, "utf-8");
+        oldTranscriptExistsAtMutation = fs.existsSync(oldTranscriptPath);
+      },
     });
 
     const store = loadSessionStore(storePath, { skipCache: true });
     expect(store["agent:main:room"]?.sessionId).toBe("next-session");
     expect(store["Agent:Main:Room"]).toBeUndefined();
     expect(result.previousSessionId).toBe("old-session");
+    expect(nextTranscriptAtMutation).toContain('"id":"next-session"');
+    expect(oldTranscriptExistsAtMutation).toBe(true);
     expect(result.archivedTranscripts).toHaveLength(1);
     expect(result.archivedTranscripts[0]?.archivedPath).toContain(".jsonl.reset.");
     expect(fs.existsSync(oldTranscriptPath)).toBe(false);
     expect(fs.readFileSync(nextTranscriptPath, "utf-8")).toContain('"id":"next-session"');
+  });
+
+  it("preserves a successor header when a custom transcript path is reused", async () => {
+    const sessionKey = "agent:main:custom";
+    const transcriptPath = path.join(tempDir, "custom-transcript.jsonl");
+    const oldSessionId = "11111111-1111-4111-8111-111111111111";
+    const nextSessionId = "22222222-2222-4222-8222-222222222222";
+    fs.writeFileSync(transcriptPath, `{"type":"session","id":"${oldSessionId}"}\n`, "utf-8");
+    await saveSessionStore(
+      storePath,
+      {
+        [sessionKey]: {
+          sessionFile: transcriptPath,
+          sessionId: oldSessionId,
+          updatedAt: 1,
+        },
+      },
+      { skipMaintenance: true },
+    );
+
+    await resetSessionEntryLifecycle({
+      storePath,
+      target: {
+        canonicalKey: sessionKey,
+        storeKeys: [sessionKey],
+      },
+      buildNextEntry: ({ currentEntry }): SessionEntry => ({
+        ...currentEntry,
+        sessionFile: transcriptPath,
+        sessionId: nextSessionId,
+        updatedAt: 2,
+      }),
+    });
+
+    const archivedTranscript = fs
+      .readdirSync(tempDir)
+      .find((name) => name.startsWith("custom-transcript.jsonl.deleted."));
+    if (!archivedTranscript) {
+      throw new Error("expected the previous custom transcript to be archived");
+    }
+    expect(fs.readFileSync(path.join(tempDir, archivedTranscript), "utf-8")).toContain(
+      `"id":"${oldSessionId}"`,
+    );
+    expect(fs.readFileSync(transcriptPath, "utf-8")).toContain(`"id":"${nextSessionId}"`);
   });
 
   it("deletes an entry while archiving its transcript in the same lifecycle operation", async () => {

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -1190,6 +1190,18 @@ export async function resetSessionEntryLifecycle(params: {
     if (previousSessionId) {
       mutation.previousSessionId = previousSessionId;
     }
+    const reusesTranscriptPath =
+      previousSessionFile !== undefined &&
+      normalizePathForLifecycleComparison(previousSessionFile) ===
+        normalizePathForLifecycleComparison(nextSessionFile);
+    // Generated successor paths must exist before callbacks can checkpoint them.
+    // Reused custom paths keep the old callback/archive/header order to preserve observer semantics.
+    if (!reusesTranscriptPath) {
+      ensureLifecycleTranscriptHeader({
+        sessionFile: nextSessionFile,
+        sessionId: nextEntry.sessionId,
+      });
+    }
     await params.afterEntryMutation?.(mutation);
     const archivedTranscripts = await archiveLifecycleSessionTranscripts({
       sessionId: previousSessionId,
@@ -1198,10 +1210,12 @@ export async function resetSessionEntryLifecycle(params: {
       agentId: params.agentId,
       reason: "reset",
     });
-    ensureLifecycleTranscriptHeader({
-      sessionFile: nextSessionFile,
-      sessionId: nextEntry.sessionId,
-    });
+    if (reusesTranscriptPath) {
+      ensureLifecycleTranscriptHeader({
+        sessionFile: nextSessionFile,
+        sessionId: nextEntry.sessionId,
+      });
+    }
     const result: ResetSessionEntryLifecycleResult = {
       ...mutation,
       archivedTranscripts,

--- a/test/scripts/docs-i18n.test.ts
+++ b/test/scripts/docs-i18n.test.ts
@@ -1,10 +1,12 @@
 // Docs i18n tests cover the Go module and behavior fixtures backing docs translation.
-import { spawnSync } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, it } from "vitest";
 
+const execFileAsync = promisify(execFile);
 const hasGoToolchain = spawnSync("go", ["version"], { encoding: "utf8" }).status === 0;
 
 describe.skipIf(!hasGoToolchain)("docs-i18n Go module", () => {
@@ -33,20 +35,17 @@ describe.skipIf(!hasGoToolchain)("docs-i18n Go module", () => {
     }
   });
 
-  it.each([
+  it.concurrent.each([
     ["A-F", "^Test[A-F]"],
     ["G-L", "^Test[G-L]"],
     ["M-R", "^Test[M-R]"],
     ["S-Z", "^Test[S-Z]"],
-  ])("passes Go tests in the %s partition", (_partition, pattern) => {
-    const result = spawnSync(binaryPath, ["-test.count=1", `-test.run=${pattern}`], {
+  ])("passes Go tests in the %s partition", async (partition, pattern) => {
+    await execFileAsync(binaryPath, ["-test.count=1", `-test.run=${pattern}`], {
       cwd: "scripts/docs-i18n",
       encoding: "utf8",
       // The fixture verifies Codex auth never lands under the shared system temp directory.
-      env: { ...process.env, XDG_CACHE_HOME: path.join(tempDir, "cache") },
+      env: { ...process.env, XDG_CACHE_HOME: path.join(tempDir, "cache", partition) },
     });
-
-    expect(result.error).toBeUndefined();
-    expect(result.status, [result.stderr, result.stdout].filter(Boolean).join("\n")).toBe(0);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with context-engine plugins could have new sessions remain permanently stuck after automatic session rotation because lifecycle consumers observed the successor session before its transcript existed.

## Why This Change Was Made

Create generated successor transcript headers before lifecycle callbacks can checkpoint them, while preserving the existing callback/archive/header ordering for custom sessions that intentionally reuse a transcript path. Regression coverage exercises both path shapes and verifies the previous transcript remains available during the callback.

## User Impact

Automatic session rotation no longer wedges the next session when a context engine immediately checkpoints its bootstrap state. Custom transcript-path rotation keeps its existing archive behavior.

## Evidence

- Before: focused Blacksmith Testbox regression failed with `ENOENT` when the lifecycle callback read the generated successor transcript.
- After: `src/config/sessions/store.session-lifecycle-mutation.test.ts` — 6/6 passed.
- Integration: `src/gateway/server.sessions.reset-cleanup.test.ts` — 38/38 passed.
- Changed gate: `pnpm check:changed` — passed (typecheck, changed-file lint, architecture guards).
- Review: fresh autoreview completed with no accepted/actionable findings.
- Testbox: `tbx_01kwwc0gdd3qp3t6w4c3d26hfp` (Blacksmith; stopped after proof).
- Gap: no full live Lossless Claw E2E was run; the transient lifecycle boundary has no public probe without a controlled long-running plugin fixture. The focused callback-level regression reproduces the failing boundary directly.

AI-assisted. I reviewed the implementation, tests, and behavior and understand the change.
