### PR TITLE
fix(backup): retry fs.rm on EBUSY to prevent retry-loop collapse on Windows

### DIFF
--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -187,14 +187,22 @@ async function writeTarArchiveWithRetry(params: {
       if (!isTarEofRaceError(err) || attempt === BACKUP_TAR_MAX_ATTEMPTS) {
         break;
       }
-      try {
-        await fs.rm(params.tempArchivePath, { force: true });
-      } catch (cleanupErr) {
-        const code = (cleanupErr as NodeJS.ErrnoException).code;
-        if (code && code !== "ENOENT") {
-          params.log?.(
-            `Backup archiver could not remove temp archive ${params.tempArchivePath} between retries: ${code}. Continuing.`,
-          );
+      for (let rmAttempt = 0; rmAttempt < 3; rmAttempt += 1) {
+        try {
+          await fs.rm(params.tempArchivePath, { force: true });
+          break;
+        } catch (cleanupErr) {
+          const code = (cleanupErr as NodeJS.ErrnoException).code;
+          if (code === "EBUSY" && rmAttempt < 2) {
+            await sleepFn(100 * (rmAttempt + 1));
+            continue;
+          }
+          if (code && code !== "ENOENT") {
+            params.log?.(
+              `Backup archiver could not remove temp archive ${params.tempArchivePath} between retries: ${code}. Continuing.`,
+            );
+          }
+          break;
         }
       }
       const backoff = BACKUP_TAR_BACKOFF_MS[attempt - 1] ?? 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes #101382: On Windows, `fs.rm` can throw `EBUSY` when the tar process leaked a file descriptor. The catch block logged a warning and continued, but the temp file remained locked — causing the next `runTar` attempt to fail immediately because it couldn't overwrite the locked file. This completely defeated the `BACKUP_TAR_BACKOFF_MS` retry mechanism.

## Why This Change Was Made

Added a short retry loop (3 attempts, 100ms/200ms backoff) for `EBUSY` before falling through to the existing warning path. This gives the OS time to release the file lock, allowing the retry loop to function correctly.

## User Impact

- Backup creation on Windows survives transient file descriptor leaks from the tar process
- The retry backoff mechanism now works correctly instead of being bypassed

## Evidence

- [x] `pnpm test src/infra/backup-create.test.ts` — 39 tests pass
- [x] `oxlint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
