### PR TITLE
fix(proxy-capture): guard body-less arrayBuffer reads against oversized responses

### DIFF
--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -1,5 +1,4 @@
 // Proxy capture runtime tests cover session creation and capture lifecycle.
-import { Buffer } from "node:buffer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
@@ -9,7 +8,6 @@ import {
   captureWsEvent,
   finalizeDebugProxyCapture,
   initializeDebugProxyCapture,
-  readCapturedResponseBodyBounded,
   type DebugProxyCaptureRuntimeDeps,
 } from "./runtime.js";
 
@@ -530,6 +528,62 @@ describe("debug proxy runtime", () => {
     expect(events.some((event) => event.kind === "error")).toBe(false);
   });
 
+  it("captures a spec-compliant null response body as empty", async () => {
+    initializeDebugProxyCapture("test", settings, deps);
+    captureHttpExchange(
+      {
+        url: "https://api.example.test/no-content",
+        method: "HEAD",
+        response: new Response(null, { status: 204 }),
+      },
+      settings,
+      deps,
+    );
+    await waitForResponseSettled();
+    finalizeDebugProxyCapture(settings, deps);
+
+    const response = events.find((event) => event.kind === "response");
+    expect(response?.status).toBe(204);
+    expect(response?.dataText).toBe("");
+    expect(response?.metaJson).toBeUndefined();
+    expect(events.some((event) => event.kind === "error")).toBe(false);
+  });
+
+  it.each([undefined, "invalid", "1"])(
+    "fails closed on a streamless Response-like body with content-length %s",
+    async (contentLength) => {
+      initializeDebugProxyCapture("test", settings, deps);
+      const headers = new Headers(
+        contentLength === undefined ? undefined : { "content-length": contentLength },
+      );
+      const arrayBuffer = vi.fn(async () => new Uint8Array(32 * ONE_MIB).buffer);
+      captureHttpExchange(
+        {
+          url: "https://api.example.test/streamless",
+          method: "GET",
+          response: {
+            status: 200,
+            headers,
+            arrayBuffer,
+            clone: () => ({ body: null, headers, arrayBuffer }),
+          } as unknown as Response,
+        },
+        settings,
+        deps,
+      );
+      await waitForResponseSettled();
+      finalizeDebugProxyCapture(settings, deps);
+
+      const response = events.find((event) => event.kind === "response");
+      expect(JSON.parse(String(response?.metaJson))).toMatchObject({
+        bodyCapture: "unavailable",
+      });
+      expect(response).not.toHaveProperty("dataText");
+      expect(arrayBuffer).not.toHaveBeenCalled();
+      expect(events.some((event) => event.kind === "error")).toBe(false);
+    },
+  );
+
   it("records metadata-only for non-cloneable Response-like objects", async () => {
     initializeDebugProxyCapture("test", settings, deps);
     // Some seams hand capture a Response-like object that cannot be cloned. It
@@ -577,138 +631,5 @@ describe("debug proxy runtime", () => {
     expect(response?.status).toBe(204);
     expect(response?.contentType).toBeUndefined();
     expect(JSON.parse(String(response?.metaJson))).toMatchObject({ bodyCapture: "unavailable" });
-  });
-});
-
-describe("readCapturedResponseBodyBounded", () => {
-  it("skips body read when content-length exceeds cap (body-less fallback)", async () => {
-    // Force the !body fallback with a mock clone so the content-length
-    // precheck, not the streaming path, rejects the oversized body.
-    // A real Response clone exposes body.getReader in Node 24 and would
-    // enter the streaming branch, never testing this guard.
-    const largeSize = 5 * 1024 * 1024;
-    const arrayBufferSpy = vi.fn();
-    const mockClone = {
-      headers: new Headers({ "content-length": String(largeSize) }),
-      body: null,
-      arrayBuffer: arrayBufferSpy,
-    };
-    const response = {
-      clone: () => mockClone,
-    } as unknown as Response;
-    const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 1024);
-    expect(truncated).toBe(true);
-    expect(buffer.length).toBe(0);
-    expect(arrayBufferSpy).not.toHaveBeenCalled();
-  });
-
-  it("skips body read when content-length is a huge non-safe integer (body-less fallback)", async () => {
-    // Very long digit-only Content-Length values overflow Number parsing and
-    // would bypass a naive Number.isFinite guard, still calling arrayBuffer().
-    const arrayBufferSpy = vi.fn();
-    const mockClone = {
-      headers: new Headers({ "content-length": "9".repeat(100) }),
-      body: null,
-      arrayBuffer: arrayBufferSpy,
-    };
-    const response = {
-      clone: () => mockClone,
-    } as unknown as Response;
-    const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 1024);
-    expect(truncated).toBe(true);
-    expect(buffer.length).toBe(0);
-    expect(arrayBufferSpy).not.toHaveBeenCalled();
-  });
-
-  it("reads body via fallback when content-length is zero-padded under the cap", async () => {
-    // Padding can make the raw header wider than MAX_SAFE_INTEGER's digit
-    // count while still declaring a small under-cap length. Normalize zeroes
-    // before the width guard so capture still reads the body.
-    const body = Buffer.from("padded");
-    const arrayBufferSpy = vi
-      .fn()
-      .mockResolvedValue(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength));
-    const paddedLength = `${"0".repeat(20)}${body.length}`;
-    expect(paddedLength.length).toBeGreaterThan(String(Number.MAX_SAFE_INTEGER).length);
-    const mockClone = {
-      headers: new Headers({ "content-length": paddedLength }),
-      body: null,
-      arrayBuffer: arrayBufferSpy,
-    };
-    const response = {
-      clone: () => mockClone,
-    } as unknown as Response;
-    const result = await readCapturedResponseBodyBounded(response, 1024);
-    expect(result.truncated).toBe(false);
-    expect(result.buffer.equals(body)).toBe(true);
-    expect(arrayBufferSpy).toHaveBeenCalledOnce();
-  });
-
-  it("reads body via fallback when content-length is within cap", async () => {
-    // Body-less path with a declared length under the cap: must call
-    // arrayBuffer() and return the body.
-    const body = Buffer.from("small");
-    const arrayBufferSpy = vi
-      .fn()
-      .mockResolvedValue(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength));
-    const mockClone = {
-      headers: new Headers({ "content-length": String(body.length) }),
-      body: null,
-      arrayBuffer: arrayBufferSpy,
-    };
-    const response = {
-      clone: () => mockClone,
-    } as unknown as Response;
-    const result = await readCapturedResponseBodyBounded(response, 1024);
-    expect(result.truncated).toBe(false);
-    expect(result.buffer.equals(body)).toBe(true);
-    expect(arrayBufferSpy).toHaveBeenCalledOnce();
-  });
-
-  it("reads body via fallback when content-length is missing (within cap)", async () => {
-    // Body-less path without a content-length header: must fall through
-    // to arrayBuffer() and check the actual byte length.
-    const body = Buffer.from("no length header");
-    const arrayBufferSpy = vi
-      .fn()
-      .mockResolvedValue(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength));
-    const mockClone = {
-      headers: new Headers(),
-      body: null,
-      arrayBuffer: arrayBufferSpy,
-    };
-    const response = {
-      clone: () => mockClone,
-    } as unknown as Response;
-    const result = await readCapturedResponseBodyBounded(response, 4096);
-    expect(result.truncated).toBe(false);
-    expect(result.buffer.equals(body)).toBe(true);
-    expect(arrayBufferSpy).toHaveBeenCalledOnce();
-  });
-
-  it("reads body when content-length is within cap", async () => {
-    const body = Buffer.from("small");
-    const response = new Response(body, {
-      headers: { "content-length": String(body.length) },
-    });
-    const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 1024);
-    expect(truncated).toBe(false);
-    expect(buffer.equals(body)).toBe(true);
-  });
-
-  it("reads body when content-length is missing (within cap)", async () => {
-    const body = Buffer.from("no length header");
-    const response = new Response(body);
-    const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 4096);
-    expect(truncated).toBe(false);
-    expect(buffer.equals(body)).toBe(true);
-  });
-
-  it("handles stream body (regression guard)", async () => {
-    const data = new Uint8Array(100).fill(97);
-    const response = new Response(new Blob([data]).stream());
-    const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 200);
-    expect(truncated).toBe(false);
-    expect(buffer.length).toBe(100);
   });
 });

