### PR TITLE
feat(codex): configure native app tool policy

### DIFF
--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -5428,6 +5428,8 @@ Do not edit it by hand; run `pnpm docs:map:gen`.
   - H2: App inventory and ownership
   - H2: Connected account apps
   - H2: Thread app config
+  - H3: Tool overrides
+  - H3: Upgrade and rollback
   - H2: Destructive action policy
   - H2: Troubleshooting
   - H2: Related

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -294,6 +294,9 @@ conversation bindings, or any non-Codex harness.
                 marketplaceName: "openai-curated",
                 pluginName: "google-calendar",
                 allow_destructive_actions: false,
+                tools: {
+                  "google_calendar.read_event": { enabled: false },
+                },
               },
             },
           },
@@ -329,6 +332,15 @@ conversation bindings, or any non-Codex harness.
   per-plugin destructive-action override. When omitted, the global
   `allow_destructive_actions` value is used. The per-plugin value accepts the
   same `true`, `false`, `"auto"`, or `"ask"` policies.
+- `plugins.entries.codex.config.codexPlugins.plugins.<key>.tools`: exact,
+  case-sensitive Codex per-app tool overrides as
+  `Record<string, { enabled: boolean }>`. Keys must be non-empty and trimmed;
+  rule objects reject `app` and other unknown properties. OpenClaw copies the
+  complete map to every admitted app proven to be owned by that plugin, and
+  Codex performs exact raw-name-then-title matching inside each app. This is an
+  override map, not an allowlist; unknown selectors can be configured but have
+  no effect until an exact match exists. Any `enabled: true` is blocked when
+  the effective `allow_destructive_actions` value is `false`.
 
 Each admitted plugin app that uses `"ask"` routes that app's approval requests
 to the human reviewer. Other apps and non-app thread approvals keep their

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -38,14 +38,14 @@ All Codex harness settings live under `plugins.entries.codex.config`.
 
 Top-level fields:
 
-| Field                      | Default                  | Meaning                                                                                                                                        |
-| -------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `discovery`                | enabled                  | Model discovery settings for Codex app-server `model/list`.                                                                                    |
-| `appServer`                | managed stdio app-server | Transport, command, auth, approval, sandbox, and timeout settings.                                                                             |
-| `codexDynamicToolsLoading` | `"searchable"`           | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context.                                                       |
-| `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                                    |
-| `codexPlugins`             | disabled                 | Native Codex plugin/app support, including opt-in access to connected account apps. See [Native Codex plugins](/plugins/codex-native-plugins). |
-| `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                               |
+| Field                      | Default                  | Meaning                                                                                                                                                         |
+| -------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `discovery`                | enabled                  | Model discovery settings for Codex app-server `model/list`.                                                                                                     |
+| `appServer`                | managed stdio app-server | Transport, command, auth, approval, sandbox, and timeout settings.                                                                                              |
+| `codexDynamicToolsLoading` | `"searchable"`           | Use `"direct"` to put OpenClaw dynamic tools directly in the initial Codex tool context.                                                                        |
+| `codexDynamicToolsExclude` | `[]`                     | Additional OpenClaw dynamic tool names to omit from Codex app-server turns.                                                                                     |
+| `codexPlugins`             | disabled                 | Native Codex plugin/app support, opt-in connected account apps, and exact per-plugin tool overrides. See [Native Codex plugins](/plugins/codex-native-plugins). |
+| `computerUse`              | disabled                 | Codex Computer Use setup. See [Codex Computer Use](/plugins/codex-computer-use).                                                                                |
 
 ## App-server transport
 

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -76,6 +76,10 @@ config looks like this:
                 enabled: true,
                 marketplaceName: "openai-curated",
                 pluginName: "google-calendar",
+                tools: {
+                  "google_calendar.read_event": { enabled: true },
+                  "google_calendar.create_event": { enabled: false },
+                },
               },
             },
           },
@@ -104,8 +108,11 @@ same chat where you operate the Codex harness:
 ```
 
 `/codex plugins` is an alias for `/codex plugins list`. The list shows each
-configured plugin's key, on/off state, Codex plugin name, and marketplace
-from `plugins.entries.codex.config.codexPlugins.plugins`.
+configured plugin's key, on/off state, Codex plugin name, marketplace, and
+exact tool overrides from
+`plugins.entries.codex.config.codexPlugins.plugins`. Tool status is
+`configured` or `blocked`; the command does not claim that a key currently
+matches a live Codex tool.
 
 `enable`/`disable` write only to `~/.openclaw/openclaw.json`; they never edit
 `~/.codex/config.toml` or install new Codex plugins. Only the owner or a
@@ -235,12 +242,63 @@ all set `destructive_enabled: true`, and `false` sets it `false`. Codex still
 enforces destructive tool metadata from its native app tool annotations.
 `_default` is disabled with `open_world_enabled: false`; enabled plugin apps
 get `open_world_enabled: true`. OpenClaw does not expose a separate
-plugin-level open-world policy knob and does not maintain per-plugin
-destructive tool-name deny lists.
+plugin-level open-world policy knob.
 
 Tool approval mode defaults to automatic for admitted apps, so non-destructive
 read tools run without a same-thread approval prompt. Destructive tools stay
 controlled by each app's `destructive_enabled` policy.
+
+### Tool overrides
+
+Each configured plugin can pass exact Codex per-app tool keys through to its
+owned apps:
+
+```json5
+tools: {
+  "slack.slack_read_channel": { enabled: true },
+  "slack.slack_send_message": { enabled: false },
+}
+```
+
+Keys are case-sensitive and must already be trimmed. There is no `app` field:
+OpenClaw copies the complete map to every admitted app whose ownership is
+proven for that plugin. Codex then checks a tool's raw name first and its
+normalized title second inside each app bucket. OpenClaw does not rewrite keys
+or use a lossy tool inventory to infer one target app.
+
+Run `openclaw config validate --json` before deployment. Static validation
+rejects blank or untrimmed keys, missing or non-boolean `enabled`, `app`, and
+other unknown rule properties without contacting Codex.
+
+`tools` is an override map, not an allowlist. A missing key keeps Codex's
+normal behavior. A configured key with no current exact match has no effect,
+but remains a durable selector if that owned app later exposes the key. If the
+same key matches tools in two apps owned by the plugin, the one rule applies to
+both. When at least one claimant has tool rules, apps claimed by multiple
+enabled configured plugins are excluded instead of choosing one plugin's map.
+
+Duplicate JSON or JSON5 source keys follow the existing config parser: the
+last value is retained before validation. Do not use duplicate keys for policy
+layering.
+
+An explicit `enabled: true` can precede Codex's annotation gates, so OpenClaw
+rejects the plugin's whole app set when any enabled override is combined with
+an effective `allow_destructive_actions: false`. All-false maps remain valid.
+Tool maps and ownership are persisted with the thread binding; edits take
+effect on a new binding, or immediately after `/new` or `/reset`. If live
+ownership revalidation fails for a binding with tool rules, OpenClaw rotates
+or blocks instead of resuming the stale grant.
+
+### Upgrade and rollback
+
+The tool-policy fingerprint update rotates every existing native-plugin
+binding once after upgrade, including configurations without `tools`. Tool
+rule edits then rotate stale bindings automatically before the next turn;
+`/new` and `/reset` force a fresh binding immediately.
+
+Older OpenClaw builds with the strict plugin schema reject `tools`. To roll
+back, remove every `tools` block, run `openclaw config validate --json`, deploy
+the older build, and start a new conversation.
 
 ## Destructive action policy
 
@@ -279,11 +337,16 @@ plugins, while unsafe schemas and ambiguous ownership fail closed:
 | `marketplace_missing`, `plugin_missing`           | The target Codex app-server cannot see the expected `openai-curated` marketplace or plugin.                                          | Rerun migration against the target runtime, or inspect Codex app-server plugin status.                                 |
 | `app_inventory_missing`, `app_inventory_stale`    | App readiness came from an empty or stale cache.                                                                                     | OpenClaw schedules an async refresh automatically; plugin apps stay excluded until ownership and readiness are known.  |
 | `app_ownership_ambiguous`                         | App inventory only matched by display name.                                                                                          | The app stays hidden from the Codex thread until a later refresh proves ownership.                                     |
+| `tool_policy_destructive_conflict`                | An enabled tool override exceeds an effective `allow_destructive_actions: false` ceiling.                                            | Set the override to `false` or allow destructive actions for that configured plugin.                                   |
+| `tool_policy_ownership_conflict`                  | Multiple enabled configured plugins claim one app while at least one claimant has tool rules.                                        | Remove the duplicate configured plugin claim for that app.                                                             |
 
 **Config changed but the agent cannot see the plugin:** run `/codex plugins
 list` to confirm the configured state, then `/new` or `/reset`. Existing
 Codex thread bindings keep the app config they started with until OpenClaw
 establishes a new harness session or replaces a stale binding.
+`/codex plugins list` reports only statically knowable `configured` or
+`blocked` tool state; it does not inspect live tool matches or app-ownership
+conflicts.
 
 **Destructive action is declined:** check the global and per-plugin
 `allow_destructive_actions` values. Even with `true`, `"auto"`, or `"ask"`,

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -253,10 +253,12 @@ controlled by each app's `destructive_enabled` policy.
 Each configured plugin can pass exact Codex per-app tool keys through to its
 owned apps:
 
-```json5
-tools: {
-  "slack.slack_read_channel": { enabled: true },
-  "slack.slack_send_message": { enabled: false },
+```json
+{
+  "tools": {
+    "slack.slack_read_channel": { "enabled": true },
+    "slack.slack_send_message": { "enabled": false }
+  }
 }
 ```
 

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -137,10 +137,14 @@ export default definePluginEntry({
               if (!declared || typeof declared !== "object") {
                 return Promise.resolve({
                   enabled: (codexPlugins as Record<string, unknown>).enabled === true,
+                  allow_destructive_actions: (codexPlugins as Record<string, unknown>)
+                    .allow_destructive_actions as boolean | "auto" | "ask" | undefined,
                 });
               }
               return Promise.resolve({
                 enabled: (codexPlugins as Record<string, unknown>).enabled === true,
+                allow_destructive_actions: (codexPlugins as Record<string, unknown>)
+                  .allow_destructive_actions as boolean | "auto" | "ask" | undefined,
                 plugins: declared as Record<string, never>,
               });
             },

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -127,6 +127,22 @@
                 },
                 "allow_destructive_actions": {
                   "oneOf": [{ "type": "boolean" }, { "const": "auto" }, { "const": "ask" }]
+                },
+                "tools": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": "^\\S(?:.*\\S)?$"
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["enabled"],
+                    "properties": {
+                      "enabled": { "type": "boolean" }
+                    }
+                  }
                 }
               }
             }

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -1186,6 +1186,58 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     });
   });
 
