### PR TITLE
fix(hooks): bound hook workspace manifest and HOOK.md reads

### DIFF
--- a/src/hooks/workspace.test.ts
+++ b/src/hooks/workspace.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
-import { loadWorkspaceHookEntries } from "./workspace.js";
+import { loadHookEntriesFromDir, loadWorkspaceHookEntries, workspaceTesting } from "./workspace.js";
 
 function writeHookPackageManifest(pkgDir: string, hooks: string[]): void {
   fs.writeFileSync(
@@ -251,5 +251,29 @@ describe("hooks workspace", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]?.hook.name).toBe("shared-hook");
     expect(entries[0]?.hook.source).toBe("openclaw-managed");
+  });
+
+  it("reads a file descriptor up to the byte cap", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-fd-bound-"));
+    const filePath = path.join(root, "small.txt");
+    fs.writeFileSync(filePath, "hello", "utf8");
+    const fd = fs.openSync(filePath, "r");
+    try {
+      expect(workspaceTesting.readFdUtf8Bounded(fd, 1024)).toBe("hello");
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+
+  it("rejects a file descriptor that exceeds the byte cap during read", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-fd-overflow-"));
+    const filePath = path.join(root, "big.txt");
+    fs.writeFileSync(filePath, "x".repeat(1024 + 1), "utf8");
+    const fd = fs.openSync(filePath, "r");
+    try {
+      expect(() => workspaceTesting.readFdUtf8Bounded(fd, 1024)).toThrow("File exceeds 1024 bytes");
+    } finally {
+      fs.closeSync(fd);
+    }
   });
 });

--- a/src/hooks/workspace.test.ts
+++ b/src/hooks/workspace.test.ts
@@ -8,21 +8,9 @@ import { loadWorkspaceHookEntries } from "./workspace.js";
 
 const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
 
