### PR TITLE
fix(windows): remove findstr from restart probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Windows scheduled-task restart:** replace the locale-sensitive `findstr` process-state probe with a direct PowerShell task-state exit code, preventing hidden restart helpers from hanging or flashing a console window. (#84600, #91273) Thanks @deepujain and @andyk-ms.
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.
 - **CJK Markdown emphasis:** render adjacent Chinese, Japanese, and Korean emphasis punctuation through the shared Markdown pipeline instead of leaking literal markers across channels. (#101230, #101120) Thanks @nicknmorty.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Windows scheduled-task restart:** replace the locale-sensitive `findstr` process-state probe with a direct PowerShell task-state exit code, preventing hidden restart helpers from hanging or flashing a console window. (#84600, #91273) Thanks @deepujain and @andyk-ms.
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.
 - **CJK Markdown emphasis:** render adjacent Chinese, Japanese, and Korean emphasis punctuation through the shared Markdown pipeline instead of leaking literal markers across channels. (#101230, #101120) Thanks @nicknmorty.
 - **Codex yielded native subagents:** keep the parent app-server subscription and shared client alive until yielded native subagent completion delivery settles, preventing lost wakeups and leaked one-shot cleanup.

--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -129,8 +129,9 @@ describe("relaunchGatewayScheduledTask", () => {
       'openclaw restart attempt source=windows-task-handoff target="OpenClaw Gateway (work)"',
     );
     expect(script).toContain(
-      `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "(Get-ScheduledTask -TaskName 'OpenClaw Gateway (work)' -ErrorAction SilentlyContinue).State" 2>nul | findstr /I /C:"Running" >nul 2>&1`,
+      `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "$task = Get-ScheduledTask -TaskName 'OpenClaw Gateway (work)' -ErrorAction SilentlyContinue; if ($null -ne $task -and $task.State -eq 'Running') { exit 0 }; exit 1" >nul 2>&1`,
     );
+    expect(script).not.toContain("findstr");
     expect(script).toContain('schtasks /Run /TN "OpenClaw Gateway (work)" >>');
     expect(script.indexOf("powershell.exe -NoProfile")).toBeLessThan(
       script.indexOf('schtasks /Run /TN "OpenClaw Gateway (work)"'),
@@ -167,8 +168,9 @@ describe("relaunchGatewayScheduledTask", () => {
     const scriptPath = [...createdScriptPaths][0];
     const script = fs.readFileSync(scriptPath, "utf8");
     expect(script).toContain(
-      "-Command \"(Get-ScheduledTask -TaskName 'OpenClaw Gateway (Bob''s work)' -ErrorAction SilentlyContinue).State\"",
+      `-Command "$task = Get-ScheduledTask -TaskName 'OpenClaw Gateway (Bob''s work)' -ErrorAction SilentlyContinue; if ($null -ne $task -and $task.State -eq 'Running') { exit 0 }; exit 1"`,
     );
+    expect(script).not.toContain("findstr");
   });
 
   it("returns failed when the helper cannot be spawned", () => {

--- a/src/infra/windows-task-restart.ts
+++ b/src/infra/windows-task-restart.ts
@@ -35,9 +35,11 @@ function buildScheduledTaskRestartScript(params: {
 }): string {
   const { quotedLogPath, setupLines, taskName, taskScriptPath } = params;
   const quotedTaskName = quoteCmdScriptArg(taskName);
-  const queryTaskStateCommand = `(Get-ScheduledTask -TaskName ${quotePowerShellSingleQuotedLiteral(
-    taskName,
-  )} -ErrorAction SilentlyContinue).State`;
+  const queryTaskStateCommand = [
+    `$task = Get-ScheduledTask -TaskName ${quotePowerShellSingleQuotedLiteral(taskName)} -ErrorAction SilentlyContinue`,
+    "if ($null -ne $task -and $task.State -eq 'Running') { exit 0 }",
+    "exit 1",
+  ].join("; ");
   const quotedQueryTaskStateCommand = quoteCmdScriptArg(queryTaskStateCommand);
   const lines = [
     "@echo off",
@@ -51,7 +53,7 @@ function buildScheduledTaskRestartScript(params: {
     `timeout /t ${TASK_RESTART_RETRY_DELAY_SEC} /nobreak >nul`,
     "set /a attempts+=1",
     // Avoid racing with another restart path that already started the scheduled task.
-    `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ${quotedQueryTaskStateCommand} 2>nul | findstr /I /C:"Running" >nul 2>&1`,
+    `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command ${quotedQueryTaskStateCommand} >nul 2>&1`,
     "if not errorlevel 1 goto cleanup",
     `schtasks /Run /TN ${quotedTaskName} >> ${quotedLogPath} 2>&1`,
     "if not errorlevel 1 goto cleanup",


### PR DESCRIPTION
Closes #84600
Related: #91273

## What Problem This Solves

Fixes an issue where Windows Gateway restart handoff could leave a visible or hung `cmd.exe` / `findstr.exe` process while checking whether the scheduled task was already running. Reports show the probe delaying restart for minutes and sometimes requiring manual recovery.

## Why This Change Was Made

The generated restart helper now asks PowerShell to exit `0` only when `Get-ScheduledTask` reports `Running`, and exits `1` otherwise. The existing batch `errorlevel` branch therefore keeps the same retry/fallback behavior without starting `findstr`; single-quoted PowerShell literals avoid nested escaped double quotes and preserve apostrophes in custom task names.

This is a maintainer replacement for #91273 because the contributor branch predates substantial current-main Windows restart hardening. The useful fix is preserved with co-author credit and applied on top of the current `getWindowsCmdExePath()` behavior.

## User Impact

Windows Gateway restarts no longer spawn the `findstr` subprocess implicated in visible black windows and hung restart handoffs. Existing task-state detection, retry limits, fallback startup, cleanup, and hidden detached launch behavior remain in place.

## Evidence

- Current source and shipped `v2026.6.11` contain the reported PowerShell-to-`findstr` pipeline in `src/infra/windows-task-restart.ts`.
- Focused regression coverage asserts the PowerShell-only exit-code probe, no `findstr`, ordering before `schtasks /Run`, and apostrophe-safe task names.
- Exact code head `6326ad97f0a62b56e9426db05d5631d732c0daeb` passed the full hosted CI run, including all 6 focused `src/infra/windows-task-restart.test.ts` cases: https://github.com/openclaw/openclaw/actions/runs/28842342161
- Native Windows Server 2025 run `28843194826` on `fdeb981ba8549324ff3c699768a8dfcbcf7016f5` passed 8 Windows CI shards (180 tests passed, 17 skipped). Final head `372e75b52199d3a2db24d144025fc60b8fe355f5` removes only the release-owned changelog line and restores the exact code tree from `6326ad97f0a62b56e9426db05d5631d732c0daeb`: https://github.com/openclaw/openclaw/actions/runs/28843194826
- Fresh Codex autoreview on the final current-main diff reported no accepted/actionable findings (confidence 0.82).
- Direct AWS native-Windows Task Scheduler proof was attempted twice on Crabbox lease `cbx_94ba7fc425c8`, but the fresh image never completed SSH bootstrap; the lease was stopped. No behavior claim relies on that blocked run.
