### PR TITLE
fix: microphone input menu collapses to a sliver in the chat composer

### DIFF
--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -111,6 +111,9 @@ describeControlUiE2e("Control UI browser Talk", () => {
       expect(menuBounds).not.toBeNull();
       expect(menuBounds?.x ?? 0).toBeGreaterThanOrEqual(8);
       expect((menuBounds?.x ?? 0) + (menuBounds?.width ?? 0)).toBeLessThanOrEqual(312);
+      // The menu must size against the composer box, not its button-sized
+      // wrapper; a collapsed menu still passed the edge checks above.
+      expect(menuBounds?.width ?? 0).toBeGreaterThanOrEqual(240);
       await page.getByRole("button", { name: "USB Audio Interface" }).click();
       await expect
         .poll(() => page.evaluate(() => document.activeElement?.getAttribute("aria-label")))

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1710,15 +1710,17 @@ openclaw-chat-page {
   background: color-mix(in srgb, var(--text) 6%, transparent);
 }
 
+/* No position: relative here — the menu must resolve its percentage width and
+   insets against .agent-chat__input (the composer box), not this button-sized
+   wrapper, or it collapses to the caret width. */
 .agent-chat__talk-input-picker {
   display: inline-flex;
-  position: relative;
 }
 
 .agent-chat__talk-input-menu {
   position: absolute;
-  inset-inline-start: 8px;
-  bottom: 52px;
+  inset-inline-end: 8px;
+  bottom: calc(100% + 8px);
   z-index: 95;
   width: min(320px, calc(100% - 16px));
   padding: 6px;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening the Talk "Microphone input" picker in the Control UI chat composer collapses the menu into a ~22px vertical sliver, with the heading and "Loading microphones…" text overflowing outside the popover. Microphone selection is unusable in that state.

## Why This Change Was Made

The composer-controls redesign (#100461) added `position: relative` to the button-sized `.agent-chat__talk-input-picker` wrapper, silently making it the containing block for the absolutely positioned menu. The menu geometry from #101100 (`width: min(320px, calc(100% - 16px))`, `inset-inline-start: 8px`, `bottom: 52px`) was designed against the full composer box, so it collapsed to the caret-button width. The menu is re-anchored to the composer box (`.agent-chat__input`) and now opens fully above the composer, right-aligned with the caret cluster it belongs to. The existing e2e geometry assertion is strengthened with a minimum-width check; the previous edge-only bounds checks passed even with a fully collapsed menu.

## User Impact

The microphone input menu renders at its intended width (320px, clamped to the composer width on narrow viewports) with readable device options in both the loading and populated states. No config, API, or behavior surface changes beyond the popover geometry.

## Evidence

- Before (current `main`): menu bounding box width is 22px at 900x640; the strengthened e2e fails (repro proof).
- After (this branch): menu bounding box width is 320px; `pnpm test ui/src/e2e/browser-talk-start-stop.e2e.test.ts` passes on Blacksmith Testbox through Crabbox (`tbx_01kwxs1hcc65w1j3zgzhtzewcg`).
- `oxfmt --check` and `oxlint` clean on both changed files (same Testbox).
- Autoreview (codex, gpt-5.5): clean, no actionable findings.
- Before/after screenshots in the PR comment below.
