### PR TITLE
fix(web-fetch): keep extracted text truncation UTF-16 safe

### DIFF
--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -1,6 +1,6 @@
 // web_fetch extraction utility tests cover HTML entity decoding.
 import { describe, expect, it } from "vitest";
-import { htmlToMarkdown } from "./web-fetch-utils.js";
+import { htmlToMarkdown, truncateText } from "./web-fetch-utils.js";
 
 describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
   const grin = String.fromCodePoint(0x1f600); // 😀 — an astral (> U+FFFF) code point
@@ -38,5 +38,14 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
     // A malformed numeric reference is not an entity and must survive as text,
     // not be consumed by a lenient parseInt (e.g. "&#39x;" must not become "'").
     expect(htmlToMarkdown(`<p>&#39x; end</p>`).text).toBe("&#39x; end");
+  });
+
+  it("truncates without splitting a boundary emoji", () => {
+    const prefix = "a".repeat(79);
+    const result = truncateText(`${prefix}${grin}tail`, 80);
+
+    expect(result.truncated).toBe(true);
+    expect(result.text).toBe(prefix);
+    expect(result.text).not.toContain(String.fromCharCode(0xd83d));
   });
 });

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -3,6 +3,7 @@
  *
  * Converts lightweight HTML into bounded markdown/text without pulling in a full renderer.
  */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { decodeHtmlEntityAt } from "../utils/html.js";
 import { sanitizeHtml, stripInvisibleUnicode } from "./web-fetch-visibility.js";
 
@@ -130,7 +131,7 @@ export function truncateText(
   if (value.length <= maxChars) {
     return { text: value, truncated: false };
   }
-  return { text: value.slice(0, maxChars), truncated: true };
+  return { text: truncateUtf16Safe(value, maxChars), truncated: true };
 }
 
 /** Sanitizes HTML and extracts either markdown or plain text content. */


### PR DESCRIPTION
## Summary

- AI-assisted with Codex; I inspected the changed production path and can explain the change.
- Web fetch extracted/returned text truncation preserves UTF-16 boundaries instead of returning a dangling surrogate when an emoji crosses the character cap.
- Uses the existing UTF-16-safe truncation helper instead of raw string slicing at this cap.
- Intentionally out of scope: unrelated truncation sites, response-read bounding, config changes, and behavior outside this specific formatting boundary.

## Linked context

- No linked issue.
- Related to the existing OpenClaw UTF-16-safe truncation hardening pattern.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** Web fetch extracted/returned text truncation preserves UTF-16 boundaries instead of returning a dangling surrogate when an emoji crosses the character cap.
- **Real environment tested:** local OpenClaw source checkout on Node v22.22.0; PR head c876eb8954.
- **Exact steps or command run after this patch:** node scripts/run-vitest.mjs src/agents/tools/web-fetch-utils.test.ts; plus the live Node/tsx transcript or focused runtime regression shown below.
- **Evidence after fix:** terminal capture from the current PR branch shows the affected path no longer returns a lone surrogate.

```text
$ node --import tsx -e '<drive truncateText on a boundary emoji>'
{"truncated":true,"length":79,"endsWithEmoji":false,"hasLoneSurrogate":false,"tail":"aaaaa"}

$ node scripts/run-vitest.mjs src/agents/tools/web-fetch-utils.test.ts
Test Files 1 passed
Tests 6 passed
```

- **Observed result after fix:** the affected web-fetch truncation path keeps output well-formed at the emoji/surrogate-pair boundary and preserves the existing truncation marker/cap behavior.
- **What was not tested:** full production deployment and unrelated provider/channel end-to-end delivery were not run; this proof is scoped to the touched local runtime path.
- **Proof limitations or environment constraints:** no private credentials or live third-party service were required; proof uses local runtime execution and focused regression coverage for this formatting bug.
- **Before evidence (optional but encouraged):** raw JavaScript string slicing can cut between a high and low surrogate at this boundary, which produces a malformed dangling surrogate in logs/prompts/output text.

## Tests and validation

- node scripts/run-vitest.mjs src/agents/tools/web-fetch-utils.test.ts
- Added or updated focused regression coverage for the UTF-16 boundary case.
- No known local failures from this change.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed truncated text is now avoided while preserving existing caps and truncation markers.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

web_fetch returned/error text formatting.

How is that risk mitigated?

The patch is limited to the existing truncation boundary and is covered by focused regression proof above.

## Current review state

What is the next action?

ClawSweeper re-review and maintainer review after this proof/body refresh.

What is still waiting on author, maintainer, CI, or external proof?

Nothing is waiting on the author after this proof update; waiting on CI/ClawSweeper/maintainer review.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's needs-proof feedback by using exact Real behavior proof field labels and adding copied terminal output from the current PR head.
