### PR TITLE
refactor(plugins): localize private config types

### DIFF
--- a/extensions/openrouter/video-model-catalog.ts
+++ b/extensions/openrouter/video-model-catalog.ts
@@ -45,7 +45,7 @@ type OpenRouterVideoModelsResponse = {
   data?: OpenRouterVideoModel[];
 };
 
-export type OpenRouterVideoModelCatalogCapabilities = VideoGenerationProviderCapabilities & {
+type OpenRouterVideoModelCatalogCapabilities = VideoGenerationProviderCapabilities & {
   allowedPassthroughParameters?: readonly string[];
   canonicalSlug?: string;
   created?: number;

--- a/extensions/sms/src/types.ts
+++ b/extensions/sms/src/types.ts
@@ -1,7 +1,7 @@
 // Sms type declarations define plugin contracts.
 import type { SecretInput } from "openclaw/plugin-sdk/secret-input";
 
-export type SmsChannelConfigFields = {
+type SmsChannelConfigFields = {
   enabled?: boolean;
   accountSid?: string;
   authToken?: SecretInput;
@@ -21,7 +21,7 @@ export interface SmsChannelConfig extends SmsChannelConfigFields {
   defaultAccount?: string;
 }
 
-export interface SmsAccountRaw extends SmsChannelConfigFields {}
+interface SmsAccountRaw extends SmsChannelConfigFields {}
 
 export interface ResolvedSmsAccount {
   accountId: string;


### PR DESCRIPTION
## What Problem This Solves

Three plugin-internal configuration and catalog types remained exported even though no repository consumer or public plugin barrel used them. That inflated the apparent module API and kept known private symbols in the unused-export report.

## Why This Change Was Made

Make the OpenRouter catalog capability type and two SMS configuration helper types module-local. Runtime behavior, public plugin entrypoints, and the remaining exported structural contracts are unchanged.

## User Impact

No runtime or user-visible behavior changes. Maintainers get a smaller private plugin surface and three fewer false-positive unused exports.

## Evidence

- AI-assisted: yes.
- Fresh full worktree from current `origin/main`; codebase-memory graph refreshed after each main rebase.
- Current graph: 278,152 nodes / 1,122,416 edges.
- Repository search and graph incoming edges show only same-file definitions/usages for the three types.
- Testbox `tbx_01kwxq03svr2bytrzg9cc2zv37`:
  - `pnpm test:serial extensions/openrouter/video-generation-provider.test.ts extensions/sms/src/accounts.test.ts` — 2 files / 29 tests passed.
  - `pnpm check:changed` — passed extension typechecks, lint, guards, and import-cycle checks.
  - `pnpm deadcode:report:ci:ts-unused` — all three targeted entries changed from present to absent.
- Fresh autoreview after the final rebase: no findings; patch correct, confidence 0.88.
