### PR TITLE
fix(sessions): bound trajectory snapshot and pointer reads

### DIFF
--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -10,7 +10,11 @@ import {
   TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
 } from "../trajectory/paths.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
-import { sessionsTailCommand, setSessionsTailFollowIntervalMsForTests } from "./sessions-tail.js";
+import {
+  sessionsTailCommand,
+  sessionsTailTesting,
+  setSessionsTailFollowIntervalMsForTests,
+} from "./sessions-tail.js";
 
 const mocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(() => ({})),
@@ -504,6 +508,34 @@ describe("sessionsTailCommand", () => {
 
     await expect(sessionsTailCommand({ store: storePath, sessionKey }, runtime)).rejects.toThrow(
       /File exceeds 52428800 bytes/,
+    );
+  });
+
+  it("rejects oversized follow-mode trajectory deltas", () => {
+    fs.writeFileSync(trajectoryPath, "event\n", "utf8");
+    const stat = fs.statSync(trajectoryPath);
+    const state = {
+      cursor: null,
+      fileState: { dev: stat.dev, ino: stat.ino, mtimeMs: stat.mtimeMs, size: stat.size },
+      offset: 0,
+      pending: "",
+      selection: {
+        agentId: "test",
+        key: sessionKey,
+        entry: {} as any,
+        storePath,
+        trajectoryPath,
+      },
+    };
+
+    fs.writeFileSync(
+      trajectoryPath,
+      Buffer.alloc(TRAJECTORY_RUNTIME_FILE_MAX_BYTES + 1, "x"),
+      "utf8",
+    );
+
+    expect(() => sessionsTailTesting.readNewFollowEvents(state)).toThrow(
+      /Trajectory delta exceeds 52428800 bytes/,
     );
   });
 });

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -10,11 +10,7 @@ import {
   TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
 } from "../trajectory/paths.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
-import {
-  sessionsTailCommand,
-  sessionsTailTesting,
-  setSessionsTailFollowIntervalMsForTests,
-} from "./sessions-tail.js";
+import { sessionsTailCommand, setSessionsTailFollowIntervalMsForTests } from "./sessions-tail.js";
 
 const mocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(() => ({})),
@@ -500,42 +496,33 @@ describe("sessionsTailCommand", () => {
 
   it("rejects oversized trajectory snapshots", async () => {
     const runtime = makeRuntime();
-    fs.writeFileSync(
-      trajectoryPath,
-      Buffer.alloc(TRAJECTORY_RUNTIME_FILE_MAX_BYTES + 1, "x"),
-      "utf8",
-    );
+    fs.writeFileSync(trajectoryPath, "");
+    fs.truncateSync(trajectoryPath, TRAJECTORY_RUNTIME_FILE_MAX_BYTES + 1);
 
     await expect(sessionsTailCommand({ store: storePath, sessionKey }, runtime)).rejects.toThrow(
       /File exceeds 52428800 bytes/,
     );
   });
 
-  it("rejects oversized follow-mode trajectory deltas", () => {
-    fs.writeFileSync(trajectoryPath, "event\n", "utf8");
-    const stat = fs.statSync(trajectoryPath);
-    const state = {
-      cursor: null,
-      fileState: { dev: stat.dev, ino: stat.ino, mtimeMs: stat.mtimeMs, size: stat.size },
-      offset: 0,
-      pending: "",
-      selection: {
-        agentId: "test",
-        key: sessionKey,
-        entry: {} as any,
-        storePath,
-        trajectoryPath,
-      },
-    };
+  it("rejects oversized follow-mode trajectory deltas", async () => {
+    const runtime = makeRuntime();
+    writeJsonl(trajectoryPath, [
+      makeEvent({ type: "session.started", ts: "2026-05-18T12:04:17.000Z" }),
+    ]);
 
-    fs.writeFileSync(
-      trajectoryPath,
-      Buffer.alloc(TRAJECTORY_RUNTIME_FILE_MAX_BYTES + 1, "x"),
-      "utf8",
-    );
-
-    expect(() => sessionsTailTesting.readNewFollowEvents(state)).toThrow(
-      /Trajectory delta exceeds 52428800 bytes/,
-    );
+    const run = sessionsTailCommand({ store: storePath, sessionKey, follow: true }, runtime);
+    try {
+      await waitForRuntimeOutput(runtime, "session.started");
+      const initialSize = fs.statSync(trajectoryPath).size;
+      fs.truncateSync(trajectoryPath, initialSize + TRAJECTORY_RUNTIME_FILE_MAX_BYTES + 1);
+      await vi.waitFor(() => {
+        expect(runtime.error).toHaveBeenCalledWith(
+          expect.stringContaining("Trajectory delta exceeds 52428800 bytes"),
+        );
+      });
+    } finally {
+      process.emit("SIGTERM", "SIGTERM");
+      await run;
+    }
   });
 });

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -492,4 +492,13 @@ describe("sessionsTailCommand", () => {
     expect(output).toContain("trajectory-dir ok");
     expect(output).not.toContain("No sessions found");
   });
+
+  it("rejects oversized trajectory snapshots", async () => {
+    const runtime = makeRuntime();
+    fs.writeFileSync(trajectoryPath, Buffer.alloc(16 * 1024 * 1024 + 1, "x"), "utf8");
+
+    await expect(sessionsTailCommand({ store: storePath, sessionKey }, runtime)).rejects.toThrow(
+      /exceeds limit of 16777216 bytes/,
+    );
+  });
 });

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -7,6 +7,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import {
   resolveTrajectoryFilePath,
   resolveTrajectoryPointerFilePath,
+  TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
 } from "../trajectory/paths.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
 import { sessionsTailCommand, setSessionsTailFollowIntervalMsForTests } from "./sessions-tail.js";
