### PR TITLE
fix: show exported tool results in trace viewers

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -162,11 +162,13 @@ Boolean `captureContent: true` enables `inputMessages`, `outputMessages`, `toolI
 </Note>
 
 `toolInputs`/`toolOutputs` content is captured for the built-in agent
-runtime's tool executions (`openclaw.content.tool_input` on
-completed/error spans, `openclaw.content.tool_output` on completed spans).
-External harness tool calls (Codex, Claude CLI) emit `tool.execution.*` spans
-without content payloads. Captured content travels on a trusted,
-listener-only channel and is never placed on the public diagnostic event bus.
+runtime's tool executions (`openclaw.content.tool_input` and
+`gen_ai.tool.call.arguments` on completed/error spans;
+`openclaw.content.tool_output` and `gen_ai.tool.call.result` on completed
+spans). External harness tool calls (Codex, Claude CLI) emit
+`tool.execution.*` spans without content payloads. Captured content travels on a
+trusted, listener-only channel and is never placed on the public diagnostic event
+bus.
 
 ## Sampling and flushing
 

--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -165,7 +165,9 @@ Boolean `captureContent: true` enables `inputMessages`, `outputMessages`, `toolI
 runtime's tool executions (`openclaw.content.tool_input` and
 `gen_ai.tool.call.arguments` on completed/error spans;
 `openclaw.content.tool_output` and `gen_ai.tool.call.result` on completed
-spans). External harness tool calls (Codex, Claude CLI) emit
+spans). The `openclaw.content.*` names remain the stable OpenClaw attribute
+names; the `gen_ai.tool.call.*` copies mirror them for semconv-native viewers.
+External harness tool calls (Codex, Claude CLI) emit
 `tool.execution.*` spans without content payloads. Captured content travels on a
 trusted, listener-only channel and is never placed on the public diagnostic event
 bus.
@@ -348,7 +350,7 @@ Liveness warnings also emit:
   - On completion: `openclaw.harness.result_classification`, `openclaw.harness.yield_detected`, `openclaw.harness.items.started`, `openclaw.harness.items.completed`, `openclaw.harness.items.active`
   - On error: `openclaw.harness.phase`, `openclaw.errorCategory`, optional `openclaw.harness.cleanup_failed`
 - `openclaw.tool.execution`
-  - `gen_ai.tool.name`, `openclaw.toolName`, `openclaw.tool.source`, optional `openclaw.tool.owner`, `openclaw.tool.params.*`
+  - `gen_ai.tool.name`, `gen_ai.operation.name` (`execute_tool`), `openclaw.toolName`, `openclaw.tool.source`, optional `gen_ai.tool.call.id`, `openclaw.tool.owner`, `openclaw.tool.params.*`
   - Optional `openclaw.errorCategory`/`openclaw.errorCode` on errors, `openclaw.deniedReason` and `openclaw.outcome=blocked` when denied by policy or sandbox
 - `openclaw.exec`
   - `openclaw.exec.target`, `openclaw.exec.mode`, `openclaw.outcome`, `openclaw.failureKind`, `openclaw.exec.command_length`, `openclaw.exec.exit_code`, `openclaw.exec.exit_signal`, `openclaw.exec.timed_out`

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -4830,6 +4830,7 @@ describe("diagnostics-otel service", () => {
     expect(Object.hasOwn(toolOptions?.attributes ?? {}, "gen_ai.tool.call.arguments")).toBe(false);
     expect(Object.hasOwn(toolOptions?.attributes ?? {}, "gen_ai.tool.call.result")).toBe(false);
     expect(toolOptions?.attributes?.["gen_ai.tool.call.id"]).toBe("tool-1");
+    expect(toolOptions?.attributes?.["gen_ai.operation.name"]).toBe("execute_tool");
     expect(toolOptions?.startTime).toBeTypeOf("number");
     await service.stop?.(ctx);
   });
