### PR TITLE
fix(diagnostics-otel): surface error message on run/harness error spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **OpenTelemetry run failures:** export bounded, redacted failure messages on run and harness error spans without widening metric attributes or public diagnostic event payloads. (#101244) Thanks @amknight.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **OpenTelemetry run failures:** export bounded, redacted failure messages on run and harness error spans without widening metric attributes or public diagnostic event payloads. (#101244) Thanks @amknight.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/extensions/diagnostics-otel/api.ts
+++ b/extensions/diagnostics-otel/api.ts
@@ -11,6 +11,7 @@ export {
   parseDiagnosticTraceparent,
   type DiagnosticEventMetadata,
   type DiagnosticEventPayload,
+  type DiagnosticEventPrivateData,
   type DiagnosticTraceContext,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 export { emptyPluginConfigSchema, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1455,6 +1455,98 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("run.completed error span carries the redacted message off the metric attrs", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
+    await service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "run.completed",
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5.4",
+      outcome: "error",
+      errorCategory: "Error",
+      error: "upstream model stream stalled then aborted",
+      durationMs: 100,
+    });
+    await flushDiagnosticEvents();
+
+    expect(startedSpanOptions("openclaw.run")?.attributes?.["openclaw.error"]).toBe(
+      "upstream model stream stalled then aborted",
+    );
+    expect(spanByName("openclaw.run").setStatus).toHaveBeenCalledWith({
+      code: 2,
+      message: "upstream model stream stalled then aborted",
+    });
+    // The raw message must never widen metric cardinality.
+    const runDuration = lastHistogramRecord("openclaw.run.duration_ms");
+    expect(runDuration?.[1]?.["openclaw.outcome"]).toBe("error");
+    expect(Object.hasOwn(runDuration?.[1] ?? {}, "openclaw.error")).toBe(false);
+
+    await service.stop?.(ctx);
+  });
+
+  test("harness.run.completed error span carries the redacted message", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
+    await service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "harness.run.completed",
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5.4",
+      harnessId: "openclaw",
+      outcome: "error",
+      error: "model run failed during resolve phase",
+      durationMs: 90,
+      itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+    });
+    await flushDiagnosticEvents();
+
+    expect(startedSpanOptions("openclaw.harness.run")?.attributes?.["openclaw.error"]).toBe(
+      "model run failed during resolve phase",
+    );
+    expect(spanByName("openclaw.harness.run").setStatus).toHaveBeenCalledWith({
+      code: 2,
+      message: "model run failed during resolve phase",
+    });
+    const harnessDuration = lastHistogramRecord("openclaw.harness.duration_ms");
+    expect(Object.hasOwn(harnessDuration?.[1] ?? {}, "openclaw.error")).toBe(false);
+
+    await service.stop?.(ctx);
+  });
+
+  test("harness.run.error span prefers the redacted message over the category", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
+    await service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "harness.run.error",
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5.4",
+      harnessId: "openclaw",
+      phase: "resolve",
+      errorCategory: "Error",
+      error: "harness cleanup threw",
+      durationMs: 90,
+    });
+    await flushDiagnosticEvents();
+
+    expect(startedSpanOptions("openclaw.harness.run")?.attributes?.["openclaw.error"]).toBe(
+      "harness cleanup threw",
+    );
+    expect(spanByName("openclaw.harness.run").setStatus).toHaveBeenCalledWith({
+      code: 2,
+      message: "harness cleanup threw",
+    });
+
+    await service.stop?.(ctx);
+  });
+
   test("honors disabled traces when an OpenTelemetry SDK is preloaded", async () => {
     process.env.OPENCLAW_OTEL_PRELOADED = "1";
     const service = createDiagnosticsOtelService();

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1460,16 +1460,18 @@ describe("diagnostics-otel service", () => {
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
     await service.start(ctx);
 
-    emitDiagnosticEvent({
-      type: "run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      outcome: "error",
-      errorCategory: "Error",
-      error: "upstream model stream stalled then aborted",
-      durationMs: 100,
-    });
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "run.completed",
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        outcome: "error",
+        errorCategory: "Error",
+        durationMs: 100,
+      },
+      { errorMessage: "upstream model stream stalled then aborted" },
+    );
     await flushDiagnosticEvents();
 
     expect(startedSpanOptions("openclaw.run")?.attributes?.["openclaw.error"]).toBe(
@@ -1487,22 +1489,52 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("run.completed bounds sensitive error text before export", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
+    await service.start(ctx);
+    const secret = "sk-1234567890abcdef";
+
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "run.completed",
+        runId: "run-1",
+        outcome: "error",
+        errorCategory: "Error",
+        durationMs: 100,
+      },
+      { errorMessage: `OPENAI_API_KEY=${secret} ${"x".repeat(8 * 1024)}` },
+    );
+    await flushDiagnosticEvents();
+
+    const status = mockCallArg(spanByName("openclaw.run").setStatus, 0) as {
+      message?: string;
+    };
+    expect(status.message).not.toContain(secret);
+    expect(status.message).toMatch(/\.\.\.\(truncated\)$/u);
+    expect(status.message?.length).toBeLessThanOrEqual(4 * 1024 + 20);
+
+    await service.stop?.(ctx);
+  });
+
   test("harness.run.completed error span carries the redacted message", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
     await service.start(ctx);
 
-    emitDiagnosticEvent({
-      type: "harness.run.completed",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      harnessId: "openclaw",
-      outcome: "error",
-      error: "model run failed during resolve phase",
-      durationMs: 90,
-      itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
-    });
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "harness.run.completed",
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        harnessId: "openclaw",
+        outcome: "error",
+        durationMs: 90,
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+      },
+      { errorMessage: "model run failed during resolve phase" },
+    );
     await flushDiagnosticEvents();
 
     expect(startedSpanOptions("openclaw.harness.run")?.attributes?.["openclaw.error"]).toBe(
@@ -1523,17 +1555,19 @@ describe("diagnostics-otel service", () => {
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true, metrics: true });
     await service.start(ctx);
 
-    emitDiagnosticEvent({
-      type: "harness.run.error",
-      runId: "run-1",
-      provider: "openai",
-      model: "gpt-5.4",
-      harnessId: "openclaw",
-      phase: "resolve",
-      errorCategory: "Error",
-      error: "harness cleanup threw",
-      durationMs: 90,
-    });
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "harness.run.error",
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        harnessId: "openclaw",
+        phase: "resolve",
+        errorCategory: "Error",
+        durationMs: 90,
+      },
+      { errorMessage: "harness cleanup threw" },
+    );
     await flushDiagnosticEvents();
 
     expect(startedSpanOptions("openclaw.harness.run")?.attributes?.["openclaw.error"]).toBe(

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -3092,6 +3092,11 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         if (evt.errorCategory) {
           spanAttrs["openclaw.errorCategory"] = lowCardinalityAttr(evt.errorCategory, "other");
         }
+        // Redacted message goes on the span only, never the low-cardinality metric attrs.
+        const redactedError = evt.error ? redactSensitiveText(evt.error) : undefined;
+        if (redactedError) {
+          spanAttrs["openclaw.error"] = redactedError;
+        }
         const trustedTrace = trustedTraceContext(evt, metadata);
         const trackedSpan = trustedTrace?.spanId
           ? activeTrustedSpans.get(trustedTrace.spanId)
@@ -3104,9 +3109,11 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           });
         setSpanAttrs(span, spanAttrs);
         if (evt.outcome === "error") {
+          const message =
+            redactedError ?? (evt.errorCategory ? redactSensitiveText(evt.errorCategory) : undefined);
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            ...(evt.errorCategory ? { message: redactSensitiveText(evt.errorCategory) } : {}),
+            ...(message ? { message } : {}),
           });
         }
         if (trackedSpan && trustedTrace?.spanId) {
@@ -3170,6 +3177,11 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           spanAttrs["openclaw.harness.items.completed"] = evt.itemLifecycle.completedCount;
           spanAttrs["openclaw.harness.items.active"] = evt.itemLifecycle.activeCount;
         }
