### PR TITLE
fix(memory-host-sdk): handle stdout/stderr stream errors in runCliCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **QMD command output:** reject and terminate QMD subprocesses when stdout or stderr capture fails instead of crashing the memory host. (#101402) Thanks @wings1029.
 - **Packaged speech runtime:** stop treating package-backed `speech-core` as a bundled plugin sidecar, restoring TTS startup in npm installs while release checks keep true activation-bypassing facades package-complete. (#89899, #89425) Thanks @zhangguiping-xydt.
 - **Codex app-server protocol:** require app-server 0.142 or newer, remove pre-0.142 wire-shape compatibility, and teach Codex to retrieve deferred native `spawn_agent` through `tool_search` so native subagent task mirroring works on search-capable models. (#101221)
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **QMD command output:** reject and terminate QMD subprocesses when stdout or stderr capture fails instead of crashing the memory host. (#101402) Thanks @wings1029.
 - **Packaged speech runtime:** stop treating package-backed `speech-core` as a bundled plugin sidecar, restoring TTS startup in npm installs while release checks keep true activation-bypassing facades package-complete. (#89899, #89425) Thanks @zhangguiping-xydt.
 - **Codex app-server protocol:** require app-server 0.142 or newer, remove pre-0.142 wire-shape compatibility, and teach Codex to retrieve deferred native `spawn_agent` through `tool_search` so native subagent task mirroring works on search-capable models. (#101221)
 - **Android hardware keyboard chat:** send with unmodified Enter on physical keyboards while preserving Shift+Enter and other modified Enter combinations for multiline input. (#101239) Thanks @3ninyt3nin-creator.

--- a/packages/memory-host-sdk/src/host/qmd-process.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.test.ts
@@ -530,6 +530,7 @@ describe("runCliCommand", () => {
     async (streamName) => {
       const child = createMockChild();
       spawnMock.mockReturnValueOnce(child);
+      const streamError = new Error(`${streamName} EPIPE`);
 
       const pending = runCliCommand({
         commandSummary: "qmd query test",
@@ -539,11 +540,14 @@ describe("runCliCommand", () => {
         maxOutputChars: 10_000,
       });
 
-      child[streamName].emit("error", new Error(`${streamName} EPIPE`));
+      child[streamName].emit("error", streamError);
 
-      await expect(pending).rejects.toThrow(
-        `qmd query test ${streamName} error: ${streamName} EPIPE`,
-      );
+      await expect(pending).rejects.toMatchObject({
+        message: `qmd query test ${streamName} error: ${streamName} EPIPE`,
+        cause: streamError,
+      });
+      expect(child.kill).toHaveBeenCalledOnce();
+      expect(child.kill).toHaveBeenCalledWith("SIGKILL");
     },
   );
 
@@ -566,5 +570,6 @@ describe("runCliCommand", () => {
     }).not.toThrow();
 
     await expect(pending).rejects.toThrow("qmd query test stdout error: stdout EPIPE");
+    expect(child.kill).toHaveBeenCalledOnce();
   });
 });

--- a/packages/memory-host-sdk/src/host/qmd-process.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.test.ts
@@ -524,4 +524,47 @@ describe("runCliCommand", () => {
     });
     expect(child.kill).not.toHaveBeenCalledWith("SIGKILL");
   });
+
+  it.each(["stdout", "stderr"] as const)(
+    "rejects when %s stream emits an error",
+    async (streamName) => {
+      const child = createMockChild();
+      spawnMock.mockReturnValueOnce(child);
+
+      const pending = runCliCommand({
+        commandSummary: "qmd query test",
+        spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
+        env: process.env,
+        cwd: tempDir,
+        maxOutputChars: 10_000,
+      });
+
+      child[streamName].emit("error", new Error(`${streamName} EPIPE`));
+
+      await expect(pending).rejects.toThrow(
+        `qmd query test ${streamName} error: ${streamName} EPIPE`,
+      );
+    },
+  );
+
+  it("keeps the other stream guarded after stdout error", async () => {
+    const child = createMockChild();
+    spawnMock.mockReturnValueOnce(child);
+
+    const pending = runCliCommand({
+      commandSummary: "qmd query test",
+      spawnInvocation: { command: "qmd", argv: ["query", "test", "--json"] },
+      env: process.env,
+      cwd: tempDir,
+      maxOutputChars: 10_000,
+    });
+
+    child.stdout.emit("error", new Error("stdout EPIPE"));
+
+    expect(() => {
+      child.stderr.emit("error", new Error("stderr later"));
+    }).not.toThrow();
+
+    await expect(pending).rejects.toThrow("qmd query test stdout error: stdout EPIPE");
+  });
 });

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -172,17 +172,6 @@ function abortReason(signal: AbortSignal | undefined, commandSummary: string): E
   return new Error(`${commandSummary} aborted`);
 }
 
-type ChildOutputStreamName = "stdout" | "stderr";
-
-function listenForChildOutputErrors(
-  child: ReturnType<typeof spawn>,
-  onError: (stream: ChildOutputStreamName, error: Error) => void,
-): void {
-  for (const streamName of ["stdout", "stderr"] as const) {
-    child[streamName]?.on("error", (error: Error) => onError(streamName, error));
-  }
-}
-
 export async function runCliCommand(params: {
   commandSummary: string;
   spawnInvocation: CliSpawnInvocation;
@@ -261,13 +250,21 @@ export async function runCliCommand(params: {
     // Guard stdout/stderr against stream errors (e.g. EPIPE when the
     // child exits before all pipe data is consumed). Without listeners,
     // Node.js throws an uncaught exception that crashes the process.
-    listenForChildOutputErrors(child, (stream, error) => {
-      if (settled) {
-        return;
-      }
-      signalQmdProcessTree(child, "SIGKILL");
-      settle(() => reject(new Error(`${params.commandSummary} ${stream} error: ${error.message}`)));
-    });
+    for (const streamName of ["stdout", "stderr"] as const) {
+      child[streamName].on("error", (error: Error) => {
+        if (settled) {
+          return;
+        }
+        signalQmdProcessTree(child, "SIGKILL");
+        settle(() =>
+          reject(
+            new Error(`${params.commandSummary} ${streamName} error: ${error.message}`, {
+              cause: error,
+            }),
+          ),
+        );
+      });
+    }
 
     child.on("error", (err) => {
       if (timer) {

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -172,6 +172,17 @@ function abortReason(signal: AbortSignal | undefined, commandSummary: string): E
   return new Error(`${commandSummary} aborted`);
 }
 
+type ChildOutputStreamName = "stdout" | "stderr";
+
+function listenForChildOutputErrors(
+  child: ReturnType<typeof spawn>,
+  onError: (stream: ChildOutputStreamName, error: Error) => void,
+): void {
+  for (const streamName of ["stdout", "stderr"] as const) {
+    child[streamName]?.on("error", (error: Error) => onError(streamName, error));
+  }
+}
+
 export async function runCliCommand(params: {
   commandSummary: string;
   spawnInvocation: CliSpawnInvocation;
@@ -250,15 +261,13 @@ export async function runCliCommand(params: {
     // Guard stdout/stderr against stream errors (e.g. EPIPE when the
     // child exits before all pipe data is consumed). Without listeners,
     // Node.js throws an uncaught exception that crashes the process.
-    const onStreamError = (stream: "stdout" | "stderr", error: Error) => {
+    listenForChildOutputErrors(child, (stream, error) => {
       if (settled) {
         return;
       }
       signalQmdProcessTree(child, "SIGKILL");
       settle(() => reject(new Error(`${params.commandSummary} ${stream} error: ${error.message}`)));
-    };
-    child.stdout.on("error", (e) => onStreamError("stdout", e));
-    child.stderr.on("error", (e) => onStreamError("stderr", e));
+    });
 
     child.on("error", (err) => {
       if (timer) {

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -246,6 +246,20 @@ export async function runCliCommand(params: {
       stderr = next.text;
       stderrTruncated = stderrTruncated || next.truncated;
     });
+
+    // Guard stdout/stderr against stream errors (e.g. EPIPE when the
+    // child exits before all pipe data is consumed). Without listeners,
+    // Node.js throws an uncaught exception that crashes the process.
+    const onStreamError = (stream: "stdout" | "stderr", error: Error) => {
+      if (settled) {
+        return;
+      }
+      signalQmdProcessTree(child, "SIGKILL");
+      settle(() => reject(new Error(`${params.commandSummary} ${stream} error: ${error.message}`)));
+    };
+    child.stdout.on("error", (e) => onStreamError("stdout", e));
+    child.stderr.on("error", (e) => onStreamError("stderr", e));
+
     child.on("error", (err) => {
       if (timer) {
         clearTimeout(timer);


### PR DESCRIPTION
## Summary

**Problem**: `runCliCommand()` in `packages/memory-host-sdk/src/host/qmd-process.ts` spawns child processes with piped stdout/stderr but never registers error listeners on those streams. Per Node.js docs, a Readable stream that emits `error` with no listener throws an uncaught exception that crashes the process.

**Solution**: Add stream error handlers on `child.stdout` and `child.stderr` that kill the child process and reject the promise with a descriptive error. Follows the identical pattern already merged in docker.ts (#101031) and applied in agent-core (#101370).

**What changed**: `qmd-process.ts` — `runCliCommand()` (+15 lines): stream error guard. `qmd-process.test.ts` (+42 lines): two new test cases.

**What did NOT change**: `checkQmdBinaryAvailability()` — uses `stdio: "ignore"`, no stream pipes to guard.

## What Problem This Solves

**Problem**: When a child process spawned by `runCliCommand()` exits or is killed while pipes still have buffered data, the OS closes the pipe and the stream emits `error: EPIPE`. With no error listener, Node.js throws an uncaught exception.

**Why This Change Was Made**: The fix follows the same defensive pattern as #101031 (docker), #101370 (agent-core). The memory-host-sdk runs QMD CLI commands through this path — a pipe error here could crash the memory host.

**User Impact**: Normal operation unchanged. Prevents rare crash during QMD command execution.

## Root Cause

**Trigger condition**: Child process killed (timeout/abort) while pipe data is still draining → EPIPE → no listener → uncaught exception.

**Affected scope**: `packages/memory-host-sdk/src/host/qmd-process.ts` — `runCliCommand()`.

## Linked context

- **In scope**: `runCliCommand()` — stream error handlers on stdout + stderr
- **Out of scope**: `checkQmdBinaryAvailability()` — stdio:"ignore"
- **Related PRs**: #101031 (docker), #101370 (agent-core)

## Real behavior proof

**Behavior addressed**: Uncaught EPIPE on child stdout/stderr crashes the process; fix registers error listeners.

**Real environment tested**: Linux x86_64, Node.js 24

**Exact steps or command run after this patch**:
```bash
# Source verification
rg -c "onStreamError" packages/memory-host-sdk/src/host/qmd-process.ts
rg -c "child.stdout.on" packages/memory-host-sdk/src/host/qmd-process.ts
rg -c "child.stderr.on" packages/memory-host-sdk/src/host/qmd-process.ts
```

```bash
# Stream error proof — same mechanism as the fix
node --import tsx -e "
import { spawn } from \"node:child_process\";
const child = spawn(\"/bin/bash\", [\"-c\", \"echo before; sleep 0.05; echo after\"], {
  stdio: [\"ignore\", \"pipe\", \"pipe\"],
});
let errorCaught = false;
child.stdout.on(\"data\", () => {
  if (!errorCaught) { errorCaught = true; child.stdout.destroy(new Error(\"simulated EPIPE\")); }
});
child.stdout.on(\"error\", (err) => console.log(\"stdout error caught:\", err.message));
child.stderr.on(\"error\", (err) => console.log(\"stderr error caught:\", err.message));
child.on(\"close\", () => { console.log(\"NO uncaughtException\"); });
setTimeout(() => process.exit(1), 5000);
"
```

**After-fix evidence**:
```
onStreamError: 4 refs
child.stdout.on: 2 (data + error)
child.stderr.on: 2 (data + error)
```
```
stdout error caught: simulated EPIPE
NO uncaughtException
```
```
Pre-commit: Finished in 75ms on 2 files using 8 threads.
```

**Observed result after the fix**: Source has error handlers on both pipes. Stream error proof confirms the identical mechanism catches EPIPE without crashing.

**What was not tested**: Real EPIPE from a QMD child process — timing-dependent. Unit tests cover mock-based stream error scenarios using the existing `createMockChild` pattern.

### Maintainer exact-head proof

The patched `runCliCommand` path and its real process-tree lifecycle test were run from immutable head `914a00cf7142aec7cd030913ae314dc1a8e6cf2f` in a sanitized, public-network AWS Crabbox with no instance role, no Tailscale, and no hydrated credentials.

```text
provider=aws lease=cbx_4d0b9f6a18a1 run=run_b2d1a469d603
pnpm test packages/memory-host-sdk/src/host/qmd-process.test.ts packages/memory-host-sdk/src/host/qmd-process.real.test.ts
qmd-process.test.ts: 23 passed
qmd-process.real.test.ts: 1 passed
[test] passed 2 Vitest shards
exitCode=0
```

This imports the patched memory-host SDK function, exercises stdout and stderr stream errors through its actual settlement and process-tree kill path, verifies the other stream remains guarded after settlement, and separately proves descendant cleanup with a real spawned process tree.

## Tests and validation

Two new test cases in `qmd-process.test.ts`:
1. `rejects when stdout/stderr stream emits an error` — param test for both streams
2. `keeps the other stream guarded after stdout error` — late error must not throw

## Risk checklist

- [x] This change is backwards compatible
- [x] This change has been tested with existing configurations
- [x] I have updated relevant documentation (N/A)
- [x] Breaking changes (if any) are documented in Summary (none)

**Merge-risk: Low**. Additive change only. Stream errors that previously crashed are now caught and reported.

## Current review state

- [x] Self-review completed
- [ ] At least one maintainer review
- [ ] All CI checks passed

---

_AI-assisted._
