### PR TITLE
fix: npm upgrade install fails with InstalledDistScanLimitError as packaged dist grows

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -30,7 +30,12 @@ const DEFAULT_PACKAGE_ROOT = join(scriptDir, "..");
 const DISABLE_POSTINSTALL_ENV = "OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL";
 const DISABLE_PLUGIN_REGISTRY_MIGRATION_ENV = "OPENCLAW_DISABLE_PLUGIN_REGISTRY_MIGRATION";
 const DIST_INVENTORY_PATH = "dist/postinstall-inventory.json";
-export const MAX_INSTALLED_DIST_SCAN_ENTRIES = 25_000;
+// One budget covers all three prune walks (legacy-deps prepass, file listing,
+// empty-dir sweep). npm upgrades transiently hold old+new content-hashed dist
+// files, so a real upgrade scan totals ~24k entries today (2026.6.x); keep ~4x
+// headroom so dist growth cannot fail `npm install -g` while still refusing
+// pathological/unbounded trees.
+export const MAX_INSTALLED_DIST_SCAN_ENTRIES = 100_000;
 const LEGACY_PLUGIN_RUNTIME_DEPS_DIR = "plugin-runtime-deps";
 const BAILEYS_MEDIA_FILE = join("node_modules", "baileys", "lib", "Utils", "messages-media.js");
 const BAILEYS_MEDIA_HOTFIX_NEEDLE = [

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -991,7 +991,10 @@ describe("bundled plugin postinstall", () => {
     ).toThrow(
       "installed dist scan exceeded 1 filesystem entries; refusing to scan unbounded package contents",
     );
-    expect(MAX_INSTALLED_DIST_SCAN_ENTRIES).toBeGreaterThan(1);
+    // One budget spans all three prune walks, and npm upgrades scan old+new
+    // content-hashed dist files (~24k entries as of 2026.6.x). A cap without
+    // several-x headroom fails `npm install -g openclaw` for upgrading users.
+    expect(MAX_INSTALLED_DIST_SCAN_ENTRIES).toBeGreaterThanOrEqual(100_000);
   });
 
   it("uses one packaged dist scan budget across listing and pruning phases", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `npm install -g openclaw` was one release away from failing for every upgrading user with `InstalledDistScanLimitError` during postinstall.

`pruneInstalledPackageDist` creates one shared `InstalledDistScanBudget` (cap `MAX_INSTALLED_DIST_SCAN_ENTRIES = 25_000`) consumed across all three prune walks: the legacy-dependency prepass, the dist file listing, and the empty-directory sweep. On an npm upgrade the dist dir transiently contains old+new content-hash-named files: release 2026.6.11 dist has ~8,304 entries and current `main` dist ~7,770, so an upgrade walk totals roughly legacy (~150) + listing (~16k old+new union) + empty-dir sweep (~8k) ≈ 24k entries — within ~4% of the 25k cap. One more release of dist growth trips the guard and aborts install.

## Why This Change Was Made

Raise the cap to `100_000` (several-x headroom over the observed ~24k upgrade worst case) while keeping the unbounded-scan guard intact. Per-walk budgets were considered and rejected: the file-listing walk alone scans the ~16k old+new union during upgrades, so a 25k per-walk cap only defers the same failure; a single total-work bound with real headroom keeps the guard semantics simple and still refuses pathological/unbounded trees. The sizing rationale is documented at the constant, and the test now ratchets the cap at >= 100k so it cannot be quietly lowered back into the failure zone.

## User Impact

`npm install -g openclaw` upgrades keep working as the packaged dist grows; no behavior change otherwise. The safety guard against runaway/unbounded postinstall scans (e.g. dist trees doubled by macOS AppleDouble files beyond the cap) remains.

## Evidence

- Verified 2026-07-06 by hand: a dist doubled by macOS AppleDouble files (15.5k entries) reliably fails install with `InstalledDistScanLimitError` under the old 25k cap.
- Focused suite on Linux Node 24 (Crabbox `local-container`, `node:24-bookworm`, lease `cbx_e8d2afa21348`, full `pnpm install --frozen-lockfile`): `pnpm test test/scripts/postinstall-bundled-plugins.test.ts` — 1 file, 39/39 tests passed, exit 0.
- Autoreview (codex, gpt-5.5): clean, no accepted/actionable findings.
