### PR TITLE
fix(discord): keep thread title truncation UTF-16 safe

### DIFF
--- a/extensions/discord/src/monitor/thread-title.generate.test.ts
+++ b/extensions/discord/src/monitor/thread-title.generate.test.ts
@@ -200,6 +200,22 @@ describe("generateThreadTitle", () => {
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
   });
 
+  it("preserves code points when prompt fields hit truncation boundaries", async () => {
+    await generateThreadTitle({
+      cfg: EMPTY_DISCORD_TEST_CONFIG,
+      agentId: "main",
+      messageText: `${"m".repeat(599)}😀tail`,
+      channelName: `${"n".repeat(119)}😀tail`,
+      channelDescription: `${"d".repeat(319)}😀tail`,
+    });
+
+    expect(firstCompletionArgs().context.messages.at(0)?.content).toBe(
+      `Channel: ${"n".repeat(119)}...\n\n` +
+        `Channel description: ${"d".repeat(319)}...\n\n` +
+        `Message:\n${"m".repeat(599)}...`,
+    );
+  });
+
   it("clamps completion budget to the selected model output cap", async () => {
     prepareSimpleCompletionModelForAgentMock.mockResolvedValueOnce({
       selection: {

--- a/extensions/discord/src/monitor/thread-title.ts
+++ b/extensions/discord/src/monitor/thread-title.ts
@@ -6,6 +6,7 @@ import {
   extractAssistantText,
   prepareSimpleCompletionModelForAgent,
 } from "openclaw/plugin-sdk/simple-completion-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { withAbortTimeout } from "./timeouts.js";
 
 const DEFAULT_THREAD_TITLE_TIMEOUT_MS = 60_000;
@@ -132,7 +133,7 @@ function truncateThreadTitleSourceText(sourceText: string): string {
   if (sourceText.length <= MAX_THREAD_TITLE_SOURCE_CHARS) {
     return sourceText;
   }
-  return `${sourceText.slice(0, MAX_THREAD_TITLE_SOURCE_CHARS)}...`;
+  return `${truncateUtf16Safe(sourceText, MAX_THREAD_TITLE_SOURCE_CHARS)}...`;
 }
 
 function resolveThreadTitleTimeoutMs(timeoutMs: number | undefined): number {
@@ -201,5 +202,5 @@ function normalizeTitleContextField(raw: string | undefined, maxChars: number): 
   if (singleLine.length <= maxChars) {
     return singleLine;
   }
-  return `${singleLine.slice(0, maxChars)}...`;
+  return `${truncateUtf16Safe(singleLine, maxChars)}...`;
 }


### PR DESCRIPTION
## What Problem This Solves

Discord thread-title prompt fields were truncated with raw UTF-16 slicing. A limit that landed between an emoji's surrogate pair could send malformed text to the title completion model.

## Why This Change Was Made

All three bounded fields now use the existing plugin SDK `truncateUtf16Safe` helper. Maintainer cleanup keeps the prompt formatter private and tests the real `generateThreadTitle` completion path instead of exporting production code only for a test.

## User Impact

Long Discord message text, channel names, and channel descriptions no longer produce lone UTF-16 surrogates in generated thread-title prompts. Limits and ellipsis behavior are unchanged.

## Evidence

- Blacksmith Testbox: `corepack pnpm test extensions/discord/src/monitor/thread-title.generate.test.ts` — 8/8 passed.
- Blacksmith Testbox: `corepack pnpm check:changed` — passed for the final two-file diff.
- Canonical oxfmt check and `git diff --check` — passed.
- Fresh Codex autoreview — no findings, correctness 0.99.
- Live PR diff verified at 2 files, +19/-2, based directly on current `main`.

Full Discord/provider delivery was not run: the changed behavior is deterministic prompt construction and is exercised through the production completion entry point with the completion call mocked.
