### PR TITLE
refactor(github-copilot): localize internal helpers

### DIFF
--- a/extensions/github-copilot/connection-bound-ids.ts
+++ b/extensions/github-copilot/connection-bound-ids.ts
@@ -70,7 +70,7 @@ export function rewriteCopilotConnectionBoundResponseIds(input: unknown): boolea
   return sanitizeCopilotReplayResponseIds(input);
 }
 
-export function sanitizeCopilotReplayResponsePayloadIds(payload: unknown): boolean {
+function sanitizeCopilotReplayResponsePayloadIds(payload: unknown): boolean {
   if (!payload || typeof payload !== "object") {
     return false;
   }

--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -260,12 +260,12 @@ function normalizeGitHubDeviceUserCode(raw: string): string {
   return userCode;
 }
 
-export type GitHubCopilotDeviceFlowResult =
+type GitHubCopilotDeviceFlowResult =
   | { status: "authorized"; accessToken: string }
   | { status: "access_denied" }
   | { status: "expired" };
 
-export type GitHubCopilotDeviceFlowIO = {
+type GitHubCopilotDeviceFlowIO = {
   showCode(args: { verificationUrl: string; userCode: string; expiresInMs: number }): Promise<void>;
   openUrl?: (url: string) => Promise<void>;
 };

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -245,7 +245,7 @@ function asCopilotApiModelEntry(value: unknown): CopilotApiModelEntry {
   return value as CopilotApiModelEntry;
 }
 
-export type FetchCopilotModelCatalogParams = {
+type FetchCopilotModelCatalogParams = {
   /** Short-lived Copilot API token (from `resolveCopilotApiToken`). */
   copilotApiToken: string;
   /** Resolved baseUrl from the same token-exchange response. */

--- a/extensions/github-copilot/stream.ts
+++ b/extensions/github-copilot/stream.ts
@@ -34,7 +34,7 @@ function inferCopilotInitiator(messages: Context["messages"]): "agent" | "user" 
   return last.role === "user" ? "user" : "agent";
 }
 
-export function hasCopilotVisionInput(messages: Context["messages"]): boolean {
+function hasCopilotVisionInput(messages: Context["messages"]): boolean {
   return messages.some((message) => {
     if (message.role === "user" && Array.isArray(message.content)) {
       return message.content.some((item) => containsCopilotContentType(item, "image"));

--- a/extensions/github-copilot/token.ts
+++ b/extensions/github-copilot/token.ts
@@ -3,5 +3,4 @@ export {
   DEFAULT_COPILOT_API_BASE_URL,
   deriveCopilotApiBaseUrlFromToken,
   resolveCopilotApiToken,
-  type CachedCopilotToken,
 } from "openclaw/plugin-sdk/provider-auth";


### PR DESCRIPTION
## What Problem This Solves

The private GitHub Copilot provider implementation exposed five declarations that have no consumers outside their defining modules, plus one unused type re-export from `token.ts`. This widened the apparent internal API without providing a supported plugin contract.

## Why This Change Was Made

Localize same-file-only declarations and remove the unused type re-export. The plugin entrypoint, `api.ts` facade, runtime functions, auth behavior, stream rewriting, and token resolution remain unchanged.

## User Impact

No runtime behavior changes. Maintainers get a smaller, more accurate provider implementation surface.

## Evidence

- Blacksmith Testbox `tbx_01kwxhm0bgg9b6dc31tf9y7xsx`: 7 focused suites, 52 tests passed on the rebased head
- Same Testbox: `pnpm check:changed` passed
- `oxfmt --check` on all 5 changed files
- `git diff --check`
- Codex autoreview: no findings, patch correct at `0.89` confidence
- `models.test.ts` has one unrelated existing failure because its response mock lacks `arrayBuffer()`:
  - patch run: 28 other tests passed
  - clean `origin/main` baseline Testbox `tbx_01kwxhbwtc9ry6gdsxbzt6j7ym`: identical failure and stack

AI-assisted: yes. Transcript not attached.
