### PR TITLE
ci: keep native landing validation off queued Blacksmith capacity

### DIFF
--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -32,9 +32,11 @@ jobs:
     permissions:
       contents: read
     name: "check"
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    # Pull requests only validate the hydration steps; real Testbox leases arrive via dispatch.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
     timeout-minutes: ${{ fromJSON(inputs.timeout_minutes || '120') }}
     steps:
+      # An empty pull-request input intentionally selects the pinned action's validation mode.
       - name: Begin Testbox
         uses: useblacksmith/begin-testbox@233448af4bfdc6fca509a7f0974411ac6d8a8043
         with:
@@ -175,6 +177,7 @@ jobs:
           OPENCLAW_GEMINI_SETTINGS_JSON: ${{ secrets.OPENCLAW_GEMINI_SETTINGS_JSON }}
         run: bash scripts/ci-hydrate-testbox-env.sh
 
+      # Without lease state, the pinned action reports validation success and exits.
       - name: Run Testbox
         uses: useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d
         if: always()

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -36,8 +36,9 @@ jobs:
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}
     timeout-minutes: ${{ fromJSON(inputs.timeout_minutes || '120') }}
     steps:
-      # An empty pull-request input intentionally selects the pinned action's validation mode.
+      # Testbox lifecycle actions require Blacksmith VM metadata; PRs validate our setup steps only.
       - name: Begin Testbox
+        if: github.event_name == 'workflow_dispatch'
         uses: useblacksmith/begin-testbox@233448af4bfdc6fca509a7f0974411ac6d8a8043
         with:
           testbox_id: ${{ inputs.testbox_id }}
@@ -177,9 +178,8 @@ jobs:
           OPENCLAW_GEMINI_SETTINGS_JSON: ${{ secrets.OPENCLAW_GEMINI_SETTINGS_JSON }}
         run: bash scripts/ci-hydrate-testbox-env.sh
 
-      # Without lease state, the pinned action reports validation success and exits.
       - name: Run Testbox
         uses: useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d