--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -620,6 +620,30 @@ describe("readCapturedResponseBodyBounded", () => {
     expect(arrayBufferSpy).not.toHaveBeenCalled();
   });
 
+  it("reads body via fallback when content-length is zero-padded under the cap", async () => {
+    // Padding can make the raw header wider than MAX_SAFE_INTEGER's digit
+    // count while still declaring a small under-cap length. Normalize zeroes
+    // before the width guard so capture still reads the body.
+    const body = Buffer.from("padded");
+    const arrayBufferSpy = vi
+      .fn()
+      .mockResolvedValue(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength));
+    const paddedLength = `${"0".repeat(20)}${body.length}`;
+    expect(paddedLength.length).toBeGreaterThan(String(Number.MAX_SAFE_INTEGER).length);
+    const mockClone = {
+      headers: new Headers({ "content-length": paddedLength }),
+      body: null,
+      arrayBuffer: arrayBufferSpy,
+    };
+    const response = {
+      clone: () => mockClone,
+    } as unknown as Response;
+    const result = await readCapturedResponseBodyBounded(response, 1024);
+    expect(result.truncated).toBe(false);
+    expect(result.buffer.equals(body)).toBe(true);
+    expect(arrayBufferSpy).toHaveBeenCalledOnce();
+  });
+
   it("reads body via fallback when content-length is within cap", async () => {
     // Body-less path with a declared length under the cap: must call
     // arrayBuffer() and return the body.

--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -1,4 +1,5 @@
 // Proxy capture runtime tests cover session creation and capture lifecycle.
+import { Buffer } from "node:buffer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
@@ -8,6 +9,7 @@ import {
   captureWsEvent,
   finalizeDebugProxyCapture,
   initializeDebugProxyCapture,
+  readCapturedResponseBodyBounded,
   type DebugProxyCaptureRuntimeDeps,
 } from "./runtime.js";
 
@@ -575,5 +577,43 @@ describe("debug proxy runtime", () => {
     expect(response?.status).toBe(204);
     expect(response?.contentType).toBeUndefined();
     expect(JSON.parse(String(response?.metaJson))).toMatchObject({ bodyCapture: "unavailable" });
+  });
+});
+
+describe("readCapturedResponseBodyBounded", () => {
+  it("skips body read when content-length exceeds cap", async () => {
+    const large = Buffer.alloc(5 * 1024 * 1024, 0x61);
+    const response = new Response(large, {
+      headers: { "content-length": String(large.length) },
+    });
+    const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 1024);
+    expect(truncated).toBe(true);
+    expect(buffer.length).toBe(0);
+  });
+
+  it("reads body when content-length is within cap", async () => {
+    const body = Buffer.from("small");
+    const response = new Response(body, {
+      headers: { "content-length": String(body.length) },
+    });
+    const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 1024);
+    expect(truncated).toBe(false);
+    expect(buffer.equals(body)).toBe(true);
+  });
+
+  it("reads body when content-length is missing (within cap)", async () => {
+    const body = Buffer.from("no length header");
+    const response = new Response(body);
+    const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 4096);
+    expect(truncated).toBe(false);
+    expect(buffer.equals(body)).toBe(true);
+  });
+
+  it("handles stream body (regression guard)", async () => {
+    const data = new Uint8Array(100).fill(97);
+    const response = new Response(new Blob([data]).stream());
+    const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 200);
+    expect(truncated).toBe(false);
+    expect(buffer.length).toBe(100);
   });
 });

