### PR TITLE
fix(sessions): preserve label and displayName across implicit stale rollover (#101451)

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1259,6 +1259,64 @@ describe("initSessionState RawBody", () => {
     expect(store[sessionKey]?.pinnedAt).toBe(123);
   });
 
+  it("preserves label and displayName across an implicit daily stale rollover (#101451)", async () => {
+    // Regression: user-set session label and displayName persisted via the Control
+    // UI must survive the automatic daily/idle reset boundary, not just explicit
+    // /new and /reset. Previously label and displayName carryover was gated on
+    // resetTriggered, so the implicit stale rollover branch (resetTriggered ===
+    // false) dropped them silently.
+    const root = await makeCaseDir("openclaw-daily-rollover-label-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:dashboard:daily-rollover-label";
+    const existingSessionId = "session-before-daily-reset-label";
+    // Stale under the default daily reset (atHour 4): started ~48h ago.
+    const staleStartedAt = Date.now() - 48 * 60 * 60 * 1000;
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        lastInteractionAt: staleStartedAt,
+        systemSent: true,
+        // User-set sticky metadata (what the Control UI label input writes).
+        label: "Other",
+        displayName: "My Dashboard Session",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        // Ordinary message — NOT a reset trigger.
+        RawBody: "hello again",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // The session rolled over implicitly (stale), not via /new or /reset.
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    // The user-set label and displayName must survive the implicit rollover.
+    expect(result.sessionEntry.label).toBe("Other");
+    expect(result.sessionEntry.displayName).toBe("My Dashboard Session");
+
+    // Also verify persistence to disk.
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      { label?: string; displayName?: string }
+    >;
+    expect(store[sessionKey]?.label).toBe("Other");
+    expect(store[sessionKey]?.displayName).toBe("My Dashboard Session");
+  });
+
   it("preserves usage footer mode across daily rollover", async () => {
     const root = await makeCaseDir("openclaw-daily-rollover-usage-");
     const storePath = path.join(root, "sessions.json");

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -748,13 +748,19 @@ async function initSessionStateAttemptLocked(
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
       persistedResponseUsage = entry.responseUsage;
+      // Sticky user-owned session metadata (label, displayName) carry across
+      // ANY new-session mint — explicit /new and /reset AND implicit stale
+      // rollovers (daily/idle reset boundary). Previously these were gated on
+      // resetTriggered so labels set via the Control UI would silently drop
+      // after the daily reset hour or idle timeout (#101451).
+      persistedLabel = entry.label;
+      persistedDisplayName = entry.displayName;
     }
     // When a reset trigger (/new, /reset) starts a new session, also rotate the
-    // underlying CLI conversation and carry forward spawn lineage/label.
+    // underlying CLI conversation and carry forward spawn lineage.
     if (resetTriggered && entry) {
       // Explicit /new and /reset should rotate the underlying CLI conversation too.
       // Keep the model/auth choice, but force the next turn to mint a fresh CLI binding.
-      persistedLabel = entry.label;
       persistedSpawnedBy = entry.spawnedBy;
       persistedSpawnedWorkspaceDir = entry.spawnedWorkspaceDir;
       persistedSpawnedCwd = entry.spawnedCwd;
@@ -763,7 +769,6 @@ async function initSessionStateAttemptLocked(
       persistedSpawnDepth = entry.spawnDepth;
       persistedSubagentRole = entry.subagentRole;
       persistedSubagentControlScope = entry.subagentControlScope;
-      persistedDisplayName = entry.displayName;
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

A user-set session `label` (added via the Control UI sessions page) silently disappears after an implicit daily/idle staleness rollover. The label is correctly persisted to `sessions.json` on initial save, but when the session key rotates to a new `sessionId` at the daily reset boundary (or after idle timeout), the new entry is written without the `label` (and `displayName`) field.

Fixes #101451.

## Why This Change Was Made

The root cause is in `src/auto-reply/reply/session.ts:751-767`: `persistedLabel` and `persistedDisplayName` were only assigned inside the `if (resetTriggered && entry)` block, which only executes during explicit `/new` or `/reset` commands. During implicit stale rollover (daily/idle boundary), `resetTriggered` is `false`, so both variables stay `undefined`. At line 879, `label: persistedLabel ?? baseEntry?.label` evaluates to `undefined`, dropping the user's custom label.

This is the third occurrence of the same pattern — model/auth overrides were fixed in #90119 (`8e81bf774e`), and behavior overrides were fixed in #92562 (`0bb415bf66`). Both prior fixes moved their respective fields from the `resetTriggered`-only block into the broader `if (entry)` block that runs for ALL new-session mints.

The explicit reset path (`src/gateway/session-reset-service.ts:1147-1148`) already preserves `label` and `displayName` — this fix closes the gap for implicit rollovers only.

## Changes

- `src/auto-reply/reply/session.ts`: Move `persistedLabel` and `persistedDisplayName` from the `resetTriggered`-guarded block (line 757/766) into the broader `if (entry)` block (after line 756), alongside existing behavior overrides. Spawn lineage fields (`spawnedBy`, `spawnedWorkspaceDir`, etc.) remain in the `resetTriggered` block since they involve CLI conversation rotation that should only happen on explicit reset.
- `src/auto-reply/reply/session.test.ts`: Add regression test following the exact pattern of the #90119 and #92562 tests — seed a 48h-stale session entry with `label` and `displayName`, send an ordinary message (not a reset trigger), and assert both fields survive the implicit rollover in memory and on disk.

## Evidence

### Tests (all green)

```
pnpm test src/auto-reply/reply/session.test.ts --reporter=verbose
 ✓ initSessionState RawBody > preserves label and displayName across an implicit daily stale rollover (#101451) 59ms
 Test Files  1 passed (1)
      Tests  136 passed (136)

pnpm test src/gateway/server.sessions.reset-models.test.ts src/gateway/server.sessions.list-changed.test.ts
 Test Files  2 passed (2)
      Tests  34 passed (34)
```

### Source-level proof

The fix moves two assignments from the explicit-reset-only path to the all-rollover path:

**Before (resetTriggered-only):**
```
if (resetTriggered && entry) {       // ← only true for /new, /reset
  persistedLabel = entry.label;       // ← dropped during stale rollover
  persistedDisplayName = entry.displayName;
}
```

**After (all rollovers):**
```
// Sticky user-owned session metadata carry across ANY new-session mint
persistedLabel = entry.label;         // ← survives implicit stale rollover
persistedDisplayName = entry.displayName;
```

**Explicit reset path already safe:**
`src/gateway/session-reset-service.ts:1147-1148` — `label: currentEntry?.label` and `displayName: currentEntry?.displayName` are already carried forward during explicit reset via the Control UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
