### PR TITLE
fix(status): surface auto-fallback model in status and session_status (#96126)

### DIFF
--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -172,6 +172,42 @@ describe("status.command-sections", () => {
     ]);
   });
 
+  it("shows fallback-specific wording for auto-fallback model mismatches", () => {
+    const lines = buildStatusModelSelectionLines({
+      recent: [
+        {
+          key: "agent:main:telegram:chat-2",
+          kind: "direct",
+          updatedAt: 1,
+          age: 5_000,
+          model: "qwen3.6-blue",
+          configuredModel: "minimax/MiniMax-M3",
+          selectedModel: "ollama/qwen3.6-blue:35b-a3b",
+          modelSelectionReason: "fallback selected",
+          runtime: "OpenClaw Default",
+          totalTokens: null,
+          totalTokensFresh: false,
+          remainingTokens: null,
+          percentUsed: null,
+          contextTokens: null,
+          flags: [],
+        },
+      ],
+      shortenText: (value) => value,
+      warn: (value) => `warn(${value})`,
+      muted: (value) => `muted(${value})`,
+    });
+
+    expect(lines).toEqual([
+      "warn(Session agent:main:telegram:chat-2 is running ollama/qwen3.6-blue:35b-a3b (auto fallback); config primary is minimax/MiniMax-M3.)",
+      "  Configured default: minimax/MiniMax-M3",
+      "  Session selected: ollama/qwen3.6-blue:35b-a3b",
+      "  Reason: fallback selected",
+      "  Action: check provider availability or retry with /model",
+      "  Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-behavior",
+    ]);
+  });
+
   it("maps health channel detail lines into status rows", () => {
     const rows = buildStatusHealthRows({
       health: { durationMs: 42 } as HealthSummary,

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -388,14 +388,20 @@ export function buildStatusModelSelectionLines(params: {
     const key = params.shortenText(sess.key, 48);
     const configured = sess.configuredModel ?? "unknown";
     const selected = sess.selectedModel ?? "unknown";
+    const isFallback = sess.modelSelectionReason === "fallback selected";
+    const intro = isFallback
+      ? `Session ${key} is running ${selected} (auto fallback); config primary is ${configured}.`
+      : `Session ${key} is pinned to ${selected}; config primary ${configured} will apply to new/unpinned sessions.`;
+    const reasonLine = `  Reason: ${sess.modelSelectionReason ?? "session override"}`;
+    const clearLine = isFallback
+      ? "  Action: check provider availability or retry with /model"
+      : "  Clear with: /model default";
     lines.push(
-      params.warn(
-        `Session ${key} is pinned to ${selected}; config primary ${configured} will apply to new/unpinned sessions.`,
-      ),
+      params.warn(intro),
       `  Configured default: ${configured}`,
       `  Session selected: ${selected}`,
-      `  Reason: ${sess.modelSelectionReason ?? "session override"}`,
-      "  Clear with: /model default",
+      reasonLine,
+      clearLine,
       "  Docs: https://docs.openclaw.ai/concepts/models#selection-source-and-fallback-behavior",
     );
   }

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -677,7 +677,7 @@ describe("getStatusSummary", () => {
     expect(summary.sessions.recent[0]?.modelSelectionReason).toBeNull();
   });
 
-  it("does not mark auto fallback model overrides as pinned session selections", async () => {
+  it("marks auto fallback model overrides with a fallback reason label", async () => {
     vi.mocked(statusSummaryRuntime.resolveConfiguredStatusModelRef).mockReturnValue({
       provider: "zhipu",
       model: "glm-4.5-air",
@@ -704,7 +704,7 @@ describe("getStatusSummary", () => {
 
     expect(summary.sessions.recent[0]?.configuredModel).toBe("zhipu/glm-4.5-air");
     expect(summary.sessions.recent[0]?.selectedModel).toBe("deepseek/deepseek-v4-flash");
-    expect(summary.sessions.recent[0]?.modelSelectionReason).toBeNull();
+    expect(summary.sessions.recent[0]?.modelSelectionReason).toBe("fallback selected");
   });
 
   it("does not mark runtime-equivalent provider aliases as pinned mismatches", async () => {

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -707,6 +707,35 @@ describe("getStatusSummary", () => {
     expect(summary.sessions.recent[0]?.modelSelectionReason).toBe("fallback selected");
   });
 
+  it("does not mark configured subagent models as auto fallback", async () => {
+    vi.mocked(statusSummaryRuntime.resolveConfiguredStatusModelRef).mockReturnValue({
+      provider: "zhipu",
+      model: "glm-4.5-air",
+    });
+    vi.mocked(statusSummaryRuntime.resolveSessionModelRef).mockReturnValue({
+      provider: "deepseek",
+      model: "deepseek-v4-flash",
+    });
+    statusSummaryMocks.listSessionEntries.mockReturnValue(
+      toSessionEntrySummaries({
+        "agent:worker:subagent:configured": {
+          sessionId: "configured-subagent",
+          updatedAt: Date.now(),
+          providerOverride: "deepseek",
+          modelOverride: "deepseek-v4-flash",
+          modelOverrideSource: "auto",
+          modelOverrideFallbackOriginProvider: "deepseek",
+          modelOverrideFallbackOriginModel: "deepseek-v4-flash",
+        },
+      }),
+    );
+
+    const summary = await getStatusSummary();
+
+    expect(summary.sessions.recent[0]?.selectedModel).toBe("deepseek/deepseek-v4-flash");
+    expect(summary.sessions.recent[0]?.modelSelectionReason).toBeNull();
+  });
+
   it("does not mark runtime-equivalent provider aliases as pinned mismatches", async () => {
     vi.mocked(statusSummaryRuntime.resolveConfiguredStatusModelRef).mockReturnValue({
       provider: "openai",

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -432,7 +432,7 @@ export async function getStatusSummary(
             selectedModelComparisonLabel,
             configuredSessionModelComparisonLabel,
           ) &&
-          entry?.modelOverride != null;
+          (hasUserPinnedModelSelection(entry) || hasSessionAutoModelFallbackProvenance(entry));
         // Session rows show the live selected model and warn for user-pinned
         // differences as well as runtime fallback selections (#96126).
         const contextTokens =

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -432,8 +432,9 @@ export async function getStatusSummary(
             selectedModelComparisonLabel,
             configuredSessionModelComparisonLabel,
           ) &&
-          hasUserPinnedModelSelection(entry);
-        // Session rows show the live selected model but warn only for user-pinned differences.
+          entry?.modelOverride != null;
+        // Session rows show the live selected model and warn for user-pinned
+        // differences as well as runtime fallback selections (#96126).
         const contextTokens =
           resolveContextTokensForModel({
             cfg,
@@ -493,7 +494,11 @@ export async function getStatusSummary(
           model,
           configuredModel: configuredSessionModelLabel,
           selectedModel: selectedModelLabel,
-          modelSelectionReason: modelSelectionDiffers ? "session override" : null,
+          modelSelectionReason: modelSelectionDiffers
+            ? hasUserPinnedModelSelection(entry)
+              ? "session override"
+              : "fallback selected"
+            : null,
           runtime,
           contextTokens,
           flags: buildFlags(entry),

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -5,7 +5,10 @@ import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agen
 import { areRuntimeModelRefsEquivalent } from "../agents/model-runtime-aliases.js";
 import { getRuntimeConfig, projectConfigOntoRuntimeSourceSnapshot } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions/main-session.js";
-import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
+import {
+  hasSessionActiveAutoModelFallback,
+  hasSessionAutoModelFallbackProvenance,
+} from "../config/sessions/model-override-provenance.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { listSessionEntries } from "../config/sessions/session-accessor.js";
 import { resolveSessionTotalTokens, type SessionEntry } from "../config/sessions/types.js";
@@ -432,7 +435,7 @@ export async function getStatusSummary(
             selectedModelComparisonLabel,
             configuredSessionModelComparisonLabel,
           ) &&
-          (hasUserPinnedModelSelection(entry) || hasSessionAutoModelFallbackProvenance(entry));
+          (hasUserPinnedModelSelection(entry) || hasSessionActiveAutoModelFallback(entry));
         // Session rows show the live selected model and warn for user-pinned
         // differences as well as runtime fallback selections (#96126).
         const contextTokens =

--- a/src/config/sessions/model-override-provenance.test.ts
+++ b/src/config/sessions/model-override-provenance.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { hasSessionActiveAutoModelFallback } from "./model-override-provenance.js";
+
+describe("hasSessionActiveAutoModelFallback", () => {
+  it.each([
+    {
+      name: "different automatic selection",
+      entry: {
+        providerOverride: "fallback",
+        modelOverride: "secondary",
+        modelOverrideSource: "auto" as const,
+        modelOverrideFallbackOriginProvider: "primary",
+        modelOverrideFallbackOriginModel: "main",
+      },
+      expected: true,
+    },
+    {
+      name: "legacy fallback provenance",
+      entry: {
+        providerOverride: "fallback",
+        modelOverride: "secondary",
+        modelOverrideFallbackOriginProvider: "primary",
+        modelOverrideFallbackOriginModel: "main",
+      },
+      expected: true,
+    },
+    {
+      name: "self-origin configured selection",
+      entry: {
+        providerOverride: "primary",
+        modelOverride: "main",
+        modelOverrideSource: "auto" as const,
+        modelOverrideFallbackOriginProvider: "primary",
+        modelOverrideFallbackOriginModel: "main",
+      },
+      expected: false,
+    },
+    {
+      name: "user selection with stale provenance",
+      entry: {
+        providerOverride: "fallback",
+        modelOverride: "secondary",
+        modelOverrideSource: "user" as const,
+        modelOverrideFallbackOriginProvider: "primary",
+        modelOverrideFallbackOriginModel: "main",
+      },
+      expected: false,
+    },
+  ])("returns $expected for $name", ({ entry, expected }) => {
+    expect(hasSessionActiveAutoModelFallback(entry)).toBe(expected);
+  });
+});

--- a/src/config/sessions/model-override-provenance.ts
+++ b/src/config/sessions/model-override-provenance.ts
@@ -24,3 +24,34 @@ export function hasSessionAutoModelFallbackProvenance(
     normalizeOptionalString(entry?.modelOverrideFallbackOriginModel),
   );
 }
+
+/** Detects an active automatic fallback rather than a self-origin configured selection. */
+export function hasSessionActiveAutoModelFallback(
+  entry:
+    | Pick<
+        SessionEntry,
+        | "providerOverride"
+        | "modelOverride"
+        | "modelOverrideSource"
+        | "modelOverrideFallbackOriginProvider"
+        | "modelOverrideFallbackOriginModel"
+      >
+    | undefined,
+): boolean {
+  if (!entry) {
+    return false;
+  }
+  if (
+    !hasSessionAutoModelFallbackProvenance(entry) ||
+    (entry.modelOverrideSource !== undefined && entry.modelOverrideSource !== "auto")
+  ) {
+    return false;
+  }
+  const originProvider = normalizeOptionalString(entry.modelOverrideFallbackOriginProvider);
+  const originModel = normalizeOptionalString(entry.modelOverrideFallbackOriginModel);
+  const overrideProvider = normalizeOptionalString(entry.providerOverride) ?? originProvider;
+  const overrideModel = normalizeOptionalString(entry.modelOverride) ?? originModel;
+  // Configured subagent selections deliberately carry self-origin metadata so cleanup preserves
+  // them. Only a different effective selection represents provider failover to users.
+  return overrideProvider !== originProvider || overrideModel !== originModel;
+}

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -148,4 +148,51 @@ describe("buildStatusMessage context window", () => {
     expect(text).toContain("Context: 36k/1.0m");
     expect(text).not.toContain("Context: 36k/200k");
   });
+
+  it("shows auto-fallback override label when model differs from configured default", () => {
+    const text = buildStatusMessage({
+      config: {
+        models: {
+          providers: {
+            "ollama-cloud": {
+              baseUrl: "https://ollama.com",
+              models: [
+                statusTestModel("deepseek-v4-pro", "DeepSeek V4 Pro", 1_000_000),
+                statusTestModel("qwen3.6-blue", "Qwen 3.6 Blue", 128_000),
+              ],
+            },
+          },
+        },
+      },
+      agent: {
+        model: "ollama-cloud/deepseek-v4-pro",
+        contextTokens: 1_000_000,
+      },
+      configuredDefaultModelLabel: "ollama-cloud/deepseek-v4-pro",
+      explicitConfiguredContextTokens: 1_000_000,
+      runtimeContextTokens: 128_000,
+      sessionEntry: {
+        sessionId: "auto-fallback-qwen",
+        updatedAt: 0,
+        providerOverride: "ollama-cloud",
+        modelOverride: "qwen3.6-blue",
+        modelOverrideSource: "auto",
+        modelOverrideFallbackOriginProvider: "ollama-cloud",
+        modelOverrideFallbackOriginModel: "deepseek-v4-pro",
+        modelProvider: "ollama-cloud",
+        model: "deepseek-v4-pro",
+        totalTokens: 50_000,
+        totalTokensFresh: true,
+      },
+      sessionKey: "agent:main:telegram:direct:auto-fallback",
+      sessionScope: "per-sender",
+      queue: { mode: "steer", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(text).toContain("Model: ollama-cloud/qwen3.6-blue");
+    expect(text).toContain("auto fallback; config primary ollama-cloud/deepseek-v4-pro");
+    expect(text).toContain("check provider");
+    expect(text).not.toContain("pinned session");
+  });
 });

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -195,4 +195,42 @@ describe("buildStatusMessage context window", () => {
     expect(text).toContain("check provider");
     expect(text).not.toContain("pinned session");
   });
+
+  it("does not label a configured subagent model as auto fallback", () => {
+    const text = buildStatusMessage({
+      config: {
+        models: {
+          providers: {
+            "ollama-cloud": {
+              baseUrl: "https://ollama.com",
+              models: [
+                statusTestModel("deepseek-v4-pro", "DeepSeek V4 Pro", 1_000_000),
+                statusTestModel("qwen3.6-blue", "Qwen 3.6 Blue", 128_000),
+              ],
+            },
+          },
+        },
+      },
+      agent: { model: "ollama-cloud/deepseek-v4-pro" },
+      configuredDefaultModelLabel: "ollama-cloud/deepseek-v4-pro",
+      sessionEntry: {
+        sessionId: "configured-subagent",
+        updatedAt: 0,
+        providerOverride: "ollama-cloud",
+        modelOverride: "qwen3.6-blue",
+        modelOverrideSource: "auto",
+        modelOverrideFallbackOriginProvider: "ollama-cloud",
+        modelOverrideFallbackOriginModel: "qwen3.6-blue",
+      },
+      sessionKey: "agent:worker:subagent:configured",
+      sessionScope: "per-sender",
+      queue: { mode: "steer", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(text).toContain("Model: ollama-cloud/qwen3.6-blue");
+    expect(text).not.toContain("auto fallback");
+    expect(text).not.toContain("check provider");
+    expect(text).not.toContain("pinned session");
+  });
 });

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -1074,15 +1074,19 @@ export function buildStatusMessage(args: StatusArgs): string {
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const configuredDefaultModelLabel = normalizeOptionalString(args.configuredDefaultModelLabel);
   const sessionHasPersistedModelSelection = hasUserPinnedModelSelection(entry);
+  const sessionHasAutoFallback =
+    entry?.modelOverride != null && !hasUserPinnedModelSelection(entry);
   const configDefaultDiffersFromSession =
-    sessionHasPersistedModelSelection &&
+    (sessionHasPersistedModelSelection || sessionHasAutoFallback) &&
     configuredDefaultModelLabel &&
     selectedModelLabel !== configuredDefaultModelLabel &&
     !areRuntimeModelRefsEquivalent(selectedModelLabel, configuredDefaultModelLabel, {
       config: args.config,
     });
   const overrideLabel = configDefaultDiffersFromSession
-    ? ` · pinned session; config primary ${configuredDefaultModelLabel} · clear /model default`
+    ? sessionHasPersistedModelSelection
+      ? ` · pinned session; config primary ${configuredDefaultModelLabel} · clear /model default`
+      : ` · auto fallback; config primary ${configuredDefaultModelLabel} · check provider`
     : "";
   const modelLines = [
     `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}${overrideLabel}`,

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -1074,8 +1074,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const configuredDefaultModelLabel = normalizeOptionalString(args.configuredDefaultModelLabel);
   const sessionHasPersistedModelSelection = hasUserPinnedModelSelection(entry);
-  const sessionHasAutoFallback =
-    entry?.modelOverride != null && !hasUserPinnedModelSelection(entry);
+  const sessionHasAutoFallback = hasSessionAutoModelFallbackProvenance(entry);
   const configDefaultDiffersFromSession =
     (sessionHasPersistedModelSelection || sessionHasAutoFallback) &&
     configuredDefaultModelLabel &&

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -45,7 +45,10 @@ import {
   type SessionScope,
 } from "../config/sessions.js";
 import { resolveSessionLifecycleTimestamps } from "../config/sessions/lifecycle.js";
-import { hasSessionAutoModelFallbackProvenance } from "../config/sessions/model-override-provenance.js";
+import {
+  hasSessionActiveAutoModelFallback,
+  hasSessionAutoModelFallbackProvenance,
+} from "../config/sessions/model-override-provenance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readRecentSessionUsageFromTranscript } from "../gateway/session-transcript-readers.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
@@ -1074,7 +1077,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
   const configuredDefaultModelLabel = normalizeOptionalString(args.configuredDefaultModelLabel);
   const sessionHasPersistedModelSelection = hasUserPinnedModelSelection(entry);
-  const sessionHasAutoFallback = hasSessionAutoModelFallbackProvenance(entry);
+  const sessionHasAutoFallback = hasSessionActiveAutoModelFallback(entry);
   const configDefaultDiffersFromSession =
     (sessionHasPersistedModelSelection || sessionHasAutoFallback) &&
     configuredDefaultModelLabel &&


### PR DESCRIPTION
## Summary

Fixes #96126. `openclaw status` and `session_status` now identify an active automatic model fallback without mistaking user-selected models, runtime snapshots, aliases, or configured subagent models for provider failover.

## What Problem This Solves

Status output showed the active model but did not explain when automatic provider fallback selected it instead of the configured primary. That made a provider outage look like an unexplained configuration change.

## Why This Change Was Made

Both status surfaces now carry a closed reason for a configured-versus-selected mismatch:

- user selection: pinned session, with the existing `/model default` recovery action;
- active automatic fallback: fallback selected, with provider-availability guidance;
- ordinary runtime snapshot, runtime-equivalent alias, or configured subagent self-origin selection: no warning.

The maintainer repair adds a shared active-fallback predicate at the session-provenance owner. A configured subagent intentionally stores automatic self-origin metadata so cleanup preserves its configured model; only an effective selection that differs from that recorded origin is provider failover.

## User Impact

- `openclaw status` labels real fallback rows as `auto fallback` and suggests checking provider availability.
- `session_status` shows the configured primary next to the live fallback model.
- User-pinned model wording remains unchanged.
- Configured subagent models remain normal configured selections, not fallback warnings.

## Evidence

- Sanitized AWS Crabbox `cbx_5b68069a77a2`, exact head `fd30f4666d7d80284d623073a5a1f59864a349e7`:
  - `run_921884422a68`: 39 focused tests passed across the provenance helper, CLI status summary/sections, and `session_status`.
  - `run_dde974d8aa34`: `pnpm check:changed` passed, including project type checks, lint/format guards, and dependency/import checks.
- Fresh pre-commit autoreview: no accepted or actionable findings.
- Focused regressions cover true automatic fallback, user pinning, runtime aliases, runtime-only snapshots, and configured-subagent self-origin state.

Co-authored-by: LZY3538 <liu.zhenye@xydigit.com>
