### PR TITLE
fix(session-memory): bound session transcript reads to prevent OOM

### DIFF
--- a/src/hooks/bundled/session-memory/transcript.test.ts
+++ b/src/hooks/bundled/session-memory/transcript.test.ts
@@ -102,4 +102,13 @@ describe("session-memory transcript extraction", () => {
     expect(memoryContent).not.toContain("x".repeat(100));
     expect(memoryContent?.length).toBeLessThan(SESSION_TRANSCRIPT_MAX_BYTES);
   });
+
+  it("returns null when a single line exceeds the byte cap", async () => {
+    // A lone oversized JSONL row must not be materialized. The bounded tail
+    // read drops it when no newline appears inside the cap window.
+    const huge = message("user", "x".repeat(17 * 1024 * 1024));
+    const transcriptPath = await writeTranscript(`${huge}\n`);
+
+    await expect(getRecentSessionContent(transcriptPath)).resolves.toBeNull();
+  });
 });

--- a/src/hooks/bundled/session-memory/transcript.test.ts
+++ b/src/hooks/bundled/session-memory/transcript.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { getRecentSessionContent, sanitizeSessionMemoryTranscriptText } from "./transcript.js";
+import {
+  getRecentSessionContent,
+  sanitizeSessionMemoryTranscriptText,
+  SESSION_TRANSCRIPT_MAX_BYTES,
+} from "./transcript.js";
 
 const tempRoots: string[] = [];
 
@@ -95,5 +99,7 @@ describe("session-memory transcript extraction", () => {
 
     expect(memoryContent).toContain("user: recent user message");
     expect(memoryContent).toContain("assistant: recent assistant message");
+    expect(memoryContent).not.toContain("x".repeat(100));
+    expect(memoryContent?.length).toBeLessThan(SESSION_TRANSCRIPT_MAX_BYTES);
   });
 });

--- a/src/hooks/bundled/session-memory/transcript.test.ts
+++ b/src/hooks/bundled/session-memory/transcript.test.ts
@@ -81,10 +81,19 @@ describe("session-memory transcript extraction", () => {
     );
   });
 
-  it("returns null for oversized transcripts instead of buffering them", async () => {
-    const oversized = `${message("user", "x".repeat(1024))}\n${message("user", "x".repeat(16 * 1024 * 1024))}\n`;
-    const transcriptPath = await writeTranscript(oversized);
+  it("preserves recent messages from the tail of an oversized transcript", async () => {
+    // One huge message pushes the file over the 16 MiB cap; the small messages
+    // after it must still be reachable via a bounded tail read.
+    const huge = message("user", "x".repeat(17 * 1024 * 1024));
+    const recent = [
+      message("user", "recent user message"),
+      message("assistant", "recent assistant message"),
+    ].join("\n");
+    const transcriptPath = await writeTranscript(`${huge}\n${recent}\n`);
 
-    await expect(getRecentSessionContent(transcriptPath)).resolves.toBeNull();
+    const memoryContent = await getRecentSessionContent(transcriptPath);
+
+    expect(memoryContent).toContain("user: recent user message");
+    expect(memoryContent).toContain("assistant: recent assistant message");
   });
 });

--- a/src/hooks/bundled/session-memory/transcript.test.ts
+++ b/src/hooks/bundled/session-memory/transcript.test.ts
@@ -80,4 +80,11 @@ describe("session-memory transcript extraction", () => {
       "assistant: Answer [REMOVED_SPECIAL_TOKEN]",
     );
   });
