### PR TITLE
fix: gateway Crestodian chat on Codex-harness models reports its crestodian tool as missing

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1632,6 +1632,24 @@ describe("runCodexAppServerAttempt", () => {
     expect(sessionsYield).not.toHaveProperty("deferLoading");
   });
 
+  it("registers the ring-zero crestodian tool directly in searchable loading", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    // Ring-zero Crestodian runs (gateway crestodian.chat, TUI) carry exactly
+    // one tool; searchable loading must never defer it behind tool_search.
+    params.crestodianTool = { surface: "gateway" };
+
+    const toolBridge = createCodexToolBridgeForTest(params, [
+      createRuntimeDynamicTool("crestodian"),
+    ]);
+
+    const specs = flattenSpecsWithNamespace(toolBridge.specs);
+    const crestodian = specs.find((tool) => tool.name === "crestodian");
+    expect(crestodian).toBeDefined();
+    expect(crestodian).not.toHaveProperty("namespace");
+    expect(crestodian).not.toHaveProperty("deferLoading");
+  });
+
   it("keeps the heartbeat schema deferred and stable across normal and heartbeat turns", async () => {
     testing.setOpenClawCodingToolsFactoryForTests((options) => [
       createRuntimeDynamicTool("message"),

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3914,10 +3914,18 @@ function handleApprovalRequest(params: {
 }
 
 function resolveCodexDynamicToolDirectNames(params: EmbeddedRunAttemptParams): string[] {
-  if (params.sourceReplyDeliveryMode !== "message_tool_only") {
-    return [];
+  const names: string[] = [];
+  // Ring-zero Crestodian runs act ONLY through the single `crestodian` tool
+  // (see CRESTODIAN_AGENT_SYSTEM_PROMPT). Deferring it into the searchable
+  // tool_search namespace makes the agent report the tool as missing, so it
+  // must register directly regardless of codexDynamicToolsLoading.
+  if (params.crestodianTool) {
+    names.push("crestodian");
   }
-  return ["message"];
+  if (params.sourceReplyDeliveryMode === "message_tool_only") {
+    names.push("message");
+  }
+  return names;
 }
 
 export const testing = {

--- a/src/crestodian/assistant-backends.ts
+++ b/src/crestodian/assistant-backends.ts
@@ -94,9 +94,10 @@ export function buildCodexAppServerPlannerConfig(workspaceDir: string): OpenClaw
       entries: {
         codex: {
           enabled: true,
-          // Crestodian carries a single ring-zero tool; advertise it directly
-          // instead of hiding it behind the Codex tool-search index.
-          config: { codexDynamicToolsLoading: "direct" },
+          // No codexDynamicToolsLoading override: the harness force-registers
+          // the ring-zero crestodian tool directly for every crestodian run
+          // (resolveCodexDynamicToolDirectNames), and a per-run config override
+          // never reaches the harness pluginConfig on the gateway anyway.
         },
       },
     },


### PR DESCRIPTION
Closes #101216

## What Problem This Solves

Fixes an issue where users onboarding through the gateway Crestodian chat (macOS app, `crestodian.chat` RPC) with a Codex-harness default model (`openai/gpt-5.5`) would get replies like "I can't inspect your current OpenClaw status from here because the crestodian tool isn't exposed in this session" — the setup helper could not run status, doctor, config, or channel operations at all on that path.

The Codex app-server harness defers dynamic tools behind its tool-search namespace by default (`codexDynamicToolsLoading: "searchable"`), and `resolveCodexDynamicToolDirectNames` never registered `crestodian` directly. The system prompt requires the agent to act only through that tool, so the model correctly reported it as missing. The intended fallback-config override (`codexDynamicToolsLoading: "direct"`) was never applied on the configured-model path and, being a per-run config, never reaches the harness `pluginConfig` (resolved from the process-global config snapshot) anyway.

## Why This Change Was Made

Ring-zero Crestodian runs carry exactly one OpenClaw tool, so hiding it behind tool-search is never correct. The fix registers `crestodian` as a direct tool spec whenever the run carries `crestodianTool`, using the existing per-run direct-names seam (same mechanism that keeps `agents_list`/`sessions_spawn`/`sessions_yield` direct). This is config-independent and covers gateway + TUI, configured-model + configless-fallback paths uniformly. The now-redundant (and gateway-ineffective) `codexDynamicToolsLoading: "direct"` override in the Crestodian fallback backend config is removed so there is one canonical mechanism.

## User Impact

The Crestodian onboarding/setup chat can inspect and repair OpenClaw state again when the configured default model runs through the Codex agent harness (`openai`/`codex` providers). No config or behavior change for other runs; `message_tool_only` direct registration is preserved.

## Evidence

- Regression test: `registers the ring-zero crestodian tool directly in searchable loading` in `extensions/codex/src/app-server/run-attempt.test.ts` proves a `crestodianTool`-carrying run emits a direct spec (no `namespace`/`deferLoading`) under default searchable loading; it fails without the fix.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts` — 118/118 passed.
- `node scripts/run-vitest.mjs src/crestodian` — 43 files, 287/287 passed.
- oxlint + oxfmt clean on changed files; structured autoreview (Codex `gpt-5.5`) clean, no accepted findings.
- Known gap: tests ran via the local vitest fallback because all Crabbox/Testbox leases were queued; tsgo lanes ride on PR CI. Original failure reproduced 2026-07-06 in a Parallels macOS VM against a branch gateway; live gateway re-verification pending a Testbox slot.
