### PR TITLE
feat(codex): run remote workspaces without splitting app-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Codex remote execution preview:** keep the Gateway and Codex app-server co-located while routing only authenticated unified exec to a remote Codex exec-server, with history-preserving topology changes, filtered child environments, managed-policy checks, and Docker live-proof coverage. (#101282, #101326)
 - **Android chat agent selector:** switch the active agent directly from the live chat screen while keeping chat, Talk mode, and home canvas on the same canonical session. (#80422) Thanks @bcperry.
 - **Gateway host status:** show the connected Gateway's host, network address, OS, runtime, uptime, CPU, memory, and disk details in Control UI Settings. (#100478)
 - **iOS offline chat:** pre-paint recent sessions and canonical transcripts from a protected, bounded per-gateway cache, keep sending disabled offline, and purge cached conversation text when pairing is reset. (#100194)

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -60,7 +60,9 @@ This keeps the app-server version tied to the bundled `codex` plugin instead of
 whichever separate Codex CLI happens to be installed locally. Set
 `appServer.command` only when you intentionally want a different executable.
 
-For an already-running app-server, use WebSocket transport:
+Codex marks TCP WebSocket app-server transport as
+[experimental and unsupported](https://github.com/openai/codex/blob/rust-v0.142.5/codex-rs/app-server/README.md#protocol).
+Do not rely on it for production. For an already-running test app-server:
 
 ```json5
 {
@@ -71,7 +73,7 @@ For an already-running app-server, use WebSocket transport:
         config: {
           appServer: {
             transport: "websocket",
-            url: "ws://gateway-host:39175",
+            url: "wss://codex.example.com/app-server",
             authToken: "${CODEX_APP_SERVER_TOKEN}",
             requestTimeoutMs: 60000,
           },
@@ -106,6 +108,7 @@ For an already-running app-server, use WebSocket transport:
 | `serviceTier`                                 | unset                                                  | Optional Codex app-server service tier. `"priority"` enables fast-mode routing, `"flex"` requests flex processing, and `null` clears the override. Legacy `"fast"` is accepted as `"priority"`.                                                                                                                                                                                                 |
 | `networkProxy`                                | disabled                                               | Opt into Codex permissions-profile networking for app-server commands. OpenClaw defines the selected `permissions.<profile>.network` config and selects it with `default_permissions` instead of sending `sandbox`.                                                                                                                                                                             |
 | `experimental.sandboxExecServer`              | `false`                                                | Preview opt-in that registers an OpenClaw sandbox-backed Codex environment with the supported Codex app-server so native Codex execution can run inside the active OpenClaw sandbox.                                                                                                                                                                                                            |
+| `experimental.remoteExecution`                | unset                                                  | Preview single-target authenticated remote execution. Keeps app-server local over stdio and routes native filesystem/process work through one registry-backed exec-server. Requires `remoteWorkspaceRoot`.                                                                                                                                                                                      |
 
 `appServer.networkProxy` is explicit because it changes the Codex sandbox
 contract. When enabled, OpenClaw also sets `features.network_proxy.enabled` and
@@ -164,6 +167,64 @@ missing app ids remain fail-closed; this path only activates marketplace
 plugins via `plugin/install` and refreshes inventory. Only connect OpenClaw to
 remote app-servers that are trusted to accept OpenClaw-managed plugin installs
 and app inventory refreshes.
+
+## Remote execution environments
+
+For remote workspaces, keep the managed app-server beside the Gateway over
+stdio and register a remote executor separately:
+
+```bash
+codex exec-server \
+  --remote https://environment-registry.example.com/api \
+  --environment-id devbox-example
+```
+
+Configure `appServer.experimental.remoteExecution` with the same registry and
+environment id. Its `authToken` authenticates the app-server side of the Noise
+rendezvous; configure the exec-server's registry authentication separately.
+OpenClaw disables inherited raw exec-server URL routing and lets Codex select
+the configured remote environment as the default. See the complete
+[deployment example and preview limits](/plugins/codex-harness#remote-execution-environments).
+
+Gateway-owned stdio app-servers clear inherited `CODEX_EXEC_SERVER_URL` and
+`CODEX_EXEC_SERVER_NOISE_*` routing variables. Configure remote execution only
+through this validated plugin surface.
+
+The configuration fails closed unless transport is stdio,
+`remoteWorkspaceRoot` is an absolute POSIX path, the registry uses HTTPS or
+true loopback HTTP, and all SecretInputs resolve. It also rejects
+remote-execution environment names in `clearEnv`, `networkProxy`,
+`sandboxExecServer`, and an active OpenClaw sandbox. Codex Computer Use and
+local stdio MCP servers are unavailable because Codex `0.142.x` removes the
+local execution environment in Noise mode. HTTP MCP remains app-server-local;
+stdio MCP requires an intentional `environment_id = "remote"`. Bounded turns
+clear remote routing and remain local. Codex requirements remain owned by the
+Gateway-side app-server.
+Initialization does not prove executor registration;
+deployment readiness must check registry/executor health separately. OpenClaw
+forces unified exec and a core-only remote shell environment, clears configured
+shell `set` values, and filters default secret names plus
+`CODEX_EXEC_SERVER_*` from child environments. That filtering reduces
+accidental disclosure; it does not stop same-user code from inspecting the
+exec-server process. Use narrowly scoped, rotatable registry credentials and
+an executor isolation boundary that prevents workspace commands from reading
+the exec-server environment. Keep registry credentials out of the workspace.
+
+This preview configures exactly one authenticated registry target per spawned
+app-server process. It does not provide executor pools, failover, or per-thread
+target selection. The app-server host and remote executor must use Linux or
+macOS POSIX path semantics; Windows is unsupported on either side. Native Codex
+and OpenClaw user/project hook commands plus legacy notifications are disabled
+because Codex `0.142.x` runs them on the app-server host with the executor-native
+cwd. Codex-managed command hooks cannot be disabled this way; OpenClaw checks
+`hooks/list` and rejects remote execution when any are active. An active
+OpenClaw `before_tool_call`/trusted-tool policy also fails closed; app-server
+approval requests remain supported. Active legacy managed config or managed
+feature requirements that can override the forced execution policy also fail
+closed.
+
+After changing the remote execution topology, send a normal message before
+`/btw` so the main thread can rotate into the current environment.
 
 ## Approval and sandbox modes
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -358,10 +358,12 @@ app-server is too old, or the app-server cannot start.
 
 ## App-server policy
 
-By default, the plugin starts OpenClaw's managed Codex binary locally with
-stdio transport. Set `appServer.command` only to intentionally run a
-different executable. Use WebSocket transport only when an app-server is
-already running elsewhere:
+By default, the plugin starts OpenClaw's managed Codex binary beside the
+Gateway and owns it over stdio. Keep that control-plane topology in
+production. Codex upstream marks TCP WebSocket app-server transport
+[experimental and unsupported](https://github.com/openai/codex/blob/rust-v0.142.5/codex-rs/app-server/README.md#protocol),
+so use it only for development or diagnostics when an app-server is already
+running elsewhere:
 
 ```json5
 {
@@ -372,7 +374,7 @@ already running elsewhere:
         config: {
           appServer: {
             transport: "websocket",
-            url: "ws://gateway-host:39175",
+            url: "wss://codex.example.com/app-server",
             authToken: "${CODEX_APP_SERVER_TOKEN}",
           },
         },
@@ -381,6 +383,121 @@ already running elsewhere:
   },
 }
 ```
+
+### Remote execution environments
+
+When Codex must execute on another host, keep the managed app-server with the
+Gateway over stdio and move only filesystem and process execution:
+
+```text
+OpenClaw Gateway -> stdio -> codex app-server -> Noise registry -> codex exec-server
+```
+
+Start an authenticated executor with the environment id registered for this
+OpenClaw deployment:
+
+```bash
+codex exec-server \
+  --remote https://environment-registry.example.com/api \
+  --environment-id devbox-example
+```
+
+Then configure the Gateway-owned app-server:
+
+```json5
+{
+  plugins: {
+    entries: {
+      codex: {
+        enabled: true,
+        config: {
+          appServer: {
+            transport: "stdio",
+            mode: "guardian",
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            experimental: {
+              remoteExecution: {
+                registryUrl: "https://environment-registry.example.com/api",
+                environmentId: "devbox-example",
+                authToken: "${CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN}",
+                chatgptAccountId: "${CODEX_EXEC_SERVER_NOISE_CHATGPT_ACCOUNT_ID}",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+This preview requires Codex app-server `0.142.0` or newer, stdio transport,
+and an absolute POSIX `remoteWorkspaceRoot`. The registry URL must use HTTPS
+except for a true loopback URL. `authToken` and optional `chatgptAccountId`
+accept SecretInput values and authenticate the app-server side of the
+rendezvous; configure the exec-server's registry authentication separately.
+OpenClaw disables inherited raw exec-server URL routing so the app-server
+cannot fall back to an unauthenticated socket.
+
+Gateway-owned stdio app-servers clear inherited `CODEX_EXEC_SERVER_URL` and
+`CODEX_EXEC_SERVER_NOISE_*` routing variables. Configure remote execution only
+through this validated plugin surface.
+
+Codex auth, app inventory, thread state, and control-plane lifecycle remain
+with the Gateway-owned app-server. Normal Codex threads use the configured
+remote environment by default. Enabling this mode, or changing its registry,
+environment, account identity, credentials without an explicit account
+identity, or remote workspace root, forks the existing native Codex thread into
+the new topology so committed history is preserved.
+
+Current preview limits:
+
+- One app-server process supports exactly one authenticated remote target. The
+  configured `environmentId` is a registry rendezvous id, not a pool selector;
+  this preview does not provide failover, per-thread box selection, or dynamic
+  switching among multiple executors.
+- The Gateway/app-server host and remote executor must use Linux or macOS POSIX
+  path semantics. Windows is unsupported on either side in this preview.
+- OpenClaw forces Codex unified exec, disables zsh-fork fallbacks, legacy
+  notifications, and user/project native hooks, and clears all hook command
+  arrays. Codex-managed command hooks cannot be disabled by thread config, so
+  OpenClaw checks `hooks/list` and rejects remote execution when any are active.
+  It also rejects legacy managed config layers and managed feature requirements
+  that can override the forced execution policy.
+  An active OpenClaw `before_tool_call`/trusted-tool policy also fails closed
+  because Codex `0.142.x` cannot route those hooks back to the Gateway with a
+  Gateway-local cwd. The app-server approval bridge remains available.
+- Remote commands receive only Codex's core executor environment. OpenClaw
+  replaces shell-environment customization for remote threads, clears configured
+  `set` values, and excludes default `*KEY*`, `*SECRET*`, `*TOKEN*`, and explicit
+  `CODEX_EXEC_SERVER_*` names.
+- `appServer.networkProxy`, `appServer.experimental.sandboxExecServer`, and
+  Codex Computer Use cannot be combined with remote execution. An active
+  OpenClaw sandbox also rejects this mode. Enforce required executor egress at
+  the remote environment boundary.
+- Codex `0.142.x` removes its local execution environment when Noise remote
+  execution is active. OpenClaw therefore rejects local stdio MCP servers in
+  this mode. HTTP MCP remains app-server-local; a stdio MCP may run only when
+  its Codex config intentionally sets `environment_id = "remote"`.
+- OpenClaw bounded turns, including model-backed search, review, and media
+  understanding, intentionally clear remote routing and run in a temporary
+  local workspace.
+- After changing the remote execution topology, send a normal message before
+  `/btw` so the main thread can rotate into the current environment.
+- Codex requirements and approval policy are evaluated by the app-server.
+  Provision `/etc/codex/requirements.toml` on the Gateway/app-server host; a
+  copy on only the executor does not govern the app-server. Requirements that
+  pin incompatible execution features make this preview fail closed.
+- App-server initialization does not prove that the matching executor is
+  registered. Gate deployment readiness on registry/executor health and use a
+  harmless native operation as end-to-end proof.
+- Give the exec-server only narrowly scoped, rotatable credentials. OpenClaw's
+  enforced remote shell policy removes those variables from normal child
+  environments, reducing accidental disclosure; it is not an isolation
+  boundary against same-user code that can inspect the exec-server process.
+  Run the exec-server behind an OS, container, or VM boundary that prevents
+  workspace commands from reading its process environment, and never store
+  registry credentials inside the workspace.
 
 Local stdio app-server sessions default to the trusted local operator
 posture: `approvalPolicy: "never"`, `approvalsReviewer: "user"`, and
@@ -639,6 +756,7 @@ Supported `appServer` fields:
 | `serviceTier`                                 | unset                                                  | Optional Codex app-server service tier. `"priority"` enables fast-mode routing, `"flex"` requests flex processing, `null` clears the override, and legacy `"fast"` is accepted as `"priority"`.                                                                                                                                                                                                 |
 | `networkProxy`                                | disabled                                               | Opt into Codex permissions-profile networking for app-server commands. OpenClaw defines the selected `permissions.<profile>.network` config and selects it with `default_permissions` instead of sending `sandbox`.                                                                                                                                                                             |
 | `experimental.sandboxExecServer`              | `false`                                                | Preview opt-in that registers an OpenClaw sandbox-backed Codex environment with the supported Codex app-server so native Codex execution can run inside the active OpenClaw sandbox.                                                                                                                                                                                                            |
+| `experimental.remoteExecution`                | unset                                                  | Preview single-target authenticated remote execution. Keeps app-server local over stdio and routes native filesystem/process work through one registry-backed exec-server. Requires `remoteWorkspaceRoot`.                                                                                                                                                                                      |
 
 `appServer.networkProxy` is explicit because it changes the Codex sandbox
 contract. When enabled, OpenClaw also sets `features.network_proxy.enabled`
@@ -914,9 +1032,20 @@ headers are valid.
 `plugins.entries.codex.config.discovery.timeoutMs` or disable discovery.
 See [Codex harness reference](/plugins/codex-harness-reference#model-discovery).
 
-**WebSocket transport fails immediately:** check `appServer.url`,
+**Remote execution reaches the app-server but not the executor:** verify Codex
+app-server `0.142.0` or newer, stdio transport, an HTTPS registry URL, the exact
+environment id, resolved SecretInputs, and a registered healthy exec-server.
+`/codex status` proves only the app-server control plane; use a harmless native
+filesystem or command operation for end-to-end executor proof. A topology or
+environment identity change forks the prior thread and preserves its history.
+Remote execution forcibly disables native hook relay commands. An OpenClaw
+tool policy that requires the relay makes startup fail instead of silently
+running hooks on the Gateway with the executor cwd.
+
+**Experimental WebSocket transport fails immediately:** check `appServer.url`,
 `authToken`, headers, and that the remote app-server speaks the same Codex
-app-server protocol version.
+app-server protocol version. Do not use TCP WebSocket app-server transport as
+the production remote-execution topology.
 
 **Native shell or patch tools are blocked with `Native hook relay
 unavailable`:** the Codex thread is still trying to use a native hook relay

--- a/extensions/codex/media-understanding-provider.test.ts
+++ b/extensions/codex/media-understanding-provider.test.ts
@@ -332,6 +332,59 @@ describe("codex media understanding provider", () => {
     expect(requests[2]?.params).toEqual(expect.objectContaining({ cwd: "/tmp/openclaw-agent" }));
   });
 
+  it("keeps bounded media turns local when native execution is remote", async () => {
+    const { client, requests } = createFakeClient();
+    const clientFactory = vi.fn(async () => client);
+    const provider = buildCodexMediaUnderstandingProvider({
+      pluginConfig: {
+        appServer: {
+          remoteWorkspaceRoot: "/remote/workspace",
+          experimental: {
+            remoteExecution: {
+              registryUrl: "https://environment-registry.example.com/api",
+              environmentId: "devbox-example",
+              authToken: "registry-token",
+            },
+          },
+        },
+      },
+      clientFactory,
+    });
+
+    await provider.describeImage?.({
+      buffer: Buffer.from("image-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      provider: "codex",
+      model: "gpt-5.4",
+      timeoutMs: 30_000,
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+    });
+
+    const startOptions = clientFactory.mock.calls[0]?.[0]?.startOptions;
+    expect(startOptions).toMatchObject({
+      transport: "stdio",
+      args: ["app-server", "--listen", "stdio://"],
+      env: { CODEX_HOME: expect.any(String) },
+      clearEnv: expect.arrayContaining([
+        "CODEX_EXEC_SERVER_URL",
+        "CODEX_EXEC_SERVER_NOISE_REGISTRY_URL",
+        "CODEX_EXEC_SERVER_NOISE_ENVIRONMENT_ID",
+        "CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN",
+        "CODEX_EXEC_SERVER_NOISE_CHATGPT_ACCOUNT_ID",
+      ]),
+    });
+    expect(startOptions?.env).not.toHaveProperty("CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN");
+    expect(requests[1]?.params).toMatchObject({
+      config: { "features.hooks": false, notify: [] },
+      environments: [],
+    });
+    expect((requests[1]?.params as { cwd?: string } | undefined)?.cwd).not.toBe(
+      "/tmp/openclaw-agent",
+    );
+  });
+
   it("passes the scoped auth store into isolated app-server startup", async () => {
     const { client } = createFakeClient();
     sharedClientMocks.createIsolatedCodexAppServerClient.mockResolvedValue(client);

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -257,6 +257,17 @@
               "sandboxExecServer": {
                 "type": "boolean",
                 "default": false
+              },
+              "remoteExecution": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["registryUrl", "environmentId", "authToken"],
+                "properties": {
+                  "registryUrl": { "type": "string" },
+                  "environmentId": { "type": "string" },
+                  "authToken": { "type": ["string", "object"] },
+                  "chatgptAccountId": { "type": ["string", "object"] }
+                }
               }
             }
           }
@@ -268,7 +279,15 @@
     "secretInputs": {
       "paths": [
         { "path": "appServer.authToken", "expected": "string" },
-        { "path": "appServer.headers.*", "expected": "string" }
+        { "path": "appServer.headers.*", "expected": "string" },
+        {
+          "path": "appServer.experimental.remoteExecution.authToken",
+          "expected": "string"
+        },
+        {
+          "path": "appServer.experimental.remoteExecution.chatgptAccountId",
+          "expected": "string"
+        }
       ]
     }
   },
@@ -420,7 +439,7 @@
     },
     "appServer.remoteWorkspaceRoot": {
       "label": "Remote Workspace Root",
-      "help": "Remote Codex app-server workspace root used to project OpenClaw cwd suffixes before starting Codex threads.",
+      "help": "Remote Codex workspace root used to project OpenClaw cwd suffixes before starting Codex threads.",
       "advanced": true
     },
     "appServer.codeModeOnly": {
@@ -551,6 +570,33 @@
     "appServer.experimental.sandboxExecServer": {
       "label": "Sandbox Exec Server",
       "help": "Route native Codex execution through an OpenClaw sandbox-backed exec-server when OpenClaw sandboxing is active.",
+      "advanced": true
+    },
+    "appServer.experimental.remoteExecution": {
+      "label": "Single Remote Execution Target (Preview)",
+      "help": "Keep app-server local over stdio while routing Codex filesystem and process operations through one authenticated remote execution environment.",
+      "advanced": true
+    },
+    "appServer.experimental.remoteExecution.registryUrl": {
+      "label": "Environment Registry URL",
+      "help": "HTTPS base URL for the Codex execution environment registry.",
+      "advanced": true
+    },
+    "appServer.experimental.remoteExecution.environmentId": {
+      "label": "Registry Environment ID",
+      "help": "Single registry rendezvous identifier exposed by the remote Codex exec-server; this is not a pool selector.",
+      "advanced": true
+    },
+    "appServer.experimental.remoteExecution.authToken": {
+      "label": "Environment Registry Token",
+      "help": "Bearer token used for authenticated, encrypted exec-server rendezvous.",
+      "sensitive": true,
+      "advanced": true
+    },
+    "appServer.experimental.remoteExecution.chatgptAccountId": {
+      "label": "ChatGPT Account ID",
+      "help": "Optional account identifier sent to the execution environment registry.",
+      "sensitive": true,
       "advanced": true
     }
   }

--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -198,6 +198,28 @@ describe("startCodexAttemptThread", () => {
     expect(harness.process.stdin.destroyed).toBe(true);
   });
 
+  it("rejects local Computer Use setup with remote execution", async () => {
+    const { harness, run } = startThreadWithHarness(5_000, new AbortController().signal, {
+      pluginConfig: {
+        computerUse: { enabled: true },
+        appServer: {
+          command: "codex",
+          remoteWorkspaceRoot: "/remote/workspace",
+          experimental: {
+            remoteExecution: {
+              registryUrl: "https://environment-registry.example.com/api",
+              environmentId: "devbox-example",
+              authToken: "registry-token",
+            },
+          },
+        },
+      },
+    });
+
+    await expect(run).rejects.toThrow("removes the local execution environment");
+    expect(harness.writes).toEqual([]);
+  });
+
   it("retires a failed startup client after another active lease releases", async () => {
     const retained = createClientHarness();
     const replacement = createClientHarness();

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -52,6 +52,7 @@ import type {
   CodexTurnEnvironmentParams,
   JsonObject,
 } from "./protocol.js";
+import { ensureCodexRemoteExecutionCompatibility } from "./remote-execution.js";
 import {
   ensureCodexSandboxExecServerEnvironment,
   releaseCodexSandboxExecServerEnvironment,
@@ -131,6 +132,11 @@ export async function startCodexAttemptThread(params: {
   onStartupTimeout: () => void | Promise<void>;
   spawnedBy: EmbeddedRunAttemptParams["spawnedBy"];
 }): Promise<StartCodexAttemptThreadResult> {
+  if (params.appServer.remoteExecutionFingerprint && params.computerUseConfig.enabled) {
+    throw new Error(
+      "Codex Computer Use cannot run with appServer.experimental.remoteExecution because Codex 0.142.x removes the local execution environment required by its stdio MCP server.",
+    );
+  }
   let pluginAppServer = params.appServer;
   let releaseSharedClientLease: (() => void) | undefined;
   let startupClientForAbandonedRequestCleanup: CodexAppServerClient | undefined;
@@ -170,8 +176,7 @@ export async function startCodexAttemptThread(params: {
           : undefined;
         const computerUseMcpElicitationDelegationRequired = params.computerUseConfig.enabled;
         const mcpElicitationDelegationRequired =
-          resolvedPluginPolicy?.enabled === true ||
-          computerUseMcpElicitationDelegationRequired;
+          resolvedPluginPolicy?.enabled === true || computerUseMcpElicitationDelegationRequired;
         const enabledPluginConfigKeys = resolvedPluginPolicy
           ? resolvedPluginPolicy.pluginPolicies
               .filter((plugin) => plugin.enabled)
@@ -229,6 +234,12 @@ export async function startCodexAttemptThread(params: {
               agentDir: params.agentDir,
               authProfileId: params.startupAuthProfileId,
               config: params.config,
+            });
+            await ensureCodexRemoteExecutionCompatibility({
+              appServer: params.appServer,
+              client: activeStartupClient,
+              cwd: params.effectiveCwd,
+              signal: startupAbandonController.signal,
             });
             const turnRouter = getCodexAppServerTurnRouter(activeStartupClient);
             await ensureCodexComputerUse({

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -6,7 +6,7 @@ import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
 import { readCodexNotificationItem } from "./attempt-notifications.js";
 import type { CodexAppServerClient } from "./client.js";
-import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { CODEX_REMOTE_EXECUTION_ENV_VARS, resolveCodexAppServerRuntimeOptions } from "./config.js";
 import { readModelListResult } from "./models.js";
 import { mergeCodexThreadConfigs } from "./plugin-thread-config.js";
 import {
@@ -31,6 +31,7 @@ import { buildCodexRuntimeThreadConfig } from "./thread-lifecycle.js";
 
 const CODEX_PRIVATE_STDIO_ARGS = ["app-server", "--listen", "stdio://"];
 const OPENCLAW_CODEX_APP_SERVER_ARGS_ENV_VAR = "OPENCLAW_CODEX_APP_SERVER_ARGS";
+const CODEX_REMOTE_EXECUTION_ENV_VAR_SET = new Set<string>(CODEX_REMOTE_EXECUTION_ENV_VARS);
 const CODEX_BOUNDED_THREAD_CONFIG: JsonObject = {
   "features.multi_agent": false,
   "features.apps": false,
@@ -80,7 +81,7 @@ export async function runBoundedCodexAppServerTurn(
   const appServer = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.options.pluginConfig,
   });
-  if (params.isolation === "configured-transport") {
+  if (params.isolation === "configured-transport" && !appServer.remoteExecutionFingerprint) {
     return await runBoundedCodexAppServerTurnInWorkspace(params, appServer, {
       cwd: params.agentDir?.trim() || process.cwd(),
     });
@@ -234,13 +235,21 @@ function buildPrivateCodexAppServerStartOptions(
   codexHome: string,
 ): ReturnType<typeof resolveCodexAppServerRuntimeOptions>["start"] {
   const privateEnv = Object.fromEntries(
-    Object.entries(start.env ?? {}).filter(
-      ([name]) => name.trim().toUpperCase() !== OPENCLAW_CODEX_APP_SERVER_ARGS_ENV_VAR,
-    ),
+    Object.entries(start.env ?? {}).filter(([name]) => {
+      const normalized = name.trim().toUpperCase();
+      return (
+        normalized !== OPENCLAW_CODEX_APP_SERVER_ARGS_ENV_VAR &&
+        !CODEX_REMOTE_EXECUTION_ENV_VAR_SET.has(normalized)
+      );
+    }),
   );
   const clearEnv = (start.clearEnv ?? []).filter((name) => {
     const normalized = name.trim().toUpperCase();
-    return normalized !== "CODEX_HOME" && normalized !== OPENCLAW_CODEX_APP_SERVER_ARGS_ENV_VAR;
+    return (
+      normalized !== "CODEX_HOME" &&
+      normalized !== OPENCLAW_CODEX_APP_SERVER_ARGS_ENV_VAR &&
+      !CODEX_REMOTE_EXECUTION_ENV_VAR_SET.has(normalized)
+    );
   });
   return {
     ...start,
@@ -249,7 +258,13 @@ function buildPrivateCodexAppServerStartOptions(
       ...privateEnv,
       CODEX_HOME: codexHome,
     },
-    clearEnv: [...clearEnv, OPENCLAW_CODEX_APP_SERVER_ARGS_ENV_VAR],
+    // Private review/search turns use a temporary local cwd. Clear inherited
+    // executor routing so they cannot escape that isolated workspace.
+    clearEnv: [
+      ...clearEnv,
+      ...CODEX_REMOTE_EXECUTION_ENV_VARS,
+      OPENCLAW_CODEX_APP_SERVER_ARGS_ENV_VAR,
+    ],
   };
 }
 

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -7,9 +7,12 @@ import { describe, expect, it, vi } from "vitest";
 import {
   CODEX_APP_SERVER_CONFIG_KEYS,
   CODEX_APP_SERVER_EXPERIMENTAL_CONFIG_KEYS,
+  CODEX_APP_SERVER_REMOTE_EXECUTION_CONFIG_KEYS,
   CODEX_COMPUTER_USE_CONFIG_KEYS,
   CODEX_PLUGIN_ENTRY_CONFIG_KEYS,
   CODEX_PLUGINS_CONFIG_KEYS,
+  CODEX_REMOTE_EXECUTION_ENV_VARS,
+  applyCodexRemoteExecutionThreadConfig,
   canUseCodexModelBackedApprovalsReviewerForModel,
   codexAppServerStartOptionsKey,
   fingerprintCodexAppServerNetworkProxyConfigPatch,
@@ -304,8 +307,26 @@ describe("Codex app-server config", () => {
     });
 
     expectFields(runtime.start, "runtime start", {
-      clearEnv: ["OPENAI_API_KEY"],
+      clearEnv: ["OPENAI_API_KEY", ...CODEX_REMOTE_EXECUTION_ENV_VARS],
     });
+  });
+
+  it("clears inherited exec-server routing unless validated remote execution is configured", () => {
+    const runtime = resolveRuntimeForTest({ env: {} });
+
+    expect(runtime.start.clearEnv).toEqual(CODEX_REMOTE_EXECUTION_ENV_VARS);
+  });
+
+  it("keeps canonical exec-server clears when configured entries use different casing", () => {
+    const runtime = resolveRuntimeForTest({
+      pluginConfig: { appServer: { clearEnv: ["codex_exec_server_url"] } },
+      env: {},
+    });
+
+    expect(runtime.start.clearEnv).toEqual([
+      "codex_exec_server_url",
+      ...CODEX_REMOTE_EXECUTION_ENV_VARS,
+    ]);
   });
 
   it("normalizes legacy service tiers without discarding the rest of the config", () => {
@@ -418,6 +439,345 @@ describe("Codex app-server config", () => {
       remoteAppsSubstrate: "preconfigured",
       remoteWorkspaceRoot: "/home/oai/openclaw-workspaces",
     });
+  });
+
+  it("keeps app-server local while configuring authenticated remote execution", () => {
+    const runtime = resolveRuntimeForTest({
+      pluginConfig: {
+        appServer: {
+          remoteWorkspaceRoot: " /home/codex/workspaces ",
+          experimental: {
+            remoteExecution: {
+              registryUrl: " https://environment-registry.example.com/api/// ",
+              environmentId: " devbox-example ",
+              authToken: " registry-token ",
+              chatgptAccountId: " account-example ",
+            },
+          },
+        },
+      },
+    });
+
+    expectFields(runtime, "runtime", {
+      connectionClass: "local-loopback",
+      remoteWorkspaceRoot: "/home/codex/workspaces",
+    });
+    expect(runtime.remoteExecutionFingerprint).toMatch(/^sha256:[a-f0-9]{64}$/u);
+    expect(runtime.remoteExecutionFingerprint).not.toContain("registry-token");
+    expect(runtime.start.env).toEqual({
+      CODEX_EXEC_SERVER_URL: "none",
+      CODEX_EXEC_SERVER_NOISE_REGISTRY_URL: "https://environment-registry.example.com/api",
+      CODEX_EXEC_SERVER_NOISE_ENVIRONMENT_ID: "devbox-example",
+      CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN: "registry-token",
+      CODEX_EXEC_SERVER_NOISE_CHATGPT_ACCOUNT_ID: "account-example",
+    });
+    // The explicit empty list must override CodexAppServerClient.start() defaults,
+    // which clear remote routing for ordinary local app-server launches.
+    expect(runtime.start.clearEnv).toEqual([]);
+  });
+
+  it("enforces the remote execution thread safety policy after user config", () => {
+    const config = applyCodexRemoteExecutionThreadConfig(
+      {
+        features: { hooks: true, unified_exec: false, unrelated: true },
+        "features.unified_exec": false,
+        "features.shell_zsh_fork": true,
+        hooks: { PreToolUse: [{ hooks: [{ type: "command", command: "unsafe" }] }] },
+        "hooks.PostToolUse": [{ hooks: [{ type: "command", command: "unsafe" }] }],
+        notify: ["unsafe"],
+        shell_environment_policy: { inherit: "all", set: { SECRET_TOKEN: "unsafe" } },
+        "shell_environment_policy.ignore_default_excludes": true,
+        unrelated: "preserved",
+      },
+      { remoteExecutionFingerprint: "sha256:remote" },
+    );
+
+    expect(config).toMatchObject({
+      features: { unrelated: true },
+      "features.unified_exec": true,
+      "features.shell_zsh_fork": false,
+      "features.unified_exec_zsh_fork": false,
+      "features.hooks": false,
+      "hooks.PreToolUse": [],
+      "hooks.PostToolUse": [],
+      "hooks.PermissionRequest": [],
+      "hooks.Stop": [],
+      notify: [],
+      "shell_environment_policy.inherit": "core",
+      "shell_environment_policy.ignore_default_excludes": false,
+      "shell_environment_policy.exclude": ["CODEX_EXEC_SERVER_*"],
+      "shell_environment_policy.set": {},
+      "shell_environment_policy.include_only": [],
+      "shell_environment_policy.experimental_use_profile": false,
+      unrelated: "preserved",
+    });
+    expect(config).not.toHaveProperty("hooks");
+    expect(config).not.toHaveProperty("shell_environment_policy");
+  });
+
+  it("isolates remote execution in the shared-client key without exposing credentials", () => {
+    const resolve = (authToken: string, chatgptAccountId?: string) =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            experimental: {
+              remoteExecution: {
+                registryUrl: "https://environment-registry.example.com/api",
+                environmentId: "devbox-example",
+                authToken,
+                ...(chatgptAccountId ? { chatgptAccountId } : {}),
+              },
+            },
+          },
+        },
+      });
+    const first = resolve("registry-token-first");
+    const second = resolve("registry-token-second");
+    const stableAccountFirst = resolve("registry-token-first", "account-stable");
+    const stableAccountSecond = resolve("registry-token-second", "account-stable");
+    const otherAccount = resolve("registry-token-second", "account-other");
+    const otherWorkspace = resolveRuntimeForTest({
+      pluginConfig: {
+        appServer: {
+          remoteWorkspaceRoot: "/home/codex/other-workspace",
+          experimental: {
+            remoteExecution: {
+              registryUrl: "https://environment-registry.example.com/api",
+              environmentId: "devbox-example",
+              authToken: "registry-token-second",
+            },
+          },
+        },
+      },
+    });
+    const firstKey = codexAppServerStartOptionsKey(first.start);
+    const secondKey = codexAppServerStartOptionsKey(second.start);
+
+    expect(firstKey).not.toEqual(secondKey);
+    expect(firstKey).not.toContain("registry-token-first");
+    expect(secondKey).not.toContain("registry-token-second");
+    expect(first.remoteExecutionFingerprint).not.toEqual(second.remoteExecutionFingerprint);
+    expect(stableAccountFirst.remoteExecutionFingerprint).toEqual(
+      stableAccountSecond.remoteExecutionFingerprint,
+    );
+    expect(otherAccount.remoteExecutionFingerprint).not.toEqual(second.remoteExecutionFingerprint);
+    expect(otherWorkspace.remoteExecutionFingerprint).not.toEqual(
+      second.remoteExecutionFingerprint,
+    );
+  });
+
+  it("fails closed for incomplete or unsafe remote execution topology", () => {
+    const remoteExecution = {
+      registryUrl: "https://environment-registry.example.com/api",
+      environmentId: "devbox-example",
+      authToken: "registry-token",
+    };
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            transport: "websocket",
+            url: "ws://127.0.0.1:39175",
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            experimental: { remoteExecution },
+          },
+        },
+      }),
+    ).toThrow("remoteExecution requires appServer.transport=stdio");
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: { appServer: { experimental: { remoteExecution } } },
+      }),
+    ).toThrow("remoteExecution requires appServer.remoteWorkspaceRoot");
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            experimental: {
+              remoteExecution: { ...remoteExecution, registryUrl: "http://registry.example.com" },
+            },
+          },
+        },
+      }),
+    ).toThrow("registryUrl must use HTTPS unless it targets loopback");
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            experimental: {
+              remoteExecution: {
+                ...remoteExecution,
+                registryUrl: "https://user:password@environment-registry.example.com/api",
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow("registryUrl cannot contain credentials");
+    for (const registryUrl of [
+      "https://environment-registry.example.com/api?tenant=test",
+      "https://environment-registry.example.com/api#tenant",
+    ]) {
+      expect(() =>
+        resolveRuntimeForTest({
+          pluginConfig: {
+            appServer: {
+              remoteWorkspaceRoot: "/home/codex/workspaces",
+              experimental: {
+                remoteExecution: { ...remoteExecution, registryUrl },
+              },
+            },
+          },
+        }),
+      ).toThrow("registryUrl cannot contain a query or fragment");
+    }
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            experimental: {
+              remoteExecution: {
+                ...remoteExecution,
+                registryUrl: "http://127.attacker.example",
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow("registryUrl must use HTTPS unless it targets loopback");
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            clearEnv: ["CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN"],
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            experimental: { remoteExecution },
+          },
+        },
+      }),
+    ).toThrow("clearEnv cannot clear CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN");
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            networkProxy: { enabled: true },
+            experimental: { remoteExecution },
+          },
+        },
+      }),
+    ).toThrow("remoteExecution cannot be combined with appServer.networkProxy");
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            experimental: { remoteExecution, sandboxExecServer: true },
+          },
+        },
+      }),
+    ).toThrow("remoteExecution cannot be combined with appServer.experimental.sandboxExecServer");
+    expect(() =>
+      resolveRuntimeForTest({
+        openClawSandboxActive: true,
+        pluginConfig: {
+          appServer: {
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            experimental: { remoteExecution },
+          },
+        },
+      }),
+    ).toThrow("remoteExecution cannot run inside an active OpenClaw sandbox");
+    expect(() =>
+      resolveRuntimeForTest({
+        platform: "win32",
+        pluginConfig: {
+          appServer: {
+            remoteWorkspaceRoot: "C:\\workspace",
+            experimental: { remoteExecution },
+          },
+        },
+      }),
+    ).toThrow("remoteExecution requires a Linux or macOS app-server host");
+  });
+
+  it("requires an absolute POSIX workspace root for remote execution", () => {
+    const remoteExecution = {
+      registryUrl: "https://environment-registry.example.com/api",
+      environmentId: "devbox-example",
+      authToken: "registry-token",
+    };
+
+    for (const remoteWorkspaceRoot of ["relative/workspaces", "C:\\workspace", "C:/workspace"]) {
+      expect(() =>
+        resolveRuntimeForTest({
+          pluginConfig: {
+            appServer: {
+              remoteWorkspaceRoot,
+              experimental: { remoteExecution },
+            },
+          },
+        }),
+      ).toThrow("remoteWorkspaceRoot must be an absolute POSIX path");
+    }
+  });
+
+  it("rejects unresolved remote execution SecretRefs", () => {
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            remoteWorkspaceRoot: "/home/codex/workspaces",
+            experimental: {
+              remoteExecution: {
+                registryUrl: "https://environment-registry.example.com/api",
+                environmentId: "devbox-example",
+                authToken: envRef("CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN"),
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow(
+      'appServer.experimental.remoteExecution.authToken: unresolved SecretRef "env:default:CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN"',
+    );
+  });
+
+  it("rejects malformed remote execution config instead of falling back to local execution", () => {
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            experimental: {
+              remoteExecution: {
+                registryUrl: "https://environment-registry.example.com/api",
+                environmentId: "devbox-example",
+              },
+            },
+          },
+        } as never,
+      }),
+    ).toThrow("config is invalid while appServer.experimental.remoteExecution is configured");
+    expect(() =>
+      resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            experimental: {
+              remoteExecution: {
+                registryUrl: "https://environment-registry.example.com/api",
+                environmentId: "devbox-example",
+                authToken: "registry-token",
+                unexpected: true,
+              },
+            },
+          },
+        } as never,
+      }),
+    ).toThrow("config is invalid while appServer.experimental.remoteExecution is configured");
   });
 
   it("passes resolved app-server SecretInput strings through to auth token and headers", () => {
@@ -1921,6 +2281,7 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
         args: ["app-server", "--listen", "stdio://"],
         headers: {},
         homeScope: "agent",
+        clearEnv: CODEX_REMOTE_EXECUTION_ENV_VARS,
       },
     });
   });
