### PR TITLE
feat: sleep tool — pause execution without burning tokens

### DIFF
--- a/commit-msg.txt
+++ b/commit-msg.txt
@@ -1,0 +1,14 @@
+feat: sleep tool — pause execution without burning tokens
+
+Adds a sleep tool that allows the agent to suspend the current turn for
+N seconds (1-600) without burning tokens or spamming poll loops.
+
+How it works:
+1. Agent calls sleep({ seconds: 300, message: "Check status" })
+2. Tool schedules a one-shot cron at job to fire a systemEvent wake
+3. Tool returns status yielded - existing yield detector maps to end_turn
+4. When the timer fires the wake event resumes the session
+
+Same pattern as sessions_yield but with an automatic timer.
+
+Closes #101190

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -63,6 +63,7 @@ import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
 import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
 import { createSkillWorkshopTool } from "./tools/skill-workshop-tool.js";
+import { createSleepTool } from "./tools/sleep-tool.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { createTranscriptsTool } from "./tools/transcripts-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
@@ -527,6 +528,33 @@ export function createOpenClawTools(
     createSessionsYieldTool({
       sessionId: options?.sessionId,
       onYield: options?.onYield,
+    }),
+    createSleepTool({
+      sessionId: options?.sessionId,
+      onYield: options?.onYield,
+      scheduleWake: options?.onYield
+        ? (seconds, message) => {
+            // Schedule a one-shot cron `at` job that fires a systemEvent wake.
+            // The wake message is injected into the session, resuming the agent
+            // turn with full context intact.
+            const at = new Date(Date.now() + seconds * 1000).toISOString();
+            return openClawToolsDeps.callGateway({
+              method: "POST",
+              path: "/cron",
+              body: {
+                action: "add",
+                job: {
+                  name: `sleep-${Date.now()}`,
+                  schedule: { kind: "at", at },
+                  payload: { kind: "systemEvent", text: message },
+                  deleteAfterRun: true,
+                  enabled: true,
+                },
+                sessionKey: options?.agentSessionKey,
+              },
+            });
+          }
+        : undefined,
     }),
     createSubagentsTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/prompt-surface.ts
+++ b/src/agents/prompt-surface.ts
@@ -31,6 +31,7 @@ export function buildOpenClawToolFallbackText(params: {
       "- sessions_send: send to another session",
       "- sessions_spawn: spawn an isolated sub-agent session",
       "- sessions_yield: end this turn and wait for sub-agent completion events",
+      "- sleep: pause execution for N seconds (1-600) without burning tokens; turn ends and resumes on timer",
       "- subagents: list active/recent sub-agent runs",
       '- session_status: show usage/time/model state and answer "what model are we using?"',
     ].join("\n");

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -28,6 +28,7 @@ export const DEFAULT_TOOL_ALLOW = [
   "sessions_send",
   "sessions_spawn",
   "sessions_yield",
+  "sleep",
   "subagents",
   "session_status",
 ] as const;

--- a/src/agents/tools/sleep-tool.test.ts
+++ b/src/agents/tools/sleep-tool.test.ts
@@ -1,0 +1,101 @@
+// sleep tool tests cover duration validation, wake scheduling, and yield behavior.
+import { describe, expect, it, vi } from "vitest";
+import { createSleepTool } from "./sleep-tool.js";
+
+type SleepDetails = {
+  status?: string;
+  message?: string;
+  error?: string;
+  seconds?: number;
+};
+
+describe("sleep tool", () => {
+  it("returns error when no sessionId is provided", async () => {
+    const onYield = vi.fn();
+    const scheduleWake = vi.fn();
+    const tool = createSleepTool({ onYield, scheduleWake });
+    const result = await tool.execute("call-1", {});
+    const details = result.details as SleepDetails;
+    expect(details.status).toBe("error");
+    expect(details.error).toBe("No session context");
+    expect(onYield).not.toHaveBeenCalled();
+    expect(scheduleWake).not.toHaveBeenCalled();
+  });
+
+  it("returns error without onYield callback", async () => {
+    const tool = createSleepTool({ sessionId: "test-session" });
+    const result = await tool.execute("call-1", { seconds: 60 });
+    const details = result.details as SleepDetails;
+    expect(details.status).toBe("error");
+    expect(details.error).toBe("Yield not supported in this context");
+  });
+
+  it("rejects sleep duration over 600 seconds", async () => {
+    const onYield = vi.fn();
+    const scheduleWake = vi.fn();
+    const tool = createSleepTool({ sessionId: "test-session", onYield, scheduleWake });
+    const result = await tool.execute("call-1", { seconds: 700 });
+    const details = result.details as SleepDetails;
+    expect(details.status).toBe("error");
+    expect(details.error).toContain("600");
+    expect(onYield).not.toHaveBeenCalled();
+    expect(scheduleWake).not.toHaveBeenCalled();
+  });
+
+  it("rejects sleep duration under 1 second", async () => {
+    const onYield = vi.fn();
+    const scheduleWake = vi.fn();
+    const tool = createSleepTool({ sessionId: "test-session", onYield, scheduleWake });
+    const result = await tool.execute("call-1", { seconds: 0 });
+    const details = result.details as SleepDetails;
+    expect(details.status).toBe("error");
+    expect(details.error).toContain("at least 1");
+  });
+
+  it("schedules wake event then yields for valid duration", async () => {
+    const onYield = vi.fn();
+    const scheduleWake = vi.fn();
+    const tool = createSleepTool({ sessionId: "test-session", onYield, scheduleWake });
+    const result = await tool.execute("call-1", { seconds: 300 });
+    const details = result.details as SleepDetails;
+    expect(details.status).toBe("yielded");
+    expect(details.seconds).toBe(300);
+    expect(scheduleWake).toHaveBeenCalledOnce();
+    expect(scheduleWake).toHaveBeenCalledWith(300, expect.stringContaining("Sleep timer fired"));
+    expect(onYield).toHaveBeenCalledOnce();
+    expect(onYield).toHaveBeenCalledWith(expect.stringContaining("300s"));
+  });
+
+  it("passes custom message through to wake and yield", async () => {
+    const onYield = vi.fn();
+    const scheduleWake = vi.fn();
+    const tool = createSleepTool({ sessionId: "test-session", onYield, scheduleWake });
+    const result = await tool.execute("call-1", {
+      seconds: 60,
+      message: "Check Planclave session 33e6da31",
+    });
+    const details = result.details as SleepDetails;
+    expect(details.status).toBe("yielded");
+    expect(scheduleWake).toHaveBeenCalledWith(60, "Check Planclave session 33e6da31");
+    expect(onYield).toHaveBeenCalledWith(
+      expect.stringContaining("Check Planclave session 33e6da31"),
+    );
+  });
+
+  it("works without scheduleWake callback (testing mode)", async () => {
+    const onYield = vi.fn();
+    const tool = createSleepTool({ sessionId: "test-session", onYield });
+    const result = await tool.execute("call-1", { seconds: 30 });
+    const details = result.details as SleepDetails;
+    expect(details.status).toBe("yielded");
+    expect(onYield).toHaveBeenCalledOnce();
+  });
+
+  it("defaults to 60 seconds when seconds not provided", async () => {
+    const onYield = vi.fn();
+    const scheduleWake = vi.fn();
+    const tool = createSleepTool({ sessionId: "test-session", onYield, scheduleWake });
+    await tool.execute("call-1", {});
+    expect(scheduleWake).toHaveBeenCalledWith(60, expect.any(String));
+  });
+});

--- a/src/agents/tools/sleep-tool.ts
+++ b/src/agents/tools/sleep-tool.ts
@@ -1,0 +1,103 @@
+/**
+ * Sleep/wait built-in tool.
+ *
+ * Suspends the current turn for N seconds by yielding and scheduling a
+ * one-shot wake event.  This allows the agent to pause without burning tokens
+ * or spamming poll loops.
+ *
+ * Behaviour:
+ *   1. Schedule a one-shot wake event after `seconds` via a one-shot cron `at` job
+ *   2. Return `{ status: "yielded" }` — the existing yield detector in
+ *      `subagent-yield-output.ts` already handles this generically
+ *   3. The gateway resumes the session when the wake fires
+ *
+ * Linked issue: openclaw/openclaw#101190
+ */
+
+import { Type } from "typebox";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+
+const SleepToolSchema = Type.Object({
+  seconds: Type.Number({
+    minimum: 1,
+    maximum: 600,
+    description:
+      "Seconds to sleep before resuming (1–600). Use instead of polling loops for long-running external processes.",
+  }),
+  message: Type.Optional(
+    Type.String({
+      description: "Message injected when waking (reminder context so the agent can resume).",
+    }),
+  ),
+});
+
+/** Creates the sleep tool for runtimes that support yield callbacks. */
+export function createSleepTool(opts?: {
+  sessionId?: string;
+  /** End the current turn (same callback as sessions_yield). */
+  onYield?: (message: string) => Promise<void> | void;
+  /**
+   * Schedule a one-shot wake event. The implementer creates a transient cron
+   * `at` job (or equivalent wake mechanism) that injects `message` as a system
+   * event into the session after `seconds` has elapsed.
+   *
+   * If omitted the tool yields immediately without scheduling — useful for
+   * testing or runtimes without cron support.
+   */
+  scheduleWake?: (seconds: number, message: string) => Promise<void> | void;
+}): AnyAgentTool {
+  return {
+    label: "Sleep",
+    name: "sleep",
+    description:
+      "Pause execution for N seconds without burning tokens. The turn ends immediately and resumes when the timer fires (max 600 s). Use instead of polling loops for long-running external processes.",
+    parameters: SleepToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const seconds = readNumberParam(params, "seconds") ?? 60;
+      const message =
+        readStringParam(params, "message") ?? "Sleep timer fired. Resume pending work.";
+
+      if (!opts?.sessionId) {
+        return jsonResult({ status: "error", error: "No session context" });
+      }
+
+      if (!opts?.onYield) {
+        return jsonResult({
+          status: "error",
+          error: "Yield not supported in this context",
+        });
+      }
+
+      if (seconds > 600) {
+        return jsonResult({
+          status: "error",
+          error: "Max sleep duration is 600 seconds. Use cron for longer waits.",
+        });
+      }
+
+      if (seconds < 1) {
+        return jsonResult({
+          status: "error",
+          error: "Sleep duration must be at least 1 second.",
+        });
+      }
+
+      // Schedule wake event before yielding the turn
+      if (opts.scheduleWake) {
+        await opts.scheduleWake(seconds, message);
+      }
+
+      // Yield — the generic yield detector sees `{ status: "yielded" }` and
+      // maps it to stopReason: "end_turn", exactly like sessions_yield.
+      await opts.onYield(`Sleeping for ${seconds}s: ${message}`);
+
+      return jsonResult({
+        status: "yielded",
+        message: `Sleeping for ${seconds}s. Will resume with: ${message}`,
+        seconds,
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Problem

When an agent needs to wait for an external process to complete (background tasks, API rate limits, deployment pipelines, long-running builds), it currently has two bad options:

1. **Poll in a loop** — burn tokens on repeated tool calls checking status every few seconds. The agent becomes noisy, the turn stays open, and the user sees spam. We hit this hard with Planclave polling — 20+ poll calls burning tokens while waiting for a multi-agent planning cycle to finish.

2. **Use cron wake events as a workaround** — schedule a one-shot cron job to fire a wake event after N seconds. This works but is awkward: it creates disposable jobs, fragments turn context (wake comes back as a system event, not a continuation), and requires the agent to reconstruct its state.

Neither option is what users actually want: "wait 5 minutes, then continue where I left off."

## Proposal

Add a `sleep` tool that allows the agent to suspend the current turn and resume it after a specified delay.

### API

```
sleep({ seconds: 300, resumeMessage?: "Check Planclave session status" })
```

### Behavior

1. Agent calls `sleep({ seconds: N })`
2. Gateway **immediately ends the current turn** (no token burn during wait)
3. Gateway schedules an internal wake event after N seconds
4. When the timer fires, the gateway injects a system event and resumes the agent loop in the same session
5. Agent picks up with full turn context intact and can continue execution

### Key Requirements

- **Hard cap on duration** — configurable max (suggest 600s default) to prevent abuse
- **No token burn while waiting** — the turn must truly end, not just block
- **Same session, same context** — resume should feel like a continuation, not a new conversation
- **Interruptible** — if the user sends a message during the wait, it should cancel the timer and process the message immediately
- **Fallback** — if Gateway restarts during a sleep, the timer should not survive (fire-and-forget, not durable)

### Implementation Notes

The existing cron infrastructure already supports one-shot `at` schedules and wake events. The new piece is:

1. A thin wrapper tool that creates a one-shot wake event and signals the gateway to end the turn cleanly
2. A `resume_turn` primitive in the gateway that injects a wake event and re-enters the agent loop without user input
3. The `end_turn` signal — the tool response needs to tell the gateway "close this turn, I'll be back"

The `endTurn` concept already exists in the talk-mode session controller. The agent loop already handles system events and cron wake events. Most of the plumbing is there.

### Use Cases

- **Polling long-running processes** — Planclave cycles, CI builds, deployments, background tasks
- **Rate limit cooldowns** — "I got a 429, wait 60s then retry"
- **Awaiting external state changes** — "wait for the file to appear on the server"
- **Patient monitoring** — heartbeat-style checks where the agent doesn't need to respond to the user between polls

### Current Workarounds and Their Problems

- **Poll in a loop** — Burns tokens, spams output, turns feel slow
- **Cron wake event** — Fragmented context, disposable job creation, awkward
- **Sub-agent monitoring** — Overkill for simple waits, extra complexity
- **sessions_yield** — Only works for spawned sub-agents, not self-pauses

### Related

- #50996 (closed) — Interruptible tool calls (related pain point, different solution)

## Environment

- OpenClaw (latest)
- Windows, macOS, Linux
- All channels (webchat, Discord, Telegram, etc.)
