### PR TITLE
fix(minimax): clarify TTS volume boundary

### DIFF
--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -634,7 +634,7 @@ directive warnings.
 - `speakerVoice` / `speakerVoiceId` (legacy aliases: `voice`, `voiceName`, `voice_name`, `google_voice`, `voiceId`)
 - `model` / `google_model`
 - `stability`, `similarityBoost`, `style`, `speed`, `useSpeakerBoost`
-- `vol` / `volume` (MiniMax volume, 0–10)
+- `vol` / `volume` (MiniMax volume, `(0, 10]`)
 - `pitch` (MiniMax integer pitch, −12 to 12; fractional values are truncated)
 - `emotion` (Volcengine emotion tag)
 - `applyTextNormalization` (`auto|on|off`)

--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -291,10 +291,20 @@ describe("buildMinimaxSpeechProvider", () => {
       expect(result.overrides?.vol).toBe(3);
     });
 
-    it("warns on vol=0 (exclusive minimum)", () => {
-      const result = parseDirectiveToken({ key: "vol", value: "0", policy });
+    it("handles vol=10 (inclusive maximum)", () => {
+      const result = parseDirectiveToken({ key: "vol", value: "10", policy });
       expect(result.handled).toBe(true);
-      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings).toBeUndefined();
+      expect(result.overrides?.vol).toBe(10);
+    });
+
+    it.each(["0", "11"])("describes the MiniMax volume boundary for vol=%s", (value) => {
+      const result = parseDirectiveToken({ key: "vol", value, policy });
+      expect(result.handled).toBe(true);
+      expect(result.warnings).toEqual([
+        `invalid MiniMax volume "${value}" (must be greater than 0 and at most 10)`,
+      ]);
+      expect(result.overrides).toBeUndefined();
     });
 
     it("warns on non-decimal volume values", () => {

--- a/extensions/minimax/speech-provider.ts
+++ b/extensions/minimax/speech-provider.ts
@@ -200,7 +200,8 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext): {
         ctx,
         overrideKey: "vol",
         range: { min: 0, minExclusive: true, max: 10 },
-        warning: (value) => `invalid MiniMax volume "${value}" (0-10, exclusive)`,
+        warning: (value) =>
+          `invalid MiniMax volume "${value}" (must be greater than 0 and at most 10)`,
       });
     }
     case "pitch": {


### PR DESCRIPTION
Related: #93397

## What Problem This Solves

Fixes an issue where users who supplied an invalid MiniMax TTS volume directive saw a warning that described both range endpoints as exclusive, even though MiniMax and OpenClaw accept `10` and reject only values at or below `0` or above `10`.

## Why This Change Was Made

The warning now states the boundary in plain language: volume must be greater than 0 and at most 10. Exact boundary tests cover rejected values `0` and `11`, preserve acceptance of `10`, and the public TTS directive reference now uses the canonical `(0, 10]` notation.

This is a maintainer replacement for #93397 because the contributor branch was based far behind current `main`; refreshing that fork through GitHub's verified-commit API would have required replaying thousands of unrelated files. The useful contributor change is preserved with co-author credit.

## User Impact

MiniMax TTS users now receive an accurate, unambiguous volume warning and see the same boundary in the TTS documentation. Numeric parsing and synthesis behavior are unchanged.

## Evidence

- Current [MiniMax T2A HTTP documentation](https://platform.minimax.io/docs/api-reference/speech-t2a-http) declares `voice_setting.vol` as `(0, 10]` with `exclusiveMinimum: 0` and `maximum: 10`.
- Focused regression coverage asserts the exact warning for `vol=0` and `vol=11`, while `vol=10` remains accepted without a warning.
- Fresh Codex autoreview on the current-main diff reported no accepted/actionable findings.
- Blacksmith Testbox through Crabbox `tbx_01kwxe0113trnv147sx2kb4j27` (Actions run [28841981897](https://github.com/openclaw/openclaw/actions/runs/28841981897)): `pnpm test extensions/minimax/speech-provider.test.ts` passed 39 tests; `pnpm check:changed` passed.
- Repo-native prepare verified exact head `6d02a4ab2db5414c70d65eb0966ad822b0d5ed68` against hosted CI/Testbox gates.
