### PR TITLE
fix(zalo): sanitize outbound tool traces

### DIFF
--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -38,7 +38,10 @@ import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
-import { chunkTextForOutbound } from "openclaw/plugin-sdk/text-chunking";
+import {
+  chunkTextForOutbound,
+  sanitizeAssistantVisibleText,
+} from "openclaw/plugin-sdk/text-chunking";
 import {
   listZaloAccountIds,
   resolveDefaultZaloAccountId,
@@ -289,6 +292,7 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount, ZaloProbeResult> =
       chunker: chunkTextForOutbound,
       chunkerMode: "text",
       textChunkLimit: zaloTextChunkLimit,
+      sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
       sendPayload: async (ctx) =>
         await sendPayloadWithChunkedTextAndMedia({
           ctx,

--- a/extensions/zalo/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/zalo/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,19 @@
+// Zalo outbound must strip assistant internal tool-trace scaffolding, matching
+// the sibling channel fixes tracked under #90684 (Telegram / Google Chat / IRC /
+// Matrix / Signal / Slack / SMS / Feishu).
+import { describe, expect, it } from "vitest";
+import { zaloPlugin } from "./channel.js";
+
+describe("zalo outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(zaloPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(zaloPlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Zalo outbound delivery did not opt into the shared `sanitizeAssistantVisibleText` delivery profile used by sibling channel fixes under #90684. Compact failed-tool banners could therefore reach Zalo recipients.

Related: #90684

## Why This Change Was Made

This adds the existing shared sanitizer at `zaloPlugin.outbound.sanitizeText`, the channel-owned hook that core calls before payload normalization, empty filtering, chunk planning, and Zalo transport delivery. Zalo's chunking, media, and attached-result send flow are unchanged.

## User Impact

Zalo recipients receive the intended assistant prose without internal failed-tool banners. Ordinary user-facing text is preserved.

## Evidence

- Current head: `26b4300bbe96ee2cd4f2a99019ac48da888da038`, rebased conflict-free onto `openclaw/openclaw:main` `33720886c8a8aa948c03803f463266a68ba956e0` on 2026-07-21.
- The rebase preserved the patch exactly: the old and current commits both have stable patch id `fe20a50c32c41e9b0744918dee495fb553551fdd`.
- `git diff --check upstream/main...HEAD` passed; the branch remains surgical at 2 files, +24/-1.
- `openclaw-pre-pr.sh --plan-only` passed the rebase, whitespace, dependency/proof policy, high-risk, and changed-lane planning gates. It selected only `extensions` and `extensionTests` lanes.
- Exact-head CI passed for `26b4300bbe96ee2cd4f2a99019ac48da888da038`: https://github.com/openclaw/openclaw/actions/runs/29792180086
  - `extensions/zalo/src/outbound-tool-trace-sanitize.test.ts`: 2/2 tests passed. The test invokes the exact `zaloPlugin.outbound.sanitizeText` hook and proves both the positive trace-removal path and the negative ordinary-prose preservation path.
  - `extensions/zalo/src/outbound-payload.contract.test.ts`: 9/9 tests passed, preserving current chunking, text/media adapter, and durable receipt boundaries.
  - `checks-node-changed`, `build-artifacts`, `check-guards`, `check-shrinkwrap`, production/test types, lint/formatting, dependency checks, channel-runtime CodeQL, and the aggregate `openclaw/ci-gate` all passed.
- The package-backed local test command and full local pre-PR gate could not run in this checkout because its dependency state is not hydrated: the focused Vitest command stopped before collection on missing `p-map`, and the full wrapper stopped at its dependency-state preflight. Per task scope, no dependency install or unrelated dependency repair was performed; exact-head hosted CI supplies the executed test/gate proof above.
- Structured autoreview was attempted against current `upstream/main`, but the local helper could not start because the `codex` executable is unavailable in this checkout environment.

Shared delivery applies the hook before payload normalization, empty filtering, chunk planning, and transport dispatch.

### Overlap and remaining gate

#103377 covers the same Zalo Bot production hook with broader focused positive/negative cases and accepted exact-boundary proof (`proof: sufficient`, `status: ready for maintainer look`). It remains the stronger canonical landing candidate. This branch is current and its patch identity is verified so its state is not mistaken for staleness, but it should not be interpreted as preferable to or independent from #103377.

Not tested: a credentialed live Zalo Bot API round trip. No live account or credentials were available, so no live transport proof is claimed. The remaining decision is maintainer consolidation around #103377; if maintainers still consider this branch, live Zalo proof or an explicit proof override remains the external-transport gate.

AI-assisted change, manually reviewed and validated within the stated live-transport limit.