+        // Redacted message goes on the span only, never the low-cardinality metric attrs.
+        const redactedError = evt.error ? redactSensitiveText(evt.error) : undefined;
+        if (redactedError) {
+          spanAttrs["openclaw.error"] = redactedError;
+        }
         const trustedTrace = trustedTraceContext(evt, metadata);
         const trackedSpan = trustedTrace?.spanId
           ? activeTrustedSpans.get(trustedTrace.spanId)
@@ -3184,7 +3196,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         if (evt.outcome === "error") {
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: "error",
+            message: redactedError ?? "error",
           });
         }
         if (trackedSpan && trustedTrace?.spanId) {
@@ -3208,9 +3220,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         if (!tracesEnabled) {
           return;
         }
+        // Redacted message goes on the span only; attrs above feed the metric.
+        const redactedError = evt.error ? redactSensitiveText(evt.error) : undefined;
         const spanAttrs: Record<string, string | number | boolean> = {
           ...attrs,
           "error.type": errorType,
+          ...(redactedError ? { "openclaw.error": redactedError } : {}),
           ...(evt.cleanupFailed ? { "openclaw.harness.cleanup_failed": true } : {}),
         };
         const span =
@@ -3222,7 +3237,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         setSpanAttrs(span, spanAttrs);
         span.setStatus({
           code: SpanStatusCode.ERROR,
-          message: errorType,
+          message: redactedError ?? errorType,
         });
         span.end(evt.ts);
       };

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -39,6 +39,7 @@ import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
   DiagnosticEventMetadata,
   DiagnosticEventPayload,
+  DiagnosticEventPrivateData,
   DiagnosticTraceContext,
   OpenClawPluginService,
   OpenClawPluginServiceContext,
@@ -80,6 +81,7 @@ const MAX_OTEL_CONTENT_ARRAY_ITEMS = 200;
 const MAX_OTEL_LOG_BODY_CHARS = 4 * 1024;
 const MAX_OTEL_LOG_ATTRIBUTE_COUNT = 64;
 const MAX_OTEL_LOG_ATTRIBUTE_VALUE_CHARS = 4 * 1024;
+const MAX_OTEL_ERROR_MESSAGE_CHARS = 4 * 1024;
 const LOG_RECORD_EXPORT_FAILURE_REPORT_INTERVAL_MS = 60_000;
 const OTEL_LOG_RAW_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,64}$/u;
 const OTEL_LOG_ATTRIBUTE_KEY_RE = /^[A-Za-z0-9_.:-]{1,96}$/u;
