### PR TITLE
fix(infra): attach error listener to detached spawn to prevent unhandled rejection crash

### DIFF
--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -53,6 +53,12 @@ function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
     detached: true,
     stdio: "inherit",
   });
+  // Attach a noop error listener before unref so async spawn failures
+  // (ENOMEM, missing executable, etc.) don't crash the parent as an
+  // unhandled 'error' event on the ChildProcess.
+  if (typeof child.on === "function") {
+    child.on("error", () => {});
+  }
   child.unref();
   return { child, pid: child.pid ?? undefined };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #101458: `spawnDetachedGatewayProcess` calls `child.unref()` without attaching an error listener. If `spawn` fails asynchronously (ENOMEM, missing executable), Node.js treats the unhandled `error` event as an uncaught exception and crashes the parent process.

## Why This Change Was Made

Added a guard-checked noop error listener (`child.on("error", () => {})`) before `child.unref()`. The `typeof child.on === "function"` guard handles test mocks that return plain objects without EventEmitter methods.

## User Impact

- Detached gateway spawn failures no longer crash the parent Node process
- The spawn failure is silently ignored (detached process is best-effort)

## Evidence

- [x] `pnpm test src/infra/process-respawn.test.ts` — 25 tests pass
- [x] `oxlint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
