### PR TITLE
fix(signal): retry debounce flush on reply session initialization conflict

### DIFF
--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -125,7 +125,7 @@ export async function dispatchWithRetryOnConflict(
       if (!isConflict || attempt >= maxRetries) {
         throw err;
       }
-      await new Promise((resolve) => setTimeout(resolve, baseDelayMs * Math.pow(2, attempt)));
+      await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
     }
   }
 }

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -102,6 +102,34 @@ function resolveSignalInboundRoute(params: {
   });
 }
 
+/**
+ * Retry an async handler with bounded exponential backoff when it throws a
+ * "reply session initialization conflicted" error.  Slack and Telegram
+ * handlers already apply equivalent bounded retries; this helper lets Signal
+ * do the same without duplicating the backoff loop inline.
+ *
+ * Exported so proof scripts can exercise the retry logic directly.
+ */
+export async function dispatchWithRetryOnConflict(
+  handler: () => Promise<void>,
+  maxRetries = 3,
+  baseDelayMs = 200,
+): Promise<void> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      await handler();
+      return;
+    } catch (err) {
+      const isConflict =
+        err instanceof Error && err.message.includes("reply session initialization conflicted");
+      if (!isConflict || attempt >= maxRetries) {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, baseDelayMs * Math.pow(2, attempt)));
+    }
+  }
+}
+
 export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
   type SignalInboundEntry = {
     senderName: string;
@@ -163,7 +191,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     let combinedBody = body;
     const historyKey = entry.isGroup ? (entry.groupId ?? "unknown") : undefined;
     if (entry.isGroup && historyKey) {
-      const channelHistory = createChannelHistoryWindow({ historyMap: deps.groupHistories });
+      const channelHistory = createChannelHistoryWindow({
+        historyMap: deps.groupHistories,
+      });
       combinedBody = channelHistory.buildPendingContext({
         historyKey,
         limit: deps.historyLimit,
@@ -188,7 +218,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const signalTo = normalizeSignalMessagingTarget(signalToRaw) ?? signalToRaw;
     const inboundHistory =
       entry.isGroup && historyKey && deps.historyLimit > 0
-        ? createChannelHistoryWindow({ historyMap: deps.groupHistories }).buildInboundHistory({
+        ? createChannelHistoryWindow({
+            historyMap: deps.groupHistories,
+          }).buildInboundHistory({
             historyKey,
             limit: deps.historyLimit,
           })
@@ -201,7 +233,13 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
             contentType: entry.mediaTypes?.[index],
           }))
         : entry.mediaPath
-          ? [{ path: entry.mediaPath, url: entry.mediaPath, contentType: entry.mediaType }]
+          ? [
+              {
+                path: entry.mediaPath,
+                url: entry.mediaPath,
+                contentType: entry.mediaType,
+              },
+            ]
           : undefined;
     const ctxPayload = buildChannelInboundEventContext({
       channel: "signal",
@@ -430,8 +468,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       if (!last) {
         return;
       }
+
       if (entries.length === 1) {
-        await handleSignalInboundMessage(last);
+        await dispatchWithRetryOnConflict(() => handleSignalInboundMessage(last));
         return;
       }
       const combinedText = entries
@@ -441,14 +480,16 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       if (!combinedText.trim()) {
         return;
       }
-      await handleSignalInboundMessage({
-        ...last,
-        bodyText: combinedText,
-        mediaPath: undefined,
-        mediaType: undefined,
-        mediaPaths: undefined,
-        mediaTypes: undefined,
-      });
+      await dispatchWithRetryOnConflict(() =>
+        handleSignalInboundMessage({
+          ...last,
+          bodyText: combinedText,
+          mediaPath: undefined,
+          mediaType: undefined,
+          mediaPaths: undefined,
+          mediaTypes: undefined,
+        }),
+      );
     },
     onError: (err) => {
       deps.runtime.error?.(`signal debounce flush failed: ${String(err)}`);
@@ -461,7 +502,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     senderDisplay: string;
     reaction: SignalReactionMessage;
     hasBodyContent: boolean;
-    accessDecision: { decision: "allow" | "block" | "pairing"; reasonCode: string };
+    accessDecision: {
+      decision: "allow" | "block" | "pairing";
+      reasonCode: string;
+    };
   }): Promise<boolean> {
     if (params.hasBodyContent) {
       return false;

--- a/test/_proof_signal_retry_conflict.mts
+++ b/test/_proof_signal_retry_conflict.mts
@@ -1,0 +1,150 @@
+/**
+ * Real behavior proof: Signal dispatchWithRetryOnConflict retry logic.
+ *
+ * Calls the actual exported dispatchWithRetryOnConflict function with a
+ * controlled handler that simulates "reply session initialization
+ * conflicted" errors, exercising the real retry-with-backoff code path.
+ *
+ * Usage: node --import tsx test/_proof_signal_retry_conflict.mts
+ */
+
+let pass = 0;
+let fail = 0;
+
+function check(label: string, ok: boolean, detail = "") {
+  if (ok) {
+    pass++;
+    console.log(`PASS  ${label}${detail ? ` :: ${detail}` : ""}`);
+  } else {
+    fail++;
+    console.error(`FAIL  ${label}${detail ? ` :: ${detail}` : ""}`);
+  }
+}
+
+async function proofRetryOnConflict() {
+  const { dispatchWithRetryOnConflict } =
+    await import("../extensions/signal/src/monitor/event-handler.js");
+
+  // ---- Scenario 1: two conflicts then success ----
+  let callCount = 0;
+  const twoConflictHandler = async () => {
+    callCount++;
+    if (callCount <= 2) {
+      throw new Error(
+        "reply session initialization conflicted for agent:main:signal:direct:proof",
+      );
+    }
+  };
+
+  await dispatchWithRetryOnConflict(twoConflictHandler);
+  check(
+    "two conflicts then success: 3 total calls",
+    callCount === 3,
+    `calls=${callCount}`,
+  );
+
+  // ---- Scenario 2: always conflicts, exhausts retries ----
+  let alwaysCallCount = 0;
+  const alwaysConflictHandler = async () => {
+    alwaysCallCount++;
+    throw new Error(
+      "reply session initialization conflicted for agent:main:signal:direct:proof",
+    );
+  };
+
+  let alwaysError: unknown;
+  try {
+    await dispatchWithRetryOnConflict(alwaysConflictHandler);
+    check(
+      "always conflicts: should throw",
+      false,
+      "expected error was not thrown",
+    );
+  } catch (err: unknown) {
+    alwaysError = err;
+  }
+
+  check(
+    "always conflicts: error propagated",
+    alwaysError instanceof Error &&
+      alwaysError.message.includes("reply session initialization conflicted"),
+    `err=${String(alwaysError)}`,
+  );
+
+  check(
+    "always conflicts: 4 total calls (1 initial + 3 retries)",
+    alwaysCallCount === 4,
+    `calls=${alwaysCallCount}`,
+  );
+
+  // ---- Scenario 3: non-conflict error passes through immediately ----
+  let nonConflictCalls = 0;
+  const nonConflictHandler = async () => {
+    nonConflictCalls++;
+    throw new Error("some unrelated error");
+  };
+
+  let nonConflictError: unknown;
+  try {
+    await dispatchWithRetryOnConflict(nonConflictHandler);
+    check(
+      "non-conflict error: should throw",
+      false,
+      "expected error was not thrown",
+    );
+  } catch (err: unknown) {
+    nonConflictError = err;
+  }
+
+  check(
+    "non-conflict error: propagated",
+    nonConflictError instanceof Error &&
+      nonConflictError.message === "some unrelated error",
+    `err=${String(nonConflictError)}`,
+  );
+
+  check(
+    "non-conflict error: only 1 call (no retry)",
+    nonConflictCalls === 1,
+    `calls=${nonConflictCalls}`,
+  );
+
+  // ---- Scenario 4: success on first attempt (no retry needed) ----
+  let successCalls = 0;
+  const successHandler = async () => {
+    successCalls++;
+  };
+
+  await dispatchWithRetryOnConflict(successHandler);
+  check(
+    "success on first attempt: only 1 call",
+    successCalls === 1,
+    `calls=${successCalls}`,
+  );
+
+  // ---- Scenario 5: custom retry/backoff parameters ----
+  let customCalls = 0;
+  const customHandler = async () => {
+    customCalls++;
+    if (customCalls <= 2) {
+      throw new Error("reply session initialization conflicted for proof");
+    }
+  };
+
+  // 2 retries (3 total attempts max), 50ms base delay for faster test
+  await dispatchWithRetryOnConflict(customHandler, 2, 50);
+  check(
+    "custom params (2 retries, 50ms): 3 total calls",
+    customCalls === 3,
+    `calls=${customCalls}`,
+  );
+}
+
+async function main() {
+  console.log(`node --import tsx test/_proof_signal_retry_conflict.mts\n`);
+  await proofRetryOnConflict();
+  console.log(`\n[proof] ${pass} PASS, ${fail} FAIL`);
+  if (fail > 0) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## What Problem This Solves

Signal's debounce flush handler silently drops inbound messages when the reply session initialization throws a "reply session initialization conflicted" error. Slack and Telegram handlers already handle this error, but Signal's `onFlush` handler has no retry mechanism, so follow-up DMs are permanently lost.

## Why This Change Was Made

The dispatch is wrapped with a bounded exponential backoff retry via the exported helper `dispatchWithRetryOnConflict`:

- Up to 3 retries (4 total attempts)
- Delays: 200ms → 400ms → 800ms (using `2 ** attempt`)
- Only retries on "reply session initialization conflicted" errors
- All other errors propagate to `onError` exactly as before

## Evidence

### Real behavior proof (7/7 PASS)

```
node --import tsx test/_proof_signal_retry_conflict.mts

PASS  two conflicts then success: 3 total calls :: calls=3
PASS  always conflicts: error propagated :: err=Error: reply session initialization conflicted for agent:main:signal:direct:proof
PASS  always conflicts: 4 total calls (1 initial + 3 retries) :: calls=4
PASS  non-conflict error: propagated :: err=Error: some unrelated error
PASS  non-conflict error: only 1 call (no retry) :: calls=1
PASS  success on first attempt: only 1 call :: calls=1
PASS  custom params (2 retries, 50ms): 3 total calls :: calls=3

[proof] 7 PASS, 0 FAIL
```

### Latest commit fixes

- ClawSweeper P2: replaced `Math.pow` with `**` operator for lint compliance
- Combined `commandBody` preserved through `{...last}` spread in multi-entry flush path

## Issue

Fixes #100944

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)