### PR TITLE
fix: prevent Copilot Claude sessions failing after empty tool errors

### DIFF
--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -861,6 +861,65 @@ describe("Anthropic provider", () => {
   });
 
   it.each([
+    ["empty", ""],
+    ["whitespace-only", " \n\t "],
+    ["invalid-surrogate-only", String.fromCharCode(0xd83d)],
+  ])("replaces %s error tool results with non-empty content", async (_label, text) => {
+    let capturedPayload: unknown;
+    const stream = streamAnthropic(
+      makeAnthropicModel({ provider: "github-copilot" }),
+      {
+        messages: [
+          {
+            role: "assistant",
+            provider: "github-copilot",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            content: [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "lookup",
+            content: [{ type: "text", text }],
+            isError: true,
+            timestamp: 0,
+          },
+        ],
+      },
+      {
+        apiKey: "copilot-token",
+        onPayload: (payload) => {
+          capturedPayload = payload;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    await stream.result();
+
+    const payload = capturedPayload as {
+      messages: Array<{ role: string; content: Array<Record<string, unknown>> }>;
+    };
+    const userMessage = payload.messages.find((message) => message.role === "user");
+    const toolResult = userMessage?.content.find((entry) => entry.type === "tool_result");
+    expect(toolResult).toMatchObject({
+      content: "[tool error with no output]",
+      is_error: true,
+    });
+  });
+
+  it.each([
     ["claude-fable-5", "Claude Fable 5", "anthropic", "sk-ant-provider"],
     ["claude-mythos-5", "Claude Mythos 5", "anthropic", "sk-ant-provider"],
     ["claude-mythos-5", "Claude Mythos 5", "anthropic-vertex", "vertex-token"],

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -94,6 +94,7 @@ import {
 import { transformMessages } from "./transform-messages.js";
 
 const ANTHROPIC_CACHE_CONTROL_LIMIT = 4;
+const EMPTY_ERROR_TOOL_RESULT_TEXT = "[tool error with no output]";
 
 function getCacheControl(
   model: Model<"anthropic-messages">,
@@ -146,7 +147,10 @@ const toClaudeCodeName = (name: string) => ccToolLookup.get(name.toLowerCase()) 
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(content: readonly unknown[]):
+function convertContentBlocks(
+  content: readonly unknown[],
+  isError: boolean,
+):
   | string
   | Array<
       | { type: "text"; text: string }
@@ -170,7 +174,9 @@ function convertContentBlocks(content: readonly unknown[]):
 
   if (!hasImages) {
     const sanitized = sanitizeSurrogates(text);
-    return sanitized.trim().length > 0 ? sanitized : (mediaPlaceholder ?? "");
+    return sanitized.trim().length > 0
+      ? sanitized
+      : (mediaPlaceholder ?? (isError ? EMPTY_ERROR_TOOL_RESULT_TEXT : ""));
   }
 
   const blocks: Array<
@@ -1529,7 +1535,7 @@ function convertMessages(
       toolResults.push({
         type: "tool_result",
         tool_use_id: msg.toolCallId,
-        content: convertContentBlocks(msg.content),
+        content: convertContentBlocks(msg.content, msg.isError),
         is_error: msg.isError,
       });
 
@@ -1539,7 +1545,7 @@ function convertMessages(
         toolResults.push({
           type: "tool_result",
           tool_use_id: nextMsg.toolCallId,
-          content: convertContentBlocks(nextMsg.content),
+          content: convertContentBlocks(nextMsg.content, nextMsg.isError),
           is_error: nextMsg.isError,
         });
         j++;


### PR DESCRIPTION
Closes #97292

## What Problem This Solves

Fixes an issue where GitHub Copilot users running Claude models could permanently poison a session after a failed tool returned empty, whitespace-only, or invalid-surrogate-only output. Copilot rejected the resulting Anthropic payload because `is_error: true` was paired with empty `content`.

## Why This Change Was Made

Anthropic error tool results whose sanitized text is empty now receive a stable non-empty fallback. Successful empty tool results, real text, media placeholders, and image blocks keep their existing representation.

The current provider-boundary rewrite supersedes #97293 while preserving contributor credit.

## User Impact

GitHub Copilot Claude sessions can continue after an empty tool failure instead of repeatedly failing with HTTP 400 on every later turn.

## Evidence

- Real before-state: #97292 contains repeated Copilot 400 responses: `content cannot be empty if is_error is true`.
- Provider-boundary regression: captures the outgoing Anthropic payload and verifies a non-empty error result for empty, whitespace-only, and invalid-surrogate-only tool output.
- `corepack pnpm test packages/ai/src/providers/anthropic.test.ts` — 63 passed on Blacksmith Testbox `tbx_01kwxejvkp5pn44x4aqt9y42wp`.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm check:changed` — passed on the same Testbox.
- `corepack pnpm exec oxfmt --check --threads=1 packages/ai/src/providers/anthropic.ts packages/ai/src/providers/anthropic.test.ts` — passed.
- Fresh structured autoreview — clean; no accepted/actionable findings.
- Live after-state attempt: the isolated Testbox discovered `github-copilot/claude-sonnet-4.6`, but had no GitHub Copilot credential in its auth store, so an authenticated request could not be sent. No live success is claimed.

AI-assisted: Codex
