### PR TITLE
refactor(plugins): localize private declarations

### DIFF
--- a/extensions/amazon-bedrock/aws-credential-refresh.ts
+++ b/extensions/amazon-bedrock/aws-credential-refresh.ts
@@ -11,7 +11,7 @@ function hasStaticAwsCredentialEnv(env: NodeJS.ProcessEnv): boolean {
 }
 
 /** Return whether Bedrock should refresh the AWS shared config cache before discovery. */
-export function shouldRefreshAwsSharedConfigCacheForBedrock(env: NodeJS.ProcessEnv): boolean {
+function shouldRefreshAwsSharedConfigCacheForBedrock(env: NodeJS.ProcessEnv): boolean {
   if (env.AWS_BEDROCK_SKIP_AUTH === "1" || env.AWS_BEARER_TOKEN_BEDROCK) {
     return false;
   }

--- a/extensions/amazon-bedrock/bedrock-options.ts
+++ b/extensions/amazon-bedrock/bedrock-options.ts
@@ -5,7 +5,7 @@
 import type { ModelThinkingLevel, StreamOptions, ThinkingBudgets } from "openclaw/plugin-sdk/llm";
 
 /** How Bedrock thinking output should be displayed to users. */
-export type BedrockThinkingDisplay = "summarized" | "omitted";
+type BedrockThinkingDisplay = "summarized" | "omitted";
 
 /** Extra Bedrock-specific stream options accepted by the provider runtime. */
 export interface BedrockOptions extends StreamOptions {

--- a/extensions/amazon-bedrock/thinking-policy.ts
+++ b/extensions/amazon-bedrock/thinking-policy.ts
@@ -34,7 +34,7 @@ function isOpus46BedrockModelRef(modelRef: string): boolean {
 }
 
 /** Return whether a Bedrock model ref names Claude Opus 4.7. */
-export function isOpus47BedrockModelRef(modelRef: string): boolean {
+function isOpus47BedrockModelRef(modelRef: string): boolean {
   return /(?:^|[/.:])(?:(?:us|eu|ap|apac|au|jp|global)\.)?(?:anthropic\.)?claude-opus-4[.-]7(?:$|[-.:/])/i.test(
     modelRef,
   );

--- a/extensions/anthropic/claude-model-refs.ts
+++ b/extensions/anthropic/claude-model-refs.ts
@@ -12,7 +12,7 @@ const DEFAULT_CLAUDE_MODEL_BY_FAMILY: Record<string, string> = {
 };
 
 /** Normalized Claude CLI selection plus runtime refs used by setup migrations. */
-export type ClaudeCliAnthropicModelRefs = {
+type ClaudeCliAnthropicModelRefs = {
   selectedRef: string;
   runtimeRefs: string[];
   rewriteRef?: string;

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -206,7 +206,7 @@ export function normalizeClaudeSettingSourcesArgs(args?: string[]): string[] | u
 }
 
 /** Map OpenClaw thinking levels to Claude CLI effort flags for a model id. */
-export function mapClaudeCliThinkingLevelToEffort(
+function mapClaudeCliThinkingLevelToEffort(
   thinkingLevel?: string | null,
 ): ClaudeCliEffort | undefined {
   switch (normalizeOptionalLowercaseString(thinkingLevel)) {

--- a/extensions/bonjour/src/advertiser.ts
+++ b/extensions/bonjour/src/advertiser.ts
@@ -18,12 +18,12 @@ const childProcessModule = nodeRequire("node:child_process") as {
 };
 
 /** Running Bonjour advertiser handle. */
-export type GatewayBonjourAdvertiser = {
+type GatewayBonjourAdvertiser = {
   stop: () => Promise<void>;
 };
 
 /** Input data used to publish OpenClaw gateway Bonjour records. */
-export type GatewayBonjourAdvertiseOpts = {
+type GatewayBonjourAdvertiseOpts = {
   instanceName?: string;
   gatewayPort: number;
   sshPort?: number;

--- a/extensions/device-pair/notify-state.ts
+++ b/extensions/device-pair/notify-state.ts
@@ -81,7 +81,7 @@ export function normalizeLegacyNotifyState(raw: unknown): LegacyNotifyStateFile 
   return { subscribers, notifiedRequestIds };
 }
 
-export function normalizeNotifyThreadKey(messageThreadId?: string | number): string {
+function normalizeNotifyThreadKey(messageThreadId?: string | number): string {
   if (typeof messageThreadId === "number" && Number.isFinite(messageThreadId)) {
     return String(Math.trunc(messageThreadId));
   }

--- a/extensions/device-pair/pairing-qr-channel-data.ts
+++ b/extensions/device-pair/pairing-qr-channel-data.ts
@@ -1,8 +1,8 @@
 // Private device-pair -> Gateway live-display envelope.
 // Keep this local so pairing QR metadata does not become public Plugin SDK API.
-export const DEVICE_PAIR_PAIRING_QR_CHANNEL_DATA_KEY = "openclawPairingQr";
+const DEVICE_PAIR_PAIRING_QR_CHANNEL_DATA_KEY = "openclawPairingQr";
 
-export type DevicePairPairingQrChannelData = {
+type DevicePairPairingQrChannelData = {
   setupCode: string;
   expiresAtMs: number;
 };

--- a/extensions/llama-cpp/src/embedding-provider.ts
+++ b/extensions/llama-cpp/src/embedding-provider.ts
@@ -23,11 +23,11 @@ type LlamaCppLocalOptions = {
   contextSize?: number | "auto";
 };
 
-export type LlamaCppEmbeddingProviderRuntimeOptions = {
+type LlamaCppEmbeddingProviderRuntimeOptions = {
   nodeLlamaCppImportUrl?: string;
 };
 
-export const LLAMA_CPP_EMBEDDING_PROVIDER_ID = "local";
+const LLAMA_CPP_EMBEDDING_PROVIDER_ID = "local";
 export const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL =
   "hf:ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/embeddinggemma-300m-qat-Q8_0.gguf";
 const DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_CACHE_FILE_NAME =
@@ -155,7 +155,7 @@ export function formatLlamaCppSetupError(err: unknown): string {
 
 const requireFromPlugin = createRequire(import.meta.url);
 
-export function resolveNodeLlamaCppImportUrl(): string {
+function resolveNodeLlamaCppImportUrl(): string {
   return pathToFileURL(requireFromPlugin.resolve("node-llama-cpp")).href;
 }
 


### PR DESCRIPTION
## What Problem This Solves

The dead-code report listed 13 module-internal declarations as unused public exports across Amazon Bedrock, Anthropic, Bonjour, Device Pair, and llama.cpp. Those stray exports enlarged private plugin surfaces and obscured actionable dead-code findings.

## Why This Change Was Made

Localize declarations that have no consumers outside their defining file. Plugin entrypoints, intentional API barrels, runtime behavior, and test seams remain unchanged.

## User Impact

No user-visible behavior changes. Maintainers get narrower plugin internals and a cleaner unused-export report.

## Evidence

- Full codebase-memory MCP index at the base SHA: 277,819 nodes and 1,116,809 edges; schema and search smoke passed.
- Repository `ts-unused-exports` report identified all 13 declarations before the patch and reports zero targeted findings after it.
- Blacksmith Testbox `tbx_01kwxjy6226kb9jtp2r9bse73r`: 25 focused test files and 382 tests passed across the five plugins.
- `pnpm check:changed` passed on the same Testbox, including extension production/test typechecks, lint, database-first guard, sidecar loader guard, and runtime import-cycle check.
- `oxfmt --check` and `git diff --check` passed.
- Fresh Codex autoreview found no actionable findings; confidence 0.91.
- `extensions/anthropic/cli-migration.test.ts` has three expectation failures on both this patch and pristine `HEAD`; both receive the newly current `anthropic/claude-sonnet-5` entry. The other 12 tests in that file pass.

AI-assisted: yes.
