### PR TITLE
fix(acp): record cancelled background turns as cancelled, not succeeded

### DIFF
--- a/src/acp/control-plane/manager.background-task.ts
+++ b/src/acp/control-plane/manager.background-task.ts
@@ -178,7 +178,7 @@ export function markBackgroundTaskTerminal(
   runId: string,
   params: {
     sessionKey?: string;
-    status: "succeeded" | "failed" | "timed_out";
+    status: "succeeded" | "failed" | "timed_out" | "cancelled";
     endedAt: number;
     lastEventAt?: number;
     error?: string;
@@ -201,6 +201,8 @@ export function markBackgroundTaskTerminal(
       });
       return;
     }
+    // Non-success terminals (failed/timed_out/cancelled) record through the detached-task
+    // fail sink, which preserves the distinct terminal status instead of collapsing to success.
     failTaskRunByRunId({
       runId,
       runtime: "acp",

--- a/src/acp/control-plane/manager.background-task.ts
+++ b/src/acp/control-plane/manager.background-task.ts
@@ -201,8 +201,6 @@ export function markBackgroundTaskTerminal(
       });
       return;
     }
-    // Non-success terminals (failed/timed_out/cancelled) record through the detached-task
-    // fail sink, which preserves the distinct terminal status instead of collapsing to success.
     failTaskRunByRunId({
       runId,
       runtime: "acp",

--- a/src/acp/control-plane/manager.cancel-session.test.ts
+++ b/src/acp/control-plane/manager.cancel-session.test.ts
@@ -1,6 +1,10 @@
 /** Tests ACP manager cancellation of active turns and idle sessions. */
 import { describe, expect, it, vi } from "vitest";
 import {
+  requireTaskByRunId,
+  withAcpManagerTaskStateDir,
+} from "../../../test/helpers/acp-manager-task-state.js";
+import {
   AcpSessionManager,
   baseCfg,
   createRuntime,
@@ -8,67 +12,73 @@ import {
   extractStatesFromUpserts,
   hoisted,
   installAcpSessionManagerTestLifecycle,
+  mockParentedAcpSessionEntries,
   mockCallArg,
-  readySessionMeta,
 } from "./manager.test-helpers.js";
 
 describe("AcpSessionManager cancelSession", () => {
   installAcpSessionManagerTestLifecycle();
 
   it("preempts an active turn on cancel and returns to idle state", async () => {
-    const runtimeState = createRuntime();
-    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
-      id: "acpx",
-      runtime: runtimeState.runtime,
-    });
-    hoisted.readAcpSessionEntryMock.mockReturnValue({
-      sessionKey: "agent:codex:acp:session-1",
-      storeSessionKey: "agent:codex:acp:session-1",
-      acp: readySessionMeta(),
-    });
-
-    let enteredRun = false;
-    runtimeState.runTurn.mockImplementation(async function* (input: { signal?: AbortSignal }) {
-      enteredRun = true;
-      await new Promise<void>((resolve) => {
-        if (input.signal?.aborted) {
-          resolve();
-          return;
-        }
-        input.signal?.addEventListener("abort", () => resolve(), { once: true });
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
       });
-      yield { type: "done" as const, stopReason: "cancel" };
-    });
+      mockParentedAcpSessionEntries({
+        childSessionKey: "agent:codex:acp:child-1",
+        parentSessionKey: "agent:main:main",
+      });
 
-    const manager = new AcpSessionManager();
-    const runPromise = manager.runTurn({
-      cfg: baseCfg,
-      sessionKey: "agent:codex:acp:session-1",
-      text: "long task",
-      mode: "prompt",
-      requestId: "run-1",
-    });
-    await vi.waitFor(
-      () => {
-        expect(enteredRun).toBe(true);
-      },
-      { interval: 1 },
-    );
+      let enteredRun = false;
+      runtimeState.runTurn.mockImplementation(async function* (input: { signal?: AbortSignal }) {
+        enteredRun = true;
+        await new Promise<void>((resolve) => {
+          if (input.signal?.aborted) {
+            resolve();
+            return;
+          }
+          input.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        yield { type: "done" as const, stopReason: "cancel" };
+      });
 
-    await manager.cancelSession({
-      cfg: baseCfg,
-      sessionKey: "agent:codex:acp:session-1",
-      reason: "manual-cancel",
-    });
-    await runPromise;
+      const manager = new AcpSessionManager();
+      const runPromise = manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "long task",
+        mode: "prompt",
+        requestId: "run-1",
+      });
+      await vi.waitFor(
+        () => {
+          expect(enteredRun).toBe(true);
+        },
+        { interval: 1 },
+      );
 
-    expect(runtimeState.cancel).toHaveBeenCalledTimes(1);
-    expectRecordFields(mockCallArg(runtimeState.cancel), {
-      reason: "manual-cancel",
+      await manager.cancelSession({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        reason: "manual-cancel",
+      });
+      await runPromise;
+
+      expect(runtimeState.cancel).toHaveBeenCalledTimes(1);
+      expectRecordFields(mockCallArg(runtimeState.cancel), {
+        reason: "manual-cancel",
+      });
+      expectRecordFields(requireTaskByRunId("run-1"), {
+        ownerKey: "agent:main:main",
+        childSessionKey: "agent:codex:acp:child-1",
+        status: "cancelled",
+      });
+      const states = extractStatesFromUpserts();
+      expect(states).toContain("running");
+      expect(states).toContain("idle");
+      expect(states).not.toContain("error");
     });
-    const states = extractStatesFromUpserts();
-    expect(states).toContain("running");
-    expect(states).toContain("idle");
-    expect(states).not.toContain("error");
   });
 });

--- a/src/acp/control-plane/manager.test-helpers.ts
+++ b/src/acp/control-plane/manager.test-helpers.ts
@@ -217,6 +217,38 @@ export function readySessionMeta(overrides: Partial<SessionAcpMeta> = {}): Sessi
   };
 }
 
