### PR TITLE
fix(tests): reorder initializer arguments so the shared-kit test module compiles

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatContextUsageTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatContextUsageTests.swift
@@ -150,10 +150,10 @@ struct ChatContextUsageTests {
             inputTokens: nil,
             outputTokens: nil,
             totalTokens: 5000,
+            totalTokensFresh: false,
             modelProvider: nil,
             model: nil,
-            contextTokens: 10000,
-            totalTokensFresh: false)
+            contextTokens: 10000)
         let result = ChatContextUsageCalculator.usage(
             messages: [self.message()],
             sessionEntry: entry,
@@ -190,8 +190,8 @@ struct ChatContextUsageTests {
     @Test @MainActor func `view model resolves context totals through a selected global alias`() {
         let vm = OpenClawChatViewModel(
             sessionKey: "global",
-            activeAgentId: "ops",
-            transport: ContextUsageTestTransport())
+            transport: ContextUsageTestTransport(),
+            activeAgentId: "ops")
         vm.sessions = [OpenClawChatSessionEntry(
             key: "agent:ops:global",
             kind: nil,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionDeletionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelSessionDeletionTests.swift
@@ -99,8 +99,8 @@ struct ChatViewModelSessionDeletionTests {
         let transport = DeleteSessionTestTransport()
         let vm = OpenClawChatViewModel(
             sessionKey: "global",
-            activeAgentId: "ops",
-            transport: transport)
+            transport: transport,
+            activeAgentId: "ops")
         vm.load()
         try await waitUntil("initial bootstrap history") {
             await MainActor.run { transport.historyRequests.contains("global") }


### PR DESCRIPTION
## What Problem This Solves

`swift test --package-path apps/shared/OpenClawKit` fails to compile on current `main` with three "argument X must precede argument Y" errors in `ChatContextUsageTests.swift` (2) and `ChatViewModelSessionDeletionTests.swift` (1), blocking every local shared-kit test run.

## Why This Change Was Made

Two recently landed test files call labeled initializers with arguments out of declaration order (`totalTokensFresh` after `contextTokens` on `OpenClawChatSessionEntry`; `transport` after `activeAgentId` on `OpenClawChatViewModel`), which Swift rejects. Hosted CI does not compile the shared-kit test module on macOS, so it slipped through — the same gap as #100903 earlier today. The fix reorders the arguments at the three call sites; no behavior change.

## User Impact

None at runtime — test-only compile fix restoring local `swift test` for the shared package.

## Evidence

- Before: three compile errors on clean `origin/main` (exact messages in the diff context).
- After: `swift test --package-path apps/shared/OpenClawKit --filter "ChatContextUsageTests|ChatViewModelSessionDeletionTests"` — 11/11 pass in 2 suites; module compiles.
