### PR TITLE
fix: Windows CLI backends fail through npm shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Windows CLI backends:** launch npm-installed Gemini CLI and Claude Code through their resolved Node or native entrypoints, preserving prompt arguments without shell parsing. Thanks @wendy-chsy.
 - **Codex app-server protocol:** require app-server 0.142 or newer, remove pre-0.142 wire-shape compatibility, and teach Codex to retrieve deferred native `spawn_agent` through `tool_search` so native subagent task mirroring works on search-capable models. (#101221)
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.
 - **CJK Markdown emphasis:** render adjacent Chinese, Japanese, and Korean emphasis punctuation through the shared Markdown pipeline instead of leaking literal markers across channels. (#101230, #101120) Thanks @nicknmorty.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Windows CLI backends:** launch npm-installed Gemini CLI and Claude Code through their resolved Node or native entrypoints, preserving prompt arguments without shell parsing. Thanks @wendy-chsy.
 - **Codex app-server protocol:** require app-server 0.142 or newer, remove pre-0.142 wire-shape compatibility, and teach Codex to retrieve deferred native `spawn_agent` through `tool_search` so native subagent task mirroring works on search-capable models. (#101221)
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.
 - **CJK Markdown emphasis:** render adjacent Chinese, Japanese, and Korean emphasis punctuation through the shared Markdown pipeline instead of leaking literal markers across channels. (#101230, #101120) Thanks @nicknmorty.

--- a/src/plugin-sdk/windows-spawn.test.ts
+++ b/src/plugin-sdk/windows-spawn.test.ts
@@ -79,4 +79,31 @@ describe("resolveWindowsSpawnProgram", () => {
       windowsHide: undefined,
     });
   });
+
+  it("preserves custom batch-wrapper behavior instead of bypassing its target", async () => {
+    const dir = await createTempDir("openclaw-windows-spawn-test-");
+    const targetPath = path.join(dir, "tool.exe");
+    const wrapperPath = path.join(dir, "wrapper.cmd");
+    await writeFile(targetPath, "", "utf8");
+    await writeFile(
+      wrapperPath,
+      '@ECHO off\r\nSET WRAPPER_FLAG=1\r\n"%~dp0\\tool.exe" %*\r\n',
+      "utf8",
+    );
+
+    const resolved = resolveWindowsSpawnProgram({
+      command: wrapperPath,
+      platform: "win32",
+      env: { PATH: dir, PATHEXT: ".CMD;.EXE;.BAT" },
+      execPath: "C:\\node\\node.exe",
+      allowShellFallback: true,
+    });
+
+    expect(resolved).toEqual({
+      command: wrapperPath,
+      leadingArgv: [],
+      resolution: "shell-fallback",
+      shell: true,
+    });
+  });
 });

--- a/src/plugin-sdk/windows-spawn.test.ts
+++ b/src/plugin-sdk/windows-spawn.test.ts
@@ -106,4 +106,27 @@ describe("resolveWindowsSpawnProgram", () => {
       shell: true,
     });
   });
+
+  it("does not reinterpret a forwarded batch wrapper as a Node script", async () => {
+    const dir = await createTempDir("openclaw-windows-spawn-test-");
+    const targetPath = path.join(dir, "inner.cmd");
+    const wrapperPath = path.join(dir, "wrapper.cmd");
+    await writeFile(targetPath, "@ECHO off\r\necho inner\r\n", "utf8");
+    await writeFile(wrapperPath, '@ECHO off\r\n"%~dp0\\inner.cmd" %*\r\n', "utf8");
+
+    const resolved = resolveWindowsSpawnProgram({
+      command: wrapperPath,
+      platform: "win32",
+      env: { PATH: dir, PATHEXT: ".CMD;.EXE;.BAT" },
+      execPath: "C:\\node\\node.exe",
+      allowShellFallback: true,
+    });
+
+    expect(resolved).toEqual({
+      command: wrapperPath,
+      leadingArgv: [],
+      resolution: "shell-fallback",
+      shell: true,
+    });
+  });
 });

