### PR TITLE
fix(openai): map Responses refusal chunks during tool calls

### DIFF
--- a/packages/ai/src/internal/openai.ts
+++ b/packages/ai/src/internal/openai.ts
@@ -6,6 +6,7 @@ export * from "../providers/openai-completions.js";
 export * from "../providers/openai-prompt-cache.js";
 export * from "../providers/openai-reasoning-effort.js";
 export * from "../providers/openai-responses.js";
+export * from "../providers/openai-responses-refusal.js";
 export * from "../providers/openai-responses-stream-compat.js";
 export * from "../providers/openai-stop-reason.js";
 export * from "../providers/openai-tool-projection.js";

--- a/packages/ai/src/providers/openai-responses-refusal.ts
+++ b/packages/ai/src/providers/openai-responses-refusal.ts
@@ -1,0 +1,36 @@
+import type { AssistantMessageDiagnostic } from "../types.js";
+
+type OpenAIResponsesRefusalOutput = {
+  stopReason: string;
+  errorMessage?: string;
+  diagnostics?: AssistantMessageDiagnostic[];
+};
+
+function readNullableString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function formatOpenAIResponsesRefusalMessage(explanation: string | null): string {
+  return explanation ? `OpenAI refusal: ${explanation}` : "OpenAI refusal.";
+}
+
+export function applyOpenAIResponsesRefusal(
+  output: OpenAIResponsesRefusalOutput,
+  refusal: unknown,
+  provider: string,
+): void {
+  const explanation = readNullableString(refusal);
+  output.stopReason = "error";
+  output.errorMessage = formatOpenAIResponsesRefusalMessage(explanation);
+  output.diagnostics = [
+    ...(output.diagnostics ?? []),
+    {
+      type: "provider_refusal",
+      timestamp: Date.now(),
+      details: {
+        provider,
+        explanation,
+      },
+    },
+  ];
+}

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -931,6 +931,76 @@ describe("processResponsesStream", () => {
     ]);
   });
 
