### PR TITLE
fix(android): handle hardware Enter without breaking IME input

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -5787,7 +5787,7 @@
     },
     {
       "kind": "ui-call",
-      "line": 248,
+      "line": 256,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Type a message…",
       "surface": "android",
@@ -5795,7 +5795,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 261,
+      "line": 270,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Gateway is offline. Text messages are queued and sent after reconnecting.",
       "surface": "android",
@@ -5803,7 +5803,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 291,
+      "line": 300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Select thinking level",
       "surface": "android",
@@ -5811,7 +5811,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 316,
+      "line": 325,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Attach",
       "surface": "android",
@@ -5819,7 +5819,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 331,
+      "line": 340,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Refresh",
       "surface": "android",
@@ -5827,7 +5827,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 339,
+      "line": 348,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Abort",
       "surface": "android",
@@ -5835,7 +5835,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 374,
+      "line": 383,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "Send",
       "surface": "android",
@@ -5843,7 +5843,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 400,
+      "line": 409,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt",
       "source": "No commands found",
       "surface": "android",
@@ -6131,7 +6131,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 309,
+      "line": 300,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat needs attention",
       "surface": "android",
@@ -6139,7 +6139,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 491,
+      "line": 482,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "All",
       "surface": "android",
@@ -6147,7 +6147,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 549,
+      "line": 540,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw",
       "surface": "android",
@@ -6155,7 +6155,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 570,
+      "line": 561,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "New chat",
       "surface": "android",
@@ -6163,7 +6163,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 575,
+      "line": 566,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "More new chat options",
       "surface": "android",
@@ -6171,7 +6171,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 590,
+      "line": 581,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Refresh chat",
       "surface": "android",
@@ -6179,7 +6179,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 593,
+      "line": 584,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Chat",
       "surface": "android",
@@ -6187,7 +6187,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 741,
+      "line": 732,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Loading session",
       "surface": "android",
@@ -6195,7 +6195,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 768,
+      "line": 759,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Jump to latest",
       "surface": "android",
@@ -6203,7 +6203,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 794,
+      "line": 785,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Ready when you are",
       "surface": "android",
@@ -6211,7 +6211,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 825,
+      "line": 816,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Fix connection",
       "surface": "android",
@@ -6219,7 +6219,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 826,
+      "line": 817,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Copy diagnostics",
       "surface": "android",
@@ -6227,7 +6227,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1010,
+      "line": 1001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Preparing audio…",
       "surface": "android",
@@ -6235,7 +6235,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1010,
+      "line": 1001,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Speaking…",
       "surface": "android",
@@ -6243,7 +6243,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1031,
+      "line": 1022,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Tools running",
       "surface": "android",
@@ -6251,7 +6251,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1033,
+      "line": 1024,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is working",
       "surface": "android",
@@ -6259,7 +6259,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1036,
+      "line": 1027,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "+${toolCalls.size - 4} more",
       "surface": "android",
@@ -6267,7 +6267,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1046,
+      "line": 1037,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Thinking",
       "surface": "android",
@@ -6275,7 +6275,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1047,
+      "line": 1038,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "OpenClaw is preparing a response.",
       "surface": "android",
@@ -6283,7 +6283,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1209,
+      "line": 1200,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Stop",
       "surface": "android",
@@ -6291,7 +6291,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1275,
+      "line": 1266,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Default",
       "surface": "android",
@@ -6299,7 +6299,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1341,
+      "line": 1332,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Pin model",
       "surface": "android",
@@ -6307,7 +6307,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1341,
+      "line": 1332,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Unpin model",
       "surface": "android",
@@ -6315,7 +6315,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1358,
+      "line": 1349,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "No commands found",
       "surface": "android",
@@ -6323,7 +6323,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1420,
+      "line": 1411,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Gateway offline",
       "surface": "android",
@@ -6331,7 +6331,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1518,
+      "line": 1511,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Attach image",
       "surface": "android",
@@ -6339,7 +6339,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1542,
+      "line": 1546,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Message OpenClaw",
       "surface": "android",
@@ -6347,7 +6347,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1557,
+      "line": 1562,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Open voice",
       "surface": "android",
@@ -6355,7 +6355,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1619,
+      "line": 1611,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Remove attachment",
       "surface": "android",
@@ -6363,7 +6363,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1640,
+      "line": 1632,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Main",
       "surface": "android",
@@ -6371,7 +6371,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1648,
+      "line": 1640,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$emoji $name",
       "surface": "android",
@@ -6379,7 +6379,7 @@
     },
     {
       "kind": "ui-named-argument",
-      "line": 1707,
+      "line": 1699,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "Send",
       "surface": "android",
@@ -6387,7 +6387,7 @@
     },
     {
       "kind": "conditional-branch",
-      "line": 1747,
+      "line": 1739,
       "path": "apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt",
       "source": "$contextLabel · ${contextMeterThinkingLabel(thinkingLevel)}",
       "surface": "android",

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatComposer.kt
@@ -61,7 +61,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.onPreInterceptKeyBeforeSoftKeyboard
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -192,6 +192,7 @@ internal fun ChatComposer(
   val sendBusy = pendingRunCount > 0
   val recordingVoiceNote = voiceNoteState is VoiceNoteRecorderState.Recording
   val preparingVoiceNote = voiceNoteState is VoiceNoteRecorderState.Preparing
+  val hardwareEnterHandler = remember { PhysicalChatSendKeyHandler() }
   val sendCurrentInput = {
     val message = input.trim()
     val action = resolveSheetComposerSendAction(input = message)
@@ -232,26 +233,34 @@ internal fun ChatComposer(
     } else if (preparingVoiceNote) {
       VoiceNotePreparing()
     } else {
-      OutlinedTextField(
+      ChatTextFieldValueAdapter(
         value = input,
         onValueChange = { input = it },
-        modifier =
-          Modifier
-            .fillMaxWidth()
-            .onPreviewKeyEvent { event ->
-              handlePhysicalChatSend(
-                event = event,
-                sendEnabled = canSend,
-                onSend = sendCurrentInput,
-              )
-            },
-        placeholder = { Text("Type a message…", style = mobileBodyStyle(), color = mobileTextTertiary) },
-        minLines = 2,
-        maxLines = 5,
-        textStyle = mobileBodyStyle().copy(color = mobileText),
-        shape = RoundedCornerShape(14.dp),
-        colors = chatTextFieldColors(),
-      )
+        keyHandler = hardwareEnterHandler,
+      ) { textFieldValue, updateTextFieldValue ->
+        OutlinedTextField(
+          value = textFieldValue,
+          onValueChange = updateTextFieldValue,
+          modifier =
+            Modifier
+              .fillMaxWidth()
+              .onPreInterceptKeyBeforeSoftKeyboard { event ->
+                hardwareEnterHandler.handle(
+                  event = event,
+                  sendEnabled = canSend,
+                  textEmpty = textFieldValue.text.isEmpty(),
+                  compositionActive = textFieldValue.composition != null,
+                  onSend = sendCurrentInput,
+                )
+              },
+          placeholder = { Text("Type a message…", style = mobileBodyStyle(), color = mobileTextTertiary) },
+          minLines = 2,
+          maxLines = 5,
+          textStyle = mobileBodyStyle().copy(color = mobileText),
+          shape = RoundedCornerShape(14.dp),
+          colors = chatTextFieldColors(),
+        )
+      }
     }
 
     VoiceNoteRecorderError(voiceNoteState)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatHardwareKey.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatHardwareKey.kt
@@ -1,0 +1,134 @@
+package ai.openclaw.app.ui.chat
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.input.TextFieldValue
+
+@Composable
+internal fun ChatTextFieldValueAdapter(
+  value: String,
+  onValueChange: (String) -> Unit,
+  keyHandler: PhysicalChatSendKeyHandler,
+  content: @Composable (TextFieldValue, (TextFieldValue) -> Unit) -> Unit,
+) {
+  // Mirrors Compose's String adapter while exposing the IME composition range.
+  var textFieldValueState by remember { mutableStateOf(TextFieldValue(text = value)) }
+  val textFieldValue = textFieldValueState.copy(text = value)
+  SideEffect {
+    if (
+      textFieldValue.selection != textFieldValueState.selection ||
+      textFieldValue.composition != textFieldValueState.composition
+    ) {
+      textFieldValueState = textFieldValue
+    }
+  }
+  var lastTextValue by remember(value) { mutableStateOf(value) }
+
+  content(textFieldValue) { nextTextFieldValue ->
+    val filteredTextFieldValue =
+      keyHandler.filterTextFieldUpdate(
+        currentText = textFieldValue.text,
+        nextTextFieldValue = nextTextFieldValue,
+      )
+    textFieldValueState = filteredTextFieldValue
+
+    val stringChanged = lastTextValue != filteredTextFieldValue.text
+    lastTextValue = filteredTextFieldValue.text
+    if (stringChanged) {
+      onValueChange(filteredTextFieldValue.text)
+    }
+  }
+}
+
+internal class PhysicalChatSendKeyHandler {
+  private var ownedEnterKey: Key? = null
+  private var blankImeSequence = false
+  private var uncommittedHardwareInput = false
+
+  fun handle(
+    event: KeyEvent,
+    sendEnabled: Boolean,
+    textEmpty: Boolean,
+    compositionActive: Boolean,
+    onSend: () -> Unit,
+  ): Boolean {
+    val enterKey = event.key == Key.Enter || event.key == Key.NumPadEnter
+    if (!enterKey) {
+      val commandModified = event.isCtrlPressed || event.isAltPressed || event.isMetaPressed
+      if (
+        event.type == KeyEventType.KeyDown &&
+        event.nativeKeyEvent.repeatCount == 0 &&
+        event.nativeKeyEvent.isPrintingKey &&
+        !commandModified
+      ) {
+        // Some IMEs keep hardware-key preedit private, outside TextFieldValue.composition.
+        uncommittedHardwareInput = true
+      }
+      return false
+    }
+
+    if (event.type == KeyEventType.KeyUp) {
+      val owned = ownedEnterKey == event.key
+      if (owned) ownedEnterKey = null
+      blankImeSequence = false
+      return owned
+    }
+    if (event.type != KeyEventType.KeyDown) return false
+
+    if (event.nativeKeyEvent.repeatCount > 0) {
+      return ownedEnterKey == event.key
+    }
+
+    ownedEnterKey = null
+    blankImeSequence = false
+    val modified = event.isShiftPressed || event.isCtrlPressed || event.isAltPressed || event.isMetaPressed
+    if (modified) return false
+
+    if (compositionActive || uncommittedHardwareInput) return false
+
+    if (sendEnabled) {
+      // Own the full sequence after sending; leaked repeats insert newlines into the cleared draft.
+      ownedEnterKey = event.key
+      onSend()
+      return true
+    }
+
+    if (textEmpty) {
+      // A private IME may hold preedit text while the app-visible value is empty.
+      blankImeSequence = true
+      return false
+    }
+
+    ownedEnterKey = event.key
+    return true
+  }
+
+  fun filterTextFieldUpdate(
+    currentText: String,
+    nextTextFieldValue: TextFieldValue,
+  ): TextFieldValue {
+    val blankHardwareNewline =
+      blankImeSequence &&
+        currentText.isEmpty() &&
+        nextTextFieldValue.text == "\n"
+    uncommittedHardwareInput = false
+    return if (blankHardwareNewline) {
+      TextFieldValue()
+    } else {
+      nextTextFieldValue
+    }
+  }
+}

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -90,16 +90,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isAltPressed
-import androidx.compose.ui.input.key.isCtrlPressed
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.isShiftPressed
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.key.onPreInterceptKeyBeforeSoftKeyboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -1501,6 +1492,8 @@ private fun ChatInputPill(
   onSend: () -> Unit,
   modifier: Modifier = Modifier,
 ) {
+  val hardwareEnterHandler = remember { PhysicalChatSendKeyHandler() }
+
   Surface(
     modifier = modifier.heightIn(min = ClawTheme.spacing.touchTarget),
     shape = RoundedCornerShape(ClawTheme.radii.control),
@@ -1523,28 +1516,40 @@ private fun ChatInputPill(
         onClick = onStartVoiceNote,
       )
       Box(modifier = Modifier.weight(1f)) {
-        BasicTextField(
+        ChatTextFieldValueAdapter(
           value = value,
           onValueChange = onValueChange,
-          textStyle = ClawTheme.type.body.copy(color = ClawTheme.colors.text),
-          cursorBrush = SolidColor(ClawTheme.colors.primary),
-          minLines = 1,
-          maxLines = 4,
-          modifier =
-            Modifier
-              .fillMaxWidth()
-              .onPreviewKeyEvent { event ->
-                handlePhysicalChatSend(event = event, sendEnabled = sendEnabled, onSend = onSend)
-              },
-          decorationBox = { innerTextField ->
-            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
-              if (value.isEmpty()) {
-                Text(text = "Message OpenClaw", style = ClawTheme.type.body, color = ClawTheme.colors.textSubtle)
+          keyHandler = hardwareEnterHandler,
+        ) { textFieldValue, updateTextFieldValue ->
+          BasicTextField(
+            value = textFieldValue,
+            onValueChange = updateTextFieldValue,
+            textStyle = ClawTheme.type.body.copy(color = ClawTheme.colors.text),
+            cursorBrush = SolidColor(ClawTheme.colors.primary),
+            minLines = 1,
+            maxLines = 4,
+            modifier =
+              Modifier
+                .fillMaxWidth()
+                .onPreInterceptKeyBeforeSoftKeyboard { event ->
+                  hardwareEnterHandler.handle(
+                    event = event,
+                    sendEnabled = sendEnabled,
+                    textEmpty = textFieldValue.text.isEmpty(),
+                    compositionActive = textFieldValue.composition != null,
+                    onSend = onSend,
+                  )
+                },
+            decorationBox = { innerTextField ->
+              Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterStart) {
+                if (value.isEmpty()) {
+                  Text(text = "Message OpenClaw", style = ClawTheme.type.body, color = ClawTheme.colors.textSubtle)
+                }
+                innerTextField()
               }
-              innerTextField()
-            }
-          },
-        )
+            },
+          )
+        }
       }
       Surface(
         onClick = onVoice,
@@ -1559,19 +1564,6 @@ private fun ChatInputPill(
       }
     }
   }
-}
-
-/** Intercepts one unmodified hardware Enter before BasicTextField inserts a newline. */
-internal fun handlePhysicalChatSend(
-  event: KeyEvent,
-  sendEnabled: Boolean,
-  onSend: () -> Unit,
-): Boolean {
-  val enterKey = event.key == Key.Enter || event.key == Key.NumPadEnter
-  val modified = event.isShiftPressed || event.isCtrlPressed || event.isAltPressed || event.isMetaPressed
-  if (event.type != KeyEventType.KeyDown || event.nativeKeyEvent.repeatCount != 0 || !enterKey || modified) return false
-  if (sendEnabled) onSend()
-  return true
 }
 
 @Composable

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatHardwareKeyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatHardwareKeyTest.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.app.ui.chat
 
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.text.input.TextFieldValue
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -14,27 +15,112 @@ import android.view.KeyEvent as AndroidKeyEvent
 @Config(sdk = [34])
 class ChatHardwareKeyTest {
   @Test
-  fun unmodifiedEnterSendsOnce() {
+  fun unmodifiedEnterOwnsFullSequenceAndSendsOnce() {
     var sends = 0
+    val handler = PhysicalChatSendKeyHandler()
 
-    assertTrue(handlePhysicalChatSend(keyEvent(AndroidKeyEvent.KEYCODE_ENTER), sendEnabled = true) { sends += 1 })
-    assertTrue(handlePhysicalChatSend(keyEvent(AndroidKeyEvent.KEYCODE_NUMPAD_ENTER), sendEnabled = true) { sends += 1 })
-    assertFalse(handlePhysicalChatSend(keyEvent(AndroidKeyEvent.KEYCODE_ENTER, repeatCount = 1), sendEnabled = true) { sends += 1 })
+    assertTrue(handler.handle(keyEvent(AndroidKeyEvent.KEYCODE_ENTER), sendEnabled = true, textEmpty = false, compositionActive = false) { sends += 1 })
+    assertTrue(
+      handler.handle(
+        keyEvent(AndroidKeyEvent.KEYCODE_ENTER, repeatCount = 1, metaState = AndroidKeyEvent.META_SHIFT_ON),
+        sendEnabled = false,
+        textEmpty = true,
+        compositionActive = false,
+      ) { sends += 1 },
+    )
+    assertTrue(
+      handler.handle(
+        keyEvent(
+          AndroidKeyEvent.KEYCODE_ENTER,
+          action = AndroidKeyEvent.ACTION_UP,
+          metaState = AndroidKeyEvent.META_SHIFT_ON,
+        ),
+        sendEnabled = false,
+        textEmpty = true,
+        compositionActive = false,
+      ) { sends += 1 },
+    )
+    assertFalse(
+      handler.handle(
+        keyEvent(AndroidKeyEvent.KEYCODE_ENTER, action = AndroidKeyEvent.ACTION_UP),
+        sendEnabled = false,
+        textEmpty = true,
+        compositionActive = false,
+      ) { sends += 1 },
+    )
 
-    assertEquals(2, sends)
+    assertEquals(1, sends)
   }
 
   @Test
-  fun disabledEnterIsConsumedWithoutSending() {
-    var sent = false
+  fun numpadEnterSends() {
+    var sends = 0
+    val handler = PhysicalChatSendKeyHandler()
 
-    assertTrue(handlePhysicalChatSend(keyEvent(AndroidKeyEvent.KEYCODE_ENTER), sendEnabled = false) { sent = true })
+    assertTrue(handler.handle(keyEvent(AndroidKeyEvent.KEYCODE_NUMPAD_ENTER), sendEnabled = true, textEmpty = false, compositionActive = false) { sends += 1 })
+
+    assertEquals(1, sends)
+  }
+
+  @Test
+  fun disabledEnterWithTextOwnsSequenceWithoutSending() {
+    var sent = false
+    val handler = PhysicalChatSendKeyHandler()
+
+    assertTrue(handler.handle(keyEvent(AndroidKeyEvent.KEYCODE_ENTER), sendEnabled = false, textEmpty = false, compositionActive = false) { sent = true })
+    assertTrue(
+      handler.handle(
+        keyEvent(AndroidKeyEvent.KEYCODE_ENTER, repeatCount = 1),
+        sendEnabled = false,
+        textEmpty = false,
+        compositionActive = false,
+      ) { sent = true },
+    )
+    assertTrue(
+      handler.handle(
+        keyEvent(AndroidKeyEvent.KEYCODE_ENTER, action = AndroidKeyEvent.ACTION_UP),
+        sendEnabled = false,
+        textEmpty = false,
+        compositionActive = false,
+      ) { sent = true },
+    )
 
     assertFalse(sent)
   }
 
   @Test
-  fun modifiedEnterAndKeyUpRemainTextInput() {
+  fun blankEnterRemainsImeInputButFiltersInsertedNewline() {
+    val handler = PhysicalChatSendKeyHandler()
+
+    assertFalse(handler.handle(keyEvent(AndroidKeyEvent.KEYCODE_ENTER), sendEnabled = false, textEmpty = true, compositionActive = false) {})
+    assertEquals(
+      "",
+      handler
+        .filterTextFieldUpdate(
+          currentText = "",
+          nextTextFieldValue = TextFieldValue("\n"),
+        ).text,
+    )
+    assertEquals(
+      "nihao",
+      handler
+        .filterTextFieldUpdate(
+          currentText = "",
+          nextTextFieldValue = TextFieldValue("nihao"),
+        ).text,
+    )
+    assertFalse(
+      handler.handle(
+        keyEvent(AndroidKeyEvent.KEYCODE_ENTER, action = AndroidKeyEvent.ACTION_UP),
+        sendEnabled = false,
+        textEmpty = false,
+        compositionActive = false,
+      ) {},
+    )
+  }
+
+  @Test
+  fun compositionAndModifiedEnterRemainImeInput() {
     val modifiers =
       listOf(
         AndroidKeyEvent.META_SHIFT_ON,
@@ -42,17 +128,69 @@ class ChatHardwareKeyTest {
         AndroidKeyEvent.META_ALT_ON,
         AndroidKeyEvent.META_META_ON,
       )
+    val handler = PhysicalChatSendKeyHandler()
 
     modifiers.forEach { metaState ->
-      assertFalse(handlePhysicalChatSend(keyEvent(AndroidKeyEvent.KEYCODE_ENTER, metaState = metaState), sendEnabled = true) {})
+      assertFalse(
+        handler.handle(
+          keyEvent(AndroidKeyEvent.KEYCODE_ENTER, metaState = metaState),
+          sendEnabled = true,
+          textEmpty = false,
+          compositionActive = false,
+          onSend = {},
+        ),
+      )
     }
     assertFalse(
-      handlePhysicalChatSend(
-        keyEvent(AndroidKeyEvent.KEYCODE_ENTER, action = AndroidKeyEvent.ACTION_UP),
+      handler.handle(
+        keyEvent(AndroidKeyEvent.KEYCODE_ENTER),
         sendEnabled = true,
+        textEmpty = false,
+        compositionActive = true,
         onSend = {},
       ),
     )
+  }
+
+  @Test
+  fun privateImeInputOwnsEnterUntilTextFieldUpdates() {
+    var sends = 0
+    val handler = PhysicalChatSendKeyHandler()
+
+    assertFalse(
+      handler.handle(
+        keyEvent(AndroidKeyEvent.KEYCODE_N),
+        sendEnabled = true,
+        textEmpty = false,
+        compositionActive = false,
+        onSend = { sends += 1 },
+      ),
+    )
+    assertFalse(
+      handler.handle(
+        keyEvent(AndroidKeyEvent.KEYCODE_ENTER),
+        sendEnabled = true,
+        textEmpty = false,
+        compositionActive = false,
+        onSend = { sends += 1 },
+      ),
+    )
+
+    handler.filterTextFieldUpdate(
+      currentText = "prefix",
+      nextTextFieldValue = TextFieldValue("prefix"),
+    )
+
+    assertTrue(
+      handler.handle(
+        keyEvent(AndroidKeyEvent.KEYCODE_ENTER),
+        sendEnabled = true,
+        textEmpty = false,
+        compositionActive = false,
+        onSend = { sends += 1 },
+      ),
+    )
+    assertEquals(1, sends)
   }
 
   private fun keyEvent(


### PR DESCRIPTION
Closes #101239

## What Problem This Solves

Fixes Android hardware-keyboard Enter handling that could leak repeated key-downs into the cleared chat composer, inserting a newline after the message had already sent. The same one-event interception also risked claiming Enter while an IME was still composing text.

## Why This Change Was Made

Both Android composer implementations now share one package-owned hardware-key state machine and String-to-`TextFieldValue` adapter. They intercept physical keys at Compose's pre-soft-keyboard boundary, preserve public composition state, account for IMEs that keep hardware preedit private, and track ownership for the full Enter sequence. Each composer still uses its existing send callback; no config, protocol, or gateway surface was added.

## User Impact

Physical-keyboard users can press Enter to send once, including during key repeat, without leaving a newline in the next draft. Shift+Enter continues to insert a newline, blank Enter remains a no-op, on-screen keyboard input is unchanged, and composing IMEs get the first Enter needed to commit their input before a later Enter can send.

## Evidence

- Live current-main repro on Android 15 / API 35 with Gboard: holding physical Enter sent once and left `\n` in the cleared composer at `780ca1d25315b34d3118e1db2d8dcafcc16415f3`.
- Live patched Gboard proof: simple physical Enter sent and cleared; long-press sent once and stayed empty; blank Enter stayed empty; Shift+Enter produced `line1\nline2`; Gboard's on-screen Enter still inserted a newline rather than invoking hardware send.
- Live patched Trime 3.3.11 proof: private `nihao` preedit remained IME-owned even with committed draft text already present; physical Enter committed text instead of sending the partial draft. Trime's raw-preedit commit matched its on-screen Enter behavior in the same environment.
- Blacksmith Testbox `tbx_01kwxeq31y8q66en8zhv16stym` (`tidal-krill`): `pnpm native:i18n:check`, focused `ChatHardwareKeyTest` for Play and third-party variants, both debug assemblies, and both debug lint tasks passed.
- Focused tests cover Enter/numpad Enter, repeat and paired key-up ownership, modifier changes during a claimed sequence, disabled sends, blank newline filtering, public composition, and private IME input tracking.
- Final structured Codex autoreview: clean with no accepted or actionable findings.
- AI-assisted implementation; behavior and Compose 1.11.2 dependency contracts were reviewed directly and validated on the emulator.
