### PR TITLE
fix(web-fetch): keep spill content truncation UTF-16 safe

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -316,6 +316,7 @@ async function spillWebFetchContent(
   // maxChars/maxCharsCap bound the model-visible return text. Recoverable spill
   // uses this fixed file cap so vanished pages can still be read after truncation.
   const content = truncateUtf16Safe(value, WEB_FETCH_SPILL_MAX_CHARS);
+  const spilledChars = content.length;
   const fullOutputPath = await writePrivateTempFile(
     "openclaw-web-fetch",
     wrapWebContent(content, "web_fetch"),
@@ -325,7 +326,7 @@ async function spillWebFetchContent(
   const spillNote = sourceTruncated
     ? " Spilled available content from truncated response."
     : spillCapped
-      ? ` Spilled first ${WEB_FETCH_SPILL_MAX_CHARS} chars.`
+      ? ` Spilled first ${spilledChars} chars.`
       : "";
   const fullOutputFooter = formatFullOutputFooter(fullOutputPath);
   const footer = `\n\n[Showing truncated web_fetch content. ${fullOutputFooter}.${spillNote}]`;
@@ -345,7 +346,7 @@ async function spillWebFetchContent(
     text,
     wrappedLength: text.length,
     fullOutputPath,
-    spilledChars: content.length,
+    spilledChars,
     spillTruncated,
   };
 }

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -9,6 +9,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
 import { resolveWebProviderConfig } from "../../../packages/web-content-core/src/provider-runtime-shared.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -314,7 +315,7 @@ async function spillWebFetchContent(
   }
   // maxChars/maxCharsCap bound the model-visible return text. Recoverable spill
   // uses this fixed file cap so vanished pages can still be read after truncation.
-  const content = value.slice(0, WEB_FETCH_SPILL_MAX_CHARS);
+  const content = truncateUtf16Safe(value, WEB_FETCH_SPILL_MAX_CHARS);
   const fullOutputPath = await writePrivateTempFile(
     "openclaw-web-fetch",
     wrapWebContent(content, "web_fetch"),

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -503,6 +503,36 @@ describe("web_fetch extraction fallbacks", () => {
     await rm(details.fullOutputPath, { force: true });
   });
 
+  it("does not split an emoji at the web_fetch spill file cap", async () => {
+    const prefix = "x".repeat(WEB_FETCH_SPILL_MAX_CHARS - 1);
+    const fullText = `${prefix}${String.fromCodePoint(0x1f600)}tail`;
+    installPlainTextFetch(fullText);
+
+    const tool = createFetchTool({
+      firecrawl: { enabled: false },
+      maxChars: 500,
+      maxResponseBytes: WEB_FETCH_SPILL_MAX_CHARS + 1_000,
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/spill-utf16" });
+    const details = result?.details as {
+      fullOutputPath?: string;
+      spilledChars?: number;
+      spillTruncated?: boolean;
+    };
+    if (!details.fullOutputPath) {
+      throw new Error("expected fullOutputPath");
+    }
+
+    expect(details.spilledChars).toBe(WEB_FETCH_SPILL_MAX_CHARS - 1);
+    expect(details.spillTruncated).toBe(true);
+    const spilledText = await readFile(details.fullOutputPath, "utf8");
+    expect(spilledText).toContain(prefix);
+    expect(spilledText).not.toContain(String.fromCodePoint(0x1f600));
+    expect(spilledText).not.toContain(String.fromCharCode(0xd83d));
+    await rm(details.fullOutputPath, { force: true });
+  });
+
   it("marks byte-capped web_fetch spills as partial", async () => {
     const fullText = "z".repeat(40_000);
     installMockFetch((input: RequestInfo | URL) => {

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -516,6 +516,7 @@ describe("web_fetch extraction fallbacks", () => {
 
     const result = await tool?.execute?.("call", { url: "https://example.com/spill-utf16" });
     const details = result?.details as {
+      text?: string;
       fullOutputPath?: string;
       spilledChars?: number;
       spillTruncated?: boolean;
@@ -525,6 +526,7 @@ describe("web_fetch extraction fallbacks", () => {
     }
 
     expect(details.spilledChars).toBe(WEB_FETCH_SPILL_MAX_CHARS - 1);
+    expect(details.text).toContain(`Spilled first ${WEB_FETCH_SPILL_MAX_CHARS - 1} chars.`);
     expect(details.spillTruncated).toBe(true);
     const spilledText = await readFile(details.fullOutputPath, "utf8");
     expect(spilledText).toContain(prefix);


### PR DESCRIPTION
## Summary

- AI-assisted with Codex; I inspected the changed production path and can explain the change.
- web_fetch spill-file content truncation now preserves UTF-16 boundaries at `WEB_FETCH_SPILL_MAX_CHARS`.
- The visible spill footer now reports the actual safe-sliced character count when the helper backs off at a surrogate boundary.
- Intentionally out of scope: unrelated truncation sites, response-read bounding, config changes, and behavior outside this specific web_fetch spill formatting boundary.

## Linked context

- No linked issue.
- Related to the existing OpenClaw UTF-16-safe truncation hardening pattern.

## Real behavior proof (required for external PRs)

- **Behavior addressed:** web_fetch recoverable spill files should not contain malformed text when a response crosses `WEB_FETCH_SPILL_MAX_CHARS` inside an emoji/surrogate pair.
- **Real environment tested:** local OpenClaw source checkout on Node v22.22.0; PR head `9152389df4c611962d53f9d81937360026a35539`.
- **Exact steps or command run after this patch:**
  - `node scripts/run-vitest.mjs src/agents/tools/web-tools.fetch.test.ts`
  - Standalone `node --import tsx --input-type=module` invocation of the actual `createWebFetchTool().execute` path with a deterministic text response payload.
- **Evidence after fix:**

```text
$ node scripts/run-vitest.mjs src/agents/tools/web-tools.fetch.test.ts
[test] starting test/vitest/vitest.agents.config.ts
RUN  v4.1.9 /tmp/openclaw-utf16-prs/web-fetch-spill
Test Files  1 passed (1)
Tests  28 passed (28)
[test] passed 1 Vitest shard in 16.22s
```

Standalone tool-execution transcript from the same head, not a Vitest assertion:

```text
$ node --import tsx --input-type=module  # invokes createWebFetchTool().execute
node=v22.22.0
head=9152389df4c611962d53f9d81937360026a35539
tool=web_fetch createWebFetchTool().execute
inputChars=2000005
spilledChars=1999999
spillTruncated=true
footerHasActualCount=true
spillFileHasEmoji=false
spillFileHasLoneSurrogate=false
```

- **Observed result after fix:** the actual web_fetch tool path spills `WEB_FETCH_SPILL_MAX_CHARS - 1` characters for the surrogate-boundary case, the footer says `Spilled first 1999999 chars.`, and the spilled file has no dangling surrogate.
- **What was not tested:** full production deployment and unrelated provider/channel end-to-end delivery were not run; this proof is scoped to the touched web_fetch spill path.
- **Proof limitations or environment constraints:** the standalone proof uses a deterministic local fetch payload to avoid external-network flake or private credentials; the production `createWebFetchTool().execute` path, spill writer, footer formatter, and spill-file readback were exercised.
- **Before evidence (optional but encouraged):** raw JavaScript string slicing at this cap can cut between a high and low surrogate, leaving malformed text in the recoverable spill file.

## Tests and validation

- `node scripts/run-vitest.mjs src/agents/tools/web-tools.fetch.test.ts`
- Standalone `node --import tsx --input-type=module` tool-execution transcript shown above.
- Added focused regression coverage for the UTF-16 boundary case and footer count.
- No known local failures from this change.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. Malformed truncated spill text is now avoided, and the footer reports the actual safe-sliced character count.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

web_fetch private spill-file content formatting.

How is that risk mitigated?

The patch is limited to the existing truncation boundary, uses the existing UTF-16 helper, preserves the existing cap behavior, and is covered by focused test plus standalone tool execution proof.

## Current review state

What is the next action?

ClawSweeper re-review and maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

Nothing is waiting on the author after this update; waiting on CI/ClawSweeper/maintainer review.

Which bot or reviewer comments were addressed?

Addressed ClawSweeper's footer-count finding and needs-proof feedback with a code fix, a focused regression assertion, and standalone web_fetch tool-execution proof from the current PR head.

