### PR TITLE
fix(telegram): keep long models selectable

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2972,7 +2972,7 @@ export const registerTelegramHandlers = ({
         return;
       }
 
-      // Model selection callback handler (mdl_prov, mdl_list_*, mdl_sel_*, mdl_back)
+      // Model selection callback handler (mdl_prov, mdl_list_*, mdl_sel_*, mdl_idx_*, mdl_back)
       const modelCallback = parseModelCallbackData(data);
       if (modelCallback) {
         if (
@@ -3115,7 +3115,7 @@ export const registerTelegramHandlers = ({
           return;
         }
 
-        if (modelCallback.type === "select") {
+        if (modelCallback.type === "select" || modelCallback.type === "select-index") {
           const selection = resolveModelSelection({
             callback: modelCallback,
             providers,
@@ -3127,11 +3127,12 @@ export const registerTelegramHandlers = ({
               count: byProvider.get(p)?.size ?? 0,
             }));
             const buttons = buildTelegramModelsMenuButtons({ providers: providerInfos });
+            const unresolvedText =
+              selection.kind === "ambiguous"
+                ? `Could not resolve model "${selection.model}".`
+                : `Could not resolve model selection for "${selection.provider}".`;
             try {
-              await editMessageWithButtons(
-                `Could not resolve model "${selection.model}".\n\nSelect a provider:`,
-                buttons,
-              );
+              await editMessageWithButtons(`${unresolvedText}\n\nSelect a provider:`, buttons);
             } catch (err) {
               throw new TelegramRetryableCallbackError(err);
             }

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -5564,4 +5564,53 @@ describe("createTelegramBot", () => {
       ),
     ).toBe(false);
   });
+
+  it("resolves indexed model callbacks for long Telegram model IDs", async () => {
+    const longModel = "xentriom/gemma-4-12B-agentic-fable5-composer2.5-v2:latest";
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: "ollama/short-default",
+          models: {
+            [`ollama/${longModel}`]: {},
+          },
+        },
+      },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+        },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const callbackHandler = getOnHandler("callback_query");
+
+    await runTelegramMiddlewareChain({
+      finalHandler: callbackHandler,
+      ctx: {
+        update: { update_id: 891 },
+        callbackQuery: {
+          id: "cbq-model-index-1",
+          data: "mdl_idx_ollama_1",
+          from: { id: 9, first_name: "Ada", username: "ada_bot" },
+          message: {
+            chat: { id: 1234, type: "private" },
+            date: 1736380800,
+            message_id: 25,
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      },
+    });
+
+    expect(editMessageTextSpy).toHaveBeenCalledTimes(1);
+    const finalEditMessageText = editMessageTextSpy.mock.calls.at(-1)?.[2];
+    expect(typeof finalEditMessageText === "string" ? finalEditMessageText : "").toContain(
+      `Model changed to <b>ollama/${longModel}</b>`,
+    );
+    expect(answerCallbackQuerySpy).toHaveBeenCalledWith("cbq-model-index-1");
+  });
 });

--- a/extensions/telegram/src/model-buttons.test.ts
+++ b/extensions/telegram/src/model-buttons.test.ts
@@ -33,6 +33,7 @@ describe("parseModelCallbackData", () => {
         "mdl_sel/anthropic/claude-3-7-sonnet",
         { type: "select", model: "anthropic/claude-3-7-sonnet" },
       ],
+      ["mdl_idx_openrouter_12", { type: "select-index", provider: "openrouter", index: 12 }],
       ["  mdl_prov  ", { type: "providers" }],
     ] as const;
     for (const [input, expected] of cases) {
@@ -50,6 +51,8 @@ describe("parseModelCallbackData", () => {
       "mdl_list_openai_9007199254740993",
       "mdl_sel_noslash",
       "mdl_sel/",
+      "mdl_idx_openai_-1",
+      "mdl_idx_openai_9007199254740993",
     ];
     for (const input of invalid) {
       expect(parseModelCallbackData(input), input).toBeNull();
@@ -111,6 +114,24 @@ describe("resolveModelSelection", () => {
       matchingProviders: [],
     });
   });
+
+  it("resolves index callbacks against the sorted provider model list", () => {
+    const result = resolveModelSelection({
+      callback: { type: "select-index", provider: "openai", index: 1 },
+      providers: ["openai"],
+      byProvider: new Map([["openai", new Set(["zeta-model", "alpha-model"])]]),
+    });
+    expect(result).toEqual({ kind: "resolved", provider: "openai", model: "zeta-model" });
+  });
+
+  it("returns unavailable result when an index callback is stale", () => {
+    const result = resolveModelSelection({
+      callback: { type: "select-index", provider: "openai", index: 3 },
+      providers: ["openai"],
+      byProvider: new Map([["openai", new Set(["gpt-5.4"])]]),
+    });
+    expect(result).toEqual({ kind: "unavailable", provider: "openai", index: 3 });
+  });
 });
 
 describe("buildModelSelectionCallbackData", () => {
@@ -127,6 +148,9 @@ describe("buildModelSelectionCallbackData", () => {
   it("returns null when even compact callback exceeds Telegram limit", () => {
     const tooLongModel = "x".repeat(80);
     expect(buildModelSelectionCallbackData({ provider: "openai", model: tooLongModel })).toBeNull();
+    expect(
+      buildModelSelectionCallbackData({ provider: "openai", model: tooLongModel, index: 0 }),
+    ).toBe("mdl_idx_openai_0");
   });
 });
 
@@ -495,7 +519,7 @@ describe("large model lists (OpenRouter-scale)", () => {
     }
   });
 
-  it("skips models that would exceed callback_data limit", () => {
+  it("uses index callbacks for models that would exceed callback_data limit", () => {
     const models = [
       "short-model",
       "this-is-an-extremely-long-model-name-that-definitely-exceeds-the-sixty-four-byte-limit",
@@ -508,10 +532,15 @@ describe("large model lists (OpenRouter-scale)", () => {
       totalPages: 1,
     });
 
-    // Should have 2 model buttons (skipping the long one) + back
+    // All 3 model buttons remain visible, followed by the back button.
     const modelButtons = result.filter((row) => !row[0]?.callback_data.startsWith("mdl_back"));
-    expect(modelButtons.length).toBe(2);
+    expect(modelButtons.length).toBe(3);
     expect(modelButtons[0]?.[0]?.text).toBe("short-model");
-    expect(modelButtons[1]?.[0]?.text).toBe("another-short");
+    expect(modelButtons[1]?.[0]?.text).toBe("…ely-exceeds-the-sixty-four-byte-limit");
+    expect(modelButtons[1]?.[0]?.callback_data).toBe("mdl_idx_openrouter_1");
+    expect(
+      Buffer.byteLength(modelButtons[1]?.[0]?.callback_data ?? "", "utf8"),
+    ).toBeLessThanOrEqual(64);
+    expect(modelButtons[2]?.[0]?.text).toBe("another-short");
   });
 });

--- a/extensions/telegram/src/model-buttons.ts
+++ b/extensions/telegram/src/model-buttons.ts
@@ -6,9 +6,13 @@
  * - mdl_list_{prov}_{pg}  - show models for provider (page N, 1-indexed)
  * - mdl_sel_{provider/id} - select model (standard)
  * - mdl_sel/{model}       - select model (compact fallback when standard is >64 bytes)
+ * - mdl_idx_{prov}_{idx}  - select model by provider-local index (long model fallback)
  * - mdl_back              - back to providers list
  */
-import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
+import {
+  parseStrictNonNegativeInteger,
+  parseStrictPositiveInteger,
+} from "openclaw/plugin-sdk/number-runtime";
 import { fitsTelegramCallbackData } from "./approval-callback-data.js";
 
 export type ButtonRow = Array<{ text: string; callback_data: string }>;
@@ -17,7 +21,12 @@ export type ParsedModelCallback =
   | { type: "providers" }
   | { type: "list"; provider: string; page: number }
   | { type: "select"; provider?: string; model: string }
+  | { type: "select-index"; provider: string; index: number }
   | { type: "back" };
+
+type ParsedModelSelectionCallback =
+  | Extract<ParsedModelCallback, { type: "select" }>
+  | Extract<ParsedModelCallback, { type: "select-index" }>;
 
 export type ProviderInfo = {
   id: string;
@@ -26,7 +35,8 @@ export type ProviderInfo = {
 
 export type ResolveModelSelectionResult =
   | { kind: "resolved"; provider: string; model: string }
-  | { kind: "ambiguous"; model: string; matchingProviders: string[] };
+  | { kind: "ambiguous"; model: string; matchingProviders: string[] }
+  | { kind: "unavailable"; provider: string; index: number };
 
 export type ModelsKeyboardParams = {
   provider: string;
@@ -47,6 +57,7 @@ const CALLBACK_PREFIX = {
   list: "mdl_list_",
   selectStandard: "mdl_sel_",
   selectCompact: "mdl_sel/",
+  selectIndex: "mdl_idx_",
 } as const;
 
 /**
@@ -70,6 +81,16 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
     const page = parseStrictPositiveInteger(pageStr);
     if (provider && page !== undefined) {
       return { type: "list", provider, page };
+    }
+  }
+
+  // mdl_idx_{provider}_{index}
+  const indexSelMatch = trimmed.match(/^mdl_idx_([a-z0-9_.-]+)_(\d+)$/i);
+  if (indexSelMatch) {
+    const [, provider, indexStr] = indexSelMatch;
+    const index = parseStrictNonNegativeInteger(indexStr);
+    if (provider && index !== undefined) {
+      return { type: "select-index", provider, index };
     }
   }
 
@@ -107,40 +128,68 @@ export function parseModelCallbackData(data: string): ParsedModelCallback | null
 export function buildModelSelectionCallbackData(params: {
   provider: string;
   model: string;
+  index?: number;
 }): string | null {
   const fullCallbackData = `${CALLBACK_PREFIX.selectStandard}${params.provider}/${params.model}`;
   if (fitsTelegramCallbackData(fullCallbackData)) {
     return fullCallbackData;
   }
   const compactCallbackData = `${CALLBACK_PREFIX.selectCompact}${params.model}`;
-  return fitsTelegramCallbackData(compactCallbackData) ? compactCallbackData : null;
+  if (fitsTelegramCallbackData(compactCallbackData)) {
+    return compactCallbackData;
+  }
+  if (params.index === undefined) {
+    return null;
+  }
+  const indexedCallbackData = `${CALLBACK_PREFIX.selectIndex}${params.provider}_${params.index}`;
+  return fitsTelegramCallbackData(indexedCallbackData) ? indexedCallbackData : null;
 }
 
 export function resolveModelSelection(params: {
-  callback: Extract<ParsedModelCallback, { type: "select" }>;
+  callback: ParsedModelSelectionCallback;
   providers: readonly string[];
   byProvider: ReadonlyMap<string, ReadonlySet<string>>;
 }): ResolveModelSelectionResult {
-  if (params.callback.provider) {
+  const { callback } = params;
+  if (callback.type === "select-index") {
+    const models = [...(params.byProvider.get(callback.provider) ?? [])].toSorted((left, right) =>
+      left.localeCompare(right),
+    );
+    const model = models[callback.index];
+    if (model) {
+      return {
+        kind: "resolved",
+        provider: callback.provider,
+        model,
+      };
+    }
+    return {
+      kind: "unavailable",
+      provider: callback.provider,
+      index: callback.index,
+    };
+  }
+
+  if (callback.provider) {
     return {
       kind: "resolved",
-      provider: params.callback.provider,
-      model: params.callback.model,
+      provider: callback.provider,
+      model: callback.model,
     };
   }
   const matchingProviders = params.providers.filter((id) =>
-    params.byProvider.get(id)?.has(params.callback.model),
+    params.byProvider.get(id)?.has(callback.model),
   );
   if (matchingProviders.length === 1) {
     return {
       kind: "resolved",
       provider: matchingProviders[0],
-      model: params.callback.model,
+      model: callback.model,
     };
   }
   return {
     kind: "ambiguous",
-    model: params.callback.model,
+    model: callback.model,
     matchingProviders,
   };
 }
@@ -210,9 +259,14 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const endIndex = Math.min(startIndex + pageSize, models.length);
   const pageModels = models.slice(startIndex, endIndex);
 
-  for (const model of pageModels) {
-    const callbackData = buildModelSelectionCallbackData({ provider, model });
-    // Skip models that still exceed Telegram's callback_data limit.
+  for (const [pageIndex, model] of pageModels.entries()) {
+    // Telegram callback_data is capped at 64 bytes. The index fallback keeps
+    // very long model IDs selectable without embedding the whole ID.
+    const callbackData = buildModelSelectionCallbackData({
+      provider,
+      model,
+      index: startIndex + pageIndex,
+    });
     if (!callbackData) {
       continue;
     }


### PR DESCRIPTION
Closes #98221

## What Problem This Solves

Fixes an issue where Telegram users browsing `/model` provider models would see the header count include long model IDs, but those models would have no button when Telegram `callback_data` exceeded 64 bytes.

## Why This Change Was Made

The Telegram model picker now falls back to a short provider-local index callback only when both existing model-selection encodings are too long. The callback handler resolves that index against the same sorted provider model list used to render the page, and stale indexes fall back to the provider picker instead of selecting the wrong model.

## User Impact

Users can select long Ollama/OpenRouter-style model IDs from the Telegram `/model` picker instead of having those valid configured models silently disappear from the list.

## Evidence

- `node scripts/run-vitest.mjs extensions/telegram/src/model-buttons.test.ts` — 28 tests passed
- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts` — 114 tests passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/model-buttons.ts extensions/telegram/src/model-buttons.test.ts extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot.create-telegram-bot.test.ts` — passed
- `node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/model-buttons.ts extensions/telegram/src/model-buttons.test.ts extensions/telegram/src/bot-handlers.runtime.ts extensions/telegram/src/bot.create-telegram-bot.test.ts` — passed
- `git diff --check` — passed

No live Telegram bot session was available in this local checkout; the focused tests cover callback generation, parsing, stale index handling, and the callback handler path.
