### PR TITLE
fix(voice-call): handle tunnel child stream errors and stop-after-exit hang

### DIFF
--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -236,6 +236,7 @@ describe("voice-call tunnels", () => {
     const result = startNgrokTunnel({ port: 3334, path: "/hook" });
     proc.stdout.emit("error", new Error("EPIPE"));
     await expect(result).rejects.toThrow("ngrok stdout error: EPIPE");
+    expect(proc.killedWith).toBe("SIGKILL");
   });
 
   it("rejects when ngrok stderr emits an error before the tunnel is ready", async () => {
@@ -243,6 +244,15 @@ describe("voice-call tunnels", () => {
     const result = startNgrokTunnel({ port: 3334, path: "/hook" });
     proc.stderr.emit("error", new Error("EIO"));
     await expect(result).rejects.toThrow("ngrok stderr error: EIO");
+    expect(proc.killedWith).toBe("SIGKILL");
+  });
+
+  it("rejects and stops the ngrok auth command on stream errors", async () => {
+    const proc = nextProcess();
+    const result = startNgrokTunnel({ port: 3334, path: "/hook", authToken: "token" });
+    proc.stdout.emit("error", new Error("EPIPE"));
+    await expect(result).rejects.toThrow("ngrok command stdout error: EPIPE");
+    expect(proc.killedWith).toBe("SIGKILL");
   });
 
   it("stops immediately when the ngrok process already exited", async () => {
@@ -251,9 +261,8 @@ describe("voice-call tunnels", () => {
     emitNgrokUrl(proc, "https://early-exit.ngrok.io");
     const tunnel = await result;
     proc.emit("close", 0);
-    const start = Date.now();
-    await tunnel.stop();
-    expect(Date.now() - start).toBeLessThan(500);
+    await expect(tunnel.stop()).resolves.toBeUndefined();
+    expect(proc.killedWith).toBeNull();
   });
 
   it("rejects when Tailscale stdout emits an error before the tunnel is ready", async () => {
@@ -263,5 +272,16 @@ describe("voice-call tunnels", () => {
     await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalled());
     proc.stdout.emit("error", new Error("EPIPE"));
     await expect(result).rejects.toThrow("Tailscale serve stdout error: EPIPE");
+    expect(proc.killedWith).toBe("SIGKILL");
+  });
+
+  it("rejects and stops Tailscale when stderr emits an error before readiness", async () => {
+    mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
+    const proc = nextProcess();
+    const result = startTailscaleTunnel({ mode: "funnel", port: 3334, path: "/hook" });
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalled());
+    proc.stderr.emit("error", new Error("EIO"));
+    await expect(result).rejects.toThrow("Tailscale funnel stderr error: EIO");
+    expect(proc.killedWith).toBe("SIGKILL");
   });
 });

--- a/extensions/voice-call/src/tunnel.test.ts
+++ b/extensions/voice-call/src/tunnel.test.ts
@@ -230,4 +230,38 @@ describe("voice-call tunnels", () => {
     // The stop promise must still resolve despite the error
     await expect(stopPromise).resolves.toBeUndefined();
   });
+
+  it("rejects when ngrok stdout emits an error before the tunnel is ready", async () => {
+    const proc = nextProcess();
+    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
+    proc.stdout.emit("error", new Error("EPIPE"));
+    await expect(result).rejects.toThrow("ngrok stdout error: EPIPE");
+  });
+
+  it("rejects when ngrok stderr emits an error before the tunnel is ready", async () => {
+    const proc = nextProcess();
+    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
+    proc.stderr.emit("error", new Error("EIO"));
+    await expect(result).rejects.toThrow("ngrok stderr error: EIO");
+  });
+
+  it("stops immediately when the ngrok process already exited", async () => {
+    const proc = nextProcess();
+    const result = startNgrokTunnel({ port: 3334, path: "/hook" });
+    emitNgrokUrl(proc, "https://early-exit.ngrok.io");
+    const tunnel = await result;
+    proc.emit("close", 0);
+    const start = Date.now();
+    await tunnel.stop();
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  it("rejects when Tailscale stdout emits an error before the tunnel is ready", async () => {
+    mocks.getTailscaleDnsName.mockResolvedValue("host.tailnet.ts.net");
+    const proc = nextProcess();
+    const result = startTailscaleTunnel({ mode: "serve", port: 3334, path: "/hook" });
+    await vi.waitFor(() => expect(mocks.spawn).toHaveBeenCalled());
+    proc.stdout.emit("error", new Error("EPIPE"));
+    await expect(result).rejects.toThrow("Tailscale serve stdout error: EPIPE");
+  });
 });

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -72,6 +72,7 @@ export async function startNgrokTunnel(config: {
     });
 
     let resolved = false;
+    let closed = false;
     let publicUrl: string | null = null;
     let outputBuffer = "";
 
@@ -82,6 +83,15 @@ export async function startNgrokTunnel(config: {
         reject(new Error("ngrok startup timed out (30s)"));
       }
     }, 30000);
+
+    const rejectIfPending = (message: string) => {
+      if (!resolved) {
+        resolved = true;
+        closed = true;
+        clearTimeout(timeout);
+        reject(new Error(message));
+      }
+    };
 
     const processLine = (line: string) => {
       try {
@@ -111,9 +121,16 @@ export async function startNgrokTunnel(config: {
             publicUrl: fullUrl,
             provider: "ngrok",
             stop: async () => {
+              if (closed) {
+                return;
+              }
               proc.kill("SIGTERM");
               await new Promise<void>((res) => {
-                proc.on("close", () => res());
+                if (closed) {
+                  res();
+                  return;
+                }
+                proc.once("close", () => res());
                 setTimeout(res, 2000); // Fallback timeout
               });
             },
@@ -137,29 +154,31 @@ export async function startNgrokTunnel(config: {
         }
       }
     });
+    proc.stdout.on("error", (err) => {
+      rejectIfPending(`ngrok stdout error: ${err.message}`);
+    });
 
     proc.stderr.on("data", (data: Buffer) => {
       const msg = data.toString();
       // Check for common errors
       if (msg.includes("ERR_NGROK")) {
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeout);
-          const output = appendBoundedChildOutput(emptyBoundedChildOutput(), msg);
-          reject(new Error(`ngrok error: ${formatBoundedChildOutput(output)}`));
-        }
+        rejectIfPending(
+          `ngrok error: ${formatBoundedChildOutput(
+            appendBoundedChildOutput(emptyBoundedChildOutput(), msg),
+          )}`,
+        );
       }
+    });
+    proc.stderr.on("error", (err) => {
+      rejectIfPending(`ngrok stderr error: ${err.message}`);
     });
 
     proc.on("error", (err) => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeout);
-        reject(new Error(`Failed to start ngrok: ${err.message}`));
-      }
+      rejectIfPending(`Failed to start ngrok: ${err.message}`);
     });
 
     proc.on("close", (code) => {
+      closed = true;
       if (!resolved) {
         resolved = true;
         clearTimeout(timeout);
@@ -222,23 +241,45 @@ export async function startTailscaleTunnel(config: {
     const proc = spawn("tailscale", [config.mode, "--bg", "--yes", "--set-path", path, localUrl], {
       stdio: ["ignore", "pipe", "pipe"],
     });
+    let resolved = false;
     let stdout = emptyBoundedChildOutput();
     let stderr = emptyBoundedChildOutput();
 
     const timeout = setTimeout(() => {
-      proc.kill("SIGKILL");
-      reject(new Error(`Tailscale ${config.mode} timed out`));
+      if (!resolved) {
+        resolved = true;
+        proc.kill("SIGKILL");
+        reject(new Error(`Tailscale ${config.mode} timed out`));
+      }
     }, 10000);
 
     proc.stdout.on("data", (data) => {
       stdout = appendBoundedChildOutput(stdout, data.toString());
     });
+    proc.stdout.on("error", (err) => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timeout);
+        reject(new Error(`Tailscale ${config.mode} stdout error: ${err.message}`));
+      }
+    });
     proc.stderr.on("data", (data) => {
       stderr = appendBoundedChildOutput(stderr, data.toString());
+    });
+    proc.stderr.on("error", (err) => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timeout);
+        reject(new Error(`Tailscale ${config.mode} stderr error: ${err.message}`));
+      }
     });
 
     proc.on("close", (code) => {
       clearTimeout(timeout);
+      if (resolved) {
+        return;
+      }
+      resolved = true;
       if (code === 0) {
         const publicUrl = `https://${dnsName}${path}`;
         console.log(`[voice-call] Tailscale ${config.mode} active: ${publicUrl}`);
@@ -259,7 +300,10 @@ export async function startTailscaleTunnel(config: {
 
     proc.on("error", (err) => {
       clearTimeout(timeout);
-      reject(err);
+      if (!resolved) {
+        resolved = true;
+        reject(err);
+      }
     });
   });
 }

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -1,5 +1,5 @@
 // Voice Call plugin module implements tunnel behavior.
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import {
   appendBoundedChildOutput,
   emptyBoundedChildOutput,
@@ -8,6 +8,16 @@ import {
 import { getTailscaleDnsName } from "./webhook/tailscale.js";
 
 const NGROK_LOG_BUFFER_MAX_CHARS = 16_384;
+
+function listenForChildStreamErrors(
+  proc: Pick<ChildProcessWithoutNullStreams, "stdout" | "stderr">,
+  onError: (stream: "stdout" | "stderr", error: Error) => void,
+): void {
+  // Keep both listeners for the child lifetime: a late unhandled stream error
+  // would otherwise escape after the startup promise has already settled.
+  proc.stdout.on("error", (error) => onError("stdout", error));
+  proc.stderr.on("error", (error) => onError("stderr", error));
+}
 
 /**
  * Tunnel configuration for exposing the webhook server.
@@ -84,11 +94,13 @@ export async function startNgrokTunnel(config: {
       }
     }, 30000);
 
-    const rejectIfPending = (message: string) => {
+    const rejectIfPending = (message: string, kill = false) => {
       if (!resolved) {
         resolved = true;
-        closed = true;
         clearTimeout(timeout);
+        if (kill && !closed) {
+          proc.kill("SIGKILL");
+        }
         reject(new Error(message));
       }
     };
@@ -124,14 +136,30 @@ export async function startNgrokTunnel(config: {
               if (closed) {
                 return;
               }
-              proc.kill("SIGTERM");
               await new Promise<void>((res) => {
+                let fallback: ReturnType<typeof setTimeout> | undefined;
+                let finished = false;
+                const finish = () => {
+                  if (finished) {
+                    return;
+                  }
+                  finished = true;
+                  if (fallback) {
+                    clearTimeout(fallback);
+                  }
+                  proc.off("close", finish);
+                  res();
+                };
                 if (closed) {
                   res();
                   return;
                 }
-                proc.once("close", () => res());
-                setTimeout(res, 2000); // Fallback timeout
+                proc.once("close", finish);
+                fallback = setTimeout(finish, 2000);
+                proc.kill("SIGTERM");
+                if (closed) {
+                  finish();
+                }
               });
             },
           });
@@ -154,10 +182,6 @@ export async function startNgrokTunnel(config: {
         }
       }
     });
-    proc.stdout.on("error", (err) => {
-      rejectIfPending(`ngrok stdout error: ${err.message}`);
-    });
-
     proc.stderr.on("data", (data: Buffer) => {
       const msg = data.toString();
       // Check for common errors
@@ -166,11 +190,12 @@ export async function startNgrokTunnel(config: {
           `ngrok error: ${formatBoundedChildOutput(
             appendBoundedChildOutput(emptyBoundedChildOutput(), msg),
           )}`,
+          true,
         );
       }
     });
-    proc.stderr.on("error", (err) => {
-      rejectIfPending(`ngrok stderr error: ${err.message}`);
+    listenForChildStreamErrors(proc, (stream, error) => {
+      rejectIfPending(`ngrok ${stream} error: ${error.message}`, true);
     });
 
     proc.on("error", (err) => {
@@ -199,6 +224,18 @@ async function runNgrokCommand(args: string[]): Promise<string> {
 
     let stdout = emptyBoundedChildOutput();
     let stderr = emptyBoundedChildOutput();
+    let settled = false;
+
+    const rejectIfPending = (error: Error, kill = false) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (kill) {
+        proc.kill("SIGKILL");
+      }
+      reject(error);
+    };
 
     proc.stdout.on("data", (data) => {
       stdout = appendBoundedChildOutput(stdout, data.toString());
@@ -206,8 +243,15 @@ async function runNgrokCommand(args: string[]): Promise<string> {
     proc.stderr.on("data", (data) => {
       stderr = appendBoundedChildOutput(stderr, data.toString());
     });
+    listenForChildStreamErrors(proc, (stream, error) => {
+      rejectIfPending(new Error(`ngrok command ${stream} error: ${error.message}`), true);
+    });
 
     proc.on("close", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       if (code === 0) {
         resolve(stdout.text);
       } else {
@@ -216,7 +260,7 @@ async function runNgrokCommand(args: string[]): Promise<string> {
       }
     });
 
-    proc.on("error", reject);
+    proc.on("error", (error) => rejectIfPending(error));
   });
 }
 
@@ -245,33 +289,33 @@ export async function startTailscaleTunnel(config: {
     let stdout = emptyBoundedChildOutput();
     let stderr = emptyBoundedChildOutput();
 
-    const timeout = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        proc.kill("SIGKILL");
-        reject(new Error(`Tailscale ${config.mode} timed out`));
+    const rejectIfPending = (error: Error, kill = false) => {
+      if (resolved) {
+        return;
       }
+      resolved = true;
+      clearTimeout(timeout);
+      if (kill) {
+        proc.kill("SIGKILL");
+      }
+      reject(error);
+    };
+
+    const timeout = setTimeout(() => {
+      rejectIfPending(new Error(`Tailscale ${config.mode} timed out`), true);
     }, 10000);
 
     proc.stdout.on("data", (data) => {
       stdout = appendBoundedChildOutput(stdout, data.toString());
     });
-    proc.stdout.on("error", (err) => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeout);
-        reject(new Error(`Tailscale ${config.mode} stdout error: ${err.message}`));
-      }
-    });
     proc.stderr.on("data", (data) => {
       stderr = appendBoundedChildOutput(stderr, data.toString());
     });
-    proc.stderr.on("error", (err) => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeout);
-        reject(new Error(`Tailscale ${config.mode} stderr error: ${err.message}`));
-      }
+    listenForChildStreamErrors(proc, (stream, error) => {
+      rejectIfPending(
+        new Error(`Tailscale ${config.mode} ${stream} error: ${error.message}`),
+        true,
+      );
     });
 
     proc.on("close", (code) => {
@@ -299,11 +343,7 @@ export async function startTailscaleTunnel(config: {
     });
 
     proc.on("error", (err) => {
-      clearTimeout(timeout);
-      if (!resolved) {
-        resolved = true;
-        reject(err);
-      }
+      rejectIfPending(err);
     });
   });
 }

--- a/extensions/voice-call/src/tunnel.ts
+++ b/extensions/voice-call/src/tunnel.ts
@@ -137,16 +137,13 @@ export async function startNgrokTunnel(config: {
                 return;
               }
               await new Promise<void>((res) => {
-                let fallback: ReturnType<typeof setTimeout> | undefined;
                 let finished = false;
                 const finish = () => {
                   if (finished) {
                     return;
                   }
                   finished = true;
-                  if (fallback) {
-                    clearTimeout(fallback);
-                  }
+                  clearTimeout(fallback);
                   proc.off("close", finish);
                   res();
                 };
@@ -155,7 +152,7 @@ export async function startNgrokTunnel(config: {
                   return;
                 }
                 proc.once("close", finish);
-                fallback = setTimeout(finish, 2000);
+                const fallback = setTimeout(finish, 2000);
                 proc.kill("SIGTERM");
                 if (closed) {
                   finish();

--- a/extensions/voice-call/src/webhook/tailscale.test.ts
+++ b/extensions/voice-call/src/webhook/tailscale.test.ts
@@ -68,6 +68,16 @@ function createErrorProc() {
   return proc;
 }
 
+function createPendingProc() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  proc.stdout = new EventEmitter();
+  proc.kill = vi.fn();
+  return proc;
+}
+
 describe("voice-call tailscale helpers", () => {
   beforeEach(() => {
     vi.useRealTimers();
@@ -116,6 +126,17 @@ describe("voice-call tailscale helpers", () => {
     spawnMock.mockReturnValueOnce(createErrorProc());
 
     await expect(getTailscaleSelfInfo()).resolves.toBeNull();
+  });
+
+  it("treats a tailscale stdout stream error as unavailable and stops the child", async () => {
+    const proc = createPendingProc();
+    spawnMock.mockReturnValueOnce(proc);
+
+    const result = getTailscaleSelfInfo();
+    proc.stdout.emit("error", new Error("EPIPE"));
+
+    await expect(result).resolves.toBeNull();
+    expect(proc.kill).toHaveBeenCalledWith("SIGKILL");
   });
 
   it("tracks tailscale stdout without retaining over-limit output", () => {

--- a/extensions/voice-call/src/webhook/tailscale.ts
+++ b/extensions/voice-call/src/webhook/tailscale.ts
@@ -42,14 +42,22 @@ function runTailscaleCommand(
 
     let stdout: TailscaleCommandStdout = { bytes: 0, exceeded: false, text: "" };
     let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const finish = (result: { code: number; stdout: string }) => {
       if (settled) {
         return;
       }
       settled = true;
-      clearTimeout(timer);
+      if (timer) {
+        clearTimeout(timer);
+      }
       resolve(result);
     };
+
+    timer = setTimeout(() => {
+      proc.kill("SIGKILL");
+      finish({ code: -1, stdout: "" });
+    }, timeoutMs);
 
     proc.stdout.on("data", (data) => {
       stdout = appendTailscaleCommandStdout(stdout, data);
@@ -58,11 +66,10 @@ function runTailscaleCommand(
         finish({ code: -1, stdout: "" });
       }
     });
-
-    const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+    proc.stdout.on("error", () => {
       proc.kill("SIGKILL");
       finish({ code: -1, stdout: "" });
-    }, timeoutMs);
+    });
 
     proc.on("error", () => {
       finish({ code: -1, stdout: "" });

--- a/extensions/voice-call/src/webhook/tailscale.ts
+++ b/extensions/voice-call/src/webhook/tailscale.ts
@@ -42,19 +42,16 @@ function runTailscaleCommand(
 
     let stdout: TailscaleCommandStdout = { bytes: 0, exceeded: false, text: "" };
     let settled = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
     const finish = (result: { code: number; stdout: string }) => {
       if (settled) {
         return;
       }
       settled = true;
-      if (timer) {
-        clearTimeout(timer);
-      }
+      clearTimeout(timer);
       resolve(result);
     };
 
-    timer = setTimeout(() => {
+    const timer = setTimeout(() => {
       proc.kill("SIGKILL");
       finish({ code: -1, stdout: "" });
     }, timeoutMs);


### PR DESCRIPTION
## What Problem This Solves

`startNgrokTunnel` and `startTailscaleTunnel` attached `data` listeners to their child `stdout`/`stderr` pipes but no `error` listeners. A broken pipe (`EPIPE`) or I/O error (`EIO`) on either stream therefore became an unhandled `error` event that could crash the gateway process.

Additionally, the ngrok `stop()` closure always waited up to 2 seconds for a `close` event even if the process had already exited, causing unnecessary shutdown latency.

## Why This Change Was Made

- Added `error` handlers to ngrok and Tailscale startup `stdout`/`stderr` streams that reject the startup promise while the tunnel is still unresolved.
- Tracked a `closed` flag for ngrok and short-circuit `stop()` when the process is already gone, avoiding the 2 s fallback wait.
- Kept the existing bounded-output and timeout behavior unchanged.

## User Impact

Transient stream errors during voice-call tunnel startup are now logged and rejected cleanly instead of crashing the gateway. Stopping an already-exited ngrok tunnel returns immediately.

## Evidence

Local focused tests pass:

```bash
node scripts/run-vitest.mjs extensions/voice-call/src/tunnel.test.ts --run
```

Added regression tests for:
- ngrok `stdout` and `stderr` errors before the tunnel is ready.
- Tailscale `stdout` error before the tunnel is ready.
- `stop()` resolving immediately when the ngrok process already closed.
