### PR TITLE
fix(imessage): apply canonical outbound sanitizer

### DIFF
--- a/extensions/imessage/src/monitor/sanitize-outbound.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.ts
@@ -1,5 +1,5 @@
 // Imessage plugin module implements sanitize outbound behavior.
-import { stripAssistantInternalScaffolding } from "openclaw/plugin-sdk/text-chunking";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 
 /**
  * Patterns that indicate assistant-internal metadata leaked into text.
@@ -21,7 +21,7 @@ export function sanitizeOutboundText(text: string): string {
     return text;
   }
 
-  let cleaned = stripAssistantInternalScaffolding(text);
+  let cleaned = sanitizeAssistantVisibleText(text);
 
   cleaned = cleaned.replace(INTERNAL_SEPARATOR_RE, "");
   cleaned = cleaned.replace(ASSISTANT_ROLE_MARKER_RE, "");

--- a/extensions/imessage/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/imessage/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,23 @@
+// iMessage outbound must strip assistant internal tool-trace scaffolding,
+// matching the sibling channel fixes tracked under #90684 while preserving the
+// channel-specific plain-text cleanup that already existed.
+import { describe, expect, it } from "vitest";
+import { imessagePlugin } from "./channel.js";
+
+describe("imessage outbound sanitizeText", () => {
+  it("strips downgraded tool-call text before outbound delivery", () => {
+    const text = [
+      "[Tool Call: read (ID: toolu_1)]",
+      'Arguments: {"path":"/tmp/internal"}',
+      "Done.",
+    ].join("\n");
+
+    expect(imessagePlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(imessagePlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

iMessage outbound cleanup used the `internal-scaffolding` sanitizer profile. That profile intentionally preserves some assistant-internal delivery artifacts, including downgraded tool-call text such as `[Tool Call: …]` blocks. Other messaging adapters already use the canonical `delivery` profile tracked by #90684.

Refs #90684.

## Why This Change Was Made

This starts iMessage outbound cleanup with `sanitizeAssistantVisibleText`, then keeps the existing iMessage-specific separator and role-marker cleanup.

The change is deliberately channel-local:

- no new config or shared delivery contract
- no duplicate sanitizer pass
- the same canonical delivery profile already used by merged sibling-channel fixes

## User Impact

iMessage recipients no longer receive downgraded tool-call scaffolding that the old iMessage profile intentionally preserved. Ordinary assistant prose and the existing iMessage-specific cleanup remain unchanged.

## Evidence

- Exact head: `e03f4b69fad3cf816947c457192e9126e6a45daa`
- Rebased base: `4d8e89fd5cc447da04ce5f0615a21cff7c491f51`
- `git range-diff` reports the single PR commit as patch-equivalent across the rebase.
- The regression proves the material profile difference:
  - the `internal-scaffolding` profile preserves `[Tool Call: …]` downgraded text;
  - this PR's iMessage `sanitizeText` hook removes that block and preserves the visible answer.
- Direct hook behavior:

```text
input:  [Tool Call: read (ID: toolu_1)]
        Arguments: {"path":"/tmp/internal"}
        Done.
output: Done.
```

- Focused current-head regression: `vitest run extensions/imessage/src/outbound-tool-trace-sanitize.test.ts --config test/vitest/vitest.extension-imessage.config.ts` — passed 2 tests.
- Touched-file formatting passed.
- `git diff --check upstream/main...HEAD` passed.
- Prior redacted iMessage send/readback proof remains useful for confirming the adapter hook's output can be delivered unchanged over the iMessage service.
- Hosted CI started on this exact head. The rebase picks up current `main`'s workflow fixes for the prior branch-unrelated zizmor failure; hosted CI remains the canonical heavy validation lane.

AI-assisted change, manually reviewed and validated.
