### PR TITLE
fix(ios): persist voice notes through offline delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **iOS voice-note durability:** persist queued recordings and their routing identity through disconnects, app recreation, and canonical-history reconciliation while preventing duplicate staging and overlapping microphone owners. (#100709)
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **iOS voice-note durability:** persist queued recordings and their routing identity through disconnects, app recreation, and canonical-history reconciliation while preventing duplicate staging and overlapping microphone owners. (#100709)
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8443,7 +8443,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 129,
+      "line": 133,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
@@ -8451,7 +8451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 133,
+      "line": 137,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -8459,7 +8459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 137,
+      "line": 141,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
@@ -8467,7 +8467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 158,
+      "line": 162,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -8475,7 +8475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 171,
+      "line": 175,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
@@ -8483,7 +8483,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 280,
+      "line": 291,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -8491,7 +8491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 305,
+      "line": 316,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -8499,7 +8499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 318,
+      "line": 329,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
@@ -8507,7 +8507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 333,
+      "line": 344,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
@@ -8515,7 +8515,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 343,
+      "line": 354,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -8523,7 +8523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 396,
+      "line": 423,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -8531,7 +8531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 396,
+      "line": 423,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -8539,7 +8539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 408,
+      "line": 435,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName)...",
       "surface": "apple",
@@ -8547,7 +8547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 411,
+      "line": 438,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName); sends when connected",
       "surface": "apple",
@@ -8555,7 +8555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 413,
+      "line": 440,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -8563,7 +8563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 481,
+      "line": 538,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -8571,7 +8571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 482,
+      "line": 539,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -8579,7 +8579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 485,
+      "line": 542,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -8587,7 +8587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 486,
+      "line": 543,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -8595,7 +8595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 489,
+      "line": 546,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -8603,7 +8603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 490,
+      "line": 547,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
@@ -22403,7 +22403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1436,
+      "line": 1462,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -22411,7 +22411,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1436,
+      "line": 1462,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",
@@ -22419,7 +22419,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1660,
+      "line": 1686,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before switching chats.",
       "surface": "apple",
@@ -22427,7 +22427,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 1716,
+      "line": 1742,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
       "surface": "apple",

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -8443,7 +8443,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 121,
+      "line": 129,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unable to Export Transcript",
       "surface": "apple",
@@ -8451,7 +8451,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 125,
+      "line": 133,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OK",
       "surface": "apple",
@@ -8459,7 +8459,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 129,
+      "line": 137,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "OpenClaw could not prepare the Markdown file.",
       "surface": "apple",
@@ -8467,7 +8467,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 150,
+      "line": 158,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What would you like to work on?",
       "surface": "apple",
@@ -8475,7 +8475,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 163,
+      "line": 171,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "The session attaches once the gateway is ready.",
       "surface": "apple",
@@ -8483,7 +8483,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 268,
+      "line": 280,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Opens Settings / Gateway",
       "surface": "apple",
@@ -8491,7 +8491,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 293,
+      "line": 305,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat",
       "surface": "apple",
@@ -8499,7 +8499,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 306,
+      "line": 318,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "New Chat in Worktree",
       "surface": "apple",
@@ -8507,7 +8507,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 321,
+      "line": 333,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Export Transcript",
       "surface": "apple",
@@ -8515,7 +8515,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 331,
+      "line": 343,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Chat actions",
       "surface": "apple",
@@ -8523,7 +8523,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 384,
+      "line": 396,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connected",
       "surface": "apple",
@@ -8531,7 +8531,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 384,
+      "line": 396,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Unavailable",
       "surface": "apple",
@@ -8539,7 +8539,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 396,
+      "line": 408,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName)...",
       "surface": "apple",
@@ -8547,7 +8547,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 399,
+      "line": 411,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Message \\(self.agentDisplayName); sends when connected",
       "surface": "apple",
@@ -8555,7 +8555,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 401,
+      "line": 413,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Connect to a gateway",
       "surface": "apple",
@@ -8563,7 +8563,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 469,
+      "line": 481,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Check OpenClaw status",
       "surface": "apple",
@@ -8571,7 +8571,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 470,
+      "line": 482,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Summarize the current OpenClaw status and tell me what needs attention.",
       "surface": "apple",
@@ -8579,7 +8579,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 473,
+      "line": 485,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "What can I control here?",
       "surface": "apple",
@@ -8587,7 +8587,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 474,
+      "line": 486,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Show me which phone controls and device capabilities are available right now.",
       "surface": "apple",
@@ -8595,7 +8595,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 477,
+      "line": 489,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start voice chat",
       "surface": "apple",
@@ -8603,7 +8603,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 478,
+      "line": 490,
       "path": "apps/ios/Sources/Design/ChatProTab.swift",
       "source": "Help me start a realtime voice session from this phone.",
       "surface": "apple",
@@ -12525,9 +12525,9 @@
       "kind": "plist-string",
       "line": 70,
       "path": "apps/ios/Sources/Info.plist",
-      "source": "OpenClaw uses the microphone for realtime chat, voice wake, and push-to-talk.",
+      "source": "OpenClaw uses the microphone for realtime chat, voice wake, push-to-talk, and voice notes.",
       "surface": "apple",
