### PR TITLE
fix(openrouter): bound music SSE buffering

### DIFF
--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -172,6 +172,8 @@ and also exposes `google/lyria-3-clip-preview`. OpenClaw sends `modalities:
 ["text", "audio"]`, streams the response, collects the audio chunks, and saves
 the result as generated media for channel delivery. Lyria models accept one
 reference image through the shared `music_generate image=...` parameter.
+Streaming audio, transcript retention, and the derived SSE event envelope are
+bounded by `agents.defaults.mediaMaxMb` (the default audio cap is 16 MB).
 
 ## Text-to-speech
 

--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -41,12 +41,12 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importOriginal) => {
 
 function sseResponse(
   lines: Array<string | Uint8Array>,
-  options?: { releaseLock?: () => void },
+  options?: { cancel?: () => void; releaseLock?: () => void },
 ): Response {
   const encoder = new TextEncoder();
   const encodeLine = (line: string | Uint8Array) =>
     typeof line === "string" ? encoder.encode(line) : line;
-  if (!options?.releaseLock) {
+  if (!options?.releaseLock && !options?.cancel) {
     let index = 0;
     return new Response(
       new ReadableStream({
@@ -57,6 +57,9 @@ function sseResponse(
             return;
           }
           controller.enqueue(encodeLine(line));
+        },
+        cancel() {
+          options?.cancel?.();
         },
       }),
       { status: 200, headers: { "content-type": "text/event-stream" } },
@@ -70,8 +73,8 @@ function sseResponse(
   chunks.push({ done: true, value: undefined });
   const reader = {
     read: async () => chunks.shift() ?? { done: true, value: undefined },
-    cancel: async () => undefined,
-    releaseLock: options.releaseLock,
+    cancel: async () => options?.cancel?.(),
+    releaseLock: options?.releaseLock ?? (() => {}),
   } as ReadableStreamDefaultReader<Uint8Array>;
 
   return {
@@ -172,8 +175,8 @@ describe("openrouter music generation provider", () => {
     postJsonRequestMock.mockResolvedValue({
       response: sseResponse([
         `data: ${JSON.stringify({ choices: [{ delta: { audio: { transcript: "line " } } }] })}\n`,
-        `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: audioBase64.slice(0, 4) } } }] })}\n`,
-        `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: audioBase64.slice(4), transcript: "two" } } }] })}\n`,
+        `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: audioBase64.slice(0, 5) } } }] })}\n`,
+        `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: audioBase64.slice(5), transcript: "two" } } }] })}\n`,
         "data: [DONE]\n",
       ]),
       release,
@@ -361,9 +364,58 @@ describe("openrouter music generation provider", () => {
     ).rejects.toThrow("OpenRouter music generation stream ended before completion");
   });
 
-  it("rejects OpenRouter music SSE events that never delimit a line", async () => {
+  it("surfaces and cancels OpenRouter mid-stream errors", async () => {
+    const cancel = vi.fn();
     postJsonRequestMock.mockResolvedValue({
-      response: sseResponse([new Uint8Array(2 * 1024 * 1024 + 1)]),
+      response: sseResponse(
+        [
+          `data: ${JSON.stringify({
+            error: { code: "provider_error", message: "provider disconnected" },
+            choices: [{ delta: {}, finish_reason: "error" }],
+          })}\n`,
+        ],
+        { cancel },
+      ),
+      release: vi.fn(async () => {}),
+    });
+
+    await expect(
+      buildOpenRouterMusicGenerationProvider().generateMusic({
+        provider: "openrouter",
+        model: "google/lyria-3-clip-preview",
+        prompt: "surface provider failure",
+        cfg: {},
+      }),
+    ).rejects.toThrow("OpenRouter music generation failed: provider disconnected");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("accepts valid SSE events above the old fixed two-megabyte cap", async () => {
+    const audio = Buffer.alloc(1_600_000, 0x61);
+    postJsonRequestMock.mockResolvedValue({
+      response: sseResponse([
+        `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: audio.toString("base64") } } }] })}\n`,
+        "data: [DONE]\n",
+      ]),
+      release: vi.fn(async () => {}),
+    });
+
+    const result = await buildOpenRouterMusicGenerationProvider().generateMusic({
+      provider: "openrouter",
+      model: "google/lyria-3-clip-preview",
+      prompt: "large valid audio event",
+      cfg: { agents: { defaults: { mediaMaxMb: 2 } } },
+    });
+
+    expect(result.tracks[0]?.buffer).toEqual(audio);
+  });
+
+  it("rejects OpenRouter music SSE events outside the configured media envelope", async () => {
+    const maxBytes = 8;
+    const maxEventBytes = Math.ceil(maxBytes / 3) * 4 + maxBytes + 64 * 1024;
+    const cancel = vi.fn();
+    postJsonRequestMock.mockResolvedValue({
+      response: sseResponse([new Uint8Array(maxEventBytes + 1)], { cancel }),
       release: vi.fn(async () => {}),
     });
 
@@ -372,16 +424,27 @@ describe("openrouter music generation provider", () => {
         provider: "openrouter",
         model: "google/lyria-3-clip-preview",
         prompt: "unterminated event",
-        cfg: {},
+        cfg: { agents: { defaults: { mediaMaxMb: maxBytes / (1024 * 1024) } } },
       }),
-    ).rejects.toThrow("OpenRouter music generation SSE event exceeded 2097152 bytes");
+    ).rejects.toThrow(
+      `OpenRouter music generation SSE event exceeded ${maxEventBytes} bytes for a ${maxBytes}-byte media limit`,
+    );
+    expect(cancel).toHaveBeenCalledOnce();
   });
 
-  it("rejects oversized OpenRouter music audio chunks", async () => {
-    const oneMbAudioLine = `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: Buffer.alloc(1024 * 1024).toString("base64") } } }] })}\n`;
+  it.each([
+    {
+      label: "audio",
+      delta: { audio: { data: Buffer.from("123456789").toString("base64") } },
+    },
+    {
+      label: "transcript",
+      delta: { audio: { transcript: "123456789" } },
+    },
+  ])("rejects $label beyond agents.defaults.mediaMaxMb", async ({ label, delta }) => {
     postJsonRequestMock.mockResolvedValue({
       response: sseResponse([
-        ...Array.from({ length: 65 }, () => oneMbAudioLine),
+        `data: ${JSON.stringify({ choices: [{ delta }] })}\n`,
         "data: [DONE]\n",
       ]),
       release: vi.fn(async () => {}),
@@ -391,28 +454,9 @@ describe("openrouter music generation provider", () => {
       buildOpenRouterMusicGenerationProvider().generateMusic({
         provider: "openrouter",
         model: "google/lyria-3-clip-preview",
-        prompt: "oversized audio",
-        cfg: {},
+        prompt: `oversized ${label}`,
+        cfg: { agents: { defaults: { mediaMaxMb: 8 / (1024 * 1024) } } },
       }),
-    ).rejects.toThrow("OpenRouter music generation audio exceeded 67108864 bytes");
-  });
-
-  it("rejects oversized OpenRouter music transcripts", async () => {
-    postJsonRequestMock.mockResolvedValue({
-      response: sseResponse([
-        `data: ${JSON.stringify({ choices: [{ delta: { audio: { transcript: "x".repeat(1024 * 1024 + 1) } } }] })}\n`,
-        "data: [DONE]\n",
-      ]),
-      release: vi.fn(async () => {}),
-    });
-
-    await expect(
-      buildOpenRouterMusicGenerationProvider().generateMusic({
-        provider: "openrouter",
-        model: "google/lyria-3-clip-preview",
-        prompt: "oversized transcript",
-        cfg: {},
-      }),
-    ).rejects.toThrow("OpenRouter music generation transcript exceeded 1048576 bytes");
+    ).rejects.toThrow(`OpenRouter music generation ${label} exceeded 8 bytes`);
   });
 });

--- a/extensions/openrouter/music-generation-provider.test.ts
+++ b/extensions/openrouter/music-generation-provider.test.ts
@@ -39,16 +39,24 @@ vi.mock("openclaw/plugin-sdk/provider-http", async (importOriginal) => {
   };
 });
 
-function sseResponse(lines: string[], options?: { releaseLock?: () => void }): Response {
+function sseResponse(
+  lines: Array<string | Uint8Array>,
+  options?: { releaseLock?: () => void },
+): Response {
   const encoder = new TextEncoder();
+  const encodeLine = (line: string | Uint8Array) =>
+    typeof line === "string" ? encoder.encode(line) : line;
   if (!options?.releaseLock) {
+    let index = 0;
     return new Response(
       new ReadableStream({
-        start(controller) {
-          for (const line of lines) {
-            controller.enqueue(encoder.encode(line));
+        pull(controller) {
+          const line = lines[index++];
+          if (line === undefined) {
+            controller.close();
+            return;
           }
-          controller.close();
+          controller.enqueue(encodeLine(line));
         },
       }),
       { status: 200, headers: { "content-type": "text/event-stream" } },
@@ -57,7 +65,7 @@ function sseResponse(lines: string[], options?: { releaseLock?: () => void }): R
 
   const chunks: Array<ReadableStreamReadResult<Uint8Array>> = lines.map((line) => ({
     done: false,
-    value: encoder.encode(line),
+    value: encodeLine(line),
   }));
   chunks.push({ done: true, value: undefined });
   const reader = {
@@ -351,5 +359,60 @@ describe("openrouter music generation provider", () => {
         cfg: {},
       }),
     ).rejects.toThrow("OpenRouter music generation stream ended before completion");
+  });
+
+  it("rejects OpenRouter music SSE events that never delimit a line", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: sseResponse([new Uint8Array(2 * 1024 * 1024 + 1)]),
+      release: vi.fn(async () => {}),
+    });
+
+    await expect(
+      buildOpenRouterMusicGenerationProvider().generateMusic({
+        provider: "openrouter",
+        model: "google/lyria-3-clip-preview",
+        prompt: "unterminated event",
+        cfg: {},
+      }),
+    ).rejects.toThrow("OpenRouter music generation SSE event exceeded 2097152 bytes");
+  });
+
+  it("rejects oversized OpenRouter music audio chunks", async () => {
+    const oneMbAudioLine = `data: ${JSON.stringify({ choices: [{ delta: { audio: { data: Buffer.alloc(1024 * 1024).toString("base64") } } }] })}\n`;
+    postJsonRequestMock.mockResolvedValue({
+      response: sseResponse([
+        ...Array.from({ length: 65 }, () => oneMbAudioLine),
+        "data: [DONE]\n",
+      ]),
+      release: vi.fn(async () => {}),
+    });
+
+    await expect(
+      buildOpenRouterMusicGenerationProvider().generateMusic({
+        provider: "openrouter",
+        model: "google/lyria-3-clip-preview",
+        prompt: "oversized audio",
+        cfg: {},
+      }),
+    ).rejects.toThrow("OpenRouter music generation audio exceeded 67108864 bytes");
+  });
+
+  it("rejects oversized OpenRouter music transcripts", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: sseResponse([
+        `data: ${JSON.stringify({ choices: [{ delta: { audio: { transcript: "x".repeat(1024 * 1024 + 1) } } }] })}\n`,
+        "data: [DONE]\n",
+      ]),
+      release: vi.fn(async () => {}),
+    });
+
+    await expect(
+      buildOpenRouterMusicGenerationProvider().generateMusic({
+        provider: "openrouter",
+        model: "google/lyria-3-clip-preview",
+        prompt: "oversized transcript",
+        cfg: {},
+      }),
+    ).rejects.toThrow("OpenRouter music generation transcript exceeded 1048576 bytes");
   });
 });

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -1,5 +1,6 @@
 // Openrouter provider module implements model/runtime integration.
 import { toImageDataUrl } from "openclaw/plugin-sdk/image-generation";
+import { maxBytesForKind } from "openclaw/plugin-sdk/media-runtime";
 import type {
   MusicGenerationProvider,
   MusicGenerationRequest,
@@ -22,9 +23,8 @@ import { OPENROUTER_BASE_URL } from "./provider-catalog.js";
 const DEFAULT_OPENROUTER_MUSIC_MODEL = "google/lyria-3-pro-preview";
 const OPENROUTER_CLIP_MUSIC_MODEL = "google/lyria-3-clip-preview";
 const DEFAULT_TIMEOUT_MS = 180_000;
-const OPENROUTER_MUSIC_SSE_PENDING_MAX_BYTES = 2 * 1024 * 1024;
-const OPENROUTER_MUSIC_AUDIO_MAX_BYTES = 64 * 1024 * 1024;
-const OPENROUTER_MUSIC_TRANSCRIPT_MAX_BYTES = 1024 * 1024;
+const MB = 1024 * 1024;
+const OPENROUTER_SSE_ENVELOPE_OVERHEAD_BYTES = 64 * 1024;
 const OPENROUTER_MUSIC_MODELS = [
   DEFAULT_OPENROUTER_MUSIC_MODEL,
   OPENROUTER_CLIP_MUSIC_MODEL,
@@ -33,6 +33,15 @@ const OPENROUTER_MUSIC_MODELS = [
 type OpenRouterAudioStreamResult = {
   audioBuffer: Buffer;
   transcript: string;
+};
+
+type OpenRouterAudioStreamAccumulator = {
+  audioBuffers: Buffer[];
+  audioBytes: number;
+  audioBase64Remainder: string;
+  transcriptChunks: string[];
+  transcriptBytes: number;
+  maxBytes: number;
 };
 
 function resolveOpenRouterMusicModel(model: string | undefined): string {
@@ -115,44 +124,77 @@ function readDeltaAudio(part: unknown): { data?: string; transcript?: string } |
   };
 }
 
-function appendOpenRouterMusicAudio(
-  result: { audioBuffers: Buffer[]; audioBytes: number },
-  data: string,
+function resolveGeneratedMusicMaxBytes(req: MusicGenerationRequest): number {
+  const configured = req.cfg.agents?.defaults?.mediaMaxMb;
+  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured * MB);
+  }
+  return maxBytesForKind("audio");
+}
+
+function resolveOpenRouterSseEventMaxBytes(maxBytes: number): number {
+  const maxBase64Bytes = Math.ceil(maxBytes / 3) * 4;
+  return maxBase64Bytes + maxBytes + OPENROUTER_SSE_ENVELOPE_OVERHEAD_BYTES;
+}
+
+function createOpenRouterMusicTooLargeError(kind: "audio" | "transcript", maxBytes: number) {
+  return new Error(`OpenRouter music generation ${kind} exceeded ${maxBytes} bytes`);
+}
+
+function appendDecodedOpenRouterMusicAudio(
+  result: OpenRouterAudioStreamAccumulator,
+  base64: string,
 ): void {
-  const buffer = Buffer.from(data, "base64");
+  if (!base64) {
+    return;
+  }
+  const decodedBytes = Buffer.byteLength(base64, "base64");
+  if (decodedBytes > result.maxBytes - result.audioBytes) {
+    throw createOpenRouterMusicTooLargeError("audio", result.maxBytes);
+  }
+  const buffer = Buffer.from(base64, "base64");
   const nextBytes = result.audioBytes + buffer.byteLength;
-  if (nextBytes > OPENROUTER_MUSIC_AUDIO_MAX_BYTES) {
-    throw new Error(
-      `OpenRouter music generation audio exceeded ${OPENROUTER_MUSIC_AUDIO_MAX_BYTES} bytes`,
-    );
+  if (nextBytes > result.maxBytes) {
+    throw createOpenRouterMusicTooLargeError("audio", result.maxBytes);
   }
   result.audioBytes = nextBytes;
   result.audioBuffers.push(buffer);
 }
 
+function appendOpenRouterMusicAudio(result: OpenRouterAudioStreamAccumulator, data: string): void {
+  // OpenRouter defines delta.audio.data as slices of one base64 stream. Keep
+  // only the incomplete quartet so arbitrary provider chunk boundaries decode safely.
+  const combined = result.audioBase64Remainder + data;
+  const completeLength = combined.length - (combined.length % 4);
+  result.audioBase64Remainder = combined.slice(completeLength);
+  appendDecodedOpenRouterMusicAudio(result, combined.slice(0, completeLength));
+}
+
+function flushOpenRouterMusicAudio(result: OpenRouterAudioStreamAccumulator): void {
+  appendDecodedOpenRouterMusicAudio(result, result.audioBase64Remainder);
+  result.audioBase64Remainder = "";
+}
+
 function appendOpenRouterMusicTranscript(
-  result: { transcriptChunks: string[]; transcriptBytes: number },
+  result: OpenRouterAudioStreamAccumulator,
   transcript: string,
 ): void {
   const nextBytes = result.transcriptBytes + Buffer.byteLength(transcript, "utf8");
-  if (nextBytes > OPENROUTER_MUSIC_TRANSCRIPT_MAX_BYTES) {
-    throw new Error(
-      `OpenRouter music generation transcript exceeded ${OPENROUTER_MUSIC_TRANSCRIPT_MAX_BYTES} bytes`,
-    );
+  if (nextBytes > result.maxBytes) {
+    throw createOpenRouterMusicTooLargeError("transcript", result.maxBytes);
   }
   result.transcriptBytes = nextBytes;
   result.transcriptChunks.push(transcript);
 }
 
-function processOpenRouterSseLine(
-  line: string,
-  result: {
-    audioBuffers: Buffer[];
-    audioBytes: number;
-    transcriptChunks: string[];
-    transcriptBytes: number;
-  },
-): boolean {
+function readOpenRouterStreamError(part: unknown): string | undefined {
+  if (!isRecord(part) || !isRecord(part.error)) {
+    return undefined;
+  }
+  return normalizeOptionalString(part.error.message) ?? "unknown provider stream error";
+}
+
+function processOpenRouterSseLine(line: string, result: OpenRouterAudioStreamAccumulator): boolean {
   if (!line.startsWith("data:")) {
     return false;
   }
@@ -163,7 +205,12 @@ function processOpenRouterSseLine(
   if (data === "[DONE]") {
     return true;
   }
-  const audio = readDeltaAudio(JSON.parse(data));
+  const payload: unknown = JSON.parse(data);
+  const streamError = readOpenRouterStreamError(payload);
+  if (streamError) {
+    throw new Error(`OpenRouter music generation failed: ${streamError}`);
+  }
+  const audio = readDeltaAudio(payload);
   if (audio?.data) {
     appendOpenRouterMusicAudio(result, audio.data);
   }
@@ -208,6 +255,7 @@ async function readOpenRouterStreamChunk(
 async function readOpenRouterAudioStream(
   response: Response,
   deadline: ProviderOperationDeadline,
+  maxBytes: number,
 ): Promise<OpenRouterAudioStreamResult> {
   if (!response.body) {
     throw new Error("OpenRouter music generation response missing stream body");
@@ -217,9 +265,12 @@ async function readOpenRouterAudioStream(
   const result = {
     audioBuffers: [] as Buffer[],
     audioBytes: 0,
+    audioBase64Remainder: "",
     transcriptChunks: [] as string[],
     transcriptBytes: 0,
+    maxBytes,
   };
+  const maxEventBytes = resolveOpenRouterSseEventMaxBytes(maxBytes);
   let buffer = "";
   let pendingBytes = 0;
   let doneSeen = false;
@@ -231,9 +282,9 @@ async function readOpenRouterAudioStream(
       }
       for (const byte of value) {
         pendingBytes = byte === 0x0a ? 0 : pendingBytes + 1;
-        if (pendingBytes > OPENROUTER_MUSIC_SSE_PENDING_MAX_BYTES) {
+        if (pendingBytes > maxEventBytes) {
           throw new Error(
-            `OpenRouter music generation SSE event exceeded ${OPENROUTER_MUSIC_SSE_PENDING_MAX_BYTES} bytes`,
+            `OpenRouter music generation SSE event exceeded ${maxEventBytes} bytes for a ${maxBytes}-byte media limit`,
           );
         }
       }
@@ -242,9 +293,10 @@ async function readOpenRouterAudioStream(
       buffer = lines.pop() ?? "";
       for (const line of lines) {
         if (processOpenRouterSseLine(line.trim(), result)) {
+          flushOpenRouterMusicAudio(result);
           await reader.cancel();
           return {
-            audioBuffer: Buffer.concat(result.audioBuffers),
+            audioBuffer: Buffer.concat(result.audioBuffers, result.audioBytes),
             transcript: result.transcriptChunks.join(""),
           };
         }
@@ -253,9 +305,9 @@ async function readOpenRouterAudioStream(
     resolveOpenRouterStreamRemainingMs(deadline);
     buffer += decoder.decode();
     pendingBytes = Buffer.byteLength(buffer, "utf8");
-    if (pendingBytes > OPENROUTER_MUSIC_SSE_PENDING_MAX_BYTES) {
+    if (pendingBytes > maxEventBytes) {
       throw new Error(
-        `OpenRouter music generation SSE event exceeded ${OPENROUTER_MUSIC_SSE_PENDING_MAX_BYTES} bytes`,
+        `OpenRouter music generation SSE event exceeded ${maxEventBytes} bytes for a ${maxBytes}-byte media limit`,
       );
     }
     if (buffer.trim()) {
@@ -268,8 +320,9 @@ async function readOpenRouterAudioStream(
     if (!doneSeen) {
       throw new Error("OpenRouter music generation stream ended before completion");
     }
+    flushOpenRouterMusicAudio(result);
     return {
-      audioBuffer: Buffer.concat(result.audioBuffers),
+      audioBuffer: Buffer.concat(result.audioBuffers, result.audioBytes),
       transcript: result.transcriptChunks.join(""),
     };
   } catch (error) {
@@ -370,7 +423,11 @@ export function buildOpenRouterMusicGenerationProvider(): MusicGenerationProvide
 
       try {
         await assertOkOrThrowHttpError(response, "OpenRouter music generation failed");
-        const streamResult = await readOpenRouterAudioStream(response, streamDeadline);
+        const streamResult = await readOpenRouterAudioStream(
+          response,
+          streamDeadline,
+          resolveGeneratedMusicMaxBytes(req),
+        );
         if (streamResult.audioBuffer.byteLength === 0) {
           throw new Error("OpenRouter music generation response missing audio data");
         }

--- a/extensions/openrouter/music-generation-provider.ts
+++ b/extensions/openrouter/music-generation-provider.ts
@@ -22,6 +22,9 @@ import { OPENROUTER_BASE_URL } from "./provider-catalog.js";
 const DEFAULT_OPENROUTER_MUSIC_MODEL = "google/lyria-3-pro-preview";
 const OPENROUTER_CLIP_MUSIC_MODEL = "google/lyria-3-clip-preview";
 const DEFAULT_TIMEOUT_MS = 180_000;
+const OPENROUTER_MUSIC_SSE_PENDING_MAX_BYTES = 2 * 1024 * 1024;
+const OPENROUTER_MUSIC_AUDIO_MAX_BYTES = 64 * 1024 * 1024;
+const OPENROUTER_MUSIC_TRANSCRIPT_MAX_BYTES = 1024 * 1024;
 const OPENROUTER_MUSIC_MODELS = [
   DEFAULT_OPENROUTER_MUSIC_MODEL,
   OPENROUTER_CLIP_MUSIC_MODEL,
@@ -112,9 +115,43 @@ function readDeltaAudio(part: unknown): { data?: string; transcript?: string } |
   };
 }
 
+function appendOpenRouterMusicAudio(
+  result: { audioBuffers: Buffer[]; audioBytes: number },
+  data: string,
+): void {
+  const buffer = Buffer.from(data, "base64");
+  const nextBytes = result.audioBytes + buffer.byteLength;
+  if (nextBytes > OPENROUTER_MUSIC_AUDIO_MAX_BYTES) {
+    throw new Error(
+      `OpenRouter music generation audio exceeded ${OPENROUTER_MUSIC_AUDIO_MAX_BYTES} bytes`,
+    );
+  }
+  result.audioBytes = nextBytes;
+  result.audioBuffers.push(buffer);
+}
+
+function appendOpenRouterMusicTranscript(
+  result: { transcriptChunks: string[]; transcriptBytes: number },
+  transcript: string,
+): void {
+  const nextBytes = result.transcriptBytes + Buffer.byteLength(transcript, "utf8");
+  if (nextBytes > OPENROUTER_MUSIC_TRANSCRIPT_MAX_BYTES) {
+    throw new Error(
+      `OpenRouter music generation transcript exceeded ${OPENROUTER_MUSIC_TRANSCRIPT_MAX_BYTES} bytes`,
+    );
+  }
+  result.transcriptBytes = nextBytes;
+  result.transcriptChunks.push(transcript);
+}
+
 function processOpenRouterSseLine(
   line: string,
-  result: { audioBuffers: Buffer[]; transcriptChunks: string[] },
+  result: {
+    audioBuffers: Buffer[];
+    audioBytes: number;
+    transcriptChunks: string[];
+    transcriptBytes: number;
+  },
 ): boolean {
   if (!line.startsWith("data:")) {
     return false;
@@ -128,10 +165,10 @@ function processOpenRouterSseLine(
   }
   const audio = readDeltaAudio(JSON.parse(data));
   if (audio?.data) {
-    result.audioBuffers.push(Buffer.from(audio.data, "base64"));
+    appendOpenRouterMusicAudio(result, audio.data);
   }
   if (audio?.transcript) {
-    result.transcriptChunks.push(audio.transcript);
+    appendOpenRouterMusicTranscript(result, audio.transcript);
   }
   return false;
 }
@@ -177,14 +214,28 @@ async function readOpenRouterAudioStream(
   }
   const reader = response.body.getReader();
   const decoder = new TextDecoder();
-  const result = { audioBuffers: [] as Buffer[], transcriptChunks: [] as string[] };
+  const result = {
+    audioBuffers: [] as Buffer[],
+    audioBytes: 0,
+    transcriptChunks: [] as string[],
+    transcriptBytes: 0,
+  };
   let buffer = "";
+  let pendingBytes = 0;
   let doneSeen = false;
   try {
     for (;;) {
       const { value, done } = await readOpenRouterStreamChunk(reader, deadline);
       if (done) {
         break;
+      }
+      for (const byte of value) {
+        pendingBytes = byte === 0x0a ? 0 : pendingBytes + 1;
+        if (pendingBytes > OPENROUTER_MUSIC_SSE_PENDING_MAX_BYTES) {
+          throw new Error(
+            `OpenRouter music generation SSE event exceeded ${OPENROUTER_MUSIC_SSE_PENDING_MAX_BYTES} bytes`,
+          );
+        }
       }
       buffer += decoder.decode(value, { stream: true });
       const lines = buffer.split(/\r?\n/u);
@@ -201,6 +252,12 @@ async function readOpenRouterAudioStream(
     }
     resolveOpenRouterStreamRemainingMs(deadline);
     buffer += decoder.decode();
+    pendingBytes = Buffer.byteLength(buffer, "utf8");
+    if (pendingBytes > OPENROUTER_MUSIC_SSE_PENDING_MAX_BYTES) {
+      throw new Error(
+        `OpenRouter music generation SSE event exceeded ${OPENROUTER_MUSIC_SSE_PENDING_MAX_BYTES} bytes`,
+      );
+    }
     if (buffer.trim()) {
       for (const line of buffer.split(/\r?\n/u)) {
         if (processOpenRouterSseLine(line.trim(), result)) {
@@ -215,6 +272,9 @@ async function readOpenRouterAudioStream(
       audioBuffer: Buffer.concat(result.audioBuffers),
       transcript: result.transcriptChunks.join(""),
     };
+  } catch (error) {
+    await reader.cancel().catch(() => {});
+    throw error;
   } finally {
     try {
       reader.releaseLock();


### PR DESCRIPTION
## What Problem This Solves

OpenRouter music generation accepted an untrusted SSE response into three unbounded accumulators: the pending event text, decoded audio, and transcript. A malformed or oversized provider stream could therefore retain memory until timeout or process exhaustion.

## Why This Change Was Made

This revision keeps one product limit instead of introducing provider-local fixed caps:

- Audio and transcript accumulation are bounded by `agents.defaults.mediaMaxMb`, falling back to OpenClaw's existing audio-media limit.
- The maximum SSE event size is derived from that same media budget: base64 expansion, a same-sized transcript, and a small JSON-envelope allowance.
- Audio base64 is decoded incrementally while carrying only an incomplete quartet, matching OpenRouter's streamed-audio contract without retaining the encoded track.
- Provider errors delivered inside an otherwise successful SSE response are surfaced immediately.
- Completion, timeout, malformed data, over-limit data, and provider errors all cancel/release the stream reader and preserve the shared operation deadline.

This is a bounded refactor of the existing provider path. It adds no config, fallback path, or SDK surface.

## User Impact

Normal OpenRouter music responses still produce the same MP3/WAV track and optional transcript. Oversized or malformed streams now fail deterministically with an OpenRouter music error, using the operator's existing media-size policy.

## Evidence

- Blacksmith Testbox `tbx_01kx47gy814mtyk5njftr2dvvz`: 13/13 focused provider tests passed.
- Broad `pnpm check:changed` passed the relevant extension/docs, tsgo, lint, guard, and import-cycle lanes.
- Touched-file formatting and `git diff --check` passed.
- Fresh autoreview found no accepted/actionable findings (confidence 0.84).
- Existing real-provider proof on the contributor head completed `google/lyria-3-pro-preview` and returned a 601,040-byte MP3 through this reader: https://github.com/openclaw/openclaw/pull/101488#issuecomment-4912411421
- A prepared-head rerun was attempted. The approved scoped OpenRouter credential source and local auth profile contained no usable key, so no second live call was possible without inventing credentials; this is the only remaining proof gap.

Regression coverage includes configured/default media budgets, split base64 quartets, oversized events/audio/transcripts, provider-side stream errors, incomplete completion, reader cancellation/release, and timeout clamping.
