### PR TITLE
fix(gateway): reset channel restart counter after a stable run

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -14,7 +14,11 @@ import { createRuntimeChannel } from "../plugins/runtime/runtime-channel.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { createChannelManager, type ChannelManager } from "./server-channels.js";
+import {
+  createChannelManager,
+  STABLE_RUN_RESET_MS,
+  type ChannelManager,
+} from "./server-channels.js";
 
 const hoisted = vi.hoisted(() => {
   const computeBackoff = vi.fn(() => 10);
@@ -267,6 +271,38 @@ describe("server-channels auto restart", () => {
 
     await vi.advanceTimersByTimeAsync(200);
     expect(startAccount).toHaveBeenCalledTimes(11);
+  });
+
+  it("resets the restart counter after a stable run", async () => {
+    let calls = 0;
+    const startAccount = vi.fn(async () => {
+      calls += 1;
+      if (calls >= 3) {
+        // Stay up past STABLE_RUN_RESET_MS so the run counts as healthy.
+        await new Promise<void>((resolve) => setTimeout(resolve, STABLE_RUN_RESET_MS + 1_000));
+      }
+    });
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager();
+
+    await manager.startChannels();
+    // Two instant exits accumulate attempts 1 and 2; the third run is stable.
+    await advanceTimersUntil(
+      () => startAccount.mock.calls.length >= 3,
+      "expected two crash-loop restarts before the stable run",
+      { stepMs: 10, maxMs: 500 },
+    );
+    await advanceTimersUntil(
+      () => startAccount.mock.calls.length >= 4,
+      "expected an auto-restart after the stable run exited",
+      { stepMs: 30_000, maxMs: 4 * STABLE_RUN_RESET_MS },
+    );
+
+    const snapshot = manager.getRuntimeSnapshot();
+    const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(account?.running).toBe(true);
+    // The stable run cleared the accumulated attempts: this restart is attempt 1, not 3.
+    expect(account?.reconnectAttempts).toBe(1);
   });
 
   it("records a clean channel monitor exit before auto-restart", async () => {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -14,11 +14,7 @@ import { createRuntimeChannel } from "../plugins/runtime/runtime-channel.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
-import {
-  createChannelManager,
-  STABLE_RUN_RESET_MS,
-  type ChannelManager,
-} from "./server-channels.js";
+import { createChannelManager, type ChannelManager } from "./server-channels.js";
 
 const hoisted = vi.hoisted(() => {
   const computeBackoff = vi.fn(() => 10);
@@ -35,12 +31,17 @@ const hoisted = vi.hoisted(() => {
       );
     });
   });
-  return { computeBackoff, sleepWithAbort };
+  const startChannelApprovalHandlerBootstrap = vi.fn(async () => async () => {});
+  return { computeBackoff, sleepWithAbort, startChannelApprovalHandlerBootstrap };
 });
 
 vi.mock("../infra/backoff.js", () => ({
   computeBackoff: hoisted.computeBackoff,
   sleepWithAbort: hoisted.sleepWithAbort,
+}));
+
+vi.mock("../infra/approval-handler-bootstrap.js", () => ({
+  startChannelApprovalHandlerBootstrap: hoisted.startChannelApprovalHandlerBootstrap,
 }));
 
 type TestAccount = {
@@ -222,6 +223,7 @@ function createManager(options?: {
 }
 
 describe("server-channels auto restart", () => {
+  const stableChannelRunMs = 5 * 60_000;
   let previousRegistry: PluginRegistry | null = null;
 
   beforeEach(() => {
@@ -230,6 +232,8 @@ describe("server-channels auto restart", () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     hoisted.computeBackoff.mockClear();
     hoisted.sleepWithAbort.mockClear();
+    hoisted.startChannelApprovalHandlerBootstrap.mockReset();
+    hoisted.startChannelApprovalHandlerBootstrap.mockResolvedValue(async () => {});
   });
 
   afterEach(async () => {
@@ -273,36 +277,74 @@ describe("server-channels auto restart", () => {
     expect(startAccount).toHaveBeenCalledTimes(11);
   });
 
-  it("resets the restart counter after a stable run", async () => {
-    let calls = 0;
-    const startAccount = vi.fn(async () => {
-      calls += 1;
-      if (calls >= 3) {
-        // Stay up past STABLE_RUN_RESET_MS so the run counts as healthy.
-        await new Promise<void>((resolve) => setTimeout(resolve, STABLE_RUN_RESET_MS + 1_000));
-      }
+  it.each(["resolve", "reject"] as const)(
+    "resets the restart counter after a stable run that ends with %s",
+    async (outcome) => {
+      const attemptsAtStart: number[] = [];
+      let calls = 0;
+      const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+        attemptsAtStart.push(ctx.getStatus().reconnectAttempts ?? 0);
+        calls += 1;
+        if (calls === 3) {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, stableChannelRunMs + 1_000);
+          });
+          if (outcome === "reject") {
+            throw new Error("stable run ended");
+          }
+        }
+      });
+      installTestRegistry(createTestPlugin({ startAccount }));
+      const manager = createManager();
+
+      await manager.startChannels();
+      // Two instant exits accumulate attempts 1 and 2; the third run is stable.
+      await advanceTimersUntil(
+        () => startAccount.mock.calls.length >= 3,
+        "expected two crash-loop restarts before the stable run",
+        { stepMs: 10, maxMs: 500 },
+      );
+      await advanceTimersUntil(
+        () => startAccount.mock.calls.length >= 4,
+        "expected an auto-restart after the stable run exited",
+        { stepMs: 30_000, maxMs: 4 * stableChannelRunMs },
+      );
+
+      expect(attemptsAtStart[3]).toBe(1);
+    },
+  );
+
+  it("does not count slow cleanup as a stable channel run", async () => {
+    const attemptsAtStart: number[] = [];
+    const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+      attemptsAtStart.push(ctx.getStatus().reconnectAttempts ?? 0);
+    });
+    hoisted.startChannelApprovalHandlerBootstrap.mockImplementation(async () => {
+      const run = hoisted.startChannelApprovalHandlerBootstrap.mock.calls.length;
+      return async () => {
+        if (run === 3) {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, stableChannelRunMs + 1_000);
+          });
+        }
+      };
     });
     installTestRegistry(createTestPlugin({ startAccount }));
     const manager = createManager();
 
     await manager.startChannels();
-    // Two instant exits accumulate attempts 1 and 2; the third run is stable.
     await advanceTimersUntil(
       () => startAccount.mock.calls.length >= 3,
-      "expected two crash-loop restarts before the stable run",
+      "expected two crash-loop restarts before slow cleanup",
       { stepMs: 10, maxMs: 500 },
     );
     await advanceTimersUntil(
       () => startAccount.mock.calls.length >= 4,
-      "expected an auto-restart after the stable run exited",
-      { stepMs: 30_000, maxMs: 4 * STABLE_RUN_RESET_MS },
+      "expected an auto-restart after slow cleanup",
+      { stepMs: 30_000, maxMs: 4 * stableChannelRunMs },
     );
 
-    const snapshot = manager.getRuntimeSnapshot();
-    const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
-    expect(account?.running).toBe(true);
-    // The stable run cleared the accumulated attempts: this restart is attempt 1, not 3.
-    expect(account?.reconnectAttempts).toBe(1);
+    expect(attemptsAtStart[3]).toBe(3);
   });
 
   it("records a clean channel monitor exit before auto-restart", async () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -36,6 +36,14 @@ const CHANNEL_RESTART_POLICY: BackoffPolicy = {
   jitter: 0.1,
 };
 const MAX_RESTART_ATTEMPTS = 10;
+// A run that outlasts the maximum restart backoff counts as healthy: on exit the
+// accumulated attempt count is cleared so the next crash starts a fresh incident
+// (supervisor-window semantics, like systemd StartLimit*). Attempts otherwise only
+// reset on manual stop/start, so one isolated provider blip per day would permanently
+// kill the channel after MAX_RESTART_ATTEMPTS days (observed with Telegram's nightly
+// Bot API restart). Deliberate trade-off: a channel that keeps producing stable runs
+// between exits retries forever instead of ever reaching the give-up cap.
+export const STABLE_RUN_RESET_MS = CHANNEL_RESTART_POLICY.maxMs;
 const CHANNEL_STOP_ABORT_TIMEOUT_MS = 5_000;
 const CHANNEL_STARTUP_CONCURRENCY = 4;
 
@@ -623,13 +631,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           } catch (error) {
             log.error?.(`[${id}] native approval bootstrap failed: ${formatErrorMessage(error)}`);
           }
+          const runStartedAtMs = Date.now();
           setRuntime(channelId, id, {
             accountId: id,
             enabled: true,
             configured: true,
             running: true,
             restartPending: false,
-            lastStartAt: Date.now(),
+            lastStartAt: runStartedAtMs,
             lastError: null,
             reconnectAttempts: preserveRestartAttempts ? (restartAttempts.get(rKey) ?? 0) : 0,
           });
@@ -760,6 +769,11 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                   // abort or startup failure — runtime state was recorded by startChannelInternal
                 }
                 return;
+              }
+              // Stable run => fresh incident: without this, attempts accumulate across
+              // isolated exits days apart until the channel permanently gives up.
+              if (Date.now() - runStartedAtMs >= STABLE_RUN_RESET_MS) {
+                restartAttempts.delete(rKey);
               }
               const attempt = (restartAttempts.get(rKey) ?? 0) + 1;
               restartAttempts.set(rKey, attempt);

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -624,16 +624,14 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           } catch (error) {
             log.error?.(`[${id}] native approval bootstrap failed: ${formatErrorMessage(error)}`);
           }
