### PR TITLE
fix(imessage): handle CLI child stdout/stderr stream errors

### DIFF
--- a/extensions/imessage/src/actions.runtime.test.ts
+++ b/extensions/imessage/src/actions.runtime.test.ts
@@ -41,6 +41,23 @@ function mockSpawnJsonResponse(payload: Record<string, unknown> = { success: tru
   });
 }
 
+function mockSpawnWithStreamError(stream: "stdout" | "stderr", error: Error) {
+  spawnMock.mockImplementationOnce(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter & { setEncoding: (encoding: string) => void };
+      stderr: EventEmitter & { setEncoding: (encoding: string) => void };
+      kill: (signal: string) => void;
+    };
+    child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+    child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+    child.kill = vi.fn();
+    queueMicrotask(() => {
+      child[stream].emit("error", error);
+    });
+    return child;
+  });
+}
+
 function mockRpcChatList(chats: Array<Record<string, unknown>>) {
   const request = vi.fn().mockResolvedValue({ chats });
   const stop = vi.fn().mockResolvedValue(undefined);
@@ -81,6 +98,38 @@ describe("imessage actions runtime", () => {
       ],
       { stdio: ["ignore", "pipe", "pipe"] },
     );
+  });
+
+  it("rejects on stdout stream error", async () => {
+    mockSpawnWithStreamError("stdout", new Error("stdout pipe broken"));
+
+    await expect(
+      imessageActionsRuntime.sendReaction({
+        chatGuid: "iMessage;+;chat0000",
+        messageId: "message-guid",
+        reaction: "like",
+        options: {
+          cliPath: "imsg",
+          chatGuid: "iMessage;+;chat0000",
+        },
+      }),
+    ).rejects.toThrow("iMessage CLI stdout stream error: stdout pipe broken");
+  });
+
+  it("rejects on stderr stream error", async () => {
+    mockSpawnWithStreamError("stderr", new Error("stderr pipe broken"));
+
+    await expect(
+      imessageActionsRuntime.sendReaction({
+        chatGuid: "iMessage;+;chat0000",
+        messageId: "message-guid",
+        reaction: "like",
+        options: {
+          cliPath: "imsg",
+          chatGuid: "iMessage;+;chat0000",
+        },
+      }),
+    ).rejects.toThrow("iMessage CLI stderr stream error: stderr pipe broken");
   });
 
   it("drops cached chats.list entries when the current clock is not a valid date timestamp", async () => {

--- a/extensions/imessage/src/actions.runtime.test.ts
+++ b/extensions/imessage/src/actions.runtime.test.ts
@@ -42,6 +42,7 @@ function mockSpawnJsonResponse(payload: Record<string, unknown> = { success: tru
 }
 
 function mockSpawnWithStreamError(stream: "stdout" | "stderr", error: Error) {
+  const kill = vi.fn();
   spawnMock.mockImplementationOnce(() => {
     const child = new EventEmitter() as EventEmitter & {
       stdout: EventEmitter & { setEncoding: (encoding: string) => void };
@@ -50,12 +51,13 @@ function mockSpawnWithStreamError(stream: "stdout" | "stderr", error: Error) {
     };
     child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
     child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
-    child.kill = vi.fn();
+    child.kill = kill;
     queueMicrotask(() => {
       child[stream].emit("error", error);
     });
     return child;
   });
+  return kill;
 }
 
 function mockRpcChatList(chats: Array<Record<string, unknown>>) {
@@ -101,7 +103,7 @@ describe("imessage actions runtime", () => {
   });
 
   it("rejects on stdout stream error", async () => {
-    mockSpawnWithStreamError("stdout", new Error("stdout pipe broken"));
+    const kill = mockSpawnWithStreamError("stdout", new Error("stdout pipe broken"));
 
     await expect(
       imessageActionsRuntime.sendReaction({
@@ -114,10 +116,11 @@ describe("imessage actions runtime", () => {
         },
       }),
     ).rejects.toThrow("iMessage CLI stdout stream error: stdout pipe broken");
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
   });
 
   it("rejects on stderr stream error", async () => {
-    mockSpawnWithStreamError("stderr", new Error("stderr pipe broken"));
+    const kill = mockSpawnWithStreamError("stderr", new Error("stderr pipe broken"));
 
     await expect(
       imessageActionsRuntime.sendReaction({
@@ -130,6 +133,7 @@ describe("imessage actions runtime", () => {
         },
       }),
     ).rejects.toThrow("iMessage CLI stderr stream error: stderr pipe broken");
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
   });
 
   it("drops cached chats.list entries when the current clock is not a valid date timestamp", async () => {

--- a/extensions/imessage/src/actions.runtime.ts
+++ b/extensions/imessage/src/actions.runtime.ts
@@ -243,8 +243,28 @@ async function runIMessageCliJson(
       }
       stdout = appended.value;
     });
+    child.stdout.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      fail(
+        new Error(
+          `iMessage CLI stdout stream error: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
+    });
     child.stderr.on("data", (chunk) => {
       stderr = appendIMessageCliStderrTail(stderr, chunk);
+    });
+    child.stderr.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      fail(
+        new Error(
+          `iMessage CLI stderr stream error: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
     });
     child.on("error", (error) => {
       if (settled) {

--- a/extensions/imessage/src/actions.runtime.ts
+++ b/extensions/imessage/src/actions.runtime.ts
@@ -9,7 +9,11 @@ import {
 } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
-import { appendIMessageCliStderrTail, appendIMessageCliStdout } from "./cli-output.js";
+import {
+  appendIMessageCliStderrTail,
+  appendIMessageCliStdout,
+  listenForIMessageCliStreamErrors,
+} from "./cli-output.js";
 import { createIMessageRpcClient } from "./client.js";
 import { extractMarkdownFormatRuns } from "./markdown-format.js";
 import {
@@ -243,28 +247,13 @@ async function runIMessageCliJson(
       }
       stdout = appended.value;
     });
-    child.stdout.on("error", (error) => {
-      if (settled) {
-        return;
-      }
-      fail(
-        new Error(
-          `iMessage CLI stdout stream error: ${error instanceof Error ? error.message : String(error)}`,
-        ),
-      );
-    });
     child.stderr.on("data", (chunk) => {
       stderr = appendIMessageCliStderrTail(stderr, chunk);
     });
-    child.stderr.on("error", (error) => {
-      if (settled) {
-        return;
-      }
-      fail(
-        new Error(
-          `iMessage CLI stderr stream error: ${error instanceof Error ? error.message : String(error)}`,
-        ),
-      );
+    listenForIMessageCliStreamErrors({
+      child,
+      isSettled: () => settled,
+      fail,
     });
     child.on("error", (error) => {
       if (settled) {

--- a/extensions/imessage/src/cli-output.ts
+++ b/extensions/imessage/src/cli-output.ts
@@ -1,4 +1,6 @@
 // Imessage plugin module implements cli output behavior.
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+
 export const IMESSAGE_CLI_STDOUT_MAX_CHARS = 8 * 1024 * 1024;
 export const IMESSAGE_CLI_STDERR_TAIL_CHARS = 64 * 1024;
 
@@ -6,6 +8,28 @@ type AppendStdoutResult = { ok: true; value: string } | { ok: false; message: st
 
 function chunkToString(chunk: string | Buffer): string {
   return typeof chunk === "string" ? chunk : chunk.toString("utf8");
+}
+
+export function listenForIMessageCliStreamErrors(params: {
+  child: Pick<ChildProcessWithoutNullStreams, "stdout" | "stderr" | "kill">;
+  isSettled: () => boolean;
+  fail: (error: Error) => void;
+}): void {
+  for (const stream of ["stdout", "stderr"] as const) {
+    // Keep the listener after settlement: late stream errors still need to be
+    // consumed even though they can no longer change the command result.
+    params.child[stream].on("error", (error) => {
+      if (params.isSettled()) {
+        return;
+      }
+      params.fail(new Error(`iMessage CLI ${stream} stream error: ${error.message}`));
+      try {
+        params.child.kill("SIGKILL");
+      } catch {
+        // The helper may already be gone.
+      }
+    });
+  }
 }
 
 export function appendIMessageCliStdout(

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -1,4 +1,5 @@
 // Imessage tests cover send plugin behavior.
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -28,6 +29,13 @@ const IMESSAGE_TEST_CFG = {
     },
   },
 };
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  spawn: spawnMock,
+}));
 
 function createClient(result: Record<string, unknown>): IMessageRpcClient {
   return {
@@ -79,6 +87,7 @@ describe("sendMessageIMessage receipts", () => {
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
     vi.useRealTimers();
+    spawnMock.mockReset();
   });
 
   it("attaches a text receipt for native send ids", async () => {
@@ -1263,5 +1272,64 @@ describe("sendMessageIMessage receipts", () => {
     ).rejects.toThrow("imsg rpc error (send)");
 
     expect(runCliJson).not.toHaveBeenCalled();
+  });
+});
+
+function mockSpawnWithStreamError(stream: "stdout" | "stderr", error: Error) {
+  spawnMock.mockImplementationOnce(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter & { setEncoding: (encoding: string) => void };
+      stderr: EventEmitter & { setEncoding: (encoding: string) => void };
+      kill: (signal: string) => void;
+    };
+    child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+    child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+    child.kill = vi.fn();
+    queueMicrotask(() => {
+      child[stream].emit("error", error);
+    });
+    return child;
+  });
+}
+
+describe("sendMessageIMessage CLI stream errors", () => {
+  beforeEach(() => {
+    installIMessageStateRuntimeForTest();
+    resetIMessageShortIdState();
+    resetPersistedIMessageEchoCacheForTest();
+  });
+
+  afterEach(() => {
+    clearIMessageApprovalReactionTargetsForTest();
+    resetIMessageShortIdState();
+    resetPersistedIMessageEchoCacheForTest();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+    spawnMock.mockReset();
+  });
+
+  it("rejects on stdout stream error during attachment send", async () => {
+    mockSpawnWithStreamError("stdout", new Error("stdout pipe broken"));
+
+    await expect(
+      sendMessageIMessage("chat_guid:chat-1", "", {
+        config: IMESSAGE_TEST_CFG,
+        mediaUrl: "/tmp/image.png",
+        resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+      }),
+    ).rejects.toThrow("iMessage CLI stdout stream error: stdout pipe broken");
+  });
+
+  it("rejects on stderr stream error during attachment send", async () => {
+    mockSpawnWithStreamError("stderr", new Error("stderr pipe broken"));
+
+    await expect(
+      sendMessageIMessage("chat_guid:chat-1", "", {
+        config: IMESSAGE_TEST_CFG,
+        mediaUrl: "/tmp/image.png",
+        resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
+      }),
+    ).rejects.toThrow("iMessage CLI stderr stream error: stderr pipe broken");
   });
 });

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -1276,6 +1276,7 @@ describe("sendMessageIMessage receipts", () => {
 });
 
 function mockSpawnWithStreamError(stream: "stdout" | "stderr", error: Error) {
+  const kill = vi.fn();
   spawnMock.mockImplementationOnce(() => {
     const child = new EventEmitter() as EventEmitter & {
       stdout: EventEmitter & { setEncoding: (encoding: string) => void };
@@ -1284,12 +1285,13 @@ function mockSpawnWithStreamError(stream: "stdout" | "stderr", error: Error) {
     };
     child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
     child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
-    child.kill = vi.fn();
+    child.kill = kill;
     queueMicrotask(() => {
       child[stream].emit("error", error);
     });
     return child;
   });
+  return kill;
 }
 
 describe("sendMessageIMessage CLI stream errors", () => {
@@ -1310,7 +1312,7 @@ describe("sendMessageIMessage CLI stream errors", () => {
   });
 
   it("rejects on stdout stream error during attachment send", async () => {
-    mockSpawnWithStreamError("stdout", new Error("stdout pipe broken"));
+    const kill = mockSpawnWithStreamError("stdout", new Error("stdout pipe broken"));
 
     await expect(
       sendMessageIMessage("chat_guid:chat-1", "", {
@@ -1319,10 +1321,11 @@ describe("sendMessageIMessage CLI stream errors", () => {
         resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
       }),
     ).rejects.toThrow("iMessage CLI stdout stream error: stdout pipe broken");
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
   });
 
   it("rejects on stderr stream error during attachment send", async () => {
-    mockSpawnWithStreamError("stderr", new Error("stderr pipe broken"));
+    const kill = mockSpawnWithStreamError("stderr", new Error("stderr pipe broken"));
 
     await expect(
       sendMessageIMessage("chat_guid:chat-1", "", {
@@ -1331,5 +1334,6 @@ describe("sendMessageIMessage CLI stream errors", () => {
         resolveAttachmentImpl: async () => ({ path: "/tmp/image.png", contentType: "image/png" }),
       }),
     ).rejects.toThrow("iMessage CLI stderr stream error: stderr pipe broken");
+    expect(kill).toHaveBeenCalledWith("SIGKILL");
   });
 });

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -644,8 +644,28 @@ async function runIMessageCliJson(
       }
       stdout = appended.value;
     });
+    child.stdout.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      fail(
+        new Error(
+          `iMessage CLI stdout stream error: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
+    });
     child.stderr.on("data", (chunk) => {
       stderr = appendIMessageCliStderrTail(stderr, chunk);
+    });
+    child.stderr.on("error", (error) => {
+      if (settled) {
+        return;
+      }
+      fail(
+        new Error(
+          `iMessage CLI stderr stream error: ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      );
     });
     child.on("error", (error) => {
       if (settled) {

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -25,7 +25,11 @@ import {
   type IMessageApprovalConversationKey,
   registerIMessageApprovalReactionTargetForOutboundMessage,
 } from "./approval-reactions.js";
-import { appendIMessageCliStderrTail, appendIMessageCliStdout } from "./cli-output.js";
+import {
+  appendIMessageCliStderrTail,
+  appendIMessageCliStdout,
+  listenForIMessageCliStreamErrors,
+} from "./cli-output.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
 import { DEFAULT_IMESSAGE_SEND_TIMEOUT_MS } from "./constants.js";
 import { extractMarkdownFormatRuns } from "./markdown-format.js";
@@ -644,28 +648,13 @@ async function runIMessageCliJson(
       }
       stdout = appended.value;
     });
-    child.stdout.on("error", (error) => {
-      if (settled) {
-        return;
-      }
-      fail(
-        new Error(
-          `iMessage CLI stdout stream error: ${error instanceof Error ? error.message : String(error)}`,
-        ),
-      );
-    });
     child.stderr.on("data", (chunk) => {
       stderr = appendIMessageCliStderrTail(stderr, chunk);
     });
-    child.stderr.on("error", (error) => {
-      if (settled) {
-        return;
-      }
-      fail(
-        new Error(
-          `iMessage CLI stderr stream error: ${error instanceof Error ? error.message : String(error)}`,
-        ),
-      );
+    listenForIMessageCliStreamErrors({
+      child,
+      isSettled: () => settled,
+      fail,
     });
     child.on("error", (error) => {
       if (settled) {


### PR DESCRIPTION
## What Problem This Solves

`runIMessageCliJson` in both `actions.runtime.ts` and `send.ts` spawned an `imsg` child process and listened for `data`, child `error`, and `close` events, but it did not attach `error` listeners to the piped `stdout` and `stderr` streams. If either stream emitted an error (for example, a broken pipe or EPIPE while the child was terminating), the error became an unhandled stream error and could crash the gateway worker.

## Why This Change Was Made

Node Readable streams can emit `error` independently of the child process `error` event. For transport code that runs inside the gateway process, unhandled stream errors are a reliability risk. Adding explicit `error` handlers on both `child.stdout` and `child.stderr` lets the promise reject cleanly and gives operators a concrete error message instead of an unhandled exception.

## User Impact

- iMessage CLI sends and actions now fail gracefully when the child's stdout or stderr stream errors.
- The gateway no longer risks an unhandled stream exception from `imsg` child I/O.
- Existing success paths and timeout/kill escalation behavior are unchanged.

## Evidence

- Added `error` event handlers to `child.stdout` and `child.stderr` in both `extensions/imessage/src/actions.runtime.ts` and `extensions/imessage/src/send.ts`.
- Added regression tests in `extensions/imessage/src/actions.runtime.test.ts` and `extensions/imessage/src/send.test.ts` covering stdout and stderr stream errors.
- Local test runs:
  ```
  node scripts/run-vitest.mjs extensions/imessage/src/actions.runtime.test.ts --run  # 21 tests passed
  node scripts/run-vitest.mjs extensions/imessage/src/send.test.ts --run            # 47 tests passed
  ```