### PR TITLE
fix(mcp): remove dead duplicate assignment in stdio transport close()

### DIFF
--- a/src/agents/mcp-stdio-transport.ts
+++ b/src/agents/mcp-stdio-transport.ts
@@ -120,9 +120,6 @@ export class OpenClawStdioClientTransport implements Transport {
     this.process = undefined;
     this.closingProcess = processToClose;
     if (processToClose) {
-      this.closingProcess = processToClose;
-    }
-    if (processToClose) {
       const closePromise = new Promise<void>((resolve) => {
         processToClose.once("close", () => resolve());
       });


### PR DESCRIPTION
## What Problem This Solves

`OpenClawStdioClientTransport.close()` contains a dead code block where `this.closingProcess` is assigned the same value twice:

```typescript
this.closingProcess = processToClose;       // line 121
if (processToClose) {
  this.closingProcess = processToClose;     // line 123 — identical assignment
}
```

The inner `if` block performs no additional work beyond the outer assignment that already ran unconditionally.

## Why This Change Was Made

This is a dead-code cleanup. Line 121 already assigns the value unconditionally, so the guarded reassignment on line 123 has no effect. The `if` block appears to be a refactoring leftover — `forceClose()` (line 149) does not set `this.closingProcess` at all for the same pattern, confirming the redundant block serves no purpose.

## User Impact

No behavioral change. The `close()` method was already functionally correct; this only removes unreachable logic.

## Evidence

Verified against commit `d8c27de5` on branch `fix/mcp-stdio-close-duplicate-assign`.

Before:
```
this.closingProcess = processToClose;
if (processToClose) {                        // guard
  this.closingProcess = processToClose;      // dead reassignment
}
if (processToClose) {                        // second guard (real)
  // ... actual close logic
}
```

After:
```
this.closingProcess = processToClose;
if (processToClose) {                        // guard (real)
  // ... actual close logic
}
```

## Tests and Validation

```
$ pnpm test src/agents/mcp-stdio-transport.test.ts
Test Files  1 passed (1)
Tests       9 passed (9)
```

## Risk Checklist

- **User-visible behavior:** No — dead code removal, zero behavioral difference.
- **Config/env/migration behavior:** No.
- **Security/auth/secrets/network/tool execution:** No.
- **Plugins/providers/channels/SDK:** No — internal MCP stdio transport only.
- **Highest-risk area:** None. The removed block was semantically unreachable (same value already assigned).
- **Mitigation:** Existing 9 tests pass; `forceClose()` confirms the sibling pattern does not need this block.

Closes: N/A
