### PR TITLE
Enable Volcengine Ark reasoning compat

### DIFF
--- a/extensions/volcengine/openclaw.plugin.json
+++ b/extensions/volcengine/openclaw.plugin.json
@@ -35,6 +35,17 @@
       }
     }
   },
+  "providerEndpoints": [
+    {
+      "endpointClass": "volcengine-native",
+      "baseUrls": [
+        "https://ark.cn-beijing.volces.com/api/v3",
+        "https://ark.cn-beijing.volces.com/api/coding/v3",
+        "https://ark.ap-southeast.bytepluses.com/api/v3",
+        "https://ark.ap-southeast.bytepluses.com/api/coding/v3"
+      ]
+    }
+  ],
   "modelCatalog": {
     "providers": {
       "volcengine": {

--- a/src/agents/openai-completions-compat.test.ts
+++ b/src/agents/openai-completions-compat.test.ts
@@ -73,6 +73,20 @@ describe("resolveOpenAICompletionsCompatDefaults", () => {
     ).toBe(false);
   });
 
+  it("enables reasoning effort for Volcengine Ark native completions endpoints", () => {
+    const defaults = resolveOpenAICompletionsCompatDefaults({
+      provider: "model_square",
+      endpointClass: "volcengine-native",
+      knownProviderFamily: "model_square",
+      supportsNativeStreamingUsageCompat: true,
+      usesExplicitProxyLikeEndpoint: true,
+    });
+
+    expect(defaults.supportsReasoningEffort).toBe(true);
+    expect(defaults.supportsUsageInStreaming).toBe(true);
+    expect(defaults.thinkingFormat).toBe("openai");
+  });
+
   it("uses Together reasoning payload format for Together-family providers", () => {
     const defaults = resolveOpenAICompletionsCompatDefaults({
       provider: "together",
@@ -114,6 +128,18 @@ describe("detectOpenAICompletionsCompat", () => {
       id: "Qwen/Qwen3-Coder-Next-FP8",
     });
 
+    expect(detected.defaults.supportsUsageInStreaming).toBe(true);
+  });
+
+  it("detects Volcengine Ark native completions endpoints for custom provider ids", () => {
+    const detected = detectOpenAICompletionsCompat({
+      provider: "model_square",
+      baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+      id: "doubao-seed-2-0-pro-260215",
+    });
+
+    expect(detected.capabilities.endpointClass).toBe("volcengine-native");
+    expect(detected.defaults.supportsReasoningEffort).toBe(true);
     expect(detected.defaults.supportsUsageInStreaming).toBe(true);
   });
 });

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -72,6 +72,7 @@ export function resolveOpenAICompletionsCompatDefaults(
   const isTogether =
     knownProviderFamily === "together" ||
     (isDefaultRoute && isDefaultRouteProvider(input.provider, "together"));
+  const isVolcengine = endpointClass === "volcengine-native";
   const isXiaomi =
     endpointClass === "xiaomi-native" ||
     (isDefaultRoute && isDefaultRouteProvider(input.provider, "xiaomi"));
@@ -103,7 +104,7 @@ export function resolveOpenAICompletionsCompatDefaults(
       !isTogether &&
       knownProviderFamily !== "mistral" &&
       endpointClass !== "xai-native" &&
-      !usesExplicitProxyLikeEndpoint,
+      (!usesExplicitProxyLikeEndpoint || isVolcengine),
     supportsUsageInStreaming:
       supportsOpenAICompletionsStreamingUsageCompat ||
       (!isNonStandard &&

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -7138,6 +7138,34 @@ describe("openai transport stream", () => {
     expect(params.reasoning_effort).toBe("medium");
   });
 
+  it("adds reasoning_effort for Volcengine Ark completions behind custom provider ids", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "doubao-seed-2-0-pro-260215",
+        name: "Doubao Seed 2.0 Pro",
+        api: "openai-completions",
+        provider: "model_square",
+        baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 256000,
+        maxTokens: 4096,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      {
+        reasoning: "medium",
+      } as never,
+    ) as { reasoning_effort?: unknown; stream_options?: { include_usage?: boolean } };
+
+    expect(params.reasoning_effort).toBe("medium");
+    expect(params.stream_options).toEqual({ include_usage: true });
+  });
+
   it("uses provider-native reasoning effort values declared by model compat", () => {
     const baseModel = {
       id: "qwen/qwen3-32b",

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -32,6 +32,15 @@ const providerEndpointPlugins = vi.hoisted(() => [
       { endpointClass: "github-copilot-native", hostSuffixes: [".githubcopilot.com"] },
       { endpointClass: "groq-native", hosts: ["api.groq.com"] },
       { endpointClass: "opencode-native", hostSuffixes: ["opencode.ai"] },
+      {
+        endpointClass: "volcengine-native",
+        baseUrls: [
+          "https://ark.cn-beijing.volces.com/api/v3",
+          "https://ark.cn-beijing.volces.com/api/coding/v3",
+          "https://ark.ap-southeast.bytepluses.com/api/v3",
+          "https://ark.ap-southeast.bytepluses.com/api/coding/v3",
+        ],
+      },
       { endpointClass: "openrouter", hostSuffixes: ["openrouter.ai"] },
       { endpointClass: "zai-native", hosts: ["api.z.ai"] },
       { endpointClass: "google-generative-ai", hosts: ["generativelanguage.googleapis.com"] },
@@ -518,6 +527,14 @@ describe("provider attribution", () => {
     expectRecordFields(resolveProviderEndpoint("https://opencode.ai/api"), {
       endpointClass: "opencode-native",
       hostname: "opencode.ai",
+    });
+    expectRecordFields(resolveProviderEndpoint("https://ark.cn-beijing.volces.com/api/v3"), {
+      endpointClass: "volcengine-native",
+      hostname: "ark.cn-beijing.volces.com",
+    });
+    expectRecordFields(resolveProviderEndpoint("https://ark.ap-southeast.bytepluses.com/api/v3"), {
+      endpointClass: "volcengine-native",
+      hostname: "ark.ap-southeast.bytepluses.com",
     });
     expectRecordFields(resolveProviderEndpoint("https://api.xiaomimimo.com/v1"), {
       endpointClass: "xiaomi-native",
@@ -1111,6 +1128,22 @@ describe("provider attribution", () => {
       }),
       {
         endpointClass: "modelstudio-native",
+        supportsNativeStreamingUsageCompat: true,
+      },
+    );
+
+    expectRecordFields(
+      resolveProviderRequestCapabilities({
+        provider: "model_square",
+        api: "openai-completions",
+        baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+        capability: "llm",
+        transport: "stream",
+      }),
+      {
+        endpointClass: "volcengine-native",
+        isKnownNativeEndpoint: true,
+        usesExplicitProxyLikeEndpoint: true,
         supportsNativeStreamingUsageCompat: true,
       },
     );

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -65,6 +65,7 @@ export type ProviderEndpointClass =
   | "openai-public"
   | "openai"
   | "opencode-native"
+  | "volcengine-native"
   | "azure-openai"
   | "openrouter"
   | "xai-native"
@@ -167,6 +168,7 @@ const MANIFEST_PROVIDER_ENDPOINT_CLASSES = new Set<ProviderEndpointClass>([
   "openai-public",
   "openai",
   "opencode-native",
+  "volcengine-native",
   "azure-openai",
   "openrouter",
   "xai-native",
@@ -714,6 +716,7 @@ export function resolveProviderRequestCapabilities(
     endpointClass === "openai-public" ||
     endpointClass === "openai" ||
     endpointClass === "opencode-native" ||
+    endpointClass === "volcengine-native" ||
     endpointClass === "azure-openai" ||
     endpointClass === "openrouter" ||
     endpointClass === "xai-native" ||
@@ -781,7 +784,9 @@ export function resolveProviderRequestCapabilities(
     // Native endpoint class is the real signal here. Users can point a generic
     // provider key at Moonshot or DashScope and still need streaming usage.
     supportsNativeStreamingUsageCompat:
-      endpointClass === "moonshot-native" || endpointClass === "modelstudio-native",
+      endpointClass === "moonshot-native" ||
+      endpointClass === "modelstudio-native" ||
+      endpointClass === "volcengine-native",
     supportsOpenAICompletionsStreamingUsageCompat:
       manifestProviderRequest?.supportsOpenAICompletionsStreamingUsageCompat === true,
     compatibilityFamily,


### PR DESCRIPTION
## Summary

- classify Volcengine Ark endpoints as a native endpoint class through the bundled Volcengine provider manifest
- allow Volcengine native OpenAI-compatible routes to send `reasoning_effort` even though they use an explicitly configured Ark base URL
- enable native streaming-usage compatibility for the same Volcengine Ark route

## Scope

This PR is intentionally provider-only against current `main`.

Current `main` already contains the Core event-path pieces needed for callback-less reasoning delivery: native `thinking_delta` is emitted to the bus/archive independently from channel-specific `onReasoningStream`, and signature-only native thinking blocks remain display-silent. This PR therefore does not modify `embedded-agent-subscribe*` or `embedded-agent-utils*`.

The remaining missing piece for the validated Volcengine Ark path is provider enablement: Ark endpoint URLs must resolve to a known native endpoint class so OpenAI-compatible request defaults can send `reasoning_effort` and keep streaming-usage behavior enabled.

Refs #5086. This keeps the provider enablement that was validated internally for ArkClaw while leaving out the older 2026.5.28 backport-only Core changes and ArkClaw-specific debug switches/logging.

## Validation

- `node scripts/test-projects.mjs src/agents/openai-completions-compat.test.ts src/agents/provider-attribution.test.ts src/agents/openai-transport-stream.test.ts`
- `git diff --check`

## Notes for maintainers

Volcengine Ark endpoint URLs are declared in `extensions/volcengine/openclaw.plugin.json` via the existing provider manifest metadata path. Core recognizes only the generic `volcengine-native` endpoint class and capability gates; it does not hardcode ArkClaw debug behavior or internal ArkClaw naming.

This PR does not add a broad provider/model support matrix. Other providers still need their own adapter coverage when their raw stream fields or enablement parameters differ.