+export function mockParentedAcpSessionEntries(params: {
+  childSessionKey: string;
+  parentSessionKey: string;
+}): void {
+  hoisted.readAcpSessionEntryMock.mockImplementation((input: unknown) => {
+    const sessionKey = (input as { sessionKey?: string }).sessionKey;
+    if (sessionKey === params.childSessionKey) {
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        entry: {
+          sessionId: "child-1",
+          updatedAt: Date.now(),
+          spawnedBy: params.parentSessionKey,
+        },
+        acp: readySessionMeta(),
+      };
+    }
+    if (sessionKey === params.parentSessionKey) {
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        entry: {
+          sessionId: "parent-1",
+          updatedAt: Date.now(),
+        },
+      };
+    }
+    return null;
+  });
+}
+
 export function extractStatesFromUpserts(): SessionAcpMeta["state"][] {
   const states: SessionAcpMeta["state"][] = [];
   for (const [firstArg] of hoisted.upsertAcpSessionMetaMock.mock.calls) {

--- a/src/acp/control-plane/manager.turn-results.test.ts
+++ b/src/acp/control-plane/manager.turn-results.test.ts
@@ -15,6 +15,7 @@ import {
   extractStatesFromUpserts,
   hoisted,
   installAcpSessionManagerTestLifecycle,
+  mockParentedAcpSessionEntries,
   mockCallArg,
   readySessionMeta,
   resetAcpSessionManagerForTests,
@@ -189,147 +190,6 @@ describe("AcpSessionManager turn results", () => {
         task: "Print the current directory",
         status: "succeeded",
         progressSummary: "Current directory is /tmp/openclaw.",
-      });
-    });
-  });
-
-  it("records cancelled parented ACP turns as cancelled, not succeeded", async () => {
-    await withAcpManagerTaskStateDir(async () => {
-      const runtimeState = createRuntime();
-      runtimeState.runtime.startTurn = vi.fn((input) => ({
-        requestId: input.requestId,
-        events: (async function* () {
-          yield {
-            type: "text_delta" as const,
-            stream: "output" as const,
-            text: "Starting the investigation.",
-          };
-        })(),
-        result: Promise.resolve({
-          status: "cancelled" as const,
-          stopReason: "cancelled",
-        }),
-        cancel: vi.fn(async () => {}),
-        closeStream: vi.fn(async () => {}),
-      }));
-      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
-        id: "acpx",
-        runtime: runtimeState.runtime,
-      });
-      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
-        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
-        if (sessionKey === "agent:codex:acp:child-1") {
-          return {
-            sessionKey,
-            storeSessionKey: sessionKey,
-            entry: {
-              sessionId: "child-1",
-              updatedAt: Date.now(),
-              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
-              label: "Codex investigation",
-            },
-            acp: readySessionMeta(),
-          };
-        }
-        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
-          return {
-            sessionKey,
-            storeSessionKey: sessionKey,
-            entry: {
-              sessionId: "parent-1",
-              updatedAt: Date.now(),
-            },
-          };
-        }
-        return null;
-      });
-
-      const events: string[] = [];
-      const manager = new AcpSessionManager();
-      await manager.runTurn({
-        cfg: baseCfg,
-        sessionKey: "agent:codex:acp:child-1",
-        text: "Investigate and report back",
-        mode: "prompt",
-        requestId: "direct-parented-cancelled-run",
-        onEvent: (event) => {
-          events.push(event.type);
-        },
-      });
-
-      expect(runtimeState.runTurn).not.toHaveBeenCalled();
-      expect(events).toEqual(["text_delta", "done"]);
-      expectRecordFields(requireTaskByRunId("direct-parented-cancelled-run"), {
-        runtime: "acp",
-        ownerKey: "agent:quant:telegram:quant:direct:822430204",
-        scopeKind: "session",
-        childSessionKey: "agent:codex:acp:child-1",
-        label: "Codex investigation",
-        task: "Investigate and report back",
-        status: "cancelled",
-        progressSummary: "Starting the investigation.",
-      });
-    });
-  });
-
-  it("records cancelled parented ACP turns via runTurn stopReason as cancelled", async () => {
-    await withAcpManagerTaskStateDir(async () => {
-      const runtimeState = createRuntime();
-      // No startTurn: exercises the raw runTurn fallback, where cancellation arrives as a
-      // done event with a stopReason and no status.
-      runtimeState.runTurn.mockImplementation(async function* () {
-        yield {
-          type: "text_delta" as const,
-          stream: "output" as const,
-          text: "Working on it.",
-        };
-        yield { type: "done" as const, stopReason: "cancel" };
-      });
-      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
-        id: "acpx",
-        runtime: runtimeState.runtime,
-      });
-      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
-        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
-        if (sessionKey === "agent:codex:acp:child-1") {
-          return {
-            sessionKey,
-            storeSessionKey: sessionKey,
-            entry: {
-              sessionId: "child-1",
-              updatedAt: Date.now(),
-              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
-              label: "Codex investigation",
-            },
-            acp: readySessionMeta(),
-          };
-        }
-        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
-          return {
-            sessionKey,
-            storeSessionKey: sessionKey,
-            entry: {
-              sessionId: "parent-1",
-              updatedAt: Date.now(),
-            },
-          };
-        }
-        return null;
-      });
-
-      const manager = new AcpSessionManager();
-      await manager.runTurn({
-        cfg: baseCfg,
-        sessionKey: "agent:codex:acp:child-1",
-        text: "Investigate and report back",
-        mode: "prompt",
-        requestId: "runturn-parented-cancelled-run",
-      });
-
-      expect(runtimeState.runTurn).toHaveBeenCalled();
-      expectRecordFields(requireTaskByRunId("runturn-parented-cancelled-run"), {
-        status: "cancelled",
-        progressSummary: "Working on it.",
       });
     });
   });
