### PR TITLE
fix(update): keep self-updates on the running install's global root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ Docs: https://docs.openclaw.ai
 - **iOS Watch replies:** persist queued quick replies in the gateway-scoped chat outbox and submit them through idempotent chat delivery, preventing losses, duplicates, and cross-gateway sends after reconnects. (#100031) Thanks @NianJiuZst.
 - **iOS Gateway auth retry:** restrict stored device-token retry to parsed loopback hosts and reject wildcard bind addresses, preventing remote lookalike hostnames from receiving trusted retry credentials. (#99859) Thanks @ly85206559.
 - **Bedrock Mantle discovery:** bound model-catalog fetch time and response size, and release rejected response bodies so stalled, oversized, or failed provider responses fall back safely. (#99961) Thanks @zhangguiping-xydt.
+- **npm self-update roots:** keep staged self-updates on the global prefix that owns the running OpenClaw install when PATH's npm reports a different Node tree, preventing successful updates to a stale second copy. (#101228) Thanks @buddyh.
 
 ## 2026.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,6 @@ Docs: https://docs.openclaw.ai
 - **iOS Watch replies:** persist queued quick replies in the gateway-scoped chat outbox and submit them through idempotent chat delivery, preventing losses, duplicates, and cross-gateway sends after reconnects. (#100031) Thanks @NianJiuZst.
 - **iOS Gateway auth retry:** restrict stored device-token retry to parsed loopback hosts and reject wildcard bind addresses, preventing remote lookalike hostnames from receiving trusted retry credentials. (#99859) Thanks @ly85206559.
 - **Bedrock Mantle discovery:** bound model-catalog fetch time and response size, and release rejected response bodies so stalled, oversized, or failed provider responses fall back safely. (#99961) Thanks @zhangguiping-xydt.
-- **npm self-update roots:** keep staged self-updates on the global prefix that owns the running OpenClaw install when PATH's npm reports a different Node tree, preventing successful updates to a stale second copy. (#101228) Thanks @buddyh.
 
 ## 2026.7.1
 

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -525,6 +525,44 @@ describe("update global helpers", () => {
     });
   });
 
+  it("falls back to the running root for scoped packages when the probe is rejected", async () => {
+    await withMockedPlatform("darwin", async () => {
+      await withTempDir({ prefix: "openclaw-update-scoped-probe-" }, async (base) => {
+        const nvmPrefix = path.join(base, "home", ".nvm", "versions", "node", "v24.5.0");
+        const nvmRoot = path.join(nvmPrefix, "lib", "node_modules");
+        const pkgRoot = path.join(nvmRoot, "@scope", "cli");
+        const cellarRoot = path.join(
+          base,
+          "opt",
+          "homebrew",
+          "Cellar",
+          "node",
+          "26.3.1",
+          "lib",
+          "node_modules",
+        );
+        await fs.mkdir(pkgRoot, { recursive: true });
+
+        const runCommand = createNpmRootRunner({ defaultNpmRoot: cellarRoot });
+
+        await expect(
+          resolveGlobalInstallTarget({
+            manager: "npm",
+            runCommand,
+            timeoutMs: 1000,
+            pkgRoot,
+            packageName: "@scope/cli",
+          }),
+        ).resolves.toEqual({
+          manager: "npm",
+          command: "npm",
+          globalRoot: nvmRoot,
+          packageRoot: pkgRoot,
+        });
+      });
+    });
+  });
+
   it("still adopts the probed npm root when it matches the running per-Node tree", async () => {
     await withMockedPlatform("darwin", async () => {
       await withTempDir({ prefix: "openclaw-update-matching-probe-" }, async (base) => {

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -482,6 +482,102 @@ describe("update global helpers", () => {
     });
   });
 
+  it("does not adopt an ephemeral per-Node npm root probed from PATH", async () => {
+    await withMockedPlatform("darwin", async () => {
+      await withTempDir({ prefix: "openclaw-update-ephemeral-probe-" }, async (base) => {
+        // The running install lives in an nvm tree while `npm root -g` on
+        // PATH answers with a Homebrew Cellar root — the skew produced when a
+        // per-Node npm shim is executed by a foreign node (e.g. a launchd
+        // service PATH pairing nvm's npm with Homebrew's node). Installing
+        // into the Cellar root would create a brand-new tree the running
+        // install never loads from.
+        const nvmPrefix = path.join(base, "home", ".nvm", "versions", "node", "v24.5.0");
+        const nvmRoot = path.join(nvmPrefix, "lib", "node_modules");
+        const pkgRoot = path.join(nvmRoot, "openclaw");
+        const cellarRoot = path.join(
+          base,
+          "opt",
+          "homebrew",
+          "Cellar",
+          "node",
+          "26.3.1",
+          "lib",
+          "node_modules",
+        );
+        await fs.mkdir(pkgRoot, { recursive: true });
+
+        const runCommand = createNpmRootRunner({ defaultNpmRoot: cellarRoot });
+
+        await expect(
+          resolveGlobalInstallTarget({
+            manager: "npm",
+            runCommand,
+            timeoutMs: 1000,
+            pkgRoot,
+          }),
+        ).resolves.toEqual({
+          manager: "npm",
+          command: "npm",
+          globalRoot: nvmRoot,
+          packageRoot: pkgRoot,
+        });
+      });
+    });
+  });
+
+  it("still adopts the probed npm root when it matches the running per-Node tree", async () => {
+    await withMockedPlatform("darwin", async () => {
+      await withTempDir({ prefix: "openclaw-update-matching-probe-" }, async (base) => {
+        const nvmPrefix = path.join(base, "home", ".nvm", "versions", "node", "v24.5.0");
+        const nvmRoot = path.join(nvmPrefix, "lib", "node_modules");
+        const pkgRoot = path.join(nvmRoot, "openclaw");
+        await fs.mkdir(pkgRoot, { recursive: true });
+
+        const runCommand = createNpmRootRunner({ defaultNpmRoot: nvmRoot });
+
+        await expect(
+          resolveGlobalInstallTarget({
+            manager: "npm",
+            runCommand,
+            timeoutMs: 1000,
+            pkgRoot,
+          }),
+        ).resolves.toEqual({
+          manager: "npm",
+          command: "npm",
+          globalRoot: nvmRoot,
+          packageRoot: pkgRoot,
+        });
+      });
+    });
+  });
+
+  it("falls back to the running package root when the npm root probe fails", async () => {
+    await withMockedPlatform("darwin", async () => {
+      await withTempDir({ prefix: "openclaw-update-probe-failure-" }, async (base) => {
+        const globalRoot = path.join(base, "usr", "local", "lib", "node_modules");
+        const pkgRoot = path.join(globalRoot, "openclaw");
+        await fs.mkdir(pkgRoot, { recursive: true });
+
+        const runCommand: CommandRunner = async () => ({ stdout: "", stderr: "", code: 1 });
+
+        await expect(
+          resolveGlobalInstallTarget({
+            manager: "npm",
+            runCommand,
+            timeoutMs: 1000,
+            pkgRoot,
+          }),
+        ).resolves.toEqual({
+          manager: "npm",
+          command: "npm",
+          globalRoot,
+          packageRoot: pkgRoot,
+        });
+      });
+    });
+  });
+
   it("does not infer npm ownership from path shape alone when the owning npm binary is absent", async () => {
     await withTempDir({ prefix: "openclaw-update-npm-missing-bin-" }, async (base) => {
       const brewRoot = path.join(base, "opt", "homebrew", "lib", "node_modules");

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -482,7 +482,7 @@ describe("update global helpers", () => {
     });
   });
 
-  it("does not adopt an ephemeral per-Node npm root probed from PATH", async () => {
+  it("keeps npm self-updates on the running package root when the PATH probe diverges", async () => {
     await withMockedPlatform("darwin", async () => {
       await withTempDir({ prefix: "openclaw-update-ephemeral-probe-" }, async (base) => {
         // The running install lives in an nvm tree while `npm root -g` on
@@ -525,7 +525,7 @@ describe("update global helpers", () => {
     });
   });
 
-  it("falls back to the running root for scoped packages when the probe is rejected", async () => {
+  it("keeps scoped npm self-updates on the running package root", async () => {
     await withMockedPlatform("darwin", async () => {
       await withTempDir({ prefix: "openclaw-update-scoped-probe-" }, async (base) => {
         const nvmPrefix = path.join(base, "home", ".nvm", "versions", "node", "v24.5.0");
@@ -563,12 +563,12 @@ describe("update global helpers", () => {
     });
   });
 
-  it("still adopts the probed npm root when it matches the running per-Node tree", async () => {
+  it("keeps the npm probe when the package root is not globally installed", async () => {
     await withMockedPlatform("darwin", async () => {
-      await withTempDir({ prefix: "openclaw-update-matching-probe-" }, async (base) => {
+      await withTempDir({ prefix: "openclaw-update-probe-only-" }, async (base) => {
         const nvmPrefix = path.join(base, "home", ".nvm", "versions", "node", "v24.5.0");
         const nvmRoot = path.join(nvmPrefix, "lib", "node_modules");
-        const pkgRoot = path.join(nvmRoot, "openclaw");
+        const pkgRoot = path.join(base, "checkout", "node_modules", "openclaw");
         await fs.mkdir(pkgRoot, { recursive: true });
 
         const runCommand = createNpmRootRunner({ defaultNpmRoot: nvmRoot });
@@ -584,7 +584,7 @@ describe("update global helpers", () => {
           manager: "npm",
           command: "npm",
           globalRoot: nvmRoot,
-          packageRoot: pkgRoot,
+          packageRoot: path.join(nvmRoot, "openclaw"),
         });
       });
     });

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -442,13 +442,8 @@ function resolveBunGlobalRoot(): string {
 }
 
 function inferNpmPrefixFromPackageRoot(pkgRoot?: string | null): string | null {
-  const trimmed = pkgRoot?.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const normalized = path.resolve(trimmed);
-  const nodeModulesDir = path.dirname(normalized);
-  if (path.basename(nodeModulesDir) !== "node_modules") {
+  const nodeModulesDir = inferGlobalRootFromPackageRoot(pkgRoot);
+  if (!nodeModulesDir) {
     return null;
   }
   const parentDir = path.dirname(nodeModulesDir);
@@ -569,25 +564,6 @@ function isEphemeralNodeManagedNpmPrefix(prefix: string): boolean {
   return (
     basename === "installation" && isNodeVersionPathPart(parent) && grandparent === "node-versions"
   );
-}
-
-/**
- * Returns true when a probed `npm root -g` result is safe to adopt as the
- * install target. A probe that lands in an ephemeral per-Node prefix (Homebrew
- * Cellar, nvm/fnm/asdf/volta version dirs) means npm's PATH/node pairing is
- * skewed — for example an nvm npm shim executed by a Homebrew node derives its
- * default prefix from the foreign node's realpathed Cellar path. Installing
- * there would create a tree that no stable entrypoint loads from and that a
- * `brew upgrade node` silently deletes.
- */
-function isAdoptableProbedGlobalRoot(probedGlobalRoot: string | null): boolean {
-  if (!probedGlobalRoot) {
-    return false;
-  }
-  const probedPrefix = resolveNpmGlobalPrefixLayoutFromGlobalRoot(probedGlobalRoot, {
-    allowDirectNodeModulesRoot: true,
-  })?.prefix;
-  return !probedPrefix || !isEphemeralNodeManagedNpmPrefix(probedPrefix);
 }
 
 function resolveNpmCommandBesidePackageRoot(pkgRoot?: string | null): string | null {
@@ -818,21 +794,19 @@ export async function resolveGlobalInstallTarget(params: {
     params.pkgRoot,
   );
   const pkgRootGlobalRoot = command.manager === "pnpm" ? pnpmPackageRootGlobalRoot : null;
-  // Self-updates must mutate the tree the resolved package root lives in.
-  // `npm root -g` only decides the target when no package root is known: in a
-  // skewed environment (e.g. a service PATH whose npm does not belong to the
-  // running install's Node tree) the probe can point at a different — or
-  // brand-new — global root, leaving the running install stale after a
-  // reported-successful update.
-  const pkgRootDerivedGlobalRoot =
-    command.manager === "npm" ? inferGlobalRootFromPackageRoot(params.pkgRoot) : null;
-  const probedGlobalRoot = isAdoptableProbedGlobalRoot(globalRoot) ? globalRoot : null;
+  // The detected npm owner applies to the running package, so its prefix is
+  // authoritative. PATH's npm may belong to another Node installation and
+  // report a different root, which would leave the running tree stale.
+  const npmPackageRootGlobalRoot =
+    command.manager === "npm" && inferNpmPrefixFromPackageRoot(params.pkgRoot)
+      ? inferGlobalRootFromPackageRoot(params.pkgRoot)
+      : null;
   const targetGlobalRoot =
     (command.manager === "bun" ? bunPackageRootGlobalRoot : null) ??
     pkgRootGlobalRoot ??
     (command.manager === "npm" ? honoredPackageRootGlobalRoot : null) ??
-    pkgRootDerivedGlobalRoot ??
-    probedGlobalRoot;
+    npmPackageRootGlobalRoot ??
+    globalRoot;
   return {
     ...command,
     globalRoot: targetGlobalRoot,

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -614,7 +614,10 @@ function inferGlobalRootFromPackageRoot(pkgRoot?: string | null): string | null 
     return null;
   }
   const normalized = path.resolve(trimmed);
-  const globalRoot = path.dirname(normalized);
+  let globalRoot = path.dirname(normalized);
+  if (path.basename(globalRoot).startsWith("@")) {
+    globalRoot = path.dirname(globalRoot);
+  }
   return path.basename(globalRoot) === "node_modules" ? globalRoot : null;
 }
 

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -571,6 +571,25 @@ function isEphemeralNodeManagedNpmPrefix(prefix: string): boolean {
   );
 }
 
+/**
+ * Returns true when a probed `npm root -g` result is safe to adopt as the
+ * install target. A probe that lands in an ephemeral per-Node prefix (Homebrew
+ * Cellar, nvm/fnm/asdf/volta version dirs) means npm's PATH/node pairing is
+ * skewed — for example an nvm npm shim executed by a Homebrew node derives its
+ * default prefix from the foreign node's realpathed Cellar path. Installing
+ * there would create a tree that no stable entrypoint loads from and that a
+ * `brew upgrade node` silently deletes.
+ */
+function isAdoptableProbedGlobalRoot(probedGlobalRoot: string | null): boolean {
+  if (!probedGlobalRoot) {
+    return false;
+  }
+  const probedPrefix = resolveNpmGlobalPrefixLayoutFromGlobalRoot(probedGlobalRoot, {
+    allowDirectNodeModulesRoot: true,
+  })?.prefix;
+  return !probedPrefix || !isEphemeralNodeManagedNpmPrefix(probedPrefix);
+}
+
 function resolveNpmCommandBesidePackageRoot(pkgRoot?: string | null): string | null {
   const prefix = inferNpmPrefixFromPackageRoot(pkgRoot);
   if (!prefix) {
@@ -796,11 +815,21 @@ export async function resolveGlobalInstallTarget(params: {
     params.pkgRoot,
   );
   const pkgRootGlobalRoot = command.manager === "pnpm" ? pnpmPackageRootGlobalRoot : null;
+  // Self-updates must mutate the tree the resolved package root lives in.
+  // `npm root -g` only decides the target when no package root is known: in a
+  // skewed environment (e.g. a service PATH whose npm does not belong to the
+  // running install's Node tree) the probe can point at a different — or
+  // brand-new — global root, leaving the running install stale after a
+  // reported-successful update.
+  const pkgRootDerivedGlobalRoot =
+    command.manager === "npm" ? inferGlobalRootFromPackageRoot(params.pkgRoot) : null;
+  const probedGlobalRoot = isAdoptableProbedGlobalRoot(globalRoot) ? globalRoot : null;
   const targetGlobalRoot =
     (command.manager === "bun" ? bunPackageRootGlobalRoot : null) ??
     pkgRootGlobalRoot ??
     (command.manager === "npm" ? honoredPackageRootGlobalRoot : null) ??
-    globalRoot;
+    pkgRootDerivedGlobalRoot ??
+    probedGlobalRoot;
   return {
     ...command,
     globalRoot: targetGlobalRoot,


### PR DESCRIPTION
## What Problem This Solves

`openclaw update` can run from one npm global install while the `npm` found on `PATH` derives `npm root -g` from another Node installation. In mixed Homebrew plus nvm/asdf/Volta setups, the updater could install successfully into that second tree and leave the running OpenClaw copy unchanged.

This PR keeps npm self-updates on the global prefix that owns the running OpenClaw package. It also handles scoped package roots and retains the package-manager probe when the package root is not a valid global npm layout.

## Why This Change Was Made

The final implementation resolves the target at the shared `resolveGlobalInstallTarget` boundary:

- A running package at `<prefix>/lib/node_modules/openclaw` selects that `node_modules` root even when PATH's probe diverges.
- A scoped package at `<prefix>/lib/node_modules/@scope/name` resolves to the same owning root.
- A source checkout or other non-global package root does not override `npm root -g`.
- A failed probe can still fall back to a structurally valid running npm prefix.

This is narrower than trusting any path shaped like `node_modules`; only recognized npm global-prefix layouts receive the preference.

## User Impact

Self-update changes the OpenClaw installation that actually launched the command instead of creating or refreshing a stale second copy. No config, CLI, or migration surface changes.

## Evidence

- Blacksmith Testbox `tbx_01kwxa3ffx5t6s471n157f2dfv`: 277 focused tests passed across `update-global`, `update-runner`, and update CLI coverage.
- Full `pnpm build`: passed.
- `pnpm check:changed`: passed.
- Live filesystem/process probe: three real temporary layouts passed — divergent unscoped root, divergent scoped root, and non-global package-root fallback. The npm probe ran as a real subprocess in each case.
- Fresh exact-branch autoreview: no accepted/actionable findings.

Closes the mixed-Node self-update targeting failure described in this PR. Thanks @buddyh for the report and original fix.
