### PR TITLE
fix(agents): harden tool search child streams

### DIFF
--- a/src/agents/tool-search.stream-errors.test.ts
+++ b/src/agents/tool-search.stream-errors.test.ts
@@ -1,0 +1,90 @@
+// Regression tests for code-mode child stderr stream errors in Tool Search.
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+type MockSpawnChild = EventEmitter & {
+  stderr?: EventEmitter & { setEncoding?: (enc: string) => void };
+  send?: (message: unknown, callback?: (error?: Error | null) => void) => boolean;
+  connected?: boolean;
+  kill?: (signal?: string) => void;
+};
+
+function createMockSpawnChild() {
+  const child = new EventEmitter() as MockSpawnChild;
+  const stderr = new EventEmitter() as MockSpawnChild["stderr"];
+  stderr!.setEncoding = vi.fn();
+  child.stderr = stderr;
+  child.connected = true;
+  child.kill = vi.fn();
+  child.send = vi.fn(() => true);
+  return { child, stderr };
+}
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
+  const spawnLocal = vi.fn(
+    (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
+      const { child } = createMockSpawnChild();
+      return child as unknown as ChildProcess;
+    },
+  );
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
+    {
+      spawn: spawnLocal as unknown as typeof import("node:child_process").spawn,
+    },
+  );
+});
+
+const spawnMock = vi.mocked(spawn);
+
+let toolSearch: typeof import("./tool-search.js");
+
+describe("tool-search code-mode stream errors", () => {
+  beforeAll(async () => {
+    toolSearch = await import("./tool-search.js");
+  });
+
+  afterEach(() => {
+    toolSearch.testing.setToolSearchCodeModeSupportedForTest(undefined);
+    toolSearch.testing.setToolSearchMinCodeTimeoutMsForTest(undefined);
+  });
+
+  it("rejects stderr errors and leaves the unused stdout unpiped", async () => {
+    toolSearch.testing.setToolSearchCodeModeSupportedForTest(true);
+    toolSearch.testing.setToolSearchMinCodeTimeoutMsForTest(1000);
+
+    let spawnedChild: MockSpawnChild | undefined;
+    spawnMock.mockImplementationOnce(
+      (_command: string, _args: readonly string[], _options: SpawnOptions): ChildProcess => {
+        const { child, stderr } = createMockSpawnChild();
+        spawnedChild = child;
+        process.nextTick(() => {
+          stderr?.emit("error", new Error("stderr read failed"));
+        });
+        return child as unknown as ChildProcess;
+      },
+    );
+
+    const runtime = new toolSearch.ToolSearchRuntime(
+      {},
+      toolSearch.testing.resolveToolSearchConfig({}),
+    );
+
+    await expect(
+      toolSearch.testing.runCodeModeChild({
+        code: "return 1;",
+        config: toolSearch.testing.resolveToolSearchConfig({}),
+        logs: [],
+        parentToolCallId: "call-stderr-error",
+        runtime,
+      }),
+    ).rejects.toThrow("stderr read failed");
+    expect(spawnMock).toHaveBeenCalledOnce();
+    expect(spawnMock.mock.calls[0]?.[2]).toMatchObject({
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
+    });
+    expect(spawnedChild?.kill).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -2111,7 +2111,9 @@ function runCodeModeChild(params: {
     const child = spawn(process.execPath, buildCodeModeChildArgs(), {
       cwd: os.tmpdir(),
       env: {},
-      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      // The worker returns logs/results over IPC and never writes stdout.
+      // Ignore it so an unused pipe cannot fill or surface unhandled errors.
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
     });
     let stderrTail = "";
     let settled = false;
@@ -2153,6 +2155,9 @@ function runCodeModeChild(params: {
     child.stderr?.setEncoding("utf8");
     child.stderr?.on("data", (chunk: string) => {
       stderrTail = appendToolSearchCodeStderrTail(stderrTail, chunk);
+    });
+    child.stderr?.on("error", (error) => {
+      settle(() => reject(error));
     });
 
     child.on("error", (error) => {
@@ -2357,5 +2362,6 @@ export const testing = {
   applyToolSearchCatalog,
   addClientToolsToToolSearchCatalog,
   appendToolSearchCodeStderrTail,
+  runCodeModeChild,
 };
 export { testing as __testing };


### PR DESCRIPTION
## What Problem This Solves

Code-mode `tool_search` spawned an unused stdout pipe and left stderr stream errors unhandled. A broken diagnostic pipe could therefore surface as an uncaught `error` event instead of rejecting the tool call cleanly.

Supersedes #101022 after the contributor fork head became unstable during maintainer fixup. The original author remains credited in the commit.

## Why This Change Was Made

The worker already returns logs and results over IPC, so stdout is ignored instead of creating an unused pipe. Stderr failures now flow through the existing once-only settlement path, which rejects pending work and terminates the unusable child without duplicating lifecycle policy.

The one-off proof script and redundant testing export from the submitted branch are omitted. A focused regression exercises the real spawn owner, stderr rejection, child termination, and exact stdio contract.

## User Impact

Code-mode Tool Search fails cleanly when its child diagnostic stream breaks, instead of risking a gateway crash or stranded request. Normal IPC results and stderr diagnostics are unchanged.

## Evidence

- Fresh Codex autoreview on the final two-file patch: clean; no accepted/actionable findings.
- Targeted `oxfmt` and `git diff --check`: clean.
- Sanitized direct AWS Crabbox, provider `aws`, lease `cbx_b04650d7e1c8`, run [`run_4f37de478300`](https://crabbox.openclaw.ai/portal/runs/run_4f37de478300), exact head `411d3260ea455417dbd251ca3a48a32fd1117e4b`: focused test passed 1/1. Broker fallback to `t3.small` required an 8 GiB swap file after a prior undersized lease was OOM-killed during dependency installation before tests.
- Exact-head hosted CI [run 28838695336](https://github.com/openclaw/openclaw/actions/runs/28838695336): 71 relevant checks succeeded, none pending/failing.
