### PR TITLE
refactor(plugins): localize provider internals

### DIFF
--- a/extensions/brave/web-search-shared.ts
+++ b/extensions/brave/web-search-shared.ts
@@ -9,10 +9,10 @@ import {
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 /** Canonical config path for the Brave Search API key. */
-export const BRAVE_CREDENTIAL_PATH = "plugins.entries.brave.config.webSearch.apiKey";
+const BRAVE_CREDENTIAL_PATH = "plugins.entries.brave.config.webSearch.apiKey";
 
 /** Resolve legacy top-level Brave credentials from old web-search config. */
-export function resolveLegacyTopLevelBraveCredential(
+function resolveLegacyTopLevelBraveCredential(
   config: unknown,
 ): { path: string; value: unknown } | undefined {
   if (!isRecord(config)) {
@@ -39,7 +39,7 @@ function resolveBraveWebSearchPluginConfig(config: unknown): Record<string, unkn
 }
 
 /** Resolve Brave credentials from current plugin config or legacy fallback. */
-export function resolveConfiguredBraveCredential(config: unknown): unknown {
+function resolveConfiguredBraveCredential(config: unknown): unknown {
   return (
     resolveBraveWebSearchPluginConfig(config)?.apiKey ??
     resolveLegacyTopLevelBraveCredential(config)?.value

--- a/extensions/deepinfra/provider-models.ts
+++ b/extensions/deepinfra/provider-models.ts
@@ -70,7 +70,7 @@ interface DeepInfraAgentModelEntry {
   metadata: DeepInfraAgentModelMetadata | null;
 }
 
-export type DeepInfraSurface = "chat" | "vlm" | "embed" | "image-gen" | "video-gen" | "tts" | "stt";
+type DeepInfraSurface = "chat" | "vlm" | "embed" | "image-gen" | "video-gen" | "tts" | "stt";
 
 export interface DeepInfraSurfaceModel {
   id: string;
@@ -85,7 +85,7 @@ export interface DeepInfraSurfaceModel {
   defaultIterations?: number;
 }
 
-export interface DeepInfraDiscoveredCatalog {
+interface DeepInfraDiscoveredCatalog {
   chat: DeepInfraSurfaceModel[];
   vlm: DeepInfraSurfaceModel[];
   embed: DeepInfraSurfaceModel[];

--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -72,7 +72,7 @@ async function readFirecrawlJsonResponse(
   return await readProviderJsonResponse<Record<string, unknown>>(response, label, opts);
 }
 
-export type FirecrawlSearchParams = {
+type FirecrawlSearchParams = {
   cfg?: OpenClawConfig;
   query: string;
   count?: number;
@@ -82,7 +82,7 @@ export type FirecrawlSearchParams = {
   scrapeResults?: boolean;
 };
 
-export type FirecrawlScrapeParams = {
+type FirecrawlScrapeParams = {
   cfg?: OpenClawConfig;
   url: string;
   extractMode: "markdown" | "text";

--- a/extensions/firecrawl/web-search-shared.ts
+++ b/extensions/firecrawl/web-search-shared.ts
@@ -5,10 +5,10 @@ import {
   type WebSearchProviderPlugin,
 } from "openclaw/plugin-sdk/provider-web-search-contract";
 
-export const FIRECRAWL_CREDENTIAL_PATH = "plugins.entries.firecrawl.config.webSearch.apiKey";
-export const FIRECRAWL_FETCH_CREDENTIAL_PATH = "plugins.entries.firecrawl.config.webFetch.apiKey";
+const FIRECRAWL_CREDENTIAL_PATH = "plugins.entries.firecrawl.config.webSearch.apiKey";
+const FIRECRAWL_FETCH_CREDENTIAL_PATH = "plugins.entries.firecrawl.config.webFetch.apiKey";
 
-export function getConfiguredFirecrawlFetchCredentialFallback(config?: {
+function getConfiguredFirecrawlFetchCredentialFallback(config?: {
   plugins?: { entries?: { firecrawl?: { config?: unknown } } };
 }) {
   const apiKey = (


### PR DESCRIPTION
## What Problem This Solves

The dead-code report still classified ten private Brave, Firecrawl, and DeepInfra declarations as public exports even though every consumer is in the defining file.

## Why This Change Was Made

Keep module-private declarations module-private. The plugin packages already expose their intentional contracts through `index.ts`, `api.ts`, and the web-search contract barrels; none of these declarations crosses those boundaries.

This removes only `export` modifiers. Runtime declarations, callers, signatures, and behavior remain unchanged.

## User Impact

None. This is an internal TypeScript surface cleanup.

## Evidence

- Codebase-memory MCP graph refreshed on the rebased tree: 277,955 nodes / 1,121,794 edges.
- Graph edge audit and repo-wide search found only same-file consumers for all ten declarations.
- Blacksmith Testbox `tbx_01kwxm9nxnagqpaq1ccf6tx84w`:
  - targeted `ts-unused-exports` findings: 10 -> 0
  - `pnpm check:changed`: passed
  - seven focused files: 155 tests passed
- Local exact-tree focused proof: seven files / 155 tests passed.
- `oxfmt --check`: passed.
- `git diff --check`: passed.
- Fresh Codex autoreview: zero findings, patch correct, confidence 0.90.

AI-assisted: yes.
