### PR TITLE
fix(zalouser): sanitize outbound tool traces

### DIFF
--- a/extensions/zalouser/src/monitor.delivery-sanitization.test.ts
+++ b/extensions/zalouser/src/monitor.delivery-sanitization.test.ts
@@ -1,0 +1,225 @@
+// Zalouser custom delivery tests cover the provider lifecycle and settled post-hook payloads.
+import path from "node:path";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig, PluginRuntime } from "../runtime-api.js";
+// Preserve module setup before modules that consume it.
+// oxfmt-ignore
+import { sendMessageZalouserMock } from "./monitor.send.test-mocks.js";
+// Preserve module setup before modules that consume it.
+// oxfmt-ignore
+import { startZaloListenerMock } from "./zalo-js.test-mocks.js";
+import {
+  createRawZalouserMessageFromNormalized,
+  withZalouserIngressTestQueue,
+} from "./ingress.test-support.js";
+import { monitorZalouserProvider } from "./monitor.js";
+import { setZalouserRuntime } from "./runtime.js";
+import { createZalouserRuntimeEnv } from "./test-helpers.js";
+import type { ResolvedZalouserAccount, ZaloInboundMessage } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createAccount(): ResolvedZalouserAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    profile: "default",
+    authenticated: true,
+    config: { dmPolicy: "open", allowFrom: ["*"] },
+  };
+}
+
+function createConfig(): OpenClawConfig {
+  return {
+    agents: { defaults: { verboseDefault: "on" } },
+    channels: { zalouser: { enabled: true, dmPolicy: "open", allowFrom: ["*"] } },
+    session: {
+      store: path.join(tempDirs.make("openclaw-zalouser-delivery-"), "sessions.json"),
+    },
+  };
+}
+
+function createMessage(): ZaloInboundMessage {
+  return {
+    threadId: "u-sanitizer",
+    isGroup: false,
+    senderId: "321",
+    senderName: "Bob",
+    timestampMs: Date.now(),
+    msgId: "dm-sanitizer",
+    content: "hello",
+    raw: { source: "test" },
+  };
+}
+
+function installRuntime() {
+  type DispatchResult = Awaited<ReturnType<PluginRuntime["channel"]["inbound"]["dispatch"]>>;
+  const lifecycleDispatchResults: DispatchResult[] = [];
+
+  type TurnPlan = Parameters<PluginRuntime["channel"]["inbound"]["dispatch"]>[0];
+  const dispatch = vi.fn(async (plan: TurnPlan) => {
+    if (!("deliver" in plan.delivery) || typeof plan.delivery.deliver !== "function") {
+      throw new Error("Zalouser delivery test requires the core-owned delivery adapter");
+    }
+    for (const payload of [
+      { text: "Done.\n⚠️ 🛠️ `search repos (agent)` failed" },
+      { text: "⚠️ 🛠️ `search repos (agent)` failed" },
+    ]) {
+      const info = { kind: "tool" } as never;
+      const deliveryResult = await plan.delivery.deliver(payload, info);
+      await plan.delivery.onDelivered?.(payload, info, deliveryResult);
+    }
+    const result = { dispatched: true } as DispatchResult;
+    lifecycleDispatchResults.push(result);
+    return result;
+  });
+  const buildContext = vi.fn(
+    (params: Parameters<PluginRuntime["channel"]["inbound"]["buildContext"]>[0]) =>
+      ({
+        Body: params.message.body ?? params.message.rawBody,
+        BodyForAgent: params.message.bodyForAgent ?? params.message.rawBody,
+        RawBody: params.message.rawBody,
+        CommandBody: params.message.commandBody ?? params.message.rawBody,
+        BodyForCommands: params.message.commandBody ?? params.message.rawBody,
+        From: params.from,
+        To: params.reply.to,
+        SessionKey: params.route.dispatchSessionKey ?? params.route.routeSessionKey,
+        AccountId: params.route.accountId ?? params.accountId,
+        ChatType: params.conversation.kind,
+        SenderName: params.sender.name,
+        SenderId: params.sender.id,
+        Provider: params.provider ?? params.channel,
+        Surface: params.surface ?? params.provider ?? params.channel,
+        MessageSid: params.messageId,
+        MessageSidFull: params.messageIdFull,
+        OriginatingChannel: params.channel,
+        OriginatingTo: params.reply.originatingTo,
+        ...params.extra,
+      }) as Awaited<ReturnType<PluginRuntime["channel"]["inbound"]["buildContext"]>>,
+  );
+
+  setZalouserRuntime({
+    logging: { shouldLogVerbose: () => false },
+    channel: {
+      pairing: {
+        readAllowFromStore: vi.fn(async () => []),
+        upsertPairingRequest: vi.fn(async () => ({ code: "PAIR", created: true })),
+        buildPairingReply: vi.fn(() => "pair"),
+      },
+      commands: {
+        shouldComputeCommandAuthorized: vi.fn(() => false),
+        resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
+        isControlCommandMessage: vi.fn(() => false),
+        shouldHandleTextCommands: vi.fn(() => true),
+      },
+      mentions: {
+        buildMentionRegexes: vi.fn(() => []),
+        matchesMentionWithExplicit: vi.fn(() => false),
+      },
+      groups: {
+        resolveRequireMention: vi.fn(() => false),
+      },
+      routing: {
+        resolveAgentRoute: vi.fn(() => ({
+          agentId: "main",
+          sessionKey: "agent:main:zalouser:direct:u-sanitizer",
+          accountId: "default",
+          mainSessionKey: "agent:main:main",
+        })),
+      },
+      session: {
+        resolveStorePath: vi.fn(() => "/tmp"),
+        recordInboundSession: vi.fn(async () => {}),
+      },
+      reply: {
+        resolveEnvelopeFormatOptions: vi.fn(() => undefined),
+        formatAgentEnvelope: vi.fn(({ body }) => body),
+        finalizeInboundContext: vi.fn((ctx) => ctx),
+        dispatchReplyWithBufferedBlockDispatcher: vi.fn(),
+      },
+      inbound: {
+        dispatch,
+        buildContext:
+          buildContext as unknown as PluginRuntime["channel"]["inbound"]["buildContext"],
+      },
+      text: {
+        resolveMarkdownTableMode: vi.fn(() => "code"),
+        convertMarkdownTables: vi.fn((text: string) => text),
+        resolveChunkMode: vi.fn(() => "length"),
+        resolveTextChunkLimit: vi.fn(() => 1200),
+        chunkMarkdownTextWithMode: vi.fn((text: string) => [text]),
+      },
+    },
+  } as unknown as PluginRuntime);
+
+  return { dispatch, lifecycleDispatchResults };
+}
+
+async function processMessage(
+  statusSink: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void,
+  dispatch: ReturnType<typeof vi.fn>,
+) {
+  await withZalouserIngressTestQueue(async (ingressQueue) => {
+    const abortController = new AbortController();
+    type ZaloJsModule = typeof import("./zalo-js.js");
+    type ListenerParams = Parameters<ZaloJsModule["startZaloListener"]>[0];
+    let resolveListener: ((params: ListenerParams) => void) | undefined;
+    const listenerReady = new Promise<ListenerParams>((resolve) => {
+      resolveListener = resolve;
+    });
+    startZaloListenerMock.mockImplementationOnce(async (listenerParams) => {
+      resolveListener?.(listenerParams);
+      return { stop: vi.fn() };
+    });
+    const run = monitorZalouserProvider({
+      account: createAccount(),
+      config: createConfig(),
+      runtime: createZalouserRuntimeEnv(),
+      abortSignal: abortController.signal,
+      statusSink,
+      ingressQueue,
+    });
+    try {
+      const listenerParams = await listenerReady;
+      const message = createMessage();
+      await listenerParams.onMessage(createRawZalouserMessageFromNormalized(message));
+      if (!message.msgId) {
+        throw new Error("Zalouser delivery test message requires msgId");
+      }
+      await vi.waitFor(() => {
+        expect(dispatch).toHaveBeenCalledOnce();
+        expect(sendMessageZalouserMock).toHaveBeenCalledOnce();
+      });
+    } finally {
+      abortController.abort();
+      await run;
+    }
+  });
+}
+
+describe("zalouser final custom delivery sanitation", () => {
+  beforeEach(() => {
+    sendMessageZalouserMock.mockClear();
+    startZaloListenerMock.mockReset();
+  });
+
+  it("sanitizes mixed and trace-only message_sending rewrites before transport", async () => {
+    const statusSink = vi.fn();
+    const runtime = installRuntime();
+
+    await processMessage(statusSink, runtime.dispatch);
+
+    expect(runtime.lifecycleDispatchResults).toMatchObject([{ dispatched: true }]);
+    expect(sendMessageZalouserMock).toHaveBeenCalledWith(
+      "u-sanitizer",
+      "Done.",
+      expect.any(Object),
+    );
+    expect(sendMessageZalouserMock).toHaveBeenCalledOnce();
+    expect(
+      statusSink.mock.calls.filter(([patch]) => patch.lastOutboundAt !== undefined),
+    ).toHaveLength(1);
+  });
+});