-        if: always()
+        if: github.event_name == 'workflow_dispatch' && always()
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -846,7 +846,7 @@ jobs:
       contents: read
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_native_i18n == 'true' }}
-    runs-on: ${{ github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -119,6 +119,16 @@ describe("ci workflow guards", () => {
     expect(readFileSync(".github/workflows/ci.yml", "utf8")).toContain(
       "OPENCLAW_CI_RUN_ANDROID: ${{ github.event_name == 'workflow_dispatch' && (inputs.release_gate || inputs.include_android) && 'true' || steps.changed_scope.outputs.run_android || 'false' }}",
     );
+
+    for (const [jobName, job] of Object.entries(workflow.jobs)) {
+      const runsOn = (job as { "runs-on"?: unknown })["runs-on"];
+      if (typeof runsOn !== "string" || !runsOn.includes("blacksmith-")) {
+        continue;
+      }
+      expect(runsOn, `${jobName} must use GitHub-hosted capacity for release gates`).toContain(
+        "github.event_name == 'workflow_dispatch'",
+      );
+    }
   });
 
   it("pins every external GitHub Action reference to a full commit SHA", () => {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -141,9 +141,18 @@ describe("ci workflow guards", () => {
     expect(workflow.jobs.check["runs-on"]).toBe(
       "${{ github.event_name == 'pull_request' && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}",
     );
-    expect(workflow.jobs.check.steps[0]).toMatchObject({
-      name: "Begin Testbox",
+    const beginStep = workflow.jobs.check.steps.find(
+      (step: { name?: string }) => step.name === "Begin Testbox",
+    );
+    const runStep = workflow.jobs.check.steps.find(
+      (step: { name?: string }) => step.name === "Run Testbox",
+    );
+    expect(beginStep).toMatchObject({
+      if: "github.event_name == 'workflow_dispatch'",
       with: { testbox_id: "${{ inputs.testbox_id }}" },
+    });
+    expect(runStep).toMatchObject({
+      if: "github.event_name == 'workflow_dispatch' && always()",
     });
   });
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -21,6 +21,10 @@ function readBuildArtifactsTestboxWorkflow() {
   return parse(readFileSync(".github/workflows/ci-build-artifacts-testbox.yml", "utf8"));
 }
 
+function readTestboxWorkflow() {
+  return parse(readFileSync(".github/workflows/ci-check-testbox.yml", "utf8"));
+}
+
 function readWorkflowSanityWorkflow() {
   return parse(readFileSync(".github/workflows/workflow-sanity.yml", "utf8"));
 }
@@ -129,6 +133,18 @@ describe("ci workflow guards", () => {
         "github.event_name == 'workflow_dispatch'",
       );
     }
+  });
+
+  it("keeps Testbox pull request validation off leased runner capacity", () => {
+    const workflow = readTestboxWorkflow();
+
+    expect(workflow.jobs.check["runs-on"]).toBe(
+      "${{ github.event_name == 'pull_request' && 'ubuntu-24.04' || 'blacksmith-32vcpu-ubuntu-2404' }}",
+    );
+    expect(workflow.jobs.check.steps[0]).toMatchObject({
+      name: "Begin Testbox",
+      with: { testbox_id: "${{ inputs.testbox_id }}" },
+    });
   });
 
   it("pins every external GitHub Action reference to a full commit SHA", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1300,7 +1300,7 @@ describe("package artifact reuse", () => {
     ).toHaveLength(4);
   });
 
-  it("finalizes Testbox delegation even when setup or the remote command fails", () => {
+  it("finalizes dispatched Testbox delegation even when setup or the remote command fails", () => {
     const workflow = readFileSync(CI_CHECK_TESTBOX_WORKFLOW, "utf8");
     const checkTestboxJob = workflowJob(CI_CHECK_TESTBOX_WORKFLOW, "check");
     const runTestboxStep = workflowStep(checkTestboxJob, "Run Testbox");
@@ -1324,7 +1324,7 @@ describe("package artifact reuse", () => {
       "${{ fromJSON(inputs.timeout_minutes || '120') }}",
     );
     expect(runTestboxStep.uses).toContain("useblacksmith/run-testbox@");
-    expect(runTestboxStep.if).toBe("always()");
+    expect(runTestboxStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
     expect(runArmTestboxStep.if).toBe("always()");
     expect(runBuildArtifactsTestboxStep.if).toBe("always()");
     expect(runWindowsTestboxStep.if).toBe("always()");


### PR DESCRIPTION
## What Problem This Solves

Native landing validation could still stall on exhausted Blacksmith capacity in two places: the `native-i18n` release-gate job ignored the repository's GitHub-hosted manual-dispatch fallback, and pull-request validation of the Testbox workflow requested a real leased runner even though that event only needs to validate the repository-owned setup path.

## Why This Change Was Made

Routes `native-i18n` manual dispatches to the same GitHub-hosted capacity used by every other release-gate job. Testbox pull-request validation now uses `ubuntu-24.04` and skips the Blacksmith lifecycle actions; manual dispatch remains the sole owner of real Testbox leases. Structural workflow tests enforce both event-to-runner contracts.

## User Impact

No product behavior changes. Maintainers can use exact-SHA release gates and validate Testbox workflow edits when Blacksmith capacity is unavailable, while real dispatched Testbox runs retain the existing lease lifecycle.

## Evidence

- Capacity failure: release gates [28822648843](https://github.com/openclaw/openclaw/actions/runs/28822648843) and [28822648526](https://github.com/openclaw/openclaw/actions/runs/28822648526) each completed 108 jobs successfully while only `native-i18n` remained queued on Blacksmith.
- Lifecycle discovery: intermediate Testbox validation [28825947574](https://github.com/openclaw/openclaw/actions/runs/28825947574) reached `ubuntu-24.04` but proved the pinned lifecycle action requires Blacksmith VM metadata.
- Final Testbox validation [28826264853](https://github.com/openclaw/openclaw/actions/runs/28826264853) passed at exact head `af22a2db93fe830adb6eaa16fe2f4aedf46afa58` on `ubuntu-24.04`; lifecycle actions were skipped as designed.
- ARM Testbox validation [28826264846](https://github.com/openclaw/openclaw/actions/runs/28826264846) and Workflow Sanity [28826264873](https://github.com/openclaw/openclaw/actions/runs/28826264873) passed at the same head.
- AWS Crabbox `run_ae3ccb7c0beb`: `ci-workflow-guards` and `package-acceptance-workflow` passed all 77 tests.
- Exact-head release gate [28826377035](https://github.com/openclaw/openclaw/actions/runs/28826377035): all 109 substantive jobs passed; `native-i18n` ran successfully on `ubuntu-24.04`.
- `oxfmt --check` on the two changed workflow tests and workflows: passed.
- `git diff --check`: passed.
- Fresh Codex autoreview at the exact head: clean, 0.87 confidence.
