### PR TITLE
chore(i18n): refresh native inventory line anchors

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22403,7 +22403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1361,
+      "line": 1362,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -22411,7 +22411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1361,
+      "line": 1362,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",


### PR DESCRIPTION
## What Problem This Solves

The native app i18n inventory on `main` has two stale line anchors in `ChatViewModel.swift`. The drift is normally hidden when app paths are unchanged, but it fails `native-i18n` when that lane runs.

## Why This Change Was Made

Regenerate `apps/.i18n/native-source.json` from the current native sources so the committed inventory matches the generator.

## User Impact

No runtime behavior changes. Native i18n validation is green again for app-touching branches.

## Evidence

- `node --import tsx scripts/native-app-i18n.ts check`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean, no actionable findings

