### PR TITLE
fix(cli-runner): only reject restrictive runtime toolsAllow on CLI backends

### DIFF
--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -80,6 +80,7 @@ import {
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
+import { isRestrictiveRuntimeToolsAllow } from "../runtime-tools-allow.js";
 import { ensureSandboxWorkspaceForSession } from "../sandbox.js";
 import { buildSystemPromptReport } from "../system-prompt-report.js";
 import { appendModelIdentitySystemPrompt, buildModelIdentityPromptLine } from "../system-prompt.js";
@@ -324,9 +325,13 @@ export async function prepareCliRunContext(
   if (!backendResolved) {
     throw new Error(`Unknown CLI backend: ${params.provider}`);
   }
-  if (params.toolsAllow !== undefined) {
+  // A non-restrictive policy (undefined, or a wildcard that allows all tools) is
+  // a no-op this backend can safely ignore. Only a genuinely restrictive policy
+  // is rejected, since a CLI backend cannot mediate individual tool calls. This
+  // mirrors the ACP dispatch path so both backends agree on what they accept.
+  if (isRestrictiveRuntimeToolsAllow(params.toolsAllow)) {
     throw new Error(
-      `CLI backend ${backendResolved.id} cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy`,
+      `CLI backend ${backendResolved.id} cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy, or remove the tool allow-list to run on this backend`,
     );
   }
   const sideQuestionDisablesNativeTools =

--- a/src/agents/runtime-tools-allow.test.ts
+++ b/src/agents/runtime-tools-allow.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { isRestrictiveRuntimeToolsAllow } from "./runtime-tools-allow.js";
+
+describe("isRestrictiveRuntimeToolsAllow", () => {
+  it("treats an absent policy as non-restrictive", () => {
+    expect(isRestrictiveRuntimeToolsAllow(undefined)).toBe(false);
+  });
+
+  it("treats a wildcard policy as non-restrictive", () => {
+    expect(isRestrictiveRuntimeToolsAllow(["*"])).toBe(false);
+    expect(isRestrictiveRuntimeToolsAllow(["read", "web_search", "*"])).toBe(false);
+    expect(isRestrictiveRuntimeToolsAllow(["*", "cron"])).toBe(false);
+  });
+
+  it("treats an explicit allow-list as restrictive", () => {
+    expect(isRestrictiveRuntimeToolsAllow([])).toBe(true);
+    expect(isRestrictiveRuntimeToolsAllow(["read"])).toBe(true);
+    expect(isRestrictiveRuntimeToolsAllow(["read", "web_search"])).toBe(true);
+  });
+});

--- a/src/agents/runtime-tools-allow.ts
+++ b/src/agents/runtime-tools-allow.ts
@@ -1,0 +1,21 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+
+/**
+ * A runtime `toolsAllow` policy is "restrictive" only when it actually limits
+ * which tools a run may use.
+ *
+ * Two policies are treated as non-restrictive:
+ * - `undefined` — no policy was requested.
+ * - a wildcard policy that contains `*` — "all tools allowed", i.e. a no-op.
+ *
+ * Backends that cannot mediate individual tool calls (CLI backends and ACP
+ * dispatch) can safely run a non-restrictive policy, but must refuse a
+ * restrictive one because they have no way to enforce it. Keeping this check in
+ * one place ensures those backends stay consistent about what they accept.
+ */
+export function isRestrictiveRuntimeToolsAllow(toolsAllow: string[] | undefined): boolean {
+  if (toolsAllow === undefined) {
+    return false;
+  }
+  return !toolsAllow.some((entry) => normalizeLowercaseStringOrEmpty(entry) === "*");
+}

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -14,6 +14,7 @@ import type { AcpTurnAttachment } from "../../acp/control-plane/manager.types.js
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../../acp/policy.js";
 import { AcpRuntimeError, toAcpRuntimeError } from "../../acp/runtime/errors.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import { isRestrictiveRuntimeToolsAllow } from "../../agents/runtime-tools-allow.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
@@ -166,13 +167,6 @@ function resolveAcpTurnText(params: {
     ].join(" "),
   );
   return params.promptText ? `${guidance}\n\n${params.promptText}` : guidance;
-}
-
-function isRestrictiveRuntimeToolsAllow(toolsAllow: string[] | undefined): boolean {
-  if (toolsAllow === undefined) {
-    return false;
-  }
-  return !toolsAllow.some((entry) => normalizeLowercaseStringOrEmpty(entry) === "*");
 }
 
 async function hasBoundConversationForSession(params: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a scheduled cron job whose agent runs on a CLI backend (e.g. `claude-cli`) fails on **every** run with:

```
CLI backend claude-cli cannot enforce runtime toolsAllow; use an embedded runtime for restricted tool policy
```

Two related problems:

1. The CLI backend guard in `src/agents/cli-runner/prepare.ts` throws on **any** `toolsAllow !== undefined`, whereas ACP dispatch (`dispatch-acp.ts`) only refuses a *genuinely restrictive* policy via `isRestrictiveRuntimeToolsAllow()` (a list is non-restrictive when it contains a `*` wildcard). So a no-op `["*"]` policy works on ACP dispatch but crashes on a CLI backend.
2. When a CLI-backed scheduled job does carry a restrictive policy, it fails at **every** run with a message that doesn't tell the operator how to resolve it.

## Why This Change Was Made

Extract the "is this policy actually restrictive?" check into a single shared helper, `isRestrictiveRuntimeToolsAllow` (`src/agents/runtime-tools-allow.ts`), and use it in both the CLI backend and ACP dispatch so the two paths agree. The CLI backend now only rejects a genuinely restrictive policy, and the error names the fix ("...or remove the tool allow-list to run on this backend"). Non-goal: this does not make CLI backends *enforce* a restrictive policy — that still requires an embedded runtime — it only stops rejecting policies that restrict nothing, and improves the message when a real restriction can't be honored.

## User Impact

- Agents/jobs on a CLI backend with a non-restrictive `toolsAllow` (e.g. `["*"]`) now run instead of failing.
- Operators who hit the restrictive-policy case get an actionable error pointing at the resolution (remove the allow-list, or use an embedded runtime).
- CLI backend and ACP dispatch now share one definition of "restrictive", removing a subtle inconsistency.

## Evidence

- New focused unit test `src/agents/runtime-tools-allow.test.ts` covers the semantics: `undefined` and wildcard lists are non-restrictive; explicit allow-lists (including `[]`) are restrictive.
- The existing `prepare.test.ts` assertion ("fails closed when a runtime toolsAllow is requested for CLI backends") still passes: it uses a restrictive list, which is still rejected, and the original error substring is preserved (`toThrow` matches on substring).
- Diff is small and mirrors the existing ACP behavior:

```
 src/agents/cli-runner/prepare.ts       |  9 +++++++--
 src/agents/runtime-tools-allow.test.ts | 20 ++++++++++++++++++++
 src/agents/runtime-tools-allow.ts      | 21 +++++++++++++++++++++
 src/auto-reply/reply/dispatch-acp.ts   |  8 +-------
```