### PR TITLE
fix(gradium): TTS rejects untrusted base URLs before sending API keys

### DIFF
--- a/docs/providers/gradium.md
+++ b/docs/providers/gradium.md
@@ -74,11 +74,11 @@ Create a Gradium API key, then expose it with an env var or the config key. Conf
 }
 ```
 
-| Key                                             | Type   | Description                                                                       |
-| ----------------------------------------------- | ------ | --------------------------------------------------------------------------------- |
-| `messages.tts.providers.gradium.apiKey`         | string | Resolved API key. Supports `${ENV}` and secret refs.                              |
-| `messages.tts.providers.gradium.baseUrl`        | string | API origin override. Trailing slashes stripped. Default `https://api.gradium.ai`. |
-| `messages.tts.providers.gradium.speakerVoiceId` | string | Default voice id used when no directive override is present.                      |
+| Key                                             | Type   | Description                                                                                             |
+| ----------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------- |
+| `messages.tts.providers.gradium.apiKey`         | string | Resolved API key. Supports `${ENV}` and secret refs.                                                    |
+| `messages.tts.providers.gradium.baseUrl`        | string | HTTPS Gradium API URL on `api.gradium.ai`. Trailing slashes stripped. Default `https://api.gradium.ai`. |
+| `messages.tts.providers.gradium.speakerVoiceId` | string | Default voice id used when no directive override is present.                                            |
 
 Output format is chosen automatically by target surface (see [Output](#output)) and is not configurable in `openclaw.json`.
 

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -846,7 +846,7 @@ Reply -> TTS enabled?
 
   <Accordion title="Gradium">
     <ParamField path="apiKey" type="string">Env: `GRADIUM_API_KEY`.</ParamField>
-    <ParamField path="baseUrl" type="string">Default `https://api.gradium.ai`.</ParamField>
+    <ParamField path="baseUrl" type="string">HTTPS Gradium API URL on `api.gradium.ai`. Default `https://api.gradium.ai`.</ParamField>
     <ParamField path="speakerVoiceId" type="string">Default Emma (`YTpq7expH9539ERJ`). Legacy alias: `voiceId`.</ParamField>
   </Accordion>
 

--- a/extensions/gradium/shared.ts
+++ b/extensions/gradium/shared.ts
@@ -1,5 +1,6 @@
 // Gradium plugin module implements shared behavior.
 const DEFAULT_GRADIUM_BASE_URL = "https://api.gradium.ai";
+const ALLOWED_GRADIUM_BASE_URL_HOSTS = new Set(["api.gradium.ai"]);
 export const DEFAULT_GRADIUM_VOICE_ID = "YTpq7expH9539ERJ";
 
 export const GRADIUM_VOICES = [
@@ -13,6 +14,25 @@ export const GRADIUM_VOICES = [
 ] as const;
 
 export function normalizeGradiumBaseUrl(baseUrl?: string): string {
-  const trimmed = baseUrl?.trim();
-  return trimmed?.replace(/\/+$/, "") || DEFAULT_GRADIUM_BASE_URL;
+  const raw = baseUrl?.trim() || DEFAULT_GRADIUM_BASE_URL;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("Gradium baseUrl must be a valid https URL");
+  }
+
+  url.username = "";
+  url.password = "";
+  url.search = "";
+  url.hash = "";
+
+  if (url.protocol !== "https:") {
+    throw new Error("Gradium baseUrl must use https");
+  }
+  if (!ALLOWED_GRADIUM_BASE_URL_HOSTS.has(url.hostname.toLowerCase())) {
+    throw new Error("Gradium baseUrl must target api.gradium.ai");
+  }
+
+  return url.toString().replace(/\/+$/, "");
 }

--- a/extensions/gradium/speech-provider.test.ts
+++ b/extensions/gradium/speech-provider.test.ts
@@ -78,6 +78,25 @@ describe("gradium speech provider", () => {
     expect(result.audioBuffer).toEqual(audioData);
   });
 
+  it("rejects untrusted Gradium baseUrl config before dispatching the API key", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(Buffer.from("audio"), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      provider.synthesize({
+        text: "OpenClaw test",
+        cfg: {} as never,
+        providerConfig: { apiKey: "gsk_test123", baseUrl: "https://example.com" },
+        target: "audio-file",
+        timeoutMs: 30_000,
+      }),
+    ).rejects.toThrow("Gradium baseUrl must target api.gradium.ai");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("uses opus and voiceCompatible for voice-note target", async () => {
     const audioData = Buffer.from("opus-audio-data");
     const fetchMock = vi.fn().mockResolvedValue(new Response(audioData, { status: 200 }));

--- a/extensions/gradium/tts.test.ts
+++ b/extensions/gradium/tts.test.ts
@@ -144,6 +144,46 @@ describe("gradium tts diagnostics", () => {
     expect(result).toEqual(audioData);
   });
 
+  it("rejects HTTP base URLs before sending the API key", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(Buffer.from("audio"), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      gradiumTTS({
+        text: "hello",
+        apiKey: "gsk_test123",
+        baseUrl: "http://api.gradium.ai",
+        voiceId: "YTpq7expH9539ERJ",
+        outputFormat: "wav",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Gradium baseUrl must use https");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-Gradium base URLs before sending the API key", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(Buffer.from("audio"), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      gradiumTTS({
+        text: "hello",
+        apiKey: "gsk_test123",
+        baseUrl: "https://example.com",
+        voiceId: "YTpq7expH9539ERJ",
+        outputFormat: "wav",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Gradium baseUrl must target api.gradium.ai");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("caps streamed audio responses instead of buffering oversized TTS output", async () => {
     const streamed = createStreamingAudioResponse({
       chunkCount: 20,

--- a/extensions/gradium/tts.ts
+++ b/extensions/gradium/tts.ts
@@ -45,6 +45,7 @@ export async function gradiumTTS(params: {
       }),
     },
     timeoutMs,
+    requireHttps: true,
     policy: { hostnameAllowlist: [hostname] },
     auditContext: "gradium.tts",
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring Gradium TTS could have their Gradium API key sent to an untrusted or non-HTTPS base URL when `messages.tts.providers.gradium.baseUrl` was set outside the official Gradium API host.

## Why This Change Was Made

Gradium TTS now normalizes and validates the configured base URL before constructing the outbound request, only accepts HTTPS URLs on `api.gradium.ai`, and keeps the SSRF guarded fetch on HTTPS as a second boundary. This keeps the existing default endpoint behavior and documents that `baseUrl` is not an arbitrary provider-host override.

## User Impact

Gradium TTS users keep the same default setup. Unsafe or mistyped Gradium `baseUrl` values now fail before the provider key is dispatched, instead of sending the credential to the configured host.

## Evidence

- Red regression proof before the fix: the new TTS tests for `http://api.gradium.ai` and `https://example.com` both failed because the request reached mocked `fetch` and resolved with audio instead of rejecting before dispatch.
- `pnpm exec vitest run extensions/gradium/tts.test.ts` — 7 tests passed, including HTTP and non-Gradium host rejection before `fetch` is called.
- `pnpm exec vitest run extensions/gradium/speech-provider.test.ts` — 8 tests passed, including the `buildGradiumSpeechProvider().synthesize()` config path rejecting an untrusted `baseUrl` before dispatching the API key.
- `pnpm exec tsx gradium-real-gateway-provider-proof.mjs` — started an isolated OpenClaw `gateway:dev`, observed `/readyz` ready, then exercised `buildGradiumSpeechProvider().synthesize()` with `baseUrl=https://example.com`; it rejected with `Gradium baseUrl must target api.gradium.ai` and recorded `outboundFetchCalls=0`.
- `env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed` — passed changed-file lanes for extensions, extension tests, and docs; included extension typecheck, extension-test typecheck, changed-file lint, conflict marker guard, dependency/package patch guards, and runtime import-cycle check.
