### PR TITLE
improve(ui/usage): guard against usageResult missing its sessions array

### DIFF
--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -464,7 +464,7 @@ class UsagePage extends LitElement {
         agents:
           this.context.agents.state.agentsList?.agents.map((entry) => entry.id).filter(Boolean) ??
           [],
-        sessionsLimitReached: (this.usageResult?.sessions.length ?? 0) >= 1000,
+        sessionsLimitReached: (this.usageResult?.sessions?.length ?? 0) >= 1000,
         totals: this.usageResult?.totals ?? null,
         aggregates: this.usageResult?.aggregates ?? null,
         costDaily: this.usageCostSummary?.daily ?? [],


### PR DESCRIPTION
## What Problem This Solves

On the **Usage** page, `UsagePage.render()` computes `sessionsLimitReached` from `this.usageResult?.sessions.length`. The optional chain guards `usageResult` but not its `sessions` field, so if `usageResult` is a truthy object without a populated `sessions` array, the render throws `TypeError: Cannot read properties of undefined (reading 'length')` and the Usage page fails to render.

## Why This Change Was Made

The sibling line directly above already defends the same field with a guard:

```ts
sessions: this.usageResult?.sessions ?? [],
sessionsLimitReached: (this.usageResult?.sessions.length ?? 0) >= 1000,  // missing the second ?.
```

This change adds the missing `?.` so the two lines are consistent. It is defensive hardening; behavior is unchanged for well-formed data (where `sessions` is always present).

## User Impact

The Usage page no longer risks an uncaught render crash if it ever receives a `usageResult` object without a `sessions` array. No change for normal, well-formed responses.

## Evidence

- **Scope, stated honestly:** I found this by pointing an automated QA agent at the Control UI via the repo's `dev:ui:mock` server, where the `sessions.usage` request is unimplemented and falls through to `{}` (a non-null object with no `sessions`), which triggers the crash on `/usage`. I then traced the real gateway handler (`src/gateway/server-methods/usage.ts`): its single success path always returns `result.sessions` as an array, and every error branch is caught by the UI and sets `usageResult = null` (safe). I did **not** find a shipped path where the real gateway returns `ok: true` with a sessionless object. So I am filing this as defensive hardening consistent with the existing guard on the line above, **not** as a confirmed real-gateway crash.
- **Reproduction (LLM-free, Playwright):** against `dev:ui:mock`, a standalone repro navigating to `/usage` exits 0 (page-error reproduces) on `main` and exits 1 (no page-error) with this change. Before/after: the page went from a blank crashed render (uncaught `TypeError`) to rendering with zero page errors.

## AI Assistance

🤖 This change was found and prepared with AI assistance (an automated QA agent for discovery and deterministic reproduction). I have reviewed the one-line change and understand what it does. I attempted `codex review --base origin/main` locally; it did not complete within my time budget, so I am relying on the diff's simplicity and the reproduction evidence above.