### PR TITLE
fix(backup): retry fs.rm on EBUSY to prevent tar retry-loop collapse on Windows

### DIFF
--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -170,6 +170,30 @@ function isTarEofRaceError(err: unknown): boolean {
 
 export type BackupTarRetryLogger = (message: string) => void;
 
+const RM_EBUSY_RETRY_MAX = 3;
+const RM_EBUSY_RETRY_MS = 100;
+
+/**
+ * Removes a temp archive file, retrying on EBUSY (Windows file-lock
+ * contention) so a leaked tar fd doesn't defeat the outer retry loop.
+ */
+async function removeTempArchive(tempArchivePath: string): Promise<void> {
+  for (let attempt = 1; attempt <= RM_EBUSY_RETRY_MAX; attempt += 1) {
+    try {
+      await fs.rm(tempArchivePath, { force: true });
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") return;
+      if (code === "EBUSY" && attempt < RM_EBUSY_RETRY_MAX) {
+        await sleep(RM_EBUSY_RETRY_MS);
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
 async function writeTarArchiveWithRetry(params: {
   tempArchivePath: string;
   runTar: () => Promise<void>;
@@ -188,7 +212,7 @@ async function writeTarArchiveWithRetry(params: {
         break;
       }
       try {
-        await fs.rm(params.tempArchivePath, { force: true });
+        await removeTempArchive(params.tempArchivePath);
       } catch (cleanupErr) {
         const code = (cleanupErr as NodeJS.ErrnoException).code;
         if (code && code !== "ENOENT") {


### PR DESCRIPTION
## What Problem This Solves

On Windows, `fs.rm` in `writeTarArchiveWithRetry` can throw `EBUSY` when the `runTar` process still holds a file descriptor. The error is caught and logged, but the file is not removed — the temp archive stays locked. The next `runTar` attempt immediately fails because the file is still in use, defeating the `BACKUP_TAR_BACKOFF_MS` retry mechanism. Backup creation cascades to instant failure instead of recovering via backoff.

Fixes #101382.

## Why This Change Was Made

**Root cause**: In the cleanup path between tar retries (`src/infra/backup-create.ts:191`), `fs.rm` only attempts removal once. On Windows, a file locked by another process handle returns `EBUSY`. The old code treated `EBUSY` like any other error — log and continue — leaving the locked file behind for the next tar attempt to fail on.

**Fix**: Extract `fs.rm` into a `removeTempArchive` helper that retries up to 3 times with a 100ms sleep when the error is `EBUSY`, giving the OS time to release the file handle before the outer loop sleeps (10s/20s) and retries tar.

## User Impact

- **Windows users**: Backup creation no longer cascades to instant failure when a temporary file lock is encountered during retry.
- **Linux/macOS users**: No behavior change — `EBUSY` is Windows-specific.

## Evidence

- **Tests**: `src/infra/backup-create.test.ts` — 39 tests passed
- **Format**: `git diff --check` clean
- **Change scope**: 1 file, +25/-1 lines
- **Security**: No security impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>