### PR TITLE
fix(feishu): folder listings can continue after first page

### DIFF
--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -26,6 +26,8 @@ export const FeishuDriveSchema = Type.Union([
     folder_token: Type.Optional(
       Type.String({ description: "Folder token (optional, omit for root directory)" }),
     ),
+    page_size: Type.Optional(Type.Integer({ minimum: 1, maximum: 200, description: "Page size" })),
+    page_token: Type.Optional(Type.String({ description: "Folder list page token" })),
   }),
   Type.Object({
     action: Type.Literal("info"),

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -107,6 +107,25 @@ function expectRequestCall(
   }
 }
 
+function schemaForAction(
+  schema: unknown,
+  action: string,
+): { properties?: Record<string, unknown> } {
+  const variants =
+    (schema as { anyOf?: unknown[]; oneOf?: unknown[] }).anyOf ??
+    (schema as { anyOf?: unknown[]; oneOf?: unknown[] }).oneOf ??
+    [];
+  const variant = variants.find((entry) => {
+    const actionSchema = (entry as { properties?: { action?: { const?: unknown } } }).properties
+      ?.action;
+    return actionSchema?.const === action;
+  });
+  if (!variant) {
+    throw new Error(`Missing schema variant for action ${action}`);
+  }
+  return variant as { properties?: Record<string, unknown> };
+}
+
 describe("registerFeishuDriveTools", () => {
   const requestMock = vi.fn();
 
@@ -358,6 +377,60 @@ describe("registerFeishuDriveTools", () => {
       true,
     );
     expect((replyCommentResult.details as { reply_id?: string }).reply_id).toBe("r4");
+  });
+
+  it("lists a folder continuation page when page_token is provided", async () => {
+    const registerTool = vi.fn();
+    const listFiles = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        files: [{ token: "file_1", name: "File 1", type: "docx", url: "https://example.test/doc" }],
+        next_page_token: "page-3",
+      },
+    });
+    createFeishuToolClientMock.mockReturnValue({
+      drive: { file: { list: listFiles } },
+    });
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = firstToolFactory(registerTool);
+    const tool = toolFactory({ agentAccountId: undefined });
+    const listSchema = schemaForAction((tool as { parameters?: unknown }).parameters, "list");
+    expect(listSchema.properties?.page_token).toMatchObject({ type: "string" });
+    expect(listSchema.properties?.page_size).toMatchObject({
+      type: "integer",
+      minimum: 1,
+      maximum: 200,
+    });
+
+    const result = await tool.execute("call-list-page-2", {
+      action: "list",
+      folder_token: "folder_1",
+      page_size: 25,
+      page_token: "page-2",
+    });
+
+    expect(listFiles).toHaveBeenCalledWith({
+      params: { folder_token: "folder_1", page_size: 25, page_token: "page-2" },
+    });
+    expect(result.details).toMatchObject({
+      files: [{ token: "file_1", name: "File 1", type: "docx", url: "https://example.test/doc" }],
+      next_page_token: "page-3",
+    });
   });
 
   it("defaults add_comment file_type to docx when omitted", async () => {

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -325,11 +325,19 @@ async function getRootFolderToken(client: Lark.Client): Promise<string> {
   return token;
 }
 
-async function listFolder(client: Lark.Client, folderToken?: string) {
+async function listFolder(
+  client: Lark.Client,
+  params: { folder_token?: string; page_size?: number; page_token?: string } = {},
+) {
   // Filter out invalid folder_token values (empty, "0", etc.)
-  const validFolderToken = folderToken && folderToken !== "0" ? folderToken : undefined;
+  const validFolderToken =
+    params.folder_token && params.folder_token !== "0" ? params.folder_token : undefined;
   const res = await client.drive.file.list({
-    params: validFolderToken ? { folder_token: validFolderToken } : {},
+    params: {
+      ...(validFolderToken ? { folder_token: validFolderToken } : {}),
+      ...(params.page_size ? { page_size: params.page_size } : {}),
+      ...(params.page_token ? { page_token: params.page_token } : {}),
+    },
   });
   if (res.code !== 0) {
     throw new Error(res.msg);
@@ -766,7 +774,13 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
             });
             switch (p.action) {
               case "list":
-                return jsonResult(await listFolder(client, p.folder_token));
+                return jsonResult(
+                  await listFolder(client, {
+                    folder_token: p.folder_token,
+                    page_size: p.page_size,
+                    page_token: p.page_token,
+                  }),
+                );
               case "info":
                 return jsonResult(await getFileInfo(client, p.file_token));
               case "create_folder":


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users listing a Feishu Drive folder could receive `next_page_token` in the response but could not request the next page because the `feishu_drive` list action did not accept pagination inputs.

## Why This Change Was Made

The list action now exposes `page_token` and `page_size` in its tool schema and forwards those values, along with any folder token, to Feishu Drive's file listing API. This keeps the existing list response shape, remains scoped to manual folder list continuation, and does not change other Drive actions.

## User Impact

Users can continue Feishu Drive folder listings by passing the returned `next_page_token` as `page_token`, and can optionally set `page_size` for the folder listing request.

## Evidence

- Reviewer-visible runtime proof through the real OpenClaw gateway HTTP surface:
  `daily_fix run-validation --name runtime-proof-feishu-drive-pagination -- runtime-proof-feishu-drive-pagination/run-proof.sh`

  ```text
  Verdict: PASS
  Surface: OpenClaw gateway HTTP /tools/invoke -> bundled feishu_drive tool -> @larksuiteoapi/node-sdk default Feishu HTTPS boundary via local HTTP capture proxy
  Limitation: Uses a local HTTPS Feishu-compatible OAPI capture server because live Feishu credentials are unavailable in this environment; it is not a live tenant proof.
  ```

  Observed SDK-boundary requests after invoking `feishu_drive` via `/tools/invoke`:

  ```text
  1. GET /open-apis/drive/v1/files query={"folder_token":"folder_proof","page_size":"2"}
  2. GET /open-apis/drive/v1/files query={"folder_token":"folder_proof","page_size":"2","page_token":"proof-page-2-token"}
  3. GET /open-apis/drive/v1/files query={"folder_token":"folder_proof","page_size":"2"}
  ```

  Key assertions from `runtime-proof-summary.json`:

  ```text
  firstPageReturnedContinuationToken: true
  secondToolsInvokeAcceptedPageToken: true
  sdkUsedDefaultFeishuHttpsHost: true
  secondSdkRequestIncludedPageToken: true
  secondSdkRequestIncludedPageSize: true
  secondSdkRequestPreservedFolderToken: true
  emptyTokenProbeDidNotForwardBlankPageToken: true
  ```

- Focused regression proof: `node scripts/run-vitest.mjs run extensions/feishu/src/drive.test.ts -t "lists a folder continuation page"`

  ```text
  Test Files  1 passed (1)
       Tests  1 passed | 15 skipped (16)
  ```

- Full Feishu Drive test file: `node scripts/run-vitest.mjs run extensions/feishu/src/drive.test.ts`

  ```text
  Test Files  1 passed (1)
       Tests  16 passed (16)
  ```

- Extension test typecheck: `pnpm tsgo:test:extensions`

  ```text
  $ pnpm tsgo:extensions:test
  $ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
  ```
