### PR TITLE
fix(infra): register no-op error handler on detached gateway spawn child

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -302,7 +302,7 @@ describe("respawnGatewayProcessForUpdate", () => {
       "gateway",
       "run",
     ];
-    spawnMock.mockReturnValue({ pid: 5151, unref: vi.fn(), kill: vi.fn() });
+    spawnMock.mockReturnValue({ pid: 5151, unref: vi.fn(), kill: vi.fn(), on: vi.fn() });
 
     const result = respawnGatewayProcessForUpdate();
 
@@ -329,7 +329,7 @@ describe("respawnGatewayProcessForUpdate", () => {
       "gateway",
       "run",
     ];
-    spawnMock.mockReturnValue({ pid: 7171, unref: vi.fn(), kill: vi.fn() });
+    spawnMock.mockReturnValue({ pid: 7171, unref: vi.fn(), kill: vi.fn(), on: vi.fn() });
 
     const result = respawnGatewayProcessForUpdate();
 
@@ -352,7 +352,7 @@ describe("respawnGatewayProcessForUpdate", () => {
     const entry =
       "/app/node_modules/.pnpm/@anthropic+sdk@1.0.0/node_modules/@anthropic/sdk/dist/index.js";
     process.argv = ["/usr/local/bin/node", entry, "gateway", "run"];
-    spawnMock.mockReturnValue({ pid: 8181, unref: vi.fn(), kill: vi.fn() });
+    spawnMock.mockReturnValue({ pid: 8181, unref: vi.fn(), kill: vi.fn(), on: vi.fn() });
 
     respawnGatewayProcessForUpdate();
 
@@ -369,7 +369,7 @@ describe("respawnGatewayProcessForUpdate", () => {
     process.env.XPC_SERVICE_NAME = "ai.openclaw.mac";
     process.execArgv = [];
     process.argv = ["/usr/local/bin/node", "/repo/dist/index.js", "gateway", "run"];
-    spawnMock.mockReturnValue({ pid: 6161, unref: vi.fn(), kill: vi.fn() });
+    spawnMock.mockReturnValue({ pid: 6161, unref: vi.fn(), kill: vi.fn(), on: vi.fn() });
 
     const result = respawnGatewayProcessForUpdate();
 
@@ -412,5 +412,28 @@ describe("respawnGatewayProcessForUpdate", () => {
 
     expect(result.mode).toBe("failed");
     expect(result.detail).toContain("spawn failed");
+  });
+
+  it("registers a no-op error listener on the detached child to prevent unhandled async errors", () => {
+    delete process.env.OPENCLAW_NO_RESPAWN;
+    clearSupervisorHints();
+    setPlatform("linux");
+
+    const onMock = vi.fn();
+    spawnMock.mockReturnValue({
+      pid: 9091,
+      unref: vi.fn(),
+      kill: vi.fn(),
+      on: onMock,
+    });
+
+    const result = respawnGatewayProcessForUpdate();
+
+    expect(result.mode).toBe("spawned");
+    expect(onMock).toHaveBeenCalledWith("error", expect.any(Function));
+
+    const errorHandler = onMock.mock.calls[0]?.[1] as (...args: unknown[]) => void;
+    expect(() => errorHandler(new Error("ENOMEM"))).not.toThrow();
+    expect(() => errorHandler(new Error("spawn EBADF"))).not.toThrow();
   });
 });

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -53,6 +53,7 @@ function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
     detached: true,
     stdio: "inherit",
   });
+  child.on("error", () => {});
   child.unref();
   return { child, pid: child.pid ?? undefined };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #101458 — In `spawnDetachedGatewayProcess`, the `child_process.spawn()` call creates a detached child process and immediately calls `child.unref()` without registering an error listener. If spawn fails asynchronously (e.g., ENOMEM, missing executable), the ChildProcess emits an unhandled `error` event that crashes the parent Node.js process.

## Why This Change Was Made

The detached spawn error listener was missing, creating a crash path on async spawn failures during gateway update restarts. The sibling `restart-helper.ts` already uses the same pattern: `child.on("error", () => {})` before `child.unref()`. This fix mirrors that established pattern.

## User Impact

Prevents parent process crash when the detached gateway spawn child encounters an async error (ENOMEM, missing binary, etc.). The error is silently swallowed since the child is detached and the parent cannot recover — matching the best-effort handoff semantics of the existing restart-helper.

## Evidence

- **Sibling precedent**: `src/cli/update-cli/restart-helper.ts:417` — uses exact same `child.on("error", () => {})` + `child.unref()` pattern  
- **Node.js contract**: Confirmed via direct Node v24 probe — missing executable + no error listener → process exit 1 with unhandled error; with error listener → exit 0  
- **Tests**: 26/26 passing, including new regression test verifying the error listener is registered and is a no-op  
- **ClawSweeper**: Reviewed and confirmed `clawsweeper:fix-shape-clear`, `clawsweeper:source-repro`, `clawsweeper:queueable-fix`  

🤖 Generated with [Claude Code](https://claude.com/claude-code)