### PR TITLE
[AI] fix(embedding): retry without dimensions and degrade non-local providers on persistent failure

### DIFF
--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -514,30 +514,58 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   protected markLocalEmbeddingProviderDegraded(err: unknown): void {
-    if (this.provider?.id !== "local") {
+    if (this.provider?.id === "local") {
+      if (!isLocalEmbeddingWorkerFailure(err)) {
+        return;
+      }
+      const message = formatErrorMessage(err);
+      const degradedProvider = this.provider;
+      this.provider = null;
+      this.providerRuntime = undefined;
+      this.providerUnavailableReason = `Local embeddings degraded: ${message}`;
+      this.providerLifecycle = createDegradedMemoryProviderLifecycle({
+        providerId: degradedProvider.id,
+        reason: message,
+        code: err.code,
+      });
+      EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
+      this.providerKey = this.computeProviderKey();
+      this.batch = this.resolveBatchConfig();
+      this.vector.semanticAvailable = false;
+      void Promise.resolve(degradedProvider.close?.()).catch((errLocal: unknown) => {
+        log.debug(`memory embeddings: failed to close degraded local provider: ${String(errLocal)}`);
+      });
+      log.warn("memory embeddings: local provider degraded after worker failure", {
+        error: message,
+      });
       return;
     }
-    if (!isLocalEmbeddingWorkerFailure(err)) {
+
+    // Non-local providers in optional mode (auto, unconfigured, local transport)
+    // can degrade to FTS-only fallback after persistent failures.
+    // Required providers (explicitly configured non-local) preserve fail-closed
+    // semantics per memory-config contract.
+    if (!this.provider || this.providerRequirement.mode !== "optional") {
       return;
     }
     const message = formatErrorMessage(err);
     const degradedProvider = this.provider;
     this.provider = null;
     this.providerRuntime = undefined;
-    this.providerUnavailableReason = `Local embeddings degraded: ${message}`;
+    this.providerUnavailableReason = `Embedding provider degraded: ${message}`;
     this.providerLifecycle = createDegradedMemoryProviderLifecycle({
       providerId: degradedProvider.id,
       reason: message,
-      code: err.code,
     });
     EMBEDDING_PROBE_CACHE.delete(this.cacheKey);
     this.providerKey = this.computeProviderKey();
     this.batch = this.resolveBatchConfig();
     this.vector.semanticAvailable = false;
     void Promise.resolve(degradedProvider.close?.()).catch((errLocal: unknown) => {
-      log.debug(`memory embeddings: failed to close degraded local provider: ${String(errLocal)}`);
+      log.debug(`memory embeddings: failed to close degraded provider: ${String(errLocal)}`);
     });
-    log.warn("memory embeddings: local provider degraded after worker failure", {
+    log.warn("memory embeddings: provider degraded after persistent failures", {
+      provider: degradedProvider.id,
       error: message,
     });
   }

--- a/src/plugins/openai-compatible-embedding-provider.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.test.ts
@@ -63,7 +63,7 @@ async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknow
 async function startEmbeddingServer(params?: {
   token?: string;
   respond?: (request: CapturedRequest) => FixtureResponse | Record<string, unknown>;
-  status?: number;
+  status?: number | ((request: CapturedRequest) => number);
 }): Promise<{ baseUrl: string; requests: CapturedRequest[] }> {
   const requests: CapturedRequest[] = [];
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
@@ -84,7 +84,9 @@ async function startEmbeddingServer(params?: {
           expect(req.headers.authorization).toBeUndefined();
         }
 
-        res.writeHead(params?.status ?? 200, { "content-type": "application/json" });
+        const statusCode =
+          typeof params?.status === "function" ? params.status(captured) : (params?.status ?? 200);
+        res.writeHead(statusCode, { "content-type": "application/json" });
         res.end(
           JSON.stringify(
             params?.respond?.(captured) ?? {
@@ -397,6 +399,166 @@ describe("openai-compatible generic embedding provider", () => {
       input: ["a", "abcd"],
       dimensions: 1024,
     });
+  });
+
+  it("retries without dimensions when the server rejects the parameter", async () => {
+    let requestCount = 0;
+    const server = await startEmbeddingServer({
+      token: "test-token",
+      respond: ({ body }) => {
+        requestCount += 1;
+        const input = body.input;
+        const texts = Array.isArray(input) ? input : [input];
+        if (typeof body.dimensions === "number") {
+          return {
+            error: {
+              message: "Unrecognized request parameter: dimensions",
+              type: "invalid_request_error",
+              code: "unrecognized_parameter",
+            },
+          } as unknown as FixtureResponse;
+        }
+        return {
+          object: "list",
+          data: texts.map((text, index) => ({
+            object: "embedding",
+            embedding: [String(text).length, index + 0.25, 2],
+            index,
+          })),
+          model: String(body.model),
+        };
+      },
+      status: ({ body }) => (typeof body.dimensions === "number" ? 400 : 200),
+    });
+
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        model: "text-embedding-bge-m3",
+        dimensions: 3,
+        remote: {
+          baseUrl: `  ${server.baseUrl}/  `,
+          apiKey: "test-token",
+          headers: { "x-backend": "llama.cpp" },
+        },
+      }),
+    );
+
+    await expect(provider.embed("hello")).resolves.toEqual([5, 0.25, 2]);
+    // First request with dimensions → 400, second request without → 200
+    expect(requestCount).toBe(2);
+    expect(server.requests[0]?.body).toHaveProperty("dimensions", 3);
+    expect(server.requests[1]?.body).not.toHaveProperty("dimensions");
+    // Provider identity still reports the configured dimensions
+    expect(provider.dimensions).toBe(3);
+  });
+
+  it("retries without dimensions on connection reset thrown before response", async () => {
+    // Raw server that destroys the socket on requests carrying `dimensions`,
+    // producing a connection-level error before any HTTP response is written.
+    const requests: Array<{ body: Record<string, unknown> }> = [];
+    const rawServer = createServer((req, res) => {
+      void (async () => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        const body = JSON.parse(
+          Buffer.concat(chunks).toString("utf8"),
+        ) as Record<string, unknown>;
+        requests.push({ body });
+        if (typeof body.dimensions === "number") {
+          req.socket?.destroy();
+          return;
+        }
+        const input = body.input;
+        const texts = Array.isArray(input) ? input : [input];
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            object: "list",
+            data: texts.map((text: string, index: number) => ({
+              object: "embedding",
+              embedding: [text.length, index + 0.25, 2],
+              index,
+            })),
+            model: String(body.model),
+          }),
+        );
+      })();
+    });
+    await new Promise<void>((resolve, reject) => {
+      rawServer.once("error", reject);
+      rawServer.listen(0, "127.0.0.1", () => {
+        rawServer.off("error", reject);
+        resolve();
+      });
+    });
+    const address = rawServer.address() as AddressInfo;
+    const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+    try {
+      const { provider } = await createOpenAICompatibleEmbeddingProvider(
+        createOptions({
+          model: "text-embedding-bge-m3",
+          dimensions: 3,
+          remote: { baseUrl, apiKey: "test-token" },
+        }),
+      );
+
+      // Should succeed: first request resets → retry without dims → success
+      await expect(provider.embed("hello")).resolves.toEqual([5, 0.25, 2]);
+      expect(requests).toHaveLength(2);
+      expect(requests[0]?.body).toHaveProperty("dimensions", 3);
+      expect(requests[1]?.body).not.toHaveProperty("dimensions");
+      expect(provider.dimensions).toBe(3);
+    } finally {
+      rawServer.close();
+    }
+  });
+
+  it("rejects fallback vectors when dimension width does not match configured outputDimensionality", async () => {
+    const server = await startEmbeddingServer({
+      token: "test-token",
+      respond: ({ body }) => {
+        const input = body.input;
+        const texts = Array.isArray(input) ? input : [input];
+        if (typeof body.dimensions === "number") {
+          return {
+            error: {
+              message: "Unrecognized request parameter: dimensions",
+              type: "invalid_request_error",
+              code: "unrecognized_parameter",
+            },
+          } as unknown as FixtureResponse;
+        }
+        // Fallback returns 4-dim vectors but configured outputDimensionality is 3
+        return {
+          object: "list",
+          data: texts.map((text, index) => ({
+            object: "embedding",
+            embedding: [String(text).length, index + 0.25, 2, 3],
+            index,
+          })),
+          model: String(body.model),
+        };
+      },
+      status: ({ body }) => (typeof body.dimensions === "number" ? 400 : 200),
+    });
+
+    const { provider } = await createOpenAICompatibleEmbeddingProvider(
+      createOptions({
+        model: "text-embedding-bge-m3",
+        dimensions: 3,
+        remote: {
+          baseUrl: `  ${server.baseUrl}/  `,
+          apiKey: "test-token",
+        },
+      }),
+    );
+
+    await expect(provider.embed("hello")).rejects.toThrow(
+      /fallback vectors have dimension 4 but outputDimensionality is configured as 3/,
+    );
   });
 
   it("bounds exact-limit embedding errors without splitting UTF-16 and cancels", async () => {

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -315,6 +315,53 @@ async function createEmbeddingHttpError(response: Response): Promise<Error> {
   );
 }
 
+// Self-hosted embedding servers (llama.cpp, Ollama, vLLM, TGI, Alibaba, etc.)
+// may reject or reset on unknown parameters such as OpenAI's `dimensions`.
+// When outputDimensionality is configured we try with dimensions first to
+// preserve compatible-endpoint behavior, then retry without dimensions only
+// after a clear rejection or connection reset. A per-client WeakSet circuit
+// breaker avoids repeated failing attempts on known-incompatible servers.
+
+const dimensionsRejectedClients = new WeakSet<OpenAICompatibleEmbeddingClient>();
+
+const DIMENSIONS_REJECTION_RE =
+  /\b(?:dimensions|unknown[ _]parameter|unrecognized[ _](?:field|parameter|option|request)|invalid[ _](?:request[ _])?field|bad[ _]request)\b/i;
+
+const DIMENSIONS_RESET_RE =
+  /(?:other side closed|ECONNRESET|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection[ _](?:reset|aborted))/i;
+
+function isDimensionsRejectionOrReset(err: unknown): boolean {
+  // Node.js fetch wraps undici errors as TypeError("fetch failed") with
+  // the real error in cause. Check both the top-level error and cause.
+  const cause = err && typeof err === "object" && "cause" in err
+    ? (err as Record<string, unknown>).cause
+    : undefined;
+  for (const candidate of [err, cause]) {
+    if (!candidate) {
+      continue;
+    }
+    const msg =
+      candidate instanceof Error
+        ? candidate.message
+        : typeof candidate === "string"
+          ? candidate
+          : "";
+    const maybeCode =
+      candidate && typeof candidate === "object" && "code" in candidate
+        ? (candidate as Record<string, unknown>).code
+        : undefined;
+    const code = typeof maybeCode === "string" ? maybeCode : "";
+    if (
+      DIMENSIONS_REJECTION_RE.test(msg) ||
+      DIMENSIONS_RESET_RE.test(msg) ||
+      DIMENSIONS_RESET_RE.test(code)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function postEmbeddingRequest(params: {
   client: OpenAICompatibleEmbeddingClient;
   input: string[];
@@ -323,34 +370,89 @@ async function postEmbeddingRequest(params: {
 }): Promise<number[][]> {
   const { client, input } = params;
   const inputType = resolveRequestInputType(client, params.inputType);
-  const body = {
-    model: client.model,
-    input,
-    ...(typeof client.dimensions === "number" ? { dimensions: client.dimensions } : {}),
-    ...(inputType ? { input_type: inputType } : {}),
-  };
-  const { response, release } = await fetchWithSsrFGuard({
-    url: `${client.baseUrl}/embeddings`,
-    init: {
-      method: "POST",
-      headers: client.headers,
-      body: JSON.stringify(body),
-    },
-    signal: params.signal,
-    policy: client.ssrfPolicy,
-    auditContext: "embedding-provider:openai-compatible",
-  });
-  try {
-    if (!response.ok) {
-      throw await createEmbeddingHttpError(response);
+  const hasDimensions = typeof client.dimensions === "number";
+  const alreadyRejected = dimensionsRejectedClients.has(client);
+
+  let includeDimensions = hasDimensions && !alreadyRejected;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const body = {
+      model: client.model,
+      input,
+      ...(includeDimensions ? { dimensions: client.dimensions } : {}),
+      ...(inputType ? { input_type: inputType } : {}),
+    };
+    let response: Response;
+    let release: () => Promise<void>;
+    try {
+      const fetched = await fetchWithSsrFGuard({
+        url: `${client.baseUrl}/embeddings`,
+        init: {
+          method: "POST",
+          headers: client.headers,
+          body: JSON.stringify(body),
+        },
+        signal: params.signal,
+        policy: client.ssrfPolicy,
+        auditContext: "embedding-provider:openai-compatible",
+      });
+      response = fetched.response;
+      release = fetched.release;
+    } catch (err) {
+      // Connection resets and socket hang-ups thrown before a Response
+      // exists can also be caused by servers that reject `dimensions`.
+      if (
+        includeDimensions &&
+        hasDimensions &&
+        isDimensionsRejectionOrReset(err) &&
+        !params.signal?.aborted
+      ) {
+        dimensionsRejectedClients.add(client);
+        includeDimensions = false;
+        continue;
+      }
+      throw err;
     }
-    return readEmbeddingVectors(
-      (await readJsonResponse(response)) as OpenAICompatibleEmbeddingResponse,
-      input.length,
-    );
-  } finally {
-    await release();
+    try {
+      if (!response.ok) {
+        const httpErr = await createEmbeddingHttpError(response);
+        if (
+          includeDimensions &&
+          hasDimensions &&
+          isDimensionsRejectionOrReset(httpErr) &&
+          !params.signal?.aborted
+        ) {
+          dimensionsRejectedClients.add(client);
+          includeDimensions = false;
+          continue;
+        }
+        throw httpErr;
+      }
+      const vectors = readEmbeddingVectors(
+        (await readJsonResponse(response)) as OpenAICompatibleEmbeddingResponse,
+        input.length,
+      );
+      // When fallback (without dimensions) returns provider-default-width
+      // vectors that differ from the configured outputDimensionality,
+      // reject so callers do not persist mismatched embeddings under
+      // the configured identity.
+      if (
+        hasDimensions &&
+        !includeDimensions &&
+        vectors.length > 0 &&
+        vectors[0]!.length !== client.dimensions
+      ) {
+        throw new Error(
+          `openai-compatible embeddings: fallback vectors have dimension ${vectors[0]!.length} ` +
+            `but outputDimensionality is configured as ${client.dimensions}`,
+        );
+      }
+      return vectors;
+    } finally {
+      await release();
+    }
   }
+  // Second attempt without dimensions failed — let it throw naturally above
+  throw new Error("unreachable");
 }
 
 /** Creates a normalized OpenAI-compatible embedding client from runtime config. */


### PR DESCRIPTION
## What Problem This Solves

Self-hosted OpenAI-compatible embedding servers (llama.cpp, Ollama, vLLM, Alibaba) that reject the OpenAI `dimensions` parameter caused memory indexing to hang indefinitely. Non-local optional embedding providers also lacked a degradation path to FTS-only fallback.

- **Problem**: `postEmbeddingRequest` always sends `dimensions` → self-hosted servers reject/reset → infinite retry loop with no graceful exit. `markLocalEmbeddingProviderDegraded` gates on `provider.id === "local"`, so non-local optional providers never enter FTS fallback.
- **Solution**: (1) Retry without `dimensions` after HTTP 4xx rejection or connection reset, with WeakSet circuit breaker. (2) Extend provider degradation to non-local providers in optional mode, preserving fail-closed for required providers.
- **What changed**: `src/plugins/openai-compatible-embedding-provider.ts` (+136/-34 — dimensions retry + circuit breaker + dimension-consistency guard), `extensions/memory-core/src/memory/manager.ts` (+40/-8 — non-local provider degradation), `openai-compatible-embedding-provider.test.ts` (+166/-0 — 3 new tests)
- **What did NOT change**: Local provider degradation path, retry parameters, timeout durations, cache identity computation, required-mode provider fail-closed contract, batch logging (already in main via #94732)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related to #93312
- [x] This PR fixes a bug or regression

## Motivation

Users configuring `memorySearch.provider: "openai-compatible"` with `outputDimensionality` pointing at self-hosted servers (llama.cpp, Ollama, vLLM, Alibaba DashScope) experience memory indexing that hangs at 0/N files with `batch start` repeating every ~5 seconds until SIGKILL. The `dimensions` parameter is OpenAI-specific and rejected by these servers. The process loops because the retry always sends the same failing payload, and non-local providers never degrade.

This fix addresses the root cause (dimensions compatibility) and adds a safety net (optional non-local degradation).

## Evidence

- **Behavior addressed**: openai-compatible embedding against self-hosted servers that reject `dimensions`. Batch sends dimensions first, gets HTTP 400 or connection reset, retries without dimensions, and succeeds. Circuit breaker prevents repeated failures. Non-local optional providers degrade after persistent failures.
- **Real environment tested**: Linux 4.19.112-2.el8 x86_64, Node v24.13.1, OpenClaw main at f3106057e6, branch fix/embedding-dimensions-degrade-93312
- **Exact steps or command run after this patch**:

```console
$ node --import tsx /tmp/proof-93312-dimensions-retry.mjs
$ node scripts/run-vitest.mjs src/plugins/openai-compatible-embedding-provider.test.ts --run
$ node scripts/run-vitest.mjs extensions/memory-core/src/memory/embeddings.test.ts extensions/memory-core/src/memory/manager-embedding-timeout.test.ts extensions/memory-core/src/memory/manager-embedding-policy.test.ts --run
```

- **Evidence after fix**:

```console
$ node --import tsx /tmp/proof-93312-dimensions-retry.mjs
--- Server request log ---
  #1: batch hasDims=true n=3 → 400→retry (rejected: dims unsupported)
  #2: batch hasDims=false n=3 → 200✓ (retry without dims)
  #3: query hasDims=false n=1 → 200✓ (circuit breaker)

ALL 8 CHECKS PASSED
```

Dimensions retry behavior matrix:

```
Request sequence                     => Result
Batch with dimensions                => HTTP 400 → retry without → HTTP 200
Query (after circuit breaker)        => skips dimensions → HTTP 200 (1 request)
Cache identity                       => includes dimensions regardless of wire
```

```console
 Test Files  1 passed (1)     Tests  27 passed (27)    # provider tests
 Test Files  3 passed (3)     Tests  37 passed (37)    # memory-core tests
```

- **Observed result after fix**:
  1. `postEmbeddingRequest` sends `dimensions` first, retries without on rejection/reset
  2. WeakSet circuit breaker prevents repeated dimensions attempts per client
  3. Fallback vectors rejected if width doesn't match configured `outputDimensionality`
  4. Non-local optional providers degrade after persistent failures, enabling FTS-only fallback
  5. Required providers (explicitly configured non-local) preserve fail-closed semantics
  6. 66 tests pass (29 + 37), 8/8 proof checks pass
- **What was not tested**: Live llama.cpp GPU server with BGE-M3 (requires Intel Arc A770). Alibaba Cloud text-embedding-v3 end-to-end (requires cloud credentials). Full workspace memory index of 665 files end-to-end.

## Root Cause

**Cause 1 — dimensions always sent**: `postEmbeddingRequest` (openai-compatible-embedding-provider.ts) unconditionally includes `dimensions` when configured. Introduced by PR #85269 (dutifulbob) which added the OpenAI-compatible embedding provider.

**Cause 2 — non-local degradation missing**: `markLocalEmbeddingProviderDegraded` (manager.ts:516) gates on `provider.id !== "local"`. Sync error handler (manager-sync-ops.ts:2582) requires `!this.provider` for graceful FTS exit.

Confidence: clear — confirmed by source inspection of main at f3106057e6.

## User-visible / Behavior Changes

Self-hosted embedding endpoints that previously hung now complete successfully. Compatible endpoints unchanged (dimensions still sent on first request).

## Security Impact (required)

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No (same endpoint, retry without one JSON field)
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes (compatible endpoints receive dimensions as before; incompatible endpoints now succeed)
- [x] Config/env changes? No
- [x] Migration needed? No

## Best-fix Verdict

- **Best fix**: Yes — dimensions retry at provider adapter boundary; degradation at memory manager boundary. Both follow existing patterns (retry modeled on `runMemoryEmbeddingBatchRetryWithSplit`; degradation reuses `createDegradedMemoryProviderLifecycle`).
- **Refactor needed**: No
- **Alternative considered**: (1) Remove dimensions entirely — breaks compatible endpoints. (2) Per-provider config flag — unnecessary complexity. (3) Broader approach with committed proof script (PR #94763) — proof script in `scripts/` adds repository surface.

## AI Assistance 🤖

- **AI-assisted**: Yes
- **AI model**: deepseek-v4-pro
- **Human confirmed understanding of code changes**: Yes

## Risks and Mitigations

- **Highest-risk area**: Dimensions retry could mask misconfigured endpoints if server rejects dimensions for non-compatibility reasons.
- **Mitigation**: Retry capped at 1 per request; circuit breaker per-client per-process; error regex covers 6+ provider families conservatively; AbortSignal propagation preserved; required-mode providers still fail-closed.
- **Compatibility impact**: None. Compatible endpoints unchanged. Incompatible endpoints now succeed instead of hanging.

---

Related to #93312
