### PR TITLE
fix: route Anthropic SDK clients through guarded transport

### DIFF
--- a/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts
+++ b/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.test.ts
@@ -85,6 +85,7 @@ describe("createMantleAnthropicStreamFn", () => {
     expect(defaultHeaders["anthropic-beta"]).toBe("fine-grained-tool-streaming-2025-05-14");
     expect(defaultHeaders["X-Test"]).toBe("model-header");
     expect(defaultHeaders["X-Caller"]).toBe("caller-header");
+    expect(clientOptions.fetch).toEqual(expect.any(Function));
 
     expectFirstStreamCall(deps, model, context);
     const streamOptions = firstStreamOptions(deps);

--- a/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts
@@ -15,6 +15,7 @@ import {
   resolveClaudeMythos5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildGuardedModelFetch } from "openclaw/plugin-sdk/provider-transport-runtime";
 
 const MANTLE_ANTHROPIC_BETA = "fine-grained-tool-streaming-2025-05-14";
 type AnthropicOptions = ConstructorParameters<typeof Anthropic>[0];
@@ -177,6 +178,7 @@ export function createMantleAnthropicStreamFn(deps?: {
         model.headers,
         options?.headers,
       ),
+      fetch: buildGuardedModelFetch(model),
     });
     const base = buildMantleAnthropicBaseOptions(model, options, apiKey);
     // Plugin package deps can give this plugin a distinct physical SDK copy.

--- a/packages/ai/src/providers/anthropic.fetch-loopback.test.ts
+++ b/packages/ai/src/providers/anthropic.fetch-loopback.test.ts
@@ -1,0 +1,143 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { configureAiTransportHost } from "../host.js";
+import type { Context, Model } from "../types.js";
+import { streamAnthropic } from "./anthropic.js";
+
+type CapturedRequest = {
+  method: string;
+  path: string;
+  authorization?: string;
+  apiKey?: string;
+};
+
+const context = {
+  messages: [{ role: "user", content: "hello", timestamp: 1 }],
+} satisfies Context;
+
+function makeModel(overrides: Partial<Model<"anthropic-messages">>) {
+  return {
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    provider: "anthropic",
+    api: "anthropic-messages",
+    baseUrl: "https://api.anthropic.com",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 4_096,
+    ...overrides,
+  } satisfies Model<"anthropic-messages">;
+}
+
+afterEach(() => {
+  configureAiTransportHost({});
+});
+
+describe("Anthropic SDK host fetch wiring", () => {
+  it("routes every non-Cloudflare client branch through the host fetch", async () => {
+    const requests: CapturedRequest[] = [];
+    const server = createServer((request, response) => {
+      requests.push({
+        method: request.method ?? "",
+        path: request.url ?? "",
+        authorization: request.headers.authorization,
+        apiKey: request.headers["x-api-key"] as string | undefined,
+      });
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify({
+          type: "error",
+          error: { type: "authentication_error", message: "test rejection" },
+        }),
+      );
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    const address = server.address() as AddressInfo;
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const hostFetch = vi.fn<typeof fetch>((input, init) => globalThis.fetch(input, init));
+    const buildModelFetch = vi.fn(() => hostFetch);
+    configureAiTransportHost({ buildModelFetch });
+
+    const cases = [
+      {
+        model: makeModel({ provider: "github-copilot", baseUrl }),
+        apiKey: "copilot-token",
+      },
+      {
+        model: makeModel({ provider: "microsoft-foundry", baseUrl, authHeader: true }),
+        apiKey: "foundry-token",
+      },
+      {
+        model: makeModel({ baseUrl }),
+        apiKey: "sk-ant-oat01-oauth-token", // pragma: allowlist secret
+      },
+      {
+        model: makeModel({ baseUrl }),
+        apiKey: "sk-ant-api03-api-key", // pragma: allowlist secret
+      },
+      {
+        model: makeModel({ provider: "kimi-coding", baseUrl }),
+        apiKey: "kimi-api-key",
+        thinkingEnabled: true,
+      },
+    ];
+
+    try {
+      for (const testCase of cases) {
+        const result = await streamAnthropic(testCase.model, context, {
+          apiKey: testCase.apiKey,
+          maxRetries: 0,
+          thinkingEnabled: testCase.thinkingEnabled,
+        }).result();
+        expect(result.stopReason).toBe("error");
+      }
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+
+    expect(hostFetch).toHaveBeenCalledTimes(cases.length);
+    expect(requests).toEqual([
+      {
+        method: "POST",
+        path: "/v1/messages",
+        authorization: "Bearer copilot-token",
+        apiKey: undefined,
+      },
+      {
+        method: "POST",
+        path: "/v1/messages",
+        authorization: "Bearer foundry-token",
+        apiKey: undefined,
+      },
+      {
+        method: "POST",
+        path: "/v1/messages",
+        authorization: "Bearer sk-ant-oat01-oauth-token", // pragma: allowlist secret
+        apiKey: undefined,
+      },
+      {
+        method: "POST",
+        path: "/v1/messages",
+        authorization: undefined,
+        apiKey: "sk-ant-api03-api-key", // pragma: allowlist secret
+      },
+      {
+        method: "POST",
+        path: "/v1/messages",
+        authorization: undefined,
+        apiKey: "kimi-api-key",
+      },
+    ]);
+    expect(buildModelFetch).toHaveBeenLastCalledWith(cases.at(-1)?.model, undefined, {
+      sanitizeSse: false,
+    });
+  });
+});

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -559,6 +559,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
         const created = createClient(
           model,
           apiKey,
+          options?.thinkingEnabled === true,
           options?.interleavedThinking ?? true,
           shouldUseFineGrainedToolStreamingBeta(model, requestContext),
           options?.headers,
@@ -1101,6 +1102,7 @@ function supportsAnthropicServerSideFallback(model: Model<"anthropic-messages">)
 function createClient(
   model: Model<"anthropic-messages">,
   apiKey: string,
+  thinkingEnabled: boolean,
   interleavedThinking: boolean,
   useFineGrainedToolStreamingBeta: boolean,
   optionsHeaders?: Record<string, string>,
@@ -1117,6 +1119,11 @@ function createClient(
   if (needsInterleavedBeta) {
     betaFeatures.push(INTERLEAVED_THINKING_BETA);
   }
+  const fetchOptions =
+    /^kimi(?:-|$)/.test(model.provider) && thinkingEnabled
+      ? { sanitizeSse: false as const }
+      : undefined;
+  const fetch = getAiTransportHost().buildModelFetch(model, undefined, fetchOptions);
 
   if (model.provider === "cloudflare-ai-gateway") {
     const client = new Anthropic({
@@ -1134,7 +1141,7 @@ function createClient(
         model.headers,
         optionsHeaders,
       ),
-      fetch: getAiTransportHost().buildModelFetch(model),
+      fetch,
     });
 
     return { client, isOAuthToken: false, serverSideFallback: false };
@@ -1157,6 +1164,7 @@ function createClient(
         dynamicHeaders,
         optionsHeaders,
       ),
+      fetch,
     });
 
     return { client, isOAuthToken: false, serverSideFallback: false };
@@ -1178,6 +1186,7 @@ function createClient(
         dynamicHeaders,
         optionsHeaders,
       ),
+      fetch,
     });
 
     return { client, isOAuthToken: false, serverSideFallback: false };
@@ -1201,6 +1210,7 @@ function createClient(
         model.headers,
         optionsHeaders,
       ),
+      fetch,
     });
 
     return { client, isOAuthToken: true, serverSideFallback: false };
@@ -1230,6 +1240,7 @@ function createClient(
       model.headers,
       optionsHeaders,
     ),
+    fetch,
   });
 
   return { client, isOAuthToken: false, serverSideFallback };


