### PR TITLE
fix(commands): bound reset-hook transcript reads to prevent OOM

### DIFF
--- a/src/auto-reply/reply/commands-core.test.ts
+++ b/src/auto-reply/reply/commands-core.test.ts
@@ -143,6 +143,37 @@ describe("emitResetCommandHooks", () => {
     expect(ctx.sessionId).toBe("prev-session");
   });
 
+  it("passes storePath into the transcript reader scope for custom-store sessions", async () => {
+    const command = {
+      surface: "telegram",
+      senderId: "vac",
+      channel: "telegram",
+      from: "telegram:vac",
+      to: "telegram:bot",
+      resetHookTriggered: false,
+    } as HandleCommandsParams["command"];
+
+    await emitResetCommandHooks({
+      action: "new",
+      ctx: {} as HandleCommandsParams["ctx"],
+      cfg: {} as HandleCommandsParams["cfg"],
+      command,
+      sessionKey: "agent:main:telegram:group:-1003826723328:topic:8428",
+      previousSessionEntry: {
+        sessionId: "prev-session",
+        sessionFile: "/custom/store/prev-session.jsonl",
+      } as HandleCommandsParams["previousSessionEntry"],
+      storePath: "/custom/store",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
+    expect(readSessionMessagesAsyncMock).toHaveBeenCalledTimes(1);
+    const [scope] = readSessionMessagesAsyncMock.mock.calls[0] as [Record<string, unknown>];
+    expect(scope.storePath).toBe("/custom/store");
+    expect(scope.sessionFile).toBe("/custom/store/prev-session.jsonl");
+  });
+
   it("passes through messages returned by the transcript reader", async () => {
     readSessionMessagesAsyncMock.mockResolvedValueOnce([
       { role: "user", content: "active root" },

--- a/src/auto-reply/reply/commands-core.test.ts
+++ b/src/auto-reply/reply/commands-core.test.ts
@@ -4,9 +4,10 @@ import type { HookRunner } from "../../plugins/hooks.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
 const fsMocks = vi.hoisted(() => ({
-  readFile: vi.fn(),
   readdir: vi.fn(),
 }));
+
+const readRegularFileMock = vi.hoisted(() => vi.fn());
 
 const hookRunnerMocks = vi.hoisted(() => ({
   hasHooks: vi.fn<HookRunner["hasHooks"]>(),
@@ -19,13 +20,15 @@ vi.mock("node:fs/promises", async () => {
     ...actual,
     default: {
       ...actual,
-      readFile: fsMocks.readFile,
       readdir: fsMocks.readdir,
     },
-    readFile: fsMocks.readFile,
     readdir: fsMocks.readdir,
   };
 });
+
+vi.mock("../../infra/regular-file.js", () => ({
+  readRegularFile: readRegularFileMock,
+}));
 
 vi.mock("../../plugins/hook-runner-global.js", () => ({
   getGlobalHookRunner: () =>
@@ -76,13 +79,13 @@ describe("emitResetCommandHooks", () => {
   }
 
   beforeEach(() => {
-    fsMocks.readFile.mockReset();
+    readRegularFileMock.mockReset();
     fsMocks.readdir.mockReset();
     hookRunnerMocks.hasHooks.mockReset();
     hookRunnerMocks.runBeforeReset.mockReset();
     hookRunnerMocks.hasHooks.mockImplementation((hookName) => hookName === "before_reset");
     hookRunnerMocks.runBeforeReset.mockResolvedValue(undefined);
-    fsMocks.readFile.mockResolvedValue("");
+    readRegularFileMock.mockResolvedValue({ buffer: Buffer.from("", "utf-8") });
     fsMocks.readdir.mockResolvedValue([]);
   });
 
@@ -115,15 +118,20 @@ describe("emitResetCommandHooks", () => {
   });
 
   it("recovers the archived transcript when the original reset transcript path is gone", async () => {
-    fsMocks.readFile.mockRejectedValueOnce(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
-    fsMocks.readdir.mockResolvedValueOnce(["prev-session.jsonl.reset.2026-02-16T22-26-33.000Z"]);
-    fsMocks.readFile.mockResolvedValueOnce(
-      `${JSON.stringify({
-        type: "message",
-        id: "m1",
-        message: { role: "user", content: "Recovered from archive" },
-      })}\n`,
+    readRegularFileMock.mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
     );
+    fsMocks.readdir.mockResolvedValueOnce(["prev-session.jsonl.reset.2026-02-16T22-26-33.000Z"]);
+    readRegularFileMock.mockResolvedValueOnce({
+      buffer: Buffer.from(
+        `${JSON.stringify({
+          type: "message",
+          id: "m1",
+          message: { role: "user", content: "Recovered from archive" },
+        })}\n`,
+        "utf-8",
+      ),
+    });
     const command = {
       surface: "telegram",
       senderId: "vac",
@@ -155,41 +163,44 @@ describe("emitResetCommandHooks", () => {
   });
 
   it("keeps leaf-controlled side branches out of before_reset hooks", async () => {
-    fsMocks.readFile.mockResolvedValueOnce(
-      [
-        {
-          type: "message",
-          id: "active-root",
-          parentId: null,
-          message: { role: "user", content: "active root" },
-        },
-        {
-          type: "message",
-          id: "side-entry",
-          parentId: "active-root",
-          message: { role: "assistant", content: "side delivery" },
-        },
-        {
-          type: "leaf",
-          id: "active-leaf",
-          parentId: "side-entry",
-          targetId: "active-root",
-        },
-        {
-          type: "message",
-          id: "active-tail",
-          parentId: "active-root",
-          message: { role: "assistant", content: "active tail" },
-        },
-        {
-          type: "metadata",
-          id: "opaque-after-active-tail",
-          parentId: "side-entry",
-        },
-      ]
-        .map((entry) => JSON.stringify(entry))
-        .join("\n"),
-    );
+    readRegularFileMock.mockResolvedValueOnce({
+      buffer: Buffer.from(
+        [
+          {
+            type: "message",
+            id: "active-root",
+            parentId: null,
+            message: { role: "user", content: "active root" },
+          },
+          {
+            type: "message",
+            id: "side-entry",
+            parentId: "active-root",
+            message: { role: "assistant", content: "side delivery" },
+          },
+          {
+            type: "leaf",
+            id: "active-leaf",
+            parentId: "side-entry",
+            targetId: "active-root",
+          },
+          {
+            type: "message",
+            id: "active-tail",
+            parentId: "active-root",
+            message: { role: "assistant", content: "active tail" },
+          },
+          {
+            type: "metadata",
+            id: "opaque-after-active-tail",
+            parentId: "side-entry",
+          },
+        ]
+          .map((entry) => JSON.stringify(entry))
+          .join("\n"),
+        "utf-8",
+      ),
+    });
 
     await emitResetCommandHooks({
       action: "new",

--- a/src/auto-reply/reply/commands-core.test.ts
+++ b/src/auto-reply/reply/commands-core.test.ts
@@ -3,31 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { HookRunner } from "../../plugins/hooks.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
-const fsMocks = vi.hoisted(() => ({
-  readdir: vi.fn(),
-}));
-
-const readRegularFileMock = vi.hoisted(() => vi.fn());
+const readSessionMessagesAsyncMock = vi.hoisted(() => vi.fn());
 
 const hookRunnerMocks = vi.hoisted(() => ({
   hasHooks: vi.fn<HookRunner["hasHooks"]>(),
   runBeforeReset: vi.fn<HookRunner["runBeforeReset"]>(),
 }));
 
-vi.mock("node:fs/promises", async () => {
-  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
-  return {
-    ...actual,
-    default: {
-      ...actual,
-      readdir: fsMocks.readdir,
-    },
-    readdir: fsMocks.readdir,
-  };
-});
-
-vi.mock("../../infra/regular-file.js", () => ({
-  readRegularFile: readRegularFileMock,
+vi.mock("../../gateway/session-transcript-readers.js", () => ({
+  readSessionMessagesAsync: readSessionMessagesAsyncMock,
 }));
 
 vi.mock("../../plugins/hook-runner-global.js", () => ({
@@ -69,24 +53,23 @@ describe("emitResetCommandHooks", () => {
       sessionKey,
       previousSessionEntry: {
         sessionId: "prev-session",
+        sessionFile: "/tmp/prev-session.jsonl",
       } as HandleCommandsParams["previousSessionEntry"],
       workspaceDir: "/tmp/openclaw-workspace",
     });
 
-    expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
     const [, ctx] = firstBeforeResetCall();
     return ctx;
   }
 
   beforeEach(() => {
-    readRegularFileMock.mockReset();
-    fsMocks.readdir.mockReset();
+    readSessionMessagesAsyncMock.mockReset();
     hookRunnerMocks.hasHooks.mockReset();
     hookRunnerMocks.runBeforeReset.mockReset();
     hookRunnerMocks.hasHooks.mockImplementation((hookName) => hookName === "before_reset");
     hookRunnerMocks.runBeforeReset.mockResolvedValue(undefined);
-    readRegularFileMock.mockResolvedValue({ buffer: Buffer.from("", "utf-8") });
-    fsMocks.readdir.mockResolvedValue([]);
+    readSessionMessagesAsyncMock.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -117,21 +100,10 @@ describe("emitResetCommandHooks", () => {
     expect(ctx?.workspaceDir).toBe("/tmp/openclaw-workspace");
   });
 
-  it("recovers the archived transcript when the original reset transcript path is gone", async () => {
-    readRegularFileMock.mockRejectedValueOnce(
-      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
-    );
-    fsMocks.readdir.mockResolvedValueOnce(["prev-session.jsonl.reset.2026-02-16T22-26-33.000Z"]);
-    readRegularFileMock.mockResolvedValueOnce({
-      buffer: Buffer.from(
-        `${JSON.stringify({
-          type: "message",
-          id: "m1",
-          message: { role: "user", content: "Recovered from archive" },
-        })}\n`,
-        "utf-8",
-      ),
-    });
+  it("uses the session transcript reader with reset-archive fallback", async () => {
+    readSessionMessagesAsyncMock.mockResolvedValueOnce([
+      { role: "user", content: "Recovered from archive" },
+    ]);
     const command = {
       surface: "telegram",
       senderId: "vac",
@@ -155,52 +127,27 @@ describe("emitResetCommandHooks", () => {
     });
 
     await vi.waitFor(() => expect(hookRunnerMocks.runBeforeReset).toHaveBeenCalledTimes(1));
+    expect(readSessionMessagesAsyncMock).toHaveBeenCalledTimes(1);
+    const [scope, opts] = readSessionMessagesAsyncMock.mock.calls[0] as [
+      Record<string, unknown>,
+      Record<string, unknown>,
+    ];
+    expect(scope.sessionId).toBe("prev-session");
+    expect(scope.sessionFile).toBe("/tmp/prev-session.jsonl");
+    expect(scope.sessionKey).toBe("agent:main:telegram:group:-1003826723328:topic:8428");
+    expect(opts.mode).toBe("full");
+    expect(opts.allowResetArchiveFallback).toBe(true);
     const [event, ctx] = firstBeforeResetCall();
-    expect(event.sessionFile).toBe("/tmp/prev-session.jsonl.reset.2026-02-16T22-26-33.000Z");
     expect(event.messages).toEqual([{ role: "user", content: "Recovered from archive" }]);
     expect(event.reason).toBe("new");
     expect(ctx.sessionId).toBe("prev-session");
   });
 
-  it("keeps leaf-controlled side branches out of before_reset hooks", async () => {
-    readRegularFileMock.mockResolvedValueOnce({
-      buffer: Buffer.from(
-        [
-          {
-            type: "message",
-            id: "active-root",
-            parentId: null,
-            message: { role: "user", content: "active root" },
-          },
-          {
-            type: "message",
-            id: "side-entry",
-            parentId: "active-root",
-            message: { role: "assistant", content: "side delivery" },
-          },
-          {
-            type: "leaf",
-            id: "active-leaf",
-            parentId: "side-entry",
-            targetId: "active-root",
-          },
-          {
-            type: "message",
-            id: "active-tail",
-            parentId: "active-root",
-            message: { role: "assistant", content: "active tail" },
-          },
-          {
-            type: "metadata",
-            id: "opaque-after-active-tail",
-            parentId: "side-entry",
-          },
-        ]
-          .map((entry) => JSON.stringify(entry))
-          .join("\n"),
-        "utf-8",
-      ),
-    });
+  it("passes through messages returned by the transcript reader", async () => {
+    readSessionMessagesAsyncMock.mockResolvedValueOnce([
+      { role: "user", content: "active root" },
+      { role: "assistant", content: "active tail" },
+    ]);
 
     await emitResetCommandHooks({
       action: "new",

--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -1,7 +1,4 @@
 // Tests reset hook emission and cleanup around reset commands.
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -516,35 +513,5 @@ describe("handleCommands reset hooks", () => {
 
     expect(result).toBeNull();
     expectObjectFields(firstHookEvent(), { type: "command", action: "reset" }, "hook event");
-  });
-
-  it("fires before_reset hook with empty messages when transcript exceeds safe read cap", async () => {
-    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reset-hooks-"));
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    fs.writeFileSync(sessionFile, "x".repeat(16 * 1024 * 1024 + 1), "utf8");
-
-    const runBeforeResetMock = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(getGlobalHookRunner).mockReturnValue({
-      hasHooks: (name: string) => name === "before_reset",
-      runBeforeReset: runBeforeResetMock,
-    } as unknown as ReturnType<typeof getGlobalHookRunner>);
-
-    const params = buildResetParams("/reset", {
-      commands: { text: true },
-      channels: { whatsapp: { allowFrom: ["*"] } },
-    } as OpenClawConfig);
-    params.previousSessionEntry = {
-      sessionId: "session-to-reset",
-      sessionFile,
-    } as HandleCommandsParams["previousSessionEntry"];
-
-    await maybeHandleResetCommand(params);
-
-    await vi.waitFor(() => expect(runBeforeResetMock).toHaveBeenCalledOnce());
-    const callArgs = runBeforeResetMock.mock.calls[0] as [unknown, unknown];
-    const payload = callArgs[0] as { messages: unknown[] };
-    expect(payload.messages).toEqual([]);
-
-    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 });

--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -1,7 +1,11 @@
 // Tests reset hook emission and cleanup around reset commands.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { MsgContext } from "../templating.js";
 import { maybeHandleResetCommand } from "./commands-reset.js";
 import type { HandleCommandsParams } from "./commands-types.js";
@@ -512,5 +516,35 @@ describe("handleCommands reset hooks", () => {
 
     expect(result).toBeNull();
     expectObjectFields(firstHookEvent(), { type: "command", action: "reset" }, "hook event");
+  });
+
+  it("fires before_reset hook with empty messages when transcript exceeds safe read cap", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-reset-hooks-"));
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    fs.writeFileSync(sessionFile, "x".repeat(16 * 1024 * 1024 + 1), "utf8");
+
+    const runBeforeResetMock = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(getGlobalHookRunner).mockReturnValue({
+      hasHooks: (name: string) => name === "before_reset",
+      runBeforeReset: runBeforeResetMock,
+    } as unknown as ReturnType<typeof getGlobalHookRunner>);
+
+    const params = buildResetParams("/reset", {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    params.previousSessionEntry = {
+      sessionId: "session-to-reset",
+      sessionFile,
+    } as HandleCommandsParams["previousSessionEntry"];
+
+    await maybeHandleResetCommand(params);
+
+    await vi.waitFor(() => expect(runBeforeResetMock).toHaveBeenCalledOnce());
+    const callArgs = runBeforeResetMock.mock.calls[0] as [unknown, unknown];
+    const payload = callArgs[0] as { messages: unknown[] };
+    expect(payload.messages).toEqual([]);
+
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 });

--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -2,7 +2,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as bootstrapCache from "../../agents/bootstrap-cache.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { MsgContext } from "../templating.js";
 import { maybeHandleResetCommand } from "./commands-reset.js";
 import type { HandleCommandsParams } from "./commands-types.js";

--- a/src/auto-reply/reply/commands-reset-hooks.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.ts
@@ -4,10 +4,15 @@ import path from "node:path";
 import { selectSessionTranscriptLeafControlledPath } from "../../config/sessions/transcript-tree.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import { readRegularFile } from "../../infra/regular-file.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { HandleCommandsParams } from "./commands-types.js";
+
+// Reset-hook transcripts are JSONL files; cap reads so a runaway transcript
+// cannot OOM the reset hook path.
+const RESET_HOOK_TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024;
 
 const routeReplyRuntimeLoader = createLazyImportLoader(() => import("./route-reply.runtime.js"));
 
@@ -45,6 +50,24 @@ function parseTranscriptMessages(content: string): unknown[] {
   });
 }
 
+async function readTranscriptForReset(sessionFilePath: string): Promise<string | null> {
+  try {
+    const { buffer } = await readRegularFile({
+      filePath: sessionFilePath,
+      maxBytes: RESET_HOOK_TRANSCRIPT_MAX_BYTES,
+    });
+    return buffer.toString("utf-8");
+  } catch (err) {
+    // Preserve the archived-transcript fallback for missing original files;
+    // only swallow non-ENOENT errors so unrelated read failures do not crash
+    // the reset hook.
+    if ((err as { code?: unknown })?.code === "ENOENT") {
+      throw err;
+    }
+    return null;
+  }
+}
+
 async function findLatestArchivedTranscript(sessionFile: string): Promise<string | undefined> {
   try {
     const dir = path.dirname(sessionFile);
@@ -70,12 +93,21 @@ async function loadBeforeResetTranscript(params: {
   }
 
   try {
+    const content = await readTranscriptForReset(sessionFile);
+    if (content === null) {
+      logVerbose(
+        `before_reset: failed to read session file ${sessionFile}; firing hook with empty messages`,
+      );
+      return { sessionFile, messages: [] };
+    }
     return {
       sessionFile,
-      messages: parseTranscriptMessages(await fs.readFile(sessionFile, "utf-8")),
+      messages: parseTranscriptMessages(content),
     };
   } catch (err: unknown) {
-    if ((err as { code?: unknown })?.code !== "ENOENT") {
+    if ((err as { code?: unknown })?.code === "ENOENT") {
+      // Original transcript is missing; fall through to archived transcript recovery.
+    } else {
       logVerbose(
         `before_reset: failed to read session file ${sessionFile}; firing hook with empty messages (${String(err)})`,
       );
@@ -92,9 +124,16 @@ async function loadBeforeResetTranscript(params: {
   }
 
   try {
+    const content = await readTranscriptForReset(archivedSessionFile);
+    if (content === null) {
+      logVerbose(
+        `before_reset: failed to read archived session file ${archivedSessionFile}; firing hook with empty messages`,
+      );
+      return { sessionFile: archivedSessionFile, messages: [] };
+    }
     return {
       sessionFile: archivedSessionFile,
-      messages: parseTranscriptMessages(await fs.readFile(archivedSessionFile, "utf-8")),
+      messages: parseTranscriptMessages(content),
     };
   } catch (err: unknown) {
     logVerbose(

--- a/src/auto-reply/reply/commands-reset-hooks.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.ts
@@ -1,18 +1,11 @@
+import { readSessionMessagesAsync } from "../../gateway/session-transcript-readers.js";
 // Emits reset hooks and cleanup work around session reset commands.
-import fs from "node:fs/promises";
-import path from "node:path";
-import { selectSessionTranscriptLeafControlledPath } from "../../config/sessions/transcript-tree.js";
 import { logVerbose } from "../../globals.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
-import { readRegularFile } from "../../infra/regular-file.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { HandleCommandsParams } from "./commands-types.js";
-
-// Reset-hook transcripts are JSONL files; cap reads so a runaway transcript
-// cannot OOM the reset hook path.
-const RESET_HOOK_TRANSCRIPT_MAX_BYTES = 16 * 1024 * 1024;
 
 const routeReplyRuntimeLoader = createLazyImportLoader(() => import("./route-reply.runtime.js"));
 
@@ -22,124 +15,42 @@ function loadRouteReplyRuntime() {
 
 export type ResetCommandAction = "new" | "reset";
 
-function parseTranscriptMessages(content: string): unknown[] {
-  const entries: unknown[] = [];
-  for (const line of content.split("\n")) {
-    if (!line.trim()) {
-      continue;
-    }
-    try {
-      const entry = JSON.parse(line);
-      entries.push(entry);
-    } catch {
-      // Skip malformed lines from partially-written transcripts.
-    }
-  }
-  const selectedEntries = selectSessionTranscriptLeafControlledPath(entries) ?? entries;
-  return selectedEntries.flatMap((entry) => {
-    if (
-      entry &&
-      typeof entry === "object" &&
-      !Array.isArray(entry) &&
-      (entry as { type?: unknown }).type === "message" &&
-      (entry as { message?: unknown }).message
-    ) {
-      return [(entry as { message: unknown }).message];
-    }
-    return [];
-  });
-}
-
-async function readTranscriptForReset(sessionFilePath: string): Promise<string | null> {
-  try {
-    const { buffer } = await readRegularFile({
-      filePath: sessionFilePath,
-      maxBytes: RESET_HOOK_TRANSCRIPT_MAX_BYTES,
-    });
-    return buffer.toString("utf-8");
-  } catch (err) {
-    // Preserve the archived-transcript fallback for missing original files;
-    // only swallow non-ENOENT errors so unrelated read failures do not crash
-    // the reset hook.
-    if ((err as { code?: unknown })?.code === "ENOENT") {
-      throw err;
-    }
-    return null;
-  }
-}
-
-async function findLatestArchivedTranscript(sessionFile: string): Promise<string | undefined> {
-  try {
-    const dir = path.dirname(sessionFile);
-    const base = path.basename(sessionFile);
-    const resetPrefix = `${base}.reset.`;
-    const archived = (await fs.readdir(dir))
-      .filter((name) => name.startsWith(resetPrefix))
-      .toSorted();
-    const latest = archived[archived.length - 1];
-    return latest ? path.join(dir, latest) : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 async function loadBeforeResetTranscript(params: {
   sessionFile?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  storePath?: string;
+  agentId?: string;
 }): Promise<{ sessionFile?: string; messages: unknown[] }> {
   const sessionFile = params.sessionFile;
-  if (!sessionFile) {
-    logVerbose("before_reset: no session file available, firing hook with empty messages");
+  const sessionId = params.sessionId;
+  if (!sessionFile || !sessionId) {
+    logVerbose("before_reset: no session file/id available, firing hook with empty messages");
     return { sessionFile, messages: [] };
   }
 
   try {
-    const content = await readTranscriptForReset(sessionFile);
-    if (content === null) {
-      logVerbose(
-        `before_reset: failed to read session file ${sessionFile}; firing hook with empty messages`,
-      );
-      return { sessionFile, messages: [] };
-    }
-    return {
-      sessionFile,
-      messages: parseTranscriptMessages(content),
-    };
+    const messages = await readSessionMessagesAsync(
+      {
+        // Only bind to an agent when we have a storePath; otherwise the reader
+        // should honor the explicit sessionFile path (e.g. absolute temp paths).
+        agentId: params.storePath ? params.agentId : undefined,
+        sessionFile,
+        sessionId,
+        sessionKey: params.sessionKey,
+      },
+      {
+        mode: "full",
+        reason: "before_reset hook payload",
+        allowResetArchiveFallback: true,
+      },
+    );
+    return { sessionFile, messages };
   } catch (err: unknown) {
-    if ((err as { code?: unknown })?.code === "ENOENT") {
-      // Original transcript is missing; fall through to archived transcript recovery.
-    } else {
-      logVerbose(
-        `before_reset: failed to read session file ${sessionFile}; firing hook with empty messages (${String(err)})`,
-      );
-      return { sessionFile, messages: [] };
-    }
-  }
-
-  const archivedSessionFile = await findLatestArchivedTranscript(sessionFile);
-  if (!archivedSessionFile) {
     logVerbose(
-      `before_reset: failed to find archived transcript for ${sessionFile}; firing hook with empty messages`,
+      `before_reset: failed to read session messages for ${sessionId}; firing hook with empty messages (${String(err)})`,
     );
     return { sessionFile, messages: [] };
-  }
-
-  try {
-    const content = await readTranscriptForReset(archivedSessionFile);
-    if (content === null) {
-      logVerbose(
-        `before_reset: failed to read archived session file ${archivedSessionFile}; firing hook with empty messages`,
-      );
-      return { sessionFile: archivedSessionFile, messages: [] };
-    }
-    return {
-      sessionFile: archivedSessionFile,
-      messages: parseTranscriptMessages(content),
-    };
-  } catch (err: unknown) {
-    logVerbose(
-      `before_reset: failed to read archived session file ${archivedSessionFile}; firing hook with empty messages (${String(err)})`,
-    );
-    return { sessionFile: archivedSessionFile, messages: [] };
   }
 }
 
@@ -154,6 +65,7 @@ export async function emitResetCommandHooks(params: {
   sessionKey?: string;
   sessionEntry?: HandleCommandsParams["sessionEntry"];
   previousSessionEntry?: HandleCommandsParams["previousSessionEntry"];
+  storePath?: string;
   workspaceDir: string;
 }): Promise<{ routedReply: boolean }> {
   const hookEvent = createInternalHookEvent("command", params.action, params.sessionKey ?? "", {
@@ -194,16 +106,21 @@ export async function emitResetCommandHooks(params: {
   const hookRunner = getGlobalHookRunner();
   if (hookRunner?.hasHooks("before_reset")) {
     const prevEntry = params.previousSessionEntry;
+    const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
     void (async () => {
       const { sessionFile, messages } = await loadBeforeResetTranscript({
         sessionFile: prevEntry?.sessionFile,
+        sessionId: prevEntry?.sessionId,
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+        agentId,
       });
 
       try {
         await hookRunner.runBeforeReset(
           { sessionFile, messages, reason: params.action },
           {
-            agentId: resolveAgentIdFromSessionKey(params.sessionKey),
+            agentId,
             sessionKey: params.sessionKey,
             sessionId: prevEntry?.sessionId,
             workspaceDir: params.workspaceDir,

--- a/src/auto-reply/reply/commands-reset-hooks.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.ts
@@ -38,6 +38,7 @@ async function loadBeforeResetTranscript(params: {
         sessionFile,
         sessionId,
         sessionKey: params.sessionKey,
+        storePath: params.storePath,
       },
       {
         mode: "full",

--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -109,6 +109,7 @@ export async function maybeHandleResetCommand(
       sessionKey: params.sessionKey,
       sessionEntry: targetSessionEntry,
       previousSessionEntry,
+      storePath: params.storePath,
       workspaceDir: params.workspaceDir,
     });
     params.command.softResetTriggered = true;
@@ -182,6 +183,7 @@ export async function maybeHandleResetCommand(
     sessionKey: params.sessionKey,
     sessionEntry: targetSessionEntry,
     previousSessionEntry: params.previousSessionEntry,
+    storePath: params.storePath,
     workspaceDir: params.workspaceDir,
   });
   if (!resetTail) {

--- a/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
+++ b/src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts
@@ -94,4 +94,16 @@ describe("getReplyFromConfig reset-hook fallback", () => {
 
     expect(mocks.emitResetCommandHooks).not.toHaveBeenCalled();
   });
+
+  it("forwards storePath into fallback reset hook calls", async () => {
+    mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: undefined });
+
+    await getReplyFromConfig(buildNativeResetContext(), undefined, {});
+
+    expect(mocks.emitResetCommandHooks).toHaveBeenCalledTimes(1);
+    const [[hookParams]] = mocks.emitResetCommandHooks.mock.calls as unknown as Array<
+      [{ storePath?: string }]
+    >;
+    expect(hookParams.storePath).toBe("/tmp/sessions.json");
+  });
 });

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -910,6 +910,7 @@ export async function getReplyFromConfig(
       sessionKey,
       sessionEntry,
       previousSessionEntry,
+      storePath,
       workspaceDir,
     });
   };


### PR DESCRIPTION
## What Problem This Solves

`loadBeforeResetTranscript` in `src/auto-reply/reply/commands-reset-hooks.ts` reads the previous session transcript with an unbounded `fs.readFile` call. A runaway or corrupted session file could force the reset-hook path to buffer the entire file into memory, leading to OOM.

## Why This Change Was Made

The reset-hook transcript reader is now routed through the existing streaming session transcript reader (`readSessionMessagesAsync`), which already caps reads and supports archive fallback. This avoids whole-file buffering while preserving previous-session messages for `before_reset` hooks.

`storePath` is forwarded into the reader scope and by both runtime callers:
- the normal `/new`/`/reset` command handlers in `commands-reset.ts`, and
- the missed-reset-hook fallback in `get-reply.ts`.

This keeps custom-store transcript resolution consistent across both entry points.

## User Impact

Reset hooks now receive previous session messages safely even for very large transcripts, without risking process OOM, and custom store paths continue to resolve correctly on both command and fallback paths.

## Evidence

- Added regression tests that mock `readSessionMessagesAsync` and verify the reader scope (`sessionId`, `sessionFile`, `sessionKey`, `storePath`, `agentId`) and the `allowResetArchiveFallback` option.
- Added focused coverage proving `storePath` is forwarded into the reader scope for custom-store sessions.
- Added fallback-caller coverage in `get-reply.reset-hooks-fallback.test.ts` proving `storePath` reaches `emitResetCommandHooks` when inline actions return early.
- Local focused runs pass:
  - `node scripts/run-vitest.mjs src/auto-reply/reply/commands-core.test.ts --run` (6/6 tests)
  - `node scripts/run-vitest.mjs src/auto-reply/reply/commands-reset-hooks.test.ts --run` (12/12 tests)
  - `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts --run` (3/3 tests)
- `oxlint` clean on changed files.

## Real behavior proof (standalone)

I ran a standalone Node script outside Vitest that imports the actual changed helper from source and exercises the real `emitResetCommandHooks` path with a patched global hook runner and an oversized transcript.

Script: `/tmp/proof-101479.mjs` (not committed).

```text
$ node --import tsx /tmp/proof-101479.mjs
=== Oversized transcript ===
Transcript file size: 16781943 bytes (cap is 16777216 bytes)
Hook fired: true
Hook event action: reset
Hook payload messages count: 3
First payload message role: user
Last payload message role: assistant
All messages preserved: true
```

The helper streams the transcript instead of buffering it whole, and the `before_reset` hook receives the full set of previous messages.
