### PR TITLE
fix(browser): keep screenshots private by default

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -247,6 +247,10 @@ browser-specific model settings.
 4. If image understanding is unavailable, skipped, or fails, the browser falls
    back to returning the original image block.
 
+Screenshot image blocks are private tool results: the agent can inspect them,
+but OpenClaw does not automatically attach them to channel replies. To share a
+screenshot, ask the agent to send it explicitly with the message tool.
+
 Use the existing `tools.media.image` / `tools.media.models` fields for model
 fallbacks, timeouts, byte limits, profiles, and provider request settings.
 

--- a/extensions/browser/src/browser-tool.runtime.ts
+++ b/extensions/browser/src/browser-tool.runtime.ts
@@ -62,6 +62,7 @@ export { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "./browser/constants.js";
 export { resolveExistingUploadPaths } from "./browser/paths.js";
 export { getBrowserProfileCapabilities } from "./browser/profile-capabilities.js";
 export { applyBrowserProxyPaths, persistBrowserProxyFiles } from "./browser/proxy-files.js";
+export { stageBrowserScreenshotForSharing } from "./browser/screenshot-sharing.js";
 export {
   touchSessionBrowserTab,
   trackSessionBrowserTab,

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -179,6 +179,7 @@ const toolCommonMocks = vi.hoisted(() => ({
   describeImageFile: vi.fn(async () => ({ text: undefined, decision: { outcome: "skipped" } })),
   normalizeBrowserScreenshot: vi.fn(async (buffer: Buffer) => ({ buffer })),
   saveMediaBuffer: vi.fn(async () => ({ path: "/tmp/openclaw-media/resized.jpg" })),
+  stageBrowserScreenshotForSharing: vi.fn(async () => "/tmp/openclaw-media/outbound/share.png"),
 }));
 vi.mock("./sdk-setup-tools.js", async () => {
   const actual =
@@ -189,6 +190,7 @@ vi.mock("./sdk-setup-tools.js", async () => {
     imageResultFromFile: toolCommonMocks.imageResultFromFile,
     describeImageFile: toolCommonMocks.describeImageFile,
     saveMediaBuffer: toolCommonMocks.saveMediaBuffer,
+    stageBrowserScreenshotForSharing: toolCommonMocks.stageBrowserScreenshotForSharing,
     listNodes: nodesUtilsMocks.listNodes,
   };
 });
@@ -233,6 +235,7 @@ vi.mock("./browser-tool.runtime.js", () => {
     }),
     describeImageFile: toolCommonMocks.describeImageFile,
     saveMediaBuffer: toolCommonMocks.saveMediaBuffer,
+    stageBrowserScreenshotForSharing: toolCommonMocks.stageBrowserScreenshotForSharing,
     imageResultFromFile: toolCommonMocks.imageResultFromFile,
     jsonResult: (result: unknown) => ({
       content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
@@ -314,6 +317,9 @@ function resetBrowserToolMocks() {
     buffer,
   }));
   toolCommonMocks.saveMediaBuffer.mockResolvedValue({ path: "/tmp/openclaw-media/resized.jpg" });
+  toolCommonMocks.stageBrowserScreenshotForSharing.mockResolvedValue(
+    "/tmp/openclaw-media/outbound/share.png",
+  );
   browserToolTesting.setDepsForTest({
     browserAct: browserActionsMocks.browserAct as never,
     browserArmDialog: browserActionsMocks.browserArmDialog as never,
@@ -336,6 +342,7 @@ function resetBrowserToolMocks() {
     callGatewayTool: gatewayMocks.callGatewayTool as never,
     normalizeBrowserScreenshot: toolCommonMocks.normalizeBrowserScreenshot as never,
     saveMediaBuffer: toolCommonMocks.saveMediaBuffer as never,
+    stageBrowserScreenshotForSharing: toolCommonMocks.stageBrowserScreenshotForSharing as never,
     trackSessionBrowserTab: sessionTabRegistryMocks.trackSessionBrowserTab as never,
     untrackSessionBrowserTab: sessionTabRegistryMocks.untrackSessionBrowserTab as never,
   });
@@ -1120,9 +1127,15 @@ describe("browser tool snapshot maxChars", () => {
       details?: { media?: { outbound?: boolean } };
     }>(toolCommonMocks.imageResultFromFile, 0);
     expect(imageParams.imageSanitization).toEqual({ maxDimensionPx: 2000 });
-    expect(imageParams.extraText).toContain(JSON.stringify("/tmp/test.png"));
+    expect(imageParams.extraText).toContain(
+      JSON.stringify("/tmp/openclaw-media/outbound/share.png"),
+    );
     expect(imageParams.extraText).toContain("message tool");
     expect(imageParams.details?.media).toEqual({ outbound: false });
+    expect(toolCommonMocks.stageBrowserScreenshotForSharing).toHaveBeenCalledWith(
+      "/tmp/test.png",
+      2000,
+    );
   });
 
   it("defangs vision MEDIA-looking text and does not attach media", async () => {
@@ -1154,7 +1167,7 @@ describe("browser tool snapshot maxChars", () => {
     const joined = textBlocks.map((entry) => entry.text).join("\n");
     expect(joined).toContain("[neutralized] MEDIA:/tmp/secret.png");
     expect(joined).toContain("/tmp/secret.png");
-    expect(joined).toContain(JSON.stringify("/tmp/screen.png"));
+    expect(joined).toContain(JSON.stringify("/tmp/openclaw-media/outbound/share.png"));
     expect(joined).toContain("message tool");
     // The vision-success path must not surface raw screenshot media via
     // details.media so channel auto-delivery cannot grab the screenshot.
@@ -1196,7 +1209,9 @@ describe("browser tool snapshot maxChars", () => {
     expect(imageParams.path).toBe("/tmp/screen.png");
     expect(imageParams.extraText).toContain("[neutralized] MEDIA:/tmp/secret.png");
     expect(imageParams.extraText).toContain("/tmp/secret.png");
-    expect(imageParams.extraText).toContain(JSON.stringify("/tmp/screen.png"));
+    expect(imageParams.extraText).toContain(
+      JSON.stringify("/tmp/openclaw-media/outbound/share.png"),
+    );
     expect(imageParams.extraText).toContain("message tool");
     expect(imageParams.details?.media).toEqual({ outbound: false });
   });
@@ -1235,6 +1250,33 @@ describe("browser tool snapshot maxChars", () => {
     // bypassed whenever vision fails.
     expect(imageParams.imageSanitization).toEqual({ maxDimensionPx: 1600 });
     expect(imageParams.extraText).toContain("browser screenshot vision failed");
+  });
+
+  it("keeps the screenshot usable when explicit-share staging fails", async () => {
+    toolCommonMocks.stageBrowserScreenshotForSharing.mockRejectedValueOnce(
+      new Error("outbound store unavailable"),
+    );
+    toolCommonMocks.imageResultFromFile.mockResolvedValueOnce({
+      content: [{ type: "image", data: "base64", mimeType: "image/png" }],
+      details: { path: "/tmp/test.png" },
+    });
+
+    const tool = createBrowserTool();
+    await tool.execute?.("call-1", {
+      action: "screenshot",
+      target: "host",
+      targetId: "tab-1",
+    });
+
+    const imageParams = lastMockCallArg<{
+      path: string;
+      extraText?: string;
+      details?: { media?: { outbound?: boolean } };
+    }>(toolCommonMocks.imageResultFromFile, 0);
+    expect(imageParams.path).toBe("/tmp/test.png");
+    expect(imageParams.extraText).toContain("Screenshot sharing is unavailable");
+    expect(imageParams.extraText).not.toContain("/tmp/test.png");
+    expect(imageParams.details?.media).toEqual({ outbound: false });
   });
 
   it("passes screenshot timeoutMs through the node browser proxy", async () => {

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1116,8 +1116,10 @@ describe("browser tool snapshot maxChars", () => {
 
     const imageParams = lastMockCallArg<{
       imageSanitization?: { maxDimensionPx?: number };
+      details?: { media?: { outbound?: boolean } };
     }>(toolCommonMocks.imageResultFromFile, 0);
     expect(imageParams.imageSanitization).toEqual({ maxDimensionPx: 2000 });
+    expect(imageParams.details?.media).toEqual({ outbound: false });
   });
 
   it("defangs vision MEDIA-looking text and does not attach media", async () => {
@@ -1184,10 +1186,12 @@ describe("browser tool snapshot maxChars", () => {
     const imageParams = lastMockCallArg<{
       path: string;
       extraText?: string;
+      details?: { media?: { outbound?: boolean } };
     }>(toolCommonMocks.imageResultFromFile, 0);
     expect(imageParams.path).toBe("/tmp/screen.png");
     expect(imageParams.extraText).toContain("[neutralized] MEDIA:/tmp/secret.png");
     expect(imageParams.extraText).toContain("/tmp/secret.png");
+    expect(imageParams.details?.media).toEqual({ outbound: false });
   });
 
   it("preserves screenshot image sanitization on vision failure fallback", async () => {

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1116,9 +1116,12 @@ describe("browser tool snapshot maxChars", () => {
 
     const imageParams = lastMockCallArg<{
       imageSanitization?: { maxDimensionPx?: number };
+      extraText?: string;
       details?: { media?: { outbound?: boolean } };
     }>(toolCommonMocks.imageResultFromFile, 0);
     expect(imageParams.imageSanitization).toEqual({ maxDimensionPx: 2000 });
+    expect(imageParams.extraText).toContain(JSON.stringify("/tmp/test.png"));
+    expect(imageParams.extraText).toContain("message tool");
     expect(imageParams.details?.media).toEqual({ outbound: false });
   });
 
@@ -1151,6 +1154,8 @@ describe("browser tool snapshot maxChars", () => {
     const joined = textBlocks.map((entry) => entry.text).join("\n");
     expect(joined).toContain("[neutralized] MEDIA:/tmp/secret.png");
     expect(joined).toContain("/tmp/secret.png");
+    expect(joined).toContain(JSON.stringify("/tmp/screen.png"));
+    expect(joined).toContain("message tool");
     // The vision-success path must not surface raw screenshot media via
     // details.media so channel auto-delivery cannot grab the screenshot.
     expect((out?.details as Record<string, unknown>)?.media).toBeUndefined();
@@ -1191,6 +1196,8 @@ describe("browser tool snapshot maxChars", () => {
     expect(imageParams.path).toBe("/tmp/screen.png");
     expect(imageParams.extraText).toContain("[neutralized] MEDIA:/tmp/secret.png");
     expect(imageParams.extraText).toContain("/tmp/secret.png");
+    expect(imageParams.extraText).toContain(JSON.stringify("/tmp/screen.png"));
+    expect(imageParams.extraText).toContain("message tool");
     expect(imageParams.details?.media).toEqual({ outbound: false });
   });
 

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -829,6 +829,12 @@ export function createBrowserTool(opts?: {
               });
           touchTrackedTab(readStringValue(result.targetId) ?? targetId);
           const screenshotPath = result.path;
+          // Screenshots stay in the tool result for agent vision, but channel
+          // delivery must remain an explicit message-tool action.
+          const screenshotDetails = {
+            ...(result as Record<string, unknown>),
+            media: { outbound: false },
+          };
           const screenshotCfg = browserToolDeps.getRuntimeConfig();
           const imageSanitization = resolveRuntimeImageSanitization();
           try {
@@ -893,14 +899,14 @@ export function createBrowserTool(opts?: {
               label: "browser:screenshot",
               path: screenshotPath,
               extraText,
-              details: result,
+              details: screenshotDetails,
               imageSanitization,
             });
           }
           return await browserToolDeps.imageResultFromFile({
             label: "browser:screenshot",
             path: screenshotPath,
-            details: result,
+            details: screenshotDetails,
             imageSanitization,
           });
         }

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -50,6 +50,7 @@ import {
   resolveProfile,
   saveMediaBuffer,
   selectDefaultNodeFromList,
+  stageBrowserScreenshotForSharing,
   touchSessionBrowserTab,
   trackSessionBrowserTab,
   untrackSessionBrowserTab,
@@ -81,6 +82,7 @@ const browserToolDeps = {
   callGatewayTool,
   normalizeBrowserScreenshot,
   saveMediaBuffer,
+  stageBrowserScreenshotForSharing,
   touchSessionBrowserTab,
   trackSessionBrowserTab,
   untrackSessionBrowserTab,
@@ -110,6 +112,7 @@ export const testing = {
       callGatewayTool: typeof callGatewayTool;
       normalizeBrowserScreenshot: typeof normalizeBrowserScreenshot;
       saveMediaBuffer: typeof saveMediaBuffer;
+      stageBrowserScreenshotForSharing: typeof stageBrowserScreenshotForSharing;
       touchSessionBrowserTab: typeof touchSessionBrowserTab;
       trackSessionBrowserTab: typeof trackSessionBrowserTab;
       untrackSessionBrowserTab: typeof untrackSessionBrowserTab;
@@ -139,6 +142,8 @@ export const testing = {
     browserToolDeps.normalizeBrowserScreenshot =
       overrides?.normalizeBrowserScreenshot ?? normalizeBrowserScreenshot;
     browserToolDeps.saveMediaBuffer = overrides?.saveMediaBuffer ?? saveMediaBuffer;
+    browserToolDeps.stageBrowserScreenshotForSharing =
+      overrides?.stageBrowserScreenshotForSharing ?? stageBrowserScreenshotForSharing;
     browserToolDeps.touchSessionBrowserTab =
       overrides?.touchSessionBrowserTab ?? touchSessionBrowserTab;
     browserToolDeps.trackSessionBrowserTab =
@@ -166,6 +171,9 @@ function readTargetUrlParam(params: Record<string, unknown>) {
 function formatScreenshotShareHint(filePath: string): string {
   return `[Screenshot saved to ${JSON.stringify(filePath)}. Use this path with the message tool to share the screenshot explicitly.]`;
 }
+
+const SCREENSHOT_SHARE_UNAVAILABLE =
+  "[Screenshot sharing is unavailable because an outbound copy could not be prepared.]";
 
 const LEGACY_BROWSER_ACT_REQUEST_KEYS = [
   "kind",
@@ -833,15 +841,26 @@ export function createBrowserTool(opts?: {
               });
           touchTrackedTab(readStringValue(result.targetId) ?? targetId);
           const screenshotPath = result.path;
-          const shareHint = formatScreenshotShareHint(screenshotPath);
+          const screenshotCfg = browserToolDeps.getRuntimeConfig();
+          const imageSanitization = resolveRuntimeImageSanitization();
+          let shareHint = SCREENSHOT_SHARE_UNAVAILABLE;
+          try {
+            // The original result remains private. Only this bounded outbound
+            // copy may cross the sandbox boundary after an explicit message call.
+            const sharePath = await browserToolDeps.stageBrowserScreenshotForSharing(
+              screenshotPath,
+              imageSanitization?.maxDimensionPx,
+            );
+            shareHint = formatScreenshotShareHint(sharePath);
+          } catch {
+            // Screenshot viewing remains useful when optional outbound staging fails.
+          }
           // Screenshots stay in the tool result for agent vision, but channel
           // delivery must remain an explicit message-tool action.
           const screenshotDetails = {
             ...(result as Record<string, unknown>),
             media: { outbound: false },
           };
-          const screenshotCfg = browserToolDeps.getRuntimeConfig();
-          const imageSanitization = resolveRuntimeImageSanitization();
           try {
             const described = await describeBrowserScreenshot(
               {
@@ -884,7 +903,7 @@ export function createBrowserTool(opts?: {
                   // a text description as the deliverable output. Exposing the raw
                   // screenshot as media would cause channel delivery to auto-send
                   // potentially sensitive page content. The text block carries the
-                  // local path for an explicit message-tool send instead.
+                  // staged outbound-copy path for an explicit message-tool send.
                   vision: {
                     provider: described.provider,
                     model: described.model,

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -163,6 +163,10 @@ function readTargetUrlParam(params: Record<string, unknown>) {
   );
 }
 
+function formatScreenshotShareHint(filePath: string): string {
+  return `[Screenshot saved to ${JSON.stringify(filePath)}. Use this path with the message tool to share the screenshot explicitly.]`;
+}
+
 const LEGACY_BROWSER_ACT_REQUEST_KEYS = [
   "kind",
   "targetId",
@@ -829,6 +833,7 @@ export function createBrowserTool(opts?: {
               });
           touchTrackedTab(readStringValue(result.targetId) ?? targetId);
           const screenshotPath = result.path;
+          const shareHint = formatScreenshotShareHint(screenshotPath);
           // Screenshots stay in the tool result for agent vision, but channel
           // delivery must remain an explicit message-tool action.
           const screenshotDetails = {
@@ -870,7 +875,7 @@ export function createBrowserTool(opts?: {
                   includeWarning: true,
                 },
               );
-              const text = `${headerLines.join("\n")}\n${wrappedDescription}`;
+              const text = `${headerLines.join("\n")}\n${wrappedDescription}\n${shareHint}`;
               return {
                 content: [{ type: "text", text }],
                 details: {
@@ -878,8 +883,8 @@ export function createBrowserTool(opts?: {
                   // Do NOT include details.media here — the vision path returns
                   // a text description as the deliverable output. Exposing the raw
                   // screenshot as media would cause channel delivery to auto-send
-                  // potentially sensitive page content. The local screenshot file
-                  // is still referenced in result.path for diagnostic purposes.
+                  // potentially sensitive page content. The text block carries the
+                  // local path for an explicit message-tool send instead.
                   vision: {
                     provider: described.provider,
                     model: described.model,
@@ -894,7 +899,7 @@ export function createBrowserTool(opts?: {
             // input too, so defang line-start final-reply media directives.
             const rawReason = err instanceof Error ? err.message : String(err);
             const reason = neutralizeMediaDirectives(rawReason);
-            const extraText = `[browser screenshot vision failed: ${reason}]`;
+            const extraText = `[browser screenshot vision failed: ${reason}]\n${shareHint}`;
             return await browserToolDeps.imageResultFromFile({
               label: "browser:screenshot",
               path: screenshotPath,
@@ -906,6 +911,7 @@ export function createBrowserTool(opts?: {
           return await browserToolDeps.imageResultFromFile({
             label: "browser:screenshot",
             path: screenshotPath,
+            extraText: shareHint,
             details: screenshotDetails,
             imageSanitization,
           });

--- a/extensions/browser/src/browser/screenshot-sharing.test.ts
+++ b/extensions/browser/src/browser/screenshot-sharing.test.ts
@@ -1,13 +1,12 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
   normalizeBrowserScreenshot: vi.fn(),
   saveMediaBuffer: vi.fn(),
 }));
 
+vi.mock("node:fs/promises", () => ({ readFile: mocks.readFile }));
 vi.mock("./screenshot.js", () => ({
   DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES: 5 * 1024 * 1024,
   DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE: 2000,
@@ -19,23 +18,16 @@ vi.mock("openclaw/plugin-sdk/media-store", () => ({
 
 import { stageBrowserScreenshotForSharing } from "./screenshot-sharing.js";
 
-let tempDir: string | undefined;
-
-afterEach(async () => {
+afterEach(() => {
   vi.clearAllMocks();
-  if (tempDir) {
-    await rm(tempDir, { recursive: true, force: true });
-    tempDir = undefined;
-  }
 });
 
 describe("stageBrowserScreenshotForSharing", () => {
   it("stages a bounded copy in the outbound media store", async () => {
-    tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-browser-share-"));
-    const sourcePath = path.join(tempDir, "private-shot.png");
+    const sourcePath = "/state/media/browser/private-shot.png";
     const source = Buffer.from("private screenshot");
     const normalized = Buffer.from("bounded screenshot");
-    await writeFile(sourcePath, source);
+    mocks.readFile.mockResolvedValue(source);
     mocks.normalizeBrowserScreenshot.mockResolvedValue({
       buffer: normalized,
       contentType: "image/jpeg",
@@ -47,7 +39,7 @@ describe("stageBrowserScreenshotForSharing", () => {
     await expect(stageBrowserScreenshotForSharing(sourcePath, 1200)).resolves.toBe(
       "/state/media/outbound/share.jpg",
     );
-    expect(await readFile(sourcePath)).toEqual(source);
+    expect(mocks.readFile).toHaveBeenCalledWith(sourcePath);
     expect(mocks.normalizeBrowserScreenshot).toHaveBeenCalledWith(source, {
       maxSide: 1200,
       maxBytes: 5 * 1024 * 1024,

--- a/extensions/browser/src/browser/screenshot-sharing.test.ts
+++ b/extensions/browser/src/browser/screenshot-sharing.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  normalizeBrowserScreenshot: vi.fn(),
+  saveMediaBuffer: vi.fn(),
+}));
+
+vi.mock("./screenshot.js", () => ({
+  DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES: 5 * 1024 * 1024,
+  DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE: 2000,
+  normalizeBrowserScreenshot: mocks.normalizeBrowserScreenshot,
+}));
+vi.mock("openclaw/plugin-sdk/media-store", () => ({
+  saveMediaBuffer: mocks.saveMediaBuffer,
+}));
+
+import { stageBrowserScreenshotForSharing } from "./screenshot-sharing.js";
+
+let tempDir: string | undefined;
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  if (tempDir) {
+    await rm(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+describe("stageBrowserScreenshotForSharing", () => {
+  it("stages a bounded copy in the outbound media store", async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-browser-share-"));
+    const sourcePath = path.join(tempDir, "private-shot.png");
+    const source = Buffer.from("private screenshot");
+    const normalized = Buffer.from("bounded screenshot");
+    await writeFile(sourcePath, source);
+    mocks.normalizeBrowserScreenshot.mockResolvedValue({
+      buffer: normalized,
+      contentType: "image/jpeg",
+    });
+    mocks.saveMediaBuffer.mockResolvedValue({
+      path: "/state/media/outbound/share.jpg",
+    });
+
+    await expect(stageBrowserScreenshotForSharing(sourcePath, 1200)).resolves.toBe(
+      "/state/media/outbound/share.jpg",
+    );
+    expect(await readFile(sourcePath)).toEqual(source);
+    expect(mocks.normalizeBrowserScreenshot).toHaveBeenCalledWith(source, {
+      maxSide: 1200,
+      maxBytes: 5 * 1024 * 1024,
+    });
+    expect(mocks.saveMediaBuffer).toHaveBeenCalledWith(
+      normalized,
+      "image/jpeg",
+      "outbound",
+      5 * 1024 * 1024,
+      "private-shot.png",
+    );
+  });
+});

--- a/extensions/browser/src/browser/screenshot-sharing.ts
+++ b/extensions/browser/src/browser/screenshot-sharing.ts
@@ -1,0 +1,28 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
+import {
+  DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
+  DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
+  normalizeBrowserScreenshot,
+} from "./screenshot.js";
+
+/** Stages a bounded screenshot copy in the sandbox-authorized outbound store. */
+export async function stageBrowserScreenshotForSharing(
+  filePath: string,
+  maxDimensionPx?: number,
+): Promise<string> {
+  const source = await readFile(filePath);
+  const normalized = await normalizeBrowserScreenshot(source, {
+    maxSide: maxDimensionPx ?? DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE,
+    maxBytes: DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
+  });
+  const saved = await saveMediaBuffer(
+    normalized.buffer,
+    normalized.contentType,
+    "outbound",
+    DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES,
+    path.basename(filePath),
+  );
+  return saved.path;
+}

--- a/src/agents/embedded-agent-subscribe.tools.media.test.ts
+++ b/src/agents/embedded-agent-subscribe.tools.media.test.ts
@@ -32,6 +32,18 @@ describe("extractToolResultMediaArtifact", () => {
     });
   });
 
+  it("does not deliver explicitly private image results", () => {
+    expect(
+      extractToolResultMediaArtifact({
+        content: [{ type: "image", data: "base64data", mimeType: "image/png" }],
+        details: {
+          path: "/tmp/browser-screenshot.png",
+          media: { outbound: false },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
   it("extracts structured details.media top-level aliases", () => {
     expect(
       extractToolResultMediaArtifact({


### PR DESCRIPTION
Closes #44759

## What Problem This Solves

Fixes an issue where users asking an agent to inspect a browser screenshot could have that screenshot automatically attached to the channel reply, exposing page content they had not asked the agent to send.

## Why This Change Was Made

Browser screenshots now use the existing private tool-media contract on both raw-image paths. The image block and local path remain available to agent vision, while outbound delivery requires the agent to use the message tool explicitly. No browser permission, agent trust, or explicit media-send capability changes.

## User Impact

Agents can still inspect browser screenshots normally. Channel replies no longer gain an implicit screenshot attachment; users can still ask the agent to share one explicitly.

## Evidence

- Blacksmith Testbox `tbx_01kwxmt1fv7hpt6qt7dxr1xn3s`: 119 focused tests passed across the browser tool and tool-media extraction suites; touched TypeScript files passed `oxfmt --check`.
- Structured autoreview: clean, no accepted/actionable findings.

Live Gateway/agent proof will be added before landing.

AI-assisted: yes. I reviewed the affected browser, agent-media extraction, delivery, tests, and docs paths and understand the change.
