### PR TITLE
improve(imessage): manage imsg setup and plugin skill ownership

### DIFF
--- a/docs/channels/imessage-from-bluebubbles.md
+++ b/docs/channels/imessage-from-bluebubbles.md
@@ -43,11 +43,12 @@ The shortest safe path when you already know your old BlueBubbles config:
 
    ```bash
    brew install steipete/tap/imsg
+   brew update && brew upgrade imsg
    imsg --version
    imsg chats --limit 3
    ```
 
-   If `imsg chats` fails with `unable to open database file`, empty output, or `authorization denied`, grant Full Disk Access to the terminal, editor, Node process, Gateway service, or SSH parent process that launches `imsg`, then reopen that parent process.
+   For the usual local setup, OpenClaw setup can offer a user-confirmed Homebrew install or update for `imsg` on the signed-in Messages Mac. Manual setup and SSH-wrapper topologies remain operator-managed: repeat the Homebrew update in the same local or remote user context that will run `imsg`. If `imsg chats` fails with `unable to open database file`, empty output, or `authorization denied`, grant Full Disk Access to the terminal, editor, Node process, Gateway service, or SSH parent process that launches `imsg`, then reopen that parent process.
 
 2. Verify the read, watch, send, and RPC surfaces before changing OpenClaw config:
 
