### PR TITLE
refactor(ui): remove unused module exports

### DIFF
--- a/ui/config/control-ui-chunking.ts
+++ b/ui/config/control-ui-chunking.ts
@@ -3,7 +3,7 @@ export function normalizeModuleId(id: string): string {
   return id.replace(/\\/g, "/");
 }
 
-export function moduleIdIncludesPackage(id: string, packageName: string): boolean {
+function moduleIdIncludesPackage(id: string, packageName: string): boolean {
   const normalized = normalizeModuleId(id);
   return (
     normalized.includes(`/node_modules/${packageName}/`) ||

--- a/ui/src/app/exec-approval.ts
+++ b/ui/src/app/exec-approval.ts
@@ -200,7 +200,7 @@ export function parsePluginApprovalRequested(payload: unknown): ExecApprovalRequ
   };
 }
 
-export function pruneExecApprovalQueue(queue: ExecApprovalRequest[]): ExecApprovalRequest[] {
+function pruneExecApprovalQueue(queue: ExecApprovalRequest[]): ExecApprovalRequest[] {
   const now = Date.now();
   return queue.filter((entry) => entry.expiresAtMs > now);
 }

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -6,7 +6,7 @@ import { normalizeLowercaseStringOrEmpty } from "../lib/string-coerce.ts";
 import { matchesNodeSearch, parseConfigSearchQuery, renderNode } from "./config-form.node.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 
-export type ConfigFormProps = {
+type ConfigFormProps = {
   schema: JsonSchema | null;
   uiHints: ConfigUiHints;
   value: Record<string, unknown> | null;

--- a/ui/src/components/config-form.ts
+++ b/ui/src/components/config-form.ts
@@ -1,5 +1,5 @@
 // Control UI view renders config form screen content.
-export { renderConfigForm, type ConfigFormProps, SECTION_META } from "./config-form.render.ts";
+export { renderConfigForm, SECTION_META } from "./config-form.render.ts";
 export { analyzeConfigSchema, type ConfigSchemaAnalysis } from "./config-form.analyze.ts";
 export { renderNode } from "./config-form.node.ts";
 export { schemaType, type JsonSchema } from "./config-form.shared.ts";

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -38,7 +38,7 @@ export function formatUnknownText(
   return Object.prototype.toString.call(value);
 }
 
-export type UiTimeFormatPreference = "auto" | "12" | "24";
+type UiTimeFormatPreference = "auto" | "12" | "24";
 
 // Resolved `agents.defaults.timeFormat`, threaded in once at bootstrap. "auto"
 // (or unset) keeps the browser locale default so existing deployments render

--- a/ui/src/lib/overview-hints.node.test.ts
+++ b/ui/src/lib/overview-hints.node.test.ts
@@ -7,7 +7,6 @@ import {
   resolveAuthHintKind,
   resolvePairingHint,
   shouldShowInsecureContextHint,
-  shouldShowPairingHint,
 } from "./overview-hints.ts";
 
 afterEach(() => {
@@ -74,43 +73,31 @@ describe("resolveGatewayTokenForUrlEdit", () => {
   });
 });
 
-describe("shouldShowPairingHint", () => {
-  it("returns true for 'pairing required' close reason", () => {
-    expect(shouldShowPairingHint(false, "disconnected (1008): pairing required")).toBe(true);
-  });
-
-  it("matches case-insensitively", () => {
-    expect(shouldShowPairingHint(false, "Pairing Required")).toBe(true);
-  });
-
-  it("returns false when connected", () => {
-    expect(shouldShowPairingHint(true, "disconnected (1008): pairing required")).toBe(false);
-  });
-
-  it("returns false when lastError is null", () => {
-    expect(shouldShowPairingHint(false, null)).toBe(false);
-  });
-
-  it("returns false for unrelated errors", () => {
-    expect(shouldShowPairingHint(false, "disconnected (1006): no reason")).toBe(false);
-  });
-
-  it("returns false for auth errors", () => {
-    expect(shouldShowPairingHint(false, "disconnected (4008): unauthorized")).toBe(false);
-  });
-
-  it("returns true for structured pairing code", () => {
-    expect(
-      shouldShowPairingHint(
-        false,
-        "disconnected (4008): connect failed",
-        ConnectErrorDetailCodes.PAIRING_REQUIRED,
-      ),
-    ).toBe(true);
-  });
-});
-
 describe("resolvePairingHint", () => {
+  it.each([
+    ["close reason", "disconnected (1008): pairing required", undefined],
+    ["case-insensitive close reason", "Pairing Required", undefined],
+    [
+      "structured pairing code",
+      "disconnected (4008): connect failed",
+      ConnectErrorDetailCodes.PAIRING_REQUIRED,
+    ],
+  ])("detects pairing required from %s", (_name, lastError, lastErrorCode) => {
+    expect(resolvePairingHint(false, lastError, lastErrorCode)).toEqual({
+      kind: "pairing-required",
+      requestId: null,
+    });
+  });
+
+  it.each([
+    ["connected clients", true, "disconnected (1008): pairing required"],
+    ["missing errors", false, null],
+    ["unrelated errors", false, "disconnected (1006): no reason"],
+    ["auth errors", false, "disconnected (4008): unauthorized"],
+  ])("ignores %s", (_name, connected, lastError) => {
+    expect(resolvePairingHint(connected, lastError)).toBeNull();
+  });
+
   it("detects scope-upgrade pending approval and keeps the request id", () => {
     expect(
       resolvePairingHint(

--- a/ui/src/lib/overview-hints.ts
+++ b/ui/src/lib/overview-hints.ts
@@ -74,15 +74,6 @@ export function resolvePairingHint(
   return null;
 }
 
-/** Whether the overview should show device-pairing guidance for this error. */
-export function shouldShowPairingHint(
-  connected: boolean,
-  lastError: string | null,
-  lastErrorCode?: string | null,
-): boolean {
-  return resolvePairingHint(connected, lastError, lastErrorCode) !== null;
-}
-
 /**
  * Return the overview auth hint to show, if any.
  *

--- a/ui/src/lib/sessions/custom-groups.ts
+++ b/ui/src/lib/sessions/custom-groups.ts
@@ -3,7 +3,7 @@ import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { SessionCapability } from "./index.ts";
 import { parseAgentSessionKey } from "./session-key.ts";
 
-export const SESSION_CUSTOM_GROUPS_STORAGE_KEY = "openclaw:sessions:custom-groups";
+const SESSION_CUSTOM_GROUPS_STORAGE_KEY = "openclaw:sessions:custom-groups";
 
 export function loadStoredSessionCustomGroups(): string[] {
   try {

--- a/ui/src/lib/sessions/session-options.ts
+++ b/ui/src/lib/sessions/session-options.ts
@@ -23,7 +23,7 @@ type SessionAgentOptionsState = {
   sessionKey: string;
 };
 
-export type SessionAgentFilterOption = {
+type SessionAgentFilterOption = {
   id: string;
   label: string;
 };

--- a/ui/src/pages/chat/chat-queue.ts
+++ b/ui/src/pages/chat/chat-queue.ts
@@ -80,7 +80,7 @@ export function readChatQueueForSession(
     : (host.chatQueueBySession?.[sessionKey] ?? []);
 }
 
-export function writeChatQueueForSession(
+function writeChatQueueForSession(
   host: ChatQueueSessionHost,
   sessionKey: string,
   queue: ChatQueueItem[],

--- a/ui/src/pages/chat/chat-realtime.ts
+++ b/ui/src/pages/chat/chat-realtime.ts
@@ -59,7 +59,7 @@ export type ChatRealtimeState = {
   toggleRealtimeTalk: () => Promise<void>;
 };
 
-export function createDefaultRealtimeTalkOptions(): RealtimeTalkOptions {
+function createDefaultRealtimeTalkOptions(): RealtimeTalkOptions {
   return {
     model: "",
     voice: "",


### PR DESCRIPTION
## What Problem This Solves

The Control UI still exported several helpers and types that have no consumers outside their defining modules. One pairing-hint wrapper also duplicated the canonical resolver without adding behavior.

## Why This Change Was Made

Keep the UI module surface aligned with actual ownership:

- localize eight implementation-only symbols
- remove the unused `shouldShowPairingHint` wrapper
- exercise `resolvePairingHint` directly in the existing tests

This removes 22 net lines without changing runtime behavior.

## User Impact

No user-visible behavior change. The UI keeps the same pairing-hint decisions while exposing fewer internal symbols.

## Evidence

- rebased onto current `main` at `d86bb60fbadfb0ebe94d3e88c75c9de78e8e9307`
- codebase-memory graph refreshed after the rebase: 277,545 nodes / 1,098,333 edges
- fresh Codex autoreview: no accepted or actionable findings, 0.88 confidence
- current-main AWS Crabbox run `run_f4f6f907730c` on lease `cbx_59dd2f65386c`: all four typecheck lanes, core/extensions/scripts lint, app checks, import-cycle checks, and guard suites passed
- prior exact-patch AWS Crabbox run `run_6d2975fb12fa`: 8 targeted UI test files / 198 tests passed, plus scoped `core` and `coreTests` changed gates
- Android lint passed on the current production surface
- strict iOS Periphery baseline passed: https://github.com/openclaw/openclaw/actions/runs/28833919899
