### PR TITLE
fix(discord): validate auto thread archive durations

### DIFF
--- a/extensions/discord/src/monitor/threading.auto-thread.test.ts
+++ b/extensions/discord/src/monitor/threading.auto-thread.test.ts
@@ -27,9 +27,11 @@ const mockMessage = {
 } as unknown as Parameters<MaybeCreateDiscordAutoThreadFn>[0]["message"];
 
 function createMockMessage(overrides: Record<string, unknown>) {
-  return Object.assign({}, mockMessage, overrides) as Parameters<
-    MaybeCreateDiscordAutoThreadFn
-  >[0]["message"];
+  return Object.assign(
+    {},
+    mockMessage,
+    overrides,
+  ) as Parameters<MaybeCreateDiscordAutoThreadFn>[0]["message"];
 }
 
 function createBaseParams(
@@ -213,6 +215,21 @@ describe("maybeCreateDiscordAutoThread autoArchiveDuration", () => {
     getMock.mockResolvedValueOnce({});
     await maybeCreateDiscordAutoThread(createBaseParams());
     expectRestBodyField(postMock, "auto_archive_duration", 60);
+  });
+
+  it("defaults to 60 for unsupported autoArchiveDuration values", async () => {
+    for (const autoArchiveDuration of ["0", "abc", 999] as const) {
+      postMock.mockResolvedValueOnce({ id: "thread1" });
+      getMock.mockResolvedValueOnce({});
+      await maybeCreateDiscordAutoThread(
+        createBaseParams({
+          channelConfig: { allowed: true, autoThread: true, autoArchiveDuration },
+        }),
+      );
+      expectRestBodyField(postMock, "auto_archive_duration", 60);
+      postMock.mockClear();
+      getMock.mockClear();
+    }
   });
 });
 