@@ -61,14 +62,14 @@ The shortest safe path when you already know your old BlueBubbles config:
 
    Replace `42` with a real chat id from `imsg chats`. Sending requires Automation permission for Messages.app. If OpenClaw will run through SSH, run these commands through the same SSH wrapper or user context that OpenClaw will use. If reads work but sends fail with AppleEvents `-1743`, check whether Automation landed on `/usr/libexec/sshd-keygen-wrapper`; see [SSH wrapper sends fail with AppleEvents -1743](/channels/imessage#requirements-and-permissions-macos).
 
-3. Enable the private API bridge when you need advanced actions:
+3. Enable the private API bridge. It is strongly encouraged for OpenClaw iMessage because replies, tapbacks, effects, polls, attachment replies, and group actions depend on it:
 
    ```bash
    imsg launch
    imsg status --json
    ```
 
-   `imsg launch` requires SIP to be disabled (and on modern macOS, library validation relaxed — see [Enabling the imsg private API](/channels/imessage#enabling-the-imsg-private-api)). Basic send, history, and watch work without `imsg launch`; advanced actions do not.
+   `imsg launch` requires SIP to be disabled (and on modern macOS, library validation relaxed — see [Enabling the imsg private API](/channels/imessage#enabling-the-imsg-private-api)). Basic send, history, and watch work without `imsg launch`; the full OpenClaw iMessage action surface does not.
 
 4. After you enable `channels.imessage` and start the Gateway, verify the bridge through OpenClaw:
 

--- a/docs/channels/imessage.md
+++ b/docs/channels/imessage.md
@@ -7,7 +7,7 @@ title: "iMessage"
 ---
 
 <Note>
-For OpenClaw iMessage deployments, use `imsg` on a signed-in macOS Messages host. If your Gateway runs on Linux or Windows, point `channels.imessage.cliPath` at an SSH wrapper that runs `imsg` on the Mac.
+For the usual OpenClaw iMessage deployment, run the Gateway and `imsg` on the same signed-in macOS Messages host. If your Gateway runs elsewhere, point `channels.imessage.cliPath` at a transparent SSH wrapper that runs `imsg` on the Mac.
 
 **Inbound recovery is automatic.** After a bridge or gateway restart, iMessage replays the messages missed while it was down and suppresses the stale "backlog bomb" Apple can flush after a Push recovery, deduping so nothing is dispatched twice. There is no config to enable — see [Inbound recovery after a bridge or gateway restart](#inbound-recovery-after-a-bridge-or-gateway-restart).
 </Note>
@@ -16,7 +16,9 @@ For OpenClaw iMessage deployments, use `imsg` on a signed-in macOS Messages host
 BlueBubbles support was removed. Migrate `channels.bluebubbles` configs to `channels.imessage`; OpenClaw supports iMessage through `imsg` only. Start with [BlueBubbles removal and the imsg iMessage path](/announcements/bluebubbles-imessage) for the short announcement, or [Coming from BlueBubbles](/channels/imessage-from-bluebubbles) for the full migration table.
 </Warning>
 
-Status: native external CLI integration. The Gateway spawns `imsg rpc` and speaks JSON-RPC over stdio — no separate daemon or port. Advanced actions require `imsg launch` and a successful private API probe.
+Status: native external CLI integration. The Gateway spawns `imsg rpc` and speaks JSON-RPC over stdio — no separate daemon or port. Private API mode is strongly encouraged for a complete iMessage channel; replies, tapbacks, effects, polls, attachment replies, and group actions require `imsg launch` and a successful private API probe.
+
+For the common local setup, OpenClaw setup can offer a user-confirmed Homebrew install or update for `imsg` on the signed-in Messages Mac. Manual setup and SSH-wrapper topologies remain operator-managed: install or update `imsg` in the same user context that will run the Gateway or wrapper.
 
 <CardGroup cols={3}>
   <Card title="Private API actions" icon="wand-sparkles" href="#private-api-actions">
@@ -42,10 +44,13 @@ Status: native external CLI integration. The Gateway spawns `imsg rpc` and speak
 
 ```bash
 brew install steipete/tap/imsg
+brew update && brew upgrade imsg
 imsg rpc --help
 imsg launch
 openclaw channels status --probe
 ```
+
+        When the local setup wizard detects a missing default `imsg` command, it can prompt to install `steipete/tap/imsg` through Homebrew. If it detects a Homebrew-managed `imsg`, it can prompt to reinstall or update it. Custom `cliPath` wrappers are not modified.
 
       </Step>
 
@@ -87,11 +92,16 @@ openclaw pairing approve imessage <CODE>
   </Tab>
 
   <Tab title="Remote Mac over SSH">
-    OpenClaw only requires a stdio-compatible `cliPath`, so you can point `cliPath` at a wrapper script that SSHes to a remote Mac and runs `imsg`.
+    Most setups do not need SSH. Use this topology only when the Gateway cannot run on the signed-in Messages Mac. OpenClaw only requires a stdio-compatible `cliPath`, so you can point `cliPath` at a wrapper script that SSHes to a remote Mac and runs `imsg`.
+    Install and update `imsg` on that remote Mac, not on the Gateway host:
+
+```bash
+ssh messages-mac 'brew install steipete/tap/imsg && brew update && brew upgrade imsg'
+```
 
 ```bash
 #!/usr/bin/env bash
-exec ssh -T gateway-host imsg "$@"
+exec ssh -T messages-mac imsg "$@"
 ```
 
     Recommended config when attachments are enabled:
@@ -176,12 +186,12 @@ Use one of the supported `imsg` process contexts instead:
 
 ## Enabling the imsg private API
 
-`imsg` ships in two operational modes:
+`imsg` ships in two operational modes. For OpenClaw, Private API mode is the recommended setup because it gives the channel the native iMessage actions users expect. Basic mode remains useful for low-risk installs, initial verification, or hosts where SIP cannot be disabled.
 
 - **Basic mode** (default, no SIP changes needed): outbound text and media via `send`, inbound watch/history, chat list. This is what you get out of the box from a fresh `brew install steipete/tap/imsg` plus the standard macOS permissions above.
 - **Private API mode**: `imsg` injects a helper dylib into `Messages.app` to call internal `IMCore` functions. This unlocks `react`, `edit`, `unsend`, `reply` (threaded), `sendWithEffect`, `poll` and `poll-vote` (native Messages polls), `renameGroup`, `setGroupIcon`, `addParticipant`, `removeParticipant`, `leaveGroup`, plus typing indicators and read receipts.
 
-The advanced action surface on this page requires Private API mode. The `imsg` README is explicit about the requirement:
+The recommended action surface on this page requires Private API mode. The `imsg` README is explicit about the requirement:
 
 > Advanced features such as `read`, `typing`, `launch`, bridge-backed rich send, message mutation, and chat management are opt-in. They require SIP to be disabled and a helper dylib to be injected into `Messages.app`. `imsg launch` refuses to inject when SIP is enabled.
 
@@ -190,7 +200,7 @@ The helper-injection technique uses `imsg`'s own dylib to reach Messages private
 <Warning>
 **Disabling SIP is a real security tradeoff.** SIP is one of macOS's core protections against running modified system code; turning it off system-wide opens up additional attack surface and side effects. Notably, **disabling SIP on Apple Silicon Macs also disables the ability to install and run iOS apps on your Mac**.
 
-Treat this as a deliberate operational choice, not a default. If your threat model cannot tolerate SIP being off, bundled iMessage is limited to basic mode — text and media send/receive only, no reactions / edit / unsend / effects / group ops.
+Treat this as a deliberate operational choice, especially on a primary personal Mac. For production-quality OpenClaw iMessage, prefer a dedicated Mac or bot macOS user where you are comfortable enabling the bridge. If your threat model cannot tolerate SIP being off anywhere, bundled iMessage is limited to basic mode — text and media send/receive only, no reactions / edit / unsend / effects / group ops.
 </Warning>
 
 ### Setup
@@ -199,6 +209,7 @@ Treat this as a deliberate operational choice, not a default. If your threat mod
 
    ```bash
    brew install steipete/tap/imsg
+   brew update && brew upgrade imsg
    imsg --version
    imsg status --json
    ```

--- a/extensions/imessage/openclaw.plugin.json
+++ b/extensions/imessage/openclaw.plugin.json
@@ -4,6 +4,7 @@
   "activation": {
     "onStartup": false
   },
+  "skills": ["./skills"],
   "channels": ["imessage"],
   "configSchema": {
     "type": "object",

--- a/extensions/imessage/skills/imsg/SKILL.md
+++ b/extensions/imessage/skills/imsg/SKILL.md
@@ -42,6 +42,7 @@ Never infer a recipient from a casual name alone when several chats or handles c
 ## Host Requirements
 
 - macOS 14+ with Messages.app signed in for send/react/bridge actions.
+- Private API mode is strongly encouraged for OpenClaw iMessage. It unlocks replies, precise tapbacks, effects, polls, attachment replies, read/typing actions, and group management. Basic mode is a fallback for reads plus plain text/file send.
 - Full Disk Access for the process context that runs `imsg` or OpenClaw; reads fail without Messages DB access.
 - Automation permission for Messages.app when using public `send`.
 - Accessibility permission for the process context that runs public `imsg react`; it uses System Events UI automation. Bridge `tapback` uses private API instead.
@@ -73,13 +74,13 @@ Do not make `jq` a hard prerequisite for the skill; it is only a convenient form
 
 ## Capability Choice
 
-Use public Messages automation when enough:
+Use standard commands for reads, target resolution, and plain sends:
 
 - Read/list/search/watch: `chats`, `group`, `history`, `search`, `watch`
 - Basic text/file send: `send`
 - Standard tapback to most recent incoming message in a chat: `react`
 
-Use the private API bridge only for features public automation cannot do:
+Use the private API bridge for the native iMessage actions OpenClaw users normally expect:
 
 - Rich replies, text formatting, effects, subjects, multipart sends
 - Native Apple Messages polls and poll votes
@@ -89,7 +90,7 @@ Use the private API bridge only for features public automation cannot do:
 - Group create/name/photo/member/leave/delete/mark actions
 - Account, whois, nickname checks
 
-Before bridge actions, check:
+For OpenClaw channel setup, check bridge availability early:
 
 ```bash
 imsg status --json
@@ -102,7 +103,7 @@ imsg launch
 imsg status --json
 ```
 
-If SIP, library validation, private entitlement checks, or missing selectors still block the capability, do not ask the user to disable SIP casually. Explain that the requested private-API action is unavailable on this host and offer the closest non-bridge action, if one exists.
+If SIP, library validation, private entitlement checks, or missing selectors still block the capability, explain that the requested private-API action is unavailable on this host and offer the closest non-bridge action, if one exists. Do not silently downgrade a threaded reply, effect, subject, poll, or GUID-targeted tapback into a plain send/react.
 
 ## DM Scenarios
 
@@ -205,11 +206,11 @@ Use `send-rich --reply-to <message-guid>` for threaded replies. Confirm the refe
 
 Native Apple Messages polls require the bridge. Creation needs at least two `--option` values. Voting requires one of `--option-id`, `--option-index`, or `--option`.
 
-Messages renders only the options on a poll balloon; the `--question` title is not shown to recipients. Set `--question` (required) plus at least two `--option` values.
+Messages renders only the options on a poll balloon, so current `imsg poll send` echoes `--question` as a best-effort plain caption after the poll. Use `--comment` to override that caption. Do not retry automatically when only the caption fails: the poll may already be delivered.
 
 ```bash
 imsg poll send --chat 'iMessage;-;+15551234567' \
-  --question "Dinner?" --option "Pizza" --option "Sushi"
+  --question "Dinner?" --option "Pizza" --option "Sushi" --comment "Vote by 5pm"
 imsg poll send --chat 'iMessage;+;chat0000' --reply-to <message-guid> \
   --question "Approve?" --option "Yes" --option "No"
 imsg poll vote --chat 'iMessage;+;chat0000' \
@@ -222,7 +223,7 @@ Find poll IDs and options with:
 imsg history --chat-id 42 --limit 20 --json | jq -s '.[] | select(.poll != null) | {guid, poll}'
 ```
 
-Poll vote rows are `poll` events, not tapbacks; `watch --reactions` is not required to see them.
+`history` and `watch` backfill a title-less inbound native poll's `poll.question` from its clean caption row. Poll vote rows are `poll` events, not tapbacks; `watch --reactions` is not required to see them.
 
 ## Watch and Long-Running Agents
 
@@ -246,4 +247,4 @@ For a daemon or multi-chat integration, use `imsg rpc`. It speaks JSON-RPC 2.0 o
 - Never send to unknown numbers or ambiguous contact-name matches without approval.
 - Confirm attachments exist and are the intended files.
 - Prefer E.164 phone numbers; use `--region US` or another region only when needed for local formats.
-- Do not use bridge actions just because they are available; use them only when the requested behavior needs them.
+- Use bridge actions for bridge-only semantics, but confirm visible state changes and destructive actions first.

--- a/extensions/imessage/src/install-imsg.test.ts
+++ b/extensions/imessage/src/install-imsg.test.ts
@@ -1,0 +1,118 @@
+// iMessage tests cover imsg CLI install behavior.
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { resolveBrewExecutableMock, runPluginCommandWithTimeoutMock } = vi.hoisted(() => ({
+  resolveBrewExecutableMock: vi.fn(),
+  runPluginCommandWithTimeoutMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/setup-tools", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/setup-tools")>();
+  return {
+    ...actual,
+    resolveBrewExecutable: resolveBrewExecutableMock,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/run-command", () => ({
+  runPluginCommandWithTimeout: runPluginCommandWithTimeoutMock,
+}));
+
+const { installIMessageCli } = await import("./install-imsg.js");
+
+describe("installIMessageCli", () => {
+  const originalPlatform = process.platform;
+
+  function setProcessPlatform(platform: NodeJS.Platform) {
+    Object.defineProperty(process, "platform", { configurable: true, value: platform });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+    vi.clearAllMocks();
+  });
+
+  it("installs imsg through Homebrew on macOS", async () => {
+    setProcessPlatform("darwin");
+    await withTempDir("openclaw-imsg-brew-", async (brewPrefix) => {
+      await fs.mkdir(path.join(brewPrefix, "bin"), { recursive: true });
+      await fs.writeFile(path.join(brewPrefix, "bin", "imsg"), "");
+      resolveBrewExecutableMock.mockReturnValue("/opt/homebrew/bin/brew");
+      runPluginCommandWithTimeoutMock
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: `${brewPrefix}\n`, stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: "0.13.0\n", stderr: "" });
+
+      const result = await installIMessageCli({ log: vi.fn() } as unknown as RuntimeEnv);
+
+      expect(result).toEqual({
+        ok: true,
+        cliPath: path.join(brewPrefix, "bin", "imsg"),
+        version: "0.13.0",
+      });
+      expect(runPluginCommandWithTimeoutMock).toHaveBeenNthCalledWith(1, {
+        argv: ["/opt/homebrew/bin/brew", "install", "steipete/tap/imsg"],
+        timeoutMs: 15 * 60_000,
+      });
+    });
+  });
+
+  it("updates imsg through Homebrew when requested", async () => {
+    setProcessPlatform("darwin");
+    await withTempDir("openclaw-imsg-brew-", async (brewPrefix) => {
+      await fs.mkdir(path.join(brewPrefix, "bin"), { recursive: true });
+      await fs.writeFile(path.join(brewPrefix, "bin", "imsg"), "");
+      resolveBrewExecutableMock.mockReturnValue("/opt/homebrew/bin/brew");
+      runPluginCommandWithTimeoutMock
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: `${brewPrefix}\n`, stderr: "" })
+        .mockResolvedValueOnce({ code: 0, stdout: "0.13.1\n", stderr: "" });
+
+      const result = await installIMessageCli({ log: vi.fn() } as unknown as RuntimeEnv, {
+        upgrade: true,
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        cliPath: path.join(brewPrefix, "bin", "imsg"),
+        version: "0.13.1",
+      });
+      expect(runPluginCommandWithTimeoutMock).toHaveBeenNthCalledWith(1, {
+        argv: ["/opt/homebrew/bin/brew", "update"],
+        timeoutMs: 5 * 60_000,
+      });
+      expect(runPluginCommandWithTimeoutMock).toHaveBeenNthCalledWith(2, {
+        argv: ["/opt/homebrew/bin/brew", "upgrade", "imsg"],
+        timeoutMs: 15 * 60_000,
+      });
+    });
+  });
+
+  it("explains that Homebrew is required when brew is missing", async () => {
+    setProcessPlatform("darwin");
+    resolveBrewExecutableMock.mockReturnValue(null);
+
+    const result = await installIMessageCli({ log: vi.fn() } as unknown as RuntimeEnv);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Homebrew is required for imsg setup");
+    expect(runPluginCommandWithTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-install imsg on non-macOS hosts", async () => {
+    setProcessPlatform("linux");
+
+    const result = await installIMessageCli({ log: vi.fn() } as unknown as RuntimeEnv);
+
+    expect(result).toEqual({
+      ok: false,
+      error: "imsg auto-install is supported only on macOS.",
+    });
+    expect(resolveBrewExecutableMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/imessage/src/install-imsg.ts
+++ b/extensions/imessage/src/install-imsg.ts
@@ -1,0 +1,98 @@
+// iMessage plugin module implements imsg CLI install behavior.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { runPluginCommandWithTimeout } from "openclaw/plugin-sdk/run-command";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { resolveBrewExecutable } from "openclaw/plugin-sdk/setup-tools";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { IMESSAGE_INSTALL_COMMAND } from "./setup-core.js";
+
+export type IMessageInstallResult = {
+  ok: boolean;
+  cliPath?: string;
+  version?: string;
+  error?: string;
+};
+
+async function resolveBrewIMessageCliPath(brewExe: string): Promise<string | null> {
+  try {
+    const result = await runPluginCommandWithTimeout({
+      argv: [brewExe, "--prefix", "imsg"],
+      timeoutMs: 10_000,
+    });
+    if (result.code !== 0 || !result.stdout.trim()) {
+      return null;
+    }
+    const candidate = path.join(result.stdout.trim(), "bin", "imsg");
+    await fs.access(candidate);
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+export async function installIMessageCli(
+  runtime: RuntimeEnv,
+  opts?: { upgrade?: boolean },
+): Promise<IMessageInstallResult> {
+  if (process.platform !== "darwin") {
+    return {
+      ok: false,
+      error: "imsg auto-install is supported only on macOS.",
+    };
+  }
+
+  const brewExe = resolveBrewExecutable();
+  if (!brewExe) {
+    return {
+      ok: false,
+      error: `Homebrew is required for imsg setup. Install Homebrew (https://brew.sh), then run: ${IMESSAGE_INSTALL_COMMAND}`,
+    };
+  }
+
+  runtime.log(`${opts?.upgrade ? "Updating" : "Installing"} imsg via Homebrew (${brewExe})...`);
+  if (opts?.upgrade) {
+    const update = await runPluginCommandWithTimeout({
+      argv: [brewExe, "update"],
+      timeoutMs: 5 * 60_000,
+    });
+    if (update.code !== 0) {
+      return {
+        ok: false,
+        error: `brew update failed (exit ${update.code}): ${truncateUtf16Safe(update.stderr.trim(), 200)}`,
+      };
+    }
+  }
+  const command = opts?.upgrade ? ["upgrade", "imsg"] : ["install", "steipete/tap/imsg"];
+  const result = await runPluginCommandWithTimeout({
+    argv: [brewExe, ...command],
+    timeoutMs: 15 * 60_000,
+  });
+  if (result.code !== 0) {
+    return {
+      ok: false,
+      error: `brew ${command.join(" ")} failed (exit ${result.code}): ${truncateUtf16Safe(result.stderr.trim(), 200)}`,
+    };
+  }
+
+  const cliPath = await resolveBrewIMessageCliPath(brewExe);
+  if (!cliPath) {
+    return {
+      ok: false,
+      error: "brew install succeeded but imsg binary was not found.",
+    };
+  }
+
+  let version: string | undefined;
+  try {
+    const versionResult = await runPluginCommandWithTimeout({
+      argv: [cliPath, "--version"],
+      timeoutMs: 10_000,
+    });
+    version = versionResult.stdout.trim() || undefined;
+  } catch {
+    // Version output is helpful but not required for setup.
+  }
+
+  return { ok: true, cliPath, version };
+}

--- a/extensions/imessage/src/probe.ts
+++ b/extensions/imessage/src/probe.ts
@@ -22,6 +22,11 @@ import {
   setCachedIMessagePrivateApiStatus,
   type IMessagePrivateApiStatus,
 } from "./private-api-status.js";
+import {
+  IMESSAGE_INSTALL_COMMAND,
+  IMESSAGE_UPDATE_COMMAND,
+  isAutoManagedIMessageCliPath,
+} from "./setup-core.js";
 
 // Re-export for backwards compatibility
 export { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
@@ -123,7 +128,7 @@ async function probeRpcSupport(cliPath: string, timeoutMs: number): Promise<RpcS
       const fatal = {
         supported: false,
         fatal: true,
-        error: 'imsg CLI does not support the "rpc" subcommand (update imsg)',
+        error: `imsg CLI does not support the "rpc" subcommand. Update imsg on the Messages Mac: ${IMESSAGE_UPDATE_COMMAND}`,
       };
       setCachedRpcSupport(cliPath, fatal);
       return fatal;
@@ -292,7 +297,8 @@ export async function probeIMessage(
   opts: IMessageProbeOptions = {},
 ): Promise<IMessageProbe> {
   const cfg = opts.cliPath || opts.dbPath ? undefined : getRuntimeConfig();
-  const cliPath = opts.cliPath?.trim() || cfg?.channels?.imessage?.cliPath?.trim() || "imsg";
+  const explicitCliPath = opts.cliPath?.trim() || cfg?.channels?.imessage?.cliPath?.trim();
+  const cliPath = explicitCliPath || "imsg";
   const dbPath = opts.dbPath?.trim() || cfg?.channels?.imessage?.dbPath?.trim();
   // Use explicit timeout if provided, otherwise fall back to config, then default
   const effectiveTimeout =
@@ -305,7 +311,15 @@ export async function probeIMessage(
 
   const detected = await detectBinary(cliPath);
   if (!detected) {
-    return { ok: false, error: `imsg not found (${cliPath})` };
+    const error = isAutoManagedIMessageCliPath(cliPath, {
+      explicit: explicitCliPath !== undefined,
+    })
+      ? `imsg not found (${cliPath}). Install imsg on the Messages Mac: ${IMESSAGE_INSTALL_COMMAND}`
+      : `imsg command not found (${cliPath}). Check the configured iMessage cliPath or wrapper.`;
+    return {
+      ok: false,
+      error,
+    };
   }
 
   const rpcSupport = await probeRpcSupport(cliPath, effectiveTimeout);

--- a/extensions/imessage/src/setup-core.ts
+++ b/extensions/imessage/src/setup-core.ts
@@ -28,6 +28,28 @@ const t = createSetupTranslator();
 
 const channel = "imessage" as const;
 
+export const IMESSAGE_INSTALL_COMMAND = "brew install steipete/tap/imsg";
+export const IMESSAGE_UPDATE_COMMAND = "brew update && brew upgrade imsg";
+
+const HOMEBREW_IMSG_PATHS = new Set([
+  "/opt/homebrew/bin/imsg",
+  "/opt/homebrew/opt/imsg/bin/imsg",
+  "/usr/local/bin/imsg",
+  "/usr/local/opt/imsg/bin/imsg",
+]);
+
+export function normalizeIMessageCliPathForSetup(cliPath: string | undefined): string {
+  return cliPath?.trim() || "imsg";
+}
+
+export function isAutoManagedIMessageCliPath(
+  cliPath: string | undefined,
+  opts?: { explicit?: boolean },
+): boolean {
+  const normalized = normalizeIMessageCliPathForSetup(cliPath);
+  return (!opts?.explicit && normalized === "imsg") || HOMEBREW_IMSG_PATHS.has(normalized);
+}
+
 const CHAT_TARGET_ALLOWFROM_PREFIXES = [
   "chat_id:",
   "chatid:",
@@ -176,16 +198,23 @@ export function createIMessageCliPathTextInput(
     resolvePath: ({ cfg, accountId }) => resolveIMessageCliPath({ cfg, accountId }),
     shouldPrompt,
     helpTitle: "iMessage",
-    helpLines: ["imsg CLI path required to enable iMessage."],
+    helpLines: [
+      "imsg CLI path required to enable iMessage.",
+      `Install imsg on the Messages Mac: ${IMESSAGE_INSTALL_COMMAND}`,
+      `Update imsg when channel probes report missing RPC or private API capabilities: ${IMESSAGE_UPDATE_COMMAND}`,
+    ],
   });
 }
 
 export const imessageCompletionNote = {
   title: "iMessage next steps",
   lines: [
-    "Run OpenClaw on the Mac signed into Messages, or set cliPath to an SSH wrapper that runs imsg on that Mac.",
-    "Linux/Windows hosts cannot run the default local imsg path directly.",
-    "Run `imsg launch`, then `openclaw channels status --probe` to verify private API actions.",
+    "For the usual setup, run OpenClaw on the Mac signed into Messages.",
+    "If the Gateway runs elsewhere, set cliPath to a transparent SSH wrapper that runs imsg on the Messages Mac.",
+    `Install imsg on the Messages Mac: ${IMESSAGE_INSTALL_COMMAND}`,
+    `Update imsg after imsg fixes or missing-capability errors: ${IMESSAGE_UPDATE_COMMAND}`,
+    "Private API mode is strongly encouraged for replies, tapbacks, effects, polls, attachments, and group actions.",
+    "After Private API setup, run `imsg launch`, then `openclaw channels status --probe`.",
     "Ensure OpenClaw has Full Disk Access to Messages DB.",
     "Grant Automation permission for Messages when prompted.",
     "List chats with: imsg chats --limit 20",
@@ -221,6 +250,7 @@ export function createIMessageSetupWizardProxy(loadWizard: () => Promise<Channel
       configuredScore: imessageSetupStatusBase.configuredScore,
       unconfiguredScore: imessageSetupStatusBase.unconfiguredScore,
     },
+    delegatePrepare: true,
     credentials: [],
     textInputs: [
       createIMessageCliPathTextInput(

--- a/extensions/imessage/src/setup-surface.ts
+++ b/extensions/imessage/src/setup-surface.ts
@@ -6,32 +6,102 @@ import {
 } from "openclaw/plugin-sdk/setup";
 import { detectBinary } from "openclaw/plugin-sdk/setup-tools";
 import { resolveIMessageAccount } from "./accounts.js";
+import { installIMessageCli } from "./install-imsg.js";
 import {
   createIMessageCliPathTextInput,
+  IMESSAGE_INSTALL_COMMAND,
+  isAutoManagedIMessageCliPath,
   imessageCompletionNote,
   imessageDmPolicy,
   imessageSetupStatusBase,
+  normalizeIMessageCliPathForSetup,
   parseIMessageAllowFromEntries,
 } from "./setup-core.js";
 
 const channel = "imessage" as const;
 
+const imessageDetectedBinaryStatus = createDetectedBinaryStatus({
+  channelLabel: "iMessage",
+  binaryLabel: "imsg",
+  configuredLabel: imessageSetupStatusBase.configuredLabel,
+  unconfiguredLabel: imessageSetupStatusBase.unconfiguredLabel,
+  configuredHint: imessageSetupStatusBase.configuredHint,
+  unconfiguredHint: imessageSetupStatusBase.unconfiguredHint,
+  configuredScore: imessageSetupStatusBase.configuredScore,
+  unconfiguredScore: imessageSetupStatusBase.unconfiguredScore,
+  resolveConfigured: imessageSetupStatusBase.resolveConfigured,
+  resolveBinaryPath: ({ cfg, accountId }) =>
+    resolveIMessageAccount({ cfg, accountId }).config.cliPath ?? "imsg",
+  detectBinary,
+});
+
 export const imessageSetupWizard: ChannelSetupWizard = {
   channel,
-  status: createDetectedBinaryStatus({
-    channelLabel: "iMessage",
-    binaryLabel: "imsg",
-    configuredLabel: imessageSetupStatusBase.configuredLabel,
-    unconfiguredLabel: imessageSetupStatusBase.unconfiguredLabel,
-    configuredHint: imessageSetupStatusBase.configuredHint,
-    unconfiguredHint: imessageSetupStatusBase.unconfiguredHint,
-    configuredScore: imessageSetupStatusBase.configuredScore,
-    unconfiguredScore: imessageSetupStatusBase.unconfiguredScore,
-    resolveConfigured: imessageSetupStatusBase.resolveConfigured,
-    resolveBinaryPath: ({ cfg, accountId }) =>
-      resolveIMessageAccount({ cfg, accountId }).config.cliPath ?? "imsg",
-    detectBinary,
-  }),
+  status: {
+    ...imessageDetectedBinaryStatus,
+    async resolveStatusLines(params) {
+      const lines = (await imessageDetectedBinaryStatus.resolveStatusLines?.(params)) ?? [];
+      const configuredCliPath = resolveIMessageAccount({
+        cfg: params.cfg,
+        accountId: params.accountId,
+      }).config.cliPath;
+      const cliPath = configuredCliPath ?? "imsg";
+      if (await detectBinary(cliPath)) {
+        return lines;
+      }
+      const hint = isAutoManagedIMessageCliPath(cliPath, {
+        explicit: configuredCliPath !== undefined,
+      })
+        ? `Install imsg on the Messages Mac: ${IMESSAGE_INSTALL_COMMAND}`
+        : `imsg command not found (${cliPath}). Check the configured cliPath or wrapper.`;
+      return [...lines, hint];
+    },
+  },
+  prepare: async ({ cfg, accountId, credentialValues, runtime, prompter, options }) => {
+    if (!options?.allowIMessageInstall || process.platform !== "darwin") {
+      return undefined;
+    }
+    const credentialCliPath =
+      typeof credentialValues.cliPath === "string" ? credentialValues.cliPath : undefined;
+    const configuredCliPath = resolveIMessageAccount({ cfg, accountId }).config.cliPath;
+    const explicitCliPath = credentialCliPath ?? configuredCliPath;
+    const currentCliPath = explicitCliPath ?? "imsg";
+    const normalizedCliPath = normalizeIMessageCliPathForSetup(currentCliPath);
+    if (
+      !isAutoManagedIMessageCliPath(normalizedCliPath, {
+        explicit: explicitCliPath !== undefined,
+      })
+    ) {
+      return undefined;
+    }
+    const cliDetected = await detectBinary(normalizedCliPath);
+    const wantsInstall = await prompter.confirm({
+      message: cliDetected
+        ? "imsg detected. Reinstall/update now?"
+        : "imsg not found. Install now?",
+      initialValue: !cliDetected,
+    });
+    if (!wantsInstall) {
+      return undefined;
+    }
+    try {
+      const result = await installIMessageCli(runtime, { upgrade: cliDetected });
+      if (result.ok && result.cliPath) {
+        await prompter.note(`Installed imsg at ${result.cliPath}`, "iMessage");
+        return {
+          credentialValues: {
+            cliPath: result.cliPath,
+          },
+        };
+      }
+      if (!result.ok) {
+        await prompter.note(result.error ?? "imsg install failed.", "iMessage");
+      }
+    } catch (error) {
+      await prompter.note(`imsg install failed: ${String(error)}`, "iMessage");
+    }
+    return undefined;
+  },
   credentials: [],
   textInputs: [
     createIMessageCliPathTextInput(async ({ currentValue }) => {

--- a/extensions/imessage/src/status.test.ts
+++ b/extensions/imessage/src/status.test.ts
@@ -1,7 +1,11 @@
 // Imessage tests cover status plugin behavior.
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
-import { createPluginSetupWizardStatus } from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  createPluginSetupWizardStatus,
+  createTestWizardPrompter,
+  runSetupWizardPrepare,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import * as processRuntime from "openclaw/plugin-sdk/process-runtime";
 import * as setupRuntime from "openclaw/plugin-sdk/setup";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +13,7 @@ import { resolveIMessageAccount } from "./accounts.js";
 import * as channelRuntimeModule from "./channel.runtime.js";
 import * as clientModule from "./client.js";
 import { clearIMessagePrivateApiCache, probeIMessage, probeIMessagePrivateApi } from "./probe.js";
+import { createIMessageSetupWizardProxy } from "./setup-core.js";
 import { imessageSetupWizard } from "./setup-surface.js";
 import { probeIMessageStatusAccount } from "./status-core.js";
 
@@ -25,10 +30,15 @@ const setupToolsMocks = vi.hoisted(() => ({
   detectBinary: vi.fn(async () => false),
   formatDocsLink: vi.fn((path: string) => path),
 }));
+const installIMessageCliMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/setup-tools", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/setup-tools")>()),
   ...setupToolsMocks,
+}));
+
+vi.mock("./install-imsg.js", () => ({
+  installIMessageCli: installIMessageCliMock,
 }));
 
 function createMockChildProcess() {
@@ -49,6 +59,16 @@ function createMockChildProcess() {
     return true;
   };
   return child;
+}
+
+async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const originalPlatform = process.platform;
+  Object.defineProperty(process, "platform", { configurable: true, value: platform });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+  }
 }
 
 vi.mock("node:child_process", async () => {
@@ -193,6 +213,7 @@ describe("createIMessageRpcClient", () => {
 describe("imessage setup status", () => {
   beforeEach(() => {
     setupToolsMocks.detectBinary.mockClear();
+    installIMessageCliMock.mockReset();
   });
 
   it("does not inherit configured state from a sibling account", async () => {
@@ -280,6 +301,217 @@ describe("imessage setup status", () => {
 
     expect(status.statusLines).toContain("imsg: missing (/tmp/work-imsg)");
   });
+
+  it("setup status explains how to install imsg when the binary is missing", async () => {
+    const status = await getIMessageSetupStatus({
+      cfg: {
+        channels: {
+          imessage: {},
+        },
+      } as never,
+      accountOverrides: {},
+    });
+
+    expect(status.statusLines).toContain(
+      "Install imsg on the Messages Mac: brew install steipete/tap/imsg",
+    );
+  });
+
+  it("prepare offers to install imsg and returns the installed cliPath", async () => {
+    setupToolsMocks.detectBinary.mockResolvedValueOnce(false);
+    installIMessageCliMock.mockResolvedValueOnce({
+      ok: true,
+      cliPath: "/opt/homebrew/bin/imsg",
+      version: "0.13.0",
+    });
+    const confirm = vi.fn(async () => true);
+    const note = vi.fn(async () => {});
+
+    const result = await withPlatform("darwin", () =>
+      runSetupWizardPrepare({
+        prepare: imessageSetupWizard.prepare,
+        cfg: { channels: { imessage: {} } },
+        options: { allowIMessageInstall: true },
+        prompter: createTestWizardPrompter({ confirm, note }),
+      }),
+    );
+
+    expect(confirm).toHaveBeenCalledWith({
+      message: "imsg not found. Install now?",
+      initialValue: true,
+    });
+    expect(installIMessageCliMock).toHaveBeenCalledWith(expect.anything(), { upgrade: false });
+    expect(note).toHaveBeenCalledWith("Installed imsg at /opt/homebrew/bin/imsg", "iMessage");
+    expect(result).toEqual({
+      credentialValues: {
+        cliPath: "/opt/homebrew/bin/imsg",
+      },
+    });
+  });
+
+  it("setup status preserves an explicit PATH-based imsg wrapper", async () => {
+    const status = await getIMessageSetupStatus({
+      cfg: {
+        channels: {
+          imessage: {
+            cliPath: "imsg",
+          },
+        },
+      } as never,
+      accountOverrides: {},
+    });
+
+    expect(status.statusLines).toContain(
+      "imsg command not found (imsg). Check the configured cliPath or wrapper.",
+    );
+  });
+
+  it("prepare offers to update Homebrew-managed imsg paths", async () => {
+    setupToolsMocks.detectBinary.mockResolvedValueOnce(true);
+    installIMessageCliMock.mockResolvedValueOnce({
+      ok: true,
+      cliPath: "/opt/homebrew/bin/imsg",
+      version: "0.13.1",
+    });
+    const confirm = vi.fn(async () => true);
+    const note = vi.fn(async () => {});
+
+    const result = await withPlatform("darwin", () =>
+      runSetupWizardPrepare({
+        prepare: imessageSetupWizard.prepare,
+        cfg: {
+          channels: {
+            imessage: {
+              cliPath: "/opt/homebrew/bin/imsg",
+            },
+          },
+        } as never,
+        options: { allowIMessageInstall: true },
+        prompter: createTestWizardPrompter({ confirm, note }),
+      }),
+    );
+
+    expect(confirm).toHaveBeenCalledWith({
+      message: "imsg detected. Reinstall/update now?",
+      initialValue: false,
+    });
+    expect(installIMessageCliMock).toHaveBeenCalledWith(expect.anything(), { upgrade: true });
+    expect(result).toEqual({
+      credentialValues: {
+        cliPath: "/opt/homebrew/bin/imsg",
+      },
+    });
+  });
+
+  it("setup wizard proxy delegates imsg install preparation", async () => {
+    setupToolsMocks.detectBinary.mockResolvedValueOnce(false);
+    installIMessageCliMock.mockResolvedValueOnce({
+      ok: true,
+      cliPath: "/opt/homebrew/bin/imsg",
+      version: "0.13.0",
+    });
+    const proxy = createIMessageSetupWizardProxy(async () => imessageSetupWizard);
+    const confirm = vi.fn(async () => true);
+
+    const result = await withPlatform("darwin", () =>
+      runSetupWizardPrepare({
+        prepare: proxy.prepare,
+        cfg: { channels: { imessage: {} } },
+        options: { allowIMessageInstall: true },
+        prompter: createTestWizardPrompter({ confirm }),
+      }),
+    );
+
+    expect(confirm).toHaveBeenCalledWith({
+      message: "imsg not found. Install now?",
+      initialValue: true,
+    });
+    expect(result).toEqual({
+      credentialValues: {
+        cliPath: "/opt/homebrew/bin/imsg",
+      },
+    });
+  });
+
+  it("prepare preserves custom imsg cliPath values", async () => {
+    const confirm = vi.fn(async () => true);
+
+    const result = await withPlatform("darwin", () =>
+      runSetupWizardPrepare({
+        prepare: imessageSetupWizard.prepare,
+        cfg: {
+          channels: {
+            imessage: {
+              cliPath: "ssh imessage-host imsg",
+            },
+          },
+        } as never,
+        options: { allowIMessageInstall: true },
+        prompter: createTestWizardPrompter({ confirm }),
+      }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(setupToolsMocks.detectBinary).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+    expect(installIMessageCliMock).not.toHaveBeenCalled();
+  });
+
+  it("prepare preserves explicit PATH-based imsg wrappers", async () => {
+    const confirm = vi.fn(async () => true);
+
+    const result = await withPlatform("darwin", () =>
+      runSetupWizardPrepare({
+        prepare: imessageSetupWizard.prepare,
+        cfg: {
+          channels: {
+            imessage: {
+              cliPath: "imsg",
+            },
+          },
+        } as never,
+        options: { allowIMessageInstall: true },
+        prompter: createTestWizardPrompter({ confirm }),
+      }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(setupToolsMocks.detectBinary).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+    expect(installIMessageCliMock).not.toHaveBeenCalled();
+  });
+
+  it("prepare skips automatic imsg install on non-macOS hosts", async () => {
+    const confirm = vi.fn(async () => true);
+
+    const result = await withPlatform("linux", () =>
+      runSetupWizardPrepare({
+        prepare: imessageSetupWizard.prepare,
+        cfg: { channels: { imessage: {} } },
+        options: { allowIMessageInstall: true },
+        prompter: createTestWizardPrompter({ confirm }),
+      }),
+    );
+
+    expect(result).toBeUndefined();
+    expect(setupToolsMocks.detectBinary).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+    expect(installIMessageCliMock).not.toHaveBeenCalled();
+  });
+
+  it("prepare skips imsg install prompts unless explicitly allowed", async () => {
+    const confirm = vi.fn(async () => true);
+
+    const result = await runSetupWizardPrepare({
+      prepare: imessageSetupWizard.prepare,
+      cfg: { channels: { imessage: {} } },
+      prompter: createTestWizardPrompter({ confirm }),
+    });
+
+    expect(result).toBeUndefined();
+    expect(confirm).not.toHaveBeenCalled();
+    expect(installIMessageCliMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("probeIMessage", () => {
@@ -309,6 +541,64 @@ describe("probeIMessage", () => {
     expect(result.ok).toBe(false);
     expect(result.fatal).toBe(true);
     expect(result.error).toMatch(/rpc/i);
+    expect(result.error).toContain("brew update && brew upgrade imsg");
+    expect(createIMessageRpcClientMock).not.toHaveBeenCalled();
+  });
+
+  it("explains how to install imsg when the default binary is missing", async () => {
+    vi.spyOn(setupRuntime, "detectBinary").mockResolvedValue(false);
+    const createIMessageRpcClientMock = vi
+      .spyOn(clientModule, "createIMessageRpcClient")
+      .mockResolvedValue({
+        request: vi.fn(),
+        stop: vi.fn(),
+      } as unknown as Awaited<ReturnType<typeof clientModule.createIMessageRpcClient>>);
+
+    const result = await probeIMessage(1000, { platform: "darwin" });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe(
+      "imsg not found (imsg). Install imsg on the Messages Mac: brew install steipete/tap/imsg",
+    );
+    expect(processRuntime.runCommandWithTimeout).not.toHaveBeenCalled();
+    expect(createIMessageRpcClientMock).not.toHaveBeenCalled();
+  });
+
+  it("explains how to fix an explicit PATH-based imsg wrapper", async () => {
+    vi.spyOn(setupRuntime, "detectBinary").mockResolvedValue(false);
+    const createIMessageRpcClientMock = vi
+      .spyOn(clientModule, "createIMessageRpcClient")
+      .mockResolvedValue({
+        request: vi.fn(),
+        stop: vi.fn(),
+      } as unknown as Awaited<ReturnType<typeof clientModule.createIMessageRpcClient>>);
+
+    const result = await probeIMessage(1000, { cliPath: "imsg", platform: "darwin" });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe(
+      "imsg command not found (imsg). Check the configured iMessage cliPath or wrapper.",
+    );
+    expect(processRuntime.runCommandWithTimeout).not.toHaveBeenCalled();
+    expect(createIMessageRpcClientMock).not.toHaveBeenCalled();
+  });
+
+  it("explains how to fix a missing custom imsg wrapper", async () => {
+    vi.spyOn(setupRuntime, "detectBinary").mockResolvedValue(false);
+    const createIMessageRpcClientMock = vi
+      .spyOn(clientModule, "createIMessageRpcClient")
+      .mockResolvedValue({
+        request: vi.fn(),
+        stop: vi.fn(),
+      } as unknown as Awaited<ReturnType<typeof clientModule.createIMessageRpcClient>>);
+
+    const result = await probeIMessage(1000, { cliPath: "/usr/local/bin/imsg-wrapper" });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe(
+      "imsg command not found (/usr/local/bin/imsg-wrapper). Check the configured iMessage cliPath or wrapper.",
+    );
+    expect(processRuntime.runCommandWithTimeout).not.toHaveBeenCalled();
     expect(createIMessageRpcClientMock).not.toHaveBeenCalled();
   });
 

--- a/src/channels/plugins/setup-wizard-types.ts
+++ b/src/channels/plugins/setup-wizard-types.ts
@@ -302,6 +302,7 @@ export type ChannelSetupWizard = {
 /** Runtime options for selecting and configuring one or more channels. */
 export type SetupChannelsOptions = {
   allowDisable?: boolean;
+  allowIMessageInstall?: boolean;
   allowSignalInstall?: boolean;
   onSelection?: (selection: ChannelId[]) => void;
   onPostWriteHook?: (hook: ChannelOnboardingPostWriteHook) => void;

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -426,6 +426,7 @@ export async function agentsAddCommand(
     let selection: ChannelChoice[] = [];
     const channelAccountIds: Partial<Record<ChannelChoice, string>> = {};
     nextConfig = await setupChannels(nextConfig, runtime, prompter, {
+      allowIMessageInstall: true,
       allowSignalInstall: true,
       onSelection: (value) => {
         selection = value;

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -170,6 +170,7 @@ async function channelsAddCommandImpl(
     await prompter.intro("Channel setup");
     let nextConfigLocal = await onboardChannels.setupChannels(cfg, runtime, prompter, {
       allowDisable: false,
+      allowIMessageInstall: true,
       allowSignalInstall: true,
       onPostWriteHook: (hook) => {
         postWriteHooks.collect(hook);

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -655,6 +655,7 @@ export async function runConfigureWizard(
       if (channelMode === "configure") {
         nextConfig = await setupChannels(nextConfig, runtime, prompter, {
           allowDisable: true,
+          allowIMessageInstall: true,
           allowSignalInstall: true,
           deferStatusUntilSelection: true,
           skipConfirm: true,

--- a/src/commands/doctor-session-snapshots.test.ts
+++ b/src/commands/doctor-session-snapshots.test.ts
@@ -2,10 +2,12 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { saveSessionStore } from "../config/sessions/store.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { __testing as openClawRootTesting } from "../infra/openclaw-root.js";
 import type { Skill } from "../skills/loading/skill-contract.js";
 
 const note = vi.hoisted(() => vi.fn());
@@ -17,6 +19,7 @@ vi.mock("../../packages/terminal-core/src/note.js", () => ({
 import {
   detectSessionSnapshotHealthIssues,
   noteSessionSnapshotHealth,
+  resolveSessionSnapshotBundledSkillsDir,
   scanSessionStoreForStaleRuntimeSnapshotPaths,
   sessionSnapshotIssueToHealthFinding,
   sessionSnapshotIssueToRepairEffect,
@@ -99,6 +102,7 @@ describe("doctor session snapshot stale runtime metadata", () => {
   });
 
   afterEach(async () => {
+    openClawRootTesting.clearOpenClawPackageRootCaches();
     await fs.rm(root, { recursive: true, force: true });
   });
 
@@ -231,6 +235,95 @@ describe("doctor session snapshot stale runtime metadata", () => {
         expectedPath: path.join(bundledSkillsDir, "doctor", "SKILL.md"),
       },
     ]);
+  });
+
+  it("repairs stale imsg bundled paths to the generated plugin skill path", async () => {
+    const stalePath = path.join(
+      root,
+      "old-runtime",
+      "node_modules",
+      "openclaw",
+      "skills",
+      "imsg",
+      "SKILL.md",
+    );
+    const stateDir = path.join(root, "state");
+    const pluginSkillPath = path.join(stateDir, "plugin-skills", "imsg", "SKILL.md");
+    await fs.mkdir(path.dirname(pluginSkillPath), { recursive: true });
+    await fs.writeFile(pluginSkillPath, "# imsg\n");
+
+    const findings = scanSessionStoreForStaleRuntimeSnapshotPaths({
+      bundledSkillsDir,
+      env: { OPENCLAW_STATE_DIR: stateDir },
+      store: {
+        "agent:imsg": sessionEntry({
+          skillsSnapshot: {
+            prompt: skillPrompt(stalePath),
+            skills: [{ name: "imsg" }],
+          },
+        }),
+      },
+    });
+
+    expect(findings).toEqual([
+      {
+        sessionKey: "agent:imsg",
+        field: "skillsSnapshot.prompt",
+        cachedPath: stalePath,
+        expectedPath: pluginSkillPath,
+      },
+    ]);
+  });
+
+  it("repairs retired imsg paths even when cached under the current package skills root", async () => {
+    const packageSkillsDir = path.join(root, "node_modules", "openclaw", "skills");
+    const stalePath = path.join(packageSkillsDir, "imsg", "SKILL.md");
+    const stateDir = path.join(root, "state");
+    const pluginSkillPath = path.join(stateDir, "plugin-skills", "imsg", "SKILL.md");
+    await fs.mkdir(path.dirname(pluginSkillPath), { recursive: true });
+    await fs.writeFile(pluginSkillPath, "# imsg\n");
+
+    const findings = scanSessionStoreForStaleRuntimeSnapshotPaths({
+      bundledSkillsDir: packageSkillsDir,
+      env: { OPENCLAW_STATE_DIR: stateDir },
+      store: {
+        "agent:imsg": sessionEntry({
+          skillsSnapshot: {
+            prompt: skillPrompt(stalePath),
+            skills: [{ name: "imsg" }],
+          },
+        }),
+      },
+    });
+
+    expect(findings).toEqual([
+      {
+        sessionKey: "agent:imsg",
+        field: "skillsSnapshot.prompt",
+        cachedPath: stalePath,
+        expectedPath: pluginSkillPath,
+      },
+    ]);
+  });
+
+  it("resolves the retired package skills root for moved-skill snapshot repairs", async () => {
+    const packageRoot = path.join(root, "package");
+    const distDir = path.join(packageRoot, "dist");
+    await fs.mkdir(distDir, { recursive: true });
+    await fs.writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({ name: "openclaw" }),
+    );
+    const modulePath = path.join(distDir, "doctor-session-snapshots.js");
+    await fs.writeFile(modulePath, "// stub\n");
+
+    expect(
+      resolveSessionSnapshotBundledSkillsDir({
+        moduleUrl: pathToFileURL(modulePath).href,
+        argv1: path.join(packageRoot, "bin", "openclaw"),
+        cwd: distDir,
+      }),
+    ).toBe(path.join(packageRoot, "skills"));
   });
 
   it("ignores current bundled locations and unrelated workspace skill locations", () => {

--- a/src/commands/doctor-session-snapshots.ts
+++ b/src/commands/doctor-session-snapshots.ts
@@ -15,8 +15,9 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import { expandHomePrefix } from "../infra/home-dir.js";
 import { writeTextAtomic } from "../infra/json-files.js";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { resolveBundledSkillsDir } from "../skills/loading/bundled-dir.js";
-import { shortenHomePath } from "../utils.js";
+import { resolveConfigDir, shortenHomePath } from "../utils.js";
 
 const SESSION_SNAPSHOTS_CHECK_ID = "core/doctor/session-snapshots";
 
@@ -40,6 +41,34 @@ type StaleSessionSnapshotPathFinding = {
 export type SessionSnapshotHealthIssue = StaleSessionSnapshotPathFinding & {
   storePath: string;
 };
+
+export function resolveSessionSnapshotBundledSkillsDir(params?: {
+  bundledSkillsDir?: string;
+  argv1?: string;
+  moduleUrl?: string;
+  cwd?: string;
+  execPath?: string;
+}): string | undefined {
+  const explicit = params?.bundledSkillsDir?.trim();
+  if (explicit) {
+    return explicit;
+  }
+  const resolved = resolveBundledSkillsDir({
+    argv1: params?.argv1,
+    moduleUrl: params?.moduleUrl,
+    cwd: params?.cwd,
+    execPath: params?.execPath,
+  });
+  if (resolved) {
+    return resolved;
+  }
+  const packageRoot = resolveOpenClawPackageRootSync({
+    argv1: params?.argv1 ?? process.argv[1],
+    moduleUrl: params?.moduleUrl ?? import.meta.url,
+    cwd: params?.cwd ?? process.cwd(),
+  });
+  return packageRoot ? path.join(packageRoot, "skills") : undefined;
+}
 
 function decodeXmlText(value: string): string {
   return value
@@ -198,14 +227,37 @@ function resolveExpectedBundledSkillPath(params: {
   if (!isAbsolutePathLike(expandedCachedPath)) {
     return undefined;
   }
-  if (isInsidePath(params.bundledSkillsDir, expandedCachedPath)) {
-    return undefined;
-  }
   const relativeSegments = extractBundledSkillRelativeSegments(expandedCachedPath);
   if (!relativeSegments) {
     return undefined;
   }
+  const movedPath = resolveMovedBundledSkillPath({
+    relativeSegments,
+    pathExists: params.pathExists,
+    env: params.env,
+  });
+  if (movedPath) {
+    return movedPath;
+  }
+  if (isInsidePath(params.bundledSkillsDir, expandedCachedPath)) {
+    return undefined;
+  }
   const expectedPath = joinPathForRoot(params.bundledSkillsDir, ...relativeSegments);
+  if (params.pathExists(expectedPath)) {
+    return expectedPath;
+  }
+  return undefined;
+}
+
+function resolveMovedBundledSkillPath(params: {
+  relativeSegments: readonly string[];
+  pathExists: (filePath: string) => boolean;
+  env?: NodeJS.ProcessEnv;
+}): string | undefined {
+  if (params.relativeSegments.join("/") !== "imsg/SKILL.md") {
+    return undefined;
+  }
+  const expectedPath = path.join(resolveConfigDir(params.env), "plugin-skills", "imsg", "SKILL.md");
   return params.pathExists(expectedPath) ? expectedPath : undefined;
 }
 
@@ -299,7 +351,9 @@ export async function detectSessionSnapshotHealthIssues(params?: {
   cfg?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): Promise<SessionSnapshotHealthIssue[]> {
-  const bundledSkillsDir = params?.bundledSkillsDir ?? resolveBundledSkillsDir();
+  const bundledSkillsDir = resolveSessionSnapshotBundledSkillsDir({
+    bundledSkillsDir: params?.bundledSkillsDir,
+  });
   if (!bundledSkillsDir) {
     return [];
   }
@@ -397,7 +451,9 @@ export async function noteSessionSnapshotHealth(params?: {
   env?: NodeJS.ProcessEnv;
   shouldRepair?: boolean;
 }) {
-  const bundledSkillsDir = params?.bundledSkillsDir ?? resolveBundledSkillsDir();
+  const bundledSkillsDir = resolveSessionSnapshotBundledSkillsDir({
+    bundledSkillsDir: params?.bundledSkillsDir,
+  });
   if (!bundledSkillsDir) {
     return;
   }

--- a/src/crestodian/chat-engine.ts
+++ b/src/crestodian/chat-engine.ts
@@ -114,6 +114,7 @@ function defaultChannelSetupWizardRunner(
     const nextConfig = await setupChannels(baseConfig, defaultRuntime, prompter, {
       initialSelection: [channel],
       forceAllowFromChannels: [channel],
+      allowIMessageInstall: true,
       allowSignalInstall: true,
       deferStatusUntilSelection: true,
       quickstartDefaults: true,

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -488,6 +488,7 @@ async function runSetupWizardOnce(
             .map((plugin) => plugin.id)
         : [];
     nextConfig = await setupChannels(nextConfig, runtime, prompter, {
+      allowIMessageInstall: true,
       allowSignalInstall: true,
       deferStatusUntilSelection: flow === "quickstart",
       forceAllowFromChannels: quickstartAllowFromChannels,


### PR DESCRIPTION
Related: openclaw/imsg#157

## What Problem This Solves

Resolves a problem where OpenClaw's bundled iMessage guidance and setup flow lagged the current `imsg` CLI: the OpenClaw copy of the `imsg` skill still lived outside the iMessage plugin, did not document the landed poll behavior, and setup only reported that `imsg` was missing without offering the Homebrew install/update path most local Mac users need.

This is AI-assisted work.

## Why This Change Was Made

The `imsg` skill now lives with the bundled iMessage plugin, matching the existing Discord, Slack, WhatsApp, and QQBot channel-plugin pattern. The old top-level `skills/imsg` copy was removed.

The iMessage setup flow borrows the Signal-style prepare hook to offer macOS Homebrew install/update for the default local `imsg` path, while preserving explicit custom `cliPath` values, including SSH/PATH wrappers. Probe and setup status messages now distinguish default/Homebrew-managed `imsg` from operator-owned wrappers, and doctor can repair stale session snapshot paths to the generated plugin-skill path when that path has been published.

Clanker checked the prior Vincent/Jason history: Vincent previously moved bundled skills into plugin directories with manifest `skills` entries and did not add extra doctor migration. This PR keeps that ownership move, with a conservative doctor repair only for stale session metadata when the generated plugin-skill target exists.

Codex review note: local Codex review repeatedly flagged that moving `imsg` into plugin skills means the skill is only published when the iMessage plugin is activated. I am keeping that behavior because Omar explicitly asked to remove the old skill and align with other channel plugins; the PR body calls out the tradeoff for maintainer review.

## User Impact

Users configuring iMessage on the signed-in Messages Mac can install or update `imsg` from setup instead of manually discovering the command. Existing custom wrapper/SSH setups are left untouched, and setup/probe errors point operators at the configured wrapper when that is what is missing.

Agents using the iMessage skill get updated poll guidance, including the landed `imsg poll send` caption behavior and poll history/watch backfill notes.

## Evidence

- `pnpm docs:list`
- `pnpm format:docs:check -- docs/channels/imessage.md docs/channels/imessage-from-bluebubbles.md extensions/imessage/skills/imsg/SKILL.md`
- `pnpm format:docs:check -- docs/channels/imessage.md docs/channels/imessage-from-bluebubbles.md`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
  - Result: clean, no accepted/actionable findings. The review specifically checked that the docs now match the existing iMessage setup behavior.
- `codex review --uncommitted -c 'model="gpt-5.4"'`
  - Result: clean. The review checked the changed docs against `extensions/imessage/src/setup-surface.ts`, `extensions/imessage/src/install-imsg.ts`, `extensions/imessage/src/setup-core.ts`, and `extensions/imessage/src/status.test.ts`; it found no concrete inaccuracy or regression in the docs-only follow-up.
- Testbox `tbx_01kwxk5p1772r17gqm46862fh0` / https://github.com/openclaw/openclaw/actions/runs/28845525814
  - `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json -- env OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 corepack pnpm test extensions/imessage/src/status.test.ts extensions/imessage/src/install-imsg.test.ts src/plugins/bundled-plugin-metadata.test.ts src/skills/loading/plugin-skills.test.ts src/commands/doctor-session-snapshots.test.ts`
  - Passed 4 Vitest shards: 25 plugin-skill tests, 20 doctor snapshot tests, 35 bundled plugin metadata tests, 4 iMessage install tests, 29 iMessage status/probe/setup tests.
- Testbox-through-Crabbox release upgrade proof `tbx_01kwyrmyjprq8rqvjdb0ve7psc` / https://github.com/openclaw/openclaw/actions/runs/28884362791
  - `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --id tbx_01kwyrmyjprq8rqvjdb0ve7psc --timing-json -- bash imsg-upgrade-proof.tmp.sh` using a temporary, uncommitted proof script.
  - Scenario: isolated `openclaw@latest` global install with `channels.imessage.enabled=true`, `channels.imessage.cliPath=/tmp/imsg-wrapper`, seeded stale `agent:main:main` session snapshot pointing at `skills/imsg/SKILL.md`, candidate release tarball built with `scripts/package-openclaw-for-docker.mjs`, then candidate global upgrade plus `openclaw doctor --non-interactive --fix`.
  - Before: `OpenClaw 2026.6.11 (e085fa1)`, top-level `skills/imsg/SKILL.md` existed, generated plugin skill did not, skill list exposed `imsg` from `openclaw-bundled`, cached prompt and injected workspace file both pointed at the old top-level skill path.
  - After: candidate `OpenClaw 2026.6.11 (6139ef4)`, old top-level `skills/imsg/SKILL.md` absent, generated `state/plugin-skills/imsg/SKILL.md` present and linked to `dist/extensions/imessage/skills/imsg/SKILL.md`, skill list exposed `imsg` from plugin skills, `doctor --fix` rewrote both cached prompt and injected workspace file to the generated plugin-skill path, proof summary `result: true`.
- Local macOS setup proof on head `650ad0d` using the local dev install and an isolated `PATH` with temporary `brew`/`imsg` shims in front of the real system tools. This exercises the real iMessage plugin setup hook without modifying the machine's Homebrew packages. Current head `20b43dc` only changes `extensions/imessage/src/install-imsg.test.ts` to use the public `openclaw/plugin-sdk/test-env` temp-dir helper; runtime setup code is unchanged from the proofed head.
  - Command shape: `PATH=<proof>/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin PROOF_DIR=<proof> node --import tsx -e '<imports imessageSetupWizard from extensions/imessage/src/setup-surface.ts and calls prepare({ options: { allowIMessageInstall: true } })>'`
  - Redacted setup output:
    ```json
    {
      "platform": "darwin",
      "result": {
        "credentialValues": {
          "cliPath": "<proof>/homebrew/opt/imsg/bin/imsg"
        }
      },
      "events": [
        ["prompt.confirm", "imsg detected. Reinstall/update now?", false],
        ["runtime.log", "Updating imsg via Homebrew (<proof>/bin/brew)..."],
        ["prompt.note", "iMessage", "Installed imsg at <proof>/homebrew/opt/imsg/bin/imsg"]
      ]
    }
    ```
  - Recorded Homebrew argv from the proof shim:
    ```text
    update
    upgrade imsg
    --prefix imsg
    ```


