### PR TITLE
fix(auto-reply): add AbortSignal and ConnectTimeout to scpFile

### DIFF
--- a/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
@@ -86,4 +86,26 @@ describe("scpFile", () => {
       expect.not.objectContaining({ signal: expect.anything() }),
     );
   });
+
+  it("defers AbortError until close so tmp dir is not removed early", async () => {
+    const { child } = createChild();
+
+    const abortErr = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+    });
+
+    const resultPromise = testing.scpFile("host", "/remote/path", "/local/path");
+    child.emit("error", abortErr);
+
+    // AbortError must not settle the promise — close is authoritative
+    const settled = await Promise.race([
+      resultPromise.then(() => "resolved"),
+      new Promise((r) => setTimeout(() => r("timeout"), 100)),
+    ]);
+    expect(settled).toBe("timeout");
+
+    // close fires afterward — now it rejects with the stored abort error
+    child.emit("close", null);
+    await expect(resultPromise).rejects.toThrow("The operation was aborted");
+  });
 });

--- a/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.scp.test.ts
@@ -57,4 +57,33 @@ describe("scpFile", () => {
     await expect(resultPromise).rejects.toThrow("spawn failed");
     expect(kill).not.toHaveBeenCalled();
   });
+
+  it("passes AbortSignal to spawn options when provided", async () => {
+    const { child } = createChild();
+    const ac = new AbortController();
+
+    const resultPromise = testing.scpFile("host", "/remote/path", "/local/path", ac.signal);
+    child.emit("close", 0);
+    await expect(resultPromise).resolves.toBeUndefined();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ signal: ac.signal }),
+    );
+  });
+
+  it("calls scpFile without signal for backward compatibility", async () => {
+    const { child } = createChild();
+
+    const resultPromise = testing.scpFile("host", "/remote/path", "/local/path");
+    child.emit("close", 0);
+    await expect(resultPromise).resolves.toBeUndefined();
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.not.objectContaining({ signal: expect.anything() }),
+    );
+  });
 });

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -207,13 +207,14 @@ async function stageRemoteFileIntoRoot(params: {
   rootDir: string;
   relativeDestPath: string;
   maxBytes?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
   const tmpRoot = resolvePreferredOpenClawTmpDir();
   await fs.mkdir(tmpRoot, { recursive: true });
   const tmpDir = await fs.mkdtemp(path.join(tmpRoot, "stage-sandbox-media-"));
   const tmpPath = path.join(tmpDir, "download");
   try {
-    await scpFile(params.remoteHost, params.remotePath, tmpPath);
+    await scpFile(params.remoteHost, params.remotePath, tmpPath, params.signal);
     await stageLocalFileIntoRoot({
       sourcePath: tmpPath,
       rootDir: params.rootDir,
@@ -392,6 +393,7 @@ async function scpFile(
 
     let stderr = "";
     let settled = false;
+    let aborted: Error | null = null;
     const finish = (error?: Error) => {
       if (settled) {
         return;
@@ -414,9 +416,20 @@ async function scpFile(
       stderr = appendScpStderrTail(stderr, formatErrorMessage(error));
     });
 
-    child.once("error", finish);
+    child.once("error", (err) => {
+      // AbortError fires before SIGTERM and child close. Defer rejection
+      // to the close handler so the caller does not remove the tmp dir
+      // while the SCP child is still shutting down.
+      if (err.name === "AbortError") {
+        aborted = err;
+      } else {
+        finish(err);
+      }
+    });
     child.once("close", (code) => {
-      if (code === 0) {
+      if (aborted) {
+        finish(aborted);
+      } else if (code === 0) {
         finish();
       } else {
         finish(new Error(`scp failed (${code}): ${stderr.trim()}`));

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -359,7 +359,12 @@ function rewriteStagedMediaPaths(params: {
   }
 }
 
-async function scpFile(remoteHost: string, remotePath: string, localPath: string): Promise<void> {
+async function scpFile(
+  remoteHost: string,
+  remotePath: string,
+  localPath: string,
+  signal?: AbortSignal,
+): Promise<void> {
   const safeRemoteHost = normalizeScpRemoteHost(remoteHost);
   if (!safeRemoteHost) {
     throw new Error("invalid remote host for SCP");
@@ -376,11 +381,13 @@ async function scpFile(remoteHost: string, remotePath: string, localPath: string
         "BatchMode=yes",
         "-o",
         "StrictHostKeyChecking=yes",
+        "-o",
+        "ConnectTimeout=10",
         "--",
         `${safeRemoteHost}:${safeRemotePath}`,
         localPath,
       ],
-      { stdio: ["ignore", "ignore", "pipe"] },
+      { stdio: ["ignore", "ignore", "pipe"], ...(signal ? { signal } : {}) },
     );
 
     let stderr = "";


### PR DESCRIPTION
## Summary

Add `AbortSignal` support and `ConnectTimeout` to `scpFile()` in stage-sandbox-media to prevent child process leaks when SCP connects to an unreachable host.

## What Problem This Solves

When `scpFile()` spawns SCP to an unreachable host, the child process has no timeout mechanism and no way to be cancelled. If the caller abandons the operation (e.g., via `Promise.race` with a timeout), the SCP child process continues running and leaks system resources until the OS-level TCP timeout (~127 seconds on Linux).

**Code evidence**: In `src/auto-reply/reply/stage-sandbox-media.ts:362-418`, the `scpFile` function wraps `spawn("scp")` in a Promise but:
- Does not pass `ConnectTimeout` to SCP args (SSH-level timeout)
- Does not accept or pass an `AbortSignal` to the spawn options
- Has no way for external code to cancel the spawned child process

## Root Cause

The function introduced in commit `7c47904bb4` (`Stage managed inbound media for runner access`) wraps `spawn("scp")` in a Promise but only handles `error` and `close` events — it never provides a cancellation path. The spawned SCP command has no `ConnectTimeout` flag, so SSH relies entirely on OS TCP timeout.

## Why This Fix

Three minimal changes:

1. **Add optional `AbortSignal` parameter** — allows callers to cancel the operation
2. **Pass `signal` to `spawn()` options** — Node.js automatically sends `SIGKILL` to the child process when the signal is aborted
3. **Add `-o ConnectTimeout=10`** — gives SCP its own 10-second transport timeout as defense-in-depth

## Evidence

- **Before**: SCP to unroutable IP (192.0.2.99) leaks child process after caller abandons at 8s — child still running
- **After**: SCP with `ConnectTimeout=10` and `AbortSignal` — child process cleanly killed on abort

## Real Behavior Proof

### Before (on main)

```bash
$ node proof.mjs
=== BEFORE — no timeout/AbortSignal ===
SPAWN scp → 192.0.2.99
Caller abandoned after 8s
FAIL: SCP child process leaked! Process still running:
1471947       00:09 scp
```

### After (with fix)

```bash
$ node proof.mjs
=== AFTER — ConnectTimeout=10 + AbortSignal ===
SPAWN scp → 192.0.2.99
AbortController.abort() triggered
Child result: {"type":"error","message":"The operation was aborted"}
PASS: No SCP child process remaining — AbortSignal cleaned up correctly
```

## Tests and Validation

- Added 2 regression tests to `stage-sandbox-media.scp.test.ts`:
  - `passes AbortSignal to spawn options when provided`
  - `calls scpFile without signal for backward compatibility`
- `pnpm check` passed (pre-existing npm shrinkwrap guard failure unrelated)
- Manual verification on Linux: spawn scp → unreachable IP → abort → no orphan process