-vi.mock("../logging/subsystem.js", () => {
-  const makeLogger = () => ({
-    subsystem: "hooks/workspace",
-    isEnabled: () => true,
-    trace: vi.fn(),
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: warnMock,
-    error: vi.fn(),
-    fatal: vi.fn(),
-    raw: vi.fn(),
-    child: () => makeLogger(),
-  });
-  return { createSubsystemLogger: () => makeLogger() };
-});
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({ warn: warnMock }),
+}));
 
 function writeHookPackageManifest(pkgDir: string, hooks: string[]): void {
   fs.writeFileSync(
@@ -81,6 +69,14 @@ function loadWorkspaceEntriesFromHooksRoot(hooksRoot: string) {
 }
 
 const METADATA_MAX_BYTES = 1024 * 1024;
+
+function writePlainHook(hooksRoot: string, name: string, content?: string): string {
+  const hookDir = path.join(hooksRoot, name);
+  fs.mkdirSync(hookDir, { recursive: true });
+  fs.writeFileSync(path.join(hookDir, "HOOK.md"), content ?? `---\nname: ${name}\n---\n`);
+  fs.writeFileSync(path.join(hookDir, "handler.js"), "export default async () => {};\n");
+  return hookDir;
+}
 
 function oversizedMetadataWarnings(filePath: string): string[] {
   return warnMock.mock.calls
@@ -141,55 +137,23 @@ describe("hooks workspace", () => {
     expect(hookNames(entries)).toContain("nested");
   });
 
-  it("warns and skips hook packages with an oversized package.json", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-manifest-"));
-    const hooksRoot = path.join(root, "hooks");
-    fs.mkdirSync(hooksRoot, { recursive: true });
-
-    const pkgDir = path.join(hooksRoot, "pkg");
-    fs.mkdirSync(pkgDir, { recursive: true });
-    const manifestPath = path.join(pkgDir, "package.json");
-    fs.writeFileSync(manifestPath, "x".repeat(METADATA_MAX_BYTES + 1), "utf8");
-
-    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
-    expect(hookNames(entries)).toHaveLength(0);
-    expect(oversizedMetadataWarnings(manifestPath)).toHaveLength(1);
-  });
-
-  it("warns and skips hooks with an oversized HOOK.md", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-md-"));
-    const hooksRoot = path.join(root, "hooks");
-    fs.mkdirSync(hooksRoot, { recursive: true });
-
-    const hookDir = path.join(hooksRoot, "big-hook");
-    fs.mkdirSync(hookDir, { recursive: true });
-    const hookMdPath = path.join(hookDir, "HOOK.md");
-    fs.writeFileSync(hookMdPath, "x".repeat(METADATA_MAX_BYTES + 1), "utf8");
-    fs.writeFileSync(path.join(hookDir, "handler.js"), "export default async () => {};\n");
-
-    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
-    expect(hookNames(entries)).toHaveLength(0);
-    expect(oversizedMetadataWarnings(hookMdPath)).toHaveLength(1);
-  });
-
-  it("continues discovering other hooks after skipping oversized metadata", () => {
+  it("warns, skips oversized metadata, and continues discovering other hooks", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-mixed-"));
     const hooksRoot = path.join(root, "hooks");
     fs.mkdirSync(hooksRoot, { recursive: true });
 
-    const bigHookDir = path.join(hooksRoot, "big-hook");
-    fs.mkdirSync(bigHookDir, { recursive: true });
-    const bigHookMdPath = path.join(bigHookDir, "HOOK.md");
-    fs.writeFileSync(bigHookMdPath, "x".repeat(METADATA_MAX_BYTES + 1), "utf8");
-    fs.writeFileSync(path.join(bigHookDir, "handler.js"), "export default async () => {};\n");
+    const packageDir = path.join(hooksRoot, "big-package");
+    fs.mkdirSync(packageDir);
+    const manifestPath = path.join(packageDir, "package.json");
+    fs.writeFileSync(manifestPath, "x".repeat(METADATA_MAX_BYTES + 1));
 
-    const smallHookDir = path.join(hooksRoot, "small-hook");
-    fs.mkdirSync(smallHookDir, { recursive: true });
-    fs.writeFileSync(path.join(smallHookDir, "HOOK.md"), "---\nname: small-hook\n---\n");
-    fs.writeFileSync(path.join(smallHookDir, "handler.js"), "export default async () => {};\n");
+    const bigHookDir = writePlainHook(hooksRoot, "big-hook", "x".repeat(METADATA_MAX_BYTES + 1));
+    const bigHookMdPath = path.join(bigHookDir, "HOOK.md");
+    writePlainHook(hooksRoot, "small-hook");
 
     const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
     expect(hookNames(entries)).toEqual(["small-hook"]);
+    expect(oversizedMetadataWarnings(manifestPath)).toHaveLength(1);
     expect(oversizedMetadataWarnings(bigHookMdPath)).toHaveLength(1);
   });
 
@@ -221,12 +185,9 @@ describe("hooks workspace", () => {
     const hooksRoot = path.join(root, "hooks");
     fs.mkdirSync(hooksRoot, { recursive: true });
 
-    const hookDir = path.join(hooksRoot, "compat-hook");
-    fs.mkdirSync(hookDir, { recursive: true });
+    const hookDir = writePlainHook(hooksRoot, "compat-hook");
     const manifestPath = path.join(hookDir, "package.json");
     fs.writeFileSync(manifestPath, "x".repeat(METADATA_MAX_BYTES + 1), "utf8");
-    fs.writeFileSync(path.join(hookDir, "HOOK.md"), "---\nname: compat-hook\n---\n");
-    fs.writeFileSync(path.join(hookDir, "handler.js"), "export default async () => {};\n");
 
     const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
     expect(hookNames(entries)).toContain("compat-hook");

--- a/src/hooks/workspace.test.ts
+++ b/src/hooks/workspace.test.ts
@@ -100,6 +100,33 @@ describe("hooks workspace", () => {
     expect(hookNames(entries)).toContain("nested");
   });
 
+  it("ignores hook packages with an oversized package.json", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-manifest-"));
+    const hooksRoot = path.join(root, "hooks");
+    fs.mkdirSync(hooksRoot, { recursive: true });
+
+    const pkgDir = path.join(hooksRoot, "pkg");
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, "package.json"), "x".repeat(1024 * 1024 + 1), "utf8");
+
+    const entries = loadHookEntriesFromDir({ dir: hooksRoot, source: "openclaw-workspace" });
+    expect(hookNames(entries)).toHaveLength(0);
+  });
+
+  it("ignores hooks with an oversized HOOK.md", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-md-"));
+    const hooksRoot = path.join(root, "hooks");
+    fs.mkdirSync(hooksRoot, { recursive: true });
+
+    const hookDir = path.join(hooksRoot, "big-hook");
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.writeFileSync(path.join(hookDir, "HOOK.md"), "x".repeat(1024 * 1024 + 1), "utf8");
+    fs.writeFileSync(path.join(hookDir, "handler.js"), "export default async () => {};\n");
+
+    const entries = loadHookEntriesFromDir({ dir: hooksRoot, source: "openclaw-workspace" });
+    expect(hookNames(entries)).toHaveLength(0);
+  });
+
   it("ignores package.json hook paths that escape via symlink", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-link-"));
     const hooksRoot = path.join(root, "hooks");

--- a/src/hooks/workspace.test.ts
+++ b/src/hooks/workspace.test.ts
@@ -2,9 +2,27 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { loadWorkspaceHookEntries } from "./workspace.js";
+
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
+
+vi.mock("../logging/subsystem.js", () => {
+  const makeLogger = () => ({
+    subsystem: "hooks/workspace",
+    isEnabled: () => true,
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: warnMock,
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: () => makeLogger(),
+  });
+  return { createSubsystemLogger: () => makeLogger() };
+});
 
 function writeHookPackageManifest(pkgDir: string, hooks: string[]): void {
   fs.writeFileSync(
@@ -62,7 +80,30 @@ function loadWorkspaceEntriesFromHooksRoot(hooksRoot: string) {
   });
 }
 
+const METADATA_MAX_BYTES = 1024 * 1024;
+
+function oversizedMetadataWarnings(filePath: string): string[] {
+  return warnMock.mock.calls
+    .map(([message]) => String(message))
+    .filter((message) => message.includes(filePath) && message.includes(`${METADATA_MAX_BYTES}`));
+}
+
+function padToExactBytes(content: string, targetBytes: number): string {
+  const padding = targetBytes - Buffer.byteLength(content, "utf8");
+  return padding > 0 ? content + " ".repeat(padding) : content;
+}
+
+function exactSizeHookPackageManifest(targetBytes: number): string {
+  const base = { name: "pkg", [MANIFEST_KEY]: { hooks: ["./nested"] }, pad: "" };
+  const baseBytes = Buffer.byteLength(JSON.stringify(base), "utf8");
+  return JSON.stringify({ ...base, pad: "x".repeat(targetBytes - baseBytes) });
+}
+
 describe("hooks workspace", () => {
+  beforeEach(() => {
+    warnMock.mockClear();
+  });
+
   it("ignores package.json hook paths that traverse outside package directory", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-"));
     const hooksRoot = path.join(root, "hooks");
@@ -100,31 +141,96 @@ describe("hooks workspace", () => {
     expect(hookNames(entries)).toContain("nested");
   });
 
-  it("ignores hook packages with an oversized package.json", () => {
+  it("warns and skips hook packages with an oversized package.json", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-manifest-"));
     const hooksRoot = path.join(root, "hooks");
     fs.mkdirSync(hooksRoot, { recursive: true });
 
     const pkgDir = path.join(hooksRoot, "pkg");
     fs.mkdirSync(pkgDir, { recursive: true });
-    fs.writeFileSync(path.join(pkgDir, "package.json"), "x".repeat(1024 * 1024 + 1), "utf8");
+    const manifestPath = path.join(pkgDir, "package.json");
+    fs.writeFileSync(manifestPath, "x".repeat(METADATA_MAX_BYTES + 1), "utf8");
 
     const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
     expect(hookNames(entries)).toHaveLength(0);
+    expect(oversizedMetadataWarnings(manifestPath)).toHaveLength(1);
   });
 
-  it("ignores hooks with an oversized HOOK.md", () => {
+  it("warns and skips hooks with an oversized HOOK.md", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-md-"));
     const hooksRoot = path.join(root, "hooks");
     fs.mkdirSync(hooksRoot, { recursive: true });
 
     const hookDir = path.join(hooksRoot, "big-hook");
     fs.mkdirSync(hookDir, { recursive: true });
-    fs.writeFileSync(path.join(hookDir, "HOOK.md"), "x".repeat(1024 * 1024 + 1), "utf8");
+    const hookMdPath = path.join(hookDir, "HOOK.md");
+    fs.writeFileSync(hookMdPath, "x".repeat(METADATA_MAX_BYTES + 1), "utf8");
     fs.writeFileSync(path.join(hookDir, "handler.js"), "export default async () => {};\n");
 
     const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
     expect(hookNames(entries)).toHaveLength(0);
+    expect(oversizedMetadataWarnings(hookMdPath)).toHaveLength(1);
+  });
+
+  it("continues discovering other hooks after skipping oversized metadata", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-mixed-"));
+    const hooksRoot = path.join(root, "hooks");
+    fs.mkdirSync(hooksRoot, { recursive: true });
+
+    const bigHookDir = path.join(hooksRoot, "big-hook");
+    fs.mkdirSync(bigHookDir, { recursive: true });
+    const bigHookMdPath = path.join(bigHookDir, "HOOK.md");
+    fs.writeFileSync(bigHookMdPath, "x".repeat(METADATA_MAX_BYTES + 1), "utf8");
+    fs.writeFileSync(path.join(bigHookDir, "handler.js"), "export default async () => {};\n");
+
+    const smallHookDir = path.join(hooksRoot, "small-hook");
+    fs.mkdirSync(smallHookDir, { recursive: true });
+    fs.writeFileSync(path.join(smallHookDir, "HOOK.md"), "---\nname: small-hook\n---\n");
+    fs.writeFileSync(path.join(smallHookDir, "handler.js"), "export default async () => {};\n");
+
+    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
+    expect(hookNames(entries)).toEqual(["small-hook"]);
+    expect(oversizedMetadataWarnings(bigHookMdPath)).toHaveLength(1);
+  });
+
+  it("loads hooks whose metadata sits exactly at the byte limit", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-exact-limit-"));
+    const hooksRoot = path.join(root, "hooks");
+    fs.mkdirSync(hooksRoot, { recursive: true });
+
+    const pkgDir = path.join(hooksRoot, "pkg");
+    const nested = path.join(pkgDir, "nested");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(
+      path.join(pkgDir, "package.json"),
+      exactSizeHookPackageManifest(METADATA_MAX_BYTES),
+    );
+    fs.writeFileSync(
+      path.join(nested, "HOOK.md"),
+      padToExactBytes("---\nname: exact-limit\n---\n", METADATA_MAX_BYTES),
+    );
+    fs.writeFileSync(path.join(nested, "handler.js"), "export default async () => {};\n");
+
+    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
+    expect(hookNames(entries)).toContain("exact-limit");
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it("still loads a plain hook when its package.json is oversized", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-compat-"));
+    const hooksRoot = path.join(root, "hooks");
+    fs.mkdirSync(hooksRoot, { recursive: true });
+
+    const hookDir = path.join(hooksRoot, "compat-hook");
+    fs.mkdirSync(hookDir, { recursive: true });
+    const manifestPath = path.join(hookDir, "package.json");
+    fs.writeFileSync(manifestPath, "x".repeat(METADATA_MAX_BYTES + 1), "utf8");
+    fs.writeFileSync(path.join(hookDir, "HOOK.md"), "---\nname: compat-hook\n---\n");
+    fs.writeFileSync(path.join(hookDir, "handler.js"), "export default async () => {};\n");
+
+    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
+    expect(hookNames(entries)).toContain("compat-hook");
+    expect(oversizedMetadataWarnings(manifestPath)).toHaveLength(1);
   });
 
   it("ignores package.json hook paths that escape via symlink", () => {

--- a/src/hooks/workspace.test.ts
+++ b/src/hooks/workspace.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
-import { loadHookEntriesFromDir, loadWorkspaceHookEntries, workspaceTesting } from "./workspace.js";
+import { loadWorkspaceHookEntries } from "./workspace.js";
 
 function writeHookPackageManifest(pkgDir: string, hooks: string[]): void {
   fs.writeFileSync(
@@ -109,7 +109,7 @@ describe("hooks workspace", () => {
     fs.mkdirSync(pkgDir, { recursive: true });
     fs.writeFileSync(path.join(pkgDir, "package.json"), "x".repeat(1024 * 1024 + 1), "utf8");
 
-    const entries = loadHookEntriesFromDir({ dir: hooksRoot, source: "openclaw-workspace" });
+    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
     expect(hookNames(entries)).toHaveLength(0);
   });
 
@@ -123,7 +123,7 @@ describe("hooks workspace", () => {
     fs.writeFileSync(path.join(hookDir, "HOOK.md"), "x".repeat(1024 * 1024 + 1), "utf8");
     fs.writeFileSync(path.join(hookDir, "handler.js"), "export default async () => {};\n");
 
-    const entries = loadHookEntriesFromDir({ dir: hooksRoot, source: "openclaw-workspace" });
+    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
     expect(hookNames(entries)).toHaveLength(0);
   });
 
@@ -251,29 +251,5 @@ describe("hooks workspace", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]?.hook.name).toBe("shared-hook");
     expect(entries[0]?.hook.source).toBe("openclaw-managed");
-  });
-
-  it("reads a file descriptor up to the byte cap", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-fd-bound-"));
-    const filePath = path.join(root, "small.txt");
-    fs.writeFileSync(filePath, "hello", "utf8");
-    const fd = fs.openSync(filePath, "r");
-    try {
-      expect(workspaceTesting.readFdUtf8Bounded(fd, 1024)).toBe("hello");
-    } finally {
-      fs.closeSync(fd);
-    }
-  });
-
-  it("rejects a file descriptor that exceeds the byte cap during read", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-fd-overflow-"));
-    const filePath = path.join(root, "big.txt");
-    fs.writeFileSync(filePath, "x".repeat(1024 + 1), "utf8");
-    const fd = fs.openSync(filePath, "r");
-    try {
-      expect(() => workspaceTesting.readFdUtf8Bounded(fd, 1024)).toThrow("File exceeds 1024 bytes");
-    } finally {
-      fs.closeSync(fd);
-    }
   });
 });

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -203,7 +203,12 @@ function loadHooksFromDir(params: {
   return hooks;
 }
 
-function loadHookEntriesFromDir(params: {
+/** Test-only hooks for exercising internal bounded-read helpers. */
+export const workspaceTesting = {
+  readFdUtf8Bounded,
+};
+
+export function loadHookEntriesFromDir(params: {
   dir: string;
   source: HookSource;
   pluginId?: string;
@@ -305,12 +310,36 @@ function readRootFileUtf8(params: {
   return withOpenedRootFileSync(params, (opened) => {
     try {
       // Read through the already-validated file descriptor so a parent-directory
-      // symlink swap cannot redirect the read outside the hook root.
-      return fs.readFileSync(opened.fd, "utf-8");
+      // symlink swap cannot redirect the read outside the hook root. Enforce the
+      // byte cap while reading so a file that grows after open-time validation
+      // cannot be buffered past the intended limit.
+      return readFdUtf8Bounded(opened.fd, params.maxBytes);
     } catch {
       return null;
     }
   });
+}
+
+function readFdUtf8Bounded(fd: number, maxBytes: number): string {
+  const chunks: Buffer[] = [];
+  const buffer = Buffer.alloc(Math.min(64 * 1024, maxBytes + 1));
+  let total = 0;
+  let position = 0;
+  while (total <= maxBytes) {
+    const remaining = maxBytes - total + 1;
+    const chunkSize = Math.min(buffer.length, remaining);
+    const bytesRead = fs.readSync(fd, buffer, 0, chunkSize, position);
+    if (bytesRead === 0) {
+      break;
+    }
+    if (total + bytesRead > maxBytes) {
+      throw new Error(`File exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
+    total += bytesRead;
+    position += bytesRead;
+  }
+  return Buffer.concat(chunks).toString("utf-8");
 }
 
 function withOpenedRootFileSync<T>(

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -305,12 +305,19 @@ function readRootFileUtf8(params: {
 }): string | null {
   return withOpenedRootFileSync(params, (opened) => {
     try {
-      // Read through the already-validated file descriptor so a parent-directory
-      // symlink swap cannot redirect the read outside the hook root. Enforce the
-      // byte cap while reading so a file that grows after open-time validation
-      // cannot be buffered past the intended limit.
+      // Read through the already-validated descriptor so a parent-directory
+      // symlink swap cannot redirect the read outside the hook root. The shared
+      // bounded reader owns the byte cap, so a file that grows after the
+      // open-time checks still cannot be buffered past the limit.
       return readFileDescriptorBoundedSync(opened.fd, params.maxBytes).toString("utf-8");
-    } catch {
+    } catch (err) {
+      // Warn-and-skip contract: one actionable warning per oversized metadata
+      // file while discovery continues for the remaining hooks.
+      if (err instanceof RangeError) {
+        log.warn(
+          `Ignoring oversized hook metadata ${params.absolutePath}: file exceeds the ${params.maxBytes}-byte limit`,
+        );
+      }
       return null;
     }
   });
@@ -321,7 +328,6 @@ function withOpenedRootFileSync<T>(
     absolutePath: string;
     rootPath: string;
     boundaryLabel: string;
-    maxBytes?: number;
   },
   read: (opened: { fd: number; path: string }) => T,
 ): T | null {
@@ -329,7 +335,6 @@ function withOpenedRootFileSync<T>(
     absolutePath: params.absolutePath,
     rootPath: params.rootPath,
     boundaryLabel: params.boundaryLabel,
-    maxBytes: params.maxBytes,
   });
   if (!opened.ok) {
     return null;

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -7,11 +7,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { readFileDescriptorBoundedSync } from "../infra/file-descriptor-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-
-// Hook package manifests and HOOK.md files are small metadata; cap reads so a
-// malicious or runaway file cannot OOM workspace discovery.
-const HOOK_PACKAGE_JSON_MAX_BYTES = 1024 * 1024;
-const HOOK_MD_MAX_BYTES = 1024 * 1024;
 import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import { resolveBundledHooksDir } from "./bundled-dir.js";
@@ -23,6 +18,10 @@ import {
 import { resolvePluginHookDirs } from "./plugin-hooks.js";
 import { resolveHookEntries } from "./policy.js";
 import type { Hook, HookEntry, HookSource, ParsedHookFrontmatter } from "./types.js";
+
+// Hook descriptors are small metadata. Bounding the pinned descriptor read also
+// covers files that grow after the boundary open validates their identity.
+const HOOK_METADATA_MAX_BYTES = 1024 * 1024;
 
 type HookPackageManifest = {
   name?: string;
@@ -40,7 +39,7 @@ function readHookPackageManifest(dir: string): HookPackageManifest | null {
     absolutePath: manifestPath,
     rootPath: dir,
     boundaryLabel: "hook package directory",
-    maxBytes: HOOK_PACKAGE_JSON_MAX_BYTES,
+    maxBytes: HOOK_METADATA_MAX_BYTES,
   });
   if (raw === null) {
     return null;
@@ -80,7 +79,7 @@ function loadHookFromDir(params: {
     absolutePath: hookMdPath,
     rootPath: params.hookDir,
     boundaryLabel: "hook directory",
-    maxBytes: HOOK_MD_MAX_BYTES,
+    maxBytes: HOOK_METADATA_MAX_BYTES,
   });
   if (content === null) {
     return null;
@@ -305,14 +304,8 @@ function readRootFileUtf8(params: {
 }): string | null {
   return withOpenedRootFileSync(params, (opened) => {
     try {
-      // Read through the already-validated descriptor so a parent-directory
-      // symlink swap cannot redirect the read outside the hook root. The shared
-      // bounded reader owns the byte cap, so a file that grows after the
-      // open-time checks still cannot be buffered past the limit.
       return readFileDescriptorBoundedSync(opened.fd, params.maxBytes).toString("utf-8");
     } catch (err) {
-      // Warn-and-skip contract: one actionable warning per oversized metadata
-      // file while discovery continues for the remaining hooks.
       if (err instanceof RangeError) {
         log.warn(
           `Ignoring oversized hook metadata ${params.absolutePath}: file exceeds the ${params.maxBytes}-byte limit`,

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -6,6 +6,11 @@ import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+
+// Hook package manifests and HOOK.md files are small metadata; cap reads so a
+// malicious or runaway file cannot OOM workspace discovery.
+const HOOK_PACKAGE_JSON_MAX_BYTES = 1024 * 1024;
+const HOOK_MD_MAX_BYTES = 1024 * 1024;
 import { isPathInsideWithRealpath } from "../security/scan-paths.js";
 import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import { resolveBundledHooksDir } from "./bundled-dir.js";
@@ -34,6 +39,7 @@ function readHookPackageManifest(dir: string): HookPackageManifest | null {
     absolutePath: manifestPath,
     rootPath: dir,
     boundaryLabel: "hook package directory",
+    maxBytes: HOOK_PACKAGE_JSON_MAX_BYTES,
   });
   if (raw === null) {
     return null;
@@ -73,6 +79,7 @@ function loadHookFromDir(params: {
     absolutePath: hookMdPath,
     rootPath: params.hookDir,
     boundaryLabel: "hook directory",
+    maxBytes: HOOK_MD_MAX_BYTES,
   });
   if (content === null) {
     return null;
@@ -293,9 +300,12 @@ function readRootFileUtf8(params: {
   absolutePath: string;
   rootPath: string;
   boundaryLabel: string;
+  maxBytes: number;
 }): string | null {
   return withOpenedRootFileSync(params, (opened) => {
     try {
+      // Read through the already-validated file descriptor so a parent-directory
+      // symlink swap cannot redirect the read outside the hook root.
       return fs.readFileSync(opened.fd, "utf-8");
     } catch {
       return null;
@@ -308,6 +318,7 @@ function withOpenedRootFileSync<T>(
     absolutePath: string;
     rootPath: string;
     boundaryLabel: string;
+    maxBytes?: number;
   },
   read: (opened: { fd: number; path: string }) => T,
 ): T | null {
@@ -315,6 +326,7 @@ function withOpenedRootFileSync<T>(
     absolutePath: params.absolutePath,
     rootPath: params.rootPath,
     boundaryLabel: params.boundaryLabel,
+    maxBytes: params.maxBytes,
   });
   if (!opened.ok) {
     return null;

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -5,6 +5,7 @@ import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
+import { readFileDescriptorBoundedSync } from "../infra/file-descriptor-read.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 // Hook package manifests and HOOK.md files are small metadata; cap reads so a
@@ -308,33 +309,11 @@ function readRootFileUtf8(params: {
       // symlink swap cannot redirect the read outside the hook root. Enforce the
       // byte cap while reading so a file that grows after open-time validation
       // cannot be buffered past the intended limit.
-      return readFdUtf8Bounded(opened.fd, params.maxBytes);
+      return readFileDescriptorBoundedSync(opened.fd, params.maxBytes).toString("utf-8");
     } catch {
       return null;
     }
   });
-}
-
-function readFdUtf8Bounded(fd: number, maxBytes: number): string {
-  const chunks: Buffer[] = [];
-  const buffer = Buffer.alloc(Math.min(64 * 1024, maxBytes + 1));
-  let total = 0;
-  let position = 0;
-  while (total <= maxBytes) {
-    const remaining = maxBytes - total + 1;
-    const chunkSize = Math.min(buffer.length, remaining);
-    const bytesRead = fs.readSync(fd, buffer, 0, chunkSize, position);
-    if (bytesRead === 0) {
-      break;
-    }
-    if (total + bytesRead > maxBytes) {
-      throw new Error(`File exceeds ${maxBytes} bytes`);
-    }
-    chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
-    total += bytesRead;
-    position += bytesRead;
-  }
-  return Buffer.concat(chunks).toString("utf-8");
 }
 
 function withOpenedRootFileSync<T>(

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -203,12 +203,7 @@ function loadHooksFromDir(params: {
   return hooks;
 }
 
-/** Test-only hooks for exercising internal bounded-read helpers. */
-export const workspaceTesting = {
-  readFdUtf8Bounded,
-};
-
-export function loadHookEntriesFromDir(params: {
+function loadHookEntriesFromDir(params: {
   dir: string;
   source: HookSource;
   pluginId?: string;


### PR DESCRIPTION
## What Problem This Solves

Workspace hook discovery read `package.json` and `HOOK.md` through validated file descriptors without bounding the allocated content. A malicious or runaway hook descriptor could therefore exhaust memory during discovery.

## Why This Change Was Made

Both files are small hook metadata. Discovery now reads each already-pinned descriptor through the shared bounded reader with the maintainer-approved 1 MiB limit. This keeps the existing path, symlink, hardlink, and descriptor-identity checks while also bounding files that grow after open.

## User Impact

Oversized hook metadata is warned about and skipped. Discovery continues for other hooks, and an oversized package manifest still falls back to a plain `HOOK.md` in the same directory.

## Maintainer Changes

- Rebased onto current `main`.
- Reused one metadata limit and the canonical descriptor-pinned reader.
- Consolidated the regression coverage while retaining both oversized surfaces, continued discovery, exact-limit acceptance, and plain-hook fallback.

## Evidence

- `node scripts/run-vitest.mjs src/hooks/workspace.test.ts` — 10 tests passed.
- `oxlint src/hooks/workspace.ts src/hooks/workspace.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Full-branch autoreview — clean, no accepted/actionable findings.

Co-authored-by: 陈宪彪0668000387 <chen.xianbiao@xydigit.com>
