### PR TITLE
test(gateway): isolate reload handler plugin records

### DIFF
--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -159,6 +159,11 @@ vi.mock("../agents/agent-bundle-mcp-tools.js", () => ({
   disposeAllSessionMcpRuntimes: hoisted.disposeAllSessionMcpRuntimes,
 }));
 
+vi.mock("../plugins/installed-plugin-index-records.js", () => ({
+  loadInstalledPluginIndexInstallRecords: vi.fn(async () => ({})),
+  loadInstalledPluginIndexInstallRecordsSync: vi.fn(() => ({})),
+}));
+
 vi.mock("./server-cron.js", async () => {
   const actual = await vi.importActual<typeof import("./server-cron.js")>("./server-cron.js");
   return {


### PR DESCRIPTION
## Summary

`server-reload-handlers.test.ts` creates the managed config reloader inside a fake-timer test and then calls `vi.runAllTimersAsync()` to drain the zero-debounce config reload. In cross-file `--isolate=false` runs with `server-startup-post-attach.test.ts`, the startup tests close the shared state DB before this test runs, so the managed reloader's default installed-plugin record read reopens the DB while fake timers are active.

That DB open schedules SQLite WAL maintenance at `src/infra/sqlite-wal.ts:345` with `setInterval(1800000)`. `vi.runAllTimersAsync()` then drains that unrelated interval forever until Vitest aborts after 10000 timers. The fix mocks installed plugin index reads in `server-reload-handlers.test.ts`, keeping this reload-handler test focused on its config debounce timer and leaving installed-plugin record diff behavior to `config-reload.test.ts`.

## Verification

- `node scripts/run-vitest.mjs src/gateway/server-reload-handlers.test.ts src/gateway/server-startup-post-attach.test.ts` repeated 10 times locally: 10/10 passed.
- `node scripts/run-vitest.mjs src/gateway/server-reload-handlers.test.ts`: passed.
- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts`: passed.
- `node scripts/run-vitest.mjs src/gateway/server-reload-handlers.hot-reload-status.test.ts`: passed.
- Testbox `tbx_01kwxa0dy5njqj3zt6jzmhav9m`: `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm tsgo`: passed.
- Testbox `tbx_01kwxa0dy5njqj3zt6jzmhav9m`: `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:test-types`: passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings.