@@ -803,50 +663,56 @@ describe("AcpSessionManager turn results", () => {
   });
 
   it("keeps startTurn cancelled results as non-error terminal turns", async () => {
-    const runtimeState = createRuntime();
-    const closeStream = vi.fn(async () => {});
-    runtimeState.runtime.startTurn = vi.fn((input) => ({
-      requestId: input.requestId,
-      events: (async function* () {
-        yield { type: "text_delta" as const, stream: "output" as const, text: "stopping" };
-      })(),
-      result: Promise.resolve({
-        status: "cancelled" as const,
-      }),
-      cancel: vi.fn(async () => {}),
-      closeStream,
-    }));
-    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
-      id: "acpx",
-      runtime: runtimeState.runtime,
-    });
-    hoisted.readAcpSessionEntryMock.mockReturnValue({
-      sessionKey: "agent:codex:acp:session-1",
-      storeSessionKey: "agent:codex:acp:session-1",
-      acp: readySessionMeta(),
-    });
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      const closeStream = vi.fn(async () => {});
+      runtimeState.runtime.startTurn = vi.fn((input) => ({
+        requestId: input.requestId,
+        events: (async function* () {
+          yield { type: "text_delta" as const, stream: "output" as const, text: "stopping" };
+        })(),
+        result: Promise.resolve({
+          status: "cancelled" as const,
+        }),
+        cancel: vi.fn(async () => {}),
+        closeStream,
+      }));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      mockParentedAcpSessionEntries({
+        childSessionKey: "agent:codex:acp:child-1",
+        parentSessionKey: "agent:main:main",
+      });
 
