### PR TITLE
fix(gateway): detect unresolved env-var placeholders in gateway auth token

### DIFF
--- a/src/commands/doctor-gateway-auth-token.test.ts
+++ b/src/commands/doctor-gateway-auth-token.test.ts
@@ -219,6 +219,43 @@ describe("resolveGatewayAuthTokenForService", () => {
       "gateway.auth.token SecretRef is configured but unresolved (gateway.auth.token SecretRef is unresolved (env:default:MISSING_GATEWAY_TOKEN).).",
     );
   });
+
+  it("falls back to OPENCLAW_GATEWAY_TOKEN when config has a literal env-var placeholder without a SecretRef provider", async () => {
+    // A literal ${OPENCLAW_GATEWAY_TOKEN} in config matching the standard
+    // env var should resolve from the environment.
+    const resolved = await resolveGatewayAuthTokenForService(
+      {
+        gateway: {
+          auth: {
+            token: "${OPENCLAW_GATEWAY_TOKEN}",
+          },
+        },
+      } as OpenClawConfig,
+      {
+        OPENCLAW_GATEWAY_TOKEN: "env-fallback-token",
+      } as NodeJS.ProcessEnv,
+    );
+
+    expect(resolved).toEqual({ token: "env-fallback-token" });
+  });
+
+  it("surfaces unresolved SecretRef when env var is absent for a bare env-var placeholder", async () => {
+    // Without the env var, the literal ${OPENCLAW_GATEWAY_TOKEN} is parsed
+    // as an env-template SecretRef and reported as unresolved.
+    const resolved = await resolveGatewayAuthTokenForService(
+      {
+        gateway: {
+          auth: {
+            token: "${OPENCLAW_GATEWAY_TOKEN}",
+          },
+        },
+      } as OpenClawConfig,
+      {} as NodeJS.ProcessEnv,
+    );
+
+    expect(resolved.token).toBeUndefined();
+    expect(resolved.unavailableReason).toBeDefined();
+  });
 });
 
 describe("shouldRequireGatewayTokenForInstall", () => {

--- a/src/gateway/auth-token-resolution.ts
+++ b/src/gateway/auth-token-resolution.ts
@@ -47,15 +47,18 @@ export async function resolveGatewayAuthToken(params: {
     const configToken = trimToUndefined(tokenInput);
     if (configToken) {
       // A literal `${...}` placeholder in config is not a SecretRef
-      // and cannot be resolved here. Treat it as "no usable token" so
-      // the caller can surface a clear error instead of embedding the
-      // unresolved placeholder into a URL.
-      if (/^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/.test(configToken) && envToken) {
-        return {
-          token: envToken,
-          source: "env",
-          secretRefConfigured: false,
-        };
+      // and cannot be resolved here. Resolve from env when available;
+      // otherwise return no token so the caller surfaces a clear error
+      // instead of embedding the unresolved placeholder into a URL.
+      if (/^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/.test(configToken)) {
+        if (envToken) {
+          return {
+            token: envToken,
+            source: "env",
+            secretRefConfigured: false,
+          };
+        }
+        return { secretRefConfigured: false };
       }
       return {
         token: configToken,

--- a/src/gateway/auth-token-resolution.ts
+++ b/src/gateway/auth-token-resolution.ts
@@ -46,6 +46,17 @@ export async function resolveGatewayAuthToken(params: {
   if (!tokenRef) {
     const configToken = trimToUndefined(tokenInput);
     if (configToken) {
+      // A literal `${...}` placeholder in config is not a SecretRef
+      // and cannot be resolved here. Treat it as "no usable token" so
+      // the caller can surface a clear error instead of embedding the
+      // unresolved placeholder into a URL.
+      if (/^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/.test(configToken) && envToken) {
+        return {
+          token: envToken,
+          source: "env",
+          secretRefConfigured: false,
+        };
+      }
       return {
         token: configToken,
         source: "config",


### PR DESCRIPTION
## What Problem This Solves

Fixes #101286: When `gateway.auth.token` is configured as `${OPENCLAW_GATEWAY_TOKEN}` (not via SecretRef syntax), and the env var is absent from the process environment (e.g. macOS GUI app launched from Dock/Finder), the literal `${OPENCLAW_GATEWAY_TOKEN}` string was returned as the token. This caused the dashboard URL to contain `#token=${OPENCLAW_GATEWAY_TOKEN}` — permanently breaking dashboard access with no recovery path.

## Why This Change Was Made

`resolveGatewayAuthToken` did not distinguish between real token values and unresolved env-var placeholders. A bare `${VAR}` in config is not a SecretRef, so it was treated as a literal config token value. The fix detects `\${}` placeholders and falls back to the env var when available, matching user intent.

## User Impact

- macOS GUI-launched OpenClaw.app can now resolve `${OPENCLAW_GATEWAY_TOKEN}` when the env var is available
- When the env var is absent, returns no token so the caller shows a clear error instead of embedding an unresolved placeholder

## Evidence

- [x] `pnpm test src/commands/doctor-gateway-auth-token.test.ts` — 16 tests pass
- [x] `oxlint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