-      "id": "native.apple.41f58df89e66324e"
+      "id": "native.apple.7c2cbe7077e4eff1"
     },
     {
       "kind": "plist-string",
@@ -12731,7 +12731,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2878,
+      "line": 2889,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Action required",
       "surface": "apple",
@@ -12739,7 +12739,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 2878,
+      "line": 2889,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Approval needed",
       "surface": "apple",
@@ -12747,7 +12747,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3440,
+      "line": 3451,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting…",
       "surface": "apple",
@@ -12755,7 +12755,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3440,
+      "line": 3451,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting…",
       "surface": "apple",
@@ -12763,7 +12763,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3444,
+      "line": 3455,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -12771,7 +12771,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3444,
+      "line": 3455,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Reconnecting...",
       "surface": "apple",
@@ -12779,7 +12779,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3736,
+      "line": 3747,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Connected",
       "surface": "apple",
@@ -12787,7 +12787,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 3736,
+      "line": 3747,
       "path": "apps/ios/Sources/Model/NodeAppModel.swift",
       "source": "Offline",
       "surface": "apple",
@@ -21811,7 +21811,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 240,
+      "line": 247,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Context \\(percentage)% used",
       "surface": "apple",
@@ -21819,7 +21819,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 244,
+      "line": 251,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Thinking",
       "surface": "apple",
@@ -21827,7 +21827,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 265,
+      "line": 272,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Model",
       "surface": "apple",
@@ -21835,7 +21835,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 282,
+      "line": 289,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pinned",
       "surface": "apple",
@@ -21843,7 +21843,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 290,
+      "line": 297,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Recent",
       "surface": "apple",
@@ -21851,7 +21851,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 298,
+      "line": 305,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Models",
       "surface": "apple",
@@ -21859,7 +21859,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 327,
+      "line": 334,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Pin model",
       "surface": "apple",
@@ -21867,7 +21867,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 327,
+      "line": 334,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Unpin model",
       "surface": "apple",
@@ -21875,7 +21875,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 331,
+      "line": 338,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Session",
       "surface": "apple",
@@ -21883,7 +21883,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 395,
+      "line": 402,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Add Image",
       "surface": "apple",
@@ -21891,7 +21891,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 396,
+      "line": 403,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Attachments",
       "surface": "apple",
@@ -21899,7 +21899,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 431,
+      "line": 438,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Voice note",
       "surface": "apple",
@@ -21907,7 +21907,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 589,
+      "line": 596,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Talk",
       "surface": "apple",
@@ -21915,7 +21915,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 635,
+      "line": 642,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start realtime chat",
       "surface": "apple",
@@ -21923,7 +21923,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 635,
+      "line": 642,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop realtime chat",
       "surface": "apple",
@@ -21931,7 +21931,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 668,
+      "line": 675,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Start",
       "surface": "apple",
@@ -21939,7 +21939,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 668,
+      "line": 675,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop",
       "surface": "apple",
@@ -21947,7 +21947,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 778,
+      "line": 785,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Loading commands",
       "surface": "apple",
@@ -21955,7 +21955,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 787,
+      "line": 794,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Commands unavailable",
       "surface": "apple",
@@ -21963,7 +21963,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 796,
+      "line": 803,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Retry",
       "surface": "apple",
@@ -21971,7 +21971,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 805,
+      "line": 812,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "No matching commands",
       "surface": "apple",
@@ -21979,7 +21979,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 937,
+      "line": 944,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Stop response",
       "surface": "apple",
@@ -21987,7 +21987,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 962,
+      "line": 969,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Send message",
       "surface": "apple",
@@ -21995,7 +21995,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 977,
+      "line": 984,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -22003,7 +22003,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1108,
+      "line": 1118,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Connecting...",
       "surface": "apple",
@@ -22011,7 +22011,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1108,
+      "line": 1118,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift",
       "source": "Gateway connected",
       "surface": "apple",
@@ -22307,7 +22307,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 434,
+      "line": 436,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Retry Send",
       "surface": "apple",
@@ -22315,7 +22315,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 448,
+      "line": 450,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Delete",
       "surface": "apple",
@@ -22323,7 +22323,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 479,
+      "line": 481,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Stop Listening",
       "surface": "apple",
@@ -22331,7 +22331,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 482,
+      "line": 484,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Listen",
       "surface": "apple",
@@ -22339,7 +22339,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 555,
+      "line": 557,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest",
       "surface": "apple",
@@ -22347,7 +22347,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 566,
+      "line": 568,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Jump to latest reply",
       "surface": "apple",
@@ -22355,7 +22355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 586,
+      "line": 588,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Refresh",
       "surface": "apple",
@@ -22363,7 +22363,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 1011,
+      "line": 1013,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Loading chat",
       "surface": "apple",
@@ -22371,7 +22371,7 @@
     },
     {
       "kind": "ui-modifier",
-      "line": 1091,
+      "line": 1093,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift",
       "source": "Dismiss",
       "surface": "apple",
@@ -22379,7 +22379,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 22,
+      "line": 26,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Could not attach voice note: \\(error.localizedDescription)",
       "surface": "apple",
@@ -22387,7 +22387,7 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 27,
+      "line": 31,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "Voice note exceeds the 5 MB attachment limit",
       "surface": "apple",
@@ -22395,7 +22395,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 91,
+      "line": 98,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift",
       "source": "\\(baseName).jpg",
       "surface": "apple",
@@ -22403,7 +22403,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1362,
+      "line": 1436,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "delivery unconfirmed",
       "surface": "apple",
@@ -22411,11 +22411,27 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1362,
+      "line": 1436,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
       "source": "queued after route change",
       "surface": "apple",
       "id": "native.apple.722f1f90b97e8e45"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1660,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
+      "source": "Remove attachments or wait for delivery to resolve before switching chats.",
+      "surface": "apple",
+      "id": "native.apple.710c7bd117a7cc12"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 1716,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift",
+      "source": "Remove attachments or wait for delivery to resolve before starting a new chat.",
+      "surface": "apple",
+      "id": "native.apple.d93e6fe16ec1b0e5"
     },
     {
       "kind": "ui-modifier",
@@ -22459,7 +22475,15 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 108,
+      "line": 143,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
+      "source": "Push-to-talk is using the microphone.",
+      "surface": "apple",
+      "id": "native.apple.246c877ad41b4062"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 150,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Microphone access is required. Enable it in Settings.",
       "surface": "apple",
@@ -22467,11 +22491,19 @@
     },
     {
       "kind": "ui-localized-call",
-      "line": 121,
+      "line": 163,
       "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
       "source": "Could not start recording: \\(error.localizedDescription)",
       "surface": "apple",
       "id": "native.apple.c963f6dfaa0610b5"
+    },
+    {
+      "kind": "ui-localized-call",
+      "line": 246,
+      "path": "apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift",
+      "source": "Recording was interrupted. Try again.",
+      "surface": "apple",
+      "id": "native.apple.bb00abc2aa9ae5e1"
     },
     {
       "kind": "conditional-branch",

--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -75,6 +75,14 @@ struct ChatProTab: View {
         .onChange(of: self.appModel.chatSessionRoutingContract) { _, _ in
             self.syncChatViewModel()
         }
+        .onChange(of: self.appModel.voiceNoteRecorder.ownsPendingChatAttachment) { _, _ in
+            self.viewModel?.attachmentOwnerActivityChanged()
+            self.syncChatViewModel()
+        }
+        .onChange(of: self.viewModel?.isAttachmentOwnerPinned) { _, pinned in
+            guard pinned == false else { return }
+            self.syncChatViewModel()
+        }
         .onChange(of: self.appModel.isAppleReviewDemoModeEnabled) { _, _ in
             self.syncChatViewModel()
             self.viewModel?.refresh()
@@ -197,6 +205,9 @@ struct ChatProTab: View {
             currentTransportAgentID: self.viewModelTransportAgentID,
             nextTransportAgentID: transportAgentID)
         {
+            // Keep recording, staging, and delivery on their captured route.
+            // The pin-change observer replays this rebuild with latest state.
+            guard !viewModel.isAttachmentOwnerPinned else { return }
             self.viewModelOwnerID = ownerID
             self.viewModelTransportAgentID = transportAgentID
             self.viewModelRoutingContract = routingContract
@@ -214,6 +225,7 @@ struct ChatProTab: View {
         // One store instance backs both seams so the transcript cache and the
         // offline outbox share a single SQLite connection.
         let offlineStore = self.appModel.makeChatOfflineStore()
+        let voiceNoteRecorder = self.appModel.voiceNoteRecorder
         return OpenClawChatViewModel(
             sessionKey: sessionKey,
             // Bind durable rows and their transport lease to the exact same
@@ -221,6 +233,7 @@ struct ChatProTab: View {
             transport: self.appModel.makeChatTransport(outboxGatewayID: offlineStore?.gatewayID),
             activeAgentId: self.appModel.chatDeliveryAgentId,
             sessionRoutingContract: self.appModel.chatSessionRoutingContract,
+            attachmentOwnerIsActive: { voiceNoteRecorder.ownsPendingChatAttachment },
             transcriptCache: offlineStore,
             outbox: offlineStore,
             onSessionChanged: { sessionKey in

--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -153,7 +153,7 @@ struct ChatProTab: View {
                 showsAssistantAvatars: false,
                 composerChrome: .clean,
                 isComposerEnabled: self.gatewayConnected || self.canQueueOffline,
-                isAttachmentInputEnabled: self.gatewayConnected,
+                isAttachmentInputEnabled: self.gatewayConnected || self.canQueueOffline,
                 messagePlaceholder: self.messagePlaceholder,
                 emptyAssistantIntro: String(localized: "What would you like to work on?"),
                 emptyAssistantPrompts: Self.emptyAssistantPrompts,

--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -17,6 +17,10 @@ struct ChatProTab: View {
     // Track the real agent so gateway metadata replaces the captured transport.
     @State private var viewModelTransportAgentID = ""
     @State private var viewModelRoutingContract = ""
+    @State private var viewModelPresentationAgentID = "main"
+    @State private var viewModelPresentationAgentName = "Main"
+    @State private var viewModelPresentationAgentBadge = "M"
+    @State private var viewModelHasVerifiedOfflineRoutingIdentity = false
     @State private var speech: OpenClawChatSpeechController?
     let headerLeadingAction: OpenClawSidebarHeaderAction?
     let headerTitle: String?
@@ -157,7 +161,7 @@ struct ChatProTab: View {
                 messagePlaceholder: self.messagePlaceholder,
                 emptyAssistantIntro: String(localized: "What would you like to work on?"),
                 emptyAssistantPrompts: Self.emptyAssistantPrompts,
-                talkControl: self.talkControl,
+                talkControl: viewModel.isAttachmentOwnerPinned ? nil : self.talkControl,
                 voiceNoteControl: self.voiceNoteControl,
                 speech: self.speech)
                 // iMessage-style grey bubbles for agent replies in the clean chrome.
@@ -196,6 +200,7 @@ struct ChatProTab: View {
             self.viewModelOwnerID = ownerID
             self.viewModelTransportAgentID = transportAgentID
             self.viewModelRoutingContract = routingContract
+            self.captureCurrentPresentationIdentity()
             self.viewModel = self.makeChatViewModel(sessionKey: sessionKey)
             return
         }
@@ -211,6 +216,7 @@ struct ChatProTab: View {
             self.viewModelOwnerID = ownerID
             self.viewModelTransportAgentID = transportAgentID
             self.viewModelRoutingContract = routingContract
+            self.captureCurrentPresentationIdentity()
             self.viewModel = self.makeChatViewModel(sessionKey: sessionKey)
             return
         }
@@ -219,6 +225,16 @@ struct ChatProTab: View {
             viewModel.syncSessionRoutingContract(self.appModel.chatSessionRoutingContract)
         }
         viewModel.syncSession(to: sessionKey)
+        if !viewModel.isAttachmentOwnerPinned {
+            self.captureCurrentPresentationIdentity()
+        }
+    }
+
+    private func captureCurrentPresentationIdentity() {
+        self.viewModelPresentationAgentID = self.currentAgentID
+        self.viewModelPresentationAgentName = self.currentAgentDisplayName
+        self.viewModelPresentationAgentBadge = self.currentAgentBadge
+        self.viewModelHasVerifiedOfflineRoutingIdentity = self.appModel.hasVerifiedChatOfflineRoutingIdentity
     }
 
     private func makeChatViewModel(sessionKey: String) -> OpenClawChatViewModel {
@@ -264,11 +280,6 @@ struct ChatProTab: View {
             isTalkActive: self.appModel.isTalkCaptureActive)
     }
 
-    private var activeAgentID: String {
-        self.normalized(self.appModel.chatAgentId)
-            ?? "main"
-    }
-
     @ViewBuilder
     private var connectionStatusButton: some View {
         if let openSettings {
@@ -308,7 +319,7 @@ struct ChatProTab: View {
                     Image(systemName: "plus.bubble")
                 }
             }
-            .disabled(self.viewModel == nil || !self.gatewayConnected)
+            .disabled(self.viewModel == nil || !self.gatewayConnected || self.isAttachmentOwnerPinned)
 
             if self.activeAgent?.workspacegit == true {
                 Button {
@@ -321,7 +332,7 @@ struct ChatProTab: View {
                         Image(systemName: "arrow.triangle.branch")
                     }
                 }
-                .disabled(self.viewModel == nil || !self.gatewayConnected)
+                .disabled(self.viewModel == nil || !self.gatewayConnected || self.isAttachmentOwnerPinned)
             }
 
             Divider()
@@ -370,7 +381,23 @@ struct ChatProTab: View {
     }
 
     private var gatewayDisplayState: GatewayDisplayState {
-        GatewayStatusBuilder.build(appModel: self.appModel)
+        Self.presentationGatewayState(
+            current: GatewayStatusBuilder.build(appModel: self.appModel),
+            isAttachmentOwnerPinned: self.isAttachmentOwnerPinned,
+            capturedOwnerID: self.viewModelOwnerID,
+            currentOwnerID: self.appModel.chatViewModelOwnerID)
+    }
+
+    nonisolated static func presentationGatewayState(
+        current: GatewayDisplayState,
+        isAttachmentOwnerPinned: Bool,
+        capturedOwnerID: String,
+        currentOwnerID: String) -> GatewayDisplayState
+    {
+        if isAttachmentOwnerPinned, capturedOwnerID != currentOwnerID {
+            return .disconnected
+        }
+        return current
     }
 
     private var gatewayAccessibilityLabel: String {
@@ -415,7 +442,9 @@ struct ChatProTab: View {
 
     private var canQueueOffline: Bool {
         self.viewModel?.supportsOfflineTextOutbox == true &&
-            self.appModel.hasVerifiedChatOfflineRoutingIdentity
+            (self.isAttachmentOwnerPinned
+                ? self.viewModelHasVerifiedOfflineRoutingIdentity
+                : self.appModel.hasVerifiedChatOfflineRoutingIdentity)
     }
 
     private var headerDisplayTitle: String {
@@ -431,22 +460,50 @@ struct ChatProTab: View {
         OpenClawBrand.accent
     }
 
+    private var isAttachmentOwnerPinned: Bool {
+        self.viewModel?.isAttachmentOwnerPinned == true
+    }
+
+    private var currentAgentID: String {
+        self.normalized(self.appModel.chatAgentId) ?? "main"
+    }
+
+    private var currentActiveAgent: AgentSummary? {
+        self.appModel.gatewayAgents.first { $0.id == self.currentAgentID }
+    }
+
+    private var activeAgentID: String {
+        self.isAttachmentOwnerPinned ? self.viewModelPresentationAgentID : self.currentAgentID
+    }
+
     private var activeAgent: AgentSummary? {
         self.appModel.gatewayAgents.first { $0.id == self.activeAgentID }
     }
 
-    private var agentDisplayName: String {
-        self.normalized(self.activeAgent?.name) ?? self.appModel.chatAgentName
+    private var currentAgentDisplayName: String {
+        self.normalized(self.currentActiveAgent?.name) ?? self.appModel.chatAgentName
     }
 
-    private var agentBadge: String {
-        if let identity = activeAgent?.identity,
+    private var agentDisplayName: String {
+        self.isAttachmentOwnerPinned ? self.viewModelPresentationAgentName : self.currentAgentDisplayName
+    }
+
+    private var currentAgentBadge: String {
+        if let identity = self.currentActiveAgent?.identity,
            let emoji = identity["emoji"]?.value as? String,
            let normalizedEmoji = Self.normalizedBadgeEmoji(emoji)
         {
             return normalizedEmoji
         }
-        let words = self.agentDisplayName
+        return Self.initialsBadge(for: self.currentAgentDisplayName)
+    }
+
+    private var agentBadge: String {
+        self.isAttachmentOwnerPinned ? self.viewModelPresentationAgentBadge : self.currentAgentBadge
+    }
+
+    nonisolated static func initialsBadge(for displayName: String) -> String {
+        let words = displayName
             .split(whereSeparator: { $0.isWhitespace || $0 == "-" || $0 == "_" })
             .prefix(2)
         let initials = words.compactMap(\.first).map(String.init).joined()

--- a/apps/ios/Sources/Design/ChatProTab.swift
+++ b/apps/ios/Sources/Design/ChatProTab.swift
@@ -207,7 +207,6 @@ struct ChatProTab: View {
             self.viewModelRoutingContract = routingContract
             viewModel.syncSessionRoutingContract(self.appModel.chatSessionRoutingContract)
         }
-        guard viewModel.sessionKey != sessionKey else { return }
         viewModel.syncSession(to: sessionKey)
     }
 
@@ -249,7 +248,7 @@ struct ChatProTab: View {
     private var voiceNoteControl: OpenClawChatVoiceNoteControl {
         OpenClawChatVoiceNoteControl(
             recorder: self.appModel.voiceNoteRecorder,
-            isTalkActive: self.appModel.talkMode.isEnabled || self.appModel.talkMode.isPushToTalkActive)
+            isTalkActive: self.appModel.isTalkCaptureActive)
     }
 
     private var activeAgentID: String {

--- a/apps/ios/Sources/Info.plist
+++ b/apps/ios/Sources/Info.plist
@@ -67,7 +67,7 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>OpenClaw uses your location when you allow location sharing.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>OpenClaw uses the microphone for realtime chat, voice wake, and push-to-talk.</string>
+	<string>OpenClaw uses the microphone for realtime chat, voice wake, push-to-talk, and voice notes.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>OpenClaw may use motion data to support device-aware interactions and automations.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -709,6 +709,11 @@ final class NodeAppModel {
             self.backgroundedAt = Date()
             self.reconnectAfterBackgroundArmed = true
             self.beginBackgroundConnectionGracePeriod()
+            if self.voiceNoteRecorder.isRecording || self.voiceNoteRecorder.isRequestingPermission {
+                // Cancel first: releasing the voice-note suppression reason can
+                // schedule Voice Wake, which the background suspension must catch.
+                self.voiceNoteRecorder.cancel()
+            }
             // Release voice wake mic in background.
             self.backgroundVoiceWakeSuspended = self.voiceWake.suspendForExternalAudioCapture()
             let shouldKeepTalkActive = keepTalkActive && self.talkMode.isEnabled

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -312,6 +312,12 @@ final class NodeAppModel {
         self.operatorGateway
     }
 
+    var isTalkCaptureActive: Bool {
+        // PTT owns its Voice Wake lease before permission and audio setup.
+        // Count that pending interval so Chat cannot race another mic owner.
+        self.talkMode.isEnabled || self.talkMode.isPushToTalkActive || self.pttVoiceWakeLeaseCount > 0
+    }
+
     var localChatFixture: LocalChatFixture? {
         if self.isScreenshotFixtureModeEnabled { return .appScreenshots }
         if self.isAppleReviewDemoModeEnabled { return .appleReviewDemo }
@@ -518,6 +524,9 @@ final class NodeAppModel {
         self.watchMessagingService = watchMessagingService
         self.talkMode = talkMode
         self.voiceNoteRecorder = voiceNoteRecorder
+        self.voiceNoteRecorder.setCaptureAdmissionHandler { [weak self] in
+            self?.isTalkCaptureActive == false
+        }
         self.apnsDeviceTokenHex = UserDefaults.standard.string(forKey: Self.apnsDeviceTokenUserDefaultsKey)
         restorePersistedWatchExecApprovalBridgeState()
         GatewayDiagnostics.bootstrap()
@@ -1982,21 +1991,8 @@ final class NodeAppModel {
     }
 
     private func handleTalkInvoke(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {
-        if req.command == OpenClawTalkCommand.pttOnce.rawValue ||
-            req.command == OpenClawTalkCommand.pttStart.rawValue
-        {
-            // Composer recording and PTT use separate AVAudio stacks. Refuse the
-            // second owner before it can reconfigure the shared audio session.
-            guard !self.voiceNoteRecorder.isRecording,
-                  !self.voiceNoteRecorder.isRequestingPermission
-            else {
-                throw NSError(domain: "TalkMode", code: 8, userInfo: [
-                    NSLocalizedDescriptionKey: "Voice note recording is active",
-                ])
-            }
-        }
-
         if req.command == OpenClawTalkCommand.pttOnce.rawValue {
+            try self.rejectTalkCaptureWhileVoiceNoteActive()
             self.acquirePttVoiceWakeLease()
             defer { self.releasePttVoiceWakeLease() }
             let payload = try await talkMode.runPushToTalkOnce()
@@ -2009,6 +2005,7 @@ final class NodeAppModel {
 
         switch req.command {
         case OpenClawTalkCommand.pttStart.rawValue:
+            try self.rejectTalkCaptureWhileVoiceNoteActive()
             let acquiredLease = !self.pttSessionOwnsVoiceWakeLease
             if acquiredLease {
                 self.acquirePttVoiceWakeLease()
@@ -2048,6 +2045,15 @@ final class NodeAppModel {
                 ok: false,
                 error: OpenClawNodeError(code: .invalidRequest, message: "INVALID_REQUEST: unknown command"))
         }
+    }
+
+    private func rejectTalkCaptureWhileVoiceNoteActive() throws {
+        // Remote PTT bypasses the Chat Talk toggle. Preserve the user's draft;
+        // Talk must not reconfigure AVAudioSession while its recorder owns it.
+        guard self.voiceNoteRecorder.isRecording || self.voiceNoteRecorder.isRequestingPermission else { return }
+        throw NSError(domain: "TalkMode", code: 8, userInfo: [
+            NSLocalizedDescriptionKey: "Finish or cancel the active voice note before starting push-to-talk.",
+        ])
     }
 
     private func acquirePttVoiceWakeLease() {

--- a/apps/ios/Sources/sv.lproj/InfoPlist.strings
+++ b/apps/ios/Sources/sv.lproj/InfoPlist.strings
@@ -7,7 +7,7 @@
 "NSContactsUsageDescription" = "OpenClaw använder dina kontakter så att du kan söka efter och hänvisa till personer när du använder assistenten.";
 "NSLocationWhenInUseUsageDescription" = "OpenClaw använder din plats när du tillåter platsdelning.";
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "OpenClaw kan dela din plats i bakgrunden när du aktiverar Alltid.";
-"NSMicrophoneUsageDescription" = "OpenClaw använder mikrofonen för realtidschatt, röstaktivering och tryck-och-prata.";
+"NSMicrophoneUsageDescription" = "OpenClaw använder mikrofonen för realtidschatt, röstaktivering, tryck-och-prata och röstmeddelanden.";
 "NSMotionUsageDescription" = "OpenClaw kan använda rörelsedata för att stödja enhetsmedvetna interaktioner och automatiseringar.";
 "NSPhotoLibraryUsageDescription" = "OpenClaw låter din assistent läsa bilder som du tillåter och låter dig välja bilder att dela.";
 "NSRemindersFullAccessUsageDescription" = "OpenClaw använder dina påminnelser för att lista, lägga till och slutföra uppgifter när du aktiverar åtkomst till påminnelser.";

--- a/apps/ios/Tests/GatewayStatusBuilderTests.swift
+++ b/apps/ios/Tests/GatewayStatusBuilderTests.swift
@@ -2,8 +2,8 @@ import OpenClawKit
 import Testing
 @testable import OpenClaw
 
-@Suite struct GatewayStatusBuilderTests {
-    @Test func pausedProblemKeepsErrorStatus() {
+struct GatewayStatusBuilderTests {
+    @Test func `paused problem keeps error status`() {
         let state = GatewayStatusBuilder.build(
             gatewayServerName: nil,
             lastGatewayProblem: GatewayConnectionProblem(
@@ -19,7 +19,7 @@ import Testing
         #expect(state == .error)
     }
 
-    @Test func transientProblemAllowsConnectingStatus() {
+    @Test func `transient problem allows connecting status`() {
         let state = GatewayStatusBuilder.build(
             gatewayServerName: nil,
             lastGatewayProblem: GatewayConnectionProblem(
@@ -34,7 +34,7 @@ import Testing
         #expect(state == .connecting)
     }
 
-    @Test func chatGatewayPillLabelsMatchDisplayState() {
+    @Test func `chat gateway pill labels match display state`() {
         #expect(ChatProTab.gatewayPillTitle(state: .disconnected, isGatewayUsable: false) == "Offline")
         #expect(ChatProTab.gatewayPillTitle(state: .connecting, isGatewayUsable: false) == "Connecting")
         #expect(ChatProTab.gatewayPillTitle(state: .error, isGatewayUsable: false) == "Attention")
@@ -47,6 +47,25 @@ import Testing
         #expect(ChatProTab.normalizedBadgeEmoji("?") == nil)
         #expect(ChatProTab.normalizedBadgeEmoji("   ") == nil)
         #expect(ChatProTab.normalizedBadgeEmoji(nil) == nil)
+        #expect(ChatProTab.initialsBadge(for: "Agent Smith") == "AS")
+    }
+
+    @Test func `pinned attachment displays its captured gateway owner`() {
+        #expect(ChatProTab.presentationGatewayState(
+            current: .connected,
+            isAttachmentOwnerPinned: true,
+            capturedOwnerID: "gateway-a",
+            currentOwnerID: "gateway-b") == .disconnected)
+        #expect(ChatProTab.presentationGatewayState(
+            current: .connected,
+            isAttachmentOwnerPinned: true,
+            capturedOwnerID: "gateway-a",
+            currentOwnerID: "gateway-a") == .connected)
+        #expect(ChatProTab.presentationGatewayState(
+            current: .connected,
+            isAttachmentOwnerPinned: false,
+            capturedOwnerID: "gateway-a",
+            currentOwnerID: "gateway-b") == .connected)
     }
 
     @Test func `chat starter prompts stay stable and actionable`() {

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -1,11 +1,33 @@
 import Foundation
-import OpenClawChatUI
 import OpenClawKit
 import OpenClawProtocol
 import Testing
 import UIKit
 import UserNotifications
 @testable import OpenClaw
+@testable import OpenClawChatUI
+
+@MainActor
+private final class MockVoiceNoteAudioCapture: VoiceNoteAudioCapture {
+    private(set) var cancelCallCount = 0
+    private(set) var permissionRequestCount = 0
+
+    func requestPermission() async -> Bool {
+        self.permissionRequestCount += 1
+        return true
+    }
+
+    func start(url _: URL) throws {}
+    func stop() -> TimeInterval {
+        1
+    }
+
+    func cancel() {
+        self.cancelCallCount += 1
+    }
+
+    func setFailureHandler(_: @escaping @MainActor () -> Void) {}
+}
 
 private func makeAgentDeepLinkURL(
     message: String,
@@ -739,21 +761,24 @@ private actor WatchSnapshotSendGate {
         appModel.voiceWake.stop()
     }
 
-    @Test @MainActor func `PTT start is refused while a voice note owns the microphone`() async {
-        let voiceNoteRecorder = OpenClawVoiceNoteRecorder(capture: VoiceNoteCaptureStub())
-        let talkMode = TalkModeManager(allowSimulatorCapture: true)
-        let appModel = NodeAppModel(talkMode: talkMode, voiceNoteRecorder: voiceNoteRecorder)
-        #expect(await voiceNoteRecorder.start())
-        defer { voiceNoteRecorder.cancel() }
+    @Test @MainActor func `PTT start preserves an active voice note`() async {
+        let capture = MockVoiceNoteAudioCapture()
+        let recorder = OpenClawVoiceNoteRecorder(capture: capture)
+        #expect(await recorder.start())
+        let appModel = NodeAppModel(
+            talkMode: TalkModeManager(allowSimulatorCapture: true),
+            voiceNoteRecorder: recorder)
 
         let request = BridgeInvokeRequest(
-            id: "ptt-start-during-voice-note",
+            id: "ptt-start-with-voice-note",
             command: OpenClawTalkCommand.pttStart.rawValue)
         let response = await appModel._test_handleInvoke(request)
 
         #expect(response.ok == false)
-        #expect(response.error?.message.contains("Voice note recording is active") == true)
-        #expect(talkMode.isPushToTalkActive == false)
+        #expect(response.error?.message.contains("active voice note") == true)
+        #expect(recorder.isRecording)
+        #expect(capture.cancelCallCount == 0)
+        recorder.cancel()
     }
 
     @Test @MainActor func `overlapping PTT owners keep voice wake suspended until final release`() {
@@ -763,6 +788,7 @@ private actor WatchSnapshotSendGate {
         appModel.voiceWake.statusText = "Listening"
 
         appModel._test_acquirePttVoiceWakeLease()
+        #expect(appModel.isTalkCaptureActive == true)
         appModel._test_acquirePttVoiceWakeLease()
         #expect(appModel.voiceWake._test_isSuspendedForExternalAudio() == true)
 
@@ -771,7 +797,23 @@ private actor WatchSnapshotSendGate {
 
         appModel._test_releasePttVoiceWakeLease()
         #expect(appModel.voiceWake._test_isSuspendedForExternalAudio() == false)
+        #expect(appModel.isTalkCaptureActive == false)
         appModel.voiceWake.stop()
+    }
+
+    @Test @MainActor func `voice note start cannot race an acquired PTT lease`() async {
+        let capture = MockVoiceNoteAudioCapture()
+        let recorder = OpenClawVoiceNoteRecorder(capture: capture)
+        let appModel = NodeAppModel(
+            talkMode: TalkModeManager(allowSimulatorCapture: true),
+            voiceNoteRecorder: recorder)
+        appModel._test_acquirePttVoiceWakeLease()
+
+        #expect(await recorder.start() == false)
+        #expect(recorder.isRecording == false)
+        #expect(capture.permissionRequestCount == 0)
+
+        appModel._test_releasePttVoiceWakeLease()
     }
 
     @Test @MainActor func `late watch snapshot is repaired after gateway switch`() async throws {

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -102,21 +102,6 @@ private func makeProjectedWatchChatRawMessage(
 }
 
 @MainActor
-private final class VoiceNoteCaptureStub: VoiceNoteAudioCapture {
-    func requestPermission() async -> Bool {
-        true
-    }
-
-    func start(url _: URL) throws {}
-
-    func stop() -> TimeInterval {
-        1
-    }
-
-    func cancel() {}
-}
-
-@MainActor
 private func waitForMainActorWork(_ condition: () -> Bool) async {
     for _ in 0..<100 {
         if condition() { return }

--- a/apps/ios/project.yml
+++ b/apps/ios/project.yml
@@ -182,7 +182,7 @@ targets:
         NSContactsUsageDescription: OpenClaw uses your contacts so you can search and reference people while using the assistant.
         NSLocationWhenInUseUsageDescription: OpenClaw uses your location when you allow location sharing.
         NSLocationAlwaysAndWhenInUseUsageDescription: OpenClaw can share your location in the background when you enable Always.
-        NSMicrophoneUsageDescription: OpenClaw uses the microphone for realtime chat, voice wake, and push-to-talk.
+        NSMicrophoneUsageDescription: OpenClaw uses the microphone for realtime chat, voice wake, push-to-talk, and voice notes.
         NSMotionUsageDescription: OpenClaw may use motion data to support device-aware interactions and automations.
         NSPhotoLibraryUsageDescription: OpenClaw lets your assistant read photos you allow and lets you choose photos to share.
         PHPhotoLibraryPreventAutomaticLimitedAccessAlert: true

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -1091,7 +1091,9 @@ struct OpenClawChatComposer: View {
         else { return }
 
         self.stagingVoiceNoteURL = recording.fileURL
+        self.viewModel.beginAttachmentStaging()
         Task {
+            defer { self.viewModel.endAttachmentStaging() }
             await self.viewModel.addVoiceNoteAttachment(
                 fileURL: recording.fileURL,
                 durationSeconds: recording.durationSeconds)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -1105,6 +1105,15 @@ struct OpenClawChatComposer: View {
         }
     }
 
+    private func cancelActiveVoiceNoteIfNeeded() {
+        guard let recorder = self.voiceNoteControl?.recorder,
+              recorder.isRecording || recorder.isRequestingPermission
+        else { return }
+        // The app-owned recorder outlives this view. Release the microphone
+        // when its only recording UI disappears so capture never runs hidden.
+        recorder.cancel()
+    }
+
     private var connectionStatusText: String {
         self.connectionOK ? "Gateway connected" : "Connecting..."
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -174,13 +174,21 @@ struct OpenClawChatComposer: View {
                     guard recording != nil else { return }
                     self.stageCompletedVoiceNoteIfNeeded()
                 }
+                .onChange(of: self.voiceNoteControl?.recorder.ownsPendingChatAttachment) { _, _ in
+                    self.viewModel.attachmentOwnerActivityChanged()
+                }
                 .onChange(of: self.voiceNoteControl?.recorder.errorMessage) { _, message in
                     if let message {
                         self.viewModel.errorText = message
                     }
                 }
                 .onAppear {
+                    self.viewModel.attachmentOwnerActivityChanged()
                     self.stageCompletedVoiceNoteIfNeeded()
+                }
+                .onDisappear {
+                    self.cancelActiveVoiceNoteIfNeeded()
+                    self.viewModel.attachmentOwnerActivityChanged()
                 }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -88,7 +88,6 @@ struct OpenClawChatComposer: View {
     let messagePlaceholder: String?
     let talkControl: OpenClawChatTalkControl?
     let voiceNoteControl: OpenClawChatVoiceNoteControl?
-    @State private var stagingVoiceNoteURL: URL?
 
     #if !os(macOS)
     @State private var pickerItems: [PhotosPickerItem] = []
@@ -1087,30 +1086,22 @@ struct OpenClawChatComposer: View {
 
     private var canSendMessage: Bool {
         self.isComposerEnabled
-            && self.voiceNoteControl?.recorder.completedRecording == nil
+            && self.voiceNoteControl?.recorder.ownsPendingChatAttachment != true
             && self.viewModel.canSend
             && (self.isAttachmentInputEnabled || self.viewModel.attachments.isEmpty)
     }
 
     private func stageCompletedVoiceNoteIfNeeded() {
         guard let recorder = self.voiceNoteControl?.recorder,
-              let recording = recorder.completedRecording,
-              self.stagingVoiceNoteURL != recording.fileURL
+              let recording = recorder.claimCompletedRecording()
         else { return }
 
-        self.stagingVoiceNoteURL = recording.fileURL
-        self.viewModel.beginAttachmentStaging()
+        let viewModel = self.viewModel
         Task {
-            defer { self.viewModel.endAttachmentStaging() }
-            await self.viewModel.addVoiceNoteAttachment(
+            await viewModel.addVoiceNoteAttachment(
                 fileURL: recording.fileURL,
                 durationSeconds: recording.durationSeconds)
-            if recorder.completedRecording == recording {
-                recorder.clearCompletedRecording()
-            }
-            if self.stagingVoiceNoteURL == recording.fileURL {
-                self.stagingVoiceNoteURL = nil
-            }
+            recorder.completeStaging(recording)
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -216,6 +216,10 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         case usage
         case stopReason
         case errorMessage
+        case mediaPath = "MediaPath"
+        case mediaPaths = "MediaPaths"
+        case mediaType = "MediaType"
+        case mediaTypes = "MediaTypes"
     }
 
     public init(
@@ -268,14 +272,14 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
         self.stopReason = decodedStopReason
         self.errorMessage = decodedErrorMessage
 
-        if let decoded = try? container.decode([OpenClawChatMessageContent].self, forKey: .content) {
-            self.content = decoded
-            return
-        }
-
-        // Some session log formats store `content` as a plain string.
-        if let text = try? container.decode(String.self, forKey: .content) {
-            self.content = [
+        let decodedContent: [OpenClawChatMessageContent] = if let decoded = try? container.decode(
+            [OpenClawChatMessageContent].self,
+            forKey: .content)
+        {
+            decoded
+        } else if let text = try? container.decode(String.self, forKey: .content) {
+            // Some session log formats store `content` as a plain string.
+            [
                 OpenClawChatMessageContent(
                     type: "text",
                     text: text,
@@ -288,10 +292,35 @@ public struct OpenClawChatMessage: Codable, Hashable, Identifiable, Sendable {
                     name: nil,
                     arguments: nil),
             ]
-            return
+        } else {
+            []
         }
 
-        self.content = []
+        let mediaPaths =
+            (try? container.decode([String].self, forKey: .mediaPaths))
+            ?? (try? container.decode(String.self, forKey: .mediaPath)).map { [$0] }
+            ?? []
+        let mediaTypes =
+            (try? container.decode([String].self, forKey: .mediaTypes))
+            ?? (try? container.decode(String.self, forKey: .mediaType)).map { [$0] }
+            ?? []
+        let alreadyContainsAudio = decodedContent.contains { content in
+            content.mimeType?.lowercased().hasPrefix("audio/") == true
+        }
+        let audioAttachments: [OpenClawChatMessageContent] = alreadyContainsAudio ? [] : mediaPaths
+            .enumerated()
+            .compactMap { index, mediaPath in
+                guard mediaTypes.indices.contains(index) else { return nil }
+                let mimeType = mediaTypes[index].trimmingCharacters(in: .whitespacesAndNewlines)
+                guard mimeType.lowercased().hasPrefix("audio/") else { return nil }
+                return OpenClawChatMessageContent(
+                    type: "file",
+                    text: nil,
+                    mimeType: mimeType,
+                    fileName: (mediaPath as NSString).lastPathComponent,
+                    content: nil)
+            }
+        self.content = decodedContent + audioAttachments
     }
 
     static func displayText(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
@@ -158,7 +158,30 @@ public protocol OpenClawChatCanonicalTranscriptMerging: OpenClawChatTranscriptCa
         canonicalMessageIdempotencyKey: String) async
 }
 
-/// One durable queued chat command (text only in v1). `id` is the client UUID
+/// One attachment captured with a durable chat command.
+public struct OpenClawChatOutboxAttachment: Codable, Hashable, Sendable {
+    public let type: String
+    public let mimeType: String
+    public let fileName: String
+    public let data: Data
+    public let durationSeconds: Double?
+
+    public init(
+        type: String,
+        mimeType: String,
+        fileName: String,
+        data: Data,
+        durationSeconds: Double? = nil)
+    {
+        self.type = type
+        self.mimeType = mimeType
+        self.fileName = fileName
+        self.data = data
+        self.durationSeconds = durationSeconds
+    }
+}
+
+/// One durable queued chat command. `id` is the client UUID
 /// that becomes the transport idempotency key on flush, so at-least-once
 /// delivery stays safe across retries and app restarts.
 ///
@@ -187,6 +210,9 @@ public struct OpenClawChatOutboxCommand: Hashable, Sendable, Identifiable {
     /// retained for ownership checks on canonical agent-scoped keys.
     public let agentID: String?
     public let text: String
+    /// Attachment bytes remain owned by SQLite until canonical history proves
+    /// delivery or the user explicitly deletes the command.
+    public let attachments: [OpenClawChatOutboxAttachment]
     /// Thinking level captured when the command was queued, so a later flush
     /// never borrows the setting of whichever session is visible then.
     public let thinking: String
@@ -203,6 +229,7 @@ public struct OpenClawChatOutboxCommand: Hashable, Sendable, Identifiable {
         routingContract: String? = nil,
         agentID: String? = nil,
         text: String,
+        attachments: [OpenClawChatOutboxAttachment] = [],
         thinking: String,
         createdAt: Double,
         status: Status,
@@ -221,6 +248,7 @@ public struct OpenClawChatOutboxCommand: Hashable, Sendable, Identifiable {
         let normalizedAgentID = agentID?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         self.agentID = normalizedAgentID?.isEmpty == false ? normalizedAgentID : nil
         self.text = text
+        self.attachments = attachments
         self.thinking = thinking
         self.createdAt = createdAt
         self.status = status
@@ -245,8 +273,8 @@ public enum OpenClawChatOutboxChange: Equatable, Sendable {
 /// exactly like the transcript cache. Implementations persist queued sends so
 /// they survive app restarts and flush on reconnect.
 public protocol OpenClawChatCommandOutbox: Sendable {
-    /// Returns false when the queue is full (`maxQueuedCommands`) or storage
-    /// is unavailable; callers surface that instead of dropping text silently.
+    /// Returns false when the row or attachment-byte budget is full, or
+    /// storage is unavailable; callers surface that instead of dropping text.
     func enqueueCommand(_ command: OpenClawChatOutboxCommand) async -> Bool
     /// Gateway-scoped rows in `createdAt` order. Applies the staleness gate:
     /// old queued or unconfirmed rows become failed so reconnect never sends
@@ -331,9 +359,11 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
     public static let maxCachedSessions = 50
     public static let maxCachedTranscripts = 50
     public static let maxCachedMessagesPerSession = 200
-    /// Outbox bounds: refuse enqueue beyond this many rows per gateway, and
+    /// Outbox bounds: refuse enqueue beyond these per-gateway budgets, and
     /// expire queued commands instead of sending them after two days offline.
     public static let maxQueuedCommands = 50
+    public static let maxAttachmentBytesPerCommand = 40_000_000
+    public static let maxQueuedAttachmentBytes = 50_000_000
     public static let outboxCommandMaxAge: TimeInterval = 48 * 60 * 60
     /// Machine-readable `lastError` set by the staleness gate.
     public static let outboxExpiredError = "expired"
@@ -341,8 +371,9 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
     public static let outboxUnknownTargetError = "delivery_target_unknown"
     public static let outboxChangedTargetError = "delivery_target_changed"
     // v2 adds the durable outbox; v3 adds delivery ownership; v4 binds
-    // replay to the main-routing contract; v5 persists that verified identity.
-    static let schemaVersion: Int32 = 5
+    // replay to the main-routing contract; v5 persists that verified identity;
+    // v6 keeps bounded attachment bytes inside the same durable command owner.
+    static let schemaVersion: Int32 = 6
     private static let createOutboxTableSQL = """
     CREATE TABLE IF NOT EXISTS outbox_commands(
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -353,6 +384,8 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
         routing_contract TEXT NOT NULL DEFAULT '',
         agent_id TEXT NOT NULL DEFAULT '',
         text TEXT NOT NULL,
+        attachments TEXT NOT NULL DEFAULT '[]',
+        attachment_bytes INTEGER NOT NULL DEFAULT 0,
         thinking TEXT NOT NULL DEFAULT '',
         created_at REAL NOT NULL,
         status TEXT NOT NULL,
@@ -725,37 +758,65 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
     }
 
     public func enqueueCommand(_ command: OpenClawChatOutboxCommand) async -> Bool {
-        guard !self.isRetired, let db = await handle() else { return false }
+        guard let attachmentByteCount = Self.attachmentByteCount(command.attachments),
+              Self.canEnqueueAttachmentBytes(
+                  commandBytes: attachmentByteCount,
+                  queuedBytes: 0),
+              let attachments = Self.encodeJSON(command.attachments),
+              !self.isRetired,
+              let db = await handle(),
+              sqlite3_exec(db, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK
+        else { return false }
+        var committed = false
+        defer {
+            if !committed {
+                sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            }
+        }
         guard let count = selectInt(
             db,
             sql: "SELECT COUNT(*) FROM outbox_commands WHERE gateway_id = ?1",
-            bindings: [gatewayID])
+            bindings: [gatewayID]),
+            let queuedAttachmentBytes = selectInt(
+                db,
+                sql: "SELECT COALESCE(SUM(attachment_bytes), 0) FROM outbox_commands WHERE gateway_id = ?1",
+                bindings: [gatewayID])
         else { return false }
-        // Bound the queue per gateway across all statuses so failed rows also
-        // count: the user must clear them before queueing more.
-        guard count < Self.maxQueuedCommands else { return false }
-        return self.execute(
-            db,
-            sql: """
-            INSERT INTO outbox_commands(
-                client_uuid, gateway_id, session_key, delivery_session_key, routing_contract,
-                agent_id, text, thinking, created_at, status, retry_count, last_error
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
-            """,
-            bindings: [
-                command.id,
-                self.gatewayID,
-                command.sessionKey,
-                command.deliverySessionKey,
-                command.routingContract ?? "",
-                command.agentID ?? "",
-                command.text,
-                command.thinking,
-                command.createdAt,
-                command.status.rawValue,
-                command.retryCount,
-                command.lastError ?? "",
-            ])
+        // Count all statuses: failed and unconfirmed rows still own their bytes
+        // until canonical history or explicit deletion releases them.
+        guard count < Self.maxQueuedCommands,
+              Self.canEnqueueAttachmentBytes(
+                  commandBytes: attachmentByteCount,
+                  queuedBytes: queuedAttachmentBytes),
+              self.execute(
+                  db,
+                  sql: """
+                  INSERT INTO outbox_commands(
+                      client_uuid, gateway_id, session_key, delivery_session_key, routing_contract,
+                      agent_id, text, attachments, attachment_bytes, thinking, created_at, status,
+                      retry_count, last_error
+                  ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+                  """,
+                  bindings: [
+                      command.id,
+                      self.gatewayID,
+                      command.sessionKey,
+                      command.deliverySessionKey,
+                      command.routingContract ?? "",
+                      command.agentID ?? "",
+                      command.text,
+                      attachments,
+                      attachmentByteCount,
+                      command.thinking,
+                      command.createdAt,
+                      command.status.rawValue,
+                      command.retryCount,
+                      command.lastError ?? "",
+                  ]),
+              sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK
+        else { return false }
+        committed = true
+        return true
     }
 
     public func loadCommands() async -> [OpenClawChatOutboxCommand] {
@@ -1125,6 +1186,24 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
         return self.normalizedAgentID(agentID)
     }
 
+    private static func attachmentByteCount(_ attachments: [OpenClawChatOutboxAttachment]) -> Int? {
+        var total = 0
+        for attachment in attachments {
+            let (next, overflow) = total.addingReportingOverflow(attachment.data.count)
+            guard !overflow else { return nil }
+            total = next
+        }
+        return total
+    }
+
+    static func canEnqueueAttachmentBytes(commandBytes: Int, queuedBytes: Int) -> Bool {
+        guard commandBytes >= 0,
+              queuedBytes >= 0,
+              commandBytes <= self.maxAttachmentBytesPerCommand
+        else { return false }
+        return queuedBytes <= self.maxQueuedAttachmentBytes - commandBytes
+    }
+
     private static func encodeJSON(_ value: some Encodable) -> String? {
         guard let data = try? JSONEncoder().encode(value) else { return nil }
         return String(bytes: data, encoding: .utf8)
@@ -1296,6 +1375,11 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
                 sqlite3_close_v2(opened)
                 return nil
             }
+        } else if version == 5 {
+            guard self.migrateSchemaFromV5(opened) else {
+                sqlite3_close_v2(opened)
+                return nil
+            }
         } else if version != Self.schemaVersion {
             // Unknown schemas may contain outbox rows from a newer build.
             // The caller preserves the file and fails closed.
@@ -1391,6 +1475,7 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
                   nil,
                   nil,
                   nil) == SQLITE_OK,
+              self.addV6AttachmentColumns(db),
               self.execute(
                   db,
                   sql: """
@@ -1429,6 +1514,7 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
             nil,
             nil,
             nil) == SQLITE_OK,
+            self.addV6AttachmentColumns(db),
             self.execute(
                 db,
                 sql: """
@@ -1460,11 +1546,43 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
             }
         }
         guard sqlite3_exec(db, Self.createRoutingIdentityTableSQL, nil, nil, nil) == SQLITE_OK,
+              self.addV6AttachmentColumns(db),
               sqlite3_exec(db, "PRAGMA user_version = \(Self.schemaVersion)", nil, nil, nil) == SQLITE_OK,
               sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK
         else { return false }
         committed = true
         return true
+    }
+
+    private func migrateSchemaFromV5(_ db: OpaquePointer) -> Bool {
+        guard sqlite3_exec(db, "BEGIN IMMEDIATE", nil, nil, nil) == SQLITE_OK else { return false }
+        var committed = false
+        defer {
+            if !committed {
+                sqlite3_exec(db, "ROLLBACK", nil, nil, nil)
+            }
+        }
+        guard self.addV6AttachmentColumns(db),
+              sqlite3_exec(db, "PRAGMA user_version = \(Self.schemaVersion)", nil, nil, nil) == SQLITE_OK,
+              sqlite3_exec(db, "COMMIT", nil, nil, nil) == SQLITE_OK
+        else { return false }
+        committed = true
+        return true
+    }
+
+    private func addV6AttachmentColumns(_ db: OpaquePointer) -> Bool {
+        sqlite3_exec(
+            db,
+            "ALTER TABLE outbox_commands ADD COLUMN attachments TEXT NOT NULL DEFAULT '[]'",
+            nil,
+            nil,
+            nil) == SQLITE_OK &&
+            sqlite3_exec(
+                db,
+                "ALTER TABLE outbox_commands ADD COLUMN attachment_bytes INTEGER NOT NULL DEFAULT 0",
+                nil,
+                nil,
+                nil) == SQLITE_OK
     }
 
     private func migrateTranscriptTableToV3(_ db: OpaquePointer) -> Bool {
@@ -1535,7 +1653,7 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
         var statement: OpaquePointer?
         let sql = """
         SELECT client_uuid, session_key, delivery_session_key, routing_contract, agent_id,
-               text, thinking, created_at, status, retry_count, last_error
+               text, attachments, thinking, created_at, status, retry_count, last_error
         FROM outbox_commands WHERE gateway_id = ?1
         ORDER BY created_at ASC, id ASC
         """
@@ -1553,9 +1671,14 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
                 let deliverySessionKey = sqlite3_column_text(statement, 2).map { String(cString: $0) } ?? ""
                 let routingContract = sqlite3_column_text(statement, 3).map { String(cString: $0) }
                 let agentID = sqlite3_column_text(statement, 4).map { String(cString: $0) }
-                let thinking = sqlite3_column_text(statement, 6).map { String(cString: $0) } ?? ""
-                let statusRaw = sqlite3_column_text(statement, 8).map { String(cString: $0) } ?? ""
-                let lastError = sqlite3_column_text(statement, 10).map { String(cString: $0) } ?? ""
+                let attachmentsPayload = sqlite3_column_text(statement, 6).map { String(cString: $0) } ?? "[]"
+                guard let attachments = try? JSONDecoder().decode(
+                    [OpenClawChatOutboxAttachment].self,
+                    from: Data(attachmentsPayload.utf8))
+                else { return nil }
+                let thinking = sqlite3_column_text(statement, 7).map { String(cString: $0) } ?? ""
+                let statusRaw = sqlite3_column_text(statement, 9).map { String(cString: $0) } ?? ""
+                let lastError = sqlite3_column_text(statement, 11).map { String(cString: $0) } ?? ""
                 if let status = OpenClawChatOutboxCommand.Status(rawValue: statusRaw) {
                     commands.append(
                         OpenClawChatOutboxCommand(
@@ -1565,10 +1688,11 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
                             routingContract: routingContract,
                             agentID: agentID,
                             text: String(cString: text),
+                            attachments: attachments,
                             thinking: thinking,
-                            createdAt: sqlite3_column_double(statement, 7),
+                            createdAt: sqlite3_column_double(statement, 8),
                             status: status,
-                            retryCount: Int(sqlite3_column_int64(statement, 9)),
+                            retryCount: Int(sqlite3_column_int64(statement, 10)),
                             lastError: lastError.isEmpty ? nil : lastError))
                 }
             }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -231,8 +231,10 @@ public struct OpenClawChatView: View {
             assistantAvatarText: self.assistantAvatarText,
             assistantAvatarTint: self.assistantAvatarTint,
             composerChrome: self.composerChrome,
-            isComposerEnabled: self.isComposerEnabled,
-            isAttachmentInputEnabled: self.isAttachmentInputEnabled,
+            isComposerEnabled: self.isComposerEnabled
+                && !self.viewModel.isSendingAttachmentDraft,
+            isAttachmentInputEnabled: self.isAttachmentInputEnabled
+                && !self.viewModel.isSendingAttachmentDraft,
             messagePlaceholder: self.messagePlaceholder,
             talkControl: self.talkControl,
             voiceNoteControl: self.voiceNoteControl)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift
@@ -10,8 +10,12 @@ import UIKit
 
 extension OpenClawChatViewModel {
     /// Stages a recorded m4a voice note and removes its temporary file.
-    func addVoiceNoteAttachment(fileURL: URL, durationSeconds: Double) async {
-        defer { try? FileManager.default.removeItem(at: fileURL) }
+    public func addVoiceNoteAttachment(fileURL: URL, durationSeconds: Double) async {
+        self.beginAttachmentStaging()
+        defer {
+            try? FileManager.default.removeItem(at: fileURL)
+            self.endAttachmentStaging()
+        }
 
         let data: Data
         do {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Attachments.swift
@@ -32,6 +32,9 @@ extension OpenClawChatViewModel {
             return
         }
 
+        let normalizedDuration = durationSeconds.isFinite
+            ? min(max(0, durationSeconds), OpenClawVoiceNoteRecorder.maximumDurationSeconds)
+            : 0
         self.attachments.append(
             OpenClawPendingAttachment(
                 url: nil,
@@ -39,7 +42,7 @@ extension OpenClawChatViewModel {
                 fileName: fileURL.lastPathComponent,
                 mimeType: "audio/mp4",
                 preview: nil,
-                durationSeconds: max(0, durationSeconds)))
+                durationSeconds: normalizedDuration))
     }
 
     func loadAttachments(urls: [URL]) async {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -318,13 +318,16 @@ extension OpenClawChatViewModel {
             sessionKey: sessionKey,
             agentID: command.agentID)
         let messageKey = Self.outboxUserIdempotencyKey(command.id)
+        let canonicalMessage = Self.adoptingCanonicalMessage(
+            message,
+            over: Self.outboxUserMessage(for: command))
         let previous = self.pendingCacheWriteTask
         let task = Task.detached {
             await previous?.value
             await transcriptCache.mergeCanonicalTranscriptMessage(
                 sessionKey: sessionKey,
                 agentID: cacheAgentID,
-                message: message,
+                message: canonicalMessage,
                 canonicalMessageIdempotencyKey: messageKey)
         }
         self.pendingCacheWriteTask = task

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -129,12 +129,13 @@ extension OpenClawChatViewModel {
 
     // MARK: - Capture
 
-    /// Offline capture path used by performSend when the gateway is
-    /// unhealthy: persist first, then render the queued bubble. A full queue
-    /// refuses the enqueue and keeps the draft so no text is lost.
+    /// Durable capture path used before text or attachment delivery: persist
+    /// first, then render the queued bubble. A full queue refuses the enqueue
+    /// and keeps the exact draft intact.
     func enqueueOutboxCommand(
         text: String,
         draftInput: String,
+        draftAttachments: [OpenClawPendingAttachment] = [],
         session: SessionSnapshot) async
     {
         guard let outbox else { return }
@@ -157,6 +158,14 @@ extension OpenClawChatViewModel {
             routingContract: routingContract,
             agentID: agentID,
             text: text,
+            attachments: draftAttachments.map {
+                OpenClawChatOutboxAttachment(
+                    type: $0.type,
+                    mimeType: $0.mimeType,
+                    fileName: $0.fileName,
+                    data: $0.data,
+                    durationSeconds: $0.durationSeconds)
+            },
             thinking: self.effectiveThinkingLevelForSend,
             createdAt: Date().timeIntervalSince1970,
             status: .queued,
@@ -169,6 +178,8 @@ extension OpenClawChatViewModel {
             return
         }
         if self.input == draftInput { self.input = "" }
+        let capturedAttachmentIDs = Set(draftAttachments.map(\.id))
+        self.attachments.removeAll { capturedAttachmentIDs.contains($0.id) }
         self.errorText = nil
         self.presentOutboxCommands([command])
         // Health can recover between the send-gate check and the enqueue;
@@ -354,16 +365,26 @@ extension OpenClawChatViewModel {
     }
 
     private static func outboxUserMessage(for command: OpenClawChatOutboxCommand) -> OpenClawChatMessage {
-        OpenClawChatMessage(
+        var content = [
+            OpenClawChatMessageContent(
+                type: "text",
+                text: command.text,
+                mimeType: nil,
+                fileName: nil,
+                content: nil),
+        ]
+        content.append(contentsOf: command.attachments.map { attachment in
+            OpenClawChatMessageContent(
+                type: attachment.type,
+                text: nil,
+                mimeType: attachment.mimeType,
+                fileName: attachment.fileName,
+                durationSeconds: attachment.durationSeconds,
+                content: AnyCodable(attachment.data.base64EncodedString()))
+        })
+        return OpenClawChatMessage(
             role: "user",
-            content: [
-                OpenClawChatMessageContent(
-                    type: "text",
-                    text: command.text,
-                    mimeType: nil,
-                    fileName: nil,
-                    content: nil),
-            ],
+            content: content,
             // Message timestamps are milliseconds; outbox rows store seconds.
             timestamp: command.createdAt * 1000,
             idempotencyKey: self.outboxUserIdempotencyKey(command.id))
@@ -510,7 +531,13 @@ extension OpenClawChatViewModel {
                         next.thinking,
                         sessionKey: next.sessionKey),
                     idempotencyKey: next.id,
-                    attachments: [])
+                    attachments: next.attachments.map {
+                        OpenClawChatAttachmentPayload(
+                            type: $0.type,
+                            mimeType: $0.mimeType,
+                            fileName: $0.fileName,
+                            content: $0.data.base64EncodedString())
+                    })
                 if response.status == "error" || response.status == "timeout" {
                     // Gateway rejected the run: this burns a retry attempt,
                     // unlike transport-level failures handled in catch.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -139,6 +139,7 @@ public final class OpenClawChatViewModel {
     private let onSessionChanged: (@MainActor (String) -> Void)?
     private let onThinkingLevelChanged: (@MainActor @Sendable (String) -> Void)?
     private let diagnosticsLog: (@MainActor @Sendable (String) -> Void)?
+    private let attachmentOwnerIsActive: @MainActor () -> Bool
 
     @ObservationIgnored
     private nonisolated(unsafe) var eventTask: Task<Void, Never>?
@@ -259,6 +260,7 @@ public final class OpenClawChatViewModel {
         transport: any OpenClawChatTransport,
         activeAgentId: String? = nil,
         sessionRoutingContract: String? = nil,
+        attachmentOwnerIsActive: @escaping @MainActor () -> Bool = { false },
         haptics: OpenClawChatHaptics = OpenClawChatHaptics(),
         transcriptCache: (any OpenClawChatTranscriptCache)? = nil,
         outbox: (any OpenClawChatCommandOutbox)? = nil,
@@ -291,6 +293,7 @@ public final class OpenClawChatViewModel {
         self.onSessionChanged = onSessionChanged
         self.onThinkingLevelChanged = onThinkingLevelChanged
         self.diagnosticsLog = diagnosticsLog
+        self.attachmentOwnerIsActive = attachmentOwnerIsActive
 
         let transport = self.transport
         self.eventTask = Task { [weak self, transport] in
@@ -562,8 +565,21 @@ public final class OpenClawChatViewModel {
         !self.isSubmittingDraft && !self.isSending && self.hasDraftToSend
     }
 
+    /// True while replacing this model could move an attachment across chats.
+    public var isAttachmentOwnerPinned: Bool {
+        self.blocksAttachmentOwnerChange
+    }
+
     private var blocksAttachmentOwnerChange: Bool {
-        self.isSendingAttachmentDraft || self.attachmentStagingCount > 0 || !self.attachments.isEmpty
+        self.attachmentOwnerIsActive() ||
+            self.isSendingAttachmentDraft ||
+            self.attachmentStagingCount > 0 ||
+            !self.attachments.isEmpty
+    }
+
+    /// Applies external owner changes once recording or staging releases them.
+    public func attachmentOwnerActivityChanged() {
+        self.applyDeferredExternalStateIfReady()
     }
 
     /// File reads and image processing suspend before the attachment exists.

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -1250,7 +1250,6 @@ public final class OpenClawChatViewModel {
             self.outboxStatesByMessageID.values.contains(where: { !$0.isFailed })
         var shouldPersistAttachmentDraft = !draftAttachments.isEmpty
         if shouldPersistAttachmentDraft,
-           !mustPreserveOutboxOrder,
            self.healthOK,
            self.outbox != nil
         {
@@ -1259,6 +1258,16 @@ public final class OpenClawChatViewModel {
             if case let .unavailable(reason) = routeResult,
                reason == OpenClawChatTransportUpgradeMessage.routingContract
             {
+                guard self.hasRestoredOutboxMessages else {
+                    self.errorText = "Restoring queued messages. Try again in a moment."
+                    return
+                }
+                guard !mustPreserveOutboxOrder else {
+                    // A legacy gateway cannot drain the existing durable rows,
+                    // so keep this new attachment in the composer behind them.
+                    self.errorText = reason
+                    return
+                }
                 // Older healthy gateways can send attachments live but cannot
                 // safely replay them. Preserve that shipped live-only path.
                 shouldPersistAttachmentDraft = false

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -38,8 +38,16 @@ public final class OpenClawChatViewModel {
         let result: [OpenClawChatCommandChoice]
     }
 
+    private struct DeferredDeliveryIdentity {
+        let activeAgentID: String?
+        let sessionRoutingContract: String?
+    }
+
     public private(set) var isLoading = false
     public private(set) var isSending = false
+    public private(set) var isSendingAttachmentDraft = false
+    private var deferredExternalSessionKey: String?
+    private var deferredDeliveryIdentity: DeferredDeliveryIdentity?
     private var isSubmittingDraft = false
     public private(set) var isAborting = false
     public var errorText: String?
@@ -377,12 +385,13 @@ public final class OpenClawChatViewModel {
     public func syncActiveAgentId(_ agentId: String?) {
         self.syncDeliveryIdentity(
             activeAgentId: agentId,
-            sessionRoutingContract: self.sessionRoutingContract)
+            sessionRoutingContract: self.deferredDeliveryIdentity?.sessionRoutingContract
+                ?? self.sessionRoutingContract)
     }
 
     public func syncSessionRoutingContract(_ contract: String?) {
         self.syncDeliveryIdentity(
-            activeAgentId: self.activeAgentId,
+            activeAgentId: self.deferredDeliveryIdentity?.activeAgentID ?? self.activeAgentId,
             sessionRoutingContract: contract)
     }
 
@@ -398,7 +407,19 @@ public final class OpenClawChatViewModel {
         let nextContract = normalizedContract?.isEmpty == false ? normalizedContract : nil
         let agentChanged = self.activeAgentId != nextAgentId
         let contractChanged = self.sessionRoutingContract != nextContract
-        guard agentChanged || contractChanged else { return }
+        guard agentChanged || contractChanged else {
+            if self.blocksAttachmentOwnerChange {
+                self.deferredDeliveryIdentity = nil
+            }
+            return
+        }
+        if self.blocksAttachmentOwnerChange {
+            self.deferredDeliveryIdentity = DeferredDeliveryIdentity(
+                activeAgentID: nextAgentId,
+                sessionRoutingContract: nextContract)
+            return
+        }
+        self.deferredDeliveryIdentity = nil
         // A scoped key can be the main alias under either side of a contract
         // change. Check both or stale transcript state can survive the switch.
         let contractRoutingChanged = contractChanged &&
@@ -516,6 +537,7 @@ public final class OpenClawChatViewModel {
 
     public func removeAttachment(_ id: OpenClawPendingAttachment.ID) {
         self.attachments.removeAll { $0.id == id }
+        self.applyDeferredExternalStateIfReady()
     }
 
     public var canSend: Bool {
@@ -529,6 +551,10 @@ public final class OpenClawChatViewModel {
 
     public var canSendDraft: Bool {
         !self.isSubmittingDraft && !self.isSending && self.hasDraftToSend
+    }
+
+    private var blocksAttachmentOwnerChange: Bool {
+        self.isSendingAttachmentDraft || !self.attachments.isEmpty
     }
 
     // MARK: - Internals
@@ -702,6 +728,7 @@ public final class OpenClawChatViewModel {
         // Wholesale history replacement drops local-only queued bubbles;
         // re-adopt or re-append them from the durable outbox.
         restoreOutboxMessages(session: request.session)
+        self.applyDeferredExternalStateIfReady()
         return true
     }
 
@@ -1156,21 +1183,27 @@ public final class OpenClawChatViewModel {
         }
 
         self.isSending = true
-        defer { self.isSending = false }
+        self.isSendingAttachmentDraft = !draftAttachments.isEmpty
+        defer {
+            self.isSendingAttachmentDraft = false
+            self.isSending = false
+            self.applyDeferredExternalStateIfReady()
+        }
 
         let sessionKey = sessionSnapshot.key
 
         if !self.healthOK {
             await pollHealthIfNeeded(force: true, sessionSnapshot: sessionSnapshot)
             guard self.isCurrentSession(sessionSnapshot) else { return }
-            // Offline capture: queue text-only sends durably instead of
-            // failing. Attachments stay on the live path (text only in v1).
-            if !self.healthOK, self.outbox != nil, draftAttachments.isEmpty {
+            // Offline capture: queue the full draft durably instead of
+            // dropping user text or attachment bytes.
+            if !self.healthOK, self.outbox != nil {
                 self.logDiagnostic(
                     "chat.ui send queued offline sessionKey=\(sessionKey) inputLen=\(trimmed.count)")
                 await enqueueOutboxCommand(
-                    text: trimmed,
+                    text: trimmed.isEmpty ? "See attached." : trimmed,
                     draftInput: draftInput,
+                    draftAttachments: draftAttachments,
                     session: sessionSnapshot)
                 return
             }
@@ -1183,19 +1216,21 @@ public final class OpenClawChatViewModel {
         // the queue stays the single ordering authority; it flushes
         // immediately while healthy, so the turn still sends right away.
         // Failed rows are parked user decisions and do not hold new sends
-        // hostage. Attachment sends stay live (online-only in v1) and are
-        // documented as outside the ordering guarantee. Deliberately
-        // session-scoped: other sessions' queued rows are separate
-        // conversations with no ordering contract against this send.
-        if self.outbox != nil, draftAttachments.isEmpty,
-           !self.hasRestoredOutboxMessages
+        // hostage. Outbox-backed attachments always take this persist-first
+        // path so a crash cannot erase their only remaining bytes. Deliberately
+        // session-scoped: other sessions are separate conversations with no
+        // ordering contract.
+        if self.outbox != nil,
+           !draftAttachments.isEmpty
+           || !self.hasRestoredOutboxMessages
            || self.outboxStatesByMessageID.values.contains(where: { !$0.isFailed })
         {
             self.logDiagnostic(
                 "chat.ui send routed behind outbox sessionKey=\(sessionKey) inputLen=\(trimmed.count)")
             await enqueueOutboxCommand(
-                text: trimmed,
+                text: trimmed.isEmpty ? "See attached." : trimmed,
                 draftInput: draftInput,
+                draftAttachments: draftAttachments,
                 session: sessionSnapshot)
             return
         }
@@ -1212,7 +1247,9 @@ public final class OpenClawChatViewModel {
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
 
-        // Optimistically append user message to UI.
+        // Production attachment sends enter the durable outbox above. Fixture,
+        // preview, and embedded transports may intentionally have no outbox;
+        // keep their established live-only attachment path available.
         var userContent: [OpenClawChatMessageContent] = [
             OpenClawChatMessageContent(
                 type: "text",
@@ -1226,24 +1263,24 @@ public final class OpenClawChatViewModel {
                 name: nil,
                 arguments: nil),
         ]
-        let encodedAttachments = draftAttachments.map { att -> OpenClawChatAttachmentPayload in
+        let encodedAttachments = draftAttachments.map { attachment in
             OpenClawChatAttachmentPayload(
-                type: att.type,
-                mimeType: att.mimeType,
-                fileName: att.fileName,
-                content: att.data.base64EncodedString())
+                type: attachment.type,
+                mimeType: attachment.mimeType,
+                fileName: attachment.fileName,
+                content: attachment.data.base64EncodedString())
         }
-        for (attachment, att) in zip(draftAttachments, encodedAttachments) {
+        for (attachment, payload) in zip(draftAttachments, encodedAttachments) {
             userContent.append(
                 OpenClawChatMessageContent(
-                    type: att.type,
+                    type: payload.type,
                     text: nil,
                     thinking: nil,
                     thinkingSignature: nil,
-                    mimeType: att.mimeType,
-                    fileName: att.fileName,
+                    mimeType: payload.mimeType,
+                    fileName: payload.fileName,
                     durationSeconds: attachment.durationSeconds,
-                    content: AnyCodable(att.content),
+                    content: AnyCodable(payload.content),
                     id: nil,
                     name: nil,
                     arguments: nil))
@@ -1271,7 +1308,7 @@ public final class OpenClawChatViewModel {
             self.logDiagnostic(
                 "chat.ui transport send start sessionKey=\(sessionKey) "
                     + "localRunId=\(runId)")
-            let thinkingLevel = self.effectiveThinkingLevelForSend(storedThinkingLevel)
+            let thinkingLevel = effectiveThinkingLevelForSend(storedThinkingLevel)
             let response = try await transport.sendMessage(
                 sessionKey: sessionKey,
                 agentID: sessionSnapshot.deliveryAgentID,
@@ -1353,12 +1390,12 @@ public final class OpenClawChatViewModel {
                 let preserved = await preserveFailedLiveSend(
                     runId: runId,
                     text: messageText,
-                    thinking: self.effectiveThinkingLevelForSend(storedThinkingLevel),
+                    thinking: effectiveThinkingLevelForSend(storedThinkingLevel),
                     messageID: userMessageID,
                     session: sessionSnapshot,
                     deliveryIsAmbiguous: deliveryIsAmbiguous)
                 if preserved {
-                    self.applyTransportHealth(false)
+                    applyTransportHealth(false)
                     let outcome = deliveryIsAmbiguous ? "delivery unconfirmed" : "queued after route change"
                     self.logDiagnostic(
                         "chat.ui send \(outcome) sessionKey=\(sessionKey) "
@@ -1374,6 +1411,15 @@ public final class OpenClawChatViewModel {
             }
             if encodedAttachments.isEmpty, self.input.isEmpty {
                 self.input = messageText
+            } else if !encodedAttachments.isEmpty {
+                if self.input.isEmpty {
+                    self.input = draftInput
+                }
+                let currentAttachmentIDs = Set(attachments.map(\.id))
+                let removedDraftAttachments = draftAttachments.filter {
+                    !currentAttachmentIDs.contains($0.id)
+                }
+                self.attachments.insert(contentsOf: removedDraftAttachments, at: 0)
             }
             self.removePendingLocalUserEcho(for: runId)
             self.runMessageScopesByRunID.removeValue(forKey: runId)
@@ -1554,7 +1600,7 @@ public final class OpenClawChatViewModel {
             if let sessionSnapshot, !self.isCurrentSession(sessionSnapshot) { return }
             self.modelChoices = modelChoices
             self.syncSelectedModel()
-            self.syncThinkingLevelOptions()
+            syncThinkingLevelOptions()
         } catch {
             // Best-effort.
         }
@@ -1563,7 +1609,23 @@ public final class OpenClawChatViewModel {
     private func applySessionSwitch(to sessionKey: String, intent: SessionSwitchIntent) {
         let next = sessionKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !next.isEmpty else { return }
-        guard next != self.sessionKey else { return }
+        guard next != self.sessionKey else {
+            if intent == .externalSync {
+                self.deferredExternalSessionKey = nil
+            }
+            return
+        }
+        if self.blocksAttachmentOwnerChange {
+            switch intent {
+            case .externalSync:
+                self.deferredExternalSessionKey = next
+            case .userInitiated:
+                self.errorText = String(
+                    localized: "Remove attachments or wait for delivery to resolve before switching chats.")
+            }
+            return
+        }
+        self.deferredExternalSessionKey = nil
         self.advanceSessionGeneration()
         self.sessionKey = next
         if intent == .userInitiated {
@@ -1573,7 +1635,25 @@ public final class OpenClawChatViewModel {
         self.startBootstrap(sessionKey: next)
     }
 
+    private func applyDeferredExternalStateIfReady() {
+        guard !self.blocksAttachmentOwnerChange else { return }
+        if let identity = deferredDeliveryIdentity {
+            self.deferredDeliveryIdentity = nil
+            self.syncDeliveryIdentity(
+                activeAgentId: identity.activeAgentID,
+                sessionRoutingContract: identity.sessionRoutingContract)
+        }
+        guard let sessionKey = deferredExternalSessionKey else { return }
+        self.deferredExternalSessionKey = nil
+        self.applySessionSwitch(to: sessionKey, intent: .externalSync)
+    }
+
     private func performStartNewSession(worktree: Bool) async {
+        guard !self.blocksAttachmentOwnerChange else {
+            self.errorText = String(
+                localized: "Remove attachments or wait for delivery to resolve before starting a new chat.")
+            return
+        }
         let requested = self.generatedNewSessionKey()
         let parentSessionKey = self.sessionKey
         let next: String
@@ -1593,6 +1673,11 @@ public final class OpenClawChatViewModel {
             }
             chatUILogger.error("sessions.create failed \(error.localizedDescription, privacy: .public)")
             self.errorText = error.localizedDescription
+            return
+        }
+        guard !self.blocksAttachmentOwnerChange else {
+            self.errorText = String(
+                localized: "Remove attachments or wait for delivery to resolve before starting a new chat.")
             return
         }
         self.advanceSessionGeneration()
@@ -1724,7 +1809,7 @@ public final class OpenClawChatViewModel {
         self.latestModelSelectionIDsBySession[sessionKey] = next
         self.beginModelPatch(for: sessionKey)
         self.modelSelectionID = next
-        self.syncThinkingLevelOptions()
+        syncThinkingLevelOptions()
         self.errorText = nil
         defer { self.endModelPatch(for: sessionKey) }
 
@@ -1757,7 +1842,7 @@ public final class OpenClawChatViewModel {
             }
             guard sessionKey == self.sessionKey else { return }
             self.modelSelectionID = previous
-            self.syncThinkingLevelOptions()
+            syncThinkingLevelOptions()
             self.errorText = error.localizedDescription
             chatUILogger.error("sessions.patch(model) failed \(error.localizedDescription, privacy: .public)")
         }
@@ -2018,6 +2103,7 @@ public final class OpenClawChatViewModel {
         // run's final event already cleared pending state. Same-content turns
         // without this key remain distinct.
         if adoptCorrelatedUserMessage(incoming: sanitized) {
+            self.applyDeferredExternalStateIfReady()
             return
         }
         if adoptProvisionalFinalMessage(incoming: sanitized) {
@@ -2028,6 +2114,7 @@ public final class OpenClawChatViewModel {
         replaceMessages(Self.dedupeMessages(reconciled))
         pruneProvisionalFinalMessages()
         pruneRunMessageScopes()
+        self.applyDeferredExternalStateIfReady()
     }
 
     private func handleChatEvent(_ chat: OpenClawChatEventPayload) {
@@ -2101,6 +2188,7 @@ public final class OpenClawChatViewModel {
             self.updateStreamingAssistantText(nil)
             self.appendFinalChatMessageIfPresent(chat)
             let context = self.beginHistoryRequest()
+            self.applyDeferredExternalStateIfReady()
             Task { await self.refreshHistoryAfterRun(historyRequest: context) }
         default:
             break
@@ -2249,6 +2337,7 @@ public final class OpenClawChatViewModel {
         self.pendingToolCallsById = [:]
         self.updateStreamingAssistantText(nil)
         let context = self.beginHistoryRequest()
+        self.applyDeferredExternalStateIfReady()
         Task { await self.refreshHistoryAfterRun(historyRequest: context) }
     }
 
@@ -2381,9 +2470,7 @@ public final class OpenClawChatViewModel {
         let refresh = await refreshHistoryAfterRun(historyRequest: historyContext)
         guard self.isCurrentSession(sessionSnapshot),
               self.pendingRuns.contains(runId)
-        else {
-            return false
-        }
+        else { return false }
         if refresh.applied, refresh.runSnapshotApplied, refresh.supportsInFlightRunState {
             if refresh.hasInFlightRun {
                 return true

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -1246,6 +1246,25 @@ public final class OpenClawChatViewModel {
             }
         }
 
+        let mustPreserveOutboxOrder = !self.hasRestoredOutboxMessages ||
+            self.outboxStatesByMessageID.values.contains(where: { !$0.isFailed })
+        var shouldPersistAttachmentDraft = !draftAttachments.isEmpty
+        if shouldPersistAttachmentDraft,
+           !mustPreserveOutboxOrder,
+           self.healthOK,
+           self.outbox != nil
+        {
+            let routeResult = await self.transport.acquireOutboxRouteLease()
+            guard self.isCurrentSession(sessionSnapshot) else { return }
+            if case let .unavailable(reason) = routeResult,
+               reason == OpenClawChatTransportUpgradeMessage.routingContract
+            {
+                // Older healthy gateways can send attachments live but cannot
+                // safely replay them. Preserve that shipped live-only path.
+                shouldPersistAttachmentDraft = false
+            }
+        }
+
         // FIFO across the reconnect boundary: while this session still has
         // queued/sending outbox rows — or restore has not yet adopted rows
         // persisted by an earlier process, so we must assume a backlog — a
@@ -1258,9 +1277,7 @@ public final class OpenClawChatViewModel {
         // session-scoped: other sessions are separate conversations with no
         // ordering contract.
         if self.outbox != nil,
-           !draftAttachments.isEmpty
-           || !self.hasRestoredOutboxMessages
-           || self.outboxStatesByMessageID.values.contains(where: { !$0.isFailed })
+           shouldPersistAttachmentDraft || mustPreserveOutboxOrder
         {
             self.logDiagnostic(
                 "chat.ui send routed behind outbox sessionKey=\(sessionKey) inputLen=\(trimmed.count)")

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -49,6 +49,7 @@ public final class OpenClawChatViewModel {
     private var deferredExternalSessionKey: String?
     private var deferredDeliveryIdentity: DeferredDeliveryIdentity?
     private var isSubmittingDraft = false
+    private var attachmentStagingCount = 0
     public private(set) var isAborting = false
     public var errorText: String?
     public var attachments: [OpenClawPendingAttachment] = []
@@ -528,11 +529,19 @@ public final class OpenClawChatViewModel {
     ]
 
     public func addAttachments(urls: [URL]) {
-        Task { await self.loadAttachments(urls: urls) }
+        self.beginAttachmentStaging()
+        Task {
+            defer { self.endAttachmentStaging() }
+            await self.loadAttachments(urls: urls)
+        }
     }
 
     public func addImageAttachment(data: Data, fileName: String, mimeType: String) {
-        Task { await self.addImageAttachment(url: nil, data: data, fileName: fileName, mimeType: mimeType) }
+        self.beginAttachmentStaging()
+        Task {
+            defer { self.endAttachmentStaging() }
+            await self.addImageAttachment(url: nil, data: data, fileName: fileName, mimeType: mimeType)
+        }
     }
 
     public func removeAttachment(_ id: OpenClawPendingAttachment.ID) {
@@ -554,7 +563,19 @@ public final class OpenClawChatViewModel {
     }
 
     private var blocksAttachmentOwnerChange: Bool {
-        self.isSendingAttachmentDraft || !self.attachments.isEmpty
+        self.isSendingAttachmentDraft || self.attachmentStagingCount > 0 || !self.attachments.isEmpty
+    }
+
+    /// File reads and image processing suspend before the attachment exists.
+    /// Keep their original chat owner pinned until staging succeeds or fails.
+    func beginAttachmentStaging() {
+        self.attachmentStagingCount += 1
+    }
+
+    func endAttachmentStaging() {
+        precondition(self.attachmentStagingCount > 0)
+        self.attachmentStagingCount -= 1
+        self.applyDeferredExternalStateIfReady()
     }
 
     // MARK: - Internals

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift
@@ -40,6 +40,7 @@ public final class OpenClawVoiceNoteRecorder {
         case requestingPermission
         case recording(startedAt: Date, fileURL: URL)
         case finished(recording: OpenClawVoiceNoteRecording)
+        case staging(recording: OpenClawVoiceNoteRecording)
         case failed(message: String)
     }
 
@@ -91,7 +92,7 @@ public final class OpenClawVoiceNoteRecorder {
     /// True from permission request until the completed recording is staged.
     public var ownsPendingChatAttachment: Bool {
         switch self.state {
-        case .requestingPermission, .recording, .finished:
+        case .requestingPermission, .recording, .finished, .staging:
             true
         case .idle, .failed:
             false
@@ -112,6 +113,20 @@ public final class OpenClawVoiceNoteRecorder {
     public var completedRecording: OpenClawVoiceNoteRecording? {
         guard case let .finished(recording) = self.state else { return nil }
         return recording
+    }
+
+    /// Claims a finished recording exactly once while its captured chat stages it.
+    func claimCompletedRecording() -> OpenClawVoiceNoteRecording? {
+        guard case let .finished(recording) = self.state else { return nil }
+        self.state = .staging(recording: recording)
+        return recording
+    }
+
+    /// Releases chat ownership after the claimed recording was consumed.
+    func completeStaging(_ recording: OpenClawVoiceNoteRecording) {
+        guard self.state == .staging(recording: recording) else { return }
+        self.state = .idle
+        self.elapsedSeconds = 0
     }
 
     /// Requests permission if needed and starts a new recording.
@@ -165,6 +180,8 @@ public final class OpenClawVoiceNoteRecorder {
 
     /// Cancels permission or capture and removes any temporary audio file.
     public func cancel() {
+        // The chat view model owns the file after claiming the handoff.
+        if case .staging = self.state { return }
         let fileURL: URL? = switch self.state {
         case let .recording(_, fileURL):
             fileURL
@@ -186,13 +203,6 @@ public final class OpenClawVoiceNoteRecorder {
         if wasRecording {
             self.onRecordingActiveChanged?(false)
         }
-    }
-
-    /// Clears a completed handoff after the composer has staged it.
-    public func clearCompletedRecording() {
-        guard case .finished = self.state else { return }
-        self.state = .idle
-        self.elapsedSeconds = 0
     }
 
     private func startTimer() {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift
@@ -88,6 +88,16 @@ public final class OpenClawVoiceNoteRecorder {
         self.state == .requestingPermission
     }
 
+    /// True from permission request until the completed recording is staged.
+    public var ownsPendingChatAttachment: Bool {
+        switch self.state {
+        case .requestingPermission, .recording, .finished:
+            true
+        case .idle, .failed:
+            false
+        }
+    }
+
     /// Installs the app's synchronous microphone-ownership gate. The check and
     /// transition to requesting permission run in one MainActor turn.
     public func setCaptureAdmissionHandler(_ handler: @escaping @MainActor () -> Bool) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift
@@ -18,6 +18,9 @@ public protocol VoiceNoteAudioCapture: AnyObject {
 
     /// Stops and discards the active capture.
     func cancel()
+
+    /// Reports capture loss after a recording has started.
+    func setFailureHandler(_ handler: @escaping @MainActor () -> Void)
 }
 
 /// A completed voice-note recording ready to stage as a chat attachment.
@@ -74,6 +77,9 @@ public final class OpenClawVoiceNoteRecorder {
         self.durationLimit = durationLimit
         self.timerIntervalNanoseconds = timerIntervalNanoseconds
         self.now = now
+        self.capture.setFailureHandler { [weak self] in
+            self?.captureFailed()
+        }
     }
 
     deinit {
@@ -233,23 +239,44 @@ public final class OpenClawVoiceNoteRecorder {
         }
     }
 
+    private func captureFailed() {
+        guard case let .recording(_, fileURL) = self.state else { return }
+        self.capture.cancel()
+        try? FileManager.default.removeItem(at: fileURL)
+        self.fail(message: String(localized: "Recording was interrupted. Try again."))
+    }
+
     private func makeTemporaryFileURL() -> URL {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyyMMdd-HHmmss"
-        let timestamp = formatter.string(from: self.now())
-        return FileManager.default.temporaryDirectory
-            .appendingPathComponent("voice-note-\(timestamp).m4a")
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice-note-\(UUID().uuidString).m4a")
     }
 }
 
 /// AVAudioRecorder-backed AAC voice-note capture.
 @MainActor
-public final class OpenClawVoiceNoteAudioCapture: VoiceNoteAudioCapture {
+public final class OpenClawVoiceNoteAudioCapture: NSObject, VoiceNoteAudioCapture, AVAudioRecorderDelegate {
     private var recorder: AVAudioRecorder?
     private var ownsAudioSession = false
+    private var failureHandler: (@MainActor () -> Void)?
 
-    public init() {}
+    override public init() {
+        super.init()
+        #if os(iOS)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.audioSessionInterrupted(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance())
+        #endif
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    public func setFailureHandler(_ handler: @escaping @MainActor () -> Void) {
+        self.failureHandler = handler
+    }
 
     public func requestPermission() async -> Bool {
         #if os(iOS)
@@ -289,6 +316,7 @@ public final class OpenClawVoiceNoteAudioCapture: VoiceNoteAudioCapture {
                 AVEncoderAudioQualityKey: AVAudioQuality.medium.rawValue,
             ]
             let recorder = try AVAudioRecorder(url: url, settings: settings)
+            recorder.delegate = self
             guard recorder.record() else {
                 throw NSError(
                     domain: "OpenClawVoiceNoteAudioCapture",
@@ -315,6 +343,32 @@ public final class OpenClawVoiceNoteAudioCapture: VoiceNoteAudioCapture {
         self.recorder?.stop()
         self.recorder = nil
         self.deactivateAudioSession()
+    }
+
+    public nonisolated func audioRecorderEncodeErrorDidOccur(_ recorder: AVAudioRecorder, error: (any Error)?) {
+        Task { @MainActor [weak self] in
+            self?.captureDidFail()
+        }
+    }
+
+    #if os(iOS)
+    @objc private nonisolated func audioSessionInterrupted(_ notification: Notification) {
+        guard
+            let rawType = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+            rawType == AVAudioSession.InterruptionType.began.rawValue
+        else { return }
+        Task { @MainActor [weak self] in
+            self?.captureDidFail()
+        }
+    }
+    #endif
+
+    private func captureDidFail() {
+        guard self.recorder != nil else { return }
+        self.recorder?.stop()
+        self.recorder = nil
+        self.deactivateAudioSession()
+        self.failureHandler?()
     }
 
     private func deactivateAudioSession() {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/VoiceNoteRecorder.swift
@@ -55,6 +55,7 @@ public final class OpenClawVoiceNoteRecorder {
     @ObservationIgnored private let timerIntervalNanoseconds: UInt64
     @ObservationIgnored private let now: () -> Date
     @ObservationIgnored private var timerTask: Task<Void, Never>?
+    @ObservationIgnored private var captureAdmissionHandler: @MainActor () -> Bool = { true }
 
     /// Creates a recorder backed by the system audio recorder.
     public convenience init() {
@@ -87,6 +88,12 @@ public final class OpenClawVoiceNoteRecorder {
         self.state == .requestingPermission
     }
 
+    /// Installs the app's synchronous microphone-ownership gate. The check and
+    /// transition to requesting permission run in one MainActor turn.
+    public func setCaptureAdmissionHandler(_ handler: @escaping @MainActor () -> Bool) {
+        self.captureAdmissionHandler = handler
+    }
+
     public var errorMessage: String? {
         guard case let .failed(message) = self.state else { return nil }
         return message
@@ -101,6 +108,10 @@ public final class OpenClawVoiceNoteRecorder {
     @discardableResult
     public func start() async -> Bool {
         guard self.state == .idle || self.errorMessage != nil else { return false }
+        guard self.captureAdmissionHandler() else {
+            self.fail(message: String(localized: "Push-to-talk is using the microphone."))
+            return false
+        }
 
         self.elapsedSeconds = 0
         self.state = .requestingPermission

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatTranscriptCacheStoreTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatTranscriptCacheStoreTests.swift
@@ -62,6 +62,7 @@ private func outboxCommand(
     id: String = UUID().uuidString,
     sessionKey: String = "main",
     text: String,
+    attachments: [OpenClawChatOutboxAttachment] = [],
     thinking: String = "off",
     createdAt: Double = Date().timeIntervalSince1970) -> OpenClawChatOutboxCommand
 {
@@ -69,6 +70,7 @@ private func outboxCommand(
         id: id,
         sessionKey: sessionKey,
         text: text,
+        attachments: attachments,
         thinking: thinking,
         createdAt: createdAt,
         status: .queued,
@@ -430,6 +432,18 @@ struct ChatTranscriptCacheStoreTests {
             nil,
             nil,
             nil) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            raw,
+            "ALTER TABLE outbox_commands DROP COLUMN attachment_bytes",
+            nil,
+            nil,
+            nil) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            raw,
+            "ALTER TABLE outbox_commands DROP COLUMN attachments",
+            nil,
+            nil,
+            nil) == SQLITE_OK)
         #expect(sqlite3_exec(raw, "PRAGMA user_version = 2", nil, nil, nil) == SQLITE_OK)
         sqlite3_close_v2(raw)
 
@@ -572,6 +586,18 @@ struct ChatTranscriptCacheStoreTests {
             nil,
             nil,
             nil) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            raw,
+            "ALTER TABLE outbox_commands DROP COLUMN attachment_bytes",
+            nil,
+            nil,
+            nil) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            raw,
+            "ALTER TABLE outbox_commands DROP COLUMN attachments",
+            nil,
+            nil,
+            nil) == SQLITE_OK)
         #expect(sqlite3_exec(raw, "PRAGMA user_version = 3", nil, nil, nil) == SQLITE_OK)
         sqlite3_close_v2(raw)
 
@@ -587,7 +613,7 @@ struct ChatTranscriptCacheStoreTests {
         ])
     }
 
-    @Test func `v4 migration adds routing identity without touching outbox`() async throws {
+    @Test func `v4 migration adds routing identity and attachment storage`() async throws {
         let url = try makeDatabaseURL()
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
         do {
@@ -599,6 +625,18 @@ struct ChatTranscriptCacheStoreTests {
         var raw: OpaquePointer?
         #expect(sqlite3_open(url.path, &raw) == SQLITE_OK)
         #expect(sqlite3_exec(raw, "DROP TABLE gateway_routing_identity", nil, nil, nil) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            raw,
+            "ALTER TABLE outbox_commands DROP COLUMN attachment_bytes",
+            nil,
+            nil,
+            nil) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            raw,
+            "ALTER TABLE outbox_commands DROP COLUMN attachments",
+            nil,
+            nil,
+            nil) == SQLITE_OK)
         #expect(sqlite3_exec(raw, "PRAGMA user_version = 4", nil, nil, nil) == SQLITE_OK)
         sqlite3_close_v2(raw)
 
@@ -611,6 +649,38 @@ struct ChatTranscriptCacheStoreTests {
             defaultAgentID: "main"))
         await migrated.storeSessionRoutingIdentity(identity)
         #expect(await migrated.loadSessionRoutingIdentity() == identity)
+    }
+
+    @Test func `v5 migration preserves commands while adding attachment storage`() async throws {
+        let url = try makeDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        do {
+            let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+            #expect(await store.enqueueCommand(outboxCommand(id: "c-v5", text: "preserve me")))
+            await store.retire()
+        }
+
+        var raw: OpaquePointer?
+        #expect(sqlite3_open(url.path, &raw) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            raw,
+            "ALTER TABLE outbox_commands DROP COLUMN attachment_bytes",
+            nil,
+            nil,
+            nil) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            raw,
+            "ALTER TABLE outbox_commands DROP COLUMN attachments",
+            nil,
+            nil,
+            nil) == SQLITE_OK)
+        #expect(sqlite3_exec(raw, "PRAGMA user_version = 5", nil, nil, nil) == SQLITE_OK)
+        sqlite3_close_v2(raw)
+
+        let migrated = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+        let command = try #require(await migrated.loadCommands().first)
+        #expect(command.id == "c-v5")
+        #expect(command.attachments.isEmpty)
     }
 
     @Test func `unknown schema preserves durable outbox bytes and fails closed`() async throws {
@@ -1064,6 +1134,64 @@ struct ChatCommandOutboxStoreTests {
         // Deleting a row frees capacity again.
         #expect(await store.cancelCommand(id: "c-0") == .updated)
         #expect(await store.enqueueCommand(outboxCommand(id: "c-after-delete", text: "fits now")))
+    }
+
+    @Test func `attachment byte admission enforces command and gateway bounds`() {
+        let commandBound = OpenClawChatSQLiteTranscriptCache.maxAttachmentBytesPerCommand
+        let gatewayBound = OpenClawChatSQLiteTranscriptCache.maxQueuedAttachmentBytes
+
+        #expect(OpenClawChatSQLiteTranscriptCache.canEnqueueAttachmentBytes(
+            commandBytes: commandBound,
+            queuedBytes: gatewayBound - commandBound))
+        #expect(!OpenClawChatSQLiteTranscriptCache.canEnqueueAttachmentBytes(
+            commandBytes: commandBound + 1,
+            queuedBytes: 0))
+        #expect(!OpenClawChatSQLiteTranscriptCache.canEnqueueAttachmentBytes(
+            commandBytes: 1,
+            queuedBytes: gatewayBound))
+        #expect(!OpenClawChatSQLiteTranscriptCache.canEnqueueAttachmentBytes(
+            commandBytes: -1,
+            queuedBytes: 0))
+    }
+
+    @Test func `enqueue persists attachment bytes and refuses a full byte budget`() async throws {
+        let url = try makeDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let attachment = OpenClawChatOutboxAttachment(
+            type: "file",
+            mimeType: "audio/mp4",
+            fileName: "voice-note.m4a",
+            data: Data([0x01]))
+        do {
+            let store = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+            #expect(await store.enqueueCommand(outboxCommand(
+                id: "c-audio",
+                text: "voice note",
+                attachments: [attachment])))
+            await store.retire()
+        }
+
+        var raw: OpaquePointer?
+        #expect(sqlite3_open(url.path, &raw) == SQLITE_OK)
+        #expect(sqlite3_exec(
+            raw,
+            """
+            UPDATE outbox_commands
+            SET attachment_bytes = \(OpenClawChatSQLiteTranscriptCache.maxQueuedAttachmentBytes)
+            WHERE client_uuid = 'c-audio' AND attachment_bytes = 1
+            """,
+            nil,
+            nil,
+            nil) == SQLITE_OK)
+        #expect(sqlite3_changes(raw) == 1)
+        sqlite3_close_v2(raw)
+
+        let fullStore = OpenClawChatSQLiteTranscriptCache(databaseURL: url, gatewayID: "gw-a")
+        #expect(await !fullStore.enqueueCommand(outboxCommand(
+            id: "c-overflow",
+            text: "one byte too many",
+            attachments: [attachment])))
+        #expect(await fullStore.loadCommands().map(\.id) == ["c-audio"])
     }
 
     @Test func `outbox rows are scoped per gateway identity`() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -46,6 +46,11 @@ private actor AttachmentHealthGate {
     }
 }
 
+@MainActor
+private final class AttachmentOwnerActivity {
+    var isActive = true
+}
+
 private struct AttachmentProcessingTransport: OpenClawChatTransport {
     let capture: AttachmentSendCapture?
     let healthGate: AttachmentHealthGate?
@@ -320,12 +325,43 @@ final class ChatViewModelAttachmentTests: XCTestCase {
             activeAgentId: "work",
             sessionRoutingContract: "per-sender|main|work")
 
+        XCTAssertTrue(viewModel.isAttachmentOwnerPinned)
         XCTAssertEqual(viewModel.sessionKey, "main")
         XCTAssertEqual(viewModel.activeAgentId, "main")
         XCTAssertEqual(viewModel.sessionRoutingContract, "per-sender|main|main")
 
         viewModel.endAttachmentStaging()
 
+        XCTAssertFalse(viewModel.isAttachmentOwnerPinned)
+        XCTAssertEqual(viewModel.sessionKey, "agent:work:main")
+        XCTAssertEqual(viewModel.activeAgentId, "work")
+        XCTAssertEqual(viewModel.sessionRoutingContract, "per-sender|main|work")
+    }
+
+    @MainActor
+    func testRecordingPinsSessionAndIdentityUntilItEnds() {
+        let ownerActivity = AttachmentOwnerActivity()
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: AttachmentProcessingTransport(),
+            activeAgentId: "main",
+            sessionRoutingContract: "per-sender|main|main",
+            attachmentOwnerIsActive: { ownerActivity.isActive })
+
+        viewModel.syncSession(to: "agent:work:main")
+        viewModel.syncDeliveryIdentity(
+            activeAgentId: "work",
+            sessionRoutingContract: "per-sender|main|work")
+
+        XCTAssertTrue(viewModel.isAttachmentOwnerPinned)
+        XCTAssertEqual(viewModel.sessionKey, "main")
+        XCTAssertEqual(viewModel.activeAgentId, "main")
+        XCTAssertEqual(viewModel.sessionRoutingContract, "per-sender|main|main")
+
+        ownerActivity.isActive = false
+        viewModel.attachmentOwnerActivityChanged()
+
+        XCTAssertFalse(viewModel.isAttachmentOwnerPinned)
         XCTAssertEqual(viewModel.sessionKey, "agent:work:main")
         XCTAssertEqual(viewModel.activeAgentId, "work")
         XCTAssertEqual(viewModel.sessionRoutingContract, "per-sender|main|work")

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -671,7 +671,7 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         XCTAssertTrue(restored.2)
     }
 
-    func testCanonicalVoiceNoteConfirmationDeletesDurableBytes() async throws {
+    func testCanonicalVoiceNoteConfirmationPreservesDurationAndDeletesDurableBytes() async throws {
         let outbox = makeAttachmentOutbox()
         let viewModel = await MainActor.run {
             let viewModel = makeDurableAttachmentViewModel(
@@ -695,16 +695,23 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         }
         let awaitingCommands = await outbox.loadCommands()
         let command = try XCTUnwrap(awaitingCommands.first)
-        await viewModel.confirmOutboxCommandsNow(in: [
-            OpenClawChatMessage(
-                role: "user",
-                content: [],
-                timestamp: 1,
-                idempotencyKey: "\(command.id):user"),
-        ])
+        let canonical = try JSONDecoder().decode(
+            OpenClawChatMessage.self,
+            from: Data(
+                """
+                {"role":"user","content":"See attached.","__openclaw":{"idempotencyKey":"\(command
+                    .id):user"},"MediaPaths":["media/inbound/media-1.m4a"],"MediaTypes":["audio/mp4"]}
+                """.utf8))
+        await viewModel.confirmOutboxCommandsNow(in: [canonical])
 
         let remainingCommands = await outbox.loadCommands()
         XCTAssertTrue(remainingCommands.isEmpty)
+        let cached = await outbox.loadTranscript(sessionKey: "main", agentID: nil)
+        let cachedMessage = try XCTUnwrap(cached.first)
+        let cachedAudio = try XCTUnwrap(cachedMessage.content.first { $0.mimeType == "audio/mp4" })
+        XCTAssertEqual(cachedAudio.fileName, "media-1.m4a")
+        XCTAssertNil(cachedAudio.content)
+        XCTAssertEqual(cachedAudio.durationSeconds, 7)
     }
 
     @MainActor

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -306,6 +306,31 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         XCTAssertEqual(agentViewModel.sessionRoutingContract, oldContract)
     }
 
+    @MainActor
+    func testAttachmentStagingPinsSessionAndIdentityUntilItFinishes() {
+        let viewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: AttachmentProcessingTransport(),
+            activeAgentId: "main",
+            sessionRoutingContract: "per-sender|main|main")
+
+        viewModel.beginAttachmentStaging()
+        viewModel.syncSession(to: "agent:work:main")
+        viewModel.syncDeliveryIdentity(
+            activeAgentId: "work",
+            sessionRoutingContract: "per-sender|main|work")
+
+        XCTAssertEqual(viewModel.sessionKey, "main")
+        XCTAssertEqual(viewModel.activeAgentId, "main")
+        XCTAssertEqual(viewModel.sessionRoutingContract, "per-sender|main|main")
+
+        viewModel.endAttachmentStaging()
+
+        XCTAssertEqual(viewModel.sessionKey, "agent:work:main")
+        XCTAssertEqual(viewModel.activeAgentId, "work")
+        XCTAssertEqual(viewModel.sessionRoutingContract, "per-sender|main|work")
+    }
+
     func testAttachmentSendWithoutOutboxUsesLiveTransport() async throws {
         let capture = AttachmentSendCapture()
         let viewModel = await MainActor.run {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -461,6 +461,41 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         XCTAssertTrue(commands.isEmpty)
     }
 
+    func testLegacyGatewayRetainsAttachmentUntilOutboxRestoreCompletes() async throws {
+        let capture = AttachmentSendCapture()
+        let outbox = makeAttachmentOutbox()
+        let viewModel = await MainActor.run {
+            let viewModel = makeDurableAttachmentViewModel(
+                transport: AttachmentProcessingTransport(
+                    capture: capture,
+                    durableOutboxAvailable: false),
+                outbox: outbox)
+            viewModel.attachments = [
+                OpenClawPendingAttachment(
+                    url: nil,
+                    data: Data("restore-race".utf8),
+                    fileName: "restore-race.m4a",
+                    mimeType: "audio/mp4",
+                    preview: nil,
+                    durationSeconds: 2),
+            ]
+            return viewModel
+        }
+
+        await MainActor.run { viewModel.send() }
+        try await waitUntil("legacy draft held during restore") {
+            await MainActor.run { viewModel.errorText?.contains("Restoring queued messages") == true }
+        }
+
+        let state = await MainActor.run { (viewModel.attachments.count, viewModel.input) }
+        let sendCount = await capture.count()
+        let commands = await outbox.loadCommands()
+        XCTAssertEqual(state.0, 1)
+        XCTAssertEqual(state.1, "")
+        XCTAssertEqual(sendCount, 0)
+        XCTAssertTrue(commands.isEmpty)
+    }
+
     func testFailedAttachmentSendWithoutOutboxRestoresDraft() async throws {
         let capture = AttachmentSendCapture()
         let attachmentData = Data("retry-voice-note".utf8)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -49,13 +49,32 @@ private actor AttachmentHealthGate {
 private struct AttachmentProcessingTransport: OpenClawChatTransport {
     let capture: AttachmentSendCapture?
     let healthGate: AttachmentHealthGate?
+    let failsAmbiguously: Bool
+    let responseStatus: String
+    let returnsEmptyHistory: Bool
 
-    init(capture: AttachmentSendCapture? = nil, healthGate: AttachmentHealthGate? = nil) {
+    init(
+        capture: AttachmentSendCapture? = nil,
+        healthGate: AttachmentHealthGate? = nil,
+        failsAmbiguously: Bool = false,
+        responseStatus: String = "started",
+        returnsEmptyHistory: Bool = false)
+    {
         self.capture = capture
         self.healthGate = healthGate
+        self.failsAmbiguously = failsAmbiguously
+        self.responseStatus = responseStatus
+        self.returnsEmptyHistory = returnsEmptyHistory
     }
 
     func requestHistory(sessionKey _: String) async throws -> OpenClawChatHistoryPayload {
+        if self.returnsEmptyHistory {
+            return OpenClawChatHistoryPayload(
+                sessionKey: "main",
+                sessionId: "session-main",
+                messages: [],
+                thinkingLevel: "off")
+        }
         throw NSError(domain: "ChatViewModelAttachmentTests", code: 1)
     }
 
@@ -67,7 +86,13 @@ private struct AttachmentProcessingTransport: OpenClawChatTransport {
         attachments: [OpenClawChatAttachmentPayload]) async throws -> OpenClawChatSendResponse
     {
         await self.capture?.store(attachments)
-        return OpenClawChatSendResponse(runId: idempotencyKey, status: "started")
+        if self.failsAmbiguously {
+            throw NSError(
+                domain: "ChatViewModelAttachmentTests",
+                code: 9,
+                userInfo: [NSLocalizedDescriptionKey: "Connection lost"])
+        }
+        return OpenClawChatSendResponse(runId: idempotencyKey, status: self.responseStatus)
     }
 
     func requestHealth(timeoutMs _: Int) async throws -> Bool {
@@ -78,6 +103,25 @@ private struct AttachmentProcessingTransport: OpenClawChatTransport {
     func events() -> AsyncStream<OpenClawChatTransportEvent> {
         AsyncStream { _ in }
     }
+}
+
+private func makeAttachmentOutbox() -> OpenClawChatSQLiteTranscriptCache {
+    OpenClawChatSQLiteTranscriptCache(
+        databaseURL: FileManager.default.temporaryDirectory
+            .appendingPathComponent("attachment-outbox-\(UUID().uuidString).sqlite"),
+        gatewayID: "attachment-tests")
+}
+
+@MainActor
+private func makeDurableAttachmentViewModel(
+    transport: AttachmentProcessingTransport,
+    outbox: OpenClawChatSQLiteTranscriptCache) -> OpenClawChatViewModel
+{
+    OpenClawChatViewModel(
+        sessionKey: "main",
+        transport: transport,
+        transcriptCache: outbox,
+        outbox: outbox)
 }
 
 private func makeChatAttachmentJPEG(width: Int, height: Int) throws -> Data {
@@ -203,6 +247,143 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
     }
 
+    func testMalformedVoiceNoteDurationIsNormalized() async throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice-note-malformed-duration.m4a")
+        try Data("voice-note".utf8).write(to: fileURL)
+        let viewModel = await MainActor.run {
+            OpenClawChatViewModel(sessionKey: "main", transport: AttachmentProcessingTransport())
+        }
+
+        await viewModel.addVoiceNoteAttachment(fileURL: fileURL, durationSeconds: .infinity)
+
+        let duration = await MainActor.run { viewModel.attachments.first?.durationSeconds }
+        XCTAssertEqual(duration, 0)
+    }
+
+    @MainActor
+    func testPartialIdentitySyncPreservesTheOtherDeferredComponent() {
+        let oldContract = "per-sender|main|main"
+        let newContract = "per-sender|work-main|main"
+        let contractViewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: AttachmentProcessingTransport(),
+            activeAgentId: "main",
+            sessionRoutingContract: oldContract)
+        let contractAttachment = OpenClawPendingAttachment(
+            url: nil,
+            data: Data("contract".utf8),
+            fileName: "contract.m4a",
+            mimeType: "audio/mp4",
+            preview: nil)
+        contractViewModel.attachments = [contractAttachment]
+
+        contractViewModel.syncSessionRoutingContract(newContract)
+        contractViewModel.syncActiveAgentId("main")
+        contractViewModel.removeAttachment(contractAttachment.id)
+
+        XCTAssertEqual(contractViewModel.activeAgentId, "main")
+        XCTAssertEqual(contractViewModel.sessionRoutingContract, newContract)
+
+        let agentViewModel = OpenClawChatViewModel(
+            sessionKey: "main",
+            transport: AttachmentProcessingTransport(),
+            activeAgentId: "main",
+            sessionRoutingContract: oldContract)
+        let agentAttachment = OpenClawPendingAttachment(
+            url: nil,
+            data: Data("agent".utf8),
+            fileName: "agent.m4a",
+            mimeType: "audio/mp4",
+            preview: nil)
+        agentViewModel.attachments = [agentAttachment]
+
+        agentViewModel.syncActiveAgentId("work")
+        agentViewModel.syncSessionRoutingContract(oldContract)
+        agentViewModel.removeAttachment(agentAttachment.id)
+
+        XCTAssertEqual(agentViewModel.activeAgentId, "work")
+        XCTAssertEqual(agentViewModel.sessionRoutingContract, oldContract)
+    }
+
+    func testAttachmentSendWithoutOutboxUsesLiveTransport() async throws {
+        let capture = AttachmentSendCapture()
+        let viewModel = await MainActor.run {
+            let viewModel = OpenClawChatViewModel(
+                sessionKey: "main",
+                transport: AttachmentProcessingTransport(capture: capture))
+            viewModel.attachments = [
+                OpenClawPendingAttachment(
+                    url: nil,
+                    data: Data("fixture-voice-note".utf8),
+                    fileName: "fixture.m4a",
+                    mimeType: "audio/mp4",
+                    preview: nil,
+                    durationSeconds: 4),
+            ]
+            return viewModel
+        }
+
+        await MainActor.run { viewModel.send() }
+        try await waitUntil("live attachment sent without outbox") {
+            await capture.count() == 1
+        }
+
+        let capturedPayload = await capture.first()
+        let payload = try XCTUnwrap(capturedPayload)
+        XCTAssertEqual(payload.content, Data("fixture-voice-note".utf8).base64EncodedString())
+        let state = await MainActor.run {
+            (
+                viewModel.attachments.isEmpty,
+                viewModel.errorText,
+                viewModel.messages.last?.content.first { $0.mimeType == "audio/mp4" }?.durationSeconds)
+        }
+        XCTAssertTrue(state.0)
+        XCTAssertNil(state.1)
+        XCTAssertEqual(state.2, 4)
+    }
+
+    func testFailedAttachmentSendWithoutOutboxRestoresDraft() async throws {
+        let capture = AttachmentSendCapture()
+        let attachmentData = Data("retry-voice-note".utf8)
+        let viewModel = await MainActor.run {
+            OpenClawChatViewModel(
+                sessionKey: "main",
+                transport: AttachmentProcessingTransport(
+                    capture: capture,
+                    failsAmbiguously: true))
+        }
+        let attachmentID = await MainActor.run {
+            let attachment = OpenClawPendingAttachment(
+                url: nil,
+                data: attachmentData,
+                fileName: "retry.m4a",
+                mimeType: "audio/mp4",
+                preview: nil,
+                durationSeconds: 5)
+            viewModel.input = "retry caption"
+            viewModel.attachments = [attachment]
+            return attachment.id
+        }
+
+        await MainActor.run { viewModel.send() }
+        try await waitUntil("failed live attachment restores draft") {
+            await MainActor.run { viewModel.errorText == "Connection lost" }
+        }
+
+        let state = await MainActor.run {
+            (
+                viewModel.input,
+                viewModel.attachments.map(\.id),
+                viewModel.attachments.first?.data,
+                viewModel.messages.contains { $0.idempotencyKey?.hasSuffix(":user") == true })
+        }
+        XCTAssertEqual(state.0, "retry caption")
+        XCTAssertEqual(state.1, [attachmentID])
+        XCTAssertEqual(state.2, attachmentData)
+        XCTAssertFalse(state.3)
+    }
+
     func testVoiceNoteSendUsesExistingAttachmentPayloadAndOptimisticDuration() async throws {
         let capture = AttachmentSendCapture()
         let transport = AttachmentProcessingTransport(capture: capture)
@@ -210,8 +391,9 @@ final class ChatViewModelAttachmentTests: XCTestCase {
             .appendingPathComponent("voice-note-20260706-120001.m4a")
         let data = Data("encoded-voice-note".utf8)
         try data.write(to: fileURL)
+        let outbox = makeAttachmentOutbox()
         let viewModel = await MainActor.run {
-            OpenClawChatViewModel(sessionKey: "main", transport: transport)
+            makeDurableAttachmentViewModel(transport: transport, outbox: outbox)
         }
 
         await viewModel.addVoiceNoteAttachment(fileURL: fileURL, durationSeconds: 21.2)
@@ -277,6 +459,99 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         }
         XCTAssertEqual(optimisticAudio?.fileName, "draft.m4a")
         XCTAssertEqual(optimisticAudio?.durationSeconds, 21.2)
+    }
+
+    func testAmbiguousVoiceNoteSurvivesViewModelRecreation() async throws {
+        let outbox = makeAttachmentOutbox()
+        var firstViewModel: OpenClawChatViewModel? = await MainActor.run {
+            let viewModel = makeDurableAttachmentViewModel(
+                transport: AttachmentProcessingTransport(failsAmbiguously: true),
+                outbox: outbox)
+            viewModel.attachments = [
+                OpenClawPendingAttachment(
+                    url: nil,
+                    data: Data("durable-voice-note".utf8),
+                    fileName: "durable.m4a",
+                    mimeType: "audio/mp4",
+                    preview: nil,
+                    durationSeconds: 42),
+            ]
+            return viewModel
+        }
+
+        await MainActor.run { firstViewModel?.send() }
+        try await waitUntil("ambiguous voice note is durably parked") {
+            let command = await outbox.loadCommands().first
+            return command?.status == .failed &&
+                command?.lastError == OpenClawChatSQLiteTranscriptCache.outboxUnconfirmedError
+        }
+        let persistedCommands = await outbox.loadCommands()
+        let persisted = try XCTUnwrap(persistedCommands.first)
+        XCTAssertEqual(persisted.attachments.first?.data, Data("durable-voice-note".utf8))
+        XCTAssertEqual(persisted.attachments.first?.durationSeconds, 42)
+
+        await MainActor.run { firstViewModel = nil }
+        let restoredViewModel = await MainActor.run {
+            makeDurableAttachmentViewModel(
+                transport: AttachmentProcessingTransport(returnsEmptyHistory: true),
+                outbox: outbox)
+        }
+        await MainActor.run { restoredViewModel.load() }
+        try await waitUntil("durable voice note bubble is restored") {
+            await MainActor.run {
+                restoredViewModel.messages.contains { message in
+                    message.content.contains { $0.mimeType == "audio/mp4" }
+                }
+            }
+        }
+
+        let restored = try await MainActor.run { () throws -> (String?, Double?, Bool) in
+            let message = try XCTUnwrap(restoredViewModel.messages.first)
+            let audio = try XCTUnwrap(message.content.first { $0.mimeType == "audio/mp4" })
+            return (
+                audio.content?.value as? String,
+                audio.durationSeconds,
+                restoredViewModel.outboxState(for: message.id)?.isFailed == true)
+        }
+        XCTAssertEqual(restored.0, Data("durable-voice-note".utf8).base64EncodedString())
+        XCTAssertEqual(restored.1, 42)
+        XCTAssertTrue(restored.2)
+    }
+
+    func testCanonicalVoiceNoteConfirmationDeletesDurableBytes() async throws {
+        let outbox = makeAttachmentOutbox()
+        let viewModel = await MainActor.run {
+            let viewModel = makeDurableAttachmentViewModel(
+                transport: AttachmentProcessingTransport(),
+                outbox: outbox)
+            viewModel.attachments = [
+                OpenClawPendingAttachment(
+                    url: nil,
+                    data: Data("confirmed-voice-note".utf8),
+                    fileName: "confirmed.m4a",
+                    mimeType: "audio/mp4",
+                    preview: nil,
+                    durationSeconds: 7),
+            ]
+            return viewModel
+        }
+
+        await MainActor.run { viewModel.send() }
+        try await waitUntil("voice note awaits canonical confirmation") {
+            await outbox.loadCommands().first?.status == .awaitingConfirmation
+        }
+        let awaitingCommands = await outbox.loadCommands()
+        let command = try XCTUnwrap(awaitingCommands.first)
+        await viewModel.confirmOutboxCommandsNow(in: [
+            OpenClawChatMessage(
+                role: "user",
+                content: [],
+                timestamp: 1,
+                idempotencyKey: "\(command.id):user"),
+        ])
+
+        let remainingCommands = await outbox.loadCommands()
+        XCTAssertTrue(remainingCommands.isEmpty)
     }
 
     @MainActor

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -57,19 +57,22 @@ private struct AttachmentProcessingTransport: OpenClawChatTransport {
     let failsAmbiguously: Bool
     let responseStatus: String
     let returnsEmptyHistory: Bool
+    let durableOutboxAvailable: Bool
 
     init(
         capture: AttachmentSendCapture? = nil,
         healthGate: AttachmentHealthGate? = nil,
         failsAmbiguously: Bool = false,
         responseStatus: String = "started",
-        returnsEmptyHistory: Bool = false)
+        returnsEmptyHistory: Bool = false,
+        durableOutboxAvailable: Bool = true)
     {
         self.capture = capture
         self.healthGate = healthGate
         self.failsAmbiguously = failsAmbiguously
         self.responseStatus = responseStatus
         self.returnsEmptyHistory = returnsEmptyHistory
+        self.durableOutboxAvailable = durableOutboxAvailable
     }
 
     func requestHistory(sessionKey _: String) async throws -> OpenClawChatHistoryPayload {
@@ -103,6 +106,25 @@ private struct AttachmentProcessingTransport: OpenClawChatTransport {
     func requestHealth(timeoutMs _: Int) async throws -> Bool {
         await self.healthGate?.wait()
         return true
+    }
+
+    func acquireOutboxRouteLease() async -> OpenClawChatTransportRouteLeaseResult {
+        guard self.durableOutboxAvailable else {
+            return .unavailable(reason: OpenClawChatTransportUpgradeMessage.routingContract)
+        }
+        let transport = self
+        return .available(OpenClawChatTransportRouteLease(
+            sendMessage: { sessionKey, message, thinking, idempotencyKey, attachments in
+                try await transport.sendMessage(
+                    sessionKey: sessionKey,
+                    message: message,
+                    thinking: thinking,
+                    idempotencyKey: idempotencyKey,
+                    attachments: attachments)
+            },
+            requestHistory: { sessionKey in
+                try await transport.requestHistory(sessionKey: sessionKey)
+            }))
     }
 
     func events() -> AsyncStream<OpenClawChatTransportEvent> {
@@ -402,6 +424,41 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         XCTAssertTrue(state.0)
         XCTAssertNil(state.1)
         XCTAssertEqual(state.2, 4)
+    }
+
+    func testHealthyLegacyGatewayUsesLiveAttachmentPath() async throws {
+        let capture = AttachmentSendCapture()
+        let outbox = makeAttachmentOutbox()
+        let viewModel = await MainActor.run {
+            makeDurableAttachmentViewModel(
+                transport: AttachmentProcessingTransport(
+                    capture: capture,
+                    returnsEmptyHistory: true,
+                    durableOutboxAvailable: false),
+                outbox: outbox)
+        }
+        await MainActor.run { viewModel.load() }
+        try await waitUntil("legacy gateway bootstrap completed") {
+            await MainActor.run { viewModel.healthOK && !viewModel.isLoading }
+        }
+        await MainActor.run {
+            viewModel.attachments = [
+                OpenClawPendingAttachment(
+                    url: nil,
+                    data: Data("legacy-voice-note".utf8),
+                    fileName: "legacy.m4a",
+                    mimeType: "audio/mp4",
+                    preview: nil,
+                    durationSeconds: 3),
+            ]
+            viewModel.send()
+        }
+        try await waitUntil("legacy attachment sent live") {
+            await capture.count() == 1
+        }
+
+        let commands = await outbox.loadCommands()
+        XCTAssertTrue(commands.isEmpty)
     }
 
     func testFailedAttachmentSendWithoutOutboxRestoresDraft() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -102,7 +102,7 @@ private struct AttachmentProcessingTransport: OpenClawChatTransport {
 
     func requestHealth(timeoutMs _: Int) async throws -> Bool {
         await self.healthGate?.wait()
-        true
+        return true
     }
 
     func events() -> AsyncStream<OpenClawChatTransportEvent> {
@@ -482,24 +482,17 @@ final class ChatViewModelAttachmentTests: XCTestCase {
         let capture = AttachmentSendCapture()
         let healthGate = AttachmentHealthGate()
         let transport = AttachmentProcessingTransport(capture: capture, healthGate: healthGate)
-        let draftAttachment = OpenClawPendingAttachment(
-            url: nil,
-            data: Data("draft-audio".utf8),
-            fileName: "draft.m4a",
-            mimeType: "audio/mp4",
-            preview: nil,
-            durationSeconds: 21.2)
-        let replacementAttachment = OpenClawPendingAttachment(
-            url: nil,
-            data: Data("replacement-audio".utf8),
-            fileName: "replacement.m4a",
-            mimeType: "audio/mp4",
-            preview: nil,
-            durationSeconds: 99)
-        let viewModel = await MainActor.run {
+        let (viewModel, draftAttachmentID) = await MainActor.run {
             let viewModel = OpenClawChatViewModel(sessionKey: "main", transport: transport)
+            let draftAttachment = OpenClawPendingAttachment(
+                url: nil,
+                data: Data("draft-audio".utf8),
+                fileName: "draft.m4a",
+                mimeType: "audio/mp4",
+                preview: nil,
+                durationSeconds: 21.2)
             viewModel.attachments = [draftAttachment]
-            return viewModel
+            return (viewModel, draftAttachment.id)
         }
 
         await MainActor.run { viewModel.send() }
@@ -507,8 +500,15 @@ final class ChatViewModelAttachmentTests: XCTestCase {
             await healthGate.hasEntered()
         }
         await MainActor.run {
-            viewModel.removeAttachment(draftAttachment.id)
-            viewModel.attachments.append(replacementAttachment)
+            viewModel.removeAttachment(draftAttachmentID)
+            viewModel.attachments.append(
+                OpenClawPendingAttachment(
+                    url: nil,
+                    data: Data("replacement-audio".utf8),
+                    fileName: "replacement.m4a",
+                    mimeType: "audio/mp4",
+                    preview: nil,
+                    durationSeconds: 99))
         }
         await healthGate.release()
         try await waitUntil("voice note sent") {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelAttachmentTests.swift
@@ -624,28 +624,22 @@ final class ChatViewModelAttachmentTests: XCTestCase {
             fileName: "voice-note-local.m4a",
             durationSeconds: 14.6,
             content: AnyCodable("local"))
-        let canonicalAudio = OpenClawChatMessageContent(
-            type: "file",
-            text: nil,
-            mimeType: "audio/mp4",
-            fileName: "media-1.m4a",
-            content: AnyCodable("canonical"))
         let existing = OpenClawChatMessage(
             role: "user",
             content: [localAudio],
             timestamp: nil,
             idempotencyKey: "run:user")
-        let incoming = OpenClawChatMessage(
-            role: "user",
-            content: [canonicalAudio],
-            timestamp: nil,
-            idempotencyKey: "run:user")
+        let incoming = try JSONDecoder().decode(
+            OpenClawChatMessage.self,
+            from: Data(
+                #"{"role":"user","content":"See attached.","__openclaw":{"idempotencyKey":"run:user"},"MediaPaths":["media/inbound/media-1.m4a"],"MediaTypes":["audio/mp4"]}"#
+                    .utf8))
 
         let adopted = OpenClawChatViewModel.adoptingCanonicalMessage(incoming, over: existing)
 
-        let audio = try XCTUnwrap(adopted.content.first)
+        let audio = try XCTUnwrap(adopted.content.first { $0.mimeType == "audio/mp4" })
         XCTAssertEqual(audio.fileName, "media-1.m4a")
-        XCTAssertEqual(audio.content, AnyCodable("canonical"))
+        XCTAssertNil(audio.content)
         XCTAssertEqual(audio.durationSeconds, 14.6)
     }
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/VoiceNoteRecorderTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/VoiceNoteRecorderTests.swift
@@ -58,6 +58,26 @@ final class VoiceNoteRecorderTests: XCTestCase {
     }
 
     @MainActor
+    func testCompletedRecordingHasOneStagingOwner() async throws {
+        let capture = FakeVoiceNoteAudioCapture()
+        let recorder = OpenClawVoiceNoteRecorder(capture: capture)
+
+        let started = await recorder.start()
+        XCTAssertTrue(started)
+        let recording = try XCTUnwrap(recorder.finish())
+
+        XCTAssertEqual(recorder.claimCompletedRecording(), recording)
+        XCTAssertNil(recorder.claimCompletedRecording())
+        XCTAssertTrue(recorder.ownsPendingChatAttachment)
+
+        recorder.completeStaging(recording)
+
+        XCTAssertEqual(recorder.state, .idle)
+        XCTAssertFalse(recorder.ownsPendingChatAttachment)
+        try FileManager.default.removeItem(at: recording.fileURL)
+    }
+
+    @MainActor
     func testCancelReturnsToIdleAndDeletesTemporaryFile() async throws {
         let capture = FakeVoiceNoteAudioCapture()
         let recorder = OpenClawVoiceNoteRecorder(capture: capture)

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/VoiceNoteRecorderTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/VoiceNoteRecorderTests.swift
@@ -11,6 +11,7 @@ private final class FakeVoiceNoteAudioCapture: VoiceNoteAudioCapture {
     var cancelCount = 0
     var activeURL: URL?
     var onStart: (() -> Void)?
+    var failureHandler: (@MainActor () -> Void)?
 
     func requestPermission() async -> Bool {
         self.permissionGranted
@@ -30,6 +31,14 @@ private final class FakeVoiceNoteAudioCapture: VoiceNoteAudioCapture {
 
     func cancel() {
         self.cancelCount += 1
+    }
+
+    func setFailureHandler(_ handler: @escaping @MainActor () -> Void) {
+        self.failureHandler = handler
+    }
+
+    func failCapture() {
+        self.failureHandler?()
     }
 }
 
@@ -95,6 +104,23 @@ final class VoiceNoteRecorderTests: XCTestCase {
     }
 
     @MainActor
+    func testSuccessiveRecordingsUseUniqueTemporaryFiles() async throws {
+        let capture = FakeVoiceNoteAudioCapture()
+        let recorder = OpenClawVoiceNoteRecorder(
+            capture: capture,
+            now: { Date(timeIntervalSince1970: 0) })
+
+        await XCTAssertTrue(recorder.start())
+        let firstURL = try XCTUnwrap(capture.activeURL)
+        recorder.cancel()
+
+        await XCTAssertTrue(recorder.start())
+        let secondURL = try XCTUnwrap(capture.activeURL)
+        XCTAssertNotEqual(firstURL, secondURL)
+        recorder.cancel()
+    }
+
+    @MainActor
     func testDurationCapAutoFinishes() async throws {
         let capture = FakeVoiceNoteAudioCapture()
         capture.duration = 0.25
@@ -145,6 +171,27 @@ final class VoiceNoteRecorderTests: XCTestCase {
         guard case .failed = recorder.state else {
             return XCTFail("Expected failure state")
         }
+    }
+
+    @MainActor
+    func testCaptureInterruptionFailsAndDeletesTemporaryFile() async throws {
+        let capture = FakeVoiceNoteAudioCapture()
+        let recorder = OpenClawVoiceNoteRecorder(capture: capture)
+        var activeChanges: [Bool] = []
+        recorder.onRecordingActiveChanged = { activeChanges.append($0) }
+
+        await XCTAssertTrue(recorder.start())
+        let fileURL = try XCTUnwrap(capture.activeURL)
+
+        capture.failCapture()
+
+        XCTAssertEqual(activeChanges, [true, false])
+        XCTAssertEqual(capture.cancelCount, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+        guard case let .failed(message) = recorder.state else {
+            return XCTFail("Expected failure state")
+        }
+        XCTAssertTrue(message.contains("interrupted"))
     }
 
     @MainActor

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/VoiceNoteRecorderTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/VoiceNoteRecorderTests.swift
@@ -110,11 +110,13 @@ final class VoiceNoteRecorderTests: XCTestCase {
             capture: capture,
             now: { Date(timeIntervalSince1970: 0) })
 
-        await XCTAssertTrue(recorder.start())
+        let firstStarted = await recorder.start()
+        XCTAssertTrue(firstStarted)
         let firstURL = try XCTUnwrap(capture.activeURL)
         recorder.cancel()
 
-        await XCTAssertTrue(recorder.start())
+        let secondStarted = await recorder.start()
+        XCTAssertTrue(secondStarted)
         let secondURL = try XCTUnwrap(capture.activeURL)
         XCTAssertNotEqual(firstURL, secondURL)
         recorder.cancel()
@@ -180,7 +182,8 @@ final class VoiceNoteRecorderTests: XCTestCase {
         var activeChanges: [Bool] = []
         recorder.onRecordingActiveChanged = { activeChanges.append($0) }
 
-        await XCTAssertTrue(recorder.start())
+        let started = await recorder.start()
+        XCTAssertTrue(started)
         let fileURL = try XCTUnwrap(capture.activeURL)
 
         capture.failCapture()


### PR DESCRIPTION
## What Problem This Solves

The iOS voice-note composer added in #100946 could lose its only attachment bytes after staging, an ambiguous send, app recreation, or an offline send. It could also retarget an in-progress recording when the selected chat changed, and microphone ownership could overlap with Talk or push-to-talk.

Relates to #100709 and follows up #100946.

## Why This Change Was Made

- Persist voice-note bytes in the existing per-gateway SQLite chat outbox before modern-Gateway delivery, with bounded per-command and total attachment budgets.
- Pin the captured session, agent, gateway, and routing contract from recording through staging and canonical confirmation.
- Keep recipient presentation pinned to that captured route, including after canonical history replaces the queued bubble.
- Make staging a one-shot recorder state so SwiftUI updates cannot consume the same file twice.
- Queue recordings while offline, preserve ambiguous delivery for reconciliation, and delete durable bytes only after canonical history confirms the user turn.
- Preserve the established live attachment path for healthy older Gateways that do not support safe replay leases.
- Serialize voice-note, Talk, push-to-talk, interruption, and background microphone ownership.

## User Impact

Voice notes can be recorded and sent while offline, survive reconnects and app recreation, and deliver once without changing chats or disappearing after an uncertain network result. Healthy older Gateways continue to send attachments live; durable offline replay requires a Gateway with the routing-contract capability.

## Evidence

- `swift test --filter 'VoiceNoteRecorderTests|ChatViewModelAttachmentTests|ChatTranscriptCacheStoreTests'`: 66 tests passed.
- `xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -configuration Debug -destination 'platform=iOS Simulator,id=F8D0EA37-7040-4FA7-8CFA-BA8841C68E1A' -derivedDataPath build/DerivedData test -only-testing:OpenClawTests/NodeAppModelInvokeTests`: 114 tests passed; signed simulator app, Watch app, widget, share extension, and shared packages built successfully.
- `xcodebuild -project OpenClaw.xcodeproj -scheme OpenClaw -configuration Debug -destination 'platform=iOS Simulator,id=F8D0EA37-7040-4FA7-8CFA-BA8841C68E1A' -derivedDataPath build/DerivedData test -only-testing:OpenClawTests/GatewayStatusBuilderTests -only-testing:OpenClawTests/RootTabsPresentationTests`: 53 tests passed.
- `node --import tsx scripts/native-app-i18n.ts check`: 2,819 entries, unchanged.
- SwiftFormat lint and `git diff --check`: clean.
- Live signed-simulator proof: recorded a 19-second voice note with the Gateway stopped; Send showed one queued row; restarting the Gateway produced one attachment offload and exactly one `chat.send`; the queued label cleared and one canonical 0:19 voice-note row remained.
- Fresh structured Codex review of the full branch: no actionable findings.
