### PR TITLE
fix(llm): preserve schema tools across OpenAI failover

### DIFF
--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts
@@ -11,7 +11,7 @@ const LIVE = isLiveTestEnabled(["OPENAI_LIVE_TEST"]) && Boolean(OPENAI_KEY);
 const describeLive = LIVE ? describe : describe.skip;
 
 describeLive("OpenAI-compatible Anthropic tool payload wrapper live", () => {
-  it("sends a healthy pinned tool after quarantining an unreadable sibling", async () => {
+  it("projects and sends a custom pinned tool after quarantining an unreadable sibling", async () => {
     const liveModelId = process.env.OPENCLAW_LIVE_OPENAI_CHAT_TOOL_MODEL || "gpt-5.5";
     let projectedPayload: Record<string, unknown> | undefined;
     const baseStreamFn: StreamFn = (model, context, options) => {
@@ -36,16 +36,19 @@ describeLive("OpenAI-compatible Anthropic tool payload wrapper live", () => {
             },
           },
           {
-            name: "live_probe",
-            description: "Return the requested probe value.",
-            input_schema: {
-              type: "object",
-              properties: { value: { type: "string" } },
-              required: ["value"],
+            type: "custom",
+            custom: {
+              name: "live_probe",
+              description: "Return the requested probe value.",
+              input_schema: {
+                type: "object",
+                properties: { value: { type: "string" } },
+                required: ["value"],
+              },
             },
           },
         ],
-        tool_choice: { type: "tool", name: "live_probe" },
+        tool_choice: { type: "custom", custom: { name: "live_probe" } },
         max_completion_tokens: 128,
       };
       options?.onPayload?.(payload, model);

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.test.ts
@@ -259,7 +259,7 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
     });
   });
 
-  it("preserves custom tools and named custom choices", () => {
+  it("projects custom tools and named custom choices as OpenAI functions", () => {
     const payload = runWrapper({
       tools: [
         {
@@ -267,6 +267,51 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
           custom: {
             name: "shell",
             description: "Run a shell command.",
+            input_schema: {
+              type: "object",
+              properties: { command: { type: "string" } },
+              required: ["command"],
+            },
+          },
+        },
+      ],
+      tool_choice: {
+        type: "custom",
+        custom: { name: "shell" },
+      },
+    });
+
+    expect(payload).toEqual({
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "shell",
+            description: "Run a shell command.",
+            parameters: {
+              type: "object",
+              properties: { command: { type: "string" } },
+              required: ["command"],
+            },
+          },
+        },
+      ],
+      tool_choice: {
+        type: "function",
+        function: { name: "shell" },
+      },
+    });
+  });
+
+  it("preserves free-form custom tools and named custom choices", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          type: "custom",
+          custom: {
+            name: "shell",
+            description: "Run a shell command.",
+            format: { type: "text" },
           },
         },
       ],
@@ -283,6 +328,7 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
           custom: {
             name: "shell",
             description: "Run a shell command.",
+            format: { type: "text" },
           },
         },
       ],
@@ -293,7 +339,7 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
     });
   });
 