@@ -495,10 +496,14 @@ describe("sessionsTailCommand", () => {
 
   it("rejects oversized trajectory snapshots", async () => {
     const runtime = makeRuntime();
-    fs.writeFileSync(trajectoryPath, Buffer.alloc(16 * 1024 * 1024 + 1, "x"), "utf8");
+    fs.writeFileSync(
+      trajectoryPath,
+      Buffer.alloc(TRAJECTORY_RUNTIME_FILE_MAX_BYTES + 1, "x"),
+      "utf8",
+    );
 
     await expect(sessionsTailCommand({ store: storePath, sessionKey }, runtime)).rejects.toThrow(
-      /exceeds limit of 16777216 bytes/,
+      /File exceeds 52428800 bytes/,
     );
   });
 });

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { readRegularFileSync } from "openclaw/plugin-sdk/security-runtime";
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveSessionFilePath } from "../config/sessions/paths.js";
@@ -277,10 +278,19 @@ function formatProgressLine(event: TrajectoryEvent): string {
   return [formatTimestamp(event.ts), typeLabel, sessionLabel, preview].join(" ").trimEnd();
 }
 
+// Trajectory snapshots are read to render recent events; 16 MiB is generous
+// headroom for busy sessions while preventing a rotated/runaway file from OOMing
+// the tail command.
+const TRAJECTORY_SNAPSHOT_MAX_BYTES = 16 * 1024 * 1024;
+
 function readTrajectorySnapshot(filePath: string): TrajectorySnapshot {
   try {
     const stat = fs.statSync(filePath);
-    const text = fs.readFileSync(filePath, "utf8");
+    const { buffer } = readRegularFileSync({
+      filePath,
+      maxBytes: TRAJECTORY_SNAPSHOT_MAX_BYTES,
+    });
+    const text = buffer.toString("utf8");
     return {
       events: parseTrajectoryEventLines(text.split(/\r?\n/u)),
       fileState: fileStateFromStat(stat),
@@ -361,7 +371,11 @@ async function readTrajectoryPointerSessionId(sessionFile: string): Promise<stri
     return undefined;
   }
   try {
-    const parsed = JSON.parse(fs.readFileSync(pointerPath, "utf8")) as unknown;
+    const { buffer } = readRegularFileSync({
+      filePath: pointerPath,
+      maxBytes: 64 * 1024,
+    });
+    const parsed = JSON.parse(buffer.toString("utf8")) as unknown;
     if (!isRecord(parsed) || typeof parsed.sessionId !== "string") {
       return undefined;
     }

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -7,7 +7,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { readRegularFileSync } from "openclaw/plugin-sdk/security-runtime";
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveSessionFilePath } from "../config/sessions/paths.js";
@@ -16,11 +15,13 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import { resolveStoredSessionKeyForAgentStore } from "../gateway/session-store-key.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { parseStrictNonNegativeInteger } from "../infra/parse-finite-number.js";
+import { readRegularFileSync } from "../infra/regular-file.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   resolveTrajectoryFilePath,
   resolveTrajectoryPointerFilePath,
+  TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
 } from "../trajectory/paths.js";
 import {
   isRegularNonSymlinkFile,
@@ -278,17 +279,14 @@ function formatProgressLine(event: TrajectoryEvent): string {
   return [formatTimestamp(event.ts), typeLabel, sessionLabel, preview].join(" ").trimEnd();
 }
 
-// Trajectory snapshots are read to render recent events; 16 MiB is generous
-// headroom for busy sessions while preventing a rotated/runaway file from OOMing
-// the tail command.
-const TRAJECTORY_SNAPSHOT_MAX_BYTES = 16 * 1024 * 1024;
-
 function readTrajectorySnapshot(filePath: string): TrajectorySnapshot {
   try {
     const stat = fs.statSync(filePath);
+    // Use the runtime trajectory limit so tail accepts any file the runtime
+    // would have written and rejects anything larger.
     const { buffer } = readRegularFileSync({
       filePath,
-      maxBytes: TRAJECTORY_SNAPSHOT_MAX_BYTES,
+      maxBytes: TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
     });
     const text = buffer.toString("utf8");
     return {

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -85,6 +85,11 @@ export function setSessionsTailFollowIntervalMsForTests(intervalMs?: number): vo
   followIntervalMsForTests = intervalMs;
 }
 
+/** Test-only hooks for exercising internal follow-state helpers. */
+export const sessionsTailTesting = {
+  readNewFollowEvents,
+};
+
 function resolveFollowIntervalMs(): number {
   return followIntervalMsForTests ?? FOLLOW_INTERVAL_MS;
 }
@@ -513,7 +518,13 @@ function readNewFollowEvents(state: FollowState): TrajectoryEvent[] {
 
   const fd = fs.openSync(state.selection.trajectoryPath, "r");
   try {
-    const buffer = Buffer.alloc(fileState.size - state.offset);
+    const deltaBytes = fileState.size - state.offset;
+    if (deltaBytes > TRAJECTORY_RUNTIME_FILE_MAX_BYTES) {
+      throw new Error(
+        `Trajectory delta exceeds ${TRAJECTORY_RUNTIME_FILE_MAX_BYTES} bytes: ${deltaBytes}`,
+      );
+    }
+    const buffer = Buffer.alloc(deltaBytes);
     fs.readSync(fd, buffer, 0, buffer.length, state.offset);
     state.offset = fileState.size;
     state.fileState = fileState;

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -85,11 +85,6 @@ export function setSessionsTailFollowIntervalMsForTests(intervalMs?: number): vo
   followIntervalMsForTests = intervalMs;
 }
 
-/** Test-only hooks for exercising internal follow-state helpers. */
-export const sessionsTailTesting = {
-  readNewFollowEvents,
-};
-
 function resolveFollowIntervalMs(): number {
   return followIntervalMsForTests ?? FOLLOW_INTERVAL_MS;
 }
@@ -286,10 +281,9 @@ function formatProgressLine(event: TrajectoryEvent): string {
 
 function readTrajectorySnapshot(filePath: string): TrajectorySnapshot {
   try {
-    const stat = fs.statSync(filePath);
     // Use the runtime trajectory limit so tail accepts any file the runtime
     // would have written and rejects anything larger.
-    const { buffer } = readRegularFileSync({
+    const { buffer, stat } = readRegularFileSync({
       filePath,
       maxBytes: TRAJECTORY_RUNTIME_FILE_MAX_BYTES,
     });


### PR DESCRIPTION
## What Problem This Solves

`openclaw sessions tail` could read an entire trajectory snapshot into memory and
allocate an arbitrarily large unread follow delta. A rotated or runaway
trajectory file could therefore exhaust memory before the command rendered or
delivered the next event.

## Why This Change Was Made

- Snapshot reads now use the existing
  `TRAJECTORY_RUNTIME_FILE_MAX_BYTES` contract (50 MiB).
- Pointer files use the shared bounded regular-file reader with a 64 KiB cap.
- Follow mode rejects an unread delta above the same 50 MiB trajectory contract
  before allocating its buffer.
- The command reuses the stable file metadata returned by the bounded reader.

This keeps the reader aligned with the trajectory writer/runtime contract
instead of introducing a new configuration surface or arbitrary command-only
limit.

## User Impact

- Normal `openclaw sessions tail` output and follow behavior are unchanged.
- Oversized snapshots and follow deltas stop with a clear size-limit error
  instead of risking an unbounded allocation.
- Pointer reads are constrained to the small JSON envelope they are expected to
  contain.

## Evidence

- `node scripts/run-vitest.mjs src/commands/sessions-tail.test.ts` (13 passed)
- `node scripts/run-oxlint.mjs src/commands/sessions-tail.ts src/commands/sessions-tail.test.ts`
- `pnpm exec oxfmt --check src/commands/sessions-tail.ts src/commands/sessions-tail.test.ts`
- `git diff --check`
- Blacksmith Testbox `tbx_01kwyf5q0v4bfdq4ndm36s6a38`:
  `pnpm check:changed` passed
- Fresh branch autoreview found no actionable issues

The regression tests use sparse files and exercise both the initial snapshot
path and the real `sessionsTailCommand({ follow: true })` path without exporting
production internals for tests.

The repo-native broad serial suite also ran during preparation. Its failures
were existing current-main failures in unrelated QQBot, provider, Slack,
Telegram, browser, QA, Matrix, and LiteLLM tests; no failure touched
`src/commands/sessions-tail.ts` or its tests.
