### PR TITLE
fix: keep owner tools available in WebChat

### DIFF
--- a/src/agents/agent-tools-agent-config.test.ts
+++ b/src/agents/agent-tools-agent-config.test.ts
@@ -479,6 +479,32 @@ describe("Agent-specific tool filtering", () => {
     expect(names).not.toContain("process");
   });
 
+  it("keeps core tools for owner WebChat while restricting non-owners", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        toolsBySender: {
+          "*": { deny: ["exec", "process"] },
+        },
+      },
+    };
+    const createWebChatTools = (senderIsOwner: boolean) =>
+      createOpenClawCodingTools({
+        config: cfg,
+        messageProvider: "webchat",
+        senderIsOwner,
+        workspaceDir: "/tmp/test-webchat-owner-policy",
+        agentDir: "/tmp/agent-webchat-owner-policy",
+      }).map((tool) => tool.name);
+
+    const ownerTools = createWebChatTools(true);
+    const nonOwnerTools = createWebChatTools(false);
+
+    expect(ownerTools).toContain("exec");
+    expect(ownerTools).toContain("process");
+    expect(nonOwnerTools).not.toContain("exec");
+    expect(nonOwnerTools).not.toContain("process");
+  });
+
   it("should let agent per-sender policy override global sender wildcard", () => {
     const cfg: OpenClawConfig = {
       tools: {

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import { resolveConversationCapabilityProfile } from "./conversation-capability-profile.js";
 
 describe("resolveConversationCapabilityProfile", () => {
@@ -48,6 +49,46 @@ describe("resolveConversationCapabilityProfile", () => {
       instructionRoot: "/tmp/openclaw-agent-direct-profile",
     });
     expect(profile.skills.snapshot?.skills).toEqual([{ name: "ops" }]);
+  });
+
+  it("exempts owner WebChat from wildcard sender tool restrictions", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        toolsBySender: {
+          "*": { deny: ["exec", "process"] },
+        },
+      },
+    };
+
+    const profile = resolveConversationCapabilityProfile({
+      config: cfg,
+      messageProvider: INTERNAL_MESSAGE_CHANNEL,
+      chatType: "direct",
+      senderIsOwner: true,
+    });
+
+    expect(profile.policy.senderPolicy).toBeUndefined();
+    expect(profile.policy.explicitToolDenylist).toEqual([]);
+  });
+
+  it("keeps wildcard sender tool restrictions for owners on external channels", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        toolsBySender: {
+          "*": { deny: ["exec", "process"] },
+        },
+      },
+    };
+
+    const profile = resolveConversationCapabilityProfile({
+      config: cfg,
+      messageProvider: "discord",
+      chatType: "direct",
+      senderIsOwner: true,
+    });
+
+    expect(profile.policy.senderPolicy).toEqual({ deny: ["exec", "process"] });
+    expect(profile.policy.explicitToolDenylist).toEqual(["exec", "process"]);
   });
 
   it("prepares a shared conversation profile with group per-sender restrictions", () => {

--- a/src/agents/conversation-capability-profile.test.ts
+++ b/src/agents/conversation-capability-profile.test.ts
@@ -71,6 +71,46 @@ describe("resolveConversationCapabilityProfile", () => {
     expect(profile.policy.explicitToolDenylist).toEqual([]);
   });
 
+  it("exempts owner WebChat identified through the message channel", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        toolsBySender: {
+          "*": { deny: ["exec", "process"] },
+        },
+      },
+    };
+
+    const profile = resolveConversationCapabilityProfile({
+      config: cfg,
+      messageChannel: INTERNAL_MESSAGE_CHANNEL,
+      chatType: "direct",
+      senderIsOwner: true,
+    });
+
+    expect(profile.policy.senderPolicy).toBeUndefined();
+    expect(profile.policy.explicitToolDenylist).toEqual([]);
+  });
+
+  it("keeps wildcard sender tool restrictions for non-owner WebChat", () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        toolsBySender: {
+          "*": { deny: ["exec", "process"] },
+        },
+      },
+    };
+
+    const profile = resolveConversationCapabilityProfile({
+      config: cfg,
+      messageProvider: INTERNAL_MESSAGE_CHANNEL,
+      chatType: "direct",
+      senderIsOwner: false,
+    });
+
+    expect(profile.policy.senderPolicy).toEqual({ deny: ["exec", "process"] });
+    expect(profile.policy.explicitToolDenylist).toEqual(["exec", "process"]);
+  });
+
   it("keeps wildcard sender tool restrictions for owners on external channels", () => {
     const cfg: OpenClawConfig = {
       tools: {

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -208,21 +208,22 @@ export function resolveConversationCapabilityProfile(
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
   });
-  // Owner WebChat intentionally has no sender identity. Its trusted owner state
-  // must not fall through to the wildcard policy for external senders.
-  const senderPolicy =
+  // Owner WebChat intentionally has no external sender identity. Its trusted
+  // owner state must not fall through to the wildcard policy for guests.
+  const isOwnerInternalSession =
     params.senderIsOwner === true &&
-    normalizeMessageChannel(messageProvider) === INTERNAL_MESSAGE_CHANNEL
-      ? undefined
-      : resolveSenderToolPolicy({
-          config: params.config,
-          agentId: effective.agentId,
-          messageProvider,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-        });
+    normalizeMessageChannel(messageProvider ?? params.messageChannel) === INTERNAL_MESSAGE_CHANNEL;
+  const senderPolicy = isOwnerInternalSession
+    ? undefined
+    : resolveSenderToolPolicy({
+        config: params.config,
+        agentId: effective.agentId,
+        messageProvider,
+        senderId: params.senderId,
+        senderName: params.senderName,
+        senderUsername: params.senderUsername,
+        senderE164: params.senderE164,
+      });
   const profilePolicy = resolveToolProfilePolicy(effective.profile);
   const providerProfilePolicy = resolveToolProfilePolicy(effective.providerProfile);
   const subagentSessionKey = params.sandboxSessionKey ?? params.sessionKey;

--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -7,6 +7,8 @@ import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SkillSnapshot } from "../skills/types.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
+import { normalizeMessageChannel } from "../utils/message-channel-core.js";
 import {
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
@@ -206,15 +208,21 @@ export function resolveConversationCapabilityProfile(
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
   });
-  const senderPolicy = resolveSenderToolPolicy({
-    config: params.config,
-    agentId: effective.agentId,
-    messageProvider,
-    senderId: params.senderId,
-    senderName: params.senderName,
-    senderUsername: params.senderUsername,
-    senderE164: params.senderE164,
-  });
+  // Owner WebChat intentionally has no sender identity. Its trusted owner state
+  // must not fall through to the wildcard policy for external senders.
+  const senderPolicy =
+    params.senderIsOwner === true &&
+    normalizeMessageChannel(messageProvider) === INTERNAL_MESSAGE_CHANNEL
+      ? undefined
+      : resolveSenderToolPolicy({
+          config: params.config,
+          agentId: effective.agentId,
+          messageProvider,
+          senderId: params.senderId,
+          senderName: params.senderName,
+          senderUsername: params.senderUsername,
+          senderE164: params.senderE164,
+        });
   const profilePolicy = resolveToolProfilePolicy(effective.profile);
   const providerProfilePolicy = resolveToolProfilePolicy(effective.providerProfile);
   const subagentSessionKey = params.sandboxSessionKey ?? params.sessionKey;

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -556,6 +556,24 @@ describe("runAgentHarnessAttempt", () => {
     ).toBeUndefined();
   });
 
+  it("keeps non-owner WebChat restricted by wildcard sender policy for plugin harnesses", () => {
+    const config = {
+      tools: {
+        toolsBySender: {
+          "*": { deny: ["*"] },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolvePluginHarnessPolicyToolsAllow({
+        ...createAttemptParams(config),
+        messageProvider: "webchat",
+        senderIsOwner: false,
+      }),
+    ).toEqual([]);
+  });
+
   it("leaves OpenClaw harness params unchanged for channel group sender deny-all policy", async () => {
     await runAgentHarnessAttempt({
       ...createAttemptParams(groupSenderDenyAllConfig()),

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -538,6 +538,24 @@ describe("runAgentHarnessAttempt", () => {
     expect(resolvePluginHarnessPolicyToolsAllow(createAttemptParams(config))).toBeUndefined();
   });
 
+  it("leaves owner WebChat unrestricted by wildcard sender policy for plugin harnesses", () => {
+    const config = {
+      tools: {
+        toolsBySender: {
+          "*": { deny: ["*"] },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(
+      resolvePluginHarnessPolicyToolsAllow({
+        ...createAttemptParams(config),
+        messageProvider: "webchat",
+        senderIsOwner: true,
+      }),
+    ).toBeUndefined();
+  });
+
   it("leaves OpenClaw harness params unchanged for channel group sender deny-all policy", async () => {
     await runAgentHarnessAttempt({
       ...createAttemptParams(groupSenderDenyAllConfig()),

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -90,6 +90,7 @@ type PluginHarnessToolPolicyContext = Pick<
   | "senderName"
   | "senderUsername"
   | "senderE164"
+  | "senderIsOwner"
 >;
 
 type PluginHarnessToolPolicy = { allow?: string[]; deny?: string[] };
@@ -463,6 +464,7 @@ function resolvePluginHarnessToolPolicies(
     senderName: params.senderName,
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
+    senderIsOwner: params.senderIsOwner,
   });
   const groupPolicyParams = {
     config: params.config,

--- a/src/auto-reply/reply/commands-learn.test.ts
+++ b/src/auto-reply/reply/commands-learn.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { DEFAULT_LEARN_REQUEST } from "../../skills/workshop/learn-prompt.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { handleLearnCommand } from "./commands-learn.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
@@ -32,8 +33,8 @@ function buildLearnParams(
   return {
     cfg: { ...cfg, models: cfg.models ?? DEFAULT_TEST_MODELS },
     ctx: {
-      Provider: "web",
-      Surface: "web",
+      Provider: INTERNAL_MESSAGE_CHANNEL,
+      Surface: INTERNAL_MESSAGE_CHANNEL,
       CommandSource: "text",
       Body: commandBodyNormalized,
       RawBody: commandBodyNormalized,
@@ -47,15 +48,15 @@ function buildLearnParams(
       isAuthorizedSender: true,
       senderIsOwner: true,
       senderId: "tester",
-      channel: "web",
-      channelId: "web",
-      surface: "web",
+      channel: INTERNAL_MESSAGE_CHANNEL,
+      channelId: INTERNAL_MESSAGE_CHANNEL,
+      surface: INTERNAL_MESSAGE_CHANNEL,
       ownerList: [],
       rawBodyNormalized: commandBodyNormalized,
     },
     directives: {},
     elevated: { enabled: true, allowed: true, failures: [] },
-    sessionKey: "agent:main:web:test",
+    sessionKey: "agent:main:webchat:test",
     workspaceDir: "/tmp",
     provider: "openai",
     model: "gpt-5.5",
@@ -117,6 +118,28 @@ describe("learn command", () => {
     const params = buildLearnParams("/learn", {
       tools: { deny: ["skill_workshop"] },
     });
+
+    const result = await handleLearnCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Skill workshop is not available on this agent");
+  });
+
+  it("keeps the workshop available for owner WebChat under a wildcard sender policy", async () => {
+    const params = buildLearnParams("/learn", {
+      tools: { toolsBySender: { "*": { deny: ["skill_workshop"] } } },
+    });
+
+    const result = await handleLearnCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(true);
+  });
+
+  it("keeps the wildcard sender policy for non-owner WebChat", async () => {
+    const params = buildLearnParams("/learn", {
+      tools: { toolsBySender: { "*": { deny: ["skill_workshop"] } } },
+    });
+    params.command.senderIsOwner = false;
 
     const result = await handleLearnCommand(params, true);
 

--- a/src/auto-reply/reply/commands-learn.ts
+++ b/src/auto-reply/reply/commands-learn.ts
@@ -148,6 +148,7 @@ function workshopIsAvailable(params: HandleCommandsParams): boolean {
       senderName: params.ctx.SenderName,
       senderUsername: params.ctx.SenderUsername,
       senderE164: params.ctx.SenderE164,
+      senderIsOwner: params.command.senderIsOwner,
       agentAccountId: params.command.accountId ?? params.ctx.AccountId,
       modelProvider: params.provider,
       modelId: params.model,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where authenticated owners using Control UI/WebChat could receive only restricted web/media tools when an installation configured a restrictive default sender policy.

## Why This Change Was Made

Trusted owner turns on the internal WebChat channel now bypass the wildcard sender policy that is intended for unidentified external senders. External channels continue applying that wildcard policy, and plugin harnesses use the same owner-aware capability decision.

## User Impact

Owners can use their configured shell, filesystem, and other tools from WebChat without granting those tools to unidentified or external senders.

## Evidence

- `node scripts/test-projects.mjs src/agents/conversation-capability-profile.test.ts src/agents/harness/selection.test.ts` — 68 tests passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-webchat-owner-final.tsbuildinfo` — passed.
- `node scripts/build-all.mjs` — passed.
- Branch-mode autoreview against `upstream/main` reported no actionable findings.
- Live authenticated Control UI/WebChat verification compiled 28 tools, including `exec`, `read`, `write`, and `process`, and successfully executed a shell command. Before the fix, the same WebChat session compiled 6 restricted tools.
- Regression coverage confirms owner WebChat bypasses the wildcard sender policy while owner turns on Discord remain restricted.