+
+  it("returns null for oversized transcripts instead of buffering them", async () => {
+    const oversized = `${message("user", "x".repeat(1024))}\n${message("user", "x".repeat(16 * 1024 * 1024))}\n`;
+    const transcriptPath = await writeTranscript(oversized);
+
+    await expect(getRecentSessionContent(transcriptPath)).resolves.toBeNull();
+  });
 });

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,9 +1,14 @@
 // Session memory transcript helpers persist compact session transcript excerpts.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { readRegularFile } from "../../../infra/regular-file.js";
 import { sanitizeModelSpecialTokens } from "../../../security/external-content.js";
 import { hasInterSessionUserProvenance } from "../../../sessions/input-provenance.js";
 import { isOpenClawDeliveryMirrorAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
+
+// Session transcripts are JSONL files; a generous cap prevents a runaway file
+// from OOMing the memory-extraction path while covering normal session sizes.
+const SESSION_TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024;
 
 const SESSION_MEMORY_TOOL_DIRECTIVE_PREFIX = String.raw`(?:(?:\|DSML\|)|(?:\uFF5CDSML\uFF5C))?`;
 const SESSION_MEMORY_TOOL_DIRECTIVE_KIND = String.raw`(?:tool_calls?|function_calls?|tool_use_error)`;
@@ -61,7 +66,11 @@ export async function getRecentSessionContent(
   messageCount = 15,
 ): Promise<string | null> {
   try {
-    const content = await fs.readFile(sessionFilePath, "utf-8");
+    const { buffer } = await readRegularFile({
+      filePath: sessionFilePath,
+      maxBytes: SESSION_TRANSCRIPT_MAX_BYTES,
+    });
+    const content = buffer.toString("utf-8");
     const lines = content.trim().split("\n");
 
     const allMessages: string[] = [];

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,7 +1,8 @@
 // Session memory transcript helpers persist compact session transcript excerpts.
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { readRegularFile } from "../../../infra/regular-file.js";
+import { readRegularFile, statRegularFile } from "../../../infra/regular-file.js";
 import { sanitizeModelSpecialTokens } from "../../../security/external-content.js";
 import { hasInterSessionUserProvenance } from "../../../sessions/input-provenance.js";
 import { isOpenClawDeliveryMirrorAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
@@ -61,16 +62,54 @@ function extractTextMessageContent(content: unknown): string | undefined {
   return undefined;
 }
 
+async function readBoundedTranscriptContent(sessionFilePath: string): Promise<string | null> {
+  const statResult = await statRegularFile(sessionFilePath);
+  if (statResult.missing) {
+    return null;
+  }
+
+  if (statResult.stat.size <= SESSION_TRANSCRIPT_MAX_BYTES) {
+    const { buffer } = await readRegularFile({
+      filePath: sessionFilePath,
+      maxBytes: SESSION_TRANSCRIPT_MAX_BYTES,
+    });
+    return buffer.toString("utf-8");
+  }
+
+  // For oversized transcripts, read only the trailing cap bytes so recent
+  // session context is preserved without buffering the whole file.
+  const start = statResult.stat.size - SESSION_TRANSCRIPT_MAX_BYTES;
+  const flags =
+    fsConstants.O_RDONLY |
+    (typeof fsConstants.O_NOFOLLOW === "number" && process.platform !== "win32"
+      ? fsConstants.O_NOFOLLOW
+      : 0);
+  const fd = await fs.open(sessionFilePath, flags);
+  try {
+    const tailBuffer = Buffer.alloc(SESSION_TRANSCRIPT_MAX_BYTES);
+    const { bytesRead } = await fd.read(tailBuffer, 0, SESSION_TRANSCRIPT_MAX_BYTES, start);
+    const tail = tailBuffer.toString("utf-8", 0, bytesRead);
+    // The first line in the tail may start mid-record, so drop everything up
+    // to the first complete newline to avoid parsing a partial JSONL row.
+    const firstNewline = tail.indexOf("\n");
+    if (firstNewline === -1) {
+      return null;
+    }
+    return tail.slice(firstNewline + 1);
+  } finally {
+    await fd.close();
+  }
+}
+
 export async function getRecentSessionContent(
   sessionFilePath: string,
   messageCount = 15,
 ): Promise<string | null> {
   try {
-    const { buffer } = await readRegularFile({
-      filePath: sessionFilePath,
-      maxBytes: SESSION_TRANSCRIPT_MAX_BYTES,
-    });
-    const content = buffer.toString("utf-8");
+    const content = await readBoundedTranscriptContent(sessionFilePath);
+    if (content === null) {
+      return null;
+    }
     const lines = content.trim().split("\n");
 
     const allMessages: string[] = [];

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -8,7 +8,7 @@ import { isOpenClawDeliveryMirrorAssistantMessage } from "../../../shared/transc
 
 // Session transcripts are JSONL files; a generous cap prevents a runaway file
 // from OOMing the memory-extraction path while covering normal session sizes.
-const SESSION_TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024;
+export const SESSION_TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024;
 
 const SESSION_MEMORY_TOOL_DIRECTIVE_PREFIX = String.raw`(?:(?:\|DSML\|)|(?:\uFF5CDSML\uFF5C))?`;
 const SESSION_MEMORY_TOOL_DIRECTIVE_KIND = String.raw`(?:tool_calls?|function_calls?|tool_use_error)`;
@@ -68,11 +68,15 @@ async function readBoundedTranscriptContent(sessionFilePath: string): Promise<st
   const lines: string[] = [];
   let bytesRead = 0;
   for await (const line of streamSessionTranscriptLinesReverse(sessionFilePath)) {
-    lines.push(line);
-    bytesRead += Buffer.byteLength(line, "utf-8") + 1;
-    if (bytesRead >= SESSION_TRANSCRIPT_MAX_BYTES) {
+    const lineBytes = Buffer.byteLength(line, "utf-8") + 1;
+    // Stop before retaining a line that would cross the cap. Recent messages are
+    // yielded first, so this keeps the trailing context without buffering an
+    // oversized early record.
+    if (bytesRead + lineBytes > SESSION_TRANSCRIPT_MAX_BYTES) {
       break;
     }
+    lines.push(line);
+    bytesRead += lineBytes;
   }
   if (lines.length === 0) {
     return null;

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,4 +1,5 @@
 // Session memory transcript helpers persist compact session transcript excerpts.
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { streamSessionTranscriptLinesReverse } from "../../../config/sessions/transcript-stream.js";
@@ -62,26 +63,62 @@ function extractTextMessageContent(content: unknown): string | undefined {
 }
 
 async function readBoundedTranscriptContent(sessionFilePath: string): Promise<string | null> {
-  // Stream the transcript newest-first so we never buffer the whole file,
-  // then reverse the collected tail back into chronological order for the
-  // existing sanitizer/filter pipeline.
-  const lines: string[] = [];
-  let bytesRead = 0;
-  for await (const line of streamSessionTranscriptLinesReverse(sessionFilePath)) {
-    const lineBytes = Buffer.byteLength(line, "utf-8") + 1;
-    // Stop before retaining a line that would cross the cap. Recent messages are
-    // yielded first, so this keeps the trailing context without buffering an
-    // oversized early record.
-    if (bytesRead + lineBytes > SESSION_TRANSCRIPT_MAX_BYTES) {
-      break;
-    }
-    lines.push(line);
-    bytesRead += lineBytes;
-  }
-  if (lines.length === 0) {
+  let stat: fs.Stats;
+  try {
+    stat = await fs.stat(sessionFilePath);
+  } catch {
     return null;
   }
-  return lines.toReversed().join("\n");
+  if (!stat.isFile() || stat.size <= 0) {
+    return null;
+  }
+
+  // For files that fit under the cap, stream newest-first so we can stop early
+  // once we have retained enough trailing context.
+  if (stat.size <= SESSION_TRANSCRIPT_MAX_BYTES) {
+    const lines: string[] = [];
+    let bytesRead = 0;
+    for await (const line of streamSessionTranscriptLinesReverse(sessionFilePath)) {
+      const lineBytes = Buffer.byteLength(line, "utf-8") + 1;
+      if (bytesRead + lineBytes > SESSION_TRANSCRIPT_MAX_BYTES) {
+        break;
+      }
+      lines.push(line);
+      bytesRead += lineBytes;
+    }
+    if (lines.length === 0) {
+      return null;
+    }
+    return lines.toReversed().join("\n");
+  }
+
+  // For oversized files, read only the trailing cap bytes. This avoids
+  // materializing a single over-cap JSONL row: if the last newline falls
+  // outside the tail window, the final line is itself larger than the cap and
+  // we drop it instead of buffering the whole record.
+  const start = stat.size - SESSION_TRANSCRIPT_MAX_BYTES;
+  const flags =
+    fsConstants.O_RDONLY |
+    (typeof fsConstants.O_NOFOLLOW === "number" && process.platform !== "win32"
+      ? fsConstants.O_NOFOLLOW
+      : 0);
+  const fd = await fs.open(sessionFilePath, flags);
+  try {
+    const tailBuffer = Buffer.alloc(SESSION_TRANSCRIPT_MAX_BYTES);
+    const { bytesRead } = await fd.read(tailBuffer, 0, SESSION_TRANSCRIPT_MAX_BYTES, start);
+    const tail = tailBuffer.toString("utf-8", 0, bytesRead);
+    const firstNewline = tail.indexOf("\n");
+    if (firstNewline === -1) {
+      return null;
+    }
+    const content = tail.slice(firstNewline + 1).trim();
+    if (!content) {
+      return null;
+    }
+    return content;
+  } finally {
+    await fd.close();
+  }
 }
 
 export async function getRecentSessionContent(

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,8 +1,7 @@
 // Session memory transcript helpers persist compact session transcript excerpts.
-import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { readRegularFile, statRegularFile } from "../../../infra/regular-file.js";
+import { streamSessionTranscriptLinesReverse } from "../../../config/sessions/transcript-stream.js";
 import { sanitizeModelSpecialTokens } from "../../../security/external-content.js";
 import { hasInterSessionUserProvenance } from "../../../sessions/input-provenance.js";
 import { isOpenClawDeliveryMirrorAssistantMessage } from "../../../shared/transcript-only-openclaw-assistant.js";
@@ -63,42 +62,22 @@ function extractTextMessageContent(content: unknown): string | undefined {
 }
 
 async function readBoundedTranscriptContent(sessionFilePath: string): Promise<string | null> {
-  const statResult = await statRegularFile(sessionFilePath);
-  if (statResult.missing) {
+  // Stream the transcript newest-first so we never buffer the whole file,
+  // then reverse the collected tail back into chronological order for the
+  // existing sanitizer/filter pipeline.
+  const lines: string[] = [];
+  let bytesRead = 0;
+  for await (const line of streamSessionTranscriptLinesReverse(sessionFilePath)) {
+    lines.push(line);
+    bytesRead += Buffer.byteLength(line, "utf-8") + 1;
+    if (bytesRead >= SESSION_TRANSCRIPT_MAX_BYTES) {
+      break;
+    }
+  }
+  if (lines.length === 0) {
     return null;
   }
-
-  if (statResult.stat.size <= SESSION_TRANSCRIPT_MAX_BYTES) {
-    const { buffer } = await readRegularFile({
-      filePath: sessionFilePath,
-      maxBytes: SESSION_TRANSCRIPT_MAX_BYTES,
-    });
-    return buffer.toString("utf-8");
-  }
-
-  // For oversized transcripts, read only the trailing cap bytes so recent
-  // session context is preserved without buffering the whole file.
-  const start = statResult.stat.size - SESSION_TRANSCRIPT_MAX_BYTES;
-  const flags =
-    fsConstants.O_RDONLY |
-    (typeof fsConstants.O_NOFOLLOW === "number" && process.platform !== "win32"
-      ? fsConstants.O_NOFOLLOW
-      : 0);
-  const fd = await fs.open(sessionFilePath, flags);
-  try {
-    const tailBuffer = Buffer.alloc(SESSION_TRANSCRIPT_MAX_BYTES);
-    const { bytesRead } = await fd.read(tailBuffer, 0, SESSION_TRANSCRIPT_MAX_BYTES, start);
-    const tail = tailBuffer.toString("utf-8", 0, bytesRead);
-    // The first line in the tail may start mid-record, so drop everything up
-    // to the first complete newline to avoid parsing a partial JSONL row.
-    const firstNewline = tail.indexOf("\n");
-    if (firstNewline === -1) {
-      return null;
-    }
-    return tail.slice(firstNewline + 1);
-  } finally {
-    await fd.close();
-  }
+  return lines.toReversed().join("\n");
 }
 
 export async function getRecentSessionContent(

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,5 +1,5 @@
 // Session memory transcript helpers persist compact session transcript excerpts.
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { streamSessionTranscriptLinesReverse } from "../../../config/sessions/transcript-stream.js";
@@ -63,7 +63,7 @@ function extractTextMessageContent(content: unknown): string | undefined {
 }
 
 async function readBoundedTranscriptContent(sessionFilePath: string): Promise<string | null> {
-  let stat: fs.Stats;
+  let stat: Stats;
   try {
     stat = await fs.stat(sessionFilePath);
   } catch {


### PR DESCRIPTION
## What Problem This Solves

`getRecentSessionContent` in `src/hooks/bundled/session-memory/transcript.ts` reads session transcript JSONL files with an unbounded `fs.promises.readFile` call. A runaway or corrupted session file could force the session-memory extraction path to buffer the entire file into memory, leading to OOM.

## Why This Change Was Made

Session-memory extraction now uses a bounded hybrid reader:
- For transcripts that fit under the 16 MiB cap, it streams lines newest-first through the shared `streamSessionTranscriptLinesReverse` helper and stops before retaining a line that would cross the cap.
- For transcripts that exceed the cap, it reads only the trailing 16 MiB and drops the first partial JSONL line, so a single over-cap record is not materialized.

This avoids whole-file buffering while preserving recent session context.

## User Impact

Session-memory extraction now safely bounds oversized transcripts while still keeping the most recent messages available for context.

## Evidence

- Added regression tests covering:
  - a transcript exceeding the cap with recent trailing messages — asserts the recent messages are preserved and the huge early message is absent,
  - a single JSONL row larger than the cap — asserts `getRecentSessionContent` returns `null`.
- Local focused run: `node scripts/run-vitest.mjs src/hooks/bundled/session-memory/transcript.test.ts --run` passes (5/5 tests).

## Real behavior proof (standalone)

I ran a standalone Node script outside Vitest that imports the actual changed helper from source and exercises both the oversized-tail path and the lone over-cap row path.

Script: `/tmp/proof-101475.mjs` (not committed).

```text
$ node --import tsx /tmp/proof-101475.mjs
=== Case 1: oversized transcript with recent tail ===
File size: 17826089 bytes (cap is 16777216 bytes)
Result contains recent user message: true
Result contains recent assistant message: true
Result does NOT contain huge early message: true
Result length under cap: true

=== Case 2: lone over-cap JSONL row ===
Result is null: true
```

The helper bounds reads for both pathological layouts without buffering the entire transcript into memory.
