### PR TITLE
fix(talk): keep fast context snippets UTF-16 safe

### DIFF
--- a/src/talk/fast-context-runtime.test.ts
+++ b/src/talk/fast-context-runtime.test.ts
@@ -12,6 +12,22 @@ vi.mock("../plugins/memory-runtime.js", () => ({
 
 import { resolveRealtimeVoiceFastContextConsult } from "./fast-context-runtime.js";
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("resolveRealtimeVoiceFastContextConsult", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -78,5 +94,44 @@ describe("resolveRealtimeVoiceFastContextConsult", () => {
       "[talk] fast context lookup failed: fast context lookup timed out after 25ms",
     );
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("keeps truncated context snippets well-formed at UTF-16 boundaries", async () => {
+    mocks.getActiveMemorySearchManager.mockResolvedValue({
+      manager: {
+        search: vi.fn().mockResolvedValue([
+          {
+            path: "memory.md",
+            startLine: 10,
+            endLine: 12,
+            snippet: `${"a".repeat(698)}😀 tail`,
+            source: "memory",
+            score: 0.9,
+          },
+        ]),
+      },
+    });
+
+    const result = await resolveRealtimeVoiceFastContextConsult({
+      cfg: {},
+      agentId: "main",
+      sessionKey: "voice:15550001234",
+      config: {
+        enabled: true,
+        timeoutMs: 1_000,
+        maxResults: 3,
+        sources: ["memory", "sessions"],
+        fallbackToConsult: true,
+      },
+      args: { question: "What do you remember?" },
+      logger: {},
+    });
+
+    expect(result.handled).toBe(true);
+    if (!result.handled) {
+      return;
+    }
+    expect(result.result.text).toContain(`${"a".repeat(698)}...`);
+    expect(hasLoneSurrogate(result.result.text)).toBe(false);
   });
 });

--- a/src/talk/fast-context-runtime.ts
+++ b/src/talk/fast-context-runtime.ts
@@ -6,6 +6,7 @@
  * back to the normal consult flow.
  */
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { getActiveMemorySearchManager } from "../plugins/memory-runtime.js";
@@ -69,7 +70,7 @@ function normalizeSnippet(text: string): string {
   }
   // Keep individual memory snippets bounded so several hits still fit in a
   // short realtime response prompt.
-  return `${normalized.slice(0, MAX_SNIPPET_CHARS - 1).trimEnd()}...`;
+  return `${truncateUtf16Safe(normalized, MAX_SNIPPET_CHARS - 1).trimEnd()}...`;
 }
 
 function buildSearchQuery(args: unknown): string {


### PR DESCRIPTION
## Summary

- AI-assisted with Codex; I inspected the changed production path and can explain the change.
- Realtime voice fast-context memory snippet truncation now preserves UTF-16 boundaries before adding ellipses.
- Uses the existing UTF-16-safe truncation helper instead of raw string slicing at this cap.
- Intentionally out of scope: unrelated truncation sites, response-read bounding, config changes, and behavior outside this specific fast-context snippet formatting boundary.

## Linked context

- No linked issue.
- Related to the existing OpenClaw UTF-16-safe truncation hardening pattern.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** realtime voice fast-context snippets should not contain a dangling surrogate when memory/session search returns text cut at the snippet limit.
- **Real environment tested:** local OpenClaw source checkout on Node v22.22.0; PR head `f6c4149192c3a14f97060ec6eb72da0e2132f13f`.
- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs src/talk/fast-context-runtime.test.ts`
  - Standalone `node --import tsx --input-type=module` invocation using public `registerMemoryRuntime` and the actual `resolveRealtimeVoiceFastContextConsult` path.
- **Evidence after fix:**

```text
$ node scripts/run-vitest.mjs src/talk/fast-context-runtime.test.ts
[test] starting test/vitest/vitest.unit.config.ts
RUN  v4.1.9 /tmp/openclaw-utf16-prs/talk-fast-context
Test Files  1 passed (1)
Tests  3 passed (3)
[test] passed 1 Vitest shard in 13.10s
```

Standalone runtime transcript from the same head:

```text
$ node --import tsx --input-type=module  # registerMemoryRuntime -> resolveRealtimeVoiceFastContextConsult
node=v22.22.0
head=f6c4149192c3a14f97060ec6eb72da0e2132f13f
path=registerMemoryRuntime -> resolveRealtimeVoiceFastContextConsult
handled=true
textHasPrefix=true
textContainsEmoji=false
textHasLoneSurrogate=false
```

- **Observed result after fix:** the real fast-context runtime path returns a handled consult result whose context text contains the safe 698-character prefix plus `...`, does not include the boundary emoji, and has no lone surrogate.
- **What was not tested:** full production deployment and unrelated provider/channel end-to-end delivery were not run; this proof is scoped to the touched fast-context runtime path.
- **Proof limitations or environment constraints:** the standalone proof uses the public in-process memory runtime registration API with deterministic search results, so no private credentials or live third-party service are required.
- **Before evidence (optional but encouraged):** raw JavaScript string slicing can cut between a high and low surrogate at this boundary, producing malformed fast-context text.

## Tests and validation

- `node scripts/run-vitest.mjs src/talk/fast-context-runtime.test.ts`
- Standalone runtime transcript shown above.
- Added focused regression coverage for the UTF-16 boundary case.
- No known local failures from this change.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed truncated fast-context text is now avoided while preserving existing caps and truncation markers.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

talk fast-context snippet formatting.

How is that risk mitigated?

The patch is limited to the existing truncation boundary, uses the existing UTF-16 helper, and is covered by focused regression plus standalone runtime proof through the public memory runtime registration path.

## Current review state

What is the next action?

ClawSweeper re-review and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Nothing is waiting on the author after this proof update; waiting on CI/ClawSweeper/maintainer review.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's needs-proof feedback with standalone runtime proof from the current PR head.
