### PR TITLE
fix(ci): keep release-gate i18n on hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -846,7 +846,7 @@ jobs:
       contents: read
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_native_i18n == 'true' }}
-    runs-on: ${{ github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04') }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -119,6 +119,9 @@ describe("ci workflow guards", () => {
     expect(readFileSync(".github/workflows/ci.yml", "utf8")).toContain(
       "OPENCLAW_CI_RUN_ANDROID: ${{ github.event_name == 'workflow_dispatch' && (inputs.release_gate || inputs.include_android) && 'true' || steps.changed_scope.outputs.run_android || 'false' }}",
     );
+    expect(workflow.jobs["native-i18n"]["runs-on"]).toContain(
+      "github.event_name == 'workflow_dispatch'",
+    );
   });
 
   it("pins every external GitHub Action reference to a full commit SHA", () => {


### PR DESCRIPTION
## What Problem This Solves

The exact-SHA hosted release gate still routed `native-i18n` to Blacksmith. During Blacksmith admission stalls, that single queued job prevented the hosted fallback workflow from completing even though every other lane ran on GitHub-hosted runners.

## Why This Change Was Made

Route `native-i18n` to `ubuntu-24.04` for manual workflow dispatches, matching the existing release-gate routing used by the other CI jobs. A workflow guard keeps this lane from silently regressing.

## User Impact

Maintainers can complete an exact-SHA hosted release gate during Blacksmith queue stalls. Normal pull request and `main` runs continue using the existing Blacksmith runner.

## Evidence

- `node scripts/check-workflows.mjs`
- `./node_modules/.bin/oxfmt --check .github/workflows/ci.yml test/scripts/ci-workflow-guards.test.ts`
- `git diff --check`
- Fresh autoreview: clean, no actionable findings (0.86 confidence)
- Live evidence: two exact-SHA release-gate runs reached 99/100 and 98/100 successful jobs respectively, with `native-i18n` as the only Blacksmith-queued lane.
