### PR TITLE
feat(mobile): rename, delete, and create session groups on iOS and Android

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -147,7 +147,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 216,
+      "line": 217,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Mic off",
       "surface": "android",
@@ -155,7 +155,7 @@
     },
     {
       "kind": "ui-state-text",
-      "line": 226,
+      "line": 227,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt",
       "source": "Off",
       "surface": "android",
@@ -2635,7 +2635,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 154,
+      "line": 158,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Sessions",
       "surface": "android",
@@ -2643,7 +2643,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 156,
+      "line": 160,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Reverse session sort",
       "surface": "android",
@@ -2651,7 +2651,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 162,
+      "line": 166,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Recent",
       "surface": "android",
@@ -2659,7 +2659,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 163,
+      "line": 167,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Current",
       "surface": "android",
@@ -2667,7 +2667,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 164,
+      "line": 168,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Archived",
       "surface": "android",
@@ -2675,7 +2675,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 173,
+      "line": 177,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Search sessions",
       "surface": "android",
@@ -2683,7 +2683,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 189,
+      "line": 193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Newest",
       "surface": "android",
@@ -2691,7 +2691,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 189,
+      "line": 193,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Oldest",
       "surface": "android",
@@ -2699,7 +2699,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 192,
+      "line": 196,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Toggle session layout",
       "surface": "android",
@@ -2707,7 +2707,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 197,
+      "line": 201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Layout: Compact",
       "surface": "android",
@@ -2715,7 +2715,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 197,
+      "line": 201,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Layout: Detailed",
       "surface": "android",
@@ -2723,7 +2723,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 209,
+      "line": 213,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Start Chat",
       "surface": "android",
@@ -2731,7 +2731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 230,
+      "line": 243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Current session",
       "surface": "android",
@@ -2739,7 +2739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 230,
+      "line": 243,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "OpenClaw session",
       "surface": "android",
@@ -2747,7 +2747,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 275,
+      "line": 288,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Rename session",
       "surface": "android",
@@ -2755,7 +2755,15 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 278,
+      "line": 327,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Rename group",
+      "surface": "android",
+      "id": "native.android.fa420bc51ff675a1"
+    },
+    {
+      "kind": "ui-named-argument",
+      "line": 330,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Rename",
       "surface": "android",
@@ -2763,7 +2771,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 297,
+      "line": 345,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "New group",
       "surface": "android",
@@ -2771,7 +2779,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 300,
+      "line": 348,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Create",
       "surface": "android",
@@ -2779,7 +2787,23 @@
     },
     {
       "kind": "ui-call",
-      "line": 314,
+      "line": 362,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Delete group?",
+      "surface": "android",
+      "id": "native.android.8b1585a8a84dc4d9"
+    },
+    {
+      "kind": "ui-call",
+      "line": 363,
+      "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
+      "source": "Sessions in \"$group\" are kept and move back to Ungrouped.",
+      "surface": "android",
+      "id": "native.android.3455fc2f77d564e3"
+    },
+    {
+      "kind": "ui-call",
+      "line": 386,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Delete session?",
       "surface": "android",
@@ -2787,7 +2811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 315,
+      "line": 387,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "This permanently deletes the session and its transcript.",
       "surface": "android",
@@ -2795,7 +2819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 323,
+      "line": 395,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Delete",
       "surface": "android",
@@ -2803,7 +2827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 444,
+      "line": 516,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Pinned",
       "surface": "android",
@@ -2811,7 +2835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 450,
+      "line": 522,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Workspace",
       "surface": "android",
@@ -2819,7 +2843,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 451,
+      "line": 523,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -2827,7 +2851,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 501,
+      "line": 573,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Pin",
       "surface": "android",
@@ -2835,7 +2859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 501,
+      "line": 573,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Unpin",
       "surface": "android",
@@ -2843,7 +2867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 505,
+      "line": 577,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Mark as read",
       "surface": "android",
@@ -2851,7 +2875,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 505,
+      "line": 577,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Mark as unread",
       "surface": "android",
@@ -2859,7 +2883,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 564,
+      "line": 673,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Group name",
       "surface": "android",
@@ -2867,7 +2891,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 564,
+      "line": 673,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Name",
       "surface": "android",
@@ -2875,7 +2899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 574,
+      "line": 683,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Cancel",
       "surface": "android",
@@ -2883,7 +2907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 647,
+      "line": 765,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No sessions yet",
       "surface": "android",
@@ -2891,7 +2915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 648,
+      "line": 766,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No current session",
       "surface": "android",
@@ -2899,7 +2923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 649,
+      "line": 767,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "No archived sessions",
       "surface": "android",
@@ -2907,7 +2931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 655,
+      "line": 773,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Start a new conversation and it will show up here.",
       "surface": "android",
@@ -2915,7 +2939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 656,
+      "line": 774,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Open Chat to start or resume the current session.",
       "surface": "android",
@@ -2923,7 +2947,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 657,
+      "line": 775,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt",
       "source": "Archived sessions will show up here.",
       "surface": "android",
@@ -8787,7 +8811,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 325,
+      "line": 330,
       "path": "apps/ios/Sources/Design/CommandCenterSupport.swift",
       "source": "View More",
       "surface": "apple",
@@ -8899,7 +8923,63 @@
     },
     {
       "kind": "ui-call",
-      "line": 737,
+      "line": 743,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Group name",
+      "surface": "apple",
+      "id": "native.apple.9aba1ae114cf9848"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 748,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Create",
+      "surface": "apple",
+      "id": "native.apple.fdd3242467eb5c34"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 748,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Save",
+      "surface": "apple",
+      "id": "native.apple.b976b71411e9c78d"
+    },
+    {
+      "kind": "ui-modifier",
+      "line": 758,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Delete Group?",
+      "surface": "apple",
+      "id": "native.apple.b2ab82ca08392d29"
+    },
+    {
+      "kind": "ui-call",
+      "line": 766,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Delete Group",
+      "surface": "apple",
+      "id": "native.apple.886ca5d9c049307b"
+    },
+    {
+      "kind": "ui-call",
+      "line": 770,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Cancel",
+      "surface": "apple",
+      "id": "native.apple.ccc876bc505512fc"
+    },
+    {
+      "kind": "ui-call",
+      "line": 774,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Sessions in \\u{201C}\\(group)\\u{201D} move back to Ungrouped.",
+      "surface": "apple",
+      "id": "native.apple.82f2bbb1828494f2"
+    },
+    {
+      "kind": "ui-call",
+      "line": 786,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions",
       "surface": "apple",
@@ -8907,7 +8987,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 751,
+      "line": 800,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Archived sessions",
       "surface": "apple",
@@ -8915,7 +8995,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 760,
+      "line": 809,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Show Archived",
       "surface": "apple",
@@ -8923,7 +9003,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 774,
+      "line": 823,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Sessions unavailable",
       "surface": "apple",
@@ -8931,7 +9011,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 784,
+      "line": 833,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Connect to the gateway.",
       "surface": "apple",
@@ -8939,7 +9019,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 814,
+      "line": 860,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Loading archived sessions",
       "surface": "apple",
@@ -8947,7 +9027,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 814,
+      "line": 860,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Loading recent sessions",
       "surface": "apple",
@@ -8955,7 +9035,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 847,
+      "line": 893,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "No archived sessions",
       "surface": "apple",
@@ -8963,7 +9043,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 847,
+      "line": 893,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "No recent sessions",
       "surface": "apple",
@@ -8971,7 +9051,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 851,
+      "line": 897,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Archived sessions will appear here.",
       "surface": "apple",
@@ -8979,11 +9059,51 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 851,
+      "line": 897,
       "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
       "source": "Start a chat and it will appear here.",
       "surface": "apple",
       "id": "native.apple.bb1a311441d3cf24"
+    },
+    {
+      "kind": "ui-call",
+      "line": 927,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Rename Group…",
+      "surface": "apple",
+      "id": "native.apple.e8e8cea7ec44fe08"
+    },
+    {
+      "kind": "ui-call",
+      "line": 934,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "New Group…",
+      "surface": "apple",
+      "id": "native.apple.b2e6a4382a540792"
+    },
+    {
+      "kind": "ui-call",
+      "line": 940,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Delete Group…",
+      "surface": "apple",
+      "id": "native.apple.553df9e842173417"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 946,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "New Group",
+      "surface": "apple",
+      "id": "native.apple.7b06349d79d0c217"
+    },
+    {
+      "kind": "conditional-branch",
+      "line": 946,
+      "path": "apps/ios/Sources/Design/CommandCenterTab.swift",
+      "source": "Rename Group",
+      "surface": "apple",
+      "id": "native.apple.1b727fbf231de39f"
     },
     {
       "kind": "ui-named-argument",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -22523,7 +22523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1361,
+      "line": 1362,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -22531,7 +22531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1361,
+      "line": 1362,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -155,6 +155,7 @@ class MainViewModel(
   val modelCatalogErrorText: StateFlow<String?> = runtimeState(initial = null) { it.modelCatalogErrorText }
   val modelFavorites: StateFlow<List<String>> = prefs.modelFavorites
   val modelRecents: StateFlow<List<String>> = prefs.modelRecents
+  val sessionCustomGroups: StateFlow<List<String>> = prefs.sessionCustomGroups
   val talkSetupReadiness: StateFlow<GatewayTalkSetupReadiness> =
     runtimeState(initial = GatewayTalkSetupReadiness.unverified()) { it.talkSetupReadiness }
   val gatewayDefaultAgentId: StateFlow<String?> = runtimeState(initial = null) { it.gatewayDefaultAgentId }
@@ -763,6 +764,28 @@ class MainViewModel(
 
   suspend fun deleteChatSession(key: String) {
     ensureRuntime().deleteChatSession(key)
+  }
+
+  /** Remembers a custom session group locally so it renders as an empty section. */
+  fun addChatSessionGroup(name: String) {
+    val trimmed = name.trim()
+    if (trimmed.isEmpty()) return
+    prefs.setSessionCustomGroups(prefs.sessionCustomGroups.value + trimmed)
+  }
+
+  suspend fun renameChatSessionGroup(
+    from: String,
+    to: String,
+  ) {
+    val stored = prefs.sessionCustomGroups.value
+    // Web semantics: replace a stored name in place, otherwise remember the new name.
+    prefs.setSessionCustomGroups(if (from in stored) stored.map { if (it == from) to else it } else stored + to)
+    ensureRuntime().renameChatSessionGroup(from = from, to = to)
+  }
+
+  suspend fun deleteChatSessionGroup(group: String) {
+    prefs.setSessionCustomGroups(prefs.sessionCustomGroups.value.filterNot { it == group })
+    ensureRuntime().dissolveChatSessionGroup(group)
   }
 
   suspend fun forkChatSession(parentKey: String): String? = ensureRuntime().forkChatSession(parentKey)

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -3057,6 +3057,17 @@ class NodeRuntime private constructor(
     )
   }
 
+  suspend fun renameChatSessionGroup(
+    from: String,
+    to: String,
+  ) {
+    chat.renameSessionGroup(from = from, to = to)
+  }
+
+  suspend fun dissolveChatSessionGroup(group: String) {
+    chat.dissolveSessionGroup(group)
+  }
+
   suspend fun deleteChatSession(key: String) {
     chat.deleteSession(key)
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -65,6 +65,7 @@ class SecurePrefs(
     private const val appearanceThemeModeKey = "appearance.themeMode"
     private const val chatModelFavoritesKey = "chat.modelFavorites"
     private const val chatModelRecentsKey = "chat.modelRecents"
+    private const val sessionCustomGroupsKey = "sessions.customGroups"
     private const val maxChatModelRecents = 5
     private const val gatewayCustomHeadersKeyPrefix = "gateway.customHeaders."
   }
@@ -214,6 +215,11 @@ class SecurePrefs(
 
   private val _modelRecents = MutableStateFlow(loadChatModelRefs(chatModelRecentsKey))
   val modelRecents: StateFlow<List<String>> = _modelRecents
+
+  // Custom session group names the user created locally; assigned groups also
+  // persist server-side via the session category field (mirrors web localStorage).
+  private val _sessionCustomGroups = MutableStateFlow(loadChatModelRefs(sessionCustomGroupsKey))
+  val sessionCustomGroups: StateFlow<List<String>> = _sessionCustomGroups
 
   fun setLastDiscoveredStableId(value: String) {
     val trimmed = value.trim()
@@ -647,6 +653,12 @@ class SecurePrefs(
     val next = (listOf(trimmed) + _modelRecents.value.filterNot { it == trimmed }).take(maxChatModelRecents)
     persistChatModelRefs(chatModelRecentsKey, next)
     _modelRecents.value = next
+  }
+
+  fun setSessionCustomGroups(groups: List<String>) {
+    val sanitized = groups.map(String::trim).filter { it.isNotEmpty() }.distinct()
+    persistChatModelRefs(sessionCustomGroupsKey, sanitized)
+    _sessionCustomGroups.value = sanitized
   }
 
   private fun persistChatModelRefs(

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -389,6 +389,76 @@ class ChatController internal constructor(
     }
   }
 
+  /** Renames a session group everywhere: every member session moves to the new category. */
+  suspend fun renameSessionGroup(
+    from: String,
+    to: String,
+  ) {
+    val fromName = from.trim().takeIf { it.isNotEmpty() } ?: return
+    val toName = to.trim().takeIf { it.isNotEmpty() } ?: return
+    patchSessionGroupMembers(group = fromName, category = toName)
+  }
+
+  /** Deletes a session group: member sessions are kept and move back to Ungrouped. */
+  suspend fun dissolveSessionGroup(group: String) {
+    val groupName = group.trim().takeIf { it.isNotEmpty() } ?: return
+    patchSessionGroupMembers(group = groupName, category = null)
+  }
+
+  private suspend fun patchSessionGroupMembers(
+    group: String,
+    category: String?,
+  ) {
+    try {
+      var firstError: Throwable? = null
+      for (member in listSessionGroupMembers(group)) {
+        try {
+          val params =
+            buildJsonObject {
+              put("key", JsonPrimitive(member.key))
+              put("category", category?.let(::JsonPrimitive) ?: JsonNull)
+            }
+          requestGateway("sessions.patch", params.toString())
+        } catch (err: CancellationException) {
+          throw err
+        } catch (err: Throwable) {
+          // Best-effort: one failed member patch must not strand the rest of the group.
+          if (firstError == null) firstError = err
+        }
+      }
+      firstError?.let { updateErrorText(it.message) }
+      fetchSessionsForCurrentWindow()
+    } catch (err: CancellationException) {
+      throw err
+    } catch (err: Throwable) {
+      updateErrorText(err.message)
+    }
+  }
+
+  /**
+   * Enumerates every session assigned to the group. The UI session list is windowed
+   * (limited, archived either-or), so group mutations must not derive membership from
+   * it. An absent limit is capped at 100 rows server-side, so both queries send an
+   * explicit high bound; sessions.list filters archived rows either-or, hence two calls.
+   */
+  private suspend fun listSessionGroupMembers(group: String): List<ChatSessionEntry> {
+    val members = LinkedHashMap<String, ChatSessionEntry>()
+    for (archived in listOf(false, true)) {
+      val params =
+        buildJsonObject {
+          put("includeGlobal", JsonPrimitive(true))
+          put("includeUnknown", JsonPrimitive(false))
+          put("limit", JsonPrimitive(GROUP_MEMBER_FETCH_LIMIT))
+          if (archived) put("archived", JsonPrimitive(true))
+        }
+      val rows = parseSessions(requestGateway("sessions.list", params.toString())).sessions
+      for (row in rows) {
+        if (row.category?.trim() == group && !members.containsKey(row.key)) members[row.key] = row
+      }
+    }
+    return members.values.toList()
+  }
+
   suspend fun deleteSession(key: String) {
     val sessionKey = key.trim().takeIf { it.isNotEmpty() } ?: return
     try {
@@ -2221,6 +2291,9 @@ private enum class ChatMetadataLoadState {
 }
 
 private const val NEW_CHAT_SESSION_LABEL = "New chat"
+
+// Group mutations enumerate whole stores; far past any realistic session count.
+private const val GROUP_MEMBER_FETCH_LIMIT = 10_000
 
 internal fun nextNewChatSessionLabel(sessions: List<ChatSessionEntry>): String {
   val baseLabel = NEW_CHAT_SESSION_LABEL

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SessionsScreen.kt
@@ -89,6 +89,9 @@ internal fun SessionsScreen(
   var searchText by rememberSaveable { mutableStateOf("") }
   var searchResults by remember { mutableStateOf<List<ChatSessionEntry>>(emptyList()) }
   val searchQuery = searchText.trim()
+  var renameGroupName by rememberSaveable { mutableStateOf<String?>(null) }
+  var deleteGroupName by rememberSaveable { mutableStateOf<String?>(null) }
+  var newGroupDialogVisible by rememberSaveable { mutableStateOf(false) }
   val visibleSessions =
     (if (searchQuery.isEmpty()) sessions else searchResults)
       .let { rows ->
@@ -106,10 +109,11 @@ internal fun SessionsScreen(
           rows.sortedBy { it.lastActivityAt ?: it.updatedAtMs ?: 0L }
         }
       }
-  val sections = groupSessionEntries(visibleSessions)
+  val storedGroups by viewModel.sessionCustomGroups.collectAsState()
+  val sections = groupSessionEntries(visibleSessions, knownGroups = storedGroups)
+  // Stored group names stay offered as move targets even while they have no members.
   val categories =
-    sessions
-      .mapNotNull { it.category?.trim()?.takeIf(String::isNotEmpty) }
+    (sessions.mapNotNull { it.category?.trim()?.takeIf(String::isNotEmpty) } + storedGroups)
       .distinctBy { it.lowercase() }
       .sortedWith(String.CASE_INSENSITIVE_ORDER)
 
@@ -214,12 +218,21 @@ internal fun SessionsScreen(
         sections.forEachIndexed { index, section ->
           section.title?.let { title ->
             item(key = "section:$index:$title") {
-              Text(
-                text = title,
-                style = ClawTheme.type.label,
-                color = ClawTheme.colors.textMuted,
-                modifier = Modifier.padding(top = 6.dp),
-              )
+              if (section.isCategory) {
+                SessionGroupHeader(
+                  title = title,
+                  onRename = { renameGroupName = title },
+                  onNewGroup = { newGroupDialogVisible = true },
+                  onDelete = { deleteGroupName = title },
+                )
+              } else {
+                Text(
+                  text = title,
+                  style = ClawTheme.type.label,
+                  color = ClawTheme.colors.textMuted,
+                  modifier = Modifier.padding(top = 6.dp),
+                )
+              }
             }
           }
           items(section.entries, key = { it.key }) { session ->
@@ -302,7 +315,66 @@ internal fun SessionsScreen(
       onDismiss = { groupSessionKey = null },
       onConfirm = { value ->
         groupSessionKey = null
+        // Remember the name so the group survives locally even if the patch later empties it.
+        viewModel.addChatSessionGroup(value)
         coroutineScope.launch { viewModel.patchChatSession(key = session.key, category = value.trim()) }
+      },
+    )
+  }
+
+  renameGroupName?.let { group ->
+    SessionTextDialog(
+      title = "Rename group",
+      stateKey = "group-rename:$group",
+      initialValue = group,
+      confirmLabel = "Rename",
+      allowEmpty = false,
+      onDismiss = { renameGroupName = null },
+      onConfirm = { value ->
+        renameGroupName = null
+        val next = value.trim()
+        if (next.isNotEmpty() && next != group) {
+          coroutineScope.launch { viewModel.renameChatSessionGroup(from = group, to = next) }
+        }
+      },
+    )
+  }
+
+  if (newGroupDialogVisible) {
+    SessionTextDialog(
+      title = "New group",
+      stateKey = "group-new",
+      initialValue = "",
+      confirmLabel = "Create",
+      allowEmpty = false,
+      onDismiss = { newGroupDialogVisible = false },
+      onConfirm = { value ->
+        newGroupDialogVisible = false
+        viewModel.addChatSessionGroup(value)
+      },
+    )
+  }
+
+  deleteGroupName?.let { group ->
+    AlertDialog(
+      onDismissRequest = { deleteGroupName = null },
+      containerColor = ClawTheme.colors.surfaceRaised,
+      title = { Text("Delete group?", style = ClawTheme.type.section, color = ClawTheme.colors.text) },
+      text = { Text("Sessions in \"$group\" are kept and move back to Ungrouped.", style = ClawTheme.type.body, color = ClawTheme.colors.textMuted) },
+      confirmButton = {
+        TextButton(
+          onClick = {
+            deleteGroupName = null
+            coroutineScope.launch { viewModel.deleteChatSessionGroup(group) }
+          },
+        ) {
+          Text("Delete", color = ClawTheme.colors.danger)
+        }
+      },
+      dismissButton = {
+        TextButton(onClick = { deleteGroupName = null }) {
+          Text("Cancel")
+        }
       },
     )
   }
@@ -529,6 +601,43 @@ private fun SessionRow(
   }
 }
 
+/** Category section header; long-press opens the group management menu. */
+@Composable
+private fun SessionGroupHeader(
+  title: String,
+  onRename: () -> Unit,
+  onNewGroup: () -> Unit,
+  onDelete: () -> Unit,
+) {
+  var menuExpanded by remember { mutableStateOf(false) }
+  Box(modifier = Modifier.padding(top = 6.dp)) {
+    Text(
+      text = title,
+      style = ClawTheme.type.label,
+      color = ClawTheme.colors.textMuted,
+      modifier =
+        Modifier.combinedClickable(
+          onClick = {},
+          onLongClick = { menuExpanded = true },
+        ),
+    )
+    DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+      SessionMenuItem("Rename group…") {
+        menuExpanded = false
+        onRename()
+      }
+      SessionMenuItem("New group…") {
+        menuExpanded = false
+        onNewGroup()
+      }
+      SessionMenuItem("Delete group…") {
+        menuExpanded = false
+        onDelete()
+      }
+    }
+  }
+}
+
 @Composable
 private fun SessionMenuItem(
   text: String,
@@ -618,23 +727,32 @@ private enum class SessionFilter {
 internal data class SessionSection(
   val title: String?,
   val entries: List<ChatSessionEntry>,
+  // Only custom category sections expose group actions; "Pinned"/"Ungrouped" are structural.
+  val isCategory: Boolean = false,
 )
 
 /** Groups pinned sessions once, followed by alphabetical categories and remaining sessions. */
-internal fun groupSessionEntries(entries: List<ChatSessionEntry>): List<SessionSection> {
+internal fun groupSessionEntries(
+  entries: List<ChatSessionEntry>,
+  knownGroups: List<String> = emptyList(),
+): List<SessionSection> {
   if (entries.isEmpty()) return emptyList()
   val pinned = entries.filter { it.pinned == true }
   val remaining = entries.filterNot { it.pinned == true }
-  val categorized = remaining.filter { !it.category.isNullOrBlank() }
+  val populated = remaining.filter { !it.category.isNullOrBlank() }.groupBy { it.category.orEmpty().trim() }
+  // Stored-but-empty groups still render so they stay visible as move targets.
+  val emptyKnown =
+    knownGroups
+      .mapNotNull { it.trim().takeIf(String::isNotEmpty) }
+      .distinctBy { it.lowercase() }
+      .filterNot { name -> populated.keys.any { it.equals(name, ignoreCase = true) } }
   val categories =
-    categorized
-      .groupBy { it.category.orEmpty().trim() }
-      .toList()
+    (populated.toList() + emptyKnown.map { it to emptyList<ChatSessionEntry>() })
       .sortedBy { it.first.lowercase() }
   val ungrouped = remaining.filter { it.category.isNullOrBlank() }
   return buildList {
     if (pinned.isNotEmpty()) add(SessionSection(title = "Pinned", entries = pinned))
-    categories.forEach { (category, sessions) -> add(SessionSection(title = category, entries = sessions)) }
+    categories.forEach { (category, sessions) -> add(SessionSection(title = category, entries = sessions, isCategory = true)) }
     if (ungrouped.isNotEmpty()) {
       add(SessionSection(title = "Ungrouped".takeIf { categories.isNotEmpty() }, entries = ungrouped))
     }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerCommandControlsTest.kt
@@ -325,6 +325,80 @@ class ChatControllerCommandControlsTest {
     }
 
   @Test
+  fun renameSessionGroupPatchesEveryMemberIncludingArchivedOnlyOnes() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "sessions.list" ->
+                if (paramsJson.orEmpty().contains("\"archived\":true")) {
+                  """{"sessions":[{"key":"agent:main:active","category":"Work"},{"key":"agent:main:archived","category":" Work "}]}"""
+                } else {
+                  """{"sessions":[{"key":"agent:main:active","category":"Work"},{"key":"agent:main:other","category":"Play"}]}"""
+                }
+              else -> "{}"
+            }
+          },
+        )
+
+      controller.renameSessionGroup(from = "Work", to = "Focus")
+
+      // Membership enumeration sends the explicit high bound (absent limit is
+      // capped at 100 rows server-side) across active + archived rows.
+      val lists = requests.filter { it.first == "sessions.list" }.map { it.second.orEmpty() }
+      assertEquals(2, lists.count { it.contains("\"limit\":10000") })
+      assertEquals(1, lists.count { it.contains("\"archived\":true") })
+
+      val patches = requests.filter { it.first == "sessions.patch" }.map { it.second.orEmpty() }
+      assertEquals(2, patches.size)
+      assertTrue(patches.any { it.contains("\"key\":\"agent:main:active\"") && it.contains("\"category\":\"Focus\"") })
+      assertTrue(patches.any { it.contains("\"key\":\"agent:main:archived\"") && it.contains("\"category\":\"Focus\"") })
+      // The session list refreshes (windowed) after the fan-out.
+      assertTrue(lists.last().contains("\"limit\""))
+    }
+
+  @Test
+  fun dissolveSessionGroupClearsCategoriesBestEffort() =
+    runTest {
+      val requests = mutableListOf<Pair<String, String?>>()
+      var patchCount = 0
+      val controller =
+        ChatController(
+          scope = this,
+          json = json,
+          requestGateway = { method, paramsJson ->
+            requests += method to paramsJson
+            when (method) {
+              "sessions.list" ->
+                if (paramsJson.orEmpty().contains("\"archived\":true")) {
+                  """{"sessions":[{"key":"agent:main:archived","category":"Work"}]}"""
+                } else {
+                  """{"sessions":[{"key":"agent:main:a","category":"Work"},{"key":"agent:main:b","category":"Work"}]}"""
+                }
+              "sessions.patch" -> {
+                patchCount += 1
+                if (patchCount == 1) throw RuntimeException("offline") else "{}"
+              }
+              else -> "{}"
+            }
+          },
+        )
+
+      controller.dissolveSessionGroup("Work")
+
+      // One failed member patch must not abandon the remaining members.
+      val patches = requests.filter { it.first == "sessions.patch" }.map { it.second.orEmpty() }
+      assertEquals(3, patches.size)
+      assertTrue(patches.all { it.contains("\"category\":null") })
+      assertEquals("offline", controller.errorText.value)
+    }
+
+  @Test
   fun forkSessionReturnsCreatedKeyAndRefreshesActiveSessions() =
     runTest {
       val requests = mutableListOf<Pair<String, String?>>()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SessionsScreenGroupingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SessionsScreenGroupingTest.kt
@@ -41,6 +41,38 @@ class SessionsScreenGroupingTest {
     assertEquals(listOf("pinned"), sections.single().entries.map { it.key })
   }
 
+  @Test
+  fun knownGroupsRenderEmptyCategorySectionsInAlphabeticalMerge() {
+    val sections =
+      groupSessionEntries(
+        listOf(session("alpha", category = "Alpha"), session("loose")),
+        knownGroups = listOf(" Beta ", "beta", "alpha", "", "  "),
+      )
+
+    // Blank names drop, "beta" dedupes against " Beta ", and "alpha" merges into the populated section.
+    assertEquals(listOf("Alpha", "Beta", "Ungrouped"), sections.map { it.title })
+    assertEquals(listOf(true, true, false), sections.map { it.isCategory })
+    assertEquals(listOf("alpha"), sections[0].entries.map { it.key })
+    assertEquals(emptyList<String>(), sections[1].entries.map { it.key })
+    assertEquals(listOf("loose"), sections[2].entries.map { it.key })
+  }
+
+  @Test
+  fun knownGroupsAloneDoNotCreateSectionsWithoutSessions() {
+    assertEquals(emptyList<SessionSection>(), groupSessionEntries(emptyList(), knownGroups = listOf("Beta")))
+  }
+
+  @Test
+  fun pinnedAndUngroupedSectionsAreNotCategories() {
+    val sections =
+      groupSessionEntries(
+        listOf(session("pinned", pinned = true), session("grouped", category = "Work"), session("loose")),
+      )
+
+    assertEquals(listOf("Pinned", "Work", "Ungrouped"), sections.map { it.title })
+    assertEquals(listOf(false, true, false), sections.map { it.isCategory })
+  }
+
   private fun session(
     key: String,
     category: String? = null,

--- a/apps/ios/Sources/Design/CommandCenterSupport.swift
+++ b/apps/ios/Sources/Design/CommandCenterSupport.swift
@@ -277,7 +277,12 @@ struct CommandSessionActionsModifier: ViewModifier {
         case .rename:
             self.onRename(value)
         case .newGroup:
-            if let value { self.onMoveToGroup(value) }
+            if let value {
+                // Web parity: only prompt-created groups join the stored list,
+                // so they survive as empty sections after members leave.
+                SessionGroupStore.remember(value)
+                self.onMoveToGroup(value)
+            }
         case nil:
             break
         }

--- a/apps/ios/Sources/Design/CommandCenterTab.swift
+++ b/apps/ios/Sources/Design/CommandCenterTab.swift
@@ -377,7 +377,9 @@ struct CommandCenterTab: View {
     }
 
     private var sessionCategories: [String] {
-        CommandSessionGrouping.categories(from: self.recentChatSessions)
+        CommandSessionGrouping.categories(
+            from: self.recentChatSessions,
+            knownGroups: SessionGroupStore.load())
     }
 
     private var sessionControlsAvailable: Bool {
@@ -686,10 +688,22 @@ struct CommandCenterTab: View {
 struct CommandSessionsScreen: View {
     @Environment(NodeAppModel.self) private var appModel
     @Environment(\.dismiss) private var dismiss
+    private enum GroupEditor: Equatable {
+        case rename(String)
+        case create
+    }
+
+    /// Group mutations need the full session store, not a recency window.
+    private static let groupMemberFetchLimit = 10000
+
     @State private var sessions: [OpenClawChatSessionEntry] = []
     @State private var isLoading = false
     @State private var loadErrorText: String?
     @State private var showArchived = false
+    @State private var knownGroups = SessionGroupStore.load()
+    @State private var groupEditor: GroupEditor?
+    @State private var groupDraftText = ""
+    @State private var groupPendingDelete: String?
     let headerLeadingAction: OpenClawSidebarHeaderAction?
     let usesNativeNavigationChrome: Bool
     let openChat: () -> Void
@@ -724,6 +738,41 @@ struct CommandSessionsScreen: View {
         .toolbar(self.usesNativeNavigationChrome ? .visible : .hidden, for: .navigationBar)
         .task(id: self.refreshID) {
             await self.refreshSessions()
+        }
+        .alert(self.groupEditorTitle, isPresented: self.groupEditorBinding) {
+            TextField("Group name", text: self.$groupDraftText)
+                .font(OpenClawType.body)
+            Button {
+                self.commitGroupEditor()
+            } label: {
+                Text(self.groupEditor == .create ? "Create" : "Save")
+                    .font(OpenClawType.subheadSemiBold)
+            }
+            Button(role: .cancel) {
+                self.groupEditor = nil
+            } label: {
+                Text("Cancel")
+                    .font(OpenClawType.subheadSemiBold)
+            }
+        }
+        .alert(
+            "Delete Group?",
+            isPresented: self.groupDeleteBinding,
+            presenting: self.groupPendingDelete)
+        { group in
+            Button(role: .destructive) {
+                self.deleteGroup(group)
+            } label: {
+                Text("Delete Group")
+                    .font(OpenClawType.subheadSemiBold)
+            }
+            Button(role: .cancel) {} label: {
+                Text("Cancel")
+                    .font(OpenClawType.subheadSemiBold)
+            }
+        } message: { group in
+            Text("Sessions in \u{201C}\(group)\u{201D} move back to Ungrouped.")
+                .font(OpenClawType.caption)
         }
     }
 
@@ -790,10 +839,7 @@ struct CommandSessionsScreen: View {
                         ForEach(self.sessionSections) { section in
                             VStack(alignment: .leading, spacing: 6) {
                                 if section.showsHeader {
-                                    Text(section.title)
-                                        .font(OpenClawType.captionSemiBold)
-                                        .foregroundStyle(.secondary)
-                                        .padding(.horizontal, 4)
+                                    self.sectionHeader(section)
                                 }
                                 ForEach(section.entries) { session in
                                     self.sessionRow(session)
@@ -831,11 +877,11 @@ struct CommandSessionsScreen: View {
     }
 
     private var sessionSections: [CommandSessionSection] {
-        CommandSessionGrouping.sections(from: self.visibleSessions)
+        CommandSessionGrouping.sections(from: self.visibleSessions, knownGroups: self.knownGroups)
     }
 
     private var sessionCategories: [String] {
-        CommandSessionGrouping.categories(from: self.sessions)
+        CommandSessionGrouping.categories(from: self.sessions, knownGroups: self.knownGroups)
     }
 
     private var sessionControlsAvailable: Bool {
@@ -853,6 +899,131 @@ struct CommandSessionsScreen: View {
 
     private var refreshID: String {
         "\(self.appModel.commandSessionListMode):\(self.showArchived)"
+    }
+
+    @ViewBuilder
+    private func sectionHeader(_ section: CommandSessionSection) -> some View {
+        let title = Text(section.title)
+            .font(OpenClawType.captionSemiBold)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 4)
+        // Group management only applies to custom categories, never the
+        // Pinned/Ungrouped built-ins.
+        if case let .category(group) = section.id, self.sessionControlsAvailable {
+            title.contextMenu {
+                self.groupMenu(for: group)
+            }
+        } else {
+            title
+        }
+    }
+
+    @ViewBuilder
+    private func groupMenu(for group: String) -> some View {
+        Button {
+            self.groupDraftText = group
+            self.groupEditor = .rename(group)
+        } label: {
+            Label("Rename Group…", systemImage: "pencil")
+                .font(OpenClawType.subhead)
+        }
+        Button {
+            self.groupDraftText = ""
+            self.groupEditor = .create
+        } label: {
+            Label("New Group…", systemImage: "folder.badge.plus")
+                .font(OpenClawType.subhead)
+        }
+        Button(role: .destructive) {
+            self.groupPendingDelete = group
+        } label: {
+            Label("Delete Group…", systemImage: "trash")
+                .font(OpenClawType.subhead)
+        }
+    }
+
+    private var groupEditorTitle: String {
+        self.groupEditor == .create ? "New Group" : "Rename Group"
+    }
+
+    private var groupEditorBinding: Binding<Bool> {
+        Binding(
+            get: { self.groupEditor != nil },
+            set: { if !$0 { self.groupEditor = nil } })
+    }
+
+    private var groupDeleteBinding: Binding<Bool> {
+        Binding(
+            get: { self.groupPendingDelete != nil },
+            set: { if !$0 { self.groupPendingDelete = nil } })
+    }
+
+    private func commitGroupEditor() {
+        let editor = self.groupEditor
+        self.groupEditor = nil
+        let name = self.groupDraftText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return }
+        switch editor {
+        case let .rename(group):
+            guard name != group else { return }
+            self.updateStoredGroups { SessionGroupStore.renaming($0, from: group, to: name) }
+            self.patchGroupMembers(group, category: name)
+        case .create:
+            // Header-created groups start empty: stored-list only, no patches.
+            self.updateStoredGroups { SessionGroupStore.adding($0, name) }
+        case nil:
+            break
+        }
+    }
+
+    private func deleteGroup(_ group: String) {
+        self.groupPendingDelete = nil
+        self.updateStoredGroups { SessionGroupStore.removing($0, group) }
+        self.patchGroupMembers(group, category: nil)
+    }
+
+    private func updateStoredGroups(_ transform: ([String]) -> [String]) {
+        let updated = transform(SessionGroupStore.load())
+        SessionGroupStore.save(updated)
+        self.knownGroups = updated
+    }
+
+    /// Reassigns (or clears, when `category` is nil) every member of `group`.
+    private func patchGroupMembers(_ group: String, category: String?) {
+        self.performMutation { transport in
+            // Enumerate every member, not the windowed visible list: archived
+            // members must follow a rename so restores land in the new group.
+            // The gateway defaults an absent `limit` to 100 rows, so ask for
+            // an explicitly high limit to cover the whole store.
+            let active = try await transport.listSessions(
+                limit: Self.groupMemberFetchLimit,
+                archived: false)
+            let archived = try await transport.listSessions(
+                limit: Self.groupMemberFetchLimit,
+                archived: true)
+            let members = CommandSessionGrouping.members(
+                of: group,
+                in: [active.sessions, archived.sessions])
+            // Best effort: one failed patch must not abandon the rest of the
+            // group; the first error still surfaces via performMutation.
+            var firstError: (any Error)?
+            for member in members {
+                do {
+                    try await transport.patchSession(
+                        key: member.key,
+                        label: nil,
+                        category: .some(category),
+                        pinned: nil,
+                        archived: nil,
+                        unread: nil)
+                } catch {
+                    firstError = firstError ?? error
+                }
+            }
+            if let firstError {
+                throw firstError
+            }
+        }
     }
 
     private func sessionRow(_ session: OpenClawChatSessionEntry) -> some View {
@@ -957,6 +1128,9 @@ struct CommandSessionsScreen: View {
     }
 
     private func refreshSessions() async {
+        // Pick up groups stored by other surfaces (for example the per-session
+        // New Group editor) alongside the fresh session list.
+        self.knownGroups = SessionGroupStore.load()
         let requestsArchived = self.showArchived
         guard self.appModel.isCommandSessionListAvailable else {
             self.sessions = requestsArchived ? [] : await self.appModel.loadCachedChatSessions()

--- a/apps/ios/Sources/Design/CommandSessionGrouping.swift
+++ b/apps/ios/Sources/Design/CommandSessionGrouping.swift
@@ -15,10 +15,16 @@ struct CommandSessionSection: Identifiable {
 }
 
 enum CommandSessionGrouping {
-    static func sections(from entries: [OpenClawChatSessionEntry]) -> [CommandSessionSection] {
+    static func sections(
+        from entries: [OpenClawChatSessionEntry],
+        knownGroups: [String] = []) -> [CommandSessionSection]
+    {
         let pinned = self.sortedByActivity(entries.filter { $0.pinned == true })
         let unpinned = entries.filter { $0.pinned != true }
+        // Stored-but-empty groups still render as sections so they remain
+        // visible move targets after their last member leaves.
         let categoryNames = Set(unpinned.compactMap { self.normalizedCategory($0.category) })
+            .union(knownGroups.compactMap(self.normalizedCategory))
             .sorted(by: self.categoryComesBefore)
         var sections: [CommandSessionSection] = []
 
@@ -79,9 +85,27 @@ enum CommandSessionGrouping {
         return [current] + capped.prefix(max(0, limit - 1))
     }
 
-    static func categories(from entries: [OpenClawChatSessionEntry]) -> [String] {
+    static func categories(
+        from entries: [OpenClawChatSessionEntry],
+        knownGroups: [String] = []) -> [String]
+    {
         Set(entries.compactMap { self.normalizedCategory($0.category) })
+            .union(knownGroups.compactMap(self.normalizedCategory))
             .sorted(by: self.categoryComesBefore)
+    }
+
+    /// Union of the active and archived enumerations, deduped by key. Group
+    /// mutations must patch archived members too so restores land back in the
+    /// renamed group instead of the stale one.
+    static func members(
+        of group: String,
+        in lists: [[OpenClawChatSessionEntry]]) -> [OpenClawChatSessionEntry]
+    {
+        guard let target = self.normalizedCategory(group) else { return [] }
+        var seen = Set<String>()
+        return lists.flatMap(\.self).filter { entry in
+            self.normalizedCategory(entry.category) == target && seen.insert(entry.key).inserted
+        }
     }
 
     static func activityTimestamp(_ entry: OpenClawChatSessionEntry) -> Double {

--- a/apps/ios/Sources/Design/SessionGroupStore.swift
+++ b/apps/ios/Sources/Design/SessionGroupStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Persists custom session group names so a group without members survives
+/// refreshes and stays usable as a move target. Mirrors the web sidebar's
+/// localStorage-backed list; assigned groups still persist server-side via
+/// the session category field.
+enum SessionGroupStore {
+    static let defaultsKey = "openclaw:sessions:custom-groups"
+
+    static func load(defaults: UserDefaults = .standard) -> [String] {
+        self.normalized(defaults.stringArray(forKey: self.defaultsKey) ?? [])
+    }
+
+    static func save(_ groups: [String], defaults: UserDefaults = .standard) {
+        defaults.set(self.normalized(groups), forKey: self.defaultsKey)
+    }
+
+    static func remember(_ name: String, defaults: UserDefaults = .standard) {
+        self.save(self.adding(self.load(defaults: defaults), name), defaults: defaults)
+    }
+
+    static func normalized(_ groups: [String]) -> [String] {
+        var seen = Set<String>()
+        return groups
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0).inserted }
+    }
+
+    static func adding(_ groups: [String], _ name: String) -> [String] {
+        self.normalized(groups + [name])
+    }
+
+    /// Web parity: replace the old name in place when stored; otherwise append
+    /// the new name so renaming a live-only group still persists it.
+    static func renaming(_ groups: [String], from oldName: String, to newName: String) -> [String] {
+        let renamed = groups.contains(oldName)
+            ? groups.map { $0 == oldName ? newName : $0 }
+            : groups + [newName]
+        return self.normalized(renamed)
+    }
+
+    static func removing(_ groups: [String], _ name: String) -> [String] {
+        self.normalized(groups.filter { $0 != name })
+    }
+}

--- a/apps/ios/Tests/CommandSessionGroupingTests.swift
+++ b/apps/ios/Tests/CommandSessionGroupingTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import OpenClawChatUI
 import Testing
 @testable import OpenClaw
@@ -21,6 +22,58 @@ struct CommandSessionGroupingTests {
         #expect(sections[0].entries.map(\.key) == ["pinned"])
         #expect(sections[1].entries.map(\.key) == ["alpha-new", "alpha-old"])
         #expect(sections[3].showsHeader)
+    }
+
+    @Test func `known groups render empty sections in alphabetical merge`() {
+        let sections = CommandSessionGrouping.sections(
+            from: [
+                self.entry("beta", category: "Beta", activity: 2),
+                self.entry("plain", activity: 1),
+            ],
+            knownGroups: ["Zulu", "Alpha"])
+
+        #expect(sections.map(\.id) == [
+            .category("Alpha"),
+            .category("Beta"),
+            .category("Zulu"),
+            .ungrouped,
+        ])
+        #expect(sections[0].entries.isEmpty)
+        #expect(sections[1].entries.map(\.key) == ["beta"])
+        #expect(sections[2].entries.isEmpty)
+        #expect(sections[3].showsHeader)
+    }
+
+    @Test func `known groups ignore blanks and duplicates`() {
+        let sections = CommandSessionGrouping.sections(
+            from: [self.entry("beta", category: "Beta", activity: 1)],
+            knownGroups: ["  ", "Beta", "Beta", "Alpha"])
+
+        #expect(sections.map(\.id) == [.category("Alpha"), .category("Beta")])
+
+        let categories = CommandSessionGrouping.categories(
+            from: [self.entry("beta", category: "Beta", activity: 1)],
+            knownGroups: ["", "Beta", "Alpha", "Alpha"])
+        #expect(categories == ["Alpha", "Beta"])
+    }
+
+    @Test func `group members merge active and archived lists deduped by key`() {
+        let members = CommandSessionGrouping.members(
+            of: "Ops",
+            in: [
+                [
+                    self.entry("a", category: "Ops", activity: 1),
+                    self.entry("other", category: "Dev", activity: 2),
+                ],
+                [
+                    self.entry("a", category: "Ops", activity: 1),
+                    self.entry("b", category: " Ops ", activity: 3),
+                    self.entry("plain", activity: 4),
+                ],
+            ])
+
+        #expect(members.map(\.key) == ["a", "b"])
+        #expect(CommandSessionGrouping.members(of: "  ", in: [[self.entry("a", activity: 1)]]).isEmpty)
     }
 
     @Test func `hides ungrouped header without category sections`() {
@@ -90,5 +143,37 @@ struct CommandSessionGroupingTests {
             category: category,
             pinned: pinned,
             lastActivityAt: activity)
+    }
+}
+
+struct SessionGroupStoreTests {
+    @Test func `normalizes trims dedupes and drops blanks`() {
+        #expect(SessionGroupStore.normalized([" Ops ", "Ops", "", "  ", "Dev"]) == ["Ops", "Dev"])
+    }
+
+    @Test func `renaming replaces a stored name in place`() {
+        #expect(SessionGroupStore.renaming(["Dev", "Ops"], from: "Dev", to: "Core") == ["Core", "Ops"])
+        // Renaming onto an existing name collapses the duplicate.
+        #expect(SessionGroupStore.renaming(["Dev", "Ops"], from: "Dev", to: "Ops") == ["Ops"])
+    }
+
+    @Test func `renaming a live-only group appends the new name`() {
+        #expect(SessionGroupStore.renaming(["Ops"], from: "Dev", to: "Core") == ["Ops", "Core"])
+    }
+
+    @Test func `removing and adding keep the list unique`() {
+        #expect(SessionGroupStore.removing(["Dev", "Ops"], "Dev") == ["Ops"])
+        #expect(SessionGroupStore.adding(["Ops"], "Ops") == ["Ops"])
+        #expect(SessionGroupStore.adding(["Ops"], " Dev ") == ["Ops", "Dev"])
+    }
+
+    @Test func `load and save round-trip through user defaults`() {
+        withUserDefaults([SessionGroupStore.defaultsKey: nil]) {
+            #expect(SessionGroupStore.load() == [])
+            SessionGroupStore.save([" Dev ", "Dev", "Ops"])
+            #expect(SessionGroupStore.load() == ["Dev", "Ops"])
+            SessionGroupStore.remember("Core")
+            #expect(SessionGroupStore.load() == ["Dev", "Ops", "Core"])
+        }
     }
 }


### PR DESCRIPTION
Closes #101231
Related: #101117

## What Problem This Solves

iOS and Android gained session grouping in #100814, but groups there are write-once: no rename, no delete, and a group only exists while a session carries its category. The web sidebar got full group management in #101117; mobile users were left re-assigning member sessions one by one to reorganize.

## Why This Change Was Made

Both platforms mirror the web semantics. Category section headers gain group actions — a context menu on the iOS Command Center sessions screen ("Rename Group…", "New Group…", "Delete Group…") and a long-press menu on the Android sessions screen. Rename and delete enumerate every member with two `sessions.list` calls (active + archived) using an explicit high limit (the gateway caps an absent `limit` at 100 rows — the same cap the web implementation had to page past), then patch `category` per member best-effort so one failure cannot strand the rest; archived members are included so restores land in the renamed group. Delete keeps sessions and moves them back to Ungrouped. Known custom group names persist client-side (iOS `UserDefaults` key `openclaw:sessions:custom-groups`, matching the web localStorage key; Android SharedPreferences `sessions.customGroups`), so header-created empty groups render as sections and stay usable as move targets. iOS bulk-op enumeration/merge lives in pure `CommandSessionGrouping.members`; Android's lives in `ChatController`, keeping the controller gateway-only.

Non-goals: no group-by on/off toggle on mobile (the mobile screens keep their existing filter/sort controls), and no gateway/protocol changes.

## User Impact

Mobile session groups become maintainable in place: rename a group once instead of per session, delete a group without losing its sessions, and create an empty group before filling it. Group names created or renamed on any platform are the same server-side `category` values, so web and mobile stay consistent.

## Evidence

- Android: `pnpm android:test` (`:app:testPlayDebugUnitTest`) green locally including new tests — known-groups empty-section merge and `ChatController` bulk-op tests asserting per-member patch payloads (archived-only member included), `category:null` on delete, best-effort continuation past a failing patch, and the explicit `limit:10000` enumeration. `pnpm android:lint` (ktlint) green.
- iOS: `pnpm ios:build` green (full app typecheck). Focused simulator tests green for `CommandSessionGroupingTests` (known-groups sections, member merge/dedupe) and `SessionGroupStoreTests` (normalize/rename/remove/UserDefaults round-trip). The unrelated `OpenClawTypographyTests` failure reproduces on current `main` (offenders introduced by #100946/#101198 in `apps/shared` chat files this PR does not touch) and is tracked separately.
- `pnpm native:i18n:check` clean after inventory sync (strings follow the existing plain-literal style of these surfaces).
- Autoreview (Codex, gpt-5.5) on the feature commit: clean — no findings, "patch is correct" (confidence 0.82).