@@ -4896,15 +4897,18 @@ describe("diagnostics-otel service", () => {
     );
     expect(toolAttrs?.["openclaw.content.tool_input"]).toBe("tool input");
     expect(toolAttrs?.["gen_ai.tool.call.id"]).toBe("tool-1");
-    expect(toolAttrs?.["gen_ai.tool.call.arguments"]).toBe("tool input");
+    expect(toolAttrs?.["gen_ai.operation.name"]).toBe("execute_tool");
+    expect(toolAttrs?.["gen_ai.tool.call.arguments"]).toBe(
+      toolAttrs?.["openclaw.content.tool_input"],
+    );
+    expect(typeof toolAttrs?.["openclaw.content.tool_output"]).toBe("string");
     expect(String(toolAttrs?.["openclaw.content.tool_output"]).length).toBeLessThanOrEqual(
       MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS + OTEL_TRUNCATED_SUFFIX_MAX_CHARS,
     );
     expect(String(toolAttrs?.["openclaw.content.tool_output"])).not.toContain("a".repeat(11));
-    expect(String(toolAttrs?.["gen_ai.tool.call.result"]).length).toBeLessThanOrEqual(
-      MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS + OTEL_TRUNCATED_SUFFIX_MAX_CHARS,
+    expect(toolAttrs?.["gen_ai.tool.call.result"]).toBe(
+      toolAttrs?.["openclaw.content.tool_output"],
     );
-    expect(String(toolAttrs?.["gen_ai.tool.call.result"])).not.toContain("a".repeat(11));
     await service.stop?.(ctx);
   });
 
@@ -5020,9 +5024,7 @@ describe("diagnostics-otel service", () => {
       },
       {
         role: "tool",
-        content: '{"rows":1}',
-        tool_call_id: "call-1",
-        parts: [{ type: "tool_call_response", id: "call-1", result: { rows: 1 } }],
+        parts: [{ type: "tool_call_response", id: "call-1", response: { rows: 1 } }],
       },
     ]);
     expect(JSON.parse(stringAttribute(attrs, "gen_ai.output.messages"))).toEqual([
@@ -5045,7 +5047,7 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
-  test("adds Phoenix-readable content to explicit tool response parts", async () => {
+  test("emits semconv response text for tool response parts", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
       traces: true,
@@ -5080,6 +5082,14 @@ describe("diagnostics-otel service", () => {
               },
             ],
           },
+          {
+            role: "toolResult",
+            toolCallId: "call-2",
+            content: [
+              { type: "text", text: "alpha" },
+              { type: "text", text: "beta" },
+            ],
+          },
         ],
       },
     );
@@ -5093,20 +5103,71 @@ describe("diagnostics-otel service", () => {
     expect(JSON.parse(stringAttribute(attrs, "gen_ai.input.messages"))).toEqual([
       {
         role: "tool",
-        content: "first line\nsecond line",
-        tool_call_id: "call-1",
         parts: [
           {
             type: "tool_call_response",
             id: "call-1",
-            result: [
-              { type: "text", text: "first line" },
-              { type: "text", text: "second line" },
-            ],
+            response: "first line\nsecond line",
+          },
+        ],
+      },
+      {
+        role: "tool",
+        parts: [
+          {
+            type: "tool_call_response",
+            id: "call-2",
+            response: "alpha\nbeta",
           },
         ],
       },
     ]);
+    await service.stop?.(ctx);
+  });
+
+  test("flattens oversized pure-text tool results with a truncation marker", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+      traces: true,
+      captureContent: {
+        enabled: true,
+        inputMessages: true,
+        outputMessages: false,
+      },
+    });
+    await service.start(ctx);
+
+    const textParts = Array.from({ length: 201 }, (_, index) => ({
+      type: "text",
+      text: `line-${index}`,
+    }));
+    emitTrustedModelCallCompletedWithContent(
+      {
+        runId: "run-1",
+        callId: "call-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        durationMs: 80,
+      },
+      {
+        inputMessages: [{ role: "toolResult", toolCallId: "call-1", content: textParts }],
+      },
+    );
+    await flushDiagnosticEvents();
+
+    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
+      (call) => call[0] === "openclaw.model.call",
+    );
+    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
+      ?.attributes;
+    const messages = JSON.parse(stringAttribute(attrs, "gen_ai.input.messages")) as {
+      parts: { response?: unknown }[];
+    }[];
+    const expected = `${textParts
+      .slice(0, 200)
+      .map((part) => part.text)
+      .join("\n")}\n...(1 more text parts omitted)`;
+    expect(messages[0]?.parts[0]?.response).toBe(expected);
     await service.stop?.(ctx);
   });
 

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -4827,6 +4827,9 @@ describe("diagnostics-otel service", () => {
     expect(Object.hasOwn(toolOptions?.attributes ?? {}, "openclaw.content.tool_output")).toBe(
       false,
     );
+    expect(Object.hasOwn(toolOptions?.attributes ?? {}, "gen_ai.tool.call.arguments")).toBe(false);
+    expect(Object.hasOwn(toolOptions?.attributes ?? {}, "gen_ai.tool.call.result")).toBe(false);
+    expect(toolOptions?.attributes?.["gen_ai.tool.call.id"]).toBe("tool-1");
     expect(toolOptions?.startTime).toBeTypeOf("number");
     await service.stop?.(ctx);
   });
