### PR TITLE
fix(openrouter): preserve string STT temperature

### DIFF
--- a/extensions/openrouter/media-understanding-provider.test.ts
+++ b/extensions/openrouter/media-understanding-provider.test.ts
@@ -156,8 +156,34 @@ describe("openrouter media understanding provider", () => {
     });
   });
 
+  it("accepts string temperature via provider query options", async () => {
+    const release = vi.fn(async () => {});
+    postJsonRequestMock.mockResolvedValue({
+      response: new Response(JSON.stringify({ text: "ok" }), { status: 200 }),
+      release,
+    });
+
+    await transcribeOpenRouterAudio({
+      buffer: Buffer.from("audio"),
+      fileName: "voice.webm",
+      apiKey: "sk-openrouter",
+      timeoutMs: 5_000,
+      query: { temperature: "0.2" },
+      fetchFn: fetch,
+    });
+
+    expect(firstPostJsonRequest().body).toEqual({
+      model: "openai/whisper-large-v3-turbo",
+      input_audio: {
+        data: Buffer.from("audio").toString("base64"),
+        format: "webm",
+      },
+      temperature: 0.2,
+    });
+  });
+
   it("drops malformed temperature query options", async () => {
-    for (const temperature of [Number.NaN, Number.POSITIVE_INFINITY]) {
+    for (const temperature of [Number.NaN, Number.POSITIVE_INFINITY, "", "abc", "0x10"]) {
       const release = vi.fn(async () => {});
       postJsonRequestMock.mockResolvedValueOnce({
         response: new Response(JSON.stringify({ text: "ok" }), { status: 200 }),

--- a/extensions/openrouter/media-understanding-provider.ts
+++ b/extensions/openrouter/media-understanding-provider.ts
@@ -100,6 +100,21 @@ type OpenRouterSttResponse = {
   text?: string;
 };
 
+function resolveOpenRouterSttTemperature(value: unknown) {
+  const temperature = asFiniteNumber(value);
+  if (temperature !== undefined) {
+    return temperature;
+  }
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!/^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/iu.test(trimmed)) {
+    return undefined;
+  }
+  return asFiniteNumber(Number(trimmed));
+}
+
 export async function transcribeOpenRouterAudio(
   params: AudioTranscriptionRequest,
 ): Promise<AudioTranscriptionResult> {
@@ -126,7 +141,7 @@ export async function transcribeOpenRouterAudio(
       capability: "audio",
       transport: "media-understanding",
     });
-  const temperature = asFiniteNumber(params.query?.temperature);
+  const temperature = resolveOpenRouterSttTemperature(params.query?.temperature);
 
   const { response, release } = await postJsonRequest({
     url: `${baseUrl}/audio/transcriptions`,


### PR DESCRIPTION
## Summary

- Preserve string `query.temperature` values when building OpenRouter STT requests.
- Parse strict finite numeric strings into numbers before adding `temperature` to the JSON body.
- Keep malformed temperature values omitted, including `NaN`, `Infinity`, empty strings, non-numeric strings, and hex-like strings.

## What Problem This Solves

`AudioTranscriptionRequest.query` allows string, number, and boolean values, but the OpenRouter STT path previously used `asFiniteNumber(params.query?.temperature)`. That helper intentionally accepts only numeric values, so `query.temperature: "0.2"` was silently dropped before the `/audio/transcriptions` request body was built.

## User Impact

Users passing provider query options from string-based config or request parameters could not set OpenRouter STT temperature even though the shared request type permits string query values.

- **Why it matters / User impact:** OpenRouter STT callers can now pass `temperature` through the same string-valued query path used by config/URL-style inputs without losing a valid numeric value.
- **What did NOT change:** This patch does not change OpenRouter auth, base URL resolution, audio format detection, model selection, response parsing, HTTP transport, or malformed temperature omission behavior.
- **Architecture / source-of-truth check:** The source of truth is the OpenRouter STT JSON request body produced by `transcribeOpenRouterAudio`; parsing happens immediately before the `temperature` field is conditionally added to that body.
- **Maintainer-ready confidence:** High. The diff is limited to one provider helper and one focused regression test, with fresh verification on the exact OpenRouter provider test file.
- **Patch quality notes:** Focused root-cause parsing at the request-body boundary, with no provider transport refactor and no broad change to shared number coercion semantics.

## Origin / follow-up

Follow-up from recent OpenRouter/provider work around #77490. This PR does not close a linked issue; it fixes a sibling input-normalization gap in the OpenRouter STT request-body path.

## Competition / linked PR analysis

No open competing PR was found for this specific gap before starting this patch.

Checked for overlapping work by exact area and behavior:

```text
files: extensions/openrouter/media-understanding-provider.ts
files: extensions/openrouter/media-understanding-provider.test.ts
keywords: OpenRouter STT temperature, query.temperature, audio transcription temperature
```

The found open PR set did not include a patch that preserves string-valued STT `query.temperature` for OpenRouter.

Related open PR / same-contract scan result: no canonical PR was found for this provider query normalization behavior.

## Real behavior proof

- **Behavior or issue addressed:**

```text
OpenRouter STT request-body construction no longer drops valid numeric string query.temperature values. query.temperature: "0.2" now produces temperature: 0.2 in the provider JSON body.
```

- **Real environment tested:**

```text
Local OpenClaw OpenRouter extension provider test environment in the task worktree, exercising transcribeOpenRouterAudio through the real JSON request-body construction path with the provider HTTP boundary supplied by the existing Vitest harness.
```

- **Exact steps or command run after this patch:**

```bash
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/openrouter/media-understanding-provider.test.ts
```

- **Evidence after fix:**

```text
Test Files  1 passed (1)
Tests       10 passed (10)
```

- **Observed result after fix:**

```text
The regression case covers query.temperature: "0.2" and verifies the outgoing OpenRouter STT body includes temperature: 0.2. Existing numeric temperature behavior still passes, and malformed values remain omitted.
```

- **What was not tested:**

```text
A live OpenRouter API call was not executed in this environment. The proof covers local provider behavior up to the provider HTTP helper request body.
```

- **Fix classification:** Root cause fix

## Review findings addressed

No prior review findings are attached to this follow-up PR.

## Regression Test Plan

- **Target test file:** `extensions/openrouter/media-understanding-provider.test.ts`
- **Scenario locked in:** `query.temperature: "0.2"` previously reached `transcribeOpenRouterAudio` but was omitted from the outgoing JSON body; the regression test verifies it is parsed into `temperature: 0.2`.
- **Why this is the smallest reliable guardrail:** The test asserts the exact body passed to `postJsonRequest`, so future changes cannot drop valid numeric string temperature values without failing the provider request-body test.

```bash
OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree node scripts/run-vitest.mjs extensions/openrouter/media-understanding-provider.test.ts
```

Expected result:

```text
Test Files  1 passed (1)
Tests       10 passed (10)
```

## Risk / Compatibility

Low risk. Numeric temperature values keep using existing finite-number behavior. Valid numeric strings are newly preserved. Malformed strings and non-finite numeric values remain omitted, matching the prior malformed-value behavior.

## Merge risk

- **Risk labels considered:** `merge-risk:auth-provider` / provider request-body behavior, public query/config input surface.
- **Risk explanation:** The touched files are in a provider path, but the patch does not change authentication, headers, base URL selection, fetch behavior, timeout handling, model defaults, or response parsing. It only normalizes one query option before constructing the OpenRouter STT request body.
- **Why acceptable:** The shared request type already permits string query values. Strict parsing avoids broad coercion surprises such as hex-like strings while preserving valid finite decimal/exponent numeric strings for the provider request body.

## What was not changed

- No change to shared `asFiniteNumber` behavior.
- No change to non-OpenRouter providers.
- No change to OpenRouter image paths.
- No change to OpenRouter STT model, language, audio format, or response parsing behavior.
- No change to malformed temperature omission.

## Root Cause

- **Root cause:** The OpenRouter STT path used `asFiniteNumber` directly on `params.query?.temperature`, but that helper intentionally rejects strings even though `AudioTranscriptionRequest.query` allows string query values.

- **Why this is root-cause fix:** The patch fixes the conversion at the source of the outgoing OpenRouter STT `temperature` field, parsing strict finite numeric strings before the request body is built while preserving malformed-value omission.