--- a/extensions/zalouser/src/monitor.ts
+++ b/extensions/zalouser/src/monitor.ts
@@ -45,6 +45,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import {
   buildZalouserGroupCandidates,
   findZalouserGroupEntry,
@@ -746,8 +747,12 @@ async function deliverZalouserReply(params: {
   const { payload, profile, chatId, isGroup, runtime, core, config, accountId } = params;
   const tableMode = params.tableMode ?? "code";
   let visibleReplySent = false;
+  // message_sending runs after preparePayload, so this private transport boundary owns the final
+  // sanitizer pass; moving it earlier lets hook rewrites reintroduce internal scaffolding.
   const reply = resolveSendableOutboundReplyParts(payload, {
-    text: core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode),
+    text: sanitizeAssistantVisibleText(
+      core.channel.text.convertMarkdownTables(payload.text ?? "", tableMode),
+    ),
   });
   const chunkMode = core.channel.text.resolveChunkMode(config, "zalouser", accountId);
   const textChunkLimit = core.channel.text.resolveTextChunkLimit(config, "zalouser", accountId, {


### PR DESCRIPTION
## What Problem This Solves

Zalo Personal's custom inbound reply pipeline in `monitor.ts` can bypass the standard outbound adapter. Although upstream now sanitizes the standard Zalo Personal outbound path, custom assistant replies could still expose compact tool-trace failure lines or tool XML to recipients.

Refs #90684.

## Why This Change Was Made

- Applies `sanitizeAssistantVisibleText` at the final private Zalouser delivery boundary, after the supported `message_sending` hook. Sanitizing earlier would let a hook rewrite reintroduce internal traces before transport.
- Preserves upstream's delivery-result, `onDelivered`, partial-receipt, and explicit no-visible-payload contracts.
- Keeps low-level caller-authored `sendMessageZalouser` text unchanged, limiting the safety boundary to assistant reply delivery.
- Preserves ordinary prose, markdown, fenced examples, media fields, and existing chunking behavior; trace-only custom replies normalize to an empty visible reply and are not sent.

## User Impact

Zalo Personal recipients no longer see assistant internal tool-trace banners or tool-call scaffolding through the custom reply path. Normal user-facing text and media delivery are preserved.

## Evidence

- Exact head: `875c9009cc67a798fff9a92eae1677d5bb54c94a`; one commit over tested current-main base `c973fe7e721905ba2318994f1f47ae97677cf9ac`, with an exact clean merge simulation against the review-time upstream `main` snapshot `93e0d9ad0d3058357474e69b9312684f8a5b5971`.
- Current-main negative control: without this final boundary, the settled trace-only hook rewrite reaches a second low-level send. On this head, monitor ingress and the provider-owned delivery callback produce only the visible `Done.` send, suppress the trace-only payload, and update `lastOutboundAt` only once.
- Independent exact-head Vitest 5 rerun passes the focused lifecycle regression (`1/1`) and the full Zalo Personal extension (`293/293`) on Node `26.7.0`. Earlier exact-head owner/sibling coverage passes `61/61`.
- Changed-scope conflict-marker, max-lines/assertion ratchet, dependency-pin, Plugin SDK boundary, doctor-contract, temp-directory, Oxfmt, type-aware Oxlint, and `git diff --check` gates pass. A final independent aggregate wrapper replay reached the extension type lane, then correctly refused the externally symlinked compiler in this no-install worktree; no dependency repair or shared install mutation was attempted.
- Fresh exact-head Sol review through P2 is scope-, owner-, and supersession-clean with no actionable findings.
- Merged #112621 covers the standard outbound adapter only. This PR remains the distinct custom-monitor fallback repair, after the hook rewrite and before caption/text resolution and transport.

## Proof Boundary

Proof state: `blocked_external` for authenticated live transport. Current-head monitor-ingress and mocked-provider-boundary proof exercises the changed owner through provider submission, but Mantis has no Zalo Personal driver and this environment has no configured Zalo Personal account/recipient route. No QR login or credentialed round trip is claimed. The analogous Zalo Bot custom fallback is outside this PR's explicit Zalo Personal scope.

AI-assisted change, manually reviewed and validated.