--- a/extensions/discord/src/monitor/threading.auto-thread.test.ts
+++ b/extensions/discord/src/monitor/threading.auto-thread.test.ts
@@ -219,11 +219,16 @@ describe("maybeCreateDiscordAutoThread autoArchiveDuration", () => {
 
   it("defaults to 60 for unsupported autoArchiveDuration values", async () => {
     for (const autoArchiveDuration of ["0", "abc", 999] as const) {
+      const channelConfig = {
+        allowed: true,
+        autoThread: true,
+        autoArchiveDuration,
+      } as unknown as Parameters<MaybeCreateDiscordAutoThreadFn>[0]["channelConfig"];
       postMock.mockResolvedValueOnce({ id: "thread1" });
       getMock.mockResolvedValueOnce({});
       await maybeCreateDiscordAutoThread(
         createBaseParams({
-          channelConfig: { allowed: true, autoThread: true, autoArchiveDuration },
+          channelConfig,
         }),
       );
       expectRestBodyField(postMock, "auto_archive_duration", 60);

--- a/extensions/discord/src/monitor/threading.auto-thread.ts
+++ b/extensions/discord/src/monitor/threading.auto-thread.ts
@@ -24,6 +24,23 @@ import type {
   MaybeCreateDiscordAutoThreadParams,
 } from "./threading.types.js";
 
+const SUPPORTED_DISCORD_AUTO_ARCHIVE_DURATIONS = new Set([60, 1440, 4320, 10080]);
+
+function resolveDiscordAutoArchiveDuration(value: unknown) {
+  if (typeof value === "number") {
+    return SUPPORTED_DISCORD_AUTO_ARCHIVE_DURATIONS.has(value) ? value : 60;
+  }
+  if (typeof value !== "string") {
+    return 60;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return 60;
+  }
+  const duration = Number(trimmed);
+  return SUPPORTED_DISCORD_AUTO_ARCHIVE_DURATIONS.has(duration) ? duration : 60;
+}
+
 function resolveTrimmedDiscordMessageChannelId(params: {
   message: DiscordMessageEvent["message"];
   messageChannelId?: string;
@@ -171,9 +188,9 @@ export async function maybeCreateDiscordAutoThread(
 
     const rawThreadSource = params.baseText || params.combinedBody || "Thread";
     const threadName = sanitizeDiscordThreadName(rawThreadSource, params.message.id);
-    const archiveDuration = params.channelConfig?.autoArchiveDuration
-      ? Number(params.channelConfig.autoArchiveDuration)
-      : 60;
+    const archiveDuration = resolveDiscordAutoArchiveDuration(
+      params.channelConfig?.autoArchiveDuration,
+    );
 
     const created = await createThread<{ id?: string }>(
       params.client.rest,


### PR DESCRIPTION
## Summary

- Validate Discord auto-thread `autoArchiveDuration` before building the create-thread request body.
- Preserve supported Discord archive durations while falling back to `60` for unsupported or malformed configured values.
- Add a regression test for unsupported string and numeric values, with the malformed runtime config case typed explicitly for the test harness.

## What Problem This Solves

Discord only accepts a fixed set of auto-archive durations for thread creation. The previous auto-thread path converted any truthy configured value with `Number(...)`, so values such as `"0"`, `"abc"`, or `999` could become `0`, `NaN`, or another unsupported number in the outgoing `auto_archive_duration` body field.

## User Impact

A misconfigured Discord channel could fail to create auto-threads instead of using the existing safe default. With this patch, unsupported values fall back to `60` minutes while valid configured values continue to work.

- **Why it matters / User impact:** Users who enable Discord auto-threading should not lose thread creation because one channel config value is malformed or outside Discord's allowed archive-duration set. The visible behavior remains auto-thread creation with the existing default duration.
- **What did NOT change:** This patch does not change Discord channel routing, message delivery, auto-thread eligibility, existing-thread lookup, thread rename behavior, REST transport, or valid `autoArchiveDuration` values.
- **Architecture / source-of-truth check:** The source of truth is the request body produced by `maybeCreateDiscordAutoThread`; validation happens at the same boundary that sets `auto_archive_duration`, before the Discord REST wrapper receives the payload.
- **Maintainer-ready confidence:** High. The diff is two files, one production helper plus one regression case, plus a test-only type fix after CI identified the malformed runtime config fixture needed an explicit cast.
- **Patch quality notes:** Focused root-cause normalization with no channel routing, message delivery, thread title, or REST transport refactor.

## Origin / follow-up

Follow-up from recent Discord auto-thread work around #35065. This PR does not close a linked issue; it fixes a sibling input-normalization gap in the same auto-thread request construction path.

## Competition / linked PR analysis

No open competing PR was found for this specific gap before starting this patch.

Checked for overlapping work by exact area and behavior:

```text
files: extensions/discord/src/monitor/threading.auto-thread.ts
files: extensions/discord/src/monitor/threading.auto-thread.test.ts
keywords: autoArchiveDuration, auto_archive_duration, auto-thread archive duration
```

The found open PR set did not include a patch that validates unsupported `autoArchiveDuration` values or changes the Discord auto-thread `auto_archive_duration` fallback behavior.

Related open PR / same-contract scan result: no canonical PR was found for this public channel configuration normalization behavior.

## Real behavior proof

- **Behavior or issue addressed:**

```text
Discord auto-thread request-body construction no longer forwards unsupported configured archive durations to the create-thread REST wrapper. Unsupported values now produce auto_archive_duration: 60.
```

- **Real environment tested:**

```text
Local OpenClaw Discord extension test environment in the task worktree, exercising maybeCreateDiscordAutoThread through the real request-body construction path with the REST boundary supplied by the existing Vitest harness.
```

- **Exact steps or command run after this patch:**

```bash
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/discord/src/monitor/threading.auto-thread.test.ts
```

- **Evidence after fix:**

```text
Test Files  1 passed (1)
Tests       21 passed (21)
```

- **Observed result after fix:**

```text
The regression case covers unsupported values "0", "abc", and 999. Each now sends auto_archive_duration: 60. Existing tests still confirm valid string and numeric values are preserved.
```

- **What was not tested:**

```text
A live Discord guild/API call was not executed in this environment. The proof covers local extension behavior up to the Discord REST client wrapper request body.
```

- **Fix classification:** Root cause fix

## Review findings addressed

- `check-test-types` failed on the first pushed head because the regression test intentionally injected malformed runtime values (`"0"`, `"abc"`, `999`) through the narrow compile-time `autoArchiveDuration` config type.
- The round2 commit keeps the same runtime fixture but casts the malformed channel config through `unknown`, so the test still verifies malformed input normalization without violating the TypeScript config surface.
- Local target verification after the round2 change:

```text
Test Files  1 passed (1)
Tests       21 passed (21)
```

- Local extensions test-type attribution after the round2 change no longer reports the original Discord `TS2322` error. The remaining local direct typecheck output is outside this PR's diff (`extensions/telegram/**` and `extensions/workboard/**`) and is not changed by this PR.

## Regression Test Plan

- **Target test file:** `extensions/discord/src/monitor/threading.auto-thread.test.ts`
- **Scenario locked in:** `autoArchiveDuration` values `"0"`, `"abc"`, and `999` previously reached the outgoing request body as unsupported values; the regression test verifies each now falls back to `60`.
- **Why this is the smallest reliable guardrail:** The target test asserts the actual `auto_archive_duration` field passed to the REST wrapper, so future changes cannot reintroduce unsupported values without failing the auto-thread request-body test.

```bash
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/discord/src/monitor/threading.auto-thread.test.ts
```

Expected result:

```text
Test Files  1 passed (1)
Tests       21 passed (21)
```

## Risk / Compatibility

Low risk. The change is limited to Discord auto-thread archive-duration normalization. Supported values remain `60`, `1440`, `4320`, and `10080`; unsupported configured values now use the existing default of `60` instead of being forwarded.

## Merge risk

- **Risk labels considered:** `merge-risk:message-delivery`, public channel configuration surface.
- **Risk explanation:** The touched files are in the Discord auto-thread message-delivery path, but the patch does not change routing, message sending, thread lookup, permissions, or REST transport behavior. It only clamps one outbound request-body field to Discord-supported values.
- **Why acceptable:** Invalid or malformed configured values already could not be valid Discord archive durations. Falling back to the existing default preserves thread creation and keeps valid configured values unchanged. The related open PR scan found no canonical competing patch for this exact config normalization gap.

## What was not changed

- No change to Discord thread name generation.
- No change to auto-thread eligibility checks.
- No change to existing-thread reuse or rename behavior.
- No change to other Discord message delivery paths.
- No change to live Discord transport behavior outside the request body field value.

## Root Cause

- **Root cause:** The auto-thread path treated any truthy `autoArchiveDuration` as a number-compatible value and forwarded `Number(value)` without checking whether Discord supports the resulting duration.

- **Why this is root-cause fix:** The patch validates the duration at the source of the outgoing `auto_archive_duration` field and only permits Discord-supported durations, so malformed or unsupported config values cannot reach the create-thread request body.
