### PR TITLE
fix: retry signal session-init conflicts

### DIFF
--- a/extensions/signal/src/monitor/event-handler.session-init-retry.test.ts
+++ b/extensions/signal/src/monitor/event-handler.session-init-retry.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  sleepMock: vi.fn(async () => undefined),
+  logVerboseMock: vi.fn(),
+  runtimeErrorMock: vi.fn(),
+  dispatchInboundMessageMock: vi.fn(),
+  recordInboundSessionMock: vi.fn(async () => undefined),
+  sendTypingMock: vi.fn(async () => true),
+  sendReadReceiptMock: vi.fn(async () => true),
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/runtime-env")>(
+    "openclaw/plugin-sdk/runtime-env",
+  );
+  return {
+    ...actual,
+    sleep: hoisted.sleepMock,
+    logVerbose: hoisted.logVerboseMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/reply-runtime")>(
+    "openclaw/plugin-sdk/reply-runtime",
+  );
+  return {
+    ...actual,
+    dispatchInboundMessage: hoisted.dispatchInboundMessageMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/conversation-runtime")>(
+    "openclaw/plugin-sdk/conversation-runtime",
+  );
+  return {
+    ...actual,
+    recordInboundSession: hoisted.recordInboundSessionMock,
+    readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
+    upsertChannelPairingRequest: vi.fn(),
+  };
+});
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: vi.fn(),
+  sendTypingSignal: hoisted.sendTypingMock,
+  sendReadReceiptSignal: hoisted.sendReadReceiptMock,
+}));
+
+const [
+  { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
+  { createSignalEventHandler },
+] = await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
+
+describe("signal reply session initialization retry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.recordInboundSessionMock.mockResolvedValue(undefined);
+    hoisted.sleepMock.mockResolvedValue(undefined);
+    hoisted.dispatchInboundMessageMock
+      .mockRejectedValueOnce(
+        new Error(
+          "reply session initialization conflicted for agent:main:signal:direct:+15550001111",
+        ),
+      )
+      .mockResolvedValueOnce({ queuedFinal: false, counts: { tool: 0, block: 0, final: 1 } });
+  });
+
+  it("retries one Signal inbound turn after a reply session initialization conflict", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: { messages: { inbound: { debounceMs: 0 } } } as never,
+        historyLimit: 0,
+        runtime: {
+          log: vi.fn(),
+          error: hoisted.runtimeErrorMock,
+        } as never,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "hello again",
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(hoisted.dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+    expect(hoisted.sleepMock).toHaveBeenCalledWith(200);
+    expect(hoisted.logVerboseMock).toHaveBeenCalledWith(
+      "signal inbound retry after reply session initialization conflict (1/2) delay=200ms",
+    );
+    expect(hoisted.runtimeErrorMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("signal debounce flush failed"),
+    );
+  });
+});

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -107,6 +107,32 @@ function formatAttachmentSummaryPlaceholder(contentTypes: Array<string | undefin
   return `[${parts.join(" + ")} attached]`;
 }
 
+const SIGNAL_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS = [200, 500] as const;
+
+function isReplySessionInitializationConflict(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("reply session initialization conflicted");
+}
+
+async function runWithSignalSessionInitConflictRetry<T>(params: {
+  run: () => Promise<T>;
+}): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await params.run();
+    } catch (error) {
+      const delayMs = SIGNAL_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS[attempt];
+      if (!isReplySessionInitializationConflict(error) || delayMs === undefined) {
+        throw error;
+      }
+      logVerbose(
+        `signal inbound retry after reply session initialization conflict (${attempt + 1}/${SIGNAL_SESSION_INIT_CONFLICT_RETRY_DELAYS_MS.length}) delay=${delayMs}ms`,
+      );
+      await delay(delayMs);
+    }
+  }
+}
+
 function resolveSignalInboundRoute(params: {
   cfg: SignalEventHandlerDeps["cfg"];
   accountId: SignalEventHandlerDeps["accountId"];
@@ -655,29 +681,33 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       if (!last) {
         return;
       }
-      if (entries.length === 1) {
-        await handleSignalInboundMessage(last);
-        return;
-      }
-      const combinedText = entries
-        .map((entry) => entry.bodyText)
-        .filter(Boolean)
-        .join("\\n");
-      const combinedCommandBody = entries
-        .map((entry) => entry.commandBody)
-        .filter(Boolean)
-        .join("\\n");
-      if (!combinedText.trim()) {
-        return;
-      }
-      await handleSignalInboundMessage({
-        ...last,
-        bodyText: combinedText,
-        commandBody: combinedCommandBody,
-        mediaPath: undefined,
-        mediaType: undefined,
-        mediaPaths: undefined,
-        mediaTypes: undefined,
+      await runWithSignalSessionInitConflictRetry({
+        run: async () => {
+          if (entries.length === 1) {
+            await handleSignalInboundMessage(last);
+            return;
+          }
+          const combinedText = entries
+            .map((entry) => entry.bodyText)
+            .filter(Boolean)
+            .join("\\n");
+          const combinedCommandBody = entries
+            .map((entry) => entry.commandBody)
+            .filter(Boolean)
+            .join("\\n");
+          if (!combinedText.trim()) {
+            return;
+          }
+          await handleSignalInboundMessage({
+            ...last,
+            bodyText: combinedText,
+            commandBody: combinedCommandBody,
+            mediaPath: undefined,
+            mediaType: undefined,
+            mediaPaths: undefined,
+            mediaTypes: undefined,
+          });
+        },
       });
     },
     onError: (err) => {


### PR DESCRIPTION
## Summary
- retry Signal debounce flushes when reply session initialization conflicts with a just-finished turn
- bound the retry loop with short backoff delays and keep non-conflict failures unchanged
- add a focused regression test for the conflict-then-success path plus adjacent Signal coverage

## What Problem This Solves
A follow-up Signal DM that arrives right after the previous reply turn can hit `reply session initialization conflicted` during the debounce flush path and get dropped after a single logged failure. This patch adds a small bounded retry with backoff so the next flush attempt can reuse the just-finished session state instead of silently losing the message.

## Evidence
- `pnpm vitest run extensions/signal/src/monitor/event-handler.session-init-retry.test.ts extensions/signal/src/monitor/event-handler.inbound-context.test.ts`
- `pnpm vitest run extensions/signal/src/monitor/event-handler.silent-ingest.test.ts`
- Added regression coverage for conflict-once-then-success dispatch behavior

Fixes #100944