### PR TITLE
fix(hooks): bound HOOK.md reads during hook install validation

### DIFF
--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -479,6 +479,21 @@ describe("installHooksFromPath", () => {
     ).rejects.toThrow(/File exceeds 1048576 bytes/);
   });
 
+  it.runIf(process.platform !== "win32")("rejects a symlinked HOOK.md", async () => {
+    const stateDir = makeTempDir();
+    const workDir = makeTempDir();
+    const hookDir = path.join(workDir, "my-hook");
+    const externalHookMd = path.join(workDir, "external-HOOK.md");
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.writeFileSync(externalHookMd, "---\nname: external\n---\n", "utf8");
+    fs.symlinkSync(externalHookMd, path.join(hookDir, "HOOK.md"), "file");
+    fs.writeFileSync(path.join(hookDir, "handler.ts"), "export default async () => {};\n");
+
+    await expect(
+      installHooksFromPath({ path: hookDir, hooksDir: path.join(stateDir, "hooks") }),
+    ).rejects.toThrow(/path must be a regular file/);
+  });
+
   it("classifies hook packages that also declare plugin extensions", async () => {
     const stateDir = makeTempDir();
     const pkgDir = makeTempDir();

--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -466,6 +466,19 @@ describe("installHooksFromPath", () => {
     expect(fs.existsSync(path.join(hooksDir, "my-hook"))).toBe(false);
   });
 
+  it("rejects an oversized HOOK.md to prevent OOM during frontmatter parsing", async () => {
+    const stateDir = makeTempDir();
+    const workDir = makeTempDir();
+    const hookDir = path.join(workDir, "my-hook");
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.writeFileSync(path.join(hookDir, "HOOK.md"), "x".repeat(1024 * 1024 + 1), "utf8");
+    fs.writeFileSync(path.join(hookDir, "handler.ts"), "export default async () => {};\n");
+
+    await expect(
+      installHooksFromPath({ path: hookDir, hooksDir: path.join(stateDir, "hooks") }),
+    ).rejects.toThrow(/File exceeds 1048576 bytes/);
+  });
+
   it("classifies hook packages that also declare plugin extensions", async () => {
     const stateDir = makeTempDir();
     const pkgDir = makeTempDir();

--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -1,5 +1,5 @@
 // Hook install service installs hook packages from archives and local sources.
-import fs from "node:fs/promises";
+
 import path from "node:path";
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";

--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -5,6 +5,7 @@ import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { resolveSafeInstallDir, unscopedPackageName } from "../infra/install-safe-path.js";
 import type { NpmIntegrityDrift, NpmSpecResolution } from "../infra/install-source-utils.js";
+import { readRegularFile } from "../infra/regular-file.js";
 import { detectBundleManifestFormat } from "../plugins/bundle-manifest.js";
 import {
   scanPackageInstallSource,
@@ -16,6 +17,10 @@ import type { InstallPolicySource } from "../security/install-policy.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import { parseFrontmatter } from "./frontmatter.js";
+
+// HOOK.md is only parsed for frontmatter; a small cap prevents a malicious or
+// malformed hook package from OOMing the install path.
+const HOOK_MD_MAX_BYTES = 1024 * 1024;
 
 const loadHookInstallRuntime = createLazyRuntimeModule(() => import("./install.runtime.js"));
 
@@ -358,8 +363,8 @@ async function resolveHookNameFromDir(hookDir: string): Promise<string> {
   if (!(await runtime.fileExists(hookMdPath))) {
     throw new Error(`HOOK.md missing in ${hookDir}`);
   }
-  const raw = await fs.readFile(hookMdPath, "utf-8");
-  const frontmatter = parseFrontmatter(raw);
+  const { buffer } = await readRegularFile({ filePath: hookMdPath, maxBytes: HOOK_MD_MAX_BYTES });
+  const frontmatter = parseFrontmatter(buffer.toString("utf-8"));
   return frontmatter.name || path.basename(hookDir);
 }
 


### PR DESCRIPTION
## What Problem This Solves

`resolveHookNameFromDir` read hook-package `HOOK.md` metadata without a size bound. A malicious or malformed package could therefore make the install path buffer a very large file before frontmatter parsing.

## Why This Change Was Made

Route the read through the repository's canonical regular-file helper with a 1 MiB byte cap. That helper checks size before opening, enforces the cap while reading, verifies file identity, and rejects symlinked or otherwise non-regular metadata leaves; this keeps the package boundary on one race-safe path instead of adding a hook-specific reader.

## User Impact

Normal hook packages continue to install. Oversized, symlinked, or non-regular `HOOK.md` metadata now fails fast with a clear validation error instead of risking unbounded allocation or reading outside the package leaf.

## Evidence

- Blacksmith Testbox `tbx_01kxbm12g35zctaf2wg478ebv2`, Actions `29201000714`: `pnpm test src/hooks/install.test.ts` passed 30/30.
- Same Testbox: targeted oxfmt and oxlint passed for both touched files.
- Regression coverage exercises the 1 MiB + 1 byte limit and symlink rejection; the ordinary install-metadata path remains covered.
- Direct dependency inspection: `fs-safe/src/regular-file.ts` prechecks size, performs capped incremental reads, pins file identity, and rejects symlink/non-file leaves.
- Fresh branch autoreview: no accepted/actionable findings, correctness 0.98.
