### PR TITLE
fix(telegram): keep raw update log truncation UTF-16 safe

### DIFF
--- a/extensions/telegram/src/bot-core.raw-update-log.test.ts
+++ b/extensions/telegram/src/bot-core.raw-update-log.test.ts
@@ -173,4 +173,19 @@ describe("stringifyTelegramRawUpdateForLog", () => {
       expect(rawLog).not.toContain(privateValue);
     }
   });
+
+  it("truncates long raw update strings without splitting UTF-16 surrogate pairs", () => {
+    const prefix = "a".repeat(499);
+    const rawLog = stringifyTelegramRawUpdateForLog({
+      update_id: 123,
+      diagnostic: `${prefix}\uD83D\uDE80tail`,
+    });
+    const parsed = JSON.parse(rawLog) as { diagnostic: string };
+
+    expect(parsed.diagnostic).toBe(`${prefix}...`);
+    expect(parsed.diagnostic).not.toContain("\uD83D");
+    expect(parsed.diagnostic).not.toContain("\uDE80");
+    expect(rawLog).not.toContain("\\ud83d");
+    expect(rawLog).not.toContain("\\ude80");
+  });
 });

--- a/extensions/telegram/src/raw-update-log.ts
+++ b/extensions/telegram/src/raw-update-log.ts
@@ -1,4 +1,6 @@
 // Telegram plugin module implements raw update log behavior.
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
 const MAX_RAW_UPDATE_STRING = 500;
 const MAX_RAW_UPDATE_ARRAY = 20;
 const REDACTED_TELEGRAM_FIELD = "[redacted]";
@@ -80,7 +82,7 @@ export function stringifyTelegramRawUpdateForLog(update: unknown): string {
     }
     if (typeof value === "string") {
       return value.length > MAX_RAW_UPDATE_STRING
-        ? `${value.slice(0, MAX_RAW_UPDATE_STRING)}...`
+        ? `${truncateUtf16Safe(value, MAX_RAW_UPDATE_STRING)}...`
         : value;
     }
     if (Array.isArray(value)) {


### PR DESCRIPTION
## Summary

- AI-assisted with Codex; I inspected the changed production path and can explain the change.
- Telegram raw-update diagnostic string truncation preserves UTF-16 boundaries and does not emit escaped surrogate halves in JSON logs.
- Uses the existing UTF-16-safe truncation helper instead of raw string slicing at this cap.
- Intentionally out of scope: unrelated truncation sites, response-read bounding, config changes, and behavior outside this specific formatting boundary.

## Linked context

- No linked issue.
- Related to the existing OpenClaw UTF-16-safe truncation hardening pattern.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** Telegram raw-update diagnostic string truncation preserves UTF-16 boundaries and does not emit escaped surrogate halves in JSON logs.
- **Real environment tested:** local OpenClaw source checkout on Node v22.22.0; PR head 79027a3cfc.
- **Exact steps or command run after this patch:** node scripts/run-vitest.mjs extensions/telegram/src/bot-core.raw-update-log.test.ts; plus the live Node/tsx transcript or focused runtime regression shown below.
- **Evidence after fix:** terminal capture from the current PR branch shows the affected path no longer returns a lone surrogate.

```text
$ node --import tsx -e '<drive stringifyTelegramRawUpdateForLog on 499 chars + rocket + tail>'
{"diagnosticLength":502,"diagnosticTail":"aaa...","rawHasEscapedSurrogate":false}

$ node scripts/run-vitest.mjs extensions/telegram/src/bot-core.raw-update-log.test.ts
Test Files 1 passed
Tests 3 passed
```

- **Observed result after fix:** the affected telegram truncation path keeps output well-formed at the emoji/surrogate-pair boundary and preserves the existing truncation marker/cap behavior.
- **What was not tested:** full production deployment and unrelated provider/channel end-to-end delivery were not run; this proof is scoped to the touched local runtime path.
- **Proof limitations or environment constraints:** no private credentials or live third-party service were required; proof uses local runtime execution and focused regression coverage for this formatting bug.
- **Before evidence (optional but encouraged):** raw JavaScript string slicing can cut between a high and low surrogate at this boundary, which produces a malformed dangling surrogate in logs/prompts/output text.

## Tests and validation

- node scripts/run-vitest.mjs extensions/telegram/src/bot-core.raw-update-log.test.ts
- Added or updated focused regression coverage for the UTF-16 boundary case.
- No known local failures from this change.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed truncated text is now avoided while preserving existing caps and truncation markers.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

telegram raw update log redaction/truncation formatting.

How is that risk mitigated?

The patch is limited to the existing truncation boundary and is covered by focused regression proof above.

## Current review state

What is the next action?

ClawSweeper re-review and maintainer review after this proof/body refresh.

What is still waiting on author, maintainer, CI, or external proof?

Nothing is waiting on the author after this proof update; waiting on CI/ClawSweeper/maintainer review.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's needs-proof feedback by using exact Real behavior proof field labels and adding copied terminal output from the current PR head.
