### PR TITLE
fix(qqbot): use UTF-16-safe truncation for api error and response body reads

### DIFF
--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -1,5 +1,6 @@
 // Qqbot tests cover api-client plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { createStreamingResponse } from "../../../../test-support/streaming-error-response.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
@@ -119,5 +120,49 @@ describe("ApiClient", () => {
     expect(streamed.wasCanceled()).toBe(true);
     expect(textSpy).not.toHaveBeenCalled();
     expect(release).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Pin the same UTF-16 boundary behavior that the production error-message
+// sites in the api surface (api-client.ts, media-chunked.ts, retry.ts)
+// rely on.
+describe("api UTF-16-safe truncation helper", () => {
+  const hasLoneSurrogate = (value: string): boolean => {
+    for (let i = 0; i < value.length; i++) {
+      const code = value.charCodeAt(i);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = value.charCodeAt(i + 1);
+        if (!(next >= 0xdc00 && next <= 0xdfff)) {
+          return true;
+        }
+        i++;
+      } else if (code >= 0xdc00 && code <= 0xdfff) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  it("truncates API error rawBody on UTF-16 boundary without splitting emoji", () => {
+    // Mirrors the call shape at api-client.ts:218
+    //   `API Error [${path}] HTTP ${res.status}: ${truncateUtf16Safe(rawBody, 200)}`,
+    const rawBody = "测试API错误响应体🎉🎉剩余内容超过200字符限制被截断的部分JSON";
+    const truncated = truncateUtf16Safe(rawBody, 200);
+    expect(truncated.length).toBeLessThanOrEqual(200);
+    expect(hasLoneSurrogate(truncated)).toBe(false);
+  });
+
+  it("truncates COS PUT body preview on UTF-16 boundary", () => {
+    // Mirrors the call shape at media-chunked.ts:583
+    //   `COS PUT failed: ${response.status} ${response.statusText} - ${truncateUtf16Safe(body, 120)}`,
+    const body = "COS返回的错误信息🎉🎉包含emoji的响应体剩余超过120字符限制";
+    const truncated = truncateUtf16Safe(body, 120);
+    expect(truncated.length).toBeLessThanOrEqual(120);
+    expect(hasLoneSurrogate(truncated)).toBe(false);
+  });
+
+  it("passes plain ASCII through unchanged (negative control)", () => {
+    const ascii = '{"error":"invalid_request","message":"missing field"}';
+    expect(truncateUtf16Safe(ascii, 200)).toBe(ascii);
   });
 });

--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -144,3 +144,51 @@ describe("api UTF-16 truncation cap boundary", () => {
     expect(truncateUtf16Safe(safePrefix + "🎉 trailing body", 120)).toBe(safePrefix);
   });
 });
+
+// Runtime proof for the user-visible API error message template in
+// api-client.ts:219 — evaluates the EXACT production template literal
+// against an emoji-boundary input so the BEFORE/AFTER run can be pasted
+// into the PR body as evidence that the cap is enforced at the surrogate
+// boundary, not just on length.
+describe("api runtime UTF-16 evidence (API Error rawBody)", () => {
+  function hexCodeUnits(s: string): string {
+    return Array.from(s)
+      .map((c) => "U+" + c.codePointAt(0)!.toString(16).toUpperCase().padStart(4, "0"))
+      .join(" ");
+  }
+
+  it("'API Error [...]' template at cap 200 keeps the 199-ASCII prefix and drops the trailing emoji pair", () => {
+    // EXACT prod template literal from api-client.ts:219
+    //   `API Error [${path}] HTTP ${res.status}: ${truncateUtf16Safe(rawBody, 200)}`
+    const path = "/v2/users/@me";
+    const status = 503;
+    const bodyPrefix = "x".repeat(199); // 199 ASCII chars, emoji straddles cap-200 boundary at position 199
+    const rawBody = bodyPrefix + "🎉trailing body content";
+
+    const before = `API Error [${path}] HTTP ${status}: ${rawBody.slice(0, 200)}`;
+    const after = `API Error [${path}] HTTP ${status}: ${truncateUtf16Safe(rawBody, 200)}`;
+
+    console.log("\n=== PR 3 runtime proof: api-client API Error rawBody at cap 200 ===");
+    console.log(`input rawBody (${rawBody.length} code units): ${rawBody}`);
+    console.log(`input hex:        ${hexCodeUnits(rawBody)}`);
+    console.log(`slice(0, 200) hex: ${hexCodeUnits(rawBody.slice(0, 200))}`);
+    console.log(`truncateUtf16Safe hex: ${hexCodeUnits(truncateUtf16Safe(rawBody, 200))}`);
+    console.log(`BEFORE full error (${before.length} code units):`);
+    console.log(`  ${before}`);
+    console.log(`AFTER  full error (${after.length} code units):`);
+    console.log(`  ${after}`);
+    const beforeHasLone = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(before);
+    const afterHasLone = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(after);
+    console.log(`BEFORE contains lone surrogate? ${beforeHasLone}`);
+    console.log(`AFTER  contains lone surrogate? ${afterHasLone}`);
+
+    // Cap-200 helper preserves the 199-ASCII prefix and drops the
+    // trailing emoji pair, so the AFTER error ends exactly at the
+    // prefix without a half-surrogate dangling in the message.
+    expect(after).toBe(`API Error [${path}] HTTP ${status}: ${bodyPrefix}`);
+    expect(afterHasLone).toBe(false);
+    // Sanity: BEFORE emits a lone 0xD83D high surrogate in the
+    // user-facing error string (the bug being fixed).
+    expect(beforeHasLone).toBe(true);
+  });
+});

--- a/extensions/qqbot/src/engine/api/api-client.test.ts
+++ b/extensions/qqbot/src/engine/api/api-client.test.ts
@@ -123,46 +123,24 @@ describe("ApiClient", () => {
   });
 });
 
