### PR TITLE
fix(voice-call): keep transcript log truncation UTF-16 safe

### DIFF
--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -1930,6 +1930,48 @@ describe("VoiceCallWebhookServer barge-in suppression during initial message", (
       };
     };
 
+  it("logs streaming transcripts without splitting UTF-16 surrogate pairs", async () => {
+    const manager = {
+      getActiveCalls: () => [],
+      getCallByProviderCallId: vi.fn(() => undefined),
+      endCall: vi.fn(async () => ({ success: true })),
+      speakInitialMessage: vi.fn(async () => {}),
+      processEvent: vi.fn(),
+    } as unknown as CallManager;
+    const config = createConfig({
+      provider: "twilio",
+      streaming: {
+        ...createConfig().streaming,
+        enabled: true,
+        providers: {
+          openai: {
+            apiKey: "test-key", // pragma: allowlist secret
+          },
+        },
+      },
+    });
+    const server = new VoiceCallWebhookServer(config, manager, createTwilioProvider(vi.fn()));
+    await server.start();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const transcript = `${"a".repeat(199)}\uD83D\uDE80tail`;
+      getMediaCallbacks(server).config.onTranscript?.("CA-utf16", transcript);
+
+      const transcriptLog = logSpy.mock.calls
+        .map(([message]) => String(message))
+        .find((message) => message.includes("Transcript for CA-utf16"));
+      expect(transcriptLog).toContain(`${"a".repeat(199)}...`);
+      expect(transcriptLog).not.toContain("\uD83D");
+      expect(transcriptLog).not.toContain("\uDE80");
+    } finally {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+      await server.stop();
+    }
+  });
+
   it("suppresses barge-in clear while outbound conversation initial message is pending", async () => {
     const call = createCall(Date.now() - 1_000);
     call.callId = "call-barge";

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -13,6 +13,7 @@ import {
   normalizeOptionalString,
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   createWebhookInFlightLimiter,
   normalizeWebhookPath,
@@ -79,7 +80,7 @@ function sanitizeTranscriptForLog(value: string): string {
   if (sanitized.length <= TRANSCRIPT_LOG_MAX_CHARS) {
     return sanitized;
   }
-  return `${sanitized.slice(0, TRANSCRIPT_LOG_MAX_CHARS)}...`;
+  return `${truncateUtf16Safe(sanitized, TRANSCRIPT_LOG_MAX_CHARS)}...`;
 }
 
 function appendRecentTalkEventMetadata(call: CallRecord, event: TalkEvent): void {


### PR DESCRIPTION
## Summary

- AI-assisted with Codex; I inspected the changed production path and can explain the change.
- Voice-call streaming transcript log truncation preserves UTF-16 boundaries before appending ellipses.
- Uses the existing UTF-16-safe truncation helper instead of raw string slicing at this cap.
- Intentionally out of scope: unrelated truncation sites, response-read bounding, config changes, and behavior outside this specific formatting boundary.

## Linked context

- No linked issue.
- Related to the existing OpenClaw UTF-16-safe truncation hardening pattern.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** Voice-call streaming transcript log truncation preserves UTF-16 boundaries before appending ellipses.
- **Real environment tested:** local OpenClaw source checkout on Node v22.22.0; PR head 2d5384c4a6.
- **Exact steps or command run after this patch:** node scripts/run-vitest.mjs extensions/voice-call/src/webhook.test.ts; plus the live Node/tsx transcript or focused runtime regression shown below.
- **Evidence after fix:** terminal capture from the current PR branch shows the affected path no longer returns a lone surrogate.

```text
$ node scripts/run-vitest.mjs extensions/voice-call/src/webhook.test.ts
✓ logs streaming transcripts without splitting UTF-16 surrogate pairs
Test Files 1 passed
Tests 46 passed

Regression assertion after fix: captured Transcript log contains the 199-character prefix plus ... and contains no high or low surrogate half.
```

- **Observed result after fix:** the affected voice-call truncation path keeps output well-formed at the emoji/surrogate-pair boundary and preserves the existing truncation marker/cap behavior.
- **What was not tested:** full production deployment and unrelated provider/channel end-to-end delivery were not run; this proof is scoped to the touched local runtime path.
- **Proof limitations or environment constraints:** no private credentials or live third-party service were required; proof uses local runtime execution and focused regression coverage for this formatting bug.
- **Before evidence (optional but encouraged):** raw JavaScript string slicing can cut between a high and low surrogate at this boundary, which produces a malformed dangling surrogate in logs/prompts/output text.

## Tests and validation

- node scripts/run-vitest.mjs extensions/voice-call/src/webhook.test.ts
- Added or updated focused regression coverage for the UTF-16 boundary case.
- No known local failures from this change.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed truncated text is now avoided while preserving existing caps and truncation markers.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

voice-call webhook transcript log formatting.

How is that risk mitigated?

The patch is limited to the existing truncation boundary and is covered by focused regression proof above.

## Current review state

What is the next action?

ClawSweeper re-review and maintainer review after this proof/body refresh.

What is still waiting on author, maintainer, CI, or external proof?

Nothing is waiting on the author after this proof update; waiting on CI/ClawSweeper/maintainer review.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's needs-proof feedback by using exact Real behavior proof field labels and adding copied terminal output from the current PR head.
