### PR TITLE
feat(subagents): add completionTarget for parent-only routing (#27445)

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -135,6 +135,15 @@ Starts a sub-agent run with `deliver: false` on the global `subagent` lane,
 then runs an announce step and posts the announce reply to the requester
 chat channel.
 
+Set `completionTarget: "parent"` on a native spawn to keep the completion in
+the requester session until the parent deliberately sends a reply with the
+`message` tool to the requester route. No automatic external fallback is sent:
+if the parent does not complete that explicit send, delivery remains pending for
+retry. This native-only route is unavailable with `runtime: "acp"`,
+`collect: true`, `visible: true`, or `thread: true`, and when completion is
+owned by a sub-agent session (sub-agents cannot use the external `message`
+tool). ACP spawns use their separate `streamTo` option.
+
 Availability depends on the caller's effective tool policy. The built-in
 `coding` and `messaging` profiles include `sessions_spawn`,
 `sessions_yield`, and `subagents`; `minimal` does not. `full` allows every
@@ -230,6 +239,15 @@ Per-agent override: `agents.entries.*.subagents.delegationMode`.
 </ParamField>
 <ParamField path="cleanup" type='"delete" | "keep"' default="keep">
   `"delete"` archives the session immediately after announce (still keeps the transcript via rename).
+</ParamField>
+<ParamField path="completionTarget" type='"parent"'>
+  Native sub-agents only. `"parent"` keeps completion delivery in the requester
+  session until the parent explicitly uses the `message` tool to send to the
+  requester route. OpenClaw does not automatically post the child result as a
+  fallback; without a matching external send receipt, delivery remains pending
+  for retry. Unavailable with `runtime: "acp"`, `collect: true`,
+  `visible: true`, or `thread: true`, and when completion is owned by a
+  sub-agent session.
 </ParamField>
 <ParamField path="sandbox" type='"inherit" | "require"' default="inherit">
   `require` rejects the spawn unless the target child runtime is sandboxed.

--- a/src/agents/agent-command-restart-recovery.test.ts
+++ b/src/agents/agent-command-restart-recovery.test.ts
@@ -219,6 +219,25 @@ describe("buildRestartRecoveryTerminalDeliveryEvidence", () => {
     expect(evidence?.messagingToolSentTargetsTruncated).toBe(true);
   });
 
+  it("preserves producer truncation for an exactly bounded target set", () => {
+    const messagingToolSentTargets = Array.from({ length: 64 }, (_, index) => ({
+      provider: "discord",
+      to: `channel:${index}`,
+      text: "sent",
+    }));
+
+    expect(
+      buildRestartRecoveryTerminalDeliveryEvidence({ messagingToolSentTargets })
+        .messagingToolSentTargetsTruncated,
+    ).toBeUndefined();
+    expect(
+      buildRestartRecoveryTerminalDeliveryEvidence({
+        messagingToolSentTargets,
+        messagingToolSentTargetsTruncated: true,
+      }).messagingToolSentTargetsTruncated,
+    ).toBe(true);
+  });
+
   it("does not mark reasoning payloads as visible terminal replies", () => {
     const evidence = buildRestartRecoveryTerminalDeliveryEvidence({
       payloads: [{ isReasoning: true, mediaUrls: ["/tmp/private.png"] }],
@@ -244,7 +263,30 @@ describe("buildRestartRecoveryTerminalDeliveryEvidence", () => {
     expect(evidence).toEqual({
       captured: true,
       messagingToolAggregateEvidenceUnaccounted: true,
-      restartUnsafeSideEffectsDetected: true,
+    });
+  });
+
+  it("does not classify granular messaging receipts as restart-unsafe side effects", () => {
+    const evidence = buildRestartRecoveryTerminalDeliveryEvidence({
+      messagingToolSentTargets: [
+        {
+          provider: "discord",
+          to: "channel:123",
+          mediaUrls: ["/tmp/proof.png"],
+        },
+      ],
+    });
+
+    expect(evidence).toEqual({
+      captured: true,
+      messagingToolSentTargets: [
+        {
+          provider: "discord",
+          to: "channel:123",
+          mediaUrls: ["/tmp/proof.png"],
+          visible: true,
+        },
+      ],
     });
   });
 

--- a/src/agents/agent-command-restart-recovery.ts
+++ b/src/agents/agent-command-restart-recovery.ts
@@ -246,7 +246,8 @@ export function buildRestartRecoveryTerminalDeliveryEvidence(
         })
       : undefined;
   const messagingToolSentTargetsTruncated =
-    rawMessagingToolSentTargets && rawMessagingToolSentTargets.length > 64
+    result.messagingToolSentTargetsTruncated === true ||
+    (rawMessagingToolSentTargets?.length ?? 0) > 64
       ? (true as const)
       : undefined;
   const messagingToolAggregateEvidenceUnaccounted = hasUnaccountedMessagingToolAggregateEvidence(
@@ -255,8 +256,10 @@ export function buildRestartRecoveryTerminalDeliveryEvidence(
     ? (true as const)
     : undefined;
   const restartUnsafeSideEffectsDetected =
-    hasCommittedOutboundDeliveryEvidence(result) ||
-    result.didSendDeterministicApprovalPrompt === true
+    hasCommittedOutboundDeliveryEvidence({
+      acceptedSessionSpawns: result.acceptedSessionSpawns,
+      successfulCronAdds: result.successfulCronAdds,
+    }) || result.didSendDeterministicApprovalPrompt === true
       ? (true as const)
       : undefined;
   return {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -2556,7 +2556,10 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
   it("records generated-media delivery runs as durable terminal sources", async () => {
     setupSingleAttemptFallback();
-    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+    state.runAgentAttemptMock.mockResolvedValue({
+      ...makeSuccessResult("openai", "gpt-5.4"),
+      successfulCronAdds: 1,
+    });
     setupBareStoredSession();
     state.deliverAgentCommandResultMock.mockImplementation(async (params: unknown) => {
       const onDeliveryResult = (params as { onDeliveryResult?: (result: unknown) => void })
@@ -2782,11 +2785,29 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
         sessionKey: "agent:main:main",
         internalDeliveryMediaUrls: ["/tmp/proof.png"],
       }),
-    ).rejects.toThrow(
-      "internal delivery media constraints require automatic delivery with restart-safe tools and no message tool",
-    );
+    ).rejects.toThrow("internal delivery media constraints require a scoped restart-safe policy");
 
     expect(state.runAgentAttemptMock).not.toHaveBeenCalled();
+  });
+
+  it("admits message-owned media constraints under restart-safe recovery", async () => {
+    setupSingleAttemptFallback();
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("openai", "gpt-5.4"));
+
+    await agentCommand({
+      message: "send generated media through the source message tool",
+      sessionKey: "agent:main:main",
+      channel: "discord",
+      to: "channel:123",
+      deliver: false,
+      sourceReplyDeliveryMode: "message_tool_only",
+      disableMessageTool: false,
+      forceRestartSafeTools: true,
+      internalDeliveryMediaUrls: ["/tmp/proof.png"],
+      runId: "image:task-parent:agent-loop",
+    });
+
+    expect(state.runAgentAttemptMock).toHaveBeenCalled();
   });
 
   it("retains and clears a preclaimed transcript-only recovery run", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -95,18 +95,25 @@ async function agentCommandInternal(
           forceRestartSafeTools: prepared.sessionEntry?.restartRecoveryForceSafeTools,
         }
       : prepared.opts;
+  const hasInternalDeliveryConstraints =
+    preparedOpts.internalDeliveryMediaUrls !== undefined ||
+    preparedOpts.internalDeliverySuppressText === true;
+  const hasHostOwnedRecoveryPolicy =
+    preparedOpts.forceRestartSafeTools === true &&
+    preparedOpts.disableMessageTool === true &&
+    preparedOpts.sourceReplyDeliveryMode === "automatic";
+  const hasMessageOwnedRecoveryPolicy =
+    preparedOpts.forceRestartSafeTools === true &&
+    preparedOpts.disableMessageTool === false &&
+    preparedOpts.sourceReplyDeliveryMode === "message_tool_only";
   if (
     (preparedOpts.internalDeliverySuppressText === true &&
       preparedOpts.internalDeliveryMediaUrls === undefined) ||
-    ((preparedOpts.internalDeliveryMediaUrls !== undefined ||
-      preparedOpts.internalDeliverySuppressText === true) &&
-      (preparedOpts.forceRestartSafeTools !== true ||
-        preparedOpts.disableMessageTool !== true ||
-        preparedOpts.sourceReplyDeliveryMode !== "automatic"))
+    (hasInternalDeliveryConstraints &&
+      !hasHostOwnedRecoveryPolicy &&
+      !hasMessageOwnedRecoveryPolicy)
   ) {
-    throw new Error(
-      "internal delivery media constraints require automatic delivery with restart-safe tools and no message tool",
-    );
+    throw new Error("internal delivery media constraints require a scoped restart-safe policy");
   }
   let opts: AgentCommandOpts = {
     ...preparedOpts,

--- a/src/agents/cli-output-contracts.ts
+++ b/src/agents/cli-output-contracts.ts
@@ -53,6 +53,7 @@ export type CliOutput = {
   messagingToolSentTexts?: string[];
   messagingToolSentMediaUrls?: string[];
   messagingToolSentTargets?: MessagingToolSend[];
+  messagingToolSentTargetsTruncated?: true;
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
   yielded?: true;
 };

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -413,6 +413,9 @@ export function buildCliDeliveredFailure(params: {
     ...(evidence.messagingToolSentTargets?.length
       ? { messagingToolSentTargets: evidence.messagingToolSentTargets }
       : {}),
+    ...(evidence.messagingToolSentTargetsTruncated
+      ? { messagingToolSentTargetsTruncated: true as const }
+      : {}),
     ...(evidence.messagingToolSourceReplyPayloads?.length
       ? { messagingToolSourceReplyPayloads: evidence.messagingToolSourceReplyPayloads }
       : {}),
@@ -610,6 +613,9 @@ export function buildCliRunResult(params: {
       : {}),
     ...(output.messagingToolSentTargets?.length
       ? { messagingToolSentTargets: output.messagingToolSentTargets }
+      : {}),
+    ...(output.messagingToolSentTargetsTruncated
+      ? { messagingToolSentTargetsTruncated: true as const }
       : {}),
     ...(output.messagingToolSourceReplyPayloads?.length
       ? { messagingToolSourceReplyPayloads: output.messagingToolSourceReplyPayloads }

--- a/src/agents/cli-runner/delivery-evidence.ts
+++ b/src/agents/cli-runner/delivery-evidence.ts
@@ -12,6 +12,7 @@ type CliMessagingDeliveryEvidence = Pick<
   | "messagingToolSentTexts"
   | "messagingToolSentMediaUrls"
   | "messagingToolSentTargets"
+  | "messagingToolSentTargetsTruncated"
   | "messagingToolSourceReplyPayloads"
 >;
 
@@ -34,6 +35,9 @@ function snapshotCliMessagingDeliveryEvidence(
       : {}),
     ...(output.messagingToolSentTargets?.length
       ? { messagingToolSentTargets: output.messagingToolSentTargets.slice() }
+      : {}),
+    ...(output.messagingToolSentTargetsTruncated
+      ? { messagingToolSentTargetsTruncated: true }
       : {}),
     ...(output.messagingToolSourceReplyPayloads?.length
       ? { messagingToolSourceReplyPayloads: output.messagingToolSourceReplyPayloads.slice() }

--- a/src/agents/cli-runner/execute-tool-tracking.ts
+++ b/src/agents/cli-runner/execute-tool-tracking.ts
@@ -84,6 +84,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
   const messagingToolSentMediaUrlKeys = new Set<string>();
   const messagingToolSentTargets: MessagingToolSend[] = [];
   const messagingToolSentTargetKeys = new Set<string>();
+  let messagingToolSentTargetsTruncated = false;
   const messagingToolSourceReplyPayloads: MessagingToolSourceReplyPayload[] = [];
   const matchesCliLoopbackCall = (
     toolName: string,
@@ -279,6 +280,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
       return;
     }
     if (messagingToolSentTargets.length >= CLI_MESSAGING_EVIDENCE_MAX_CALLS) {
+      messagingToolSentTargetsTruncated = true;
       const removed = messagingToolSentTargets.shift();
       if (removed) {
         messagingToolSentTargetKeys.delete(buildMessagingToolSendEvidenceKey(removed));
@@ -474,6 +476,7 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
         // Once an unresolved send is evicted, its later result cannot be correlated.
         // Fail closed so a failed turn cannot duplicate it.
         didSendViaMessagingTool = true;
+        messagingToolSentTargetsTruncated = true;
       }
     }
     pendingMessagingCalls.set(event.toolCallId, {
@@ -590,6 +593,9 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
     messagingToolSentTexts,
     messagingToolSentMediaUrls,
     messagingToolSentTargets,
+    ...(messagingToolSentTargetsTruncated
+      ? { messagingToolSentTargetsTruncated: true as const }
+      : {}),
     messagingToolSourceReplyPayloads,
   });
   return {
@@ -616,6 +622,9 @@ export function createCliToolTracking(context: PreparedCliRunContext) {
           : {}),
         ...(current.messagingToolSentTargets.length > 0
           ? { messagingToolSentTargets: current.messagingToolSentTargets.slice() }
+          : {}),
+        ...(current.messagingToolSentTargetsTruncated
+          ? { messagingToolSentTargetsTruncated: true as const }
           : {}),
         ...(current.messagingToolSourceReplyPayloads.length > 0
           ? { messagingToolSourceReplyPayloads: current.messagingToolSourceReplyPayloads.slice() }

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -1801,6 +1801,55 @@ describe("executePreparedCliRun supervisor output capture", () => {
     ]);
   });
 
+  it("keeps exactly 64 committed JSONL message receipts without truncation", async () => {
+    const starts = Array.from({ length: 64 }, (_, index) => ({
+      type: "mcp_tool_use",
+      id: `message-send-${index}`,
+      name: "mcp__openclaw__message",
+      input: {
+        action: "send",
+        channel: "telegram",
+        target: `chat${index}`,
+        message: "done",
+      },
+    }));
+    const results = starts.map((start) => ({
+      type: "mcp_tool_result",
+      tool_use_id: start.id,
+      content: [{ type: "text", text: JSON.stringify({ status: "sent" }) }],
+    }));
+    const chunks = [
+      `${JSON.stringify({
+        type: "assistant",
+        message: { role: "assistant", content: [...starts, ...results] },
+      })}\n`,
+      `${JSON.stringify({ type: "result", session_id: "session-jsonl", result: "done" })}\n`,
+    ];
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = args[0] as SupervisorSpawnInput;
+      for (const chunk of chunks) {
+        input.onStdout?.(chunk);
+      }
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({ output: "jsonl", provider: "claude-cli" }),
+    );
+
+    expect(result.messagingToolSentTargets).toHaveLength(64);
+    expect(result.messagingToolSentTargetsTruncated).toBeUndefined();
+  });
+
   it("bounds pending and committed JSONL message delivery evidence", async () => {
     const starts = Array.from({ length: 65 }, (_, index) => ({
       type: "mcp_tool_use",
@@ -1849,6 +1898,7 @@ describe("executePreparedCliRun supervisor output capture", () => {
     expect(result.messagingToolSentTargets).toHaveLength(64);
     expect(result.messagingToolSentTargets?.[0]?.to).toBe("chat1");
     expect(result.messagingToolSentTargets?.at(-1)?.to).toBe("chat64");
+    expect(result.messagingToolSentTargetsTruncated).toBe(true);
   });
 
   it("fails closed when an unresolved JSONL message send is evicted", async () => {

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -358,7 +358,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
           terminal.metadata.terminalDelivery = terminalDelivery;
         }
         params.onTerminalDeliveryEvidenceChanged(
-          buildRestartRecoveryTerminalDeliveryEvidence(deliveryResult),
+          buildRestartRecoveryTerminalDeliveryEvidence({ ...result, ...deliveryResult }),
         );
       },
     };
@@ -422,9 +422,10 @@ export async function finalizeEmbeddedAgentCommand(params: {
                     restartRecoveryTerminalRunIds: entry.restartRecoveryTerminalRunIds,
                   },
                   recordTerminalSource: true,
-                  terminalDeliveryEvidence: buildRestartRecoveryTerminalDeliveryEvidence(
-                    deliveryResult ?? result,
-                  ),
+                  terminalDeliveryEvidence: buildRestartRecoveryTerminalDeliveryEvidence({
+                    ...result,
+                    ...deliveryResult,
+                  }),
                   terminalRunId: runId,
                 })
               : {}),

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { setPluginToolMeta } from "../../../plugins/tools.js";
+
+const mocks = vi.hoisted(() => ({
+  createOpenClawCodingTools: vi.fn(),
+}));
+
+vi.mock("../../agent-tools.js", () => ({
+  createOpenClawCodingTools: mocks.createOpenClawCodingTools,
+}));
+
+vi.mock("../../../plugins/provider-model-compat.js", () => ({
+  extractModelCompat: vi.fn(() => ({})),
+}));
+
+vi.mock("../../conversation-capability-profile.js", () => ({
+  resolveConversationCapabilityProfile: vi.fn(() => ({
+    policy: { explicitToolOverrideAllowlist: undefined },
+  })),
+}));
+
+vi.mock("../../local-model-lean.js", () => ({
+  isLocalModelLeanEnabled: vi.fn(() => false),
+  resolveLocalModelLeanPreserveToolNames: vi.fn(() => []),
+}));
+
+vi.mock("../../model-auth.js", () => ({
+  resolveModelAuthMode: vi.fn(() => undefined),
+}));
+
+vi.mock("../../model-tool-support.js", () => ({
+  supportsModelTools: vi.fn(() => true),
+}));
+
+vi.mock("../../tool-surface-plan.js", () => ({
+  resolveAgentToolSurfacePlan: vi.fn(({ config }: { config: unknown }) => ({
+    codeModeControlsEnabled: false,
+    toolSearchConfig: undefined,
+    toolSearchControlsEnabled: false,
+    toolSearchRuntimeConfig: config,
+  })),
+}));
+
+vi.mock("./attempt-tool-run-context.js", () => ({
+  buildEmbeddedAttemptToolRunContext: vi.fn(() => ({})),
+}));
+
+import { prepareEmbeddedAttemptToolBase } from "./attempt-tool-prepare.js";
+
+describe("prepareEmbeddedAttemptToolBase", () => {
+  it("retains only the concrete core message and replay-safe tools for restart recovery", () => {
+    const coreMessage = { name: "message" };
+    const pluginMessage = { name: "message" };
+    const unsafeExec = { name: "exec" };
+    const safeRead = { name: "read" };
+    setPluginToolMeta(pluginMessage as never, {
+      pluginId: "message-shadow",
+      optional: false,
+    });
+    mocks.createOpenClawCodingTools.mockReturnValue([
+      coreMessage,
+      pluginMessage,
+      unsafeExec,
+      safeRead,
+    ]);
+
+    const prepared = prepareEmbeddedAttemptToolBase({
+      agentDir: "/tmp/agent",
+      attempt: {
+        config: {},
+        forceRestartSafeTools: true,
+        model: {},
+        modelId: "test-model",
+        provider: "test-provider",
+        runId: "test-run",
+        sessionId: "test-session",
+        sessionKey: "agent:main:test",
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+      codeModeSkills: [],
+      effectiveCwd: "/tmp/workspace/cwd",
+      effectiveWorkspace: "/tmp/workspace",
+      markCoreToolStage: vi.fn(),
+      onYield: vi.fn(),
+      resolvedWorkspace: "/tmp/workspace",
+      runAbortController: new AbortController(),
+      runTrace: {},
+      sandboxSessionKey: "agent:main:test",
+      sessionAgentId: "main",
+      skillUsagePaths: [],
+      skillsSnapshot: undefined,
+      toolSearchCatalogExecutor: vi.fn(),
+    } as unknown as Parameters<typeof prepareEmbeddedAttemptToolBase>[0]);
+
+    expect(prepared.toolsRaw).toEqual([coreMessage, safeRead]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -46,6 +46,33 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 type OpenClawCodingToolsOptions = NonNullable<Parameters<typeof createOpenClawCodingTools>[0]>;
 type SkillUsagePaths = OpenClawCodingToolsOptions["skillUsagePaths"];
 
+/**
+ * Build the concrete tool surface for a restart-owned turn. A message-owned
+ * completion may retain only the unowned core message tool; plugin/channel
+ * shadows still require an explicit replay-safe declaration.
+ */
+function filterRestartSafeAgentTools<T extends { name?: string }>(
+  tools: T[],
+  options?: {
+    declaredReplaySafe?: (tool: T) => boolean | undefined;
+    preserveCoreMessageTool?: boolean;
+  },
+): T[] {
+  return tools.filter((tool) => {
+    const declaredReplaySafe = options?.declaredReplaySafe?.(tool);
+    if (
+      options?.preserveCoreMessageTool === true &&
+      declaredReplaySafe === undefined &&
+      tool.name?.trim().toLowerCase() === "message"
+    ) {
+      return true;
+    }
+    return isAgentToolRestartSafe(tool, {
+      declaredReplaySafe: () => declaredReplaySafe,
+    });
+  });
+}
+
 export function prepareEmbeddedAttemptToolBase(params: {
   agentDir: string;
   attempt: EmbeddedRunAttemptParams;
@@ -339,7 +366,10 @@ export function prepareEmbeddedAttemptToolBase(params: {
         return filteredTools;
       })();
   const toolsRaw = attempt.forceRestartSafeTools
-    ? constructedToolsRaw.filter((tool) => isAgentToolRestartSafe(tool, restartSafetyOptions))
+    ? filterRestartSafeAgentTools(constructedToolsRaw, {
+        ...restartSafetyOptions,
+        preserveCoreMessageTool: forceDirectMessageTool,
+      })
     : constructedToolsRaw;
   if (attempt.forceRestartSafeTools) {
     log.info(

--- a/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
@@ -186,7 +186,7 @@ export function hasMessagingToolDeliveryToSource(
     messagingToolSourceReplyPayloads?: unknown;
   },
   deliveryTarget: Parameters<typeof sourceDeliveryTargetsMatch>[1],
-  options?: { requireFinalReply?: boolean },
+  options?: { requireFinalReply?: boolean; requireSourceMatch?: boolean },
 ): boolean {
   const targets = Array.isArray(result.messagingToolSentTargets)
     ? result.messagingToolSentTargets
@@ -202,17 +202,27 @@ export function hasMessagingToolDeliveryToSource(
       return false;
     }
     const record = target as Parameters<typeof sourceDeliveryTargetsMatch>[0];
-    // Older source receipts omit `to`; explicit off-target sends must never satisfy it.
+    // Older source receipts omit `to`; parent-only routing requires a route-checkable receipt.
     const sourceTarget =
       typeof record.to === "string" && record.to.trim()
         ? record
-        : { ...record, to: deliveryTarget.to };
+        : options?.requireSourceMatch
+          ? record
+          : { ...record, to: deliveryTarget.to };
     return sourceDeliveryTargetsMatch(sourceTarget, deliveryTarget);
   });
+  // Parent-only routing must prove an external send to the requester route.
+  // Aggregate/source-reply evidence can describe the private internal-ui sink,
+  // so it cannot discharge the external-delivery obligation by itself.
+  const hasStrictSourceDelivery = sourceTargets.length > 0;
+  if (options?.requireSourceMatch && !hasStrictSourceDelivery) {
+    return false;
+  }
   if (options?.requireFinalReply) {
-    const hasCommittedSourceDelivery =
-      hasCommittedSourceReplyDeliveryEvidence(result) ||
-      (hasMessagingToolDeliveryEvidence(result) && sourceTargets.length > 0);
+    const hasCommittedSourceDelivery = options.requireSourceMatch
+      ? hasStrictSourceDelivery
+      : hasCommittedSourceReplyDeliveryEvidence(result) ||
+        (hasMessagingToolDeliveryEvidence(result) && sourceTargets.length > 0);
     // Only current-source final markers count; another target's final cannot
     // turn a source progress update into the owed requester reply.
     return (
@@ -222,6 +232,9 @@ export function hasMessagingToolDeliveryToSource(
         messagingToolSourceReplyPayloads: result.messagingToolSourceReplyPayloads,
       }) !== false
     );
+  }
+  if (options?.requireSourceMatch) {
+    return true;
   }
   if (
     hasCommittedSourceReplyDeliveryEvidence(result) ||

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -324,6 +324,7 @@ async function deliverDiscordDirectMessageCompletion(params: {
   signal?: AbortSignal;
   onDeliveryResult?: Parameters<typeof deliverSubagentAnnouncement>[0]["onDeliveryResult"];
   isSourceSessionEffectsAllowed?: () => boolean;
+  completionTarget?: "parent";
 }) {
   const origin = {
     channel: "discord",
@@ -356,6 +357,7 @@ async function deliverDiscordDirectMessageCompletion(params: {
     directOrigin: origin,
     requesterIsSubagent: false,
     expectsCompletionMessage: true,
+    completionTarget: params.completionTarget,
     bestEffortDeliver: true,
     directIdempotencyKey: "announce-dm-fallback-empty",
     internalEvents: params.internalEvents,
@@ -433,6 +435,7 @@ async function deliverSlackChannelAnnouncement(params: {
   isActive?: boolean;
   sessionId?: string;
   expectsCompletionMessage?: boolean;
+  completionTarget?: "parent";
   directIdempotencyKey: string;
   requesterSessionKey?: string;
   requesterOrigin?: {
@@ -495,6 +498,7 @@ async function deliverSlackChannelAnnouncement(params: {
     directOrigin: params.requesterOrigin ?? origin,
     requesterIsSubagent: false,
     expectsCompletionMessage: params.expectsCompletionMessage !== false,
+    completionTarget: params.completionTarget,
     bestEffortDeliver: true,
     directIdempotencyKey: params.directIdempotencyKey,
     internalEvents: params.internalEvents,
@@ -1877,6 +1881,23 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("does not raw-send a parent-only completion when the announce agent returns incomplete", async () => {
+    const callGateway = vi.fn(async () => {
+      throw new Error("incomplete terminal response code=incomplete_result");
+    }) as unknown as typeof runtimeCallGateway;
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      completionTarget: "parent",
+      internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
+    });
+
+    expect(result).toMatchObject({ delivered: false, path: "direct" });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("uses in-process agent dispatch for dormant completion requesters", async () => {
     const callGateway = createGatewayMock();
     const dispatchGatewayMethodInProcess = createInProcessGatewayMock({
@@ -2129,10 +2150,101 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
   });
 
-  it("rejects session-only subagent completion handoff when the parent only replies NO_REPLY", async () => {
+  it.each([
+    { name: "bare NO_REPLY", result: { payloads: [{ text: "NO_REPLY" }] } },
+    {
+      name: "coarse message-tool evidence",
+      result: { payloads: [], didSendViaMessagingTool: true },
+    },
+    {
+      name: "an off-target message-tool send",
+      result: {
+        payloads: [],
+        didSendViaMessagingTool: true,
+        messagingToolSentTargets: [
+          { tool: "message", provider: "slack", accountId: "acct-1", to: "user:OTHER" },
+        ],
+      },
+    },
+    {
+      name: "a private internal-ui source reply",
+      result: {
+        payloads: [],
+        didSendViaMessagingTool: true,
+        didDeliverSourceReplyViaMessageTool: true,
+        messagingToolSourceReplyPayloads: [
+          { text: "Private parent summary", sourceReplyFinal: true },
+        ],
+        messagingToolSentTargets: [],
+      },
+    },
+  ])("keeps a parent-only completion pending after $name", async ({ result: agentResult }) => {
+    const sendMessage = vi.fn();
+    const dispatchGatewayMethodInProcess = createInProcessGatewayMock({
+      result: agentResult,
+    });
+    testing.setDepsForTest({
+      dispatchGatewayMethodInProcess,
+      getRequesterSessionActivity: () => ({
+        sessionId: "requester-session-local",
+        isActive: false,
+      }),
+      getRuntimeConfig: () => ({}) as never,
+      sendMessage,
+    });
+
+    const requesterOrigin = {
+      channel: "slack",
+      to: "user:U123",
+      accountId: "acct-1",
+    };
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:local-session",
+      targetRequesterSessionKey: "agent:main:local-session",
+      triggerMessage: "child done",
+      steerMessage: "child done",
+      requesterSessionOrigin: requesterOrigin,
+      completionDirectOrigin: requesterOrigin,
+      directOrigin: requesterOrigin,
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      completionTarget: "parent",
+      bestEffortDeliver: true,
+      directIdempotencyKey: "announce-local-subagent-silent",
+      sourceTool: "subagent_announce",
+    });
+
+    expectRecordFields(result, {
+      delivered: false,
+      path: "direct",
+      reason: "message_tool_delivery_missing",
+      error: "completion agent did not use the message tool for message-tool-only delivery",
+    });
+    expectInProcessAgentParams(dispatchGatewayMethodInProcess, {
+      deliver: false,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "user:U123",
+      bestEffortDeliver: true,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a parent-only source receipt may have been truncated", async () => {
+    const sendMessage = vi.fn();
     const dispatchGatewayMethodInProcess = createInProcessGatewayMock({
       result: {
-        payloads: [{ text: "NO_REPLY" }],
+        payloads: [],
+        didSendViaMessagingTool: true,
+        messagingToolSentTargetsTruncated: true,
+        messagingToolSentTargets: Array.from({ length: 64 }, (_, index) => ({
+          tool: "message",
+          provider: "slack",
+          accountId: "acct-1",
+          to: `user:OTHER-${index}`,
+        })),
       },
     });
     testing.setDepsForTest({
@@ -2142,32 +2254,39 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         isActive: false,
       }),
       getRuntimeConfig: () => ({}) as never,
+      sendMessage,
     });
 
+    const requesterOrigin = {
+      channel: "slack",
+      to: "user:U123",
+      accountId: "acct-1",
+    };
     const result = await deliverSubagentAnnouncement({
       requesterSessionKey: "agent:main:local-session",
       targetRequesterSessionKey: "agent:main:local-session",
       triggerMessage: "child done",
       steerMessage: "child done",
+      requesterSessionOrigin: requesterOrigin,
+      completionDirectOrigin: requesterOrigin,
+      directOrigin: requesterOrigin,
       requesterIsSubagent: false,
       expectsCompletionMessage: true,
+      completionTarget: "parent",
       bestEffortDeliver: true,
-      directIdempotencyKey: "announce-local-subagent-silent",
+      directIdempotencyKey: "announce-local-subagent-truncated-receipts",
       sourceTool: "subagent_announce",
     });
 
     expectRecordFields(result, {
       delivered: false,
       path: "direct",
-      reason: "visible_reply_missing",
-      error: "completion agent did not produce a visible reply",
+      reason: "message_tool_delivery_missing",
+      error:
+        "parent-only completion message-tool receipts were truncated before source-route delivery could be verified",
+      disposition: "ambiguous",
     });
-    expectInProcessAgentParams(dispatchGatewayMethodInProcess, {
-      deliver: false,
-      channel: undefined,
-      to: undefined,
-      bestEffortDeliver: true,
-    });
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -2724,6 +2843,33 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     },
   );
 
+  it("forces parent-only generated media through message-tool delivery", async () => {
+    const callGateway = createPayloadGatewayMock();
+    const sendMessage = createSendMessageMock();
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      completionTarget: "parent",
+      sourceTool: "image_generate",
+      internalEvents: imageCompletionEvents(),
+    });
+
+    expectDeliveryPath(result, "queued");
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sessionDeliveryQueueMocks.enqueueClaimedSessionDelivery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "agentTurn",
+        sessionKey: "agent:main:discord:dm:U123",
+        sourceReplyDeliveryMode: "message_tool_only",
+        completionTarget: "parent",
+        expectedMediaUrls: ["/tmp/generated-daily.png"],
+        idempotencyKey: "announce-dm-fallback-empty:agent-loop",
+      }),
+      expect.any(Number),
+    );
+  });
+
   it("queues generated-media failure notices without raw delivery", async () => {
     const callGateway = createGatewayMock();
     const sendMessage = createSendMessageMock();
@@ -3231,6 +3377,56 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
 
     expectDeliveryPath(result, "direct");
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps a pending parent-only requester run retryable without an external receipt", async () => {
+    const callGateway = createGatewayMock({
+      runId: "subagent:child:parent-only",
+      status: "accepted",
+      acceptedAt: Date.now(),
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      completionTarget: "parent",
+      directIdempotencyKey: "announce-parent-only-pending",
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        taskLabel: "parent-only pending smoke",
+      }),
+    });
+
+    expectRecordFields(result, {
+      delivered: false,
+      path: "direct",
+      reason: "message_tool_delivery_missing",
+      error:
+        "parent-only completion requester run is still pending without a source-matched external send receipt",
+    });
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("requires an external receipt for a parent-only requester settle wake", async () => {
+    const callGateway = createPayloadGatewayMock({ text: "private consolidated answer" });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      completionTarget: "parent",
+      expectsCompletionMessage: false,
+      directIdempotencyKey: "announce-parent-only-settle-without-receipt",
+    });
+
+    expectRecordFields(result, {
+      delivered: false,
+      path: "direct",
+      reason: "message_tool_delivery_missing",
+      error: "completion agent did not use the message tool for message-tool-only delivery",
+    });
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/src/agents/subagents/announce/subagent-announce-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.ts
@@ -94,6 +94,7 @@ export async function deliverSubagentAnnouncement(params: {
   targetRequesterSessionKey: string;
   requesterIsSubagent: boolean;
   expectsCompletionMessage: boolean;
+  completionTarget?: "parent";
   requireDirectDelivery?: boolean;
   requireVisibleReply?: boolean;
   bestEffortDeliver?: boolean;
@@ -135,21 +136,23 @@ export async function deliverSubagentAnnouncement(params: {
         params.targetRequesterSessionKey,
         params.requesterAgentId,
       ).entry;
-      // No external route exists for an internal-only handoff. Let the normal
-      // agent final enter the owning transcript instead of requiring a message tool target.
+      // Ordinary internal-only handoffs may enter the owning transcript. Parent-only
+      // completions stay message-tool-only so generated media cannot bypass the boundary.
       const sourceReplyDeliveryMode =
-        queuedRoute.route.channel === INTERNAL_MESSAGE_CHANNEL
-          ? "automatic"
-          : completionRequiresMessageToolDelivery({
-                cfg,
-                requesterSessionKey: params.requesterSessionKey,
-                targetRequesterSessionKey: canonicalSessionKey,
-                requesterEntry,
-                directOrigin: effectiveDirectOrigin,
-                requesterSessionOrigin,
-              })
-            ? "message_tool_only"
-            : "automatic";
+        params.completionTarget === "parent"
+          ? "message_tool_only"
+          : queuedRoute.route.channel === INTERNAL_MESSAGE_CHANNEL
+            ? "automatic"
+            : completionRequiresMessageToolDelivery({
+                  cfg,
+                  requesterSessionKey: params.requesterSessionKey,
+                  targetRequesterSessionKey: canonicalSessionKey,
+                  requesterEntry,
+                  directOrigin: effectiveDirectOrigin,
+                  requesterSessionOrigin,
+                })
+              ? "message_tool_only"
+              : "automatic";
       const queuePayload = {
         kind: "agentTurn",
         sessionKey: canonicalSessionKey,
@@ -164,6 +167,7 @@ export async function deliverSubagentAnnouncement(params: {
           sourceTool: params.sourceTool ?? "subagent_announce",
         },
         sourceReplyDeliveryMode,
+        ...(params.completionTarget ? { completionTarget: params.completionTarget } : {}),
         expectedMediaUrls: collectExpectedMediaFromInternalEvents(params.internalEvents),
         idempotencyKey: `${params.directIdempotencyKey}:agent-loop`,
       } as const;
@@ -219,7 +223,7 @@ export async function deliverSubagentAnnouncement(params: {
 
   return await runSubagentAnnounceDispatch({
     expectsCompletionMessage: params.expectsCompletionMessage,
-    requireDirectDelivery: params.requireDirectDelivery,
+    requireDirectDelivery: params.requireDirectDelivery || params.completionTarget === "parent",
     signal: params.signal,
     steer: async () => {
       if (sourceOwnerChanged()) {
@@ -255,6 +259,7 @@ export async function deliverSubagentAnnouncement(params: {
         isCompletionOwnedByRequesterYield: params.isCompletionOwnedByRequesterYield,
         requesterIsSubagent: params.requesterIsSubagent,
         expectsCompletionMessage: params.expectsCompletionMessage,
+        completionTarget: params.completionTarget,
         requireVisibleReply: params.requireVisibleReply,
         onDeliveryResult: params.onDeliveryResult,
         signal: params.signal,

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -91,6 +91,7 @@ export async function sendSubagentAnnounceDirectly(params: {
   triggerMessage: string;
   internalEvents?: AgentInternalEvent[];
   expectsCompletionMessage: boolean;
+  completionTarget?: "parent";
   requireVisibleReply?: boolean;
   bestEffortDeliver?: boolean;
   directIdempotencyKey: string;
@@ -184,7 +185,9 @@ export async function sendSubagentAnnounceDirectly(params: {
       isSubagentCompletion &&
       deliveryTarget.deliver &&
       isDirectMessageDeliveryTarget(deliveryTarget, canonicalRequesterSessionKey);
+    const parentOnlyCompletion = params.completionTarget === "parent";
     const requiresMessageToolDelivery =
+      parentOnlyCompletion ||
       completionRouteRequiresMessageToolDelivery ||
       subagentDirectMessageCompletionRequiresMessageTool;
     const requesterActivity = resolveRequesterSessionActivity(
@@ -244,6 +247,14 @@ export async function sendSubagentAnnounceDirectly(params: {
       requesterActivity.sessionId &&
       requesterActivity.isActive
     ) {
+      if (parentOnlyCompletion) {
+        return {
+          delivered: false,
+          path: "none",
+          reason: "visible_reply_missing",
+          error: "parent-only completion is waiting for the requester session to become idle",
+        };
+      }
       const wakeOptions: EmbeddedAgentQueueMessageOptions = {
         deliveryTimeoutMs: announceTimeoutMs,
         steeringMode: "all",
@@ -383,6 +394,7 @@ export async function sendSubagentAnnounceDirectly(params: {
         throw err;
       }
       if (
+        !parentOnlyCompletion &&
         params.expectsCompletionMessage &&
         (shouldDeliverAgentFinal || subagentDirectMessageCompletionRequiresMessageTool) &&
         isSubagentCompletion &&
@@ -401,6 +413,15 @@ export async function sendSubagentAnnounceDirectly(params: {
 
     const directAnnounceStillPending = isGatewayAgentRunPending(directAnnounceResponse);
     if (directAnnounceStillPending) {
+      if (parentOnlyCompletion) {
+        return {
+          delivered: false,
+          path: "direct",
+          reason: "message_tool_delivery_missing",
+          error:
+            "parent-only completion requester run is still pending without a source-matched external send receipt",
+        };
+      }
       return {
         delivered: true,
         path: "direct",
@@ -424,8 +445,12 @@ export async function sendSubagentAnnounceDirectly(params: {
     }
     const hasMessagingToolDelivery = Boolean(
       directAnnounceResult &&
-      hasMessagingToolDeliveryToSource(directAnnounceResult, deliveryTarget),
+      hasMessagingToolDeliveryToSource(directAnnounceResult, deliveryTarget, {
+        requireSourceMatch: parentOnlyCompletion,
+      }),
     );
+    const hasTruncatedMessagingToolReceipts =
+      directAnnounceResult?.messagingToolSentTargetsTruncated === true;
     const completionPayloadVisibility = {
       includeErrorPayloads: false,
       includeReasoningPayloads: false,
@@ -485,13 +510,24 @@ export async function sendSubagentAnnounceDirectly(params: {
       };
     }
     if (
-      params.expectsCompletionMessage &&
+      (params.expectsCompletionMessage || parentOnlyCompletion) &&
       requiresMessageToolDelivery &&
       !hasMessagingToolDelivery &&
-      (!hasIntentionalSilentCompletionReply ||
+      (parentOnlyCompletion ||
+        !hasIntentionalSilentCompletionReply ||
         subagentDirectMessageCompletionRequiresMessageTool ||
         hasRequiredSubagentNoOutputCompletion)
     ) {
+      if (parentOnlyCompletion && hasTruncatedMessagingToolReceipts) {
+        return {
+          delivered: false,
+          path: "direct",
+          reason: "message_tool_delivery_missing",
+          error:
+            "parent-only completion message-tool receipts were truncated before source-route delivery could be verified",
+          disposition: "ambiguous",
+        };
+      }
       if (hasRequiredSubagentNoOutputCompletion) {
         return {
           delivered: false,
@@ -500,7 +536,7 @@ export async function sendSubagentAnnounceDirectly(params: {
           error: "completion agent did not produce a visible reply",
         };
       }
-      if (subagentDirectMessageCompletionRequiresMessageTool) {
+      if (!parentOnlyCompletion && subagentDirectMessageCompletionRequiresMessageTool) {
         const textDelivery = await tryTextCompletionDirectDelivery();
         if (textDelivery) {
           return textDelivery;
@@ -518,6 +554,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       ((params.requireVisibleReply
         ? hasMessagingToolDeliveryToSource(directAnnounceResult, deliveryTarget, {
             requireFinalReply: true,
+            requireSourceMatch: parentOnlyCompletion,
           })
         : hasMessagingToolDelivery) ||
         (hasVisibleAgentPayload(

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.parent-only.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.parent-only.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeliveryContext } from "../../../utils/delivery-context.types.js";
+import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
+
+const REQUESTER = "agent:main:main";
+const deliverSpy = vi.fn(async (_params: Record<string, unknown>) => ({
+  delivered: true,
+  path: "direct",
+}));
+const completeBatchSpy = vi.fn();
+
+const { registryRuntimeMock } = vi.hoisted(() => ({
+  registryRuntimeMock: {
+    hasDescendantRunAwaitingSettle: vi.fn(() => false),
+    listSubagentRunsForRequester: vi.fn((_requesterSessionKey: string): unknown[] => []),
+    getLatestSubagentRunByChildSessionKey: vi.fn(() => undefined),
+  },
+}));
+
+vi.mock("../registry/subagent-registry-read.js", () => registryRuntimeMock);
+vi.mock("./subagent-announce.runtime.js", () => ({
+  callGateway: vi.fn(async () => ({})),
+  dispatchGatewayMethodInProcess: vi.fn(async () => ({})),
+  isEmbeddedAgentRunActive: vi.fn(() => false),
+  getRuntimeConfig: () => ({ session: { mainKey: "main", scope: "per-sender" } }),
+  loadSessionStore: vi.fn(() => ({})),
+  readSessionMessagesAsync: vi.fn(async () => []),
+  readSubagentSessionEntry: vi.fn(() => undefined),
+  resolveAgentIdFromSessionKey: vi.fn(() => "main"),
+  resolveMainSessionKey: vi.fn(() => REQUESTER),
+  resolveSessionStorePathCore: vi.fn(() => "/tmp/sessions.json"),
+  waitForEmbeddedAgentRunEnd: vi.fn(async () => true),
+}));
+vi.mock("./subagent-announce-delivery.js", () => ({
+  deliverSubagentAnnouncement: (params: Record<string, unknown>) => deliverSpy(params),
+  loadRequesterSessionEntry: (sessionKey: string) => ({
+    entry: { sessionId: `session:${sessionKey}` },
+    canonicalKey: sessionKey,
+  }),
+  loadSessionEntryByKey: () => undefined,
+  runAnnounceDeliveryWithRetry: async <T>(params: { run: () => Promise<T> }) => await params.run(),
+  resolveSubagentAnnounceTimeoutMs: () => 10_000,
+  resolveSubagentCompletionOrigin: async (params: { requesterOrigin?: unknown }) =>
+    params.requesterOrigin,
+}));
+vi.mock("../spawn/subagent-depth.js", () => ({
+  getSubagentDepthFromSessionStore: () => 0,
+}));
+
+import { maybeWakeRequesterAfterAllChildrenSettled } from "./subagent-announce.requester-settle-wake.js";
+
+function makeChild(params: {
+  runId: string;
+  requesterOrigin?: DeliveryContext;
+  parentOnly?: boolean;
+}): SubagentRunRecord {
+  return {
+    runId: params.runId,
+    childSessionKey: `agent:main:subagent:${params.runId}`,
+    requesterSessionKey: REQUESTER,
+    requesterDisplayKey: "main",
+    requesterOrigin: params.requesterOrigin,
+    task: "investigate",
+    cleanup: "keep",
+    createdAt: 1_000,
+    execution: { status: "terminal", startedAt: 2_000, endedAt: 3_000 },
+    completion: { required: true, resultText: `${params.runId} findings` },
+    completionTarget: params.parentOnly ? "parent" : undefined,
+    expectsCompletionMessage: true,
+    delivery: { status: "pending" },
+    requesterSettleWake: { status: "pending", attemptCount: 0 },
+  };
+}
+
+async function wake(params: {
+  settledEntry: SubagentRunRecord;
+  requesterOrigin?: DeliveryContext;
+}) {
+  return await maybeWakeRequesterAfterAllChildrenSettled({
+    requesterSessionKey: REQUESTER,
+    settledEntry: params.settledEntry,
+    requesterOrigin: params.requesterOrigin,
+    transitionBatch: vi.fn(),
+    completeBatch: completeBatchSpy,
+  });
+}
+
+function deliveryParams(): Record<string, unknown> {
+  const params = deliverSpy.mock.calls[0]?.[0];
+  if (!params) {
+    throw new Error("expected settle delivery");
+  }
+  return params;
+}
+
+describe("parent-only requester settle wake routing", () => {
+  beforeEach(() => {
+    deliverSpy.mockReset().mockResolvedValue({ delivered: true, path: "direct" });
+    completeBatchSpy.mockReset();
+    registryRuntimeMock.hasDescendantRunAwaitingSettle.mockReset().mockReturnValue(false);
+    registryRuntimeMock.listSubagentRunsForRequester.mockReset().mockReturnValue([]);
+    registryRuntimeMock.getLatestSubagentRunByChildSessionKey
+      .mockReset()
+      .mockReturnValue(undefined);
+  });
+
+  it("propagates the strict parent-only receipt contract", async () => {
+    const child = makeChild({ runId: "run-parent-only", parentOnly: true });
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
+
+    await expect(wake({ settledEntry: child })).resolves.toBe(true);
+
+    expect(deliveryParams()).toMatchObject({
+      completionTarget: "parent",
+      expectsCompletionMessage: false,
+      requireDirectDelivery: true,
+    });
+  });
+
+  it("credits only the scheduling row's persisted route partition", async () => {
+    const telegram = makeChild({
+      runId: "run-telegram",
+      parentOnly: true,
+      requesterOrigin: { channel: "telegram", to: "telegram:123", accountId: "primary" },
+    });
+    const slack = makeChild({
+      runId: "run-slack",
+      parentOnly: true,
+      requesterOrigin: { channel: "slack", to: "channel:C123", accountId: "primary" },
+    });
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([telegram, slack]);
+
+    await expect(
+      wake({ settledEntry: telegram, requesterOrigin: telegram.requesterOrigin }),
+    ).resolves.toBe(true);
+
+    expect(deliveryParams()).toMatchObject({
+      completionTarget: "parent",
+      requesterSessionOrigin: telegram.requesterOrigin,
+    });
+    expect(completeBatchSpy).toHaveBeenCalledWith(["run-telegram"], undefined, {
+      delivered: true,
+      path: "direct",
+    });
+    expect(completeBatchSpy.mock.calls.every(([runIds]) => !runIds.includes("run-slack"))).toBe(
+      true,
+    );
+  });
+
+  it("keeps same-route ordinary siblings in the strict partition", async () => {
+    const requesterOrigin = { channel: "telegram", to: "telegram:123", accountId: "primary" };
+    const parentOnly = makeChild({
+      runId: "run-parent-only",
+      parentOnly: true,
+      requesterOrigin,
+    });
+    const ordinary = makeChild({ runId: "run-ordinary", requesterOrigin });
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([parentOnly, ordinary]);
+
+    await expect(wake({ settledEntry: parentOnly, requesterOrigin })).resolves.toBe(true);
+
+    expect(deliveryParams()).toMatchObject({
+      completionTarget: "parent",
+      requesterSessionOrigin: requesterOrigin,
+    });
+    expect(completeBatchSpy).toHaveBeenCalledWith(["run-ordinary", "run-parent-only"], undefined, {
+      delivered: true,
+      path: "direct",
+    });
+  });
+
+  it("preserves ordinary cross-route batching without a parent-only obligation", async () => {
+    const telegram = makeChild({
+      runId: "run-telegram-ordinary",
+      requesterOrigin: { channel: "telegram", to: "telegram:123" },
+    });
+    const slack = makeChild({
+      runId: "run-slack-ordinary",
+      requesterOrigin: { channel: "slack", to: "channel:C123" },
+    });
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([telegram, slack]);
+
+    await expect(
+      wake({ settledEntry: telegram, requesterOrigin: telegram.requesterOrigin }),
+    ).resolves.toBe(true);
+
+    expect(completeBatchSpy).toHaveBeenCalledWith(
+      ["run-slack-ordinary", "run-telegram-ordinary"],
+      undefined,
+      { delivered: true, path: "direct" },
+    );
+  });
+});

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -10,6 +10,7 @@ import { logWarn } from "../../../logger.js";
 import { isCronSessionKey } from "../../../sessions/session-key-utils.js";
 import {
   type DeliveryContext,
+  deliveryContextKey,
   normalizeDeliveryContext,
 } from "../../../utils/delivery-context.shared.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../../utils/message-channel.js";
@@ -288,6 +289,24 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
       currentSettledEntry,
     );
   }
+  // Delivery credit is route-specific. A single requester session can retain
+  // overlapping children from turns on different channels or targets, so a
+  // receipt for the scheduling row's route must never discharge another
+  // route's parent-only obligation. Each retained row schedules its own wake;
+  // partition this attempt to the current row's normalized route.
+  if (
+    settledBatch.some(
+      (entry) =>
+        entry.expectsCompletionMessage === true &&
+        entry.completionTarget === "parent" &&
+        entry.delivery?.status !== "delivered",
+    )
+  ) {
+    const currentRouteKey = deliveryContextKey(currentSettledEntry.requesterOrigin);
+    settledBatch = settledBatch.filter(
+      (entry) => deliveryContextKey(entry.requesterOrigin) === currentRouteKey,
+    );
+  }
   if (settledBatch.length === 0) {
     return false;
   }
@@ -307,6 +326,9 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   const requiredSettled = settledBatch.filter((entry) => entry.expectsCompletionMessage === true);
   const hasUndeliveredRequiredCompletion = requiredSettled.some(
     (entry) => entry.delivery?.status !== "delivered",
+  );
+  const requiresParentOnlyReceipt = requiredSettled.some(
+    (entry) => entry.completionTarget === "parent" && entry.delivery?.status !== "delivered",
   );
   // A yielded batch owns a rearm generation even when its child settles later.
   // Otherwise a delivered single child clears the batch before its requester wakes.
@@ -445,6 +467,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
         targetRequesterSessionKey: requesterSessionKey,
         requesterIsSubagent: false,
         expectsCompletionMessage: false,
+        ...(requiresParentOnlyReceipt ? { completionTarget: "parent" as const } : {}),
         requireDirectDelivery: true,
         ...(requesterYieldedAfterDelivery ? { requireVisibleReply: true } : {}),
         directIdempotencyKey: buildAnnounceIdempotencyKey(

--- a/src/agents/subagents/announce/subagent-announce.ts
+++ b/src/agents/subagents/announce/subagent-announce.ts
@@ -180,6 +180,7 @@ export async function runSubagentAnnounceFlow(params: {
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
   expectsCompletionMessage?: boolean;
+  completionTarget?: "parent";
   spawnMode?: SpawnSubagentMode;
   wakeOnDescendantSettle?: boolean;
   /** Deliver only frozen terminal facts; never inspect or mutate the child session. */
@@ -478,6 +479,10 @@ export async function runSubagentAnnounceFlow(params: {
         const parentSessionAlive = hasUsableSessionEntry(parentSessionEntry);
 
         if (!parentSessionAlive) {
+          if (params.completionTarget === "parent") {
+            shouldDeleteChildSession = false;
+            return "retryable";
+          }
           const fallback = resolveRequesterForChildSession(targetRequesterSessionKey);
           if (!fallback?.requesterSessionKey) {
             shouldDeleteChildSession = false;
@@ -585,6 +590,7 @@ export async function runSubagentAnnounceFlow(params: {
       targetRequesterSessionKey,
       requesterIsSubagent,
       expectsCompletionMessage,
+      completionTarget: params.completionTarget,
       bestEffortDeliver: params.bestEffortDeliver,
       directIdempotencyKey,
       onDeliveryResult: reportDeliveryResult,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -513,8 +513,13 @@ export const startSubagentAnnounceCleanupFlow = (
       await retireSupersededCleanupIfNeeded(context, runId, entry, cleanupGeneration);
       return;
     }
+    // Parent-only completion requires a route-checkable external transport
+    // receipt. A requester transcript mirror can come from the private
+    // internal-ui sink, so it must not discharge that delivery obligation.
     const shouldCreditPriorDelivery =
-      announceOutcome !== "delivered" && (await hasPriorRequesterDeliveryMirror(params, entry));
+      pendingPayload.completionTarget !== "parent" &&
+      announceOutcome !== "delivered" &&
+      (await hasPriorRequesterDeliveryMirror(params, entry));
     if (!context.isCleanupAttemptCurrent(runId, entry, cleanupGeneration)) {
       await retireSupersededCleanupIfNeeded(context, runId, entry, cleanupGeneration);
       return;
@@ -553,6 +558,7 @@ export const startSubagentAnnounceCleanupFlow = (
     outcome: pendingPayload.outcome,
     spawnMode: pendingPayload.spawnMode,
     expectsCompletionMessage: pendingPayload.expectsCompletionMessage,
+    completionTarget: pendingPayload.completionTarget,
     wakeOnDescendantSettle: pendingPayload.wakeOnDescendantSettle === true,
     suppressChildSessionEffects: suppressSessionEffects,
     isChildSessionEffectsAllowed: childSessionEffectsAllowed,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
@@ -478,6 +478,7 @@ export const loadPendingFinalDeliveryPayload = (
     outcome: entry.delivery?.payload?.outcome ?? entry.execution.outcome,
     expectsCompletionMessage:
       entry.delivery?.payload?.expectsCompletionMessage ?? entry.expectsCompletionMessage,
+    completionTarget: entry.delivery?.payload?.completionTarget ?? entry.completionTarget,
     spawnMode: entry.delivery?.payload?.spawnMode ?? entry.spawnMode,
     wakeOnDescendantSettle:
       entry.delivery?.payload?.wakeOnDescendantSettle ?? entry.wakeOnDescendantSettle,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -3715,6 +3715,91 @@ describe("subagent registry lifecycle hardening", () => {
     expect(persist).toHaveBeenCalled();
   });
 
+  it("does not credit a private internal-ui mirror for parent-only completion", async () => {
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: true,
+      completionTarget: "parent",
+      retainAttachmentsOnKeep: true,
+    });
+    gatewayMocks.callGateway.mockResolvedValueOnce({
+      messages: [
+        {
+          role: "assistant",
+          provider: "openclaw",
+          model: "delivery-mirror",
+          content: "final completion reply",
+          timestamp: 12_345,
+          idempotencyKey: `${buildExpectedAnnounceIdempotencyKey(entry)}:message-tool:internal-source-reply:0`,
+        },
+      ],
+    });
+    const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
+      async (announceParams) => {
+        expect(announceParams.completionTarget).toBe("parent");
+        announceParams.onDeliveryResult?.({
+          delivered: false,
+          path: "direct",
+          reason: "message_tool_delivery_missing",
+          error: "completion agent did not use the message tool for message-tool-only delivery",
+        });
+        return "retryable" as const;
+      },
+    );
+    const controller = createLifecycleController({ entry, runSubagentAnnounceFlow });
+
+    await completeRun(controller, entry, { triggerCleanup: true });
+
+    expect(entry.delivery).toMatchObject({
+      status: "suspended",
+      suspendedReason: "expiry",
+      lastError:
+        "completion agent did not use the message tool for message-tool-only delivery; message_tool_delivery_missing",
+    });
+    expect(entry.delivery?.deliveredAt).toBeUndefined();
+    expect(entry.delivery?.announcedAt).toBeUndefined();
+    expect(entry.delivery?.discardedAt).toBeUndefined();
+    expect(entry.cleanupCompletedAt).toBeUndefined();
+    expect(hasDeliveredTaskStatusUpdate(entry.runId)).toBe(false);
+    expect(gatewayMocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("does not clear parent-only delivery after requester-run admission without a receipt", async () => {
+    const entry = createRunEntry({
+      endedAt: 4_000,
+      expectsCompletionMessage: true,
+      completionTarget: "parent",
+      retainAttachmentsOnKeep: true,
+    });
+    const runSubagentAnnounceFlow: LifecycleControllerParams["runSubagentAnnounceFlow"] = vi.fn(
+      async (announceParams) => {
+        announceParams.onDeliveryResult?.({
+          delivered: false,
+          path: "direct",
+          reason: "message_tool_delivery_missing",
+          error:
+            "parent-only completion requester run is still pending without a source-matched external send receipt",
+        });
+        return "retryable" as const;
+      },
+    );
+    const controller = createLifecycleController({ entry, runSubagentAnnounceFlow });
+
+    await completeRun(controller, entry, { triggerCleanup: true });
+
+    expect(entry.delivery).toMatchObject({
+      status: "suspended",
+      suspendedReason: "expiry",
+      lastError:
+        "parent-only completion requester run is still pending without a source-matched external send receipt; message_tool_delivery_missing",
+    });
+    expect(entry.delivery?.deliveredAt).toBeUndefined();
+    expect(entry.delivery?.announcedAt).toBeUndefined();
+    expect(entry.delivery?.payload).toMatchObject({ completionTarget: "parent" });
+    expect(entry.cleanupCompletedAt).toBeUndefined();
+    expect(hasDeliveredTaskStatusUpdate(entry.runId)).toBe(false);
+  });
+
   it("credits only current-run requester delivery mirrors before retrying NO_REPLY", async () => {
     const entry = await runNoReplyMirrorScenario({ timestamp: 12_345 });
 

--- a/src/agents/subagents/registry/subagent-registry-run-launch.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-launch.ts
@@ -70,6 +70,7 @@ export type RegisterSubagentRunParams = {
   workspaceDir?: string;
   runTimeoutSeconds?: number;
   expectsCompletionMessage?: boolean;
+  completionTarget?: "parent";
   spawnMode?: "run" | "session";
   attachmentsDir?: string;
   attachmentsRootDir?: string;
@@ -130,6 +131,7 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
       taskName: registerParams.taskName,
       cleanup: registerParams.cleanup,
       expectsCompletionMessage: registerParams.expectsCompletionMessage,
+      completionTarget: registerParams.completionTarget,
       spawnMode,
       label: registerParams.label,
       model: registerParams.model,

--- a/src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
@@ -32,6 +32,7 @@ function createRun(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecor
     cleanup: "keep",
     createdAt: 100,
     expectsCompletionMessage: true,
+    completionTarget: "parent",
     execution: {
       status: "terminal",
       startedAt: 110,
@@ -60,6 +61,7 @@ function createRun(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecor
         endedAt: 250,
         outcome: { status: "ok" },
         expectsCompletionMessage: true,
+        completionTarget: "parent",
       },
     },
     ...overrides,
@@ -248,6 +250,8 @@ describe("subagent registry sqlite store", () => {
       closeOpenClawStateDatabaseForTest();
       const restored = loadSubagentRegistryFromSqlite().get(run.runId);
       expect(restored?.expectsCompletionMessage).toBe(true);
+      expect(restored?.completionTarget).toBe("parent");
+      expect(restored?.delivery?.payload?.completionTarget).toBe("parent");
       expect(restored?.completion?.resultText).toBe("done");
       expect(restored?.delivery).toMatchObject({ status: "pending", lastError: "retry later" });
       expect(restored?.requesterSettleWake).toEqual(run.requesterSettleWake);

--- a/src/agents/subagents/registry/subagent-registry.types.ts
+++ b/src/agents/subagents/registry/subagent-registry.types.ts
@@ -53,6 +53,7 @@ export type PendingFinalDeliveryPayload = {
   endedAt?: number;
   outcome?: SubagentRunOutcome;
   expectsCompletionMessage?: boolean;
+  completionTarget?: "parent";
   spawnMode?: SpawnSubagentMode;
   wakeOnDescendantSettle?: boolean;
   terminalReply?: AgentRunTerminalReplySnapshot;
@@ -260,6 +261,8 @@ export type SubagentRunRecord = {
   /** Durable requester-stop policy until silent completion cleanup finishes. */
   suppressCompletionDelivery?: boolean;
   expectsCompletionMessage?: boolean;
+  /** Explicit completion route; omitted preserves automatic requester delivery. */
+  completionTarget?: "parent";
   endedReason?: SubagentLifecycleEndedReason;
   pauseReason?: "sessions_yield";
   wakeOnDescendantSettle?: boolean;

--- a/src/agents/subagents/spawn/subagent-spawn-contract.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-contract.ts
@@ -29,6 +29,8 @@ export type SpawnSubagentParams = {
   context?: SpawnSubagentContextMode;
   lightContext?: boolean;
   expectsCompletionMessage?: boolean;
+  /** Route completion through the requester session without automatic external delivery. */
+  completionTarget?: "parent";
   attachments?: Array<{
     name: string;
     content: string;

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -1134,6 +1134,7 @@ describe("spawnSubagentDirect seam flow", () => {
       {
         task: "inspect the spawn seam",
         model: "openai/gpt-5.4",
+        completionTarget: "parent",
       },
       {
         agentSessionKey: "agent:main:main",
@@ -1178,6 +1179,7 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(registerInput.model).toBe("openai/gpt-5.4");
     expect(registerInput.workspaceDir).toBe("/tmp/requester-workspace");
     expect(registerInput.expectsCompletionMessage).toBe(true);
+    expect(registerInput.completionTarget).toBe("parent");
     expect(registerInput.spawnMode).toBe("run");
     expect(hoisted.emitSessionLifecycleEventMock).toHaveBeenCalledWith({
       sessionKey: childSessionKey,

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -506,6 +506,7 @@ export async function spawnSubagentDirect(
           workspaceDir: spawnedMetadata.workspaceDir,
           runTimeoutSeconds,
           expectsCompletionMessage: shouldAnnounceCompletion,
+          completionTarget: params.completionTarget,
           spawnMode,
           collect: params.collect === true,
           swarmRequesterSessionKey: params.collect ? requesterInternalKey : undefined,

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -1241,6 +1241,61 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
   });
 
+  it("forwards parent-only completion routing and rejects thread-bound delivery", async () => {
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });
+
+    await tool.execute("parent-only", {
+      task: "build feature",
+      completionTarget: "parent",
+    });
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({ completionTarget: "parent" }),
+      expect.any(Object),
+    );
+
+    await expect(
+      tool.execute("parent-only-thread", {
+        task: "build feature",
+        thread: true,
+        completionTarget: "parent",
+      }),
+    ).rejects.toThrow('"completionTarget" is unavailable with thread=true');
+  });
+
+  it("rejects parent-only completion owned by a subagent session", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:subagent:orchestrator",
+      completionOwnerKey: "agent:main:subagent:orchestrator",
+    });
+
+    await expect(
+      tool.execute("parent-only-nested", {
+        task: "build feature",
+        completionTarget: "parent",
+      }),
+    ).rejects.toThrow(
+      '"completionTarget" is unavailable when completion is owned by a subagent session',
+    );
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
+  it("allows a subagent controller to proxy parent-only completion to a main owner", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:subagent:orchestrator",
+      completionOwnerKey: "agent:main:main",
+    });
+
+    await tool.execute("parent-only-proxy", {
+      task: "build feature",
+      completionTarget: "parent",
+    });
+
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({ completionTarget: "parent" }),
+      expect.objectContaining({ completionOwnerKey: "agent:main:main" }),
+    );
+  });
+
   it("passes inherited tool denies to subagent spawns", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -12,7 +12,7 @@ import {
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveSnakeCaseParamKey } from "../../param-key.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
+import { isSubagentSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import {
   findAcpUnsupportedInheritedToolAllow,
@@ -129,6 +129,7 @@ function resolveSessionsSpawnThreadAvailability(opts?: {
 
 function createSessionsSpawnToolSchema(params: {
   acpAvailable: boolean;
+  parentCompletionAvailable: boolean;
   threadAvailable: boolean;
   swarmEnabled: boolean;
 }) {
@@ -181,6 +182,14 @@ function createSessionsSpawnToolSchema(params: {
     cleanup: optionalStringEnum(["delete", "keep"] as const, {
       description: "Hidden session cleanup; visible=true always keeps the session.",
     }),
+    ...(params.parentCompletionAvailable
+      ? {
+          completionTarget: optionalStringEnum(["parent"] as const, {
+            description:
+              'Native run completion route; "parent" wakes the requester and requires an explicit message-tool send for external delivery; unavailable with thread=true.',
+          }),
+        }
+      : {}),
     sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES, {
       description: '"inherit" parent sandbox policy; "require" fails unless child is sandboxed.',
     }),
@@ -295,6 +304,10 @@ export function createSessionsSpawnTool(
   });
   const threadAvailability = resolveSessionsSpawnThreadAvailability(opts);
   const threadAvailable = hasAnyThreadAvailability(threadAvailability);
+  const completionOwnerSessionKey =
+    opts?.completionOwnerKey?.trim() || opts?.agentSessionKey?.trim();
+  const parentCompletionAvailable =
+    !completionOwnerSessionKey || !isSubagentSessionKey(completionOwnerSessionKey);
   const requesterAgentId =
     opts?.requesterAgentIdOverride ?? parseAgentSessionKey(opts?.agentSessionKey)?.agentId;
   const swarmConfig = resolveSwarmConfig(opts?.config, requesterAgentId);
@@ -323,6 +336,7 @@ export function createSessionsSpawnTool(
     }),
     parameters: createSessionsSpawnToolSchema({
       acpAvailable,
+      parentCompletionAvailable,
       threadAvailable,
       swarmEnabled: swarmConfig.enabled,
     }),
@@ -383,8 +397,34 @@ export function createSessionsSpawnTool(
       const taskName = taskNameResult.taskName;
       const label = readToolStringParam(params, "label") ?? "";
       const runtime = params.runtime === "acp" ? "acp" : "subagent";
+      const completionTarget = params.completionTarget === "parent" ? "parent" : undefined;
+      if (completionTarget && !parentCompletionAvailable) {
+        throw new ToolInputError(
+          'sessions_spawn "completionTarget" is unavailable when completion is owned by a subagent session.',
+        );
+      }
       if (collect && runtime === "acp") {
         throw new ToolInputError('sessions_spawn collect=true supports runtime="subagent" only.');
+      }
+      if (runtime === "acp" && completionTarget) {
+        throw new ToolInputError(
+          'sessions_spawn "completionTarget" is native-only; use ACP "streamTo" instead.',
+        );
+      }
+      if (collect && completionTarget) {
+        throw new ToolInputError(
+          'sessions_spawn "completionTarget" is unavailable with collect=true.',
+        );
+      }
+      if (params.visible === true && completionTarget) {
+        throw new ToolInputError(
+          'sessions_spawn "completionTarget" is unavailable with visible=true.',
+        );
+      }
+      if (params.thread === true && completionTarget) {
+        throw new ToolInputError(
+          'sessions_spawn "completionTarget" is unavailable with thread=true.',
+        );
       }
       const requestedAgentId = readToolStringParam(params, "agentId");
       const resumeSessionId = readToolStringParam(params, "resumeSessionId");
@@ -574,6 +614,7 @@ export function createSessionsSpawnTool(
           context,
           lightContext,
           expectsCompletionMessage,
+          completionTarget,
           attachments,
           attachMountPath:
             params.attachAs && typeof params.attachAs === "object"

--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -6,6 +6,7 @@ import {
   getGatewayAgentResult,
   hasCommittedOutboundDeliveryEvidence,
   hasCompleteAutomaticMediaDeliveryOutcomeEvidence,
+  hasUnaccountedMessagingToolAggregateEvidence,
   hasVisibleAgentPayload,
   type AgentDeliveryEvidence,
 } from "../agents/embedded-agent-runner/delivery-evidence.js";
@@ -17,6 +18,7 @@ import {
 } from "../config/sessions/restart-recovery-state.js";
 import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import { sourceDeliveryTargetsMatch } from "../infra/outbound/source-delivery-plan.js";
 import {
   advanceSessionDeliveryAgentRun,
   deferSessionDelivery,
@@ -91,6 +93,110 @@ function hasUnexpectedRecoverySideEffects(result: AgentDeliveryEvidence): boolea
   );
 }
 
+function hasUnaccountedOrUnsafeParentOnlyDeliveryEvidence(result: AgentDeliveryEvidence): boolean {
+  if (
+    result.restartUnsafeSideEffectsDetected === true ||
+    result.messagingToolAggregateEvidenceUnaccounted === true ||
+    result.messagingToolSentTargetsTruncated === true ||
+    result.didSendDeterministicApprovalPrompt === true ||
+    hasUnaccountedMessagingToolAggregateEvidence(result) ||
+    (Array.isArray(result.messagingToolSentTargets) && result.messagingToolSentTargets.length > 64)
+  ) {
+    return true;
+  }
+  const hasConcreteMessagingToolReceipt =
+    Array.isArray(result.messagingToolSentTargets) &&
+    result.messagingToolSentTargets.some(
+      (target) => target !== null && typeof target === "object" && !Array.isArray(target),
+    );
+  const hasCommittedNonMessagingEffect = hasCommittedOutboundDeliveryEvidence({
+    acceptedSessionSpawns: result.acceptedSessionSpawns,
+    successfulCronAdds: result.successfulCronAdds,
+  });
+  return (
+    hasCommittedNonMessagingEffect ||
+    (hasCommittedOutboundDeliveryEvidence(result) && !hasConcreteMessagingToolReceipt)
+  );
+}
+
+function collectParentOnlySourceRouteMedia(params: {
+  result: AgentDeliveryEvidence;
+  route: SessionDeliveryRoute;
+}): { matchedRoute: boolean; mediaUrls: Set<string> } {
+  if (params.route.channel === INTERNAL_MESSAGE_CHANNEL) {
+    return { matchedRoute: false, mediaUrls: new Set() };
+  }
+  const targets = Array.isArray(params.result.messagingToolSentTargets)
+    ? params.result.messagingToolSentTargets
+    : [];
+  let matchedRoute = false;
+  const mediaUrls = new Set<string>();
+  for (const target of targets) {
+    if (!target || typeof target !== "object" || Array.isArray(target)) {
+      continue;
+    }
+    if (!sourceDeliveryTargetsMatch(target, params.route)) {
+      continue;
+    }
+    matchedRoute = true;
+    const targetMediaUrls = (target as { mediaUrls?: unknown }).mediaUrls;
+    if (Array.isArray(targetMediaUrls)) {
+      for (const mediaUrl of targetMediaUrls) {
+        if (typeof mediaUrl === "string" && mediaUrl.trim()) {
+          mediaUrls.add(normalizeMediaReferenceForComparison(mediaUrl));
+        }
+      }
+    }
+  }
+  return { matchedRoute, mediaUrls };
+}
+
+async function rearmParentOnlyGeneratedMediaAgentRun(params: {
+  entry: QueuedAgentTurnSessionDelivery;
+  stateDir?: string;
+  reason?: string;
+  updates?: {
+    expectedMediaUrls?: string[];
+    message?: string;
+    suppressTextDelivery?: boolean;
+  };
+}): Promise<never> {
+  const reason =
+    params.reason ??
+    "queued parent-only generated-media agent turn completed without a matching source-route message-tool receipt";
+  const currentAgentRunAttempt = params.entry.agentRunAttempt ?? 0;
+  if (params.entry.lastChargedAgentRunAttempt !== currentAgentRunAttempt) {
+    await failSessionDelivery(
+      params.entry.id,
+      reason,
+      ...sessionDeliveryStateDirArgs(params.stateDir),
+    );
+  }
+  try {
+    if (params.stateDir !== undefined) {
+      await advanceSessionDeliveryAgentRun(params.entry.id, params.updates, params.stateDir);
+    } else if (params.updates) {
+      await advanceSessionDeliveryAgentRun(params.entry.id, params.updates);
+    } else {
+      await advanceSessionDeliveryAgentRun(params.entry.id);
+    }
+    await deferSessionDelivery(
+      params.entry.id,
+      AGENT_DELIVERY_OWNERSHIP_RETRY_MS,
+      ...sessionDeliveryStateDirArgs(params.stateDir),
+    );
+  } catch (error) {
+    log.warn("queued parent-only generated-media retry transition remains pending", {
+      queueId: params.entry.id,
+      error: String(error),
+    });
+    throw new SessionDeliveryRetryChargedError(
+      `${reason}; queue state transition failed after retry charge`,
+    );
+  }
+  throw new SessionDeliveryDeferredError(reason);
+}
+
 function resolveQueuedAgentRunId(entry: QueuedAgentTurnSessionDelivery) {
   const base = entry.idempotencyKey ?? entry.messageId;
   return entry.agentRunAttempt ? `${base}:attempt:${entry.agentRunAttempt}` : base;
@@ -163,6 +269,41 @@ async function evaluateQueuedGeneratedMediaAgentResult(params: {
   stateDir?: string;
   persistInternalMedia?: (mediaUrls: string[]) => Promise<void>;
 }) {
+  if (params.entry.completionTarget === "parent") {
+    if (hasUnaccountedOrUnsafeParentOnlyDeliveryEvidence(params.result)) {
+      log.warn("parent-only generated-media recovery has unaccounted or unsafe evidence", {
+        queueId: params.entry.id,
+      });
+      await deadLetterSessionDelivery(
+        params.entry,
+        "queued parent-only generated-media delivery dead-lettered after unaccounted or unsafe delivery evidence",
+        params.stateDir,
+      );
+    }
+    const sourceReceipt = collectParentOnlySourceRouteMedia(params);
+    const expectedMediaUrls = params.entry.expectedMediaUrls ?? [];
+    const missingMediaUrls = expectedMediaUrls.filter(
+      (mediaUrl) => !sourceReceipt.mediaUrls.has(normalizeMediaReferenceForComparison(mediaUrl)),
+    );
+    if (sourceReceipt.matchedRoute && missingMediaUrls.length === 0) {
+      return;
+    }
+    if (sourceReceipt.matchedRoute) {
+      const retryMessage = formatGeneratedMediaDeliveryRetryForPrompt(missingMediaUrls);
+      await rearmParentOnlyGeneratedMediaAgentRun({
+        entry: params.entry,
+        ...(params.stateDir !== undefined ? { stateDir: params.stateDir } : {}),
+        reason:
+          "queued parent-only generated-media agent turn completed without all expected media on the matching source route",
+        updates: {
+          expectedMediaUrls: missingMediaUrls,
+          ...(retryMessage ? { message: retryMessage } : {}),
+          suppressTextDelivery: true,
+        },
+      });
+    }
+    await rearmParentOnlyGeneratedMediaAgentRun(params);
+  }
   if (hasUnexpectedRecoverySideEffects(params.result)) {
     log.warn("queued generated-media recovery reported an unexpected committed side effect", {
       queueId: params.entry.id,
@@ -326,8 +467,13 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
   }
 
   const queuedRunId = resolveQueuedAgentRunId(entry);
+  const parentOnlyCompletion = entry.completionTarget === "parent";
   const deliveryMode = resolveDurableCompletionDeliveryMode(entry.sourceReplyDeliveryMode);
-  if (deliveryMode === "host_owned" && route.channel === INTERNAL_MESSAGE_CHANNEL) {
+  if (
+    !parentOnlyCompletion &&
+    deliveryMode === "host_owned" &&
+    route.channel === INTERNAL_MESSAGE_CHANNEL
+  ) {
     return await deadLetterSessionDelivery(
       entry,
       "queued host-owned generated-media delivery requires an external route",
@@ -412,10 +558,9 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
       params.stateDir,
     );
   }
-  // `host_owned` is the explicit-send equivalent of message-tool-only policy.
-  // The queue owner fixes route/media and disables the model-facing message tool,
-  // so only this one system completion can use the normal final-delivery transport.
-  const sourceReplyDeliveryMode = "automatic" as const;
+  // Ordinary host-owned media uses fixed automatic transport. Parent-only
+  // completions preserve message-tool ownership through the durable consumer.
+  const sourceReplyDeliveryMode = parentOnlyCompletion ? "message_tool_only" : "automatic";
   const cronLifecycleRevision = params.sessionEntry?.cronRunContinuation?.lifecycleRevision?.trim();
   const cronSessionId = cronLifecycleRevision ? params.sessionEntry?.sessionId?.trim() : undefined;
   // Fence before gateway admission. Recovery clears it only for an explicit
@@ -429,8 +574,7 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
       {
         sessionKey: params.canonicalKey,
         message: entry.message,
-        deliver:
-          sourceReplyDeliveryMode === "automatic" && route.channel !== INTERNAL_MESSAGE_CHANNEL,
+        deliver: !parentOnlyCompletion && route.channel !== INTERNAL_MESSAGE_CHANNEL,
         bestEffortDeliver: false,
         channel: route.channel,
         accountId: route.accountId,
@@ -439,7 +583,7 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
         ...(cronSessionId ? { sessionId: cronSessionId } : {}),
         inputProvenance: entry.inputProvenance,
         sourceReplyDeliveryMode,
-        disableMessageTool: true,
+        disableMessageTool: !parentOnlyCompletion,
         forceRestartSafeTools: true,
         idempotencyKey: queuedRunId,
       },

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -1085,6 +1085,261 @@ describe("scheduleRestartSentinelWake", () => {
     );
   });
 
+  it("requires parent-only generated media to send through the matching source route", async () => {
+    mocks.dispatchGatewayMethodInProcess.mockResolvedValueOnce({
+      status: "ok",
+      result: {
+        messagingToolSentTargets: [
+          {
+            provider: "discord",
+            to: "channel:123",
+            mediaUrls: ["/tmp/proof.png"],
+          },
+        ],
+      },
+    });
+
+    await deliverGeneratedMedia({
+      id: "session-delivery-media-parent",
+      messageId: "image:task-parent:agent-loop",
+      completionTarget: "parent",
+      sourceReplyDeliveryMode: "message_tool_only",
+      expectedMediaUrls: ["/tmp/proof.png"],
+    });
+
+    expect(mocks.dispatchGatewayMethodInProcess).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        deliver: false,
+        sourceReplyDeliveryMode: "message_tool_only",
+        disableMessageTool: false,
+      }),
+      expect.any(Object),
+    );
+    expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
+    expect(mocks.deferSessionDelivery).not.toHaveBeenCalled();
+    expect(mocks.markSessionDeliverySettlement).not.toHaveBeenCalled();
+  });
+
+  it("retries parent-only generated media without a matching source receipt", async () => {
+    mocks.dispatchGatewayMethodInProcess.mockResolvedValueOnce({
+      status: "ok",
+      result: { payloads: [{ text: "ready", mediaUrls: ["/tmp/proof.png"] }] },
+    });
+
+    await expect(
+      deliverGeneratedMedia({
+        id: "session-delivery-media-parent-missing-receipt",
+        messageId: "image:task-parent-missing-receipt:agent-loop",
+        completionTarget: "parent",
+        sourceReplyDeliveryMode: "message_tool_only",
+        expectedMediaUrls: ["/tmp/proof.png"],
+      }),
+    ).rejects.toThrow("without a matching source-route message-tool receipt");
+
+    expect(mocks.advanceSessionDeliveryAgentRun).toHaveBeenCalledWith(
+      "session-delivery-media-parent-missing-receipt",
+    );
+    expect(mocks.deferSessionDelivery).toHaveBeenCalledWith(
+      "session-delivery-media-parent-missing-receipt",
+      1_000,
+    );
+    expect(mocks.markSessionDeliverySettlement).not.toHaveBeenCalled();
+  });
+
+  it("retries parent-only generated media after a concrete off-route receipt", async () => {
+    mocks.dispatchGatewayMethodInProcess.mockResolvedValueOnce({
+      status: "ok",
+      result: {
+        messagingToolSentTargets: [
+          {
+            provider: "discord",
+            to: "channel:wrong",
+            mediaUrls: ["/tmp/proof.png"],
+          },
+        ],
+      },
+    });
+
+    await expect(
+      deliverGeneratedMedia({
+        id: "session-delivery-media-parent-off-route",
+        messageId: "image:task-parent-off-route:agent-loop",
+        completionTarget: "parent",
+        sourceReplyDeliveryMode: "message_tool_only",
+        expectedMediaUrls: ["/tmp/proof.png"],
+      }),
+    ).rejects.toThrow("without a matching source-route message-tool receipt");
+
+    expect(mocks.advanceSessionDeliveryAgentRun).toHaveBeenCalledWith(
+      "session-delivery-media-parent-off-route",
+    );
+    expect(mocks.deferSessionDelivery).toHaveBeenCalledWith(
+      "session-delivery-media-parent-off-route",
+      1_000,
+    );
+    expect(mocks.markSessionDeliverySettlement).not.toHaveBeenCalled();
+  });
+
+  it("retries parent-only generated media when a source-route receipt omits the media", async () => {
+    mocks.dispatchGatewayMethodInProcess.mockResolvedValueOnce({
+      status: "ok",
+      result: {
+        messagingToolSentTargets: [
+          {
+            provider: "discord",
+            to: "channel:123",
+            text: "ready",
+          },
+        ],
+      },
+    });
+
+    await expect(
+      deliverGeneratedMedia({
+        id: "session-delivery-media-parent-missing-media",
+        messageId: "image:task-parent-missing-media:agent-loop",
+        completionTarget: "parent",
+        sourceReplyDeliveryMode: "message_tool_only",
+        expectedMediaUrls: ["/tmp/proof.png"],
+      }),
+    ).rejects.toThrow("without all expected media on the matching source route");
+
+    expect(mocks.advanceSessionDeliveryAgentRun).toHaveBeenCalledWith(
+      "session-delivery-media-parent-missing-media",
+      {
+        expectedMediaUrls: ["/tmp/proof.png"],
+        message: expect.stringContaining("/tmp/proof.png"),
+        suppressTextDelivery: true,
+      },
+    );
+    expect(mocks.deferSessionDelivery).toHaveBeenCalledWith(
+      "session-delivery-media-parent-missing-media",
+      1_000,
+    );
+    expect(mocks.markSessionDeliverySettlement).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when matching parent-only media evidence is truncated", async () => {
+    mocks.dispatchGatewayMethodInProcess.mockResolvedValueOnce({
+      status: "ok",
+      result: {
+        messagingToolSentTargets: Array.from({ length: 64 }, (_, index) => ({
+          provider: "discord",
+          to: "channel:123",
+          mediaUrls: [`/tmp/${index}.png`],
+        })),
+        messagingToolSentTargetsTruncated: true,
+      },
+    });
+
+    await expect(
+      deliverGeneratedMedia({
+        id: "session-delivery-media-parent-truncated",
+        messageId: "image:task-parent-truncated:agent-loop",
+        completionTarget: "parent",
+        sourceReplyDeliveryMode: "message_tool_only",
+        expectedMediaUrls: ["/tmp/0.png", "/tmp/missing.png"],
+      }),
+    ).rejects.toThrow("dead-lettered after unaccounted or unsafe delivery evidence");
+
+    expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
+    expect(mocks.deferSessionDelivery).not.toHaveBeenCalled();
+    expect(mocks.markSessionDeliverySettlement).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "session-delivery-media-parent-truncated" }),
+      "moved-to-failed",
+    );
+  });
+
+  it("fails closed on raw oversized parent-only message-tool target evidence", async () => {
+    mocks.dispatchGatewayMethodInProcess.mockResolvedValueOnce({
+      status: "ok",
+      result: {
+        messagingToolSentTargets: Array.from({ length: 65 }, (_, index) => ({
+          provider: "discord",
+          to: "channel:123",
+          mediaUrls: [`/tmp/${index}.png`],
+        })),
+      },
+    });
+
+    await expect(
+      deliverGeneratedMedia({
+        id: "session-delivery-media-parent-raw-truncated",
+        messageId: "image:task-parent-raw-truncated:agent-loop",
+        completionTarget: "parent",
+        sourceReplyDeliveryMode: "message_tool_only",
+        expectedMediaUrls: ["/tmp/0.png"],
+      }),
+    ).rejects.toThrow("dead-lettered after unaccounted or unsafe delivery evidence");
+
+    expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
+    expect(mocks.deferSessionDelivery).not.toHaveBeenCalled();
+  });
+
+  it("fails closed on raw unaccounted parent-only aggregate message-tool evidence", async () => {
+    mocks.dispatchGatewayMethodInProcess.mockResolvedValueOnce({
+      status: "ok",
+      result: {
+        didSendViaMessagingTool: true,
+        messagingToolSentMediaUrls: ["/tmp/one.png", "/tmp/unaccounted.png"],
+        messagingToolSentTargets: [
+          {
+            provider: "discord",
+            to: "channel:123",
+            mediaUrls: ["/tmp/one.png"],
+          },
+        ],
+      },
+    });
+
+    await expect(
+      deliverGeneratedMedia({
+        id: "session-delivery-media-parent-raw-unaccounted",
+        messageId: "image:task-parent-raw-unaccounted:agent-loop",
+        completionTarget: "parent",
+        sourceReplyDeliveryMode: "message_tool_only",
+        expectedMediaUrls: ["/tmp/one.png", "/tmp/two.png"],
+      }),
+    ).rejects.toThrow("dead-lettered after unaccounted or unsafe delivery evidence");
+
+    expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
+    expect(mocks.deferSessionDelivery).not.toHaveBeenCalled();
+  });
+
+  it("keeps parent-only generated media retryable for a private internal route", async () => {
+    mocks.dispatchGatewayMethodInProcess.mockResolvedValueOnce({
+      status: "ok",
+      result: { payloads: [{ text: "ready", mediaUrls: ["/tmp/proof.png"] }] },
+    });
+
+    await expect(
+      deliverGeneratedMedia({
+        id: "session-delivery-media-parent-internal",
+        messageId: "image:task-parent-internal:agent-loop",
+        completionTarget: "parent",
+        sourceReplyDeliveryMode: "message_tool_only",
+        route: { channel: "internal", to: "agent:main:main", chatType: "direct" },
+        expectedMediaUrls: ["/tmp/proof.png"],
+      }),
+    ).rejects.toThrow("without a matching source-route message-tool receipt");
+
+    expect(mocks.dispatchGatewayMethodInProcess).toHaveBeenCalledWith(
+      "agent",
+      expect.objectContaining({
+        deliver: false,
+        sourceReplyDeliveryMode: "message_tool_only",
+        disableMessageTool: false,
+      }),
+      expect.any(Object),
+    );
+    expect(mocks.deferSessionDelivery).toHaveBeenCalledWith(
+      "session-delivery-media-parent-internal",
+      1_000,
+    );
+    expect(mocks.markSessionDeliverySettlement).not.toHaveBeenCalled();
+  });
+
   it("fences an adopted generic turn in its explicit queue state directory", async () => {
     mocks.recordInboundSessionAndDispatchReply.mockImplementationOnce(async (params) => {
       await params.turnAdoptionLifecycle?.onAdopted();
@@ -1330,6 +1585,97 @@ describe("scheduleRestartSentinelWake", () => {
       1_000,
     );
     expect(mocks.dispatchGatewayMethodInProcess).not.toHaveBeenCalled();
+  });
+
+  it("accepts a persisted matching parent-only media receipt after restart", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      entry: {
+        sessionId: "agent:main:main",
+        restartRecoveryTerminalRunIds: ["image:task-terminal-parent-match:agent-loop"],
+        restartRecoveryTerminalDeliveryEvidence: [
+          {
+            runId: "image:task-terminal-parent-match:agent-loop",
+            messagingToolSentTargets: [
+              {
+                provider: "discord",
+                to: "channel:123",
+                mediaUrls: ["/tmp/proof.png"],
+                visible: true,
+              },
+            ],
+          },
+        ],
+        updatedAt: 1,
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      storeKeys: ["agent:main:main"],
+      legacyKey: undefined,
+    });
+
+    await deliverGeneratedMedia({
+      id: "session-delivery-media-terminal-parent-match",
+      messageId: "image:task-terminal-parent-match:agent-loop",
+      completionTarget: "parent",
+      sourceReplyDeliveryMode: "message_tool_only",
+      expectedMediaUrls: ["/tmp/proof.png"],
+    });
+
+    expect(mocks.dispatchGatewayMethodInProcess).not.toHaveBeenCalled();
+    expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
+    expect(mocks.deferSessionDelivery).not.toHaveBeenCalled();
+    expect(mocks.markSessionDeliverySettlement).not.toHaveBeenCalled();
+  });
+
+  it("retries a persisted off-route parent-only media receipt after restart", async () => {
+    mocks.loadSessionEntry.mockReturnValue({
+      cfg: {},
+      entry: {
+        sessionId: "agent:main:main",
+        restartRecoveryTerminalRunIds: ["image:task-terminal-parent-off-route:agent-loop"],
+        restartRecoveryTerminalDeliveryEvidence: [
+          {
+            runId: "image:task-terminal-parent-off-route:agent-loop",
+            messagingToolSentTargets: [
+              {
+                provider: "discord",
+                to: "channel:wrong",
+                mediaUrls: ["/tmp/proof.png"],
+                visible: true,
+              },
+            ],
+          },
+        ],
+        updatedAt: 1,
+      },
+      store: {},
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      storeKeys: ["agent:main:main"],
+      legacyKey: undefined,
+    });
+
+    await expect(
+      deliverGeneratedMedia({
+        id: "session-delivery-media-terminal-parent-off-route",
+        messageId: "image:task-terminal-parent-off-route:agent-loop",
+        completionTarget: "parent",
+        sourceReplyDeliveryMode: "message_tool_only",
+        expectedMediaUrls: ["/tmp/proof.png"],
+      }),
+    ).rejects.toThrow("without a matching source-route message-tool receipt");
+
+    expect(mocks.dispatchGatewayMethodInProcess).not.toHaveBeenCalled();
+    expect(mocks.advanceSessionDeliveryAgentRun).toHaveBeenCalledWith(
+      "session-delivery-media-terminal-parent-off-route",
+    );
+    expect(mocks.deferSessionDelivery).toHaveBeenCalledWith(
+      "session-delivery-media-terminal-parent-off-route",
+      1_000,
+    );
+    expect(mocks.markSessionDeliverySettlement).not.toHaveBeenCalled();
   });
 
   it("dead-letters an interrupted attempt without durable agent evidence", async () => {

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -71,6 +71,7 @@ export type QueuedSessionDeliveryPayload =
       deliveryContext?: SessionDeliveryContext;
       inputProvenance?: InputProvenance;
       sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+      completionTarget?: "parent";
       expectedMediaUrls?: string[];
       suppressTextDelivery?: true;
       idempotencyKey?: string;

--- a/src/infra/session-delivery-queue.storage.test.ts
+++ b/src/infra/session-delivery-queue.storage.test.ts
@@ -301,6 +301,7 @@ describe("session-delivery queue storage", () => {
             sourceTool: "image_generate",
           },
           sourceReplyDeliveryMode: "message_tool_only",
+          completionTarget: "parent",
           expectedMediaUrls: ["/tmp/proof.png"],
         },
         tempDir,
@@ -311,6 +312,7 @@ describe("session-delivery queue storage", () => {
           route: expect.objectContaining({ channel: "discord", to: "channel:123" }),
           inputProvenance: expect.objectContaining({ sourceTool: "image_generate" }),
           sourceReplyDeliveryMode: "message_tool_only",
+          completionTarget: "parent",
           expectedMediaUrls: ["/tmp/proof.png"],
         }),
       ]);

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -46,6 +46,11 @@
             "enum": ["delete", "keep"],
             "type": "string"
           },
+          "completionTarget": {
+            "description": "Native run completion route; \"parent\" wakes the requester and requires an explicit message-tool send for external delivery; unavailable with thread=true.",
+            "enum": ["parent"],
+            "type": "string"
+          },
           "context": {
             "description": "Native: omit/isolated clean; fork only needing requester transcript; visible fork requires same agent.",
             "enum": ["isolated", "fork"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -182,6 +182,11 @@
           "enum": ["delete", "keep"],
           "type": "string"
         },
+        "completionTarget": {
+          "description": "Native run completion route; \"parent\" wakes the requester and requires an explicit message-tool send for external delivery; unavailable with thread=true.",
+          "enum": ["parent"],
+          "type": "string"
+        },
         "context": {
           "description": "Native: omit/isolated clean; fork only needing requester transcript; visible fork requires same agent.",
           "enum": ["isolated", "fork"],

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 49173,
-    "roughTokens": 12294
+    "chars": 49479,
+    "roughTokens": 12370
   },
   "openClawDeveloperInstructions": {
     "chars": 4479,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7216
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78037,
-    "roughTokens": 19510
+    "chars": 78343,
+    "roughTokens": 19586
   },
   "userInputText": {
     "chars": 1300,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -227,8 +227,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 48865,
-    "roughTokens": 12217
+    "chars": 49171,
+    "roughTokens": 12293
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -239,8 +239,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6846
   },
   "totalWithDynamicToolsJson": {
-    "chars": 76249,
-    "roughTokens": 19063
+    "chars": 76555,
+    "roughTokens": 19139
   },
   "userInputText": {
     "chars": 929,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -222,8 +222,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 50399,
-    "roughTokens": 12600
+    "chars": 50705,
+    "roughTokens": 12677
   },
   "openClawDeveloperInstructions": {
     "chars": 3370,
@@ -234,8 +234,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6950
   },
   "totalWithDynamicToolsJson": {
-    "chars": 78199,
-    "roughTokens": 19550
+    "chars": 78505,
+    "roughTokens": 19627
   },
   "userInputText": {
     "chars": 1271,


### PR DESCRIPTION
## Important: this replaces the earlier implementation and proof

This PR was rebuilt from current `main` as one signed commit. The earlier
`announceTarget`/migration design and all proof tied to prior heads no longer
describe the code under review. The current API is a per-spawn native option
named `completionTarget`; it adds no config default or database migration.

## What Problem This Solves

An orchestrating agent may need to review, combine, or redact a child result
before anything reaches the external chat. Prompt instructions cannot enforce
that boundary because runtime completion delivery can bypass the parent.

This adds an explicit native `sessions_spawn` opt-in:

```json
{ "completionTarget": "parent" }
```

The child completion remains an obligation of the requester session until the
parent deliberately sends through the source route with the `message` tool.
There is no automatic external fallback for the raw child result.

Fixes #27445.

## Why This Change Was Made

Parent-only completion is fail-closed:

- success requires a completed requester turn with a source-route-matching
  `messagingToolSentTargets` receipt;
- bare `NO_REPLY`, private `internal-ui` mirrors, nonterminal `accepted`
  responses, off-route sends, and receipt-free terminal responses do not
  discharge the obligation;
- cleanup and requester-settle wakes preserve the pending payload until a
  valid receipt exists;
- settle-wake batches are partitioned by canonical persisted requester route,
  so one route cannot credit another;
- generated-media recovery requires every expected media URL on matching
  source-route receipts and retries only the missing media without duplicating
  text;
- immediate and persisted recovery fail closed on unaccounted, truncated, or
  restart-unsafe delivery evidence; and
- omitted `completionTarget` preserves existing behavior.

The option is native-only and rejected for ACP, `collect: true`,
`visible: true`, `thread: true`, and subagent-owned requesters. A parent-only
spawn requires an explicit external `message` send; no fallback is performed
when that send is absent or rejected.

## User Impact

- Orchestrators gain a runtime-enforced review/synthesis boundary for an
  individual native spawn.
- Existing spawns are unchanged unless they opt in.
- This adds no global or per-agent default, no database schema migration, and
  no policy for other completion modes.

## Evidence

Exact head under review: `c529d540d932031e9b543c313eacd4147dc0a0d5`

Current diff scope: `40 files, +1542/-75`

The diff is one signed commit based on
`061c9c2f7f5899255b057f828a1f82a122152f24`. Fast-moving `main` advanced by
two non-overlapping commits after validation, and the merge-tree remains clean.

Proof status: **pending on this exact head.** The upstream owner split required
relocating the two-line `completionTarget` propagation into
`subagent-registry-run-launch.ts`; no other feature behavior changed. Proof
from earlier trees is intentionally not claimed for this replacement
implementation. ClawSweeper re-review will
not be requested until the new proof is complete and this body is updated with
its redacted receipts.

### Exact-tree validation

Morty Build Node validated the exact replacement tree and its narrow repair:

- the combined focused suite passed 795/795 tests across the touched command,
  delivery, recovery, persistence, spawning, and tool-contract areas;
- dead-code, production and test typechecks, full format, touched-file oxlint,
  prompt snapshots, import cycles, and `git diff --check` passed; and
- independent exact-delta Sol review returned APPROVE with no P0-P2 findings.

The new production-boundary regression constructs unowned core `message`, a
plugin-owned shadow `message`, unsafe `exec`, and safe `read` through
`prepareEmbeddedAttemptToolBase`; only core `message` and `read` survive. This
closes the coverage gap created when the one-caller filter moved beside its
production owner.

The boundary coverage includes matching and missing source receipts, private
internal sinks, nonterminal requester runs, cross-route settle wakes, partial
generated-media receipts, unsafe side-effect persistence, immediate raw
unaccounted evidence, and exact-64 versus overflowed CLI/Codex receipt sets.

### Exact-head behavioral proof

Pending on the current head. The proof contract will exercise both ordinary
busy-parent text delivery and generated-media restart recovery, including:

- exactly one parent `message` call and one source-route-matching Telegram
  transport receipt for the positive path;
- zero external sends with a durable retry obligation for the private
  `internal-ui` sink;
- matching, missing, and off-route generated-media receipts; and
- persisted/reloaded truncation and unsafe-evidence fail-closed behavior.

### Hosted CI status

Fresh hosted CI is pending for this exact head. Upstream merged PR #122879
(`dabf55727b2`) to fix the unrelated `channels.add.test.ts` timeout that blocked
the preceding runs, and this candidate includes that fix through its current
base. It also preserves the parent-only contract across upstream's split of
the announcement-delivery owner. Independent review found and the candidate
closed one additional duplicate-delivery edge: when concrete message-tool
receipts are truncated, a missing retained requester-route receipt now becomes
an ambiguous terminal result rather than a retryable missing-delivery result.
The regression covers the exact 64-retained-off-target-receipt eviction case.
No behavioral proof is claimed until the exact-head Mantis run completes.

## Known Gaps / Non-Goals

- This does not add a global or per-agent default or change omitted/default
  completion behavior.
- ACP, collect-mode, visible sessions, thread-bound sessions, and subagent-
  owned requesters are intentionally outside this native parent-only route.
- Any head change invalidates behavioral proof and requires a fresh run.
- Maintainer sponsorship of this opt-in core API remains a product decision.

AI-assisted: yes. Codex was used for implementation and independent review.
