### PR TITLE
refactor(android): remove obsolete global cache cleanup

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/SecurePrefs.kt
@@ -531,17 +531,6 @@ class SecurePrefs(
     defaultValue: Int,
   ): Int = plainPrefs.getInt(key, defaultValue)
 
-  internal fun putPlainString(
-    key: String,
-    value: String,
-  ) {
-    plainPrefs.edit { putString(key, value) }
-  }
-
-  internal fun removePlainKey(key: String) {
-    plainPrefs.edit { remove(key) }
-  }
-
   internal fun movePlainString(
     sourceKey: String,
     destinationKey: String?,

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatCommandOutbox.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatCommandOutbox.kt
@@ -121,9 +121,6 @@ interface ChatCommandOutbox {
     gatewayId: String,
     nowMs: Long,
   )
-
-  /** Purges every row for all gateways; used when pairing/auth state is reset. */
-  suspend fun clearAll()
 }
 
 @Entity(tableName = "outbox_commands")
@@ -201,9 +198,6 @@ internal interface ChatOutboxDao {
 
   @Query("DELETE FROM outbox_commands WHERE gatewayId = :gatewayId")
   suspend fun deleteGateway(gatewayId: String)
-
-  @Query("DELETE FROM outbox_commands")
-  suspend fun deleteAll()
 }
 
 /**
@@ -338,10 +332,6 @@ class RoomChatCommandOutbox internal constructor(
       failedStatus = ChatOutboxStatus.Failed.dbValue,
       error = OUTBOX_EXPIRED_ERROR,
     )
-  }
-
-  override suspend fun clearAll() {
-    database.outboxDao().deleteAll()
   }
 
   private fun scopedGatewayId(gatewayId: String): String? = gatewayId.trim().takeIf { it.isNotEmpty() }

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -280,15 +280,6 @@ class ChatController internal constructor(
     scope.launch { publishOutbox() }
   }
 
-  /** Purges cached transcripts and queued sends after old-scope writes finish. */
-  internal suspend fun clearTranscriptCache() {
-    val cache = transcriptCache ?: return
-    cacheMutationMutex.withLock {
-      cache.clearAll()
-      commandOutbox?.clearAll()
-    }
-  }
-
   /** Purges cached transcripts and queued sends for one retired authentication scope. */
   internal suspend fun clearGatewayCache(gatewayId: String) {
     cacheMutationMutex.withLock {

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatTranscriptCache.kt
@@ -13,39 +13,12 @@ import androidx.room.withTransaction
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
-import java.io.File
 import java.util.UUID
 
 /** Upper bound of cached session rows per gateway; oldest list positions are evicted on write. */
 internal const val MAX_CACHED_SESSIONS = 50
 
 internal const val CHAT_TRANSCRIPT_CACHE_DB_NAME = "chat-transcript-cache.db"
-
-/**
- * Deletes the cache database and every SQLite-owned companion file. Only safe while no
- * [RoomChatTranscriptCache] is open in this process; used before the node runtime exists.
- */
-internal fun deleteChatTranscriptCacheDatabase(context: Context): Boolean = deleteDatabaseFiles(context, CHAT_TRANSCRIPT_CACHE_DB_NAME)
-
-internal fun deleteDatabaseFiles(
-  context: Context,
-  databaseName: String,
-): Boolean {
-  val databasePath = context.getDatabasePath(databaseName)
-  context.deleteDatabase(databaseName)
-  val fixedFiles =
-    listOf(
-      databasePath,
-      File(databasePath.path + "-journal"),
-      File(databasePath.path + "-shm"),
-      File(databasePath.path + "-wal"),
-    )
-  if (fixedFiles.any(File::exists)) return false
-  val parent = databasePath.parentFile ?: return true
-  val siblings = parent.listFiles() ?: return !parent.exists()
-  val masterJournalPrefix = databasePath.name + "-mj"
-  return siblings.none { file -> file.name.startsWith(masterJournalPrefix) }
-}
 
 /** Upper bound of cached transcript rows per session; only the newest messages are kept. */
 internal const val MAX_CACHED_MESSAGES_PER_SESSION = 200
@@ -85,9 +58,6 @@ interface ChatTranscriptCache {
 
   /** Removes every cached transcript row owned by one gateway identity. */
   suspend fun clearGateway(gatewayId: String)
-
-  /** Purges every cached row for all gateways; used when pairing/auth state is reset. */
-  suspend fun clearAll()
 }
 
 @Entity(tableName = "cached_sessions", primaryKeys = ["gatewayId", "sessionKey"])
@@ -146,12 +116,6 @@ internal interface ChatCacheDao {
 
   @Query("DELETE FROM cached_messages WHERE gatewayId = :gatewayId")
   suspend fun deleteMessages(gatewayId: String)
-
-  @Query("DELETE FROM cached_sessions")
-  suspend fun deleteAllSessions()
-
-  @Query("DELETE FROM cached_messages")
-  suspend fun deleteAllMessages()
 
   @Query("DELETE FROM cached_sessions WHERE gatewayId = :gatewayId AND sessionKey = :sessionKey")
   suspend fun deleteSessionRow(
@@ -340,14 +304,6 @@ class RoomChatTranscriptCache internal constructor(
       )
       dao.evictSessionsBeyondKeeping(gateway, keepSessionKey = key, keep = MAX_CACHED_SESSIONS - 1)
       dao.evictOrphanedTranscripts(gateway)
-    }
-  }
-
-  override suspend fun clearAll() {
-    val dao = database.dao()
-    database.withTransaction {
-      dao.deleteAllSessions()
-      dao.deleteAllMessages()
     }
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerOutboxTest.kt
@@ -131,11 +131,6 @@ class ChatControllerOutboxTest {
         }
       }
     }
-
-    override suspend fun clearAll() {
-      rows.clear()
-      gatewayIds.clear()
-    }
   }
 
   /** Toggleable gateway seam: records chat.send idempotency keys and echoes them as run ids. */

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerTranscriptCacheTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerTranscriptCacheTest.kt
@@ -60,11 +60,6 @@ class ChatControllerTranscriptCacheTest {
       savedTranscripts.removeAll { it.first == gatewayId }
       savedSessions.removeAll { it.first == gatewayId }
     }