@@ -4892,10 +4895,16 @@ describe("diagnostics-otel service", () => {
       "sk-1234567890abcdef1234567890abcdef", // pragma: allowlist secret
     );
     expect(toolAttrs?.["openclaw.content.tool_input"]).toBe("tool input");
+    expect(toolAttrs?.["gen_ai.tool.call.id"]).toBe("tool-1");
+    expect(toolAttrs?.["gen_ai.tool.call.arguments"]).toBe("tool input");
     expect(String(toolAttrs?.["openclaw.content.tool_output"]).length).toBeLessThanOrEqual(
       MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS + OTEL_TRUNCATED_SUFFIX_MAX_CHARS,
     );
     expect(String(toolAttrs?.["openclaw.content.tool_output"])).not.toContain("a".repeat(11));
+    expect(String(toolAttrs?.["gen_ai.tool.call.result"]).length).toBeLessThanOrEqual(
+      MAX_TEST_OTEL_CONTENT_ATTRIBUTE_CHARS + OTEL_TRUNCATED_SUFFIX_MAX_CHARS,
+    );
+    expect(String(toolAttrs?.["gen_ai.tool.call.result"])).not.toContain("a".repeat(11));
     await service.stop?.(ctx);
   });
 
@@ -5011,6 +5020,8 @@ describe("diagnostics-otel service", () => {
       },
       {
         role: "tool",
+        content: '{"rows":1}',
+        tool_call_id: "call-1",
         parts: [{ type: "tool_call_response", id: "call-1", result: { rows: 1 } }],
       },
     ]);
@@ -5031,6 +5042,71 @@ describe("diagnostics-otel service", () => {
     ]);
     expect(attrs?.["input.mime_type"]).toBe("application/json");
     expect(attrs?.["output.mime_type"]).toBe("application/json");
