### PR TITLE
fix(ui): clear stale sidebar run state after chat final

### DIFF
--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -38,16 +38,27 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     await server?.close();
   });
 
-  it("keeps Send visible when a stale active row outlives the terminal toast", async () => {
+  it("clears shared session activity when chat final arrives first", async () => {
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     const context = await browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;
-    const gateway = await installMockGateway(currentPage);
+    const gateway = await installMockGateway(currentPage, {
+      historyMessages: [
+        {
+          content: [{ text: "Ready for run lifecycle verification.", type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+    });
 
     await currentPage.goto(`${server?.baseUrl ?? ""}chat`);
+    await currentPage
+      .getByText("Ready for run lifecycle verification.")
+      .waitFor({ timeout: 10_000 });
     await gateway.waitForRequest("sessions.list");
-    await currentPage.locator(".agent-chat__composer-combobox textarea").fill("finish this run");
+    await currentPage.locator(".agent-chat__input textarea").fill("finish this run");
     await currentPage.getByRole("button", { name: "Send message" }).click();
     const send = await gateway.waitForRequest("chat.send");
     const params = send.params as { idempotencyKey?: unknown };
@@ -55,9 +66,22 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
     const runId = params.idempotencyKey as string;
 
     await currentPage.getByRole("button", { name: "Stop generating" }).waitFor();
+    const mainSession = currentPage.locator(".sidebar-recent-session").filter({ hasText: "Main" });
+    await gateway.emitGatewayEvent("sessions.changed", {
+      activeRunIds: [runId],
+      hasActiveRun: true,
+      key: "main",
+      kind: "direct",
+      reason: "lifecycle",
+      startedAt: Date.now() - 1_000,
+      status: "running",
+      updatedAt: Date.now(),
+    });
+    await mainSession.locator(".session-run-spinner").waitFor();
+
     await gateway.emitChatFinal({ runId, text: "Run complete." });
     await currentPage.getByText("Run complete.", { exact: true }).waitFor();
-    await currentPage.getByRole("button", { name: "Send message" }).waitFor();
+    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
 
     await gateway.emitGatewayEvent("sessions.changed", {
       activeRunIds: [runId],
@@ -70,10 +94,11 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       updatedAt: Date.now(),
     });
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
+    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
 
     await currentPage.waitForTimeout(CHAT_RUN_STATUS_TOAST_DURATION_MS + 250);
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    expect(await currentPage.getByRole("button", { name: "Send message" }).count()).toBe(1);
+    expect(await mainSession.locator(".session-run-spinner").count()).toBe(0);
 
     await gateway.emitGatewayEvent("sessions.changed", {
       key: "agent:main:another-session",
@@ -83,7 +108,7 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       updatedAt: Date.now(),
     });
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    expect(await currentPage.getByRole("button", { name: "Send message" }).count()).toBe(1);
+    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
 
     // Re-publish after the former 10-second suppression window. The completed
     // run identity stays terminal until the Gateway publishes different state.
@@ -99,6 +124,6 @@ describeControlUiE2e("Control UI chat run lifecycle", () => {
       updatedAt: Date.now(),
     });
     expect(await currentPage.getByRole("button", { name: "Stop generating" }).count()).toBe(0);
-    expect(await currentPage.getByRole("button", { name: "Send message" }).count()).toBe(1);
+    await expect.poll(() => mainSession.locator(".session-run-spinner").count()).toBe(0);
   });
 });

--- a/ui/src/lib/sessions/index.test.ts
+++ b/ui/src/lib/sessions/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewayEventFrame } from "../../api/gateway.ts";
 import type { SessionsListResult } from "../../api/types.ts";
-import { createSessionCapability } from "./index.ts";
+import { createSessionCapability, reconcileSessionRunTerminal } from "./index.ts";
 
 function sessionsResult(sessions: SessionsListResult["sessions"], ts: number): SessionsListResult {
   return {
@@ -116,6 +116,139 @@ describe("createSessionCapability", () => {
     ]);
     stop();
     sessions.dispose();
+  });
+
+  it("publishes terminal run state to shared session subscribers", async () => {
+    const key = "agent:main:main";
+    const request = vi.fn(async (method: string) => {
+      if (method !== "sessions.list") {
+        throw new Error(`Unexpected request: ${method}`);
+      }
+      return sessionsResult(
+        [
+          {
+            key,
+            kind: "direct",
+            updatedAt: 1,
+            hasActiveRun: true,
+            activeRunIds: ["run-1"],
+            status: "running",
+            startedAt: 100,
+          },
+        ],
+        1,
+      );
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const sessions = createSessionCapability({
+      snapshot: {
+        client,
+        connected: true,
+        sessionKey: key,
+        assistantAgentId: "main",
+        hello: null,
+      },
+      subscribe: () => () => undefined,
+      subscribeEvents: () => () => undefined,
+    });
+    await sessions.refresh({ agentId: "main", force: true });
+
+    expect(
+      sessions.reconcileRunTerminal({
+        sessionKeys: ["main"],
+        runId: "run-1",
+        status: "done",
+        endedAt: 160,
+      }),
+    ).toBe(true);
+    expect(sessions.state.result?.sessions[0]).toMatchObject({
+      key,
+      hasActiveRun: false,
+      activeRunIds: [],
+      status: "done",
+      endedAt: 160,
+      runtimeMs: 60,
+    });
+
+    expect(
+      sessions.reconcile({
+        key,
+        kind: "direct",
+        updatedAt: 2,
+        hasActiveRun: true,
+        activeRunIds: ["run-2"],
+        status: "running",
+        startedAt: 200,
+      }),
+    ).toBe(true);
+    expect(
+      sessions.reconcileRunTerminal({
+        sessionKeys: ["main"],
+        runId: "run-1",
+        status: "done",
+        endedAt: 260,
+      }),
+    ).toBe(false);
+    expect(sessions.state.result?.sessions[0]).toMatchObject({
+      hasActiveRun: true,
+      activeRunIds: ["run-2"],
+      status: "running",
+    });
+
+    expect(
+      sessions.reconcile({
+        key,
+        kind: "direct",
+        updatedAt: 3,
+        hasActiveRun: true,
+        status: "running",
+        startedAt: 300,
+      }),
+    ).toBe(true);
+    expect(
+      sessions.reconcileRunTerminal({
+        sessionKeys: ["main"],
+        runId: "run-1",
+        status: "done",
+        endedAt: 360,
+      }),
+    ).toBe(false);
+    expect(sessions.state.result?.sessions[0]).toMatchObject({
+      hasActiveRun: true,
+      status: "running",
+    });
+    expect(
+      sessions.reconcileRunTerminal({
+        sessionKeys: ["main"],
+        status: "done",
+        endedAt: 360,
+      }),
+    ).toBe(false);
+    sessions.dispose();
+  });
+
+  it("preserves registry-active terminal rows without matching run identity", () => {
+    const result = sessionsResult(
+      [
+        {
+          key: "agent:main:main",
+          kind: "direct",
+          updatedAt: 1,
+          hasActiveRun: true,
+          status: "done",
+        },
+      ],
+      1,
+    );
+
+    expect(
+      reconcileSessionRunTerminal(result, {
+        sessionKeys: ["main"],
+        runId: "run-1",
+        status: "done",
+        endedAt: 160,
+      }),
+    ).toBe(result);
   });
 
   it("refreshes stale active rows after a terminal session message", async () => {

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -3,6 +3,7 @@ import type {
   FastMode,
   GatewaySessionRow,
   SessionCompactionCheckpoint,
+  SessionRunStatus,
   SessionsCompactionBranchResult,
   SessionsCompactionListResult,
   SessionsCompactionRestoreResult,
@@ -11,6 +12,7 @@ import type {
   SessionWorkspaceGetResult,
   SessionWorkspaceListResult,
 } from "../../api/types.ts";
+import { isSessionRunActive } from "../session-run-state.ts";
 import {
   requestSessionCreate,
   resolveSessionCreateParams,
@@ -65,6 +67,13 @@ export type SessionRefreshOptions = SessionListOptions & {
   force?: boolean;
   // Sidebar startup hydration must not block session creation or drop the open session.
   backgroundHydrate?: boolean;
+};
+
+export type SessionRunTerminal = {
+  sessionKeys: readonly string[];
+  runId?: string | null;
+  status: Exclude<SessionRunStatus, "running">;
+  endedAt: number;
 };
 
 export type SessionPatch = {
@@ -139,6 +148,7 @@ export type SessionCapability = {
     options?: SessionReconcileOptions,
   ) => boolean;
   reconcileChanged: (payload: unknown, options?: SessionReconcileOptions) => SessionChangedResult;
+  reconcileRunTerminal: (terminal: SessionRunTerminal) => boolean;
   refresh: (options?: SessionRefreshOptions) => Promise<void>;
   create: (params?: SessionCreateParams) => Promise<string | null>;
   patch: (
@@ -483,6 +493,66 @@ function canReconcileSessionEvent(options: SessionListOptions): boolean {
   );
 }
 
+export function reconcileSessionRunTerminal(
+  result: SessionsListResult | null,
+  terminal: SessionRunTerminal,
+): SessionsListResult | null {
+  const keys = terminal.sessionKeys.map((key) => key.trim()).filter(Boolean);
+  if (!result || keys.length === 0) {
+    return result;
+  }
+  const runId = terminal.runId?.trim() || null;
+  let changed = false;
+  const sessions = result.sessions.map((row): GatewaySessionRow => {
+    if (!keys.some((key) => areUiSessionKeysEquivalent(row.key, key))) {
+      return row;
+    }
+    if (row.hasActiveRun === true || isSessionRunActive(row)) {
+      // Active rows without matching identity may describe a newer or embedded
+      // run. Only terminalize an active row when this event owns its run ID.
+      if (!runId || !row.activeRunIds?.includes(runId)) {
+        return row;
+      }
+    }
+    const remainingRunIds = runId ? row.activeRunIds?.filter((id) => id !== runId) : [];
+    if (remainingRunIds?.length) {
+      changed = true;
+      return {
+        ...row,
+        activeRunIds: remainingRunIds,
+        hasActiveRun: true,
+        status: "running" as const,
+      };
+    }
+    const endedAt = row.endedAt ?? terminal.endedAt;
+    const runtimeMs =
+      typeof row.startedAt === "number" ? Math.max(0, endedAt - row.startedAt) : row.runtimeMs;
+    const activeRunIds = row.activeRunIds?.length ? [] : row.activeRunIds;
+    const abortedLastRun = terminal.status === "killed" ? true : row.abortedLastRun;
+    if (
+      row.hasActiveRun === false &&
+      row.status === terminal.status &&
+      row.endedAt === endedAt &&
+      row.runtimeMs === runtimeMs &&
+      row.activeRunIds === activeRunIds &&
+      row.abortedLastRun === abortedLastRun
+    ) {
+      return row;
+    }
+    changed = true;
+    return {
+      ...row,
+      activeRunIds,
+      hasActiveRun: false,
+      status: terminal.status,
+      endedAt,
+      runtimeMs,
+      abortedLastRun,
+    };
+  });
+  return changed ? { ...result, sessions } : result;
+}
+
 export function createSessionCapability(gateway: SessionGateway): SessionCapability {
   let state: SessionState = {
     result: null,
@@ -737,6 +807,15 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       });
     }
     return reconciled;
+  };
+
+  const reconcileRunTerminal = (terminal: SessionRunTerminal): boolean => {
+    const result = reconcileSessionRunTerminal(state.result, terminal);
+    if (result === state.result) {
+      return false;
+    }
+    publish({ ...state, result, error: null });
+    return true;
   };
 
   const remove = async (key: string, options: SessionDeleteOptions = {}): Promise<boolean> => {
@@ -1031,6 +1110,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     list: requestList,
     reconcile,
     reconcileChanged,
+    reconcileRunTerminal,
     refresh,
     create,
     patch,

--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -797,6 +797,7 @@ describe("handleChatEvent", () => {
             kind: "direct",
             updatedAt: 1,
             hasActiveRun: true,
+            activeRunIds: ["run-1"],
             status: "running",
             startedAt: 100,
           },

--- a/ui/src/pages/chat/run-lifecycle.test.ts
+++ b/ui/src/pages/chat/run-lifecycle.test.ts
@@ -81,6 +81,14 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     const host = makeHost({
       chatRunId: "run-before-terminal-event",
       chatStream: "final answer",
+      sessionsResult: makeSessionsResult([
+        {
+          key: "s1",
+          hasActiveRun: true,
+          activeRunIds: ["run-before-terminal-event"],
+          status: "running",
+        },
+      ]),
     });
 
     expect(
@@ -95,6 +103,29 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     expect(host.chatRunId).toBeNull();
     expect(host.chatStream).toBeNull();
     expect(rowActive(host)).toBe(false);
+  });
+
+  it("suppresses a stale completed run published under an equivalent alias", () => {
+    const host = makeHost({
+      sessionKey: "main",
+      sessionsResult: makeSessionsResult([
+        {
+          key: "agent:main:main",
+          hasActiveRun: true,
+          activeRunIds: ["r1"],
+          status: "running",
+        },
+      ]),
+      lastLocalTerminalReconcile: {
+        sessionKey: "main",
+        runId: "r1",
+        phase: "done",
+        sessionStatus: "done",
+      },
+    });
+
+    expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(true);
+    expect(isSessionRunActive(host.sessionsResult?.sessions[0] ?? {})).toBe(false);
   });
 
   it("suppresses a stale active row after a recent local completion", () => {
@@ -173,7 +204,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     expect(rowActive(host)).toBe(true);
   });
 
-  it("clears the flag once the server poll reports a non-active row", () => {
+  it("retains completed run identity across a terminal row projection", () => {
     const host = makeHost({
       sessionsResult: makeSessionsResult([{ key: "s1", hasActiveRun: false, status: "done" }]),
       lastLocalTerminalReconcile: {
@@ -184,7 +215,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
       },
     });
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
-    expect(host.lastLocalTerminalReconcile).toBeNull();
+    expect(host.lastLocalTerminalReconcile?.runId).toBe("r1");
   });
 
   it("does not arm stale-row suppression from generic lifecycle cleanup", () => {
@@ -206,6 +237,22 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
       { key: "s1", hasActiveRun: true, activeRunIds: ["r1"], status: "running" },
     ]);
     expect(reconcileChatRunFromCurrentSessionRow(host)).toBe(false);
+    expect(rowActive(host)).toBe(true);
+  });
+
+  it("does not clear an unidentified active row from an unowned terminal event", () => {
+    const host = makeHost({
+      sessionsResult: makeSessionsResult([{ key: "s1", hasActiveRun: true, status: "running" }]),
+    });
+
+    reconcileChatRunLifecycle(host, {
+      outcome: "done",
+      sessionStatus: "done",
+      runId: null,
+      sessionKey: "s1",
+      publishRunStatus: false,
+    });
+
     expect(rowActive(host)).toBe(true);
   });
 
@@ -312,6 +359,48 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     expect(host.chatStream).toBeNull();
   });
 
+  it("publishes the canonical global row key for a selected agent alias", () => {
+    const reconcileRunTerminal = vi.fn();
+    const host = makeHost({
+      sessionKey: "agent:work:main",
+      chatRunId: "run-global",
+      chatStream: "streaming",
+      sessionsResult: makeSessionsResult([
+        {
+          key: "global",
+          hasActiveRun: true,
+          activeRunIds: ["run-global"],
+          status: "running",
+        },
+      ]),
+      sessions: {
+        reconcileRunTerminal,
+        setModelOverride: vi.fn(),
+      },
+    });
+
+    reconcileChatRunLifecycle(host, {
+      outcome: "done",
+      sessionStatus: "done",
+      runId: "run-global",
+      sessionKey: "agent:work:main",
+      clearLocalRun: true,
+      clearChatStream: true,
+    });
+
+    expect(host.sessionsResult?.sessions[0]).toMatchObject({
+      key: "global",
+      hasActiveRun: false,
+      status: "done",
+    });
+    expect(reconcileRunTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-global",
+        sessionKeys: expect.arrayContaining(["agent:work:main", "global"]),
+      }),
+    );
+  });
+
   it("arms suppression on a completed turn, then suppresses the racing refresh", () => {
     const host = makeHost({
       chatRunId: "r1",
@@ -393,7 +482,7 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     }
   });
 
-  it("waits for terminal status to expire before reconciling session publications", () => {
+  it("reconciles stale session publications while terminal status is visible", () => {
     const completedAt = Date.now();
     const host = makeHost({
       chatRunStatus: {
@@ -410,10 +499,6 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
       },
     });
 
-    expect(reconcileStaleChatRunAfterSessionStatePublication(host)).toBe(false);
-    expect(rowActive(host)).toBe(true);
-
-    host.chatRunStatus = null;
     expect(reconcileStaleChatRunAfterSessionStatePublication(host)).toBe(true);
     expect(rowActive(host)).toBe(false);
   });

--- a/ui/src/pages/chat/run-lifecycle.test.ts
+++ b/ui/src/pages/chat/run-lifecycle.test.ts
@@ -401,6 +401,36 @@ describe("reconcileChatRunFromCurrentSessionRow stale-active suppression (#87875
     );
   });
 
+  it("publishes the canonical global key before the local session list loads", () => {
+    const reconcileRunTerminal = vi.fn();
+    const host = makeHost({
+      sessionKey: "agent:work:main",
+      chatRunId: "run-global",
+      chatStream: "streaming",
+      sessionsResult: null,
+      sessions: {
+        reconcileRunTerminal,
+        setModelOverride: vi.fn(),
+      },
+    });
+
+    reconcileChatRunLifecycle(host, {
+      outcome: "done",
+      sessionStatus: "done",
+      runId: "run-global",
+      sessionKey: "agent:work:main",
+      clearLocalRun: true,
+      clearChatStream: true,
+    });
+
+    expect(reconcileRunTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-global",
+        sessionKeys: expect.arrayContaining(["agent:work:main", "global"]),
+      }),
+    );
+  });
+
   it("arms suppression on a completed turn, then suppresses the racing refresh", () => {
     const host = makeHost({
       chatRunId: "r1",

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -229,6 +229,9 @@ function sessionKeysFor(host: RunLifecycleHost, options: ReconcileOptions): Set<
   if (primary) {
     keys.add(primary);
   }
+  if (uiSessionRowMatchesSelectedChat(host, "global", primary)) {
+    keys.add("global");
+  }
   for (const row of host.sessionsResult?.sessions ?? []) {
     if (uiSessionRowMatchesSelectedChat(host, row.key, primary)) {
       keys.add(row.key);

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -1,7 +1,13 @@
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow, SessionRunStatus, SessionsListResult } from "../../api/types.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
-import { scopedAgentParamsForSession, type SessionScopeHost } from "../../lib/sessions/index.ts";
+import {
+  reconcileSessionRunTerminal,
+  scopedAgentParamsForSession,
+  type SessionCapability,
+  type SessionRunTerminal,
+  type SessionScopeHost,
+} from "../../lib/sessions/index.ts";
 import { uiSessionRowMatchesSelectedChat } from "../../lib/sessions/session-key.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import { formatConnectError } from "./connect-error.ts";
@@ -18,16 +24,21 @@ export type ChatRunUiStatus = {
   occurredAt: number;
 };
 
+type TerminalSessionRunStatus = Exclude<SessionRunStatus, "running">;
+
 type LocalTerminalReconcile = {
   sessionKey: string;
   runId: string | null;
   phase: ChatRunUiStatus["phase"];
-  sessionStatus: SessionRunStatus;
+  sessionStatus: TerminalSessionRunStatus;
 };
 
 type TimerHandle = ReturnType<typeof globalThis.setTimeout>;
 
-type RunLifecycleHost = Omit<Partial<Parameters<typeof resetToolStream>[0]>, "hello"> & {
+type RunLifecycleHost = Omit<
+  Partial<Parameters<typeof resetToolStream>[0]>,
+  "hello" | "sessions"
+> & {
   sessionKey: string;
   agentsList?: { mainKey?: string | null } | null;
   hello?: { snapshot?: unknown } | null;
@@ -42,13 +53,14 @@ type RunLifecycleHost = Omit<Partial<Parameters<typeof resetToolStream>[0]>, "he
   chatRunStatus?: ChatRunUiStatus | null;
   chatRunStatusClearTimer?: TimerHandle | number | null;
   sessionsResult?: SessionsListResult | null;
+  sessions?: Pick<SessionCapability, "reconcileRunTerminal" | "setModelOverride">;
   lastLocalTerminalReconcile?: LocalTerminalReconcile | null;
   requestUpdate?: () => void;
 };
 
 type ReconcileOptions = {
   outcome?: ChatRunUiStatus["phase"];
-  sessionStatus?: SessionRunStatus;
+  sessionStatus?: TerminalSessionRunStatus;
   runId?: string | null;
   sessionKey?: string | null;
   sessionKeys?: readonly (string | null | undefined)[];
@@ -159,7 +171,9 @@ function clearTimer(timer: TimerHandle | number | null | undefined) {
   }
 }
 
-function canResetToolStream(host: RunLifecycleHost): host is Parameters<typeof resetToolStream>[0] {
+function canResetToolStream(
+  host: RunLifecycleHost,
+): host is RunLifecycleHost & Parameters<typeof resetToolStream>[0] {
   return (
     host.toolStreamById instanceof Map &&
     Array.isArray(host.toolStreamOrder) &&
@@ -215,6 +229,11 @@ function sessionKeysFor(host: RunLifecycleHost, options: ReconcileOptions): Set<
   if (primary) {
     keys.add(primary);
   }
+  for (const row of host.sessionsResult?.sessions ?? []) {
+    if (uiSessionRowMatchesSelectedChat(host, row.key, primary)) {
+      keys.add(row.key);
+    }
+  }
   for (const key of options.sessionKeys ?? []) {
     const normalized = toSessionKey(key);
     if (normalized) {
@@ -229,7 +248,7 @@ function reconcileSessionRows(
   options: ReconcileOptions,
   occurredAt: number,
 ) {
-  if (!options.outcome || !host.sessionsResult) {
+  if (!options.outcome) {
     return;
   }
   const keys = sessionKeysFor(host, options);
@@ -238,29 +257,16 @@ function reconcileSessionRows(
   }
   const status =
     options.sessionStatus ?? (options.outcome === "done" ? ("done" as const) : ("killed" as const));
-  let changed = false;
-  const sessions = host.sessionsResult.sessions.map((row) => {
-    if (!keys.has(row.key)) {
-      return row;
-    }
-    const next = {
-      ...row,
-      hasActiveRun: false,
-      status,
-      endedAt: row.endedAt ?? occurredAt,
-    };
-    if (status === "killed") {
-      next.abortedLastRun = true;
-    }
-    if (typeof next.startedAt === "number" && typeof next.endedAt === "number") {
-      next.runtimeMs = Math.max(0, next.endedAt - next.startedAt);
-    }
-    changed = true;
-    return next;
-  });
-  if (changed) {
-    host.sessionsResult = { ...host.sessionsResult, sessions };
+  const terminal: SessionRunTerminal = {
+    sessionKeys: [...keys],
+    runId: options.runId ?? host.chatRunId ?? null,
+    status,
+    endedAt: occurredAt,
+  };
+  if (host.sessionsResult) {
+    host.sessionsResult = reconcileSessionRunTerminal(host.sessionsResult, terminal);
   }
+  host.sessions?.reconcileRunTerminal(terminal);
 }
 
 export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: ReconcileOptions = {}) {
@@ -311,7 +317,9 @@ export function reconcileChatRunLifecycle(host: RunLifecycleHost, options: Recon
 }
 
 function currentSessionRow(host: RunLifecycleHost) {
-  return host.sessionsResult?.sessions.find((row) => row.key === host.sessionKey);
+  return host.sessionsResult?.sessions.find((row) =>
+    uiSessionRowMatchesSelectedChat(host, row.key, host.sessionKey),
+  );
 }
 
 // After a terminal chat event clears local run state, a racing sessions.list
@@ -333,8 +341,9 @@ function reconcileStaleSelectedSessionRunAfterLocalCompletion(host: RunLifecycle
     return false;
   }
   if (!isSessionRunActive(row)) {
-    // The server now reflects a non-active state, so stop suppressing.
-    host.lastLocalTerminalReconcile = null;
+    // This may be our own shared terminal projection rather than a Gateway
+    // publication. Retain the identity so a duplicate stale event cannot
+    // revive the completed run.
     return false;
   }
   // Browser and Gateway clocks can differ. Only an exact active-run identity
@@ -349,7 +358,12 @@ function reconcileStaleSelectedSessionRunAfterLocalCompletion(host: RunLifecycle
   }
   reconcileSessionRows(
     host,
-    { outcome: recent.phase, sessionStatus: recent.sessionStatus, sessionKey: recent.sessionKey },
+    {
+      outcome: recent.phase,
+      sessionStatus: recent.sessionStatus,
+      sessionKey: recent.sessionKey,
+      runId: recent.runId,
+    },
     Date.now(),
   );
   host.requestUpdate?.();
@@ -374,10 +388,7 @@ export function reconcileStaleChatRunAfterSessionStatePublication(host: RunLifec
   // Both session subscriptions and direct event reconciliation can republish
   // canonical rows after the local terminal projection; guard both paths.
   const canReconcile =
-    host.chatRunStatus == null &&
-    host.lastLocalTerminalReconcile != null &&
-    !host.chatRunId &&
-    host.chatStream == null;
+    host.lastLocalTerminalReconcile != null && !host.chatRunId && host.chatStream == null;
   return canReconcile && reconcileChatRunFromCurrentSessionRow(host, { publishRunStatus: false });
 }
 
@@ -418,7 +429,7 @@ export function reconcileChatRunFromSessionRow(
   }
   reconcileChatRunLifecycle(host, {
     outcome: row.status === "done" ? "done" : "interrupted",
-    sessionStatus: row.status === "done" ? "done" : (row.status ?? "killed"),
+    sessionStatus: row.status === "running" || row.status === undefined ? "killed" : row.status,
     runId: host.chatRunId,
     sessionKey: host.sessionKey,
     sessionKeys: [row.key],


### PR DESCRIPTION
## Summary

- reconcile terminal chat events into the shared session capability so sidebar subscribers clear the completed run immediately
- retain completed-run identity across duplicate stale session publications while preserving newer, unidentified, embedded, and canonical-global activity
- add capability, lifecycle, alias, and Playwright coverage for the final-before-`sessions.changed` race

## Root cause

The composer lifecycle fix cleared the chat pane's local session projection, but the sidebar reads the shared `SessionCapability` cache. When a final chat event arrived before the terminal session publication, the composer could become idle while the shared sidebar row remained active. A duplicate stale session publication could also revive the completed run after the local terminal projection.

This change publishes the owned terminal run through both projections and keeps its identity as a tombstone until the Gateway reports terminal state or a different run. Active rows are only cleared when their advertised run ID matches the terminal event.

## Testing

- `pnpm tsgo:test:ui`
- `node scripts/run-oxlint.mjs ui/src/e2e/chat-run-lifecycle.e2e.test.ts ui/src/lib/sessions/index.test.ts ui/src/lib/sessions/index.ts ui/src/pages/chat/run-lifecycle.test.ts ui/src/pages/chat/run-lifecycle.ts`
- `pnpm test ui/src/lib/sessions/index.test.ts ui/src/pages/chat/run-lifecycle.test.ts ui/src/e2e/chat-run-lifecycle.e2e.test.ts -- --reporter=verbose`
- autoreview: clean, no accepted/actionable findings
