### PR TITLE
fix(process): handle async spawn errors in taskkill force-kill fallback

### DIFF
--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -414,6 +414,85 @@ describe("runCommandWithTimeout", () => {
 
     expect(result.preservedStdoutLines).toEqual(["x".repeat(22)]);
   });
+
+  it(
+    "falls back to SIGKILL when force-kill taskkill spawn emits async error",
+    { timeout: 5_000 },
+    async () => {
+      vi.useFakeTimers();
+
+      const platformStub = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+      // Create a child that survives the first taskkill so the force-kill
+      // timer fires: exitCode/signalCode must stay null.
+      const mainChild = new EventEmitter() as EventEmitter & ChildProcess;
+      mainChild.stdout = new EventEmitter() as NonNullable<ChildProcess["stdout"]>;
+      mainChild.stderr = new EventEmitter() as NonNullable<ChildProcess["stderr"]>;
+      mainChild.stdin = new EventEmitter() as NonNullable<ChildProcess["stdin"]>;
+      mainChild.stdin.write = vi.fn(() => true) as NonNullable<ChildProcess["stdin"]>["write"];
+      mainChild.stdin.end = vi.fn() as NonNullable<ChildProcess["stdin"]>["end"];
+      let mainKilled = false;
+      const killSpy = vi.fn((_signal?: NodeJS.Signals) => {
+        mainKilled = true;
+        return true;
+      });
+      mainChild.kill = killSpy as ChildProcess["kill"];
+      Object.defineProperties(mainChild, {
+        pid: { get: () => 5678 },
+        killed: { get: () => mainKilled },
+        exitCode: { get: () => null },
+        signalCode: { get: () => null },
+      });
+
+      let forceKillChild: EventEmitter | undefined;
+
+      let spawnCount = 0;
+      spawnMock.mockImplementation(() => {
+        spawnCount++;
+        if (spawnCount >= 3) {
+          // Third spawn: force-kill taskkill inside the 300ms timer.
+          forceKillChild = new EventEmitter();
+          (forceKillChild as EventEmitter & { kill?: unknown }).kill = vi.fn(() => true);
+          return forceKillChild;
+        }
+        // First spawn: main child. Second spawn: first taskkill.
+        if (spawnCount === 1) return mainChild;
+        // Return a dummy for the first taskkill so it doesn't crash.
+        const dummy = new EventEmitter();
+        (dummy as EventEmitter & { kill?: unknown }).kill = vi.fn(() => true);
+        return dummy;
+      });
+
+      await loadExecModules({ mockSpawn: true });
+
+      const resultPromise = runCommandWithTimeout(createSilentIdleArgv(), {
+        timeoutMs: 100,
+        killProcessTree: true,
+      });
+
+      // Advance past the timeout to trigger killChild → first taskkill → timer.
+      await vi.advanceTimersByTimeAsync(150);
+      // Advance past COMMAND_PROCESS_TREE_KILL_GRACE_MS so the force-kill spawns.
+      await vi.advanceTimersByTimeAsync(350);
+
+      if (!forceKillChild) {
+        throw new Error("expected force-kill child to be spawned");
+      }
+
+      // Async spawn error: taskkill.exe not found / failed to execute.
+      forceKillChild.emit("error", new Error("taskkill.exe not found"));
+
+      expect(killSpy).toHaveBeenCalledWith("SIGKILL");
+
+      // Let the process settle.
+      mainChild.emit("exit", null, "SIGTERM");
+      mainChild.emit("close", null, "SIGTERM");
+      await vi.runAllTimersAsync();
+      await resultPromise;
+
+      platformStub.mockRestore();
+    },
+  );
 });
 
 describe("attachChildProcessBridge", () => {

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -543,9 +543,12 @@ export async function runCommandWithTimeout(
                   return;
                 }
                 try {
-                  spawn(taskkillPath, ["/PID", String(child.pid), "/T", "/F"], {
+                  const forceKill = spawn(taskkillPath, ["/PID", String(child.pid), "/T", "/F"], {
                     stdio: "ignore",
                     windowsHide: true,
+                  });
+                  forceKill.on("error", () => {
+                    child.kill("SIGKILL");
                   });
                 } catch {
                   child.kill("SIGKILL");


### PR DESCRIPTION
## What Problem This Solves

Closes #101381

In `src/process/exec.ts`, the force-kill taskkill fallback on Windows spawns `taskkill /PID /T /F` inside a `try/catch` block. However, Node's `spawn()` does **not** throw synchronously when the binary is missing or fails to execute — it emits an `'error'` event **asynchronously**. The catch block (`child.kill("SIGKILL")`) never executes, so the child process tree is permanently leaked.

This happens specifically at the force-kill site (line 546), which is the safety-net fallback after the first graceful taskkill attempt. If `taskkill.exe` can't be spawned (missing system32 path, misconfigured environment, etc.), the child process and its descendants silently leak.

## Why This Change Was Made

The fix adds an `'error'` event listener on the spawned taskkill process that calls `child.kill("SIGKILL")` — mirroring the existing catch-block fallback. Both the sync `catch` and the async `'error'` handler now produce the same final outcome.

The change is minimal: 3 added lines that save the spawn result and attach the error handler.

## Evidence

### New regression test: "falls back to SIGKILL when force-kill taskkill spawn emits async error"

The test simulates the Windows kill path with `vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')`:
1. Spawns a child with `killProcessTree: true` and a short timeout
2. Advances timers past the timeout to trigger the force-kill spawn
3. Emits an `'error'` event on the spawned taskkill process
4. Asserts `child.kill("SIGKILL")` was called

### All tests pass (20/20)

```
$ npx vitest run src/process/exec.test.ts --no-coverage --pool forks

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  14:17:20
   Duration  2.38s
```

### Not tested

- Real Windows taskkill.exe behavior (fix verified through Vitest mocking on Linux)
- End-to-end process tree cleanup on a Windows machine

## Merge Risk

**Low**. The change:
- Adds 3 lines (error listener on spawned process)
- Only affects the Windows `process.platform === "win32"` code path
- Both the sync catch and async error handler call the same `child.kill("SIGKILL")`
- No new dependencies, no data model changes, no config changes