### PR TITLE
fix(voice-call): keep realtime context truncation UTF-16 safe

### DIFF
--- a/extensions/voice-call/src/realtime-agent-context.test.ts
+++ b/extensions/voice-call/src/realtime-agent-context.test.ts
@@ -95,11 +95,12 @@ describe("buildRealtimeVoiceInstructions", () => {
   });
 
   it("truncates injected context without splitting UTF-16 surrogate pairs", async () => {
-    const agentId = `abc\uD83D\uDE80tail`;
+    const agentId = "abc🚀tail";
+    const expectedContext = "OpenClaw agent voice context:\n\n- Agent id: abc";
     const config = createConfig({
       agentContext: {
         enabled: true,
-        maxChars: "OpenClaw agent voice context:\n\n- Agent id: abc".length + 33,
+        maxChars: expectedContext.length + 33,
         includeIdentity: false,
         includeWorkspaceFiles: false,
         files: [],
@@ -111,11 +112,9 @@ describe("buildRealtimeVoiceInstructions", () => {
       baseInstructions: "Base voice instructions.",
       config,
       coreConfig: { agents: { list: [{ id: agentId }] } } as CoreConfig,
-      agentRuntime: createAgentRuntime(await createWorkspace()),
+      agentRuntime: createAgentRuntime("/unused"),
     });
 
-    expect(instructions).toContain("- Agent id: abc\n[truncated]");
-    expect(instructions).not.toContain("\uD83D");
-    expect(instructions).not.toContain("\uDE80");
+    expect(instructions).toBe(`Base voice instructions.\n\n${expectedContext}\n[truncated]`);
   });
 });

--- a/extensions/voice-call/src/realtime-agent-context.test.ts
+++ b/extensions/voice-call/src/realtime-agent-context.test.ts
@@ -93,4 +93,29 @@ describe("buildRealtimeVoiceInstructions", () => {
     expect(instructions).toContain("### IDENTITY.md");
     expect(instructions).not.toContain("do not include");
   });
+
+  it("truncates injected context without splitting UTF-16 surrogate pairs", async () => {
+    const agentId = `abc\uD83D\uDE80tail`;
+    const config = createConfig({
+      agentContext: {
+        enabled: true,
+        maxChars: "OpenClaw agent voice context:\n\n- Agent id: abc".length + 33,
+        includeIdentity: false,
+        includeWorkspaceFiles: false,
+        files: [],
+      },
+    });
+    config.agentId = agentId;
+
+    const instructions = await buildRealtimeVoiceInstructions({
+      baseInstructions: "Base voice instructions.",
+      config,
+      coreConfig: { agents: { list: [{ id: agentId }] } } as CoreConfig,
+      agentRuntime: createAgentRuntime(await createWorkspace()),
+    });
+
+    expect(instructions).toContain("- Agent id: abc\n[truncated]");
+    expect(instructions).not.toContain("\uD83D");
+    expect(instructions).not.toContain("\uDE80");
+  });
 });

--- a/extensions/voice-call/src/realtime-agent-context.ts
+++ b/extensions/voice-call/src/realtime-agent-context.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { buildRealtimeVoiceAgentConsultPolicyInstructions } from "openclaw/plugin-sdk/realtime-voice";
 import { root } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeOptionalString as normalizeString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { VoiceCallConfig } from "./config.js";
 import type { CoreAgentDeps, CoreConfig } from "./core-bridge.js";
 
@@ -22,7 +23,7 @@ function limitText(text: string, maxChars: number): string {
   if (text.length <= maxChars) {
     return text;
   }
-  return `${text.slice(0, Math.max(0, maxChars - 32)).trimEnd()}\n[truncated]`;
+  return `${truncateUtf16Safe(text, Math.max(0, maxChars - 32)).trimEnd()}\n[truncated]`;
 }
 
 /** Read configured workspace context files through the safe workspace root. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where realtime voice sessions could receive malformed injected agent context when the configured character cap landed between the UTF-16 code units of an emoji.

## Why This Change Was Made

The existing voice-context limiter now uses OpenClaw's shared UTF-16-safe truncation helper while preserving the existing character budget and `[truncated]` marker. The focused regression drives the public instruction builder at the exact split-surrogate boundary and asserts the complete result.

## User Impact

Realtime voice prompts remain valid Unicode at emoji boundaries instead of containing a dangling surrogate. Context limits and behavior outside truncation are unchanged.

## Evidence

- Blacksmith Testbox through Crabbox `tbx_01kwxyz3apwmff73p7mhnzna80`: `corepack pnpm test extensions/voice-call/src/realtime-agent-context.test.ts` — 1 file, 2 tests passed.
- Same Testbox: `corepack pnpm check:changed` — passed.
- Exact-head CI for `c1bb06a35e24a89ed49004f917a2118c4479f8e2`: https://github.com/openclaw/openclaw/actions/runs/28857280475 — passed.
- Codex autoreview: production branch diff clean at 0.99 confidence; maintainer test cleanup clean at 0.98 confidence.
- Live provider credentials were not needed because the defect and fix are entirely within deterministic prompt formatting.

AI-assisted; maintainer-reviewed and tested.
