### PR TITLE
fix: refresh gateway auth status after CLI auth writes

### DIFF
--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -54,6 +54,7 @@ const mocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(),
   loadValidConfigOrThrow: vi.fn(),
   updateConfig: vi.fn(),
+  callGateway: vi.fn(),
   logConfigUpdated: vi.fn(),
   openUrl: vi.fn(),
   isRemoteEnvironment: vi.fn(() => false),
@@ -153,6 +154,10 @@ vi.mock("./shared.js", async (importOriginal) => {
     updateConfig: mocks.updateConfig,
   };
 });
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: mocks.callGateway,
+}));
 
 vi.mock("../../config/logging.js", () => ({
   logConfigUpdated: mocks.logConfigUpdated,
@@ -389,6 +394,8 @@ describe("modelsAuthLoginCommand", () => {
         return lastUpdatedConfig;
       },
     );
+    mocks.callGateway.mockReset();
+    mocks.callGateway.mockResolvedValue({ ts: Date.now(), providers: [] });
     mocks.createClackPrompter.mockReturnValue({
       note: vi.fn(async () => {}),
       select: vi.fn(),
@@ -499,6 +506,23 @@ describe("modelsAuthLoginCommand", () => {
     );
     expect(runtime.log).toHaveBeenCalledWith(
       "Default model available: openai/gpt-5.5 (use --set-default to apply)",
+    );
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      config: currentConfig,
+      method: "models.authStatus",
+      params: { refresh: true },
+    });
+  });
+
+  it("keeps login successful when gateway model-auth refresh fails", async () => {
+    const runtime = createRuntime();
+    mocks.callGateway.mockRejectedValueOnce(new Error("gateway unreachable"));
+
+    await modelsAuthLoginCommand({ provider: "openai" }, runtime);
+
+    expect(runProviderAuth).toHaveBeenCalledOnce();
+    expect(runtime.log).toHaveBeenCalledWith(
+      "Saved auth profile openai:user@example.com (openai), but the running gateway did not refresh model auth status: gateway unreachable",
     );
   });
 
@@ -1342,6 +1366,11 @@ describe("modelsAuthLoginCommand", () => {
     expect(runtime.log).toHaveBeenCalledWith(
       "Anthropic staff told us this OpenClaw path is allowed again.",
     );
+    expect(mocks.callGateway).toHaveBeenCalledWith({
+      config: currentConfig,
+      method: "models.authStatus",
+      params: { refresh: true },
+    });
   });
 
   it("writes pasted tokens to the requested agent store", async () => {

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -41,6 +41,8 @@ import { parseDurationMs } from "../../cli/parse-duration.js";
 import { logConfigUpdated } from "../../config/logging.js";
 import { normalizeAgentModelRefForConfig } from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { callGateway } from "../../gateway/call.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { isRemoteEnvironment } from "../../infra/remote-env.js";
 import {
   applyProviderAuthConfigPatch,
@@ -594,6 +596,15 @@ async function runProviderAuthMethod(params: {
     setDefault: params.setDefault,
   });
 
+  const nextConfig = await loadValidConfigOrThrow();
+  const refreshedProfile = profiles[0];
+  await refreshRunningGatewayModelAuthStatus({
+    cfg: nextConfig,
+    runtime: params.runtime,
+    provider: normalizeProviderId(refreshedProfile?.credential.provider) || selectedProviderId,
+    profileId: refreshedProfile?.profileId ?? selectedProviderId,
+  });
+
   return { result, profiles };
 }
 
@@ -712,9 +723,16 @@ export async function modelsAuthPasteTokenCommand(
   });
 
   await updateConfig((cfg) => applyAuthProfileConfig(cfg, { profileId, provider, mode: "token" }));
+  const nextConfig = await loadValidConfigOrThrow();
 
   logConfigUpdated(runtime);
   runtime.log(`Auth profile: ${profileId} (${provider}/token)`);
+  await refreshRunningGatewayModelAuthStatus({
+    cfg: nextConfig,
+    runtime,
+    provider,
+    profileId,
+  });
   if (provider === "anthropic") {
     runtime.log("Anthropic setup-token auth is supported in OpenClaw.");
     runtime.log("OpenClaw prefers Claude CLI reuse when it is available on the host.");
@@ -770,9 +788,16 @@ export async function modelsAuthPasteApiKeyCommand(
   await updateConfig((cfg) =>
     applyAuthProfileConfig(cfg, { profileId, provider, mode: "api_key" }),
   );
+  const nextConfig = await loadValidConfigOrThrow();
 
   logConfigUpdated(runtime);
   runtime.log(`Auth profile: ${profileId} (${provider}/api_key)`);
+  await refreshRunningGatewayModelAuthStatus({
+    cfg: nextConfig,
+    runtime,
+    provider,
+    profileId,
+  });
 }
 
 async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
@@ -780,6 +805,25 @@ async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams)
   if (!updated) {
     throw new Error(
       "Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry.",
+    );
+  }
+}
+
+async function refreshRunningGatewayModelAuthStatus(params: {
+  cfg: OpenClawConfig;
+  runtime: RuntimeEnv;
+  provider: string;
+  profileId: string;
+}): Promise<void> {
+  try {
+    await callGateway({
+      config: params.cfg,
+      method: "models.authStatus",
+      params: { refresh: true },
+    });
+  } catch (error) {
+    params.runtime.log(
+      `Saved auth profile ${params.profileId} (${params.provider}), but the running gateway did not refresh model auth status: ${formatErrorMessage(error)}`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- refresh running gateway model auth status after CLI login/paste-token/paste-api-key writes auth
- keep auth writes successful when no gateway is reachable by logging a best-effort note instead
- cover the refresh call and non-fatal gateway failure in auth command tests

## What Problem This Solves
CLI auth writes were updating config and auth profile state, but a running Gateway could keep serving stale model-auth snapshots until a separate secrets reload. This patch triggers the existing `models.authStatus` refresh path immediately after successful CLI auth writes so the running process sees the new credentials without a manual reload.

## Evidence
- `pnpm vitest run src/commands/models/auth.test.ts src/gateway/server-methods/models-auth-status.test.ts`
- Added regression coverage for successful gateway refresh calls and non-fatal gateway-unreachable fallback after login/token/api-key auth writes

Fixes #101254