### PR TITLE
fix(codex): crestodian ring-zero tool hidden behind tool search when the dead per-run plugin config override is ignored

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1649,6 +1649,27 @@ describe("runCodexAppServerAttempt", () => {
     expect(sessionsYield).not.toHaveProperty("deferLoading");
   });
 
+  it("registers the ring-zero crestodian tool directly without a per-run plugin config", () => {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
+    expect(testing.resolveCodexDynamicToolDirectNames(params)).toEqual([]);
+
+    params.crestodianTool = { surface: "cli", proposalRef: {}, directiveRef: {} };
+    expect(testing.resolveCodexDynamicToolDirectNames(params)).toEqual(["crestodian"]);
+
+    params.sourceReplyDeliveryMode = "message_tool_only";
+    expect(testing.resolveCodexDynamicToolDirectNames(params)).toEqual(["crestodian", "message"]);
+
+    const toolBridge = createCodexToolBridgeForTest(params, [
+      createRuntimeDynamicTool("crestodian"),
+    ]);
+    const crestodian = flattenSpecsWithNamespace(toolBridge.specs).find(
+      (tool) => tool.name === "crestodian",
+    );
+    expect(crestodian).not.toHaveProperty("namespace");
+    expect(crestodian).not.toHaveProperty("deferLoading");
+  });
+
   it("keeps the heartbeat schema deferred and stable across normal and heartbeat turns", async () => {
     testing.setOpenClawCodingToolsFactoryForTests((options) => [
       createRuntimeDynamicTool("message"),

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3894,10 +3894,18 @@ function handleApprovalRequest(params: {
 }
 
 function resolveCodexDynamicToolDirectNames(params: EmbeddedRunAttemptParams): string[] {
-  if (params.sourceReplyDeliveryMode !== "message_tool_only") {
-    return [];
+  const names: string[] = [];
+  // The ring-zero crestodian tool is the run's entire tool surface; register it
+  // directly instead of deferring it behind Codex tool_search discovery. This is
+  // structural: per-run configs cannot flip codexDynamicToolsLoading because the
+  // harness resolves plugin config from the live global config, not params.config.
+  if (params.crestodianTool) {
+    names.push("crestodian");
   }
-  return ["message"];
+  if (params.sourceReplyDeliveryMode === "message_tool_only") {
+    names.push("message");
+  }
+  return names;
 }
 
 export const testing = {

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -143,6 +143,12 @@ export type RunEmbeddedAgentParams = {
   /** Task working directory for tool/runtime execution. Defaults to workspaceDir. */
   cwd?: string;
   agentDir?: string;
+  /**
+   * Run config consumed by core paths (model selection, tools, plugin
+   * activation). Plugin harnesses resolve `plugins.entries.<id>.config` from
+   * the live global config, NOT from this object — per-run plugin-config
+   * overrides are unsupported; use an explicit run param instead.
+   */
   config?: OpenClawConfig;
   skillsSnapshot?: SkillSnapshot;
   prompt: string;

--- a/src/crestodian/assistant-backends.ts
+++ b/src/crestodian/assistant-backends.ts
@@ -90,14 +90,14 @@ export function buildCodexAppServerPlannerConfig(workspaceDir: string): OpenClaw
         model: { primary: CODEX_APP_SERVER_DEFAULT_MODEL_REF },
       },
     },
+    // `enabled` gates plugin activation for this run; do not add a `config`
+    // block here — harnesses resolve plugin config from the live global
+    // config, so per-run `plugins.entries.*.config` keys are silently ignored.
+    // The crestodian tool's direct registration is structural (crestodianTool
+    // run param -> resolveCodexDynamicToolDirectNames in the codex plugin).
     plugins: {
       entries: {
-        codex: {
-          enabled: true,
-          // Crestodian carries a single ring-zero tool; advertise it directly
-          // instead of hiding it behind the Codex tool-search index.
-          config: { codexDynamicToolsLoading: "direct" },
-        },
+        codex: { enabled: true },
       },
     },
     // The Codex app-server harness runs a local process; the ephemeral


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Crestodian's ring-zero `crestodian` tool could be hidden behind Codex tool-search discovery instead of being directly callable. The ephemeral run config built by `buildCodexAppServerPlannerConfig` set `plugins.entries.codex.config.codexDynamicToolsLoading: "direct"` expecting a per-run effect, but the Codex harness resolves its plugin config from the live global config (`resolveLivePluginConfigObject(api.runtime.config.current, ...)` in `extensions/codex/index.ts`), never from the per-run `params.config`. The override was silently ignored in gateway/steady-state runs and only incidentally effective in a cold CLI process via the `api.pluginConfig` startup fallback.

## Why This Change Was Made

Per-run plugin behavior belongs in typed run params, not synthesized `plugins.entries.*.config` keys that the harness cannot see. `resolveCodexDynamicToolDirectNames` now registers `crestodian` directly whenever the run carries the `crestodianTool` param (structural, mode-independent), the dead config override is deleted, and per-run plugin-config overrides are documented as unsupported on `RunEmbeddedAgentParams.config`. A harness fallback to `resolvePluginConfigObject(params.config, id)` was deliberately rejected: it would create a second config-resolution path with unclear merge semantics and split-brain within one plugin, since the provider/media/command surfaces of the same plugin would still read the global config.

Audit scope: `buildCodexAppServerPlannerConfig` (shared by Crestodian agent turns and setup-inference's `codex-cli` probe plan) was the only non-test ephemeral run-config builder carrying a `plugins.entries.*.config` key. The `enabled: true` entry is kept because `ensureSelectedAgentHarnessPlugin` reads the per-run config for plugin activation.

## User Impact

Crestodian conversational setup/repair turns on the Codex app-server backend now always see their single `crestodian` tool as a directly callable function with full schema, regardless of the operator's global `codexDynamicToolsLoading` setting or process history. No config surface changes; the removed key never worked as a per-run override.

## Evidence

- Codex dependency contract verified in sibling `codex` source: `codex-rs/tools/src/tool_search.rs` (deferred/namespace tools get `defer_loading = Some(true)` with schemas stripped and require tool-search loading), `codex-rs/tools/src/responses_api.rs`, `codex-rs/tools/src/tool_definition.rs` — direct function specs ship with full schema up front.
- New test `registers the ring-zero crestodian tool directly without a per-run plugin config` in `extensions/codex/src/app-server/run-attempt.test.ts` covers direct-name resolution (none / crestodian / crestodian+message) and asserts the bridged spec has no namespace/deferLoading.
- Blacksmith Testbox proof (exit 0 each): `pnpm test extensions/codex/src/app-server/run-attempt.test.ts` (runs 28829618624), `pnpm test src/crestodian/assistant.test.ts src/crestodian/agent-turn.test.ts src/crestodian/setup-inference.test.ts` (28829725967), `pnpm check:changed` (28829727922).
- Autoreview (Codex `gpt-5.5`) on the diff: clean, no accepted/actionable findings.