### PR DESCRIPTION
Related: #100550

AI-assisted: Codex

## What Problem This Solves

Fixes an issue where Anthropic-compatible requests from GitHub Copilot, Microsoft Foundry, Anthropic OAuth/API-key clients, Kimi, and Amazon Bedrock Mantle could bypass OpenClaw's guarded model transport when the Anthropic SDK created the HTTP request.

## Why This Change Was Made

Every Anthropic SDK client now receives the host-built guarded fetch, matching the existing Cloudflare and extracted Anthropic transport paths. Kimi thinking streams retain their required SSE sanitizer bypass, and Mantle uses the public provider transport runtime seam.

## User Impact

Anthropic-compatible provider routes now consistently receive OpenClaw's request policy, response normalization, and managed stream cleanup instead of depending on the SDK's default fetch. Provider auth and request payload behavior are unchanged.

## Evidence

- Baseline negative control at `21d919deb801939d185e548cb70268b05045ebf9`: the real-SDK loopback test failed because the host fetch recorded zero calls.
- Rebased focused proof at `31432bf10160512956573c8010b0d1bb5cdf75f2`: 61 core Anthropic tests and 11 Mantle tests passed. The loopback test exercised the real Anthropic SDK over HTTP and verified Copilot, Foundry, OAuth, API-key, and Kimi auth/request paths.
- `pnpm check:changed` on Blacksmith Testbox `tbx_01kwxc5vmckc01qzmfff04chka`: core/plugin typechecks, lint, dependency guards, import-cycle checks, and boundary checks passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.5 --thinking high`: clean, no accepted/actionable findings.

Dependency contract checked against `@anthropic-ai/sdk` `sdk-v0.109.1`: `ClientOptions.fetch` is the supported constructor seam and request dispatch uses that configured fetch.
