### PR TITLE
fix(gateway): don't over-claim a crash on a 1006 abnormal close

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -1642,10 +1642,6 @@ describe("callGateway error details", () => {
   });
 
   it("does not over-claim a gateway crash on a 1006 abnormal close", async () => {
-    // Regression for #100941 ask 3: 1006 is an abnormal closure with no close
-    // frame, most often a connection dropped under load — not a crash. The
-    // human-readable message must lead with the actionable cause and not assert
-    // that the gateway crashed as a co-equal possibility.
     startMode = "close";
     closeCode = 1006;
     closeReason = "";
@@ -1657,7 +1653,9 @@ describe("callGateway error details", () => {
     });
 
     const message = (err as { message: string }).message;
-    expect(message).toMatch(/connection dropped.*retry/i);
+    expect(message).toContain(
+      "Connection dropped without a close frame (retry; check network and gateway load)",
+    );
     expect(message).not.toContain("crashed or was terminated unexpectedly");
     expect(message).toContain("Run `openclaw doctor`");
   });

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -1641,6 +1641,27 @@ describe("callGateway error details", () => {
     });
   });
 
+  it("does not over-claim a gateway crash on a 1006 abnormal close", async () => {
+    // Regression for #100941 ask 3: 1006 is an abnormal closure with no close
+    // frame, most often a connection dropped under load — not a crash. The
+    // human-readable message must lead with the actionable cause and not assert
+    // that the gateway crashed as a co-equal possibility.
+    startMode = "close";
+    closeCode = 1006;
+    closeReason = "";
+    setLocalLoopbackGatewayConfig();
+
+    let err: unknown;
+    await callGateway({ method: "health" }).catch((caught: unknown) => {
+      err = caught;
+    });
+
+    const message = (err as { message: string }).message;
+    expect(message).toMatch(/connection dropped.*retry/i);
+    expect(message).not.toContain("crashed or was terminated unexpectedly");
+    expect(message).toContain("Run `openclaw doctor`");
+  });
+
   it("formats typed request errors for CLI JSON output", () => {
     const error = Object.assign(new Error("unauthorized role: operator"), {
       name: "GatewayClientRequestError",

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -819,10 +819,10 @@ function formatGatewayCloseError(
   if (code === 1006) {
     message +=
       "\n\nPossible causes:" +
-      "\n- Connection dropped, often under a burst of concurrent tool calls or event-loop saturation (retry)" +
+      "\n- Connection dropped without a close frame (retry; check network and gateway load)" +
       "\n- Gateway not yet ready to accept connections (retry after a moment)" +
       "\n- TLS mismatch (connecting with ws:// to a wss:// gateway, or vice versa)" +
-      "\n- Gateway process unreachable or terminated (rare; confirm it is still running)" +
+      "\n- Gateway process stopped or became unreachable (confirm it is still running)" +
       "\nRun `openclaw doctor` for diagnostics.";
   }
   return message;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -819,9 +819,10 @@ function formatGatewayCloseError(
   if (code === 1006) {
     message +=
       "\n\nPossible causes:" +
+      "\n- Connection dropped, often under a burst of concurrent tool calls or event-loop saturation (retry)" +
       "\n- Gateway not yet ready to accept connections (retry after a moment)" +
       "\n- TLS mismatch (connecting with ws:// to a wss:// gateway, or vice versa)" +
-      "\n- Gateway crashed or was terminated unexpectedly" +
+      "\n- Gateway process unreachable or terminated (rare; confirm it is still running)" +
       "\nRun `openclaw doctor` for diagnostics.";
   }
   return message;


### PR DESCRIPTION
## What Problem This Solves

Operators seeing a WebSocket `1006` abnormal closure were told the Gateway may
have "crashed or was terminated unexpectedly." A `1006` only establishes that
the connection ended without a received close frame, so the diagnostic should
not present a process crash as an observed fact.

This addresses ask 3 of #100941 only. Connection pooling and platform-tool
concurrency remain intentionally out of scope.

Refs #100941

## Why This Change Was Made

The `1006` troubleshooting block in `formatGatewayCloseError` now:

- identifies the missing close frame and recommends retrying;
- suggests checking network and Gateway load without asserting a cause;
- keeps the existing readiness, TLS mismatch, process reachability, and
  `openclaw doctor` guidance.

## User Impact

The error gives operators useful checks without implying that the Gateway
process crashed or prescribing an unnecessary restart.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/call.test.ts`
  - 4 files passed
  - 472 tests passed
- `oxfmt --check src/gateway/call.ts src/gateway/call.test.ts`
- `git diff --check`
- Fresh exact-head hosted CI is required for the maintainer-repaired head.
