### PR TITLE
fix(memory): preserve archived sessions with cron-shaped user text

### DIFF
--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -779,29 +779,59 @@ describe("buildSessionEntry", () => {
     expect(checkpointEntry.lineMap).toStrictEqual([]);
   });
 
-  it("keeps cron-run deleted archives opaque when the live session store entry is gone", async () => {
-    const archivePath = path.join(tmpDir, "cron-run.jsonl.deleted.2026-02-16T22-27-33.000Z");
-    const jsonlLines = [
-      JSON.stringify({
-        type: "message",
-        message: {
-          role: "user",
-          content: "[cron:job-1 Codex Sessions Sync] Run internal sync.",
+  it.each([
+    [
+      "as the first message",
+      [],
+      [
+        "Assistant: The digest job failed because the API token expired.",
+        "User: Please remember: my preferred vendor is Acme Robotics and budget is 5000 USD.",
+        "Assistant: Noted. Acme Robotics, budget 5000 USD.",
+      ],
+      [2, 3, 4],
+    ],
+    [
+      "after ordinary messages",
+      [
+        { role: "user", content: "Remember before: project codename is Atlas." },
+        { role: "assistant", content: "Saved project codename Atlas." },
+      ],
+      [
+        "User: Remember before: project codename is Atlas.",
+        "Assistant: Saved project codename Atlas.",
+        "Assistant: The digest job failed because the API token expired.",
+        "User: Please remember: my preferred vendor is Acme Robotics and budget is 5000 USD.",
+        "Assistant: Noted. Acme Robotics, budget 5000 USD.",
+      ],
+      [1, 2, 4, 5, 6],
+    ],
+  ])(
+    "does not wipe an archive when a user message starts with [cron: %s (#98241)",
+    async (_position, precedingMessages, expectedContent, expectedLineMap) => {
+      const archivePath = path.join(tmpDir, "ordinary.jsonl.deleted.2026-02-16T22-27-33.000Z");
+      const messages = [
+        ...precedingMessages,
+        { role: "user", content: "[cron:daily-digest] why did my digest job fail last night?" },
+        {
+          role: "assistant",
+          content: "The digest job failed because the API token expired.",
         },
-      }),
-      JSON.stringify({
-        type: "message",
-        message: { role: "assistant", content: "Internal cron output that must stay out." },
-      }),
-    ];
-    fsSync.writeFileSync(archivePath, jsonlLines.join("\n"));
+        {
+          role: "user",
+          content: "Please remember: my preferred vendor is Acme Robotics and budget is 5000 USD.",
+        },
+        { role: "assistant", content: "Noted. Acme Robotics, budget 5000 USD." },
+      ];
+      const jsonlLines = messages.map((message) => JSON.stringify({ type: "message", message }));
+      fsSync.writeFileSync(archivePath, jsonlLines.join("\n"));
 
-    const entry = requireSessionEntry(await buildSessionEntry(archivePath));
+      const entry = requireSessionEntry(await buildSessionEntry(archivePath));
 
-    expect(entry.content).toBe("");
-    expect(entry.lineMap).toStrictEqual([]);
-    expect(entry.generatedByCronRun).toBe(true);
-  });
+      expect(entry.generatedByCronRun).toBeFalsy();
+      expect(entry.content).toBe(expectedContent.join("\n"));
+      expect(entry.lineMap).toStrictEqual(expectedLineMap);
+    },
+  );
 
   it("keeps cron-run reset archives opaque when session metadata preserves the cron key", async () => {
     const archivePath = path.join(tmpDir, "cron-run.jsonl.reset.2026-02-16T22-26-33.000Z");

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -762,7 +762,7 @@ export async function buildSessionEntry(
       false;
     let generatedByCronRun =
       opts.generatedByCronRun ?? sessionStoreClassification?.generatedByCronRun ?? false;
-    const allowArchiveContentCronClassification =
+    const allowArchiveRecordCronClassification =
       isUsageCountedSessionArchiveTranscriptPath(absPath);
     for (let jsonlIdx = 0, lineStart = 0; lineStart <= raw.length; jsonlIdx++) {
       await yieldSessionEntryParseIfNeeded(jsonlIdx, parseYieldEveryLines);
@@ -784,7 +784,7 @@ export async function buildSessionEntry(
       }
       if (
         !generatedByCronRun &&
-        allowArchiveContentCronClassification &&
+        allowArchiveRecordCronClassification &&
         isCronRunGeneratedRecord(record)
       ) {
         generatedByCronRun = true;
@@ -815,16 +815,8 @@ export async function buildSessionEntry(
       if (rawText === null) {
         continue;
       }
-      if (
-        !generatedByCronRun &&
-        allowArchiveContentCronClassification &&
-        isGeneratedCronPromptMessage(normalizeSessionText(rawText), message.role)
-      ) {
-        generatedByCronRun = true;
-        collected.length = 0;
-        lineMap.length = 0;
-        messageTimestampsMs.length = 0;
-      }
+      // User text is not trusted archive-wide provenance. Per-message sanitization
+      // drops cron prompts without clearing unrelated content from the archive.
       const text = sanitizeSessionText(rawText, message.role);
       if (!text) {
         // Assistant-side machinery (silent replies, system wrappers) is already


### PR DESCRIPTION
Closes #98241
Related: #98624

## What Problem This Solves

Fixes an issue where reset or deleted session history became unsearchable when any user-authored message began with `[cron:]`. The archive indexer treated ordinary message text as archive-wide cron provenance, cleared content already collected, and suppressed everything that followed.

## Why This Change Was Made

Archive-wide cron classification now trusts only canonical session-store metadata or structured transcript records. Cron-shaped user text is still removed from that individual message by the existing sanitizer, but it can no longer erase unrelated archive content. Metadata-less orphan cron archives may contribute benign search noise; this is intentional because message text cannot distinguish a generated prompt from user-authored text without risking false-positive data loss.

This clean maintainer replacement preserves the original contributor's authorship with a `Co-authored-by` trailer.

## User Impact

After a reset or deletion, `memory_search` can still find facts before and after a user message such as `[cron:daily-digest] why did it fail?`. Genuine cron archives with structured session-key provenance remain opaque.

## Evidence

- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts -- -t "does not wipe an archive"` — 2 passed.
- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/session-files.test.ts` — 38 passed.
- Fresh Codex autoreview of the exact two-file branch diff — clean, no accepted/actionable findings (0.86 correctness confidence).
- `git diff --check` — clean.

Fresh exact-head sanitized AWS and hosted CI evidence will be added before merge.
