### PR TITLE
fix(process): handle async taskkill spawn errors to prevent Windows process leaks

### DIFF
--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -110,11 +110,16 @@ function signalProcessTreeUnix(
 
 function runTaskkill(args: string[]): void {
   try {
-    spawn("taskkill", args, {
+    const child = spawn("taskkill", args, {
       stdio: "ignore",
       detached: true,
       windowsHide: true,
     });
+    // taskkill spawn errors are asynchronous — Node emits 'error' on the child
+    // when the executable cannot start. Without a listener the process would
+    // crash on an unhandled error. Silently drop the error here; this function
+    // is documented as best-effort.
+    child.once("error", () => {});
   } catch {
     // Ignore taskkill spawn failures.
   }

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -527,9 +527,14 @@ export async function runCommandWithTimeout(
         if (process.platform === "win32") {
           const taskkillPath = getWindowsSystem32ExePath("taskkill.exe");
           try {
-            spawn(taskkillPath, ["/PID", String(child.pid), "/T"], {
+            const gracefulKiller = spawn(taskkillPath, ["/PID", String(child.pid), "/T"], {
               stdio: "ignore",
               windowsHide: true,
+            });
+            // taskkill spawn errors are asynchronous — try/catch won't see them.
+            // Fall back to direct child kill so the process tree is never leaked.
+            gracefulKiller.on("error", () => {
+              child.kill("SIGKILL");
             });
             if (!processTreeForceKillTimer) {
               processTreeForceKillTimer = setTimeout(() => {
@@ -543,9 +548,12 @@ export async function runCommandWithTimeout(
                   return;
                 }
                 try {
-                  spawn(taskkillPath, ["/PID", String(child.pid), "/T", "/F"], {
+                  const forceKiller = spawn(taskkillPath, ["/PID", String(child.pid), "/T", "/F"], {
                     stdio: "ignore",
                     windowsHide: true,
+                  });
+                  forceKiller.on("error", () => {
+                    child.kill("SIGKILL");
                   });
                 } catch {
                   child.kill("SIGKILL");
@@ -563,7 +571,7 @@ export async function runCommandWithTimeout(
       }
       if (process.platform === "win32" && typeof child.pid === "number" && child.pid > 0) {
         try {
-          spawn(
+          const directKiller = spawn(
             getWindowsSystem32ExePath("taskkill.exe"),
             ["/PID", String(child.pid), "/T", "/F"],
             {
@@ -571,6 +579,9 @@ export async function runCommandWithTimeout(
               windowsHide: true,
             },
           );
+          directKiller.on("error", () => {
+            child.kill("SIGKILL");
+          });
           return;
         } catch {
           // Fall through to Node's direct child kill as a last resort.

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -514,6 +514,30 @@ export async function runCommandWithTimeout(
       processTreeForceKillTimer = null;
     };
 
+    const killDirectChild = () => {
+      if (settled || childExitState != null || child.exitCode != null || child.signalCode != null) {
+        return;
+      }
+      child.kill("SIGKILL");
+    };
+
+    // Spawn taskkill.exe from System32 with a fallback on async spawn failure.
+    // Node spawn() emits 'error' asynchronously when the executable cannot start,
+    // so try/catch alone is insufficient. Returns whether spawn started.
+    const spawnTaskkillOrFallback = (args: string[], onSpawnError: () => void): boolean => {
+      try {
+        const taskkillChild = spawn(getWindowsSystem32ExePath("taskkill.exe"), args, {
+          stdio: "ignore",
+          windowsHide: true,
+        });
+        taskkillChild.once("error", onSpawnError);
+        return true;
+      } catch {
+        onSpawnError();
+        return false;
+      }
+    };
+
     const killChild = (byTimeout = true) => {
       if (settled || typeof child?.kill !== "function") {
         return;
@@ -525,17 +549,13 @@ export async function runCommandWithTimeout(
       }
       if (killProcessTree && typeof child.pid === "number" && child.pid > 0) {
         if (process.platform === "win32") {
-          const taskkillPath = getWindowsSystem32ExePath("taskkill.exe");
-          try {
-            const gracefulKiller = spawn(taskkillPath, ["/PID", String(child.pid), "/T"], {
-              stdio: "ignore",
-              windowsHide: true,
-            });
-            // taskkill spawn errors are asynchronous — try/catch won't see them.
-            // Fall back to direct child kill so the process tree is never leaked.
-            gracefulKiller.on("error", () => {
-              child.kill("SIGKILL");
-            });
+          // Graceful taskkill /T first; if it fails to spawn, clean up timer
+          // and fall back to direct child kill to avoid leaking the process.
+          const taskkillStarted = spawnTaskkillOrFallback(["/PID", String(child.pid), "/T"], () => {
+            clearProcessTreeForceKillTimer();
+            killDirectChild();
+          });
+          if (taskkillStarted) {
             if (!processTreeForceKillTimer) {
               processTreeForceKillTimer = setTimeout(() => {
                 processTreeForceKillTimer = null;
@@ -547,47 +567,21 @@ export async function runCommandWithTimeout(
                 ) {
                   return;
                 }
-                try {
-                  const forceKiller = spawn(taskkillPath, ["/PID", String(child.pid), "/T", "/F"], {
-                    stdio: "ignore",
-                    windowsHide: true,
-                  });
-                  forceKiller.on("error", () => {
-                    child.kill("SIGKILL");
-                  });
-                } catch {
-                  child.kill("SIGKILL");
-                }
+                spawnTaskkillOrFallback(["/PID", String(child.pid), "/T", "/F"], killDirectChild);
               }, COMMAND_PROCESS_TREE_KILL_GRACE_MS);
               processTreeForceKillTimer.unref();
             }
-            return;
-          } catch {
-            // Fall through to Node's direct child kill as a last resort.
           }
+          return;
         }
         terminateProcessTree(child.pid, { graceMs: COMMAND_PROCESS_TREE_KILL_GRACE_MS });
         return;
       }
       if (process.platform === "win32" && typeof child.pid === "number" && child.pid > 0) {
-        try {
-          const directKiller = spawn(
-            getWindowsSystem32ExePath("taskkill.exe"),
-            ["/PID", String(child.pid), "/T", "/F"],
-            {
-              stdio: "ignore",
-              windowsHide: true,
-            },
-          );
-          directKiller.on("error", () => {
-            child.kill("SIGKILL");
-          });
-          return;
-        } catch {
-          // Fall through to Node's direct child kill as a last resort.
-        }
+        spawnTaskkillOrFallback(["/PID", String(child.pid), "/T", "/F"], killDirectChild);
+        return;
       }
-      child.kill("SIGKILL");
+      killDirectChild();
     };
 
     const armNoOutputTimer = () => {

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -514,6 +514,78 @@ describe("windows command wrapper behavior", () => {
     }
   });
 
+  it("defends every taskkill spawn against async error by falling back to direct SIGKILL", async () => {
+    // Prove both the graceful and forced taskkill paths survive async spawn
+    // errors. A single test exercises the full timeout → graceful → force chain
+    // with the graceful kill emitting error to trigger the fallback.
+    vi.useFakeTimers();
+    const child = createMockChild({ autoClose: false });
+    child.exitCode = null;
+    const badTaskkill = createMockChild({ autoClose: false });
+
+    // First spawn() = child, second = graceful taskkill (will fail async)
+    spawnMock.mockImplementationOnce(() => child).mockImplementationOnce(() => badTaskkill);
+
+    try {
+      await withMockedWindowsPlatform(async () => {
+        const resultPromise = runCommandWithTimeout(["node", "idle.js"], {
+          killProcessTree: true,
+          timeoutMs: 80,
+        });
+
+        // Timeout fires → graceful taskkill spawned, then emits error
+        await vi.advanceTimersByTimeAsync(81);
+        badTaskkill.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+
+        // Must have fallen back to direct child kill
+        expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+
+        // Force timer must have been cleared — advancing past the grace
+        // period must not trigger a third spawn attempt
+        await vi.advanceTimersByTimeAsync(300);
+        const spawnCount = spawnMock.mock.calls.length;
+        expect(spawnCount).toBe(2);
+
+        child.emit("close", null, "SIGKILL");
+        const result = await resultPromise;
+        expect(result.termination).toBe("timeout");
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("defends non-tree-kill taskkill path against async spawn error too", async () => {
+    // The no-tree-kill /T /F path must also fall back to direct kill.
+    vi.useFakeTimers();
+    const child = createMockChild({ autoClose: false });
+    child.exitCode = null;
+    child.pid = 9999;
+    const badTaskkill = createMockChild({ autoClose: false });
+
+    spawnMock.mockImplementationOnce(() => child).mockImplementationOnce(() => badTaskkill);
+
+    try {
+      await withMockedWindowsPlatform(async () => {
+        const resultPromise = runCommandWithTimeout(["node", "idle.js"], {
+          killProcessTree: false,
+          timeoutMs: 50,
+        });
+
+        await vi.advanceTimersByTimeAsync(51);
+        // Graceful taskkill spawned, fails async
+        badTaskkill.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+
+        expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+
+        child.emit("close", null, "SIGKILL");
+        await resultPromise;
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("decodes GBK stdout and stderr from runExec on Windows", async () => {
     const stdout = Buffer.from([0xb2, 0xe2, 0xca, 0xd4]);
     const stderr = Buffer.from([0xa3, 0xbb]);

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -1,4 +1,5 @@
 // Kill tree tests cover process tree termination and platform-specific fallbacks.
+import { EventEmitter } from "node:events";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 
@@ -235,6 +236,21 @@ describe("killProcessTree", () => {
 
       expect(spawnMock).toHaveBeenCalledTimes(1);
       expectTaskkillCall(0, ["/F", "/T", "/PID", "9999"]);
+    });
+  });
+
+  it("on Windows ignores async taskkill spawn errors instead of crashing", async () => {
+    const taskkillChild = new EventEmitter();
+    spawnMock.mockReturnValueOnce(taskkillChild);
+
+    await withMockedPlatform("win32", async () => {
+      killProcessTree(9191, { force: true });
+
+      // Emitting error on a child that has a listener must not throw.
+      expect(() =>
+        taskkillChild.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" })),
+      ).not.toThrow();
+      expectTaskkillCall(0, ["/F", "/T", "/PID", "9191"]);
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes #101381

In `src/process/exec.ts`, the Windows `taskkill.exe` process tree cleanup uses `spawn()` inside `try/catch` blocks, but Node.js `spawn()` errors are emitted asynchronously — not thrown synchronously. If `taskkill.exe` fails to start (missing binary, permission denied, antivirus interception), the `try/catch` never fires, `child.kill("SIGKILL")` is never called, and the orphaned child process tree **permanently leaks** system resources.

## Why This Change Was Made

Three `spawn(taskkillPath, ...)` calls in the `killChild` function had no `error` event handlers. The fix captures the returned `ChildProcess` and attaches `.on("error", () => child.kill("SIGKILL"))` so any async spawn failure falls back to direct child termination.

### Fixed locations

| Line | Context | Fix |
|------|---------|-----|
| 530 | Graceful `taskkill /T` | `gracefulKiller.on("error", () => child.kill("SIGKILL"))` |
| 550 | Force `taskkill /T /F` (post-timeout) | `forceKiller.on("error", () => child.kill("SIGKILL"))` |
| 571 | Direct `taskkill /T /F` (no-tree-kill path) | `directKiller.on("error", () => child.kill("SIGKILL"))` |

All three paths now defend against both synchronous (`catch` clause) and asynchronous (`error` event) spawn failures.

## User Impact

- **Before**: underprivileged, corrupted, or blocked `taskkill.exe` → orphaned Windows process trees accumulate indefinitely
- **After**: async spawn failure → `child.kill("SIGKILL")` runs, process tree is terminated

## Evidence

- `pnpm tsgo` — pass
- `node scripts/run-vitest.mjs src/process/exec.test.ts src/process/exec.windows.test.ts src/process/kill-tree.test.ts` — 49 tests passed