-          const runStartedAtMs = Date.now();
-          let channelRunStartedAt: number | undefined;
-          let channelRunSettledAt: number | undefined;
+          let channelRunDurationMs: number | undefined;
           setRuntime(channelId, id, {
             accountId: id,
             enabled: true,
             configured: true,
             running: true,
             restartPending: false,
-            lastStartAt: runStartedAtMs,
+            lastStartAt: Date.now(),
             lastError: null,
             reconnectAttempts: preserveRestartAttempts ? (restartAttempts.get(rKey) ?? 0) : 0,
           });
@@ -652,7 +650,10 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 return;
               }
               const runStartAccount = () => {
-                channelRunStartedAt = Date.now();
+                const startedAt = Date.now();
+                const recordDuration = () => {
+                  channelRunDurationMs = Date.now() - startedAt;
+                };
                 try {
                   return startAccount({
                     cfg,
@@ -667,11 +668,9 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                         ? setRuntimeFromTaskStatus(channelId, id, next, abort.signal)
                         : getRuntime(channelId, id),
                     ...(channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}),
-                  }).finally(() => {
-                    channelRunSettledAt = Date.now();
-                  });
+                  }).finally(recordDuration);
                 } catch (error) {
-                  channelRunSettledAt = Date.now();
+                  recordDuration();
                   throw error;
                 }
               };
