### PR TITLE
fix: stagger delivery recovery retries

### DIFF
--- a/src/infra/delivery-recovery.shared.ts
+++ b/src/infra/delivery-recovery.shared.ts
@@ -1,4 +1,6 @@
 const RECOVERY_BACKOFF_MS: readonly number[] = [5_000, 25_000, 120_000, 600_000];
+const RECOVERY_RETRY_JITTER_MAX_MS = 1_000;
+const RECOVERY_REPLAY_PACING_MAX_MS = 250;
 
 export function computeBackoffMs(retryCount: number): number {
   if (retryCount <= 0) {
@@ -9,6 +11,50 @@ export function computeBackoffMs(retryCount: number): number {
     RECOVERY_BACKOFF_MS.at(-1) ??
     0
   );
+}
+
+function normalizeDelayCeilingMs(maxDelayMs: number): number {
+  if (!Number.isFinite(maxDelayMs) || maxDelayMs <= 0) {
+    return 0;
+  }
+  return Math.trunc(maxDelayMs);
+}
+
+function stableHash(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+export function computeRecoveryRetryJitterMs(
+  entryId: string,
+  retryCount: number,
+  maxJitterMs = RECOVERY_RETRY_JITTER_MAX_MS,
+): number {
+  const ceiling = normalizeDelayCeilingMs(maxJitterMs);
+  if (retryCount <= 0 || ceiling <= 0) {
+    return 0;
+  }
+  return stableHash(`${entryId}:${retryCount}:retry-jitter`) % (ceiling + 1);
+}
+
+export function computeRecoveryRetryDelayMs(entryId: string, retryCount: number): number {
+  return computeBackoffMs(retryCount) + computeRecoveryRetryJitterMs(entryId, retryCount);
+}
+
+export function computeRecoveryReplayPacingMs(
+  entryId: string,
+  retryCount: number,
+  maxPacingMs = RECOVERY_REPLAY_PACING_MAX_MS,
+): number {
+  const ceiling = normalizeDelayCeilingMs(maxPacingMs);
+  if (retryCount <= 0 || ceiling <= 0) {
+    return 0;
+  }
+  return (stableHash(`${entryId}:${retryCount}:replay-pacing`) % ceiling) + 1;
 }
 
 export function getErrnoCode(err: unknown): string | null {

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -12,6 +12,8 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   claimRecoveryEntry as claimSharedRecoveryEntry,
   computeBackoffMs,
+  computeRecoveryReplayPacingMs,
+  computeRecoveryRetryDelayMs,
   getErrnoCode,
   releaseRecoveryEntry as releaseSharedRecoveryEntry,
 } from "../delivery-recovery.shared.js";
@@ -66,6 +68,8 @@ export interface RecoveryLogger {
   error(msg: string): void;
 }
 
+type RecoveryDelayFn = (delayMs: number) => Promise<void>;
+
 export interface PendingDeliveryDrainDecision {
   match: boolean;
   bypassBackoff?: boolean;
@@ -93,6 +97,12 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
 
 const drainInProgress = new Map<string, boolean>();
 const entriesInProgress = new Set<string>();
+
+function waitForRecoveryDelay(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
 
 function resolveRecoveryDeadlineMs(maxRecoveryMs: number | undefined): number {
   const durationMs =
@@ -330,8 +340,8 @@ export function isEntryEligibleForRecoveryRetry(
   entry: QueuedDelivery,
   now: number,
 ): { eligible: true } | { eligible: false; remainingBackoffMs: number } {
-  const backoff = computeBackoffMs(entry.retryCount + 1);
-  if (backoff <= 0) {
+  const retryDelay = computeRecoveryRetryDelayMs(entry.id, entry.retryCount + 1);
+  if (retryDelay <= 0) {
     return { eligible: true };
   }
   const firstReplayAfterCrash = entry.retryCount === 0 && entry.lastAttemptAt === undefined;
@@ -345,7 +355,7 @@ export function isEntryEligibleForRecoveryRetry(
   const baseAttemptAt = hasAttemptTimestamp
     ? (entry.lastAttemptAt ?? entry.enqueuedAt)
     : entry.enqueuedAt;
-  const nextEligibleAt = baseAttemptAt + backoff;
+  const nextEligibleAt = baseAttemptAt + retryDelay;
   if (now >= nextEligibleAt) {
     return { eligible: true };
   }
@@ -727,6 +737,8 @@ export async function recoverPendingDeliveries(opts: {
   stateDir?: string;
   /** Maximum wall-clock time for recovery in ms. Remaining entries are deferred to next startup. Default: 60 000. */
   maxRecoveryMs?: number;
+  /** Test seam for retry pacing delays. */
+  recoveryDelay?: RecoveryDelayFn;
 }): Promise<RecoverySummary> {
   const pending = await loadPendingDeliveries(opts.stateDir);
   if (pending.length === 0) {
@@ -776,6 +788,24 @@ export async function recoverPendingDeliveries(opts: {
           `Delivery ${currentEntry.id} not ready for retry yet — backoff ${currentRetryEligibility.remainingBackoffMs}ms remaining`,
         );
         continue;
+      }
+
+      const pacingDelayMs = computeRecoveryReplayPacingMs(currentEntry.id, currentEntry.retryCount);
+      if (pacingDelayMs > 0) {
+        if (Date.now() + pacingDelayMs >= deadline) {
+          opts.log.warn(
+            `Recovery time budget exceeded — remaining entries deferred to next startup`,
+          );
+          break;
+        }
+        opts.log.info(`Delivery ${currentEntry.id} pacing retry recovery by ${pacingDelayMs}ms`);
+        await (opts.recoveryDelay ?? waitForRecoveryDelay)(pacingDelayMs);
+        if (Date.now() >= deadline) {
+          opts.log.warn(
+            `Recovery time budget exceeded — remaining entries deferred to next startup`,
+          );
+          break;
+        }
       }
 
       const result = await drainQueuedEntry({

--- a/src/infra/outbound/delivery-queue.policy.test.ts
+++ b/src/infra/outbound/delivery-queue.policy.test.ts
@@ -78,7 +78,7 @@ describe("delivery-queue policy", () => {
         enqueuedAt: now - 30_000,
         retryCount: 3,
         lastAttemptAt: now,
-      } as const;
+      };
       const retryDelay = computeRecoveryRetryDelayMs(entry.id, entry.retryCount + 1);
       const result = isEntryEligibleForRecoveryRetry(entry, now + retryDelay - 1);
       expect(result.eligible).toBe(false);

--- a/src/infra/outbound/delivery-queue.policy.test.ts
+++ b/src/infra/outbound/delivery-queue.policy.test.ts
@@ -1,6 +1,7 @@
 // Covers delivery retry policy: permanent-error classification, backoff timing,
 // and first-replay eligibility after crashes.
 import { describe, expect, it } from "vitest";
+import { computeRecoveryRetryDelayMs } from "../delivery-recovery.shared.js";
 import {
   computeBackoffMs,
   isEntryEligibleForRecoveryRetry,
@@ -69,23 +70,32 @@ describe("delivery-queue policy", () => {
 
     it("defers retry entries until backoff window elapses", () => {
       const now = Date.now();
-      const result = isEntryEligibleForRecoveryRetry(
-        {
-          id: "entry-2",
-          channel: "demo-channel",
-          to: "+1",
-          payloads: [{ text: "a" }],
-          enqueuedAt: now - 30_000,
-          retryCount: 3,
-          lastAttemptAt: now,
-        },
-        now,
-      );
+      const entry = {
+        id: "entry-2",
+        channel: "demo-channel",
+        to: "+1",
+        payloads: [{ text: "a" }],
+        enqueuedAt: now - 30_000,
+        retryCount: 3,
+        lastAttemptAt: now,
+      } as const;
+      const retryDelay = computeRecoveryRetryDelayMs(entry.id, entry.retryCount + 1);
+      const result = isEntryEligibleForRecoveryRetry(entry, now + retryDelay - 1);
       expect(result.eligible).toBe(false);
       if (result.eligible) {
         throw new Error("Expected ineligible retry entry");
       }
-      expect(result.remainingBackoffMs).toBe(600_000);
+      expect(result.remainingBackoffMs).toBe(1);
+      expect(isEntryEligibleForRecoveryRetry(entry, now + retryDelay)).toEqual({
+        eligible: true,
+      });
+    });
+
+    it("adds stable bounded jitter to retry eligibility", () => {
+      const retryDelay = computeRecoveryRetryDelayMs("entry-with-jitter", 2);
+      expect(retryDelay).toBeGreaterThanOrEqual(25_000);
+      expect(retryDelay).toBeLessThanOrEqual(26_000);
+      expect(computeRecoveryRetryDelayMs("entry-with-jitter", 2)).toBe(retryDelay);
     });
   });
 });

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -3,6 +3,10 @@
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import {
+  computeRecoveryReplayPacingMs,
+  computeRecoveryRetryDelayMs,
+} from "../delivery-recovery.shared.js";
 import { OutboundDeliveryError, type OutboundPayloadDeliveryOutcome } from "./deliver-types.js";
 import { attachOutboundDeliveryCommitHook } from "./delivery-commit-hooks.js";
 import {
@@ -78,10 +82,12 @@ describe("delivery-queue recovery", () => {
     deliver,
     log = createRecoveryLog(),
     maxRecoveryMs,
+    recoveryDelay,
   }: {
     deliver: ReturnType<typeof vi.fn>;
     log?: ReturnType<typeof createRecoveryLog>;
     maxRecoveryMs?: number;
+    recoveryDelay?: (delayMs: number) => Promise<void>;
   }) => {
     const result = await recoverPendingDeliveries({
       deliver: asDeliverFn(deliver),
@@ -89,6 +95,7 @@ describe("delivery-queue recovery", () => {
       cfg: baseCfg,
       stateDir: tmpDir(),
       ...(maxRecoveryMs === undefined ? {} : { maxRecoveryMs }),
+      recoveryDelay: recoveryDelay ?? (async () => {}),
     });
     return { result, log };
   };
@@ -1121,6 +1128,51 @@ describe("delivery-queue recovery", () => {
     expect(remaining[0]?.id).toBe(blockedId);
   });
 
+  it("paces eligible retry replays with deterministic per-entry delays", async () => {
+    const now = Date.now();
+    const firstId = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "first" }] },
+      tmpDir(),
+    );
+    const secondId = await enqueueDelivery(
+      { channel: "demo-channel-b", to: "2", payloads: [{ text: "second" }] },
+      tmpDir(),
+    );
+    setQueuedEntryState(tmpDir(), firstId, {
+      retryCount: 1,
+      lastAttemptAt: now - 60_000,
+      enqueuedAt: now - 20_000,
+    });
+    setQueuedEntryState(tmpDir(), secondId, {
+      retryCount: 1,
+      lastAttemptAt: now - 60_000,
+      enqueuedAt: now - 10_000,
+    });
+
+    const recoveryDelays: number[] = [];
+    const deliver = vi.fn().mockResolvedValue([]);
+    const { result } = await runRecovery({
+      deliver,
+      maxRecoveryMs: 60_000,
+      recoveryDelay: async (delayMs) => {
+        recoveryDelays.push(delayMs);
+      },
+    });
+
+    expect(result).toEqual({
+      recovered: 2,
+      failed: 0,
+      skippedMaxRetries: 0,
+      deferredBackoff: 0,
+    });
+    expect(deliver).toHaveBeenCalledTimes(2);
+    expect(recoveryDelays).toEqual([
+      computeRecoveryReplayPacingMs(firstId, 1),
+      computeRecoveryReplayPacingMs(secondId, 1),
+    ]);
+    expect(recoveryDelays.every((delayMs) => delayMs > 0)).toBe(true);
+  });
+
   it("recovers deferred entries on a later restart once backoff elapsed", async () => {
     vi.useFakeTimers();
     const start = new Date("2026-01-01T00:00:00.000Z");
@@ -1142,7 +1194,7 @@ describe("delivery-queue recovery", () => {
     });
     expect(firstDeliver).not.toHaveBeenCalled();
 
-    vi.setSystemTime(new Date(start.getTime() + 600_000 + 1));
+    vi.setSystemTime(new Date(start.getTime() + computeRecoveryRetryDelayMs(id, 4) + 1));
     const secondDeliver = vi.fn().mockResolvedValue([]);
     const secondRun = await runRecovery({ deliver: secondDeliver, maxRecoveryMs: 60_000 });
     expect(secondRun.result).toEqual({

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -6,7 +6,8 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import {
   claimRecoveryEntry as claimSharedRecoveryEntry,
-  computeBackoffMs,
+  computeRecoveryReplayPacingMs,
+  computeRecoveryRetryDelayMs,
   getErrnoCode,
   releaseRecoveryEntry as releaseSharedRecoveryEntry,
 } from "./delivery-recovery.shared.js";
@@ -30,6 +31,7 @@ type SessionDeliveryRecoverySummary = {
 };
 
 type DeliverSessionDeliveryFn = (entry: QueuedSessionDelivery) => Promise<void>;
+type SessionDeliveryRecoveryDelayFn = (delayMs: number) => Promise<void>;
 
 export interface SessionDeliveryRecoveryLogger {
   info(msg: string): void;
@@ -46,6 +48,12 @@ const MAX_SESSION_DELIVERY_RETRIES = 5;
 
 const drainInProgress = new Map<string, boolean>();
 const entriesInProgress = new Set<string>();
+
+function waitForSessionDeliveryRecoveryDelay(delayMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+}
 
 function createEmptyRecoverySummary(): SessionDeliveryRecoverySummary {
   return {
@@ -72,8 +80,8 @@ export function isSessionDeliveryEligibleForRetry(
   entry: QueuedSessionDelivery,
   now: number,
 ): { eligible: true } | { eligible: false; remainingBackoffMs: number } {
-  const backoff = computeBackoffMs(entry.retryCount);
-  if (backoff <= 0) {
+  const retryDelay = computeRecoveryRetryDelayMs(entry.id, entry.retryCount);
+  if (retryDelay <= 0) {
     return { eligible: true };
   }
   const firstReplayAfterCrash = entry.retryCount === 0 && entry.lastAttemptAt === undefined;
@@ -84,7 +92,7 @@ export function isSessionDeliveryEligibleForRetry(
     typeof entry.lastAttemptAt === "number" && entry.lastAttemptAt > 0
       ? entry.lastAttemptAt
       : entry.enqueuedAt;
-  const nextEligibleAt = baseAttemptAt + backoff;
+  const nextEligibleAt = baseAttemptAt + retryDelay;
   if (now >= nextEligibleAt) {
     return { eligible: true };
   }
@@ -202,6 +210,7 @@ export async function recoverPendingSessionDeliveries(opts: {
   stateDir?: string;
   maxRecoveryMs?: number;
   maxEnqueuedAt?: number;
+  recoveryDelay?: SessionDeliveryRecoveryDelayFn;
 }): Promise<SessionDeliveryRecoverySummary> {
   const pending = (await loadPendingSessionDeliveries(opts.stateDir)).filter(
     (entry) => opts.maxEnqueuedAt == null || entry.enqueuedAt <= opts.maxEnqueuedAt,
@@ -247,6 +256,23 @@ export async function recoverPendingSessionDeliveries(opts: {
       if (!retryEligibility.eligible) {
         summary.deferredBackoff += 1;
         continue;
+      }
+
+      const pacingDelayMs = computeRecoveryReplayPacingMs(currentEntry.id, currentEntry.retryCount);
+      if (pacingDelayMs > 0) {
+        if (Date.now() + pacingDelayMs >= deadline) {
+          opts.log.warn(
+            "Session delivery recovery time budget exceeded — remaining entries deferred",
+          );
+          break;
+        }
+        await (opts.recoveryDelay ?? waitForSessionDeliveryRecoveryDelay)(pacingDelayMs);
+        if (Date.now() >= deadline) {
+          opts.log.warn(
+            "Session delivery recovery time budget exceeded — remaining entries deferred",
+          );
+          break;
+        }
       }
 
       const result = await drainQueuedEntry({

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -2,6 +2,7 @@
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import { withTempDir } from "../test-helpers/temp-dir.js";
+import { computeRecoveryRetryDelayMs } from "./delivery-recovery.shared.js";
 import {
   drainPendingSessionDeliveries,
   enqueueSessionDelivery,
@@ -222,10 +223,17 @@ describe("session-delivery queue recovery", () => {
       if (typeof lastAttemptAt !== "number") {
         throw new Error("expected failed delivery attempt timestamp");
       }
-      const notReady = isSessionDeliveryEligibleForRetry(failedEntry, lastAttemptAt + 4_999);
+      const retryDelay = computeRecoveryRetryDelayMs(failedEntry.id, failedEntry.retryCount);
+      expect(retryDelay).toBeGreaterThanOrEqual(5_000);
+      expect(retryDelay).toBeLessThanOrEqual(6_000);
+
+      const notReady = isSessionDeliveryEligibleForRetry(
+        failedEntry,
+        lastAttemptAt + retryDelay - 1,
+      );
       expect(notReady).toEqual({ eligible: false, remainingBackoffMs: 1 });
 
-      const ready = isSessionDeliveryEligibleForRetry(failedEntry, lastAttemptAt + 5_000);
+      const ready = isSessionDeliveryEligibleForRetry(failedEntry, lastAttemptAt + retryDelay);
       expect(ready).toEqual({ eligible: true });
     });
 


### PR DESCRIPTION
Closes #101058

AI-assisted with Codex.

## What Problem This Solves

Fixes an issue where users recovering outbound or session deliveries after transient failures could have retryable pending entries bunch together on startup when those entries shared the same retry state. That tight replay burst can increase provider/channel rate-limit risk during recovery.

## Why This Change Was Made

This adds deterministic per-entry jitter to the shared recovery retry delay and applies a small bounded per-entry pacing delay before startup replay of already-failed retry entries. First replay after a crash remains immediate, reconnect drains keep their existing backoff/bypass behavior, and this does not add a new config surface.

## User Impact

Startup recovery now spreads retryable delivery replays instead of driving a same-tier retry batch at one fixed eligibility time. Operators should see less burst pressure after outages while existing max-retry, budget deferral, unknown-send reconciliation, and reconnect-drain protections remain intact.

## Evidence

- Failing-first check: after adding the focused tests, `node scripts/run-vitest.mjs src/infra/outbound/delivery-queue.policy.test.ts src/infra/outbound/delivery-queue.recovery.test.ts src/infra/session-delivery-queue.recovery.test.ts` failed because `computeRecoveryRetryDelayMs` was not implemented yet.
- `node scripts/run-vitest.mjs src/infra/outbound/delivery-queue.policy.test.ts src/infra/outbound/delivery-queue.recovery.test.ts src/infra/outbound/delivery-queue.reconnect-drain.test.ts src/infra/session-delivery-queue.recovery.test.ts` passed.
- `node_modules/.bin/oxfmt --check --threads=1 src/infra/delivery-recovery.shared.ts src/infra/outbound/delivery-queue-recovery.ts src/infra/session-delivery-queue-recovery.ts src/infra/outbound/delivery-queue.policy.test.ts src/infra/outbound/delivery-queue.recovery.test.ts src/infra/session-delivery-queue.recovery.test.ts` passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/infra/delivery-recovery.shared.ts src/infra/outbound/delivery-queue-recovery.ts src/infra/session-delivery-queue-recovery.ts src/infra/outbound/delivery-queue.policy.test.ts src/infra/outbound/delivery-queue.recovery.test.ts src/infra/session-delivery-queue.recovery.test.ts` passed.
- `git diff --check` passed.
- `codex review --base origin/main` completed with: "I did not find a concrete regression in the changed surfaces."
- Attempted `pnpm check:changed -- src/infra/delivery-recovery.shared.ts src/infra/outbound/delivery-queue-recovery.ts src/infra/session-delivery-queue-recovery.ts src/infra/outbound/delivery-queue.policy.test.ts src/infra/outbound/delivery-queue.recovery.test.ts src/infra/outbound/delivery-queue.reconnect-drain.test.ts src/infra/session-delivery-queue.recovery.test.ts`; it delegated to Blacksmith Testbox and exited before running the checks because the selected `crabbox` binary failed basic `--version`/`--help` sanity checks.