--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -602,6 +602,24 @@ describe("readCapturedResponseBodyBounded", () => {
     expect(arrayBufferSpy).not.toHaveBeenCalled();
   });
 
+  it("skips body read when content-length is a huge non-safe integer (body-less fallback)", async () => {
+    // Very long digit-only Content-Length values overflow Number parsing and
+    // would bypass a naive Number.isFinite guard, still calling arrayBuffer().
+    const arrayBufferSpy = vi.fn();
+    const mockClone = {
+      headers: new Headers({ "content-length": "9".repeat(100) }),
+      body: null,
+      arrayBuffer: arrayBufferSpy,
+    };
+    const response = {
+      clone: () => mockClone,
+    } as unknown as Response;
+    const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 1024);
+    expect(truncated).toBe(true);
+    expect(buffer.length).toBe(0);
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+  });
+
   it("reads body via fallback when content-length is within cap", async () => {
     // Body-less path with a declared length under the cap: must call
     // arrayBuffer() and return the body.

--- a/src/proxy-capture/runtime.test.ts
+++ b/src/proxy-capture/runtime.test.ts
@@ -581,14 +581,67 @@ describe("debug proxy runtime", () => {
 });
 
 describe("readCapturedResponseBodyBounded", () => {
-  it("skips body read when content-length exceeds cap", async () => {
-    const large = Buffer.alloc(5 * 1024 * 1024, 0x61);
-    const response = new Response(large, {
-      headers: { "content-length": String(large.length) },
-    });
+  it("skips body read when content-length exceeds cap (body-less fallback)", async () => {
+    // Force the !body fallback with a mock clone so the content-length
+    // precheck, not the streaming path, rejects the oversized body.
+    // A real Response clone exposes body.getReader in Node 24 and would
+    // enter the streaming branch, never testing this guard.
+    const largeSize = 5 * 1024 * 1024;
+    const arrayBufferSpy = vi.fn();
+    const mockClone = {
+      headers: new Headers({ "content-length": String(largeSize) }),
+      body: null,
+      arrayBuffer: arrayBufferSpy,
+    };
+    const response = {
+      clone: () => mockClone,
+    } as unknown as Response;
     const { buffer, truncated } = await readCapturedResponseBodyBounded(response, 1024);
     expect(truncated).toBe(true);
     expect(buffer.length).toBe(0);
+    expect(arrayBufferSpy).not.toHaveBeenCalled();
+  });
+
+  it("reads body via fallback when content-length is within cap", async () => {
+    // Body-less path with a declared length under the cap: must call
+    // arrayBuffer() and return the body.
+    const body = Buffer.from("small");
+    const arrayBufferSpy = vi
+      .fn()
+      .mockResolvedValue(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength));
+    const mockClone = {
+      headers: new Headers({ "content-length": String(body.length) }),
+      body: null,
+      arrayBuffer: arrayBufferSpy,
+    };
+    const response = {
+      clone: () => mockClone,
+    } as unknown as Response;
+    const result = await readCapturedResponseBodyBounded(response, 1024);
+    expect(result.truncated).toBe(false);
+    expect(result.buffer.equals(body)).toBe(true);
+    expect(arrayBufferSpy).toHaveBeenCalledOnce();
+  });
+
+  it("reads body via fallback when content-length is missing (within cap)", async () => {
+    // Body-less path without a content-length header: must fall through
+    // to arrayBuffer() and check the actual byte length.
+    const body = Buffer.from("no length header");
+    const arrayBufferSpy = vi
+      .fn()
+      .mockResolvedValue(body.buffer.slice(body.byteOffset, body.byteOffset + body.byteLength));
+    const mockClone = {
+      headers: new Headers(),
+      body: null,
+      arrayBuffer: arrayBufferSpy,
+    };
+    const response = {
+      clone: () => mockClone,
+    } as unknown as Response;
+    const result = await readCapturedResponseBodyBounded(response, 4096);
+    expect(result.truncated).toBe(false);
+    expect(result.buffer.equals(body)).toBe(true);
+    expect(arrayBufferSpy).toHaveBeenCalledOnce();
   });
 
   it("reads body when content-length is within cap", async () => {

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -30,6 +30,30 @@ const REDACTED_CAPTURE_BINARY_PAYLOAD = Buffer.from("[REDACTED BINARY PAYLOAD]",
 // response would otherwise be buffered fully into memory just to record it.
 const MAX_CAPTURED_RESPONSE_BODY_BYTES = 16 * 1024 * 1024;
 
+function declaredContentLengthExceedsCap(headers: Headers, maxBytes: number): boolean {
+  const raw = headers.get("content-length");
+  if (!raw) {
+    return false;
+  }
+  const trimmed = raw.trim();
+  // Only accept plain digit strings; reject scientific notation, decimals,
+  // signs, or non-numeric values. Those are treated as unknown length and
+  // verified after the actual arrayBuffer() read.
+  if (!/^\d+$/u.test(trimmed)) {
+    return false;
+  }
+  // Any digit-only value with more digits than MAX_SAFE_INTEGER is definitely
+  // above the cap and cannot be safely represented as a Number.
+  if (trimmed.length > String(Number.MAX_SAFE_INTEGER).length) {
+    return true;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isSafeInteger(parsed)) {
+    return true;
+  }
+  return parsed > maxBytes;
+}
+
 // Reads a cloned capture response body under a byte cap. Returns truncated=true
 // (and discards the partial buffer) once the cap is exceeded so oversized or
 // hostile/endless bodies are recorded as metadata-only instead of buffered.
@@ -51,8 +75,7 @@ export async function readCapturedResponseBodyBounded(
     // body before allocating through arrayBuffer(). The stream path above
     // cancels on overflow; this path must pre-check content-length then
     // still verify the full read stayed within the cap.
-    const declaredLength = Number(clone.headers.get("content-length"));
-    if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    if (declaredContentLengthExceedsCap(clone.headers, maxBytes)) {
       return { buffer: Buffer.alloc(0), truncated: true };
     }
     const bytes = Buffer.from(await clone.arrayBuffer());

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -40,14 +40,21 @@ const MAX_CAPTURED_RESPONSE_BODY_BYTES = 16 * 1024 * 1024;
 // settles (it only resolves once BOTH branches cancel). Awaiting it would hang
 // the capture pipeline and retain the buffered prefix forever, so we cancel
 // fire-and-forget, mirroring src/agents/tools/web-shared.ts#readResponseText.
-async function readCapturedResponseBodyBounded(
+export async function readCapturedResponseBodyBounded(
   response: Response,
   maxBytes: number,
 ): Promise<{ buffer: Buffer; truncated: boolean }> {
   const clone = response.clone();
   const body = (clone as unknown as { body?: ReadableStream<Uint8Array> | null }).body;
   if (!body || typeof body.getReader !== "function") {
-    // Non-streaming clone (e.g. test doubles): bounded arrayBuffer fallback.
+    // Non-streaming clone (e.g. test doubles): guard against an oversized
+    // body before allocating through arrayBuffer(). The stream path above
+    // cancels on overflow; this path must pre-check content-length then
+    // still verify the full read stayed within the cap.
+    const declaredLength = Number(clone.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+      return { buffer: Buffer.alloc(0), truncated: true };
+    }
     const bytes = Buffer.from(await clone.arrayBuffer());
     return bytes.length > maxBytes
       ? { buffer: Buffer.alloc(0), truncated: true }

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -42,12 +42,15 @@ function declaredContentLengthExceedsCap(headers: Headers, maxBytes: number): bo
   if (!/^\d+$/u.test(trimmed)) {
     return false;
   }
+  // Strip leading zeroes before the digit-count guard so values like
+  // "000…001" are not treated as oversized solely due to padding width.
+  const normalized = trimmed.replace(/^0+/u, "") || "0";
   // Any digit-only value with more digits than MAX_SAFE_INTEGER is definitely
   // above the cap and cannot be safely represented as a Number.
-  if (trimmed.length > String(Number.MAX_SAFE_INTEGER).length) {
+  if (normalized.length > String(Number.MAX_SAFE_INTEGER).length) {
     return true;
   }
-  const parsed = Number.parseInt(trimmed, 10);
+  const parsed = Number.parseInt(normalized, 10);
   if (!Number.isSafeInteger(parsed)) {
     return true;
   }

--- a/src/proxy-capture/runtime.ts
+++ b/src/proxy-capture/runtime.ts
@@ -30,36 +30,13 @@ const REDACTED_CAPTURE_BINARY_PAYLOAD = Buffer.from("[REDACTED BINARY PAYLOAD]",
 // response would otherwise be buffered fully into memory just to record it.
 const MAX_CAPTURED_RESPONSE_BODY_BYTES = 16 * 1024 * 1024;
 
-function declaredContentLengthExceedsCap(headers: Headers, maxBytes: number): boolean {
-  const raw = headers.get("content-length");
-  if (!raw) {
-    return false;
-  }
-  const trimmed = raw.trim();
-  // Only accept plain digit strings; reject scientific notation, decimals,
-  // signs, or non-numeric values. Those are treated as unknown length and
-  // verified after the actual arrayBuffer() read.
-  if (!/^\d+$/u.test(trimmed)) {
-    return false;
-  }
-  // Strip leading zeroes before the digit-count guard so values like
-  // "000…001" are not treated as oversized solely due to padding width.
-  const normalized = trimmed.replace(/^0+/u, "") || "0";
-  // Any digit-only value with more digits than MAX_SAFE_INTEGER is definitely
-  // above the cap and cannot be safely represented as a Number.
-  if (normalized.length > String(Number.MAX_SAFE_INTEGER).length) {
-    return true;
-  }
-  const parsed = Number.parseInt(normalized, 10);
-  if (!Number.isSafeInteger(parsed)) {
-    return true;
-  }
-  return parsed > maxBytes;
-}
+type CapturedResponseBodyResult =
+  | { status: "captured"; buffer: Buffer }
+  | { status: "too-large" | "unavailable" };
 
-// Reads a cloned capture response body under a byte cap. Returns truncated=true
-// (and discards the partial buffer) once the cap is exceeded so oversized or
-// hostile/endless bodies are recorded as metadata-only instead of buffered.
+// Reads a cloned capture response body under a byte cap. Oversized or
+// non-streaming Response-like bodies return a metadata-only status instead of
+// allocating the full body.
 //
 // Unlike media-core's readResponseWithLimit this never awaits reader.cancel():
 // the body here is one branch of a Response.clone() tee whose sibling (the
@@ -67,24 +44,18 @@ function declaredContentLengthExceedsCap(headers: Headers, maxBytes: number): bo
 // settles (it only resolves once BOTH branches cancel). Awaiting it would hang
 // the capture pipeline and retain the buffered prefix forever, so we cancel
 // fire-and-forget, mirroring src/agents/tools/web-shared.ts#readResponseText.
-export async function readCapturedResponseBodyBounded(
+async function readCapturedResponseBodyBounded(
   response: Response,
   maxBytes: number,
-): Promise<{ buffer: Buffer; truncated: boolean }> {
+): Promise<CapturedResponseBodyResult> {
   const clone = response.clone();
   const body = (clone as unknown as { body?: ReadableStream<Uint8Array> | null }).body;
   if (!body || typeof body.getReader !== "function") {
-    // Non-streaming clone (e.g. test doubles): guard against an oversized
-    // body before allocating through arrayBuffer(). The stream path above
-    // cancels on overflow; this path must pre-check content-length then
-    // still verify the full read stayed within the cap.
-    if (declaredContentLengthExceedsCap(clone.headers, maxBytes)) {
-      return { buffer: Buffer.alloc(0), truncated: true };
-    }
-    const bytes = Buffer.from(await clone.arrayBuffer());
-    return bytes.length > maxBytes
-      ? { buffer: Buffer.alloc(0), truncated: true }
-      : { buffer: bytes, truncated: false };
+    // A real null-body Response consumes as empty. Response-like objects without
+    // a stream cannot be read under a byte cap, so never call arrayBuffer().
+    return clone instanceof Response && clone.body === null
+      ? { status: "captured", buffer: Buffer.alloc(0) }
+      : { status: "unavailable" };
   }
   const reader = body.getReader();
   const chunks: Buffer[] = [];
@@ -117,8 +88,8 @@ export async function readCapturedResponseBodyBounded(
     }
   }
   return truncated
-    ? { buffer: Buffer.alloc(0), truncated: true }
-    : { buffer: Buffer.concat(chunks, total), truncated: false };
+    ? { status: "too-large" }
+    : { status: "captured", buffer: Buffer.concat(chunks, total) };
 }
 const SENSITIVE_CAPTURE_HEADER_NAMES = new Set([
   "authorization",
@@ -618,16 +589,15 @@ export function captureHttpExchange(
     return;
   }
   void readCapturedResponseBodyBounded(params.response, MAX_CAPTURED_RESPONSE_BODY_BYTES)
-    .then(({ buffer, truncated }) => {
-      if (truncated) {
-        // Body exceeded the cap mid-stream (chunked / understated length). The
-        // bounded reader already cancelled the clone and discarded the partial
-        // buffer; record metadata only instead of persisting an oversized blob.
-        recordResponseMetadataOnly("too-large");
+    .then((result) => {
+      if (result.status !== "captured") {
+        // The body either exceeded the cap or offered no bounded streaming path.
+        // Preserve the exchange as metadata instead of allocating the whole body.
+        recordResponseMetadataOnly(result.status);
         return;
       }
       const responsePayload = runtime.persistEventPayload(store, {
-        data: redactCapturePayload(buffer),
+        data: redactCapturePayload(result.buffer),
         contentType: responseContentType,
       });
       store.recordEvent({


### PR DESCRIPTION
## Summary

- remove the unbounded `arrayBuffer()` fallback from debug proxy response capture
- preserve empty capture for real Fetch responses whose body is genuinely null
- record streamless Response-like bodies as unavailable without trusting `Content-Length`

## What Problem This Solves

The bounded proxy-capture reader still called `arrayBuffer()` when a clone did not expose a readable stream. That allocates the complete body before its size can be checked. A declared `Content-Length` precheck cannot uphold the byte cap when the header is missing, malformed, or understated.

## Solution

The reader now returns a typed outcome: captured, too large, or unavailable. Real null-body `Response` objects are safely captured as empty. Nonstandard Response-like clones without a readable stream fail closed as metadata-only and never call `arrayBuffer()`.

This is a pure bug fix. No config, API, or capability surface changes.

## Evidence

Head: `1a36e9dd7d25`

- `node scripts/run-vitest.mjs src/proxy-capture/runtime.test.ts --reporter=verbose` — 22/22 passed.
- `node scripts/check-changed.mjs -- src/proxy-capture/runtime.ts src/proxy-capture/runtime.test.ts` — passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/29533459876
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no findings, confidence 0.93.
- Loopback Node fetch proof showed a GET clone exposes a readable stream while a HEAD clone has a null body and consumes to zero bytes.

## Dependency contract

Undici 8.5.0 exposes non-null response bodies as readable streams, preserves null bodies across `Response.clone()`, and resolves body mixins for a null body with an empty byte sequence. The implementation now follows that contract and fails closed for nonstandard Response-like objects.
