### PR TITLE
refactor(deadcode): localize internal type aliases

### DIFF
--- a/extensions/browser/src/browser/pw-download-capture.ts
+++ b/extensions/browser/src/browser/pw-download-capture.ts
@@ -7,7 +7,7 @@ import { writeExternalFileWithinOutputRoot } from "./output-files.js";
 import { DEFAULT_DOWNLOAD_DIR } from "./paths.js";
 import { sanitizeUntrustedFileName } from "./safe-filename.js";
 
-export type BrowserDownloadCaptureState = {
+type BrowserDownloadCaptureState = {
   downloadWaiterDepth: number;
 };
 

--- a/extensions/canvas/src/a2ui-jsonl.ts
+++ b/extensions/canvas/src/a2ui-jsonl.ts
@@ -10,7 +10,7 @@ const A2UI_ACTION_KEYS = [
 ] as const;
 
 /** Supported A2UI message dialects accepted by the Canvas host. */
-export type A2UIVersion = "v0.8" | "v0.9";
+type A2UIVersion = "v0.8" | "v0.9";
 
 /** Builds a minimal A2UI JSONL payload that renders text in a single surface. */
 export function buildA2UITextJsonl(text: string) {

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -9,7 +9,7 @@ import type { ResolvedCopilotProvider } from "./provider-bridge.js";
 
 const LOOPBACK_HOST = "127.0.0.1";
 
-export type CopilotByokProxyHandle = {
+type CopilotByokProxyHandle = {
   close: () => Promise<void>;
   provider: ResolvedCopilotProvider;
 };

--- a/extensions/discord/src/inbound-event-delivery.ts
+++ b/extensions/discord/src/inbound-event-delivery.ts
@@ -5,7 +5,7 @@ import {
   normalizeOptionalString as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 
-export type DiscordInboundEventDeliveryEnd = () => void;
+type DiscordInboundEventDeliveryEnd = () => void;
 
 type ActiveEvent = {
   outboundTo: string;

--- a/src/agents/bootstrap-routing.ts
+++ b/src/agents/bootstrap-routing.ts
@@ -31,7 +31,7 @@ type BootstrapRoutingInput = {
 };
 
 /** Bootstrap placement decision consumed by system/runtime context assembly. */
-export type WorkspaceBootstrapRouting = {
+type WorkspaceBootstrapRouting = {
   bootstrapMode: BootstrapMode;
   includeBootstrapInSystemContext: boolean;
   includeBootstrapInRuntimeContext: boolean;

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -116,7 +116,7 @@ export function clearAllCliSessions(entry: Partial<MutableCliSessionFields>): vo
 
 type CliSessionInvalidatedReason = "auth-profile" | "auth-epoch" | "message-policy" | "cwd" | "mcp";
 
-export type CliSessionContentDriftReason = "system-prompt" | "prompt-tools";
+type CliSessionContentDriftReason = "system-prompt" | "prompt-tools";
 
 export type CliSessionReuseResult =
   | { mode: "none" }

--- a/src/agents/tools/gateway-caller-context.ts
+++ b/src/agents/tools/gateway-caller-context.ts
@@ -6,7 +6,7 @@ import { copyChannelAgentToolMeta } from "../channel-tools.js";
 import { copyToolTerminalPresentation } from "../tool-terminal-presentation.js";
 import type { AnyAgentTool } from "./common.js";
 
-export type GatewayToolCallerIdentity = {
+type GatewayToolCallerIdentity = {
   agentId: string;
   sessionKey: string;
 };

--- a/src/agents/worktrees/git.ts
+++ b/src/agents/worktrees/git.ts
@@ -11,7 +11,7 @@ export type GitResult = {
   code: number | null;
 };
 
-export type WorktreeListEntry = {
+type WorktreeListEntry = {
   path: string;
   lockedReason?: string;
 };

--- a/ui/src/app/web-push.ts
+++ b/ui/src/app/web-push.ts
@@ -2,7 +2,7 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ApplicationGateway } from "./gateway.ts";
 
-export type WebPushSnapshot = {
+type WebPushSnapshot = {
   supported: boolean;
   permission: NotificationPermission | "unsupported";
   subscribed: boolean;

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -28,7 +28,7 @@ export type SessionChangedResult = {
   result: SessionsListResult | null;
 };
 
-export type SessionChangedEventInfo = {
+type SessionChangedEventInfo = {
   key: string;
   agentId: string | null;
   runId: string | null;

--- a/ui/src/pages/chat/user-message-content.ts
+++ b/ui/src/pages/chat/user-message-content.ts
@@ -2,7 +2,7 @@
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import { getChatAttachmentPreviewUrl } from "./attachment-payload-store.ts";
 
-export type UserChatMessageContentBlock = {
+type UserChatMessageContentBlock = {
   type: string;
   text?: string;
   url?: string;

--- a/ui/src/pages/plugin/route.ts
+++ b/ui/src/pages/plugin/route.ts
@@ -1,7 +1,7 @@
 import { definePage } from "@openclaw/uirouter";
 import { html } from "lit";
 
-export type PluginTabRef = { pluginId: string; id: string };
+type PluginTabRef = { pluginId: string; id: string };
 
 /** Reads the plugin tab reference from a `/plugin?plugin=<pluginId>&id=<tab>` search string. */
 export function pluginTabRefFromSearch(search: string): PluginTabRef {


### PR DESCRIPTION
## What Problem This Solves

Internal implementation types were still exported across core, Control UI, and bundled plugins even though no repository consumer imports them. Those exports enlarge module surfaces and keep appearing in dead-code reports.

## Why This Change Was Made

The fresh codebase-memory graph and exact-head `ts-unused-exports` report agreed on 12 file-local type aliases. Repository-wide reference checks confirmed each symbol is used only by its defining module and is not re-exported through a public barrel or plugin API.

This localizes:

- 4 core agent types
- 4 Control UI types
- 4 bundled plugin types

Runtime implementations and exported functions are unchanged.

## User Impact

No user-visible behavior changes. The internal API surface is smaller and the dead-code signal is less noisy.

## Evidence

- Fresh full, non-shallow worktree from `origin/main`
- codebase-memory MCP index: 20,910 files, 276,935 nodes, 1,111,784 edges
- graph query: all 12 selected types had zero in-degree/out-degree and were not entry points
- exact Testbox dead-code report: 3,685 lines before, 3,669 after; all 12 selected symbols absent
- Testbox `tbx_01kwwzqg6e2sz1qbbebcya65mt`: 6 Vitest shards, 8 focused files, 142 tests passed
- Testbox `check:changed`: core, core tests, extensions, and extension tests lanes passed
- `git diff --check`
- fresh Codex autoreview: clean, no accepted/actionable findings, 0.87 confidence
