### PR TITLE
fix(models): refresh provider auth after CLI login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Model auth live refresh:** refresh the running Gateway's auth snapshot after successful CLI provider login and token/API-key writes so newly authenticated models become available without a manual reload or restart. (#101254) Thanks @fuller-stack-dev.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Model auth live refresh:** refresh the running Gateway's auth snapshot after successful CLI provider login and token/API-key writes so newly authenticated models become available without a manual reload or restart. (#101254) Thanks @fuller-stack-dev.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -62,6 +62,7 @@ const mocks = vi.hoisted(() => ({
   listProfilesForProvider: vi.fn(),
   promoteAuthProfileInOrder: vi.fn(),
   clearAuthProfileCooldown: vi.fn(),
+  callGateway: vi.fn(),
   resolvePluginSetupProvider: vi.fn(),
   resolvePluginSetupRegistry: vi.fn(),
 }));
@@ -164,6 +165,10 @@ vi.mock("../onboard-helpers.js", () => ({
 
 vi.mock("../../infra/remote-env.js", () => ({
   isRemoteEnvironment: mocks.isRemoteEnvironment,
+}));
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: mocks.callGateway,
 }));
 
 vi.mock("../../plugins/provider-oauth-flow.js", () => ({
@@ -419,6 +424,8 @@ describe("modelsAuthLoginCommand", () => {
     mocks.loadAuthProfileStoreForRuntime.mockReturnValue({ profiles: {}, usageStats: {} });
     mocks.listProfilesForProvider.mockReturnValue([]);
     mocks.clearAuthProfileCooldown.mockResolvedValue(undefined);
+    mocks.callGateway.mockReset();
+    mocks.callGateway.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -500,6 +507,25 @@ describe("modelsAuthLoginCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       "Default model available: openai/gpt-5.5 (use --set-default to apply)",
     );
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "models.authStatus",
+      params: { refresh: true },
+      timeoutMs: 3000,
+    });
+  });
+
+  it("keeps login successful when the running gateway cannot refresh auth state", async () => {
+    const runtime = createRuntime();
+    mocks.callGateway.mockRejectedValueOnce(new Error("gateway unavailable"));
+
+    await expect(modelsAuthLoginCommand({ provider: "openai" }, runtime)).resolves.toBeUndefined();
+
+    expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledOnce();
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "models.authStatus",
+      params: { refresh: true },
+      timeoutMs: 3000,
+    });
   });
 
   it("creates store order for relogin when configured profiles would shadow the new profile", async () => {
@@ -1316,6 +1342,11 @@ describe("modelsAuthLoginCommand", () => {
         credential: expect.objectContaining({ type: "token", token: "openai-token" }),
       }),
     );
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "models.authStatus",
+      params: { refresh: true },
+      timeoutMs: 3000,
+    });
   });
 
   it("writes pasted Anthropic setup-tokens and logs the preference note", async () => {
@@ -1454,6 +1485,11 @@ describe("modelsAuthLoginCommand", () => {
       mode: "api_key",
     });
     expect(runtime.log).toHaveBeenCalledWith("Auth profile: openai:manual (openai/api_key)");
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      method: "models.authStatus",
+      params: { refresh: true },
+      timeoutMs: 3000,
+    });
   });
 
   it("writes piped OpenAI Codex API keys to API-key profiles", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -41,6 +41,7 @@ import { parseDurationMs } from "../../cli/parse-duration.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import { normalizeAgentModelRefForConfig } from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { callGateway } from "../../gateway/call.js";
 import { isRemoteEnvironment } from "../../infra/remote-env.js";
 import {
   applyProviderAuthConfigPatch,
@@ -71,6 +72,19 @@ import { repairCopilotRuntimePluginInstallForModelSelection } from "../copilot-r
 import { loadValidConfigOrThrow, resolveKnownAgentId, updateConfig } from "./shared.js";
 
 type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
+
+// CLI auth writes occur outside the gateway process, which may retain an older runtime snapshot.
+async function refreshRunningGatewayAuthState(): Promise<void> {
+  try {
+    await callGateway({
+      method: "models.authStatus",
+      params: { refresh: true },
+      timeoutMs: 3000,
+    });
+  } catch {
+    // Auth writes must still succeed when no local gateway is running.
+  }
+}
 
 function resolveManualTokenExpiryMs(expiresIn: string | undefined): number | undefined {
   const normalizedExpiresIn = normalizeStringifiedOptionalString(expiresIn);
@@ -493,6 +507,8 @@ async function persistProviderAuthResult(params: {
     logConfigUpdated(params.runtime);
   }
 
+  await refreshRunningGatewayAuthState();
+
   for (const profile of profiles) {
     params.runtime.log(
       `Auth profile: ${profile.profileId} (${profile.credential.provider}/${credentialMode(profile.credential)})`,
@@ -713,6 +729,8 @@ export async function modelsAuthPasteTokenCommand(
 
   await updateConfig((cfg) => applyAuthProfileConfig(cfg, { profileId, provider, mode: "token" }));
 
+  await refreshRunningGatewayAuthState();
+
   logConfigUpdated(runtime);
   runtime.log(`Auth profile: ${profileId} (${provider}/token)`);
   if (provider === "anthropic") {
@@ -770,6 +788,8 @@ export async function modelsAuthPasteApiKeyCommand(
   await updateConfig((cfg) =>
     applyAuthProfileConfig(cfg, { profileId, provider, mode: "api_key" }),
   );
+
+  await refreshRunningGatewayAuthState();
 
   logConfigUpdated(runtime);
   runtime.log(`Auth profile: ${profileId} (${provider}/api_key)`);


### PR DESCRIPTION
Closes #101254

## What Problem This Solves

The CLI could persist valid provider credentials while a running Gateway continued serving its stale auth snapshot. Newly authenticated models then remained unavailable until the Gateway restarted or secrets were reloaded manually.

## Why This Change Was Made

Every successful provider OAuth, setup-token, pasted-token, and API-key write now requests the existing `models.authStatus` refresh contract through one shared helper. The request is best-effort and bounded to three seconds: it refreshes the running Gateway when present without making offline credential setup depend on Gateway availability.

## User Impact

Newly authenticated models become available to the running Gateway and Control UI immediately. CLI auth still succeeds normally when the Gateway is offline.

## Evidence

- Blacksmith Testbox `tbx_01kwx8ws3fsbnrvsm7wx4rgemj`: 39 provider-auth command tests plus 72 Gateway auth-status tests passed; exact changed gate passed.
- Direct AWS Crabbox `cbx_b33918875031`, run `run_a4a1b2814e1a`: model availability changed from false to true without a Gateway restart; a real `openai/gpt-5.5` turn returned `AUTH_REFRESH_OK`; offline credential setup passed; captured CLI output contained no credential value.
- Fresh exact-head autoreview: clean, no actionable findings (0.83 confidence).
- Review artifacts validated at `43a3fff3a515c89a530373900ebe61a4c280ab3d`.

Thanks @fuller-stack-dev for the original fix.

AI-assisted: yes, implementation and review used Codex. No transcript is attached.
