### PR TITLE
fix(file-transfer): suppress stdout/stderr stream errors in node-host dir-fetch subprocesses

### DIFF
--- a/extensions/file-transfer/src/node-host/dir-fetch.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.ts
@@ -75,6 +75,9 @@ async function preflightDu(dirPath: string, maxBytes: number): Promise<boolean> 
   return new Promise((resolve) => {
     const du = spawn("du", ["-sk", dirPath], { stdio: ["ignore", "pipe", "ignore"] });
     let output = "";
+
+    const ignoreOutputStreamError = () => {};
+    du.stdout.on("error", ignoreOutputStreamError);
     du.stdout.on("data", (chunk: Buffer) => {
       output += chunk.toString();
     });
@@ -104,6 +107,17 @@ async function listTarEntries(tarBuffer: Buffer): Promise<string[]> {
   // loop for up to 10s. Other in-flight requests continue to be served.
   return new Promise<string[]>((resolve) => {
     const child = spawn("tar", ["-tzf", "-"], { stdio: ["pipe", "pipe", "ignore"] });
+
+    // Fail closed on stdout read errors — partial listing is worse than no listing
+    child.stdout.on("error", () => {
+      if (aborted) {
+        return;
+      }
+      aborted = true;
+      clearTimeout(watchdog);
+      try { child.kill("SIGKILL"); } catch { /* gone */ }
+      resolve([]);
+    });
     let stdoutBuf = "";
     let aborted = false;
     const watchdog = setTimeout(() => {
@@ -268,6 +282,18 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
     const child = spawn(tarBin, tarArgs, {
       stdio: ["ignore", "pipe", "pipe"],
     });
+
+    // Fail closed on stdout (archive data) read errors — partial archive is worse than ERROR
+    child.stdout.on("error", () => {
+      if (aborted) {
+        return;
+      }
+      aborted = true;
+      clearTimeout(watchdog);
+      try { child.kill("SIGKILL"); } catch { /* already gone */ }
+      resolve("ERROR");
+    });
+    child.stderr.on("error", () => {});
 
     const chunks: Buffer[] = [];
     let totalBytes = 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stdout/stderr pipe errors from `du` and `tar` subprocesses in the file-transfer node-host dir-fetch path could surface as unhandled Node stream errors, and ensures data-producing streams fail closed instead of returning partial payloads.

## Why This Change Was Made

`node-host/dir-fetch.ts` spawns `du` for directory size estimation and `tar` for archive creation and listing with pipe stdio. All three spawn paths consume stdout via `data` listeners, but none register error listeners. The fix adds error handling that distinguishes between diagnostic and data streams:

- **`preflightDu`** — no-op error listener. Output is a size estimate only; child `close`/`error` events handle the real outcome.
- **`listTarEntries`** — fail closed on stdout error. Partial file listing could return incorrect metadata; the handler resolves `[]` and stops the child.
- **`handleDirFetch`** (archive payload) — fail closed on stdout error. Partial archive bytes could return a truncated payload as `ok:true`; the handler resolves `"ERROR"` and stops the child.
- **`handleDirFetch` stderr** — no-op error listener. stderr is not consumed as returned data.

This matches the established pattern from sibling subprocess paths while providing fail-closed semantics for payload streams, as recommended by ClawSweeper (#101437 review).

## User Impact

Node-host dir-fetch operations no longer risk unhandled stream errors during edge-case process terminations, and data-stream failures are reported as errors instead of silently returning partial results.

## Evidence

Node Readable stream `error` event contract:

```text
$ node outputs/issue-101437/proof-v2.mjs

--- 1. Node Readable stream error contract ---

  WITHOUT listener → EPIPE (uncaught exception on current main)
  WITH listener    → error suppressed (safe)

--- 3. listTarEntries — fail-closed on stdout error ---
  Outcome: fail-closed: []

--- 4. handleDirFetch stdout (archive data) — fail-closed ---
  Outcome: fail-closed: ERROR
```

- Without the listener, the `error` event on the stream has no handler and Node emits an unhandled exception, crashing the process.
- With the listener, the error is handled according to stream type: diagnostic streams suppress, data streams fail closed.

AI-assisted: built with Codex