### PR TITLE
fix(slack): prevent duplicate reply controls

### DIFF
--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -148,6 +148,34 @@ describe("handleSlackMessageAction", () => {
     expect(elementAt(actionsBlock, 0).value).toBe("approve");
   });
 
+  it("sends an exact mirrored portable control row once", async () => {
+    const invoke = createInvokeSpy();
+    const buttons = [{ label: "Approve", action: { type: "callback" as const, value: "approve" } }];
+
+    await handleSlackMessageAction({
+      providerId: "slack",
+      ctx: {
+        action: "send",
+        cfg: {},
+        params: {
+          to: "channel:C1",
+          message: "Deploy?",
+          presentation: { blocks: [{ type: "buttons", buttons }] },
+          interactive: { blocks: [{ type: "buttons", buttons }] },
+        },
+      } as never,
+      invoke: invoke as never,
+    });
+
+    const action = firstAction(invoke);
+    expect(action).not.toHaveProperty("blocks");
+    const message = preparedMessages(invoke)[0]!;
+    const blocks = message.blocks as Array<Record<string, unknown>> | undefined;
+    const actions = blocks?.filter((block) => block.type === "actions") ?? [];
+    expect(actions).toHaveLength(1);
+    expect(elementAt(actions[0]!, 0).value).toBe("approve");
+  });
+
   it("sends native charts with a complete accessible text representation", async () => {
     const invoke = createInvokeSpy();
 

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -883,6 +883,24 @@ describe("slackOutbound sendPayload", () => {
     ]);
   });
 