@@ -774,13 +773,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 }
                 return;
               }
-              const completedStableRun =
-                channelRunStartedAt !== undefined &&
-                channelRunSettledAt !== undefined &&
-                channelRunSettledAt - channelRunStartedAt >= CHANNEL_STABLE_RUN_MS;
               // Only plugin task lifetime counts. Deferred handoff and cleanup must not
               // make a short crash look stable and erase crash-loop attempts.
-              if (completedStableRun) {
+              if (
+                channelRunDurationMs !== undefined &&
+                channelRunDurationMs >= CHANNEL_STABLE_RUN_MS
+              ) {
                 restartAttempts.delete(rKey);
               }
               const attempt = (restartAttempts.get(rKey) ?? 0) + 1;

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -36,14 +36,7 @@ const CHANNEL_RESTART_POLICY: BackoffPolicy = {
   jitter: 0.1,
 };
 const MAX_RESTART_ATTEMPTS = 10;
-// A run that outlasts the maximum restart backoff counts as healthy: on exit the
-// accumulated attempt count is cleared so the next crash starts a fresh incident
-// (supervisor-window semantics, like systemd StartLimit*). Attempts otherwise only
-// reset on manual stop/start, so one isolated provider blip per day would permanently
-// kill the channel after MAX_RESTART_ATTEMPTS days (observed with Telegram's nightly
-// Bot API restart). Deliberate trade-off: a channel that keeps producing stable runs
-// between exits retries forever instead of ever reaching the give-up cap.
-export const STABLE_RUN_RESET_MS = CHANNEL_RESTART_POLICY.maxMs;
+const CHANNEL_STABLE_RUN_MS = CHANNEL_RESTART_POLICY.maxMs;
 const CHANNEL_STOP_ABORT_TIMEOUT_MS = 5_000;
 const CHANNEL_STARTUP_CONCURRENCY = 4;
 
@@ -632,6 +625,8 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             log.error?.(`[${id}] native approval bootstrap failed: ${formatErrorMessage(error)}`);
           }
           const runStartedAtMs = Date.now();
