### PR TITLE
fix(infra): handle detached respawn child errors

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -408,6 +408,8 @@ describe("respawnGatewayProcessForUpdate", () => {
     expect(result.mode).toBe("spawned");
     expect(result.child).toBe(child);
     expect(child.on).toHaveBeenCalledWith("error", expect.any(Function));
+    const errorListener = child.on.mock.calls.find(([event]) => event === "error")?.[1];
+    expect(() => errorListener?.(new Error("spawn ENOENT"))).not.toThrow();
     expect(child.unref).toHaveBeenCalledOnce();
     const onCallOrder = child.on.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY;
     const unrefCallOrder = child.unref.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY;

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -395,7 +395,7 @@ describe("respawnGatewayProcessForUpdate", () => {
     );
   });
 
-  it("handles asynchronous detached child errors before unref", () => {
+  it("registers a no-op detached child error listener before unref", () => {
     clearSupervisorHints();
     setPlatform("linux");
     process.execArgv = [];

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -54,6 +54,15 @@ function clearSupervisorHints() {
   }
 }
 
+function mockDetachedChild(pid: number) {
+  return {
+    pid,
+    kill: vi.fn(),
+    on: vi.fn(),
+    unref: vi.fn(),
+  };
+}
+
 function expectLaunchdSupervisedWithoutKickstart(params?: { launchJobLabel?: string }) {
   setPlatform("darwin");
   if (params?.launchJobLabel) {
@@ -302,7 +311,7 @@ describe("respawnGatewayProcessForUpdate", () => {
       "gateway",
       "run",
     ];
-    spawnMock.mockReturnValue({ pid: 5151, unref: vi.fn(), kill: vi.fn() });
+    spawnMock.mockReturnValue(mockDetachedChild(5151));
 
     const result = respawnGatewayProcessForUpdate();
 
@@ -329,7 +338,7 @@ describe("respawnGatewayProcessForUpdate", () => {
       "gateway",
       "run",
     ];
-    spawnMock.mockReturnValue({ pid: 7171, unref: vi.fn(), kill: vi.fn() });
+    spawnMock.mockReturnValue(mockDetachedChild(7171));
 
     const result = respawnGatewayProcessForUpdate();
 
@@ -352,7 +361,7 @@ describe("respawnGatewayProcessForUpdate", () => {
     const entry =
       "/app/node_modules/.pnpm/@anthropic+sdk@1.0.0/node_modules/@anthropic/sdk/dist/index.js";
     process.argv = ["/usr/local/bin/node", entry, "gateway", "run"];
-    spawnMock.mockReturnValue({ pid: 8181, unref: vi.fn(), kill: vi.fn() });
+    spawnMock.mockReturnValue(mockDetachedChild(8181));
 
     respawnGatewayProcessForUpdate();
 
@@ -369,7 +378,7 @@ describe("respawnGatewayProcessForUpdate", () => {
     process.env.XPC_SERVICE_NAME = "ai.openclaw.mac";
     process.execArgv = [];
     process.argv = ["/usr/local/bin/node", "/repo/dist/index.js", "gateway", "run"];
-    spawnMock.mockReturnValue({ pid: 6161, unref: vi.fn(), kill: vi.fn() });
+    spawnMock.mockReturnValue(mockDetachedChild(6161));
 
     const result = respawnGatewayProcessForUpdate();
 
@@ -384,6 +393,25 @@ describe("respawnGatewayProcessForUpdate", () => {
         stdio: "inherit",
       },
     );
+  });
+
+  it("handles asynchronous detached child errors before unref", () => {
+    clearSupervisorHints();
+    setPlatform("linux");
+    process.execArgv = [];
+    process.argv = ["/usr/local/bin/node", "/repo/dist/index.js", "gateway", "run"];
+    const child = mockDetachedChild(9191);
+    spawnMock.mockReturnValue(child);
+
+    const result = respawnGatewayProcessForUpdate();
+
+    expect(result.mode).toBe("spawned");
+    expect(result.child).toBe(child);
+    expect(child.on).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(child.unref).toHaveBeenCalledOnce();
+    const onCallOrder = child.on.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY;
+    const unrefCallOrder = child.unref.mock.invocationCallOrder[0] ?? Number.NEGATIVE_INFINITY;
+    expect(onCallOrder).toBeLessThan(unrefCallOrder);
   });
 
   it("exits to a managed supervisor for updates even when respawn is disabled", () => {

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -53,6 +53,8 @@ function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
     detached: true,
     stdio: "inherit",
   });
+  // Detached spawn failures can arrive asynchronously after spawn() returns.
+  // Keep this listener before unref() so the parent does not crash during handoff.
   child.on("error", () => {});
   child.unref();
   return { child, pid: child.pid ?? undefined };

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -53,6 +53,7 @@ function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
     detached: true,
     stdio: "inherit",
   });
+  child.on("error", () => {});
   child.unref();
   return { child, pid: child.pid ?? undefined };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #101458. Detached gateway update respawns can emit an asynchronous ChildProcess `error` after `spawn()` returns; without a listener, Node treats that as unhandled and crashes the current process.

## Why This Change Was Made

The detached respawn path now attaches a best-effort `error` listener before `unref()`, matching the existing restart-helper pattern. The update handoff still returns the child/pid when spawn succeeds, and synchronous spawn failures still flow through the existing failed result.

## User Impact

Users hitting a missing or invalid executable during detached update respawn no longer get an extra uncaught child-process error on the parent process.

## Evidence

- `npx -y node@24.18.0` real ChildProcess probe with a missing detached executable:

```text
## without-listener
node=v24.18.0
exit=1 signal=none
stdout=""
stderr-summary=["      throw er; // Unhandled 'error' event","Error: spawn /tmp/openclaw-missing-detached-gateway-1957 ENOENT","  code: 'ENOENT',"]
## with-listener
node=v24.18.0
exit=0 signal=none
stdout="handled child error: ENOENT\nparent still alive"
stderr-summary=[]
```

- `node scripts/run-vitest.mjs src/infra/process-respawn.test.ts`
- `git diff --check`
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm check:changed -- src/infra/process-respawn.ts src/infra/process-respawn.test.ts`