--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -182,6 +182,8 @@ function resolveEntrypointFromCmdShim(wrapperPath: string): string | null {
   try {
     const content = readFileSync(wrapperPath, "utf8");
     const normalizedContent = content.replaceAll("\r\n", "\n").toLowerCase();
+    // Only npm cmd-shim launchers are safe to bypass; arbitrary batch wrappers
+    // can depend on setup commands before dispatching their target.
     const isNpmCmdShim =
       normalizedContent.includes("\ngoto start\n") &&
       normalizedContent.includes("\n:find_dp0\n") &&

--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -182,14 +182,22 @@ function resolveEntrypointFromCmdShim(wrapperPath: string): string | null {
   try {
     const content = readFileSync(wrapperPath, "utf8");
     const normalizedContent = content.replaceAll("\r\n", "\n").toLowerCase();
-    // Only npm cmd-shim launchers are safe to bypass; arbitrary batch wrappers
-    // can depend on setup commands before dispatching their target.
+    const significantLines = content
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter(Boolean);
     const isNpmCmdShim =
       normalizedContent.includes("\ngoto start\n") &&
       normalizedContent.includes("\n:find_dp0\n") &&
       normalizedContent.includes("set dp0=%~dp0") &&
       normalizedContent.includes("call :find_dp0");
-    if (!isNpmCmdShim) {
+    const isDirectForwarder =
+      significantLines.length === 2 &&
+      /^@echo off$/iu.test(significantLines[0] ?? "") &&
+      /^"%~?dp0%?[\\/][^"\r\n]+"\s+%\*$/iu.test(significantLines[1] ?? "");
+    // Only known direct-forwarder shapes are safe to bypass; arbitrary batch
+    // wrappers can depend on setup commands before dispatching their target.
+    if (!isNpmCmdShim && !isDirectForwarder) {
       return null;
     }
     const candidates: string[] = [];
@@ -210,6 +218,12 @@ function resolveEntrypointFromCmdShim(wrapperPath: string): string | null {
       const base = normalizeLowercaseStringOrEmpty(path.basename(candidate));
       return base !== "node.exe" && base !== "node";
     });
+    if (isDirectForwarder && nonNode) {
+      const ext = normalizeLowercaseStringOrEmpty(path.extname(nonNode));
+      if (ext !== ".exe" && ext !== ".js" && ext !== ".cjs" && ext !== ".mjs") {
+        return null;
+      }
+    }
     return nonNode ?? null;
   } catch {
     return null;

--- a/src/plugin-sdk/windows-spawn.ts
+++ b/src/plugin-sdk/windows-spawn.ts
@@ -181,6 +181,15 @@ function resolveEntrypointFromCmdShim(wrapperPath: string): string | null {
 
   try {
     const content = readFileSync(wrapperPath, "utf8");
+    const normalizedContent = content.replaceAll("\r\n", "\n").toLowerCase();
+    const isNpmCmdShim =
+      normalizedContent.includes("\ngoto start\n") &&
+      normalizedContent.includes("\n:find_dp0\n") &&
+      normalizedContent.includes("set dp0=%~dp0") &&
+      normalizedContent.includes("call :find_dp0");
+    if (!isNpmCmdShim) {
+      return null;
+    }
     const candidates: string[] = [];
     for (const match of content.matchAll(/"([^"\r\n]*)"/g)) {
       const token = match[1] ?? "";

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -430,6 +430,7 @@ describe("createChildAdapter", () => {
     await createAdapterHarness({
       pid: 3335,
       argv: ["pnpm", "--version"],
+      env: { PATH: "", PATHEXT: ".EXE;.CMD;.BAT" },
     });
 
     const spawnArgs = firstSpawnWithFallbackParams();
@@ -463,7 +464,8 @@ describe("createChildAdapter", () => {
     });
 
     const spawnArgs = firstSpawnWithFallbackParams();
-    expect(spawnArgs.argv).toEqual([nodePath, entrypoint, "--prompt", prompt]);
+    expect(spawnArgs.argv?.[0]?.toLowerCase()).toBe(nodePath.toLowerCase());
+    expect(spawnArgs.argv?.slice(1)).toEqual([entrypoint, "--prompt", prompt]);
     expect(spawnArgs.options?.windowsVerbatimArguments).toBeUndefined();
     expect(spawnArgs.fallbacks).toStrictEqual([]);
   });

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -1,9 +1,11 @@
 // Child adapter tests cover adapting child processes to supervisor runs.
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   getWindowsInstallRoots,
   resetWindowsInstallRootsForTests,
@@ -37,6 +39,7 @@ vi.mock("../../../infra/windows-encoding.js", () => ({
 }));
 
 let createChildAdapter: typeof import("./child.js").createChildAdapter;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createStubChild(pid = 1234) {
   const child = new EventEmitter() as ChildProcess;
@@ -160,6 +163,25 @@ describe("createChildAdapter", () => {
     }
     vi.useRealTimers();
   });
+
+  const createWindowsNpmShim = async (params: { command: string; packagePath: string[] }) => {
+    const binDir = tempDirs.make("openclaw-child-shim-");
+    const entrypoint = path.join(binDir, "node_modules", ...params.packagePath);
+    await mkdir(path.dirname(entrypoint), { recursive: true });
+    await writeFile(entrypoint, "", "utf8");
+    const relativeEntrypoint = path.relative(binDir, entrypoint).replaceAll(path.sep, "\\");
+    const shimHead =
+      "@ECHO off\r\nGOTO start\r\n:find_dp0\r\nSET dp0=%~dp0\r\nEXIT /b\r\n:start\r\nSETLOCAL\r\nCALL :find_dp0\r\n";
+    const shimCommand = entrypoint.endsWith(".exe")
+      ? `"%dp0%\\${relativeEntrypoint}" %*\r\n`
+      : `IF EXIST "%dp0%\\node.exe" (\r\n  SET "_prog=%dp0%\\node.exe"\r\n) ELSE (\r\n  SET "_prog=node"\r\n)\r\nendLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" "%dp0%\\${relativeEntrypoint}" %*\r\n`;
+    await writeFile(
+      path.join(binDir, `${params.command}.cmd`),
+      `${shimHead}${shimCommand}`,
+      "utf8",
+    );
+    return { binDir, entrypoint };
+  };
 
   it("uses process-tree kill for default SIGKILL", async () => {
     const { adapter, killMock } = await createAdapterHarness({ pid: 4321 });
@@ -421,6 +443,47 @@ describe("createChildAdapter", () => {
     expect(spawnArgs.options?.detached).toBe(false);
     expect(spawnArgs.options?.windowsHide).toBe(true);
     expect(spawnArgs.options?.windowsVerbatimArguments).toBe(true);
+    expect(spawnArgs.fallbacks).toStrictEqual([]);
+  });
+
+  it("unwraps Gemini's npm shim and preserves prompt argv on Windows", async () => {
+    setPlatform("win32");
+    const { binDir, entrypoint } = await createWindowsNpmShim({
+      command: "gemini",
+      packagePath: ["@google", "gemini-cli", "bundle", "gemini.js"],
+    });
+    const nodePath = path.join(binDir, "node.exe");
+    await writeFile(nodePath, "", "utf8");
+    const prompt = "explain A&B | C > D and 100% coverage";
+
+    await createAdapterHarness({
+      pid: 3336,
+      argv: ["gemini", "--prompt", prompt],
+      env: { PATH: binDir, PATHEXT: ".EXE;.CMD;.BAT" },
+    });
+
+    const spawnArgs = firstSpawnWithFallbackParams();
+    expect(spawnArgs.argv).toEqual([nodePath, entrypoint, "--prompt", prompt]);
+    expect(spawnArgs.options?.windowsVerbatimArguments).toBeUndefined();
+    expect(spawnArgs.fallbacks).toStrictEqual([]);
+  });
+
+  it("unwraps Claude's npm shim to its native executable on Windows", async () => {
+    setPlatform("win32");
+    const { binDir, entrypoint } = await createWindowsNpmShim({
+      command: "claude",
+      packagePath: ["@anthropic-ai", "claude-code", "bin", "claude.exe"],
+    });
+
+    await createAdapterHarness({
+      pid: 3337,
+      argv: ["claude", "--version"],
+      env: { PATH: binDir, PATHEXT: ".EXE;.CMD;.BAT" },
+    });
+
+    const spawnArgs = firstSpawnWithFallbackParams();
+    expect(spawnArgs.argv).toEqual([entrypoint, "--version"]);
+    expect(spawnArgs.options?.windowsVerbatimArguments).toBeUndefined();
     expect(spawnArgs.fallbacks).toStrictEqual([]);
   });
 

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -2,6 +2,10 @@
 import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_process";
 import { toErrorObject } from "../../../infra/errors.js";
 import { createWindowsOutputDecoder } from "../../../infra/windows-encoding.js";
+import {
+  resolveWindowsExecutablePath,
+  resolveWindowsSpawnProgramCandidate,
+} from "../../../plugin-sdk/windows-spawn.js";
 import { signalProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
@@ -16,21 +20,37 @@ import { toStringEnv } from "./env.js";
 
 const FORCE_KILL_WAIT_FALLBACK_MS = 4000;
 const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
+const WINDOWS_PACKAGE_MANAGER_SHIMS = ["npm", "pnpm", "yarn", "npx"] as const;
 
-function resolveCommand(command: string): string {
-  return resolveWindowsCommandShim({
-    command,
-    cmdCommands: ["npm", "pnpm", "yarn", "npx"],
-  });
-}
-
-function resolveChildInvocation(params: { argv: string[]; windowsVerbatimArguments?: boolean }): {
+function resolveChildInvocation(params: {
+  argv: string[];
+  env?: NodeJS.ProcessEnv;
+  windowsVerbatimArguments?: boolean;
+}): {
   args: string[];
   command: string;
   windowsVerbatimArguments?: boolean;
 } {
-  const resolvedCommand = resolveCommand(params.argv[0] ?? "");
-  const args = params.argv.slice(1);
+  const command = params.argv[0] ?? "";
+  const candidate = resolveWindowsSpawnProgramCandidate({
+    command,
+    env: params.env,
+    // npm shims invoke `node` from PATH; process.execPath may be a packaged OpenClaw executable.
+    execPath:
+      process.platform === "win32"
+        ? resolveWindowsExecutablePath("node", params.env ?? process.env)
+        : undefined,
+  });
+  const args = [...candidate.leadingArgv, ...params.argv.slice(1)];
+  // Keep the historical package-manager fallback when PATH probing cannot see
+  // its shim; every resolved wrapper takes the direct Node/exe path above.
+  const resolvedCommand =
+    candidate.resolution === "direct" && candidate.command === command
+      ? resolveWindowsCommandShim({
+          command,
+          cmdCommands: WINDOWS_PACKAGE_MANAGER_SHIMS,
+        })
+      : candidate.command;
   if (!isWindowsBatchCommand(resolvedCommand)) {
     return {
       command: resolvedCommand,
@@ -59,11 +79,12 @@ export async function createChildAdapter(params: {
   input?: string;
   stdinMode?: "inherit" | "pipe-open" | "pipe-closed";
 }): Promise<ChildAdapter> {
+  const baseEnv = params.env ? toStringEnv(params.env) : undefined;
   const invocation = resolveChildInvocation({
     argv: params.argv,
+    env: baseEnv,
     windowsVerbatimArguments: params.windowsVerbatimArguments,
   });
-  const baseEnv = params.env ? toStringEnv(params.env) : undefined;
   const preparedSpawn = prepareOomScoreAdjustedSpawn(invocation.command, invocation.args, {
     env: baseEnv,
   });


### PR DESCRIPTION
Closes #98573
Closes #92054
Closes #91489

Supersedes #98952, with contributor credit to @wendy-chsy.

## What Problem This Solves

Fixes an issue where Windows users running globally installed Gemini CLI or Claude Code backends could fail to start the CLI because Node does not execute npm `.cmd` launchers directly.

## Why This Change Was Made

Resolve standard Windows npm launchers through the existing generic spawn-program resolver, then execute their Node entrypoint or native executable directly. This keeps provider policy out of the process supervisor and preserves structured arguments, including Gemini prompts containing shell metacharacters, without opting into `shell: true` or `cmd.exe` parsing.

## User Impact

Gemini CLI and Claude Code backends installed through npm now start on Windows while prompts and arguments remain intact. Existing package-manager shim handling remains unchanged when PATH probing cannot resolve a wrapper.

## Evidence

- Focused tests pass on Blacksmith Testbox through Crabbox (`tbx_01kwxdx905kdbyrwcjgr2nrmnm`): 21/21 child-adapter tests, 6/6 Windows-spawn tests, and 3/3 Docker-invocation sibling tests.
- `check:changed` passed on the same Testbox, including tsgo, all oxlint shards, import-cycle checks, package guards, and generated-surface checks.
- Regression fixtures use the current `cmd-shim` launcher shape for Gemini's JavaScript entrypoint and Claude's native executable, including a prompt with `&`, `|`, `>`, and `%`.
- Fresh structured autoreview completed with no actionable findings.
- Native Windows Server proof passed on AWS Crabbox `cbx_4f9050b097eb`, run `run_4b48efb2298b`, using Node 24.18.0: 4/4 targeted npm-shim and custom-wrapper tests passed.
