### PR TITLE
docs: refresh generated map for Mythos heading

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -7250,7 +7250,7 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
 - Headings:
   - H2: Usage and cost tracking
   - H2: Getting started
-  - H2: Thinking defaults (Claude Sonnet 5, Fable 5, 4.8, and 4.6)
+  - H2: Thinking defaults (Claude Sonnet 5, Mythos 5, Fable 5, 4.8, and 4.6)
   - H2: Safety refusal fallback (Claude Fable 5)
   - H3: Why this exists
   - H3: How it works


### PR DESCRIPTION
## What Problem This Solves

Current `main` has a stale generated docs-map row: the Anthropic model guide heading includes Mythos 5, but `docs/docs_map.md` still lists the previous heading.

## Why This Change Was Made

Regenerate the docs map after the concurrent plugin-SDK budget repair landed independently in `0e8870da766`.

## User Impact

No runtime behavior changes. Docs navigation and broad PR CI match the current model guide again.

## Evidence

- `node scripts/generate-docs-map.mjs --check`
- Blacksmith Testbox `tbx_01kwx089bg75m32kcyawjj51nr`: `pnpm docs:map:check` — passed
- Fresh Codex autoreview — no accepted/actionable findings
