### PR TITLE
fix(proxy): handle aborted upstream responses

### DIFF
--- a/src/proxy-capture/proxy-server.test.ts
+++ b/src/proxy-capture/proxy-server.test.ts
@@ -1,6 +1,10 @@
 // Proxy capture server tests cover request recording and response handling.
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import { request as httpRequest, createServer as createHttpServer } from "node:http";
+import {
+  request as httpRequest,
+  createServer as createHttpServer,
+  type IncomingMessage,
+} from "node:http";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -91,6 +95,104 @@ async function startLargeBodyOrigin(): Promise<{
       }),
     url: `http://127.0.0.1:${address.port}/capture`,
   };
+}
+
+async function startResponseErrorOrigin(): Promise<{
+  stop: () => Promise<void>;
+  url: string;
+}> {
+  const server = createHttpServer((req, res) => {
+    if (req.url === "/before-headers") {
+      res.socket?.destroy();
+      return;
+    }
+    if (req.url === "/after-headers") {
+      res.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+      res.flushHeaders();
+      res.write("partial");
+      setTimeout(() => res.socket?.destroy(), 50);
+      return;
+    }
+    res.writeHead(200, {
+      "content-length": 2,
+      "content-type": "text/plain; charset=utf-8",
+    });
+    res.end("ok");
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    stop: async () =>
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+type ProxyResponseResult = {
+  body: string;
+  complete: boolean;
+  errorMessage?: string;
+  statusCode?: number;
+};
+
+async function getThroughProxy(proxyUrl: string, targetUrl: string): Promise<ProxyResponseResult> {
+  const proxy = new URL(proxyUrl);
+  return await new Promise<ProxyResponseResult>((resolve) => {
+    let settled = false;
+    let body = "";
+    let response: IncomingMessage | undefined;
+    const finish = (error?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve({
+        body,
+        complete: response?.complete ?? false,
+        ...(error ? { errorMessage: error.message } : {}),
+        ...(response?.statusCode === undefined ? {} : { statusCode: response.statusCode }),
+      });
+    };
+    const req = httpRequest(
+      {
+        host: proxy.hostname,
+        port: Number(proxy.port),
+        method: "GET",
+        path: targetUrl,
+        headers: { connection: "close" },
+      },
+      (res) => {
+        response = res;
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => finish());
+        res.on("error", finish);
+        res.on("close", () => {
+          if (!res.complete) {
+            finish(new Error("response closed before completion"));
+          }
+        });
+      },
+    );
+    req.on("error", finish);
+    req.end();
+  });
 }
 
 async function postThroughProxy(params: {
@@ -184,6 +286,55 @@ describe("startDebugProxyServer", () => {
         capturePreviewBytes: 8192,
         captureTruncated: true,
       });
+    } finally {
+      await proxy.stop();
+      await origin.stop();
+    }
+  });
+
+  it("returns a complete 502 and survives an upstream failure before response headers", async () => {
+    const settings = await makeSettings();
+    const origin = await startResponseErrorOrigin();
+    const proxy = await startDebugProxyServer({ settings });
+
+    try {
+      const failed = await getThroughProxy(proxy.proxyUrl, `${origin.url}/before-headers`);
+      expect(failed).toMatchObject({
+        body: "Bad Gateway\n",
+        complete: true,
+        statusCode: 502,
+      });
+
+      const healthy = await getThroughProxy(proxy.proxyUrl, `${origin.url}/healthy`);
+      expect(healthy).toMatchObject({ body: "ok", complete: true, statusCode: 200 });
+      expect(getDebugProxyCaptureStore().getSessionEvents(settings.sessionId, 20)).toContainEqual(
+        expect.objectContaining({ direction: "local", kind: "error" }),
+      );
+    } finally {
+      await proxy.stop();
+      await origin.stop();
+    }
+  });
+
+  it("aborts a partial response after headers and survives the upstream stream error", async () => {
+    const settings = await makeSettings();
+    const origin = await startResponseErrorOrigin();
+    const proxy = await startDebugProxyServer({ settings });
+
+    try {
+      const failed = await getThroughProxy(proxy.proxyUrl, `${origin.url}/after-headers`);
+      expect(failed).toMatchObject({
+        body: "partial",
+        complete: false,
+        statusCode: 200,
+      });
+      expect(failed.errorMessage).toBeDefined();
+
+      const healthy = await getThroughProxy(proxy.proxyUrl, `${origin.url}/healthy`);
+      expect(healthy).toMatchObject({ body: "ok", complete: true, statusCode: 200 });
+      expect(getDebugProxyCaptureStore().getSessionEvents(settings.sessionId, 20)).toContainEqual(
+        expect.objectContaining({ direction: "inbound", kind: "error" }),
+      );
     } finally {
       await proxy.stop();
       await origin.stop();

--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -14,6 +14,7 @@ const TRUTHY_ENV = new Set(["1", "true", "yes", "on"]);
 const DEBUG_PROXY_DIRECT_CONNECT_OVERRIDE =
   "OPENCLAW_DEBUG_PROXY_ALLOW_DIRECT_CONNECT_WITH_MANAGED_PROXY";
 const CAPTURE_BODY_PREVIEW_BYTES = 8192;
+const BAD_GATEWAY_BODY = "Bad Gateway\n";
 
 type BodyPreviewCapture = {
   chunks: Buffer[];
@@ -148,6 +149,24 @@ function finishBodyPreviewCapture(capture: BodyPreviewCapture): {
   };
 }
 
+function finishProxyResponseAfterUpstreamError(res: ServerResponse): void {
+  if (res.destroyed || res.writableEnded) {
+    return;
+  }
+  // HTTP status cannot be replaced after forwarding upstream headers. Closing
+  // the downstream prevents a partial 2xx body from looking complete.
+  if (res.headersSent) {
+    res.destroy();
+    return;
+  }
+  res.writeHead(502, {
+    Connection: "close",
+    "Content-Type": "text/plain; charset=utf-8",
+    "Content-Length": Buffer.byteLength(BAD_GATEWAY_BODY),
+  });
+  res.end(BAD_GATEWAY_BODY);
+}
+
 export async function startDebugProxyServer(params: {
   host?: string;
   port?: number;
@@ -240,6 +259,14 @@ export async function startDebugProxyServer(params: {
             });
             res.end();
           });
+          upstreamRes.on("error", (error) => {
+            recordTargetEvent({
+              direction: "inbound",
+              kind: "error",
+              errorText: error.message,
+            });
+            finishProxyResponseAfterUpstreamError(res);
+          });
           res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
         },
       );
@@ -268,8 +295,7 @@ export async function startDebugProxyServer(params: {
           kind: "error",
           errorText: error.message,
         });
-        res.statusCode = 502;
-        res.end(error.message);
+        finishProxyResponseAfterUpstreamError(res);
       });
       req.pipe(upstream);
     })();


