### PR TITLE
fix(voice-call): keep media log truncation UTF-16 safe

### DIFF
--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -444,6 +444,13 @@ describe("MediaStreamHandler security hardening", () => {
     expect(reason).toContain("forged line entry");
   });
 
+  it("truncates websocket close reason without splitting UTF-16 surrogate pairs", () => {
+    const reason = sanitizeLogText(`abc\uD83D\uDE80tail`, 4);
+    expect(reason).toBe("abc...");
+    expect(reason).not.toContain("\uD83D");
+    expect(reason).not.toContain("\uDE80");
+  });
+
   it("closes idle pre-start connections after timeout", async () => {
     const shouldAcceptStreamCalls: Array<{ callId: string; streamSid: string; token?: string }> =
       [];

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -23,6 +23,7 @@ import {
   type TalkEventInput,
   type TalkSessionController,
 } from "openclaw/plugin-sdk/realtime-voice";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { type RawData, WebSocket, WebSocketServer } from "ws";
 
 /**
@@ -109,7 +110,7 @@ export function sanitizeLogText(value: string, maxChars: number): string {
   if (sanitized.length <= maxChars) {
     return sanitized;
   }
-  return `${sanitized.slice(0, maxChars)}...`;
+  return `${truncateUtf16Safe(sanitized, maxChars)}...`;
 }
 
 function normalizeWsMessageData(data: RawData): Buffer {


### PR DESCRIPTION
## Summary

- AI-assisted with Codex; I inspected the changed production path and can explain the change.
- Voice-call WebSocket close-reason log truncation preserves UTF-16 boundaries.
- Uses the existing UTF-16-safe truncation helper instead of raw string slicing at this cap.
- Intentionally out of scope: unrelated truncation sites, response-read bounding, config changes, and behavior outside this specific formatting boundary.

## Linked context

- No linked issue.
- Related to the existing OpenClaw UTF-16-safe truncation hardening pattern.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** Voice-call WebSocket close-reason log truncation preserves UTF-16 boundaries.
- **Real environment tested:** local OpenClaw source checkout on Node v22.22.0; PR head d546bdec4b.
- **Exact steps or command run after this patch:** node scripts/run-vitest.mjs extensions/voice-call/src/media-stream.test.ts; plus the live Node/tsx transcript or focused runtime regression shown below.
- **Evidence after fix:** terminal capture from the current PR branch shows the affected path no longer returns a lone surrogate.

```text
$ node --import tsx -e '<drive sanitizeLogText on abc + rocket + tail with maxChars=4>'
{"value":"abc...","hasLoneSurrogate":false,"containsRocket":false}

$ node scripts/run-vitest.mjs extensions/voice-call/src/media-stream.test.ts
Test Files 1 passed
Tests 22 passed
```

- **Observed result after fix:** the affected voice-call truncation path keeps output well-formed at the emoji/surrogate-pair boundary and preserves the existing truncation marker/cap behavior.
- **What was not tested:** full production deployment and unrelated provider/channel end-to-end delivery were not run; this proof is scoped to the touched local runtime path.
- **Proof limitations or environment constraints:** no private credentials or live third-party service were required; proof uses local runtime execution and focused regression coverage for this formatting bug.
- **Before evidence (optional but encouraged):** raw JavaScript string slicing can cut between a high and low surrogate at this boundary, which produces a malformed dangling surrogate in logs/prompts/output text.

## Tests and validation

- node scripts/run-vitest.mjs extensions/voice-call/src/media-stream.test.ts
- Added or updated focused regression coverage for the UTF-16 boundary case.
- No known local failures from this change.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed truncated text is now avoided while preserving existing caps and truncation markers.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

voice-call media stream log formatting.

How is that risk mitigated?

The patch is limited to the existing truncation boundary and is covered by focused regression proof above.

## Current review state

What is the next action?

ClawSweeper re-review and maintainer review after this proof/body refresh.

What is still waiting on author, maintainer, CI, or external proof?

Nothing is waiting on the author after this proof update; waiting on CI/ClawSweeper/maintainer review.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's needs-proof feedback by using exact Real behavior proof field labels and adding copied terminal output from the current PR head.