+  it("parses exact native plugin tool overrides in deterministic key order", () => {
+    const config = readCodexPluginConfig({
+      codexPlugins: {
+        enabled: true,
+        plugins: {
+          slack: {
+            marketplaceName: "openai-curated",
+            pluginName: "slack",
+            tools: {
+              "slack.slack_send_message": { enabled: false },
+              "slack.slack_read_channel": { enabled: true },
+            },
+          },
+        },
+      },
+    });
+
+    expect(resolveCodexPluginsPolicy(config).pluginPolicies[0]?.tools).toEqual({
+      "slack.slack_read_channel": true,
+      "slack.slack_send_message": false,
+    });
+  });
+
+  it.each([
+    ["missing enabled", { "slack.tool": {} }],
+    ["non-boolean enabled", { "slack.tool": { enabled: "yes" } }],
+    ["app field", { "slack.tool": { enabled: true, app: "slack" } }],
+    ["unknown field", { "slack.tool": { enabled: true, extra: false } }],
+    ["array map", []],
+    ["array rule", { "slack.tool": [] }],
+    ["null rule", { "slack.tool": null }],
+    ["blank key", { "": { enabled: true } }],
+    ["leading whitespace", { " slack.tool": { enabled: true } }],
+    ["trailing whitespace", { "slack.tool ": { enabled: true } }],
+    ["internal newline", { "slack.tool\nnext": { enabled: true } }],
+  ])("rejects invalid native plugin tool config: %s", (_name, tools) => {
+    expect(
+      readCodexPluginConfig({
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            slack: {
+              marketplaceName: "openai-curated",
+              pluginName: "slack",
+              tools,
+            },
+          },
+        },
+      }).codexPlugins,
+    ).toBeUndefined();
+  });
+
   it("parses auto native Codex plugin destructive policy", () => {
     const config = readCodexPluginConfig({
       codexPlugins: {
@@ -2651,6 +2703,24 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     expect(Object.keys(pluginEntryProperties).toSorted()).toEqual(
       [...CODEX_PLUGIN_ENTRY_CONFIG_KEYS].toSorted(),
     );
+    const tools = pluginEntryProperties.tools as {
+      propertyNames: { minLength: number; pattern: string };
+      additionalProperties: {
+        additionalProperties: boolean;
+        required: string[];
+        properties: { enabled: { type: string } };
+      };
+    };
+    expect(tools.propertyNames).toEqual({
+      type: "string",
+      minLength: 1,
+      pattern: "^\\S(?:.*\\S)?$",
+    });
+    expect(tools.additionalProperties).toMatchObject({
+      additionalProperties: false,
+      required: ["enabled"],
+      properties: { enabled: { type: "boolean" } },
+    });
   });
 
   it("does not schema-default mode-derived policy fields", async () => {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -107,6 +107,7 @@ export type CodexPluginEntryConfig = {
   marketplaceName?: string;
   pluginName?: string;
   allow_destructive_actions?: CodexPluginDestructivePolicy;
+  tools?: Record<string, { enabled: boolean }>;
 };
 
 export type CodexPluginsConfig = {
@@ -155,6 +156,7 @@ export type ResolvedCodexPluginPolicy = {
   enabled: boolean;
   allowDestructiveActions: boolean;
   destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
+  tools?: Record<string, boolean>;
 };
 
 export type ResolvedCodexPluginsPolicy = {
@@ -300,6 +302,7 @@ export const CODEX_PLUGIN_ENTRY_CONFIG_KEYS = [
   "marketplaceName",
   "pluginName",
   "allow_destructive_actions",
+  "tools",
 ] as const;
 
 const DEFAULT_CODEX_COMPUTER_USE_PLUGIN_NAME = "computer-use";
@@ -360,12 +363,20 @@ const codexAppServerNetworkProxySchema = z
   })
   .strict();
 
+const codexPluginToolKeySchema = z.string().regex(/^\S(?:.*\S)?$/, "invalid tool key");
+const codexPluginToolConfigSchema = z
+  .object({
+    enabled: z.boolean(),
+  })
+  .strict();
+
 const codexPluginEntryConfigSchema = z
   .object({
     enabled: z.boolean().optional(),
     marketplaceName: z.literal(CODEX_PLUGINS_MARKETPLACE_NAME).optional(),
     pluginName: z.string().trim().min(1).optional(),
     allow_destructive_actions: codexPluginDestructivePolicySchema.optional(),
+    tools: z.record(codexPluginToolKeySchema, codexPluginToolConfigSchema).optional(),
   })
   .strict();
 
@@ -485,6 +496,9 @@ export function resolveCodexPluginsPolicy(pluginConfig?: unknown): ResolvedCodex
       const entryDestructivePolicy = resolveCodexPluginDestructivePolicy(
         entry.allow_destructive_actions ?? config?.allow_destructive_actions ?? true,
       );
+      const toolEntries = Object.entries(entry.tools ?? {}).toSorted(([left], [right]) =>
+        left.localeCompare(right),
+      );
       return [
         {
           configKey,
@@ -493,6 +507,13 @@ export function resolveCodexPluginsPolicy(pluginConfig?: unknown): ResolvedCodex
           enabled: enabled && entry.enabled !== false,
           allowDestructiveActions: entryDestructivePolicy.allowDestructiveActions,
           destructiveApprovalMode: entryDestructivePolicy.destructiveApprovalMode,
+          ...(toolEntries.length > 0
+            ? {
+                tools: Object.fromEntries(
+                  toolEntries.map(([toolKey, tool]) => [toolKey, tool.enabled]),
+                ),
+              }
+            : {}),
         },
       ];
     })

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -336,6 +336,10 @@ describe("Codex plugin thread config", () => {
           allowDestructiveActions: true,
           destructiveApprovalMode: "ask",
           mcpServerNames: ["ask"],
+          tools: {
+            "calendar.calendar_read": true,
+            "calendar.calendar_write": false,
+          },
         },
         "auto-app": {
           configKey: "auto",
@@ -365,6 +369,10 @@ describe("Codex plugin thread config", () => {
           destructive_enabled: true,
           open_world_enabled: true,
           default_tools_approval_mode: "auto",
+          tools: {
+            "calendar.calendar_read": { enabled: true },
+            "calendar.calendar_write": { enabled: false },
+          },
         },
         "auto-app": {
           enabled: true,
@@ -793,9 +801,7 @@ describe("Codex plugin thread config", () => {
             apps: {
               "chatgpt-meetings": {
                 tools:
-                  configReadCount === 1
-                    ? { import_meeting: { approval_mode: "approve" } }
-                    : {},
+                  configReadCount === 1 ? { import_meeting: { approval_mode: "approve" } } : {},
               },
             },
           },
@@ -1671,6 +1677,327 @@ describe("Codex plugin thread config", () => {
     });
     expect(second).toBe(first);
     expect(third).not.toBe(second);
+    expect(first).not.toBe("59d881b67ea73b224718de2cbc767fc6262554eaeaaa3ebd155e13f00db02be3");
+  });
+
+  it("copies exact tool selectors to every admitted app owned by one plugin", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async () => ({
+        data: [appInfo("slack-primary", true), appInfo("slack-secondary", true)],
+        nextCursor: null,
+      }),
+    });
+    const tools = {
+      "slack.unknown_future_tool": { enabled: true },
+      "slack.slack_send_message": { enabled: false },
+    };
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            slack: {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "slack",
+              tools,
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request: async (method) => {
+        if (method === "plugin/list") {
+          return pluginList([pluginSummary("slack", { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read") {
+          return pluginDetail(
+            "slack",
+            [appSummary("slack-primary"), appSummary("slack-secondary")],
+            ["slack"],
+          );
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    const expectedTools = {
+      "slack.slack_send_message": { enabled: false },
+      "slack.unknown_future_tool": { enabled: true },
+    };
+    expect(config.configPatch).toMatchObject({
+      apps: {
+        "slack-primary": { default_tools_approval_mode: "auto", tools: expectedTools },
+        "slack-secondary": { default_tools_approval_mode: "auto", tools: expectedTools },
+      },
+    });
+    expect(config.policyContext.apps["slack-primary"]).toMatchObject({
+      tools: {
+        "slack.slack_send_message": false,
+        "slack.unknown_future_tool": true,
+      },
+    });
+    expect(config.policyContext.apps["slack-secondary"]).toMatchObject({
+      tools: {
+        "slack.slack_send_message": false,
+        "slack.unknown_future_tool": true,
+      },
+    });
+  });
+
+  it("fails closed on enabled selectors under a disabled destructive ceiling", async () => {
+    const blocked = await buildReadyGoogleCalendarThreadConfig({
+      codexPlugins: {
+        enabled: true,
+        plugins: {
+          "google-calendar": {
+            marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+            pluginName: "google-calendar",
+            allow_destructive_actions: false,
+            tools: { "calendar.read": { enabled: true } },
+          },
+        },
+      },
+    });
+    expect(blocked.configPatch?.apps).toEqual({
+      _default: {
+        enabled: false,
+        destructive_enabled: false,
+        open_world_enabled: false,
+      },
+    });
+    expect(blocked.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "tool_policy_destructive_conflict",
+        toolKey: "calendar.read",
+        enabled: true,
+        status: "blocked",
+      }),
+    );
+
+    const denied = await buildReadyGoogleCalendarThreadConfig({
+      codexPlugins: {
+        enabled: true,
+        plugins: {
+          "google-calendar": {
+            marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+            pluginName: "google-calendar",
+            allow_destructive_actions: false,
+            tools: { "calendar.write": { enabled: false } },
+          },
+        },
+      },
+    });
+    expect(denied.configPatch).toMatchObject({
+      apps: {
+        "google-calendar-app": {
+          destructive_enabled: false,
+          tools: { "calendar.write": { enabled: false } },
+        },
+      },
+    });
+  });
+
+  it("excludes an app claimed by multiple configured plugins", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async () => ({ data: [appInfo("shared-app", true)], nextCursor: null }),
+    });
+    const pluginConfig = {
+      codexPlugins: {
+        enabled: true,
+        plugins: {
+          alpha: {
+            marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+            pluginName: "alpha",
+            tools: { "shared.tool": { enabled: false } },
+          },
+          beta: {
+            marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+            pluginName: "beta",
+            tools: { "shared.tool": { enabled: true } },
+          },
+        },
+      },
+    };
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig,
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request: async (method, requestParams) => {
+        if (method === "plugin/list") {
+          return pluginList([
+            pluginSummary("alpha", { installed: true, enabled: true }),
+            pluginSummary("beta", { installed: true, enabled: true }),
+          ]);
+        }
+        if (method === "plugin/read") {
+          const pluginName = (requestParams as { pluginName: string }).pluginName;
+          return pluginDetail(pluginName, [appSummary("shared-app")]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    expect(config.configPatch?.apps).toEqual({
+      _default: {
+        enabled: false,
+        destructive_enabled: false,
+        open_world_enabled: false,
+      },
+    });
+    expect(
+      config.diagnostics.filter(({ code }) => code === "tool_policy_ownership_conflict"),
+    ).toHaveLength(2);
+
+    const reversed = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          ...pluginConfig.codexPlugins,
+          plugins: {
+            beta: pluginConfig.codexPlugins.plugins.beta,
+            alpha: pluginConfig.codexPlugins.plugins.alpha,
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request: async (method, requestParams) => {
+        if (method === "plugin/list") {
+          return pluginList([
+            pluginSummary("beta", { installed: true, enabled: true }),
+            pluginSummary("alpha", { installed: true, enabled: true }),
+          ]);
+        }
+        if (method === "plugin/read") {
+          const pluginName = (requestParams as { pluginName: string }).pluginName;
+          return pluginDetail(pluginName, [appSummary("shared-app")]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+    expect(reversed.configPatch).toEqual(config.configPatch);
+    expect(reversed.diagnostics).toEqual(config.diagnostics);
+  });
+
+  it("preserves duplicate ownership behavior when no claimant has tool policy", async () => {
+    const appCache = new CodexAppInventoryCache();
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async () => ({ data: [appInfo("shared-app", true)], nextCursor: null }),
+    });
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          plugins: {
+            alpha: {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "alpha",
+            },
+            beta: {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "beta",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      nowMs: 1,
+      request: async (method, requestParams) => {
+        if (method === "plugin/list") {
+          return pluginList([
+            pluginSummary("alpha", { installed: true, enabled: true }),
+            pluginSummary("beta", { installed: true, enabled: true }),
+          ]);
+        }
+        if (method === "plugin/read") {
+          const pluginName = (requestParams as { pluginName: string }).pluginName;
+          return pluginDetail(pluginName, [appSummary("shared-app")]);
+        }
+        throw new Error(`unexpected request ${method}`);
+      },
+    });
+
+    expect(config.configPatch?.apps).toHaveProperty("shared-app");
+    expect(config.policyContext.apps["shared-app"]).toMatchObject({ configKey: "beta" });
+    expect(config.diagnostics).not.toContainEqual(
+      expect.objectContaining({ code: "tool_policy_ownership_conflict" }),
+    );
+  });
+
+  it("fingerprints exact tool rules independent of insertion order", () => {
+    const base = {
+      enabled: true,
+      plugins: {
+        slack: {
+          marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+          pluginName: "slack",
+        },
+      },
+    };
+    const fingerprint = (tools: Record<string, { enabled: boolean }>) =>
+      buildCodexPluginThreadConfigInputFingerprint({
+        pluginConfig: {
+          codexPlugins: {
+            ...base,
+            plugins: { slack: { ...base.plugins.slack, tools } },
+          },
+        },
+        appCacheKey: "runtime-a",
+      });
+    const first = fingerprint({
+      "slack.b": { enabled: false },
+      "slack.a": { enabled: true },
+    });
+    expect(
+      fingerprint({
+        "slack.a": { enabled: true },
+        "slack.b": { enabled: false },
+      }),
+    ).toBe(first);
+    expect(
+      fingerprint({
+        "slack.a": { enabled: false },
+        "slack.b": { enabled: false },
+      }),
+    ).not.toBe(first);
+    expect(
+      fingerprint({
+        "slack.a": { enabled: true },
+        "slack.c": { enabled: false },
+      }),
+    ).not.toBe(first);
+    expect(
+      buildCodexPluginThreadConfigInputFingerprint({
+        pluginConfig: {
+          codexPlugins: {
+            enabled: true,
+            plugins: {
+              "slack-renamed": {
+                ...base.plugins.slack,
+                tools: {
+                  "slack.a": { enabled: true },
+                  "slack.b": { enabled: false },
+                },
+              },
+            },
+          },
+        },
+        appCacheKey: "runtime-a",
+      }),
+    ).not.toBe(first);
   });
 
   it("uses app-level destructive policy for plugins without OpenClaw tool-name knowledge", async () => {

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -482,7 +482,7 @@ function buildDisabledAppsConfigPatch(): JsonObject {
 function buildEnabledAppConfig(
   policy: {
     allowDestructiveActions: boolean;
-    destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
+    destructiveApprovalMode?: CodexPluginDestructiveApprovalMode;
   },
   tools?: Record<string, boolean>,
 ): JsonObject {

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -40,6 +40,7 @@ export type PluginAppPolicyContextEntry = {
   allowDestructiveActions: boolean;
   destructiveApprovalMode?: CodexPluginDestructiveApprovalMode;
   mcpServerNames: string[];
+  tools?: Record<string, boolean>;
 };
 
 /** Policy context for one account-connected app admitted without a plugin package. */
@@ -52,9 +53,7 @@ export type AccountAppPolicyContextEntry = {
 };
 
 /** Policy context for any app exposed to a native Codex thread. */
-export type CodexAppPolicyContextEntry =
-  | PluginAppPolicyContextEntry
-  | AccountAppPolicyContextEntry;
+export type CodexAppPolicyContextEntry = PluginAppPolicyContextEntry | AccountAppPolicyContextEntry;
 
 /** Stable app-to-plugin ownership context persisted with Codex thread bindings. */
 export type PluginAppPolicyContext = {
@@ -71,8 +70,15 @@ export type CodexPluginThreadConfigDiagnostic =
         | "plugin_activation_failed"
         | "app_not_ready"
         | "account_app_inventory_unavailable"
-        | "approval_overrides_clear_failed";
+        | "approval_overrides_clear_failed"
+        | "tool_policy_destructive_conflict"
+        | "tool_policy_ownership_conflict";
       plugin?: ResolvedCodexPluginPolicy;
+      appId?: string;
+      toolKey?: string;
+      enabled?: boolean;
+      status?: "blocked";
+      remediation?: string;
       message: string;
     };
 
@@ -97,7 +103,7 @@ export type BuildCodexPluginThreadConfigParams = {
   nowMs?: number;
 };
 
-const CODEX_PLUGIN_THREAD_CONFIG_INPUT_FINGERPRINT_VERSION = 3;
+const CODEX_PLUGIN_THREAD_CONFIG_INPUT_FINGERPRINT_VERSION = 4;
 const CODEX_PLUGIN_THREAD_CONFIG_FINGERPRINT_VERSION = 2;
 
 /** Returns true when plugin config exists and thread config may need app patches. */
@@ -136,17 +142,18 @@ export async function buildCodexPluginThreadConfig(
     });
   }
 
-  let inventory = policy.pluginPolicies.length > 0
-    ? await readCodexPluginInventory({
-        pluginConfig: params.pluginConfig,
-        policy,
-        request: params.request,
-        appCache,
-        appCacheKey: params.appCacheKey,
-        nowMs: params.nowMs,
-        suppressAppInventoryRefresh: true,
-      })
-    : emptyCodexPluginInventory(policy);
+  let inventory =
+    policy.pluginPolicies.length > 0
+      ? await readCodexPluginInventory({
+          pluginConfig: params.pluginConfig,
+          policy,
+          request: params.request,
+          appCache,
+          appCacheKey: params.appCacheKey,
+          nowMs: params.nowMs,
+          suppressAppInventoryRefresh: true,
+        })
+      : emptyCodexPluginInventory(policy);
   const appInventoryRefreshDeferredForActivation =
     inventory.records.some((record) => record.activationRequired) &&
     shouldRefreshMissingAppInventory(params, policy, inventory);
@@ -243,9 +250,7 @@ export async function buildCodexPluginThreadConfig(
   }
 
   const accountAppsResult: Awaited<ReturnType<typeof readAccessibleAccountApps>> =
-    policy.allowAllPlugins
-    ? await readAccessibleAccountApps(params, appCache)
-    : { apps: [] };
+    policy.allowAllPlugins ? await readAccessibleAccountApps(params, appCache) : { apps: [] };
 
   const diagnostics: CodexPluginThreadConfigDiagnostic[] = [
     ...inventory.diagnostics,
@@ -261,6 +266,20 @@ export async function buildCodexPluginThreadConfig(
   };
   const policyApps: Record<string, CodexAppPolicyContextEntry> = {};
   const pluginAppIds: Record<string, string[]> = {};
+  const pluginClaimsByAppId = collectPluginClaimsByAppId(inventory.records);
+  const toolPolicyConfigKeys = new Set(
+    inventory.records
+      .filter((record) => Object.keys(record.policy.tools ?? {}).length > 0)
+      .map((record) => record.policy.configKey),
+  );
+  const conflictedAppIds = new Set(
+    [...pluginClaimsByAppId.entries()]
+      .filter(
+        ([, configKeys]) =>
+          configKeys.length > 1 && configKeys.some((key) => toolPolicyConfigKeys.has(key)),
+      )
+      .map(([appId]) => appId),
+  );
   const pluginOwnedAppIds = new Set(
     inventory.records.flatMap((record) =>
       record.appOwnership === "proven" ? record.ownedAppIds : [],
@@ -277,7 +296,39 @@ export async function buildCodexPluginThreadConfig(
       continue;
     }
     pluginAppIds[record.policy.configKey] = [...record.ownedAppIds].toSorted();
+    const enabledToolKeys = Object.entries(record.policy.tools ?? {})
+      .filter(([, enabled]) => enabled)
+      .map(([toolKey]) => toolKey)
+      .toSorted();
+    if (!record.policy.allowDestructiveActions && enabledToolKeys.length > 0) {
+      for (const toolKey of enabledToolKeys) {
+        diagnostics.push({
+          code: "tool_policy_destructive_conflict",
+          plugin: record.policy,
+          toolKey,
+          enabled: true,
+          status: "blocked",
+          remediation:
+            "Set enabled to false or allow destructive actions for this configured plugin.",
+          message: `${record.policy.configKey} tool ${toolKey} cannot be enabled while destructive actions are disabled; all apps owned by this plugin were excluded.`,
+        });
+      }
+      continue;
+    }
     for (const app of resolveThreadConfigAppsForRecord({ record, inventory })) {
+      if (conflictedAppIds.has(app.id)) {
+        diagnostics.push({
+          code: "tool_policy_ownership_conflict",
+          plugin: record.policy,
+          appId: app.id,
+          status: "blocked",
+          remediation: "Remove the duplicate configured plugin claim for this app.",
+          message: `${app.id} is claimed by configured plugins ${
+            pluginClaimsByAppId.get(app.id)?.join(", ") ?? "unknown"
+          }; it was excluded from every claimant.`,
+        });
+        continue;
+      }
       if (!isPluginAppReadyForThreadStart(app)) {
         diagnostics.push({
           code: "app_not_ready",
@@ -298,7 +349,7 @@ export async function buildCodexPluginThreadConfig(
       ) {
         continue;
       }
-      apps[app.id] = buildEnabledAppConfig(record.policy);
+      apps[app.id] = buildEnabledAppConfig(record.policy, record.policy.tools);
       policyApps[app.id] = {
         configKey: record.policy.configKey,
         marketplaceName: record.policy.marketplaceName,
@@ -306,6 +357,7 @@ export async function buildCodexPluginThreadConfig(
         allowDestructiveActions: record.policy.allowDestructiveActions,
         destructiveApprovalMode: record.policy.destructiveApprovalMode,
         mcpServerNames: [...(record.detail?.mcpServers ?? [])].toSorted(),
+        ...(record.policy.tools ? { tools: { ...record.policy.tools } } : {}),
       };
     }
   }
@@ -427,16 +479,21 @@ function buildDisabledAppsConfigPatch(): JsonObject {
   };
 }
 
-function buildEnabledAppConfig(policy: {
-  allowDestructiveActions: boolean;
-  destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
-}): JsonObject {
+function buildEnabledAppConfig(
+  policy: {
+    allowDestructiveActions: boolean;
+    destructiveApprovalMode: CodexPluginDestructiveApprovalMode;
+  },
+  tools?: Record<string, boolean>,
+): JsonObject {
+  const toolConfig = buildToolConfigPatch(tools);
   return {
     enabled: true,
     destructive_enabled: policy.allowDestructiveActions,
     open_world_enabled: true,
     default_tools_approval_mode: "auto",
     ...(policy.destructiveApprovalMode === "ask" ? { approvals_reviewer: "user" } : {}),
+    ...(toolConfig ? { tools: toolConfig } : {}),
   };
 }
 
@@ -454,13 +511,17 @@ export function buildCodexPluginAppsConfigPatchFromPolicyContext(
   for (const [appId, policy] of Object.entries(policyContext.apps).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
-    apps[appId] = {
-      enabled: true,
-      destructive_enabled: policy.allowDestructiveActions,
-      open_world_enabled: true,
-      default_tools_approval_mode: "auto",
-      ...(policy.destructiveApprovalMode === "ask" ? { approvals_reviewer: "user" } : {}),
-    };
+    if (
+      policy.source !== "account" &&
+      !policy.allowDestructiveActions &&
+      Object.values(policy.tools ?? {}).some(Boolean)
+    ) {
+      continue;
+    }
+    apps[appId] = buildEnabledAppConfig(
+      policy,
+      policy.source === "account" ? undefined : policy.tools,
+    );
   }
   return { apps };
 }
@@ -649,9 +710,9 @@ async function readAccessibleAccountApps(
     };
   }
   return {
-    apps: snapshot.apps.filter((app) => app.isAccessible).toSorted((left, right) =>
-      left.id.localeCompare(right.id),
-    ),
+    apps: snapshot.apps
+      .filter((app) => app.isAccessible)
+      .toSorted((left, right) => left.id.localeCompare(right.id)),
   };
 }
 
@@ -707,6 +768,13 @@ function policyFingerprint(policy: ResolvedCodexPluginsPolicy): JsonValue {
     allowAllPlugins: policy.allowAllPlugins,
     allowDestructiveActions: policy.allowDestructiveActions,
     destructiveApprovalMode: policy.destructiveApprovalMode,
+    toolRules: policy.pluginPolicies.flatMap((plugin) =>
+      Object.entries(plugin.tools ?? {}).map(([toolKey, enabled]) => ({
+        configKey: plugin.configKey,
+        toolKey,
+        enabled,
+      })),
+    ),
     plugins: policy.pluginPolicies.map((plugin) => ({
       configKey: plugin.configKey,
       marketplaceName: plugin.marketplaceName,
@@ -716,6 +784,37 @@ function policyFingerprint(policy: ResolvedCodexPluginsPolicy): JsonValue {
       destructiveApprovalMode: plugin.destructiveApprovalMode,
     })),
   };
+}
+
+function buildToolConfigPatch(tools?: Record<string, boolean>): JsonObject | undefined {
+  const entries = Object.entries(tools ?? {}).toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return Object.fromEntries(entries.map(([toolKey, enabled]) => [toolKey, { enabled }]));
+}
+
+function collectPluginClaimsByAppId(
+  records: readonly CodexPluginInventoryRecord[],
+): Map<string, string[]> {
+  const claims = new Map<string, Set<string>>();
+  for (const record of records) {
+    if (record.appOwnership !== "proven") {
+      continue;
+    }
+    for (const appId of record.ownedAppIds) {
+      const configKeys = claims.get(appId) ?? new Set<string>();
+      configKeys.add(record.policy.configKey);
+      claims.set(appId, configKeys);
+    }
+  }
+  return new Map(
+    [...claims.entries()]
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([appId, configKeys]) => [appId, [...configKeys].toSorted()]),
+  );
 }
 
 function mergeJsonObjects(left: JsonObject, right: JsonObject): JsonObject {

--- a/extensions/codex/src/app-server/session-binding.test.ts
+++ b/extensions/codex/src/app-server/session-binding.test.ts
@@ -111,6 +111,36 @@ describe("Codex app-server binding store", () => {
     expect(imported?.binding.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
   });
 
+  it("round-trips active plugin tool policy context", async () => {
+    const { state } = createStateStore();
+    const store = createCodexAppServerBindingStore(state);
+    const identity = { kind: "session" as const, agentId: "main", sessionId: "session-tools" };
+    const pluginAppPolicyContext = {
+      fingerprint: "tool-policy-1",
+      apps: {
+        slack: {
+          configKey: "slack",
+          marketplaceName: "openai-curated" as const,
+          pluginName: "slack",
+          allowDestructiveActions: true,
+          mcpServerNames: ["slack"],
+          tools: {
+            "slack.slack_read_channel": true,
+            "slack.slack_send_message": false,
+          },
+        },
+      },
+      pluginAppIds: { slack: ["slack"] },
+    };
+
+    await store.mutate(identity, {
+      kind: "set",
+      binding: { threadId: "thread-tools", cwd: "/repo", pluginAppPolicyContext },
+    });
+
+    await expect(store.read(identity)).resolves.toMatchObject({ pluginAppPolicyContext });
+  });
+
   it("canonicalizes undefined fields before writing to JSON-only plugin state", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-codex-binding-state-"));
     try {
@@ -764,6 +794,50 @@ describe("Codex app-server binding store", () => {
 
     expect(stored?.binding.pluginAppPolicyContext?.apps.app?.destructiveApprovalMode).toBe("ask");
     expect(invalid?.binding.pluginAppPolicyContext).toBeUndefined();
+  });
+
+  it("round-trips exact plugin tool policy and drops unsafe persisted grants", () => {
+    const policyContext = {
+      fingerprint: "policy-tools",
+      apps: {
+        slack: {
+          configKey: "slack",
+          marketplaceName: "openai-curated",
+          pluginName: "slack",
+          allowDestructiveActions: true,
+          mcpServerNames: ["slack"],
+          tools: {
+            "slack.slack_read_channel": true,
+            "slack.slack_send_message": false,
+          },
+        },
+      },
+      pluginAppIds: { slack: ["slack"] },
+    };
+    const stored = createStoredCodexAppServerBinding({
+      schemaVersion: 2,
+      threadId: "thread-tools",
+      cwd: "/repo",
+      pluginAppPolicyContext: policyContext,
+    });
+    const unsafe = createStoredCodexAppServerBinding({
+      schemaVersion: 2,
+      threadId: "thread-unsafe-tools",
+      cwd: "/repo",
+      pluginAppPolicyContext: {
+        ...policyContext,
+        apps: {
+          slack: {
+            ...policyContext.apps.slack,
+            allowDestructiveActions: false,
+            tools: { "slack.slack_send_message": true },
+          },
+        },
+      },
+    });
+
+    expect(stored?.binding.pluginAppPolicyContext).toEqual(policyContext);
+    expect(unsafe?.binding.pluginAppPolicyContext).toBeUndefined();
   });
 
   it("serializes writes from another facade behind a native-compaction lease", async () => {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -102,6 +102,7 @@ const destructiveApprovalModeSchema = z
   .enum(["allow", "deny", "auto", "ask"])
   .optional()
   .catch(undefined);
+const pluginToolPolicySchema = z.record(z.string().regex(/^\S(?:.*\S)?$/), z.boolean()).optional();
 // Account-connected apps are admitted without a plugin package; both entry
 // shapes must round-trip or stored policy context silently drops on read.
 const accountAppPolicyEntrySchema = z
@@ -122,8 +123,18 @@ const pluginAppPolicyEntrySchema = z
     allowDestructiveActions: z.boolean(),
     destructiveApprovalMode: destructiveApprovalModeSchema,
     mcpServerNames: z.array(z.string()),
+    tools: pluginToolPolicySchema,
   })
-  .strict();
+  .strict()
+  .superRefine((entry, ctx) => {
+    if (!entry.allowDestructiveActions && Object.values(entry.tools ?? {}).some(Boolean)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["tools"],
+        message: "enabled tool policy exceeds the destructive-action ceiling",
+      });
+    }
+  });
 const pluginAppPolicyContextSchema = z
   .object({
     fingerprint: z.string(),
@@ -900,6 +911,7 @@ function readPluginAppPolicyContext(
     if (entry.source === "account") {
       if (
         "appId" in entry ||
+        "tools" in entry ||
         typeof entry.appName !== "string" ||
         typeof entry.allowDestructiveActions !== "boolean" ||
         destructiveApprovalMode === "invalid" ||
@@ -916,6 +928,7 @@ function readPluginAppPolicyContext(
       };
       continue;
     }
+    const tools = readPluginToolPolicy(entry.tools);
     if (
       "appId" in entry ||
       (entry.source !== undefined && entry.source !== "plugin") ||
@@ -924,6 +937,10 @@ function readPluginAppPolicyContext(
       typeof entry.pluginName !== "string" ||
       typeof entry.allowDestructiveActions !== "boolean" ||
       destructiveApprovalMode === "invalid" ||
+      tools === "invalid" ||
+      (entry.allowDestructiveActions === false &&
+        tools !== undefined &&
+        Object.values(tools).some(Boolean)) ||
       !mcpServerNamesValid
     ) {
       return undefined;
@@ -935,6 +952,7 @@ function readPluginAppPolicyContext(
       allowDestructiveActions: entry.allowDestructiveActions,
       ...(destructiveApprovalMode ? { destructiveApprovalMode } : {}),
       mcpServerNames: entry.mcpServerNames as string[],
+      ...(tools ? { tools } : {}),
     };
   }
   const parsedPluginAppIds: PluginAppPolicyContext["pluginAppIds"] = {};
@@ -959,6 +977,30 @@ function readPluginAppPolicyContext(
     apps: parsedApps,
     pluginAppIds: parsedPluginAppIds,
   };
+}
+
+function readPluginToolPolicy(value: unknown): Record<string, boolean> | undefined | "invalid" {
+  if (value === undefined) {
+    return undefined;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return "invalid";
+  }
+  const entries = Object.entries(record);
+  if (
+    entries.some(
+      ([toolKey, enabled]) => !/^\S(?:.*\S)?$/.test(toolKey) || typeof enabled !== "boolean",
+    )
+  ) {
+    return "invalid";
+  }
+  if (entries.length === 0) {
+    return undefined;
+  }
+  return Object.fromEntries(
+    entries.toSorted(([left], [right]) => left.localeCompare(right)),
+  ) as Record<string, boolean>;
 }
 
 function readDestructiveApprovalMode(

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -938,7 +938,7 @@ function readPluginAppPolicyContext(
       typeof entry.allowDestructiveActions !== "boolean" ||
       destructiveApprovalMode === "invalid" ||
       tools === "invalid" ||
-      (entry.allowDestructiveActions === false &&
+      (!entry.allowDestructiveActions &&
         tools !== undefined &&
         Object.values(tools).some(Boolean)) ||
       !mcpServerNamesValid

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -2008,6 +2008,71 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(binding?.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
   });
 
+  it("fails closed when revalidation of a tool-policy binding fails", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const basePolicyContext = createPluginAppPolicyContext();
+    const pluginAppPolicyContext = {
+      ...basePolicyContext,
+      apps: {
+        ...basePolicyContext.apps,
+        "google-calendar-app": {
+          ...basePolicyContext.apps["google-calendar-app"],
+          tools: { "calendar.calendar_read": false },
+        },
+      },
+    };
+    await writeCodexAppServerBinding(sessionFile, {
+      threadId: "thread-existing",
+      cwd: workspaceDir,
+      model: "gpt-5.4-codex",
+      modelProvider: "openai",
+      dynamicToolsFingerprint: "[]",
+      pluginAppsFingerprint: "plugin-apps-config-1",
+      pluginAppsInputFingerprint: "plugin-apps-input-1",
+      pluginAppPolicyContext,
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    const appServer = createThreadLifecycleAppServerOptions();
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-fresh");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const safeConfig = {
+      enabled: true,
+      configPatch: createPluginAppConfigPatch(),
+      fingerprint: "plugin-apps-config-2",
+      inputFingerprint: "plugin-apps-input-1",
+      policyContext: createPluginAppPolicyContext(),
+      diagnostics: [],
+    };
+    const buildPluginThreadConfig = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("plugin inventory unavailable"))
+      .mockResolvedValueOnce(safeConfig);
+
+    const binding = await startOrResumeThread({
+      client: { request } as never,
+      params,
+      cwd: workspaceDir,
+      dynamicTools: [],
+      appServer,
+      pluginThreadConfig: {
+        enabled: true,
+        inputFingerprint: "plugin-apps-input-1",
+        enabledPluginConfigKeys: ["google-calendar"],
+        build: buildPluginThreadConfig,
+      },
+    });
+
+    expect(buildPluginThreadConfig).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start"]);
+    expect(binding.threadId).toBe("thread-fresh");
+    expect(binding.lifecycle).toEqual({ action: "started" });
+  });
+
   it("rebuilds an empty plugin app binding after app inventory recovers", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -631,10 +631,15 @@ export async function startOrResumeThread(params: {
           pluginBindingStale =
             prebuiltPluginThreadConfig?.fingerprint !== binding.pluginAppsFingerprint;
         } catch (error) {
+          const failClosed = bindingHasPluginToolPolicy(binding);
           embeddedAgentLog.warn("codex app-server plugin app config recovery check failed", {
             error,
+            failClosed,
             threadId: binding.threadId,
           });
+          if (failClosed) {
+            pluginBindingStale = true;
+          }
         }
       }
       if (pluginBindingStale) {
@@ -871,6 +876,31 @@ export async function startOrResumeThread(params: {
           params.pluginThreadConfig?.build(),
         )))
       : undefined;
+    if (pluginThreadConfig) {
+      embeddedAgentLog.debug("codex app-server plugin app policy resolved", {
+        fingerprint: pluginThreadConfig.fingerprint,
+        inputFingerprint: pluginThreadConfig.inputFingerprint,
+        diagnostics: pluginThreadConfig.diagnostics.map((diagnostic) => ({
+          code: diagnostic.code,
+          ...(diagnostic.plugin ? { pluginConfigKey: diagnostic.plugin.configKey } : {}),
+          ...("appId" in diagnostic && typeof diagnostic.appId === "string"
+            ? { appId: diagnostic.appId }
+            : {}),
+          ...("toolKey" in diagnostic && typeof diagnostic.toolKey === "string"
+            ? { toolKey: diagnostic.toolKey }
+            : {}),
+          ...("enabled" in diagnostic && typeof diagnostic.enabled === "boolean"
+            ? { enabled: diagnostic.enabled }
+            : {}),
+          ...("status" in diagnostic && typeof diagnostic.status === "string"
+            ? { status: diagnostic.status }
+            : {}),
+          ...("remediation" in diagnostic && typeof diagnostic.remediation === "string"
+            ? { remediation: diagnostic.remediation }
+            : {}),
+        })),
+      });
+    }
     const finalConfigPatch = params.buildFinalConfigPatch?.({ action: "start" }) ?? {
       configPatch: params.finalConfigPatch,
       nativeHookRelayGeneration: params.nativeHookRelayGeneration,
@@ -1174,6 +1204,12 @@ function shouldRecheckRecoverablePluginBinding(params: {
   }
   const expectedPluginConfigKeys = params.pluginThreadConfig.enabledPluginConfigKeys ?? [];
   return Object.keys(policyContext.apps).length === 0 || expectedPluginConfigKeys.length > 0;
+}
+
+function bindingHasPluginToolPolicy(binding: CodexAppServerThreadBinding): boolean {
+  return Object.values(binding.pluginAppPolicyContext?.apps ?? {}).some(
+    (app) => app.source !== "account" && Object.keys(app.tools ?? {}).length > 0,
+  );
 }
 
 export function buildThreadStartParams(

--- a/extensions/codex/src/command-plugins-management.test.ts
+++ b/extensions/codex/src/command-plugins-management.test.ts
@@ -10,13 +10,17 @@ import {
 
 function inMemoryIO(
   initial: Record<string, CodexPluginConfigEntry> = {},
-  options: { enabled?: boolean } = { enabled: true },
+  options: {
+    enabled?: boolean;
+    allow_destructive_actions?: boolean | "auto" | "ask";
+  } = { enabled: true },
 ): CodexPluginsManagementIO & {
   current: () => Record<string, CodexPluginConfigEntry>;
   currentConfig: () => CodexPluginsConfigBlock;
 } {
   const store: CodexPluginsConfigBlock = {
     enabled: options.enabled,
+    allow_destructive_actions: options.allow_destructive_actions,
     plugins: structuredClone(initial),
   };
   return {
@@ -81,6 +85,32 @@ describe("Codex /codex plugins subcommand", () => {
     const result = await handleCodexPluginsSubcommand(fakeCtx, ["list"], io);
     expect(result.text).toContain("OFF  google-calendar");
     expect(result.text).toContain("Global codexPlugins.enabled is off");
+  });
+
+  it("lists exact tool selectors with only configured or blocked policy status", async () => {
+    const io = inMemoryIO(
+      {
+        slack: {
+          enabled: true,
+          marketplaceName: "openai-curated",
+          pluginName: "slack",
+          tools: {
+            "slack.slack_send_message": { enabled: true },
+            "slack.slack_read_channel": { enabled: false },
+          },
+        },
+      },
+      { enabled: true, allow_destructive_actions: false },
+    );
+
+    const result = await handleCodexPluginsSubcommand(fakeCtx, ["list"], io);
+    const text = result.text ?? "";
+    expect(text).toContain("slack.slack_read_channel: false [configured]");
+    expect(text).toContain("slack.slack_send_message: true [blocked]");
+    expect(text.indexOf("slack.slack_read_channel")).toBeLessThan(
+      text.indexOf("slack.slack_send_message"),
+    );
+    expect(text).not.toMatch(/matched|resolved|inert/);
   });
 
   it("renders the plugins menu as portable slash-command buttons", async () => {

--- a/extensions/codex/src/command-plugins-management.ts
+++ b/extensions/codex/src/command-plugins-management.ts
@@ -15,6 +15,7 @@ import {
 export type CodexPluginsManagementIO = {
   readConfig: () => Promise<{
     enabled?: boolean;
+    allow_destructive_actions?: boolean | "auto" | "ask";
     plugins?: Record<string, CodexPluginConfigEntry>;
   }>;
   mutate: (update: (block: CodexPluginsConfigBlock) => void) => Promise<void>;
@@ -25,10 +26,12 @@ export type CodexPluginConfigEntry = {
   marketplaceName?: string;
   pluginName?: string;
   allow_destructive_actions?: boolean | "auto" | "ask";
+  tools?: Record<string, { enabled: boolean }>;
 };
 
 export type CodexPluginsConfigBlock = {
   enabled?: boolean;
+  allow_destructive_actions?: boolean | "auto" | "ask";
   plugins?: Record<string, CodexPluginConfigEntry>;
 };
 
@@ -67,7 +70,10 @@ export async function handleCodexPluginsSubcommand(
     }
     const current = await io.readConfig();
     return {
-      text: formatPluginList(current.plugins ?? {}, { globalEnabled: current.enabled === true }),
+      text: formatPluginList(current.plugins ?? {}, {
+        globalEnabled: current.enabled === true,
+        globalDestructivePolicy: current.allow_destructive_actions,
+      }),
     };
   }
 
@@ -210,7 +216,10 @@ export function buildPluginsHelp(): string {
 
 export function formatPluginList(
   plugins: Record<string, CodexPluginConfigEntry>,
-  options: { globalEnabled?: boolean } = {},
+  options: {
+    globalEnabled?: boolean;
+    globalDestructivePolicy?: boolean | "auto" | "ask";
+  } = {},
 ): string {
   const globalEnabled = options.globalEnabled === true;
   const keys = Object.keys(plugins).toSorted();
@@ -223,17 +232,26 @@ export function formatPluginList(
     const displayKey = formatCodexDisplayText(key);
     const pluginName = formatCodexDisplayText(entry.pluginName ?? key);
     const marketplace = formatCodexDisplayText(entry.marketplaceName ?? "?");
-    return { displayKey, state, pluginName, marketplace };
+    const destructivePolicy =
+      entry.allow_destructive_actions ?? options.globalDestructivePolicy ?? true;
+    const tools = Object.entries(entry.tools ?? {})
+      .toSorted(([left], [right]) => left.localeCompare(right))
+      .map(([toolKey, tool]) => ({
+        displayKey: formatCodexDisplayText(toolKey),
+        enabled: tool.enabled,
+        status: tool.enabled && destructivePolicy === false ? "blocked" : "configured",
+      }));
+    return { displayKey, state, pluginName, marketplace, tools };
   });
   const keyW = Math.max(...rows.map((r) => r.displayKey.length));
   const pluginW = Math.max(...rows.map((r) => r.pluginName.length));
   return [
     "Codex sub-plugins in Openclaw config (~/.openclaw/openclaw.json):",
     "",
-    ...rows.map(
-      (r) =>
-        `  ${r.state}  ${r.displayKey.padEnd(keyW)}  ${r.pluginName.padEnd(pluginW)}  [${r.marketplace}]`,
-    ),
+    ...rows.flatMap((r) => [
+      `  ${r.state}  ${r.displayKey.padEnd(keyW)}  ${r.pluginName.padEnd(pluginW)}  [${r.marketplace}]`,
+      ...r.tools.map((tool) => `        ${tool.displayKey}: ${tool.enabled} [${tool.status}]`),
+    ]),
     "",
     ...(globalEnabled
       ? []

--- a/extensions/codex/src/command-plugins-management.ts
+++ b/extensions/codex/src/command-plugins-management.ts
@@ -248,10 +248,13 @@ export function formatPluginList(
   return [
     "Codex sub-plugins in Openclaw config (~/.openclaw/openclaw.json):",
     "",
-    ...rows.flatMap((r) => [
-      `  ${r.state}  ${r.displayKey.padEnd(keyW)}  ${r.pluginName.padEnd(pluginW)}  [${r.marketplace}]`,
-      ...r.tools.map((tool) => `        ${tool.displayKey}: ${tool.enabled} [${tool.status}]`),
-    ]),
+    ...rows.flatMap((r) =>
+      [
+        `  ${r.state}  ${r.displayKey.padEnd(keyW)}  ${r.pluginName.padEnd(pluginW)}  [${r.marketplace}]`,
+      ].concat(
+        r.tools.map((tool) => `        ${tool.displayKey}: ${tool.enabled} [${tool.status}]`),
+      ),
+    ),
     "",
     ...(globalEnabled
       ? []


### PR DESCRIPTION
Related: #101438

## What Problem This Solves

OpenClaw operators can admit or exclude a native Codex plugin's apps, but cannot currently disable or explicitly enable one exact app method without changing the entire app or plugin. Least-privilege deployments therefore have to choose between removing useful app access and accepting methods they intended to deny.

## Why This Change Was Made

This adds a strict optional `codexPlugins.plugins.<plugin>.tools.<exact-tool-key>.enabled` map and copies it unchanged into every admitted app whose ownership is proven for that enabled plugin. OpenClaw does not infer an app or discover tools; Codex remains the enforcement point, while existing destructive-action ceilings, approval reviewers, guardian behavior, and managed requirements remain final.

Unsafe combinations fail closed: an enabled override beneath `allow_destructive_actions: false` excludes the plugin's apps, duplicate ownership involving a nonempty tool policy excludes the shared app from all enabled claimants, and stale tool-policy bindings rotate if they cannot be safely revalidated.

## User Impact

Operators can now enable or disable an exact Codex app-tool key through plugin configuration while retaining the rest of the owned app surface. Existing configurations without `tools` keep their behavior after one intentional native binding rotation from input fingerprint v3 to v4.

## Evidence

- Exact-head CI passed for PR head `9f8ee836f44ef83da0b2cafaa7d823566b4e3c30` in workflow run `28848861534`, including production/test type checks, lint, docs, plugin contracts, dependency guards, and focused test shards.
- Live `openclaw-codex-dev` TUI proof used the exact PR runtime artifact with Slack enabled and `slack.slack_send_message = { enabled: false }`.
- In a fresh TUI session, `slack.slack_search_channels` produced one tool call and one non-error result, proving other methods from the enabled Slack app remained callable.
- A direct request for `slack.slack_send_message` returned that the tool was unavailable and produced zero matching tool calls; no Slack message was posted.
- The live loopback gateway passed its RPC read probe, and the captured session proof replayed successfully with Showboat.
- Existing Google Calendar `allowDestructiveActions: auto` configuration remained unchanged during the live proof.

Redacted live TUI/gateway evidence:

```text
tool=start:codex_apps.slack.slack_search_channels
tool=result:codex_apps.slack.slack_search_channels err=false
slack.slack_send_message is unavailable.

searchToolCalls: 1
searchToolResults: 1
searchToolErrors: 0
sendToolCalls: 0
unavailableResponsePresent: true
```

- Independent code, documentation, dead-code, and acceptance reviews completed with no blocker or major findings.
- `oxfmt --check` passed for all changed source and documentation files.
- `extensions/codex/openclaw.plugin.json` parsed successfully as JSON.
- `node scripts/generate-docs-map.mjs --check` passed.
- `git diff --check` passed.
- Focused tests cover enable/disable projection, multiple owned apps, invalid selectors, duplicate ownership, stale binding rotation/recovery, command diagnostics, and unchanged destructive/approval behavior.

AI-assisted: yes. The change was implemented and independently reviewed with Codex; the author reviewed the resulting contract, patch, and live integration proof.
