### PR TITLE
fix(gateway): require shared secret for tailscale serve auth

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -535,6 +535,7 @@ See [Inferred commitments](/concepts/commitments).
       // password: "your-password", // or OPENCLAW_GATEWAY_PASSWORD
       // trustedProxy: { userHeader: "x-forwarded-user" }, // for mode=trusted-proxy; see /gateway/trusted-proxy-auth
       allowTailscale: true,
+      requireTailscaleSharedSecret: false,
       rateLimit: {
         maxAttempts: 10,
         windowMs: 60000,
@@ -616,6 +617,7 @@ See [Inferred commitments](/concepts/commitments).
 - `gateway.auth.mode: "none"`: explicit no-auth mode. Use only for trusted local loopback setups; this is intentionally not offered by onboarding prompts.
 - `gateway.auth.mode: "trusted-proxy"`: delegate browser/user auth to an identity-aware reverse proxy and trust identity headers from `gateway.trustedProxies` (see [Trusted Proxy Auth](/gateway/trusted-proxy-auth)). This mode expects a **non-loopback** proxy source by default; same-host loopback reverse proxies require explicit `gateway.auth.trustedProxy.allowLoopback = true`. Internal same-host callers can use `gateway.auth.password` as a local direct fallback; `gateway.auth.token` remains mutually exclusive with trusted-proxy mode.
 - `gateway.auth.allowTailscale`: when `true`, Tailscale Serve identity headers can satisfy Control UI/WebSocket auth (verified via `tailscale whois`). HTTP API endpoints do **not** use that Tailscale header auth; they follow the gateway's normal HTTP auth mode instead. This tokenless flow assumes the gateway host is trusted. Defaults to `true` when `tailscale.mode = "serve"`.
+- `gateway.auth.requireTailscaleSharedSecret`: when `true`, Tailscale Serve Control UI/WebSocket requests must pass both verified Tailscale identity and the configured `token` or `password` auth mode. Leave unset or `false` to keep Tailscale identity as the Control UI/WebSocket auth layer.
 - `gateway.auth.rateLimit`: optional failed-auth limiter. Applies per client IP and per auth scope (shared-secret and device-token are tracked independently). Blocked attempts return `429` + `Retry-After`.
   - On the async Tailscale Serve Control UI path, failed attempts for the same `{scope, clientIp}` are serialized before the failure write. Concurrent bad attempts from the same client can therefore trip the limiter on the second request instead of both racing through as plain mismatches.
   - `gateway.auth.rateLimit.exemptLoopback` defaults to `true`; set `false` when you intentionally want localhost traffic rate-limited too (for test setups or strict proxy deployments).

--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -108,6 +108,23 @@ When `tailscale.mode: "serve"` and `gateway.auth.allowTailscale` is `true`, Cont
 
 This tokenless flow assumes the gateway host is trusted. If untrusted local code may run on the same host, set `gateway.auth.allowTailscale: false` and require token/password auth instead.
 
+To require both Tailscale identity and a Gateway shared secret for Control UI/WebSocket access, keep `allowTailscale: true` and set `requireTailscaleSharedSecret: true` with `auth.mode: "token"` or `"password"`:
+
+```json5
+{
+  gateway: {
+    bind: "loopback",
+    tailscale: { mode: "serve" },
+    auth: {
+      mode: "password",
+      password: "replace-me",
+      allowTailscale: true,
+      requireTailscaleSharedSecret: true,
+    },
+  },
+}
+```
+
 Scope of the bypass:
 
 - Applies only to the Control UI WebSocket auth surface. HTTP API endpoints (`/v1/*`, `/tools/invoke`, `/api/channels/*`, etc.) never use Tailscale identity-header auth; they always follow the gateway's normal HTTP auth mode.

--- a/src/config/config.gateway-tailscale-bind.test.ts
+++ b/src/config/config.gateway-tailscale-bind.test.ts
@@ -3,6 +3,49 @@ import { describe, expect, it } from "vitest";
 import { validateConfigObject } from "./validation.js";
 
 describe("gateway tailscale bind validation", () => {
+  it.each(["none", "trusted-proxy"] as const)(
+    "rejects requireTailscaleSharedSecret with %s auth mode",
+    (mode) => {
+      const res = validateConfigObject({
+        gateway: {
+          auth: {
+            mode,
+            requireTailscaleSharedSecret: true,
+            ...(mode === "trusted-proxy"
+              ? { trustedProxy: { userHeader: "x-forwarded-user" } }
+              : {}),
+          },
+        },
+      });
+
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.issues).toContainEqual({
+          path: "gateway.auth.mode",
+          message:
+            "gateway.auth.requireTailscaleSharedSecret=true requires gateway.auth.mode=token or password",
+        });
+      }
+    },
+  );
+
+  it.each(["token", "password"] as const)(
+    "accepts requireTailscaleSharedSecret with %s auth mode",
+    (mode) => {
+      const res = validateConfigObject({
+        gateway: {
+          auth: {
+            mode,
+            requireTailscaleSharedSecret: true,
+            ...(mode === "token" ? { token: "secret" } : { password: "secret" }),
+          },
+        },
+      });
+
+      expect(res.ok).toBe(true);
+    },
+  );
+
   it("accepts loopback bind when tailscale serve/funnel is enabled", () => {
     const serveRes = validateConfigObject({
       gateway: {

--- a/src/config/schema.gateway-auth.ts
+++ b/src/config/schema.gateway-auth.ts
@@ -1,0 +1,23 @@
+export const GATEWAY_AUTH_FIELD_HELP: Record<string, string> = {
+  "gateway.auth":
+    "Authentication policy for gateway HTTP/WebSocket access including mode, credentials, trusted-proxy behavior, and rate limiting. Keep auth enabled for every non-loopback deployment.",
+  "gateway.auth.mode":
+    'Gateway auth mode: "none", "token", "password", or "trusted-proxy" depending on your edge architecture. Use token/password for direct exposure, and trusted-proxy only behind hardened identity-aware proxies.',
+  "gateway.auth.allowTailscale":
+    "Allows trusted Tailscale identity paths to satisfy gateway auth checks when configured. Use this only when your tailnet identity posture is strong and operator workflows depend on it.",
+  "gateway.auth.requireTailscaleSharedSecret":
+    "Requires Tailscale Serve Control UI/WebSocket requests to pass both verified Tailscale identity and the configured token/password. Enable when tailnet membership is not enough by itself.",
+  "gateway.auth.rateLimit":
+    "Login/auth attempt throttling controls to reduce credential brute-force risk at the gateway boundary. Keep enabled in exposed environments and tune thresholds to your traffic baseline.",
+  "gateway.auth.trustedProxy":
+    "Trusted-proxy auth header mapping for upstream identity providers that inject user claims. Use only with known proxy CIDRs and strict header allowlists to prevent spoofed identity headers.",
+};
+
+export const GATEWAY_AUTH_FIELD_LABELS: Record<string, string> = {
+  "gateway.auth": "Gateway Auth",
+  "gateway.auth.mode": "Gateway Auth Mode",
+  "gateway.auth.allowTailscale": "Gateway Auth Allow Tailscale Identity",
+  "gateway.auth.requireTailscaleSharedSecret": "Gateway Auth Require Tailscale Shared Secret",
+  "gateway.auth.rateLimit": "Gateway Auth Rate Limit",
+  "gateway.auth.trustedProxy": "Gateway Trusted Proxy Auth",
+};

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1,5 +1,6 @@
 // Defines user-facing config field help text for docs and UI surfaces.
 import { MEDIA_AUDIO_FIELD_HELP } from "./media-audio-field-metadata.js";
+import { GATEWAY_AUTH_FIELD_HELP } from "./schema.gateway-auth.js";
 import { NODE_CAPABILITY_FIELD_HELP } from "./schema.node-capabilities.js";
 import { describeTalkSilenceTimeoutDefaults } from "./talk-defaults.js";
 export const FIELD_HELP: Record<string, string> = {
@@ -143,16 +144,7 @@ export const FIELD_HELP: Record<string, string> = {
     "Shell executable the operator terminal launches. Leave unset to use the host login shell ($SHELL on Unix, %ComSpec% on Windows), or pin an explicit interpreter for a consistent operator environment.",
   "gateway.terminal.detachedSessionTimeoutSeconds":
     "Seconds a terminal session survives after its connection drops (laptop sleep, page reload), staying reattachable via terminal.attach with its recent output replayed. Set 0 to kill sessions the moment the connection drops. Default: 300 (5 minutes). Detached sessions keep running their commands, so shorten this on shared or exposed hosts.",
-  "gateway.auth":
-    "Authentication policy for gateway HTTP/WebSocket access including mode, credentials, trusted-proxy behavior, and rate limiting. Keep auth enabled for every non-loopback deployment.",
-  "gateway.auth.mode":
-    'Gateway auth mode: "none", "token", "password", or "trusted-proxy" depending on your edge architecture. Use token/password for direct exposure, and trusted-proxy only behind hardened identity-aware proxies.',
-  "gateway.auth.allowTailscale":
-    "Allows trusted Tailscale identity paths to satisfy gateway auth checks when configured. Use this only when your tailnet identity posture is strong and operator workflows depend on it.",
-  "gateway.auth.rateLimit":
-    "Login/auth attempt throttling controls to reduce credential brute-force risk at the gateway boundary. Keep enabled in exposed environments and tune thresholds to your traffic baseline.",
-  "gateway.auth.trustedProxy":
-    "Trusted-proxy auth header mapping for upstream identity providers that inject user claims. Use only with known proxy CIDRs and strict header allowlists to prevent spoofed identity headers.",
+  ...GATEWAY_AUTH_FIELD_HELP,
   "gateway.trustedProxies":
     "CIDR/IP allowlist of upstream proxies permitted to provide forwarded client identity headers. Keep this list narrow so untrusted hops cannot impersonate users.",
   "gateway.allowRealIpFallback":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -1,5 +1,6 @@
 // Defines user-facing config field labels used by schema metadata.
 import { MEDIA_AUDIO_FIELD_LABELS } from "./media-audio-field-metadata.js";
+import { GATEWAY_AUTH_FIELD_LABELS } from "./schema.gateway-auth.js";
 import { NODE_CAPABILITY_FIELD_LABELS } from "./schema.node-capabilities.js";
 
 export const FIELD_LABELS: Record<string, string> = {
@@ -147,11 +148,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.terminal.enabled": "Operator Terminal Enabled",
   "gateway.terminal.shell": "Operator Terminal Shell",
   "gateway.terminal.detachedSessionTimeoutSeconds": "Operator Terminal Detached Session Timeout",
-  "gateway.auth": "Gateway Auth",
-  "gateway.auth.mode": "Gateway Auth Mode",
-  "gateway.auth.allowTailscale": "Gateway Auth Allow Tailscale Identity",
-  "gateway.auth.rateLimit": "Gateway Auth Rate Limit",
-  "gateway.auth.trustedProxy": "Gateway Trusted Proxy Auth",
+  ...GATEWAY_AUTH_FIELD_LABELS,
   "gateway.trustedProxies": "Gateway Trusted Proxy CIDRs",
   "gateway.allowRealIpFallback": "Gateway Allow x-real-ip Fallback",
   "gateway.tools": "Gateway Tool Exposure Policy",

--- a/src/config/types.gateway-auth.ts
+++ b/src/config/types.gateway-auth.ts
@@ -1,0 +1,65 @@
+import type { SecretInput } from "./types.secrets.js";
+
+/** Gateway authentication strategy for WebSocket and HTTP clients. */
+export type GatewayAuthMode = "none" | "token" | "password" | "trusted-proxy";
+
+/**
+ * Configuration for trusted reverse proxy authentication.
+ * Used when Clawdbot runs behind an identity-aware proxy (Pomerium, Caddy + OAuth, etc.)
+ * that handles authentication and passes user identity via headers.
+ */
+export type GatewayTrustedProxyConfig = {
+  /**
+   * Header name containing the authenticated user identity (required).
+   * Common values: "x-forwarded-user", "x-remote-user", "x-pomerium-claim-email"
+   */
+  userHeader: string;
+  /**
+   * Additional headers that MUST be present for the request to be trusted.
+   * Use this to verify the request actually came through the proxy.
+   * Example: ["x-forwarded-proto", "x-forwarded-host"]
+   */
+  requiredHeaders?: string[];
+  /**
+   * Optional allowlist of user identities that can access the gateway.
+   * If empty or omitted, all authenticated users from the proxy are allowed.
+   * Example: ["nick@example.com", "admin@company.org"]
+   */
+  allowUsers?: string[];
+  /**
+   * Allow loopback proxy sources (127.0.0.1, ::1) in trusted-proxy mode.
+   * Default false; enable only when a same-host reverse proxy is the intended
+   * trust boundary and direct Gateway access is otherwise locked down.
+   */
+  allowLoopback?: boolean;
+};
+
+export type GatewayAuthConfig = {
+  /** Authentication mode for Gateway connections. Defaults to token when unset. */
+  mode?: GatewayAuthMode;
+  /** Shared token for token mode (plaintext or SecretRef). */
+  token?: SecretInput;
+  /** Shared password for password mode (consider env instead). */
+  password?: SecretInput;
+  /** Allow Tailscale identity headers when serve mode is enabled. */
+  allowTailscale?: boolean;
+  requireTailscaleSharedSecret?: boolean;
+  /** Rate-limit configuration for failed authentication attempts. */
+  rateLimit?: GatewayAuthRateLimitConfig;
+  /**
+   * Configuration for trusted-proxy auth mode.
+   * Required when mode is "trusted-proxy".
+   */
+  trustedProxy?: GatewayTrustedProxyConfig;
+};
+
+export type GatewayAuthRateLimitConfig = {
+  /** Maximum failed attempts per IP before blocking.  @default 10 */
+  maxAttempts?: number;
+  /** Sliding window duration in milliseconds.  @default 60000 (1 min) */
+  windowMs?: number;
+  /** Lockout duration in milliseconds after the limit is exceeded.  @default 300000 (5 min) */
+  lockoutMs?: number;
+  /** Exempt localhost/loopback addresses from auth rate limiting.  @default true */
+  exemptLoopback?: boolean;
+};

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -1,5 +1,13 @@
 // Defines gateway runtime and networking configuration types.
+import type { GatewayAuthConfig } from "./types.gateway-auth.js";
 import type { SecretInput } from "./types.secrets.js";
+
+export type {
+  GatewayAuthConfig,
+  GatewayAuthMode,
+  GatewayAuthRateLimitConfig,
+  GatewayTrustedProxyConfig,
+} from "./types.gateway-auth.js";
 
 /** Gateway bind-address policy for local server startup. */
 export type GatewayBindMode = "auto" | "lan" | "loopback" | "custom" | "tailnet";
@@ -166,69 +174,6 @@ export type GatewayControlUiConfig = {
   allowInsecureAuth?: boolean;
   /** DANGEROUS: Disable device identity checks for the Control UI (default: false). */
   dangerouslyDisableDeviceAuth?: boolean;
-};
-
-/** Gateway authentication strategy for WebSocket and HTTP clients. */
-export type GatewayAuthMode = "none" | "token" | "password" | "trusted-proxy";
-
-/**
- * Configuration for trusted reverse proxy authentication.
- * Used when Clawdbot runs behind an identity-aware proxy (Pomerium, Caddy + OAuth, etc.)
- * that handles authentication and passes user identity via headers.
- */
-export type GatewayTrustedProxyConfig = {
-  /**
-   * Header name containing the authenticated user identity (required).
-   * Common values: "x-forwarded-user", "x-remote-user", "x-pomerium-claim-email"
-   */
-  userHeader: string;
-  /**
-   * Additional headers that MUST be present for the request to be trusted.
-   * Use this to verify the request actually came through the proxy.
-   * Example: ["x-forwarded-proto", "x-forwarded-host"]
-   */
-  requiredHeaders?: string[];
-  /**
-   * Optional allowlist of user identities that can access the gateway.
-   * If empty or omitted, all authenticated users from the proxy are allowed.
-   * Example: ["nick@example.com", "admin@company.org"]
-   */
-  allowUsers?: string[];
-  /**
-   * Allow loopback proxy sources (127.0.0.1, ::1) in trusted-proxy mode.
-   * Default false; enable only when a same-host reverse proxy is the intended
-   * trust boundary and direct Gateway access is otherwise locked down.
-   */
-  allowLoopback?: boolean;
-};
-
-export type GatewayAuthConfig = {
-  /** Authentication mode for Gateway connections. Defaults to token when unset. */
-  mode?: GatewayAuthMode;
-  /** Shared token for token mode (plaintext or SecretRef). */
-  token?: SecretInput;
-  /** Shared password for password mode (consider env instead). */
-  password?: SecretInput;
-  /** Allow Tailscale identity headers when serve mode is enabled. */
-  allowTailscale?: boolean;
-  /** Rate-limit configuration for failed authentication attempts. */
-  rateLimit?: GatewayAuthRateLimitConfig;
-  /**
-   * Configuration for trusted-proxy auth mode.
-   * Required when mode is "trusted-proxy".
-   */
-  trustedProxy?: GatewayTrustedProxyConfig;
-};
-
-export type GatewayAuthRateLimitConfig = {
-  /** Maximum failed attempts per IP before blocking.  @default 10 */
-  maxAttempts?: number;
-  /** Sliding window duration in milliseconds.  @default 60000 (1 min) */
-  windowMs?: number;
-  /** Lockout duration in milliseconds after the limit is exceeded.  @default 300000 (5 min) */
-  lockoutMs?: number;
-  /** Exempt localhost/loopback addresses from auth rate limiting.  @default true */
-  exemptLoopback?: boolean;
 };
 
 /** Tailscale exposure mode for gateway HTTP/WebSocket surfaces. */

--- a/src/config/zod-schema.gateway-auth.ts
+++ b/src/config/zod-schema.gateway-auth.ts
@@ -36,4 +36,19 @@ export const GatewayAuthSchema = z
       .optional(),
   })
   .strict()
+  .superRefine((auth, ctx) => {
+    if (
+      auth.requireTailscaleSharedSecret === true &&
+      auth.mode !== undefined &&
+      auth.mode !== "token" &&
+      auth.mode !== "password"
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["mode"],
+        message:
+          "gateway.auth.requireTailscaleSharedSecret=true requires gateway.auth.mode=token or password",
+      });
+    }
+  })
   .optional();

--- a/src/config/zod-schema.gateway-auth.ts
+++ b/src/config/zod-schema.gateway-auth.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { SecretInputSchema } from "./zod-schema.core.js";
+import { sensitive } from "./zod-schema.sensitive.js";
+
+export const GatewayAuthSchema = z
+  .object({
+    mode: z
+      .union([
+        z.literal("none"),
+        z.literal("token"),
+        z.literal("password"),
+        z.literal("trusted-proxy"),
+      ])
+      .optional(),
+    token: SecretInputSchema.optional().register(sensitive),
+    password: SecretInputSchema.optional().register(sensitive),
+    allowTailscale: z.boolean().optional(),
+    requireTailscaleSharedSecret: z.boolean().optional(),
+    rateLimit: z
+      .object({
+        maxAttempts: z.number().optional(),
+        windowMs: z.number().optional(),
+        lockoutMs: z.number().optional(),
+        exemptLoopback: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    trustedProxy: z
+      .object({
+        userHeader: z.string().min(1, "userHeader is required for trusted-proxy mode"),
+        requiredHeaders: z.array(z.string()).optional(),
+        allowUsers: z.array(z.string()).optional(),
+        allowLoopback: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .optional();

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -25,6 +25,7 @@ import {
   SecretInputSchema,
   SecretsConfigSchema,
 } from "./zod-schema.core.js";
+import { GatewayAuthSchema } from "./zod-schema.gateway-auth.js";
 import { HookMappingSchema, HooksGmailSchema, InternalHooksSchema } from "./zod-schema.hooks.js";
 import { BrowserSnapshotDefaultsSchema, NodeHostAgentRunsSchema } from "./zod-schema.node-host.js";
 import { ProxyConfigSchema } from "./zod-schema.proxy.js";
@@ -642,7 +643,10 @@ export const OpenClawSchema = z
               .transform((n, ctx) => {
                 const d = new Date(n);
                 if (Number.isNaN(d.getTime())) {
-                  ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Invalid timestamp" });
+                  ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: "Invalid timestamp",
+                  });
                   return z.NEVER;
                 }
                 return d.toISOString();
@@ -1169,37 +1173,7 @@ export const OpenClawSchema = z
             detachedSessionTimeoutSeconds: z.number().int().min(0).optional(),
           })
           .optional(),
-        auth: z
-          .strictObject({
-            mode: z
-              .union([
-                z.literal("none"),
-                z.literal("token"),
-                z.literal("password"),
-                z.literal("trusted-proxy"),
-              ])
-              .optional(),
-            token: SecretInputSchema.optional().register(sensitive),
-            password: SecretInputSchema.optional().register(sensitive),
-            allowTailscale: z.boolean().optional(),
-            rateLimit: z
-              .strictObject({
-                maxAttempts: z.number().optional(),
-                windowMs: z.number().optional(),
-                lockoutMs: z.number().optional(),
-                exemptLoopback: z.boolean().optional(),
-              })
-              .optional(),
-            trustedProxy: z
-              .strictObject({
-                userHeader: z.string().min(1, "userHeader is required for trusted-proxy mode"),
-                requiredHeaders: z.array(z.string()).optional(),
-                allowUsers: z.array(z.string()).optional(),
-                allowLoopback: z.boolean().optional(),
-              })
-              .optional(),
-          })
-          .optional(),
+        auth: GatewayAuthSchema,
         trustedProxies: z.array(z.string()).optional(),
         allowRealIpFallback: z.boolean().optional(),
         tools: z

--- a/src/gateway/auth-resolve.ts
+++ b/src/gateway/auth-resolve.ts
@@ -21,6 +21,7 @@ export type ResolvedGatewayAuth = {
   token?: string;
   password?: string;
   allowTailscale: boolean;
+  requireTailscaleSharedSecret?: boolean;
   trustedProxy?: GatewayTrustedProxyConfig;
 };
 
@@ -55,6 +56,9 @@ export function resolveGatewayAuth(params: {
     }
     if (authOverride.allowTailscale !== undefined) {
       authConfig.allowTailscale = authOverride.allowTailscale;
+    }
+    if (authOverride.requireTailscaleSharedSecret !== undefined) {
+      authConfig.requireTailscaleSharedSecret = authOverride.requireTailscaleSharedSecret;
     }
     if (authOverride.rateLimit !== undefined) {
       authConfig.rateLimit = authOverride.rateLimit;
@@ -112,6 +116,7 @@ export function resolveGatewayAuth(params: {
     token,
     password,
     allowTailscale,
+    requireTailscaleSharedSecret: authConfig.requireTailscaleSharedSecret === true,
     trustedProxy,
   };
 }

--- a/src/gateway/auth-shared-secret.ts
+++ b/src/gateway/auth-shared-secret.ts
@@ -1,0 +1,103 @@
+import { safeEqualSecret } from "../security/secret-equal.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth-resolve.js";
+
+/** Normalized outcome for gateway shared-secret, Tailscale, device, and proxy auth. */
+export type GatewayAuthResult = {
+  ok: boolean;
+  method?:
+    | "none"
+    | "token"
+    | "password"
+    | "tailscale"
+    | "device-token"
+    | "bootstrap-token"
+    | "trusted-proxy";
+  user?: string;
+  reason?: string;
+  /** Present when the request was blocked by the rate limiter. */
+  rateLimited?: boolean;
+  /** Milliseconds the client should wait before retrying (when rate-limited). */
+  retryAfterMs?: number;
+};
+
+export type ConnectAuth = {
+  token?: string;
+  password?: string;
+};
+
+function authorizeTokenAuth(params: {
+  authToken?: string;
+  connectToken?: string;
+  limiter?: AuthRateLimiter;
+  ip?: string;
+  rateLimitScope: string;
+}): GatewayAuthResult {
+  if (!params.authToken) {
+    return { ok: false, reason: "token_missing_config" };
+  }
+  if (!params.connectToken) {
+    // Don't burn rate-limit slots for missing credentials — the client
+    // simply hasn't provided a token yet (e.g. bare browser open).
+    // Only actual *wrong* credentials should count as failures.
+    return { ok: false, reason: "token_missing" };
+  }
+  if (!safeEqualSecret(params.connectToken, params.authToken)) {
+    params.limiter?.recordFailure(params.ip, params.rateLimitScope);
+    return { ok: false, reason: "token_mismatch" };
+  }
+  params.limiter?.reset(params.ip, params.rateLimitScope);
+  return { ok: true, method: "token" };
+}
+
+export function authorizePasswordAuth(params: {
+  authPassword?: string;
+  connectPassword?: string;
+  limiter?: AuthRateLimiter;
+  ip?: string;
+  rateLimitScope: string;
+}): GatewayAuthResult {
+  if (!params.authPassword) {
+    return { ok: false, reason: "password_missing_config" };
+  }
+  if (!params.connectPassword) {
+    // Same as token_missing — don't penalize absent credentials.
+    return { ok: false, reason: "password_missing" };
+  }
+  if (!safeEqualSecret(params.connectPassword, params.authPassword)) {
+    params.limiter?.recordFailure(params.ip, params.rateLimitScope);
+    return { ok: false, reason: "password_mismatch" };
+  }
+  params.limiter?.reset(params.ip, params.rateLimitScope);
+  return { ok: true, method: "password" };
+}
+
+export function authorizeSharedSecretAuth(params: {
+  auth: ResolvedGatewayAuth;
+  connectAuth?: ConnectAuth | null;
+  limiter?: AuthRateLimiter;
+  ip?: string;
+  rateLimitScope: string;
+}): GatewayAuthResult {
+  const { auth, connectAuth, limiter, ip, rateLimitScope } = params;
+  if (auth.mode === "token") {
+    return authorizeTokenAuth({
+      authToken: auth.token,
+      connectToken: connectAuth?.token,
+      limiter,
+      ip,
+      rateLimitScope,
+    });
+  }
+  if (auth.mode === "password") {
+    return authorizePasswordAuth({
+      authPassword: auth.password,
+      connectPassword: connectAuth?.password,
+      limiter,
+      ip,
+      rateLimitScope,
+    });
+  }
+  limiter?.recordFailure(ip, rateLimitScope);
+  return { ok: false, reason: "tailscale_shared_secret_auth_unavailable" };
+}

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -471,6 +471,80 @@ describe("gateway auth", () => {
     expect(res.user).toBe("peter");
   });
 
+  it("requires shared token auth with tailscale identity when configured", async () => {
+    const missing = await authorizeWsControlUiGatewayConnect({
+      auth: {
+        mode: "token",
+        token: "secret",
+        allowTailscale: true,
+        requireTailscaleSharedSecret: true,
+      },
+      connectAuth: null,
+      tailscaleWhois: createTailscaleWhois(),
+      req: createTailscaleForwardedReq(),
+    });
+    expect(missing.ok).toBe(false);
+    expect(missing.reason).toBe("token_missing");
+
+    const accepted = await authorizeWsControlUiGatewayConnect({
+      auth: {
+        mode: "token",
+        token: "secret",
+        allowTailscale: true,
+        requireTailscaleSharedSecret: true,
+      },
+      connectAuth: { token: "secret" },
+      tailscaleWhois: createTailscaleWhois(),
+      req: createTailscaleForwardedReq(),
+    });
+    expect(accepted.ok).toBe(true);
+    expect(accepted.method).toBe("token");
+    expect(accepted.user).toBe("peter");
+  });
+
+  it("rejects shared token without tailscale identity when layered auth is configured", async () => {
+    const missingUser = await authorizeWsControlUiGatewayConnect({
+      auth: {
+        mode: "token",
+        token: "secret",
+        allowTailscale: true,
+        requireTailscaleSharedSecret: true,
+      },
+      connectAuth: { token: "secret" },
+      tailscaleWhois: createTailscaleWhois(),
+      req: {
+        socket: { remoteAddress: "127.0.0.1" },
+        headers: {
+          host: "gateway.local",
+          "x-forwarded-for": "100.64.0.1",
+          "x-forwarded-proto": "https",
+          "x-forwarded-host": "ai-hub.bone-egret.ts.net",
+        },
+      } as never,
+    });
+
+    expect(missingUser.ok).toBe(false);
+    expect(missingUser.reason).toBe("tailscale_user_missing");
+
+    const directRemote = await authorizeWsControlUiGatewayConnect({
+      auth: {
+        mode: "token",
+        token: "secret",
+        allowTailscale: true,
+        requireTailscaleSharedSecret: true,
+      },
+      connectAuth: { token: "secret" },
+      tailscaleWhois: createTailscaleWhois(),
+      req: {
+        socket: { remoteAddress: "203.0.113.10" },
+        headers: { host: "gateway.example.com" },
+      } as never,
+    });
+
+    expect(directRemote.ok).toBe(false);
+    expect(directRemote.reason).toBe("tailscale_user_missing");
+  });
+
   it("serializes async auth attempts per rate-limit key", async () => {
     const limiter = createAuthRateLimiter({
       maxAttempts: 1,
@@ -659,6 +733,24 @@ describe("gateway auth", () => {
     expect(() => assertGatewayAuthConfigured(auth, { mode: "password" })).toThrow(
       "gateway auth mode is password, but no password was configured",
     );
+  });
+
+  it("requires token config when tailscale shared-secret auth is configured", () => {
+    const auth = resolveGatewayAuth({
+      authConfig: {
+        mode: "token",
+        allowTailscale: true,
+        requireTailscaleSharedSecret: true,
+      },
+    });
+
+    expect(() =>
+      assertGatewayAuthConfigured(auth, {
+        mode: "token",
+        allowTailscale: true,
+        requireTailscaleSharedSecret: true,
+      }),
+    ).toThrow("gateway auth mode is token, but no token was configured");
   });
 });
 

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -752,6 +752,25 @@ describe("gateway auth", () => {
       }),
     ).toThrow("gateway auth mode is token, but no token was configured");
   });
+
+  it.each(["none", "trusted-proxy"] as const)(
+    "rejects requireTailscaleSharedSecret with %s auth mode",
+    (mode) => {
+      const auth = resolveGatewayAuth({
+        authConfig: {
+          mode,
+          requireTailscaleSharedSecret: true,
+          ...(mode === "trusted-proxy"
+            ? { trustedProxy: { userHeader: "x-forwarded-user" } }
+            : {}),
+        },
+      });
+
+      expect(() => assertGatewayAuthConfigured(auth)).toThrow(
+        "gateway.auth.requireTailscaleSharedSecret=true requires gateway.auth.mode=token or password",
+      );
+    },
+  );
 });
 
 describe("trusted-proxy auth", () => {

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -760,9 +760,7 @@ describe("gateway auth", () => {
         authConfig: {
           mode,
           requireTailscaleSharedSecret: true,
-          ...(mode === "trusted-proxy"
-            ? { trustedProxy: { userHeader: "x-forwarded-user" } }
-            : {}),
+          ...(mode === "trusted-proxy" ? { trustedProxy: { userHeader: "x-forwarded-user" } } : {}),
         },
       });
 

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -7,13 +7,18 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import type { GatewayAuthConfig, GatewayTrustedProxyConfig } from "../config/types.gateway.js";
 import { readTailscaleWhoisIdentity, type TailscaleWhoisIdentity } from "../infra/tailscale.js";
-import { safeEqualSecret } from "../security/secret-equal.js";
 import {
   AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
   type AuthRateLimiter,
   type RateLimitCheckResult,
 } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth-resolve.js";
+import {
+  authorizePasswordAuth,
+  authorizeSharedSecretAuth,
+  type ConnectAuth,
+  type GatewayAuthResult,
+} from "./auth-shared-secret.js";
 import {
   isLoopbackAddress,
   resolveLocalInterfaceAddressMatch,
@@ -28,33 +33,10 @@ export {
   resolveGatewayAuth,
   type ResolvedGatewayAuth,
 } from "./auth-resolve.js";
+export type { GatewayAuthResult } from "./auth-shared-secret.js";
 
 const LEGACY_OPENCLAW_ENV_NOTE =
   " Legacy CLAWDBOT_* and MOLTBOT_* environment variables are ignored; use OPENCLAW_* names.";
-
-/** Normalized outcome for gateway shared-secret, Tailscale, device, and proxy auth. */
-export type GatewayAuthResult = {
-  ok: boolean;
-  method?:
-    | "none"
-    | "token"
-    | "password"
-    | "tailscale"
-    | "device-token"
-    | "bootstrap-token"
-    | "trusted-proxy";
-  user?: string;
-  reason?: string;
-  /** Present when the request was blocked by the rate limiter. */
-  rateLimited?: boolean;
-  /** Milliseconds the client should wait before retrying (when rate-limited). */
-  retryAfterMs?: number;
-};
-
-type ConnectAuth = {
-  token?: string;
-  password?: string;
-};
 
 type GatewayAuthSurface = "http" | "ws-control-ui";
 
@@ -256,7 +238,7 @@ export function assertGatewayAuthConfigured(
   rawAuthConfig?: GatewayAuthConfig | null,
 ): void {
   if (auth.mode === "token" && !auth.token) {
-    if (auth.allowTailscale) {
+    if (auth.allowTailscale && auth.requireTailscaleSharedSecret !== true) {
       return;
     }
     throw new Error(
@@ -396,52 +378,6 @@ function authorizeTrustedProxyBrowserOrigin(params: {
   });
 }
 
-function authorizeTokenAuth(params: {
-  authToken?: string;
-  connectToken?: string;
-  limiter?: AuthRateLimiter;
-  ip?: string;
-  rateLimitScope: string;
-}): GatewayAuthResult {
-  if (!params.authToken) {
-    return { ok: false, reason: "token_missing_config" };
-  }
-  if (!params.connectToken) {
-    // Don't burn rate-limit slots for missing credentials — the client
-    // simply hasn't provided a token yet (e.g. bare browser open).
-    // Only actual *wrong* credentials should count as failures.
-    return { ok: false, reason: "token_missing" };
-  }
-  if (!safeEqualSecret(params.connectToken, params.authToken)) {
-    params.limiter?.recordFailure(params.ip, params.rateLimitScope);
-    return { ok: false, reason: "token_mismatch" };
-  }
-  params.limiter?.reset(params.ip, params.rateLimitScope);
-  return { ok: true, method: "token" };
-}
-
-function authorizePasswordAuth(params: {
-  authPassword?: string;
-  connectPassword?: string;
-  limiter?: AuthRateLimiter;
-  ip?: string;
-  rateLimitScope: string;
-}): GatewayAuthResult {
-  if (!params.authPassword) {
-    return { ok: false, reason: "password_missing_config" };
-  }
-  if (!params.connectPassword) {
-    // Same as token_missing — don't penalize absent credentials.
-    return { ok: false, reason: "password_missing" };
-  }
-  if (!safeEqualSecret(params.connectPassword, params.authPassword)) {
-    params.limiter?.recordFailure(params.ip, params.rateLimitScope);
-    return { ok: false, reason: "password_mismatch" };
-  }
-  params.limiter?.reset(params.ip, params.rateLimitScope);
-  return { ok: true, method: "password" };
-}
-
 function rejectIfRateLimited(params: {
   limiter?: AuthRateLimiter;
   ip?: string;
@@ -525,7 +461,11 @@ async function authorizeGatewayConnectCore(
       return { ok: true, method: "trusted-proxy", user: result.user };
     }
     if (localDirect && auth.password && connectAuth?.password) {
-      const rateLimitResult = rejectIfRateLimited({ limiter, ip, rateLimitScope });
+      const rateLimitResult = rejectIfRateLimited({
+        limiter,
+        ip,
+        rateLimitScope,
+      });
       if (rateLimitResult) {
         return rateLimitResult;
       }
@@ -558,12 +498,33 @@ async function authorizeGatewayConnectCore(
     return rateLimitResult;
   }
 
-  if (
-    allowTailscaleHeaderAuth &&
-    auth.allowTailscale &&
-    !localDirect &&
-    !hasExplicitSharedSecretAuth(connectAuth)
-  ) {
+  const canUseTailscaleHeaderAuth = allowTailscaleHeaderAuth && auth.allowTailscale && !localDirect;
+
+  if (canUseTailscaleHeaderAuth && auth.requireTailscaleSharedSecret === true) {
+    const tailscaleCheck = await resolveVerifiedTailscaleUser({
+      req,
+      tailscaleWhois,
+    });
+    if (!tailscaleCheck.ok) {
+      return tailscaleCheck;
+    }
+    const sharedSecretResult = authorizeSharedSecretAuth({
+      auth,
+      connectAuth,
+      limiter,
+      ip,
+      rateLimitScope,
+    });
+    if (!sharedSecretResult.ok) {
+      return sharedSecretResult;
+    }
+    return {
+      ...sharedSecretResult,
+      user: tailscaleCheck.user.login,
+    };
+  }
+
+  if (canUseTailscaleHeaderAuth && !hasExplicitSharedSecretAuth(connectAuth)) {
     const tailscaleCheck = await resolveVerifiedTailscaleUser({
       req,
       tailscaleWhois,
@@ -578,28 +539,13 @@ async function authorizeGatewayConnectCore(
     }
   }
 
-  if (auth.mode === "token") {
-    return authorizeTokenAuth({
-      authToken: auth.token,
-      connectToken: connectAuth?.token,
-      limiter,
-      ip,
-      rateLimitScope,
-    });
-  }
-
-  if (auth.mode === "password") {
-    return authorizePasswordAuth({
-      authPassword: auth.password,
-      connectPassword: connectAuth?.password,
-      limiter,
-      ip,
-      rateLimitScope,
-    });
-  }
-
-  limiter?.recordFailure(ip, rateLimitScope);
-  return { ok: false, reason: "unauthorized" };
+  return authorizeSharedSecretAuth({
+    auth,
+    connectAuth,
+    limiter,
+    ip,
+    rateLimitScope,
+  });
 }
 
 /** Authorize an HTTP gateway request with Tailscale forwarded-header auth disabled. */

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -38,6 +38,9 @@ export type { GatewayAuthResult } from "./auth-shared-secret.js";
 const LEGACY_OPENCLAW_ENV_NOTE =
   " Legacy CLAWDBOT_* and MOLTBOT_* environment variables are ignored; use OPENCLAW_* names.";
 
+const TAILSCALE_SHARED_SECRET_AUTH_MODE_ERROR =
+  "gateway.auth.requireTailscaleSharedSecret=true requires gateway.auth.mode=token or password";
+
 type GatewayAuthSurface = "http" | "ws-control-ui";
 
 /** Inputs needed to authorize one HTTP or websocket gateway connection. */
@@ -232,11 +235,23 @@ async function resolveVerifiedTailscaleUser(params: {
   };
 }
 
+/** Reject layered Tailscale auth when the effective mode cannot validate a shared secret. */
+export function assertTailscaleSharedSecretAuthMode(auth: ResolvedGatewayAuth): void {
+  if (
+    auth.requireTailscaleSharedSecret === true &&
+    auth.mode !== "token" &&
+    auth.mode !== "password"
+  ) {
+    throw new Error(TAILSCALE_SHARED_SECRET_AUTH_MODE_ERROR);
+  }
+}
+
 /** Validate that the selected gateway auth mode has the required resolved credentials/config. */
 export function assertGatewayAuthConfigured(
   auth: ResolvedGatewayAuth,
   rawAuthConfig?: GatewayAuthConfig | null,
 ): void {
+  assertTailscaleSharedSecretAuthMode(auth);
   if (auth.mode === "token" && !auth.token) {
     if (auth.allowTailscale && auth.requireTailscaleSharedSecret !== true) {
       return;

--- a/src/gateway/server.auth.modes.suite.ts
+++ b/src/gateway/server.auth.modes.suite.ts
@@ -294,10 +294,12 @@ export function registerAuthModesSuite(): void {
       port = await getFreePort();
       server = await startGatewayServer(port);
 
-      const withoutToken = await openTailscaleWs(port);
+      const withoutToken = await openTailscaleWs(port, { origin: tailscaleOrigin });
       const rejected = await connectReq(withoutToken, {
         skipDefaultAuth: true,
-        device: null,
+        client: {
+          ...CONTROL_UI_CLIENT,
+        },
       });
       expect(rejected.ok).toBe(false);
       expect(rejected.error?.message ?? "").toContain("unauthorized");

--- a/src/gateway/server.auth.modes.suite.ts
+++ b/src/gateway/server.auth.modes.suite.ts
@@ -285,21 +285,12 @@ export function registerAuthModesSuite(): void {
 
     test("requires the shared token when layered tailscale auth is enabled", async () => {
       await server.close();
-      const { replaceConfigFile } = await import("../config/config.js");
-      await replaceConfigFile({
-        nextConfig: {
-          gateway: {
-            auth: {
-              mode: "token",
-              token: "secret",
-              allowTailscale: true,
-              requireTailscaleSharedSecret: true,
-            },
-            controlUi: testState.gatewayControlUi,
-          },
-        },
-        afterWrite: { mode: "auto" },
-      });
+      testState.gatewayAuth = {
+        mode: "token",
+        token: "secret",
+        allowTailscale: true,
+        requireTailscaleSharedSecret: true,
+      };
       port = await getFreePort();
       server = await startGatewayServer(port);
 

--- a/src/gateway/server.auth.modes.suite.ts
+++ b/src/gateway/server.auth.modes.suite.ts
@@ -15,10 +15,7 @@ import {
   testState,
   testTailscaleWhois,
 } from "./server.auth.test-helpers.js";
-import {
-  loadGatewayConfig,
-  waitForGatewayWsClose,
-} from "./shared-auth.test-helpers.js";
+import { loadGatewayConfig, waitForGatewayWsClose } from "./shared-auth.test-helpers.js";
 
 export function registerAuthModesSuite(): void {
   describe("password auth", () => {

--- a/src/gateway/server.auth.modes.suite.ts
+++ b/src/gateway/server.auth.modes.suite.ts
@@ -15,6 +15,10 @@ import {
   testState,
   testTailscaleWhois,
 } from "./server.auth.test-helpers.js";
+import {
+  loadGatewayConfig,
+  waitForGatewayWsClose,
+} from "./shared-auth.test-helpers.js";
 
 export function registerAuthModesSuite(): void {
   describe("password auth", () => {
@@ -212,6 +216,63 @@ export function registerAuthModesSuite(): void {
       const health = await rpcReq(ws, "health");
       expect(health.ok).toBe(true);
       ws.close();
+    });
+
+    test("requires the shared token when layered tailscale auth is enabled", async () => {
+      testState.gatewayAuth = {
+        mode: "token",
+        token: "secret",
+        allowTailscale: true,
+        requireTailscaleSharedSecret: true,
+      };
+
+      const withoutToken = await openTailscaleWs(port);
+      const rejected = await connectReq(withoutToken, {
+        skipDefaultAuth: true,
+        device: null,
+      });
+      expect(rejected.ok).toBe(false);
+      expect(rejected.error?.message ?? "").toContain("unauthorized");
+      withoutToken.close();
+
+      const withToken = await openTailscaleWs(port);
+      const accepted = await connectReq(withToken, {
+        token: "secret",
+        device: null,
+      });
+      expect(accepted.ok, JSON.stringify(accepted)).toBe(true);
+      withToken.close();
+    });
+
+    test("disconnects a tokenless tailscale session when config.patch enables layered auth", async () => {
+      const ws = await openTailscaleWs(port, { origin: tailscaleOrigin });
+      const connected = await connectReq(ws, {
+        skipDefaultAuth: true,
+        client: {
+          ...CONTROL_UI_CLIENT,
+        },
+      });
+      expect(connected.ok, JSON.stringify(connected)).toBe(true);
+
+      const current = await loadGatewayConfig(ws);
+      const closed = waitForGatewayWsClose(ws);
+      const patched = await rpcReq(ws, "config.patch", {
+        baseHash: current.hash,
+        raw: JSON.stringify({
+          gateway: {
+            auth: {
+              requireTailscaleSharedSecret: true,
+            },
+          },
+        }),
+        restartDelayMs: 1_000,
+      });
+
+      expect(patched.ok).toBe(true);
+      await expect(closed).resolves.toEqual({
+        code: 4001,
+        reason: "gateway auth changed",
+      });
     });
   });
 }

--- a/src/gateway/server.auth.modes.suite.ts
+++ b/src/gateway/server.auth.modes.suite.ts
@@ -214,31 +214,42 @@ export function registerAuthModesSuite(): void {
       expect(health.ok).toBe(true);
       ws.close();
     });
+  });
 
-    test("requires the shared token when layered tailscale auth is enabled", async () => {
-      testState.gatewayAuth = {
-        mode: "token",
-        token: "secret",
-        allowTailscale: true,
-        requireTailscaleSharedSecret: true,
-      };
+  describe("layered tailscale auth", () => {
+    let server: Awaited<ReturnType<typeof startGatewayServer>>;
+    let port: number;
+    const tailscaleOrigin = "https://layered-gateway.tailnet.ts.net";
 
-      const withoutToken = await openTailscaleWs(port);
-      const rejected = await connectReq(withoutToken, {
-        skipDefaultAuth: true,
-        device: null,
+    beforeAll(async () => {
+      testState.gatewayAuth = undefined;
+      testState.gatewayControlUi = { allowedOrigins: [tailscaleOrigin] };
+      const { replaceConfigFile } = await import("../config/config.js");
+      await replaceConfigFile({
+        nextConfig: {
+          gateway: {
+            auth: { mode: "token", token: "secret", allowTailscale: true },
+            controlUi: testState.gatewayControlUi,
+          },
+        },
+        afterWrite: { mode: "auto" },
       });
-      expect(rejected.ok).toBe(false);
-      expect(rejected.error?.message ?? "").toContain("unauthorized");
-      withoutToken.close();
+      port = await getFreePort();
+      server = await startGatewayServer(port);
+    });
 
-      const withToken = await openTailscaleWs(port);
-      const accepted = await connectReq(withToken, {
-        token: "secret",
-        device: null,
-      });
-      expect(accepted.ok, JSON.stringify(accepted)).toBe(true);
-      withToken.close();
+    beforeEach(() => {
+      testState.gatewayAuth = undefined;
+      testState.gatewayControlUi = { allowedOrigins: [tailscaleOrigin] };
+      testTailscaleWhois.value = { login: "peter", name: "Peter" };
+    });
+
+    afterEach(() => {
+      testTailscaleWhois.value = null;
+    });
+
+    afterAll(async () => {
+      await server.close();
     });
 
     test("disconnects a tokenless tailscale session when config.patch enables layered auth", async () => {
@@ -270,6 +281,25 @@ export function registerAuthModesSuite(): void {
         code: 4001,
         reason: "gateway auth changed",
       });
+    });
+
+    test("requires the shared token when layered tailscale auth is enabled", async () => {
+      const withoutToken = await openTailscaleWs(port);
+      const rejected = await connectReq(withoutToken, {
+        skipDefaultAuth: true,
+        device: null,
+      });
+      expect(rejected.ok).toBe(false);
+      expect(rejected.error?.message ?? "").toContain("unauthorized");
+      withoutToken.close();
+
+      const withToken = await openTailscaleWs(port);
+      const accepted = await connectReq(withToken, {
+        token: "secret",
+        device: null,
+      });
+      expect(accepted.ok, JSON.stringify(accepted)).toBe(true);
+      withToken.close();
     });
   });
 }

--- a/src/gateway/server.auth.modes.suite.ts
+++ b/src/gateway/server.auth.modes.suite.ts
@@ -284,6 +284,25 @@ export function registerAuthModesSuite(): void {
     });
 
     test("requires the shared token when layered tailscale auth is enabled", async () => {
+      await server.close();
+      const { replaceConfigFile } = await import("../config/config.js");
+      await replaceConfigFile({
+        nextConfig: {
+          gateway: {
+            auth: {
+              mode: "token",
+              token: "secret",
+              allowTailscale: true,
+              requireTailscaleSharedSecret: true,
+            },
+            controlUi: testState.gatewayControlUi,
+          },
+        },
+        afterWrite: { mode: "auto" },
+      });
+      port = await getFreePort();
+      server = await startGatewayServer(port);
+
       const withoutToken = await openTailscaleWs(port);
       const rejected = await connectReq(withoutToken, {
         skipDefaultAuth: true,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -690,6 +690,7 @@ export async function startGatewayServer(
             "token",
             "password",
             "allowTailscale",
+            "requireTailscaleSharedSecret",
             "rateLimit",
             "trustedProxy",
           ] as const satisfies readonly (keyof GatewayAuthConfig)[]

--- a/src/gateway/server/ws-connection/connect-auth.ts
+++ b/src/gateway/server/ws-connection/connect-auth.ts
@@ -395,11 +395,15 @@ export async function authenticateGatewayConnect(
   advanceHandshakePhase("auth_validated");
   const usesSharedGatewayAuth =
     authMethod === "token" || authMethod === "password" || authMethod === "trusted-proxy";
-  const sharedGatewaySessionGeneration = usesSharedGatewayAuth
-    ? resolveSharedGatewaySessionGeneration(resolvedAuth, trustedProxies)
-    : undefined;
+  const tracksTailscaleAuthPolicy = authMethod === "tailscale";
+  const sharedGatewaySessionGeneration =
+    usesSharedGatewayAuth || tracksTailscaleAuthPolicy
+      ? resolveSharedGatewaySessionGeneration(resolvedAuth, trustedProxies)
+      : undefined;
   const sessionUsesSharedGatewayAuth =
-    usesSharedGatewayAuth || deviceTokenSharedGatewaySessionGeneration !== undefined;
+    usesSharedGatewayAuth ||
+    deviceTokenSharedGatewaySessionGeneration !== undefined ||
+    (tracksTailscaleAuthPolicy && sharedGatewaySessionGeneration !== undefined);
   const sessionSharedGatewaySessionGeneration =
     sharedGatewaySessionGeneration ?? deviceTokenSharedGatewaySessionGeneration;
   if (sessionUsesSharedGatewayAuth) {

--- a/src/gateway/server/ws-shared-generation.test.ts
+++ b/src/gateway/server/ws-shared-generation.test.ts
@@ -57,4 +57,26 @@ describe("resolveSharedGatewaySessionGeneration", () => {
       resolveSharedGatewaySessionGeneration(auth, ["10.0.0.10"]),
     );
   });
+
+  it("rotates the generation when requireTailscaleSharedSecret toggles", () => {
+    const auth = {
+      mode: "token" as const,
+      allowTailscale: true,
+      token: "shared-token",
+    };
+
+    const withoutRequirement = resolveSharedGatewaySessionGeneration(auth);
+    const withRequirement = resolveSharedGatewaySessionGeneration({
+      ...auth,
+      requireTailscaleSharedSecret: true,
+    });
+
+    expect(withRequirement).not.toBe(withoutRequirement);
+    expect(
+      resolveSharedGatewaySessionGeneration({
+        ...auth,
+        requireTailscaleSharedSecret: false,
+      }),
+    ).toBe(withoutRequirement);
+  });
 });

--- a/src/gateway/server/ws-shared-generation.ts
+++ b/src/gateway/server/ws-shared-generation.ts
@@ -38,9 +38,11 @@ export function resolveSharedGatewaySessionGeneration(
   auth: ResolvedGatewayAuth,
   trustedProxies?: readonly string[],
 ): string | undefined {
+  const tailscaleRequirementMarker =
+    auth.requireTailscaleSharedSecret === true ? "\u0000require-tailscale-shared-secret" : "";
   const shared = resolveSharedSecret(auth);
   if (shared) {
-    return sha256Base64Url(`${shared.mode}\u0000${shared.secret}`);
+    return sha256Base64Url(`${shared.mode}\u0000${shared.secret}${tailscaleRequirementMarker}`);
   }
   if (auth.mode === "trusted-proxy") {
     return sha256Base64Url(

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -3,7 +3,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { assertGatewayAuthNotKnownWeak } from "./known-weak-gateway-secrets.js";
-import { ensureGatewayStartupAuth, mergeGatewayTailscaleConfig } from "./startup-auth.js";
+import {
+  ensureGatewayStartupAuth,
+  mergeGatewayAuthConfig,
+  mergeGatewayTailscaleConfig,
+} from "./startup-auth.js";
 
 const KNOWN_WEAK_GATEWAY_TOKEN_PLACEHOLDERS = [
   "change-me-to-a-long-random-token",
@@ -73,6 +77,22 @@ describe("mergeGatewayTailscaleConfig", () => {
         { serviceName: "svc:openclaw" },
       ),
     ).toEqual({ mode: "serve", serviceName: "svc:openclaw", resetOnExit: false });
+  });
+});
+
+describe("mergeGatewayAuthConfig", () => {
+  it("preserves explicit tailscale shared-secret overrides", () => {
+    expect(
+      mergeGatewayAuthConfig(
+        { mode: "token", token: "old", allowTailscale: true },
+        { requireTailscaleSharedSecret: true },
+      ),
+    ).toEqual({
+      mode: "token",
+      token: "old",
+      allowTailscale: true,
+      requireTailscaleSharedSecret: true,
+    });
   });
 });
 

--- a/src/gateway/startup-auth.test.ts
+++ b/src/gateway/startup-auth.test.ts
@@ -336,6 +336,40 @@ describe("ensureGatewayStartupAuth", () => {
     );
   });
 
+  it.each(["none", "trusted-proxy"] as const)(
+    "rejects requireTailscaleSharedSecret with effective %s auth mode",
+    async (mode) => {
+      await expect(
+        runStartupAuth({
+          cfg: gatewayAuthConfig({
+            mode,
+            requireTailscaleSharedSecret: true,
+            ...(mode === "trusted-proxy"
+              ? { trustedProxy: { userHeader: "x-forwarded-user" } }
+              : {}),
+          }),
+        }),
+      ).rejects.toThrow(
+        "gateway.auth.requireTailscaleSharedSecret=true requires gateway.auth.mode=token or password",
+      );
+    },
+  );
+
+  it("rejects a runtime override that changes layered auth to an unsupported mode", async () => {
+    await expect(
+      runStartupAuth({
+        cfg: gatewayAuthConfig({
+          mode: "token",
+          token: "configured-token",
+          requireTailscaleSharedSecret: true,
+        }),
+        authOverride: { mode: "none" },
+      }),
+    ).rejects.toThrow(
+      "gateway.auth.requireTailscaleSharedSecret=true requires gateway.auth.mode=token or password",
+    );
+  });
+
   it("treats undefined token override as no override", async () => {
     await expectResolvedToken({
       cfg: {

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -10,7 +10,11 @@ import {
   resolveGatewayTokenSecretRefValue,
 } from "./auth-config-utils.js";
 import { assertExplicitGatewayAuthModeWhenBothConfigured } from "./auth-mode-policy.js";
-import { resolveGatewayAuth, type ResolvedGatewayAuth } from "./auth.js";
+import {
+  assertTailscaleSharedSecretAuthMode,
+  resolveGatewayAuth,
+  type ResolvedGatewayAuth,
+} from "./auth.js";
 import {
   hasGatewayPasswordEnvCandidate,
   hasGatewayTokenEnvCandidate,
@@ -224,6 +228,7 @@ export async function ensureGatewayStartupAuth(params: {
     authOverride,
     tailscaleOverride: params.tailscaleOverride,
   });
+  assertTailscaleSharedSecretAuthMode(resolved);
   if (resolved.mode !== "token" || (resolved.token?.trim().length ?? 0) > 0) {
     assertGatewayAuthNotKnownWeak(resolved);
     warnHooksTokenReuseGatewayAuth({ cfg: params.cfg, auth: resolved, warn: params.warn });
@@ -248,6 +253,7 @@ export async function ensureGatewayStartupAuth(params: {
     authOverride: params.authOverride,
     tailscaleOverride: params.tailscaleOverride,
   });
+  assertTailscaleSharedSecretAuthMode(nextAuth);
   // The generated token is crypto-random, so this cannot match the weak set
   // in practice — but running the assertion on both branches documents that
   // the rule applies uniformly and guards against any future path that might

--- a/src/gateway/startup-auth.ts
+++ b/src/gateway/startup-auth.ts
@@ -42,6 +42,9 @@ export function mergeGatewayAuthConfig(
   if (override.allowTailscale !== undefined) {
     merged.allowTailscale = override.allowTailscale;
   }
+  if (override.requireTailscaleSharedSecret !== undefined) {
+    merged.requireTailscaleSharedSecret = override.requireTailscaleSharedSecret;
+  }
   if (override.rateLimit !== undefined) {
     merged.rateLimit = override.rateLimit;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes #57110.

Tailscale Serve currently allows a verified Tailscale Control UI/WebSocket identity to authenticate without also proving possession of the configured Gateway token or password. Operators who want defense in depth have no supported way to require both factors.

This PR adds the opt-in public config contract `gateway.auth.requireTailscaleSharedSecret`. When enabled, a Tailscale Serve WebSocket must pass both verified Tailscale identity and the configured token or password.

## Why This Change Was Made

Gateway auth already owns both Tailscale identity verification and shared-secret comparison, so the layered check belongs in the existing Gateway authorization path.

The final contract fails closed:

- `requireTailscaleSharedSecret: true` is schema-valid only with `auth.mode: "token"` or `"password"` when a mode is explicit.
- Startup rejects an effective `none` or `trusted-proxy` mode, including sparse runtime overrides that would otherwise bypass the persisted setting.
- Existing token/password startup validation still requires a resolved shared secret; token mode may use the existing ephemeral-token generation path when no durable token exists.

Toggling the setting participates in the existing shared-Gateway session generation. Enabling it rotates the generation and disconnects sessions admitted under the tokenless Tailscale policy. Leaving it unset or `false` preserves the previous generation, so default deployments and existing shared-auth device tokens do not rotate merely because OpenClaw was upgraded.

HTTP Gateway auth is unchanged. Tailscale forwarded-header auth remains limited to the WebSocket Control UI auth surface.

## User Impact

Existing deployments are unchanged by default.

Operators who enable the setting must use Gateway `token` or `password` mode. Unsupported combinations are rejected during config validation/startup instead of silently ignoring the security requirement. Enabling or disabling the setting at runtime disconnects affected sessions with close code `4001` and reason `gateway auth changed`, requiring them to authenticate under the new policy.

## Evidence

Exact tested head: `bc185b43d8add1ef54d338491455e9cd87e69af2`.

Exact-head upstream Gateway/auth shard: https://github.com/openclaw/openclaw/actions/runs/29519421453/job/87692741501 — `src/gateway/server.auth.modes.test.ts` passed 11/11; the shard passed 27 files and 341 tests.

The exact-head running-Gateway regressions start the real Gateway WebSocket server and exercise production handshake/config-reload paths:

- `src/gateway/server.auth.modes.suite.ts` — `requires the shared token when layered tailscale auth is enabled`: the same Tailscale-forwarded WebSocket is rejected without the token and accepted with the configured token.
- `src/gateway/server.auth.modes.suite.ts` — `disconnects a tokenless tailscale session when config.patch enables layered auth`: a tokenless Tailscale Control UI session connects while the setting is off, then a real `config.patch` enables it and the live socket closes with `4001 gateway auth changed`.

Focused regression coverage also includes:

- `src/config/config.gateway-tailscale-bind.test.ts`: schema rejects `none` and `trusted-proxy`, and accepts `token` and `password`.
- `src/gateway/startup-auth.test.ts`: startup rejects unsupported effective modes and a sparse runtime override from layered token auth to `none`.
- `src/gateway/auth.test.ts`: final runtime auth validation rejects unsupported modes and still rejects layered token mode without a token.
- `src/gateway/server/ws-shared-generation.test.ts`: the setting rotates the generation only when enabled; explicit `false` preserves the prior generation.

Known remaining gate: explicit Gateway security-owner approval is required for the permanent public config surface and generation coupling. The branch was rebased onto upstream `main` before this proof run, and GitHub reports the PR as mergeable.
