### PR TITLE
fix(android): auto-detect the Android SDK when fresh worktrees lack local.properties

### DIFF
--- a/scripts/run-android-gradle.mjs
+++ b/scripts/run-android-gradle.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -39,11 +41,35 @@ export function linuxArmAndroidGradleSkipMessage(platform = process.platform, ar
   );
 }
 
-export function run(command, args, cwd) {
+// Fresh git worktrees do not carry the gitignored apps/android/local.properties,
+// so AGP tasks fail with "SDK location not found" even when an SDK is installed.
+// Fall back to the Android Studio default install path when nothing names one.
+export function resolveAndroidSdkEnv(options = {}) {
+  const env = options.env ?? process.env;
+  if (env.ANDROID_HOME || env.ANDROID_SDK_ROOT) {
+    return env;
+  }
+  const existsSync = options.existsSync ?? fs.existsSync;
+  if (existsSync(path.join(androidDir, "local.properties"))) {
+    return env;
+  }
+  const homeDir = options.homeDir ?? os.homedir();
+  const platform = options.platform ?? process.platform;
+  const defaultSdkDir =
+    platform === "darwin"
+      ? path.join(homeDir, "Library", "Android", "sdk")
+      : path.join(homeDir, "Android", "Sdk");
+  if (!existsSync(defaultSdkDir)) {
+    return env;
+  }
+  return { ...env, ANDROID_HOME: defaultSdkDir };
+}
+
+export function run(command, args, cwd, env = process.env) {
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       cwd,
-      env: process.env,
+      env,
       stdio: "inherit",
     });
     child.on("close", (status, signal) => {
@@ -78,12 +104,13 @@ export async function main(argv = process.argv.slice(2)) {
     return 0;
   }
 
-  const gradleStatus = await run("./gradlew", gradleArgs, androidDir);
+  const env = resolveAndroidSdkEnv();
+  const gradleStatus = await run("./gradlew", gradleArgs, androidDir, env);
   if (gradleStatus !== 0 || postArgs.length === 0) {
     return gradleStatus;
   }
 
-  return await run(postArgs[0], postArgs.slice(1), repoRoot);
+  return await run(postArgs[0], postArgs.slice(1), repoRoot, env);
 }
 
 if (isMain) {

--- a/test/scripts/run-android-gradle.test.ts
+++ b/test/scripts/run-android-gradle.test.ts
@@ -1,6 +1,8 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   linuxArmAndroidGradleSkipMessage,
+  resolveAndroidSdkEnv,
   shouldSkipLinuxArmAndroidGradle,
   splitAndroidGradleArgs,
 } from "../../scripts/run-android-gradle.mjs";
@@ -36,5 +38,56 @@ describe("run-android-gradle", () => {
     expect(linuxArmAndroidGradleSkipMessage("linux", "arm64")).toContain(
       "OPENCLAW_ANDROID_GRADLE_ALLOW_LINUX_ARM=1",
     );
+  });
+
+  describe("resolveAndroidSdkEnv", () => {
+    const macSdk = path.join("/Users/dev", "Library", "Android", "sdk");
+    const linuxSdk = path.join("/home/dev", "Android", "Sdk");
+
+    it("keeps env untouched when ANDROID_HOME or ANDROID_SDK_ROOT is set", () => {
+      const env = { ANDROID_HOME: "/opt/sdk" };
+      expect(resolveAndroidSdkEnv({ env, existsSync: () => true })).toBe(env);
+      const rootEnv = { ANDROID_SDK_ROOT: "/opt/sdk" };
+      expect(resolveAndroidSdkEnv({ env: rootEnv, existsSync: () => true })).toBe(rootEnv);
+    });
+
+    it("keeps env untouched when local.properties exists", () => {
+      const env = {};
+      const result = resolveAndroidSdkEnv({
+        env,
+        existsSync: (p: string) => p.endsWith("local.properties"),
+        homeDir: "/Users/dev",
+        platform: "darwin",
+      });
+      expect(result).toBe(env);
+    });
+
+    it("falls back to the Android Studio default SDK path per platform", () => {
+      const darwin = resolveAndroidSdkEnv({
+        env: {},
+        existsSync: (p: string) => p === macSdk,
+        homeDir: "/Users/dev",
+        platform: "darwin",
+      });
+      expect(darwin.ANDROID_HOME).toBe(macSdk);
+      const linux = resolveAndroidSdkEnv({
+        env: {},
+        existsSync: (p: string) => p === linuxSdk,
+        homeDir: "/home/dev",
+        platform: "linux",
+      });
+      expect(linux.ANDROID_HOME).toBe(linuxSdk);
+    });
+
+    it("keeps env untouched when no default SDK install exists", () => {
+      const env = {};
+      const result = resolveAndroidSdkEnv({
+        env,
+        existsSync: () => false,
+        homeDir: "/Users/dev",
+        platform: "darwin",
+      });
+      expect(result).toBe(env);
+    });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running any SDK-dependent Android lane (`pnpm android:test`, `android:assemble`, `android:install`, `android:run`) from a fresh git worktree would hit `SDK location not found` even though an Android SDK is installed. `apps/android/local.properties` is gitignored, so new worktrees never carry it, and nothing else names the SDK unless `ANDROID_HOME`/`ANDROID_SDK_ROOT` happens to be exported. The ktlint lanes (`android:format`/`android:lint`) mask the gap because they never touch the SDK.

## Why This Change Was Made

`scripts/run-android-gradle.mjs` now resolves the SDK before spawning Gradle: explicit `ANDROID_HOME`/`ANDROID_SDK_ROOT` and an existing `local.properties` keep full precedence, and only when neither names an SDK does the wrapper fall back to the Android Studio default install path (`~/Library/Android/sdk` on macOS, `~/Android/Sdk` elsewhere) — and only if that directory actually exists. No files are written; the fallback is passed as `ANDROID_HOME` to the spawned process only. CI is unaffected since it exports `ANDROID_HOME` explicitly.

## User Impact

Android Gradle lanes work out of the box in fresh worktrees and clones on machines with a default-located SDK, with no manual `local.properties` setup. Existing explicit configuration behaves exactly as before.

## Evidence

Repro and fix on a fresh worktree (no `local.properties`, no SDK env vars):

- Before: `pnpm android:test` → `SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file...` (BUILD FAILED in 616ms)
- After: `env -u ANDROID_HOME -u ANDROID_SDK_ROOT pnpm android:test` → `BUILD SUCCESSFUL` (`:app:testPlayDebugUnitTest`)

Focused tests: `test/scripts/run-android-gradle.test.ts` — 8 passed, including 4 new `resolveAndroidSdkEnv` cases covering env-var precedence, `local.properties` precedence, per-platform default fallback, and missing-SDK passthrough.
