### PR TITLE
fix(agents): resolve fable-5 1M context window for claude-cli provider

### DIFF
--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -156,7 +156,7 @@ export function resolveAnthropicFixedContextWindow(
     return undefined;
   }
   if (
-    (provider === "anthropic" || provider === "anthropic-vertex") &&
+    (provider === "anthropic" || provider === "anthropic-vertex" || provider === "claude-cli") &&
     /^claude-fable-5(?=$|[^a-z0-9])/.test(modelId)
   ) {
     return ANTHROPIC_FABLE_CONTEXT_TOKENS;

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -89,12 +89,14 @@ describe("applyDiscoveredContextWindows", () => {
         { id: "claude-cli/claude-opus-4.8-20260514", contextWindow: 200_000 },
         { id: "claude-cli/claude-opus-4.7-20260219", contextWindow: 200_000 },
         { id: "claude-cli/claude-sonnet-4-6", contextWindow: 200_000 },
+        { id: "claude-cli/claude-fable-5", contextWindow: 200_000 },
       ],
     });
 
     expect(cache.get("claude-cli/claude-opus-4.8-20260514")).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
     expect(cache.get("claude-cli/claude-opus-4.7-20260219")).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
     expect(cache.get("claude-cli/claude-sonnet-4-6")).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+    expect(cache.get("claude-cli/claude-fable-5")).toBe(ANTHROPIC_FABLE_CONTEXT_TOKENS);
   });
 
   it("does not upgrade non-Anthropic GA 1M model ids from discovery", () => {
@@ -425,6 +427,7 @@ describe("resolveContextTokensForModel", () => {
     ["anthropic", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
     ["anthropic-vertex", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
     ["claude-cli", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
+    ["claude-cli", "claude-fable-5", ANTHROPIC_FABLE_CONTEXT_TOKENS],
     ["anthropic", "claude-sonnet-4-6", ANTHROPIC_CONTEXT_1M_TOKENS],
     ["anthropic-vertex", "claude-sonnet-4-6", ANTHROPIC_VERTEX_CONTEXT_1M_TOKENS],
   ])(
@@ -466,6 +469,7 @@ describe("resolveContextTokensForModel", () => {
   it.each([
     ["anthropic", "claude-fable-5"],
     ["anthropic-vertex", "claude-fable-5"],
+    ["claude-cli", "claude-fable-5"],
     ["anthropic", "claude-sonnet-4-6"],
     ["anthropic-vertex", "claude-sonnet-4-6"],
   ])("honors an authored %s window for fixed model %s", (provider, modelId) => {
@@ -564,6 +568,7 @@ describe("resolveContextTokensForModel", () => {
     ["anthropic", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
     ["anthropic-vertex", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
     ["claude-cli", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
+    ["claude-cli", "claude-fable-5", ANTHROPIC_FABLE_CONTEXT_TOKENS],
     ["anthropic", "claude-sonnet-4-6", ANTHROPIC_CONTEXT_1M_TOKENS],
     ["anthropic-vertex", "claude-sonnet-4-6", ANTHROPIC_VERTEX_CONTEXT_1M_TOKENS],
   ])(


### PR DESCRIPTION
## What Problem This Solves

`claude-cli + claude-fable-5` falls back to the default 200K context window instead of 1M. The `resolveAnthropicFixedContextWindow` Fable 5 guard only matched `anthropic` and `anthropic-vertex` providers, leaving `claude-cli` unhandled.

Both call paths were affected:
- `resolveContextTokensForModelFromCache` (direct context resolution)
- `resolveDiscoveredAnthropicFixedContextWindow` (discovery cache upgrade)

Same root cause as #100572: a new model was added to the catalog but the `claude-cli` provider boundary was not enumerated in the Fable 5 guard.

## Why This Change Was Made

Add `provider === 'claude-cli'` to the existing Fable 5 fixed-window guard, matching the pattern already used by the Mythos 5 / Sonnet 5 guards and the GA 1M prefix check on the next branch.

## User Impact

`claude-cli/claude-fable-5` now correctly resolves to 1,000,000 token context window via `ANTHROPIC_FABLE_CONTEXT_TOKENS`. All three Anthropic-affiliated providers (anthropic, anthropic-vertex, claude-cli) now receive the correct fixed context window for Fable 5.

## Evidence

### Unit tests (66 passed, 0 failed)

```
$ node scripts/run-vitest.mjs run src/agents/context.test.ts

 Test Files  1 passed (1)
      Tests  66 passed (66)
```

### Real behavior proof — `resolveAnthropicFixedContextWindow` live output

A proof script exercised `resolveAnthropicFixedContextWindow()` directly against the production source to verify that `claude-cli/claude-fable-5` resolves to the correct 1M context window:

```
=== resolveAnthropicFixedContextWindow — Real Behavior Proof ===

  ✓ provider="claude-cli" model="claude-fable-5"
    result=1000000 expected=1000000
  ✓ provider="anthropic" model="claude-fable-5"
    result=1000000 expected=1000000
  ✓ provider="anthropic-vertex" model="claude-fable-5"
    result=1000000 expected=1000000
  ✓ provider="claude-cli" model="claude-opus-4-8-20260514"
    result=1048576 expected=1048576
  ✓ provider="claude-cli" model="claude-sonnet-4-6"
    result=1048576 expected=1048576
  ✓ provider="openai" model="gpt-5.5"
    result=undefined expected=undefined
  ✓ provider="claude-cli" model="claude-haiku-4-5"
    result=undefined expected=undefined

7/7 assertions checked
✓ All assertions passed — claude-cli/claude-fable-5 resolves to 1M context window
```

Key coverage:
- **claude-cli Fable 5** → 1,000,000 (the fix target)
- **anthropic / anthropic-vertex Fable 5** → 1,000,000 (existing coverage preserved)
- **claude-cli GA 1M models** → 1,048,576 (Opus 4.8, Sonnet 4.6 via existing prefix-based branch)
- **Non-Anthropic** → undefined (openai correctly excluded)
- **Non-1M Anthropic** → undefined (claude-haiku-4-5 correctly excluded)

Real environment tested: Linux Node 24, commit 4a1919d4c012, branch fix/gap-ctx-claude-cli-fable5-context-window
Exact command run: `npx tsx scripts/proof-context-resolution.mjs` (exercising `resolveAnthropicFixedContextWindow` from production source)
What was not tested: Live gateway end-to-end with actual claude-cli provider subscription (requires Claude CLI subscription and API key)
