### PR TITLE
fix(markdown-core): CJK-friendly emphasis flanking so **标签：**正文 renders bold (#101120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.
+- **CJK Markdown emphasis:** render adjacent Chinese, Japanese, and Korean emphasis punctuation through the shared Markdown pipeline instead of leaking literal markers across channels. (#101230, #101120) Thanks @nicknmorty.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -94,6 +94,12 @@ describe("markdownToTelegramHtml", () => {
     expect(markdownToTelegramRichHtml("<sup>1</sup>")).toBe("<sup>1</sup>");
   });
 
+  it("renders bold spans that close before CJK punctuation in rich markdown", () => {
+    expect(markdownToTelegramRichHtml("边界：**社区显示：**Fable 与 **有效**。")).toBe(
+      "边界：<b>社区显示：</b>Fable 与 <b>有效</b>。",
+    );
+  });
+
   it("materializes inline and paragraph newlines as <br> for rich messages", () => {
     // The exact reported symptom: literal "• " bullets (not Markdown list markers)
     // joined by soft breaks, which Bot API 10.1 rich messages collapse without <br>.

--- a/packages/markdown-core/package.json
+++ b/packages/markdown-core/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "markdown-it": "14.3.0",
+    "markdown-it-cjk-friendly": "2.0.2",
     "yaml": "2.9.0"
   }
 }

--- a/packages/markdown-core/src/ir.emphasis-cjk.test.ts
+++ b/packages/markdown-core/src/ir.emphasis-cjk.test.ts
@@ -27,6 +27,20 @@ describe("markdownToIR CJK emphasis flanking", () => {
     expect(styledText("foo**bar**baz")).toEqual(["bar"]);
   });
 