+  it("maps function-call refusal deltas to provider refusal errors", async () => {
+    const output = createAssistantOutput();
+    const stream = new AssistantMessageEventStream();
+    const events: Array<Record<string, unknown>> = [];
+    const collect = (async () => {
+      for await (const event of stream) {
+        events.push(event as unknown as Record<string, unknown>);
+      }
+    })();
+
+    await processResponsesStream(
+      responseEvents([
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "function_call",
+            id: "fc_blocked",
+            call_id: "call_blocked",
+            name: "write",
+            arguments: "",
+          },
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          delta: '{"path":"forbidden.txt"}',
+        },
+        {
+          type: "response.refusal.delta",
+          delta: "Tool use is not allowed.",
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_blocked",
+            call_id: "call_blocked",
+            name: "write",
+            arguments: '{"path":"forbidden.txt"}',
+          },
+        },
+        {
+          type: "response.completed",
+          response: {
+            id: "resp_refusal",
+            status: "completed",
+          },
+        },
+      ]),
+      output,
+      stream,
+      nativeOpenAIModel,
+    );
+    stream.end();
+    await collect;
+
+    expect(output.stopReason).toBe("error");
+    expect(output.content).toEqual([]);
+    expect(output.errorMessage).toBe("OpenAI refusal: Tool use is not allowed.");
+    expect(output.diagnostics).toEqual([
+      expect.objectContaining({
+        type: "provider_refusal",
+        details: {
+          provider: nativeOpenAIModel.provider,
+          explanation: "Tool use is not allowed.",
+        },
+      }),
+    ]);
+    expect(events.map((event) => event.type)).toEqual(["toolcall_start", "toolcall_delta"]);
+  });
+
   it("prices cache-write tokens separately from ordinary Responses input", async () => {
     const model = {
       ...gpt56SolModel,

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -46,6 +46,7 @@ import {
   resolveOpenAIReasoningEffortForModel,
   supportsOpenAIReasoningEffort,
 } from "./openai-reasoning-effort.js";
+import { applyOpenAIResponsesRefusal } from "./openai-responses-refusal.js";
 import {
   AZURE_RESPONSES_TEXT_CONTENT_PART_TYPE,
   OPENAI_RESPONSES_OUTPUT_TEXT_CONTENT_PART_TYPE,
@@ -673,6 +674,7 @@ export async function processResponsesStream<TApi extends Api>(
   // its public block is deferred so a collapsed item never leaves an
   // unbalanced text_start behind (#91959). null = no deferral in progress.
   let pendingMessageText: string | null = null;
+  let pendingFunctionCallRefusal: string | null = null;
   const blocks = output.content;
   const blockIndex = () => blocks.length - 1;
   const appendPendingMessageDelta = (delta: string) => {
@@ -693,6 +695,16 @@ export async function processResponsesStream<TApi extends Api>(
       partial: output,
     });
     pendingMessageText = null;
+  };
+  const removeCurrentToolCallBlock = () => {
+    if (currentBlock?.type !== "toolCall") {
+      return;
+    }
+    const index = blocks.indexOf(currentBlock);
+    if (index >= 0) {
+      blocks.splice(index, 1);
+    }
+    currentBlock = null;
   };
 
   const guardedStream = withFirstStreamEventTimeout(openaiStream, {
@@ -733,6 +745,7 @@ export async function processResponsesStream<TApi extends Api>(
         }
       } else if (item.type === "function_call") {
         currentItem = item;
+        pendingFunctionCallRefusal = null;
         currentBlock = {
           type: "toolCall",
           id: `${item.call_id}|${item.id}`,
@@ -861,6 +874,8 @@ export async function processResponsesStream<TApi extends Api>(
             });
           }
         }
+      } else if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
+        pendingFunctionCallRefusal = `${pendingFunctionCallRefusal ?? ""}${event.delta}`;
       }
     } else if (event.type === "response.function_call_arguments.delta") {
       if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
@@ -917,6 +932,7 @@ export async function processResponsesStream<TApi extends Api>(
           partial: output,
         });
         currentBlock = null;
+        pendingFunctionCallRefusal = null;
       } else if (
         item.type === "message" &&
         (currentBlock?.type === "text" || pendingMessageText !== null)
@@ -971,6 +987,13 @@ export async function processResponsesStream<TApi extends Api>(
         }
         currentBlock = null;
       } else if (item.type === "function_call") {
+        if (pendingFunctionCallRefusal !== null) {
+          removeCurrentToolCallBlock();
+          applyOpenAIResponsesRefusal(output, pendingFunctionCallRefusal, model.provider);
+          pendingFunctionCallRefusal = null;
+          currentBlock = null;
+          continue;
+        }
         const args =
           currentBlock?.type === "toolCall" && currentBlock.partialJson
             ? parseStreamingJson(currentBlock.partialJson)
@@ -1029,10 +1052,12 @@ export async function processResponsesStream<TApi extends Api>(
           : (response?.service_tier ?? options.serviceTier);
         options.applyServiceTierPricing(output.usage, serviceTier);
       }
-      // Map status to stop reason
-      output.stopReason = mapStopReason(response?.status);
-      if (output.content.some((b) => b.type === "toolCall") && output.stopReason === "stop") {
-        output.stopReason = "toolUse";
+      if (output.stopReason !== "aborted" && output.stopReason !== "error") {
+        // Map status to stop reason unless an earlier refusal already canonicalized the result.
+        output.stopReason = mapStopReason(response?.status);
+        if (output.content.some((b) => b.type === "toolCall") && output.stopReason === "stop") {
+          output.stopReason = "toolUse";
+        }
       }
     } else if (event.type === "error") {
       throw new Error(

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -637,6 +637,69 @@ describe("openai transport stream", () => {
     expect(output.content[2]).toMatchObject({ type: "text", text: "Done." });
   });
 
+  it("maps function-call refusal deltas to provider refusal errors", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+    const pushSpy = vi.fn();
+
+    await testing.processResponsesStream(
+      streamChunks([
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "function_call",
+            id: "fc_blocked",
+            call_id: "call_blocked",
+            name: "write",
+            arguments: "",
+          },
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          delta: '{"path":"forbidden.txt"}',
+        },
+        {
+          type: "response.refusal.delta",
+          delta: "Tool use is not allowed.",
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_blocked",
+            call_id: "call_blocked",
+            name: "write",
+            arguments: '{"path":"forbidden.txt"}',
+          },
+        },
+        {
+          type: "response.completed",
+          response: { id: "resp-refusal", status: "completed" },
+        },
+      ]),
+      output,
+      { push: pushSpy },
+      model,
+    );
+
+    expect(output.stopReason).toBe("error");
+    expect(output.content).toEqual([]);
+    expect(output.errorMessage).toBe("OpenAI refusal: Tool use is not allowed.");
+    expect(output.diagnostics).toEqual([
+      expect.objectContaining({
+        type: "provider_refusal",
+        details: {
+          provider: model.provider,
+          explanation: "Tool use is not allowed.",
+        },
+      }),
+    ]);
+    expect(pushSpy.mock.calls.map(([event]) => (event as { type?: string }).type)).toEqual([
+      "toolcall_start",
+      "toolcall_delta",
+    ]);
+  });
+
   it("collapses cumulative message snapshots in completed-response backfill (#91959)", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -685,15 +685,17 @@ describe("openai transport stream", () => {
     expect(output.stopReason).toBe("error");
     expect(output.content).toEqual([]);
     expect(output.errorMessage).toBe("OpenAI refusal: Tool use is not allowed.");
-    expect(output.diagnostics).toEqual([
-      expect.objectContaining({
-        type: "provider_refusal",
-        details: {
-          provider: model.provider,
-          explanation: "Tool use is not allowed.",
-        },
-      }),
-    ]);
+    expect(output).toMatchObject({
+      diagnostics: [
+        expect.objectContaining({
+          type: "provider_refusal",
+          details: {
+            provider: model.provider,
+            explanation: "Tool use is not allowed.",
+          },
+        }),
+      ],
+    });
     expect(pushSpy.mock.calls.map(([event]) => (event as { type?: string }).type)).toEqual([
       "toolcall_start",
       "toolcall_delta",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -16,6 +16,7 @@ import {
   isResponsesTextDeltaEventType,
   mapOpenAIStopReason,
   normalizeOpenAIReasoningEffort,
+  applyOpenAIResponsesRefusal,
   normalizeOpenAIStrictToolParameters,
   projectOpenAITools,
   reconcileOpenAICompletionsToolChoice,
@@ -1448,6 +1449,7 @@ async function processResponsesStream(
   // its public block is deferred so a collapsed item never leaves an
   // unbalanced text_start behind (#91959). null = no deferral in progress.
   let pendingMessageText: string | null = null;
+  let pendingFunctionCallRefusal: string | null = null;
   const streamStartedAt = Date.now();
   let eventCount = 0;
   const eventTypes = new Map<string, number>();
@@ -1466,6 +1468,16 @@ async function processResponsesStream(
     stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
     stream.push({ type: "text_delta", contentIndex: blockIndex(), delta: pendingMessageText });
     pendingMessageText = null;
+  };
+  const removeCurrentToolCallBlock = () => {
+    if (currentBlock?.type !== "toolCall") {
+      return;
+    }
+    const index = output.content.indexOf(currentBlock);
+    if (index >= 0) {
+      output.content.splice(index, 1);
+    }
+    currentBlock = null;
   };
   const appendCompletedResponseTextItem = (item: Record<string, unknown>) => {
     const text = readResponsesOutputMessageText(item);
@@ -1610,6 +1622,7 @@ async function processResponsesStream(
         }
       } else if (item.type === "function_call") {
         currentItem = item;
+        pendingFunctionCallRefusal = null;
         currentBlock = {
           type: "toolCall",
           id: `${stringifyUnknown(item.call_id)}|${stringifyUnknown(item.id)}`,
@@ -1642,6 +1655,12 @@ async function processResponsesStream(
             delta: stringifyUnknown(event.delta),
           });
         }
+      } else if (
+        type === "response.refusal.delta" &&
+        currentItem?.type === "function_call" &&
+        currentBlock?.type === "toolCall"
+      ) {
+        pendingFunctionCallRefusal = `${pendingFunctionCallRefusal ?? ""}${stringifyUnknown(event.delta)}`;
       }
     } else if (type === "response.function_call_arguments.delta") {
       if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
@@ -1685,6 +1704,7 @@ async function processResponsesStream(
           partial: output,
         });
         currentBlock = null;
+        pendingFunctionCallRefusal = null;
       } else if (
         item.type === "message" &&
         (currentBlock?.type === "text" || pendingMessageText !== null)
@@ -1747,6 +1767,13 @@ async function processResponsesStream(
         }
         currentBlock = null;
       } else if (item.type === "function_call") {
+        if (pendingFunctionCallRefusal !== null) {
+          removeCurrentToolCallBlock();
+          applyOpenAIResponsesRefusal(output, pendingFunctionCallRefusal, model.provider);
+          pendingFunctionCallRefusal = null;
+          currentBlock = null;
+          continue;
+        }
         const args =
           currentBlock?.type === "toolCall" && currentBlock.partialJson
             ? parseStreamingJson(stringifyJsonLike(currentBlock.partialJson, "{}"))
@@ -1808,12 +1835,14 @@ async function processResponsesStream(
             options.serviceTier,
         );
       }
-      output.stopReason = mapResponsesStopReason(response?.status as string | undefined);
-      if (
-        output.content.some((block) => block.type === "toolCall") &&
-        output.stopReason === "stop"
-      ) {
-        output.stopReason = "toolUse";
+      if (output.stopReason !== "aborted" && output.stopReason !== "error") {
+        output.stopReason = mapResponsesStopReason(response?.status as string | undefined);
+        if (
+          output.content.some((block) => block.type === "toolCall") &&
+          output.stopReason === "stop"
+        ) {
+          output.stopReason = "toolUse";
+        }
       }
     } else if (type === "error") {
       throw new Error(


### PR DESCRIPTION
Fixes #101059

## What Problem This Solves

Fixes an issue where users running OpenAI Responses models with strict tool usage would get a generic tool-call failure instead of a handled refusal when the provider emitted refusal chunks during a tool call stream.

## Why This Change Was Made

This change teaches the OpenAI Responses stream parsers to treat refusal chunks that arrive while a function call is in progress as provider refusals instead of finishing an empty or partial tool call. The fix is intentionally narrow: it updates both the shared `@openclaw/ai` provider path and the agent transport sibling path, while preserving the existing stop-reason mapping for non-refusal completions.

## User Impact

Users now get a stable provider-refusal error instead of a cryptic tool-call parsing failure when an OpenAI Responses model refuses a tool call mid-stream. This keeps refusal handling consistent across the shared provider adapter and the agent transport path, and avoids surfacing a broken partial tool invocation as if it were a normal tool call.

## Evidence

Focused local validation passed on the touched paths:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run \
  packages/ai/src/providers/openai-responses-shared.test.ts \
  src/agents/openai-transport-stream.test.ts
```

Results:
- `test/vitest/vitest.unit.config.ts`: `35 passed`
- `test/vitest/vitest.agents.config.ts`: `296 passed`
- `[test] passed 2 Vitest shards in 56.22s`

Additional checks:
- `git diff --check` passed

Regression coverage added for both stream parser paths:
- shared OpenAI Responses provider path now converts function-call refusal deltas into `provider_refusal`
- agent transport path now does the same and drops the incomplete tool-call block before finalization
