### PR TITLE
policy: preview review-required tool repairs

### DIFF
--- a/docs/cli/policy.md
+++ b/docs/cli/policy.md
@@ -975,6 +975,13 @@ more than the scoped policy target. Gateway HTTP URL-fetch allowlist findings
 remain manual because automatic repair cannot choose the correct endpoint URL
 allowlist values.
 
+Gateway bind and node-command findings stay review-required. When
+`policy/gateway-non-loopback-bind` or `policy/gateway-node-command-denied`
+can be mapped to a config path, `doctor --fix` reports the proposed
+`gateway.bind` or `gateway.nodes.denyCommands` change as skipped preview
+guidance. It does not apply the change, and the finding does not count as
+repaired until an operator reviews and updates config or policy.
+
 ```jsonc
 {
   "plugins": {

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -1797,6 +1797,127 @@ describe("registerPolicyDoctorChecks", () => {
     });
   });
 
+  it("previews review-required gateway bind repair without mutating config", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy({ workspaceRepairs: true }),
+      gateway: { bind: "lan" },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ gateway: { exposure: { allowNonLoopbackBind: false } } }),
+      "utf-8",
+    );
+
+    const result = await runPolicyRepairCheck(
+      "policy/gateway-non-loopback-bind",
+      repairCtx(configPath, cfg),
+    );
+
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toBe("policy repair requires review before changing config");
+    expect(result.changes).toEqual([
+      "Review required: set gateway.bind=loopback for policy conformance.",
+    ]);
+    expect(result.warnings).toEqual([
+      "Review required: set gateway.bind=loopback for policy conformance.",
+    ]);
+    expect(result.effects).toEqual([
+      {
+        kind: "config",
+        action: "would-set-after-review",
+        target: "gateway.bind=loopback",
+        dryRunSafe: true,
+      },
+    ]);
+    expect(result.config.gateway?.bind).toBe("lan");
+    expect(result.remainingFindings).toHaveLength(1);
+  });
+
+  it("previews review-required custom gateway bind repair without mutating config", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy({ workspaceRepairs: true }),
+      gateway: { bind: "custom", customBindHost: "10.0.0.4" },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ gateway: { exposure: { allowNonLoopbackBind: false } } }),
+      "utf-8",
+    );
+
+    const result = await runPolicyRepairCheck(
+      "policy/gateway-non-loopback-bind",
+      repairCtx(configPath, cfg),
+    );
+
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        ocPath: "oc://openclaw.config/gateway/customBindHost",
+      }),
+    ]);
+    expect(result.status).toBe("skipped");
+    expect(result.changes).toEqual([
+      "Review required: set gateway.bind=loopback for policy conformance.",
+    ]);
+    expect(result.warnings).toEqual([
+      "Review required: set gateway.bind=loopback for policy conformance.",
+    ]);
+    expect(result.effects).toEqual([
+      {
+        kind: "config",
+        action: "would-set-after-review",
+        target: "gateway.bind=loopback",
+        dryRunSafe: true,
+      },
+    ]);
+    expect(result.config.gateway).toMatchObject({
+      bind: "custom",
+      customBindHost: "10.0.0.4",
+    });
+    expect(result.remainingFindings).toHaveLength(1);
+  });
+
+  it("previews review-required gateway node command repairs without mutating config", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy({ workspaceRepairs: true }),
+      gateway: { nodes: { denyCommands: ["mcp.help"] } },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ gateway: { nodes: { denyCommands: ["mcp.help", "system.run"] } } }),
+      "utf-8",
+    );
+
+    const result = await runPolicyRepairCheck(
+      "policy/gateway-node-command-denied",
+      repairCtx(configPath, cfg),
+    );
+
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toBe("policy repair requires review before changing config");
+    expect(result.changes).toEqual([
+      "Review required: add system.run to gateway.nodes.denyCommands for policy conformance.",
+    ]);
+    expect(result.warnings).toEqual([
+      "Review required: add system.run to gateway.nodes.denyCommands for policy conformance.",
+    ]);
+    expect(result.effects).toEqual([
+      {
+        kind: "config",
+        action: "would-append-after-review",
+        target: "gateway.nodes.denyCommands += system.run",
+        dryRunSafe: true,
+      },
+    ]);
+    expect(result.config.gateway?.nodes?.denyCommands).toEqual(["mcp.help"]);
+    expect(result.remainingFindings).toHaveLength(1);
+  });
+
   it("repairs automatic channel ingress narrowing findings", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {
@@ -2161,7 +2282,7 @@ describe("registerPolicyDoctorChecks", () => {
     ]);
   });
 
-  it("does not register repair for review-required policy findings", () => {
+  it("does not register repair for non-previewable policy findings", () => {
     const check = registerChecks().find(
       (entry) => entry.id === "policy/gateway-http-url-fetch-unrestricted",
     );

--- a/extensions/policy/src/doctor/register.test.ts
+++ b/extensions/policy/src/doctor/register.test.ts
@@ -1918,6 +1918,127 @@ describe("registerPolicyDoctorChecks", () => {
     expect(result.remainingFindings).toHaveLength(1);
   });
 
+  it("previews review-required agent workspace access repair without mutating config", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy({ workspaceRepairs: true }),
+      agents: {
+        defaults: { sandbox: { mode: "all", workspaceAccess: "rw" } },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({ agents: { workspace: { allowedAccess: ["none", "ro"] } } }),
+      "utf-8",
+    );
+
+    const result = await runPolicyRepairCheck(
+      "policy/agents-workspace-access-denied",
+      repairCtx(configPath, cfg),
+    );
+
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toBe("policy repair requires review before changing config");
+    expect(result.changes).toEqual([
+      "Review required: set agent sandbox workspace access to an allowed policy value for policy conformance.",
+    ]);
+    expect(result.warnings).toEqual([
+      "Review required: set agent sandbox workspace access to an allowed policy value for policy conformance.",
+    ]);
+    expect(result.effects).toEqual([
+      {
+        kind: "config",
+        action: "would-set-after-review",
+        target: "agents.defaults.sandbox.workspaceAccess -> allowed value",
+        dryRunSafe: true,
+      },
+    ]);
+    expect(result.config.agents?.defaults?.sandbox?.workspaceAccess).toBe("rw");
+    expect(result.remainingFindings).toHaveLength(1);
+  });
+
+  it("previews review-required tool posture repairs without mutating config", async () => {
+    const configPath = join(workspaceDir, "openclaw.jsonc");
+    const cfg = {
+      ...cfgWithPolicy({ workspaceRepairs: true }),
+      tools: {
+        profile: "full",
+        fs: { workspaceOnly: false },
+        exec: { security: "full", ask: "off", host: "gateway" },
+      },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(configPath, "{}", "utf-8");
+    await fs.writeFile(
+      join(workspaceDir, "policy.jsonc"),
+      JSON.stringify({
+        tools: {
+          profiles: { allow: ["coding"] },
+          fs: { requireWorkspaceOnly: true },
+          exec: {
+            allowSecurity: ["deny"],
+            requireAsk: ["always"],
+            allowHosts: ["sandbox"],
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const cases = [
+      {
+        checkId: "policy/tools-profile-unapproved",
+        change:
+          "Review required: set tools.profile to an approved policy value for policy conformance.",
+        target: "tools.profile -> approved value",
+      },
+      {
+        checkId: "policy/tools-fs-workspace-only-required",
+        change: "Review required: set tools.fs.workspaceOnly=true for policy conformance.",
+        target: "tools.fs.workspaceOnly -> true",
+      },
+      {
+        checkId: "policy/tools-exec-security-unapproved",
+        change:
+          "Review required: set tools.exec.security to an approved policy value for policy conformance.",
+        target: "tools.exec.security -> approved value",
+      },
+      {
+        checkId: "policy/tools-exec-ask-unapproved",
+        change:
+          "Review required: set tools.exec.ask to an approved policy value for policy conformance.",
+        target: "tools.exec.ask -> approved value",
+      },
+      {
+        checkId: "policy/tools-exec-host-unapproved",
+        change:
+          "Review required: set tools.exec.host to an approved policy value for policy conformance.",
+        target: "tools.exec.host -> approved value",
+      },
+    ];
+
+    for (const entry of cases) {
+      const result = await runPolicyRepairCheck(entry.checkId, repairCtx(configPath, cfg));
+
+      expect(result.status).toBe("skipped");
+      expect(result.reason).toBe("policy repair requires review before changing config");
+      expect(result.changes).toEqual([entry.change]);
+      expect(result.warnings).toEqual([entry.change]);
+      expect(result.effects).toEqual([
+        {
+          kind: "config",
+          action: "would-set-after-review",
+          target: entry.target,
+          dryRunSafe: true,
+        },
+      ]);
+      expect(result.remainingFindings).toHaveLength(1);
+    }
+    expect(cfg.tools?.profile).toBe("full");
+    expect(cfg.tools?.fs?.workspaceOnly).toBe(false);
+    expect(cfg.tools?.exec).toMatchObject({ security: "full", ask: "off", host: "gateway" });
+  });
+
   it("repairs automatic channel ingress narrowing findings", async () => {
     const configPath = join(workspaceDir, "openclaw.jsonc");
     const cfg = {

--- a/extensions/policy/src/doctor/review-required-repairs.ts
+++ b/extensions/policy/src/doctor/review-required-repairs.ts
@@ -1,0 +1,138 @@
+// Policy review-required repairs surface proposed config changes without applying them.
+import type {
+  HealthFinding,
+  HealthRepairContext,
+  HealthRepairEffect,
+  HealthRepairResult,
+} from "openclaw/plugin-sdk/health";
+import { POLICY_FIX_METADATA_BY_CHECK_ID } from "./fix-metadata.js";
+import { CHECK_IDS, type POLICY_CHECK_IDS } from "./metadata.js";
+
+type PolicyCheckId = (typeof POLICY_CHECK_IDS)[number];
+
+const REVIEW_REQUIRED_REPAIR_CHECK_IDS = new Set<PolicyCheckId>([
+  CHECK_IDS.policyGatewayNonLoopbackBind,
+  CHECK_IDS.policyGatewayNodeCommandDenied,
+]);
+
+export function previewPolicyReviewRequiredRepair(
+  _ctx: HealthRepairContext,
+  findings: readonly HealthFinding[],
+  checkId: PolicyCheckId,
+): Promise<HealthRepairResult> {
+  const metadata = POLICY_FIX_METADATA_BY_CHECK_ID.get(checkId);
+  if (!REVIEW_REQUIRED_REPAIR_CHECK_IDS.has(checkId) || metadata?.fixClass !== "reviewRequired") {
+    return Promise.resolve({
+      status: "skipped",
+      reason: "policy finding does not have a review-required repair preview",
+      changes: [],
+    });
+  }
+  if (
+    findings.length === 0 ||
+    findings.some(
+      (finding) =>
+        finding.checkId !== checkId ||
+        POLICY_FIX_METADATA_BY_CHECK_ID.get(finding.checkId)?.fixClass !== "reviewRequired",
+    )
+  ) {
+    return Promise.resolve({
+      status: "skipped",
+      reason: "policy finding is not classified as review-required",
+      changes: [],
+    });
+  }
+
+  const previews = findings.flatMap((finding) => previewForFinding(finding, checkId));
+  if (previews.length === 0) {
+    return Promise.resolve({
+      status: "skipped",
+      reason: "policy review-required repair had no previewable config changes",
+      changes: [],
+    });
+  }
+
+  return Promise.resolve({
+    status: "skipped",
+    reason: "policy repair requires review before changing config",
+    changes: uniqueStrings(previews.map((preview) => preview.change)),
+    warnings: uniqueStrings(previews.map((preview) => preview.change)),
+    effects: uniqueEffects(previews.map((preview) => preview.effect)),
+  });
+}
+
+function previewForFinding(
+  finding: HealthFinding,
+  checkId: PolicyCheckId,
+): readonly { readonly change: string; readonly effect: HealthRepairEffect }[] {
+  switch (checkId) {
+    case CHECK_IDS.policyGatewayNonLoopbackBind:
+      return previewGatewayLoopbackBind(finding);
+    case CHECK_IDS.policyGatewayNodeCommandDenied:
+      return previewGatewayNodeDenyCommand(finding);
+    default:
+      return [];
+  }
+}
+
+function previewGatewayLoopbackBind(
+  finding: HealthFinding,
+): readonly { readonly change: string; readonly effect: HealthRepairEffect }[] {
+  if (
+    finding.ocPath !== "oc://openclaw.config/gateway/bind" &&
+    finding.ocPath !== "oc://openclaw.config/gateway/customBindHost"
+  ) {
+    return [];
+  }
+  return [
+    {
+      change: "Review required: set gateway.bind=loopback for policy conformance.",
+      effect: {
+        kind: "config",
+        action: "would-set-after-review",
+        target: "gateway.bind=loopback",
+        dryRunSafe: true,
+      },
+    },
+  ];
+}
+
+function previewGatewayNodeDenyCommand(
+  finding: HealthFinding,
+): readonly { readonly change: string; readonly effect: HealthRepairEffect }[] {
+  const command = finding.message.match(/Gateway node command '([^']+)'/)?.[1]?.trim();
+  if (
+    command === undefined ||
+    command === "" ||
+    finding.ocPath !== "oc://openclaw.config/gateway/nodes/denyCommands"
+  ) {
+    return [];
+  }
+  return [
+    {
+      change: `Review required: add ${command} to gateway.nodes.denyCommands for policy conformance.`,
+      effect: {
+        kind: "config",
+        action: "would-append-after-review",
+        target: `gateway.nodes.denyCommands += ${command}`,
+        dryRunSafe: true,
+      },
+    },
+  ];
+}
+
+function uniqueStrings(values: readonly string[]): readonly string[] {
+  return [...new Set(values)];
+}
+
+function uniqueEffects(values: readonly HealthRepairEffect[]): readonly HealthRepairEffect[] {
+  const seen = new Set<string>();
+  return values.filter((value) => {
+    const key = JSON.stringify(value);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}

--- a/extensions/policy/src/doctor/review-required-repairs.ts
+++ b/extensions/policy/src/doctor/review-required-repairs.ts
@@ -13,6 +13,12 @@ type PolicyCheckId = (typeof POLICY_CHECK_IDS)[number];
 const REVIEW_REQUIRED_REPAIR_CHECK_IDS = new Set<PolicyCheckId>([
   CHECK_IDS.policyGatewayNonLoopbackBind,
   CHECK_IDS.policyGatewayNodeCommandDenied,
+  CHECK_IDS.policyAgentsWorkspaceAccessDenied,
+  CHECK_IDS.policyToolsProfileUnapproved,
+  CHECK_IDS.policyToolsFsWorkspaceOnlyRequired,
+  CHECK_IDS.policyToolsExecSecurityUnapproved,
+  CHECK_IDS.policyToolsExecAskUnapproved,
+  CHECK_IDS.policyToolsExecHostUnapproved,
 ]);
 
 export function previewPolicyReviewRequiredRepair(
@@ -70,6 +76,43 @@ function previewForFinding(
       return previewGatewayLoopbackBind(finding);
     case CHECK_IDS.policyGatewayNodeCommandDenied:
       return previewGatewayNodeDenyCommand(finding);
+    case CHECK_IDS.policyAgentsWorkspaceAccessDenied:
+      return previewAgentWorkspaceAccess(finding);
+    case CHECK_IDS.policyToolsProfileUnapproved:
+      return previewConfigPathSet(
+        finding,
+        "/tools/profile",
+        "set tools.profile to an approved policy value",
+        "approved value",
+      );
+    case CHECK_IDS.policyToolsFsWorkspaceOnlyRequired:
+      return previewConfigPathSet(
+        finding,
+        "/tools/fs/workspaceOnly",
+        "set tools.fs.workspaceOnly=true",
+        "true",
+      );
+    case CHECK_IDS.policyToolsExecSecurityUnapproved:
+      return previewConfigPathSet(
+        finding,
+        "/tools/exec/security",
+        "set tools.exec.security to an approved policy value",
+        "approved value",
+      );
+    case CHECK_IDS.policyToolsExecAskUnapproved:
+      return previewConfigPathSet(
+        finding,
+        "/tools/exec/ask",
+        "set tools.exec.ask to an approved policy value",
+        "approved value",
+      );
+    case CHECK_IDS.policyToolsExecHostUnapproved:
+      return previewConfigPathSet(
+        finding,
+        "/tools/exec/host",
+        "set tools.exec.host to an approved policy value",
+        "approved value",
+      );
     default:
       return [];
   }
@@ -119,6 +162,63 @@ function previewGatewayNodeDenyCommand(
       },
     },
   ];
+}
+
+function previewAgentWorkspaceAccess(
+  finding: HealthFinding,
+): readonly { readonly change: string; readonly effect: HealthRepairEffect }[] {
+  const target = configTargetFromOcPath(finding.ocPath);
+  if (
+    target === undefined ||
+    !finding.ocPath.includes("/agents/") ||
+    !finding.ocPath.includes("/sandbox/") ||
+    !(finding.ocPath.endsWith("/workspaceAccess") || finding.ocPath.endsWith("/mode"))
+  ) {
+    return [];
+  }
+  return [
+    {
+      change:
+        "Review required: set agent sandbox workspace access to an allowed policy value for policy conformance.",
+      effect: {
+        kind: "config",
+        action: "would-set-after-review",
+        target: `${target} -> allowed value`,
+        dryRunSafe: true,
+      },
+    },
+  ];
+}
+
+function previewConfigPathSet(
+  finding: HealthFinding,
+  suffix: string,
+  changeText: string,
+  targetValue: string,
+): readonly { readonly change: string; readonly effect: HealthRepairEffect }[] {
+  const target = configTargetFromOcPath(finding.ocPath);
+  if (target === undefined || !finding.ocPath.endsWith(suffix)) {
+    return [];
+  }
+  return [
+    {
+      change: `Review required: ${changeText} for policy conformance.`,
+      effect: {
+        kind: "config",
+        action: "would-set-after-review",
+        target: `${target} -> ${targetValue}`,
+        dryRunSafe: true,
+      },
+    },
+  ];
+}
+
+function configTargetFromOcPath(ocPath: string | undefined): string | undefined {
+  const prefix = "oc://openclaw.config/";
+  if (ocPath === undefined || !ocPath.startsWith(prefix)) {
+    return undefined;
+  }
+  return ocPath.slice(prefix.length).replaceAll("/", ".");
 }
 
 function uniqueStrings(values: readonly string[]): readonly string[] {

--- a/extensions/policy/src/doctor/scopes/gateway.ts
+++ b/extensions/policy/src/doctor/scopes/gateway.ts
@@ -3,6 +3,7 @@ import type { HealthCheck, HealthFinding } from "openclaw/plugin-sdk/health";
 import type { PolicyEvidence } from "../../policy-state.js";
 import { repairPolicyAutomaticNarrower } from "../automatic-repairs.js";
 import { CHECK_IDS } from "../metadata.js";
+import { previewPolicyReviewRequiredRepair } from "../review-required-repairs.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 import { readPolicyBoolean, readStringList } from "../utils.js";
 
@@ -16,6 +17,13 @@ export function createPolicyGatewayChecks(deps: PolicyDoctorCheckDeps): readonly
     source: "policy",
     async detect(ctx) {
       return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyGatewayNonLoopbackBind);
+    },
+    repair(ctx, findings) {
+      return previewPolicyReviewRequiredRepair(
+        ctx,
+        findings,
+        CHECK_IDS.policyGatewayNonLoopbackBind,
+      );
     },
   };
   const policyGatewayAuthDisabledCheck: HealthCheck = {
@@ -107,6 +115,13 @@ export function createPolicyGatewayChecks(deps: PolicyDoctorCheckDeps): readonly
     source: "policy",
     async detect(ctx) {
       return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyGatewayNodeCommandDenied);
+    },
+    repair(ctx, findings) {
+      return previewPolicyReviewRequiredRepair(
+        ctx,
+        findings,
+        CHECK_IDS.policyGatewayNodeCommandDenied,
+      );
     },
   };
 

--- a/extensions/policy/src/doctor/scopes/tools.ts
+++ b/extensions/policy/src/doctor/scopes/tools.ts
@@ -2,6 +2,7 @@
 import type { HealthCheck } from "openclaw/plugin-sdk/health";
 import { repairPolicyAutomaticNarrower } from "../automatic-repairs.js";
 import { CHECK_IDS } from "../metadata.js";
+import { previewPolicyReviewRequiredRepair } from "../review-required-repairs.js";
 import type { PolicyDoctorCheckDeps } from "../types.js";
 
 export function createPolicyAgentToolChecks(deps: PolicyDoctorCheckDeps): readonly HealthCheck[] {
@@ -15,6 +16,13 @@ export function createPolicyAgentToolChecks(deps: PolicyDoctorCheckDeps): readon
     async detect(ctx) {
       return findingsForCheck(
         await evaluatePolicy(ctx),
+        CHECK_IDS.policyAgentsWorkspaceAccessDenied,
+      );
+    },
+    repair(ctx, findings) {
+      return previewPolicyReviewRequiredRepair(
+        ctx,
+        findings,
         CHECK_IDS.policyAgentsWorkspaceAccessDenied,
       );
     },
@@ -39,6 +47,13 @@ export function createPolicyAgentToolChecks(deps: PolicyDoctorCheckDeps): readon
     async detect(ctx) {
       return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyToolsProfileUnapproved);
     },
+    repair(ctx, findings) {
+      return previewPolicyReviewRequiredRepair(
+        ctx,
+        findings,
+        CHECK_IDS.policyToolsProfileUnapproved,
+      );
+    },
   };
   const policyToolsFsWorkspaceOnlyRequiredCheck: HealthCheck = {
     id: CHECK_IDS.policyToolsFsWorkspaceOnlyRequired,
@@ -48,6 +63,13 @@ export function createPolicyAgentToolChecks(deps: PolicyDoctorCheckDeps): readon
     async detect(ctx) {
       return findingsForCheck(
         await evaluatePolicy(ctx),
+        CHECK_IDS.policyToolsFsWorkspaceOnlyRequired,
+      );
+    },
+    repair(ctx, findings) {
+      return previewPolicyReviewRequiredRepair(
+        ctx,
+        findings,
         CHECK_IDS.policyToolsFsWorkspaceOnlyRequired,
       );
     },
@@ -63,6 +85,13 @@ export function createPolicyAgentToolChecks(deps: PolicyDoctorCheckDeps): readon
         CHECK_IDS.policyToolsExecSecurityUnapproved,
       );
     },
+    repair(ctx, findings) {
+      return previewPolicyReviewRequiredRepair(
+        ctx,
+        findings,
+        CHECK_IDS.policyToolsExecSecurityUnapproved,
+      );
+    },
   };
   const policyToolsExecAskUnapprovedCheck: HealthCheck = {
     id: CHECK_IDS.policyToolsExecAskUnapproved,
@@ -72,6 +101,13 @@ export function createPolicyAgentToolChecks(deps: PolicyDoctorCheckDeps): readon
     async detect(ctx) {
       return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyToolsExecAskUnapproved);
     },
+    repair(ctx, findings) {
+      return previewPolicyReviewRequiredRepair(
+        ctx,
+        findings,
+        CHECK_IDS.policyToolsExecAskUnapproved,
+      );
+    },
   };
   const policyToolsExecHostUnapprovedCheck: HealthCheck = {
     id: CHECK_IDS.policyToolsExecHostUnapproved,
@@ -80,6 +116,13 @@ export function createPolicyAgentToolChecks(deps: PolicyDoctorCheckDeps): readon
     source: "policy",
     async detect(ctx) {
       return findingsForCheck(await evaluatePolicy(ctx), CHECK_IDS.policyToolsExecHostUnapproved);
+    },
+    repair(ctx, findings) {
+      return previewPolicyReviewRequiredRepair(
+        ctx,
+        findings,
+        CHECK_IDS.policyToolsExecHostUnapproved,
+      );
     },
   };
   const policyToolsElevatedEnabledCheck: HealthCheck = {

--- a/src/flows/doctor-repair-flow.test.ts
+++ b/src/flows/doctor-repair-flow.test.ts
@@ -292,7 +292,7 @@ describe("runDoctorHealthRepairs", () => {
           return {
             status: "skipped",
             reason: "manual confirmation required",
-            changes: [],
+            changes: ["Review required before changing gateway.mode."],
           };
         },
       }),
@@ -304,6 +304,7 @@ describe("runDoctorHealthRepairs", () => {
     expect(result.checksRepaired).toBe(0);
     expect(result.checksValidated).toBe(0);
     expect(result.remainingFindings).toEqual([]);
+    expect(result.changes).toEqual(["Review required before changing gateway.mode."]);
     expect(result.warnings).toEqual(["test/skipped repair skipped: manual confirmation required"]);
   });
 

--- a/src/flows/doctor-repair-flow.ts
+++ b/src/flows/doctor-repair-flow.ts
@@ -130,6 +130,7 @@ async function runSplitHealthCheck(
     warnings.push(...(result.warnings ?? []));
     diffs.push(...(result.diffs ?? []));
     effects.push(...(result.effects ?? []));
+    changes.push(...result.changes);
     const status = result.status ?? "repaired";
     if (status !== "repaired") {
       warnings.push(`${check.id} repair ${status}${result.reason ? `: ${result.reason}` : ""}`);
@@ -138,7 +139,6 @@ async function runSplitHealthCheck(
     if (result.config !== undefined && opts.dryRun !== true) {
       cfg = result.config;
     }
-    changes.push(...result.changes);
     checksRepaired++;
     if (opts.dryRun === true) {
       return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects, {


### PR DESCRIPTION
## Summary
- Restacked on #99776 head `cd718e1`, which documents Gateway review-required previews in `docs/cli/policy.md`.
- Extends policy doctor review-required repair previews from Gateway findings into agent/tool posture findings.
- Wires previews for agent workspace access, tool profile, fs workspace-only, exec security, exec ask, and exec host checks.
- Adds registered-check coverage proving previews are skipped review-required repairs and do not mutate config.

## Real behavior proof
Behavior or issue addressed:
`doctor --fix` surfaces review-required preview guidance for agent/tool policy findings without mutating config or counting the check as repaired.

Real environment tested:
Windows PowerShell in `C:\src\openclaw-policy-also-allow-push`, source checkout at PR head `e065bd2`, stacked after #99776 head `cd718e1`.

Exact steps or command run after this patch:
1. `git diff --check`
2. `rg -n "<<<<<<<|=======|>>>>>>>" docs/cli/policy.md extensions/policy/src/doctor`
3. `git diff --stat policy-doctor-review-required-previews..policy-doctor-tools-agent-previews`

Evidence after fix:
Whitespace check exited 0. Conflict marker search returned no matches. The follow-up diff over #99776 is three files and 264 insertions: registered policy tests, additional review-required repair metadata, and tool scope wiring.

Observed result after fix:
Registered tool/agent policy findings produce skipped review-required preview repairs with warning/change text and dry-run-safe config effects; they do not directly mutate config.

What was not tested:
Focused Vitest was not rerun after this rebase in the clean push checkout. GitHub CI is running on pushed PR head `e065bd2`.

## Stack
- Stacked after #99776 (`policy: preview review-required gateway repairs`).
- Follow-up: #101916 adds `tools.alsoAllow` review-required previews.
- Leaves any future automatic `alsoAllow` mutation out of scope because that can widen or remove explicit tool permissions.