@@ -681,6 +683,14 @@ function clampOtelLogText(value: string, maxChars: number): string {
 
 function normalizeOtelLogString(value: string, maxChars: number): string {
   return clampOtelLogText(redactSensitiveText(value), maxChars);
+}
+
+function normalizeOtelErrorMessage(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const normalized = normalizeOtelLogString(value.trim(), MAX_OTEL_ERROR_MESSAGE_CHARS);
+  return normalized || undefined;
 }
 
 function resolveContentCapturePolicy(value: unknown): OtelContentCapturePolicy {
@@ -3066,6 +3076,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const recordRunCompleted = (
         evt: Extract<DiagnosticEventPayload, { type: "run.completed" }>,
         metadata: DiagnosticEventMetadata,
+        privateData: DiagnosticEventPrivateData,
       ) => {
         const attrs: Record<string, string | number> = {
           "openclaw.outcome": evt.outcome,
@@ -3093,7 +3104,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           spanAttrs["openclaw.errorCategory"] = lowCardinalityAttr(evt.errorCategory, "other");
         }
         // Redacted message goes on the span only, never the low-cardinality metric attrs.
-        const redactedError = evt.error ? redactSensitiveText(evt.error) : undefined;
+        const redactedError = normalizeOtelErrorMessage(privateData.errorMessage);
         if (redactedError) {
           spanAttrs["openclaw.error"] = redactedError;
         }
@@ -3110,7 +3121,8 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         setSpanAttrs(span, spanAttrs);
         if (evt.outcome === "error") {
           const message =
-            redactedError ?? (evt.errorCategory ? redactSensitiveText(evt.errorCategory) : undefined);
+            redactedError ??
+            (evt.errorCategory ? redactSensitiveText(evt.errorCategory) : undefined);
           span.setStatus({
             code: SpanStatusCode.ERROR,
             ...(message ? { message } : {}),
@@ -3156,6 +3168,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const recordHarnessRunCompleted = (
         evt: Extract<DiagnosticEventPayload, { type: "harness.run.completed" }>,
         metadata: DiagnosticEventMetadata,
+        privateData: DiagnosticEventPrivateData,
       ) => {
         harnessDurationHistogram.record(evt.durationMs, harnessRunMetricAttrs(evt));
         if (!tracesEnabled) {
@@ -3178,7 +3191,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           spanAttrs["openclaw.harness.items.active"] = evt.itemLifecycle.activeCount;
         }
         // Redacted message goes on the span only, never the low-cardinality metric attrs.
-        const redactedError = evt.error ? redactSensitiveText(evt.error) : undefined;
+        const redactedError = normalizeOtelErrorMessage(privateData.errorMessage);
         if (redactedError) {
           spanAttrs["openclaw.error"] = redactedError;
         }
@@ -3209,6 +3222,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
       const recordHarnessRunError = (
         evt: Extract<DiagnosticEventPayload, { type: "harness.run.error" }>,
         metadata: DiagnosticEventMetadata,
+        privateData: DiagnosticEventPrivateData,
       ) => {
         const errorType = lowCardinalityAttr(evt.errorCategory, "other");
         const attrs = {
@@ -3221,7 +3235,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           return;
         }
         // Redacted message goes on the span only; attrs above feed the metric.
-        const redactedError = evt.error ? redactSensitiveText(evt.error) : undefined;
+        const redactedError = normalizeOtelErrorMessage(privateData.errorMessage);
         const spanAttrs: Record<string, string | number | boolean> = {
           ...attrs,
           "error.type": errorType,
@@ -3902,16 +3916,16 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
               recordRunStarted(evt, metadata);
               return;
             case "run.completed":
-              recordRunCompleted(evt, metadata);
+              recordRunCompleted(evt, metadata, privateData);
               return;
             case "harness.run.started":
               recordHarnessRunStarted(evt, metadata);
               return;
             case "harness.run.completed":
-              recordHarnessRunCompleted(evt, metadata);
+              recordHarnessRunCompleted(evt, metadata, privateData);
               return;
             case "harness.run.error":
-              recordHarnessRunError(evt, metadata);
+              recordHarnessRunError(evt, metadata, privateData);
               return;
             case "context.assembled":
               recordContextAssembled(evt, metadata);

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.diagnostics.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.diagnostics.test.ts
@@ -1,0 +1,69 @@
+// Coverage for trusted diagnostics emitted by a full embedded attempt.
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  onTrustedInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPrivateData,
+  type DiagnosticEventPayload,
+} from "../../../infra/diagnostic-events.js";
+import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
+  createContextEngineBootstrapAndAssemble,
+  preloadRunEmbeddedAttemptForTests,
+  resetEmbeddedAttemptHarness,
+} from "./attempt.spawn-workspace.test-support.js";
+
+describe("runEmbeddedAttempt diagnostics", () => {
+  const tempPaths: string[] = [];
+
+  beforeAll(async () => {
+    await preloadRunEmbeddedAttemptForTests();
+  });
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness();
+    resetDiagnosticEventsForTest();
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+    resetDiagnosticEventsForTest();
+  });
+
+  it("keeps run failure text on the trusted private channel", async () => {
+    const completed: Array<{
+      event: DiagnosticEventPayload;
+      privateData: DiagnosticEventPrivateData;
+    }> = [];
+    const unsubscribe = onTrustedInternalDiagnosticEvent((event, _metadata, privateData) => {
+      if (event.type === "run.completed") {
+        completed.push({ event, privateData });
+      }
+    });
+
+    try {
+      await createContextEngineAttemptRunner({
+        contextEngine: createContextEngineBootstrapAndAssemble(),
+        sessionKey: "agent:main:diagnostic-failure",
+        tempPaths,
+        sessionPrompt: async () => {
+          throw new Error("provider stream failed");
+        },
+      });
+      await waitForDiagnosticEventsDrained();
+    } finally {
+      unsubscribe();
+    }
+
+    expect(completed).toHaveLength(1);
+    expect(completed[0]?.event).toMatchObject({
+      type: "run.completed",
+      outcome: "error",
+      errorCategory: "Error",
+    });
+    expect(completed[0]?.event).not.toHaveProperty("error");
+    expect(completed[0]?.privateData.errorMessage).toBe("provider stream failed");
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -33,8 +33,14 @@ import {
 import { resolveContextEngineOwnerPluginId } from "../../../context-engine/registry.js";
 import { buildContextEngineRuntimeSettings } from "../../../context-engine/runtime-settings.js";
 import type { AssembleResult } from "../../../context-engine/types.js";
-import { diagnosticErrorCategory } from "../../../infra/diagnostic-error-metadata.js";
-import { emitTrustedDiagnosticEvent } from "../../../infra/diagnostic-events.js";
+import {
+  diagnosticErrorCategory,
+  diagnosticErrorMessage,
+} from "../../../infra/diagnostic-error-metadata.js";
+import {
+  emitTrustedDiagnosticEvent,
+  emitTrustedDiagnosticEventWithPrivateData,
+} from "../../../infra/diagnostic-events.js";
 import { resolveDiagnosticModelContentCapturePolicy } from "../../../infra/diagnostic-llm-content.js";
 import {
   createChildDiagnosticTraceContext,
@@ -1188,14 +1194,19 @@ export async function runEmbeddedAttempt(
         return;
       }
       diagnosticRunCompleted = true;
-      emitTrustedDiagnosticEvent({
-        type: "run.completed",
-        ...diagnosticRunBase,
-        durationMs: Date.now() - diagnosticRunStartedAt,
-        outcome,
-        ...(extra?.blockedBy ? { blockedBy: extra.blockedBy } : {}),
-        ...(err && outcome !== "blocked" ? { errorCategory: diagnosticErrorCategory(err) } : {}),
-      });
+      const failed = err != null && outcome !== "blocked";
+      const errorMessage = failed ? diagnosticErrorMessage(err) : undefined;
+      emitTrustedDiagnosticEventWithPrivateData(
+        {
+          type: "run.completed",
+          ...diagnosticRunBase,
+          durationMs: Date.now() - diagnosticRunStartedAt,
+          outcome,
+          ...(extra?.blockedBy ? { blockedBy: extra.blockedBy } : {}),
+          ...(failed ? { errorCategory: diagnosticErrorCategory(err) } : {}),
+        },
+        errorMessage ? { errorMessage } : undefined,
+      );
     };
     const corePluginToolStages = createEmbeddedRunStageTracker();
     const forceDirectMessageTool =

--- a/src/agents/harness/lifecycle.test.ts
+++ b/src/agents/harness/lifecycle.test.ts
@@ -4,8 +4,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host-compat.js";
 import type { ContextEngine } from "../../context-engine/types.js";
 import {
-  onInternalDiagnosticEvent,
+  onTrustedInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
+  type DiagnosticEventPrivateData,
   type DiagnosticEventMetadata,
   type DiagnosticEventPayload,
 } from "../../infra/diagnostic-events.js";
@@ -110,13 +111,21 @@ function captureDiagnosticEvents(
   filter: (event: DiagnosticEventPayload) => boolean = (event) =>
     event.type.startsWith("harness.run."),
 ): {
-  events: Array<{ event: DiagnosticEventPayload; metadata: DiagnosticEventMetadata }>;
+  events: Array<{
+    event: DiagnosticEventPayload;
+    metadata: DiagnosticEventMetadata;
+    privateData: DiagnosticEventPrivateData;
+  }>;
   unsubscribe: () => void;
 } {
-  const events: Array<{ event: DiagnosticEventPayload; metadata: DiagnosticEventMetadata }> = [];
-  const unsubscribe = onInternalDiagnosticEvent((event, metadata) => {
+  const events: Array<{
+    event: DiagnosticEventPayload;
+    metadata: DiagnosticEventMetadata;
+    privateData: DiagnosticEventPrivateData;
+  }> = [];
+  const unsubscribe = onTrustedInternalDiagnosticEvent((event, metadata, privateData) => {
     if (filter(event)) {
-      events.push({ event, metadata });
+      events.push({ event, metadata, privateData });
     }
   });
   return { events, unsubscribe };
@@ -320,6 +329,41 @@ describe("AgentHarness lifecycle runner", () => {
     expect(attemptResult?.diagnosticTrace).toEqual(harnessTrace);
   });
 
+  it("keeps plugin harness failure messages on the trusted private channel", async () => {
+    const params = createAttemptParams();
+    const harnessTrace = createDiagnosticTrace();
+    const result = {
+      ...createAttemptResult(),
+      promptError: new Error("provider stream failed"),
+    } as EmbeddedRunAttemptResult;
+    const harness: AgentHarness = {
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => result,
+    };
+    const diagnostics = captureDiagnosticEvents(
+      (event) => event.type === "run.completed" || event.type === "harness.run.completed",
+    );
+    try {
+      await runWithDiagnosticTraceContext(harnessTrace, () =>
+        runAgentHarnessLifecycleAttempt(harness, params),
+      );
+      await flushDiagnosticEvents();
+    } finally {
+      diagnostics.unsubscribe();
+    }
+
+    expect(diagnostics.events.map(({ event }) => event.type)).toEqual([
+      "run.completed",
+      "harness.run.completed",
+    ]);
+    for (const { event, privateData } of diagnostics.events) {
+      expect(event).not.toHaveProperty("error");
+      expect(privateData.errorMessage).toBe("provider stream failed");
+    }
+  });
+
   it("emits plugin before-agent-run hook blocks as blocked run completions", async () => {
     resetDiagnosticEventsForTest();
     const params = createAttemptParams();
@@ -390,6 +434,7 @@ describe("AgentHarness lifecycle runner", () => {
     expect(errorEvent?.type).toBe("harness.run.error");
     expect(errorEvent?.phase).toBe("send");
     expect(errorEvent?.errorCategory).toBe("Error");
+    expect(diagnostics.events[1]?.privateData.errorMessage).toBe("codex app-server send failed");
     expect(errorEvent).not.toHaveProperty("cleanupFailed");
     expect(errorEvent?.harnessId).toBe("codex");
     expect(typeof errorEvent?.durationMs).toBe("number");

--- a/src/agents/harness/lifecycle.ts
+++ b/src/agents/harness/lifecycle.ts
@@ -14,6 +14,7 @@ import {
 } from "../../infra/diagnostic-error-metadata.js";
 import {
   emitTrustedDiagnosticEvent,
+  emitTrustedDiagnosticEventWithPrivateData,
   type DiagnosticHarnessRunErrorEvent,
   type DiagnosticHarnessRunOutcome,
 } from "../../infra/diagnostic-events.js";
@@ -174,18 +175,20 @@ function emitAgentHarnessRunCompleted(params: {
   // A classified (non-thrown) failure carries its error on result.promptError;
   // forward the message so the error span shows more than a bare category.
   const errorMessage = outcome === "error" ? diagnosticErrorMessage(result.promptError) : undefined;
-  emitTrustedDiagnosticEvent({
-    type: "harness.run.completed",
-    ...agentHarnessDiagnosticBase(harness, attemptParams, trace ?? result.diagnosticTrace),
-    durationMs: Date.now() - startedAt,
-    outcome,
-    ...(errorMessage ? { error: errorMessage } : {}),
-    ...(result.agentHarnessResultClassification
-      ? { resultClassification: result.agentHarnessResultClassification }
-      : {}),
-    ...(typeof result.yieldDetected === "boolean" ? { yieldDetected: result.yieldDetected } : {}),
-    itemLifecycle: { ...result.itemLifecycle },
-  });
+  emitTrustedDiagnosticEventWithPrivateData(
+    {
+      type: "harness.run.completed",
+      ...agentHarnessDiagnosticBase(harness, attemptParams, trace ?? result.diagnosticTrace),
+      durationMs: Date.now() - startedAt,
+      outcome,
+      ...(result.agentHarnessResultClassification
+        ? { resultClassification: result.agentHarnessResultClassification }
+        : {}),
+      ...(typeof result.yieldDetected === "boolean" ? { yieldDetected: result.yieldDetected } : {}),
+      itemLifecycle: { ...result.itemLifecycle },
+    },
+    errorMessage ? { errorMessage } : undefined,
+  );
 }
 
 function emitAgentHarnessRunError(params: {
@@ -198,14 +201,16 @@ function emitAgentHarnessRunError(params: {
 }): void {
   const { harness, attemptParams, startedAt, phase, error, trace } = params;
   const errorMessage = diagnosticErrorMessage(error);
-  emitTrustedDiagnosticEvent({
-    type: "harness.run.error",
-    ...agentHarnessDiagnosticBase(harness, attemptParams, trace),
-    durationMs: Date.now() - startedAt,
-    phase,
-    errorCategory: diagnosticErrorCategory(error),
-    ...(errorMessage ? { error: errorMessage } : {}),
-  });
+  emitTrustedDiagnosticEventWithPrivateData(
+    {
+      type: "harness.run.error",
+      ...agentHarnessDiagnosticBase(harness, attemptParams, trace),
+      durationMs: Date.now() - startedAt,
+      phase,
+      errorCategory: diagnosticErrorCategory(error),
+    },
+    errorMessage ? { errorMessage } : undefined,
+  );
 }
 
 /** Runs one harness attempt with diagnostics, tracing, and result classification. */
@@ -225,17 +230,19 @@ export async function runAgentHarnessLifecycleAttempt(
       return;
     }
     agentRunCompleted = true;
-    const failed = completion.outcome === "error" && Boolean(completion.error);
+    const failed = completion.outcome === "error" && completion.error != null;
     const errorMessage = failed ? diagnosticErrorMessage(completion.error) : undefined;
-    emitTrustedDiagnosticEvent({
-      type: "run.completed",
-      ...agentRunDiagnosticBase(params, agentRunTrace),
-      durationMs: Date.now() - agentRunStartedAt,
-      outcome: completion.outcome,
-      ...(completion.blockedBy ? { blockedBy: completion.blockedBy } : {}),
-      ...(failed ? { errorCategory: diagnosticErrorCategory(completion.error) } : {}),
-      ...(errorMessage ? { error: errorMessage } : {}),
-    });
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "run.completed",
+        ...agentRunDiagnosticBase(params, agentRunTrace),
+        durationMs: Date.now() - agentRunStartedAt,
+        outcome: completion.outcome,
+        ...(completion.blockedBy ? { blockedBy: completion.blockedBy } : {}),
+        ...(failed ? { errorCategory: diagnosticErrorCategory(completion.error) } : {}),
+      },
+      errorMessage ? { errorMessage } : undefined,
+    );
   };
 
   emitAgentHarnessRunStarted(harness, params, activeHarnessTrace);

--- a/src/agents/harness/lifecycle.ts
+++ b/src/agents/harness/lifecycle.ts
@@ -8,7 +8,10 @@ import {
   assertContextEngineHostSupport,
   type ContextEngineHostSupport,
 } from "../../context-engine/host-compat.js";
-import { diagnosticErrorCategory } from "../../infra/diagnostic-error-metadata.js";
+import {
+  diagnosticErrorCategory,
+  diagnosticErrorMessage,
+} from "../../infra/diagnostic-error-metadata.js";
 import {
   emitTrustedDiagnosticEvent,
   type DiagnosticHarnessRunErrorEvent,
@@ -167,11 +170,16 @@ function emitAgentHarnessRunCompleted(params: {
   trace?: DiagnosticTraceContext;
 }): void {
   const { harness, attemptParams, result, startedAt, trace } = params;
+  const outcome = agentHarnessRunOutcome(result);
+  // A classified (non-thrown) failure carries its error on result.promptError;
+  // forward the message so the error span shows more than a bare category.
+  const errorMessage = outcome === "error" ? diagnosticErrorMessage(result.promptError) : undefined;
   emitTrustedDiagnosticEvent({
     type: "harness.run.completed",
     ...agentHarnessDiagnosticBase(harness, attemptParams, trace ?? result.diagnosticTrace),
     durationMs: Date.now() - startedAt,
-    outcome: agentHarnessRunOutcome(result),
+    outcome,
+    ...(errorMessage ? { error: errorMessage } : {}),
     ...(result.agentHarnessResultClassification
       ? { resultClassification: result.agentHarnessResultClassification }
       : {}),
@@ -189,12 +197,14 @@ function emitAgentHarnessRunError(params: {
   trace?: DiagnosticTraceContext;
 }): void {
   const { harness, attemptParams, startedAt, phase, error, trace } = params;
+  const errorMessage = diagnosticErrorMessage(error);
   emitTrustedDiagnosticEvent({
     type: "harness.run.error",
     ...agentHarnessDiagnosticBase(harness, attemptParams, trace),
     durationMs: Date.now() - startedAt,
     phase,
     errorCategory: diagnosticErrorCategory(error),
+    ...(errorMessage ? { error: errorMessage } : {}),
   });
 }
 
@@ -215,15 +225,16 @@ export async function runAgentHarnessLifecycleAttempt(
       return;
     }
     agentRunCompleted = true;
+    const failed = completion.outcome === "error" && Boolean(completion.error);
+    const errorMessage = failed ? diagnosticErrorMessage(completion.error) : undefined;
     emitTrustedDiagnosticEvent({
       type: "run.completed",
       ...agentRunDiagnosticBase(params, agentRunTrace),
       durationMs: Date.now() - agentRunStartedAt,
       outcome: completion.outcome,
       ...(completion.blockedBy ? { blockedBy: completion.blockedBy } : {}),
-      ...(completion.error && completion.outcome === "error"
-        ? { errorCategory: diagnosticErrorCategory(completion.error) }
-        : {}),
+      ...(failed ? { errorCategory: diagnosticErrorCategory(completion.error) } : {}),
+      ...(errorMessage ? { error: errorMessage } : {}),
     });
   };
 

--- a/src/infra/diagnostic-error-metadata.test.ts
+++ b/src/infra/diagnostic-error-metadata.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   diagnosticErrorCategory,
   diagnosticErrorFailureKind,
+  diagnosticErrorMessage,
   diagnosticHttpStatusCode,
   diagnosticProviderRequestIdHash,
 } from "./diagnostic-error-metadata.js";
@@ -20,6 +21,24 @@ describe("diagnostic error metadata", () => {
     expect(diagnosticErrorCategory(namedFailure)).toBe("Error");
     expect(diagnosticErrorCategory("bad")).toBe("string");
     expect(diagnosticErrorCategory(null)).toBe("null");
+  });
+
+  it("normalizes Error and string messages", () => {
+    expect(diagnosticErrorMessage(new Error("  provider failed  "))).toBe("provider failed");
+    expect(diagnosticErrorMessage("  connection closed  ")).toBe("connection closed");
+    expect(diagnosticErrorMessage("   ")).toBeUndefined();
+  });
+
+  it("does not invoke message getters", () => {
+    const errorLike = Object.create(null, {
+      message: {
+        get() {
+          throw new Error("getter must not run");
+        },
+      },
+    });
+
+    expect(diagnosticErrorMessage(errorLike)).toBeUndefined();
   });
 
   it("accepts only own HTTP status data properties as error codes", () => {

--- a/src/infra/diagnostic-error-metadata.ts
+++ b/src/infra/diagnostic-error-metadata.ts
@@ -157,6 +157,20 @@ export function diagnosticErrorCategory(err: unknown): string {
   return typeof err;
 }
 
+/**
+ * Human-readable error message for diagnostics. Complements
+ * {@link diagnosticErrorCategory} (low-cardinality class name) with the actual
+ * message so error spans/events carry a real status message instead of a bare
+ * category. Returns undefined for non-Error, non-string throwables so the
+ * category stays the sole signal there. Emitted raw onto diagnostic events;
+ * span/log exporters redact it before it leaves the process.
+ */
+export function diagnosticErrorMessage(err: unknown): string | undefined {
+  const text = err instanceof Error ? err.message : typeof err === "string" ? err : undefined;
+  const trimmed = text?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 /** Extracts a safe HTTP status code from own `status` or `statusCode` data properties. */
 export function diagnosticHttpStatusCode(err: unknown): string | undefined {
   const status = readOwnDataProperty(err, "status");

--- a/src/infra/diagnostic-error-metadata.ts
+++ b/src/infra/diagnostic-error-metadata.ts
@@ -160,13 +160,12 @@ export function diagnosticErrorCategory(err: unknown): string {
 /**
  * Human-readable error message for diagnostics. Complements
  * {@link diagnosticErrorCategory} (low-cardinality class name) with the actual
- * message so error spans/events carry a real status message instead of a bare
- * category. Returns undefined for non-Error, non-string throwables so the
- * category stays the sole signal there. Emitted raw onto diagnostic events;
- * span/log exporters redact it before it leaves the process.
+ * message so error spans carry a real status message instead of a bare
+ * category. Reads only an own data property so diagnostics never invoke a
+ * user-defined getter.
  */
 export function diagnosticErrorMessage(err: unknown): string | undefined {
-  const text = err instanceof Error ? err.message : typeof err === "string" ? err : undefined;
+  const text = readDirectMessage(err);
   const trimmed = text?.trim();
   return trimmed ? trimmed : undefined;
 }

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -545,6 +545,8 @@ export type DiagnosticRunCompletedEvent = DiagnosticRunBaseEvent & {
   durationMs: number;
   outcome: "completed" | "aborted" | "blocked" | "error";
   errorCategory?: string;
+  /** Raw error message when outcome is "error"; span/log exporters redact it. */
+  error?: string;
   blockedBy?: string;
 };
 
@@ -572,6 +574,8 @@ export type DiagnosticHarnessRunCompletedEvent = DiagnosticHarnessRunBaseEvent &
   type: "harness.run.completed";
   durationMs: number;
   outcome: DiagnosticHarnessRunOutcome;
+  /** Raw error message when outcome is "error"; span/log exporters redact it. */
+  error?: string;
   resultClassification?: "empty" | "reasoning-only" | "planning-only";
   yieldDetected?: boolean;
   itemLifecycle?: {
@@ -586,6 +590,8 @@ export type DiagnosticHarnessRunErrorEvent = DiagnosticHarnessRunBaseEvent & {
   durationMs: number;
   phase: DiagnosticHarnessRunPhase;
   errorCategory: string;
+  /** Raw error message; span/log exporters redact it. */
+  error?: string;
   cleanupFailed?: boolean;
 };
 

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -545,8 +545,6 @@ export type DiagnosticRunCompletedEvent = DiagnosticRunBaseEvent & {
   durationMs: number;
   outcome: "completed" | "aborted" | "blocked" | "error";
   errorCategory?: string;
-  /** Raw error message when outcome is "error"; span/log exporters redact it. */
-  error?: string;
   blockedBy?: string;
 };
 
@@ -574,8 +572,6 @@ export type DiagnosticHarnessRunCompletedEvent = DiagnosticHarnessRunBaseEvent &
   type: "harness.run.completed";
   durationMs: number;
   outcome: DiagnosticHarnessRunOutcome;
-  /** Raw error message when outcome is "error"; span/log exporters redact it. */
-  error?: string;
   resultClassification?: "empty" | "reasoning-only" | "planning-only";
   yieldDetected?: boolean;
   itemLifecycle?: {
@@ -590,8 +586,6 @@ export type DiagnosticHarnessRunErrorEvent = DiagnosticHarnessRunBaseEvent & {
   durationMs: number;
   phase: DiagnosticHarnessRunPhase;
   errorCategory: string;
-  /** Raw error message; span/log exporters redact it. */
-  error?: string;
   cleanupFailed?: boolean;
 };
 
@@ -845,6 +839,8 @@ export type DiagnosticSkillUsagePrivateData = Readonly<{
 }>;
 
 export type DiagnosticEventPrivateData = Readonly<{
+  /** Raw failure text for trusted diagnostics exporters; never part of the public event payload. */
+  errorMessage?: string;
   modelContent?: DiagnosticModelCallContent;
   skillUsage?: DiagnosticSkillUsagePrivateData;
   toolContent?: DiagnosticToolCallContent;

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
@@ -1645,10 +1645,15 @@ function assertSmoke(params: {
   const failedRunSpans = params.spans.filter(
     (span) =>
       (span.name === "openclaw.run" || span.name === "openclaw.harness.run") &&
-      span.attributes["openclaw.error"] === `${DIRECT_ERROR_MESSAGE} OPENAI_API_KEY=sk-123…cdef`,
+      span.attributes["openclaw.error"] === `${DIRECT_ERROR_MESSAGE} OPENAI_API_KEY=***`,
   );
   if (failedRunSpans.length !== 2) {
-    failures.push("run and harness spans did not export the redacted failure message");
+    const observed = params.spans
+      .filter((span) => span.name === "openclaw.run" || span.name === "openclaw.harness.run")
+      .map((span) => ({ name: span.name, error: span.attributes["openclaw.error"] }));
+    failures.push(
+      `run and harness spans did not export the redacted failure message: ${JSON.stringify(observed)}`,
+    );
   }
   if ((params.bodyText.metrics ?? []).some((body) => body.includes(DIRECT_ERROR_MESSAGE))) {
     failures.push("run failure message leaked into OTLP metric attributes");

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke-runtime.ts
@@ -127,6 +127,8 @@ const REQUIRED_SPAN_NAMES = [
 const REQUIRED_METRIC_NAMES = ["openclaw.harness.duration_ms"] as const;
 const DIRECT_RUN_ID = "qa-otel-direct-run";
 const DIRECT_CALL_ID = "qa-otel-direct-call";
+const DIRECT_ERROR_MESSAGE = "QA OTEL provider stream failed";
+const DIRECT_ERROR_SECRET = "sk-1234567890abcdef";
 const DISALLOWED_ATTRIBUTE_KEYS = new Set([
   "openclaw.runId",
   "openclaw.chatId",
@@ -146,6 +148,7 @@ const DISALLOWED_ATTRIBUTE_KEYS = new Set([
 const DISALLOWED_BODY_NEEDLES = [
   "OTEL-QA-SECRET",
   "OTEL-QA-OK",
+  DIRECT_ERROR_SECRET,
   DIRECT_RUN_ID,
   DIRECT_CALL_ID,
 ];
@@ -1410,28 +1413,38 @@ async function runDirectTelemetryProducer(params: {
         },
       },
     );
-    emitTrustedDiagnosticEvent({
-      type: "run.completed",
-      runId: DIRECT_RUN_ID,
-      provider: "openai",
-      model: "gpt-5.5",
-      channel: "qa",
-      durationMs: 8,
-      outcome: "completed",
-      trace: runTrace,
-    });
-    emitTrustedDiagnosticEvent({
-      type: "harness.run.completed",
-      runId: DIRECT_RUN_ID,
-      harnessId: "qa-otel-direct",
-      pluginId: "diagnostics-otel",
-      provider: "openai",
-      model: "gpt-5.5",
-      channel: "qa",
-      durationMs: 10,
-      outcome: "completed",
-      trace: harnessTrace,
-    });
+    const failurePrivateData = {
+      errorMessage: `${DIRECT_ERROR_MESSAGE} OPENAI_API_KEY=${DIRECT_ERROR_SECRET}`,
+    };
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "run.completed",
+        runId: DIRECT_RUN_ID,
+        provider: "openai",
+        model: "gpt-5.5",
+        channel: "qa",
+        durationMs: 8,
+        outcome: "error",
+        errorCategory: "Error",
+        trace: runTrace,
+      },
+      failurePrivateData,
+    );
+    emitTrustedDiagnosticEventWithPrivateData(
+      {
+        type: "harness.run.completed",
+        runId: DIRECT_RUN_ID,
+        harnessId: "qa-otel-direct",
+        pluginId: "diagnostics-otel",
+        provider: "openai",
+        model: "gpt-5.5",
+        channel: "qa",
+        durationMs: 10,
+        outcome: "error",
+        trace: harnessTrace,
+      },
+      failurePrivateData,
+    );
     await waitForDiagnosticEventsDrained();
   } finally {
     await service.stop?.(context);
@@ -1627,6 +1640,18 @@ function assertSmoke(params: {
   });
   if (modelErrorSpans.length > 0) {
     failures.push("successful QA run exported model-call error attributes");
+  }
+
+  const failedRunSpans = params.spans.filter(
+    (span) =>
+      (span.name === "openclaw.run" || span.name === "openclaw.harness.run") &&
+      span.attributes["openclaw.error"] === `${DIRECT_ERROR_MESSAGE} OPENAI_API_KEY=sk-123…cdef`,
+  );
+  if (failedRunSpans.length !== 2) {
+    failures.push("run and harness spans did not export the redacted failure message");
+  }
+  if ((params.bodyText.metrics ?? []).some((body) => body.includes(DIRECT_ERROR_MESSAGE))) {
+    failures.push("run failure message leaked into OTLP metric attributes");
   }
 
   const serializedAttributes = JSON.stringify(params.spans.map((span) => span.attributes));

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
@@ -91,8 +91,20 @@ describe("qa-otel-smoke receiver bounds", () => {
       stdoutLogLines: [],
       stdoutLogRecords: [],
       spans: [
-        { name: "openclaw.run", parent: false, attributes: {} },
-        { name: "openclaw.harness.run", parent: true, attributes: {} },
+        {
+          name: "openclaw.run",
+          parent: false,
+          attributes: {
+            "openclaw.error": "QA OTEL provider stream failed OPENAI_API_KEY=sk-123…cdef",
+          },
+        },
+        {
+          name: "openclaw.harness.run",
+          parent: true,
+          attributes: {
+            "openclaw.error": "QA OTEL provider stream failed OPENAI_API_KEY=sk-123…cdef",
+          },
+        },
         { name: "openclaw.context.assembled", parent: true, attributes: {} },
         { name: "openclaw.message.delivery", parent: true, attributes: {} },
         {

--- a/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/qa-otel-smoke.e2e.test.ts
@@ -95,14 +95,14 @@ describe("qa-otel-smoke receiver bounds", () => {
           name: "openclaw.run",
           parent: false,
           attributes: {
-            "openclaw.error": "QA OTEL provider stream failed OPENAI_API_KEY=sk-123…cdef",
+            "openclaw.error": "QA OTEL provider stream failed OPENAI_API_KEY=***",
           },
         },
         {
           name: "openclaw.harness.run",
           parent: true,
           attributes: {
-            "openclaw.error": "QA OTEL provider stream failed OPENAI_API_KEY=sk-123…cdef",
+            "openclaw.error": "QA OTEL provider stream failed OPENAI_API_KEY=***",
           },
         },
         { name: "openclaw.context.assembled", parent: true, attributes: {} },


### PR DESCRIPTION
## What Problem This Solves

Failed run and plugin-harness OpenTelemetry spans reported only a generic error category, leaving operators without the failure detail needed to diagnose the run.

## Why This Change Was Made

The original proposal covered the plugin harness only and put raw error strings on the public diagnostic payload. The revised change covers both the default embedded runner and plugin harness, carries failure text only through the trusted private diagnostics channel, and bounds and redacts it before OpenTelemetry export. Metrics retain their existing low-cardinality attributes.

## User Impact

Failed `openclaw.run` and harness spans now include a useful redacted error description. Success and blocked spans are unchanged, public diagnostic events do not expose raw failure text, and metrics do not gain error-message labels.

## Evidence

- Exact revised head: `7594f8eb0de0595dbdac2a7ee5bd149552dfce43`
- Blacksmith Testbox through Crabbox: `tbx_01kwx7v5n5nfs1wrnekc4kt3kq` ([hydration run](https://github.com/openclaw/openclaw/actions/runs/28838058296))
- Focused diagnostics, harness, embedded-runner, and redaction tests: 128 passed
- QA OTEL E2E: 28 passed
- Live OTLP smoke: 5 spans, 6 metrics, 1 log; failed spans contained bounded useful detail, an API-key-shaped value was exported as `***`, and the raw value was absent from metrics
- Exact-head `check:changed`: core, extension, test, docs, and tooling lanes
- Fresh structured Codex autoreview: clean, no actionable findings (0.84 confidence)

AI-assisted maintainer hardening and review: yes. Contributor credit is preserved in the commit and changelog.
