### PR TITLE
refactor(qa): share Matrix flows across channel drivers

### DIFF
--- a/extensions/qa-lab/src/ci-smoke-plan.ts
+++ b/extensions/qa-lab/src/ci-smoke-plan.ts
@@ -2,8 +2,8 @@
 import { OPENCLAW_CRABLINE_DEFAULT_CHANNEL } from "@openclaw/crabline";
 import { defaultQaModelForMode, normalizeQaProviderMode } from "./model-selection.js";
 import { readQaScenarioPack } from "./scenario-catalog.js";
+import { scenarioMatchesQaProviderLane } from "./scenario-lane.js";
 import { readQaScorecardTaxonomyReport } from "./scorecard-taxonomy.js";
-import { scenarioMatchesQaProviderLane } from "./suite-planning.js";
 
 const QA_SMOKE_PROFILE = "smoke-ci";
 const QA_SMOKE_CI_PARTS = ["profile-1", "profile-2"] as const;
@@ -73,6 +73,7 @@ export function createQaSmokeCiPart(partId: string): QaSmokeCiPart {
         providerMode,
         primaryModel,
         channelDriver: profile.channelDriver,
+        channel: scenario.execution.channel ?? OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
       }),
   );
   if (scenarios.length === 0) {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -75,6 +75,7 @@ import {
   readQaScenarioPack,
   type QaRuntimeParityTier,
 } from "./scenario-catalog.js";
+import { scenarioMatchesQaProviderLane } from "./scenario-lane.js";
 import { resolveQaScenarioPackScenarioIds } from "./scenario-packs.js";
 import { attachQaProfileScorecardEvidenceToFile } from "./scorecard-evidence.js";
 import {
@@ -86,11 +87,7 @@ import {
 } from "./scorecard-taxonomy.js";
 import { isQaSelfCheckSuccessful } from "./self-check.js";
 import { runQaFlowSuiteFromRuntime, runQaSuite } from "./suite-launch.runtime.js";
-import {
-  resolveQaSuiteScenarioChannel,
-  resolveQaSuiteScenarioChannels,
-  scenarioMatchesQaProviderLane,
-} from "./suite-planning.js";
+import { resolveQaSuiteScenarioChannel, resolveQaSuiteScenarioChannels } from "./suite-planning.js";
 import { readQaSuiteFailedOrSkippedScenarioCountFromFile } from "./suite-summary.js";
 import {
   buildTokenEfficiencyReport,
@@ -353,6 +350,7 @@ function resolveQaRuntimeParityTierScenarioIds(params: {
       providerMode: params.providerMode,
       primaryModel: params.primaryModel,
       channelDriver: params.channelDriver,
+      channel: scenario.execution.channel,
       claudeCliAuthMode: params.claudeCliAuthMode,
     }),
   );
@@ -796,6 +794,7 @@ export async function runQaProfileCommand(opts: QaProfileCommandOptions) {
       providerMode: normalizedProviderMode,
       primaryModel,
       channelDriver: profileReport.channelDriver,
+      channel: scenario.execution.channel,
     }),
   );
   if (scenarios.length === 0) {
@@ -863,6 +862,7 @@ function selectQaScenarioDefinitionsForChannelResolution(params: {
       providerMode: params.providerMode,
       primaryModel: params.primaryModel,
       channelDriver: params.channelDriver,
+      channel: scenario.execution.channel,
       claudeCliAuthMode: params.claudeCliAuthMode,
     }),
   );

--- a/extensions/qa-lab/src/coverage-report.test.ts
+++ b/extensions/qa-lab/src/coverage-report.test.ts
@@ -352,6 +352,34 @@ describe("qa coverage report", () => {
     );
   });
 