-    const events: AcpRuntimeEvent[] = [];
-    const manager = new AcpSessionManager();
-    await manager.runTurn({
-      cfg: baseCfg,
-      sessionKey: "agent:codex:acp:session-1",
-      text: "long task",
-      mode: "prompt",
-      requestId: "run-1",
-      onEvent: (event) => {
-        events.push(event);
-      },
-    });
+      const events: AcpRuntimeEvent[] = [];
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "long task",
+        mode: "prompt",
+        requestId: "run-1",
+        onEvent: (event) => {
+          events.push(event);
+        },
+      });
 
-    expect(runtimeState.runTurn).not.toHaveBeenCalled();
-    expect(closeStream).toHaveBeenCalledWith({ reason: "turn-result-cancelled" });
-    expect(events.map((event) => event.type)).toEqual(["text_delta", "done"]);
-    expect(events.at(-1)).toEqual({ type: "done", status: "cancelled" });
-    const states = extractStatesFromUpserts();
-    expect(states).toContain("running");
-    expect(states).toContain("idle");
-    expect(states).not.toContain("error");
+      expect(runtimeState.runTurn).not.toHaveBeenCalled();
+      expect(closeStream).toHaveBeenCalledWith({ reason: "turn-result-cancelled" });
+      expect(events.map((event) => event.type)).toEqual(["text_delta", "done"]);
+      expect(events.at(-1)).toEqual({ type: "done", status: "cancelled" });
+      expectRecordFields(requireTaskByRunId("run-1"), {
+        ownerKey: "agent:main:main",
+        childSessionKey: "agent:codex:acp:child-1",
+        status: "cancelled",
+      });
+      const states = extractStatesFromUpserts();
+      expect(states).toContain("running");
+      expect(states).toContain("idle");
+      expect(states).not.toContain("error");
+    });
   });
 
   it("fails immediately when startTurn events fail before terminal result settles", async () => {

--- a/src/acp/control-plane/manager.turn-results.test.ts
+++ b/src/acp/control-plane/manager.turn-results.test.ts
@@ -193,6 +193,147 @@ describe("AcpSessionManager turn results", () => {
     });
   });
 
