### PR TITLE
chore(i18n): refresh native source inventory

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22403,7 +22403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1361,
+      "line": 1362,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -22411,7 +22411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1361,
+      "line": 1362,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",


### PR DESCRIPTION
## What Problem This Solves

Fixes current-main `native-i18n` CI failure caused by stale source-line metadata after `ChatViewModel.swift` moved two conditional strings by one line.

## Why This Change Was Made

Regenerates the canonical native localization source inventory. Only the two recorded line numbers change; localized content and runtime behavior remain unchanged.

## User Impact

No user-visible behavior change. Native localization inventory checks become green again.

## Evidence

- Before: QA exact CI job 85504502241 failed with native app i18n inventory drift
- `pnpm native:i18n:sync`: `entries=2815 changed=true`
- `pnpm native:i18n:check`: `entries=2815 changed=false`
- Exact native i18n CI job 85505222692: passed
- Fresh Codex autoreview: clean, no actionable findings
- `git diff --check`
