### PR TITLE
fix(tts): keep status detail truncation UTF-16 safe

### DIFF
--- a/src/tts/status-config.test.ts
+++ b/src/tts/status-config.test.ts
@@ -7,6 +7,22 @@ import type { OpenClawConfig } from "../config/types.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { resolveStatusTtsSnapshot } from "./status-config.js";
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 let fixtureRoot = "";
 let fixtureId = 0;
 
@@ -195,6 +211,38 @@ describe("resolveStatusTtsSnapshot", () => {
         maxLength: 1500,
         summarize: true,
       });
+    });
+  });
+
+  it("keeps truncated status detail fields well-formed at UTF-16 boundaries", async () => {
+    await withStatusTempHome(async () => {
+      const displayName = `${"d".repeat(92)}😀tail`;
+      const model = `${"m".repeat(92)}😀tail`;
+      const voice = `${"v".repeat(92)}😀tail`;
+      const snapshot = resolveStatusTtsSnapshot({
+        cfg: {
+          messages: {
+            tts: {
+              auto: "always",
+              provider: "elevenlabs",
+              providers: {
+                elevenlabs: {
+                  displayName,
+                  model,
+                  voice,
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+      });
+
+      expect(snapshot?.displayName).toBe(`${"d".repeat(92)}...`);
+      expect(snapshot?.model).toBe(`${"m".repeat(92)}...`);
+      expect(snapshot?.voice).toBe(`${"v".repeat(92)}...`);
+      expect(hasLoneSurrogate(snapshot?.displayName ?? "")).toBe(false);
+      expect(hasLoneSurrogate(snapshot?.model ?? "")).toBe(false);
+      expect(hasLoneSurrogate(snapshot?.voice ?? "")).toBe(false);
     });
   });
 

--- a/src/tts/status-config.ts
+++ b/src/tts/status-config.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../config/types.js";
 import type { TtsAutoMode, TtsConfig, TtsProvider } from "../config/types.tts.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
@@ -114,7 +115,9 @@ function normalizeStatusDetail(
   if (!normalized) {
     return undefined;
   }
-  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 3)}...` : normalized;
+  return normalized.length > maxLength
+    ? `${truncateUtf16Safe(normalized, maxLength - 3)}...`
+    : normalized;
 }
 
 function sanitizeBaseUrlForStatus(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary

- AI-assisted with Codex; I inspected the changed production path and can explain the change.
- TTS status displayName/model/voice detail truncation preserves UTF-16 boundaries before adding ellipses.
- Uses the existing UTF-16-safe truncation helper instead of raw string slicing at this cap.
- Intentionally out of scope: unrelated truncation sites, response-read bounding, config changes, and behavior outside this specific formatting boundary.

## Linked context

- No linked issue.
- Related to the existing OpenClaw UTF-16-safe truncation hardening pattern.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** TTS status displayName/model/voice detail truncation preserves UTF-16 boundaries before adding ellipses.
- **Real environment tested:** local OpenClaw source checkout on Node v22.22.0; PR head 351d0cd5a8.
- **Exact steps or command run after this patch:** node scripts/run-vitest.mjs src/tts/status-config.test.ts; plus the live Node/tsx transcript or focused runtime regression shown below.
- **Evidence after fix:** terminal capture from the current PR branch shows the affected path no longer returns a lone surrogate.

```text
$ node --import tsx -e '<drive resolveStatusTtsSnapshot with displayName/model/voice at emoji boundary>'
{"displayName":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd...","model":"mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm...","voice":"vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv...","hasLoneSurrogate":false}

$ node scripts/run-vitest.mjs src/tts/status-config.test.ts
Test Files 1 passed
Tests 11 passed
```

- **Observed result after fix:** the affected tts truncation path keeps output well-formed at the emoji/surrogate-pair boundary and preserves the existing truncation marker/cap behavior.
- **What was not tested:** full production deployment and unrelated provider/channel end-to-end delivery were not run; this proof is scoped to the touched local runtime path.
- **Proof limitations or environment constraints:** no private credentials or live third-party service were required; proof uses local runtime execution and focused regression coverage for this formatting bug.
- **Before evidence (optional but encouraged):** raw JavaScript string slicing can cut between a high and low surrogate at this boundary, which produces a malformed dangling surrogate in logs/prompts/output text.

## Tests and validation

- node scripts/run-vitest.mjs src/tts/status-config.test.ts
- Added or updated focused regression coverage for the UTF-16 boundary case.
- No known local failures from this change.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed truncated text is now avoided while preserving existing caps and truncation markers.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

TTS status/config display text formatting.

How is that risk mitigated?

The patch is limited to the existing truncation boundary and is covered by focused regression proof above.

## Current review state

What is the next action?

ClawSweeper re-review and maintainer review after this proof/body refresh.

What is still waiting on author, maintainer, CI, or external proof?

Nothing is waiting on the author after this proof update; waiting on CI/ClawSweeper/maintainer review.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's needs-proof feedback by using exact Real behavior proof field labels and adding copied terminal output from the current PR head.