### PR DESCRIPTION
Related to #82442. The CONNECT client-socket crash reported there was fixed by #82444; this PR covers the distinct HTTP upstream-response stream failure path.

This is the clean maintainer replacement for #88052. GitHub could not reparent the contributor fork branch after fixups, so that PR began showing unrelated `main` files despite the reviewed two-file tree.

## What Problem This Solves

The debug proxy consumed upstream `IncomingMessage` bodies without an `error` listener. If an origin closed the connection after sending response headers, Node emitted a response-stream error that could become unhandled and crash the proxy.

The old candidate handler also tried to end the downstream response with the upstream error text. Once a 2xx status and partial body had already been forwarded, that would make a truncated response look complete and append diagnostic text to application data.

## Why This Change Was Made

- Record upstream response-stream failures as inbound capture errors.
- Before downstream headers are committed, return a complete generic `502 Bad Gateway` response with `Connection: close`.
- After downstream headers are committed, destroy the downstream response so clients observe an incomplete response rather than a valid partial 2xx body.
- Reuse the same terminal-response helper for request-level upstream failures, without reflecting upstream error strings to clients.
- Preserve current body-preview capture behavior and current managed-proxy policy.
- Preserve @SebTardif's contributor credit in the co-authored maintainer commit.

This follows Node's documented HTTP lifecycle: a premature upstream close after the response begins emits `aborted`/`close`/`error` on the incoming response, while destroying an outgoing response closes its socket. See the [Node HTTP documentation](https://nodejs.org/api/http.html).

## User Impact

Broken origins no longer crash the local debug proxy. Failures before headers produce a truthful 502; failures after headers terminate the partial response; the proxy remains available for subsequent requests.

## Evidence

- Exact reviewed head: `5ef0700be070b6bc1b5bb01fcc562f6e1d1cc23c`.
- Sanitized AWS Crabbox run `run_246cffe1bd2b`, lease `cbx_71a6b7c8518f`, Node `v24.15.0`, public networking, no Tailscale, no instance profile.
- Command: `pnpm test src/proxy-capture/proxy-server.test.ts src/proxy-capture/proxy-server.managed-proxy.test.ts`.
- Result: 2 test files and 13 tests passed.
- Real-wire regressions prove a complete generic 502 before headers, an incomplete partial 200 after headers with no appended error text, capture-store error records for both paths, and a successful second request through the same proxy after each failure.
- Fresh exact-head autoreview will be recorded before merge.

The original contributor reproduction established the missing-listener crash surface. The maintainer rewrite preserves contributor credit and strengthens the client-visible contract and regression proof.

Original contributor PR: #88052.