+  it("treats ideographic space (U+3000) as whitespace, not a flanking CJK char", () => {
+    // Opening delimiter followed by U+3000 must not be forced open.
+    expect(styledText("前**\u3000加粗**后")).toEqual([]);
+    // U+3000-separated emphasis keeps normal CommonMark behavior.
+    expect(styledText("前\u3000**加粗**\u3000后")).toEqual(["加粗"]);
+  });
+
+  it("treats Unicode thin space (U+2009) as whitespace in delimiter scanning", () => {
+    // Opening delimiter followed by U+2009 must not be forced open.
+    expect(styledText("前**\u2009加粗**后")).toEqual([]);
+    // Closing delimiter after CJK punctuation still closes when followed by U+2009.
+    expect(styledText("前**加粗：**\u2009后")).toEqual(["加粗："]);
+  });
+
   it("leaves code spans and links on their existing paths", () => {
     const code = markdownToIR("`前**加粗：**后`");
     expect(code.text).toBe("前**加粗：**后");

--- a/packages/markdown-core/src/ir.emphasis-cjk.test.ts
+++ b/packages/markdown-core/src/ir.emphasis-cjk.test.ts
@@ -22,6 +22,16 @@ describe("markdownToIR CJK emphasis flanking", () => {
     expect(styledText("이것은 **강조:**입니다")).toEqual(["강조:"]);
   });
 
+  it("handles supplementary CJK and variation selectors at emphasis boundaries", () => {
+    expect(styledText("𰻞𰻞**（ビャンビャン）**麺")).toEqual(["（ビャンビャン）"]);
+    expect(styledText("葛󠄀**(こちらが正式表記)**城市")).toEqual(["(こちらが正式表記)"]);
+  });
+
+  it("supports CJK-friendly underscore flanking without enabling Latin intraword emphasis", () => {
+    expect(styledText("__注意__：注意事項")).toEqual(["注意"]);
+    expect(styledText("foo_bar_baz", "italic")).toEqual([]);
+  });
+
   it("keeps ASCII CommonMark emphasis behavior", () => {
     expect(styledText("**bold** text")).toEqual(["bold"]);
     expect(styledText("foo**bar**baz")).toEqual(["bar"]);

--- a/packages/markdown-core/src/ir.emphasis-cjk.test.ts
+++ b/packages/markdown-core/src/ir.emphasis-cjk.test.ts
@@ -1,0 +1,44 @@
+// Markdown Core tests cover CJK-friendly emphasis flanking.
+import { describe, expect, it } from "vitest";
+import { markdownToIR } from "./ir.js";
+
+function styledText(markdown: string, style: "bold" | "italic" = "bold"): string[] {
+  const ir = markdownToIR(markdown);
+  return ir.styles
+    .filter((span) => span.style === style)
+    .map((span) => ir.text.slice(span.start, span.end));
+}
+
+describe("markdownToIR CJK emphasis flanking", () => {
+  it("closes strong emphasis before adjacent Chinese text", () => {
+    expect(styledText("前**加粗：**后")).toEqual(["加粗："]);
+  });
+
+  it("closes strong emphasis before adjacent Japanese text", () => {
+    expect(styledText("これは**強調。**です")).toEqual(["強調。"]);
+  });
+
+  it("closes strong emphasis before adjacent Korean text", () => {
+    expect(styledText("이것은 **강조:**입니다")).toEqual(["강조:"]);
+  });
+
+  it("keeps ASCII CommonMark emphasis behavior", () => {
+    expect(styledText("**bold** text")).toEqual(["bold"]);
+    expect(styledText("foo**bar**baz")).toEqual(["bar"]);
+  });
+
+  it("leaves code spans and links on their existing paths", () => {
+    const code = markdownToIR("`前**加粗：**后`");
+    expect(code.text).toBe("前**加粗：**后");
+    expect(code.styles.map((span) => span.style)).toEqual(["code"]);
+
+    const linked = markdownToIR("[前**加粗：**后](https://example.com)");
+    expect(linked.text).toBe("前加粗：后");
+    expect(linked.links).toEqual([
+      { start: 0, end: linked.text.length, href: "https://example.com" },
+    ]);
+    expect(linked.styles.filter((span) => span.style === "bold")).toEqual([
+      { start: 1, end: 4, style: "bold" },
+    ]);
+  });
+});

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -1,5 +1,7 @@
 // Markdown Core module implements ir behavior.
 import MarkdownIt from "markdown-it";
+import type StateInline from "markdown-it/lib/rules_inline/state_inline.mjs";
+import type { Scanned as DelimiterScanResult } from "markdown-it/lib/rules_inline/state_inline.mjs";
 import { chunkText } from "./chunk-text.js";
 import type { MarkdownTableMode } from "./types.js";
 
@@ -34,11 +36,9 @@ type MarkdownToken = {
 
 type MarkdownItWithInlineState = MarkdownIt & {
   inline: MarkdownIt["inline"] & {
-    State: typeof MarkdownIt.StateInline;
+    State: typeof StateInline;
   };
 };
-
-type DelimiterScanResult = MarkdownIt.StateInline.Scanned;
 
 export type MarkdownStyle =
   | "bold"

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -185,8 +185,30 @@ function getCodePointAt(value: string, index: number): number {
   return code;
 }
 
+// Mirrors markdown-it's isWhiteSpace (Zs plus control whitespace) so the
+// CJK-friendly override never forces delimiter flags where markdown-it's
+// flanking rules see whitespace (notably U+3000, which is also in the East
+// Asian ranges below).
 function isMarkdownWhitespace(codePoint: number): boolean {
-  return codePoint === 0x20 || codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d;
+  if (codePoint >= 0x2000 && codePoint <= 0x200a) {
+    return true;
+  }
+  switch (codePoint) {
+    case 0x09:
+    case 0x0a:
+    case 0x0b:
+    case 0x0c:
+    case 0x0d:
+    case 0x20:
+    case 0xa0:
+    case 0x1680:
+    case 0x202f:
+    case 0x205f:
+    case 0x3000:
+      return true;
+    default:
+      return false;
+  }
 }
 
 function isEastAsianMarkdownFlankingChar(codePoint: number): boolean {

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -1,7 +1,6 @@
 // Markdown Core module implements ir behavior.
 import MarkdownIt from "markdown-it";
-import type StateInline from "markdown-it/lib/rules_inline/state_inline.mjs";
-import type { Scanned as DelimiterScanResult } from "markdown-it/lib/rules_inline/state_inline.mjs";
+import markdownItCjkFriendly from "markdown-it-cjk-friendly";
 import { chunkText } from "./chunk-text.js";
 import type { MarkdownTableMode } from "./types.js";
 
@@ -32,12 +31,6 @@ type MarkdownToken = {
   attrGet?: (name: string) => string | null;
   hidden?: boolean;
   level?: number;
-};
-
-type MarkdownItWithInlineState = MarkdownIt & {
-  inline: MarkdownIt["inline"] & {
-    State: typeof StateInline;
-  };
 };
 
 export type MarkdownStyle =
@@ -151,122 +144,6 @@ export type MarkdownParseOptions = {
   tableMode?: MarkdownTableMode;
 };
 
-function getCodePointBefore(value: string, index: number): number {
-  if (index <= 0) {
-    return 0x20;
-  }
-  const previous = value.charCodeAt(index - 1);
-  if ((previous & 0xfc00) === 0xdc00 && index > 1) {
-    const high = value.charCodeAt(index - 2);
-    if ((high & 0xfc00) === 0xd800) {
-      return 0x10000 + ((high - 0xd800) << 10) + (previous - 0xdc00);
-    }
-  }
-  if ((previous & 0xf800) === 0xd800) {
-    return 0xfffd;
-  }
-  return previous;
-}
-
-function getCodePointAt(value: string, index: number): number {
-  if (index >= value.length) {
-    return 0x20;
-  }
-  const code = value.charCodeAt(index);
-  if ((code & 0xfc00) === 0xd800 && index + 1 < value.length) {
-    const low = value.charCodeAt(index + 1);
-    if ((low & 0xfc00) === 0xdc00) {
-      return 0x10000 + ((code - 0xd800) << 10) + (low - 0xdc00);
-    }
-  }
-  if ((code & 0xfc00) === 0xdc00) {
-    return 0xfffd;
-  }
-  return code;
-}
-
-// Mirrors markdown-it's isWhiteSpace (Zs plus control whitespace) so the
-// CJK-friendly override never forces delimiter flags where markdown-it's
-// flanking rules see whitespace (notably U+3000, which is also in the East
-// Asian ranges below).
-function isMarkdownWhitespace(codePoint: number): boolean {
-  if (codePoint >= 0x2000 && codePoint <= 0x200a) {
-    return true;
-  }
-  switch (codePoint) {
-    case 0x09:
-    case 0x0a:
-    case 0x0b:
-    case 0x0c:
-    case 0x0d:
-    case 0x20:
-    case 0xa0:
-    case 0x1680:
-    case 0x202f:
-    case 0x205f:
-    case 0x3000:
-      return true;
-    default:
-      return false;
-  }
-}
-
-function isEastAsianMarkdownFlankingChar(codePoint: number): boolean {
-  return (
-    (codePoint >= 0x1100 && codePoint <= 0x11ff) ||
-    (codePoint >= 0x2e80 && codePoint <= 0x2eff) ||
-    (codePoint >= 0x2f00 && codePoint <= 0x2fdf) ||
-    (codePoint >= 0x3000 && codePoint <= 0x303f) ||
-    (codePoint >= 0x3040 && codePoint <= 0x30ff) ||
-    (codePoint >= 0x3130 && codePoint <= 0x318f) ||
-    (codePoint >= 0x31a0 && codePoint <= 0x31ff) ||
-    (codePoint >= 0x3400 && codePoint <= 0x4dbf) ||
-    (codePoint >= 0x4e00 && codePoint <= 0x9fff) ||
-    (codePoint >= 0xa960 && codePoint <= 0xa97f) ||
-    (codePoint >= 0xac00 && codePoint <= 0xd7af) ||
-    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
-    (codePoint >= 0xfe10 && codePoint <= 0xfe1f) ||
-    (codePoint >= 0xfe30 && codePoint <= 0xfe4f) ||
-    (codePoint >= 0xff00 && codePoint <= 0xffef) ||
-    (codePoint >= 0x20000 && codePoint <= 0x3fffd)
-  );
-}
-
-function applyCjkFriendlyDelimiterScanning(md: MarkdownIt): void {
-  const inline = (md as MarkdownItWithInlineState).inline;
-  const PreviousState = inline.State;
-
-  // CommonMark treats CJK punctuation before a closing delimiter as non-flanking.
-  class CjkFriendlyState extends PreviousState {
-    override scanDelims(start: number, canSplitWord: boolean): DelimiterScanResult {
-      const scanned = super.scanDelims(start, canSplitWord);
-      if (!canSplitWord) {
-        return scanned;
-      }
-
-      const marker = this.src.charCodeAt(start);
-      let pos = start;
-      while (pos < this.posMax && this.src.charCodeAt(pos) === marker) {
-        pos += 1;
-      }
-
-      const lastChar = getCodePointBefore(this.src, start);
-      const nextChar = getCodePointAt(this.src, pos);
-      if (
-        isMarkdownWhitespace(lastChar) ||
-        isMarkdownWhitespace(nextChar) ||
-        (!isEastAsianMarkdownFlankingChar(lastChar) && !isEastAsianMarkdownFlankingChar(nextChar))
-      ) {
-        return scanned;
-      }
-
-      return { ...scanned, can_open: true, can_close: true };
-    }
-  }
-
-  inline.State = CjkFriendlyState;
-}
-
 function createMarkdownIt(options: MarkdownParseOptions): MarkdownIt {
   const md = new MarkdownIt({
     html: false,
@@ -274,7 +151,7 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownIt {
     breaks: false,
     typographer: false,
   });
-  applyCjkFriendlyDelimiterScanning(md);
+  md.use(markdownItCjkFriendly);
   md.enable("strikethrough");
   if (options.tableMode && options.tableMode !== "off") {
     md.enable("table");

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -32,6 +32,14 @@ type MarkdownToken = {
   level?: number;
 };
 
+type MarkdownItWithInlineState = MarkdownIt & {
+  inline: MarkdownIt["inline"] & {
+    State: typeof MarkdownIt.StateInline;
+  };
+};
+
+type DelimiterScanResult = MarkdownIt.StateInline.Scanned;
+
 export type MarkdownStyle =
   | "bold"
   | "italic"
@@ -143,6 +151,100 @@ export type MarkdownParseOptions = {
   tableMode?: MarkdownTableMode;
 };
 
+function getCodePointBefore(value: string, index: number): number {
+  if (index <= 0) {
+    return 0x20;
+  }
+  const previous = value.charCodeAt(index - 1);
+  if ((previous & 0xfc00) === 0xdc00 && index > 1) {
+    const high = value.charCodeAt(index - 2);
+    if ((high & 0xfc00) === 0xd800) {
+      return 0x10000 + ((high - 0xd800) << 10) + (previous - 0xdc00);
+    }
+  }
+  if ((previous & 0xf800) === 0xd800) {
+    return 0xfffd;
+  }
+  return previous;
+}
+
+function getCodePointAt(value: string, index: number): number {
+  if (index >= value.length) {
+    return 0x20;
+  }
+  const code = value.charCodeAt(index);
+  if ((code & 0xfc00) === 0xd800 && index + 1 < value.length) {
+    const low = value.charCodeAt(index + 1);
+    if ((low & 0xfc00) === 0xdc00) {
+      return 0x10000 + ((code - 0xd800) << 10) + (low - 0xdc00);
+    }
+  }
+  if ((code & 0xfc00) === 0xdc00) {
+    return 0xfffd;
+  }
+  return code;
+}
+
+function isMarkdownWhitespace(codePoint: number): boolean {
+  return codePoint === 0x20 || codePoint === 0x09 || codePoint === 0x0a || codePoint === 0x0d;
+}
+
+function isEastAsianMarkdownFlankingChar(codePoint: number): boolean {
+  return (
+    (codePoint >= 0x1100 && codePoint <= 0x11ff) ||
+    (codePoint >= 0x2e80 && codePoint <= 0x2eff) ||
+    (codePoint >= 0x2f00 && codePoint <= 0x2fdf) ||
+    (codePoint >= 0x3000 && codePoint <= 0x303f) ||
+    (codePoint >= 0x3040 && codePoint <= 0x30ff) ||
+    (codePoint >= 0x3130 && codePoint <= 0x318f) ||
+    (codePoint >= 0x31a0 && codePoint <= 0x31ff) ||
+    (codePoint >= 0x3400 && codePoint <= 0x4dbf) ||
+    (codePoint >= 0x4e00 && codePoint <= 0x9fff) ||
+    (codePoint >= 0xa960 && codePoint <= 0xa97f) ||
+    (codePoint >= 0xac00 && codePoint <= 0xd7af) ||
+    (codePoint >= 0xf900 && codePoint <= 0xfaff) ||
+    (codePoint >= 0xfe10 && codePoint <= 0xfe1f) ||
+    (codePoint >= 0xfe30 && codePoint <= 0xfe4f) ||
+    (codePoint >= 0xff00 && codePoint <= 0xffef) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3fffd)
+  );
+}
+
+function applyCjkFriendlyDelimiterScanning(md: MarkdownIt): void {
+  const inline = (md as MarkdownItWithInlineState).inline;
+  const PreviousState = inline.State;
+
+  // CommonMark treats CJK punctuation before a closing delimiter as non-flanking.
+  class CjkFriendlyState extends PreviousState {
+    override scanDelims(start: number, canSplitWord: boolean): DelimiterScanResult {
+      const scanned = super.scanDelims(start, canSplitWord);
+      if (!canSplitWord) {
+        return scanned;
+      }
+
+      const marker = this.src.charCodeAt(start);
+      let pos = start;
+      while (pos < this.posMax && this.src.charCodeAt(pos) === marker) {
+        pos += 1;
+      }
+
+      const lastChar = getCodePointBefore(this.src, start);
+      const nextChar = getCodePointAt(this.src, pos);
+      if (
+        isMarkdownWhitespace(lastChar) ||
+        isMarkdownWhitespace(nextChar) ||
+        (!isEastAsianMarkdownFlankingChar(lastChar) && !isEastAsianMarkdownFlankingChar(nextChar))
+      ) {
+        return scanned;
+      }
+
+      return { ...scanned, can_open: true, can_close: true };
+    }
+  }
+
+  inline.State = CjkFriendlyState;
+}
+
 function createMarkdownIt(options: MarkdownParseOptions): MarkdownIt {
   const md = new MarkdownIt({
     html: false,
@@ -150,6 +252,7 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownIt {
     breaks: false,
     typographer: false,
   });
+  applyCjkFriendlyDelimiterScanning(md);
   md.enable("strikethrough");
   if (options.tableMode && options.tableMode !== "off") {
     md.enable("table");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1918,6 +1918,9 @@ importers:
       markdown-it:
         specifier: 14.3.0
         version: 14.3.0
+      markdown-it-cjk-friendly:
+        specifier: 2.0.2
+        version: 2.0.2(@types/markdown-it@14.1.2)(markdown-it@14.3.0)
       yaml:
         specifier: 2.9.0
         version: 2.9.0
@@ -5998,6 +6001,16 @@ packages:
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
+
+  markdown-it-cjk-friendly@2.0.2:
+    resolution: {integrity: sha512-KXCl6sd129UqkAiRDb+NcAHrxC9xRa2WsGIsMMvtp2y1YlbeIaNYzArX2zfDoGhOjsyNMfJrGO7xGBss27YQSA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/markdown-it': '*'
+      markdown-it: '*'
+    peerDependenciesMeta:
+      '@types/markdown-it':
+        optional: true
 
   markdown-it-task-lists@2.1.1:
     resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
@@ -11809,6 +11822,13 @@ snapshots:
       - supports-color
 
   markdown-extensions@2.0.0: {}
+
+  markdown-it-cjk-friendly@2.0.2(@types/markdown-it@14.1.2)(markdown-it@14.3.0):
+    dependencies:
+      get-east-asian-width: 1.6.0
+      markdown-it: 14.3.0
+    optionalDependencies:
+      '@types/markdown-it': 14.1.2
 
   markdown-it-task-lists@2.1.1: {}
 


### PR DESCRIPTION
Fixes #101120

## What Problem This Solves

CJK Markdown such as `**标题：**正文` can render literal emphasis markers. CommonMark's closing-delimiter rule rejects punctuation immediately inside `**` when adjacent CJK text follows without whitespace. Because Telegram, Signal, and Slack consume the shared Markdown IR, the defect belongs in `packages/markdown-core`, not in one transport.

## Why This Change Was Made

- Enable the maintained MIT `markdown-it-cjk-friendly` 2.0.2 plugin at the shared `MarkdownIt` construction point.
- Keep the dependency local to `@openclaw/markdown-core`; its only runtime dependency, `get-east-asian-width`, was already resolved in this workspace.
- Replace the submitted 125-line local delimiter/Unicode implementation with the upstream amendment, which directly covers supplementary CJK, variation selectors, ambiguous punctuation, underscores, Unicode whitespace, and the CommonMark corpus.
- Keep Telegram's reported-output regression while adding shared IR regressions for Chinese, Japanese, Korean, supplementary-plane CJK, variation selectors, Unicode whitespace, ordinary Latin, intraword underscores, code spans, and links.

## User Impact

CJK emphasis now renders consistently through every channel using the shared Markdown IR. Ordinary CommonMark behavior remains unchanged outside the CJK-friendly amendment; invalid whitespace-delimited openers remain literal.

## Evidence

Reviewed head: `dbc66f154026d80e23b496d723e60762712cd0ca`

- Sanitized AWS Crabbox `cbx_ed9e9a7749ff` / `coral-lobster`, public network, no Tailscale, empty instance profile, no credential hydration.
- Run `run_837ab245e94c`: `pnpm test packages/markdown-core/src/ir.emphasis-cjk.test.ts extensions/telegram/src/format.test.ts` — 77 passed; `pnpm check:changed -- ...` — passed; `pnpm build` — passed.
- Run `run_4947d71286b2`: clean full build plus source-blind built-artifact validation — 11/11 behavior fixtures passed.
- `git diff --check` and focused `oxfmt --check` — passed.
- Two fresh autoreviews after the dependency rewrite and changelog — clean, no accepted/actionable findings (0.96 and 0.97 confidence).
- Direct dependency inspection: `markdown-it-cjk-friendly` 2.0.2 source/tests/package metadata and `markdown-it` 14.3.0 delimiter scanner; package is ESM-only, MIT, Node 18+, actively maintained, and tests parity against the CommonMark 0.31.2 corpus.

## Docs

No command, configuration, or operator workflow changed. The maintainer changelog entry thanks @nicknmorty and references this PR and #101120.
