### PR TITLE
fix(qa-lab): bound Crabline inbound JSON response size

### DIFF
--- a/extensions/qa-lab/src/crabline-transport.inbound-bound.test.ts
+++ b/extensions/qa-lab/src/crabline-transport.inbound-bound.test.ts
@@ -1,0 +1,185 @@
+// Qa Lab tests cover Crabline inbound JSON response bounds.
+import type {
+  CrablineServerManifest,
+  OpenClawCrablineChannelDriverSelection,
+  StartedOpenClawCrablineAdapter,
+} from "@openclaw/crabline";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+
+const startOpenClawCrablineAdapterMock = vi.hoisted(() => vi.fn());
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@openclaw/crabline", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@openclaw/crabline")>();
+  return {
+    ...actual,
+    startOpenClawCrablineAdapter: startOpenClawCrablineAdapterMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+  };
+});
+
+let createQaCrablineTransportAdapter: typeof import("./crabline-transport.js").createQaCrablineTransportAdapter;
+
+function createSelection(channel: OpenClawCrablineChannelDriverSelection["channel"] = "telegram") {
+  return {
+    capabilityMatrixPath: "crabline-fake-provider-capabilities.json",
+    channel,
+    channelDriver: "crabline",
+    smokeArtifactPath: "crabline-fake-provider-smoke.json",
+  } as const;
+}
+
+function createMockAdapter(channel: string): StartedOpenClawCrablineAdapter {
+  const manifest: CrablineServerManifest = {
+    provider: channel,
+    adminToken: "test-admin-token",
+    endpoints: {
+      adminInboundUrl: "http://127.0.0.1:9999/admin/inbound",
+      apiRoot: "http://127.0.0.1:9999",
+    },
+  } as unknown as CrablineServerManifest;
+  return {
+    accountId: "default",
+    channel,
+    close: vi.fn().mockResolvedValue(undefined),
+    createAgentDelivery: ({ target }) => ({
+      channel,
+      replyChannel: channel,
+      replyTo: target,
+      to: target,
+    }),
+    createChannelDriverSmokeEnv: (env) => env,
+    createGatewayConfig: () => ({ channels: { [channel]: { enabled: true } } }),
+    createInbound: ({ input }) => ({
+      providerBody: {
+        update_id: 1,
+        message: {
+          chat: {
+            id: input.conversation.id,
+            type: input.conversation.kind === "group" ? "supergroup" : "private",
+          },
+          from: { id: Number(input.senderId), first_name: input.senderName ?? "QA" },
+          message_id: 1,
+          text: input.text,
+        },
+      },
+      providerHeaders: { "content-type": "application/json" },
+      providerTargetKey: input.conversation.id,
+      providerUrl: manifest.endpoints.adminInboundUrl,
+      qaTarget: input.conversation.id,
+      stateConversation: {
+        id: input.conversation.id,
+        kind: input.conversation.kind as "direct" | "group",
+      },
+    }),
+    createOutboundFromRecorderEvent: () => null,
+    manifest,
+    probe: vi.fn().mockResolvedValue({}),
+    requiredPluginIds: [channel],
+  } as unknown as StartedOpenClawCrablineAdapter;
+}
+
+function jsonResponse(body: unknown) {
+  return {
+    response: new Response(JSON.stringify(body), {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    }),
+    release: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function oversizedJsonResponse() {
+  const chunk = Buffer.alloc(1024 * 1024, "x");
+  const stream = new ReadableStream({
+    start(controller) {
+      for (let i = 0; i < 17; i++) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+  return {
+    response: new Response(stream, {
+      headers: { "content-type": "application/json" },
+      status: 200,
+    }),
+    release: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("postCrablineInbound JSON response bounds", () => {
+  beforeAll(async () => {
+    ({ createQaCrablineTransportAdapter } = await import("./crabline-transport.js"));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses a normal JSON inbound response", async () => {
+    await withTempDir("qa-crabline-inbound-bound-", async (outputDir) => {
+      const adapter = createMockAdapter("telegram");
+      startOpenClawCrablineAdapterMock.mockResolvedValueOnce(adapter);
+      fetchWithSsrFGuardMock.mockResolvedValueOnce(jsonResponse({ update_id: 42 }));
+
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection(),
+        state: createQaBusState(),
+      });
+
+      try {
+        const message = await transport.sendInbound({
+          conversation: { id: "alice", kind: "direct" },
+          senderId: "100001",
+          senderName: "Alice",
+          text: "hello",
+        });
+
+        expect(message.text).toBe("hello");
+        expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+        const call = fetchWithSsrFGuardMock.mock.calls[0];
+        expect(call?.[0].url).toBe(adapter.manifest.endpoints.adminInboundUrl);
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+
+  it("rejects an oversized JSON inbound response", async () => {
+    await withTempDir("qa-crabline-inbound-bound-", async (outputDir) => {
+      const adapter = createMockAdapter("telegram");
+      startOpenClawCrablineAdapterMock.mockResolvedValueOnce(adapter);
+      fetchWithSsrFGuardMock.mockResolvedValueOnce(oversizedJsonResponse());
+
+      const transport = await createQaCrablineTransportAdapter({
+        outputDir,
+        selection: createSelection(),
+        state: createQaBusState(),
+      });
+
+      try {
+        await expect(
+          transport.sendInbound({
+            conversation: { id: "alice", kind: "direct" },
+            senderId: "100001",
+            senderName: "Alice",
+            text: "hello",
+          }),
+        ).rejects.toThrow(/qa-lab-crabline-telegram-inbound: JSON response exceeds/);
+      } finally {
+        await transport.cleanup?.();
+      }
+    });
+  });
+});

--- a/extensions/qa-lab/src/crabline-transport.ts
+++ b/extensions/qa-lab/src/crabline-transport.ts
@@ -11,6 +11,7 @@ import {
 } from "@openclaw/crabline";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   isRecord,
@@ -43,6 +44,10 @@ import type {
 const CRABLINE_TRANSPORT_ID = "crabline";
 const TELEGRAM_QA_DRIVER_ID = "100001";
 const TELEGRAM_QA_OBSERVER_ID = "100002";
+// Crabline inbound injection responses are small metadata envelopes. Cap the
+// JSON parse size so a misbehaving local adapter cannot push an unbounded body
+// into the gateway QA worker.
+const CRABLINE_INBOUND_JSON_MAX_BYTES = 16 * 1024 * 1024;
 
 type QaCrablineTransportState = QaTransportState & {
   cleanup: () => Promise<void>;
@@ -209,7 +214,11 @@ async function postCrablineInbound(params: {
         `Crabline ${params.adapter.channel} inbound injection failed with HTTP ${response.status}.`,
       );
     }
-    const result: unknown = await response.json();
+    const result: unknown = await readProviderJsonResponse(
+      response,
+      `qa-lab-crabline-${params.adapter.channel}-inbound`,
+      { maxBytes: CRABLINE_INBOUND_JSON_MAX_BYTES },
+    );
     if (params.adapter.channel === "matrix" && isRecord(result) && isRecord(result.event)) {
       return readStringValue(result.event.event_id);
     }


### PR DESCRIPTION
## What Problem This Solves

`postCrablineInbound` in `extensions/qa-lab/src/crabline-transport.ts` called `await response.json()` without any byte limit. A misbehaving or compromised local Crabline adapter could stream an unbounded JSON body into the gateway QA worker, causing memory exhaustion or denial of service during inbound injection.

## Why This Change Was Made

The gateway already has a shared `readProviderJsonResponse` helper that reads the response body under a configurable byte cap and cancels the stream on overflow. Crabline inbound injection responses are small metadata envelopes (message IDs / status), so a 16 MiB cap is generous while still protecting the worker.

## User Impact

- QA-lab Crabline inbound injection now rejects oversized JSON responses before they are fully buffered.
- The error message names the QA adapter and the exceeded limit for clear diagnostics.
- Normal inbound responses continue to work unchanged.

## Evidence

- Replaced `await response.json()` with `readProviderJsonResponse(response, label, { maxBytes: CRABLINE_INBOUND_JSON_MAX_BYTES })` in `extensions/qa-lab/src/crabline-transport.ts`.
- Added isolated regression tests in `extensions/qa-lab/src/crabline-transport.inbound-bound.test.ts` covering:
  - normal JSON inbound responses parse successfully;
  - responses larger than 16 MiB are rejected with a clear size-limit error.
- Local test run:
  ```
  node scripts/run-vitest.mjs extensions/qa-lab/src/crabline-transport.inbound-bound.test.ts --run
  # 2 tests passed
  ```