### PR TITLE
refactor(copilot): localize internal runtime types

### DIFF
--- a/extensions/copilot/harness.ts
+++ b/extensions/copilot/harness.ts
@@ -35,7 +35,7 @@ export type { CopilotClientPool, CopilotClientPoolOptions };
 
 const COPILOT_PROVIDER_IDS: ReadonlySet<string> = new Set(["github-copilot"]);
 
-export interface CreateCopilotAgentHarnessOptions {
+interface CreateCopilotAgentHarnessOptions {
   id?: string;
   label?: string;
   pluginConfig?: unknown;
@@ -423,7 +423,7 @@ function computeSessionKey(
       ? p.model
       : p.runtimeModel && typeof p.runtimeModel === "object"
         ? p.runtimeModel
-      : { id: typeof p.model === "string" ? p.model : undefined };
+        : { id: typeof p.model === "string" ? p.model : undefined };
   const provider = modelObj.provider ?? (typeof p.provider === "string" ? p.provider : "");
   const modelId =
     modelObj.id ??

--- a/extensions/copilot/src/attempt.ts
+++ b/extensions/copilot/src/attempt.ts
@@ -156,12 +156,11 @@ type ModelRefInputObject = {
   maxTokens?: number;
 };
 
-export type { AttemptParamsLike as CopilotPoolAcquireInput, ModelRef };
 export { SUPPORTED_PROVIDERS };
 
-export type ResolveSandboxContextFn = typeof defaultResolveSandboxContext;
+type ResolveSandboxContextFn = typeof defaultResolveSandboxContext;
 
-export interface CopilotAttemptDeps {
+interface CopilotAttemptDeps {
   pool: CopilotClientPool;
   now?: () => number;
   createToolBridge?: typeof createCopilotToolBridge;
@@ -1612,7 +1611,7 @@ function readResolvedAttemptPath(value: unknown): string | undefined {
   return resolveUserPath(raw);
 }
 
-export function resolveModelRef(params: AttemptParamsLike): ModelRef {
+function resolveModelRef(params: AttemptParamsLike): ModelRef {
   const rawModel = (params as { runtimeModel?: unknown }).runtimeModel ?? params.model;
   if (rawModel && typeof rawModel === "object") {
     const model = rawModel as ModelRefInputObject;
@@ -1748,7 +1747,7 @@ export function toError(error: unknown): Error {
  * version bump that changes the wording will safely fall through to
  * the generic prompt-error path.
  */
-export function isSdkSendAndWaitTimeoutError(error: unknown): boolean {
+function isSdkSendAndWaitTimeoutError(error: unknown): boolean {
   if (error === null || typeof error !== "object") {
     return false;
   }

--- a/extensions/copilot/src/auth-bridge.ts
+++ b/extensions/copilot/src/auth-bridge.ts
@@ -53,7 +53,7 @@ export const COPILOT_TOKEN_PROFILE_ERROR =
 export const COPILOT_DEFAULT_AGENT_ID = "copilot";
 
 /** Resolved auth shape that the runtime / pool consumes. */
-export interface ResolvedCopilotAuth {
+interface ResolvedCopilotAuth {
   authMode: "useLoggedInUser" | "gitHubToken" | "byok";
   /** Present only when authMode is "gitHubToken". */
   gitHubToken?: string;
@@ -94,7 +94,7 @@ export function createCopilotByokAuth(input: {
   };
 }
 
-export interface ResolveCopilotAuthInput {
+interface ResolveCopilotAuthInput {
   agentId?: string;
   agentDir?: string;
   workspaceDir?: string;

--- a/extensions/copilot/src/compaction-bridge.ts
+++ b/extensions/copilot/src/compaction-bridge.ts
@@ -17,8 +17,6 @@ import type { SessionConfig } from "@github/copilot-sdk";
 
 type SdkInfiniteSessionConfig = NonNullable<SessionConfig["infiniteSessions"]>;
 
-export type { SdkInfiniteSessionConfig as CopilotInfiniteSessionConfig };
-
 export interface CopilotInfiniteSessionOptions {
   enabled?: boolean;
   backgroundCompactionThreshold?: number;

--- a/extensions/copilot/src/dual-write-transcripts.ts
+++ b/extensions/copilot/src/dual-write-transcripts.ts
@@ -93,7 +93,7 @@ function buildMirrorDedupeIdentity(message: MirroredAgentMessage): string {
   return `${message.role}:${fingerprintMirrorMessageContent(message)}`;
 }
 
-export interface MirrorCopilotTranscriptParams {
+interface MirrorCopilotTranscriptParams {
   sessionFile: string;
   sessionId: string;
   sessionKey?: string;

--- a/extensions/copilot/src/event-bridge.ts
+++ b/extensions/copilot/src/event-bridge.ts
@@ -39,7 +39,7 @@ export interface SessionLike {
   sessionId?: string;
 }
 
-export interface EventBridgeOptions {
+interface EventBridgeOptions {
   onAssistantDelta?: (payload: OnAssistantDeltaPayload) => void | Promise<void>;
   onAgentEvent?: (event: {
     stream: "item" | "plan";
@@ -60,7 +60,7 @@ export interface EventBridgeOptions {
   isAborted: () => boolean;
 }
 
-export interface EventBridgeSnapshot {
+interface EventBridgeSnapshot {
   readonly assistantTexts: readonly string[];
   readonly completedCount: number;
   readonly lastAssistantEvent: Extract<SessionEvent, { type: "assistant.message" }> | undefined;
@@ -70,12 +70,12 @@ export interface EventBridgeSnapshot {
   readonly usage: AssistantUsageSnapshot | undefined;
 }
 
-export interface BuildAssistantMessageArgs {
+interface BuildAssistantMessageArgs {
   modelRef: { api?: string; id: string; provider: string };
   now: () => number;
 }
 
-export interface EventBridgeController {
+interface EventBridgeController {
   recordSendResult(result: SessionEvent | undefined): boolean;
   awaitCompactionChain(): Promise<void>;
   awaitCompactionCompletion(): Promise<void>;

--- a/extensions/copilot/src/hooks-bridge.ts
+++ b/extensions/copilot/src/hooks-bridge.ts
@@ -17,7 +17,7 @@ type SessionStartHandler = NonNullable<SdkSessionHooks["onSessionStart"]>;
 type SessionEndHandler = NonNullable<SdkSessionHooks["onSessionEnd"]>;
 type ErrorOccurredHandler = NonNullable<SdkSessionHooks["onErrorOccurred"]>;
 
-export interface CopilotHooksBridgeOptions {
+interface CopilotHooksBridgeOptions {
   onUserPromptSubmitted?: (submission: { prompt: string; additionalContext?: string }) => void;
 }
 

--- a/extensions/copilot/src/provider-bridge.ts
+++ b/extensions/copilot/src/provider-bridge.ts
@@ -43,9 +43,9 @@ const CREDENTIAL_QUERY_PARAM_NAMES = new Set([
 ]);
 const QUERY_PARAM_NAME_SEPARATOR_RE = /[\p{C}\p{Z}\u115F\u1160\u3164\uFFA0+]/gu;
 
-export type CopilotProviderMode = "github-copilot" | "byok";
+type CopilotProviderMode = "github-copilot" | "byok";
 
-export type CopilotModelProviderInput = {
+type CopilotModelProviderInput = {
   api?: string;
   id: string;
   provider: string;

--- a/extensions/copilot/src/replay-shim.ts
+++ b/extensions/copilot/src/replay-shim.ts
@@ -20,7 +20,7 @@
 //   - `src/agents/pi-embedded-runner/run/types.ts` —
 //     `AgentHarnessAttemptResult.replayMetadata` field requirement.
 
-export type ReplayDecision =
+type ReplayDecision =
   | {
       readonly action: "resume";
       readonly sdkSessionId: string;
@@ -32,7 +32,7 @@ export type ReplayDecision =
       readonly downgradeReason: "no-replay-state" | "no-sdk-session-id" | "replay-invalid";
     };
 
-export interface ReplayShimInput {
+interface ReplayShimInput {
   readonly sdkSessionId?: string;
   readonly replayInvalid?: boolean;
 }
@@ -86,9 +86,9 @@ export function decideReplayAction(input?: ReplayShimInput): ReplayDecision {
   };
 }
 
-export type ResumeFailureKind = "missing" | "unknown";
+type ResumeFailureKind = "missing" | "unknown";
 
-export interface ResumeFailureClassification {
+interface ResumeFailureClassification {
   readonly recoverable: boolean;
   readonly kind: ResumeFailureKind;
 }
@@ -167,7 +167,7 @@ export function classifyResumeFailure(error: unknown): ResumeFailureClassificati
   return { recoverable: false, kind: "unknown" };
 }
 
-export interface ReplayMetadataComputeInput {
+interface ReplayMetadataComputeInput {
   readonly priorReplayInvalid?: boolean;
   readonly priorHadPotentialSideEffects?: boolean;
   readonly thisAttemptTimedOut?: boolean;
@@ -176,7 +176,7 @@ export interface ReplayMetadataComputeInput {
   readonly thisAttemptResumeFailureRecovered?: boolean;
 }
 
-export interface ComputedReplayMetadata {
+interface ComputedReplayMetadata {
   readonly hadPotentialSideEffects: boolean;
   readonly replaySafe: boolean;
 }

--- a/extensions/copilot/src/sdk-loader.ts
+++ b/extensions/copilot/src/sdk-loader.ts
@@ -14,7 +14,7 @@ export const COPILOT_SDK_SPEC = "@github/copilot-sdk@1.0.5";
 
 let cached: Promise<typeof Sdk> | undefined;
 
-export interface LoadCopilotSdkOptions {
+interface LoadCopilotSdkOptions {
   readonly fallbackDir?: string;
   readonly primaryImport?: () => Promise<typeof Sdk>;
   readonly fallbackImport?: (absolutePath: string) => Promise<typeof Sdk>;

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -57,9 +57,9 @@ export interface CopilotSessionHolder {
  * fixtures may omit this field entirely and fall back to the flat
  * fields below for minimal-config wiring.
  */
-export type CopilotToolAttemptParams = Partial<EmbeddedRunAttemptParams>;
+type CopilotToolAttemptParams = Partial<EmbeddedRunAttemptParams>;
 
-export type CopilotToolCompletion = {
+type CopilotToolCompletion = {
   toolName: string;
   toolCallId: string;
   args: Record<string, unknown>;
@@ -135,13 +135,13 @@ export interface CopilotToolBridgeInput {
   }) => void | Promise<void>;
 }
 
-export interface CopilotToolBridge {
+interface CopilotToolBridge {
   cleanup?: () => void;
   sdkTools: SdkTool[];
   sourceTools: AnyAgentTool[];
 }
 
-export const SUPPORTED_TOOL_PROVIDERS: ReadonlySet<string> = new Set(["github-copilot"]);
+const SUPPORTED_TOOL_PROVIDERS: ReadonlySet<string> = new Set(["github-copilot"]);
 const BASE_COPILOT_CODING_TOOL_NAMES = new Set(["edit", "read", "write"]);
 const SHELL_COPILOT_CODING_TOOL_NAMES = new Set(["apply_patch", "exec", "process"]);
 

--- a/extensions/copilot/src/workspace-bootstrap.ts
+++ b/extensions/copilot/src/workspace-bootstrap.ts
@@ -34,7 +34,7 @@ const COPILOT_BOOTSTRAP_CONTEXT_ORDER = new Map<string, number>([
   ["memory.md", 70],
 ]);
 
-export type CopilotWorkspaceBootstrapResult = {
+type CopilotWorkspaceBootstrapResult = {
   bootstrapFiles: Awaited<ReturnType<typeof resolveBootstrapContextForRun>>["bootstrapFiles"];
   contextFiles: EmbeddedContextFile[];
   instructions?: string;


### PR DESCRIPTION
## What Problem This Solves

The Copilot plugin exposed implementation-only types and constants that have no consumers outside their defining modules. That widened the apparent internal API and left two unused type aliases in place.

## Why This Change Was Made

Localize same-file-only declarations and remove the unused aliases. Runtime functions, plugin entrypoints, and cross-module contracts are unchanged.

## User Impact

No runtime behavior changes. Maintainers get a smaller, more accurate Copilot implementation surface.

## Evidence

- `13` focused Copilot suites: `446` tests passed on Blacksmith Testbox `tbx_01kwxg8gs2cfq6rkr89ndnas6j`
- `pnpm check:changed`: passed on Blacksmith Testbox `tbx_01kwxg8gs2cfq6rkr89ndnas6j`
- `oxfmt --check` on all 12 changed files
- `git diff --check`
- Codex autoreview: no findings, patch correct at `0.84` confidence

AI-assisted: yes. Transcript not attached.
