### PR TITLE
refactor(opencode-go): localize stream internals

### DIFF
--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -390,7 +390,7 @@ const OPENCODE_GO_MODELS = (
   ] satisfies OpencodeGoModelDefinition[]
 ).map((model) => normalizeModelCompat(model) as OpencodeGoModelDefinition);
 
-export type FetchOpencodeGoLiveModelIdsParams = {
+type FetchOpencodeGoLiveModelIdsParams = {
   apiKey?: string;
   discoveryApiKey?: string;
   fetchGuard?: LiveModelCatalogFetchGuard;

--- a/extensions/opencode-go/stream-termination.ts
+++ b/extensions/opencode-go/stream-termination.ts
@@ -7,7 +7,7 @@ import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-ent
 
 type ProviderStreamFn = NonNullable<ProviderWrapStreamFnContext["streamFn"]>;
 
-export interface OpencodeGoStalledStreamWrapperOptions {
+interface OpencodeGoStalledStreamWrapperOptions {
   /**
    * Provider id this wrapper applies to. Calls whose model.provider does not
    * match are forwarded untouched so the wrapper stays provider-scoped.

--- a/extensions/opencode-go/stream.ts
+++ b/extensions/opencode-go/stream.ts
@@ -16,7 +16,7 @@ function isOpencodeGoDeepSeekV4ModelId(modelId: unknown): boolean {
   return modelId === "deepseek-v4-flash" || modelId === "deepseek-v4-pro";
 }
 
-export function createOpencodeGoDeepSeekV4Wrapper(
+function createOpencodeGoDeepSeekV4Wrapper(
   baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
   thinkingLevel: ProviderWrapStreamFnContext["thinkingLevel"],
 ): ProviderWrapStreamFnContext["streamFn"] {
@@ -32,7 +32,7 @@ function stripReasoningParams(payloadObj: Record<string, unknown>): void {
   stripOpencodeGoKimiReasoningPayload(payloadObj);
 }
 
-export function createOpencodeGoKimiNoReasoningWrapper(
+function createOpencodeGoKimiNoReasoningWrapper(
   baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
 ): ProviderWrapStreamFnContext["streamFn"] {
   if (!baseStreamFn) {


### PR DESCRIPTION
## What Problem This Solves

OpenCode Go still exposed four declarations that are used only inside their defining modules. This made private stream and live-catalog implementation details look like supported extension surfaces and kept them in unused-export reports.

## Why This Change Was Made

Localize the two stream wrapper helpers and the two parameter types without changing their implementations, callers, runtime behavior, or the plugin's public `api.ts` surface.

## User Impact

No user-visible behavior changes. Maintainers get a narrower private implementation surface and cleaner dead-code reports.

## Evidence

- AI-assisted: yes.
- Full codebase-memory graph refreshed at `e024eacf176caf103101de3c37bd81f596652379`: 277,997 nodes and 1,120,665 edges.
- Graph incoming-edge query found only same-file `DEFINES`, `USAGE`, and `CALLS` edges for all four declarations.
- Blacksmith Testbox `tbx_01kwxnhj0z18r2rzxyme4jr51c`:
  - `corepack pnpm test extensions/opencode-go` - 5 files, 29 tests passed.
  - `corepack pnpm check:changed` - extension production/test typecheck, lint, guards, and import cycles passed.
  - `corepack pnpm deadcode:report:ci:ts-unused` - zero remaining matches for the four declarations.
- `oxfmt --check` and `git diff --check` passed.
- Fresh post-rebase autoreview: no accepted/actionable findings; patch correct, confidence 0.90.
