### PR TITLE
fix(feishu): keep operator logs UTF-16 safe

### DIFF
--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -511,6 +511,30 @@ describe("Feishu Card Action Handler", () => {
     expect(handleMessage().chat_type).toBe("p2p");
   });
 
+  it("keeps Feishu chat lookup error logs UTF-16 safe at the truncation boundary", async () => {
+    const log = vi.fn();
+    createFeishuClientMock.mockReturnValueOnce({
+      im: {
+        chat: {
+          get: vi
+            .fn()
+            .mockResolvedValue({ code: 99, msg: `${"x".repeat(499)}😀tail` }),
+        },
+      },
+    });
+    const event = createCardActionEvent({
+      token: "tok9d-utf16",
+      chatId: "oc_unknown_chat_utf16",
+      actionValue: { text: "/help" },
+    });
+
+    await handleFeishuCardAction({ cfg, event, runtime: { ...runtime, log } });
+
+    expect(log).toHaveBeenCalledWith(
+      `feishu[mock-account]: failed to resolve chat type: ${"x".repeat(499)}; defaulting to p2p`,
+    );
+  });
+
   it("falls back to p2p when Feishu chat API throws", async () => {
     createFeishuClientMock.mockReturnValueOnce({
       im: {

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -4,6 +4,7 @@ import {
   isFutureDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ClawdbotConfig, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
@@ -244,7 +245,7 @@ function pruneChatTypeCache(now: number): void {
 }
 
 function sanitizeLogValue(v: string): string {
-  return v.replace(/[\r\n]/g, " ").slice(0, 500);
+  return truncateUtf16Safe(v.replace(/[\r\n]/g, " "), 500);
 }
 
 function resolveFeishuApprovalCardExpiresAt(nowRaw = Date.now()): number | undefined {

--- a/extensions/feishu/src/monitor.cleanup.test.ts
+++ b/extensions/feishu/src/monitor.cleanup.test.ts
@@ -376,6 +376,38 @@ describe("feishu websocket cleanup", () => {
     expect(errorMessage).not.toContain("secret_token");
   });
 
+  it("keeps websocket close error logs UTF-16 safe at the truncation boundary", async () => {
+    const wsClient = createWsClient();
+    wsClient.close.mockImplementationOnce(() => {
+      throw new Error(`${"x".repeat(499)}😀tail`);
+    });
+    createFeishuWSClientMock.mockReturnValue(wsClient);
+
+    const abortController = new AbortController();
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    const monitorPromise = monitorWebSocket({
+      account: createAccount("close-error-utf16"),
+      accountId: "close-error-utf16",
+      runtime,
+      abortSignal: abortController.signal,
+      eventDispatcher: {} as never,
+    });
+
+    await vi.waitFor(() => {
+      expect(wsClient.start).toHaveBeenCalledTimes(1);
+    });
+    abortController.abort();
+    await monitorPromise;
+
+    expect(firstRuntimeError(runtime)).toBe(
+      `feishu[close-error-utf16]: error closing WebSocket client: ${"x".repeat(499)}...`,
+    );
+  });
+
   it("closes targeted websocket clients during stop cleanup", async () => {
     const alphaClient = createWsClient();
     const betaClient = createWsClient();

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -2,6 +2,7 @@
 import crypto from "node:crypto";
 import * as http from "node:http";
 import * as Lark from "@larksuiteoapi/node-sdk";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { waitForAbortableDelay } from "./async.js";
 import { createFeishuWSClient } from "./client.js";
 import {
@@ -151,7 +152,7 @@ function formatFeishuWsErrorForLog(err: unknown): string {
   if (redacted.length <= FEISHU_WS_LOG_ERROR_MAX_LENGTH) {
     return redacted;
   }
-  return `${redacted.slice(0, FEISHU_WS_LOG_ERROR_MAX_LENGTH)}...`;
+  return `${truncateUtf16Safe(redacted, FEISHU_WS_LOG_ERROR_MAX_LENGTH)}...`;
 }
 
 function isFeishuWsTerminalError(err: Error): boolean {


### PR DESCRIPTION
Related: #101284

## What Problem This Solves

Fixes an issue where Feishu operator logs could contain a dangling UTF-16 surrogate when an emoji or other supplementary-plane character straddled the 500-code-unit truncation boundary. The malformed tail could render as a replacement character in card-action chat lookup errors and WebSocket cleanup errors.

## Why This Change Was Made

Both remaining Feishu log truncation sites now use OpenClaw's existing `truncateUtf16Safe` helper, matching sibling Feishu log previews and preserving the current length, redaction, newline, and control-character behavior. Caller-path regressions drive the actual card-action and WebSocket cleanup loggers with an emoji beginning at index 499.

This is a maintainer replacement for #101284 because its contributor branch was based far behind current `main`; refreshing that fork through GitHub's verified-commit API made the PR ancestry include thousands of unrelated files. The contributor's useful fix is preserved with co-author credit.

## User Impact

Feishu operators get clean, valid log text at truncation boundaries instead of a potentially garbled replacement character. Message delivery, configuration, and API behavior are unchanged.

## Evidence

- `bot.card-action.test.ts` drives a non-zero Feishu chat lookup response through the runtime logger and proves the boundary output ends before the split emoji.
- `monitor.cleanup.test.ts` drives a thrown WebSocket close error through cleanup and proves the bounded runtime error log contains 499 complete code units plus the ellipsis.
- The shared helper contract in `packages/normalization-core/src/utf16-slice.ts` backs off when the requested end would split a surrogate pair.
- Fresh Codex autoreview on the current-main diff reported no accepted/actionable findings.
- Blacksmith Testbox through Crabbox `tbx_01kwxe0113trnv147sx2kb4j27` (Actions run [28841981897](https://github.com/openclaw/openclaw/actions/runs/28841981897)): both focused Feishu test files passed (36 tests); `pnpm check:changed` passed.
- Repo-native prepare verified exact head `4e9f372158c4694ee3c4d72c983f9204f1fc8d2c` against hosted CI/Testbox gates.