-
-    override suspend fun clearAll() {
-      transcripts.clear()
-      sessions = emptyList()
-    }
   }
 
   private fun cachedMessage(

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatCommandOutboxTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatCommandOutboxTest.kt
@@ -171,16 +171,4 @@ class RoomChatCommandOutboxTest {
 
       assertEquals(listOf("for other"), store.load("gateway-a").map { it.text })
     }
-
-  @Test
-  fun clearAllPurgesEveryGatewayScope() =
-    runTest {
-      store.enqueueQueued("a command", nowMs = 10, gatewayId = "gateway-a")
-      store.enqueueQueued("b command", nowMs = 20, gatewayId = "gateway-b")
-
-      store.clearAll()
-
-      assertEquals(emptyList<ChatOutboxItem>(), store.load("gateway-a"))
-      assertEquals(emptyList<ChatOutboxItem>(), store.load("gateway-b"))
-    }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatTranscriptCacheTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/RoomChatTranscriptCacheTest.kt
@@ -1,18 +1,14 @@
 package ai.openclaw.app.chat
 
-import android.content.ContextWrapper
 import androidx.room.Room
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import java.io.File
-import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class RoomChatTranscriptCacheTest {
@@ -27,41 +23,6 @@ class RoomChatTranscriptCacheTest {
   }
 
   private fun cache(): RoomChatTranscriptCache = RoomChatTranscriptCache(database = database)
-
-  @Test
-  fun databaseDeleteFailsWhenCompanionFileSurvives() {
-    val app = RuntimeEnvironment.getApplication()
-    val databaseName = "chat-cache-delete-test-${UUID.randomUUID()}.db"
-    val databasePath = app.getDatabasePath(databaseName)
-    databasePath.parentFile?.mkdirs()
-    val walFile = File(databasePath.path + "-wal")
-    walFile.writeText("stale cache")
-    val noOpDeleteContext =
-      object : ContextWrapper(app) {
-        override fun deleteDatabase(name: String): Boolean = true
-      }
-
-    assertFalse(deleteDatabaseFiles(noOpDeleteContext, databaseName))
-    assertTrue(walFile.exists())
-    assertTrue(deleteDatabaseFiles(app, databaseName))
-    assertFalse(walFile.exists())
-  }
-
-  @Test
-  fun databaseDeleteSucceedsBeforeDatabaseDirectoryExists() {
-    val app = RuntimeEnvironment.getApplication()
-    val missingParent = File(app.cacheDir, "missing-database-dir-${UUID.randomUUID()}")
-    val databasePath = File(missingParent, "chat-cache.db")
-    val freshInstallContext =
-      object : ContextWrapper(app) {
-        override fun getDatabasePath(name: String): File = databasePath
-
-        override fun deleteDatabase(name: String): Boolean = true
-      }
-
-    assertFalse(missingParent.exists())
-    assertTrue(deleteDatabaseFiles(freshInstallContext, databasePath.name))
-  }
 
   private fun message(
     text: String,
@@ -274,22 +235,6 @@ class RoomChatTranscriptCacheTest {
 
       assertEquals(listOf("gateway a text"), store.loadTranscript("gateway-a", "main").map { it.content.single().text })
       assertEquals(listOf("main"), store.loadSessions("gateway-a").map { it.key })
-    }
-
-  @Test
-  fun clearAllPurgesEveryGatewayScope() =
-    runTest {
-      val store = cache()
-      store.saveSessions("gateway-a", listOf(ChatSessionEntry(key = "main", updatedAtMs = 1)))
-      store.saveTranscript(gatewayId = "gateway-a", sessionKey = "main", messages = listOf(message("a text")))
-      store.saveTranscript(gatewayId = "gateway-b", sessionKey = "main", messages = listOf(message("b text")))
-
-      store.clearAll()
-
-      assertEquals(emptyList<ChatMessage>(), store.loadTranscript("gateway-b", "main"))
-      assertEquals(emptyList<ChatSessionEntry>(), store.loadSessions("gateway-b"))
-      assertEquals(emptyList<ChatMessage>(), store.loadTranscript("gateway-a", "main"))
-      assertEquals(emptyList<ChatSessionEntry>(), store.loadSessions("gateway-a"))
     }
 
   @Test


### PR DESCRIPTION
## What Problem This Solves

Android still exposed global transcript-cache and command-outbox purge paths after authentication cleanup moved to gateway-scoped deletion. Those unused APIs, DAO queries, preference helpers, and tests described a second cleanup model that production no longer called.

## Why This Change Was Made

Remove the obsolete global cleanup surface and retain the canonical per-gateway `clearGatewayCache` path used by reset and forget flows. This is a deletion-only cleanup with no runtime behavior change.

## User Impact

No user-visible behavior changes. Android cache ownership now has one smaller, gateway-scoped cleanup path instead of retaining unused global purge machinery.

## Evidence

- `:app:ktlintCheck` passed on Blacksmith Testbox `tbx_01kwxrqn7ztayqr7v8c0wedhkc`.
- Targeted `:app:testThirdPartyDebugUnitTest` passed for `SecurePrefsTest`, `GatewayBootstrapAuthTest`, both controller cache/outbox tests, and both Room cache/outbox tests.
- `:app:lintPlayDebug :app:lintThirdPartyDebug` passed, 60 tasks.
- `pnpm check:changed` passed on the Android-only branch; the final exact-head gate runs through the repository `prepare-run` Testbox flow.
- Codebase Memory MCP full graph refreshed after the final rebase: 278,239 nodes / 1,115,187 edges. Removed symbols return zero graph results; gateway-scoped cleanup remains indexed.
- Fresh Codex autoreview passed before commit and again on the committed branch with no accepted/actionable findings.
- `git diff --check` passed.

AI-assisted: yes. The implementation was inspected and validated by the author.
