### PR TITLE
Workspaces: persist widget state in SQLite

### DIFF
--- a/docs/web/workspaces.md
+++ b/docs/web/workspaces.md
@@ -83,6 +83,12 @@ An agent can author a real HTML widget with `workspace_widget_scaffold` (or you 
 Sending a prompt into chat from a widget additionally requires a manifest capability, a
 per-invocation confirmation quoting the exact text, and passes a rate limit.
 
+Widgets that declare the `state:persist` capability may keep up to 64 KB of JSON state.
+The iframe sends `workspace:getState` or `workspace:setState` over its document-bound
+bridge; the trusted parent supplies the rendered widget's ID, so child code cannot select
+another widget's record. A set may include the version returned by the last read as
+`expectedVersion`; stale writes fail instead of silently overwriting newer state.
+
 ## CLI
 
 ```sh
@@ -97,8 +103,8 @@ the Control UI does not, because the browser already holds it.
 
 ## Storage
 
-The workspace document, the custom-widget registry, and a 20-entry undo ring live in
-`<stateDir>/workspaces/workspaces.sqlite`. Agent-authored widget assets stay on disk under
+The workspace document, the custom-widget registry, widget state, and a 20-entry undo ring
+live in `<stateDir>/workspaces/workspaces.sqlite`. Agent-authored widget assets stay on disk under
 `<stateDir>/workspaces/widgets/<name>/`, and file-binding data under
 `<stateDir>/workspaces/data/`, because an agent authors those with ordinary file tools and
 the widget route serves their bytes.

--- a/extensions/workspaces/src/gateway.test.ts
+++ b/extensions/workspaces/src/gateway.test.ts
@@ -69,6 +69,8 @@ describe("workspace gateway methods", () => {
       "workspaces.widget.setLayout",
       "workspaces.widget.scaffold",
       "workspaces.widget.approve",
+      "workspaces.widget.state.get",
+      "workspaces.widget.state.set",
       "workspaces.replace",
       "workspaces.undo",
       "workspaces.data.read",
@@ -81,13 +83,78 @@ describe("workspace gateway methods", () => {
     expect(methods.get("workspaces.widget.approve")?.opts).toEqual({
       scope: "operator.approvals",
     });
-    const readOnly = new Set(["workspaces.get", "workspaces.widget.frame", "workspaces.data.read"]);
+    const readOnly = new Set([
+      "workspaces.get",
+      "workspaces.widget.frame",
+      "workspaces.widget.state.get",
+      "workspaces.data.read",
+    ]);
     for (const [name, method] of methods) {
       if (readOnly.has(name) || name === "workspaces.widget.approve") {
         continue;
       }
       expect(method.opts).toEqual({ scope: "operator.write" });
     }
+  });
+
+  it("persists only the trusted-parent widget id with optimistic concurrency", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const { api, methods } = createApi();
+      registerWorkspaceGatewayMethods({ api, store: new WorkspaceStore({ stateDir }) });
+      const broadcast = vi.fn();
+
+      const empty = await callMethod(
+        methods.get("workspaces.widget.state.get")!,
+        { widgetId: "cost-today" },
+        broadcast,
+      );
+      expect(empty.response?.[1]).toEqual({ state: null, version: 0 });
+
+      const first = await callMethod(
+        methods.get("workspaces.widget.state.set")!,
+        { widgetId: "cost-today", state: { text: "a" }, expectedVersion: 0 },
+        broadcast,
+      );
+      expect(first.response?.[0]).toBe(true);
+      expect(first.response?.[1]).toEqual({ widgetId: "cost-today", version: 1 });
+      expect(broadcast).toHaveBeenCalledWith("plugin.workspaces.widget-state.changed", {
+        widgetId: "cost-today",
+        version: 1,
+      });
+
+      const read = await callMethod(
+        methods.get("workspaces.widget.state.get")!,
+        { widgetId: "cost-today" },
+        broadcast,
+      );
+      expect(read.response?.[1]).toMatchObject({ state: { text: "a" }, version: 1 });
+
+      broadcast.mockClear();
+      const stale = await callMethod(
+        methods.get("workspaces.widget.state.set")!,
+        { widgetId: "cost-today", state: { text: "clobber" }, expectedVersion: 0 },
+        broadcast,
+      );
+      expect(stale.response?.[0]).toBe(false);
+      expect(stale.response?.[2]?.message).toContain("version conflict");
+      expect(broadcast).not.toHaveBeenCalled();
+
+      const malformed = await callMethod(
+        methods.get("workspaces.widget.state.set")!,
+        { widgetId: "cost-today", state: null, expectedVersion: -1 },
+        broadcast,
+      );
+      expect(malformed.response?.[0]).toBe(false);
+      expect(malformed.response?.[2]?.message).toContain("non-negative integer");
+
+      const smuggled = await callMethod(
+        methods.get("workspaces.widget.state.set")!,
+        { widgetId: "cost-today", state: {}, targetWidgetId: "other" },
+        broadcast,
+      );
+      expect(smuggled.response?.[0]).toBe(false);
+      expect(smuggled.response?.[2]?.message).toContain("unexpected param");
+    });
   });
 
   it("returns the workspace without broadcasting and broadcasts successful writes", async () => {

--- a/extensions/workspaces/src/gateway.ts
+++ b/extensions/workspaces/src/gateway.ts
@@ -765,6 +765,56 @@ export function registerWorkspaceGatewayMethods(options: WorkspaceGatewayMethodO
     { scope: APPROVE_SCOPE },
   );
 
+  // The browser parent calls these on behalf of a sandboxed custom widget. The
+  // parent supplies the widget id from its trusted render context; iframe input
+  // is never allowed to select another widget's state record.
+  api.registerGatewayMethod(
+    "workspaces.widget.state.get",
+    async ({ params: requestParams, respond }) => {
+      try {
+        const params = readParams(requestParams, ["widgetId"]);
+        const widgetId = readWidgetId(params, "widgetId");
+        const record = store.readWidgetState(widgetId);
+        respond(true, record ?? { state: null, version: 0 });
+      } catch (error) {
+        respondError(respond, error);
+      }
+    },
+    { scope: READ_SCOPE },
+  );
+
+  api.registerGatewayMethod(
+    "workspaces.widget.state.set",
+    async (opts) => {
+      try {
+        const params = readParams(opts.params, ["widgetId", "state", "expectedVersion"]);
+        const widgetId = readWidgetId(params, "widgetId");
+        if (!Object.hasOwn(params, "state")) {
+          throw new Error("state is required");
+        }
+        let expectedVersion: number | undefined;
+        if (params.expectedVersion !== undefined) {
+          if (
+            typeof params.expectedVersion !== "number" ||
+            !Number.isInteger(params.expectedVersion) ||
+            params.expectedVersion < 0
+          ) {
+            throw new Error("expectedVersion must be a non-negative integer");
+          }
+          expectedVersion = params.expectedVersion;
+        }
+        const { version } = store.writeWidgetState(widgetId, params.state as JsonValue, {
+          expectedVersion,
+        });
+        opts.context.broadcast("plugin.workspaces.widget-state.changed", { widgetId, version });
+        opts.respond(true, { widgetId, version });
+      } catch (error) {
+        respondError(opts.respond, error);
+      }
+    },
+    { scope: WRITE_SCOPE },
+  );
+
   api.registerGatewayMethod(
     "workspaces.replace",
     async (opts) => {

--- a/extensions/workspaces/src/manifest.test.ts
+++ b/extensions/workspaces/src/manifest.test.ts
@@ -36,6 +36,21 @@ const VALID_MANIFEST = {
 };
 
 describe("validateWidgetManifest", () => {
+  it("accepts the state:persist capability", () => {
+    expect(
+      validateWidgetManifest(
+        {
+          schemaVersion: 1,
+          name: "chart",
+          title: "Chart",
+          entrypoint: "index.html",
+          bindings: [],
+          capabilities: ["state:persist"],
+        },
+        "chart",
+      ).capabilities,
+    ).toEqual(["state:persist"]);
+  });
   it("accepts a well-formed manifest", () => {
     expect(validateWidgetManifest(VALID_MANIFEST)).toEqual(VALID_MANIFEST);
   });

--- a/extensions/workspaces/src/manifest.ts
+++ b/extensions/workspaces/src/manifest.ts
@@ -200,7 +200,7 @@ export function matchesApprovedFile(
   return expected !== undefined && expected === hashBytes(bytes);
 }
 const BINDING_ID_PATTERN = /^(?!__proto__$)[A-Za-z0-9._-]{1,64}$/;
-const WIDGET_CAPABILITIES = ["data:read", "prompt:send"] as const;
+const WIDGET_CAPABILITIES = ["data:read", "prompt:send", "state:persist"] as const;
 
 type WidgetCapability = (typeof WIDGET_CAPABILITIES)[number];
 

--- a/extensions/workspaces/src/store.test.ts
+++ b/extensions/workspaces/src/store.test.ts
@@ -27,6 +27,111 @@ function docWithPendingWidget(store: WorkspaceStore): WorkspaceDoc {
 }
 
 describe("WorkspaceStore", () => {
+  it("persists size-capped widget state in SQLite with monotonic versions", async () => {
+    await withStore((store) => {
+      expect(store.readWidgetState("cost-today")).toBeNull();
+
+      expect(store.writeWidgetState("cost-today", { text: "hello" })).toMatchObject({ version: 1 });
+      expect(store.readWidgetState("cost-today")).toMatchObject({
+        state: { text: "hello" },
+        version: 1,
+        updatedAt: expect.any(String),
+      });
+
+      expect(
+        store.writeWidgetState("cost-today", { text: "updated" }, { expectedVersion: 1 }),
+      ).toMatchObject({ version: 2 });
+      expect(store.readWidgetState("cost-today")).toMatchObject({
+        state: { text: "updated" },
+        version: 2,
+      });
+    });
+  });
+
+  it("keeps widget state after the store is reopened", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-reopen-"));
+    try {
+      const first = new WorkspaceStore({ stateDir });
+      first.writeWidgetState("cost-today", { text: "durable" });
+      first.close();
+
+      const reopened = new WorkspaceStore({ stateDir });
+      try {
+        expect(reopened.readWidgetState("cost-today")).toMatchObject({
+          state: { text: "durable" },
+          version: 1,
+        });
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects stale, invalid, and oversized widget state without changing prior state", async () => {
+    await withStore((store) => {
+      store.writeWidgetState("cost-today", { text: "safe" }, { expectedVersion: 0 });
+
+      expect(() =>
+        store.writeWidgetState("cost-today", { text: "stale" }, { expectedVersion: 0 }),
+      ).toThrow("widget state version conflict: expected 0, found 1");
+      expect(() => store.writeWidgetState("../escape", { nope: true })).toThrow(
+        "widget id is invalid",
+      );
+      expect(() => store.writeWidgetState("cost-today", { text: "x".repeat(70 * 1024) })).toThrow(
+        "widget state exceeds 64 KB",
+      );
+      expect(() => store.writeWidgetState("cost-today", { bad: undefined } as never)).toThrow(
+        "widget state must be valid JSON",
+      );
+
+      expect(store.readWidgetState("cost-today")).toMatchObject({
+        state: { text: "safe" },
+        version: 1,
+      });
+    });
+  });
+
+  it("deletes state when a widget is removed or replaced with a different kind", async () => {
+    await withStore((store) => {
+      store.writeWidgetState("cost-today", { text: "private" });
+      store.mutate(
+        (draft) => {
+          draft.tabs[0]!.widgets = draft.tabs[0]!.widgets.filter(
+            (widget) => widget.id !== "cost-today",
+          );
+        },
+        { actor: "user" },
+      );
+      expect(store.readWidgetState("cost-today")).toBeNull();
+      expect(() => store.writeWidgetState("cost-today", { text: "orphan" })).toThrow(
+        "workspace widget not found",
+      );
+
+      store.mutate(
+        (draft) => {
+          draft.tabs[0]!.widgets.push({
+            id: "cost-today",
+            kind: "builtin:markdown",
+            title: "Replacement",
+            grid: { x: 0, y: 0, w: 4, h: 2 },
+            collapsed: false,
+            hidden: false,
+            createdBy: "user",
+          });
+        },
+        { actor: "user" },
+      );
+      expect(store.readWidgetState("cost-today")).toBeNull();
+      expect(
+        store.writeWidgetState("cost-today", { text: "fresh" }, { expectedVersion: 0 }),
+      ).toEqual({
+        version: 1,
+      });
+    });
+  });
+
   it("seeds the default workspace on first read", async () => {
     await withStore((store) => {
       const doc = store.read();

--- a/extensions/workspaces/src/store.ts
+++ b/extensions/workspaces/src/store.ts
@@ -28,6 +28,7 @@ import { WidgetAssetTokens } from "./asset-tokens.js";
 import { DEFAULT_WORKSPACE } from "./default-workspace.js";
 import {
   validateWorkspaceDoc,
+  type JsonValue,
   type WorkspaceActor,
   type WorkspaceWidgetRegistryEntry,
   type WorkspaceDoc,
@@ -35,12 +36,21 @@ import {
 
 type WorkspaceMutationOptions = { actor: WorkspaceActor };
 type WorkspaceMutationResult = { doc: WorkspaceDoc; changed: boolean };
+type WidgetStateRecord = {
+  state: JsonValue;
+  version: number;
+  updatedAt: string;
+};
+type WidgetStateWriteOptions = { expectedVersion?: number };
+type WidgetStateWriteResult = { version: number };
 
 const MAX_WORKSPACE_BYTES = 256 * 1024;
+const MAX_WIDGET_STATE_BYTES = 64 * 1024;
 const UNDO_RING_SIZE = 20;
 const DIR_MODE = 0o700;
 const FILE_MODE = 0o600;
 const BUSY_TIMEOUT_MS = 5000;
+const WIDGET_ID_PATTERN = /^[A-Za-z0-9_-]{1,48}$/;
 
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS workspace (
@@ -54,6 +64,13 @@ CREATE TABLE IF NOT EXISTS undo (
   doc TEXT NOT NULL,
   created_ms INTEGER NOT NULL
 );
+CREATE TABLE IF NOT EXISTS widget_state (
+  widget_id TEXT PRIMARY KEY,
+  widget_kind TEXT NOT NULL,
+  version INTEGER NOT NULL CHECK (version >= 1),
+  state TEXT NOT NULL,
+  updated_ms INTEGER NOT NULL
+);
 `;
 
 function serializeWorkspaceDoc(doc: WorkspaceDoc): string {
@@ -64,6 +81,66 @@ function assertWorkspaceSize(serialized: string): void {
   if (Buffer.byteLength(serialized, "utf8") > MAX_WORKSPACE_BYTES) {
     throw new Error("workspace document exceeds 256 KB");
   }
+}
+
+function assertWidgetId(widgetId: string): void {
+  if (!WIDGET_ID_PATTERN.test(widgetId)) {
+    throw new Error("widget id is invalid");
+  }
+}
+
+function assertJsonValue(value: unknown, seen = new Set<object>()): asserts value is JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
+  ) {
+    return;
+  }
+  if (typeof value !== "object") {
+    throw new Error("widget state must be valid JSON");
+  }
+  if (seen.has(value)) {
+    throw new Error("widget state must be valid JSON");
+  }
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        assertJsonValue(entry, seen);
+      }
+      return;
+    }
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error("widget state must be valid JSON");
+    }
+    for (const entry of Object.values(value as Record<string, unknown>)) {
+      assertJsonValue(entry, seen);
+    }
+  } finally {
+    seen.delete(value);
+  }
+}
+
+function serializeWidgetState(value: unknown): string {
+  assertJsonValue(value);
+  const serialized = JSON.stringify(value);
+  if (Buffer.byteLength(serialized, "utf8") > MAX_WIDGET_STATE_BYTES) {
+    throw new Error("widget state exceeds 64 KB");
+  }
+  return serialized;
+}
+
+function widgetKind(doc: WorkspaceDoc, widgetId: string): string | null {
+  for (const tab of doc.tabs) {
+    const widget = tab.widgets.find((entry) => entry.id === widgetId);
+    if (widget) {
+      return widget.kind;
+    }
+  }
+  return null;
 }
 
 /**
@@ -169,6 +246,78 @@ export class WorkspaceStore {
     return this.widgetEntry(name)?.status ?? null;
   }
 
+  /** Reads one widget's opaque state blob without mixing it into the workspace document. */
+  readWidgetState(widgetId: string): WidgetStateRecord | null {
+    assertWidgetId(widgetId);
+    const row = this.db
+      .prepare("SELECT version, state, updated_ms FROM widget_state WHERE widget_id = ?")
+      .get(widgetId) as { version: number; state: string; updated_ms: number } | undefined;
+    if (!row) {
+      return null;
+    }
+    const state: unknown = JSON.parse(row.state);
+    assertJsonValue(state);
+    return {
+      state,
+      version: row.version,
+      updatedAt: new Date(row.updated_ms).toISOString(),
+    };
+  }
+
+  /**
+   * Atomically writes one widget's state. `expectedVersion: 0` means the widget
+   * has never written state; omitting it preserves last-write-wins behavior.
+   */
+  writeWidgetState(
+    widgetId: string,
+    state: JsonValue,
+    options: WidgetStateWriteOptions = {},
+  ): WidgetStateWriteResult {
+    assertWidgetId(widgetId);
+    if (
+      options.expectedVersion !== undefined &&
+      (!Number.isInteger(options.expectedVersion) || options.expectedVersion < 0)
+    ) {
+      throw new Error("expectedVersion must be a non-negative integer");
+    }
+    const serialized = serializeWidgetState(state);
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      // Bind persistence to the current widget identity inside the same write
+      // transaction. Arbitrary IDs cannot create orphan rows, and a removed or
+      // replaced widget cannot inherit another widget's opaque state.
+      this.cached = null;
+      const kind = widgetKind(this.read(), widgetId);
+      if (kind === null) {
+        throw new Error(`workspace widget not found: ${widgetId}`);
+      }
+      const previous = this.db
+        .prepare("SELECT version, widget_kind FROM widget_state WHERE widget_id = ?")
+        .get(widgetId) as { version: number; widget_kind: string } | undefined;
+      if (previous && previous.widget_kind !== kind) {
+        this.db.prepare("DELETE FROM widget_state WHERE widget_id = ?").run(widgetId);
+      }
+      const currentVersion = previous?.widget_kind === kind ? previous.version : 0;
+      if (options.expectedVersion !== undefined && options.expectedVersion !== currentVersion) {
+        throw new Error(
+          `widget state version conflict: expected ${options.expectedVersion}, found ${currentVersion}`,
+        );
+      }
+      const version = currentVersion + 1;
+      this.db
+        .prepare(
+          "INSERT INTO widget_state (widget_id, widget_kind, version, state, updated_ms) VALUES (?, ?, ?, ?, ?) " +
+            "ON CONFLICT(widget_id) DO UPDATE SET widget_kind = excluded.widget_kind, version = excluded.version, state = excluded.state, updated_ms = excluded.updated_ms",
+        )
+        .run(widgetId, kind, version, serialized, Date.now());
+      this.db.exec("COMMIT");
+      return { version };
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
   /**
    * Applies `fn` to a draft of the current document and persists the result.
    * `fn` must be synchronous: it runs inside the write transaction, which is what
@@ -244,6 +393,21 @@ export class WorkspaceStore {
         ...derive(current),
         workspaceVersion: current.workspaceVersion + 1,
       });
+      const nextKinds = new Map(
+        next.tabs.flatMap((tab) => tab.widgets.map((widget) => [widget.id, widget.kind] as const)),
+      );
+      const stateRows = this.db
+        .prepare("SELECT widget_id, widget_kind FROM widget_state")
+        .all() as Array<{
+        widget_id: string;
+        widget_kind: string;
+      }>;
+      const deleteState = this.db.prepare("DELETE FROM widget_state WHERE widget_id = ?");
+      for (const row of stateRows) {
+        if (nextKinds.get(row.widget_id) !== row.widget_kind) {
+          deleteState.run(row.widget_id);
+        }
+      }
       this.commit(next, { snapshot: options.snapshot === false ? null : current });
       this.db.exec("COMMIT");
       return { doc: next, changed: true };

--- a/ui/src/components/workspace-custom-widget.test.ts
+++ b/ui/src/components/workspace-custom-widget.test.ts
@@ -70,7 +70,7 @@ describe("loadWidgetManifestView", () => {
       manifest: {
         entrypoint: "index.html",
         bindings: [{ id: "value", source: "static", value: 1 }],
-        capabilities: ["data:read", "prompt:send"],
+        capabilities: ["data:read", "prompt:send", "state:persist"],
       },
     }));
     const view = await loadWidgetManifestView({ request } as never, "revenue-chart");
@@ -80,7 +80,7 @@ describe("loadWidgetManifestView", () => {
       frameExpiresAt: FRAME_EXPIRES_AT,
       entrypoint: "index.html",
       bindings: { value: { source: "static", value: 1 } },
-      capabilities: ["data:read", "prompt:send"],
+      capabilities: ["data:read", "prompt:send", "state:persist"],
     });
   });
 
@@ -168,6 +168,48 @@ function connectWidgetBridge(params: {
 }
 
 describe("attachWidgetBridge document-bound channel", () => {
+  it("binds state RPCs to the host widget id, never a child-provided id", async () => {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ state: { text: "old" }, version: 2 })
+      .mockResolvedValueOnce({ widgetId: "w_custom", version: 3 });
+    const { childPort, detach, posts } = connectWidgetBridge({
+      iframe,
+      manifest: manifest({ capabilities: ["state:persist"] }),
+      context: host({ client: { request } as never }),
+    });
+
+    childPort.postMessage(
+      { v: 1, type: "workspace:getState", requestId: "g1", widgetId: "other" },
+      [],
+    );
+    await vi.waitFor(() => expect(posts).toHaveLength(1));
+    childPort.postMessage(
+      {
+        v: 1,
+        type: "workspace:setState",
+        requestId: "s1",
+        widgetId: "other",
+        state: { text: "new" },
+        expectedVersion: 2,
+      },
+      [],
+    );
+    await vi.waitFor(() => expect(posts).toHaveLength(2));
+
+    expect(request).toHaveBeenNthCalledWith(1, "workspaces.widget.state.get", {
+      widgetId: "w_custom",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "workspaces.widget.state.set", {
+      widgetId: "w_custom",
+      state: { text: "new" },
+      expectedVersion: 2,
+    });
+    detach();
+  });
+
   it("drops a foreign bootstrap and accepts the iframe's token-bound port", async () => {
     const iframe = document.createElement("iframe");
     const foreign = document.createElement("iframe");

--- a/ui/src/components/workspace-custom-widget.ts
+++ b/ui/src/components/workspace-custom-widget.ts
@@ -160,7 +160,8 @@ export async function loadWidgetManifestView(
       bindings[parsedBinding.id] = parsedBinding.binding;
     }
     const capabilities = (Array.isArray(record.capabilities) ? record.capabilities : []).filter(
-      (cap): cap is WorkspaceWidgetCapability => cap === "data:read" || cap === "prompt:send",
+      (cap): cap is WorkspaceWidgetCapability =>
+        cap === "data:read" || cap === "prompt:send" || cap === "state:persist",
     );
     // The approval gate hashes the manifest's declared entrypoint. Loading a
     // different file would mount code the operator never approved.
@@ -236,6 +237,39 @@ export function attachWidgetBridge(params: {
           deliver: false,
           idempotencyKey: generateUUID(),
         });
+      },
+      getWidgetState: async () => {
+        if (!context.client) {
+          throw new Error("Not connected.");
+        }
+        const payload = (await context.client.request("workspaces.widget.state.get", {
+          widgetId: widget.id,
+        })) as { state?: unknown; version?: unknown } | null;
+        const version = payload?.version;
+        return {
+          state: payload?.state ?? null,
+          ...(typeof version === "number" && Number.isInteger(version) && version >= 0
+            ? { version }
+            : {}),
+        };
+      },
+      setWidgetState: async (state, expectedVersion) => {
+        if (!context.client) {
+          throw new Error("Not connected.");
+        }
+        const payload = (await context.client.request("workspaces.widget.state.set", {
+          widgetId: widget.id,
+          state,
+          ...(expectedVersion !== undefined ? { expectedVersion } : {}),
+        })) as { version?: unknown } | null;
+        if (
+          typeof payload?.version !== "number" ||
+          !Number.isInteger(payload.version) ||
+          payload.version < 1
+        ) {
+          throw new Error("Invalid widget state response.");
+        }
+        return { version: payload.version };
       },
     });
 

--- a/ui/src/lib/workspace/bridge.test.ts
+++ b/ui/src/lib/workspace/bridge.test.ts
@@ -148,6 +148,87 @@ describe("getTheme", () => {
   });
 });
 
+describe("widget state capability", () => {
+  it("denies state access before invoking host dependencies when capability is absent", async () => {
+    const getWidgetState = vi.fn(async () => ({ state: { secret: true }, version: 1 }));
+    const setWidgetState = vi.fn(async () => ({ version: 2 }));
+    const { bridge, posted } = makeBridge({ getWidgetState, setWidgetState });
+
+    bridge.handleMessage({ v: 1, type: "workspace:getState", requestId: "g1" });
+    bridge.handleMessage({
+      v: 1,
+      type: "workspace:setState",
+      requestId: "s1",
+      state: { text: "nope" },
+    });
+
+    await vi.waitFor(() => expect(posted).toHaveLength(2));
+    expect(posted).toEqual([
+      expect.objectContaining({
+        type: "workspace:error",
+        code: "capability_denied",
+        requestId: "g1",
+      }),
+      expect.objectContaining({
+        type: "workspace:error",
+        code: "capability_denied",
+        requestId: "s1",
+      }),
+    ]);
+    expect(getWidgetState).not.toHaveBeenCalled();
+    expect(setWidgetState).not.toHaveBeenCalled();
+  });
+
+  it("gets and sets state while forwarding an optional expectedVersion", async () => {
+    const getWidgetState = vi.fn(async () => ({ state: { text: "old" }, version: 3 }));
+    const setWidgetState = vi.fn(async (_state: unknown, _expectedVersion?: number) => ({
+      version: 4,
+    }));
+    const { bridge, posted } = makeBridge({
+      manifest: manifest({ capabilities: ["state:persist"] }),
+      getWidgetState,
+      setWidgetState,
+    });
+
+    bridge.handleMessage({ v: 1, type: "workspace:getState", requestId: "g1" });
+    bridge.handleMessage({
+      v: 1,
+      type: "workspace:setState",
+      requestId: "s1",
+      state: { text: "new" },
+      expectedVersion: 3,
+      widgetId: "ignored-child-id",
+    });
+
+    await vi.waitFor(() => expect(posted).toHaveLength(2));
+    expect(getWidgetState).toHaveBeenCalledOnce();
+    expect(setWidgetState).toHaveBeenCalledWith({ text: "new" }, 3);
+    expect(posted).toEqual([
+      { v: 1, type: "workspace:state", requestId: "g1", state: { text: "old" }, version: 3 },
+      { v: 1, type: "workspace:state", requestId: "s1", state: { text: "new" }, version: 4 },
+    ]);
+  });
+
+  it("drops malformed expectedVersion without invoking the state writer", () => {
+    const setWidgetState = vi.fn(async () => ({ version: 1 }));
+    const { bridge } = makeBridge({
+      manifest: manifest({ capabilities: ["state:persist"] }),
+      setWidgetState,
+    });
+
+    expect(
+      bridge.handleMessage({
+        v: 1,
+        type: "workspace:setState",
+        requestId: "s1",
+        state: {},
+        expectedVersion: -1,
+      }),
+    ).toBe(false);
+    expect(setWidgetState).not.toHaveBeenCalled();
+  });
+});
+
 describe("sendPrompt capability + confirm + rate limit", () => {
   it("denies without a dialog when the capability is absent", async () => {
     const confirmPrompt = vi.fn(async () => true);

--- a/ui/src/lib/workspace/bridge.ts
+++ b/ui/src/lib/workspace/bridge.ts
@@ -26,7 +26,9 @@ export type WidgetInboundType =
   | "workspace:ready"
   | "workspace:getData"
   | "workspace:getTheme"
-  | "workspace:sendPrompt";
+  | "workspace:sendPrompt"
+  | "workspace:getState"
+  | "workspace:setState";
 
 export type WidgetErrorCode =
   | "binding_denied"
@@ -41,6 +43,7 @@ export type WidgetOutboundMessage =
   | { v: 1; type: "workspace:data"; requestId: string; bindingId: string; data: unknown }
   | { v: 1; type: "workspace:push"; bindingId: string; data: unknown }
   | { v: 1; type: "workspace:theme"; requestId: string; tokens: Record<string, string> }
+  | { v: 1; type: "workspace:state"; requestId: string; state: unknown; version?: number }
   | { v: 1; type: "workspace:error"; requestId?: string; code: WidgetErrorCode; message: string };
 
 /** Injected side effects — real implementations live in the browser host. */
@@ -60,6 +63,10 @@ export type WidgetBridgeDeps = {
   confirmPrompt: (text: string) => Promise<boolean>;
   /** Dispatch the prompt through the existing chat-send path. */
   sendPrompt: (text: string) => Promise<void>;
+  /** Read state for the parent-bound widget identity. */
+  getWidgetState?: () => Promise<{ state: unknown; version?: number }>;
+  /** Write state for the parent-bound widget identity. */
+  setWidgetState?: (state: unknown, expectedVersion?: number) => Promise<{ version: number }>;
   /** Post a message to the child (host wires targetOrigin "*"). */
   post: (message: WidgetOutboundMessage) => void;
   /** getData answer deadline; posts a timeout error if the resolver overruns. Default 10s. */
@@ -113,6 +120,8 @@ const INBOUND_TYPES = new Set<WidgetInboundType>([
   "workspace:getData",
   "workspace:getTheme",
   "workspace:sendPrompt",
+  "workspace:getState",
+  "workspace:setState",
 ]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -245,6 +254,50 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
     }
   }
 
+  async function handleGetState(requestId: string): Promise<void> {
+    if (!capabilities.has("state:persist") || !deps.getWidgetState) {
+      error("capability_denied", "widget lacks the state:persist capability", requestId);
+      return;
+    }
+    try {
+      const result = await deps.getWidgetState();
+      if (!disposed) {
+        deps.post({
+          v: 1,
+          type: "workspace:state",
+          requestId,
+          state: result.state,
+          ...(result.version !== undefined ? { version: result.version } : {}),
+        });
+      }
+    } catch (err) {
+      if (!disposed) {
+        error("resolve_failed", err instanceof Error ? err.message : String(err), requestId);
+      }
+    }
+  }
+
+  async function handleSetState(
+    requestId: string,
+    state: unknown,
+    expectedVersion?: number,
+  ): Promise<void> {
+    if (!capabilities.has("state:persist") || !deps.setWidgetState) {
+      error("capability_denied", "widget lacks the state:persist capability", requestId);
+      return;
+    }
+    try {
+      const { version } = await deps.setWidgetState(state, expectedVersion);
+      if (!disposed) {
+        deps.post({ v: 1, type: "workspace:state", requestId, state, version });
+      }
+    } catch (err) {
+      if (!disposed) {
+        error("resolve_failed", err instanceof Error ? err.message : String(err), requestId);
+      }
+    }
+  }
+
   function handleMessage(data: unknown): boolean {
     if (disposed) {
       return false;
@@ -283,6 +336,38 @@ export function createWidgetBridge(deps: WidgetBridgeDeps): WidgetBridge {
           return false;
         }
         void handleSendPrompt(requestId, text);
+        return true;
+      }
+      case "workspace:getState": {
+        const requestId = typeof data.requestId === "string" ? data.requestId : null;
+        if (requestId === null) {
+          dropped += 1;
+          return false;
+        }
+        void handleGetState(requestId);
+        return true;
+      }
+      case "workspace:setState": {
+        const requestId = typeof data.requestId === "string" ? data.requestId : null;
+        const hasState = Object.hasOwn(data, "state");
+        const hasExpectedVersion = Object.hasOwn(data, "expectedVersion");
+        const expectedVersion = data.expectedVersion;
+        if (
+          requestId === null ||
+          !hasState ||
+          (hasExpectedVersion &&
+            (typeof expectedVersion !== "number" ||
+              !Number.isInteger(expectedVersion) ||
+              expectedVersion < 0))
+        ) {
+          dropped += 1;
+          return false;
+        }
+        void handleSetState(
+          requestId,
+          data.state,
+          hasExpectedVersion ? (expectedVersion as number) : undefined,
+        );
         return true;
       }
       default:

--- a/ui/src/lib/workspace/types.ts
+++ b/ui/src/lib/workspace/types.ts
@@ -80,7 +80,7 @@ export type WorkspaceDocument = {
 };
 
 /** Capability names a custom widget may hold (00 §2). */
-export type WorkspaceWidgetCapability = "data:read" | "prompt:send";
+export type WorkspaceWidgetCapability = "data:read" | "prompt:send" | "state:persist";
 
 /**
  * The subset of a custom widget's `widget.json` manifest the parent bridge needs


### PR DESCRIPTION
## What Problem This Solves

Approved custom widgets had no safe way to persist their own small UI state. The old #101329 implementation used per-widget JSON files and was built on the pre-#104139 Dashboard stack, so it no longer matched OpenClaw's Workspaces or SQLite storage rules.

## Why This Change Was Made

This rebuild adds a `state:persist` manifest capability, document-bound bridge messages, and read/write gateway methods backed by the existing plugin-owned Workspaces SQLite database. The trusted parent supplies the rendered widget ID; iframe input cannot select another widget's state.

Writes are strict-JSON validated, capped at 64 KiB, serialized through `BEGIN IMMEDIATE`, and optionally guarded by `expectedVersion`. Empty reads return version `0`, so first creation participates in optimistic concurrency. State rows are tied to widget ID plus kind and are deleted transactionally when a widget is removed or replaced, preventing stale-state inheritance and unbounded orphan growth.

## User Impact

- Approved widgets can read and persist small JSON state without gateway credentials or direct storage access.
- Concurrent editors can reject stale writes instead of silently overwriting newer state.
- Deleted or replaced widgets cannot inherit another widget's persisted data.
- State remains separate from the workspace document and does not consume its 256 KiB limit.

## Evidence

- Rebased onto upstream main at `843e3c787806389cdaac884300e671fba658dab6` during the final recovery pass; the feature commit range-diffs identically and preserves current main's private capability/store helpers while adding `state:persist`.
- Final-head focused Vitest: 47 extension + 43 UI tests passed across SQLite store, gateway RPCs, manifest validation, bridge gating, and iframe-host identity binding.
- Final-head extension/UI/UI-test TypeScript checks, scoped formatting, scoped oxlint, and `git diff --check` passed.
- Independent adversarial review: clean at least 95% confidence.
- Repository autoreview found missing version-0 and lifecycle cleanup, both were fixed transactionally; the final rerun was clean with no accepted/actionable findings.

Closes #101146.