+  it("uses the live lane for channel scenarios without a driver restriction", () => {
+    const matches = findQaScenarioMatches(readQaScenarioPack().scenarios, "dm-per-room-session");
+    const report = renderQaScenarioMatchesMarkdownReport({
+      query: "dm-per-room-session",
+      matches,
+    });
+
+    expect(report).toContain(
+      "- Suite command: `pnpm openclaw qa suite --channel-driver live --channel matrix --scenario dm-per-room-session`",
+    );
+  });
+
+  it("splits flow commands across channel lanes", () => {
+    const scenarios = readQaScenarioPack().scenarios;
+    const matches = [
+      ...findQaScenarioMatches(scenarios, "dm-per-room-session"),
+      ...findQaScenarioMatches(scenarios, "whatsapp-access-control-group-disabled"),
+    ];
+    const report = renderQaScenarioMatchesMarkdownReport({ query: "channel lanes", matches });
+
+    expect(report).toContain(
+      "--channel-driver live --channel matrix --scenario dm-per-room-session",
+    );
+    expect(report).toContain(
+      "--channel-driver live --channel whatsapp --scenario whatsapp-access-control-group-disabled",
+    );
+  });
+
   it("splits qa suite targets when matches mix execution kinds", () => {
     const playwrightExecutionPath = "ui/src/e2e/chat-flow.e2e.test.ts";
     const flowScenario = scenarioWithCoverage({

--- a/extensions/qa-lab/src/coverage-report.ts
+++ b/extensions/qa-lab/src/coverage-report.ts
@@ -481,36 +481,29 @@ function formatOptionalScenarioMetadata(match: QaScenarioSearchMatch) {
   return metadata.length > 0 ? metadata.join("; ") : "none";
 }
 
+function uniqueScenarioValues(values: (string | undefined)[]) {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))];
+}
+
 function formatSuiteCommand(matches: readonly QaScenarioSearchMatch[]) {
   const scenarioArgs = matches.map((match) => `--scenario ${match.id}`).join(" ");
-  const requiredDrivers = [
-    ...new Set(
-      matches
-        .map((match) => match.requiredChannelDriver)
-        .filter((driver): driver is string => Boolean(driver)),
-    ),
-  ];
+  const requiredDrivers = uniqueScenarioValues(matches.map((match) => match.requiredChannelDriver));
+  const channels = uniqueScenarioValues(matches.map((match) => match.channel));
+  const selectedDriver =
+    requiredDrivers.length === 1 ? requiredDrivers[0] : channels.length === 1 ? "live" : undefined;
   const driverArg =
-    requiredDrivers.length === 1 && requiredDrivers[0] !== "qa-channel"
-      ? ` --channel-driver ${requiredDrivers[0]}`
-      : "";
-  const channels = [
-    ...new Set(
-      matches
-        .map((match) => match.channel)
-        .filter((channel): channel is string => Boolean(channel)),
-    ),
-  ];
+    selectedDriver && selectedDriver !== "qa-channel" ? ` --channel-driver ${selectedDriver}` : "";
   const channelArg = driverArg && channels.length === 1 ? ` --channel ${channels[0]}` : "";
   return `pnpm openclaw qa suite${driverArg}${channelArg} ${scenarioArgs}`;
 }
 
 function scenarioMatchCommandGroups(matches: readonly QaScenarioSearchMatch[]) {
-  const groups = new Map<QaScenarioSearchMatch["executionKind"], QaScenarioSearchMatch[]>();
+  const groups = new Map<string, QaScenarioSearchMatch[]>();
   for (const match of matches) {
-    const group = groups.get(match.executionKind) ?? [];
+    const key = JSON.stringify([match.executionKind, match.channel, match.requiredChannelDriver]);
+    const group = groups.get(key) ?? [];
     group.push(match);
-    groups.set(match.executionKind, group);
+    groups.set(key, group);
   }
   const executionOrder: QaScenarioSearchMatch["executionKind"][] = [
     "flow",
@@ -518,10 +511,13 @@ function scenarioMatchCommandGroups(matches: readonly QaScenarioSearchMatch[]) {
     "vitest",
     "playwright",
   ];
-  return executionOrder.flatMap((executionKind) => {
-    const group = groups.get(executionKind);
-    return group && group.length > 0 ? [{ executionKind, matches: group }] : [];
-  });
+  return [...groups.values()]
+    .toSorted(
+      (left, right) =>
+        executionOrder.indexOf(left[0]!.executionKind) -
+        executionOrder.indexOf(right[0]!.executionKind),
+    )
+    .map((group) => ({ executionKind: group[0]!.executionKind, matches: group }));
 }
 
 export function renderQaScenarioMatchesMarkdownReport(params: {

--- a/extensions/qa-lab/src/crabline-provider-targets.ts
+++ b/extensions/qa-lab/src/crabline-provider-targets.ts
@@ -1,0 +1,156 @@
+import { createHash } from "node:crypto";
+import type {
+  OpenClawCrablineInbound,
+  OpenClawCrablineInboundInput,
+  StartedOpenClawCrablineAdapter,
+} from "@openclaw/crabline";
+import type { QaBusInboundMessageInput } from "./runtime-api.js";
+
+const TELEGRAM_QA_DRIVER_ID = "100001";
+const TELEGRAM_QA_OBSERVER_ID = "100002";
+const MATRIX_QA_SERVER_NAME = "matrix-qa.test";
+const MATRIX_QA_DRIVER_ID = `@driver:${MATRIX_QA_SERVER_NAME}`;
+
+export function resolveTelegramQaSenderId(senderId: string) {
+  return senderId === "driver"
+    ? TELEGRAM_QA_DRIVER_ID
+    : senderId === "observer"
+      ? TELEGRAM_QA_OBSERVER_ID
+      : senderId;
+}
+
+function resolveMatrixQaSenderId(senderId: string) {
+  return senderId === "driver"
+    ? MATRIX_QA_DRIVER_ID
+    : senderId === "observer"
+      ? `@observer:${MATRIX_QA_SERVER_NAME}`
+      : senderId;
+}
+
+function resolveMatrixQaConversationId(conversationId: string) {
+  const trimmed = conversationId.trim();
+  if (!trimmed) {
+    throw new Error("Matrix QA conversation id must be non-empty");
+  }
+  if (trimmed.startsWith("!") && trimmed.includes(":")) {
+    return trimmed;
+  }
+  const digest = createHash("sha256").update(trimmed).digest("hex").slice(0, 16);
+  return `!${digest}:${MATRIX_QA_SERVER_NAME}`;
+}
+
+function normalizeExplicitMatrixTarget(target: string) {
+  let normalized = target.trim();
+  for (const prefix of ["matrix:", "room:", "user:"]) {
+    if (normalized.toLowerCase().startsWith(prefix)) {
+      normalized = normalized.slice(prefix.length).trim();
+    }
+  }
+  return /^[!@#]/u.test(normalized) && normalized.includes(":") ? normalized : undefined;
+}
+
+function encodeQaThreadComponent(value: string) {
+  return value.replaceAll("%", "%25").replaceAll("/", "%2F");
+}
+
+function resolveMatrixQaTarget(target: string) {
+  const explicitTarget = normalizeExplicitMatrixTarget(target);
+  if (explicitTarget) {
+    return explicitTarget;
+  }
+  if (target.startsWith("thread:")) {
+    if (target.startsWith("thread:/v1/")) {
+      const rest = target.slice("thread:/v1/".length);
+      const separator = rest.indexOf("/");
+      if (separator > 0) {
+        try {
+          const conversationId = decodeURIComponent(rest.slice(0, separator));
+          const resolvedConversationId =
+            normalizeExplicitMatrixTarget(conversationId) ??
+            resolveMatrixQaConversationId(conversationId);
+          return `thread:/v1/${encodeQaThreadComponent(resolvedConversationId)}${rest.slice(separator)}`;
+        } catch {
+          return target;
+        }
+      }
+    }
+    const threadTarget = target.slice("thread:".length);
+    const separator = threadTarget.indexOf("/");
+    if (separator > 0) {
+      const conversationId = threadTarget.slice(0, separator);
+      const resolvedConversationId =
+        normalizeExplicitMatrixTarget(conversationId) ??
+        resolveMatrixQaConversationId(conversationId);
+      return `thread:${resolvedConversationId}${threadTarget.slice(separator)}`;
+    }
+  }
+  for (const prefix of ["channel:", "group:", "dm:"]) {
+    if (target.startsWith(prefix)) {
+      const conversationId = target.slice(prefix.length);
+      const resolvedConversationId =
+        normalizeExplicitMatrixTarget(conversationId) ??
+        resolveMatrixQaConversationId(conversationId);
+      return `${prefix}${resolvedConversationId}`;
+    }
+  }
+  return resolveMatrixQaConversationId(target);
+}
+
+function resolveMatrixQaText(text: string, botUserId: string) {
+  return text.replace(
+    /(^|[\s([{])@openclaw(?=$|[\s.,!?;)\]}])/gu,
+    (_match, prefix: string) => `${prefix}${botUserId}`,
+  );
+}
+
+export function createCrablineProviderInboundInput(
+  adapter: StartedOpenClawCrablineAdapter,
+  input: QaBusInboundMessageInput,
+): OpenClawCrablineInboundInput {
+  const kind = input.conversation.kind === "direct" ? "direct" : "group";
+  return {
+    ...input,
+    conversation: {
+      ...input.conversation,
+      id:
+        adapter.channel === "matrix"
+          ? resolveMatrixQaConversationId(input.conversation.id)
+          : input.conversation.id,
+      kind,
+    },
+    senderId:
+      adapter.channel === "telegram"
+        ? resolveTelegramQaSenderId(input.senderId)
+        : adapter.channel === "matrix"
+          ? resolveMatrixQaSenderId(input.senderId)
+          : input.senderId,
+    text:
+      adapter.channel === "matrix" && adapter.manifest.provider === "matrix"
+        ? resolveMatrixQaText(input.text, adapter.manifest.botUserId)
+        : input.text,
+  };
+}
+
+export function resolveCrablineStateConversation(params: {
+  adapter: StartedOpenClawCrablineAdapter;
+  input: QaBusInboundMessageInput;
+  providerInbound: OpenClawCrablineInbound;
+}) {
+  return params.adapter.channel === "matrix"
+    ? params.input.conversation
+    : params.providerInbound.stateConversation;
+}
+
+export function createCrablineProviderDelivery(
+  adapter: StartedOpenClawCrablineAdapter,
+  target: string,
+) {
+  const delivery = adapter.createAgentDelivery({
+    target: adapter.channel === "matrix" ? resolveMatrixQaTarget(target) : target,
+  });
+  return {
+    delivery,
+    providerTargetKey:
+      adapter.channel === "matrix" ? delivery.to.replace(/^room:/u, "") : delivery.to,
+  };
+}

--- a/extensions/qa-lab/src/crabline-transport.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.test.ts
@@ -671,17 +671,44 @@ describe("crabline transport", () => {
           MATRIX_USER_ID: "@openclaw:matrix.test",
         });
 
-        const roomId = "!qa:matrix.test";
-        expect(transport.buildAgentDelivery({ target: `group:${roomId}` })).toEqual({
+        const roomId = "main";
+        const delivery = transport.buildAgentDelivery({ target: `group:${roomId}` });
+        expect(delivery).toEqual({
           channel: "matrix",
           replyChannel: "matrix",
-          replyTo: `room:${roomId}`,
-          to: `room:${roomId}`,
+          replyTo: expect.stringMatching(/^room:![a-f0-9]{16}:matrix-qa\.test$/u),
+          to: expect.stringMatching(/^room:![a-f0-9]{16}:matrix-qa\.test$/u),
         });
+        expect(transport.buildAgentDelivery({ target: "!qa:matrix.test" })).toEqual({
+          channel: "matrix",
+          replyChannel: "matrix",
+          replyTo: "room:!qa:matrix.test",
+          to: "room:!qa:matrix.test",
+        });
+        expect(transport.buildAgentDelivery({ target: "matrix:room:!qa:matrix.test" })).toEqual({
+          channel: "matrix",
+          replyChannel: "matrix",
+          replyTo: "room:!qa:matrix.test",
+          to: "room:!qa:matrix.test",
+        });
+        expect(() => transport.buildAgentDelivery({ target: "group:" })).toThrow(
+          "Matrix QA conversation id must be non-empty",
+        );
+        expect(() => transport.buildAgentDelivery({ target: "thread:/v1/main/%24event" })).toThrow(
+          "Matrix thread targets require OpenClaw QA thread forwarding",
+        );
+        await expect(
+          transport.state.addInboundMessage({
+            conversation: { id: "  ", kind: "group" },
+            senderId: "driver",
+            senderName: "Alice",
+            text: "Matrix invalid blank room.",
+          }),
+        ).rejects.toThrow("Matrix QA conversation id must be non-empty");
         await expect(
           transport.state.addInboundMessage({
             conversation: { id: roomId, kind: "group" },
-            senderId: "@alice:matrix.test",
+            senderId: "driver",
             senderName: "Alice",
             text: "Matrix baseline marker check.",
           }),
@@ -689,7 +716,7 @@ describe("crabline transport", () => {
           conversation: { id: roomId, kind: "group" },
           direction: "inbound",
           id: expect.stringMatching(/^\$[a-f0-9]{16}:matrix\.test$/u),
-          senderId: "@alice:matrix.test",
+          senderId: "driver",
           text: "Matrix baseline marker check.",
         });
       } finally {
@@ -707,13 +734,14 @@ describe("crabline transport", () => {
       });
 
       try {
-        const roomId = "!qa:matrix.test";
+        const roomId = "main";
         await transport.state.addInboundMessage({
           conversation: { id: roomId, kind: "group" },
-          senderId: "@alice:matrix.test",
+          senderId: "driver",
           senderName: "Alice",
-          text: "Matrix baseline marker check.",
+          text: "Provision Matrix room.",
         });
+        await transport.state.reset();
         const delivery = transport.buildAgentDelivery({ target: `group:${roomId}` });
         const providerRoomId = delivery.to.replace(/^room:/u, "");
         const env = transport.createRuntimeEnvPatch?.() ?? {};

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -17,6 +17,12 @@ import {
   readStringValue,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { createQaBusState, type QaBusState } from "./bus-state.js";
+import {
+  createCrablineProviderDelivery,
+  createCrablineProviderInboundInput,
+  resolveCrablineStateConversation,
+  resolveTelegramQaSenderId,
+} from "./crabline-provider-targets.js";
 import { QaSuiteInfraError } from "./errors.js";
 import {
   QaStateBackedTransportAdapter,
@@ -40,8 +46,6 @@ import type {
 } from "./runtime-api.js";
 
 const CRABLINE_TRANSPORT_ID = "crabline";
-const TELEGRAM_QA_DRIVER_ID = "100001";
-const TELEGRAM_QA_OBSERVER_ID = "100002";
 
 type QaCrablineTransportState = QaTransportState & {
   cleanup: () => Promise<void>;
@@ -56,14 +60,6 @@ function formatLogicalQaTarget({ conversation, threadId }: QaBusInboundMessageIn
 }
 
 const TELEGRAM_LIFECYCLE_METHOD_RE = /\/(sendMessage|editMessageText|deleteMessage)$/u;
-
-function resolveTelegramQaSenderId(senderId: string) {
-  return senderId === "driver"
-    ? TELEGRAM_QA_DRIVER_ID
-    : senderId === "observer"
-      ? TELEGRAM_QA_OBSERVER_ID
-      : senderId;
-}
 
 function readTelegramLifecycleEvent(params: {
   cursor: number;
@@ -294,19 +290,8 @@ function createCrablineState(params: {
       }
     },
     async addInboundMessage(input: QaBusInboundMessageInput) {
-      const providerSenderId =
-        params.adapter.channel === "telegram"
-          ? resolveTelegramQaSenderId(input.senderId)
-          : input.senderId;
       const providerInbound = params.adapter.createInbound({
-        input: {
-          ...input,
-          conversation: {
-            ...input.conversation,
-            kind: input.conversation.kind === "direct" ? "direct" : "group",
-          },
-          senderId: providerSenderId,
-        },
+        input: createCrablineProviderInboundInput(params.adapter, input),
       });
       // Providers may coerce channel conversations to groups; preserve the scenario's logical
       // target so outbound waits and assertions still match the original input.
@@ -317,7 +302,11 @@ function createCrablineState(params: {
       });
       const message = baseState.addInboundMessage({
         ...input,
-        conversation: providerInbound.stateConversation,
+        conversation: resolveCrablineStateConversation({
+          adapter: params.adapter,
+          input,
+          providerInbound,
+        }),
         ...(providerInbound.threadId ? { threadId: providerInbound.threadId } : {}),
       });
       if (providerMessageId) {
@@ -429,8 +418,8 @@ class QaCrablineTransport extends QaStateBackedTransportAdapter {
     });
 
   buildAgentDelivery = ({ target }: { target: string }) => {
-    const delivery = this.#adapter.createAgentDelivery({ target });
-    this.#state.rememberProviderTarget(delivery.to ?? delivery.replyTo, target);
+    const { delivery, providerTargetKey } = createCrablineProviderDelivery(this.#adapter, target);
+    this.#state.rememberProviderTarget(providerTargetKey, target);
     return delivery;
   };
 

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -1,0 +1,66 @@
+import type { QaCliBackendAuthMode } from "./gateway-child.js";
+import { splitQaModelRef, type QaProviderMode } from "./model-selection.js";
+import { getQaProvider } from "./providers/index.js";
+import type { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
+import type { QaScorecardChannelDriver } from "./scorecard-taxonomy.js";
+
+type QaSeedScenario = ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"][number];
+
+function normalizeQaConfigString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function describeQaProviderLaneMismatches(params: {
+  scenario: QaSeedScenario;
+  primaryModel: string;
+  providerMode: QaProviderMode;
+  channelDriver?: QaScorecardChannelDriver | null;
+  channel?: string | null;
+  claudeCliAuthMode?: QaCliBackendAuthMode;
+}) {
+  const mismatches: string[] = [];
+  const provider = getQaProvider(params.providerMode);
+  if (params.scenario.runtimeParityTier === "live-only" && provider.kind !== "live") {
+    mismatches.push("live provider mode");
+  }
+  const config = params.scenario.execution.config ?? {};
+  const requiredProviderMode = normalizeQaConfigString(config.requiredProviderMode);
+  if (requiredProviderMode && params.providerMode !== requiredProviderMode) {
+    mismatches.push(`providerMode=${requiredProviderMode}`);
+  }
+  const requiredChannelDriver = normalizeQaConfigString(config.requiredChannelDriver);
+  const effectiveChannelDriver = params.channelDriver ?? "qa-channel";
+  if (requiredChannelDriver && effectiveChannelDriver !== requiredChannelDriver) {
+    mismatches.push(`channelDriver=${requiredChannelDriver}`);
+  }
+  const scenarioChannel = params.scenario.execution.channel?.trim().toLowerCase();
+  if (
+    scenarioChannel &&
+    (effectiveChannelDriver === "qa-channel" || params.channel !== scenarioChannel)
+  ) {
+    mismatches.push(`channel=${scenarioChannel}`);
+  }
+  if (provider.kind !== "live") {
+    return mismatches;
+  }
+  const selected = splitQaModelRef(params.primaryModel);
+  const requiredProvider = normalizeQaConfigString(config.requiredProvider);
+  if (requiredProvider && selected?.provider !== requiredProvider) {
+    mismatches.push(`provider=${requiredProvider}`);
+  }
+  const requiredModel = normalizeQaConfigString(config.requiredModel);
+  if (requiredModel && selected?.model !== requiredModel) {
+    mismatches.push(`model=${requiredModel}`);
+  }
+  const requiredAuthMode = normalizeQaConfigString(config.authMode);
+  if (requiredAuthMode && params.claudeCliAuthMode !== requiredAuthMode) {
+    mismatches.push(`authMode=${requiredAuthMode}`);
+  }
+  return mismatches;
+}
+
+export function scenarioMatchesQaProviderLane(
+  params: Parameters<typeof describeQaProviderLaneMismatches>[0],
+) {
+  return describeQaProviderLaneMismatches(params).length === 0;
+}

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -693,6 +693,47 @@ describe("qa suite planning helpers", () => {
     ).toEqual(["qa-channel-only"]);
   });
 
+  it("requires an external lane matching a channel-specific scenario", () => {
+    const scenarios = [
+      makeQaSuiteTestScenario("matrix-transport", {
+        channel: "matrix",
+      }),
+    ];
+
+    expect(() =>
+      selectQaFlowSuiteScenarios({
+        scenarios,
+        scenarioIds: ["matrix-transport"],
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.5",
+      }),
+    ).toThrow(
+      "selected QA scenario(s) do not match the current QA lane: matrix-transport (channel=matrix)",
+    );
+
+    expect(
+      selectQaFlowSuiteScenarios({
+        scenarios,
+        scenarioIds: ["matrix-transport"],
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.5",
+        channelDriver: "crabline",
+        channel: "matrix",
+      }).map((scenario) => scenario.id),
+    ).toEqual(["matrix-transport"]);
+
+    expect(
+      selectQaFlowSuiteScenarios({
+        scenarios,
+        scenarioIds: ["matrix-transport"],
+        providerMode: "mock-openai",
+        primaryModel: "mock-openai/gpt-5.5",
+        channelDriver: "live",
+        channel: "matrix",
+      }).map((scenario) => scenario.id),
+    ).toEqual(["matrix-transport"]);
+  });
+
   it("keeps live-only runtime parity scenarios out of implicit mock selections", () => {
     const scenarios = [
       makeQaSuiteTestScenario("generic"),

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -7,8 +7,11 @@ import { createQaArtifactRunId } from "./artifact-run-id.js";
 import { ensureRepoBoundDirectory, resolveRepoRelativeOutputDir } from "./cli-paths.js";
 import type { QaCliBackendAuthMode } from "./gateway-child.js";
 import { splitQaModelRef as splitModelRef, type QaProviderMode } from "./model-selection.js";
-import { getQaProvider } from "./providers/index.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
+import {
+  describeQaProviderLaneMismatches,
+  scenarioMatchesQaProviderLane,
+} from "./scenario-lane.js";
 import type { QaScorecardChannelDriver } from "./scorecard-taxonomy.js";
 import { applyQaMergePatch, isQaMergePatchObject } from "./suite-merge-patch.js";
 
@@ -23,67 +26,13 @@ const QA_IMPLICIT_ISOLATION_FLOW_CALLS = new Set([
 
 type QaSeedScenario = ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"][number];
 
-function normalizeQaConfigString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function describeQaProviderLaneMismatches(params: {
-  scenario: QaSeedScenario;
-  primaryModel: string;
-  providerMode: QaProviderMode;
-  channelDriver?: QaScorecardChannelDriver | null;
-  claudeCliAuthMode?: QaCliBackendAuthMode;
-}) {
-  const mismatches: string[] = [];
-  const provider = getQaProvider(params.providerMode);
-  if (params.scenario.runtimeParityTier === "live-only" && provider.kind !== "live") {
-    mismatches.push("live provider mode");
-  }
-  const config = params.scenario.execution.config ?? {};
-  const requiredProviderMode = normalizeQaConfigString(config.requiredProviderMode);
-  if (requiredProviderMode && params.providerMode !== requiredProviderMode) {
-    mismatches.push(`providerMode=${requiredProviderMode}`);
-  }
-  const requiredChannelDriver = normalizeQaConfigString(config.requiredChannelDriver);
-  const effectiveChannelDriver = params.channelDriver ?? "qa-channel";
-  if (requiredChannelDriver && effectiveChannelDriver !== requiredChannelDriver) {
-    mismatches.push(`channelDriver=${requiredChannelDriver}`);
-  }
-  if (provider.kind !== "live") {
-    return mismatches;
-  }
-  const selected = splitModelRef(params.primaryModel);
-  const requiredProvider = normalizeQaConfigString(config.requiredProvider);
-  if (requiredProvider && selected?.provider !== requiredProvider) {
-    mismatches.push(`provider=${requiredProvider}`);
-  }
-  const requiredModel = normalizeQaConfigString(config.requiredModel);
-  if (requiredModel && selected?.model !== requiredModel) {
-    mismatches.push(`model=${requiredModel}`);
-  }
-  const requiredAuthMode = normalizeQaConfigString(config.authMode);
-  if (requiredAuthMode && params.claudeCliAuthMode !== requiredAuthMode) {
-    mismatches.push(`authMode=${requiredAuthMode}`);
-  }
-  return mismatches;
-}
-
-function scenarioMatchesQaProviderLane(params: {
-  scenario: QaSeedScenario;
-  primaryModel: string;
-  providerMode: QaProviderMode;
-  channelDriver?: QaScorecardChannelDriver | null;
-  claudeCliAuthMode?: QaCliBackendAuthMode;
-}) {
-  return describeQaProviderLaneMismatches(params).length === 0;
-}
-
 function selectQaFlowSuiteScenarios(params: {
   scenarios: ReturnType<typeof readQaBootstrapScenarioCatalog>["scenarios"];
   scenarioIds?: string[];
   providerMode: QaProviderMode;
   primaryModel: string;
   channelDriver?: QaScorecardChannelDriver | null;
+  channel?: string | null;
   claudeCliAuthMode?: QaCliBackendAuthMode;
 }) {
   const requestedScenarioIds =
@@ -116,8 +65,11 @@ function selectQaFlowSuiteScenarios(params: {
         providerMode: params.providerMode,
         primaryModel: params.primaryModel,
         channelDriver: params.channelDriver,
+        channel: params.channel,
         claudeCliAuthMode: params.claudeCliAuthMode,
-      }).filter((mismatch) => mismatch.startsWith("channelDriver="));
+      }).filter(
+        (mismatch) => mismatch.startsWith("channelDriver=") || mismatch.startsWith("channel="),
+      );
       return mismatches.length > 0 ? [`${scenario.id} (${mismatches.join(", ")})`] : [];
     });
     if (channelDriverMismatches.length > 0) {
@@ -135,6 +87,7 @@ function selectQaFlowSuiteScenarios(params: {
         providerMode: params.providerMode,
         primaryModel: params.primaryModel,
         channelDriver: params.channelDriver,
+        channel: params.channel,
         claudeCliAuthMode: params.claudeCliAuthMode,
       }),
   );
@@ -488,7 +441,6 @@ export {
   resolveQaSuiteOutputDir,
   scenarioRequiresControlUi,
   scenarioRequiresIsolatedQaSuiteWorker,
-  scenarioMatchesQaProviderLane,
   selectQaFlowSuiteScenarios,
   shouldUseIsolatedQaSuiteScenarioWorkers,
   splitModelRef,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -1338,18 +1338,17 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
     params?.alternateModel,
     defaultQaModelForMode(providerMode, true),
   );
-  const fastMode =
-    typeof params?.fastMode === "boolean"
-      ? params.fastMode
-      : isQaFastModeEnabled({ primaryModel, alternateModel });
+  const fastMode = params?.fastMode ?? isQaFastModeEnabled({ primaryModel, alternateModel });
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, params?.outputDir);
   const catalog = readQaBootstrapScenarioCatalog();
+  const channelDriver = params?.channelDriver ?? params?.channelDriverSelection?.channelDriver;
   const selectedScenarios = selectQaFlowSuiteScenarios({
     scenarios: catalog.scenarios,
     scenarioIds: params?.scenarioIds,
     providerMode,
     primaryModel,
-    channelDriver: params?.channelDriver ?? params?.channelDriverSelection?.channelDriver,
+    channelDriver,
+    channel: params?.channelId ?? params?.channelDriverSelection?.channel,
     claudeCliAuthMode: params?.claudeCliAuthMode,
   });
   const enabledPluginIds = [
@@ -1363,7 +1362,8 @@ export async function runQaFlowSuite(params?: QaSuiteRunParams): Promise<QaSuite
   ];
   const gatewayConfigPatch = collectQaSuiteGatewayConfigPatch(
     selectedScenarios,
-    params?.adapterOptions?.sutAccountId?.trim() || "sut",
+    params?.adapterOptions?.sutAccountId?.trim() ||
+      (channelDriver === "crabline" ? "default" : "sut"),
   );
   const gatewayRuntimeOptions = collectQaSuiteGatewayRuntimeOptions(selectedScenarios);
   const concurrency = normalizeQaSuiteConcurrency(

--- a/qa/scenarios/channels/dm-per-room-session.yaml
+++ b/qa/scenarios/channels/dm-per-room-session.yaml
@@ -23,13 +23,11 @@ scenario:
   codeRefs:
     - extensions/matrix/src/session-route.ts
     - extensions/matrix/src/matrix/monitor/handler.ts
-    - extensions/qa-matrix/src/adapter.runtime.ts
   execution:
     kind: flow
     channel: matrix
     summary: Send consecutive DMs in two Matrix rooms and require per-room isolation.
     config:
-      requiredChannelDriver: live
       primaryConversationId: driver-dm
       secondaryConversationId: driver-dm-shared
       primaryMarker: QA-MATRIX-DM-PER-ROOM-PRIMARY-OK
@@ -39,16 +37,13 @@ flow:
   steps:
     - name: suppresses the cross-room shared-session notice
       actions:
-        - assert:
-            expr: transport.id === 'matrix'
-            message: Matrix per-room DM session scenario requires the live Matrix adapter
         - resetTransport: true
         - sendInbound:
             conversation:
               id:
                 ref: config.primaryConversationId
               kind: direct
-            senderId: "@driver:matrix.test"
+            senderId: driver
             senderName: QA Driver
             text:
               expr: "`Reply exactly: ${config.primaryMarker}`"
@@ -69,7 +64,7 @@ flow:
               id:
                 ref: config.secondaryConversationId
               kind: direct
-            senderId: "@driver:matrix.test"
+            senderId: driver
             senderName: QA Driver
             text:
               expr: "`Reply exactly: ${config.secondaryMarker}`"

--- a/qa/scenarios/channels/dm-shared-session.yaml
+++ b/qa/scenarios/channels/dm-shared-session.yaml
@@ -15,13 +15,11 @@ scenario:
     - docs/channels/matrix.md
   codeRefs:
     - extensions/matrix/src/matrix/monitor/handler.ts
-    - extensions/qa-matrix/src/adapter.runtime.ts
   execution:
     kind: flow
     channel: matrix
     summary: Send consecutive DMs from one Matrix user in two rooms and require the shared-session notice.
     config:
-      requiredChannelDriver: live
       primaryConversationId: driver-dm
       secondaryConversationId: driver-dm-shared
       primaryMarker: QA-MATRIX-DM-PRIMARY-OK
@@ -31,16 +29,13 @@ flow:
   steps:
     - name: emits the cross-room shared-session notice
       actions:
-        - assert:
-            expr: transport.id === 'matrix'
-            message: Matrix shared DM session scenario requires the live Matrix adapter
         - resetTransport: true
         - sendInbound:
             conversation:
               id:
                 ref: config.primaryConversationId
               kind: direct
-            senderId: "@driver:matrix.test"
+            senderId: driver
             senderName: QA Driver
             text:
               expr: "`Reply exactly: ${config.primaryMarker}`"
@@ -61,7 +56,7 @@ flow:
               id:
                 ref: config.secondaryConversationId
               kind: direct
-            senderId: "@driver:matrix.test"
+            senderId: driver
             senderName: QA Driver
             text:
               expr: "`Reply exactly: ${config.secondaryMarker}`"


### PR DESCRIPTION
## What Problem This Solves

QA Lab channel scenarios were tied to one driver, so the same Matrix DM behavior could not run unchanged through both the live Matrix adapter and Crabline's Matrix provider bridge.

## Why This Change Was Made

- Treat a scenario's `execution.channel` as the lane boundary: implicit `qa-channel` runs reject channel-specific scenarios, while matching `live` and `crabline` lanes accept them without a scenario-side driver whitelist.
- Keep the two existing Matrix DM session flows portable (`driver` actor IDs and logical conversation IDs) while the normal Matrix plugin still owns behavior.
- Isolate Crabline provider-native target normalization from shared transport orchestration, including native target preservation, encoded thread handling, standalone QA mention expansion, and fail-fast blank identifiers.
- Select Crabline's actual `default` account from the effective channel driver while live Matrix continues to use `sut`.
- Generate runnable coverage commands and split mixed-channel search results into separate channel lanes.

This remains stack PR 1 of 4. It does not migrate the legacy Matrix profile catalog, switch release workflows, or remove `qa-matrix`.

## User Impact

No shipped Matrix channel behavior changes. QA maintainers can run the same shared/per-room Matrix DM scenarios against Crabline or the live Matrix adapter without a Matrix-specific scenario executor or a second scenario host.

## Evidence

- Rebased conflict-free onto `main` at `df5097b6e70e6711f583f740a446b3b279cc092d`; exact PR head `c46453636198c2a59aa324ea362ebfb61dafaf6c`.
- ClawSweeper's awaited-reset finding is fixed.
- Blacksmith Testbox through Crabbox `tbx_01kxfj8f5vk73j5a6n21y1691n` (`quick-crab`, run `29309155612`): exact rebased-tree transport/planning/coverage/smoke/suite tests passed 94/94.
- Exact-head CI run `29309742170` is active; dependency guard, workflow sanity, OpenGrep, critical CodeQL, and real-behavior proof already pass.
- The identical two-scenario CLI proof previously passed 2/2 through Crabline and 2/2 through live Matrix/Tuwunel.
- Fresh post-push whole-branch Codex autoreview on `c46453636198c2a59aa324ea362ebfb61dafaf6c`: clean, no accepted/actionable findings.