-  it("filters allowed tool choices against surviving function and custom tools", () => {
+  it("projects allowed custom tool choices against surviving functions", () => {
     const payload = runWrapper({
       tools: [
         {
@@ -306,6 +352,7 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
           type: "custom",
           custom: {
             name: "shell",
+            input_schema: { type: "object", properties: {} },
           },
         },
       ],
@@ -325,9 +372,32 @@ describe("createOpenAIAnthropicToolPayloadCompatibilityWrapper", () => {
       type: "allowed_tools",
       allowed_tools: {
         mode: "required",
-        tools: [{ type: "custom", custom: { name: "shell" } }],
+        tools: [{ type: "function", function: { name: "shell" } }],
       },
     });
+  });
+
+  it("does not match allowed tools across tool kinds", () => {
+    const payload = runWrapper({
+      tools: [
+        {
+          type: "custom",
+          custom: {
+            name: "shell",
+            input_schema: { type: "object", properties: {} },
+          },
+        },
+      ],
+      tool_choice: {
+        type: "allowed_tools",
+        allowed_tools: {
+          mode: "auto",
+          tools: [{ type: "function", function: { name: "shell" } }],
+        },
+      },
+    });
+
+    expect(payload?.tool_choice).toBe("none");
   });
 
   it("disables tool calls when no auto-allowed tools survive", () => {

--- a/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
+++ b/src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts
@@ -17,10 +17,12 @@ type PayloadFieldRead = { ok: true; value: unknown } | { ok: false };
 type OpenAiToolProjection = {
   readonly kind?: "custom" | "function";
   readonly name?: string;
+  readonly projectedKind?: "custom" | "function";
   readonly tool: Record<string, unknown>;
 };
 
 type OpenAiFunctionToolsProjection = {
+  readonly customFunctionNames: ReadonlySet<string>;
   readonly customNames: ReadonlySet<string>;
   readonly functionNames: ReadonlySet<string>;
   readonly tools: readonly Record<string, unknown>[];
@@ -214,6 +216,7 @@ function normalizeOpenAiFunctionAnthropicToolDefinition(
     return {
       kind: "function",
       name,
+      projectedKind: "function",
       tool: {
         ...metadata,
         type: "function",
@@ -234,7 +237,27 @@ function normalizeOpenAiFunctionAnthropicToolDefinition(
     }
     if (snapshot.type === "custom" && isRecord(snapshot.custom)) {
       const name = normalizeOptionalString(snapshot.custom.name) ?? undefined;
-      return name ? { kind: "custom", name, tool: snapshot } : undefined;
+      if (!name) {
+        return undefined;
+      }
+      const inputSchema = snapshot.custom.input_schema;
+      if (inputSchema === undefined) {
+        return { kind: "custom", name, projectedKind: "custom", tool: snapshot };
+      }
+      const parameters = projectJsonObjectSchema(inputSchema, `${name}.input_schema`);
+      if (!parameters) {
+        return undefined;
+      }
+      const functionSpec: Record<string, unknown> = { name, parameters };
+      if (typeof snapshot.custom.description === "string" && snapshot.custom.description.trim()) {
+        functionSpec.description = snapshot.custom.description;
+      }
+      return {
+        kind: "custom",
+        name,
+        projectedKind: "function",
+        tool: { type: "function", function: functionSpec },
+      };
     }
     return { tool: snapshot };
   }
@@ -284,6 +307,7 @@ function normalizeOpenAiFunctionAnthropicToolDefinition(
   return {
     kind: "function",
     name: rawName,
+    projectedKind: "function",
     tool: {
       type: "function",
       function: functionSpec,
@@ -295,6 +319,7 @@ function projectOpenAiFunctionAnthropicTools(
   tools: readonly unknown[],
 ): OpenAiFunctionToolsProjection {
   const projectedTools: Record<string, unknown>[] = [];
+  const customFunctionNames = new Set<string>();
   const customNames = new Set<string>();
   const functionNames = new Set<string>();
   for (const tool of tools) {
@@ -305,11 +330,15 @@ function projectOpenAiFunctionAnthropicTools(
     projectedTools.push(projection.tool);
     if (projection.kind === "custom" && projection.name) {
       customNames.add(projection.name);
+      if (projection.projectedKind === "function") {
+        customFunctionNames.add(projection.name);
+      }
     } else if (projection.kind === "function" && projection.name) {
       functionNames.add(projection.name);
     }
   }
   return {
+    customFunctionNames,
     customNames,
     functionNames,
     tools: projectedTools,
@@ -326,6 +355,14 @@ function isProjectedToolAvailable(
   );
 }
 
+function projectToolChoiceKind(
+  projection: OpenAiFunctionToolsProjection,
+  kind: "custom" | "function",
+  name: string,
+): "custom" | "function" {
+  return kind === "custom" && projection.customFunctionNames.has(name) ? "function" : kind;
+}
+
 function normalizeAllowedToolChoice(
   choice: Record<string, unknown>,
   toolProjection: OpenAiFunctionToolsProjection | undefined,
@@ -337,16 +374,21 @@ function normalizeAllowedToolChoice(
   if ((mode !== "auto" && mode !== "required") || !Array.isArray(choice.allowed_tools.tools)) {
     return choice;
   }
-  const tools = choice.allowed_tools.tools.flatMap((tool) => {
+  const tools = choice.allowed_tools.tools.flatMap<Record<string, unknown>>((tool) => {
     const snapshot = snapshotJsonRecord(tool);
     if (!snapshot) {
       return [];
     }
     const kind =
-      snapshot.type === "custom" ? "custom" : snapshot.type === "function" ? "function" : undefined;
+      snapshot.type === "custom" || snapshot.type === "function" ? snapshot.type : undefined;
     const definition = kind && isRecord(snapshot[kind]) ? snapshot[kind] : undefined;
     const name = definition ? (normalizeOptionalString(definition.name) ?? "") : "";
-    return kind && name && isProjectedToolAvailable(toolProjection, kind, name) ? [snapshot] : [];
+    if (!kind || !name || !isProjectedToolAvailable(toolProjection, kind, name)) {
+      return [];
+    }
+    return projectToolChoiceKind(toolProjection, kind, name) === "function"
+      ? [{ type: "function", function: { name } }]
+      : [{ type: "custom", custom: { name } }];
   });
   if (tools.length === 0) {
     if (mode === "auto") {
@@ -433,10 +475,9 @@ function normalizeOpenAiStringModeAnthropicToolChoice(
       );
     }
     if (name) {
-      return {
-        type: "custom",
-        custom: { name },
-      };
+      return toolProjection && projectToolChoiceKind(toolProjection, "custom", name) === "function"
+        ? { type: "function", function: { name } }
+        : { type: "custom", custom: { name } };
     }
   }
   if (choice.type === "allowed_tools") {


### PR DESCRIPTION
Closes #97020

## What Problem This Solves

Fixes an issue where Anthropic-family compatibility payloads could send schema-bearing `custom` tools to OpenAI Chat Completions as free-form custom tools, losing their JSON-schema function semantics and causing rejected or unusable tool calls.

## Why This Change Was Made

The wrapper now projects only the legacy/schema-bearing custom shape (`custom.input_schema`) into OpenAI function definitions, including matching pinned and allowed choices. Genuine current OpenAI free-form custom tools, including their optional format, remain custom; availability checks also remain tool-kind aware so equal names cannot authorize the wrong kind.

## User Impact

Tool-bearing Anthropic-family failover requests can reach OpenAI with the schema and choice form that the endpoint expects, while native free-form OpenAI custom tools keep their current behavior.

## Evidence

- Focused Testbox run: 18/18 tests passed for the compatibility wrapper, including definitions, pinned choices, allowed choices, same-name cross-kind authorization, malformed schemas, and genuine free-form custom tools (`tbx_01kwxmw5gdd7jacxbjmazvv6he`).
- Full remote `pnpm check:changed`: passed core/core-test typechecks, lint with zero findings, DB-first checks, loader checks, import-cycle checks, and webhook/pairing policy guards.
- Targeted `oxfmt`: passed.
- Fresh autoreview: clean after fixing the free-form custom and cross-kind authorization edge cases it identified.
- Current OpenAI Chat Completions API docs and installed SDK types were inspected directly: native custom tools have `name`, optional `description`, and optional `format`; the schema-bearing compatibility form is therefore distinguished by `input_schema`.
- The live test now exercises a schema-bearing pinned tool through the wrapper to Chat Completions. A paid live call was not run because the configured personal OpenAI key item was absent; no broad credential search was performed. The reporter's real endpoint 400 remains the live before-proof.

- [x] AI-assisted implementation
- [ ] Sanitized agent transcript attached (not requested)
