### PR TITLE
refactor(ui): localize unused module exports

### DIFF
--- a/ui/src/api/gateway.ts
+++ b/ui/src/api/gateway.ts
@@ -235,7 +235,7 @@ export type GatewayConnectAuth = {
   password?: string;
 };
 
-export type GatewayConnectDevice = {
+type GatewayConnectDevice = {
   id: string;
   publicKey: string;
   signature: string;
@@ -243,7 +243,7 @@ export type GatewayConnectDevice = {
   nonce: string;
 };
 
-export type GatewayConnectClientInfo = {
+type GatewayConnectClientInfo = {
   id: GatewayClientName;
   version: string;
   platform: string;
@@ -319,7 +319,7 @@ type GatewayRequestTiming = {
   errorCode?: string;
 };
 
-export type GatewayConnectTimingPhase =
+type GatewayConnectTimingPhase =
   | "socket-open"
   | "challenge"
   | "fallback"

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -369,7 +369,7 @@ export type AgentsFilesSetResult = {
   file: AgentFileEntry;
 };
 
-export type SessionWorkspaceFileEntry = {
+type SessionWorkspaceFileEntry = {
   path: string;
   workspacePath?: string;
   name: string;
@@ -397,7 +397,7 @@ type SessionWorkspaceBrowserResult = {
   truncated?: boolean;
 };
 
-export type SessionWorkspaceArtifactEntry = {
+type SessionWorkspaceArtifactEntry = {
   id: string;
   type: string;
   title: string;

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -23,7 +23,7 @@ import { page as usagePage } from "./pages/usage/route.ts";
 import { page as workboardPage } from "./pages/workboard/route.ts";
 import { page as worktreesPage } from "./pages/worktrees/route.ts";
 
-export type AppRouteModule = {
+type AppRouteModule = {
   render: (data: unknown) => unknown;
 };
 

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -56,7 +56,7 @@ export type BorderRadiusStop = (typeof BORDER_RADIUS_STOPS)[number];
 export const TEXT_SCALE_STOPS = [90, 100, 110, 125, 140] as const;
 export type TextScaleStop = (typeof TEXT_SCALE_STOPS)[number];
 
-export const CHAT_AUTO_SCROLL_MODES = ["always", "near-bottom", "off"] as const;
+const CHAT_AUTO_SCROLL_MODES = ["always", "near-bottom", "off"] as const;
 export type ChatAutoScrollMode = (typeof CHAT_AUTO_SCROLL_MODES)[number];
 
 export function normalizeChatAutoScrollMode(value: unknown): ChatAutoScrollMode {
@@ -65,7 +65,7 @@ export function normalizeChatAutoScrollMode(value: unknown): ChatAutoScrollMode 
     : "near-bottom";
 }
 
-export const CHAT_SEND_SHORTCUTS = ["enter", "modifier-enter"] as const;
+const CHAT_SEND_SHORTCUTS = ["enter", "modifier-enter"] as const;
 export type ChatSendShortcut = (typeof CHAT_SEND_SHORTCUTS)[number];
 
 export function normalizeChatSendShortcut(value: unknown): ChatSendShortcut {
@@ -143,7 +143,7 @@ export function setLastActiveSessionKey(host: LastActiveSessionHost, next: strin
   host.applySettings({ ...host.settings, lastActiveSessionKey: trimmed });
 }
 
-export type ApplicationStartupLocation = {
+type ApplicationStartupLocation = {
   pathname: string;
   search: string;
   hash: string;

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -405,7 +405,7 @@ const TAIL_LINK_BLUR_CLASS = "chat-link-tail-blur";
 const FENCE_OPEN_RE = /^[ \t]{0,3}(`{3,}|~{3,})/;
 const FENCE_CONTAINER_PREFIX_RE = /^[ \t]{0,3}(?:(?:>\s?)|(?:(?:[-+*]|\d{1,9}[.)])[ \t]+))/;
 
-export type MarkdownCodeBlockChrome = "copy" | "none";
+type MarkdownCodeBlockChrome = "copy" | "none";
 
 export type MarkdownRenderOptions = {
   codeBlockChrome?: MarkdownCodeBlockChrome;
@@ -1407,7 +1407,7 @@ export function toSanitizedMarkdownHtml(
   return sanitized;
 }
 
-export function toEscapedPlainTextHtml(value: string): string {
+function toEscapedPlainTextHtml(value: string): string {
   return `<div class="markdown-plain-text-fallback">${escapeHtml(value.replace(/\r\n?/g, "\n"))}</div>`;
 }
 

--- a/ui/src/components/terminal/terminal-connection.ts
+++ b/ui/src/components/terminal/terminal-connection.ts
@@ -31,7 +31,7 @@ export type TerminalSessionInfo = {
   createdAtMs: number;
 };
 
-export type TerminalExitInfo = {
+type TerminalExitInfo = {
   exitCode: number | null;
   signal: number | null;
   reason?: string;

--- a/ui/src/lib/agents/index.ts
+++ b/ui/src/lib/agents/index.ts
@@ -60,13 +60,13 @@ type AgentGateway = {
   subscribe: (listener: (snapshot: AgentGatewaySnapshot) => void) => () => void;
 };
 
-export type AgentFilesStatus = {
+type AgentFilesStatus = {
   list: AgentsFilesListResult | null;
   loading: boolean;
   error: string | null;
 };
 
-export type AgentCapabilityState = {
+type AgentCapabilityState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
   agentsLoading: boolean;
@@ -86,7 +86,7 @@ export type AgentCapability = {
   dispose: () => void;
 };
 
-export async function loadAgentsList(client: GatewayBrowserClient): Promise<AgentsListResult> {
+async function loadAgentsList(client: GatewayBrowserClient): Promise<AgentsListResult> {
   return client.request<AgentsListResult>("agents.list", {});
 }
 

--- a/ui/src/lib/channels/index.ts
+++ b/ui/src/lib/channels/index.ts
@@ -34,7 +34,7 @@ export type ChannelsState = {
   whatsappBusy: boolean;
 };
 
-export type LoadChannelsOptions = {
+type LoadChannelsOptions = {
   softTimeoutMs?: number;
 };
 

--- a/ui/src/lib/chat/commands.ts
+++ b/ui/src/lib/chat/commands.ts
@@ -5,8 +5,8 @@ import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
 
 export type SlashCommandCategory = "session" | "model" | "agents" | "tools";
 
-export type SlashCommandTier = "essential" | "standard" | "power";
-export type ChatIconName = string;
+type SlashCommandTier = "essential" | "standard" | "power";
+type ChatIconName = string;
 
 export type SlashCommandDef = {
   key: string;

--- a/ui/src/lib/chat/model-ref.ts
+++ b/ui/src/lib/chat/model-ref.ts
@@ -211,7 +211,7 @@ function createNameProviderKey(name: string, provider?: string | null): string {
   return `${name.toLowerCase()}\u0000${provider?.trim().toLowerCase() ?? ""}`;
 }
 
-export type ChatModelDisplayLookup = ReadonlyMap<string, string>;
+type ChatModelDisplayLookup = ReadonlyMap<string, string>;
 
 export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<string, string> {
   const nameToValues = new Map<string, Set<string>>();

--- a/ui/src/lib/chat/thinking.ts
+++ b/ui/src/lib/chat/thinking.ts
@@ -85,7 +85,7 @@ type ChatThinkingSelectState = {
   options: Array<{ value: string; label: string }>;
 };
 
-export function resolveThinkingLevelOptionsForSession(
+function resolveThinkingLevelOptionsForSession(
   session: GatewaySessionRow | undefined,
   defaults: ThinkingSessionDefaults,
 ): GatewayThinkingLevelOption[] {

--- a/ui/src/lib/chat/tool-display.ts
+++ b/ui/src/lib/chat/tool-display.ts
@@ -39,7 +39,7 @@ export type ToolDisplay = {
 };
 
 export type EmbedSandboxMode = ControlUiEmbedSandboxMode;
-export type ChatToolIconName = string;
+type ChatToolIconName = string;
 
 const EMOJI_ICON_MAP: Record<string, ChatToolIconName> = {
   "🧩": "puzzle",

--- a/ui/src/lib/config/index.ts
+++ b/ui/src/lib/config/index.ts
@@ -76,7 +76,7 @@ export type RuntimeConfigCapability = {
   dispose: () => void;
 };
 
-export type LoadConfigOptions = {
+type LoadConfigOptions = {
   discardPendingChanges?: boolean;
 };
 

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -24,7 +24,7 @@ import {
 } from "../gateway-errors.ts";
 import { normalizeLowercaseStringOrEmpty, sortUniqueStrings } from "../string-coerce.ts";
 
-export const CRON_CHANNEL_LAST = "last";
+const CRON_CHANNEL_LAST = "last";
 
 export type CronFormState = {
   name: string;

--- a/ui/src/lib/sessions/grouping.ts
+++ b/ui/src/lib/sessions/grouping.ts
@@ -24,7 +24,7 @@ export type SessionRowGroup = {
   rows: GatewaySessionRow[];
 };
 
-export type SidebarSessionSection<Row> = {
+type SidebarSessionSection<Row> = {
   id: "pinned" | "ungrouped" | `category:${string}`;
   category?: string;
   rows: Row[];

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -110,7 +110,7 @@ export type SkillsState = {
   skillCardErrors: Record<string, string>;
 };
 
-export type SkillMessage = {
+type SkillMessage = {
   kind: "success" | "error";
   message: string;
 };

--- a/ui/src/lib/workboard/index.ts
+++ b/ui/src/lib/workboard/index.ts
@@ -16,16 +16,10 @@ export const WORKBOARD_STATUSES = [
 ] as const;
 
 export const WORKBOARD_PRIORITIES = ["low", "normal", "high", "urgent"] as const;
-export const WORKBOARD_EXECUTION_ENGINES = ["codex", "claude"] as const;
-export const WORKBOARD_EXECUTION_MODES = ["autonomous", "manual"] as const;
-export const WORKBOARD_EXECUTION_STATUSES = [
-  "idle",
-  "running",
-  "review",
-  "blocked",
-  "done",
-] as const;
-export const WORKBOARD_EVENT_KINDS = [
+const WORKBOARD_EXECUTION_ENGINES = ["codex", "claude"] as const;
+const WORKBOARD_EXECUTION_MODES = ["autonomous", "manual"] as const;
+const WORKBOARD_EXECUTION_STATUSES = ["idle", "running", "review", "blocked", "done"] as const;
+const WORKBOARD_EVENT_KINDS = [
   "created",
   "edited",
   "moved",

--- a/ui/src/pages/chat/chat-send-timing.ts
+++ b/ui/src/pages/chat/chat-send-timing.ts
@@ -10,7 +10,7 @@ import {
   scheduleControlUiAfterPaint,
 } from "./performance.ts";
 
-export type ChatSendTimingPhase =
+type ChatSendTimingPhase =
   | "pending-visible"
   | "pending-painted"
   | "request-start"

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -55,8 +55,8 @@ type CachedChatItems = {
   items: ReturnType<typeof buildChatItems>;
 };
 
-export type RenderChatItem = ReturnType<typeof buildChatItems>[number];
-export type StreamRunRenderItem = {
+type RenderChatItem = ReturnType<typeof buildChatItems>[number];
+type StreamRunRenderItem = {
   kind: "stream-run";
   key: string;
   parts: Array<Extract<ChatItem, { kind: "stream" } | { kind: "reading-indicator" }>>;

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -66,7 +66,7 @@ const CHAT_ATTACHMENT_ACCEPT =
   "image/*,audio/*,application/pdf,text/*,.csv,.json,.md,.txt,.zip," +
   ".doc,.docx,.xls,.xlsx,.ppt,.pptx";
 
-export type ChatComposerProps = {
+type ChatComposerProps = {
   paneId: string;
   sessionKey: string;
   currentAgentId: string;
@@ -904,7 +904,7 @@ function renderSlashMenu(
   `;
 }
 
-export type ChatAttachmentControlsProps = {
+type ChatAttachmentControlsProps = {
   attachments?: ChatAttachment[];
   onAttachmentsChange?: (attachments: ChatAttachment[]) => void;
 };

--- a/ui/src/pages/chat/components/chat-session-workspace.ts
+++ b/ui/src/pages/chat/components/chat-session-workspace.ts
@@ -33,7 +33,7 @@ export type SessionWorkspaceProps = {
   onOpenArtifact: (artifactId: string) => void;
 };
 
-export type SessionWorkspaceState = {
+type SessionWorkspaceState = {
   activeId: string | null;
   agentId: string;
   browserPath: string;

--- a/ui/src/pages/chat/realtime-talk-conversation.ts
+++ b/ui/src/pages/chat/realtime-talk-conversation.ts
@@ -1,5 +1,5 @@
 // Control UI chat module implements realtime talk conversation behavior.
-export type RealtimeTalkConversationRole = "user" | "assistant";
+type RealtimeTalkConversationRole = "user" | "assistant";
 
 export type RealtimeTalkConversationEntry = {
   id: string;

--- a/ui/src/pages/chat/realtime-talk-input.ts
+++ b/ui/src/pages/chat/realtime-talk-input.ts
@@ -5,7 +5,7 @@ export type RealtimeTalkInputDevice = {
   label: string;
 };
 
-export type RealtimeTalkInputDiscovery = {
+type RealtimeTalkInputDiscovery = {
   devices: RealtimeTalkInputDevice[];
   warning: string | null;
 };

--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -20,7 +20,7 @@ export type RealtimeTalkCallbacks = {
   onTalkEvent?: (event: RealtimeTalkEvent) => void;
 };
 
-export type RealtimeTalkEventInput<TPayload = unknown> = {
+type RealtimeTalkEventInput<TPayload = unknown> = {
   type: RealtimeTalkEvent["type"];
   payload?: TPayload;
   turnId?: string;
@@ -31,7 +31,7 @@ export type RealtimeTalkEventInput<TPayload = unknown> = {
   parentId?: string;
 };
 
-export type RealtimeTalkAudioContract = {
+type RealtimeTalkAudioContract = {
   inputEncoding: "pcm16" | "g711_ulaw";
   inputSampleRateHz: number;
   outputEncoding: "pcm16" | "g711_ulaw";

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -34,7 +34,7 @@ export type RealtimeTalkLaunchOptions = {
   reasoningEffort?: string;
 };
 
-export type RealtimeTalkLocalOptions = {
+type RealtimeTalkLocalOptions = {
   inputDeviceId?: string;
 };
 

--- a/ui/src/pages/chat/session-message-cache.ts
+++ b/ui/src/pages/chat/session-message-cache.ts
@@ -16,7 +16,7 @@ const MAX_CACHED_CHAT_MESSAGES = 100;
 
 export type ChatMessageCache = Map<string, unknown[]>;
 
-export type ChatMessageCacheTarget = {
+type ChatMessageCacheTarget = {
   sessionKey: string;
   agentId?: string | null;
 };

--- a/ui/src/pages/chat/split-layout.ts
+++ b/ui/src/pages/chat/split-layout.ts
@@ -1,5 +1,5 @@
 export type ChatSplitPane = { id: string; sessionKey: string };
-export type ChatSplitColumn = { id: string; panes: ChatSplitPane[]; paneWeights: number[] };
+type ChatSplitColumn = { id: string; panes: ChatSplitPane[]; paneWeights: number[] };
 export type ChatSplitEdge = "left" | "right" | "up" | "down";
 export type ChatSplitLayout = {
   columns: ChatSplitColumn[];

--- a/ui/src/pages/chat/stream-reconciliation.ts
+++ b/ui/src/pages/chat/stream-reconciliation.ts
@@ -110,10 +110,10 @@ function extractToolMessageRefs(message: unknown): ToolMessageRef[] {
   return refs;
 }
 
-export type AssistantMessageVisibility = (message: unknown) => boolean;
-export type StreamVisibility = (stream: string) => boolean;
+type AssistantMessageVisibility = (message: unknown) => boolean;
+type StreamVisibility = (stream: string) => boolean;
 
-export type MaterializeVisibleStreamOptions = {
+type MaterializeVisibleStreamOptions = {
   includeCurrent?: boolean;
   requirePersistedTool?: boolean;
   replacementMessages?: unknown[];
@@ -131,7 +131,7 @@ export function currentLiveToolCallIds(state: StreamReconciliationState): string
     : [];
 }
 
-export function lastUserMessageIndex(messages: unknown[]): number {
+function lastUserMessageIndex(messages: unknown[]): number {
   for (let index = messages.length - 1; index >= 0; index--) {
     const message = messages[index];
     if (!message || typeof message !== "object") {

--- a/ui/src/pages/chat/tool-stream.ts
+++ b/ui/src/pages/chat/tool-stream.ts
@@ -281,7 +281,7 @@ function syncToolStreamMessages(host: ToolStreamHost) {
     .filter((msg): msg is Record<string, unknown> => Boolean(msg));
 }
 
-export function flushToolStreamSync(host: ToolStreamHost) {
+function flushToolStreamSync(host: ToolStreamHost) {
   if (host.toolStreamSyncTimer != null) {
     clearTimeout(host.toolStreamSyncTimer);
     host.toolStreamSyncTimer = null;

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -47,7 +47,7 @@ export type ConfigPageId =
   | "ai-agents";
 
 type ConfigFormMode = "form" | "raw";
-export type ConfigSelection = { activeSection: string | null; activeSubsection: string | null };
+type ConfigSelection = { activeSection: string | null; activeSubsection: string | null };
 
 const CONFIG_PAGE_I18N_KEYS = {
   config: "config",

--- a/ui/src/pages/config/presets.ts
+++ b/ui/src/pages/config/presets.ts
@@ -15,7 +15,7 @@ type ConfigPresetPatch = {
   };
 };
 
-export type ConfigPreset = {
+type ConfigPreset = {
   id: ConfigPresetId;
   label: string;
   description: string;

--- a/ui/src/pages/dreams/dreaming.ts
+++ b/ui/src/pages/dreams/dreaming.ts
@@ -53,7 +53,7 @@ export type DreamingEntry = {
   lastRecalledAt?: string;
 };
 
-export type DreamingStatus = {
+type DreamingStatus = {
   enabled: boolean;
   timezone?: string;
   verboseLogging: boolean;
@@ -83,7 +83,7 @@ export type DreamingStatus = {
   };
 };
 
-export type WikiImportInsightItem = {
+type WikiImportInsightItem = {
   pagePath: string;
   title: string;
   riskLevel: "low" | "medium" | "high" | "unknown";
@@ -106,7 +106,7 @@ export type WikiImportInsightItem = {
   updatedAt?: string;
 };
 
-export type WikiImportInsightCluster = {
+type WikiImportInsightCluster = {
   key: string;
   label: string;
   itemCount: number;
@@ -124,7 +124,7 @@ export type WikiImportInsights = {
   clusters: WikiImportInsightCluster[];
 };
 
-export type WikiMemoryPalaceItem = {
+type WikiMemoryPalaceItem = {
   pagePath: string;
   title: string;
   kind: "entity" | "concept" | "source" | "synthesis" | "report";
@@ -140,7 +140,7 @@ export type WikiMemoryPalaceItem = {
   snippet?: string;
 };
 
-export type WikiMemoryPalaceCluster = {
+type WikiMemoryPalaceCluster = {
   key: WikiMemoryPalaceItem["kind"];
   label: string;
   itemCount: number;
@@ -151,7 +151,7 @@ export type WikiMemoryPalaceCluster = {
   items: WikiMemoryPalaceItem[];
 };
 
-export type WikiMemoryPalacePageCounts = Record<WikiMemoryPalaceItem["kind"], number>;
+type WikiMemoryPalacePageCounts = Record<WikiMemoryPalaceItem["kind"], number>;
 
 export type WikiMemoryPalace = {
   totalItems: number;

--- a/ui/src/pages/plugin/logbook-controller.ts
+++ b/ui/src/pages/plugin/logbook-controller.ts
@@ -45,13 +45,13 @@ type LogbookDayStatsPayload = {
   apps: Array<{ domain: string; ms: number }>;
 };
 
-export type LogbookTimelinePayload = {
+type LogbookTimelinePayload = {
   day: string;
   cards: LogbookCardPayload[];
   stats: LogbookDayStatsPayload;
 };
 
-export type LogbookDaysPayload = {
+type LogbookDaysPayload = {
   days: Array<{ day: string; cards: number; firstMs: number; lastMs: number }>;
 };
 

--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -29,9 +29,9 @@ import {
 } from "./storage.ts";
 import { renderSkillWorkshop } from "./view.ts";
 
-export type SkillWorkshopPageContext = ApplicationContext & SkillWorkshopContext;
+type SkillWorkshopPageContext = ApplicationContext & SkillWorkshopContext;
 
-export type SkillWorkshopRevisionRequest = (
+type SkillWorkshopRevisionRequest = (
   instructions: string,
   proposal: SkillWorkshopState["skillWorkshopProposals"][number],
   proposalAgentId: string,

--- a/ui/src/pages/skill-workshop/view.ts
+++ b/ui/src/pages/skill-workshop/view.ts
@@ -15,7 +15,7 @@ import {
 
 type SkillWorkshopEmptyIcon = "search" | "clock" | "check" | "x" | "shield" | "refresh";
 
-export type SkillWorkshopProps = {
+type SkillWorkshopProps = {
   loading: boolean;
   error: string | null;
   inspectingKey: string | null;

--- a/ui/src/pages/tasks/data.ts
+++ b/ui/src/pages/tasks/data.ts
@@ -1,7 +1,7 @@
 export type TaskStatus = "queued" | "running" | "completed" | "failed" | "cancelled" | "timed_out";
 
 export type TaskRuntime = "subagent" | "cron" | "acp" | "cli";
-export type TaskTimestamp = number | string;
+type TaskTimestamp = number | string;
 
 export type TaskSummary = {
   id: string;

--- a/ui/src/pages/usage/metrics.ts
+++ b/ui/src/pages/usage/metrics.ts
@@ -13,7 +13,7 @@ import type { UsageSessionEntry, UsageTotals, UsageAggregates } from "./types.ts
 const CHARS_PER_TOKEN = 4;
 const DAY_MS = 86_400_000;
 
-export type UsageCostWindowSummary = {
+type UsageCostWindowSummary = {
   days: number;
   startDate: string;
   endDate: string;


### PR DESCRIPTION
## What Problem This Solves

The Control UI exposes internal-only types, constants, and helpers from 37 modules. Those exports inflate the module API surface and make static dead-code analysis noisier even though no other repository module imports them.

## Why This Change Was Made

Localize 62 symbols that are referenced only inside their declaration module. This preserves runtime behavior and local typing while narrowing the public module surface.

## User Impact

No user-visible behavior change. The UI module boundaries are smaller and future unused-code reports have less false-positive noise.

## Evidence

- Whole-repository identifier search confirmed each localized symbol has no external importer.
- `git diff --check`
- Control UI suite: 141 files passed, 2,285 tests passed, including Chromium responsive/mobile coverage.
- `pnpm check:changed` on the patched tree: passed.
- Exact committed patch SHA-256: `992cac3b9d237adfba2f08d525f3d5897cfdadcfcc954bece1d53f8eac2f7f50`.
- Fresh autoreview: no accepted/actionable findings.