@@ -2628,6 +2989,21 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     ]);
     for (const key of CODEX_APP_SERVER_EXPERIMENTAL_CONFIG_KEYS) {
       expectUiHintLabel(manifest, `appServer.experimental.${key}`);
+    }
+    const remoteExecutionSchema = appServerExperimentalProperties.remoteExecution as {
+      properties: Record<string, unknown>;
+      required: string[];
+    };
+    expect(Object.keys(remoteExecutionSchema.properties).toSorted()).toEqual([
+      ...CODEX_APP_SERVER_REMOTE_EXECUTION_CONFIG_KEYS,
+    ]);
+    expect(remoteExecutionSchema.required.toSorted()).toEqual([
+      "authToken",
+      "environmentId",
+      "registryUrl",
+    ]);
+    for (const key of CODEX_APP_SERVER_REMOTE_EXECUTION_CONFIG_KEYS) {
+      expectUiHintLabel(manifest, `appServer.experimental.remoteExecution.${key}`);
     }
     const computerUseManifestKeys = Object.keys(
       manifest.configSchema.properties.computerUse.properties,

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -1,6 +1,7 @@
 // Codex helper module supports config behavior.
 import { createHash, createHmac, randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { isIP } from "node:net";
 import { homedir as readHomeDir, hostname as readHostName } from "node:os";
 import path from "node:path";
 import {
@@ -21,7 +22,13 @@ import {
 import { normalizeTrimmedStringList } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { detectWindowsSpawnCommandInlineArgs } from "openclaw/plugin-sdk/windows-spawn";
 import { z } from "zod";
-import type { CodexSandboxPolicy, CodexServiceTier, JsonObject, JsonValue } from "./protocol.js";
+import {
+  isJsonObject,
+  type CodexSandboxPolicy,
+  type CodexServiceTier,
+  type JsonObject,
+  type JsonValue,
+} from "./protocol.js";
 
 const START_OPTIONS_KEY_SECRET_SYMBOL = Symbol.for("openclaw.codexAppServerStartOptionsKeySecret");
 const START_OPTIONS_KEY_SECRET = getStartOptionsKeySecret();
@@ -29,6 +36,43 @@ const UNIX_CODEX_REQUIREMENTS_PATH = "/etc/codex/requirements.toml";
 const WINDOWS_CODEX_REQUIREMENTS_SUFFIX = "\\OpenAI\\Codex\\requirements.toml";
 const CODEX_APP_SERVER_HOME_DIRNAME = "codex-home";
 const CODEX_CONFIG_TOML_FILENAME = "config.toml";
+const CODEX_EXEC_SERVER_URL_ENV_VAR = "CODEX_EXEC_SERVER_URL";
+const CODEX_EXEC_SERVER_NOISE_REGISTRY_URL_ENV_VAR = "CODEX_EXEC_SERVER_NOISE_REGISTRY_URL";
+const CODEX_EXEC_SERVER_NOISE_ENVIRONMENT_ID_ENV_VAR = "CODEX_EXEC_SERVER_NOISE_ENVIRONMENT_ID";
+const CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN_ENV_VAR = "CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN";
+const CODEX_EXEC_SERVER_NOISE_CHATGPT_ACCOUNT_ID_ENV_VAR =
+  "CODEX_EXEC_SERVER_NOISE_CHATGPT_ACCOUNT_ID";
+export const CODEX_REMOTE_EXECUTION_ENV_VARS = [
+  CODEX_EXEC_SERVER_URL_ENV_VAR,
+  CODEX_EXEC_SERVER_NOISE_REGISTRY_URL_ENV_VAR,
+  CODEX_EXEC_SERVER_NOISE_ENVIRONMENT_ID_ENV_VAR,
+  CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN_ENV_VAR,
+  CODEX_EXEC_SERVER_NOISE_CHATGPT_ACCOUNT_ID_ENV_VAR,
+] as const;
+const CODEX_REMOTE_EXECUTION_ENV_VAR_SET = new Set<string>(CODEX_REMOTE_EXECUTION_ENV_VARS);
+const CODEX_REMOTE_EXECUTION_FEATURE_KEYS = [
+  "hooks",
+  "shell_zsh_fork",
+  "unified_exec",
+  "unified_exec_zsh_fork",
+] as const;
+const CODEX_REMOTE_EXECUTION_THREAD_CONFIG: JsonObject = {
+  "features.unified_exec": true,
+  "features.shell_zsh_fork": false,
+  "features.unified_exec_zsh_fork": false,
+  "features.hooks": false,
+  "hooks.PreToolUse": [],
+  "hooks.PostToolUse": [],
+  "hooks.PermissionRequest": [],
+  "hooks.Stop": [],
+  notify: [],
+  "shell_environment_policy.inherit": "core",
+  "shell_environment_policy.ignore_default_excludes": false,
+  "shell_environment_policy.exclude": ["CODEX_EXEC_SERVER_*"],
+  "shell_environment_policy.set": {},
+  "shell_environment_policy.include_only": [],
+  "shell_environment_policy.experimental_use_profile": false,
+};
 const PLAIN_DECIMAL_NUMBER_RE = /^[+-]?(?:(?:\d+\.?\d*)|(?:\.\d+))$/;
 
 type CodexAppServerTransportMode = "stdio" | "websocket";
@@ -118,6 +162,14 @@ export type CodexPluginsConfig = {
 
 export type CodexAppServerExperimentalConfig = {
   sandboxExecServer?: boolean;
+  remoteExecution?: CodexAppServerRemoteExecutionConfig;
+};
+
+type CodexAppServerRemoteExecutionConfig = {
+  registryUrl: string;
+  environmentId: string;
+  authToken: SecretInput;
+  chatgptAccountId?: SecretInput;
 };
 
 export type CodexAppServerNetworkProxyDomainPermission = "allow" | "deny";
@@ -185,6 +237,7 @@ export type CodexAppServerRuntimeOptions = {
   connectionClass: CodexAppServerConnectionClass;
   remoteAppsSubstrate: CodexAppServerRemoteAppsSubstrate;
   remoteWorkspaceRoot?: string;
+  remoteExecutionFingerprint?: string;
   codeModeOnly: boolean;
   requestTimeoutMs: number;
   turnCompletionIdleTimeoutMs: number;
@@ -275,7 +328,17 @@ export const CODEX_APP_SERVER_CONFIG_KEYS = [
   "experimental",
 ] as const;
 
-export const CODEX_APP_SERVER_EXPERIMENTAL_CONFIG_KEYS = ["sandboxExecServer"] as const;
+export const CODEX_APP_SERVER_EXPERIMENTAL_CONFIG_KEYS = [
+  "remoteExecution",
+  "sandboxExecServer",
+] as const;
+
+export const CODEX_APP_SERVER_REMOTE_EXECUTION_CONFIG_KEYS = [
+  "authToken",
+  "chatgptAccountId",
+  "environmentId",
+  "registryUrl",
+] as const;
 
 export const CODEX_COMPUTER_USE_CONFIG_KEYS = [
   "enabled",
@@ -334,6 +397,15 @@ const codexAppServerServiceTierSchema = z
 const codexAppServerExperimentalSchema = z
   .object({
     sandboxExecServer: z.boolean().optional(),
+    remoteExecution: z
+      .object({
+        registryUrl: z.string().trim().min(1),
+        environmentId: z.string().trim().min(1),
+        authToken: SecretInputSchema,
+        chatgptAccountId: SecretInputSchema.optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 const codexAppServerRemoteWorkspaceRootSchema = z.string().trim().min(1);
@@ -435,6 +507,11 @@ const codexPluginConfigSchema = z
 export function readCodexPluginConfig(value: unknown): CodexPluginConfig {
   const parsed = codexPluginConfigSchema.safeParse(value);
   if (!parsed.success) {
+    if (hasCodexRemoteExecutionConfig(value)) {
+      throw new Error(
+        "plugins.entries.codex.config is invalid while appServer.experimental.remoteExecution is configured; refusing to fall back to local execution",
+      );
+    }
     return {};
   }
   const { codexPlugins: rawCodexPlugins, ...config } = parsed.data;
@@ -443,6 +520,13 @@ export function readCodexPluginConfig(value: unknown): CodexPluginConfig {
     return config;
   }
   return { ...config, ...(plugins.data ? { codexPlugins: plugins.data } : {}) };
+}
+
+function hasCodexRemoteExecutionConfig(value: unknown): boolean {
+  const pluginConfig = readRecord(value);
+  const appServer = readRecord(pluginConfig?.appServer);
+  const experimental = readRecord(appServer?.experimental);
+  return Boolean(experimental && Object.hasOwn(experimental, "remoteExecution"));
 }
 
 export function isCodexSandboxExecServerEnabled(pluginConfig?: unknown): boolean {
@@ -565,6 +649,38 @@ export function resolveCodexAppServerRuntimeOptions(
   const connectionClass = inferCodexAppServerConnectionClass({ transport, url });
   const remoteAppsSubstrate: CodexAppServerRemoteAppsSubstrate = "preconfigured";
   const remoteWorkspaceRoot = normalizeRemoteWorkspaceRoot(config.remoteWorkspaceRoot);
+  if (config.experimental?.remoteExecution && config.experimental.sandboxExecServer) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution cannot be combined with appServer.experimental.sandboxExecServer",
+    );
+  }
+  if (config.experimental?.remoteExecution && config.networkProxy?.enabled === true) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution cannot be combined with appServer.networkProxy because its loopback proxy is not reachable from the remote executor",
+    );
+  }
+  if (config.experimental?.remoteExecution && params.openClawSandboxActive) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution cannot run inside an active OpenClaw sandbox because that policy disables Codex native execution",
+    );
+  }
+  if (config.experimental?.remoteExecution && (params.platform ?? process.platform) === "win32") {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution requires a Linux or macOS app-server host until Codex unified exec supports Windows",
+    );
+  }
+  const remoteExecution = resolveCodexAppServerRemoteExecution({
+    config: config.experimental?.remoteExecution,
+    transport,
+    remoteWorkspaceRoot,
+    clearEnv,
+  });
+  const spawnClearEnv = resolveCodexAppServerClearEnv({
+    configured: clearEnv,
+    remoteExecutionEnabled: Boolean(remoteExecution),
+  });
+  // Keep an empty remote-execution list explicit: client startup merges defaults,
+  // whose local-runtime clears would otherwise delete the injected routing env.
   const execMode = resolveEffectiveOpenClawExecModeForCodexAppServer({
     execMode: params.execMode,
     execPolicy: params.execPolicy,
@@ -694,11 +810,13 @@ export function resolveCodexAppServerRuntimeOptions(
       ...(url ? { url } : {}),
       ...(authToken ? { authToken } : {}),
       headers,
-      ...(transport === "stdio" && clearEnv.length > 0 ? { clearEnv } : {}),
+      ...(remoteExecution ? { env: remoteExecution.env } : {}),
+      ...(transport === "stdio" ? { clearEnv: spawnClearEnv } : {}),
     },
     connectionClass,
     remoteAppsSubstrate,
     ...(remoteWorkspaceRoot ? { remoteWorkspaceRoot } : {}),
+    ...(remoteExecution ? { remoteExecutionFingerprint: remoteExecution.fingerprint } : {}),
     codeModeOnly: config.codeModeOnly === true,
     requestTimeoutMs: normalizePositiveNumber(config.requestTimeoutMs, 60_000),
     turnCompletionIdleTimeoutMs: normalizePositiveNumber(
@@ -1071,6 +1189,179 @@ function resolveTransport(value: unknown): CodexAppServerTransportMode {
 
 function normalizeRemoteWorkspaceRoot(value: string | undefined): string | undefined {
   return readNonEmptyString(value);
+}
+
+function resolveCodexAppServerClearEnv(params: {
+  configured: string[];
+  remoteExecutionEnabled: boolean;
+}): string[] {
+  if (params.remoteExecutionEnabled) {
+    return params.configured;
+  }
+  // Remote routing needs workspace projection, version, and topology checks.
+  // Clear inherited Codex routing so only the validated plugin surface can enable it.
+  const configured = new Set(params.configured);
+  return [
+    ...params.configured,
+    ...CODEX_REMOTE_EXECUTION_ENV_VARS.filter((key) => !configured.has(key)),
+  ];
+}
+
+/** Applies the non-overridable Codex thread policy for authenticated remote execution. */
+export function applyCodexRemoteExecutionThreadConfig(
+  config: JsonObject | undefined,
+  appServer: Pick<CodexAppServerRuntimeOptions, "remoteExecutionFingerprint">,
+): JsonObject | undefined {
+  if (!appServer.remoteExecutionFingerprint) {
+    return config;
+  }
+  const safeConfig: JsonObject = { ...config };
+  const features = isJsonObject(safeConfig.features) ? { ...safeConfig.features } : undefined;
+  for (const key of CODEX_REMOTE_EXECUTION_FEATURE_KEYS) {
+    delete safeConfig[`features.${key}`];
+    if (features) {
+      delete features[key];
+    }
+  }
+  if (features) {
+    if (Object.keys(features).length > 0) {
+      safeConfig.features = features;
+    } else {
+      delete safeConfig.features;
+    }
+  }
+  delete safeConfig.hooks;
+  delete safeConfig.shell_environment_policy;
+  for (const key of Object.keys(safeConfig)) {
+    if (key.startsWith("hooks.") || key.startsWith("shell_environment_policy.")) {
+      delete safeConfig[key];
+    }
+  }
+  return { ...safeConfig, ...CODEX_REMOTE_EXECUTION_THREAD_CONFIG };
+}
+
+function resolveCodexAppServerRemoteExecution(params: {
+  config: CodexAppServerRemoteExecutionConfig | undefined;
+  transport: CodexAppServerTransportMode;
+  remoteWorkspaceRoot: string | undefined;
+  clearEnv: string[];
+}): { env: Record<string, string>; fingerprint: string } | undefined {
+  if (!params.config) {
+    return undefined;
+  }
+  if (params.transport !== "stdio") {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution requires appServer.transport=stdio",
+    );
+  }
+  if (!params.remoteWorkspaceRoot) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution requires appServer.remoteWorkspaceRoot",
+    );
+  }
+  if (
+    !path.posix.isAbsolute(params.remoteWorkspaceRoot) ||
+    params.remoteWorkspaceRoot.includes("\\")
+  ) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.remoteWorkspaceRoot must be an absolute POSIX path when appServer.experimental.remoteExecution is configured",
+    );
+  }
+  const clearedRemoteExecutionEnv = params.clearEnv.find((key) =>
+    CODEX_REMOTE_EXECUTION_ENV_VAR_SET.has(key.trim().toUpperCase()),
+  );
+  if (clearedRemoteExecutionEnv) {
+    throw new Error(
+      `plugins.entries.codex.config.appServer.clearEnv cannot clear ${clearedRemoteExecutionEnv.trim()} while appServer.experimental.remoteExecution is configured`,
+    );
+  }
+
+  const registryUrl = normalizeCodexRemoteExecutionRegistryUrl(params.config.registryUrl);
+  const environmentId = readNonEmptyString(params.config.environmentId);
+  if (!environmentId) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution.environmentId must be non-empty",
+    );
+  }
+  const authToken = normalizeCodexAppServerSecretInput({
+    value: params.config.authToken,
+    path: "plugins.entries.codex.config.appServer.experimental.remoteExecution.authToken",
+  });
+  if (!authToken) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution.authToken must be non-empty",
+    );
+  }
+  const chatgptAccountId = normalizeCodexAppServerSecretInput({
+    value: params.config.chatgptAccountId,
+    path: "plugins.entries.codex.config.appServer.experimental.remoteExecution.chatgptAccountId",
+  });
+
+  const fingerprint = createHash("sha256")
+    .update("openclaw:codex:remote-execution:v2")
+    .update("\0")
+    .update(registryUrl)
+    .update("\0")
+    .update(environmentId)
+    .update("\0")
+    .update(params.remoteWorkspaceRoot)
+    .update("\0")
+    // Without an explicit account id, the bearer token can select the registry
+    // tenant. Hash it into topology identity so account changes rotate threads.
+    .update(chatgptAccountId ?? authToken)
+    .digest("hex");
+  return {
+    env: {
+      // Noise rendezvous is the authenticated remote path. Disable any inherited
+      // raw exec-server URL so the child cannot fall back to an unauthenticated socket.
+      [CODEX_EXEC_SERVER_URL_ENV_VAR]: "none",
+      [CODEX_EXEC_SERVER_NOISE_REGISTRY_URL_ENV_VAR]: registryUrl,
+      [CODEX_EXEC_SERVER_NOISE_ENVIRONMENT_ID_ENV_VAR]: environmentId,
+      [CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN_ENV_VAR]: authToken,
+      // Override ambient identity too; Codex treats empty as unset.
+      [CODEX_EXEC_SERVER_NOISE_CHATGPT_ACCOUNT_ID_ENV_VAR]: chatgptAccountId ?? "",
+    },
+    fingerprint: `sha256:${fingerprint}`,
+  };
+}
+
+function normalizeCodexRemoteExecutionRegistryUrl(value: string): string {
+  const registryUrl = readNonEmptyString(value);
+  if (!registryUrl) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution.registryUrl must be non-empty",
+    );
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(registryUrl);
+  } catch {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution.registryUrl must be a valid URL",
+    );
+  }
+  const host = parsed.hostname.toLowerCase();
+  const ipHost = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+  const loopback =
+    host === "localhost" ||
+    ipHost === "::1" ||
+    (isIP(ipHost) === 4 && ipHost.split(".")[0] === "127");
+  if (parsed.username || parsed.password) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution.registryUrl cannot contain credentials; use authToken instead",
+    );
+  }
+  if (parsed.protocol !== "https:" && !(parsed.protocol === "http:" && loopback)) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution.registryUrl must use HTTPS unless it targets loopback",
+    );
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error(
+      "plugins.entries.codex.config.appServer.experimental.remoteExecution.registryUrl cannot contain a query or fragment",
+    );
+  }
+  return registryUrl.replace(/\/+$/u, "");
 }
 
 function inferCodexAppServerConnectionClass(params: {

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -167,7 +167,7 @@ describe("Codex app-server dynamic tool build", () => {
     ).toBe("discord");
   });
 
-  it("maps local gateway workspace suffixes to the remote Codex app-server root", () => {
+  it("maps local gateway workspace suffixes to the remote Codex workspace root", () => {
     expect(
       mapCodexAppServerRemoteWorkspacePath({
         value: "/Users/kevinlin/code/openclaw/packages/example",
@@ -194,7 +194,7 @@ describe("Codex app-server dynamic tool build", () => {
     ).toThrow("outside OpenClaw workspace root");
   });
 
-  it("maps Windows child paths through remote Codex app-server workspaces", () => {
+  it("maps Windows child paths through remote Codex workspaces", () => {
     expect(
       mapCodexAppServerRemoteWorkspacePath({
         value: "C:\\Users\\kevinlin\\code\\openclaw\\packages\\example",

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -604,7 +604,7 @@ export function resolveCodexAppServerExecutionCwd(params: {
   });
 }
 
-/** Projects a local OpenClaw workspace cwd into the remote Codex app-server workspace root. */
+/** Projects a local OpenClaw workspace cwd into the remote Codex workspace root. */
 export function mapCodexAppServerRemoteWorkspacePath(params: {
   value: string;
   localWorkspaceRoot: string;
@@ -625,7 +625,7 @@ export function mapCodexAppServerRemoteWorkspacePath(params: {
   const prefix = `${localRoot}/`;
   if (!normalizedValue.startsWith(prefix)) {
     throw new Error(
-      `Codex remoteWorkspaceRoot is configured but cwd ${params.value} is outside OpenClaw workspace root ${params.localWorkspaceRoot}; refusing to send a gateway-local cwd to the remote Codex app-server.`,
+      `Codex remoteWorkspaceRoot is configured but cwd ${params.value} is outside OpenClaw workspace root ${params.localWorkspaceRoot}; refusing to send a gateway-local cwd to the remote Codex workspace.`,
     );
   }
   return joinRemoteWorkspacePath(remoteRoot, normalizedValue.slice(prefix.length));

--- a/extensions/codex/src/app-server/plugin-app-cache-key.test.ts
+++ b/extensions/codex/src/app-server/plugin-app-cache-key.test.ts
@@ -116,4 +116,27 @@ describe("resolveCodexPluginAppCacheEndpoint", () => {
     expect(first).not.toContain("secret-token");
     expect(second).not.toContain("secret-token");
   });
+
+  it("rotates thread fingerprints with the remote execution environment", () => {
+    const start = {
+      transport: "stdio" as const,
+      command: "codex",
+      args: ["app-server", "--listen", "stdio://"],
+      headers: {},
+    };
+    const firstAppServer = {
+      start,
+      connectionClass: "local-loopback" as const,
+      remoteWorkspaceRoot: "/home/codex/workspaces",
+      remoteExecutionFingerprint: "sha256:environment-first",
+    };
+    const secondAppServer = {
+      ...firstAppServer,
+      remoteExecutionFingerprint: "sha256:environment-second",
+    };
+
+    expect(buildCodexAppServerRuntimeFingerprint({ appServer: firstAppServer })).not.toEqual(
+      buildCodexAppServerRuntimeFingerprint({ appServer: secondAppServer }),
+    );
+  });
 });

--- a/extensions/codex/src/app-server/plugin-app-cache-key.ts
+++ b/extensions/codex/src/app-server/plugin-app-cache-key.ts
@@ -50,7 +50,7 @@ export function buildCodexPluginAppCacheKey(params: CodexPluginAppCacheKeyParams
 export function buildCodexAppServerRuntimeFingerprint(params: {
   appServer: Pick<
     CodexAppServerRuntimeOptions,
-    "start" | "connectionClass" | "remoteWorkspaceRoot"
+    "start" | "connectionClass" | "remoteWorkspaceRoot" | "remoteExecutionFingerprint"
   >;
   appServerVersion?: string;
   runtimeIdentity?: CodexAppServerRuntimeIdentity;
@@ -59,6 +59,7 @@ export function buildCodexAppServerRuntimeFingerprint(params: {
     endpoint: resolveCodexPluginAppCacheEndpoint(params.appServer),
     connectionClass: params.appServer.connectionClass,
     remoteWorkspaceRoot: params.appServer.remoteWorkspaceRoot ?? null,
+    remoteExecutionFingerprint: params.appServer.remoteExecutionFingerprint ?? null,
     appServerVersion: params.appServerVersion ?? params.runtimeIdentity?.serverVersion ?? null,
     runtimeIdentity: params.runtimeIdentity ?? null,
   });

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -116,6 +116,7 @@ export type CodexThreadStartParams = JsonObject & {
 
 export type CodexThreadResumeParams = JsonObject & {
   threadId: string;
+  cwd?: string;
   model?: string;
   modelProvider?: string | null;
   personality?: string | null;
@@ -133,7 +134,15 @@ export type CodexThreadStartResponse = {
   modelProvider?: string | null;
 };
 
-export type CodexThreadForkParams = CodexThreadStartParams & {
+export type CodexThreadForkParams = Omit<
+  CodexThreadStartParams,
+  | "dynamicTools"
+  | "environments"
+  | "experimentalRawEvents"
+  | "input"
+  | "personality"
+  | "serviceName"
+> & {
   threadId: string;
   baseInstructions?: string;
   ephemeral?: boolean;

--- a/extensions/codex/src/app-server/remote-execution.test.ts
+++ b/extensions/codex/src/app-server/remote-execution.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CodexAppServerClient } from "./client.js";
+import { ensureCodexRemoteExecutionCompatibility } from "./remote-execution.js";
+
+function createClient(hooks: unknown[], layers: unknown[] = []) {
+  return {
+    request: vi.fn(async (method: string) => {
+      if (method === "configRequirements/read") {
+        return { requirements: null };
+      }
+      if (method === "config/read") {
+        return { config: {}, origins: {}, layers };
+      }
+      if (method === "hooks/list") {
+        return { data: hooks };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    }),
+  } as unknown as CodexAppServerClient;
+}
+
+const remoteAppServer = {
+  remoteExecutionFingerprint: "sha256:remote",
+  requestTimeoutMs: 1_000,
+};
+
+describe("Codex remote execution hook compatibility", () => {
+  it("allows local execution without querying Codex hooks", async () => {
+    const client = createClient([]);
+
+    await ensureCodexRemoteExecutionCompatibility({
+      appServer: { requestTimeoutMs: 1_000 },
+      client,
+      cwd: "/workspace",
+    });
+
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("allows unmanaged hooks", async () => {
+    const client = createClient([
+      {
+        cwd: "/workspace",
+        hooks: [{ enabled: true, handlerType: "command", isManaged: false }],
+        errors: [],
+      },
+    ]);
+
+    await ensureCodexRemoteExecutionCompatibility({
+      appServer: remoteAppServer,
+      client,
+      cwd: "/workspace",
+    });
+    expect(client.request).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects enabled managed command hooks", async () => {
+    const client = createClient([
+      {
+        cwd: "/workspace",
+        hooks: [
+          {
+            enabled: true,
+            eventName: "preToolUse",
+            handlerType: "command",
+            isManaged: true,
+            source: "cloudRequirements",
+          },
+        ],
+        errors: [],
+      },
+    ]);
+
+    await expect(
+      ensureCodexRemoteExecutionCompatibility({
+        appServer: remoteAppServer,
+        client,
+        cwd: "/workspace",
+      }),
+    ).rejects.toThrow("managed command hooks (cloudRequirements:preToolUse)");
+  });
+
+  it("fails closed when hook discovery is incomplete", async () => {
+    const client = createClient([{ cwd: "/workspace", hooks: [], errors: [{ message: "bad" }] }]);
+
+    await expect(
+      ensureCodexRemoteExecutionCompatibility({
+        appServer: remoteAppServer,
+        client,
+        cwd: "/workspace",
+      }),
+    ).rejects.toThrow("could not inspect hooks");
+  });
+
+  it("rejects active legacy managed config that can override thread safety", async () => {
+    const client = createClient(
+      [{ cwd: "/workspace", hooks: [], errors: [] }],
+      [
+        {
+          name: { type: "legacyManagedConfigTomlFromFile", file: "/etc/codex/managed_config.toml" },
+          version: "1",
+          config: {},
+        },
+      ],
+    );
+
+    await expect(
+      ensureCodexRemoteExecutionCompatibility({
+        appServer: remoteAppServer,
+        client,
+        cwd: "/workspace",
+      }),
+    ).rejects.toThrow("active legacy managed_config.toml layer");
+    expect(client.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects effective local stdio MCP servers", async () => {
+    const client = createClient([{ cwd: "/workspace", hooks: [], errors: [] }]);
+    vi.mocked(client.request).mockImplementation(async (method: string) => {
+      if (method === "configRequirements/read") {
+        return { requirements: null } as never;
+      }
+      if (method === "config/read") {
+        return {
+          config: { mcp_servers: { computer: { command: "computer-use" } } },
+          origins: {},
+          layers: [],
+        } as never;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await expect(
+      ensureCodexRemoteExecutionCompatibility({
+        appServer: remoteAppServer,
+        client,
+        cwd: "/workspace",
+      }),
+    ).rejects.toThrow('local stdio MCP server "computer"');
+  });
+
+  it("allows disabled local stdio MCP servers", async () => {
+    const client = createClient([{ cwd: "/workspace", hooks: [], errors: [] }]);
+    vi.mocked(client.request).mockImplementation(async (method: string) => {
+      if (method === "configRequirements/read") {
+        return { requirements: null } as never;
+      }
+      if (method === "config/read") {
+        return {
+          config: {
+            mcp_servers: { computer: { command: "computer-use", enabled: false } },
+          },
+          origins: {},
+          layers: [],
+        } as never;
+      }
+      if (method === "hooks/list") {
+        return { data: [{ cwd: "/workspace", hooks: [], errors: [] }] } as never;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await ensureCodexRemoteExecutionCompatibility({
+      appServer: remoteAppServer,
+      client,
+      cwd: "/workspace",
+    });
+    expect(client.request).toHaveBeenCalledTimes(3);
+  });
+
+  it("rejects managed feature requirements that defeat remote safety", async () => {
+    const client = createClient([{ cwd: "/workspace", hooks: [], errors: [] }]);
+    vi.mocked(client.request).mockImplementation(async (method: string) => {
+      if (method === "configRequirements/read") {
+        return { requirements: { featureRequirements: { unified_exec: false } } } as never;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await expect(
+      ensureCodexRemoteExecutionCompatibility({
+        appServer: remoteAppServer,
+        client,
+        cwd: "/workspace",
+      }),
+    ).rejects.toThrow("managed feature requirements");
+  });
+});

--- a/extensions/codex/src/app-server/remote-execution.ts
+++ b/extensions/codex/src/app-server/remote-execution.ts
@@ -1,0 +1,166 @@
+/** Remote-execution compatibility checks that require a live Codex app-server. */
+import { getBeforeToolCallPolicyDiagnosticState } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { CodexAppServerClient } from "./client.js";
+import type { CodexAppServerRuntimeOptions } from "./config.js";
+import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
+
+/**
+ * Managed command hooks ignore per-thread disablement in Codex 0.142.x. Reject
+ * them before thread startup because they inherit the app-server environment
+ * and try to use the executor-native cwd on the Gateway host.
+ */
+export async function ensureCodexRemoteExecutionCompatibility(params: {
+  appServer: Pick<CodexAppServerRuntimeOptions, "remoteExecutionFingerprint" | "requestTimeoutMs">;
+  client: CodexAppServerClient;
+  cwd: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  if (!params.appServer.remoteExecutionFingerprint) {
+    return;
+  }
+  const beforeToolCallPolicy = getBeforeToolCallPolicyDiagnosticState();
+  if (
+    beforeToolCallPolicy.hasBeforeToolCallHook ||
+    beforeToolCallPolicy.trustedToolPolicies.length > 0
+  ) {
+    throw new Error(
+      "Codex remote execution cannot enforce OpenClaw before_tool_call or trusted-tool policy until Codex supports Gateway-local native hooks",
+    );
+  }
+  let requirementsRead: JsonValue;
+  try {
+    requirementsRead = await params.client.request(
+      "configRequirements/read",
+      {},
+      { timeoutMs: params.appServer.requestTimeoutMs, signal: params.signal },
+    );
+  } catch (cause) {
+    throw new Error("Codex remote execution could not verify managed feature requirements", {
+      cause,
+    });
+  }
+  if (!isJsonObject(requirementsRead)) {
+    throw new Error("Codex remote execution received an invalid configRequirements/read response");
+  }
+  const requirements = requirementsRead.requirements;
+  if (requirements != null && !isJsonObject(requirements)) {
+    throw new Error("Codex remote execution received invalid managed feature requirements");
+  }
+  const featureRequirements = isJsonObject(requirements)
+    ? requirements.featureRequirements
+    : undefined;
+  if (featureRequirements != null && !isJsonObject(featureRequirements)) {
+    throw new Error("Codex remote execution received invalid managed feature requirements");
+  }
+  const requiredFeatures = featureRequirements as JsonObject | undefined;
+  if (
+    requiredFeatures?.unified_exec === false ||
+    requiredFeatures?.shell_zsh_fork === true ||
+    requiredFeatures?.unified_exec_zsh_fork === true ||
+    requiredFeatures?.hooks === true
+  ) {
+    throw new Error(
+      "Codex remote execution is incompatible with managed feature requirements that override its execution safety policy",
+    );
+  }
+
+  let configRead: JsonValue;
+  try {
+    configRead = await params.client.request(
+      "config/read",
+      { includeLayers: true, cwd: params.cwd },
+      { timeoutMs: params.appServer.requestTimeoutMs, signal: params.signal },
+    );
+  } catch (cause) {
+    throw new Error("Codex remote execution could not verify managed configuration precedence", {
+      cause,
+    });
+  }
+  if (
+    !isJsonObject(configRead) ||
+    !isJsonObject(configRead.config) ||
+    !Array.isArray(configRead.layers)
+  ) {
+    throw new Error("Codex remote execution received an invalid config/read response");
+  }
+  for (const layer of configRead.layers) {
+    if (!isJsonObject(layer) || !isJsonObject(layer.name)) {
+      throw new Error("Codex remote execution received an invalid config layer");
+    }
+    const type = layer.name.type;
+    if (
+      (type === "legacyManagedConfigTomlFromFile" || type === "legacyManagedConfigTomlFromMdm") &&
+      layer.disabledReason == null
+    ) {
+      throw new Error(
+        "Codex remote execution cannot safely override an active legacy managed_config.toml layer",
+      );
+    }
+  }
+  const mcpServers = isJsonObject(configRead.config.mcp_servers)
+    ? configRead.config.mcp_servers
+    : undefined;
+  for (const [name, server] of Object.entries(mcpServers ?? {})) {
+    if (
+      isJsonObject(server) &&
+      server.enabled !== false &&
+      typeof server.command === "string" &&
+      server.environment_id !== "remote"
+    ) {
+      throw new Error(
+        `Codex remote execution cannot use local stdio MCP server ${JSON.stringify(name)} because Codex 0.142.x removes its local execution environment`,
+      );
+    }
+  }
+
+  let data: JsonValue[];
+  try {
+    const response = await params.client.request(
+      "hooks/list",
+      { cwds: [params.cwd] },
+      { timeoutMs: params.appServer.requestTimeoutMs, signal: params.signal },
+    );
+    data = response.data;
+  } catch (cause) {
+    throw new Error(
+      "Codex remote execution could not verify that managed command hooks are absent",
+      { cause },
+    );
+  }
+
+  if (data.length === 0) {
+    throw new Error("Codex remote execution received an empty hooks/list response");
+  }
+  const managedCommands: string[] = [];
+  for (const entry of data) {
+    if (!isJsonObject(entry) || !Array.isArray(entry.hooks) || !Array.isArray(entry.errors)) {
+      throw new Error("Codex remote execution received an invalid hooks/list response");
+    }
+    if (entry.errors.length > 0) {
+      throw new Error("Codex remote execution could not inspect hooks for its local workspace");
+    }
+    for (const value of entry.hooks) {
+      if (!isJsonObject(value)) {
+        throw new Error("Codex remote execution received an invalid hooks/list response");
+      }
+      if (
+        typeof value.isManaged !== "boolean" ||
+        typeof value.enabled !== "boolean" ||
+        typeof value.handlerType !== "string"
+      ) {
+        throw new Error("Codex remote execution received an invalid hook description");
+      }
+      if (!value.isManaged || !value.enabled || value.handlerType !== "command") {
+        continue;
+      }
+      const source = typeof value.source === "string" ? value.source : "managed";
+      const eventName = typeof value.eventName === "string" ? value.eventName : "hook";
+      managedCommands.push(`${source}:${eventName}`);
+    }
+  }
+  if (managedCommands.length > 0) {
+    throw new Error(
+      `Codex remote execution cannot run with managed command hooks (${managedCommands.toSorted().join(", ")}) because Codex runs them on the app-server host with the remote cwd`,
+    );
+  }
+}

--- a/extensions/codex/src/app-server/request.test.ts
+++ b/extensions/codex/src/app-server/request.test.ts
@@ -4,12 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const sharedClientMocks = vi.hoisted(() => ({
   createIsolatedCodexAppServerClient: vi.fn(),
   getSharedCodexAppServerClient: vi.fn(),
+  releaseLeasedSharedCodexAppServerClient: vi.fn(),
 }));
 
 vi.mock("./shared-client.js", () => ({
   ...sharedClientMocks,
   getLeasedSharedCodexAppServerClient: sharedClientMocks.getSharedCodexAppServerClient,
-  releaseLeasedSharedCodexAppServerClient: vi.fn(),
 }));
 
 const { requestCodexAppServerJson } = await import("./request.js");
@@ -18,6 +18,7 @@ describe("requestCodexAppServerJson sandbox guard", () => {
   beforeEach(() => {
     sharedClientMocks.createIsolatedCodexAppServerClient.mockReset();
     sharedClientMocks.getSharedCodexAppServerClient.mockReset();
+    sharedClientMocks.releaseLeasedSharedCodexAppServerClient.mockReset();
   });
 
   it("fails closed before raw app-server bypass methods in sandboxed sessions", async () => {
@@ -65,7 +66,11 @@ describe("requestCodexAppServerJson sandbox guard", () => {
       }),
     ).resolves.toEqual({ ok: true });
 
-    expect(request).toHaveBeenCalledWith("thread/list", { limit: 10 }, { timeoutMs: 60_000 });
+    expect(request).toHaveBeenCalledWith(
+      "thread/list",
+      { limit: 10 },
+      expect.objectContaining({ timeoutMs: 60_000, signal: expect.anything() }),
+    );
   });
 
   it("allows current native thread management methods in sandboxed sessions", async () => {
@@ -130,7 +135,11 @@ describe("requestCodexAppServerJson sandbox guard", () => {
       }),
     ).resolves.toEqual({ ok: true });
 
-    expect(request).toHaveBeenCalledWith("thread/list", { limit: 10 }, { timeoutMs: 60_000 });
+    expect(request).toHaveBeenCalledWith(
+      "thread/list",
+      { limit: 10 },
+      expect.objectContaining({ timeoutMs: 60_000, signal: expect.anything() }),
+    );
   });
 
   it("allows config value writes in sandboxed sessions", async () => {
@@ -151,7 +160,11 @@ describe("requestCodexAppServerJson sandbox guard", () => {
       }),
     ).resolves.toEqual({ ok: true });
 
-    expect(request).toHaveBeenCalledWith("config/value/write", params, { timeoutMs: 60_000 });
+    expect(request).toHaveBeenCalledWith(
+      "config/value/write",
+      params,
+      expect.objectContaining({ timeoutMs: 60_000, signal: expect.anything() }),
+    );
   });
 
   it("allows config reads in sandboxed sessions", async () => {
@@ -168,7 +181,11 @@ describe("requestCodexAppServerJson sandbox guard", () => {
       }),
     ).resolves.toEqual({ config: { apps: { apps: {} } } });
 
-    expect(request).toHaveBeenCalledWith("config/read", params, { timeoutMs: 60_000 });
+    expect(request).toHaveBeenCalledWith(
+      "config/read",
+      params,
+      expect.objectContaining({ timeoutMs: 60_000, signal: expect.anything() }),
+    );
   });
 
   it("allows sandbox-pinned thread starts in sandboxed sessions", async () => {
@@ -188,7 +205,67 @@ describe("requestCodexAppServerJson sandbox guard", () => {
       }),
     ).resolves.toEqual({ thread: { id: "thread-1" }, model: "gpt-5.5" });
 
-    expect(request).toHaveBeenCalledWith("thread/start", params, { timeoutMs: 60_000 });
+    expect(request).toHaveBeenCalledWith(
+      "thread/start",
+      params,
+      expect.objectContaining({ timeoutMs: 60_000, signal: expect.anything() }),
+    );
+  });
+
+  it("never sends a remote mutation after its compatibility deadline expires", async () => {
+    vi.useFakeTimers();
+    let resolveRequirements: ((value: { requirements: null }) => void) | undefined;
+    const requirements = new Promise<{ requirements: null }>((resolve) => {
+      resolveRequirements = resolve;
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "configRequirements/read") {
+        return await requirements;
+      }
+      if (method === "config/read") {
+        return { config: {}, origins: {}, layers: [] };
+      }
+      if (method === "hooks/list") {
+        return { data: [{ cwd: "/workspace", hooks: [], errors: [] }] };
+      }
+      if (method === "thread/fork") {
+        return { thread: { id: "unexpected" }, model: "gpt-5.5" };
+      }
+      throw new Error(`unexpected request: ${method}`);
+    });
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });
+    const released = new Promise<void>((resolve) => {
+      sharedClientMocks.releaseLeasedSharedCodexAppServerClient.mockImplementation(() => resolve());
+    });
+
+    try {
+      const result = requestCodexAppServerJson({
+        method: "thread/fork",
+        requestParams: { threadId: "thread-1" },
+        timeoutMs: 25,
+        remoteExecution: {
+          remoteExecutionFingerprint: "sha256:remote",
+          requestTimeoutMs: 60_000,
+        },
+        remoteExecutionHookCwd: "/workspace",
+      });
+      const rejected = expect(result).rejects.toThrow("codex app-server thread/fork timed out");
+
+      await vi.advanceTimersByTimeAsync(25);
+      await rejected;
+      expect(request.mock.calls.map(([method]) => method)).toEqual(["configRequirements/read"]);
+
+      resolveRequirements?.({ requirements: null });
+      await released;
+      expect(request.mock.calls.map(([method]) => method)).toEqual([
+        "configRequirements/read",
+        "config/read",
+        "hooks/list",
+      ]);
+      expect(request).not.toHaveBeenCalledWith("thread/fork", expect.anything(), expect.anything());
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("blocks thread starts with sandbox environments when exec host=node is active", async () => {

--- a/extensions/codex/src/app-server/request.ts
+++ b/extensions/codex/src/app-server/request.ts
@@ -3,20 +3,60 @@
  * checks, shared-client leasing, and isolated-client shutdown handling.
  */
 import type { resolveCodexAppServerAuthProfileIdForAgent } from "./auth-bridge.js";
-import type { CodexAppServerStartOptions } from "./config.js";
+import type { CodexAppServerRuntimeOptions, CodexAppServerStartOptions } from "./config.js";
 import type {
   CodexAppServerRequestMethod,
   CodexAppServerRequestParams,
   CodexAppServerRequestResult,
   JsonValue,
 } from "./protocol.js";
+import { ensureCodexRemoteExecutionCompatibility } from "./remote-execution.js";
 import { resolveCodexAppServerDirectSandboxBypassBlock } from "./sandbox-guard.js";
 import {
   createIsolatedCodexAppServerClient,
   getLeasedSharedCodexAppServerClient,
   releaseLeasedSharedCodexAppServerClient,
 } from "./shared-client.js";
-import { withTimeout } from "./timeout.js";
+
+const REMOTE_EXECUTION_COMPATIBILITY_METHODS = new Set([
+  "thread/start",
+  "thread/resume",
+  "thread/fork",
+  "turn/start",
+  "thread/compact/start",
+  "review/start",
+]);
+
+async function withCodexAppServerRequestDeadline<T>(params: {
+  method: string;
+  timeoutMs: number;
+  run: (signal: AbortSignal) => Promise<T>;
+}): Promise<T> {
+  const controller = new AbortController();
+  if (params.timeoutMs <= 0) {
+    return await params.run(controller.signal);
+  }
+  const timeoutError = Object.assign(new Error(`codex app-server ${params.method} timed out`), {
+    name: "TimeoutError",
+  });
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      // Abort before rejecting. Even a fake or stale preflight that ignores the
+      // signal must cross the post-preflight abort check before the target RPC.
+      controller.abort(timeoutError);
+      reject(timeoutError);
+    }, params.timeoutMs);
+    timeout.unref?.();
+  });
+  try {
+    return await Promise.race([params.run(controller.signal), expired]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 /** Sends a typed Codex app-server request and returns the method-specific response shape. */
 export async function requestCodexAppServerJson<M extends CodexAppServerRequestMethod>(params: {
@@ -30,6 +70,11 @@ export async function requestCodexAppServerJson<M extends CodexAppServerRequestM
   sessionKey?: string;
   sessionId?: string;
   isolated?: boolean;
+  remoteExecution?: Pick<
+    CodexAppServerRuntimeOptions,
+    "remoteExecutionFingerprint" | "requestTimeoutMs"
+  >;
+  remoteExecutionHookCwd?: string;
 }): Promise<CodexAppServerRequestResult<M>>;
 export async function requestCodexAppServerJson<T = JsonValue | undefined>(params: {
   method: string;
@@ -42,6 +87,11 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
   sessionKey?: string;
   sessionId?: string;
   isolated?: boolean;
+  remoteExecution?: Pick<
+    CodexAppServerRuntimeOptions,
+    "remoteExecutionFingerprint" | "requestTimeoutMs"
+  >;
+  remoteExecutionHookCwd?: string;
 }): Promise<T>;
 export async function requestCodexAppServerJson<T = JsonValue | undefined>(params: {
   method: string;
@@ -54,6 +104,11 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
   sessionKey?: string;
   sessionId?: string;
   isolated?: boolean;
+  remoteExecution?: Pick<
+    CodexAppServerRuntimeOptions,
+    "remoteExecutionFingerprint" | "requestTimeoutMs"
+  >;
+  remoteExecutionHookCwd?: string;
 }): Promise<T> {
   const sandboxBlock = resolveCodexAppServerDirectSandboxBypassBlock({
     method: params.method,
@@ -66,8 +121,10 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
     throw new Error(sandboxBlock);
   }
   const timeoutMs = params.timeoutMs ?? 60_000;
-  return await withTimeout(
-    (async () => {
+  return await withCodexAppServerRequestDeadline({
+    method: params.method,
+    timeoutMs,
+    run: async (signal) => {
       const client = await (
         params.isolated ? createIsolatedCodexAppServerClient : getLeasedSharedCodexAppServerClient
       )({
@@ -76,9 +133,35 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
         authProfileId: params.authProfileId,
         agentDir: params.agentDir,
         config: params.config,
+        abandonSignal: signal,
+        ...(params.isolated
+          ? {
+              onStartedClient: (startedClient) => {
+                const close = () => startedClient.close();
+                if (signal.aborted) {
+                  close();
+                } else {
+                  signal.addEventListener("abort", close, { once: true });
+                }
+              },
+            }
+          : {}),
       });
       try {
-        return await client.request<T>(params.method, params.requestParams, { timeoutMs });
+        signal.throwIfAborted();
+        if (
+          params.remoteExecution?.remoteExecutionFingerprint &&
+          REMOTE_EXECUTION_COMPATIBILITY_METHODS.has(params.method)
+        ) {
+          await ensureCodexRemoteExecutionCompatibility({
+            appServer: params.remoteExecution,
+            client,
+            cwd: params.remoteExecutionHookCwd ?? process.cwd(),
+            signal,
+          });
+        }
+        signal.throwIfAborted();
+        return await client.request<T>(params.method, params.requestParams, { timeoutMs, signal });
       } finally {
         if (params.isolated) {
           // Wait for the child to actually exit (with a SIGKILL fallback) so
@@ -91,8 +174,6 @@ export async function requestCodexAppServerJson<T = JsonValue | undefined>(param
           releaseLeasedSharedCodexAppServerClient(client);
         }
       }
-    })(),
-    timeoutMs,
-    `codex app-server ${params.method} timed out`,
-  );
+    },
+  });
 }

--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -497,6 +497,15 @@ export function createStartedThreadHarness(
     if (override !== undefined) {
       return override;
     }
+    if (method === "hooks/list") {
+      return { data: [{ cwd: "/tmp/workspace", hooks: [], errors: [] }] };
+    }
+    if (method === "configRequirements/read") {
+      return { requirements: null };
+    }
+    if (method === "config/read") {
+      return { config: {}, origins: {}, layers: [] };
+    }
     if (method === "thread/start") {
       return threadStartResult();
     }
@@ -509,6 +518,15 @@ export function createStartedThreadHarness(
 
 export function createResumeHarness() {
   return createAppServerHarness(async (method, params) => {
+    if (method === "hooks/list") {
+      return { data: [{ cwd: "/tmp/workspace", hooks: [], errors: [] }] };
+    }
+    if (method === "configRequirements/read") {
+      return { requirements: null };
+    }
+    if (method === "config/read") {
+      return { config: {}, origins: {}, layers: [] };
+    }
     if (method === "thread/resume") {
       // Resume must echo the requested thread; a different id is rejected as
       // an unsafe subscription.

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -36,6 +36,19 @@ const DISABLED_CODEX_WEB_SEARCH_THREAD_CONFIG_FINGERPRINT = JSON.stringify({
   web_search: "disabled",
 });
 
+const REMOTE_EXECUTION_PLUGIN_CONFIG = {
+  appServer: {
+    remoteWorkspaceRoot: "/remote/workspace",
+    experimental: {
+      remoteExecution: {
+        registryUrl: "https://environment-registry.example.com/api",
+        environmentId: "worker-1",
+        authToken: "registry-token",
+      },
+    },
+  },
+} as const;
+
 function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppServerBinding>) {
   const [sessionFile, binding, lookup] = args;
   return writeRawCodexAppServerBinding(
@@ -49,6 +62,68 @@ function writeCodexAppServerBinding(...args: Parameters<typeof writeRawCodexAppS
 }
 
 describe("runCodexAppServerAttempt native hook relay", () => {
+  it("disables native hooks instead of registering a Gateway relay for remote execution", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness();
+
+    const run = runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+      pluginConfig: REMOTE_EXECUTION_PLUGIN_CONFIG,
+      nativeHookRelay: { enabled: true },
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const config = (startRequest?.params as { config?: Record<string, unknown> } | undefined)
+      ?.config;
+    expect(config).toMatchObject({
+      "features.unified_exec": true,
+      "features.hooks": false,
+      "hooks.PreToolUse": [],
+      "hooks.PostToolUse": [],
+      "hooks.PermissionRequest": [],
+      "hooks.Stop": [],
+      notify: [],
+      "shell_environment_policy.ignore_default_excludes": false,
+    });
+  });
+
+  it("rejects managed command hooks before starting a remote thread", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const harness = createStartedThreadHarness(async (method) =>
+      method === "hooks/list"
+        ? {
+            data: [
+              {
+                cwd: workspaceDir,
+                hooks: [
+                  {
+                    enabled: true,
+                    eventName: "preToolUse",
+                    handlerType: "command",
+                    isManaged: true,
+                    source: "cloudRequirements",
+                  },
+                ],
+                errors: [],
+              },
+            ],
+          }
+        : undefined,
+    );
+
+    await expect(
+      runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+        pluginConfig: REMOTE_EXECUTION_PLUGIN_CONFIG,
+        nativeHookRelay: { enabled: true },
+      }),
+    ).rejects.toThrow("managed command hooks (cloudRequirements:preToolUse)");
+    expect(harness.requests.some((request) => request.method === "thread/start")).toBe(false);
+  });
+
   it("registers native hook relay config for an enabled Codex turn and cleans it up", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -68,13 +68,13 @@ import {
   turnStartResult,
   userMessage,
 } from "./run-attempt-test-harness.js";
-import { resetCodexTestBindingStore } from "./session-binding.test-helpers.js";
 import { testing } from "./run-attempt.js";
 import {
   ensureCodexSandboxExecServerEnvironment,
   releaseCodexSandboxExecServerEnvironment,
 } from "./sandbox-exec-server.js";
 import { createSandboxContext } from "./sandbox-exec-server.test-helpers.js";
+import { resetCodexTestBindingStore } from "./session-binding.test-helpers.js";
 import {
   readCodexAppServerBinding,
   registerCodexTestSessionIdentity,
@@ -2549,6 +2549,71 @@ describe("runCodexAppServerAttempt", () => {
     expect(inputText).toContain("is the previous message trustworthy?");
   });
 
+  it("does not replay native-owned history after a remote execution fork", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeExistingBinding(sessionFile, workspaceDir);
+    const binding = await readCodexAppServerBinding(sessionFile);
+    const bindingUpdatedAt = Date.parse(binding?.historyCoveredThrough ?? "");
+    if (!Number.isFinite(bindingUpdatedAt)) {
+      throw new Error("expected valid Codex binding timestamp");
+    }
+    const sessionManager = SessionManager.open(sessionFile);
+    sessionManager.appendMessage(
+      userMessage("native-owned history must not be replayed", bindingUpdatedAt - 2_000),
+    );
+    sessionManager.appendMessage(
+      userMessage("newer user continuity crosses the fork", bindingUpdatedAt + 1_000),
+    );
+    sessionManager.appendMessage(
+      assistantMessage("newer assistant continuity crosses the fork", bindingUpdatedAt + 2_000),
+    );
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/fork") {
+        return threadStartResult("thread-remote");
+      }
+      return undefined;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.config = {
+      tools: { web: { search: { enabled: false } } },
+    } as EmbeddedRunAttemptParams["config"];
+    params.prompt = "continue after moving execution remotely";
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: {
+        appServer: {
+          mode: "yolo",
+          remoteWorkspaceRoot: "/remote/workspace",
+          experimental: {
+            remoteExecution: {
+              registryUrl: "https://registry.example.com",
+              environmentId: "remote-test",
+              authToken: "remote-test-token",
+            },
+          },
+        },
+      },
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-remote", turnId: "turn-1" });
+    await run;
+
+    expect(harness.requests.map((request) => request.method)).toContain("thread/fork");
+    expect(harness.requests.map((request) => request.method)).not.toContain("thread/start");
+    const turnStart = harness.requests.find((request) => request.method === "turn/start");
+    const inputText =
+      (turnStart?.params as { input?: Array<{ text?: string }> } | undefined)?.input?.[0]?.text ??
+      "";
+
+    expect(inputText).toContain("OpenClaw assembled context for this turn:");
+    expect(inputText).not.toContain("native-owned history must not be replayed");
+    expect(inputText).toContain("newer user continuity crosses the fork");
+    expect(inputText).toContain("newer assistant continuity crosses the fork");
+    expect(inputText).toContain("Current user request:");
+    expect(inputText).toContain("continue after moving execution remotely");
+  });
+
   it("does not project Codex mirrored transcript echoes as stale binding continuity", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
@@ -3487,6 +3552,32 @@ describe("runCodexAppServerAttempt", () => {
         trustedToolPolicies: [],
       },
     );
+  });
+
+  it("rejects remote execution when before_tool_call policy needs native enforcement", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),
+    );
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    createStartedThreadHarness();
+
+    await expect(
+      runCodexAppServerAttempt(createParams(sessionFile, workspaceDir), {
+        pluginConfig: {
+          appServer: {
+            remoteWorkspaceRoot: "/remote/workspace",
+            experimental: {
+              remoteExecution: {
+                registryUrl: "https://environment-registry.example.com/api",
+                environmentId: "worker-1",
+                authToken: "registry-token",
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow("remote execution cannot enforce OpenClaw before_tool_call");
   });
 
   it("keeps explicit Codex yolo mode unpromoted when OpenClaw tool policy exists", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -694,6 +694,15 @@ export async function runCodexAppServerAttempt(
     env: process.env,
     agentDir,
   });
+  if (
+    appServer.remoteExecutionFingerprint &&
+    (beforeToolCallPolicy.hasBeforeToolCallHook ||
+      beforeToolCallPolicy.trustedToolPolicies.length > 0)
+  ) {
+    throw new Error(
+      "Codex remote execution cannot enforce OpenClaw before_tool_call or trusted-tool policy until Codex supports Gateway-local native hooks",
+    );
+  }
   pluginAppServer = appServer;
   nativeHookRelayEvents = resolveCodexNativeHookRelayEvents({
     configuredEvents: options.nativeHookRelay?.events,
@@ -1335,11 +1344,19 @@ export async function runCodexAppServerAttempt(
     return projected;
   };
   const applyNoContextEngineContinuityProjection = (
-    action: "started" | "resumed",
+    lifecycle: CodexAppServerThreadLifecycleBinding["lifecycle"],
     binding?: CodexAppServerThreadBinding,
   ) => {
+    const { action } = lifecycle;
     if (activeContextEngine || !historyMessages.some((message) => message.role === "user")) {
       return false;
+    }
+    if (lifecycle.forkedWithHistory && binding) {
+      // The fork reconstructed the source rollout. Only bridge visible messages
+      // newer than the source binding's coverage watermark.
+      return precomputedStaleBindingContinuityProjectionApplied
+        ? true
+        : applyResumeStaleBindingContinuityProjection(binding);
     }
     if (action === "resumed" && precomputedStaleBindingContinuityProjectionApplied) {
       return true;
@@ -1546,6 +1563,13 @@ export async function runCodexAppServerAttempt(
     decision: { action: "resume"; binding: CodexAppServerThreadBinding } | { action: "start" },
   ) => {
     nativeHookRelay?.unregister();
+    nativeHookRelay = undefined;
+    if (appServer.remoteExecutionFingerprint) {
+      return {
+        configPatch: buildCodexNativeHookRelayDisabledConfig(),
+        nativeHookRelayGeneration: undefined,
+      };
+    }
     nativeHookRelay = createCodexNativeHookRelay({
       options: options.nativeHookRelay,
       generation:
@@ -1698,7 +1722,7 @@ export async function runCodexAppServerAttempt(
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
     throw error;
   }
-  if (applyNoContextEngineContinuityProjection(thread.lifecycle.action, thread)) {
+  if (applyNoContextEngineContinuityProjection(thread.lifecycle, thread)) {
     await rebuildCodexTurnPromptTextFromCurrentProjection();
   }
   trajectoryRecorder?.recordEvent("session.started", {
@@ -2745,6 +2769,7 @@ export async function runCodexAppServerAttempt(
       appServer: turnAppServer,
       promptText: codexTurnPromptText,
       sandboxPolicy: codexSandboxPolicy,
+      nativeCodeModeEnabled: nativeToolSurfaceEnabled,
       environmentSelection: codexEnvironmentSelection,
       model: thread.model,
       modelProvider: thread.modelProvider,

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -63,11 +63,20 @@ describe("Codex app-server binding store", () => {
 
     await store.mutate(identity, {
       kind: "set",
-      binding: { threadId: "thread-1", cwd: "/repo", model: "gpt-5.4-codex" },
+      binding: {
+        threadId: "thread-1",
+        cwd: "/repo",
+        model: "gpt-5.4-codex",
+        remoteExecutionFingerprint: "sha256:remote-environment",
+      },
     });
 
     const binding = await store.read(identity);
-    expect(binding).toMatchObject({ threadId: "thread-1", cwd: "/repo" });
+    expect(binding).toMatchObject({
+      threadId: "thread-1",
+      cwd: "/repo",
+      remoteExecutionFingerprint: "sha256:remote-environment",
+    });
     expect(binding).not.toHaveProperty("sessionFile");
     expect(binding).not.toHaveProperty("schemaVersion");
     expect(values.get("session:main:session-1")).toMatchObject({

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -166,6 +166,7 @@ const threadBindingSchema = z.object({
   mcpServersFingerprint: optionalStringSchema,
   nativeHookRelayGeneration: optionalNonBlankStringSchema,
   appServerRuntimeFingerprint: optionalStringSchema,
+  remoteExecutionFingerprint: optionalStringSchema,
   pluginAppsFingerprint: optionalStringSchema,
   pluginAppsInputFingerprint: optionalStringSchema,
   pluginAppPolicyContext: pluginAppPolicyContextSchema.optional().catch(undefined),

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -221,6 +221,35 @@ describe("shared Codex app-server client", () => {
     expect(startSpy.mock.calls[1]?.[0]).not.toHaveProperty("managedFallbackCommandPaths");
   });
 
+  it("falls back to a managed app-server that supports remote execution", async () => {
+    const desktop = createClientHarness();
+    const pluginLocal = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(desktop.client)
+      .mockReturnValueOnce(pluginLocal.client);
+    const clientPromise = getSharedCodexAppServerClient({
+      startOptions: {
+        transport: "stdio",
+        command: "/Applications/Codex.app/Contents/Resources/codex",
+        commandSource: "resolved-managed",
+        managedFallbackCommandPaths: ["/cache/openclaw/codex"],
+        args: ["app-server", "--listen", "stdio://"],
+        headers: {},
+        env: {
+          CODEX_EXEC_SERVER_NOISE_REGISTRY_URL: "https://environment-registry.example.com/api",
+        },
+      },
+    });
+    await sendInitializeResult(desktop, "openclaw/0.141.0 (macOS; test)");
+    await sendInitializeResult(pluginLocal, "openclaw/0.142.0 (macOS; test)");
+
+    await expect(clientPromise).resolves.toBe(pluginLocal.client);
+    expect(desktop.process.stdin.destroyed).toBe(true);
+    expect(pluginLocal.process.stdin.destroyed).toBe(false);
+    expect(startSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("closes and clears a shared app-server when initialize times out", async () => {
     const first = createClientHarness();
     const second = createClientHarness();

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -14,6 +14,8 @@ import {
 } from "openclaw/plugin-sdk/hook-runtime";
 import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { buildCodexAppServerRuntimeFingerprint } from "./plugin-app-cache-key.js";
 import type { CodexServerNotification, JsonObject, JsonValue, RpcRequest } from "./protocol.js";
 import {
   createCodexTestBindingStore,
@@ -28,6 +30,23 @@ const createOpenClawCodingToolsMock = vi.fn();
 const toolExecuteMock = vi.fn();
 const handleCodexAppServerApprovalRequestMock = vi.fn();
 const resolveCodexProviderWebSearchSupportForClientMock = vi.fn();
+const codexRequirementsTomlMock = vi.hoisted(() => vi.fn<() => string | undefined>());
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync(filePath: string | URL | number, options?: BufferEncoding | object | null) {
+      if (filePath === "/etc/codex/requirements.toml") {
+        const content = codexRequirementsTomlMock();
+        if (content !== undefined) {
+          return content;
+        }
+      }
+      return actual.readFileSync(filePath, options);
+    },
+  };
+});
 
 vi.mock("./session-binding.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./session-binding.js")>()),
@@ -91,6 +110,8 @@ type FakeClient = {
   addRequestHandler: ReturnType<typeof vi.fn>;
   notifications: Array<(notification: CodexServerNotification) => void>;
   requests: Array<(request: ServerRequest) => unknown>;
+  getRuntimeIdentity: ReturnType<typeof vi.fn>;
+  getServerVersion: ReturnType<typeof vi.fn>;
   emit: (notification: CodexServerNotification) => void;
   handleRequest: (request: ServerRequest) => Promise<unknown>;
 };
@@ -101,6 +122,8 @@ function createFakeClient(): FakeClient {
   const client: FakeClient = {
     notifications,
     requests,
+    getRuntimeIdentity: vi.fn(() => undefined),
+    getServerVersion: vi.fn(() => "0.142.5"),
     request: vi.fn<ClientRequest>(),
     addNotificationHandler: vi.fn((handler: (notification: CodexServerNotification) => void) => {
       notifications.push(handler);
@@ -136,6 +159,15 @@ function createFakeClient(): FakeClient {
     },
   };
   client.request.mockImplementation(async (method: string) => {
+    if (method === "configRequirements/read") {
+      return { requirements: null };
+    }
+    if (method === "config/read") {
+      return { config: {}, origins: {}, layers: [] };
+    }
+    if (method === "hooks/list") {
+      return { data: [{ cwd: "/tmp/workspace", hooks: [], errors: [] }] };
+    }
     if (method === "thread/fork") {
       return threadResult("side-thread");
     }
@@ -356,6 +388,28 @@ function sideParams(overrides: Partial<Parameters<typeof runCodexAppServerSideQu
   } satisfies Parameters<typeof runCodexAppServerSideQuestion>[0];
 }
 
+const REMOTE_EXECUTION_PLUGIN_CONFIG = {
+  appServer: {
+    remoteWorkspaceRoot: "/remote/workspaces",
+    experimental: {
+      remoteExecution: {
+        registryUrl: "https://environment-registry.example.com/api",
+        environmentId: "devbox-example",
+        authToken: "registry-token",
+      },
+    },
+  },
+};
+const REMOTE_EXECUTION_RUNTIME = resolveCodexAppServerRuntimeOptions({
+  env: {},
+  requirementsToml: null,
+  pluginConfig: REMOTE_EXECUTION_PLUGIN_CONFIG,
+});
+const REMOTE_EXECUTION_RUNTIME_FINGERPRINT = buildCodexAppServerRuntimeFingerprint({
+  appServer: REMOTE_EXECUTION_RUNTIME,
+  appServerVersion: "0.142.5",
+});
+
 async function runSideQuestionWithManagedWebSearchCall(
   params: Parameters<typeof runCodexAppServerSideQuestion>[0] = sideParams(),
   options: { preserveToolFactory?: boolean } = {},
@@ -413,6 +467,7 @@ async function runSideQuestionWithManagedWebSearchCall(
 
 describe("runCodexAppServerSideQuestion", () => {
   beforeEach(() => {
+    codexRequirementsTomlMock.mockReturnValue("");
     nativeHookRelayTesting.clearNativeHookRelaysForTests();
     readCodexAppServerBindingMock.mockReset();
     isCodexAppServerNativeAuthProfileMock.mockReset();
@@ -508,14 +563,12 @@ describe("runCodexAppServerSideQuestion", () => {
       "developerInstructions",
       "ephemeral",
       "model",
-      "personality",
       "sandbox",
       "threadId",
       "threadSource",
     ]);
     expect(forkParams?.threadId).toBe("parent-thread");
     expect(forkParams?.model).toBe("gpt-5.5");
-    expect(forkParams?.personality).toBe("none");
     expect(forkParams?.approvalPolicy).toBe("on-request");
     expect(forkParams?.sandbox).toBe("workspace-write");
     expect(forkParams?.ephemeral).toBe(true);
@@ -565,6 +618,7 @@ describe("runCodexAppServerSideQuestion", () => {
         model: "gpt-5.5",
         personality: "none",
         effort: null,
+        environments: [{ environmentId: "local", cwd: "/tmp/workspace" }],
         collaborationMode: {
           mode: "default",
           settings: {
@@ -612,6 +666,61 @@ describe("runCodexAppServerSideQuestion", () => {
       senderIsOwner: true,
     });
     expect(toolOptions).toHaveProperty("requireExplicitMessageTarget", true);
+  });
+
+  it("requires the main thread to rotate before forking into remote execution", async () => {
+    const client = createFakeClient();
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
+    await expect(
+      runCodexAppServerSideQuestion(sideParams(), {
+        pluginConfig: REMOTE_EXECUTION_PLUGIN_CONFIG,
+      }),
+    ).rejects.toThrow(
+      "Codex /btw needs a thread from the current execution environment. Send a normal message first",
+    );
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("forks a binding that already matches the remote execution environment", async () => {
+    const client = createFakeClient();
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+    readCodexAppServerBindingMock.mockResolvedValue({
+      schemaVersion: 2,
+      threadId: "parent-thread",
+      sessionFile: "/tmp/session-1.jsonl",
+      cwd: "/remote/workspaces",
+      authProfileId: "openai:work",
+      model: "gpt-5.5",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      appServerRuntimeFingerprint: REMOTE_EXECUTION_RUNTIME_FINGERPRINT,
+      remoteExecutionFingerprint: REMOTE_EXECUTION_RUNTIME.remoteExecutionFingerprint,
+      createdAt: new Date(0).toISOString(),
+      updatedAt: new Date(0).toISOString(),
+    });
+
+    await expect(
+      runCodexAppServerSideQuestion(sideParams(), {
+        pluginConfig: REMOTE_EXECUTION_PLUGIN_CONFIG,
+        nativeHookRelay: { enabled: true },
+      }),
+    ).resolves.toEqual({ text: "Side answer." });
+    const forkCall = client.request.mock.calls.find(([method]) => method === "thread/fork");
+    const forkParams = forkCall?.[1] as
+      | { cwd?: unknown; config?: Record<string, unknown> }
+      | undefined;
+    expect(forkParams?.cwd).toBe("/remote/workspaces");
+    expect(forkParams?.config).toMatchObject({
+      "features.unified_exec": true,
+      "features.hooks": false,
+      "hooks.PreToolUse": [],
+      "hooks.PostToolUse": [],
+      "hooks.PermissionRequest": [],
+      "hooks.Stop": [],
+      notify: [],
+      "shell_environment_policy.ignore_default_excludes": false,
+    });
   });
 
   it("allocates one fallback run ID per side-question invocation", async () => {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -25,6 +25,7 @@ import { handleCodexAppServerApprovalRequest } from "./approval-bridge.js";
 import { ensureCodexAppServerClientRuntime } from "./client-runtime.js";
 import { isCodexAppServerApprovalRequest, type CodexAppServerClient } from "./client.js";
 import {
+  applyCodexRemoteExecutionThreadConfig,
   canUseCodexModelBackedApprovalsReviewerForModel,
   readCodexPluginConfig,
   resolveOpenClawExecPolicyForCodexAppServer,
@@ -65,6 +66,7 @@ import {
   readCodexNotificationThreadId,
   readCodexNotificationTurnId,
 } from "./notification-correlation.js";
+import { buildCodexAppServerRuntimeFingerprint } from "./plugin-app-cache-key.js";
 import {
   buildCodexPluginAppsConfigPatchFromPolicyContext,
   mergeCodexThreadConfigs,
@@ -86,6 +88,7 @@ import {
 import { resolveCodexProviderWebSearchSupportForClient } from "./provider-capabilities.js";
 import { readRecentCodexRateLimits } from "./rate-limit-cache.js";
 import { formatCodexUsageLimitErrorMessage } from "./rate-limits.js";
+import { ensureCodexRemoteExecutionCompatibility } from "./remote-execution.js";
 import { resolveCodexNativeExecutionBlock } from "./sandbox-guard.js";
 import {
   isCodexAppServerNativeAuthProfile,
@@ -103,6 +106,7 @@ import {
   resolveCodexAppServerModelProvider,
   resolveCodexBindingModelProviderFallback,
   resolveReasoningEffort,
+  shouldRotateCodexAppServerBindingForRuntime,
 } from "./thread-lifecycle.js";
 import { filterToolsForVisionInputs } from "./vision-tools.js";
 import {
@@ -317,6 +321,30 @@ export async function runCodexAppServerSideQuestion(
   let nativeHookRelay: NativeHookRelayRegistrationHandle | undefined;
 
   try {
+    if (
+      appServer.remoteExecutionFingerprint ||
+      binding.remoteExecutionFingerprint ||
+      binding.appServerRuntimeFingerprint
+    ) {
+      const currentRuntimeFingerprint = buildCodexAppServerRuntimeFingerprint({
+        appServer,
+        appServerVersion: client.getServerVersion(),
+        runtimeIdentity: client.getRuntimeIdentity(),
+      });
+      if (
+        shouldRotateCodexAppServerBindingForRuntime({
+          connectionClass: appServer.connectionClass,
+          current: currentRuntimeFingerprint,
+          binding: binding.appServerRuntimeFingerprint,
+          currentRemoteExecution: appServer.remoteExecutionFingerprint,
+          bindingRemoteExecution: binding.remoteExecutionFingerprint,
+        })
+      ) {
+        throw new Error(
+          "Codex /btw needs a thread from the current execution environment. Send a normal message first to refresh the thread, then try /btw again.",
+        );
+      }
+    }
     const modelScopedAppServer = resolveCodexAppServerForModelProvider({
       appServer,
       provider: reviewerPolicyContext.modelProvider,
@@ -324,6 +352,12 @@ export async function runCodexAppServerSideQuestion(
       config: params.cfg,
       env: process.env,
       agentDir: params.agentDir,
+    });
+    await ensureCodexRemoteExecutionCompatibility({
+      appServer: modelScopedAppServer,
+      client,
+      cwd: params.workspaceDir || process.cwd(),
+      signal: runAbortController.signal,
     });
     const useModelScopedPolicy = !canUseCodexModelBackedApprovalsReviewerForModel({
       modelProvider: reviewerPolicyContext.modelProvider,
@@ -460,51 +494,54 @@ export async function runCodexAppServerSideQuestion(
       configuredEvents: options.nativeHookRelay?.events,
       approvalPolicy,
     });
-    nativeHookRelay = options.nativeHookRelay
-      ? registerCodexSideNativeHookRelay({
-          options: options.nativeHookRelay,
-          events: nativeHookRelayEvents,
-          agentId: sessionAgentId,
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          config: params.cfg,
-          runId: sideRunParams.runId,
-          channelId: buildAgentHookContextChannelFields({
+    nativeHookRelay =
+      options.nativeHookRelay && !modelScopedAppServer.remoteExecutionFingerprint
+        ? registerCodexSideNativeHookRelay({
+            options: options.nativeHookRelay,
+            events: nativeHookRelayEvents,
+            agentId: sessionAgentId,
+            sessionId: params.sessionId,
             sessionKey: params.sessionKey,
-            messageChannel: params.messageChannel,
-            messageProvider: params.messageProvider,
-            currentChannelId: params.currentChannelId,
-          }).channelId,
-          requestTimeoutMs: appServer.requestTimeoutMs,
-          completionTimeoutMs: Math.max(
-            appServer.turnCompletionIdleTimeoutMs,
-            SIDE_QUESTION_COMPLETION_TIMEOUT_MS,
-          ),
-          signal: runAbortController.signal,
-          onPreToolUseFailure: (failure) => {
-            if (nativePreToolUseFailureFallbackActive) {
-              emitNativePreToolUseFailure(failure);
-            } else if (nativeToolLifecycleProjector) {
-              nativeToolLifecycleProjector.recordPreToolUseFailure(
-                failure,
-                nativeToolRunWasAbortedBeforeCleanup,
-              );
-            } else {
-              pendingNativePreToolUseFailures.push(failure);
-            }
-          },
-        })
-      : undefined;
-    const nativeHookRelayConfig = nativeHookRelay
-      ? buildCodexNativeHookRelayConfig({
-          relay: nativeHookRelay,
-          events: nativeHookRelayEvents,
-          hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
-          clearOmittedEvents: true,
-        })
-      : options.nativeHookRelay?.enabled === false
-        ? buildCodexNativeHookRelayDisabledConfig()
+            config: params.cfg,
+            runId: sideRunParams.runId,
+            channelId: buildAgentHookContextChannelFields({
+              sessionKey: params.sessionKey,
+              messageChannel: params.messageChannel,
+              messageProvider: params.messageProvider,
+              currentChannelId: params.currentChannelId,
+            }).channelId,
+            requestTimeoutMs: appServer.requestTimeoutMs,
+            completionTimeoutMs: Math.max(
+              appServer.turnCompletionIdleTimeoutMs,
+              SIDE_QUESTION_COMPLETION_TIMEOUT_MS,
+            ),
+            signal: runAbortController.signal,
+            onPreToolUseFailure: (failure) => {
+              if (nativePreToolUseFailureFallbackActive) {
+                emitNativePreToolUseFailure(failure);
+              } else if (nativeToolLifecycleProjector) {
+                nativeToolLifecycleProjector.recordPreToolUseFailure(
+                  failure,
+                  nativeToolRunWasAbortedBeforeCleanup,
+                );
+              } else {
+                pendingNativePreToolUseFailures.push(failure);
+              }
+            },
+          })
         : undefined;
+    const nativeHookRelayConfig = modelScopedAppServer.remoteExecutionFingerprint
+      ? buildCodexNativeHookRelayDisabledConfig()
+      : nativeHookRelay
+        ? buildCodexNativeHookRelayConfig({
+            relay: nativeHookRelay,
+            events: nativeHookRelayEvents,
+            hookTimeoutSec: options.nativeHookRelay?.hookTimeoutSec,
+            clearOmittedEvents: true,
+          })
+        : options.nativeHookRelay?.enabled === false
+          ? buildCodexNativeHookRelayDisabledConfig()
+          : undefined;
     const runtimeThreadConfig = buildCodexRuntimeThreadConfig(webSearchPlan.threadConfig, {
       nativeCodeModeEnabled: nativeToolSurfaceEnabled,
       nativeCodeModeOnlyEnabled: appServer.codeModeOnly,
@@ -514,13 +551,16 @@ export async function runCodexAppServerSideQuestion(
     const pluginAppsConfigPatch = binding.pluginAppPolicyContext
       ? buildCodexPluginAppsConfigPatchFromPolicyContext(binding.pluginAppPolicyContext)
       : undefined;
-    const threadConfig =
+    const mergedThreadConfig =
       mergeCodexThreadConfigs(
         nativeHookRelayConfig,
         runtimeThreadConfig,
         pluginAppsConfigPatch,
         modelScopedAppServer.networkProxy?.configPatch,
       ) ?? runtimeThreadConfig;
+    const threadConfig =
+      applyCodexRemoteExecutionThreadConfig(mergedThreadConfig, modelScopedAppServer) ??
+      mergedThreadConfig;
     const forkResponse = assertCodexThreadForkResponse(
       await forkCodexSideThread(
         client,
@@ -528,7 +568,6 @@ export async function runCodexAppServerSideQuestion(
           threadId: binding.threadId,
           model: modelSelection.model,
           ...(modelSelection.modelProvider ? { modelProvider: modelSelection.modelProvider } : {}),
-          personality: CODEX_NATIVE_PERSONALITY_NONE,
           cwd,
           approvalPolicy,
           approvalsReviewer: modelScopedAppServer.approvalsReviewer,
@@ -569,6 +608,11 @@ export async function runCodexAppServerSideQuestion(
           personality: CODEX_NATIVE_PERSONALITY_NONE,
           ...(serviceTier ? { serviceTier } : {}),
           effort,
+          ...(nativeToolSurfaceEnabled === false
+            ? { environments: [] }
+            : modelScopedAppServer.remoteExecutionFingerprint
+              ? {}
+              : { environments: [{ environmentId: "local", cwd }] }),
           collaborationMode: {
             mode: "default",
             settings: {

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -296,6 +296,212 @@ describe("Codex app-server thread lifecycle bindings", () => {
         current: "local-runtime-v1",
       }),
     ).toBe(false);
+    expect(
+      shouldRotateCodexAppServerBindingForRuntime({
+        connectionClass: "local-loopback",
+        current: "remote-execution-v1",
+        currentRemoteExecution: "sha256:remote-environment",
+      }),
+    ).toBe(true);
+    expect(
+      shouldRotateCodexAppServerBindingForRuntime({
+        connectionClass: "local-loopback",
+        current: "remote-execution-v1",
+        currentRemoteExecution: "sha256:remote-environment",
+        bindingRemoteExecution: "sha256:remote-environment",
+      }),
+    ).toBe(false);
+  });
+
+  it("forks a legacy local binding into remote execution without dropping history", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const remoteWorkspaceDir = "/remote/workspace";
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-local",
+      cwd: workspaceDir,
+      model: "openai/gpt-oss-20b",
+      modelProvider: "lmstudio",
+      dynamicToolsFingerprint: "[]",
+      approvalPolicy: "on-request",
+      sandbox: "workspace-write",
+      historyCoveredThrough: "2026-07-07T00:00:00.000Z",
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.provider = "codex";
+    params.modelId = "openai/gpt-oss-20b";
+    const appServer = {
+      ...createThreadLifecycleAppServerOptions(),
+      remoteExecutionFingerprint: "sha256:remote-environment",
+    };
+    const request = vi.fn(async (method: string, _requestParams?: unknown) => {
+      if (method === "thread/fork") {
+        const response = threadStartResult("thread-remote");
+        response.model = "openai/gpt-oss-20b";
+        response.modelProvider = "lmstudio";
+        response.thread.modelProvider = "lmstudio";
+        return response;
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const binding = await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: remoteWorkspaceDir,
+      dynamicTools: [],
+      appServer,
+      appServerRuntimeFingerprint: "remote-runtime-v1",
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/fork"]);
+    expect(request.mock.calls[0]?.[1]).toMatchObject({
+      threadId: "thread-local",
+      cwd: remoteWorkspaceDir,
+      config: {
+        "features.unified_exec": true,
+        "features.hooks": false,
+        "shell_environment_policy.exclude": ["CODEX_EXEC_SERVER_*"],
+      },
+    });
+    expect(request.mock.calls[0]?.[1]).not.toHaveProperty("environments");
+    expect(request.mock.calls[0]?.[1]).not.toHaveProperty("dynamicTools");
+    expect(binding.threadId).toBe("thread-remote");
+    expect(binding.appServerRuntimeFingerprint).toBe("remote-runtime-v1");
+    expect(binding.remoteExecutionFingerprint).toBe("sha256:remote-environment");
+    expect(binding.historyCoveredThrough).toBe("2026-07-07T00:00:00.000Z");
+    expect(binding.lifecycle).toMatchObject({
+      action: "started",
+      forkedWithHistory: true,
+    });
+    const saved = await readCodexAppServerBinding(sessionFile);
+    expect(saved?.threadId).toBe("thread-remote");
+    expect(saved?.appServerRuntimeFingerprint).toBe("remote-runtime-v1");
+    expect(saved?.remoteExecutionFingerprint).toBe("sha256:remote-environment");
+    expect(saved?.historyCoveredThrough).toBe("2026-07-07T00:00:00.000Z");
+  });
+
+  it("forks when the remote execution app-server identity changes", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-remote-old",
+      cwd: "/remote/workspace",
+      dynamicToolsFingerprint: "[]",
+      appServerRuntimeFingerprint: "remote-runtime-v0",
+      remoteExecutionFingerprint: "sha256:remote-environment",
+    });
+    const request = vi.fn(async (method: string, requestParams?: unknown) => {
+      if (method === "thread/fork") {
+        expect(requestParams).toMatchObject({ threadId: "thread-remote-old" });
+        return threadStartResult("thread-remote-new");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const binding = await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: "/remote/workspace",
+      dynamicTools: [],
+      appServer: {
+        ...createThreadLifecycleAppServerOptions(),
+        remoteExecutionFingerprint: "sha256:remote-environment",
+      },
+      appServerRuntimeFingerprint: "remote-runtime-v1",
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/fork"]);
+    expect(binding).toMatchObject({
+      threadId: "thread-remote-new",
+      appServerRuntimeFingerprint: "remote-runtime-v1",
+      remoteExecutionFingerprint: "sha256:remote-environment",
+    });
+  });
+
+  it("starts fresh only when the remote rotation fork source is confirmed missing", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-local",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+      historyCoveredThrough: "2026-07-07T00:00:00.000Z",
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/fork") {
+        throw new CodexAppServerRpcError(
+          { code: -32_602, message: "no rollout found for thread id thread-local" },
+          method,
+        );
+      }
+      if (method === "thread/start") {
+        await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
+          threadId: "thread-local",
+        });
+        return threadStartResult("thread-remote-fresh");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const binding = await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir),
+      cwd: "/remote/workspace",
+      dynamicTools: [],
+      appServer: {
+        ...createThreadLifecycleAppServerOptions(),
+        remoteExecutionFingerprint: "sha256:remote-environment",
+      },
+      appServerRuntimeFingerprint: "remote-runtime-v1",
+    });
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/fork", "thread/start"]);
+    expect(binding.threadId).toBe("thread-remote-fresh");
+    expect(binding.historyCoveredThrough).toBeUndefined();
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
+      threadId: "thread-remote-fresh",
+      remoteExecutionFingerprint: "sha256:remote-environment",
+    });
+  });
+
+  it("keeps the old binding when a remote rotation fork fails", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-local",
+      cwd: workspaceDir,
+      dynamicToolsFingerprint: "[]",
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/fork") {
+        throw new CodexAppServerRpcError(
+          { code: -32_000, message: "remote executor unavailable" },
+          method,
+        );
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        params: createParams(sessionFile, workspaceDir),
+        cwd: "/remote/workspace",
+        dynamicTools: [],
+        appServer: {
+          ...createThreadLifecycleAppServerOptions(),
+          remoteExecutionFingerprint: "sha256:remote-environment",
+        },
+        appServerRuntimeFingerprint: "remote-runtime-v1",
+      }),
+    ).rejects.toThrow("remote executor unavailable");
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/fork"]);
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
+      threadId: "thread-local",
+      cwd: workspaceDir,
+    });
   });
 
   it("does not write a binding when thread start resolves after abort", async () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -411,6 +411,82 @@ describe("Codex app-server native code mode config", () => {
     expect(request.personality).toBe("none");
   });
 
+  it("opts into Codex's default environment only for configured remote execution", () => {
+    const localRequest = buildThreadStartParams(createAttemptParams({ provider: "codex" }), {
+      cwd: "/workspace",
+      dynamicTools: [],
+      appServer: createAppServerOptions() as never,
+      developerInstructions: "test instructions",
+      nativeCodeModeEnabled: true,
+    });
+    const remoteRequest = buildThreadStartParams(createAttemptParams({ provider: "codex" }), {
+      cwd: "/remote/workspace",
+      dynamicTools: [],
+      appServer: {
+        ...createAppServerOptions(),
+        remoteExecutionFingerprint: "sha256:remote",
+      } as never,
+      developerInstructions: "test instructions",
+      nativeCodeModeEnabled: true,
+    });
+
+    expect(localRequest.environments).toEqual([{ environmentId: "local", cwd: "/workspace" }]);
+    expect(remoteRequest).not.toHaveProperty("environments");
+  });
+
+  it("applies remote execution safety last on thread start and resume", () => {
+    const appServer = {
+      ...createAppServerOptions(),
+      remoteExecutionFingerprint: "sha256:remote",
+    } as never;
+    const unsafeConfig = {
+      features: { unified_exec: false, hooks: true, unrelated: true },
+      "features.unified_exec": false,
+      "features.shell_zsh_fork": true,
+      "features.unified_exec_zsh_fork": true,
+      "features.hooks": true,
+      "hooks.PreToolUse": [{ hooks: [{ type: "command", command: "unsafe" }] }],
+      notify: ["unsafe"],
+      shell_environment_policy: { inherit: "all", set: { CODEX_API_KEY: "unsafe" } },
+      "shell_environment_policy.ignore_default_excludes": true,
+      unrelated: "preserved",
+    } as const;
+
+    const started = buildThreadStartParams(createAttemptParams({ provider: "codex" }), {
+      cwd: "/remote/workspace",
+      dynamicTools: [],
+      appServer,
+      config: unsafeConfig as never,
+    });
+    const resumed = buildThreadResumeParams(createAttemptParams({ provider: "codex" }), {
+      threadId: "thread-1",
+      appServer,
+      config: unsafeConfig as never,
+    });
+
+    for (const config of [started.config, resumed.config]) {
+      expect(config).toMatchObject({
+        features: { unrelated: true },
+        "features.unified_exec": true,
+        "features.shell_zsh_fork": false,
+        "features.unified_exec_zsh_fork": false,
+        "features.hooks": false,
+        "hooks.PreToolUse": [],
+        "hooks.PostToolUse": [],
+        "hooks.PermissionRequest": [],
+        "hooks.Stop": [],
+        notify: [],
+        "shell_environment_policy.inherit": "core",
+        "shell_environment_policy.ignore_default_excludes": false,
+        "shell_environment_policy.exclude": ["CODEX_EXEC_SERVER_*"],
+        "shell_environment_policy.set": {},
+        unrelated: "preserved",
+      });
+      expect(config).not.toHaveProperty("hooks");
+      expect(config).not.toHaveProperty("shell_environment_policy");
+    }
+  });
+
   it("enables hosted Codex web search on thread/start by default", () => {
     const request = buildThreadStartParams(createAttemptParams({ provider: "codex" }), {
       cwd: "/repo",
@@ -573,6 +649,25 @@ describe("Codex app-server native code mode config", () => {
     });
 
     expect(request.personality).toBe("none");
+  });
+
+  it("prevents local turns from selecting an ambient remote environment", () => {
+    const localRequest = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
+      threadId: "thread-local",
+      cwd: "/repo",
+      appServer: createAppServerOptions() as never,
+    });
+    const remoteRequest = buildTurnStartParams(createAttemptParams({ provider: "openai" }), {
+      threadId: "thread-remote",
+      cwd: "/remote/repo",
+      appServer: {
+        ...createAppServerOptions(),
+        remoteExecutionFingerprint: "sha256:remote",
+      } as never,
+    });
+
+    expect(localRequest.environments).toEqual([{ environmentId: "local", cwd: "/repo" }]);
+    expect(remoteRequest).not.toHaveProperty("environments");
   });
 
   it("honors an explicit top-level reviewer on thread start and resume", () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -29,7 +29,11 @@ import {
   isCodexAppServerConnectionClosedError,
   type CodexAppServerClient,
 } from "./client.js";
-import { codexSandboxPolicyForTurn, type CodexAppServerRuntimeOptions } from "./config.js";
+import {
+  applyCodexRemoteExecutionThreadConfig,
+  codexSandboxPolicyForTurn,
+  type CodexAppServerRuntimeOptions,
+} from "./config.js";
 import {
   resolveCodexContextEngineProjectionMaxChars,
   resolveCodexContextEngineProjectionReserveTokens,
@@ -46,13 +50,18 @@ import {
   type CodexPluginThreadConfig,
 } from "./plugin-thread-config.js";
 import { isCodexAppServerProfilerEnabled } from "./profiler-flag.js";
-import { assertCodexThreadStartResponse } from "./protocol-validators.js";
+import {
+  assertCodexThreadForkResponse,
+  assertCodexThreadStartResponse,
+} from "./protocol-validators.js";
 import {
   flattenCodexDynamicToolFunctions,
   isJsonObject,
   type CodexDynamicToolSpec,
   type CodexSandboxPolicy,
+  type CodexThreadForkParams,
   type CodexThreadResumeParams,
+  type CodexThreadStartResponse,
   type CodexThreadStartParams,
   type CodexTurnEnvironmentParams,
   type CodexTurnStartParams,
@@ -77,6 +86,8 @@ import { resolveCodexWebSearchPlan, type CodexNativeWebSearchSupport } from "./w
 
 export type CodexAppServerThreadLifecycle = {
   action: "started" | "resumed";
+  /** The new thread already owns the source rollout; do not replay mirrored history as fresh. */
+  forkedWithHistory?: boolean;
   rotatedContextEngineBinding?: boolean;
   activeTurnIds?: string[];
 };
@@ -409,6 +420,7 @@ export async function startOrResumeThread(params: {
         );
       }
     }
+    let remoteExecutionRotationSource: CodexAppServerThreadBinding | undefined;
     const clearCurrentBinding = async (operation: string) => {
       const current = binding;
       if (!current?.threadId) {
@@ -421,6 +433,7 @@ export async function startOrResumeThread(params: {
       if (!cleared) {
         throw new CodexThreadBindingConflictError(current.threadId, operation);
       }
+      remoteExecutionRotationSource = undefined;
       binding = undefined;
     };
     if (
@@ -429,14 +442,21 @@ export async function startOrResumeThread(params: {
         connectionClass: params.appServer.connectionClass,
         current: params.appServerRuntimeFingerprint,
         binding: binding.appServerRuntimeFingerprint,
+        currentRemoteExecution: params.appServer.remoteExecutionFingerprint,
+        bindingRemoteExecution: binding.remoteExecutionFingerprint,
       })
     ) {
       embeddedAgentLog.debug("codex app-server runtime identity changed; starting a new thread", {
         threadId: binding.threadId,
         connectionClass: params.appServer.connectionClass,
       });
-      await clearCurrentBinding("rotating a stale thread binding");
-      binding = undefined;
+      if (params.appServer.remoteExecutionFingerprint || binding.remoteExecutionFingerprint) {
+        // A fork moves persisted history onto the new executor without asking
+        // thread/resume to mutate a possibly loaded thread in place.
+        remoteExecutionRotationSource = binding;
+      } else {
+        await clearCurrentBinding("rotating a stale thread binding");
+      }
     }
     const startModelSelection = resolveCodexAppServerThreadModelSelection({
       provider: params.params.provider,
@@ -695,7 +715,7 @@ export async function startOrResumeThread(params: {
           );
           await clearCurrentBinding("rotating a stale thread binding");
         }
-      } else {
+      } else if (!remoteExecutionRotationSource) {
         const resumeBinding = binding;
         let resumeReservation: { release: () => void } | undefined;
         try {
@@ -780,6 +800,7 @@ export async function startOrResumeThread(params: {
             nativeHookRelayGeneration:
               finalConfigPatch.nativeHookRelayGeneration ?? resumeBinding.nativeHookRelayGeneration,
             appServerRuntimeFingerprint: params.appServerRuntimeFingerprint,
+            remoteExecutionFingerprint: params.appServer.remoteExecutionFingerprint,
             pluginAppsFingerprint: resumeBinding.pluginAppsFingerprint,
             pluginAppsInputFingerprint: resumeBinding.pluginAppsInputFingerprint,
             pluginAppPolicyContext: resumeBinding.pluginAppPolicyContext,
@@ -903,17 +924,55 @@ export async function startOrResumeThread(params: {
       typeof startParams.modelProvider === "string" && startParams.modelProvider.trim()
         ? startParams.modelProvider
         : undefined;
-    const threadStartResponse = await lifecycleTiming.measure("thread-start-request", async () => {
+    let response: CodexThreadStartResponse | undefined;
+    let forkedRemoteExecutionBinding = false;
+    const replacingRemoteExecutionBinding = Boolean(
+      remoteExecutionRotationSource && !preserveExistingBinding,
+    );
+    if (remoteExecutionRotationSource && !preserveExistingBinding) {
       try {
-        return await params.client.request("thread/start", startParams, { signal: params.signal });
+        const threadForkResponse = await lifecycleTiming.measure("thread-fork-request", () =>
+          params.client.request(
+            "thread/fork",
+            buildRemoteExecutionRotationForkParams(
+              remoteExecutionRotationSource.threadId,
+              startParams,
+            ),
+            { signal: params.signal },
+          ),
+        );
+        response = assertCodexThreadForkResponse(threadForkResponse);
+        forkedRemoteExecutionBinding = true;
       } catch (error) {
-        if (error instanceof CodexAppServerRpcError) {
-          throw new CodexThreadStartRequestError(error);
+        if (!isMissingCodexForkSourceError(error)) {
+          throw error;
         }
-        throw error;
+        // An unmaterialized or missing rollout has no history to preserve. Keep
+        // the old binding until its fresh replacement has started successfully.
+        embeddedAgentLog.warn(
+          "codex remote execution thread fork source missing; starting a new thread",
+          { error, threadId: remoteExecutionRotationSource.threadId },
+        );
       }
-    });
-    const response = assertCodexThreadStartResponse(threadStartResponse);
+    }
+    if (!response) {
+      const threadStartResponse = await lifecycleTiming.measure(
+        "thread-start-request",
+        async () => {
+          try {
+            return await params.client.request("thread/start", startParams, {
+              signal: params.signal,
+            });
+          } catch (error) {
+            if (error instanceof CodexAppServerRpcError) {
+              throw new CodexThreadStartRequestError(error);
+            }
+            throw error;
+          }
+        },
+      );
+      response = assertCodexThreadStartResponse(threadStartResponse);
+    }
     throwIfAborted();
     const modelProvider = resolveCodexAppServerModelProvider({
       provider: params.params.provider,
@@ -925,38 +984,49 @@ export async function startOrResumeThread(params: {
     const nextMcpServersFingerprint =
       params.mcpServersFingerprintEvaluated === true ? params.mcpServersFingerprint : undefined;
     if (!preserveExistingBinding) {
+      const nextBinding = {
+        threadId: response.thread.id,
+        cwd: params.cwd,
+        authProfileId: params.params.authProfileId,
+        model: response.model ?? startParams.model ?? params.params.modelId,
+        modelProvider: normalizeBindingModelProvider(
+          params.params.authProfileId,
+          response.modelProvider ?? requestModelProvider ?? startModelProvider ?? modelProvider,
+        ),
+        dynamicToolsFingerprint,
+        dynamicToolsContainDeferred,
+        webSearchThreadConfigFingerprint,
+        userMcpServersFingerprint,
+        mcpServersFingerprint: nextMcpServersFingerprint,
+        networkProxyProfileName: params.appServer.networkProxy?.profileName,
+        networkProxyConfigFingerprint,
+        nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
+        appServerRuntimeFingerprint: params.appServerRuntimeFingerprint,
+        remoteExecutionFingerprint: params.appServer.remoteExecutionFingerprint,
+        pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
+        pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
+        pluginAppPolicyContext: pluginThreadConfig?.policyContext,
+        contextEngine: contextEngineBinding,
+        environmentSelectionFingerprint,
+        ...(forkedRemoteExecutionBinding
+          ? { historyCoveredThrough: remoteExecutionRotationSource?.historyCoveredThrough }
+          : {}),
+      } satisfies CodexAppServerThreadBinding;
       const committed = await lifecycleTiming.measure("thread-start-write-binding", () =>
-        params.bindingStore.mutate(bindingIdentity, {
-          kind: "set",
-          if: { kind: "absent" },
-          binding: {
-            threadId: response.thread.id,
-            cwd: params.cwd,
-            authProfileId: params.params.authProfileId,
-            model: response.model ?? startParams.model ?? params.params.modelId,
-            modelProvider: normalizeBindingModelProvider(
-              params.params.authProfileId,
-              response.modelProvider ?? requestModelProvider ?? startModelProvider ?? modelProvider,
-            ),
-            dynamicToolsFingerprint,
-            dynamicToolsContainDeferred,
-            webSearchThreadConfigFingerprint,
-            userMcpServersFingerprint,
-            mcpServersFingerprint: nextMcpServersFingerprint,
-            networkProxyProfileName: params.appServer.networkProxy?.profileName,
-            networkProxyConfigFingerprint,
-            nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
-            appServerRuntimeFingerprint: params.appServerRuntimeFingerprint,
-            pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
-            pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
-            pluginAppPolicyContext: pluginThreadConfig?.policyContext,
-            contextEngine: contextEngineBinding,
-            environmentSelectionFingerprint,
-          },
-        }),
+        params.bindingStore.mutate(
+          bindingIdentity,
+          replacingRemoteExecutionBinding
+            ? { kind: "set", binding: nextBinding }
+            : { kind: "set", if: { kind: "absent" }, binding: nextBinding },
+        ),
       );
       if (!committed) {
-        throw new CodexThreadBindingConflictError(response.thread.id, "committing a fresh thread");
+        throw new CodexThreadBindingConflictError(
+          response.thread.id,
+          replacingRemoteExecutionBinding
+            ? "committing a remote execution thread rotation"
+            : "committing a fresh thread",
+        );
       }
       if (contextEngineBinding) {
         embeddedAgentLog.info("codex app-server wrote context-engine thread binding", {
@@ -966,7 +1036,8 @@ export async function startOrResumeThread(params: {
           engineId: contextEngineBinding.engineId,
           epoch: contextEngineBinding.projection?.epoch,
           fingerprint: contextEngineBinding.projection?.fingerprint,
-          action: rotatedContextEngineBinding ? "rotated" : "started",
+          action:
+            rotatedContextEngineBinding || replacingRemoteExecutionBinding ? "rotated" : "started",
         });
       }
     }
@@ -976,7 +1047,8 @@ export async function startOrResumeThread(params: {
       sessionId: params.params.sessionId,
       sessionKey: params.params.sessionKey,
       threadId: response.thread.id,
-      action: rotatedContextEngineBinding ? "rotated" : "started",
+      action:
+        rotatedContextEngineBinding || replacingRemoteExecutionBinding ? "rotated" : "started",
     });
     return {
       threadId: response.thread.id,
@@ -993,13 +1065,18 @@ export async function startOrResumeThread(params: {
       networkProxyConfigFingerprint,
       nativeHookRelayGeneration: finalConfigPatch.nativeHookRelayGeneration,
       appServerRuntimeFingerprint: params.appServerRuntimeFingerprint,
+      remoteExecutionFingerprint: params.appServer.remoteExecutionFingerprint,
       pluginAppsFingerprint: pluginThreadConfig?.fingerprint,
       pluginAppsInputFingerprint: pluginThreadConfig?.inputFingerprint,
       pluginAppPolicyContext: pluginThreadConfig?.policyContext,
       contextEngine: contextEngineBinding,
       environmentSelectionFingerprint,
+      ...(forkedRemoteExecutionBinding
+        ? { historyCoveredThrough: remoteExecutionRotationSource?.historyCoveredThrough }
+        : {}),
       lifecycle: {
         action: "started",
+        ...(forkedRemoteExecutionBinding ? { forkedWithHistory: true } : {}),
         ...(rotatedContextEngineBinding ? { rotatedContextEngineBinding } : {}),
       },
     };
@@ -1010,7 +1087,12 @@ export function shouldRotateCodexAppServerBindingForRuntime(params: {
   connectionClass: CodexAppServerRuntimeOptions["connectionClass"];
   current?: string;
   binding?: string;
+  currentRemoteExecution?: string;
+  bindingRemoteExecution?: string;
 }): boolean {
+  if (params.bindingRemoteExecution !== params.currentRemoteExecution) {
+    return true;
+  }
   if (!params.current) {
     return false;
   }
@@ -1176,6 +1258,38 @@ function shouldRecheckRecoverablePluginBinding(params: {
   return Object.keys(policyContext.apps).length === 0 || expectedPluginConfigKeys.length > 0;
 }
 
+function buildRemoteExecutionRotationForkParams(
+  threadId: string,
+  start: CodexThreadStartParams,
+): CodexThreadForkParams {
+  return {
+    threadId,
+    ...(start.model !== undefined ? { model: start.model } : {}),
+    ...(start.modelProvider !== undefined ? { modelProvider: start.modelProvider } : {}),
+    ...(start.serviceTier !== undefined ? { serviceTier: start.serviceTier } : {}),
+    ...(start.cwd !== undefined ? { cwd: start.cwd } : {}),
+    ...(start.approvalPolicy !== undefined ? { approvalPolicy: start.approvalPolicy } : {}),
+    ...(start.approvalsReviewer !== undefined
+      ? { approvalsReviewer: start.approvalsReviewer }
+      : {}),
+    ...(start.sandbox !== undefined ? { sandbox: start.sandbox } : {}),
+    ...(start.permissions !== undefined ? { permissions: start.permissions } : {}),
+    ...(start.config !== undefined ? { config: start.config } : {}),
+    ...(start.developerInstructions !== undefined
+      ? { developerInstructions: start.developerInstructions }
+      : {}),
+  };
+}
+
+function isMissingCodexForkSourceError(error: unknown): boolean {
+  return (
+    error instanceof CodexAppServerRpcError &&
+    (/\bno rollout found for thread id\b/u.test(error.message) ||
+      /\bincludeTurns is unavailable before first user message\b/u.test(error.message) ||
+      /\bthread not found:\s*/iu.test(error.message))
+  );
+}
+
 export function buildThreadStartParams(
   params: EmbeddedRunAttemptParams,
   options: {
@@ -1208,6 +1322,14 @@ export function buildThreadStartParams(
     agentDir: params.agentDir,
     config: params.config,
   });
+  const config = buildCodexRuntimeThreadConfigForRun(params, options.config, {
+    nativeCodeModeEnabled: options.nativeCodeModeEnabled,
+    nativeProviderWebSearchSupport: options.nativeProviderWebSearchSupport,
+    nativeCodeModeOnlyEnabled: options.nativeCodeModeOnlyEnabled,
+    webSearchAllowed: options.webSearchAllowed,
+    appServer: options.appServer,
+  });
+  assertCodexRemoteExecutionMcpCompatibility(options.appServer, config);
   return {
     model: modelSelection.model,
     ...(modelSelection.modelProvider ? { modelProvider: modelSelection.modelProvider } : {}),
@@ -1220,13 +1342,7 @@ export function buildThreadStartParams(
       : {}),
     personality: CODEX_NATIVE_PERSONALITY_NONE,
     serviceName: "OpenClaw",
-    config: buildCodexRuntimeThreadConfigForRun(params, options.config, {
-      nativeCodeModeEnabled: options.nativeCodeModeEnabled,
-      nativeProviderWebSearchSupport: options.nativeProviderWebSearchSupport,
-      nativeCodeModeOnlyEnabled: options.nativeCodeModeOnlyEnabled,
-      webSearchAllowed: options.webSearchAllowed,
-      appServer: options.appServer,
-    }),
+    config,
     ...resolveCodexThreadEnvironmentSelection(options),
     developerInstructions:
       options.developerInstructions ??
@@ -1270,6 +1386,14 @@ export function buildThreadResumeParams(
     agentDir: params.agentDir,
     config: params.config,
   });
+  const config = buildCodexRuntimeThreadConfigForRun(params, options.config, {
+    nativeCodeModeEnabled: options.nativeCodeModeEnabled,
+    nativeProviderWebSearchSupport: options.nativeProviderWebSearchSupport,
+    nativeCodeModeOnlyEnabled: options.nativeCodeModeOnlyEnabled,
+    webSearchAllowed: options.webSearchAllowed,
+    appServer: options.appServer,
+  });
+  assertCodexRemoteExecutionMcpCompatibility(options.appServer, config);
   return {
     threadId: options.threadId,
     model: modelSelection.model,
@@ -1281,17 +1405,33 @@ export function buildThreadResumeParams(
       ? { serviceTier: options.appServer.serviceTier }
       : {}),
     personality: CODEX_NATIVE_PERSONALITY_NONE,
-    config: buildCodexRuntimeThreadConfigForRun(params, options.config, {
-      nativeCodeModeEnabled: options.nativeCodeModeEnabled,
-      nativeProviderWebSearchSupport: options.nativeProviderWebSearchSupport,
-      nativeCodeModeOnlyEnabled: options.nativeCodeModeOnlyEnabled,
-      webSearchAllowed: options.webSearchAllowed,
-      appServer: options.appServer,
-    }),
+    config,
     developerInstructions:
       options.developerInstructions ??
       buildDeveloperInstructions(params, { dynamicTools: options.dynamicTools }),
   };
+}
+
+function assertCodexRemoteExecutionMcpCompatibility(
+  appServer: Pick<CodexAppServerRuntimeOptions, "remoteExecutionFingerprint">,
+  config: JsonObject,
+): void {
+  if (!appServer.remoteExecutionFingerprint) {
+    return;
+  }
+  const mcpServers = isUnknownRecord(config.mcp_servers) ? config.mcp_servers : undefined;
+  for (const [name, server] of Object.entries(mcpServers ?? {})) {
+    if (
+      isUnknownRecord(server) &&
+      server.enabled !== false &&
+      typeof server.command === "string" &&
+      server.environment_id !== "remote"
+    ) {
+      throw new Error(
+        `Codex remote execution cannot use local stdio MCP server ${JSON.stringify(name)} because Codex 0.142.x removes its local execution environment; use HTTP or set environment_id="remote" intentionally`,
+      );
+    }
+  }
 }
 
 export function resolveCodexBindingModelProviderFallback(params: {
@@ -1439,7 +1579,7 @@ function buildCodexRuntimeThreadConfigForRun(
     nativeProviderWebSearchSupport?: CodexNativeWebSearchSupport;
     nativeCodeModeOnlyEnabled?: boolean;
     webSearchAllowed?: boolean;
-    appServer?: Pick<CodexAppServerRuntimeOptions, "networkProxy">;
+    appServer?: Pick<CodexAppServerRuntimeOptions, "networkProxy" | "remoteExecutionFingerprint">;
   } = {},
 ): JsonObject {
   const webSearchConfig = resolveCodexWebSearchPlan({
@@ -1461,15 +1601,16 @@ function buildCodexRuntimeThreadConfigForRun(
         ? CODEX_TOOL_SEARCH_UNSUPPORTED_THREAD_CONFIG
         : undefined,
     ) ?? baseConfig;
-  if (params.bootstrapContextMode !== "lightweight") {
-    return runtimeConfig;
-  }
-  return (
-    mergeCodexThreadConfigs(runtimeConfig, CODEX_LIGHTWEIGHT_CONTEXT_THREAD_CONFIG) ?? {
-      ...runtimeConfig,
-      ...CODEX_LIGHTWEIGHT_CONTEXT_THREAD_CONFIG,
-    }
-  );
+  const contextConfig =
+    params.bootstrapContextMode === "lightweight"
+      ? (mergeCodexThreadConfigs(runtimeConfig, CODEX_LIGHTWEIGHT_CONTEXT_THREAD_CONFIG) ?? {
+          ...runtimeConfig,
+          ...CODEX_LIGHTWEIGHT_CONTEXT_THREAD_CONFIG,
+        })
+      : runtimeConfig;
+  return options.appServer
+    ? (applyCodexRemoteExecutionThreadConfig(contextConfig, options.appServer) ?? contextConfig)
+    : contextConfig;
 }
 
 export function buildTurnStartParams(
@@ -1480,6 +1621,7 @@ export function buildTurnStartParams(
     appServer: CodexAppServerRuntimeOptions;
     promptText?: string;
     sandboxPolicy?: CodexSandboxPolicy;
+    nativeCodeModeEnabled?: boolean;
     environmentSelection?: CodexTurnEnvironmentParams[];
     model?: string | null;
     modelProvider?: string | null;
@@ -1521,7 +1663,7 @@ export function buildTurnStartParams(
       modelSelection.model,
       readCodexSupportedReasoningEfforts(params.model?.compat),
     ),
-    ...(options.environmentSelection ? { environments: options.environmentSelection } : {}),
+    ...resolveCodexThreadEnvironmentSelection(options),
     collaborationMode: buildTurnCollaborationMode(params, {
       model: modelSelection.model,
       turnScopedDeveloperInstructions: options.turnScopedDeveloperInstructions,
@@ -1549,6 +1691,8 @@ function codexThreadSandboxOrPermissions(
 }
 
 function resolveCodexThreadEnvironmentSelection(options: {
+  appServer: Pick<CodexAppServerRuntimeOptions, "remoteExecutionFingerprint">;
+  cwd: string;
   nativeCodeModeEnabled?: boolean;
   environmentSelection?: CodexTurnEnvironmentParams[];
 }): Pick<CodexThreadStartParams, "environments"> {
@@ -1558,7 +1702,12 @@ function resolveCodexThreadEnvironmentSelection(options: {
   if (options.environmentSelection) {
     return { environments: options.environmentSelection };
   }
-  return {};
+  // Only this plugin surface may opt into the process-level remote default.
+  // Explicit local selection preserves native tools without inheriting an
+  // ambient CODEX_HOME/environments.toml remote default.
+  return options.appServer.remoteExecutionFingerprint
+    ? {}
+    : { environments: [{ environmentId: "local", cwd: options.cwd }] };
 }
 
 type CodexTurnCollaborationMode = NonNullable<CodexTurnStartParams["collaborationMode"]>;

--- a/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.user-mcp-servers.test.ts
@@ -151,6 +151,71 @@ describe("startOrResumeThread — user mcp.servers projection (regression: #8081
     });
   });
 
+  it("rejects local stdio MCP servers in a remote execution environment", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const request = vi.fn();
+
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        params: createParams(sessionFile, workspaceDir, {
+          mcp: {
+            servers: {
+              outlook: {
+                transport: "stdio",
+                command: "node",
+                args: ["/opt/outlook-mcp/dist/index.js"],
+              },
+            },
+          },
+        } as unknown as EmbeddedRunAttemptParams["config"]),
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: {
+          ...createAppServerOptions(),
+          remoteExecutionFingerprint: "sha256:remote",
+        },
+      }),
+    ).rejects.toThrow('cannot use local stdio MCP server "outlook"');
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("allows disabled local stdio MCP servers in a remote execution environment", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    await startOrResumeThread({
+      client: { request } as never,
+      params: createParams(sessionFile, workspaceDir, {
+        mcp: {
+          servers: {
+            outlook: {
+              transport: "stdio",
+              command: "node",
+              args: ["/opt/outlook-mcp/dist/index.js"],
+              enabled: false,
+            },
+          },
+        },
+      } as unknown as EmbeddedRunAttemptParams["config"]),
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer: {
+        ...createAppServerOptions(),
+        remoteExecutionFingerprint: "sha256:remote",
+      },
+    });
+
+    expect(request).toHaveBeenCalledWith("thread/start", expect.any(Object), expect.any(Object));
+  });
+
   it("projects only Codex user MCP servers scoped to the current agent", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -12,9 +12,17 @@ import {
   readCodexComputerUseStatus,
   type CodexComputerUseSetupParams,
 } from "./app-server/computer-use.js";
-import { isCodexFastServiceTier, type CodexComputerUseConfig } from "./app-server/config.js";
+import {
+  isCodexFastServiceTier,
+  readCodexPluginConfig,
+  resolveCodexAppServerRuntimeOptions,
+  type CodexComputerUseConfig,
+} from "./app-server/config.js";
 import { listAllCodexAppServerModels } from "./app-server/models.js";
-import { assertCodexThreadResumeResponse } from "./app-server/protocol-validators.js";
+import {
+  assertCodexThreadForkResponse,
+  assertCodexThreadResumeResponse,
+} from "./app-server/protocol-validators.js";
 import { isJsonObject, type JsonValue } from "./app-server/protocol.js";
 import {
   resolveCodexNativeExecutionBlock,
@@ -888,32 +896,52 @@ async function resumeThread(
       agentDir: scope.agentDir,
       config: ctx.config,
     });
-    const response = assertCodexThreadResumeResponse(
-      await deps.codexControlRequest(
-        pluginConfig,
-        CODEX_CONTROL_METHODS.resumeThread,
-        {
-          threadId: normalizedThreadId,
-          excludeTurns: true,
-        },
-        {
-          config: ctx.config,
-          agentDir: scope.agentDir,
-          authProfileId,
-          sessionKey: ctx.sessionKey,
-          sessionId: ctx.sessionId,
-        },
-      ),
+    const hasRemoteExecution = Boolean(
+      readCodexPluginConfig(pluginConfig).appServer?.experimental?.remoteExecution,
     );
+    const appServer = hasRemoteExecution
+      ? resolveCodexAppServerRuntimeOptions({ pluginConfig })
+      : undefined;
+    const remoteCwd = appServer?.remoteWorkspaceRoot;
+    const attachMethod = appServer?.remoteExecutionFingerprint
+      ? CODEX_CONTROL_METHODS.forkThread
+      : CODEX_CONTROL_METHODS.resumeThread;
+    const rawResponse = await deps.codexControlRequest(
+      pluginConfig,
+      attachMethod,
+      {
+        threadId: normalizedThreadId,
+        ...(remoteCwd ? { cwd: remoteCwd } : {}),
+        excludeTurns: true,
+        ...(attachMethod === CODEX_CONTROL_METHODS.forkThread ? { threadSource: "user" } : {}),
+      },
+      {
+        config: ctx.config,
+        agentDir: scope.agentDir,
+        authProfileId,
+        sessionKey: ctx.sessionKey,
+        sessionId: ctx.sessionId,
+        remoteExecutionHookCwd: deps.resolveCodexDefaultWorkspaceDir(pluginConfig),
+      },
+    );
+    const response =
+      attachMethod === CODEX_CONTROL_METHODS.forkThread
+        ? assertCodexThreadForkResponse(rawResponse)
+        : assertCodexThreadResumeResponse(rawResponse);
     const effectiveThreadId = response.thread.id;
-    if (effectiveThreadId !== normalizedThreadId) {
+    if (
+      attachMethod === CODEX_CONTROL_METHODS.resumeThread &&
+      effectiveThreadId !== normalizedThreadId
+    ) {
       throw new Error(
         `Codex thread/resume returned ${effectiveThreadId} for ${normalizedThreadId}`,
       );
     }
     const resumedCwd = response.thread.cwd;
-    if (typeof resumedCwd !== "string") {
-      throw new Error(`Codex thread/resume returned no cwd for ${normalizedThreadId}`);
+    if (typeof resumedCwd !== "string" || !resumedCwd.trim()) {
+      throw new Error(
+        `Codex thread/${attachMethod === CODEX_CONTROL_METHODS.forkThread ? "fork" : "resume"} returned no cwd for ${normalizedThreadId}`,
+      );
     }
     const modelProvider = normalizeCodexAppServerBindingModelProvider({
       authProfileId,
@@ -929,15 +957,16 @@ async function resumeThread(
         authProfileId,
         model: response.model,
         modelProvider,
+        remoteExecutionFingerprint: appServer?.remoteExecutionFingerprint,
         historyCoveredThrough: new Date().toISOString(),
       },
     });
     if (!committed) {
       throw new Error("Codex thread binding changed while attaching the resumed thread.");
     }
-    return `Attached this OpenClaw session to Codex thread ${formatCodexDisplayText(
-      effectiveThreadId,
-    )}.`;
+    return appServer?.remoteExecutionFingerprint
+      ? `Attached this OpenClaw session to Codex thread ${formatCodexDisplayText(effectiveThreadId)}, forked from ${formatCodexDisplayText(normalizedThreadId)} for the remote execution environment.`
+      : `Attached this OpenClaw session to Codex thread ${formatCodexDisplayText(effectiveThreadId)}.`;
   });
 }
 
@@ -2109,6 +2138,10 @@ async function startThreadAction(
   if (!binding?.threadId) {
     return `No Codex thread is attached to this OpenClaw session yet.`;
   }
+  const appServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
+  if (binding.remoteExecutionFingerprint !== appServer.remoteExecutionFingerprint) {
+    return `Cannot start Codex ${label} until a normal message refreshes this thread for the current execution environment.`;
+  }
   await deps.codexControlRequest(
     pluginConfig,
     kind === "compact" ? CODEX_CONTROL_METHODS.compact : CODEX_CONTROL_METHODS.review,
@@ -2119,6 +2152,7 @@ async function startThreadAction(
       agentDir: target.agentDir,
       authProfileId: binding.authProfileId,
       config: ctx.config,
+      remoteExecutionHookCwd: deps.resolveCodexDefaultWorkspaceDir(pluginConfig),
     },
   );
   return `Started Codex ${label} for thread ${formatCodexDisplayText(binding.threadId)}.`;

--- a/extensions/codex/src/command-rpc.test.ts
+++ b/extensions/codex/src/command-rpc.test.ts
@@ -1,7 +1,15 @@
 // Codex tests cover command rpc plugin behavior.
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CodexAppServerRpcError } from "./app-server/client.js";
-import { safeValue } from "./command-rpc.js";
+import { codexControlRequest, safeValue } from "./command-rpc.js";
+
+const requestCodexAppServerJson = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("./app-server/request.js", () => ({ requestCodexAppServerJson }));
+
+beforeEach(() => {
+  requestCodexAppServerJson.mockClear();
+});
 
 describe("Codex command RPC helpers", () => {
   it("formats unsupported control methods from JSON-RPC error codes", async () => {
@@ -13,5 +21,45 @@ describe("Codex command RPC helpers", () => {
       ok: false,
       error: "unsupported by this Codex app-server",
     });
+  });
+
+  it("forces the remote execution policy onto control-plane thread resumes", async () => {
+    await codexControlRequest(
+      {
+        appServer: {
+          remoteWorkspaceRoot: "/remote/workspace",
+          experimental: {
+            remoteExecution: {
+              registryUrl: "https://environment-registry.example.com/api",
+              environmentId: "worker-1",
+              authToken: "registry-token",
+            },
+          },
+        },
+      },
+      "thread/resume",
+      {
+        threadId: "thread-1",
+        config: {
+          "features.unified_exec": false,
+          "features.hooks": true,
+          "shell_environment_policy.ignore_default_excludes": true,
+        },
+      },
+    );
+
+    expect(requestCodexAppServerJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "thread/resume",
+        requestParams: expect.objectContaining({
+          threadId: "thread-1",
+          config: expect.objectContaining({
+            "features.unified_exec": true,
+            "features.hooks": false,
+            "shell_environment_policy.ignore_default_excludes": false,
+          }),
+        }),
+      }),
+    );
   });
 });

--- a/extensions/codex/src/command-rpc.ts
+++ b/extensions/codex/src/command-rpc.ts
@@ -5,13 +5,18 @@ import {
   describeControlFailure,
   type CodexControlMethod,
 } from "./app-server/capabilities.js";
-import { resolveCodexAppServerRuntimeOptions } from "./app-server/config.js";
+import {
+  applyCodexRemoteExecutionThreadConfig,
+  resolveCodexAppServerRuntimeOptions,
+} from "./app-server/config.js";
 import { listCodexAppServerModels } from "./app-server/models.js";
-import type {
-  CodexAppServerRequestMethod,
-  CodexAppServerRequestParams,
-  CodexAppServerRequestResult,
-  JsonValue,
+import {
+  isJsonObject,
+  type CodexAppServerRequestMethod,
+  type CodexAppServerRequestParams,
+  type CodexAppServerRequestResult,
+  type JsonObject,
+  type JsonValue,
 } from "./app-server/protocol.js";
 import { requestCodexAppServerJson } from "./app-server/request.js";
 
@@ -28,6 +33,7 @@ export type CodexControlRequestOptions = {
   sessionKey?: string;
   sessionId?: string;
   isolated?: boolean;
+  remoteExecutionHookCwd?: string;
 };
 
 export function requestOptions(
@@ -45,6 +51,11 @@ export function requestOptions(
 }
 
 type CodexControlRequestMethod = CodexControlMethod & CodexAppServerRequestMethod;
+
+const CODEX_THREAD_CONFIG_METHODS = new Set<CodexControlMethod>([
+  CODEX_CONTROL_METHODS.resumeThread,
+  CODEX_CONTROL_METHODS.forkThread,
+]);
 
 export function codexControlRequest<M extends CodexControlRequestMethod>(
   pluginConfig: unknown,
@@ -65,9 +76,14 @@ export async function codexControlRequest(
   options: CodexControlRequestOptions = {},
 ): Promise<unknown> {
   const runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig });
-  return await requestCodexAppServerJson({
+  const effectiveRequestParams = applyRemoteExecutionControlRequestConfig(
     method,
     requestParams,
+    runtime,
+  );
+  return await requestCodexAppServerJson({
+    method,
+    requestParams: effectiveRequestParams,
     timeoutMs: runtime.requestTimeoutMs,
     startOptions: runtime.start,
     config: options.config,
@@ -76,7 +92,25 @@ export async function codexControlRequest(
     authProfileId: options.authProfileId,
     agentDir: options.agentDir,
     isolated: options.isolated,
+    remoteExecution: runtime,
+    remoteExecutionHookCwd: options.remoteExecutionHookCwd,
   });
+}
+
+function applyRemoteExecutionControlRequestConfig(
+  method: CodexControlMethod,
+  requestParams: unknown,
+  runtime: ReturnType<typeof resolveCodexAppServerRuntimeOptions>,
+): unknown {
+  if (!runtime.remoteExecutionFingerprint || !CODEX_THREAD_CONFIG_METHODS.has(method)) {
+    return requestParams;
+  }
+  const params = isJsonObject(requestParams) ? requestParams : {};
+  const config = isJsonObject(params.config) ? (params.config as JsonObject) : undefined;
+  return {
+    ...params,
+    config: applyCodexRemoteExecutionThreadConfig(config, runtime),
+  };
 }
 
 export function safeCodexControlRequest<M extends CodexControlRequestMethod>(

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -454,6 +454,57 @@ describe("codex command", () => {
     });
   });
 
+  it("attaches a resumed thread to the configured remote execution environment", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const pluginConfig = {
+      appServer: {
+        remoteWorkspaceRoot: "/remote/workspace",
+        experimental: {
+          remoteExecution: {
+            registryUrl: "https://environment-registry.example.com/api",
+            environmentId: "devbox-example",
+            authToken: "registry-token",
+          },
+        },
+      },
+    };
+    const codexControlRequest = vi.fn(async () =>
+      createThreadResumeResponse({ threadId: "thread-remote-fork", cwd: "/remote/workspace" }),
+    );
+
+    await expect(
+      handleCodexCommand(createContext("resume thread-remote", sessionFile), {
+        pluginConfig,
+        deps: createDeps({ codexControlRequest }),
+      }),
+    ).resolves.toEqual({
+      text: "Attached this OpenClaw session to Codex thread thread-remote-fork, forked from thread-remote for the remote execution environment.",
+    });
+
+    expect(codexControlRequest).toHaveBeenCalledWith(
+      pluginConfig,
+      CODEX_CONTROL_METHODS.forkThread,
+      {
+        threadId: "thread-remote",
+        cwd: "/remote/workspace",
+        excludeTurns: true,
+        threadSource: "user",
+      },
+      expect.any(Object),
+    );
+    await expect(
+      testCodexAppServerBindingStore.read({
+        kind: "session",
+        agentId: "main",
+        sessionId: "session-1",
+      }),
+    ).resolves.toMatchObject({
+      threadId: "thread-remote-fork",
+      cwd: "/remote/workspace",
+      remoteExecutionFingerprint: expect.any(String),
+    });
+  });
+
   it("serializes manual resume with other session binding owners", async () => {
     const identity = {
       kind: "session" as const,

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -155,12 +155,24 @@ const NETWORK_PROXY_PROFILE_NAME = NETWORK_PROXY_RUNTIME.networkProxy?.profileNa
 const NETWORK_PROXY_CONFIG_PATCH = NETWORK_PROXY_RUNTIME.networkProxy?.configPatch ?? {};
 const NETWORK_PROXY_CONFIG_FINGERPRINT =
   NETWORK_PROXY_RUNTIME.networkProxy?.configFingerprint ?? "missing";
+const REMOTE_EXECUTION_PLUGIN_CONFIG = {
+  appServer: {
+    remoteWorkspaceRoot: "/remote/workspaces",
+    experimental: {
+      remoteExecution: {
+        registryUrl: "https://environment-registry.example.com/api",
+        environmentId: "devbox-example",
+        authToken: "registry-token",
+      },
+    },
+  },
+};
 
-function conversationThreadStartResult(threadId: string) {
+function conversationThreadStartResult(threadId: string, cwd = tempDir) {
   return {
     approvalPolicy: "never",
     approvalsReviewer: "user",
-    cwd: tempDir,
+    cwd,
     model: "gpt-5.4-mini",
     modelProvider: "openai",
     sandbox: { type: "workspaceWrite", networkAccess: false },
@@ -176,7 +188,7 @@ function conversationThreadStartResult(threadId: string) {
       updatedAt: 1,
       status: { type: "idle" },
       path: null,
-      cwd: tempDir,
+      cwd,
       cliVersion: "0.125.0",
       source: "unknown",
       agentNickname: null,
@@ -235,6 +247,7 @@ describe("codex conversation binding", () => {
       defaultAgentId: "main",
       sessionAgentId: "main",
     });
+    codexRequirementsTomlMock.mockReturnValue("");
   });
 
   it("uses the default Codex auth profile and omits the public OpenAI provider for new binds", async () => {
@@ -320,7 +333,7 @@ describe("codex conversation binding", () => {
     expect(requests[0]?.params.config).toMatchObject(NETWORK_PROXY_CONFIG_PATCH);
   });
 
-  it("starts a fresh proxy-backed thread when binding an explicit app-server thread id", async () => {
+  it("forks an explicit app-server thread into the proxy profile without dropping history", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
@@ -342,14 +355,257 @@ describe("codex conversation binding", () => {
       modelProvider: "openai",
     });
 
-    expect(requests.map((request) => request.method)).toEqual(["thread/start"]);
-    expect(requests[0]?.params).not.toHaveProperty("threadId");
+    expect(requests.map((request) => request.method)).toEqual(["thread/fork"]);
+    expect(requests[0]?.params.threadId).toBe("thread-old");
     expect(requests[0]?.params).not.toHaveProperty("sandbox");
     expect(requests[0]?.params.config).toMatchObject(NETWORK_PROXY_CONFIG_PATCH);
     const bindingAfterStart = await readCodexAppServerBinding(sessionFile);
     expect(bindingAfterStart?.threadId).toBe("thread-new");
     expect(bindingAfterStart?.networkProxyProfileName).toBe(NETWORK_PROXY_PROFILE_NAME);
     expect(bindingAfterStart?.networkProxyConfigFingerprint).toBe(NETWORK_PROXY_CONFIG_FINGERPRINT);
+  });
+
+  it("starts remote conversation bindings with the projected executor cwd", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "configRequirements/read") {
+          return { requirements: null };
+        }
+        if (method === "config/read") {
+          return { config: {}, origins: {}, layers: [] };
+        }
+        if (method === "hooks/list") {
+          return { data: [{ cwd: tempDir, hooks: [], errors: [] }] };
+        }
+        if (method === "thread/resume") {
+          throw new Error("remote binding must not resume an unverified thread");
+        }
+        return conversationThreadStartResult("thread-remote", "/remote/workspaces");
+      }),
+      getServerVersion: vi.fn(() => "0.142.5"),
+      getRuntimeIdentity: vi.fn(() => undefined),
+    });
+
+    await startCodexConversationThread({
+      pluginConfig: REMOTE_EXECUTION_PLUGIN_CONFIG,
+      sessionFile,
+      threadId: "thread-local",
+      workspaceDir: tempDir,
+    });
+
+    expect(requests.map((request) => request.method)).toEqual([
+      "configRequirements/read",
+      "config/read",
+      "hooks/list",
+      "thread/fork",
+    ]);
+    expect(requests[3]?.params.cwd).toBe("/remote/workspaces");
+    const binding = await readCodexAppServerBinding(sessionFile);
+    expect(binding?.threadId).toBe("thread-remote");
+    expect(binding?.cwd).toBe("/remote/workspaces");
+    expect(binding?.appServerRuntimeFingerprint).toEqual(expect.any(String));
+    expect(binding?.remoteExecutionFingerprint).toBe(
+      resolveCodexAppServerRuntimeOptions({
+        pluginConfig: REMOTE_EXECUTION_PLUGIN_CONFIG,
+        requirementsToml: null,
+      }).remoteExecutionFingerprint,
+    );
+    expect(binding?.remoteExecutionFingerprint).toEqual(expect.any(String));
+  });
+
+  it("forks an inherited remote source thread into a local conversation binding", async () => {
+    const sourceIdentity = {
+      kind: "session" as const,
+      agentId: "main",
+      sessionId: "source-session",
+    };
+    await testCodexAppServerBindingStore.mutate(sourceIdentity, {
+      kind: "set",
+      binding: {
+        threadId: "thread-source",
+        cwd: "/remote/workspaces",
+        appServerRuntimeFingerprint: "remote-runtime-v1",
+        remoteExecutionFingerprint: "sha256:remote-environment",
+      },
+    });
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "thread/fork") {
+          return conversationThreadStartResult("thread-local-fork");
+        }
+        if (method === "turn/start") {
+          setImmediate(() =>
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-local-fork",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+                },
+              },
+            }),
+          );
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "hello",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 2,
+            bindingId: "binding-data-1",
+            workspaceDir: tempDir,
+            agentId: "main",
+            source: {
+              agentId: "main",
+              sessionId: "source-session",
+              threadId: "thread-source",
+            },
+          },
+        },
+      },
+      { timeoutMs: 50 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    expect(requests.map(({ method }) => method)).toEqual(["thread/fork", "turn/start"]);
+    expect(requests[0]?.params.threadId).toBe("thread-source");
+    expect(requests[0]?.params.cwd).toBe(tempDir);
+    await expect(testCodexAppServerBindingStore.read(sourceIdentity)).resolves.toBeUndefined();
+    await expect(
+      testCodexAppServerBindingStore.read({
+        kind: "conversation",
+        bindingId: "binding-data-1",
+      }),
+    ).resolves.toMatchObject({
+      threadId: "thread-local-fork",
+      cwd: tempDir,
+      conversationSourceTransferComplete: true,
+    });
+    expect(
+      await testCodexAppServerBindingStore.read({
+        kind: "conversation",
+        bindingId: "binding-data-1",
+      }),
+    ).not.toHaveProperty("remoteExecutionFingerprint");
+  });
+
+  it("forks an explicit local rebind after remote execution is disabled", async () => {
+    const identity = { kind: "conversation" as const, bindingId: "binding-data-1" };
+    await testCodexAppServerBindingStore.mutate(identity, {
+      kind: "set",
+      binding: {
+        threadId: "thread-remote-old",
+        cwd: "/remote/workspaces",
+        appServerRuntimeFingerprint: "remote-runtime-v1",
+        remoteExecutionFingerprint: "sha256:remote-environment",
+        conversationStartId: "start-old",
+      },
+    });
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "thread/fork") {
+          return conversationThreadStartResult("thread-local-requested");
+        }
+        if (method === "turn/start") {
+          setImmediate(() =>
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-local-requested",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+                },
+              },
+            }),
+          );
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue locally",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 2,
+            bindingId: "binding-data-1",
+            workspaceDir: tempDir,
+            start: { id: "start-new", threadId: "thread-local-requested" },
+          },
+        },
+      },
+      { timeoutMs: 50 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    expect(requests.map(({ method }) => method)).toEqual(["thread/fork", "turn/start"]);
+    expect(requests[0]?.params.threadId).toBe("thread-local-requested");
+    expect(requests[0]?.params.cwd).toBe(tempDir);
+    const binding = await testCodexAppServerBindingStore.read(identity);
+    expect(binding).toMatchObject({
+      threadId: "thread-local-requested",
+      cwd: tempDir,
+      conversationStartId: "start-new",
+    });
+    expect(binding).not.toHaveProperty("remoteExecutionFingerprint");
   });
 
   it("starts a new bind thread when no model override is provided", async () => {
@@ -1182,6 +1438,7 @@ describe("codex conversation binding", () => {
 
   it("recreates a missing bound thread and preserves auth plus turn overrides", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
+    const boundCwd = path.join(tempDir, "bound-workspace");
     agentRuntimeMocks.ensureAuthProfileStore.mockReturnValue({
       version: 1,
       profiles: {
@@ -1194,7 +1451,7 @@ describe("codex conversation binding", () => {
     });
     await writeTestConversationBinding(sessionFile, {
       threadId: "thread-old",
-      cwd: tempDir,
+      cwd: boundCwd,
       authProfileId: "work",
       model: "gpt-5.4-mini",
       modelProvider: "openai",
@@ -1212,7 +1469,7 @@ describe("codex conversation binding", () => {
         }
         if (method === "thread/start") {
           return {
-            thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+            thread: { id: "thread-new", sessionId: "session-1", cwd: boundCwd },
             model: "gpt-5.4-mini",
           };
         }
@@ -1292,6 +1549,7 @@ describe("codex conversation binding", () => {
     expect(requests[1]?.params.approvalPolicy).toBe("on-request");
     expect(requests[1]?.params.sandbox).toBe("workspace-write");
     expect(requests[1]?.params.serviceTier).toBe("priority");
+    expect(requests[1]?.params.cwd).toBe(boundCwd);
     expect(requests[1]?.params).not.toHaveProperty("modelProvider");
     expect(requests[2]?.params.threadId).toBe("thread-new");
     expect(requests[2]?.params.approvalPolicy).toBe("on-request");
@@ -1939,6 +2197,161 @@ describe("codex conversation binding", () => {
     });
   });
 
+  it("rotates a legacy bound thread into the configured remote environment", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await writeTestConversationBinding(sessionFile, {
+      threadId: "thread-local",
+      cwd: tempDir,
+    });
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    let recoverRemoteThread = false;
+    let startedThreadId = "thread-remote";
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "configRequirements/read") {
+          return { requirements: null };
+        }
+        if (method === "config/read") {
+          return { config: {}, origins: {}, layers: [] };
+        }
+        if (method === "hooks/list") {
+          return { data: [{ cwd: tempDir, hooks: [], errors: [] }] };
+        }
+        if (method === "thread/fork" || method === "thread/start") {
+          return conversationThreadStartResult(startedThreadId, "/remote/workspaces");
+        }
+        if (method === "turn/start") {
+          const threadId = String(requestParams.threadId);
+          if (recoverRemoteThread && threadId === "thread-remote") {
+            throw new Error(`thread not found: ${threadId}`);
+          }
+          setImmediate(() =>
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId,
+                turn: {
+                  id: `turn-${threadId}`,
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "remote done" }],
+                },
+              },
+            }),
+          );
+          return { turn: { id: `turn-${threadId}` } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      getServerVersion: vi.fn(() => "0.142.5"),
+      getRuntimeIdentity: vi.fn(() => undefined),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue remotely",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { pluginConfig: REMOTE_EXECUTION_PLUGIN_CONFIG, timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "remote done" } });
+    const executionMethods = () =>
+      requests
+        .filter(
+          (request) =>
+            request.method !== "configRequirements/read" &&
+            request.method !== "config/read" &&
+            request.method !== "hooks/list",
+        )
+        .map((request) => request.method);
+    expect(executionMethods()).toEqual(["thread/fork", "turn/start"]);
+    expect(requests.find((request) => request.method === "thread/fork")?.params.cwd).toBe(
+      "/remote/workspaces",
+    );
+    expect(requests.find((request) => request.method === "turn/start")?.params.cwd).toBe(
+      "/remote/workspaces",
+    );
+    const binding = await readTestConversationBinding(sessionFile);
+    expect(binding?.threadId).toBe("thread-remote");
+    expect(binding?.cwd).toBe("/remote/workspaces");
+    expect(binding?.appServerRuntimeFingerprint).toEqual(expect.any(String));
+
+    recoverRemoteThread = true;
+    startedThreadId = "thread-recovered";
+    const recovered = await handleCodexConversationInboundClaim(
+      {
+        content: "recover remotely",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { pluginConfig: REMOTE_EXECUTION_PLUGIN_CONFIG, timeoutMs: 500 },
+    );
+
+    expect(recovered).toEqual({ handled: true, reply: { text: "remote done" } });
+    expect(executionMethods()).toEqual([
+      "thread/fork",
+      "turn/start",
+      "turn/start",
+      "thread/start",
+      "turn/start",
+    ]);
+    expect(requests.findLast((request) => request.method === "thread/start")?.params.cwd).toBe(
+      "/remote/workspaces",
+    );
+    await expect(readTestConversationBinding(sessionFile)).resolves.toMatchObject({
+      threadId: "thread-recovered",
+      cwd: "/remote/workspaces",
+      appServerRuntimeFingerprint: binding?.appServerRuntimeFingerprint,
+      remoteExecutionFingerprint: binding?.remoteExecutionFingerprint,
+    });
+  });
+
   it("keeps network-proxy bound app-server turns on their thread permissions profile", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     await writeTestConversationBinding(sessionFile, {
@@ -2037,7 +2450,7 @@ describe("codex conversation binding", () => {
     sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
       request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
         requests.push({ method, params: requestParams });
-        if (method === "thread/start") {
+        if (method === "thread/fork") {
           return conversationThreadStartResult("thread-new");
         }
         if (method === "turn/start") {
@@ -2107,7 +2520,8 @@ describe("codex conversation binding", () => {
     );
 
     expect(result).toEqual({ handled: true, reply: { text: "done" } });
-    expect(requests.map((request) => request.method)).toEqual(["thread/start", "turn/start"]);
+    expect(requests.map((request) => request.method)).toEqual(["thread/fork", "turn/start"]);
+    expect(requests[0]?.params.threadId).toBe("thread-old");
     expect(requests[0]?.params.config).toMatchObject(NETWORK_PROXY_CONFIG_PATCH);
     expect(requests[0]?.params).not.toHaveProperty("sandbox");
     expect(requests[0]?.params.serviceTier).toBe("priority");

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -17,6 +17,7 @@ import { resolveCodexAppServerForModelProvider } from "./app-server/app-server-p
 import { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-bridge.js";
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import {
+  applyCodexRemoteExecutionThreadConfig,
   canUseCodexModelBackedApprovalsReviewerForModel,
   codexSandboxPolicyForTurn,
   resolveOpenClawExecPolicyForCodexAppServer,
@@ -25,15 +26,22 @@ import {
   type CodexAppServerSandboxMode,
   type OpenClawExecPolicyForCodexAppServer,
 } from "./app-server/config.js";
-import { assertCodexThreadStartResponse } from "./app-server/protocol-validators.js";
+import { mapCodexAppServerRemoteWorkspacePath } from "./app-server/dynamic-tool-build.js";
+import { buildCodexAppServerRuntimeFingerprint } from "./app-server/plugin-app-cache-key.js";
+import {
+  assertCodexThreadForkResponse,
+  assertCodexThreadStartResponse,
+} from "./app-server/protocol-validators.js";
 import type {
   CodexServiceTier,
+  CodexThreadForkResponse,
   CodexThreadResumeResponse,
   CodexThreadStartResponse,
   CodexTurnStartResponse,
   JsonObject,
   JsonValue,
 } from "./app-server/protocol.js";
+import { ensureCodexRemoteExecutionCompatibility } from "./app-server/remote-execution.js";
 import {
   resolveCodexNativeExecutionBlock,
   resolveCodexNativeSandboxBlock,
@@ -211,6 +219,7 @@ export async function startCodexConversationThread(
       config: params.config,
       sessionKey: params.sessionKey,
       agentId: params.agentId,
+      forkExistingThread: Boolean(existingBinding?.remoteExecutionFingerprint),
     });
   } else {
     await createThread({
@@ -370,6 +379,7 @@ type CodexThreadBindingParams = {
   config?: CodexAppServerAuthProfileLookup["config"];
   agentId?: string;
   sessionKey?: string;
+  forkExistingThread?: boolean;
 };
 
 type ConversationAppServerRuntime = Awaited<ReturnType<typeof resolveConversationAppServerRuntime>>;
@@ -377,6 +387,8 @@ type ConversationAppServerRuntime = Awaited<ReturnType<typeof resolveConversatio
 type CodexThreadBindingRuntime = ConversationAppServerRuntime & {
   agentLookup: ReturnType<typeof buildAgentLookup>;
   client: Awaited<ReturnType<typeof getLeasedSharedCodexAppServerClient>>;
+  executionCwd: string;
+  appServerRuntimeFingerprint?: string;
   model?: string;
   modelProvider?: string;
 };
@@ -439,14 +451,56 @@ async function resolveThreadBindingRuntime(
     authProfileId: params.authProfileId,
     ...agentLookup,
   });
+  try {
+    await ensureCodexRemoteExecutionCompatibility({
+      appServer: modelScopedRuntime,
+      client,
+      cwd: params.workspaceDir,
+    });
+  } catch (error) {
+    releaseLeasedSharedCodexAppServerClient(client);
+    throw error;
+  }
+  const executionCwd = resolveConversationExecutionCwd(params.workspaceDir, modelScopedRuntime);
+  const appServerRuntimeFingerprint = buildConversationRemoteRuntimeFingerprint(
+    modelScopedRuntime,
+    client,
+  );
   return {
     execPolicy,
     runtime: modelScopedRuntime,
     agentLookup,
+    executionCwd,
+    ...(appServerRuntimeFingerprint ? { appServerRuntimeFingerprint } : {}),
     model: modelSelection?.model,
     modelProvider: modelSelection?.modelProvider ?? modelProvider,
     client,
   };
+}
+
+function resolveConversationExecutionCwd(
+  workspaceDir: string,
+  runtime: Pick<ConversationAppServerRuntime["runtime"], "remoteWorkspaceRoot">,
+): string {
+  return mapCodexAppServerRemoteWorkspacePath({
+    value: workspaceDir,
+    localWorkspaceRoot: workspaceDir,
+    remoteWorkspaceRoot: runtime.remoteWorkspaceRoot,
+  });
+}
+
+function buildConversationRemoteRuntimeFingerprint(
+  runtime: ConversationAppServerRuntime["runtime"],
+  client: Awaited<ReturnType<typeof getLeasedSharedCodexAppServerClient>>,
+): string | undefined {
+  if (!runtime.remoteExecutionFingerprint) {
+    return undefined;
+  }
+  return buildCodexAppServerRuntimeFingerprint({
+    appServer: runtime,
+    appServerVersion: client.getServerVersion(),
+    runtimeIdentity: client.getRuntimeIdentity(),
+  });
 }
 
 function buildThreadRequestRuntimeOptions(
@@ -474,19 +528,20 @@ function buildThreadRequestRuntimeOptions(
 }
 
 function codexConversationSandboxOrPermissions(
-  runtime: Pick<ConversationAppServerRuntime["runtime"], "networkProxy">,
+  runtime: Pick<
+    ConversationAppServerRuntime["runtime"],
+    "networkProxy" | "remoteExecutionFingerprint"
+  >,
   sandbox: ConversationAppServerRuntime["runtime"]["sandbox"],
 ): {
   sandbox?: ConversationAppServerRuntime["runtime"]["sandbox"];
   config?: JsonObject;
 } {
-  const networkProxy = runtime.networkProxy;
-  if (networkProxy) {
-    return {
-      config: networkProxy.configPatch,
-    };
-  }
-  return { sandbox };
+  const config = applyCodexRemoteExecutionThreadConfig(runtime.networkProxy?.configPatch, runtime);
+  return {
+    ...(runtime.networkProxy ? {} : { sandbox }),
+    ...(config ? { config } : {}),
+  };
 }
 
 async function requestNewConversationBindingThread(
@@ -496,16 +551,45 @@ async function requestNewConversationBindingThread(
   return await resolved.client.request(
     "thread/start",
     {
-      cwd: params.workspaceDir,
+      cwd: resolved.executionCwd,
       ...(resolved.model ? { model: resolved.model } : {}),
       ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
       personality: CODEX_NATIVE_PERSONALITY_NONE,
       ...buildThreadRequestRuntimeOptions(params, resolved),
+      ...(resolved.runtime.remoteExecutionFingerprint
+        ? {}
+        : { environments: [{ environmentId: "local", cwd: resolved.executionCwd }] }),
       developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
       experimentalRawEvents: true,
     },
     { timeoutMs: resolved.runtime.requestTimeoutMs },
   );
+}
+
+async function requestForkedConversationBindingThread(
+  params: CodexThreadBindingParams & { threadId: string },
+  resolved: CodexThreadBindingRuntime,
+): Promise<CodexThreadForkResponse> {
+  const response = assertCodexThreadForkResponse(
+    await resolved.client.request(
+      CODEX_CONTROL_METHODS.forkThread,
+      {
+        threadId: params.threadId,
+        cwd: resolved.executionCwd,
+        ...(resolved.model ? { model: resolved.model } : {}),
+        ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
+        ...buildThreadRequestRuntimeOptions(params, resolved),
+        developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
+        threadSource: "user",
+        excludeTurns: true,
+      },
+      { timeoutMs: resolved.runtime.requestTimeoutMs },
+    ),
+  );
+  if (!response.thread.cwd?.trim()) {
+    throw new Error("Codex thread/fork returned no cwd for the replacement thread");
+  }
+  return response;
 }
 
 async function writeThreadBindingFromResponse(
@@ -521,7 +605,7 @@ async function writeThreadBindingFromResponse(
     kind: "set",
     binding: {
       threadId: response.thread.id,
-      cwd: response.thread.cwd ?? params.workspaceDir,
+      cwd: response.thread.cwd ?? resolved.executionCwd,
       authProfileId: params.authProfileId,
       model: response.model ?? resolved.model ?? params.model,
       modelProvider: normalizeCodexAppServerBindingModelProvider({
@@ -538,6 +622,8 @@ async function writeThreadBindingFromResponse(
       serviceTier: params.serviceTier ?? resolved.runtime.serviceTier ?? undefined,
       networkProxyProfileName: resolved.runtime.networkProxy?.profileName,
       networkProxyConfigFingerprint: resolved.runtime.networkProxy?.configFingerprint,
+      appServerRuntimeFingerprint: resolved.appServerRuntimeFingerprint,
+      remoteExecutionFingerprint: resolved.runtime.remoteExecutionFingerprint,
     },
   });
   if (!committed) {
@@ -552,22 +638,29 @@ async function attachExistingThread(
 ): Promise<void> {
   const resolved = await resolveThreadBindingRuntime(params);
   try {
-    // Codex applies network-proxy permission profiles at thread/start. Resuming
-    // an arbitrary existing thread cannot prove that profile is active.
-    const response: CodexThreadResumeResponse | CodexThreadStartResponse = resolved.runtime
-      .networkProxy
-      ? await requestNewConversationBindingThread(params, resolved)
-      : await resolved.client.request(
-          CODEX_CONTROL_METHODS.resumeThread,
-          {
-            threadId: params.threadId,
-            ...(resolved.model ? { model: resolved.model } : {}),
-            ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
-            personality: CODEX_NATIVE_PERSONALITY_NONE,
-            ...buildThreadRequestRuntimeOptions(params, resolved),
-          },
-          { timeoutMs: resolved.runtime.requestTimeoutMs },
-        );
+    // Forking applies the new runtime deterministically while retaining the
+    // source rollout. A blank thread is only safe when Codex proves it is gone.
+    const response: CodexThreadResumeResponse | CodexThreadStartResponse =
+      params.forkExistingThread ||
+      resolved.runtime.networkProxy ||
+      resolved.runtime.remoteExecutionFingerprint
+        ? await requestForkedConversationBindingThread(params, resolved).catch(async (error) => {
+            if (!isCodexThreadNotFoundError(error)) {
+              throw error;
+            }
+            return await requestNewConversationBindingThread(params, resolved);
+          })
+        : await resolved.client.request(
+            CODEX_CONTROL_METHODS.resumeThread,
+            {
+              threadId: params.threadId,
+              ...(resolved.model ? { model: resolved.model } : {}),
+              ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
+              personality: CODEX_NATIVE_PERSONALITY_NONE,
+              ...buildThreadRequestRuntimeOptions(params, resolved),
+            },
+            { timeoutMs: resolved.runtime.requestTimeoutMs },
+          );
     await writeThreadBindingFromResponse(params, resolved, response);
   } finally {
     releaseLeasedSharedCodexAppServerClient(resolved.client);
@@ -601,7 +694,7 @@ async function runBoundTurn(params: {
     throw new Error("bound Codex conversation has no thread binding");
   }
   let threadId = binding.threadId;
-  const workspaceDir = binding.cwd || params.data.workspaceDir;
+  const localWorkspaceDir = params.data.workspaceDir;
   const reviewerModelProvider = resolveModelBackedReviewerPolicyProvider({
     authProfileId: binding.authProfileId,
     modelProvider: binding.modelProvider,
@@ -612,7 +705,7 @@ async function runBoundTurn(params: {
     config: params.config,
     agentId: params.data.agentId,
     sessionKey: params.sessionKey,
-    workspaceDir,
+    workspaceDir: localWorkspaceDir,
     modelProvider: reviewerModelProvider,
     model: binding.model,
     agentDir: params.data.agentDir,
@@ -671,38 +764,87 @@ async function runBoundTurn(params: {
     authProfileId: binding.authProfileId,
     ...agentLookup,
   });
+  const appServerRuntimeFingerprint = buildConversationRemoteRuntimeFingerprint(
+    modelScopedRuntime,
+    client,
+  );
+  const remoteExecutionBindingChanged =
+    binding.remoteExecutionFingerprint !== modelScopedRuntime.remoteExecutionFingerprint;
+  const runtimeBindingChanged =
+    remoteExecutionBindingChanged ||
+    (modelScopedRuntime.remoteExecutionFingerprint
+      ? binding.appServerRuntimeFingerprint !== appServerRuntimeFingerprint
+      : Boolean(binding.appServerRuntimeFingerprint));
+  let executionCwd = runtimeBindingChanged
+    ? resolveConversationExecutionCwd(localWorkspaceDir, modelScopedRuntime)
+    : binding.cwd || resolveConversationExecutionCwd(localWorkspaceDir, modelScopedRuntime);
   let notificationCleanup: () => void = () => undefined;
   let requestCleanup: () => void = () => undefined;
+  const threadConfig = applyCodexRemoteExecutionThreadConfig(
+    modelScopedRuntime.networkProxy?.configPatch,
+    modelScopedRuntime,
+  );
   try {
-    if (networkProxyBindingChanged) {
-      const response = assertCodexThreadStartResponse(
-        await client.request(
-          "thread/start",
-          {
-            cwd: workspaceDir,
-            ...(modelSelection?.model ? { model: modelSelection.model } : {}),
-            ...(modelSelection?.modelProvider
-              ? { modelProvider: modelSelection.modelProvider }
-              : {}),
-            personality: CODEX_NATIVE_PERSONALITY_NONE,
-            approvalPolicy,
-            approvalsReviewer: modelScopedRuntime.approvalsReviewer,
-            ...(modelScopedRuntime.networkProxy
-              ? { config: modelScopedRuntime.networkProxy.configPatch }
-              : { sandbox }),
-            ...(serviceTier ? { serviceTier } : {}),
-            developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
-            experimentalRawEvents: true,
-          },
-          { timeoutMs: runtime.requestTimeoutMs },
-        ),
-      );
+    await ensureCodexRemoteExecutionCompatibility({
+      appServer: modelScopedRuntime,
+      client,
+      cwd: localWorkspaceDir,
+    });
+    if (networkProxyBindingChanged || runtimeBindingChanged) {
+      const replacementParams = {
+        cwd: executionCwd,
+        ...(modelSelection?.model ? { model: modelSelection.model } : {}),
+        ...(modelSelection?.modelProvider ? { modelProvider: modelSelection.modelProvider } : {}),
+        approvalPolicy,
+        approvalsReviewer: modelScopedRuntime.approvalsReviewer,
+        ...(modelScopedRuntime.networkProxy ? {} : { sandbox }),
+        ...(threadConfig ? { config: threadConfig } : {}),
+        ...(serviceTier ? { serviceTier } : {}),
+        developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
+      };
+      let response: CodexThreadStartResponse;
+      try {
+        response = assertCodexThreadForkResponse(
+          await client.request(
+            CODEX_CONTROL_METHODS.forkThread,
+            {
+              threadId,
+              ...replacementParams,
+              threadSource: "user",
+              excludeTurns: true,
+            },
+            { timeoutMs: runtime.requestTimeoutMs },
+          ),
+        );
+        if (!response.thread.cwd?.trim()) {
+          throw new Error("Codex thread/fork returned no cwd for the replacement thread");
+        }
+      } catch (error) {
+        if (!isCodexThreadNotFoundError(error)) {
+          throw error;
+        }
+        response = assertCodexThreadStartResponse(
+          await client.request(
+            "thread/start",
+            {
+              ...replacementParams,
+              personality: CODEX_NATIVE_PERSONALITY_NONE,
+              ...(modelScopedRuntime.remoteExecutionFingerprint
+                ? {}
+                : { environments: [{ environmentId: "local", cwd: executionCwd }] }),
+              experimentalRawEvents: true,
+            },
+            { timeoutMs: runtime.requestTimeoutMs },
+          ),
+        );
+      }
       threadId = response.thread.id;
+      executionCwd = response.thread.cwd ?? executionCwd;
       const committed = await params.bindingStore.mutate(identity, {
         kind: "set",
         binding: {
           threadId,
-          cwd: response.thread.cwd ?? workspaceDir,
+          cwd: executionCwd,
           authProfileId: binding.authProfileId,
           model: response.model ?? modelSelection?.model ?? binding.model,
           modelProvider: normalizeCodexAppServerBindingModelProvider({
@@ -716,6 +858,8 @@ async function runBoundTurn(params: {
           serviceTier: serviceTier ?? undefined,
           networkProxyProfileName: modelScopedRuntime.networkProxy?.profileName,
           networkProxyConfigFingerprint: modelScopedRuntime.networkProxy?.configFingerprint,
+          appServerRuntimeFingerprint,
+          remoteExecutionFingerprint: modelScopedRuntime.remoteExecutionFingerprint,
           conversationStartId: binding.conversationStartId,
           conversationSourceTransferComplete: binding.conversationSourceTransferComplete,
           historyCoveredThrough: binding.historyCoveredThrough,
@@ -772,15 +916,18 @@ async function runBoundTurn(params: {
           prompt: params.prompt,
           event: params.event,
         }),
-        cwd: workspaceDir,
+        cwd: executionCwd,
         approvalPolicy,
         approvalsReviewer: modelScopedRuntime.approvalsReviewer,
         ...(useStickyNetworkProfile
           ? {}
-          : { sandboxPolicy: codexSandboxPolicyForTurn(sandbox, workspaceDir) }),
+          : { sandboxPolicy: codexSandboxPolicyForTurn(sandbox, executionCwd) }),
         ...(modelSelection?.model ? { model: modelSelection.model } : {}),
         personality: CODEX_NATIVE_PERSONALITY_NONE,
         ...(serviceTier ? { serviceTier } : {}),
+        ...(modelScopedRuntime.remoteExecutionFingerprint
+          ? {}
+          : { environments: [{ environmentId: "local", cwd: executionCwd }] }),
       },
       { timeoutMs: runtime.requestTimeoutMs },
     );
@@ -884,13 +1031,18 @@ async function prepareConversationBinding(
       sessionKey: params.sessionKey,
     });
     const agentLookup = buildAgentLookup({ agentDir: params.data.agentDir, config: params.config });
+    // This marker ships with remote execution. The generic runtime fingerprint
+    // also exists on local sessions, so it cannot classify transferred cwd state.
+    // Remote bindings store an executor cwd. Recovery must start from the local
+    // workspace so thread creation can project it into the current environment.
+    const inheritedWorkspaceDir = inherited?.remoteExecutionFingerprint
+      ? params.data.workspaceDir
+      : (inherited?.cwd ?? params.data.workspaceDir);
     const bindingParams: CodexThreadBindingParams = {
       bindingStore: params.bindingStore,
       identity,
       pluginConfig: params.pluginConfig,
-      workspaceDir: requested
-        ? params.data.workspaceDir
-        : (inherited?.cwd ?? params.data.workspaceDir),
+      workspaceDir: requested ? params.data.workspaceDir : inheritedWorkspaceDir,
       ...agentLookup,
       model: requested?.model ?? inherited?.model,
       modelProvider: requested?.modelProvider ?? inherited?.modelProvider,
@@ -901,6 +1053,7 @@ async function prepareConversationBinding(
       config: params.config,
       sessionKey: params.sessionKey,
       agentId: params.data.agentId,
+      forkExistingThread: Boolean(inherited?.remoteExecutionFingerprint),
     };
     const threadId = requested?.threadId ?? (!current ? params.data.source?.threadId : undefined);
     if (threadId && !options.forceNew) {
@@ -1069,6 +1222,8 @@ function isCodexThreadNotFoundError(error: unknown): boolean {
   const message = formatErrorMessage(error);
   return (
     /\bthread not found:/iu.test(message) ||
+    /\bno rollout found for thread id\b/iu.test(message) ||
+    /\bincludeTurns is unavailable before first user message\b/u.test(message) ||
     /\bbound Codex conversation has no thread binding\b/u.test(message)
   );
 }

--- a/extensions/codex/src/conversation-control.ts
+++ b/extensions/codex/src/conversation-control.ts
@@ -1,6 +1,7 @@
 // Codex plugin module implements conversation control behavior.
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import {
+  applyCodexRemoteExecutionThreadConfig,
   isCodexFastServiceTier,
   resolveCodexModelBackedReviewerPolicyContext,
   resolveCodexAppServerRuntimeOptions,
@@ -8,6 +9,7 @@ import {
   type CodexAppServerSandboxMode,
 } from "./app-server/config.js";
 import type { CodexServiceTier, CodexThreadResumeResponse } from "./app-server/protocol.js";
+import { ensureCodexRemoteExecutionCompatibility } from "./app-server/remote-execution.js";
 import {
   bindingStoreKey,
   isCodexAppServerNativeAuthProfile,
@@ -184,6 +186,24 @@ export async function setCodexConversationModel(params: {
     authProfileId: binding.authProfileId,
     ...lookup,
   });
+  if (runtime.remoteExecutionFingerprint) {
+    const nextModelProvider = normalizeCodexAppServerBindingModelProvider({
+      authProfileId: binding.authProfileId,
+      modelProvider: modelSelection.modelProvider,
+      ...lookup,
+    });
+    const modelChanged =
+      modelSelection.model !== binding.model || nextModelProvider !== binding.modelProvider;
+    await patchThreadBinding(params.bindingStore, params.identity, binding.threadId, {
+      model: modelSelection.model,
+      modelProvider: nextModelProvider,
+      ...(modelChanged && binding.contextEngine?.projection
+        ? { contextEngine: { ...binding.contextEngine, projection: undefined } }
+        : {}),
+      serviceTier: binding.serviceTier ?? runtime.serviceTier ?? undefined,
+    });
+    return `Codex model set to ${formatCodexDisplayText(model)}.`;
+  }
   const response = await resumeThreadWithOverrides({
     runtime,
     threadId: binding.threadId,
@@ -333,6 +353,12 @@ async function resumeThreadWithOverrides(params: {
     ...buildBindingLookup(params),
   });
   try {
+    await ensureCodexRemoteExecutionCompatibility({
+      appServer: runtime,
+      client,
+      cwd: params.agentDir?.trim() || process.cwd(),
+    });
+    const config = applyCodexRemoteExecutionThreadConfig(undefined, runtime);
     return await client.request(
       CODEX_CONTROL_METHODS.resumeThread,
       {
@@ -343,6 +369,7 @@ async function resumeThreadWithOverrides(params: {
         sandbox: params.sandbox ?? runtime.sandbox,
         approvalsReviewer: runtime.approvalsReviewer,
         ...(params.serviceTier ? { serviceTier: params.serviceTier } : {}),
+        ...(config ? { config } : {}),
       },
       { timeoutMs: runtime.requestTimeoutMs },
     );

--- a/extensions/codex/src/native-thread-tool.test.ts
+++ b/extensions/codex/src/native-thread-tool.test.ts
@@ -38,6 +38,7 @@ describe("native Codex thread tool", () => {
   function createTool(params?: {
     owner?: boolean;
     homeScope?: "agent" | "user";
+    pluginConfig?: unknown;
     request?: ReturnType<typeof vi.fn>;
     sessionId?: string | null;
   }) {
@@ -63,7 +64,8 @@ describe("native Codex thread tool", () => {
       bindingStore: testCodexAppServerBindingStore,
       context,
       runtime,
-      getPluginConfig: () => ({ appServer: { homeScope: params?.homeScope ?? "user" } }),
+      getPluginConfig: () =>
+        params?.pluginConfig ?? { appServer: { homeScope: params?.homeScope ?? "user" } },
       request: params?.request as never,
     });
   }
@@ -143,6 +145,43 @@ describe("native Codex thread tool", () => {
         action: "fork",
         sourceThreadId: "source-thread",
         attached: true,
+      });
+    }));
+
+  it("forks into the configured remote execution environment before attaching", () =>
+    withFixture(async () => {
+      const pluginConfig = {
+        appServer: {
+          homeScope: "user",
+          remoteWorkspaceRoot: "/remote/workspace",
+          experimental: {
+            remoteExecution: {
+              registryUrl: "https://environment-registry.example.com/api",
+              environmentId: "devbox-example",
+              authToken: "registry-token",
+            },
+          },
+        },
+      };
+      const request = vi.fn(async () => ({
+        thread: { id: "forked-remote", cwd: "/remote/workspace", status: { type: "idle" } },
+      }));
+
+      await createTool({ pluginConfig, request })?.execute("call-remote", {
+        action: "fork",
+        thread_id: "source-thread",
+      });
+
+      expect(request).toHaveBeenCalledWith(
+        pluginConfig,
+        CODEX_CONTROL_METHODS.forkThread,
+        { threadId: "source-thread", cwd: "/remote/workspace", threadSource: "user" },
+        expect.any(Object),
+      );
+      await expect(readCodexAppServerBinding("session-id")).resolves.toMatchObject({
+        threadId: "forked-remote",
+        cwd: "/remote/workspace",
+        remoteExecutionFingerprint: expect.any(String),
       });
     }));
 

--- a/extensions/codex/src/native-thread-tool.ts
+++ b/extensions/codex/src/native-thread-tool.ts
@@ -11,7 +11,7 @@ import {
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import { Type } from "typebox";
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
-import { readCodexPluginConfig } from "./app-server/config.js";
+import { readCodexPluginConfig, resolveCodexAppServerRuntimeOptions } from "./app-server/config.js";
 import { CODEX_INTERACTIVE_THREAD_SOURCE_KINDS, isJsonObject } from "./app-server/protocol.js";
 import {
   sessionBindingIdentity,
@@ -171,6 +171,7 @@ export function createCodexThreadsTool(options: CodexThreadsToolOptions): AnyAge
       options.context.config,
     sessionId: options.context.sessionId,
     sessionKey: options.context.sessionKey,
+    remoteExecutionHookCwd: options.context.workspaceDir,
   });
   const currentSession = () => resolveToolSession(options.context, options.runtime);
   const currentIdentity = (sessionId: string) => {
@@ -281,6 +282,15 @@ export function createCodexThreadsTool(options: CodexThreadsToolOptions): AnyAge
         throw new Error(`unsupported codex_threads action: ${action}`);
       }
 
+      const hasRemoteExecution = Boolean(
+        readCodexPluginConfig(pluginConfig).appServer?.experimental?.remoteExecution,
+      );
+      const appServer = hasRemoteExecution
+        ? resolveCodexAppServerRuntimeOptions({ pluginConfig })
+        : undefined;
+      const remoteCwd = appServer?.remoteExecutionFingerprint
+        ? appServer.remoteWorkspaceRoot
+        : undefined;
       const attach = readBoolean(params.attach, true);
       if (attach && !session) {
         throw new Error("cannot attach a Codex fork without an active OpenClaw session");
@@ -299,7 +309,7 @@ export function createCodexThreadsTool(options: CodexThreadsToolOptions): AnyAge
       const response = await request(
         pluginConfig,
         CODEX_CONTROL_METHODS.forkThread,
-        { threadId, threadSource: "user" },
+        { threadId, ...(remoteCwd ? { cwd: remoteCwd } : {}), threadSource: "user" },
         requestOptions(),
       );
       if (!isJsonObject(response) || !isJsonObject(response.thread)) {
@@ -312,18 +322,23 @@ export function createCodexThreadsTool(options: CodexThreadsToolOptions): AnyAge
       if (!forkThreadId) {
         throw new Error("Codex app-server thread/fork response did not include a thread id");
       }
+      const forkCwd =
+        typeof response.thread.cwd === "string" && response.thread.cwd.trim()
+          ? response.thread.cwd
+          : undefined;
+      if (!forkCwd) {
+        throw new Error("Codex app-server thread/fork response did not include a cwd");
+      }
       if (attach && session) {
         const attached = await options.bindingStore.mutate(currentIdentity(session.sessionId), {
           kind: "set",
           binding: {
             threadId: forkThreadId,
-            cwd:
-              typeof response.thread.cwd === "string"
-                ? response.thread.cwd
-                : (options.context.workspaceDir ?? ""),
+            cwd: forkCwd,
             model: typeof response.model === "string" ? response.model : undefined,
             modelProvider:
               typeof response.modelProvider === "string" ? response.modelProvider : undefined,
+            remoteExecutionFingerprint: appServer?.remoteExecutionFingerprint,
             historyCoveredThrough: new Date().toISOString(),
           },
         });

--- a/extensions/codex/src/web-search-provider.test.ts
+++ b/extensions/codex/src/web-search-provider.test.ts
@@ -245,6 +245,14 @@ describe("codex web search provider", () => {
             "mcp_servers.external.command='unsafe'",
           ],
           clearEnv: ["CODEX_HOME", "KEEP_CLEARED"],
+          remoteWorkspaceRoot: "/home/codex/workspaces",
+          experimental: {
+            remoteExecution: {
+              registryUrl: "https://environment-registry.example.com/api",
+              environmentId: "devbox-example",
+              authToken: "registry-token",
+            },
+          },
         },
       }),
       clientFactory: async (options) => {
@@ -314,8 +322,15 @@ describe("codex web search provider", () => {
     expect(isolatedStartOptions?.args).toEqual(["app-server", "--listen", "stdio://"]);
     expect(isolatedStartOptions?.clearEnv).toEqual([
       "KEEP_CLEARED",
+      "CODEX_EXEC_SERVER_URL",
+      "CODEX_EXEC_SERVER_NOISE_REGISTRY_URL",
+      "CODEX_EXEC_SERVER_NOISE_ENVIRONMENT_ID",
+      "CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN",
+      "CODEX_EXEC_SERVER_NOISE_CHATGPT_ACCOUNT_ID",
       "OPENCLAW_CODEX_APP_SERVER_ARGS",
     ]);
+    expect(isolatedStartOptions?.env).not.toHaveProperty("CODEX_EXEC_SERVER_URL");
+    expect(isolatedStartOptions?.env).not.toHaveProperty("CODEX_EXEC_SERVER_NOISE_AUTH_TOKEN");
     expect(isolatedCodexHome).toEqual(expect.any(String));
     if (!threadStartCwd || !isolatedCodexHome) {
       throw new Error("expected isolated Codex home and workspace");

--- a/scripts/test-live-codex-harness-docker.sh
+++ b/scripts/test-live-codex-harness-docker.sh
@@ -27,10 +27,20 @@ DOCKER_TRUSTED_HARNESS_CONTAINER_DIR=""
 DOCKER_CACHE_CONTAINER_DIR="/tmp/openclaw-cache"
 DOCKER_CLI_TOOLS_CONTAINER_DIR="/tmp/openclaw-npm-global"
 DOCKER_EXTRA_ENV_FILES=()
+DOCKER_REMOTE_NETWORK_ARGS=()
 DOCKER_AUTH_PRESTAGED=0
 
 openclaw_live_codex_harness_is_ci() {
   openclaw_live_is_ci
+}
+
+openclaw_live_codex_harness_validate_env_file_value() {
+  local name="${1:?environment variable name required}"
+  local value="${2-}"
+  if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
+    echo "ERROR: $name cannot contain a newline when passed through a Docker env file." >&2
+    exit 1
+  fi
 }
 
 openclaw_live_codex_harness_append_build_extension() {
@@ -178,6 +188,9 @@ fi
 
 DOCKER_AUTH_ENV=()
 if [[ "$CODEX_HARNESS_AUTH_MODE" == "api-key" ]]; then
+  openclaw_live_codex_harness_validate_env_file_value OPENAI_API_KEY "$OPENAI_API_KEY"
+  openclaw_live_codex_harness_validate_env_file_value CODEX_API_KEY "${CODEX_API_KEY:-$OPENAI_API_KEY}"
+  openclaw_live_codex_harness_validate_env_file_value OPENAI_BASE_URL "${OPENAI_BASE_URL:-}"
   docker_env_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/openclaw-codex-harness-env.XXXXXX")"
   TEMP_DIRS+=("$docker_env_dir")
   docker_env_file="$docker_env_dir/openai.env"
@@ -189,6 +202,41 @@ if [[ "$CODEX_HARNESS_AUTH_MODE" == "api-key" ]]; then
     fi
   } >"$docker_env_file"
   DOCKER_EXTRA_ENV_FILES+=(--env-file "$docker_env_file")
+fi
+
+REMOTE_EXECUTION_ENV_NAMES=(
+  OPENCLAW_LIVE_CODEX_REMOTE_AUTH_TOKEN
+  OPENCLAW_LIVE_CODEX_REMOTE_ENVIRONMENT_ID
+  OPENCLAW_LIVE_CODEX_REMOTE_PROBE_TOKEN
+  OPENCLAW_LIVE_CODEX_REMOTE_REGISTRY_URL
+  OPENCLAW_LIVE_CODEX_REMOTE_WORKSPACE_ROOT
+)
+REMOTE_EXECUTION_ENABLED=0
+for remote_env_name in "${REMOTE_EXECUTION_ENV_NAMES[@]}"; do
+  if [[ -n "${!remote_env_name:-}" ]]; then
+    REMOTE_EXECUTION_ENABLED=1
+    break
+  fi
+done
+if [[ "$REMOTE_EXECUTION_ENABLED" == "1" ]]; then
+  for remote_env_name in "${REMOTE_EXECUTION_ENV_NAMES[@]}"; do
+    if [[ -z "${!remote_env_name:-}" ]]; then
+      echo "ERROR: remote Codex live proof requires $remote_env_name." >&2
+      exit 1
+    fi
+  done
+  remote_env_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/openclaw-codex-remote-env.XXXXXX")"
+  TEMP_DIRS+=("$remote_env_dir")
+  remote_env_file="$remote_env_dir/remote.env"
+  for remote_env_name in "${REMOTE_EXECUTION_ENV_NAMES[@]}"; do
+    openclaw_live_codex_harness_validate_env_file_value "$remote_env_name" "${!remote_env_name}"
+    printf '%s=%s\n' "$remote_env_name" "${!remote_env_name}" >>"$remote_env_file"
+  done
+  chmod 600 "$remote_env_file"
+  DOCKER_EXTRA_ENV_FILES+=(--env-file "$remote_env_file")
+  DOCKER_REMOTE_NETWORK_ARGS+=(
+    --network "${OPENCLAW_LIVE_CODEX_REMOTE_DOCKER_NETWORK:-host}"
+  )
 fi
 
 read -r -d '' LIVE_TEST_CMD <<'EOF' || true
@@ -338,6 +386,7 @@ echo "==> Profile file: $PROFILE_STATUS"
 echo "==> CI-safe Codex config: ${OPENCLAW_LIVE_CODEX_HARNESS_USE_CI_SAFE_CODEX_CONFIG:-1}"
 echo "==> Test files: ${OPENCLAW_LIVE_CODEX_TEST_FILES:-src/gateway/gateway-codex-harness.live.test.ts}"
 echo "==> Codex CLI package: $CODEX_CLI_PACKAGE_SPEC"
+echo "==> Remote execution probe: $REMOTE_EXECUTION_ENABLED"
 echo "==> Harness fallback: none"
 echo "==> Auth files: ${AUTH_FILES_CSV:-none}"
 DOCKER_RUN_ARGS=()
@@ -389,6 +438,7 @@ openclaw_live_append_array DOCKER_RUN_ARGS DOCKER_AUTH_ENV
 openclaw_live_append_array DOCKER_RUN_ARGS DOCKER_EXTRA_ENV_FILES
 openclaw_live_append_array DOCKER_RUN_ARGS DOCKER_HOME_MOUNT
 openclaw_live_append_array DOCKER_RUN_ARGS DOCKER_TRUSTED_HARNESS_MOUNT
+openclaw_live_append_array DOCKER_RUN_ARGS DOCKER_REMOTE_NETWORK_ARGS
 DOCKER_RUN_ARGS+=(\
   -v "$ROOT_DIR":/src:ro \
   -v "$CONFIG_DIR":/home/node/.openclaw \

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -80,6 +80,7 @@ const CODEX_HARNESS_AGENT_TIMEOUT_SECONDS = Math.max(
 );
 const CODEX_HARNESS_AUTH_MODE =
   process.env.OPENCLAW_LIVE_CODEX_HARNESS_AUTH === "api-key" ? "api-key" : "codex-auth";
+const CODEX_HARNESS_REMOTE_EXECUTION = resolveRemoteExecutionLiveConfig(process.env);
 const describeLive = LIVE && CODEX_HARNESS_LIVE ? describe : describe.skip;
 const describeDisabled = LIVE && !CODEX_HARNESS_LIVE ? describe : describe.skip;
 const CODEX_HARNESS_TIMEOUT_MS = 900_000;
@@ -93,6 +94,34 @@ type CapturedAgentEvent = {
 };
 
 type GuardianPluginApprovalDecision = "allow-once" | "deny";
+
+type RemoteExecutionLiveConfig = {
+  authToken: string;
+  environmentId: string;
+  probeToken: string;
+  registryUrl: string;
+  workspaceRoot: string;
+};
+
+function resolveRemoteExecutionLiveConfig(
+  env: NodeJS.ProcessEnv,
+): RemoteExecutionLiveConfig | undefined {
+  const values = {
+    authToken: env.OPENCLAW_LIVE_CODEX_REMOTE_AUTH_TOKEN?.trim(),
+    environmentId: env.OPENCLAW_LIVE_CODEX_REMOTE_ENVIRONMENT_ID?.trim(),
+    probeToken: env.OPENCLAW_LIVE_CODEX_REMOTE_PROBE_TOKEN?.trim(),
+    registryUrl: env.OPENCLAW_LIVE_CODEX_REMOTE_REGISTRY_URL?.trim(),
+    workspaceRoot: env.OPENCLAW_LIVE_CODEX_REMOTE_WORKSPACE_ROOT?.trim(),
+  };
+  const configuredCount = Object.values(values).filter(Boolean).length;
+  if (configuredCount === 0) {
+    return undefined;
+  }
+  if (configuredCount !== Object.keys(values).length) {
+    throw new Error("incomplete OPENCLAW_LIVE_CODEX_REMOTE_* configuration");
+  }
+  return values as RemoteExecutionLiveConfig;
+}
 
 function resolveLiveTimeoutMs(raw: string | undefined, fallback: number): number {
   const parsed = raw ? Number(raw) : Number.NaN;
@@ -208,6 +237,7 @@ async function writeLiveGatewayConfig(params: {
   configPath: string;
   modelKey: string;
   port: number;
+  remoteExecution?: RemoteExecutionLiveConfig;
   token: string;
   workspace: string;
 }): Promise<void> {
@@ -227,6 +257,18 @@ async function writeLiveGatewayConfig(params: {
             appServer: {
               mode: params.codexAppServerMode ?? "yolo",
               ...(params.codeModeOnly === true ? { codeModeOnly: true } : {}),
+              ...(params.remoteExecution
+                ? {
+                    remoteWorkspaceRoot: params.remoteExecution.workspaceRoot,
+                    experimental: {
+                      remoteExecution: {
+                        registryUrl: params.remoteExecution.registryUrl,
+                        environmentId: params.remoteExecution.environmentId,
+                        authToken: params.remoteExecution.authToken,
+                      },
+                    },
+                  }
+                : {}),
             },
           },
         },
@@ -1080,6 +1122,7 @@ describeLive("gateway live (Codex harness)", () => {
         configPath,
         modelKey,
         port,
+        remoteExecution: CODEX_HARNESS_REMOTE_EXECUTION,
         token,
         workspace,
         codexAppServerMode: CODEX_HARNESS_GUARDIAN_PROBE ? "guardian" : "yolo",
@@ -1180,6 +1223,29 @@ describeLive("gateway live (Codex harness)", () => {
               });
               expect(secondText).toContain(secondToken);
               logCodexLiveStep("second-turn", { secondText });
+
+              if (CODEX_HARNESS_REMOTE_EXECUTION) {
+                const gatewayDecoyPath = path.join(workspace, "gateway-only.txt");
+                const gatewayDecoy = `GATEWAY-ONLY-${randomUUID()}`;
+                await fs.writeFile(gatewayDecoyPath, gatewayDecoy);
+                await expect(
+                  fs.access(path.join(workspace, "openclaw-remote-exec-proof.sh")),
+                ).rejects.toThrow();
+                const remoteProbeText = await requestAgentText({
+                  client: activeClient,
+                  sessionKey,
+                  expectedToken: CODEX_HARNESS_REMOTE_EXECUTION.probeToken,
+                  message: [
+                    "Use exec_command to run this exact command in the current workspace:",
+                    "./openclaw-remote-exec-proof.sh",
+                    "Then reply with exactly the command's stdout and nothing else.",
+                  ].join("\n"),
+                });
+                expect(remoteProbeText).toContain(CODEX_HARNESS_REMOTE_EXECUTION.probeToken);
+                expect(await fs.readFile(gatewayDecoyPath, "utf8")).toBe(gatewayDecoy);
+                await expect(fs.access(path.join(workspace, "proof.json"))).rejects.toThrow();
+                logCodexLiveStep("remote-execution-probe", { remoteProbeText });
+              }
 
               if (CODEX_HARNESS_CODE_MODE_ONLY) {
                 logCodexLiveStep("code-mode-only-tool-probe:start", { sessionKey });


### PR DESCRIPTION
Closes #101282

Related: #101221, #94203

AI-assisted: yes. I understand the topology, compatibility boundaries, and fail-closed behavior in this change. Agent transcript: omitted.

## What Problem This Solves

Remote Codex workspaces currently require operators to split Codex app-server from Gateway. That separates lifecycle, auth, hooks, thread state, local MCP integration, and filesystem ownership across hosts while depending on Codex's experimental app-server WebSocket transport.

## Why This Change Was Made

This preview keeps Gateway and its managed Codex app-server together over stdio. Only Codex filesystem/process execution moves to one authenticated registry-backed exec-server environment. This matches Codex's supported control-plane ownership while using its existing Noise-authenticated remote executor path.

The implementation:

- validates an HTTPS (or loopback) registry, SecretRef-compatible credentials, an absolute POSIX `remoteWorkspaceRoot`, and one explicit environment id;
- clears inherited executor-routing variables, then injects the validated target only into the managed app-server child;
- forces unified exec and disables remote hooks/notify, unsupported local stdio MCP servers, proxying, sandbox combinations, and Windows hosts;
- checks managed config requirements and hooks before a remote thread mutation, and fails closed when local policy cannot be enforced remotely;
- forks existing Codex rollouts when execution topology changes, preserves the source binding until replacement succeeds, and projects only history newer than the source coverage watermark;
- keeps bounded media work local and prevents remote workspace paths from being persisted as Gateway-local paths; and
- stores only durable routing fingerprints/bindings, never raw registry credentials.

This is intentionally one target, with no pool selection or failover in OpenClaw. The infrastructure remains responsible for registry availability and executor registration.

Security boundary: child-environment filtering reduces accidental credential leakage, but it is not isolation from code running as the same OS user as the exec-server. Such code can inspect the exec-server parent process. Executors therefore need a dedicated user/container/process boundary and narrowly scoped, rotatable credentials.

## User Impact

Operators can keep one canonical Gateway/app-server control plane while running Codex shell and filesystem work on a different machine. The feature is opt-in under `plugins.entries.codex.config.appServer.experimental.remoteExecution`; existing local stdio and explicit remote app-server configurations are unchanged.

Thread resume, explicit rebind, command-driven resume/model changes, side questions, and conversation transfer now preserve the correct execution topology and history without replaying native-owned context.

## Evidence

Final head: `e0845291b548d93b2bf64eae3a68ebea673afaf8`, rebased onto current `origin/main` and reduced from four follow-up commits to one commit.

- Full Codex Docker suite on the rebased tree: 96 files / 2,025 tests passed in four one-worker shards (601 + 355 + 366 + 703).

  ```text
  docker buildx build --target build --load -t openclaw:test-final .
  docker run --rm openclaw:test-final node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex.config.ts extensions/codex --maxWorkers 1 --shard 1/4
  # repeated for shards 2/4, 3/4, and 4/4
  ```

- Exact production Dockerfile build passed, including `build:docker`, CLI import guards, runtime post-build, plugin assets, package import closure, and Control UI. Runtime smoke returned `OpenClaw 2026.6.11`.

  ```text
  docker buildx build --load -t openclaw:remote-final .
  docker run --rm openclaw:remote-final node openclaw.mjs --version
  ```

- Live Docker user-path proof used separate Gateway/app-server and Codex 0.142.5 exec-server containers with an authenticated registry/opaque Noise relay and a real `gpt-5.5` turn. Resume worked; a later turn executed in `/remote-workspace`; direct child-secret probes were absent; the Gateway decoy workspace remained unchanged; registry register/connect/validate occurred; encrypted relay frames contained no plaintext probe. Result: 1 passed, 1 intentionally skipped in 202.12s.
- A subsequent managed-account live run stopped before thread start when cloud `PreToolUse` hooks were present, proving the new fail-closed managed-hook guard. The positive relay run preceded that guard; the final Docker suite covers the guard and all resulting topology/history changes.
- Crabbox pool run `run_10e2c67bc313`: 7 focused files / 426 tests passed. The broker became unavailable for later runs, so the final complete suite, production build, and live proof used Docker as the requested fallback.
- `oxfmt`, direct `oxlint`, `git diff --check`, plugin manifest parsing, changelog attribution, docs MDX validation (699 files), and docs link audit (5,754 links, 0 broken) passed.
- Two fresh autoreviews reported no accepted/actionable findings; the final review specifically confirmed that isolating the history-fork regression from unrelated dynamic-tool construction preserves the behavior under test.

Dependency contract checked directly at exact Codex tag `rust-v0.142.5` (`26de83050b20f7e0ee211b9739e52ae00ce8032a`):

- app-server transport support status: https://github.com/openai/codex/blob/rust-v0.142.5/codex-rs/app-server/README.md#L20-L37
- authenticated registry environment construction/default selection: https://github.com/openai/codex/blob/rust-v0.142.5/codex-rs/exec-server/src/environment.rs#L33-L55 and https://github.com/openai/codex/blob/rust-v0.142.5/codex-rs/exec-server/src/environment.rs#L109-L153
- authenticated Noise registry client and reconnect ownership: https://github.com/openai/codex/blob/rust-v0.142.5/codex-rs/exec-server/src/remote.rs#L245-L330
