### PR TITLE
fix(ci): stabilize Windows startup fallback tests

### DIFF
--- a/scripts/ci-changed-scope.mjs
+++ b/scripts/ci-changed-scope.mjs
@@ -47,6 +47,8 @@ const WINDOWS_SCOPE_RE =
   /^(src\/process\/|src\/infra\/windows-install-roots\.ts$|src\/shared\/(?:import-specifier|runtime-import)(?:\.test)?\.ts$|scripts\/(?:install\.ps1|(?:npm-runner|pnpm-runner|ui|vitest-process-group)\.(?:mjs|js)|lib\/format-generated-module\.mjs)$|test\/scripts\/(?:format-generated-module|install-ps1|npm-runner|pnpm-runner|ui|vitest-process-group)\.test\.ts$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$|\.github\/workflows\/ci\.yml$|\.github\/actions\/setup-node-env\/action\.yml$|\.github\/actions\/setup-pnpm-store-cache\/action\.yml$)/;
 const WINDOWS_TEST_SCOPE_RE =
   /^(src\/process\/(?:exec\.windows|windows-command)\.test\.ts$|src\/infra\/windows-install-roots\.test\.ts$|src\/shared\/runtime-import\.test\.ts$|test\/scripts\/(?:format-generated-module|npm-runner|pnpm-runner|ui|vitest-process-group)\.test\.ts$)/;
+const WINDOWS_DAEMON_SCOPE_RE =
+  /^src\/daemon\/(?:schtasks(?:[-.][^/]+)?|runtime-hints\.windows-paths(?:\.test)?|test-helpers\/schtasks-(?:base-mocks|fixtures))\.ts$/;
 const TEST_ONLY_PATH_RE =
   /(^test\/|\/test\/|\/tests\/|(?:^|\/)[^/]+\.(?:test|spec|test-utils|test-support|test-harness|e2e-harness)\.[cm]?[jt]sx?$)/;
 const CONTROL_UI_I18N_SCOPE_RE =
@@ -132,8 +134,10 @@ export function detectChangedScope(changedPaths) {
     }
 
     if (
-      WINDOWS_SCOPE_RE.test(path) &&
-      (!TEST_ONLY_PATH_RE.test(path) || WINDOWS_TEST_SCOPE_RE.test(path))
+      (WINDOWS_SCOPE_RE.test(path) || WINDOWS_DAEMON_SCOPE_RE.test(path)) &&
+      (!TEST_ONLY_PATH_RE.test(path) ||
+        WINDOWS_TEST_SCOPE_RE.test(path) ||
+        WINDOWS_DAEMON_SCOPE_RE.test(path))
     ) {
       runWindows = true;
     }

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -320,6 +320,8 @@ function runningTaskQueryOutput() {
 
 beforeEach(() => {
   resetSchtasksBaseMocks();
+  // Keep generic lifecycle cases host-independent; Windows ownership cases opt in below.
+  vi.spyOn(process, "platform", "get").mockReturnValue("linux");
   findVerifiedGatewayListenerPidsOnPortSync.mockReset();
   findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
   inspectPortUsage.mockResolvedValue({

--- a/src/scripts/ci-changed-scope.test.ts
+++ b/src/scripts/ci-changed-scope.test.ts
@@ -420,6 +420,24 @@ describe("detectChangedScope", () => {
       runChangedSmoke: false,
       runControlUiI18n: false,
     });
+    for (const daemonPath of [
+      "src/daemon/schtasks.ts",
+      "src/daemon/schtasks-exec.ts",
+      "src/daemon/schtasks.startup-fallback.test.ts",
+      "src/daemon/runtime-hints.windows-paths.test.ts",
+      "src/daemon/test-helpers/schtasks-fixtures.ts",
+    ]) {
+      expect(detectChangedScope([daemonPath]), daemonPath).toEqual({
+        runNode: true,
+        runMacos: false,
+        runIosBuild: false,
+        runAndroid: false,
+        runWindows: true,
+        runSkillsPython: false,
+        runChangedSmoke: false,
+        runControlUiI18n: false,
+      });
+    }
     expect(detectChangedScope(["src/shared/runtime-import.ts"])).toEqual({
       runNode: true,
       runMacos: false,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Windows Node test job reported 10 failures in `schtasks.startup-fallback.test.ts` after stricter Windows ownership checks landed, because generic lifecycle fixtures inherited the runner host platform.

## Why This Change Was Made

Pins generic lifecycle cases to a deterministic non-Windows process platform. Cases that exercise Windows process ownership already opt into `win32` explicitly, preserving their intended coverage. Also routes Windows daemon scheduler sources, tests, and shared fixtures to the Windows CI lane so future platform-specific regressions cannot bypass this proof.

## User Impact

No user-visible behavior change. Windows CI once again distinguishes generic lifecycle coverage from explicit Windows ownership coverage.

## Evidence

- Before: `checks-windows-node-test` job 85500597403: 10 failures in `src/daemon/schtasks.startup-fallback.test.ts`
- Blacksmith Testbox run 28830248962: 88 focused tests passed
- Exact Windows CI job 85502670710: passed
- Direct scope probe: scheduler sources, tests, and fixtures all select `runWindows: true`
- Fresh Codex autoreview: clean, no actionable findings
- `git diff --check`