+          let channelRunStartedAt: number | undefined;
+          let channelRunSettledAt: number | undefined;
           setRuntime(channelId, id, {
             accountId: id,
             enabled: true,
@@ -656,21 +651,30 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               if (abort.signal.aborted || manuallyStopped.has(rKey)) {
                 return;
               }
-              const runStartAccount = () =>
-                startAccount({
-                  cfg,
-                  accountId: id,
-                  account,
-                  runtime,
-                  abortSignal: abort.signal,
-                  log,
-                  getStatus: () => getRuntime(channelId, id),
-                  setStatus: (next) =>
-                    isCurrentTask()
-                      ? setRuntimeFromTaskStatus(channelId, id, next, abort.signal)
-                      : getRuntime(channelId, id),
-                  ...(channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}),
-                });
+              const runStartAccount = () => {
+                channelRunStartedAt = Date.now();
+                try {
+                  return startAccount({
+                    cfg,
+                    accountId: id,
+                    account,
+                    runtime,
+                    abortSignal: abort.signal,
+                    log,
+                    getStatus: () => getRuntime(channelId, id),
+                    setStatus: (next) =>
+                      isCurrentTask()
+                        ? setRuntimeFromTaskStatus(channelId, id, next, abort.signal)
+                        : getRuntime(channelId, id),
+                    ...(channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}),
+                  }).finally(() => {
+                    channelRunSettledAt = Date.now();
+                  });
+                } catch (error) {
+                  channelRunSettledAt = Date.now();
+                  throw error;
+                }
+              };
               const routeRegistry = getPluginHttpRouteRegistry?.();
               startAccountTask = routeRegistry
                 ? withPluginHttpRouteRegistry(routeRegistry, runStartAccount)
@@ -770,9 +774,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 }
                 return;
               }
-              // Stable run => fresh incident: without this, attempts accumulate across
-              // isolated exits days apart until the channel permanently gives up.
-              if (Date.now() - runStartedAtMs >= STABLE_RUN_RESET_MS) {
+              const completedStableRun =
+                channelRunStartedAt !== undefined &&
+                channelRunSettledAt !== undefined &&
+                channelRunSettledAt - channelRunStartedAt >= CHANNEL_STABLE_RUN_MS;
+              // Only plugin task lifetime counts. Deferred handoff and cleanup must not
+              // make a short crash look stable and erase crash-loop attempts.
+              if (completedStableRun) {
                 restartAttempts.delete(rKey);
               }
               const attempt = (restartAttempts.get(rKey) ?? 0) + 1;


### PR DESCRIPTION
## Summary

Channel self-restart attempts were preserved across every automatic recovery, even when the channel then ran normally for a long time. Isolated transport exits could therefore consume the manager's ten-attempt crash-loop budget across separate incidents.

The repaired implementation treats a channel task that runs for at least the existing maximum-backoff window (five minutes) as a recovered incident. When that task later settles, the next automatic restart begins at attempt 1. Rapid exits still accumulate and hit the existing cap.

The default channel health monitor already revisits a stopped account and clears its attempts on a later check, so manager give-up is normally bounded by the monitor interval rather than permanent. This change removes that avoidable recovery pause and repeated give-up warning; it also protects deployments where health monitoring is disabled.

## What Problem This Solves

On current main, `startChannelInternal` preserves restart attempts for automatic restarts. A channel can recover and remain healthy for hours or days, then have a later isolated exit counted against the same old incident. Repeated isolated exits eventually trigger manager give-up even though the channel never formed a crash loop.

## Why This Change Was Made

The channel manager already owns both restart-attempt state and the `startAccount` task. It now records only the duration of that returned promise, for both resolution and rejection, and clears accumulated attempts when that task itself outlives the stable-run window.

Measuring the plugin task is important: deferred startup and approval/runtime cleanup happen outside the channel run. Counting either could make a short crash appear stable and erase real crash-loop attempts. The threshold remains private, and current task-ownership, terminal-disconnect, and timed-out-recovery paths are unchanged.

## User Impact

- A channel that runs normally for at least five minutes starts a fresh restart incident after its next exit.
- A rapid crash loop still backs off and stops self-restarting after ten attempts.
- Slow startup handoff or manager cleanup cannot falsely reset the crash-loop counter.
- With the default health monitor enabled, its later recovery remains unchanged.

## Evidence

- Sanitized AWS exact-head run `run_013c35462622`: 6 files and 248 tests passed, covering `server-channels` and `channel-health-monitor` across configured gateway shards.
- Sanitized AWS exact-head run `run_67d0b1bb4a16`: `pnpm check:changed` passed, including core/core-test typechecks, changed-file lint with 0 warnings/errors, database-first checks, and runtime import-cycle checks.
- Regression coverage includes stable resolve, stable rejection, short task plus slow cleanup, the unchanged hard crash-loop cap, and health-monitor recovery.
- Fresh Codex autoreview after the final code shape: no accepted or actionable findings (0.90 confidence).

Co-authored with and thanks to @clintoncodewell for identifying and reproducing the restart-budget issue.