+  it("sends an exact mirrored portable control row once", async () => {
+    const buttons = [{ label: "Approve", action: { type: "callback" as const, value: "approve" } }];
+    const { run, sendMock } = createHarness({
+      payload: {
+        text: "Deploy?",
+        presentation: { blocks: [{ type: "buttons", buttons }] },
+        interactive: { blocks: [{ type: "buttons", buttons }] },
+      },
+    });
+
+    await run();
+
+    const actions = sendOptions(sendCall(sendMock, 0)).blocks?.filter(
+      (block) => block.type === "actions",
+    );
+    expect(actions).toHaveLength(1);
+  });
+
   it("marks inline legacy text as represented when native data is compiled with it", async () => {
     const payload: ReplyPayload = {
       text: "Before [[slack_buttons: OK:ok]] after",

--- a/extensions/slack/src/reply-blocks.test.ts
+++ b/extensions/slack/src/reply-blocks.test.ts
@@ -1,3 +1,7 @@
+import {
+  presentationToInteractiveControlsReply,
+  type MessagePresentation,
+} from "openclaw/plugin-sdk/interactive-runtime";
 import { describe, expect, it } from "vitest";
 import { resolveSlackReplyBlockResolution, resolveSlackReplyText } from "./reply-blocks.js";
 
@@ -514,5 +518,197 @@ describe("resolveSlackReplyText", () => {
         { block_id: "openclaw_reply_buttons_1", elements: [{ value: "refresh" }] },
       ],
     });
+  });
+
+  it("subtracts exact legacy mirrors for every typed action family", () => {
+    const presentation = {
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            {
+              label: "Command",
+              action: { type: "command", command: "/approve req-1 allow-once" },
+            },
+            { label: "Callback", action: { type: "callback", value: "callback-button" } },
+            {
+              label: "Approval",
+              action: {
+                type: "approval",
+                approvalId: "plugin:req-1",
+                approvalKind: "plugin",
+                decision: "allow-once",
+              },
+            },
+            { label: "URL", action: { type: "url", url: "https://example.com/docs" } },
+            {
+              label: "Web app",
+              action: { type: "web-app", url: "https://example.com/app" },
+            },
+          ],
+        },
+        {
+          type: "select",
+          placeholder: "Command select",
+          options: [
+            {
+              label: "Deny",
+              action: { type: "command", command: "/approve req-2 deny" },
+            },
+          ],
+        },
+        {
+          type: "select",
+          placeholder: "Callback select",
+          options: [{ label: "Retry", action: { type: "callback", value: "callback-select" } }],
+        },
+      ],
+    } satisfies MessagePresentation;
+
+    const { segments } = resolveSlackReplyBlockResolution({
+      presentation,
+      interactive: presentationToInteractiveControlsReply(presentation),
+    });
+    const blocks = segments[0]?.kind === "blocks" ? segments[0].blocks : [];
+    const actionIds = blocks.flatMap((block) =>
+      block.type === "actions"
+        ? ((block as { elements?: Array<{ action_id?: string }> }).elements ?? []).flatMap(
+            (element) => (element.action_id ? [element.action_id] : []),
+          )
+        : [],
+    );
+
+    expect(segments).toHaveLength(1);
+    expect(blocks).toHaveLength(3);
+    expect(actionIds).toEqual([
+      "openclaw:reply_button:1:1",
+      "openclaw:callback_button:1:2",
+      "openclaw:approval_button:1:3",
+      "openclaw:reply_link:1:4",
+      "openclaw:reply_link:1:5",
+      "openclaw:reply_select:1",
+      "openclaw:callback_select:2",
+    ]);
+  });
+
+  it("keeps transport-distinct controls with the same visible content", () => {
+    const { segments } = resolveSlackReplyBlockResolution({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Run", action: { type: "callback", value: "same" } }],
+          },
+        ],
+      },
+      interactive: {
+        blocks: [{ type: "buttons", buttons: [{ label: "Run", value: "same" }] }],
+      },
+    });
+    const blocks = segments[0]?.kind === "blocks" ? segments[0].blocks : [];
+
+    expect(blocks).toHaveLength(2);
+    expect(
+      blocks.map(
+        (block) => (block as { elements?: Array<{ action_id?: string }> }).elements?.[0]?.action_id,
+      ),
+    ).toEqual(["openclaw:callback_button:1:1", "openclaw:reply_button:2:1"]);
+  });
+
+  it("subtracts mirrors as a multiset and keeps surplus or changed rows", () => {
+    const repeated = {
+      type: "buttons" as const,
+      buttons: [{ label: "Run", action: { type: "callback" as const, value: "same" } }],
+    };
+    const { segments } = resolveSlackReplyBlockResolution({
+      presentation: { blocks: [repeated, repeated] },
+      interactive: {
+        blocks: [
+          repeated,
+          repeated,
+          repeated,
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Run",
+                action: { type: "callback", value: "same" },
+                style: "danger",
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const blocks = segments[0]?.kind === "blocks" ? segments[0].blocks : [];
+
+    expect(blocks).toHaveLength(4);
+    expect(
+      blocks.map(
+        (block) => (block as { elements?: Array<{ style?: string }> }).elements?.[0]?.style,
+      ),
+    ).toEqual([undefined, undefined, undefined, "danger"]);
+  });
+
+  it("keeps legacy controls when their presentation mirror falls back to text", () => {
+    const presentation = {
+      blocks: [
+        {
+          type: "buttons",
+          buttons: Array.from({ length: 26 }, (_entry, index) => ({
+            label: `Action ${String(index + 1)}`,
+            action: { type: "callback" as const, value: `action-${String(index + 1)}` },
+          })),
+        },
+      ],
+    } satisfies MessagePresentation;
+    const { segments } = resolveSlackReplyBlockResolution({
+      presentation,
+      interactive: presentationToInteractiveControlsReply(presentation),
+    });
+
+    expect(segments.map((segment) => segment.kind)).toEqual(["text", "blocks"]);
+    const blocks = segments[1]?.kind === "blocks" ? segments[1].blocks : [];
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as { elements?: unknown[] }).elements).toHaveLength(25);
+  });
+
+  it("subtracts mirrors before enforcing each Slack message block limit", () => {
+    const presentation = {
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [{ label: "Approve", action: { type: "callback", value: "approve" } }],
+        },
+      ],
+    } satisfies MessagePresentation;
+    const interactive = presentationToInteractiveControlsReply(presentation);
+    const channelData = {
+      slack: { blocks: Array.from({ length: 49 }, () => ({ type: "divider" })) },
+    };
+
+    const exact = resolveSlackReplyBlockResolution({ channelData, presentation, interactive });
+    expect(exact.segments).toHaveLength(1);
+    expect(exact.segments[0]?.kind === "blocks" ? exact.segments[0].blocks : []).toHaveLength(50);
+
+    const withUniqueRow = resolveSlackReplyBlockResolution({
+      channelData,
+      presentation,
+      interactive: {
+        blocks: [
+          ...(interactive?.blocks ?? []),
+          { type: "buttons", buttons: [{ label: "Later", value: "later" }] },
+        ],
+      },
+    });
+    expect(withUniqueRow.segments).toHaveLength(2);
+    expect(
+      withUniqueRow.segments[1]?.kind === "blocks" ? withUniqueRow.segments[1].blocks : [],
+    ).toMatchObject([
+      {
+        block_id: "openclaw_reply_buttons_3",
+        elements: [{ action_id: "openclaw:reply_button:3:1", value: "later" }],
+      },
+    ]);
   });
 });

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -28,6 +28,15 @@ import {
 } from "./native-data-blocks.js";
 import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
 import { SLACK_SECTION_TEXT_MAX } from "./presentation.js";
