### PR TITLE
fix: WebChat duplicates external reply events

### DIFF
--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -493,6 +493,25 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Live reply");
   });
 
+  it("ignores duplicate delta event frames for the same run sequence", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "Live",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      seq: 7,
+      sessionKey: "main",
+      state: "delta",
+      deltaText: " reply",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(state.chatStream).toBe("Live reply");
+  });
+
   it("uses the cumulative snapshot when the first observed delta joins mid-stream", () => {
     const state = createState({
       sessionKey: "main",
@@ -916,6 +935,27 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages[0]).toEqual(payload.message);
   });
 
+  it("ignores duplicate final event frames from another run without clearing active stream", () => {
+    const state = createActiveStreamingState();
+    const payload: ChatEventPayload = {
+      runId: "run-announce",
+      seq: 9,
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Sub-agent findings" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(state.chatRunId).toBe("run-user");
+    expect(state.chatStream).toBe("Working...");
+    expect(state.chatStreamStartedAt).toBe(123);
+    expect(state.chatMessages).toEqual([payload.message]);
+  });
+
   it("drops NO_REPLY final payload from another run without clearing active stream", () => {
     const state = createActiveStreamingState();
     const payload = createOtherRunNoReplyFinalPayload();
@@ -1134,6 +1174,96 @@ describe("handleChatEvent", () => {
     expect(handleChatEvent(state, payload)).toBe("final");
     expect(state.chatMessages).toEqual([finalMsg]);
     expect(state.chatStream).toBe(null);
+  });
+
+  it("ignores duplicate final event frames for the same run sequence", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: null,
+    });
+    const finalMsg = {
+      role: "assistant",
+      content: [{ type: "text", text: "Complete reply" }],
+      timestamp: 101,
+    };
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      seq: 8,
+      sessionKey: "main",
+      state: "final",
+      message: finalMsg,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(handleChatEvent(state, payload)).toBe(null);
+    expect(state.chatMessages).toEqual([finalMsg]);
+    expect(state.chatStream).toBe(null);
+  });
+
+  it("does not append an identical assistant final already present in the current turn", () => {
+    const user = {
+      role: "user",
+      content: [{ type: "text", text: "repeat" }],
+      timestamp: 1,
+    };
+    const existingAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Already persisted" }],
+      timestamp: 2,
+    };
+    const finalAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Already persisted" }],
+      timestamp: 3,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [user, existingAssistant],
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: finalAssistant,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([user, finalAssistant]);
+  });
+
+  it("does not append a final whose visible text is already present from refreshed history", () => {
+    const user = {
+      role: "user",
+      content: [{ type: "text", text: "repeat" }],
+      timestamp: 1,
+    };
+    const historyAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "Already persisted" }],
+      __openclaw: { seq: 2 },
+    };
+    const finalAssistant = {
+      role: "assistant",
+      text: "Already persisted",
+      timestamp: 3,
+    };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [user, historyAssistant],
+      chatStream: "Already persisted",
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: finalAssistant,
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([user, finalAssistant]);
   });
 
   it("keeps repeated assistant final text from a later turn", () => {
@@ -3413,6 +3543,83 @@ describe("loadChatHistory retry handling", () => {
     await loadChatHistory(state);
 
     expect(state.chatMessages).toEqual([historyUser, historyAssistant]);
+  });
+
+  it("does not append a live assistant tail already present in the current history turn", async () => {
+    const historyUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const historyAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "latest answer" }],
+      __openclaw: { seq: 2 },
+    };
+    const liveAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "latest answer" }],
+      timestamp: Date.now() + 1_000,
+    };
+    const history = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const request = vi.fn(() => history.promise);
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [historyUser],
+    });
+
+    const loadPromise = loadChatHistory(state);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    state.chatMessages = [historyUser, liveAssistant];
+    history.resolve({
+      messages: [historyUser, historyAssistant],
+      thinkingLevel: "low",
+    });
+    await loadPromise;
+
+    expect(state.chatMessages).toEqual([historyUser, historyAssistant]);
+  });
+
+  it("keeps a late assistant tail when a new user turn repeats the latest history answer", async () => {
+    const historyUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest persisted ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const historyAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "same answer" }],
+      __openclaw: { seq: 2 },
+    };
+    const lateUser = {
+      role: "user",
+      content: [{ type: "text", text: "new ask" }],
+      timestamp: Date.now(),
+    };
+    const lateAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "same answer" }],
+      timestamp: Date.now() + 1_000,
+    };
+    const history = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const request = vi.fn(() => history.promise);
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [historyUser, historyAssistant],
+    });
+
+    const loadPromise = loadChatHistory(state);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    state.chatMessages = [historyUser, historyAssistant, lateUser, lateAssistant];
+    history.resolve({
+      messages: [historyUser, historyAssistant],
+      thinkingLevel: "low",
+    });
+    await loadPromise;
+
+    expect(state.chatMessages).toEqual([historyUser, historyAssistant, lateUser, lateAssistant]);
   });
 
   it("shows a targeted message when chat history is unauthorized", async () => {

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -24,6 +24,9 @@ import {
 
 export type { ChatEventPayload, ChatState } from "./chat-history.ts";
 
+const CHAT_EVENT_DEDUPE_LIMIT = 200;
+const acceptedChatEventKeys = new WeakMap<object, Map<string, number>>();
+
 type AssistantMessageNormalizationOptions = {
   roleRequirement: "required" | "optional";
   roleCaseSensitive?: boolean;
@@ -152,10 +155,51 @@ function appendCachedChatMessage(
   appendChatMessageToCache(state.chatMessagesBySession, state, { sessionKey, agentId }, message);
 }
 
-export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
-  if (!payload) {
+function chatEventDedupeKey(payload: ChatEventPayload): string | null {
+  if (typeof payload.runId !== "string" || !payload.runId.trim()) {
     return null;
   }
+  if (typeof payload.seq !== "number" || !Number.isFinite(payload.seq)) {
+    return null;
+  }
+  // Gateway chat frames are ordered per run; use frame identity so legitimate
+  // repeated assistant text from later turns is still rendered.
+  return [
+    payload.sessionKey,
+    typeof payload.agentId === "string" ? payload.agentId : "",
+    payload.runId,
+    payload.seq,
+    payload.state,
+  ].join("\0");
+}
+
+function acceptChatEventFrame(state: ChatState, payload: ChatEventPayload): boolean {
+  const key = chatEventDedupeKey(payload);
+  if (!key) {
+    return true;
+  }
+  const stateKey = state as object;
+  let accepted = acceptedChatEventKeys.get(stateKey);
+  if (!accepted) {
+    accepted = new Map();
+    acceptedChatEventKeys.set(stateKey, accepted);
+  }
+  if (accepted.has(key)) {
+    return false;
+  }
+  accepted.set(key, Date.now());
+  if (accepted.size > CHAT_EVENT_DEDUPE_LIMIT) {
+    for (const staleKey of accepted.keys()) {
+      accepted.delete(staleKey);
+      if (accepted.size <= CHAT_EVENT_DEDUPE_LIMIT) {
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+function handleChatEventInner(state: ChatState, payload: ChatEventPayload) {
   const hadActiveRunBeforeEvent = state.chatRunId !== null;
   const sessionMatches = chatEventSessionMatches(state, payload);
   const activeRunMatches =
@@ -233,7 +277,9 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         });
         clearToolStreamSegments(state);
       }
-      state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, finalMessage);
+      state.chatMessages = appendTerminalAssistantMessage(state.chatMessages, finalMessage, {
+        replacementTexts: typeof state.chatStream === "string" ? [state.chatStream] : [],
+      });
     } else {
       state.chatMessages = materializeVisibleAssistantStreamMessages(state.chatMessages, state);
     }
@@ -277,6 +323,16 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
     setChatError(state, payload.errorMessage ?? "chat error");
   }
   return payload.state;
+}
+
+export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
+  if (!payload) {
+    return null;
+  }
+  if (!acceptChatEventFrame(state, payload)) {
+    return null;
+  }
+  return handleChatEventInner(state, payload);
 }
 
 export function handleChatGatewayEvent(state: ChatState, payload?: ChatEventPayload) {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -61,6 +61,7 @@ import {
   currentLiveToolCallIds,
   hasVisibleStreamParts,
   historyReplacedVisibleStream,
+  lastUserMessageIndex,
   materializeVisibleStreamState,
   messageTimestampMs,
   maybeResetToolStream,
@@ -266,6 +267,12 @@ function messageDisplaySignature(message: unknown): string | null {
   }
 }
 
+function messageRole(message: unknown): string {
+  return message && typeof message === "object"
+    ? normalizeLowercaseStringOrEmpty((message as { role?: unknown }).role)
+    : "";
+}
+
 function historyHasSameOrNewerDisplayMessage(
   historyMessages: unknown[],
   signature: string,
@@ -282,6 +289,67 @@ function historyHasSameOrNewerDisplayMessage(
     const historyTimestamp = messageTimestampMs(historyMessage);
     return historyTimestamp != null && historyTimestamp >= timestamp;
   });
+}
+
+function currentHistoryTurnReplacesAssistantMessage(
+  historyMessages: unknown[],
+  message: unknown,
+): boolean {
+  if (messageRole(message) !== "assistant") {
+    return false;
+  }
+  const messageText = extractText(message)?.trim();
+  if (!messageText) {
+    return false;
+  }
+  const startIndex = lastUserMessageIndex(historyMessages) + 1;
+  return historyMessages.slice(startIndex).some((historyMessage) => {
+    if (messageRole(historyMessage) !== "assistant") {
+      return false;
+    }
+    const historyText = extractText(historyMessage)?.trim();
+    return Boolean(
+      historyText && (historyText === messageText || historyText.startsWith(messageText)),
+    );
+  });
+}
+
+function hasOptimisticUserAfterSharedHistoryTail(
+  previousMessages: unknown[],
+  historyMessages: unknown[],
+): boolean {
+  if (previousMessages.length === 0 || historyMessages.length === 0) {
+    return false;
+  }
+  const historySignatureIndexes = new Map<string, number>();
+  historyMessages.forEach((message, index) => {
+    const signature = messageDisplaySignature(message);
+    if (signature) {
+      historySignatureIndexes.set(signature, index);
+    }
+  });
+  let sharedPreviousIndex = -1;
+  let sharedHistoryIndex = -1;
+  for (let index = previousMessages.length - 1; index >= 0; index--) {
+    const signature = messageDisplaySignature(previousMessages[index]);
+    const historyIndex = signature ? historySignatureIndexes.get(signature) : undefined;
+    if (typeof historyIndex === "number") {
+      sharedPreviousIndex = index;
+      sharedHistoryIndex = historyIndex;
+      break;
+    }
+  }
+  if (sharedPreviousIndex < 0 || sharedHistoryIndex < historyMessages.length - 1) {
+    return false;
+  }
+  return previousMessages
+    .slice(sharedPreviousIndex + 1)
+    .some(
+      (message) =>
+        messageRole(message) === "user" &&
+        isLocallyOptimisticHistoryMessage(message) &&
+        !shouldHideHistoryMessage(message),
+    );
 }
 
 export function preserveOptimisticTailMessages(
@@ -349,6 +417,10 @@ function collectLateOptimisticTailMessages(
     return [];
   }
   const lateTail: unknown[] = [];
+  const hasOptimisticUserBeforeLateTail = hasOptimisticUserAfterSharedHistoryTail(
+    previousMessages,
+    historyMessages,
+  );
   for (const message of currentMessages.slice(previousMessages.length)) {
     if (!isLocallyOptimisticHistoryMessage(message) || shouldHideHistoryMessage(message)) {
       return [];
@@ -357,7 +429,13 @@ function collectLateOptimisticTailMessages(
     if (!signature) {
       return [];
     }
-    if (historyHasSameOrNewerDisplayMessage(historyMessages, signature, message)) {
+    if (
+      historyHasSameOrNewerDisplayMessage(historyMessages, signature, message) ||
+      (messageRole(message) === "assistant" &&
+        !hasOptimisticUserBeforeLateTail &&
+        !lateTail.some((tailMessage) => messageRole(tailMessage) === "user") &&
+        currentHistoryTurnReplacesAssistantMessage(historyMessages, message))
+    ) {
       continue;
     }
     lateTail.push(message);
@@ -463,6 +541,7 @@ export type ChatMetadataResult = CommandsListResult & {
 
 export type ChatEventPayload = {
   runId?: string;
+  seq?: number;
   sessionKey: string;
   agentId?: string;
   state: "delta" | "final" | "aborted" | "error";

--- a/ui/src/pages/chat/stream-reconciliation.ts
+++ b/ui/src/pages/chat/stream-reconciliation.ts
@@ -254,12 +254,94 @@ function terminalMessageReplacesStreamFallback(message: unknown, fallback: unkno
   );
 }
 
-export function appendTerminalAssistantMessage(messages: unknown[], message: unknown): unknown[] {
+function isHiddenAssistantContentBlockType(type: string): boolean {
+  return type === "thinking" || type === "reasoning" || type === "redacted_thinking";
+}
+
+function assistantMessageContentSignature(message: unknown): string | null {
+  if (!message || typeof message !== "object") {
+    return null;
+  }
+  const record = message as { content?: unknown; role?: unknown };
+  const role = normalizeLowercaseStringOrEmpty(record.role);
+  if (role !== "assistant") {
+    return null;
+  }
+  if (Array.isArray(record.content)) {
+    const displayBlocks = record.content.filter((block) => {
+      if (!block || typeof block !== "object") {
+        return false;
+      }
+      const type = normalizeLowercaseStringOrEmpty((block as { type?: unknown }).type);
+      return (
+        type !== "text" &&
+        type !== "input_text" &&
+        type !== "output_text" &&
+        !isHiddenAssistantContentBlockType(type)
+      );
+    });
+    if (displayBlocks.length > 0) {
+      return JSON.stringify(record.content);
+    }
+  }
+  const text = extractText(message)?.trim();
+  return text ? `text:${text}` : null;
+}
+
+function terminalMessageDuplicatesExisting(message: unknown, existing: unknown): boolean {
+  const terminalSignature = assistantMessageContentSignature(message);
+  return Boolean(
+    terminalSignature && terminalSignature === assistantMessageContentSignature(existing),
+  );
+}
+
+function hasTranscriptMeta(message: unknown): boolean {
+  return Boolean(
+    message &&
+    typeof message === "object" &&
+    (message as { __openclaw?: unknown })["__openclaw"] &&
+    typeof (message as { __openclaw?: unknown })["__openclaw"] === "object",
+  );
+}
+
+function existingMessageMatchesReplacementText(
+  existing: unknown,
+  replacementTexts: readonly string[],
+): boolean {
+  if (replacementTexts.length === 0) {
+    return false;
+  }
+  if (!existing || typeof existing !== "object") {
+    return false;
+  }
+  const role = normalizeLowercaseStringOrEmpty((existing as { role?: unknown }).role);
+  if (role !== "assistant") {
+    return false;
+  }
+  if (!hasTranscriptMeta(existing)) {
+    return false;
+  }
+  const text = extractText(existing)?.trim();
+  return Boolean(text && replacementTexts.some((candidate) => text === candidate));
+}
+
+export function appendTerminalAssistantMessage(
+  messages: unknown[],
+  message: unknown,
+  opts?: { replacementTexts?: readonly string[] },
+): unknown[] {
+  const replacementTexts = (opts?.replacementTexts ?? [])
+    .map((text) => text.trim())
+    .filter((text) => text.length > 0);
   const retainedMessages = messages.filter((existing, index) => {
     if (index <= lastUserMessageIndex(messages)) {
       return true;
     }
-    return !terminalMessageReplacesStreamFallback(message, existing);
+    return (
+      !terminalMessageReplacesStreamFallback(message, existing) &&
+      !terminalMessageDuplicatesExisting(message, existing) &&
+      !existingMessageMatchesReplacementText(existing, replacementTexts)
+    );
   });
   return [...retainedMessages, message];
 }


### PR DESCRIPTION
Related: #85771

## What Problem This Solves

Fixes a WebChat-only duplicate reply bug where an externally triggered turn, such as a WeChat/AKK event, could render two identical assistant bubbles even though the durable transcript already had only one assistant message for that turn.

The duplication was visible in WebChat after live streaming completed. The affected session could receive the same assistant answer through two UI data paths:

- `chat.history` refresh already returned the persisted assistant message for the current turn.
- The still-active live stream later delivered the terminal `final` event for the same assistant answer.

Before this fix, WebChat appended the terminal final message even when the same visible assistant reply had already arrived through the refreshed history snapshot.

## Why This Change Was Made

The final fix keeps the reconciliation in Control UI, where the duplicate is created:

- `appendTerminalAssistantMessage` now treats terminal assistant finals as replacements for matching assistant messages already present after the latest user turn.
- The matching is based on assistant-visible content. Hidden reasoning/thinking blocks are ignored, while visible non-text blocks, such as canvas-style blocks, keep the full content signature to avoid over-deduping rich replies.
- If the active text stream has already been persisted into history, the terminal final replaces that history/stream placeholder instead of appending a second bubble.
- `loadChatHistory` now drops a late optimistic assistant tail only when the refreshed current history turn already replaces that assistant text. It preserves legitimate repeated assistant replies from later user turns.

This avoids changing transcript persistence, plugin behavior, WeChat/AKK delivery, or gateway event semantics.

## User Impact

WebChat no longer displays duplicate assistant bubbles when a refreshed history snapshot and the live terminal event both contain the same current-turn assistant reply.

Legitimate repeated assistant text is still preserved when it belongs to a distinct later user turn or includes visible non-text content that should render as a separate reply.

## Evidence

### Automated validation

```text
pnpm test ui/src/ui/controllers/chat.test.ts

Test Files  1 passed (1)
Tests       140 passed (140)
```

```text
pnpm build
```

```text
pnpm format:check ui/src/ui/chat/stream-reconciliation.ts ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts
```

```text
node scripts/run-oxlint.mjs ui/src/ui/chat/stream-reconciliation.ts ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts
```

```text
git diff --check
```

```text
.agents/skills/autoreview/scripts/autoreview --mode local

autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.8)
```

`pnpm check:changed` was attempted, but the local Crabbox/Testbox wrapper failed before running project checks:

```text
[crabbox] selected binary failed basic --version/--help sanity checks
```

### Manual WebChat repro proof

The following logs are redacted console proof from the affected WebChat session. They use counts, run ids, sequence numbers, and content hashes only; they do not include message content.

#### Before fix

WebChat history had already applied the persisted assistant answer for the current turn, then the terminal final event appended another visible bubble:

```text
history before apply:
  status=before-history-apply
  sessionKey=agent:main:openclaw-weixin:direct:[wechat-contact]@im.wechat
  responseTail included assistant:persisted:len=474:hash=3d69233e

live terminal final:
  runId=899794e0-5809-40c1-b882-3054c7fdc28f
  seq=275
  state=final
  before final: chatMessages=100, chatStreamChars=474
  after final:  chatMessages=101, chatStreamChars=0
```

The `chatMessages` count increasing from `100` to `101` after the final event is the duplicate WebChat append.

#### After fix

With this patch, the same current-turn shape reconciles the persisted history assistant and the terminal final instead of appending a second bubble:

```text
history before apply:
  status=before-history-apply
  sessionKey=agent:main:openclaw-weixin:direct:[wechat-contact]@im.wechat
  responseTail included assistant:persisted:len=455:hash=230f659f

live terminal final:
  runId=1c3143ee-c6ec-42fd-8bab-becf615a84bc
  seq=254
  state=final
  before final: chatMessages=100, chatStreamChars=455
  after final:  chatMessages=100, chatStreamChars=0
```

The `chatMessages` count staying at `100` after the final event proves WebChat did not append the duplicate terminal bubble.

### Screenshot slots

- Before fix duplicate WebChat reply: 
<img width="1500" height="769" alt="before_1" src="https://github.com/user-attachments/assets/24bbc2ee-cf2e-4145-9ab5-09ba51234536" />

- After fix single WebChat reply: 
<img width="1503" height="811" alt="after_1" src="https://github.com/user-attachments/assets/813be219-d9bb-4868-916a-c18777fb4c0b" />



### Regression coverage added

The focused tests cover:

- terminal final already present in the current turn
- visible text already present from refreshed history
- hidden reasoning/thinking blocks ignored for duplicate matching
- active stream text already persisted by history
- partial live assistant tail replaced by current history
- repeated assistant text after a new user turn preserved
- repeated assistant text with visible non-text content preserved

