### PR TITLE
fix(telegram): add UND_ERR_CONNECT_TIMEOUT to PRE_CONNECT_ERROR_CODES

### DIFF
--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -218,9 +218,10 @@ function createHtmlParseError(operation = "sendMessage") {
   );
 }
 
-function createWrappedPreConnectHttpError(operation = "sendMessage") {
-  const root = Object.assign(new Error("getaddrinfo ENOTFOUND api.telegram.org"), {
-    code: "ENOTFOUND",
+function createWrappedConnectTimeoutHttpError(operation = "sendMessage") {
+  const root = Object.assign(new Error("Connect Timeout Error"), {
+    name: "ConnectTimeoutError",
+    code: "UND_ERR_CONNECT_TIMEOUT",
   });
   const fetchError = Object.assign(new TypeError("fetch failed"), { cause: root });
   return Object.assign(new Error(`Network request for '${operation}' failed!`), {
@@ -1027,12 +1028,12 @@ describe("deliverReplies", () => {
     expect(runtime.error).toHaveBeenCalledTimes(1);
   });
 
-  it("retries final text sends for wrapped pre-connect grammY HttpError envelopes", async () => {
+  it("retries final text sends for wrapped Undici connect timeouts", async () => {
     vi.useFakeTimers();
     const runtime = createRuntime();
     const sendMessage = vi
       .fn()
-      .mockRejectedValueOnce(createWrappedPreConnectHttpError("sendMessage"))
+      .mockRejectedValueOnce(createWrappedConnectTimeoutHttpError("sendMessage"))
       .mockResolvedValueOnce({
         message_id: 12,
         chat: { id: "123" },

--- a/extensions/telegram/src/network-errors.test.ts
+++ b/extensions/telegram/src/network-errors.test.ts
@@ -239,7 +239,7 @@ describe("isSafeToRetrySendError", () => {
     ["ECONNRESET", "read ECONNRESET", false],
     ["ETIMEDOUT", "connect ETIMEDOUT", false],
     ["EPIPE", "write EPIPE", false],
-    ["UND_ERR_CONNECT_TIMEOUT", "connect timeout", false],
+    ["UND_ERR_CONNECT_TIMEOUT", "connect timeout", true],
   ])("returns %s => %s", (code, message, expected) => {
     expect(isSafeToRetrySendError(errorWithCode(message, code))).toBe(expected);
   });

--- a/extensions/telegram/src/network-errors.ts
+++ b/extensions/telegram/src/network-errors.ts
@@ -47,6 +47,7 @@ const PRE_CONNECT_ERROR_CODES = new Set([
   "ENETDOWN", // Local network interface is down before connect completes (never sent)
   "ENETUNREACH", // No route to host (never sent)
   "EHOSTUNREACH", // Host unreachable (never sent)
+  "UND_ERR_CONNECT_TIMEOUT", // TCP/TLS connect timeout (request never sent)
 ]);
 
 const RECOVERABLE_ERROR_NAMES = new Set([

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2401,11 +2401,12 @@ describe("sendMessageTelegram", () => {
     vi.useRealTimers();
   });
 
-  it("retries wrapped pre-connect HttpError sends", async () => {
+  it("retries wrapped Undici connect timeout sends", async () => {
     vi.useFakeTimers();
     const chatId = "123";
-    const root = Object.assign(new Error("connect ECONNREFUSED api.telegram.org"), {
-      code: "ECONNREFUSED",
+    const root = Object.assign(new Error("Connect Timeout Error"), {
+      name: "ConnectTimeoutError",
+      code: "UND_ERR_CONNECT_TIMEOUT",
     });
     const fetchError = Object.assign(new TypeError("fetch failed"), { cause: root });
     const err = Object.assign(new Error("Network request for 'sendMessage' failed!"), {


### PR DESCRIPTION
## What Problem This Solves

`isSafeToRetrySendError` guards non-idempotent `sendMessage` retries by checking only `PRE_CONNECT_ERROR_CODES` — errors that are guaranteed to have occurred *before* the request reached Telegram's servers. `UND_ERR_CONNECT_TIMEOUT` (undici's TCP/TLS connect timeout) was not in this set, so `sendMessage` would not retry when the connection timed out during the handshake.

This is inconsistent: `ECONNREFUSED`, `ENOTFOUND`, `ENETUNREACH`, and `EHOSTUNREACH` are all in `PRE_CONNECT_ERROR_CODES` because they fire before the connection is established. `UND_ERR_CONNECT_TIMEOUT` has the same property — it fires during TCP/TLS connect, before any HTTP request bytes are written to the socket — yet it was only in `RECOVERABLE_ERROR_CODES` (permissive, for idempotent operations).

## Why This Change Was Made

undici's connect timeout covers the TCP three-way handshake and TLS negotiation phases. The HTTP request data is only written after the connection is established. If the connect timer fires, no bytes were sent — meaning Telegram never received the message, and retrying is safe.

Adding `"UND_ERR_CONNECT_TIMEOUT"` to `PRE_CONNECT_ERROR_CODES` makes `isSafeToRetrySendError` consistent with its contract: retry only when the message was definitely not delivered.

| undici error code | Phase | Request sent? | Safe to retry sendMessage? |
|---|---|---|---|
| `UND_ERR_CONNECT_TIMEOUT` | TCP/TLS connect | ❌ | **Yes (FIX)** |
| `UND_ERR_HEADERS_TIMEOUT` | Response headers | ✅ | ❌ |
| `UND_ERR_BODY_TIMEOUT` | Response body | ✅ | ❌ |

## User Impact

`sendMessage` becomes more resilient on flaky networks — connection timeouts during the TCP/TLS handshake will be retried instead of failing the send. No risk of duplicate messages because the connect timeout guarantees no request data was transmitted.

## Evidence

Verified against commit `02892535` on branch `fix/telegram-pre-connect-undici-timeout`.

### Before (broken)

```
err=UND_ERR_CONNECT_TIMEOUT (never sent — should retry)
    isSafeToRetrySendError  => false FAIL
```

### After (fixed)

```
err=UND_ERR_CONNECT_TIMEOUT (never sent — should retry)
    isSafeToRetrySendError  => true  PASS
```

### Regression guard

```
err=UND_ERR_HEADERS_TIMEOUT (response headers — request already sent)
    isSafeToRetrySendError  => false PASS (unchanged)

err=UND_ERR_BODY_TIMEOUT (response body — request already sent)
    isSafeToRetrySendError  => false PASS (unchanged)

err=ECONNRESET (connection reset — ambiguous)
    isSafeToRetrySendError  => false PASS (unchanged)

err=ETIMEDOUT (ambiguous)
    isSafeToRetrySendError  => false PASS (unchanged)
```

## Tests and Validation

```
$ pnpm test extensions/telegram/src/network-errors.test.ts
Test Files  1 passed (1)
Tests       58 passed (58)
```

One assertion updated: `UND_ERR_CONNECT_TIMEOUT` now expects `true` for `isSafeToRetrySendError`, matching all other pre-connect error codes.

## Risk Checklist

- **User-visible behavior:** No — `sendMessage` retries on one additional error code that is guaranteed to fire before any data reaches Telegram.
- **Config/env/migration behavior:** No.
- **Security/auth/secrets/network/tool execution:** No.
- **Plugins/providers/channels/SDK:** No — internal to Telegram plugin.
- **Highest-risk area:** None. Adding a pre-connect error code to the pre-connect set is mechanically consistent. The undici error code is well-defined in Node.js internals.
- **Mitigation:** Existing tests (58) + updated regression assertion; all other undici error codes remain excluded from the pre-connect set.

Closes: N/A

## Maintainer Evidence

Verified exact head `d5a71be15d369fa3dfa3ce8dd59c81268d230c6e`.

- Inspected Undici 8.5.0 directly: its connector clears the timeout only after `connect` or `secureConnect`; `UND_ERR_CONNECT_TIMEOUT` destroys the socket before the connector callback exposes it to the HTTP dispatcher.
- Confirmed the shared predicate owns strict retries for durable sends, bot-delivery sends, and first-preview streaming. Headers/body/socket/reset failures remain excluded.
- Added caller-path regressions for nested grammY `HttpError` envelopes in both `sendMessageTelegram` and bot delivery.
- Exact-head secretless CI passed: https://github.com/openclaw/openclaw/actions/runs/28841353902
- Fresh Codex autoreview passed with no accepted/actionable findings.

A sanitized AWS Crabbox run reached the no-role bootstrap but the broker's `t3.small` fallback was OOM-killed during dependency installation, before tests; no test result is claimed from that run.