+  it("records cancelled parented ACP turns as cancelled, not succeeded", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runtime.startTurn = vi.fn((input) => ({
+        requestId: input.requestId,
+        events: (async function* () {
+          yield {
+            type: "text_delta" as const,
+            stream: "output" as const,
+            text: "Starting the investigation.",
+          };
+        })(),
+        result: Promise.resolve({
+          status: "cancelled" as const,
+          stopReason: "cancelled",
+        }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      }));
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "Codex investigation",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-1",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      const events: string[] = [];
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "Investigate and report back",
+        mode: "prompt",
+        requestId: "direct-parented-cancelled-run",
+        onEvent: (event) => {
+          events.push(event.type);
+        },
+      });
+
+      expect(runtimeState.runTurn).not.toHaveBeenCalled();
+      expect(events).toEqual(["text_delta", "done"]);
+      expectRecordFields(requireTaskByRunId("direct-parented-cancelled-run"), {
+        runtime: "acp",
+        ownerKey: "agent:quant:telegram:quant:direct:822430204",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child-1",
+        label: "Codex investigation",
+        task: "Investigate and report back",
+        status: "cancelled",
+        progressSummary: "Starting the investigation.",
+      });
+    });
+  });
+
+  it("records cancelled parented ACP turns via runTurn stopReason as cancelled", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      // No startTurn: exercises the raw runTurn fallback, where cancellation arrives as a
+      // done event with a stopReason and no status.
+      runtimeState.runTurn.mockImplementation(async function* () {
+        yield {
+          type: "text_delta" as const,
+          stream: "output" as const,
+          text: "Working on it.",
+        };
+        yield { type: "done" as const, stopReason: "cancel" };
+      });
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-1") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-1",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:telegram:quant:direct:822430204",
+              label: "Codex investigation",
+            },
+            acp: readySessionMeta(),
+          };
+        }
+        if (sessionKey === "agent:quant:telegram:quant:direct:822430204") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-1",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-1",
+        text: "Investigate and report back",
+        mode: "prompt",
+        requestId: "runturn-parented-cancelled-run",
+      });
+
+      expect(runtimeState.runTurn).toHaveBeenCalled();
+      expectRecordFields(requireTaskByRunId("runturn-parented-cancelled-run"), {
+        status: "cancelled",
+        progressSummary: "Working on it.",
+      });
+    });
+  });
+
   it("keeps parented ACP turns successful when final output follows progress text", async () => {
     await withAcpManagerTaskStateDir(async () => {
       const runtimeState = createRuntime();

--- a/src/acp/control-plane/manager.turn-runner.ts
+++ b/src/acp/control-plane/manager.turn-runner.ts
@@ -294,9 +294,11 @@ export async function runManagerTurn(params: {
           });
           if (taskContext) {
             const terminalResult = resolveBackgroundTaskTerminalResult(taskProgressSummary);
+            // A cancelled turn also resolves without throwing; record it honestly
+            // rather than mirroring the child task as succeeded.
             markBackgroundTaskTerminal(taskContext.runId, {
               sessionKey,
-              status: "succeeded",
+              status: turnOutcome.terminalStatus === "cancelled" ? "cancelled" : "succeeded",
               endedAt: Date.now(),
               lastEventAt: Date.now(),
               error: undefined,

--- a/src/acp/control-plane/manager.turn-runner.ts
+++ b/src/acp/control-plane/manager.turn-runner.ts
@@ -283,7 +283,7 @@ export async function runManagerTurn(params: {
               });
             },
           });
-          if (!turnOutcome.sawTerminalEvent) {
+          if (!turnOutcome.terminalStatus) {
             throw new AcpRuntimeError(
               "ACP_TURN_FAILED",
               "ACP turn ended without a terminal done event.",
@@ -294,8 +294,6 @@ export async function runManagerTurn(params: {
           });
           if (taskContext) {
             const terminalResult = resolveBackgroundTaskTerminalResult(taskProgressSummary);
-            // A cancelled turn also resolves without throwing; record it honestly
-            // rather than mirroring the child task as succeeded.
             markBackgroundTaskTerminal(taskContext.runId, {
               sessionKey,
               status: turnOutcome.terminalStatus === "cancelled" ? "cancelled" : "succeeded",

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -17,15 +17,9 @@ type AcpTurnEventGate = {
 /** Summary of whether a turn stream emitted user-visible output or terminal events. */
 type AcpTurnStreamOutcome = {
   sawOutput: boolean;
-  sawTerminalEvent: boolean;
-  // Closed terminal status so callers preserve cancel/complete precedence instead of
-  // assuming success; undefined when the stream ended without a terminal done event.
   terminalStatus?: "completed" | "cancelled";
 };
 
-// Legacy runTurn `done` events may omit status and signal cancellation via stopReason;
-// mirror the acpx adapter (extensions/acpx runtime-turn.ts) so the raw fallback path does
-// not silently convert a cancelled turn into a completed one.
 function isCancellationStopReason(stopReason: string | undefined): boolean {
   return stopReason === "cancel" || stopReason === "cancelled" || stopReason === "manual-cancel";
 }
@@ -40,15 +34,14 @@ async function consumeAcpTurnEvents(params: {
 }): Promise<AcpTurnStreamOutcome> {
   let streamError: AcpRuntimeError | null = null;
   let sawOutput = false;
-  let sawTerminalEvent = false;
-  let terminalStatus: "completed" | "cancelled" | undefined;
+  let terminalStatus: AcpTurnStreamOutcome["terminalStatus"];
 
   for await (const event of params.events) {
     if (!params.eventGate.open) {
       continue;
     }
     if (event.type === "done") {
-      sawTerminalEvent = true;
+      // Legacy runTurn adapters may omit status but retain the cancellation reason.
       terminalStatus =
         event.status ?? (isCancellationStopReason(event.stopReason) ? "cancelled" : "completed");
     } else if (event.type === "error") {
@@ -70,7 +63,6 @@ async function consumeAcpTurnEvents(params: {
 
   return {
     sawOutput,
-    sawTerminalEvent,
     terminalStatus,
   };
 }
@@ -194,7 +186,6 @@ export async function consumeAcpTurnStream(params: {
     }
     return {
       sawOutput: eventOutcome.sawOutput,
-      sawTerminalEvent: true,
       terminalStatus: result.status,
     };
   }

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -18,7 +18,17 @@ type AcpTurnEventGate = {
 type AcpTurnStreamOutcome = {
   sawOutput: boolean;
   sawTerminalEvent: boolean;
+  // Closed terminal status so callers preserve cancel/complete precedence instead of
+  // assuming success; undefined when the stream ended without a terminal done event.
+  terminalStatus?: "completed" | "cancelled";
 };
+
+// Legacy runTurn `done` events may omit status and signal cancellation via stopReason;
+// mirror the acpx adapter (extensions/acpx runtime-turn.ts) so the raw fallback path does
+// not silently convert a cancelled turn into a completed one.
+function isCancellationStopReason(stopReason: string | undefined): boolean {
+  return stopReason === "cancel" || stopReason === "cancelled" || stopReason === "manual-cancel";
+}
 
 async function consumeAcpTurnEvents(params: {
   events: AsyncIterable<AcpRuntimeEvent>;
@@ -31,6 +41,7 @@ async function consumeAcpTurnEvents(params: {
   let streamError: AcpRuntimeError | null = null;
   let sawOutput = false;
   let sawTerminalEvent = false;
+  let terminalStatus: "completed" | "cancelled" | undefined;
 
   for await (const event of params.events) {
     if (!params.eventGate.open) {
@@ -38,6 +49,8 @@ async function consumeAcpTurnEvents(params: {
     }
     if (event.type === "done") {
       sawTerminalEvent = true;
+      terminalStatus =
+        event.status ?? (isCancellationStopReason(event.stopReason) ? "cancelled" : "completed");
     } else if (event.type === "error") {
       streamError = new AcpRuntimeError(
         normalizeAcpErrorCode(event.code),
@@ -58,6 +71,7 @@ async function consumeAcpTurnEvents(params: {
   return {
     sawOutput,
     sawTerminalEvent,
+    terminalStatus,
   };
 }
 
@@ -181,6 +195,7 @@ export async function consumeAcpTurnStream(params: {
     return {
       sawOutput: eventOutcome.sawOutput,
       sawTerminalEvent: true,
+      terminalStatus: result.status,
     };
   }
 


### PR DESCRIPTION
## Summary

**Prompt request:** Make the ACP manager record a cancelled background turn as `cancelled` instead of `succeeded`, while leaving completed, failed, and timed-out turns on their current terminal status.

**Proof target:** Show that a cancelled parented ACP turn lands in the detached-task registry with `status: "cancelled"`, and that a completed turn still records as succeeded.

## What Problem This Solves

A parented ACP child turn that is cancelled is recorded in the detached-task registry as **succeeded**.

`consumeAcpTurnStream` only throws when the runtime result is `failed`; a `cancelled` result returns normally with `sawTerminalEvent: true` (the same as `completed`). The turn-runner success path then calls `markBackgroundTaskTerminal(runId, { status: "succeeded", ... })` unconditionally, and `markBackgroundTaskTerminal` had no `cancelled` status at all — so the child run is mirrored into `openclaw task list` / task summaries and the requester-facing progress message as a success, not a cancellation.

## Why This Change Was Made

A cancelled turn should keep its cancelled status through to the detached-task record instead of collapsing into success. The fix threads the closed terminal status out of the turn stream and records it:

- `AcpTurnStreamOutcome` now carries `terminalStatus` (`"completed" | "cancelled"`). The `startTurn` path returns `result.status`; the raw `runTurn` fallback infers cancellation from the `done` event's optional `status`, falling back to `stopReason` (`cancel` / `cancelled` / `manual-cancel`) — mirroring the acpx adapter's own legacy-runTurn inference, since core cannot import the plugin helper across the extensions boundary.
- The runner branches on `terminalStatus` at the success-path terminal write: `cancelled` is recorded as `cancelled`, everything else as `succeeded`.
- `markBackgroundTaskTerminal`'s status union accepts `cancelled`, routed through the existing `failTaskRunByRunId` sink, which already supports the `cancelled` terminal status.

This change is limited to success-path terminal recording for ACP background turns; the failure and timeout catch paths are untouched.

## User Impact

`openclaw task list`, task summaries, and the requester's completion message now report a cancelled ACP child run as cancelled instead of succeeded, so operators are no longer told a cancelled sub-task finished successfully.

## Evidence

Behavior tests (mock runtime — this is internal status plumbing, not external-runtime behavior), added in `manager.turn-results.test.ts`:

- `records cancelled parented ACP turns as cancelled, not succeeded` — `startTurn` result `{ status: "cancelled" }` for a parented session records `status: "cancelled"`.
- `records cancelled parented ACP turns via runTurn stopReason as cancelled` — `runTurn` fallback emitting `done { stopReason: "cancel" }` (no `status`) records `status: "cancelled"`.
- Negative control: reverting the runner branch to the unconditional `succeeded` write fails the first test with `expected 'succeeded' to deeply equal 'cancelled'`.

Regression: `manager.turn-results.test.ts` (20), `manager.test.ts` (28), and `manager.cancel-session.test.ts` (1) pass locally via `node scripts/run-vitest.mjs`. `git diff --check` is clean. Type, lint, and the full changed-suite are covered by CI.
