### PR TITLE
fix(qqbot): use UTF-16-safe truncation for messaging outbound previews

### DIFF
--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayAccount } from "../types.js";
 
 const { sendTextMock, senderSendMediaMock } = vi.hoisted(() => ({
@@ -148,47 +148,23 @@ describe("outbound deliver sandbox media", () => {
   });
 });
 
-// Pin the same UTF-16 boundary behavior that the production debugLog sites
-// in outbound-deliver.ts rely on. The helper is the same one used by 130+
-// other extension sites (Discord, Feishu, Telegram, msteams, voice-call,
-// iMessage, etc.) for log/error preview truncation.
-describe("outbound-deliver UTF-16-safe truncation helper", () => {
-  const hasLoneSurrogate = (value: string): boolean => {
-    for (let i = 0; i < value.length; i++) {
-      const code = value.charCodeAt(i);
-      if (code >= 0xd800 && code <= 0xdbff) {
-        const next = value.charCodeAt(i + 1);
-        if (!(next >= 0xdc00 && next <= 0xdfff)) {
-          return true;
-        }
-        i++;
-      } else if (code >= 0xdc00 && code <= 0xdfff) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  it("truncates sent-chunk preview on UTF-16 boundary without splitting emoji", () => {
+// Cap-precise regression for the inline `truncateUtf16Safe` sites touched
+// by this branch: sent-chunk preview (cap 50) and media-URL preview
+// (cap 80) in outbound-deliver.ts. Each test pins the exact code-unit
+// output for one cap value, so the "safe truncation" claim is enforced
+// at the boundary, not just on length.
+describe("outbound-deliver UTF-16 truncation cap boundary", () => {
+  it("cap 50 keeps a 49-char ASCII prefix and drops the trailing emoji pair", () => {
     // Mirrors the call shape at outbound-deliver.ts sent-chunk debugLog sites
     //   `Sent text chunk (${chunk.length}/${text.length} chars): ${truncateUtf16Safe(chunk, 50)}...`
-    const input = "测试消息🎉🎉🎉剩余内容这是50个字符文本测试";
-    const truncated = truncateUtf16Safe(input, 50);
-    expect(truncated.length).toBeLessThanOrEqual(50);
-    expect(hasLoneSurrogate(truncated)).toBe(false);
+    const safePrefix = "x".repeat(49);
+    expect(truncateUtf16Safe(safePrefix + "🎉 trailing content", 50)).toBe(safePrefix);
   });
 
-  it("truncates media-URL preview on UTF-16 boundary", () => {
+  it("cap 80 keeps a 79-char ASCII prefix and drops the trailing emoji pair", () => {
     // Mirrors the call shape at the media-URL debugLog / onSuccess sites in
     // outbound-deliver.ts (url.slice / mediaUrl.slice / imgUrl.slice / nextImageUrl.slice).
-    const urlWithEmoji = "https://example.com/测试🎉🎉/path/to/file.jpg";
-    const truncated = truncateUtf16Safe(urlWithEmoji, 80);
-    expect(truncated.length).toBeLessThanOrEqual(80);
-    expect(hasLoneSurrogate(truncated)).toBe(false);
-  });
-
-  it("passes plain ASCII through unchanged (negative control)", () => {
-    const ascii = "https://example.com/path/to/file.jpg";
-    expect(truncateUtf16Safe(ascii, 80)).toBe(ascii);
+    const safePrefix = "x".repeat(79);
+    expect(truncateUtf16Safe(safePrefix + "🎉 trailing url", 80)).toBe(safePrefix);
   });
 });

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { GatewayAccount } from "../types.js";
 
 const { sendTextMock, senderSendMediaMock } = vi.hoisted(() => ({
@@ -144,5 +145,50 @@ describe("outbound deliver sandbox media", () => {
       }),
     );
     expect(sendTextMock.mock.calls.map((call) => call[1])).toEqual([DEFAULT_MEDIA_SEND_ERROR]);
+  });
+});
+
+// Pin the same UTF-16 boundary behavior that the production debugLog sites
+// in outbound-deliver.ts rely on. The helper is the same one used by 130+
+// other extension sites (Discord, Feishu, Telegram, msteams, voice-call,
+// iMessage, etc.) for log/error preview truncation.
+describe("outbound-deliver UTF-16-safe truncation helper", () => {
+  const hasLoneSurrogate = (value: string): boolean => {
+    for (let i = 0; i < value.length; i++) {
+      const code = value.charCodeAt(i);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = value.charCodeAt(i + 1);
+        if (!(next >= 0xdc00 && next <= 0xdfff)) {
+          return true;
+        }
+        i++;
+      } else if (code >= 0xdc00 && code <= 0xdfff) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  it("truncates sent-chunk preview on UTF-16 boundary without splitting emoji", () => {
+    // Mirrors the call shape at outbound-deliver.ts sent-chunk debugLog sites
+    //   `Sent text chunk (${chunk.length}/${text.length} chars): ${truncateUtf16Safe(chunk, 50)}...`
+    const input = "测试消息🎉🎉🎉剩余内容这是50个字符文本测试";
+    const truncated = truncateUtf16Safe(input, 50);
+    expect(truncated.length).toBeLessThanOrEqual(50);
+    expect(hasLoneSurrogate(truncated)).toBe(false);
+  });
+
+  it("truncates media-URL preview on UTF-16 boundary", () => {
+    // Mirrors the call shape at the media-URL debugLog / onSuccess sites in
+    // outbound-deliver.ts (url.slice / mediaUrl.slice / imgUrl.slice / nextImageUrl.slice).
+    const urlWithEmoji = "https://example.com/测试🎉🎉/path/to/file.jpg";
+    const truncated = truncateUtf16Safe(urlWithEmoji, 80);
+    expect(truncated.length).toBeLessThanOrEqual(80);
+    expect(hasLoneSurrogate(truncated)).toBe(false);
+  });
+
+  it("passes plain ASCII through unchanged (negative control)", () => {
+    const ascii = "https://example.com/path/to/file.jpg";
+    expect(truncateUtf16Safe(ascii, 80)).toBe(ascii);
   });
 });

--- a/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-deliver.ts
@@ -7,6 +7,7 @@
  */
 
 import type { GatewayAccount } from "../types.js";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatErrorMessage } from "../utils/format.js";
 import { getImageSize, formatQQBotMarkdownImage, hasQQBotImageSize } from "../utils/image-size.js";
 import { normalizeMediaTags } from "../utils/media-tags.js";
@@ -242,7 +243,7 @@ async function sendTextChunks(
     allowDm: true,
     log,
     onSuccess: (chunk) =>
-      `Sent text chunk (${chunk.length}/${text.length} chars): ${chunk.slice(0, 50)}...`,
+      `Sent text chunk (${chunk.length}/${text.length} chars): ${truncateUtf16Safe(chunk, 50)}...`,
     onError: (err) => `Failed to send text chunk: ${formatErrorMessage(err)}`,
   });
 }
@@ -271,7 +272,7 @@ export async function sendTextOnlyReply(
     forcePlainText: true,
     log,
     onSuccess: (chunk) =>
-      `Sent text-only chunk (${chunk.length}/${safeText.length} chars): ${chunk.slice(0, 50)}...`,
+      `Sent text-only chunk (${chunk.length}/${safeText.length} chars): ${truncateUtf16Safe(chunk, 50)}...`,
     onError: (err) => `Failed to send text-only chunk: ${formatErrorMessage(err)}`,
   });
 }
@@ -600,7 +601,7 @@ export async function sendPlainReply(
       if (!collectedImageUrls.includes(url)) {
         collectedImageUrls.push(url);
         log?.debug?.(
-          `Collected ${isDataUrl ? "Base64" : "media URL"}: ${isDataUrl ? `(length: ${url.length})` : url.slice(0, 80) + "..."}`,
+          `Collected ${isDataUrl ? "Base64" : "media URL"}: ${isDataUrl ? `(length: ${url.length})` : truncateUtf16Safe(url, 80) + "..."}`,
         );
       }
       return true;
@@ -632,7 +633,7 @@ export async function sendPlainReply(
     if (url && !collectedImageUrls.includes(url)) {
       if (isHttpUrl(url)) {
         collectedImageUrls.push(url);
-        log?.debug?.(`Extracted HTTP image from markdown: ${url.slice(0, 80)}...`);
+        log?.debug?.(`Extracted HTTP image from markdown: ${truncateUtf16Safe(url, 80)}...`);
       } else if (isLocalFilePath(url)) {
         if (!localMediaToSend.includes(url)) {
           localMediaToSend.push(url);
@@ -650,7 +651,7 @@ export async function sendPlainReply(
     const url = m[1];
     if (url && !collectedImageUrls.includes(url)) {
       collectedImageUrls.push(url);
-      log?.debug?.(`Extracted bare image URL: ${url.slice(0, 80)}...`);
+      log?.debug?.(`Extracted bare image URL: ${truncateUtf16Safe(url, 80)}...`);
     }
   }
 
@@ -743,7 +744,7 @@ export async function sendPlainReply(
       ...(actx.mediaLocalRoots ? { mediaLocalRoots: actx.mediaLocalRoots } : {}),
       ...(actx.mediaReadFile ? { mediaReadFile: actx.mediaReadFile } : {}),
       log,
-      onSuccess: (mediaUrl) => `Forwarded tool media: ${mediaUrl.slice(0, 80)}...`,
+      onSuccess: (mediaUrl) => `Forwarded tool media: ${truncateUtf16Safe(mediaUrl, 80)}...`,
       onResultError: (_mediaUrl, error) => `Tool media forward error: ${error}`,
       onThrownError: (_mediaUrl, error) => `Tool media forward failed: ${error}`,
     });
@@ -826,7 +827,7 @@ async function sendMarkdownReply(
         const size = await getImageSize(url);
         imagesToAppend.push(formatQQBotMarkdownImage(url, size));
         log?.debug?.(
-          `Formatted HTTP image: ${size ? `${size.width}x${size.height}` : "default size"} - ${url.slice(0, 60)}...`,
+          `Formatted HTTP image: ${size ? `${size.width}x${size.height}` : "default size"} - ${truncateUtf16Safe(url, 60)}...`,
         );
       } catch (err) {
         log?.debug?.(`Failed to get image size, using default: ${formatErrorMessage(err)}`);
@@ -846,7 +847,7 @@ async function sendMarkdownReply(
         const size = await getImageSize(imgUrl);
         result = result.replace(fullMatch, formatQQBotMarkdownImage(imgUrl, size));
         log?.debug?.(
-          `Updated image with size: ${size ? `${size.width}x${size.height}` : "default"} - ${imgUrl.slice(0, 60)}...`,
+          `Updated image with size: ${size ? `${size.width}x${size.height}` : "default"} - ${truncateUtf16Safe(imgUrl, 60)}...`,
         );
       } catch (err) {
         log?.debug?.(
@@ -923,7 +924,7 @@ async function sendPlainTextReply(
         imageUrl,
         mediaSender: deps.mediaSender,
         log,
-        onSuccess: (nextImageUrl) => `Sent image via sendPhoto: ${nextImageUrl.slice(0, 80)}...`,
+        onSuccess: (nextImageUrl) => `Sent image via sendPhoto: ${truncateUtf16Safe(nextImageUrl, 80)}...`,
         onError: (error) => `Failed to send image: ${error}`,
       });
     }

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
@@ -2,8 +2,8 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 const { audioPortMock } = vi.hoisted(() => ({
   audioPortMock: {
@@ -663,36 +663,16 @@ describe("trySendViaHostRead error handling", () => {
   });
 });
 
-// Pin the same UTF-16 boundary behavior that the production error-return
-// sites in outbound-media-send.ts rely on.
-describe("outbound-media-send UTF-16-safe truncation helper", () => {
-  const hasLoneSurrogate = (value: string): boolean => {
-    for (let i = 0; i < value.length; i++) {
-      const code = value.charCodeAt(i);
-      if (code >= 0xd800 && code <= 0xdbff) {
-        const next = value.charCodeAt(i + 1);
-        if (!(next >= 0xdc00 && next <= 0xdfff)) {
-          return true;
-        }
-        i++;
-      } else if (code >= 0xdc00 && code <= 0xdfff) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  it("truncates error-message media path on UTF-16 boundary", () => {
+// Cap-precise regression for the inline `truncateUtf16Safe` sites touched
+// by this branch: error-message media path (cap 80) in
+// outbound-media-send.ts. Each test pins the exact code-unit output for
+// one cap value, so the "safe truncation" claim is enforced at the
+// boundary, not just on length.
+describe("outbound-media-send UTF-16 truncation cap boundary", () => {
+  it("cap 80 keeps a 79-char ASCII prefix and drops the trailing emoji pair", () => {
     // Mirrors the call shape at outbound-media-send.ts error-return sites
     //   return { channel: "qqbot", error: `Failed to download image: ${truncateUtf16Safe(mediaPath, 80)}` };
-    const mediaPath = "/path/to/测试图片文件🎉🎉🎉剩余路径超过80字符限制的部分被截断.png";
-    const truncated = truncateUtf16Safe(mediaPath, 80);
-    expect(truncated.length).toBeLessThanOrEqual(80);
-    expect(hasLoneSurrogate(truncated)).toBe(false);
-  });
-
-  it("passes plain ASCII paths through unchanged (negative control)", () => {
-    const asciiPath = "/path/to/some-image-file-name-without-special-chars.png";
-    expect(truncateUtf16Safe(asciiPath, 80)).toBe(asciiPath);
+    const safePrefix = "x".repeat(79);
+    expect(truncateUtf16Safe(safePrefix + "🎉 trailing path", 80)).toBe(safePrefix);
   });
 });

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 const { audioPortMock } = vi.hoisted(() => ({
   audioPortMock: {
@@ -659,5 +660,39 @@ describe("trySendViaHostRead error handling", () => {
         localPathForMeta: expect.stringMatching(/clip-.*\.mp3$/),
       }),
     );
+  });
+});
+
+// Pin the same UTF-16 boundary behavior that the production error-return
+// sites in outbound-media-send.ts rely on.
+describe("outbound-media-send UTF-16-safe truncation helper", () => {
+  const hasLoneSurrogate = (value: string): boolean => {
+    for (let i = 0; i < value.length; i++) {
+      const code = value.charCodeAt(i);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = value.charCodeAt(i + 1);
+        if (!(next >= 0xdc00 && next <= 0xdfff)) {
+          return true;
+        }
+        i++;
+      } else if (code >= 0xdc00 && code <= 0xdfff) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  it("truncates error-message media path on UTF-16 boundary", () => {
+    // Mirrors the call shape at outbound-media-send.ts error-return sites
+    //   return { channel: "qqbot", error: `Failed to download image: ${truncateUtf16Safe(mediaPath, 80)}` };
+    const mediaPath = "/path/to/测试图片文件🎉🎉🎉剩余路径超过80字符限制的部分被截断.png";
+    const truncated = truncateUtf16Safe(mediaPath, 80);
+    expect(truncated.length).toBeLessThanOrEqual(80);
+    expect(hasLoneSurrogate(truncated)).toBe(false);
+  });
+
+  it("passes plain ASCII paths through unchanged (negative control)", () => {
+    const asciiPath = "/path/to/some-image-file-name-without-special-chars.png";
+    expect(truncateUtf16Safe(asciiPath, 80)).toBe(asciiPath);
   });
 });

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts
@@ -676,3 +676,57 @@ describe("outbound-media-send UTF-16 truncation cap boundary", () => {
     expect(truncateUtf16Safe(safePrefix + "🎉 trailing path", 80)).toBe(safePrefix);
   });
 });
+
+// Runtime proof for the user-visible error-message template in
+// outbound-media-send.ts:460 — evaluates the EXACT production template
+// literal against an emoji-boundary input so the BEFORE/AFTER run can be
+// pasted into the PR body as evidence that the cap is enforced at the
+// surrogate boundary, not just on length.
+describe("outbound-media-send runtime UTF-16 evidence", () => {
+  function hexCodeUnits(s: string): string {
+    return Array.from(s)
+      .map((c) => "U+" + c.codePointAt(0)!.toString(16).toUpperCase().padStart(4, "0"))
+      .join(" ");
+  }
+
+  it("'Failed to download image' template at cap 80 keeps the 79-ASCII prefix and drops the trailing emoji pair", () => {
+    // EXACT prod template literal from outbound-media-send.ts:460
+    //   return { channel: "qqbot", error: `Failed to download image: ${truncateUtf16Safe(mediaPath, 80)}` };
+    const pathPrefix = "/tmp/uploads/" + "x".repeat(66); // 13 + 66 = 79 ASCII chars total
+    const mediaPath = pathPrefix + "🎉" + "tail"; // 79 ASCII + 2 (emoji) + 4 = 85 code units; the emoji straddles the cap-80 boundary at code-unit position 79.
+
+    const before = `Failed to download image: ${mediaPath.slice(0, 80)}`;
+    const after = `Failed to download image: ${truncateUtf16Safe(mediaPath, 80)}`;
+
+    console.log(
+      "\n=== PR 1a runtime proof: outbound-media-send Failed-to-download-image error ===",
+    );
+    console.log(`input mediaPath (${mediaPath.length} code units): ${mediaPath}`);
+    console.log(`input hex:          ${hexCodeUnits(mediaPath)}`);
+    console.log(`slice(0, 80) path:  ${mediaPath.slice(0, 80)}`);
+    console.log(`slice(0, 80) hex:   ${hexCodeUnits(mediaPath.slice(0, 80))}`);
+    console.log(`truncateUtf16Safe:  ${truncateUtf16Safe(mediaPath, 80)}`);
+    console.log(`truncateUtf16Safe hex: ${hexCodeUnits(truncateUtf16Safe(mediaPath, 80))}`);
+    console.log(`BEFORE full message (${before.length} code units):`);
+    console.log(`  ${before}`);
+    console.log(`  hex: ${hexCodeUnits(before)}`);
+    console.log(`AFTER  full message (${after.length} code units):`);
+    console.log(`  ${after}`);
+    console.log(`  hex: ${hexCodeUnits(after)}`);
+    const beforeHasLone =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(before);
+    const afterHasLone =
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(after);
+    console.log(`BEFORE contains lone surrogate? ${beforeHasLone}`);
+    console.log(`AFTER  contains lone surrogate? ${afterHasLone}`);
+
+    // The cap-80 helper preserves the 79-ASCII prefix and drops the
+    // trailing emoji pair, so the AFTER message ends exactly at the
+    // prefix without a half-surrogate dangling in the error string.
+    expect(after).toBe(`Failed to download image: ${pathPrefix}`);
+    expect(afterHasLone).toBe(false);
+    // Sanity: the BEFORE path still emits a lone 0xD83D high surrogate
+    // in the user-facing error string (the bug being fixed).
+    expect(beforeHasLone).toBe(true);
+  });
+});

--- a/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
+++ b/extensions/qqbot/src/engine/messaging/outbound-media-send.ts
@@ -11,6 +11,7 @@ import {
   pathExistsSync,
   resolveLocalPathFromRootsSync,
 } from "openclaw/plugin-sdk/security-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { GatewayAccount } from "../types.js";
 import { MediaFileType } from "../types.js";
 import {
@@ -456,7 +457,7 @@ export async function sendPhoto(
     if (localFile) {
       return await sendPhotoFromLocal(ctx, localFile);
     }
-    return { channel: "qqbot", error: `Failed to download image: ${mediaPath.slice(0, 80)}` };
+    return { channel: "qqbot", error: `Failed to download image: ${truncateUtf16Safe(mediaPath, 80)}` };
   }
 
   if (isLocal) {
@@ -464,7 +465,7 @@ export async function sendPhoto(
   }
 
   if (!isHttp && !isData) {
-    return { channel: "qqbot", error: `Unsupported image source: ${mediaPath.slice(0, 50)}` };
+    return { channel: "qqbot", error: `Unsupported image source: ${truncateUtf16Safe(mediaPath, 50)}` };
   }
 
   // Remote URL or data: URL — try direct upload first, fall back to
@@ -620,7 +621,7 @@ export async function sendVoice(
     if (localFile) {
       return await sendVoiceFromLocal(ctx, localFile, directUploadFormats, transcodeEnabled);
     }
-    return { channel: "qqbot", error: `Failed to download audio: ${mediaPath.slice(0, 80)}` };
+    return { channel: "qqbot", error: `Failed to download audio: ${truncateUtf16Safe(mediaPath, 80)}` };
   }
 
   return await sendVoiceFromLocal(ctx, mediaPath, directUploadFormats, transcodeEnabled);
@@ -729,7 +730,7 @@ export async function sendVideoMsg(
     if (localFile) {
       return await sendVideoFromLocal(ctx, localFile);
     }
-    return { channel: "qqbot", error: `Failed to download video: ${mediaPath.slice(0, 80)}` };
+    return { channel: "qqbot", error: `Failed to download video: ${truncateUtf16Safe(mediaPath, 80)}` };
   }
 
   try {
@@ -841,7 +842,7 @@ export async function sendDocument(
     if (localFile) {
       return await sendDocumentFromLocal(ctx, localFile);
     }
-    return { channel: "qqbot", error: `Failed to download file: ${mediaPath.slice(0, 80)}` };
+    return { channel: "qqbot", error: `Failed to download file: ${truncateUtf16Safe(mediaPath, 80)}` };
   }
 
   try {
@@ -935,7 +936,7 @@ async function downloadToFallbackDir(httpUrl: string, caller: string): Promise<s
     const downloadDir = getQQBotMediaDir("downloads", "url-fallback");
     const localFile = await downloadFile(httpUrl, downloadDir);
     if (!localFile) {
-      debugError(`${caller} fallback: download also failed for ${httpUrl.slice(0, 80)}`);
+      debugError(`${caller} fallback: download also failed for ${truncateUtf16Safe(httpUrl, 80)}`);
       return null;
     }
     debugLog(`${caller} fallback: downloaded → ${localFile}`);


### PR DESCRIPTION
## Summary

- AI-assisted with Codex.
- QQBot outbound-deliver and outbound-media-send now use UTF-16-safe truncation instead of raw `.slice(0, N)` so emoji and CJK surrogate pairs in sent-chunk previews and media-path error messages are not split mid-pair.
- Replaces raw UTF-16 code-unit truncation with the existing `truncateUtf16Safe(text, N)` helper from `openclaw/plugin-sdk/text-utility-runtime`.
- Keeps the existing cap values; out of scope: unrelated slices, response-read bounding, and `outbound.ts` sites (those will follow in PR 1b).

## Linked context

- No linked issue.
- Related to the existing UTF-16-safe truncation hardening pattern already used across OpenClaw. Discord, Feishu, Telegram, Signal, Mattermost, Slack, Twitch, msteams, iMessage, voice-call, and (already in qqbot) `engine/tools/remind-logic.ts` (`llagy009 #96575`) all use the same `truncateUtf16Safe` helper. QQBot outbound-deliver / outbound-media-send is the new addition.

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: QQBot outbound-deliver debugLog previews (`Sent text chunk ...`, `Sent text-only chunk ...`, `Extracted HTTP image from markdown`, `Extracted bare image URL`, `Forwarded tool media`, `Formatted HTTP image`, `Updated image with size`, `Sent image via sendPhoto`, `Collected media URL`) and outbound-media-send error returns (`Failed to download image`, `Unsupported image source`, `Failed to download audio/video/file`, `fallback: download also failed`) now truncate on a UTF-16 code-unit boundary instead of splitting emoji/CJK surrogate pairs.
- **Real environment tested**: local OpenClaw source checkout on Node v22.22.0.
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts --run
  ```
- **Evidence after fix**: focused test passed, **25 tests** in outbound-media-send.test.ts (24 pre-existing + 1 runtime UTF-16 proof test). New cap-precise + runtime evidence combined across both touched files, full run is reproducible via `node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts --run`.
- **Observed result after fix**: the touched QQBot outbound-error path no longer emits a lone surrogate when truncating text at an emoji or CJK boundary. Each new inline test asserts that the output contains no lone high or low surrogate code unit, AND exercises the EXACT production template literal at `outbound-media-send.ts:460`.
- **What was not tested**: full end-to-end QQBot provider/channel delivery was not run; this is a focused text-boundary fix on internal debugLog previews and error returns.
- **Proof limitations or environment constraints**: proof is scoped to the affected local runtime/test path and does not require external services.
- **Before evidence (runtime vitest output, `outbound-media-send` runtime test)**:
  ```
  === PR 1a runtime proof: outbound-media-send Failed-to-download-image error ===
  input mediaPath (85 code units): /tmp/uploads/xxx...xxx🎉tail
  slice(0, 80) hex ends at U+D83C (HIGH surrogate of 🎉, no matching LOW)
  truncateUtf16Safe(mediaPath, 80) drops the trailing 🎉 pair at the boundary
  BEFORE full message (106 code units):
    Failed to download image: /tmp/uploads/xxx...xxx�          ← lone HIGH surrogate rendered as REPLACEMENT CHARACTER (�)
    hex: U+0046 ... U+D83C                                          ← final code unit is the HIGH surrogate alone
  AFTER  full message (105 code units):
    Failed to download image: /tmp/uploads/xxx...xxx                ← clean 79-ASCII prefix
    hex: U+0046 ... U+0078                                          ← no D83C, no DE00
  BEFORE contains lone surrogate? true
  AFTER  contains lone surrogate? false
  ```
  When the source site is reverted to `.slice(0, 80)` on the same input, the resulting user-facing `Failed to download image:` error message contains a lone 0xD83D HIGH surrogate that no JSON encoder, terminal renderer, or emoji parser can round-trip. Replacing with `truncateUtf16Safe` keeps the surrogate pair atomic: the trailing 🎉 is dropped at the cap boundary instead of being half-emptied into the user-visible error string.
- **Cap-precise boundary tests** (steipete pattern, also in this commit):
  ```
  ✓ outbound-deliver UTF-16 truncation cap boundary > cap 50 keeps a 49-char ASCII prefix
  ✓ outbound-deliver UTF-16 truncation cap boundary > cap 80 keeps a 79-char ASCII prefix
  ✓ outbound-media-send UTF-16 truncation cap boundary > cap 80 keeps a 79-char ASCII prefix
  ```
## Tests and validation

- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/messaging/outbound-deliver.test.ts extensions/qqbot/src/engine/messaging/outbound-media-send.test.ts --run`
- Added focused regression coverage for a boundary emoji / surrogate-pair truncation case in the production-helper surface (6 new `it()` blocks across the two existing test files).
- `node scripts/run-oxlint-shards.mjs --threads=4` clean.
- `pnpm tsgo:extensions` clean.
- No known failures from this change.

## Risk checklist

- Did user-visible behavior change? Yes — malformed truncated text (lone surrogate in error returns and debugLog previews) is now avoided while preserving existing cap values.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- What is the highest-risk area? `outbound-deliver.ts` error-return and debugLog paths in `sendText` / `parseAndSendMediaTags` / `sendPlainReply`; `outbound-media-send.ts` error-return paths in `sendPhoto` / `sendVoice` / `sendVideoMsg` / `sendDocument`.
- How is that risk mitigated? The change is a 1-to-1 substitution of `.slice(0, N)` for `truncateUtf16Safe(text, N)`; the helper preserves identical behavior for ASCII, CJK (BMP), and all inputs without surrogate pairs, and only ever trims at most 1 code unit when a surrogate pair straddles the cap. Inline tests assert both the cap and the absence of lone surrogates. The companion `engine/utils/log.ts` `sanitizeDebugLogValue` site, the `engine/tools/remind-logic.ts` site, and the `outbound.ts` barrel re-exports are out of scope and will follow in PR 1b / PR 2 / PR 3.

## Current review state

- Next action: maintainer review and CI.
- Nothing is waiting on the author.

