### PR TITLE
fix(ios): skip onboarding for configured gateways

### DIFF
--- a/apps/ios/Sources/RootTabsNavigation.swift
+++ b/apps/ios/Sources/RootTabsNavigation.swift
@@ -243,15 +243,12 @@ extension RootTabs {
         if gatewayConnected {
             return .none
         }
-        if shouldPresentOnLaunch {
-            return .onboarding
-        }
         // Saved gateway state survives independently of the onboarding markers.
-        // Only an explicit presentation request should cover a configured app.
+        // Explicit resets bypass this route through evaluateOnboardingPresentation(force:).
         if hasExistingGatewayConfig {
             return .none
         }
-        if !hasConnectedOnce || !onboardingComplete {
+        if shouldPresentOnLaunch || !hasConnectedOnce || !onboardingComplete {
             return .onboarding
         }
         return .settings

--- a/apps/ios/Sources/RootTabsNavigation.swift
+++ b/apps/ios/Sources/RootTabsNavigation.swift
@@ -243,13 +243,18 @@ extension RootTabs {
         if gatewayConnected {
             return .none
         }
-        if shouldPresentOnLaunch || !hasConnectedOnce || !onboardingComplete {
+        if shouldPresentOnLaunch {
             return .onboarding
         }
-        if !hasExistingGatewayConfig {
-            return .settings
+        // Saved gateway state survives independently of the onboarding markers.
+        // Only an explicit presentation request should cover a configured app.
+        if hasExistingGatewayConfig {
+            return .none
         }
-        return .none
+        if !hasConnectedOnce || !onboardingComplete {
+            return .onboarding
+        }
+        return .settings
     }
 
     static func shouldPresentQuickSetup(

--- a/apps/ios/Tests/RootTabsPresentationTests.swift
+++ b/apps/ios/Tests/RootTabsPresentationTests.swift
@@ -5,26 +5,15 @@ import UIKit
 
 @MainActor
 struct RootTabsPresentationTests {
-    @Test func `configured gateway bypasses stale onboarding markers`() {
+    @Test func `configured gateway bypasses launch request and stale onboarding markers`() {
         let route = RootTabs.startupPresentationRoute(
             gatewayConnected: false,
             hasConnectedOnce: false,
             onboardingComplete: false,
             hasExistingGatewayConfig: true,
-            shouldPresentOnLaunch: false)
-
-        #expect(route == .none)
-    }
-
-    @Test func `explicit onboarding request wins over configured gateway`() {
-        let route = RootTabs.startupPresentationRoute(
-            gatewayConnected: false,
-            hasConnectedOnce: true,
-            onboardingComplete: true,
-            hasExistingGatewayConfig: true,
             shouldPresentOnLaunch: true)
 
-        #expect(route == .onboarding)
+        #expect(route == .none)
     }
 
     @Test func `fresh install presents onboarding`() {

--- a/apps/ios/Tests/RootTabsPresentationTests.swift
+++ b/apps/ios/Tests/RootTabsPresentationTests.swift
@@ -5,6 +5,50 @@ import UIKit
 
 @MainActor
 struct RootTabsPresentationTests {
+    @Test func `configured gateway bypasses stale onboarding markers`() {
+        let route = RootTabs.startupPresentationRoute(
+            gatewayConnected: false,
+            hasConnectedOnce: false,
+            onboardingComplete: false,
+            hasExistingGatewayConfig: true,
+            shouldPresentOnLaunch: false)
+
+        #expect(route == .none)
+    }
+
+    @Test func `explicit onboarding request wins over configured gateway`() {
+        let route = RootTabs.startupPresentationRoute(
+            gatewayConnected: false,
+            hasConnectedOnce: true,
+            onboardingComplete: true,
+            hasExistingGatewayConfig: true,
+            shouldPresentOnLaunch: true)
+
+        #expect(route == .onboarding)
+    }
+
+    @Test func `fresh install presents onboarding`() {
+        let route = RootTabs.startupPresentationRoute(
+            gatewayConnected: false,
+            hasConnectedOnce: false,
+            onboardingComplete: false,
+            hasExistingGatewayConfig: false,
+            shouldPresentOnLaunch: false)
+
+        #expect(route == .onboarding)
+    }
+
+    @Test func `completed setup without gateway opens settings`() {
+        let route = RootTabs.startupPresentationRoute(
+            gatewayConnected: false,
+            hasConnectedOnce: true,
+            onboardingComplete: true,
+            hasExistingGatewayConfig: false,
+            shouldPresentOnLaunch: false)
+
+        #expect(route == .settings)
+    }
+
     @Test func `quick setup does not present when gateway already configured`() {
         let shouldPresent = RootTabs.shouldPresentQuickSetup(
             quickSetupDismissed: false,


### PR DESCRIPTION
Closes #98570

## What Problem This Solves

Fixes an issue where an already-configured iOS app could reopen the full onboarding flow when older `hasConnectedOnce` or `onboardingComplete` markers were false, hiding the normal Chat, Talk, and Settings surfaces.

## Why This Change Was Made

Startup routing now treats saved gateway configuration as sufficient to open the normal app shell before consulting automatic launch and legacy completion markers. Explicit reset requests continue to bypass startup routing through the existing forced-presentation path; fresh installs still enter onboarding, and completed setups with no gateway configuration still open Gateway Settings.

## User Impact

Users with a saved or paired gateway return to the normal iOS app even when legacy onboarding markers are stale. Explicit reset/re-onboarding requests continue to work.

## Evidence

- Added focused route tests covering configured gateways with automatic launch plus stale markers, fresh installs, and completed setup without a gateway.
- Executed a five-case matrix directly from the production `startupPresentationRoute` implementation; all cases passed.
- `swiftformat --lint --config config/swiftformat apps/ios/Sources/RootTabsNavigation.swift apps/ios/Tests/RootTabsPresentationTests.swift`
- `git diff --check`
- Testbox-through-Crabbox `tbx_01kwxrzhxhd261ndhzwk6sbj4w`: `pnpm check:changed` passed.
- Fresh Codex autoreview: no accepted/actionable findings.
- Full local Xcode test execution is currently blocked before the test target by unrelated current-main SwiftFormat 0.62 drift and missing generated `SessionGroupStore` project membership; PR CI remains the platform build gate.
