### PR TITLE
fix(anthropic): add Fable 5 to Claude CLI catalog

### DIFF
--- a/extensions/anthropic/claude-model-refs.ts
+++ b/extensions/anthropic/claude-model-refs.ts
@@ -8,6 +8,7 @@ import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_MODEL_ALIASES } from "./cli-constants
 const DEFAULT_CLAUDE_MODEL_BY_FAMILY: Record<string, string> = {
   opus: "claude-opus-4-8",
   sonnet: "claude-sonnet-5",
+  fable: "claude-fable-5",
   haiku: "claude-haiku-4-5",
 };
 

--- a/extensions/anthropic/cli-catalog.ts
+++ b/extensions/anthropic/cli-catalog.ts
@@ -9,6 +9,7 @@ import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS } from "./cli-
 const CLAUDE_CLI_DEFAULT_CONTEXT_WINDOW = 200_000;
 const CLAUDE_CLI_CONTEXT_WINDOWS: Record<string, number> = {
   "claude-sonnet-5": 1_000_000,
+  "claude-fable-5": 1_000_000,
 };
 const CLAUDE_CLI_DEFAULT_MAX_OUTPUT_TOKENS = 64_000;
 const CLAUDE_CLI_MAX_OUTPUT_TOKENS: Record<string, number> = {
@@ -24,12 +25,18 @@ const CLAUDE_CLI_MODEL_LABELS: Record<string, string> = {
   "claude-opus-4-7": "Claude Opus 4.7 (Claude CLI)",
   "claude-opus-4-6": "Claude Opus 4.6 (Claude CLI)",
   "claude-sonnet-5": "Claude Sonnet 5 (Claude CLI)",
+  "claude-fable-5": "Claude Fable 5 (Claude CLI)",
   "claude-sonnet-4-6": "Claude Sonnet 4.6 (Claude CLI)",
 };
 
 function resolveClaudeCliImageMediaInput(id: string): ModelCatalogEntry["mediaInput"] {
   const maxSidePx =
-    id === "claude-opus-4-8" || id === "claude-opus-4-7" || id === "claude-sonnet-5" ? 2576 : 1568;
+    id === "claude-opus-4-8" ||
+    id === "claude-opus-4-7" ||
+    id === "claude-sonnet-5" ||
+    id === "claude-fable-5"
+      ? 2576
+      : 1568;
   return {
     image: {
       maxSidePx,

--- a/extensions/anthropic/cli-catalog.ts
+++ b/extensions/anthropic/cli-catalog.ts
@@ -17,6 +17,7 @@ const CLAUDE_CLI_MAX_OUTPUT_TOKENS: Record<string, number> = {
   "claude-opus-4-7": 128_000,
   "claude-opus-4-6": 128_000,
   "claude-sonnet-5": 128_000,
+  "claude-fable-5": 128_000,
   "claude-sonnet-4-6": 128_000,
 };
 

--- a/extensions/anthropic/cli-constants.ts
+++ b/extensions/anthropic/cli-constants.ts
@@ -20,6 +20,7 @@ export const CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_REF = `anthropic/${CLAUDE_CLI_CA
 export const CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS = [
   CLAUDE_CLI_DEFAULT_MODEL_REF,
   `${CLAUDE_CLI_BACKEND_ID}/claude-sonnet-5`,
+  `${CLAUDE_CLI_BACKEND_ID}/claude-fable-5`,
   `${CLAUDE_CLI_BACKEND_ID}/claude-opus-4-7`,
   `${CLAUDE_CLI_BACKEND_ID}/claude-sonnet-4-6`,
   `${CLAUDE_CLI_BACKEND_ID}/claude-opus-4-6`,
@@ -39,6 +40,9 @@ export const CLAUDE_CLI_MODEL_ALIASES: Record<string, string> = {
   "claude-sonnet-5": "claude-sonnet-5",
   "sonnet-4.6": "claude-sonnet-4-6",
   "claude-sonnet-4-6": "claude-sonnet-4-6",
+  fable: "fable",
+  "fable-5": "claude-fable-5",
+  "claude-fable-5": "claude-fable-5",
   haiku: "haiku",
 };
 

--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -166,14 +166,15 @@ describe("anthropic cli migration", () => {
               alias: "Opus",
               agentRuntime: { id: "claude-cli" },
             },
-            "anthropic/claude-opus-4-8": { agentRuntime: { id: "claude-cli" } },
-            "anthropic/claude-sonnet-5": { agentRuntime: { id: "claude-cli" } },
-            "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-opus-4-6": {
               alias: "Opus",
               agentRuntime: { id: "claude-cli" },
             },
             "openai/gpt-5.2": {},
+            "anthropic/claude-opus-4-8": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-sonnet-5": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-fable-5": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
           },
         },
       },
@@ -259,9 +260,10 @@ describe("anthropic cli migration", () => {
         defaults: {
           models: {
             "openai/gpt-5.2": {},
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-opus-4-8": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-sonnet-5": { agentRuntime: { id: "claude-cli" } },
-            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-fable-5": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-opus-4-6": { agentRuntime: { id: "claude-cli" } },
           },
@@ -304,9 +306,10 @@ describe("anthropic cli migration", () => {
         defaults: {
           model: { primary: "anthropic/claude-opus-4-7" },
           models: {
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-opus-4-8": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-sonnet-5": { agentRuntime: { id: "claude-cli" } },
-            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-fable-5": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
             "anthropic/claude-opus-4-6": { agentRuntime: { id: "claude-cli" } },
           },

--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -61,6 +61,20 @@ describe("anthropic Claude model refs", () => {
     );
   });
 
+  it("canonicalizes fable family aliases in bare and provider-qualified forms", () => {
+    // "fable-5" must map to the full model id, not the family name: the
+    // canonicalizer only accepts alias values that already start with
+    // "claude-", so a family-name value would leave the shorthand unresolved.
+    expect(resolveKnownAnthropicModelRef("fable")).toBe("anthropic/claude-fable-5");
+    expect(resolveKnownAnthropicModelRef("fable-5")).toBe("anthropic/claude-fable-5");
+    expect(resolveKnownAnthropicModelRef("claude-fable-5")).toBe("anthropic/claude-fable-5");
+    expect(resolveKnownAnthropicModelRef("claude-cli/fable")).toBe("anthropic/claude-fable-5");
+    expect(resolveKnownAnthropicModelRef("claude-cli/fable-5")).toBe("anthropic/claude-fable-5");
+    expect(resolveKnownAnthropicModelRef("claude-cli/claude-fable-5")).toBe(
+      "anthropic/claude-fable-5",
+    );
+  });
+
   it("preserves the current claude-haiku-4-5 model and its bare alias", () => {
     // claude-haiku-4-5 is a current production model (not retired), so neither
     // its full ref, its dotted variant, nor the bare "haiku" family alias must

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -134,6 +134,20 @@ describe("anthropic provider replay hooks", () => {
     });
   });
 
+  it("publishes Claude Fable 5 CLI metadata without downgrading its API contract", () => {
+    expect(
+      buildClaudeCliCatalogEntries().find((model) => model.id === "claude-fable-5"),
+    ).toMatchObject({
+      id: "claude-fable-5",
+      name: "Claude Fable 5 (Claude CLI)",
+      contextWindow: 1_000_000,
+      maxTokens: 128_000,
+      mediaInput: {
+        image: { maxSidePx: 2576, preferredSidePx: 2576, tokenMode: "provider" },
+      },
+    });
+  });
+
   it("keeps bare Claude CLI context plan-safe while publishing output limits", () => {
     const models = buildClaudeCliCatalogEntries();
     for (const id of [

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -29,6 +29,17 @@
             "maxTokens": 128000
           },
           {
+            "id": "claude-fable-5",
+            "name": "Claude Fable 5 (Claude CLI)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "mediaInput": {
+              "image": { "maxSidePx": 2576, "preferredSidePx": 2576, "tokenMode": "provider" }
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 128000
+          },
+          {
             "id": "claude-opus-4-8",
             "name": "Claude Opus 4.8 (Claude CLI)",
             "reasoning": true,

--- a/extensions/anthropic/openclaw.plugin.json
+++ b/extensions/anthropic/openclaw.plugin.json
@@ -14,7 +14,7 @@
   "providerCatalogEntry": "./provider-discovery.ts",
   "modelCatalog": {
     "runtimeAugment": true,
-        "providers": {
+    "providers": {
       "claude-cli": {
         "models": [
           {

--- a/src/agents/cli-runner/prepare-claude.ts
+++ b/src/agents/cli-runner/prepare-claude.ts
@@ -10,6 +10,8 @@ export const CLAUDE_CLI_CONTEXT_MODEL_ALIASES: Record<string, string> = {
   "sonnet-5": "claude-sonnet-5",
   "sonnet-4.6": "claude-sonnet-4-6",
   "sonnet-4-6": "claude-sonnet-4-6",
+  fable: "claude-fable-5",
+  "fable-5": "claude-fable-5",
 };
 
 export function resolveNodeClaudePlacement(params: {

--- a/src/agents/context-resolution.ts
+++ b/src/agents/context-resolution.ts
@@ -197,13 +197,13 @@ export function resolveAnthropicFixedContextWindow(
     return undefined;
   }
   if (
-    (provider === "anthropic" || provider === "anthropic-vertex") &&
+    (provider === "anthropic" || provider === "anthropic-vertex" || provider === "claude-cli") &&
     /^claude-fable-5(?=$|[^a-z0-9])/.test(modelId)
   ) {
     return ANTHROPIC_FABLE_CONTEXT_TOKENS;
   }
   if (
-    (provider === "anthropic" || provider === "anthropic-vertex") &&
+    (provider === "anthropic" || provider === "anthropic-vertex" || provider === "claude-cli") &&
     /^claude-mythos-5(?=$|[^a-z0-9])/.test(modelId)
   ) {
     return ANTHROPIC_MYTHOS_5_CONTEXT_TOKENS;

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -558,8 +558,10 @@ describe("resolveContextTokensForModel", () => {
   it.each([
     ["anthropic", "claude-fable-5", ANTHROPIC_FABLE_CONTEXT_TOKENS],
     ["anthropic-vertex", "claude-fable-5", ANTHROPIC_FABLE_CONTEXT_TOKENS],
+    ["claude-cli", "claude-fable-5", ANTHROPIC_FABLE_CONTEXT_TOKENS],
     ["anthropic", "claude-mythos-5", ANTHROPIC_MYTHOS_5_CONTEXT_TOKENS],
     ["anthropic-vertex", "claude-mythos-5", ANTHROPIC_MYTHOS_5_CONTEXT_TOKENS],
+    ["claude-cli", "claude-mythos-5", ANTHROPIC_MYTHOS_5_CONTEXT_TOKENS],
     ["anthropic", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
     ["anthropic-vertex", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
     ["claude-cli", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
@@ -697,8 +699,10 @@ describe("resolveContextTokensForModel", () => {
   it.each([
     ["anthropic", "claude-fable-5", ANTHROPIC_FABLE_CONTEXT_TOKENS],
     ["anthropic-vertex", "claude-fable-5", ANTHROPIC_FABLE_CONTEXT_TOKENS],
+    ["claude-cli", "claude-fable-5", ANTHROPIC_FABLE_CONTEXT_TOKENS],
     ["anthropic", "claude-mythos-5", ANTHROPIC_MYTHOS_5_CONTEXT_TOKENS],
     ["anthropic-vertex", "claude-mythos-5", ANTHROPIC_MYTHOS_5_CONTEXT_TOKENS],
+    ["claude-cli", "claude-mythos-5", ANTHROPIC_MYTHOS_5_CONTEXT_TOKENS],
     ["anthropic", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
     ["anthropic-vertex", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],
     ["claude-cli", "claude-sonnet-5", ANTHROPIC_SONNET_5_CONTEXT_TOKENS],


### PR DESCRIPTION
## What Problem This Solves

Anthropic's `claude-fable-5` was supported by the direct Anthropic route but missing from OpenClaw's independently maintained Claude CLI selection and metadata surfaces. Users could not browse/select it consistently, and shorthand refs fell back to incorrect context budgeting.

## Solution

- Add `claude-cli/claude-fable-5` to the Claude CLI setup allowlist and static manifest catalog.
- Add `fable`, `fable-5`, and `claude-fable-5` alias normalization.
- Publish matching runtime/static metadata: 1M context, 128K output, text+image input, and the Fable 5 label.
- Route Fable aliases through model-ref and context-budget canonicalization.
- Include Claude CLI in the existing Fable 5 and Mythos 5 fixed-context rules.

The model limits match Anthropic's [model overview](https://docs.anthropic.com/en/docs/about-claude/models/overview), and the installed Claude CLI documents both `fable` and `claude-fable-5` as valid `--model` selectors.

## Behavior

`openclaw models list --all --provider claude-cli` now includes:

```text
claude-cli/claude-fable-5  text+image  1000k
```

Bare and provider-qualified Fable aliases canonicalize to `anthropic/claude-fable-5` for the Claude CLI runtime.

## Evidence

- Blacksmith Testbox `tbx_01kxssbptwtvkpg3hykmh0a5v0`: Anthropic migration/catalog and agent context suites — 141 passed.
- Installed Claude CLI 2.1.209 live turn: `claude --model claude-fable-5 ... -p` returned exactly `FABLE_OK`.
- Fresh maintainer-fixup autoreview: clean (`patch is correct`, 0.99).
- Full build passed during repo-native prepare; `git diff --check` passed.

## Risk

Bounded to Anthropic plugin-owned Claude CLI metadata, aliases, and existing context rules. No auth mechanism, credential storage, dependency, or provider protocol changes.