+    await service.stop?.(ctx);
+  });
+
+  test("adds Phoenix-readable content to explicit tool response parts", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, {
+      traces: true,
+      captureContent: {
+        enabled: true,
+        inputMessages: true,
+        outputMessages: false,
+      },
+    });
+    await service.start(ctx);
+
+    emitTrustedModelCallCompletedWithContent(
+      {
+        runId: "run-1",
+        callId: "call-1",
+        provider: "openai",
+        model: "gpt-5.4",
+        durationMs: 80,
+      },
+      {
+        inputMessages: [
+          {
+            role: "tool",
+            parts: [
+              {
+                type: "tool_call_response",
+                id: "call-1",
+                result: [
+                  { type: "text", text: "first line" },
+                  { type: "text", text: "second line" },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    );
+    await flushDiagnosticEvents();
+
+    const modelCall = telemetryState.tracer.startSpan.mock.calls.find(
+      (call) => call[0] === "openclaw.model.call",
+    );
+    const attrs = (modelCall?.[1] as { attributes?: Record<string, unknown> } | undefined)
+      ?.attributes;
+    expect(JSON.parse(stringAttribute(attrs, "gen_ai.input.messages"))).toEqual([
+      {
+        role: "tool",
+        content: "first line\nsecond line",
+        tool_call_id: "call-1",
+        parts: [
+          {
+            type: "tool_call_response",
+            id: "call-1",
+            result: [
+              { type: "text", text: "first line" },
+              { type: "text", text: "second line" },
+            ],
+          },
+        ],
+      },
+    ]);
     await service.stop?.(ctx);
   });
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -30,7 +30,11 @@ import {
   ATTR_GEN_AI_INPUT_MESSAGES,
   ATTR_GEN_AI_OUTPUT_MESSAGES,
   ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+  ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
+  ATTR_GEN_AI_TOOL_CALL_ID,
+  ATTR_GEN_AI_TOOL_CALL_RESULT,
   ATTR_GEN_AI_TOOL_DEFINITIONS,
+  GEN_AI_OPERATION_NAME_VALUE_EXECUTE_TOOL,
 } from "@opentelemetry/semantic-conventions/incubating";
 import { waitForDiagnosticEventsDrained } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { createNodeProxyAgent } from "openclaw/plugin-sdk/fetch-runtime";
@@ -912,53 +916,53 @@ function textPart(content: string): Record<string, unknown> {
   return { type: "text", content };
 }
 
+// Shared text-part reading for gen_ai message normalization: OpenClaw emits
+// {type:"text", text}; some harness shapes carry {type:"text", content}.
+function textPartContent(part: Record<string, unknown>): string | undefined {
+  if (part.type !== "text") {
+    return undefined;
+  }
+  if (typeof part.text === "string") {
+    return part.text;
+  }
+  return typeof part.content === "string" ? part.content : undefined;
+}
+
+// Tool results usually arrive as arrays of text parts. Flatten pure-text arrays
+// into one plain string so the part's `response` renders as readable text in
+// trace viewers; mixed/structured results keep their raw (bounded, redacted) shape.
+function toolCallResponseValue(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+  const textItems: string[] = [];
+  for (const item of value) {
+    const text =
+      typeof item === "string" ? item : isRecord(item) ? textPartContent(item) : undefined;
+    if (typeof text !== "string") {
+      return value;
+    }
+    textItems.push(text);
+  }
+  const kept = textItems.slice(0, MAX_OTEL_CONTENT_ARRAY_ITEMS);
+  const joined = kept.filter((text) => text.length > 0).join("\n");
+  if (joined.length === 0) {
+    return value;
+  }
+  const omitted = textItems.length - kept.length;
+  return omitted > 0 ? `${joined}\n...(${omitted} more text parts omitted)` : joined;
+}
+
 function toolCallResponsePart(part: Record<string, unknown>): Record<string, unknown> {
   return {
     type: "tool_call_response",
     ...(typeof part.id === "string" ? { id: part.id } : {}),
-    result: part.result ?? part.response ?? part.content ?? part.details ?? "",
-  };
-}
-
-function toolCallResponseResultText(result: unknown): string | undefined {
-  if (typeof result === "string") {
-    return normalizeOtelLogString(result, MAX_OTEL_CONTENT_ATTRIBUTE_CHARS);
-  }
-  if (Array.isArray(result)) {
-    const textItems: string[] = [];
-    for (const item of result.slice(0, MAX_OTEL_CONTENT_ARRAY_ITEMS)) {
-      if (typeof item === "string" && item.length > 0) {
-        textItems.push(item);
-      } else if (isRecord(item)) {
-        const text =
-          typeof item.text === "string"
-            ? item.text
-            : typeof item.content === "string"
-              ? item.content
-              : undefined;
-        if (text && text.length > 0) {
-          textItems.push(text);
-        }
-      }
-    }
-    if (textItems.length > 0) {
-      return normalizeOtelLogString(textItems.join("\n"), MAX_OTEL_CONTENT_ATTRIBUTE_CHARS);
-    }
-  }
-  return normalizeOtelContentValue(result);
-}
-
-function phoenixToolMessageFields(
-  parts: readonly Record<string, unknown>[],
-): Record<string, unknown> {
-  const toolResponse = parts.find((part) => part.type === "tool_call_response");
-  if (!toolResponse) {
-    return {};
-  }
-  const content = toolCallResponseResultText(toolResponse.result);
-  return {
-    ...(typeof toolResponse.id === "string" ? { tool_call_id: toolResponse.id } : {}),
-    ...(content ? { content } : {}),
+    // Semconv gen_ai.*.messages requires the `response` key on tool_call_response
+    // parts (gen-ai-input-messages.json, since v1.37). Schema-validating viewers
+    // (e.g. Phoenix) silently drop parts keyed `result`, hiding tool output.
+    response: toolCallResponseValue(
+      part.response ?? part.result ?? part.content ?? part.details ?? "",
+    ),
   };
 }
 
@@ -987,10 +991,9 @@ function contentParts(value: unknown): Record<string, unknown>[] {
     if (!isRecord(part)) {
       continue;
     }
-    if (part.type === "text" && typeof part.text === "string") {
-      parts.push(textPart(part.text));
-    } else if (part.type === "text" && typeof part.content === "string") {
-      parts.push(textPart(part.content));
+    const text = textPartContent(part);
+    if (text !== undefined) {
+      parts.push(textPart(text));
     } else if (part.type === "thinking" && typeof part.thinking === "string") {
       parts.push({ type: "reasoning", content: part.thinking });
     } else if (part.type === "toolCall" && typeof part.name === "string") {
@@ -1044,7 +1047,7 @@ function normalizeGenAiMessage(
         : [
             toolCallResponsePart({
               id: value.toolCallId,
-              result: value.content ?? value.details ?? "",
+              response: value.content ?? value.details ?? "",
             }),
           ];
   } else {
@@ -1055,7 +1058,6 @@ function normalizeGenAiMessage(
   }
   return {
     role,
-    ...(role === "tool" ? phoenixToolMessageFields(parts) : {}),
     parts,
     ...(typeof value.name === "string" ? { name: value.name } : {}),
     ...(typeof value.finish_reason === "string" ? { finish_reason: value.finish_reason } : {}),
@@ -1160,9 +1162,13 @@ function assignOtelToolIdentityAttributes(
   attributes: Record<string, string | number | boolean>,
   evt: { toolCallId?: string },
 ): void {
+  // Semconv execute_tool identity, span-only by design: metric attrs must stay
+  // low-cardinality, and unlike the dropped openclaw.toolCallId passthrough keys
+  // (DROPPED_OTEL_ATTRIBUTE_KEYS) the semconv id is a deliberate per-span export.
+  attributes["gen_ai.operation.name"] = GEN_AI_OPERATION_NAME_VALUE_EXECUTE_TOOL;
   const toolCallId = evt.toolCallId?.trim();
   if (toolCallId) {
-    attributes["gen_ai.tool.call.id"] = toolCallId;
+    attributes[ATTR_GEN_AI_TOOL_CALL_ID] = toolCallId;
   }
 }
 
@@ -1203,13 +1209,21 @@ function assignOtelToolContentAttributes(
   content: OtelToolCallContent | undefined,
   policy: OtelContentCapturePolicy,
 ): void {
+  // Mirror captured content onto the semconv keys next to the shipped
+  // openclaw.content.* names; normalize once so both copies stay byte-identical.
   if (policy.toolInputs) {
-    assignOtelContentAttribute(attributes, "gen_ai.tool.call.arguments", content?.toolInput);
-    assignOtelContentAttribute(attributes, "openclaw.content.tool_input", content?.toolInput);
+    const toolInput = normalizeOtelContentValue(content?.toolInput);
+    if (toolInput) {
+      attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] = toolInput;
+      attributes["openclaw.content.tool_input"] = toolInput;
+    }
   }
   if (policy.toolOutputs) {
-    assignOtelContentAttribute(attributes, "gen_ai.tool.call.result", content?.toolOutput);
-    assignOtelContentAttribute(attributes, "openclaw.content.tool_output", content?.toolOutput);
+    const toolOutput = normalizeOtelContentValue(content?.toolOutput);
+    if (toolOutput) {
+      attributes[ATTR_GEN_AI_TOOL_CALL_RESULT] = toolOutput;
+      attributes["openclaw.content.tool_output"] = toolOutput;
+    }
   }
 }
 
@@ -3633,9 +3647,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         if (!tracesEnabled) {
           return;
         }
-        const spanAttrs: Record<string, string | number | boolean> = {
-          ...toolExecutionBaseAttrs(evt),
-        };
+        const spanAttrs: Record<string, string | number | boolean> = { ...attrs };
         addRunAttrs(spanAttrs, evt);
         assignOtelToolIdentityAttributes(spanAttrs, evt);
         assignOtelToolContentAttributes(spanAttrs, toolContent, contentCapturePolicy);
@@ -3662,10 +3674,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         if (!tracesEnabled) {
           return;
         }
-        const spanAttrs: Record<string, string | number | boolean> = {
-          ...toolExecutionBaseAttrs(evt),
-          "openclaw.errorCategory": lowCardinalityAttr(evt.errorCategory, "other"),
-        };
+        const spanAttrs: Record<string, string | number | boolean> = { ...attrs };
         addRunAttrs(spanAttrs, evt);
         assignOtelToolIdentityAttributes(spanAttrs, evt);
         if (evt.errorCode) {

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -920,6 +920,48 @@ function toolCallResponsePart(part: Record<string, unknown>): Record<string, unk
   };
 }
 
+function toolCallResponseResultText(result: unknown): string | undefined {
+  if (typeof result === "string") {
+    return normalizeOtelLogString(result, MAX_OTEL_CONTENT_ATTRIBUTE_CHARS);
+  }
+  if (Array.isArray(result)) {
+    const textItems: string[] = [];
+    for (const item of result.slice(0, MAX_OTEL_CONTENT_ARRAY_ITEMS)) {
+      if (typeof item === "string" && item.length > 0) {
+        textItems.push(item);
+      } else if (isRecord(item)) {
+        const text =
+          typeof item.text === "string"
+            ? item.text
+            : typeof item.content === "string"
+              ? item.content
+              : undefined;
+        if (text && text.length > 0) {
+          textItems.push(text);
+        }
+      }
+    }
+    if (textItems.length > 0) {
+      return normalizeOtelLogString(textItems.join("\n"), MAX_OTEL_CONTENT_ATTRIBUTE_CHARS);
+    }
+  }
+  return normalizeOtelContentValue(result);
+}
+
+function phoenixToolMessageFields(
+  parts: readonly Record<string, unknown>[],
+): Record<string, unknown> {
+  const toolResponse = parts.find((part) => part.type === "tool_call_response");
+  if (!toolResponse) {
+    return {};
+  }
+  const content = toolCallResponseResultText(toolResponse.result);
+  return {
+    ...(typeof toolResponse.id === "string" ? { tool_call_id: toolResponse.id } : {}),
+    ...(content ? { content } : {}),
+  };
+}
+
 function contentParts(value: unknown): Record<string, unknown>[] {
   if (typeof value === "string") {
     return value.length > 0 ? [textPart(value)] : [];
@@ -1013,6 +1055,7 @@ function normalizeGenAiMessage(
   }
   return {
     role,
+    ...(role === "tool" ? phoenixToolMessageFields(parts) : {}),
     parts,
     ...(typeof value.name === "string" ? { name: value.name } : {}),
     ...(typeof value.finish_reason === "string" ? { finish_reason: value.finish_reason } : {}),
@@ -1113,6 +1156,16 @@ function assignOtelContentAttribute(
   }
 }
 
+function assignOtelToolIdentityAttributes(
+  attributes: Record<string, string | number | boolean>,
+  evt: { toolCallId?: string },
+): void {
+  const toolCallId = evt.toolCallId?.trim();
+  if (toolCallId) {
+    attributes["gen_ai.tool.call.id"] = toolCallId;
+  }
+}
+
 function assignOtelModelContentAttributes(
   attributes: Record<string, string | number | boolean>,
   content: OtelModelCallContent | undefined,
@@ -1151,9 +1204,11 @@ function assignOtelToolContentAttributes(
   policy: OtelContentCapturePolicy,
 ): void {
   if (policy.toolInputs) {
+    assignOtelContentAttribute(attributes, "gen_ai.tool.call.arguments", content?.toolInput);
     assignOtelContentAttribute(attributes, "openclaw.content.tool_input", content?.toolInput);
   }
   if (policy.toolOutputs) {
+    assignOtelContentAttribute(attributes, "gen_ai.tool.call.result", content?.toolOutput);
     assignOtelContentAttribute(attributes, "openclaw.content.tool_output", content?.toolOutput);
   }
 }
@@ -3556,10 +3611,12 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         if (!tracesEnabled || !metadata.trusted) {
           return;
         }
+        const spanAttrs = toolExecutionBaseAttrs(evt);
+        assignOtelToolIdentityAttributes(spanAttrs, evt);
         trackTrustedSpan(
           evt,
           metadata,
-          spanWithDuration("openclaw.tool.execution", toolExecutionBaseAttrs(evt), undefined, {
+          spanWithDuration("openclaw.tool.execution", spanAttrs, undefined, {
             parentContext: activeTrustedParentContext(evt, metadata),
             startTimeMs: evt.ts,
           }),
@@ -3580,6 +3637,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           ...toolExecutionBaseAttrs(evt),
         };
         addRunAttrs(spanAttrs, evt);
+        assignOtelToolIdentityAttributes(spanAttrs, evt);
         assignOtelToolContentAttributes(spanAttrs, toolContent, contentCapturePolicy);
         const span =
           takeTrackedTrustedSpan(evt, metadata) ??
@@ -3609,6 +3667,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           "openclaw.errorCategory": lowCardinalityAttr(evt.errorCategory, "other"),
         };
         addRunAttrs(spanAttrs, evt);
+        assignOtelToolIdentityAttributes(spanAttrs, evt);
         if (evt.errorCode) {
           spanAttrs["openclaw.errorCode"] = lowCardinalityAttr(evt.errorCode, "other");
         }
@@ -3644,6 +3703,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           "openclaw.deniedReason": lowCardinalityAttr(evt.deniedReason, "other"),
         };
         addRunAttrs(spanAttrs, evt);
+        assignOtelToolIdentityAttributes(spanAttrs, evt);
         const span = spanWithDuration("openclaw.tool.execution", spanAttrs, 0, {
           parentContext: activeTrustedParentContext(evt, metadata),
           endTimeMs: evt.ts,


### PR DESCRIPTION
## What Problem This Solves

Fixes tool results being invisible in LLM trace viewers that consume the OTel GenAI semantic conventions. Local Phoenix traces showed tool-result message cards with no visible output, and tool execution spans exposed captured tool I/O only under OpenClaw-private attribute names.

## Why This Change Was Made

Root cause: the exporter emitted `tool_call_response` message parts keyed `result`, but the OTel GenAI semconv JSON Schema (`docs/gen-ai/gen-ai-input-messages.json`, unchanged since its introduction in v1.37) requires that field to be named `response`. Schema-validating viewers fail the typed part match and silently drop the part — Phoenix's gen_ai-to-OpenInference converter (pydantic models generated from that schema) renders an empty tool card, which is exactly the reported symptom.

- `tool_call_response` parts in `gen_ai.input.messages`/`gen_ai.output.messages` now emit the semconv `response` key (loose producer keys `result`/`content`/`details` are still accepted on input). Pure-text part arrays are flattened into one readable string (with a disclosed `...(N more text parts omitted)` marker past the array cap); mixed/structured results keep their raw (bounded, redacted) shape.
- Tool execution spans now carry the semconv execute_tool identity: `gen_ai.operation.name=execute_tool` (the Required classifier semconv-aware backends key on) and `gen_ai.tool.call.id`, and mirror explicitly captured tool inputs/results to `gen_ai.tool.call.arguments`/`gen_ai.tool.call.result` (still gated by `diagnostics.otel.captureContent.toolInputs`/`toolOutputs`, normalized once and byte-identical to the shipped `openclaw.content.tool_*` names).

AI-assisted.

## User Impact

Operators inspecting future OpenClaw traces see captured tool results in Phoenix chat views (`message.tool_call_id` + `message.content` derived from the `tool_call_response` part) and in standard GenAI tool span views (Langfuse/Opik map `gen_ai.tool.call.arguments`/`result` to observation input/output). Existing traces are not rewritten. `openclaw.content.*` remain the stable OpenClaw attribute names; the `gen_ai.*` copies mirror them for semconv-native viewers.

## Evidence

- Blacksmith Testbox unit suite: `pnpm test extensions/diagnostics-otel/src/service.test.ts` — 106/106 passed.
- Blacksmith Testbox live E2E (lease `golden-lobster`): real gateway + `diagnostics-otel` + `captureContent` enabled, OTLP/http-protobuf to an otelcol-contrib 0.155.0 fan-out (file exporter + forward to a real Phoenix 17.20.0), one-shot `openclaw agent` turn on `xai/grok-4.3` that invoked the `read` tool:
  - Wire (collector file exporter): tool span carries `gen_ai.operation.name=execute_tool`, `gen_ai.tool.call.id`, `gen_ai.tool.call.arguments={"path":...}`, `gen_ai.tool.call.result` byte-identical to `openclaw.content.tool_output`; the tool message part exported as `{type:"tool_call_response", id, response:"otel-e2e-proof-7431: ..."}` — 1 `response` key, 0 legacy `result` keys across all exported messages.
  - Phoenix (queried via client API): tool span converted to `span_kind=TOOL` with `tool.id`/`tool.name`/`tool.parameters`/`output.value` populated, and the LLM span's `llm.input_messages` contains `{"message.role":"tool","message.tool_call_id":"...","message.content":"otel-e2e-proof-7431: semconv response key smoke\n"}` — the previously-empty tool card now renders its content.
- `oxfmt --check --threads=1` on both changed TS files; `git diff --check` clean.
- Dependency contract proof (read from source):
  - OTel semconv `gen-ai-input-messages.json` at v1.37.0 and v1.41.0: `ToolCallResponsePart` `required: ["type", "response"]` — `result` was never the schema key. The three new span attributes use the `ATTR_GEN_AI_TOOL_CALL_*` constants from the pinned `@opentelemetry/semantic-conventions@1.41.1`.
  - Phoenix `src/phoenix/trace/gen_ai/conversion.py` `_flatten_message`: maps part `id` → `message.tool_call_id` and part `response` → `message.content`; parts keyed `result` fail the generated pydantic model (`response` required) and are silently dropped as `GenericPart`.
  - Langfuse `packages/shared/src/server/otel/OtelIngestionProcessor.ts`: presence-based fallback maps `gen_ai.tool.call.arguments`/`gen_ai.tool.call.result` → observation input/output.
  - Opik `apps/opik-backend/.../otel/GenAIMappingRules.java`: same tool-span input/output mapping.
