### PR TITLE
fix(media): keep audit context truncation UTF-16 safe

### DIFF
--- a/src/media-understanding/shared.test.ts
+++ b/src/media-understanding/shared.test.ts
@@ -637,6 +637,23 @@ describe("fetchWithTimeoutGuarded", () => {
     expect(call.timeoutMs).toBe(5000);
   });
 
+  it("truncates auditContext without leaving a lone surrogate at the max boundary", async () => {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: new Response(null, { status: 200 }),
+      finalUrl: "https://example.com",
+      release: async () => {},
+    });
+
+    const prefix = "a".repeat(79);
+    await fetchWithTimeoutGuarded("https://example.com", {}, 5000, fetch, {
+      auditContext: `${prefix}${String.fromCodePoint(0x1f600)}tail`,
+    });
+
+    const call = getFirstGuardedFetchCall();
+    expect(call.auditContext).toBe(prefix);
+    expect(call.auditContext).not.toContain(String.fromCharCode(0xd83d));
+  });
+
   it("passes configured explicit proxy policy through the SSRF guard", async () => {
     fetchWithSsrFGuardMock.mockResolvedValue({
       response: new Response(null, { status: 200 }),

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -1,6 +1,7 @@
 // Shared provider HTTP/audio helpers for media-understanding integrations,
 // including guarded fetches, deadlines, retries, and multipart upload bodies.
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   assertOkOrThrowHttpError,
   createProviderHttpError,
@@ -321,7 +322,7 @@ function sanitizeAuditContext(auditContext: string | undefined): string | undefi
   if (!cleaned) {
     return undefined;
   }
-  return cleaned.slice(0, MAX_AUDIT_CONTEXT_CHARS);
+  return truncateUtf16Safe(cleaned, MAX_AUDIT_CONTEXT_CHARS);
 }
 
 type ResolvedProviderHttpRequestConfig = {


### PR DESCRIPTION
## Summary

- AI-assisted with Codex; I inspected the changed production path and can explain the change.
- Media provider guarded-fetch `auditContext` truncation now preserves UTF-16 boundaries before passing context to the network guard.
- Uses the existing UTF-16-safe truncation helper instead of raw string slicing at this cap.
- Intentionally out of scope: unrelated truncation sites, response-read bounding, config changes, and behavior outside this specific audit-context formatting boundary.

## Linked context

- No linked issue.
- Related to the existing OpenClaw UTF-16-safe truncation hardening pattern.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** media provider guarded-fetch `auditContext` truncation should not leave a dangling surrogate when the 80-code-unit cap lands inside an emoji/surrogate pair.
- **Real environment tested:** local OpenClaw source checkout on Node v22.22.0; PR head `91baf0c239fa2f64f6838a811298e318607ab55e`.
- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs src/media-understanding/shared.test.ts`
  - Standalone `node --import tsx --input-type=module` invocation of the actual `fetchWithTimeoutGuarded -> fetchWithSsrFGuard` blocked-URL path.
- **Evidence after fix:**

```text
$ node scripts/run-vitest.mjs src/media-understanding/shared.test.ts
[test] starting test/vitest/vitest.media-understanding.config.ts
RUN  v4.1.9 /tmp/openclaw-utf16-prs/media-audit-context
Test Files  1 passed (1)
Tests  44 passed (44)
[test] passed 1 Vitest shard in 14.83s
```

Standalone runtime transcript from the same head:

```text
$ node --import tsx --input-type=module  # calls fetchWithTimeoutGuarded with auditContext, then SSRF guard blocks localhost
node=v22.22.0
head=91baf0c239fa2f64f6838a811298e318607ab55e
path=fetchWithTimeoutGuarded -> fetchWithSsrFGuard blocked URL log
inputAuditChars=85
blocked=true
loggedAuditPrefixChars=79
logContainsPrefix=true
logContainsEmoji=false
logHasLoneSurrogate=false
```

- **Observed result after fix:** the real guarded-fetch path logs the sanitized 79-character prefix, does not include the emoji cut at the boundary, and does not emit a lone surrogate.
- **What was not tested:** full production deployment and unrelated provider/channel end-to-end delivery were not run; this proof is scoped to the touched media audit-context path.
- **Proof limitations or environment constraints:** the standalone proof intentionally uses a blocked localhost URL so the actual SSRF guard produces observable sanitized audit-context output without external credentials or live provider traffic.
- **Before evidence (optional but encouraged):** raw JavaScript string slicing can cut between a high and low surrogate at this boundary, producing malformed text in logs/prompts/output text.

## Tests and validation

- `node scripts/run-vitest.mjs src/media-understanding/shared.test.ts`
- Standalone runtime transcript shown above.
- Added focused regression coverage for the UTF-16 boundary case.
- No known local failures from this change.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed truncated audit-context text is now avoided while preserving the existing cap.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

media-understanding provider audit context formatting.

How is that risk mitigated?

The patch is limited to the existing truncation boundary, uses the existing UTF-16 helper, and is covered by focused regression plus actual guarded-fetch runtime proof.

## Current review state

What is the next action?

ClawSweeper re-review and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Nothing is waiting on the author after this proof update; waiting on CI/ClawSweeper/maintainer review.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's needs-proof feedback with standalone runtime proof from the current PR head.

