### PR TITLE
fix(gateway): reset model discovery cache on hot reload

### DIFF
--- a/src/agents/embedded-agent-runner/model-discovery-cache.ts
+++ b/src/agents/embedded-agent-runner/model-discovery-cache.ts
@@ -188,7 +188,12 @@ export function discoverCachedAgentStores(
   return stores;
 }
 
+/** Clears process-local discovery snapshots after config/model/auth sources are refreshed. */
+export function resetModelDiscoveryCache(): void {
+  DISCOVERY_STORE_CACHE.clear();
+}
+
 /** Clears the process-local discovery cache between tests that mutate model/auth fixtures. */
 export function resetModelDiscoveryCacheForTest(): void {
-  DISCOVERY_STORE_CACHE.clear();
+  resetModelDiscoveryCache();
 }

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -386,7 +386,7 @@ describe("gateway hot reload model state", () => {
           anthropic: {
             baseUrl: "https://api.anthropic.com/v1",
             apiKey: "${ANTHROPIC_API_KEY}",
-            api: "anthropic",
+            api: "anthropic-messages",
             models: [{ id: "claude-opus-4-6" }],
           },
         },

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -60,6 +60,7 @@ const hoisted = vi.hoisted(() => ({
   reloadEvents: [] as string[],
   loadModelCatalog: vi.fn(async (_params: { config: OpenClawConfig }) => []),
   resetModelCatalogCache: vi.fn(() => {}),
+  resetModelDiscoveryCache: vi.fn(() => {}),
   refreshContextWindowCache: vi.fn(async (_cfg: OpenClawConfig) => {}),
   clearCurrentProviderAuthState: vi.fn(() => {}),
   warmCurrentProviderAuthStateOffMainThread: vi.fn(async (_cfg: OpenClawConfig) => {}),
@@ -134,6 +135,13 @@ vi.mock("../agents/model-catalog.js", () => ({
   resetModelCatalogCache: () => {
     hoisted.reloadEvents.push("reset-model-catalog");
     hoisted.resetModelCatalogCache();
+  },
+}));
+
+vi.mock("../agents/embedded-agent-runner/model-discovery-cache.js", () => ({
+  resetModelDiscoveryCache: () => {
+    hoisted.reloadEvents.push("reset-model-discovery");
+    hoisted.resetModelDiscoveryCache();
   },
 }));
 
@@ -243,6 +251,7 @@ afterEach(() => {
   hoisted.reloadEvents.length = 0;
   hoisted.loadModelCatalog.mockClear();
   hoisted.resetModelCatalogCache.mockClear();
+  hoisted.resetModelDiscoveryCache.mockClear();
   hoisted.refreshContextWindowCache.mockClear();
   hoisted.clearCurrentProviderAuthState.mockClear();
   hoisted.warmCurrentProviderAuthStateOffMainThread.mockClear();
@@ -354,9 +363,11 @@ describe("gateway hot reload model state", () => {
     expect(firstResetIndex).toBeGreaterThanOrEqual(0);
     expect(hoisted.reloadEvents.slice(firstResetIndex)).toEqual([
       "reset-model-catalog",
+      "reset-model-discovery",
       "clear-provider-auth",
       "reload-plugins",
       "reset-model-catalog",
+      "reset-model-discovery",
       "clear-provider-auth",
       "refresh-context-window",
       "load-model-catalog",
@@ -365,6 +376,52 @@ describe("gateway hot reload model state", () => {
     expect(hoisted.refreshContextWindowCache).toHaveBeenCalledWith(nextConfig);
     expect(hoisted.loadModelCatalog).toHaveBeenCalledWith({ config: nextConfig });
     expect(hoisted.warmCurrentProviderAuthStateOffMainThread).toHaveBeenCalledWith(nextConfig);
+  });
+
+  it("clears embedded model discovery stores on non-plugin model hot reloads", async () => {
+    const { applyHotReload } = createReloadHandlersForTest();
+    const nextConfig = {
+      models: {
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.com/v1",
+            apiKey: "${ANTHROPIC_API_KEY}",
+            api: "anthropic",
+            models: [{ id: "claude-opus-4-6" }],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await applyHotReload(
+      {
+        changedPaths: ["models.providers.anthropic.models.0.id"],
+        restartGateway: false,
+        restartReasons: [],
+        hotReasons: ["models.providers.anthropic.models.0.id"],
+        reloadHooks: false,
+        restartGmailWatcher: false,
+        restartCron: false,
+        restartHeartbeat: false,
+        restartHealthMonitor: false,
+        reloadPlugins: false,
+        restartChannels: new Set(),
+        disposeMcpRuntimes: false,
+        noopPaths: [],
+      },
+      nextConfig,
+    );
+
+    expect(hoisted.resetModelDiscoveryCache).toHaveBeenCalledTimes(1);
+    expect(hoisted.reloadEvents).toEqual([
+      "reset-model-catalog",
+      "reset-model-discovery",
+      "clear-provider-auth",
+      "refresh-context-window",
+      "load-model-catalog",
+      "warm-provider-auth",
+    ]);
+    expect(hoisted.refreshContextWindowCache).toHaveBeenCalledWith(nextConfig);
   });
 
   it("disposes cached MCP runtimes on MCP config hot reloads", async () => {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -2,6 +2,7 @@
 // Applies config reload plans to hooks, cron, heartbeat, plugins, channels, and restarts.
 import { disposeAllSessionMcpRuntimes } from "../agents/agent-bundle-mcp-tools.js";
 import { refreshContextWindowCache } from "../agents/context.js";
+import { resetModelDiscoveryCache } from "../agents/embedded-agent-runner/model-discovery-cache.js";
 import {
   getActiveEmbeddedRunCount,
   listActiveEmbeddedRunSessionIds,
@@ -112,6 +113,7 @@ const CHANNEL_RELOAD_STILL_PENDING_WARN_MS = 30_000;
 
 function resetPreparedModelRuntimeStateForHotReload(): void {
   resetModelCatalogCache();
+  resetModelDiscoveryCache();
   clearCurrentProviderAuthState();
   markGatewayModelCatalogStaleForReload();
 }


### PR DESCRIPTION
## Summary

Resets the embedded-agent model discovery cache whenever the gateway applies a hot config reload, so long-lived gateway processes do not keep stale in-memory model registries after model/provider config changes.

## Issue/Motivation

Refs #99773.

The issue reports phantom `Unknown model` failover errors after hot reload even though fresh CLI config loads still resolve the include-defined models. Gateway hot reload already clears the prepared model catalog and provider auth state, but embedded-agent runs can reuse `discoverCachedAgentStores()` entries keyed only by agent/auth/model file metadata. When the hot reload changes resolved model/provider config without a corresponding agent file metadata change, those cached discovery stores can continue serving the old registry until process restart.

## Changes

- Expose `resetModelDiscoveryCache()` from the embedded-agent discovery cache module.
- Call it from the existing hot-reload model runtime reset path next to model catalog and provider auth invalidation.
- Add gateway reload tests proving non-plugin `models.*` hot reloads clear embedded model discovery stores, and update the plugin reload ordering assertion.

## Testing

- `pnpm exec vitest run src/gateway/server-reload-handlers.test.ts src/agents/embedded-agent-runner/model.test.ts` — 3 files passed, 277 tests passed.
- `git diff --check` — passed.
- Diff secret scan (`AKIA`, `ghp_`, `github_pat_`, `sk-`, `AIza` patterns over changed diff) — passed.

## What Problem This Solves

Prevents the gateway from keeping a stale embedded-agent model registry after hot reload updates model/provider config. That addresses the issue’s failure mode where the running gateway rejects include-defined models with `Unknown model` until a full restart, while a fresh CLI process resolves the same config correctly.

## Evidence

- Regression coverage added in `src/gateway/server-reload-handlers.test.ts` verifies a `models.providers.*` hot reload calls the embedded discovery cache reset before context/model catalog warming.
- Existing embedded model discovery tests still pass, including cache reuse/invalidation behavior in `src/agents/embedded-agent-runner/model.test.ts`.
- Verification run:
  - `pnpm exec vitest run src/gateway/server-reload-handlers.test.ts src/agents/embedded-agent-runner/model.test.ts` → 3 files passed, 277 tests passed.
  - `git diff --check` → passed.
  - Diff secret scan → passed.
