### PR TITLE
fix(android): send chat with hardware Enter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.
 - **Discord streamed finals:** send completion replies as fresh messages so inactive channels become unread, while preserving targeted mentions without escalating `@everyone` or `@here`. (#99711, #99662) Thanks @davelutztx.
 - **OpenAI-compatible SSE parsing:** recognize event streams mislabeled as JSON without prepending a second `data:` prefix, preserving valid streamed responses from non-conforming providers. (#96503) Thanks @ZengWen-DT.

--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -6131,7 +6131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 299,
+      "line": 309,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -6139,7 +6139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 481,
+      "line": 491,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -6147,7 +6147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 539,
+      "line": 549,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -6155,7 +6155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 560,
+      "line": 570,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -6163,7 +6163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 565,
+      "line": 575,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "More new chat options",
       "surface": "android",
@@ -6171,7 +6171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 580,
+      "line": 590,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -6179,7 +6179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 583,
+      "line": 593,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -6187,7 +6187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 731,
+      "line": 741,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -6195,7 +6195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 758,
+      "line": 768,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -6203,7 +6203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 784,
+      "line": 794,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -6211,7 +6211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 815,
+      "line": 825,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -6219,7 +6219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 816,
+      "line": 826,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -6227,7 +6227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1000,
+      "line": 1010,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -6235,7 +6235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1000,
+      "line": 1010,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -6243,7 +6243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1021,
+      "line": 1031,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -6251,7 +6251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1023,
+      "line": 1033,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -6259,7 +6259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1026,
+      "line": 1036,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -6267,7 +6267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1036,
+      "line": 1046,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -6275,7 +6275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1037,
+      "line": 1047,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -6283,7 +6283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1196,
+      "line": 1209,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -6291,7 +6291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1262,
+      "line": 1275,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -6299,7 +6299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1328,
+      "line": 1341,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -6307,7 +6307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1328,
+      "line": 1341,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -6315,7 +6315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1345,
+      "line": 1358,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -6323,7 +6323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1407,
+      "line": 1420,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -6331,7 +6331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1503,
+      "line": 1518,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -6339,7 +6339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1522,
+      "line": 1542,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -6347,7 +6347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1537,
+      "line": 1557,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open voice",
       "surface": "android",
@@ -6355,7 +6355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1586,
+      "line": 1619,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -6363,7 +6363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1607,
+      "line": 1640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -6371,7 +6371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1615,
+      "line": 1648,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -6379,7 +6379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1674,
+      "line": 1707,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -6387,7 +6387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1714,
+      "line": 1747,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -90,6 +90,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -1100,6 +1110,15 @@ private fun ChatComposer(
     remember(value, commands) {
       matchingSlashCommands(input = value, commands = commands)
     }
+  val sendEnabled =
+    voiceNoteState !is VoiceNoteRecorderState.Recording &&
+      voiceNoteState !is VoiceNoteRecorderState.Preparing &&
+      pendingRunCount == 0 &&
+      if (healthOk) {
+        value.trim().isNotEmpty() || attachments.isNotEmpty()
+      } else {
+        value.trim().isNotEmpty() && attachments.isEmpty()
+      }
 
   Column(modifier = Modifier.fillMaxWidth().imePadding(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
     if (attachments.isNotEmpty()) {
@@ -1150,20 +1169,14 @@ private fun ChatComposer(
           onStartVoiceNote = onStartVoiceNote,
           recordVoiceNoteEnabled = recordVoiceNoteEnabled,
           onVoice = onVoice,
+          sendEnabled = sendEnabled,
+          onSend = onSend,
           modifier = Modifier.weight(1f),
         )
       }
       SendButton(
         // Offline, only text sends are enabled: they queue durably (text-only v1).
-        enabled =
-          voiceNoteState !is VoiceNoteRecorderState.Recording &&
-            voiceNoteState !is VoiceNoteRecorderState.Preparing &&
-            pendingRunCount == 0 &&
-            if (healthOk) {
-              value.trim().isNotEmpty() || attachments.isNotEmpty()
-            } else {
-              value.trim().isNotEmpty() && attachments.isEmpty()
-            },
+        enabled = sendEnabled,
         onClick = onSend,
       )
     }
@@ -1484,6 +1497,8 @@ private fun ChatInputPill(
   onStartVoiceNote: () -> Unit,
   recordVoiceNoteEnabled: Boolean,
   onVoice: () -> Unit,
+  sendEnabled: Boolean,
+  onSend: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
   Surface(
@@ -1515,7 +1530,12 @@ private fun ChatInputPill(
           cursorBrush = SolidColor(ClawTheme.colors.primary),
           minLines = 1,
           maxLines = 4,
-          modifier = Modifier.fillMaxWidth(),
+          modifier =
+            Modifier
+              .fillMaxWidth()
+              .onPreviewKeyEvent { event ->
+                handlePhysicalChatSend(event = event, sendEnabled = sendEnabled, onSend = onSend)
+              },
           decorationBox = { innerTextField ->
             Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
               if (value.isEmpty()) {
@@ -1539,6 +1559,19 @@ private fun ChatInputPill(
       }
     }
   }
+}
+
+/** Intercepts one unmodified hardware Enter before BasicTextField inserts a newline. */
+internal fun handlePhysicalChatSend(
+  event: KeyEvent,
+  sendEnabled: Boolean,
+  onSend: () -> Unit,
+): Boolean {
+  val enterKey = event.key == Key.Enter || event.key == Key.NumPadEnter
+  val modified = event.isShiftPressed || event.isCtrlPressed || event.isAltPressed || event.isMetaPressed
+  if (event.type != KeyEventType.KeyDown || event.nativeKeyEvent.repeatCount != 0 || !enterKey || modified) return false
+  if (sendEnabled) onSend()
+  return true
 }
 
 @Composable

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatHardwareKeyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatHardwareKeyTest.kt
@@ -1,0 +1,74 @@
+package ai.openclaw.app.ui.chat
+
+import android.view.KeyEvent as AndroidKeyEvent
+import androidx.compose.ui.input.key.KeyEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class ChatHardwareKeyTest {
+  @Test
+  fun unmodifiedEnterSendsOnce() {
+    var sends = 0
+
+    assertTrue(handlePhysicalChatSend(keyEvent(AndroidKeyEvent.KEYCODE_ENTER), sendEnabled = true) { sends += 1 })
+    assertTrue(handlePhysicalChatSend(keyEvent(AndroidKeyEvent.KEYCODE_NUMPAD_ENTER), sendEnabled = true) { sends += 1 })
+    assertFalse(handlePhysicalChatSend(keyEvent(AndroidKeyEvent.KEYCODE_ENTER, repeatCount = 1), sendEnabled = true) { sends += 1 })
+
+    assertEquals(2, sends)
+  }
+
+  @Test
+  fun disabledEnterIsConsumedWithoutSending() {
+    var sent = false
+
+    assertTrue(handlePhysicalChatSend(keyEvent(AndroidKeyEvent.KEYCODE_ENTER), sendEnabled = false) { sent = true })
+
+    assertFalse(sent)
+  }
+
+  @Test
+  fun modifiedEnterAndKeyUpRemainTextInput() {
+    val modifiers =
+      listOf(
+        AndroidKeyEvent.META_SHIFT_ON,
+        AndroidKeyEvent.META_CTRL_ON,
+        AndroidKeyEvent.META_ALT_ON,
+        AndroidKeyEvent.META_META_ON,
+      )
+
+    modifiers.forEach { metaState ->
+      assertFalse(handlePhysicalChatSend(keyEvent(AndroidKeyEvent.KEYCODE_ENTER, metaState = metaState), sendEnabled = true) {})
+    }
+    assertFalse(
+      handlePhysicalChatSend(
+        keyEvent(AndroidKeyEvent.KEYCODE_ENTER, action = AndroidKeyEvent.ACTION_UP),
+        sendEnabled = true,
+        onSend = {},
+      ),
+    )
+  }
+
+  private fun keyEvent(
+    keyCode: Int,
+    action: Int = AndroidKeyEvent.ACTION_DOWN,
+    repeatCount: Int = 0,
+    metaState: Int = 0,
+  ): KeyEvent =
+    KeyEvent(
+      AndroidKeyEvent(
+        0L,
+        0L,
+        action,
+        keyCode,
+        repeatCount,
+        metaState,
+      ),
+    )
+}


### PR DESCRIPTION
Closes #101239

## What Problem This Solves

Fixes an issue where Android users typing with a physical keyboard would insert a newline instead of sending when pressing Enter in chat.

## Why This Change Was Made

The chat composer now intercepts an unmodified physical Enter key before `BasicTextField` applies its newline behavior and uses the same enablement and send action as the visible Send button. Shift+Enter and other modified Enter combinations remain text input; repeats and key-up events do not send.

## User Impact

Physical-keyboard users can press Enter to send messages. Modified Enter combinations continue to support multiline composition.

## Evidence

- Blacksmith Testbox `tbx_01kwx6hpzsqm3t2jswgr0a6wgw`
- `pnpm native:i18n:check`
- focused Robolectric `ChatHardwareKeyTest`: Enter, numpad Enter, repeat, disabled-send, modifier, and key-up cases
- `:app:assemblePlayDebug`
- `:app:lintPlayDebug`
- Isolated-package launch attempted on a Pixel 10a / Android 16 device; interaction proof was blocked by the device fingerprint lock. The isolated package was removed and the existing OpenClaw app was not replaced.
