### PR TITLE
fix(signal): bound outbound container attachment file reads

### DIFF
--- a/extensions/signal/src/client-adapter.ts
+++ b/extensions/signal/src/client-adapter.ts
@@ -177,7 +177,11 @@ export async function detectSignalApiMode(
 export async function signalRpcRequest<T = unknown>(
   method: string,
   params: Record<string, unknown> | undefined,
-  opts: SignalRpcOptions & { accountId?: string; apiMode?: SignalApiMode },
+  opts: SignalRpcOptions & {
+    accountId?: string;
+    apiMode?: SignalApiMode;
+    maxAttachmentBytes?: number;
+  },
 ): Promise<T> {
   const mode = await resolveApiModeForOperation({
     baseUrl: opts.baseUrl,

--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -591,6 +591,70 @@ describe("containerSendMessage", () => {
 
     await fs.rm(tmpDir, { recursive: true });
   });
+
+  it("honors a configured attachment cap above the default", async () => {
+    const fs = await import("node:fs/promises");
+    const os = await import("node:os");
+    const path = await import("node:path");
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "signal-test-"));
+    const tmpFile = path.join(tmpDir, "configured-large.bin");
+    const fileBytes = 8 * 1024 * 1024 + 1;
+    try {
+      await fs.writeFile(tmpFile, Buffer.alloc(fileBytes));
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        ...bodyStream(JSON.stringify({})),
+      });
+
+      await containerSendMessage({
+        baseUrl: "http://localhost:8080",
+        account: "+14259798283",
+        recipients: ["+15550001111"],
+        message: "Configured large attachment",
+        attachments: [tmpFile],
+        maxAttachmentBytes: fileBytes,
+      });
+
+      const body = parseFetchBody();
+      expect(body.base64_attachments).toEqual([
+        expect.stringMatching(
+          /^data:application\/octet-stream;filename=configured-large\.bin;base64,/,
+        ),
+      ]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true });
+    }
+  });
+
+  it("applies the attachment cap to the whole container request", async () => {
+    const fs = await import("node:fs/promises");
+    const os = await import("node:os");
+    const path = await import("node:path");
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "signal-test-"));
+    const firstFile = path.join(tmpDir, "first.bin");
+    const secondFile = path.join(tmpDir, "second.bin");
+    try {
+      await fs.writeFile(firstFile, Buffer.alloc(6));
+      await fs.writeFile(secondFile, Buffer.alloc(6));
+
+      await expect(
+        containerSendMessage({
+          baseUrl: "http://localhost:8080",
+          account: "+14259798283",
+          recipients: ["+15550001111"],
+          message: "Two attachments",
+          attachments: [firstFile, secondFile],
+          maxAttachmentBytes: 10,
+        }),
+      ).rejects.toThrow("exceeds 4 bytes");
+      expect(mockFetch).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true });
+    }
+  });
 });
 
 describe("containerSendTyping", () => {

--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -569,6 +569,28 @@ describe("containerSendMessage", () => {
     // Cleanup
     await fs.rm(tmpDir, { recursive: true });
   });
+
+  it("rejects outbound attachments that exceed the size cap", async () => {
+    const fs = await import("node:fs/promises");
+    const os = await import("node:os");
+    const path = await import("node:path");
+
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "signal-test-"));
+    const tmpFile = path.join(tmpDir, "huge.bin");
+    await fs.writeFile(tmpFile, Buffer.alloc(8 * 1024 * 1024 + 1));
+
+    await expect(
+      containerSendMessage({
+        baseUrl: "http://localhost:8080",
+        account: "+14259798283",
+        recipients: ["+15550001111"],
+        message: "Photo",
+        attachments: [tmpFile],
+      }),
+    ).rejects.toThrow("exceeds");
+
+    await fs.rm(tmpDir, { recursive: true });
+  });
 });
 
 describe("containerSendTyping", () => {

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -25,6 +25,7 @@ export type ContainerRpcOptions = {
   baseUrl: string;
   timeoutMs?: number;
   maxResponseBytes?: number;
+  maxAttachmentBytes?: number;
 };
 
 export type ContainerWebSocketMessage = {
@@ -60,7 +61,7 @@ const SIGNAL_CONTAINER_WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
 // Outbound file paths are converted to base64 before posting to the container. Cap
 // reads to the same default the native signal send path uses (8 MiB) so a path to a
 // huge or symlinked file cannot OOM the gateway before encoding.
-const SIGNAL_CONTAINER_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
+const DEFAULT_SIGNAL_CONTAINER_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
 const CONTAINER_TEXT_STYLE_MARKERS: Record<string, string> = {
   BOLD: "**",
   ITALIC: "*",
@@ -396,13 +397,20 @@ export async function streamContainerEvents(params: {
  * Convert local file paths to base64 data URIs for the container REST API.
  * The bbernhard container /v2/send only accepts `base64_attachments` (not file paths).
  */
-async function filesToBase64DataUris(filePaths: string[]): Promise<string[]> {
+async function filesToBase64DataUris(
+  filePaths: string[],
+  maxAttachmentBytes: number,
+): Promise<string[]> {
   const results: string[] = [];
+  let remainingBytes = maxAttachmentBytes;
   for (const filePath of filePaths) {
+    // One send owns one raw-byte budget. A per-file cap would let attachment
+    // count multiply the memory consumed before the container request starts.
     const { buffer } = await readRegularFile({
       filePath,
-      maxBytes: SIGNAL_CONTAINER_MAX_ATTACHMENT_BYTES,
+      maxBytes: remainingBytes,
     });
+    remainingBytes -= buffer.byteLength;
     const mime = (await detectMime({ buffer, filePath })) ?? "application/octet-stream";
     const filename = nodePath.basename(filePath);
     const b64 = buffer.toString("base64");
@@ -491,6 +499,7 @@ export async function containerSendMessage(params: {
   message: string;
   textStyles?: Array<{ start: number; length: number; style: string }>;
   attachments?: string[];
+  maxAttachmentBytes?: number;
   quoteTimestamp?: number;
   quoteAuthor?: string;
   quoteMessage?: string;
@@ -509,7 +518,17 @@ export async function containerSendMessage(params: {
 
   if (params.attachments && params.attachments.length > 0) {
     // Container API only accepts base64-encoded attachments, not file paths.
-    payload.base64_attachments = await filesToBase64DataUris(params.attachments);
+    const configuredMaxBytes = params.maxAttachmentBytes;
+    const maxAttachmentBytes =
+      typeof configuredMaxBytes === "number" &&
+      Number.isFinite(configuredMaxBytes) &&
+      configuredMaxBytes >= 0
+        ? Math.floor(configuredMaxBytes)
+        : DEFAULT_SIGNAL_CONTAINER_MAX_ATTACHMENT_BYTES;
+    payload.base64_attachments = await filesToBase64DataUris(
+      params.attachments,
+      maxAttachmentBytes,
+    );
   }
   if (params.quoteTimestamp !== undefined && params.quoteAuthor) {
     payload.quote_timestamp = params.quoteTimestamp;
@@ -702,6 +721,7 @@ export async function containerRpcRequest<T = unknown>(
         message: (p.message as string) ?? "",
         textStyles,
         attachments: p.attachments as string[] | undefined,
+        maxAttachmentBytes: opts.maxAttachmentBytes,
         quoteTimestamp,
         quoteAuthor: quoteAuthor ? stripUuidPrefix(quoteAuthor) : undefined,
         quoteMessage: normalizeContainerQuoteText(p.quoteMessage ?? p["quote-message"]),

--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -6,7 +6,6 @@
  * to keep the two modes cleanly isolated.
  */
 
-import fs from "node:fs/promises";
 import nodePath from "node:path";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import { detectMime, parseMediaContentLength } from "openclaw/plugin-sdk/media-runtime";
@@ -19,6 +18,7 @@ import {
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { readRegularFile } from "openclaw/plugin-sdk/security-runtime";
 import WebSocket from "ws";
 
 export type ContainerRpcOptions = {
@@ -57,6 +57,10 @@ const DEFAULT_ATTACHMENT_RESPONSE_MAX_BYTES = 1_048_576;
 // Receive envelopes contain JSON metadata; attachment bytes are fetched separately.
 // Keep the ws pre-buffer limit narrow so a container cannot force 100 MiB frames.
 const SIGNAL_CONTAINER_WS_MAX_PAYLOAD_BYTES = 1024 * 1024;
+// Outbound file paths are converted to base64 before posting to the container. Cap
+// reads to the same default the native signal send path uses (8 MiB) so a path to a
+// huge or symlinked file cannot OOM the gateway before encoding.
+const SIGNAL_CONTAINER_MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
 const CONTAINER_TEXT_STYLE_MARKERS: Record<string, string> = {
   BOLD: "**",
   ITALIC: "*",
@@ -395,7 +399,10 @@ export async function streamContainerEvents(params: {
 async function filesToBase64DataUris(filePaths: string[]): Promise<string[]> {
   const results: string[] = [];
   for (const filePath of filePaths) {
-    const buffer = await fs.readFile(filePath);
+    const { buffer } = await readRegularFile({
+      filePath,
+      maxBytes: SIGNAL_CONTAINER_MAX_ATTACHMENT_BYTES,
+    });
     const mime = (await detectMime({ buffer, filePath })) ?? "application/octet-stream";
     const filename = nodePath.basename(filePath);
     const b64 = buffer.toString("base64");

--- a/extensions/signal/src/send.test.ts
+++ b/extensions/signal/src/send.test.ts
@@ -3,7 +3,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const signalRpcRequestMock = vi.hoisted(() => vi.fn());
 const resolveOutboundAttachmentFromUrlMock = vi.hoisted(() =>
-  vi.fn(async (_params: unknown) => ({ path: "/tmp/image.png", contentType: "image/png" })),
+  vi.fn(async (..._args: unknown[]) => ({
+    path: "/tmp/image.png",
+    contentType: "image/png",
+  })),
 );
 
 vi.mock("./client-adapter.js", () => ({
@@ -16,8 +19,8 @@ vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
   );
   return {
     ...actual,
-    resolveOutboundAttachmentFromUrl: (params: unknown) =>
-      resolveOutboundAttachmentFromUrlMock(params),
+    resolveOutboundAttachmentFromUrl: (...args: unknown[]) =>
+      resolveOutboundAttachmentFromUrlMock(...args),
   };
 });
 
@@ -86,14 +89,25 @@ describe("sendMessageSignal receipts", () => {
 
   it("attaches a media receipt for attachment sends", async () => {
     signalRpcRequestMock.mockResolvedValueOnce({ timestamp: 1234567891 });
+    const maxBytes = 12 * 1024 * 1024;
 
     const result = await sendMessageSignal("group:group-1", "", {
       cfg: SIGNAL_TEST_CFG,
       mediaUrl: "/tmp/image.png",
       mediaLocalRoots: ["/tmp"],
+      maxBytes,
     });
 
-    expect(resolveOutboundAttachmentFromUrlMock).toHaveBeenCalled();
+    expect(resolveOutboundAttachmentFromUrlMock).toHaveBeenCalledWith(
+      "/tmp/image.png",
+      maxBytes,
+      expect.objectContaining({ localRoots: ["/tmp"] }),
+    );
+    expect(signalRpcRequestMock).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ attachments: ["/tmp/image.png"] }),
+      expect.objectContaining({ maxAttachmentBytes: maxBytes }),
+    );
     expect(result.messageId).toBe("1234567891");
     expect(result.timestamp).toBe(1234567891);
     expect(result.receipt.primaryPlatformMessageId).toBe("1234567891");

--- a/extensions/signal/src/send.ts
+++ b/extensions/signal/src/send.ts
@@ -339,6 +339,7 @@ export async function sendMessageSignal(
     baseUrl,
     timeoutMs: opts.timeoutMs,
     apiMode,
+    maxAttachmentBytes: maxBytes,
   };
   let nativeReplyStatus: "sent" | "fallback" | undefined;
   let result: { timestamp?: number } | undefined;


### PR DESCRIPTION
## What Problem This Solves

`containerSendMessage` converted local file attachment paths to base64 data URIs using an unbounded `fs.readFile()`. A path to a multi-gigabyte file (or a symlink to a device path) could exhaust gateway memory before the bbernhard signal-cli-rest-api container ever saw the request.

## Why This Change Was Made

Replaced the raw read with `readRegularFile` from the shared fs-safe runtime, capped at the same 8 MiB default the native Signal send path uses (`send.ts`). This rejects oversized regular files, symlinks, and unsafe device paths before buffering, matching the bounded-read pattern already used for inbound Signal attachments and outbound media in other channels.

## User Impact

No behavior change for normal attachments under the cap. Oversized or suspicious outbound attachment paths now fail fast with a clear error instead of risking an OOM.

## Evidence

Local focused test passes:

```bash
node scripts/run-vitest.mjs extensions/signal/src/client-container.test.ts --run
```

The new regression test creates an 8 MiB + 1 byte temporary file and asserts that `containerSendMessage` rejects before posting to the container API.