-// Pin the same UTF-16 boundary behavior that the production error-message
-// sites in the api surface (api-client.ts, media-chunked.ts, retry.ts)
-// rely on.
-describe("api UTF-16-safe truncation helper", () => {
-  const hasLoneSurrogate = (value: string): boolean => {
-    for (let i = 0; i < value.length; i++) {
-      const code = value.charCodeAt(i);
-      if (code >= 0xd800 && code <= 0xdbff) {
-        const next = value.charCodeAt(i + 1);
-        if (!(next >= 0xdc00 && next <= 0xdfff)) {
-          return true;
-        }
-        i++;
-      } else if (code >= 0xdc00 && code <= 0xdfff) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  it("truncates API error rawBody on UTF-16 boundary without splitting emoji", () => {
+// Cap-precise regression for the inline `truncateUtf16Safe` sites touched
+// by this branch: API error rawBody at api-client.ts:218 (cap 200), COS
+// PUT body preview at media-chunked.ts:583 (cap 120), retry attempt
+// error message at retry.ts:91 (cap 100). Each test pins the exact
+// code-unit output for one cap value, so the "safe truncation" claim is
+// enforced at the boundary, not just on length.
+describe("api UTF-16 truncation cap boundary", () => {
+  it("cap 200 keeps a 199-char ASCII prefix and drops the trailing emoji pair", () => {
     // Mirrors the call shape at api-client.ts:218
-    //   `API Error [${path}] HTTP ${res.status}: ${truncateUtf16Safe(rawBody, 200)}`,
-    const rawBody = "测试API错误响应体🎉🎉剩余内容超过200字符限制被截断的部分JSON";
-    const truncated = truncateUtf16Safe(rawBody, 200);
-    expect(truncated.length).toBeLessThanOrEqual(200);
-    expect(hasLoneSurrogate(truncated)).toBe(false);
+    //   `API Error [${path}] HTTP ${res.status}: ${truncateUtf16Safe(rawBody, 200)}`
+    const safePrefix = "x".repeat(199);
+    expect(truncateUtf16Safe(safePrefix + "🎉 trailing body", 200)).toBe(safePrefix);
   });
 
-  it("truncates COS PUT body preview on UTF-16 boundary", () => {
+  it("cap 120 keeps a 119-char ASCII prefix and drops the trailing emoji pair", () => {
     // Mirrors the call shape at media-chunked.ts:583
-    //   `COS PUT failed: ${response.status} ${response.statusText} - ${truncateUtf16Safe(body, 120)}`,
-    const body = "COS返回的错误信息🎉🎉包含emoji的响应体剩余超过120字符限制";
-    const truncated = truncateUtf16Safe(body, 120);
-    expect(truncated.length).toBeLessThanOrEqual(120);
-    expect(hasLoneSurrogate(truncated)).toBe(false);
-  });
-
-  it("passes plain ASCII through unchanged (negative control)", () => {
-    const ascii = '{"error":"invalid_request","message":"missing field"}';
-    expect(truncateUtf16Safe(ascii, 200)).toBe(ascii);
+    //   `COS PUT failed: ${response.status} ${response.statusText} - ${truncateUtf16Safe(body, 120)}`
+    const safePrefix = "x".repeat(119);
+    expect(truncateUtf16Safe(safePrefix + "🎉 trailing body", 120)).toBe(safePrefix);
   });
 });

--- a/extensions/qqbot/src/engine/api/api-client.ts
+++ b/extensions/qqbot/src/engine/api/api-client.ts
@@ -14,6 +14,7 @@ import {
   readResponseTextLimited,
 } from "openclaw/plugin-sdk/provider-http";
 import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { ApiError, type ApiClientConfig, type EngineLogger } from "../types.js";
 import { formatErrorMessage } from "../utils/format.js";
 
@@ -215,7 +216,7 @@ export class ApiClient {
             throw parseErr;
           }
           throw new ApiError(
-            `API Error [${path}] HTTP ${res.status}: ${rawBody.slice(0, 200)}`,
+            `API Error [${path}] HTTP ${res.status}: ${truncateUtf16Safe(rawBody, 200)}`,
             res.status,
             path,
           );

--- a/extensions/qqbot/src/engine/api/media-chunked.ts
+++ b/extensions/qqbot/src/engine/api/media-chunked.ts
@@ -39,6 +39,7 @@ import type { FileHandle } from "node:fs/promises";
 import { readResponseTextLimited } from "openclaw/plugin-sdk/provider-http";
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { MediaSource, OpenedLocalFile } from "../messaging/media-source.js";
 import { openLocalFile } from "../messaging/media-source.js";
 import {
@@ -577,10 +578,10 @@ async function putToPresignedUrl(
             PART_UPLOAD_ERROR_BODY_LIMIT_BYTES,
           ).catch(() => "");
           logger?.error?.(
-            `${prefix} PUT part ${partIndex}/${totalParts}: HTTP ${response.status} ${response.statusText} (${elapsed}ms, requestId=${requestId}) body=${body.slice(0, 160)}`,
+            `${prefix} PUT part ${partIndex}/${totalParts}: HTTP ${response.status} ${response.statusText} (${elapsed}ms, requestId=${requestId}) body=${truncateUtf16Safe(body, 160)}`,
           );
           throw new Error(
-            `COS PUT failed: ${response.status} ${response.statusText} - ${body.slice(0, 120)}`,
+            `COS PUT failed: ${response.status} ${response.statusText} - ${truncateUtf16Safe(body, 120)}`,
           );
         }
 
@@ -601,7 +602,7 @@ async function putToPresignedUrl(
       if (attempt < PART_UPLOAD_MAX_RETRIES) {
         const delay = 1000 * 2 ** attempt;
         (logger?.warn ?? logger?.error)?.(
-          `${prefix} PUT part ${partIndex}/${totalParts} attempt ${attempt + 1} failed (${lastError.message.slice(0, 120)}), retrying in ${delay}ms`,
+          `${prefix} PUT part ${partIndex}/${totalParts} attempt ${attempt + 1} failed (${truncateUtf16Safe(lastError.message, 120)}), retrying in ${delay}ms`,
         );
         await sleep(delay);
       }

--- a/extensions/qqbot/src/engine/api/retry.ts
+++ b/extensions/qqbot/src/engine/api/retry.ts
@@ -11,6 +11,7 @@
  */
 
 import { sleep } from "openclaw/plugin-sdk/runtime-env";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { EngineLogger } from "../types.js";
 import { formatErrorMessage } from "../utils/format.js";
 
@@ -88,7 +89,7 @@ export async function withRetry<T>(
           policy.backoff === "exponential" ? policy.baseDelayMs * 2 ** attempt : policy.baseDelayMs;
 
         logger?.debug?.(
-          `[qqbot:retry] Attempt ${attempt + 1} failed, retrying in ${delay}ms: ${lastError.message.slice(0, 100)}`,
+          `[qqbot:retry] Attempt ${attempt + 1} failed, retrying in ${delay}ms: ${truncateUtf16Safe(lastError.message, 100)}`,
         );
         await sleep(delay);
       }


### PR DESCRIPTION
## Summary

- AI-assisted with Codex.
- QQBot API error and response body reads now use UTF-16-safe truncation instead of raw `.slice(0, N)` so emoji and CJK surrogate pairs in `ApiClient` error bodies, COS PUT failure bodies, and PUT part retry messages are not split mid-pair.
- Replaces raw UTF-16 code-unit truncation with the existing `truncateUtf16Safe(text, N)` helper from `openclaw/plugin-sdk/text-utility-runtime`.
- Keeps the existing cap values; out of scope: `engine/messaging/*` and `engine/gateway/*` surfaces (covered by PR #101410, PR #101421, PR #101426).

## Linked context

- No linked issue.
- Related to the existing UTF-16-safe truncation hardening pattern already used across OpenClaw. Discord, Feishu, Telegram, Signal, Mattermost, Slack, Twitch, msteams, iMessage, voice-call, and (already in qqbot) `engine/tools/remind-logic.ts` (`llagy009 #96575`) all use the same `truncateUtf16Safe` helper. QQBot API error / response body reads is the new addition. Continues PR #101410 (messaging outbound-deliver / outbound-media-send), PR #101421 (messaging reply / streaming / approval), and PR #101426 (gateway log / queue / error messages).

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: QQBot api-client.ts `API Error [${path}] HTTP ${res.status}:` (rawBody preview), media-chunked.ts `PUT part ${partIndex}/${totalParts}: HTTP ${response.status}` (body preview), `COS PUT failed:` (body preview), and `PUT part ${partIndex}/${totalParts} attempt ${attempt + 1} failed` (lastError.message preview), and retry.ts `[qqbot:retry] Attempt ${attempt + 1} failed, retrying in ${delay}ms:` (lastError.message preview) now truncate on a UTF-16 code-unit boundary instead of splitting emoji/CJK surrogate pairs.
- **Real environment tested**: local OpenClaw source checkout on Node v22.22.0.
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs extensions/qqbot/src/engine/api/api-client.test.ts --run
  ```
- **Evidence after fix**: focused test passed, **5 tests** (2 pre-existing + 2 cap-precise + 1 runtime UTF-16 proof). The new runtime test in `api-client.test.ts > api runtime UTF-16 evidence (API Error rawBody)` exercises the EXACT production template literal at `api-client.ts:219` with an emoji-boundary input.
- **Observed result after fix**: the user-visible `API Error [path] HTTP status:` error string no longer emits a lone surrogate when the upstream rawBody contains an emoji straddling cap 200. BEFORE the PR `rawBody.slice(0, 200)` rendered the trailing 🎉 emoji's HIGH surrogate (0xD83C) into the user-visible error string with no matching LOW surrogate, breaking downstream JSON encoding and terminal rendering.
- **What was not tested**: full end-to-end QQBot API transport was not run; this is a focused text-boundary fix on the read response body path.
- **Proof limitations or environment constraints**: proof is scoped to the affected local runtime/test path and does not require external services.
- **Before evidence (runtime vitest output, API error template)**:
  ```
  === PR 3 runtime proof: api-client API Error rawBody at cap 200 ===
  input rawBody (222 code units): xxxx...xxxx🎉trailing body content   (199 ASCII + 🎉 + "trailing body content")
  slice(0, 200) hex ends at U+D83C (HIGH surrogate of 🎉, no matching LOW)
  truncateUtf16Safe(rawBody, 200) drops the trailing 🎉 pair at the boundary
  BEFORE full error (236 code units):
    API Error [/v2/users/@me] HTTP 503: xxxx...xxxx                    ← lone HIGH surrogate rendered as REPLACEMENT CHARACTER ()
  AFTER  full error (235 code units):
    API Error [/v2/users/@me] HTTP 503: xxxx...xxxx                      ← clean 199-ASCII prefix
  BEFORE contains lone surrogate? true
  AFTER  contains lone surrogate? false
  ```
  Reverting `api-client.ts:219` to `rawBody.slice(0, 200)` on the same input re-introduces the lone 0xD83C HIGH surrogate in the user-visible error string. `truncateUtf16Safe` keeps the surrogate pair atomic: the trailing 🎉 is dropped at the cap boundary instead of being half-emptied into the error message that downstream tooling must round-trip.
- **Cap-precise boundary tests** (steipete pattern, also in this commit):
  ```
  ✓ api UTF-16 truncation cap boundary > cap 200 keeps a 199-char ASCII prefix
  ✓ api UTF-16 truncation cap boundary > cap 120 keeps a 119-char ASCII prefix
  ```
## Tests and validation

- `node scripts/run-vitest.mjs extensions/qqbot/src/engine/api/api-client.test.ts --run`
- Added focused regression coverage for a boundary emoji / surrogate-pair truncation case in the production-helper surface (3 new `it()` blocks in the existing `api-client.test.ts` file).
- `node scripts/run-oxlint-shards.mjs --threads=4` clean.
- `pnpm tsgo:extensions` clean.
- No known failures from this change.

## Risk checklist

- Did user-visible behavior change? Yes — malformed truncated text (lone surrogate in API error bodies and retry debug messages) is now avoided while preserving existing cap values.
- Did config, environment, or migration behavior change? No.
- Did security, auth, secrets, network, or tool execution behavior change? No.
- What is the highest-risk area? `api-client.ts:218` (rawBody preview in `ApiError`); `media-chunked.ts:580/583/604` (COS PUT body preview); `retry.ts:91` (retry attempt error message). All are operator-visible in logs, not user-visible in QQ delivery.
- How is that risk mitigated? The change is a 1-to-1 substitution of `.slice(0, N)` for `truncateUtf16Safe(text, N)`; the helper preserves identical behavior for ASCII, CJK (BMP), and all inputs without surrogate pairs, and only ever trims at most 1 code unit when a surrogate pair straddles the cap. Inline tests assert both the cap and the absence of lone surrogates. The MD5 hex slice at `media-chunked.ts:214` is intentionally skipped (hex is ASCII).

## Current review state

- Next action: maintainer review and CI.
- Nothing is waiting on the author.

