### PR TITLE
fix(process): fall back when Windows taskkill cannot spawn

### DIFF
--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -110,11 +110,12 @@ function signalProcessTreeUnix(
 
 function runTaskkill(args: string[]): void {
   try {
-    spawn("taskkill", args, {
+    const child = spawn("taskkill", args, {
       stdio: "ignore",
       detached: true,
       windowsHide: true,
     });
+    child.once("error", () => {});
   } catch {
     // Ignore taskkill spawn failures.
   }

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -514,6 +514,32 @@ export async function runCommandWithTimeout(
       processTreeForceKillTimer = null;
     };
 
+    const killDirectChild = () => {
+      if (
+        settled ||
+        childExitState != null ||
+        child.exitCode != null ||
+        child.signalCode != null
+      ) {
+        return;
+      }
+      child.kill("SIGKILL");
+    };
+
+    const spawnTaskkillOrFallback = (args: string[], onSpawnError: () => void): boolean => {
+      try {
+        const taskkillChild = spawn(getWindowsSystem32ExePath("taskkill.exe"), args, {
+          stdio: "ignore",
+          windowsHide: true,
+        });
+        taskkillChild.once("error", onSpawnError);
+        return true;
+      } catch {
+        onSpawnError();
+        return false;
+      }
+    };
+
     const killChild = (byTimeout = true) => {
       if (settled || typeof child?.kill !== "function") {
         return;
@@ -525,12 +551,14 @@ export async function runCommandWithTimeout(
       }
       if (killProcessTree && typeof child.pid === "number" && child.pid > 0) {
         if (process.platform === "win32") {
-          const taskkillPath = getWindowsSystem32ExePath("taskkill.exe");
-          try {
-            spawn(taskkillPath, ["/PID", String(child.pid), "/T"], {
-              stdio: "ignore",
-              windowsHide: true,
-            });
+          const taskkillStarted = spawnTaskkillOrFallback(
+            ["/PID", String(child.pid), "/T"],
+            () => {
+              clearProcessTreeForceKillTimer();
+              killDirectChild();
+            },
+          );
+          if (taskkillStarted) {
             if (!processTreeForceKillTimer) {
               processTreeForceKillTimer = setTimeout(() => {
                 processTreeForceKillTimer = null;
@@ -542,41 +570,24 @@ export async function runCommandWithTimeout(
                 ) {
                   return;
                 }
-                try {
-                  spawn(taskkillPath, ["/PID", String(child.pid), "/T", "/F"], {
-                    stdio: "ignore",
-                    windowsHide: true,
-                  });
-                } catch {
-                  child.kill("SIGKILL");
-                }
+                spawnTaskkillOrFallback(
+                  ["/PID", String(child.pid), "/T", "/F"],
+                  killDirectChild,
+                );
               }, COMMAND_PROCESS_TREE_KILL_GRACE_MS);
               processTreeForceKillTimer.unref();
             }
-            return;
-          } catch {
-            // Fall through to Node's direct child kill as a last resort.
           }
+          return;
         }
         terminateProcessTree(child.pid, { graceMs: COMMAND_PROCESS_TREE_KILL_GRACE_MS });
         return;
       }
       if (process.platform === "win32" && typeof child.pid === "number" && child.pid > 0) {
-        try {
-          spawn(
-            getWindowsSystem32ExePath("taskkill.exe"),
-            ["/PID", String(child.pid), "/T", "/F"],
-            {
-              stdio: "ignore",
-              windowsHide: true,
-            },
-          );
-          return;
-        } catch {
-          // Fall through to Node's direct child kill as a last resort.
-        }
+        spawnTaskkillOrFallback(["/PID", String(child.pid), "/T", "/F"], killDirectChild);
+        return;
       }
-      child.kill("SIGKILL");
+      killDirectChild();
     };
 
     const armNoOutputTimer = () => {

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -514,6 +514,65 @@ describe("windows command wrapper behavior", () => {
     }
   });
 
+  it("falls back to direct child kill when forced Windows taskkill emits a spawn error", async () => {
+    vi.useFakeTimers();
+    const child = createMockChild({ autoClose: false });
+    child.exitCode = null;
+    const taskkillChild = createMockChild({ autoClose: false });
+
+    spawnMock.mockImplementationOnce(() => child).mockImplementationOnce(() => taskkillChild);
+
+    try {
+      await withMockedWindowsPlatform(async () => {
+        const resultPromise = runCommandWithTimeout(["node", "idle.js"], { timeoutMs: 80 });
+
+        await vi.advanceTimersByTimeAsync(81);
+        taskkillChild.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+
+        expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+
+        child.emit("close", null, "SIGKILL");
+        const result = await resultPromise;
+        expect(result.termination).toBe("timeout");
+        expect(result.code).toBe(124);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("falls back to direct child kill when graceful Windows taskkill emits a spawn error", async () => {
+    vi.useFakeTimers();
+    const child = createMockChild({ autoClose: false });
+    child.exitCode = null;
+    const taskkillChild = createMockChild({ autoClose: false });
+
+    spawnMock.mockImplementationOnce(() => child).mockImplementationOnce(() => taskkillChild);
+
+    try {
+      await withMockedWindowsPlatform(async () => {
+        const resultPromise = runCommandWithTimeout(["node", "idle.js"], {
+          killProcessTree: true,
+          timeoutMs: 80,
+        });
+
+        await vi.advanceTimersByTimeAsync(81);
+        taskkillChild.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+
+        expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+        await vi.advanceTimersByTimeAsync(300);
+        expect(spawnMock).toHaveBeenCalledTimes(2);
+
+        child.emit("close", null, "SIGKILL");
+        const result = await resultPromise;
+        expect(result.termination).toBe("timeout");
+        expect(result.code).toBe(124);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("decodes GBK stdout and stderr from runExec on Windows", async () => {
     const stdout = Buffer.from([0xb2, 0xe2, 0xca, 0xd4]);
     const stderr = Buffer.from([0xa3, 0xbb]);

--- a/src/process/kill-tree.test.ts
+++ b/src/process/kill-tree.test.ts
@@ -1,4 +1,5 @@
 // Kill tree tests cover process tree termination and platform-specific fallbacks.
+import { EventEmitter } from "node:events";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 
@@ -235,6 +236,18 @@ describe("killProcessTree", () => {
 
       expect(spawnMock).toHaveBeenCalledTimes(1);
       expectTaskkillCall(0, ["/F", "/T", "/PID", "9999"]);
+    });
+  });
+
+  it("on Windows ignores async taskkill spawn errors", async () => {
+    const taskkillChild = new EventEmitter();
+    spawnMock.mockReturnValueOnce(taskkillChild);
+
+    await withMockedPlatform("win32", async () => {
+      killProcessTree(9191, { force: true });
+
+      expect(() => taskkillChild.emit("error", new Error("spawn ENOENT"))).not.toThrow();
+      expectTaskkillCall(0, ["/F", "/T", "/PID", "9191"]);
     });
   });
 });


### PR DESCRIPTION
Closes #101381

## What Problem This Solves

Fixes an issue where Windows timeout cleanup could fail to terminate a timed-out command when `taskkill.exe` failed after `spawn()` returned. Node reports failed child-process spawns through the child process `error` event, so the old `try/catch` fallback could miss the failure and leave the original command process running.

## Why This Change Was Made

The Windows cleanup path now attaches an async spawn-error fallback to each `taskkill.exe` child and routes both synchronous and asynchronous failures through the same direct `child.kill("SIGKILL")` fallback. The change keeps the trusted System32 `taskkill.exe` resolution in `src/process/exec.ts`; the shared process-tree helper also now observes async `taskkill` errors so its existing best-effort ignore contract covers both failure modes.

This is the canonical candidate for #101381 after #101389 was closed as the weaker duplicate; #101392 keeps the timer cleanup, shared helper guard, and focused Windows regression coverage.

## User Impact

Windows users should no longer accumulate leaked direct child processes when command timeout cleanup cannot start `taskkill.exe`. Normal `taskkill.exe` cleanup behavior is unchanged when it starts successfully.

## Evidence

Node contract premise:
- Official Node child_process docs: `ChildProcess` emits `error` when a process could not be spawned, and `close` follows `exit` or `error`: https://nodejs.org/api/child_process.html#event-error
- Local Node 24 premise check:

```text
$ node -e "const {spawn}=require('node:child_process'); let caught=false; try { const child=spawn('/definitely/missing/openclaw-taskkill.exe'); child.on('error', err => console.log(JSON.stringify({caught, event:'error', code:err.code}))); } catch (err) { caught=true; console.log(JSON.stringify({caught, code:err.code})); } setTimeout(()=>{},20);"
{"caught":false,"event":"error","code":"ENOENT"}
```

Before/after behavior harness:

```text
$ node --input-type=module - <<'EOF'
import { EventEmitter } from 'node:events';
const taskkillChild = new EventEmitter();
let fallbackCalled = false;
try {
  taskkillChild.emit('error', Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }));
} catch (err) {
  console.log(JSON.stringify({ before: 'no-listener-throws', code: err.code ?? null, fallbackCalled }));
}
const taskkillChildAfter = new EventEmitter();
taskkillChildAfter.once('error', () => { fallbackCalled = true; });
taskkillChildAfter.emit('error', Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' }));
console.log(JSON.stringify({ after: 'listener-routes-fallback', fallbackCalled }));
EOF
{"before":"no-listener-throws","code":"ENOENT","fallbackCalled":false}
{"after":"listener-routes-fallback","fallbackCalled":true}
```

Focused local tests:

```text
$ node scripts/run-vitest.mjs src/process/exec.test.ts src/process/exec.windows.test.ts src/process/kill-tree.test.ts
[test] starting test/vitest/vitest.process.config.ts

 RUN  v4.1.9 /srv/projects/openclaw/contrib/.radar/worktrees/issue-101381

 Test Files  3 passed (3)
      Tests  52 passed (52)
[test] passed 1 Vitest shard in 4.61s
```

Windows runner proof from this PR:
- GitHub Actions run: https://github.com/openclaw/openclaw/actions/runs/28844539463/job/85545399409
- Runner: Blacksmith Windows 2025, machine `WIN-FE737MTRSOT`.
- Command executed by CI: `pnpm test:windows:ci`.
- The Windows job included `src/process/exec.windows.test.ts`, which contains the new forced and graceful taskkill child `error` fallback tests. The job log shows:

```text
$ node scripts/test-projects.mjs src/shared/runtime-import.test.ts src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/windows-install-roots.test.ts src/node-host/invoke-system-run-allowlist.test.ts src/daemon/schtasks.startup-fallback.test.ts extensions/lobster/src/lobster-runner.test.ts test/scripts/format-generated-module.test.ts test/scripts/npm-runner.test.ts test/scripts/pnpm-runner.test.ts test/scripts/run-with-env.test.ts test/scripts/ui.test.ts test/scripts/vitest-process-group.test.ts
✓ process src/process/exec.windows.test.ts (21 tests) 281ms
Test Files 1 passed (1)
Tests 21 passed (21)
[test] passed 8 Vitest shards in 25.31s
```

Other local checks:

```text
$ git diff --check
# passed

$ .agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.82)
```

Not run locally: full `pnpm check` / `pnpm test`; this linked checkout is using focused local proof and GitHub CI for broad gates. Live Windows terminal proof from my local environment was not available because `powershell.exe`, `pwsh`, and `cmd.exe` were not present; the Windows behavior is covered by the Node child_process contract check, focused OpenClaw regression tests, and the Windows CI runner log above.

AI-assisted: AI-assisted; proof run manually.
