### PR TITLE
fix(ai): preserve nextChar after invalid escape in repairJson()

### DIFF
--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -93,6 +93,7 @@ export function repairJson(json: string): string {
       }
 
       repaired += "\\\\";
+      repaired += nextChar;  // fix #14452: preserve nextChar after invalid escape
       stringValuePrefix += "\\";
       continue;
     }


### PR DESCRIPTION
Closes #14452

## Problem

`repairJson()` dropped `nextChar` after invalid escape sequences, causing literal `\n in `write()` output instead of real newlines (0x0A).

## Fix

Added `repaired += nextChar;` after the invalid escape handling line in `json-parse.ts`.

## Testing

Verified on two different systems (.133 Spark ARM64 and .85 VM Intel):
- Tests 1-4: write(), heredoc, printf, echo -e all produce real 0x0A bytes
- Tests 5-6: Multi-line JSON/Python files with escape sequences work correctly
- Test 7: Unicode/emoji/Tab characters all work
- All 7 tests pass on both architectures

## Root Cause

In `json-parse.ts`, when an invalid escape is detected, the function doubled the backslash but dropped the next character entirely.