+import {
+  SLACK_APPROVAL_BUTTON_ACTION_ID,
+  SLACK_APPROVAL_SELECT_ACTION_ID,
+  SLACK_CALLBACK_BUTTON_ACTION_ID,
+  SLACK_CALLBACK_SELECT_ACTION_ID,
+  SLACK_REPLY_BUTTON_ACTION_ID,
+  SLACK_REPLY_LINK_ACTION_ID,
+  SLACK_REPLY_SELECT_ACTION_ID,
+} from "./reply-action-ids.js";
 
 export type SlackReplyBlockSegment =
   | { kind: "blocks"; blocks: SlackBlock[] }
@@ -344,6 +353,73 @@ function appendPresentationPart(
   );
 }
 
+const SLACK_BUTTON_CONTROL_ACTION_IDS = [
+  SLACK_APPROVAL_BUTTON_ACTION_ID,
+  SLACK_CALLBACK_BUTTON_ACTION_ID,
+  SLACK_REPLY_BUTTON_ACTION_ID,
+  SLACK_REPLY_LINK_ACTION_ID,
+] as const;
+const SLACK_SELECT_CONTROL_ACTION_IDS = [
+  SLACK_APPROVAL_SELECT_ACTION_ID,
+  SLACK_CALLBACK_SELECT_ACTION_ID,
+  SLACK_REPLY_SELECT_ACTION_ID,
+] as const;
+
+function readGeneratedSlackControlRowKey(block: SlackBlock): string | undefined {
+  const record = block as { block_id?: unknown; elements?: unknown; type?: unknown };
+  if (record.type !== "actions" || typeof record.block_id !== "string") {
+    return undefined;
+  }
+  const expectedElementType = /^openclaw_reply_buttons_[1-9]\d*$/.test(record.block_id)
+    ? "button"
+    : /^openclaw_reply_select_[1-9]\d*$/.test(record.block_id)
+      ? "static_select"
+      : undefined;
+  if (!expectedElementType || !Array.isArray(record.elements) || record.elements.length === 0) {
+    return undefined;
+  }
+  const actionIds =
+    expectedElementType === "button"
+      ? SLACK_BUTTON_CONTROL_ACTION_IDS
+      : SLACK_SELECT_CONTROL_ACTION_IDS;
+  const elements = record.elements.map((element) => {
+    if (!element || typeof element !== "object" || Array.isArray(element)) {
+      return undefined;
+    }
+    const { action_id: actionId, ...content } = element as Record<string, unknown>;
+    const actionFamily =
+      typeof actionId === "string"
+        ? actionIds.find((candidate) => actionId.startsWith(`${candidate}:`))
+        : undefined;
+    return actionFamily && content.type === expectedElementType
+      ? { ...content, action_id: actionFamily }
+      : undefined;
+  });
+  return elements.some((element) => element === undefined) ? undefined : JSON.stringify(elements);
+}
+
+function subtractMirroredSlackControlRows(params: {
+  interactiveBlocks: readonly SlackBlock[];
+  presentationBlocks: readonly SlackBlock[];
+}): SlackBlock[] {
+  const remainingMirrors = new Map<string, number>();
+  for (const block of params.presentationBlocks) {
+    const key = readGeneratedSlackControlRowKey(block);
+    if (key) {
+      remainingMirrors.set(key, (remainingMirrors.get(key) ?? 0) + 1);
+    }
+  }
+  return params.interactiveBlocks.filter((block) => {
+    const key = readGeneratedSlackControlRowKey(block);
+    const remaining = key ? (remainingMirrors.get(key) ?? 0) : 0;
+    if (!key || remaining === 0) {
+      return true;
+    }
+    remainingMirrors.set(key, remaining - 1);
+    return false;
+  });
+}
+
 /**
  * Resolve reply content into transport-order segments. Each blocks segment is
  * one Slack message; text segments carry complete fallback content between it.
@@ -383,18 +459,28 @@ export function resolveSlackReplyBlockResolution(
   }
 
   const presentation = normalizeMessagePresentation(payload.presentation);
+  const presentationBlockOffset = readAllNativeBlocks(segments).length;
   if (presentation?.title) {
     appendPresentationPart(segments, { title: presentation.title, blocks: [] });
   }
   for (const block of presentation?.blocks ?? []) {
     appendPresentationPart(segments, { blocks: [block] });
   }
+  const renderedPresentationBlocks = readAllNativeBlocks(segments).slice(presentationBlockOffset);
 
   const interactiveBlocks = buildSlackInteractiveBlocks(
     payload.interactive,
     resolveSlackBlockOffsets(readAllNativeBlocks(segments)),
   );
-  appendBlockSegment(segments, interactiveBlocks);
+  // Compare final Slack rows, not source payloads: fallbacks and transport
+  // limits can prevent an apparent source mirror from rendering at all.
+  appendBlockSegment(
+    segments,
+    subtractMirroredSlackControlRows({
+      interactiveBlocks,
+      presentationBlocks: renderedPresentationBlocks,
+    }),
+  );
   const renderedTextFragments = segments.flatMap((segment) => {
     if (segment.kind === "text") {
       return [segment.text];

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -392,7 +392,7 @@ function readGeneratedSlackControlRowKey(block: SlackBlock): string | undefined 
         ? actionIds.find((candidate) => actionId.startsWith(`${candidate}:`))
         : undefined;
     return actionFamily && content.type === expectedElementType
-      ? { ...content, action_id: actionFamily }
+      ? [actionFamily, content]
       : undefined;
   });
   return elements.some((element) => element === undefined) ? undefined : JSON.stringify(elements);


### PR DESCRIPTION
## What Problem This Solves

Slack could render the same reply controls twice when one reply carried both the canonical portable `presentation` and its deprecated `interactive` mirror.

## Why This Change Was Made

The maintainer rewrite moves exact rendered-row subtraction into `resolveSlackReplyBlockResolution`, the shared owner for ordinary replies, message-action sends, outbound delivery, and Slack's 50-block message segmentation. It compares final Block Kit rows as a multiset, normalizes generated indices to typed action families, and covers command, callback, approval, URL/web-app, and select controls.

Only exact transport-equivalent mirrors are removed. Raw Slack blocks, controls that fell back to text, callback-versus-legacy controls, changed styles or content, and intentional surplus rows remain deliverable.

## User Impact

Mirrored Slack buttons and selects now render once. Intentionally repeated or meaningfully different controls still render independently, including at the 50-block boundary.

## Evidence

- Exact pushed head: `6ee994350daf0adcc36681f6e97af6d92ff5b923` (two focused maintainer commits on `5e45ebe82b1cba48be892207c5c2b5c7cae79008`; contributor credit preserved).
- Red current-main proof: four expected failures across resolver action families, 50-block segmentation, message-action dispatch, and final outbound delivery; 87 adjacent tests passed.
- Green focused Testbox proof: 93/93 across `reply-blocks.test.ts`, `message-action-dispatch.test.ts`, and `outbound-payload.test.ts`.
- Full Testbox `check:changed`: passed extension production/test typechecks, lint, formatting, guards, and runtime import-cycle check.
- Live Slack proof: the exact resolver output contained one actions row; Slack's official Block Kit Builder rendered exactly one proof button; clicking it opened the exact [Actions block documentation](https://docs.slack.dev/reference/block-kit/blocks/actions-block/) URL.
- Source-blind behavior validation: all three tasks plus reload and real-destination anti-cheat probes passed.
- Fresh full-patch and lint-follow-up autoreviews: no accepted or actionable findings.
- Exact-head hosted [CI run](https://github.com/openclaw/openclaw/actions/runs/29206645703): passed all 61 jobs.

#103947 remains complementary inbound action work and is not replaced by this outbound dedupe fix.

AI-assisted: the contributor branch was narrowed and rewritten with Codex; contributor credit is preserved.
