### PR TITLE
fix: block mixed-case cron shell jobs from agent tool [AI]

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -1066,10 +1066,7 @@ describe("cron tool", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ["canonical", "on-exit"],
-    ["mixed-case", "On-Exit"],
-  ])("rejects %s on-exit schedules from the agent cron tool on add", async (_case, kind) => {
+  it("rejects on-exit schedules from the agent cron tool on add", async () => {
     const tool = createTestCronTool();
 
     await expect(
@@ -1077,7 +1074,7 @@ describe("cron tool", () => {
         action: "add",
         job: {
           name: "watch command",
-          schedule: { kind, command: "make" },
+          schedule: { kind: "on-exit", command: "make" },
           payload: { kind: "agentTurn", message: "done" },
         },
       }),
@@ -2097,10 +2094,7 @@ describe("cron tool", () => {
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ["canonical", "on-exit"],
-    ["mixed-case", "On-Exit"],
-  ])("rejects %s on-exit schedules from the agent cron tool on update", async (_case, kind) => {
+  it("rejects on-exit schedules from the agent cron tool on update", async () => {
     const tool = createTestCronTool();
 
     await expect(
@@ -2108,7 +2102,7 @@ describe("cron tool", () => {
         action: "update",
         id: "job-4",
         patch: {
-          schedule: { kind, command: "make" },
+          schedule: { kind: "on-exit", command: "make" },
         },
       }),
     ).rejects.toThrow("cron on-exit schedules cannot be created or edited");

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -1046,7 +1046,10 @@ describe("cron tool", () => {
     expect(params?.failureAlert).toBe(false);
   });
 
-  it("rejects command payloads from the agent cron tool on add", async () => {
+  it.each([
+    ["canonical", "command"],
+    ["mixed-case", "Command"],
+  ])("rejects %s command payloads from the agent cron tool on add", async (_case, kind) => {
     const tool = createTestCronTool();
 
     await expect(
@@ -1056,14 +1059,17 @@ describe("cron tool", () => {
           name: "command",
           schedule: { at: new Date(123).toISOString() },
           sessionTarget: "isolated",
-          payload: { kind: "command", argv: ["sh", "-lc", "echo ok"] },
+          payload: { kind, argv: ["sh", "-lc", "echo ok"] },
         },
       }),
     ).rejects.toThrow("cron command payloads cannot be created or edited");
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
-  it("rejects on-exit schedules from the agent cron tool on add", async () => {
+  it.each([
+    ["canonical", "on-exit"],
+    ["mixed-case", "On-Exit"],
+  ])("rejects %s on-exit schedules from the agent cron tool on add", async (_case, kind) => {
     const tool = createTestCronTool();
 
     await expect(
@@ -1071,7 +1077,7 @@ describe("cron tool", () => {
         action: "add",
         job: {
           name: "watch command",
-          schedule: { kind: "on-exit", command: "make" },
+          schedule: { kind, command: "make" },
           payload: { kind: "agentTurn", message: "done" },
         },
       }),
@@ -2073,7 +2079,10 @@ describe("cron tool", () => {
     expect(params?.patch?.failureAlert).toBe(false);
   });
 
-  it("rejects command payloads from the agent cron tool on update", async () => {
+  it.each([
+    ["canonical", "command"],
+    ["mixed-case", "Command"],
+  ])("rejects %s command payloads from the agent cron tool on update", async (_case, kind) => {
     const tool = createTestCronTool();
 
     await expect(
@@ -2081,14 +2090,17 @@ describe("cron tool", () => {
         action: "update",
         id: "job-4",
         patch: {
-          payload: { kind: "command", argv: ["sh", "-lc", "echo ok"] },
+          payload: { kind, argv: ["sh", "-lc", "echo ok"] },
         },
       }),
     ).rejects.toThrow("cron command payloads cannot be created or edited");
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
-  it("rejects on-exit schedules from the agent cron tool on update", async () => {
+  it.each([
+    ["canonical", "on-exit"],
+    ["mixed-case", "On-Exit"],
+  ])("rejects %s on-exit schedules from the agent cron tool on update", async (_case, kind) => {
     const tool = createTestCronTool();
 
     await expect(
@@ -2096,7 +2108,7 @@ describe("cron tool", () => {
         action: "update",
         id: "job-4",
         patch: {
-          schedule: { kind: "on-exit", command: "make" },
+          schedule: { kind, command: "make" },
         },
       }),
     ).rejects.toThrow("cron on-exit schedules cannot be created or edited");

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -444,13 +444,13 @@ function assertNoCronShellExecution(value: unknown): void {
     return;
   }
   const payload = isRecord(value.payload) ? value.payload : undefined;
-  if (payload?.kind === "command") {
+  if (normalizeLowercaseStringOrEmpty(payload?.kind) === "command") {
     throw new Error(
       "cron command payloads cannot be created or edited through the agent cron tool; use the CLI or Gateway API.",
     );
   }
   const schedule = isRecord(value.schedule) ? value.schedule : undefined;
-  if (schedule?.kind === "on-exit") {
+  if (normalizeLowercaseStringOrEmpty(schedule?.kind) === "on-exit") {
     throw new Error(
       "cron on-exit schedules cannot be created or edited through the agent cron tool; use the CLI or Gateway API.",
     );

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -450,7 +450,7 @@ function assertNoCronShellExecution(value: unknown): void {
     );
   }
   const schedule = isRecord(value.schedule) ? value.schedule : undefined;
-  if (normalizeLowercaseStringOrEmpty(schedule?.kind) === "on-exit") {
+  if (schedule?.kind === "on-exit") {
     throw new Error(
       "cron on-exit schedules cannot be created or edited through the agent cron tool; use the CLI or Gateway API.",
     );


### PR DESCRIPTION
## What Problem This Solves

Agent-created cron jobs could bypass the cron tool's shell-execution restriction by sending `payload.kind: "Command"`. The tool checked for the exact lowercase spelling before cron normalization later canonicalized the payload to an executable `command` job.

## Why This Change Was Made

The agent cron tool now applies the existing lowercase-string normalizer at its command-payload deny boundary for both add and update. The change intentionally leaves the separate `on-exit` guard unchanged: cron tool canonicalization already converts a schedule containing `command` to `on-exit` before this guard, including mixed-case input.

## User Impact

Agent and MCP tool calls can no longer create or edit command-backed cron jobs by changing the casing of the payload kind. CLI and direct Gateway cron APIs retain their existing command-job support.

## Evidence

- Sanitized AWS Crabbox baseline run `run_21427c843258` combined the regression tests with current `main`; both mixed-case command add/update cases failed as expected before the fix.
- Sanitized AWS Crabbox baseline run `run_beacbda457f9` proved mixed-case on-exit add/update were already rejected on current `main` (2/2 passed), so the redundant on-exit change was removed.
- Sanitized AWS Crabbox exact-head run `run_b62a042cc371`, provider `aws`, lease `cbx_e4653c3a8908`: `pnpm test src/agents/tools/cron-tool.test.ts` passed 142/142 tests.
- `git diff --check` passed.
- Structured autoreview on exact head `efcdfa377123298cea8f4cf3c17cfad82775ecff` was clean with 0.91 confidence.
