### PR TITLE
fix(codex): surface native apply_patch diagnostics

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -2856,6 +2856,144 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolCall.input).toEqual({ changes: expectedChanges });
   });
 
+  it("does not inspect rollout diagnostics for a successful native file change", async () => {
+    const readNativePatchFailureDiagnostic = vi.fn();
+    const projector = await createProjector(undefined, { readNativePatchFailureDiagnostic });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "fileChange",
+          id: "patch-success",
+          changes: [{ path: "src/safe.ts", kind: { type: "update" } }],
+          status: "completed",
+        },
+      }),
+    );
+
+    expect(readNativePatchFailureDiagnostic).not.toHaveBeenCalled();
+  });
+
+  it("emits one bounded redacted diagnostic for a failed native file change", async () => {
+    const onAgentEvent = vi.fn();
+    const recordEvent = vi.fn();
+    const params = await createParams();
+    const diagnostic = {
+      schema: "openclaw.sandbox.write_diagnostic.v1" as const,
+      operation: "apply_patch" as const,
+      boundary: "codex_native_patch_apply_end_rollout" as const,
+      phase: "native_patch_apply_end_observation" as const,
+      fileChangeItemId: "patch-failed",
+      turnId: TURN_ID,
+      nativePatchApplyEndObserved: true,
+      nativePatchApplyEndStatus: "failed",
+      nativePatchApplyEndSuccess: false,
+      nativePatchApplyEndStderrPreview: "cannot write <redacted-filechange-path>",
+      nativePatchApplyEndScanBounded: true as const,
+    };
+    const readNativePatchFailureDiagnostic = vi.fn().mockResolvedValue(diagnostic);
+    const projector = await createProjector(
+      { ...params, onAgentEvent },
+      {
+        readNativePatchFailureDiagnostic,
+        trajectoryRecorder: { recordEvent, flush: vi.fn() },
+      },
+    );
+    const failedItem = {
+      type: "fileChange",
+      id: "patch-failed",
+      changes: [],
+      status: "failed",
+    };
+
+    await projector.handleNotification(forCurrentTurn("item/completed", { item: failedItem }));
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: { id: TURN_ID, status: "completed", items: [failedItem] },
+      }),
+    );
+
+    expect(readNativePatchFailureDiagnostic).toHaveBeenCalledTimes(1);
+    expect(readNativePatchFailureDiagnostic).toHaveBeenCalledWith({
+      threadId: THREAD_ID,
+      turnId: TURN_ID,
+      callId: "patch-failed",
+    });
+    expect(recordEvent).toHaveBeenCalledWith(
+      "diagnostic.native_patch_apply_end",
+      expect.objectContaining({ diagnostic }),
+    );
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "codex_app_server.native_patch_apply_end",
+        data: diagnostic,
+      }),
+    );
+    expect(JSON.stringify(onAgentEvent.mock.calls)).not.toContain("/Users/");
+  });
+
+  it("re-sanitizes every string field before emitting native patch diagnostics", async () => {
+    const onAgentEvent = vi.fn();
+    const recordEvent = vi.fn();
+    const params = await createParams();
+    const unsafeThreadId = "thread-TOKEN=thread-secret";
+    const unsafeTurnId = "turn-PASSWORD=turn-secret";
+    const unsafeCallId = "patch-SECRET=call-secret";
+    const readNativePatchFailureDiagnostic = vi.fn().mockResolvedValue({
+      schema: "openclaw.sandbox.write_diagnostic.v1",
+      operation: "apply_patch",
+      boundary: "codex_native_patch_apply_end_rollout",
+      phase: "native_patch_apply_end_observation",
+      fileChangeItemId: unsafeCallId,
+      turnId: unsafeTurnId,
+      nativePatchApplyEndObserved: true,
+      nativePatchApplyEndStatus: "TOKEN=status-secret",
+      nativePatchApplyEndStderrPreview: "diff --git a/secret b/secret",
+      nativePatchApplyEndStdoutPreview: "@@ -1 +1 @@",
+      nativePatchApplyEndChanges: [
+        { path: "src/API_KEY=path-secret.ts", kind: "PASSWORD=kind-secret" },
+      ],
+      nativePatchApplyEndDiagnosticFallback: "TOKEN=fallback-secret",
+      nativePatchApplyEndScanBounded: true,
+    });
+    const projector = new CodexAppServerEventProjector(
+      { ...params, onAgentEvent },
+      unsafeThreadId,
+      unsafeTurnId,
+      {
+        readNativePatchFailureDiagnostic,
+        trajectoryRecorder: { recordEvent, flush: vi.fn() },
+      },
+    );
+
+    await projector.handleNotification({
+      method: "item/completed",
+      params: {
+        threadId: unsafeThreadId,
+        turnId: unsafeTurnId,
+        item: { type: "fileChange", id: unsafeCallId, changes: [], status: "failed" },
+      },
+    });
+
+    const emitted = JSON.stringify({
+      agentEvents: onAgentEvent.mock.calls.filter(
+        ([event]) => event.stream === "codex_app_server.native_patch_apply_end",
+      ),
+      trajectoryEvents: recordEvent.mock.calls.filter(
+        ([eventName]) => eventName === "diagnostic.native_patch_apply_end",
+      ),
+    });
+    expect(emitted).not.toMatch(
+      /thread-secret|turn-secret|call-secret|status-secret|path-secret|kind-secret|fallback-secret|diff --git|@@ -1/u,
+    );
+    expect(emitted).toContain("<redacted-thread-id>");
+    expect(emitted).toContain("<redacted-turn-id>");
+    expect(emitted).toContain("<redacted-call-id>");
+    expect(emitted).toContain("<redacted-status>");
+    expect(emitted).toContain("<redacted-filechange-path>");
+    expect(emitted).toContain("<redacted-change-kind>");
+  });
+
   it("bounds mirrored file-change diffs without losing full stats", async () => {
     const diff = [
       "--- a/src/large.ts",

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -34,6 +34,10 @@ import {
 } from "./event-projector-values.js";
 import type { CodexNativePreToolUseFailure } from "./native-hook-relay.js";
 import {
+  createCodexNativePatchFailureDiagnosticEmitter,
+  type CodexNativePatchFailureDiagnosticReader,
+} from "./native-patch-diagnostic-emitter.js";
+import {
   readCodexNotificationThreadId,
   readCodexNotificationTurnId,
 } from "./notification-correlation.js";
@@ -77,6 +81,7 @@ type CodexAppServerEventProjectorOptions = {
   trajectoryRecorder?: CodexTrajectoryRecorder | null;
   onContextCompacted?: () => void;
   upstreamUserText?: string;
+  readNativePatchFailureDiagnostic?: CodexNativePatchFailureDiagnosticReader;
 };
 
 export class CodexAppServerEventProjector {
@@ -87,6 +92,9 @@ export class CodexAppServerEventProjector {
   private readonly activeCompactionItemIds = new Set<string>();
   private readonly terminalPresentationClearedItemIds = new Set<string>();
   private readonly nativeToolOutcomeOrdinals = new Map<string, number>();
+  private readonly nativePatchFailureDiagnosticEmitter: ReturnType<
+    typeof createCodexNativePatchFailureDiagnosticEmitter
+  >;
   private readonly generatedMediaProjection: CodexGeneratedMediaProjection;
   private readonly eventProjection: CodexEventProjection;
   private readonly nativeToolLifecycleProjector: CodexNativeToolLifecycleProjector;
@@ -106,6 +114,14 @@ export class CodexAppServerEventProjector {
     private readonly turnId: string,
     private readonly options: CodexAppServerEventProjectorOptions = {},
   ) {
+    this.nativePatchFailureDiagnosticEmitter = createCodexNativePatchFailureDiagnosticEmitter({
+      attempt: params,
+      threadId,
+      turnId,
+      trajectoryRecorder: options.trajectoryRecorder,
+      emitAgentEvent: (event) => this.emitAgentEvent(event),
+      readDiagnostic: options.readNativePatchFailureDiagnostic,
+    });
     this.nativeToolLifecycleProjector = new CodexNativeToolLifecycleProjector(
       params,
       threadId,
@@ -554,6 +570,7 @@ export class CodexAppServerEventProjector {
       stream: "codex_app_server.item",
       data: { phase: "completed", itemId, type: item?.type },
     });
+    await this.nativePatchFailureDiagnosticEmitter.handle(item);
   }
 
   private handleTokenUsage(params: JsonObject): void {
@@ -614,6 +631,7 @@ export class CodexAppServerEventProjector {
       this.toolTranscriptProjection.emitAfterToolCallObservation(item);
       this.toolProgressProjection.emitToolResultSummary(item);
       this.toolProgressProjection.emitToolResultOutput(item);
+      await this.nativePatchFailureDiagnosticEmitter.handle(item);
     }
     this.activeCompactionItemIds.clear();
     await this.reasoningProjection.maybeEndReasoning();

--- a/extensions/codex/src/app-server/native-patch-diagnostic-emitter.ts
+++ b/extensions/codex/src/app-server/native-patch-diagnostic-emitter.ts
@@ -1,0 +1,97 @@
+import {
+  embeddedAgentLog,
+  type EmbeddedRunAttemptParams,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { resolveAgentDir, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  readBoundedCodexNativePatchFailureDiagnostic,
+  sanitizeNativePatchDiagnosticForEmission,
+  sanitizeNativePatchDiagnosticIdentifier,
+  type CodexNativePatchFailureDiagnostic,
+} from "./notification-correlation.js";
+import type { CodexThreadItem } from "./protocol.js";
+
+export type CodexNativePatchFailureDiagnosticReader = (params: {
+  threadId: string;
+  turnId: string;
+  callId: string;
+}) => Promise<CodexNativePatchFailureDiagnostic>;
+
+/** Creates the failed-fileChange-only diagnostic boundary for one active turn. */
+export function createCodexNativePatchFailureDiagnosticEmitter(params: {
+  attempt: EmbeddedRunAttemptParams;
+  threadId: string;
+  turnId: string;
+  trajectoryRecorder?: {
+    recordEvent: (type: string, data?: Record<string, unknown>) => void;
+  } | null;
+  emitAgentEvent: (
+    event: Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0],
+  ) => void;
+  readDiagnostic?: CodexNativePatchFailureDiagnosticReader;
+}): { handle: (item: CodexThreadItem | undefined) => Promise<void> } {
+  const completedItemIds = new Set<string>();
+  return {
+    async handle(item) {
+      if (
+        item?.type !== "fileChange" ||
+        (item.status !== "failed" && item.status !== "error") ||
+        completedItemIds.has(item.id)
+      ) {
+        return;
+      }
+      completedItemIds.add(item.id);
+      let diagnostic: CodexNativePatchFailureDiagnostic;
+      try {
+        diagnostic = params.readDiagnostic
+          ? await params.readDiagnostic({
+              threadId: params.threadId,
+              turnId: params.turnId,
+              callId: item.id,
+            })
+          : await readBoundedCodexNativePatchFailureDiagnostic({
+              agentDir: resolveAgentDir(
+                params.attempt.config ?? {},
+                params.attempt.agentId ?? resolveDefaultAgentId(params.attempt.config ?? {}),
+              ),
+              threadId: params.threadId,
+              turnId: params.turnId,
+              callId: item.id,
+            });
+      } catch {
+        diagnostic = {
+          schema: "openclaw.sandbox.write_diagnostic.v1",
+          operation: "apply_patch",
+          boundary: "codex_native_patch_apply_end_rollout",
+          phase: "native_patch_apply_end_observation",
+          fileChangeItemId: item.id,
+          turnId: params.turnId,
+          nativePatchApplyEndObserved: false,
+          nativePatchApplyEndDiagnosticFallback: "diagnostic_scan_failed",
+          nativePatchApplyEndScanBounded: true,
+        };
+      }
+      diagnostic = sanitizeNativePatchDiagnosticForEmission(diagnostic);
+      const emittedThreadId = sanitizeNativePatchDiagnosticIdentifier(
+        params.threadId,
+        "<redacted-thread-id>",
+      );
+      params.trajectoryRecorder?.recordEvent("diagnostic.native_patch_apply_end", {
+        threadId: emittedThreadId,
+        turnId: diagnostic.turnId,
+        fileChangeItemId: diagnostic.fileChangeItemId,
+        diagnostic,
+      });
+      embeddedAgentLog.warn("codex native apply_patch failure diagnostic", {
+        threadId: emittedThreadId,
+        turnId: diagnostic.turnId,
+        fileChangeItemId: diagnostic.fileChangeItemId,
+        diagnostic,
+      });
+      params.emitAgentEvent({
+        stream: "codex_app_server.native_patch_apply_end",
+        data: diagnostic,
+      });
+    },
+  };
+}

--- a/extensions/codex/src/app-server/notification-correlation.ts
+++ b/extensions/codex/src/app-server/notification-correlation.ts
@@ -2,6 +2,10 @@
  * Correlates Codex app-server notifications with the active thread/turn so
  * projectors can ignore global or stale events without losing diagnostics.
  */
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveCodexAppServerHomeDir } from "./auth-bridge.js";
 import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
 
 /** Returns true when a notification payload belongs to the exact active thread and turn. */
@@ -43,4 +47,541 @@ function readNestedTurnId(record: JsonObject): string | undefined {
 function readString(record: JsonObject, key: string): string | undefined {
   const value = record[key];
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+const NATIVE_PATCH_DIAGNOSTIC_MAX_ENTRIES = 256;
+const NATIVE_PATCH_DIAGNOSTIC_MAX_DIRECTORIES = 48;
+const NATIVE_PATCH_DIAGNOSTIC_MAX_FILES = 4;
+const NATIVE_PATCH_DIAGNOSTIC_MAX_FILE_BYTES = 5 * 1024 * 1024;
+const NATIVE_PATCH_DIAGNOSTIC_MAX_TAIL_BYTES = 512 * 1024;
+const NATIVE_PATCH_DIAGNOSTIC_MAX_LINES = 2_048;
+const NATIVE_PATCH_DIAGNOSTIC_MAX_DURATION_MS = 250;
+const NATIVE_PATCH_DIAGNOSTIC_PREVIEW_MAX_CHARS = 1_000;
+const NATIVE_PATCH_DIAGNOSTIC_UNSAFE_TEXT_RE =
+  /(?:\*\*\* Begin Patch|\*\*\* End Patch|\b[A-Z_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY)[A-Z_]*\s*=|authorization|bearer\s+[a-z0-9._~+/=-]{8,}|password|secret|token|sk-[a-z0-9_-]{8,})/iu;
+const NATIVE_PATCH_DIAGNOSTIC_UNIFIED_DIFF_RE =
+  /(?:^|\n)(?:diff --git\b|---\s+a\/|\+\+\+\s+b\/|@@(?:\s|$))/iu;
+const NATIVE_PATCH_DIAGNOSTIC_ABSOLUTE_PATH_RE = /\/[^\s"'`<>]+/g;
+const NATIVE_PATCH_DIAGNOSTIC_ID_RE = /^[a-z0-9][a-z0-9._:-]{0,127}$/iu;
+const NATIVE_PATCH_DIAGNOSTIC_PATH_RE = /^[a-z0-9._/-]{1,512}$/iu;
+const NATIVE_PATCH_DIAGNOSTIC_STATUSES = new Set([
+  "cancelled",
+  "completed",
+  "error",
+  "failed",
+  "incomplete",
+  "ok",
+  "success",
+  "succeeded",
+]);
+const NATIVE_PATCH_DIAGNOSTIC_CHANGE_KINDS = new Set([
+  "add",
+  "create",
+  "delete",
+  "move",
+  "rename",
+  "unknown",
+  "update",
+]);
+const NATIVE_PATCH_DIAGNOSTIC_FALLBACKS = new Set([
+  "diagnostic_scan_failed",
+  "invalid_correlation",
+  "patch_apply_end_unavailable",
+  "rollout_oversized",
+  "rollout_unavailable",
+  "rollout_unreadable",
+  "scan_directory_limit",
+  "scan_entry_limit",
+  "scan_file_limit",
+  "scan_line_limit",
+  "scan_time_limit",
+  "unsafe_stderr_redacted",
+]);
+
+export type CodexNativePatchFailureDiagnostic = {
+  schema: "openclaw.sandbox.write_diagnostic.v1";
+  operation: "apply_patch";
+  boundary: "codex_native_patch_apply_end_rollout";
+  phase: "native_patch_apply_end_observation";
+  fileChangeItemId: string;
+  turnId: string;
+  nativePatchApplyEndObserved: boolean;
+  nativePatchApplyEndStatus?: string;
+  nativePatchApplyEndSuccess?: boolean;
+  nativePatchApplyEndStderrPreview?: string;
+  nativePatchApplyEndStdoutPreview?: string;
+  nativePatchApplyEndChanges?: Array<{ path: string; kind: string }>;
+  nativePatchApplyEndDiagnosticFallback?: string;
+  nativePatchApplyEndScanBounded: true;
+};
+
+type CodexNativePatchDiagnosticLimits = {
+  maxEntries: number;
+  maxDirectories: number;
+  maxFiles: number;
+  maxFileBytes: number;
+  maxTailBytes: number;
+  maxLines: number;
+  maxDurationMs: number;
+};
+
+const NATIVE_PATCH_DIAGNOSTIC_LIMITS: CodexNativePatchDiagnosticLimits = {
+  maxEntries: NATIVE_PATCH_DIAGNOSTIC_MAX_ENTRIES,
+  maxDirectories: NATIVE_PATCH_DIAGNOSTIC_MAX_DIRECTORIES,
+  maxFiles: NATIVE_PATCH_DIAGNOSTIC_MAX_FILES,
+  maxFileBytes: NATIVE_PATCH_DIAGNOSTIC_MAX_FILE_BYTES,
+  maxTailBytes: NATIVE_PATCH_DIAGNOSTIC_MAX_TAIL_BYTES,
+  maxLines: NATIVE_PATCH_DIAGNOSTIC_MAX_LINES,
+  maxDurationMs: NATIVE_PATCH_DIAGNOSTIC_MAX_DURATION_MS,
+};
+
+/**
+ * Reads the current failed native apply_patch observation without putting a
+ * recursive session-root walk on successful or unrelated turns. Every
+ * filesystem dimension is capped because this runs on the turn drain path.
+ */
+export async function readBoundedCodexNativePatchFailureDiagnostic(params: {
+  agentDir: string;
+  codexHome?: string;
+  threadId: string;
+  turnId: string;
+  callId: string;
+  /** Test-only bound overrides; production callers use the fixed defaults. */
+  limits?: Partial<CodexNativePatchDiagnosticLimits>;
+}): Promise<CodexNativePatchFailureDiagnostic> {
+  const base = baseNativePatchFailureDiagnostic(params.callId, params.turnId);
+  const threadId = params.threadId.trim();
+  const turnId = params.turnId.trim();
+  const callId = params.callId.trim();
+  if (!threadId || !turnId || !callId) {
+    return { ...base, nativePatchApplyEndDiagnosticFallback: "invalid_correlation" };
+  }
+  const limits = normalizeNativePatchDiagnosticLimits(params.limits);
+  const deadline = Date.now() + limits.maxDurationMs;
+  const rolloutFiles = await listBoundedCodexRolloutFilesForThread({
+    agentDir: params.agentDir,
+    codexHome: params.codexHome,
+    threadId,
+    deadline,
+    limits,
+  });
+  if (rolloutFiles.reason === "scan_time_limit") {
+    return { ...base, nativePatchApplyEndDiagnosticFallback: rolloutFiles.reason };
+  }
+  if (rolloutFiles.files.length === 0) {
+    return { ...base, nativePatchApplyEndDiagnosticFallback: "rollout_unavailable" };
+  }
+  let scanFallback: string | undefined;
+  for (const file of rolloutFiles.files) {
+    if (Date.now() >= deadline) {
+      return { ...base, nativePatchApplyEndDiagnosticFallback: "scan_time_limit" };
+    }
+    const match = await readBoundedNativePatchApplyEndFromFile({
+      file,
+      turnId,
+      callId,
+      deadline,
+      limits,
+    });
+    if (match.payload) {
+      return sanitizeNativePatchFailureDiagnostic(base, match.payload);
+    }
+    scanFallback ??= match.reason;
+    if (match.reason === "scan_time_limit" || match.reason === "rollout_oversized") {
+      return { ...base, nativePatchApplyEndDiagnosticFallback: match.reason };
+    }
+  }
+  return {
+    ...base,
+    nativePatchApplyEndDiagnosticFallback:
+      scanFallback ?? rolloutFiles.reason ?? "patch_apply_end_unavailable",
+  };
+}
+
+function normalizeNativePatchDiagnosticLimits(
+  overrides: Partial<CodexNativePatchDiagnosticLimits> | undefined,
+): CodexNativePatchDiagnosticLimits {
+  const positiveInteger = (value: number | undefined, fallback: number) =>
+    typeof value === "number" && Number.isFinite(value) && value > 0
+      ? Math.max(1, Math.floor(value))
+      : fallback;
+  return {
+    maxEntries: positiveInteger(overrides?.maxEntries, NATIVE_PATCH_DIAGNOSTIC_LIMITS.maxEntries),
+    maxDirectories: positiveInteger(
+      overrides?.maxDirectories,
+      NATIVE_PATCH_DIAGNOSTIC_LIMITS.maxDirectories,
+    ),
+    maxFiles: positiveInteger(overrides?.maxFiles, NATIVE_PATCH_DIAGNOSTIC_LIMITS.maxFiles),
+    maxFileBytes: positiveInteger(
+      overrides?.maxFileBytes,
+      NATIVE_PATCH_DIAGNOSTIC_LIMITS.maxFileBytes,
+    ),
+    maxTailBytes: positiveInteger(
+      overrides?.maxTailBytes,
+      NATIVE_PATCH_DIAGNOSTIC_LIMITS.maxTailBytes,
+    ),
+    maxLines: positiveInteger(overrides?.maxLines, NATIVE_PATCH_DIAGNOSTIC_LIMITS.maxLines),
+    maxDurationMs: positiveInteger(
+      overrides?.maxDurationMs,
+      NATIVE_PATCH_DIAGNOSTIC_LIMITS.maxDurationMs,
+    ),
+  };
+}
+
+async function listBoundedCodexRolloutFilesForThread(params: {
+  agentDir: string;
+  codexHome?: string;
+  threadId: string;
+  deadline: number;
+  limits: CodexNativePatchDiagnosticLimits;
+}): Promise<{ files: Array<{ path: string; bytes: number }>; reason?: string }> {
+  const resolvedAgentDir = path.resolve(params.agentDir);
+  const resolvedCodexHome = params.codexHome?.trim()
+    ? path.resolve(params.codexHome)
+    : resolveCodexAppServerHomeDir(resolvedAgentDir);
+  const roots = [
+    path.join(resolvedCodexHome, "sessions"),
+    path.join(resolveCodexAppServerHomeDir(resolvedAgentDir), "sessions"),
+    path.join(resolvedAgentDir, "agent", "codex-home", "sessions"),
+    path.join(path.dirname(resolvedAgentDir), "codex-home", "sessions"),
+  ];
+  const files: Array<{ path: string; bytes: number }> = [];
+  const visitedRoots = new Set<string>();
+  const visitedFiles = new Set<string>();
+  let entryCount = 0;
+  let directoryCount = 0;
+  for (const root of roots) {
+    if (visitedRoots.has(root)) {
+      continue;
+    }
+    visitedRoots.add(root);
+    const stack = [root];
+    while (stack.length > 0) {
+      if (Date.now() >= params.deadline) {
+        return { files, reason: "scan_time_limit" };
+      }
+      if (directoryCount >= params.limits.maxDirectories) {
+        return { files, reason: "scan_directory_limit" };
+      }
+      const dir = stack.pop();
+      if (!dir) {
+        continue;
+      }
+      directoryCount += 1;
+      let entries: Dirent[];
+      try {
+        entries = await fs.readdir(dir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      // Codex session paths are date-shaped; reverse lexical order reaches the
+      // active rollout first while still respecting the hard traversal caps.
+      entries.sort((left, right) => left.name.localeCompare(right.name));
+      for (const entry of entries) {
+        entryCount += 1;
+        if (entryCount > params.limits.maxEntries) {
+          return { files, reason: "scan_entry_limit" };
+        }
+        const candidate = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          stack.push(candidate);
+          continue;
+        }
+        if (
+          !entry.isFile() ||
+          !isCodexAppServerRolloutFileNameForThread(candidate, params.threadId) ||
+          visitedFiles.has(candidate)
+        ) {
+          continue;
+        }
+        visitedFiles.add(candidate);
+        try {
+          files.push({ path: candidate, bytes: (await fs.stat(candidate)).size });
+        } catch {
+          continue;
+        }
+        if (files.length >= params.limits.maxFiles) {
+          return { files, reason: "scan_file_limit" };
+        }
+      }
+    }
+  }
+  return { files };
+}
+
+async function readBoundedNativePatchApplyEndFromFile(params: {
+  file: { path: string; bytes: number };
+  turnId: string;
+  callId: string;
+  deadline: number;
+  limits: CodexNativePatchDiagnosticLimits;
+}): Promise<{ payload?: JsonObject; reason?: string }> {
+  if (params.file.bytes > params.limits.maxFileBytes) {
+    return { reason: "rollout_oversized" };
+  }
+  const bytesToRead = Math.min(params.file.bytes, params.limits.maxTailBytes);
+  const offset = Math.max(0, params.file.bytes - bytesToRead);
+  let handle: Awaited<ReturnType<typeof fs.open>>;
+  try {
+    handle = await fs.open(params.file.path, "r");
+  } catch {
+    return { reason: "rollout_unreadable" };
+  }
+  try {
+    const buffer = Buffer.alloc(bytesToRead);
+    const { bytesRead } = await handle.read(buffer, 0, bytesToRead, offset);
+    let text = buffer.subarray(0, bytesRead).toString("utf8");
+    if (offset > 0) {
+      const firstNewline = text.indexOf("\n");
+      text = firstNewline >= 0 ? text.slice(firstNewline + 1) : "";
+    }
+    const lines = text.split("\n");
+    let inspected = 0;
+    for (let index = lines.length - 1; index >= 0; index -= 1) {
+      if (Date.now() >= params.deadline) {
+        return { reason: "scan_time_limit" };
+      }
+      if (inspected >= params.limits.maxLines) {
+        return { reason: "scan_line_limit" };
+      }
+      const line = lines[index]?.trim();
+      if (!line) {
+        continue;
+      }
+      inspected += 1;
+      let record: JsonValue;
+      try {
+        record = JSON.parse(line) as JsonValue;
+      } catch {
+        continue;
+      }
+      const payload = isJsonObject(record) && isJsonObject(record.payload) ? record.payload : null;
+      if (
+        payload?.type === "patch_apply_end" &&
+        payload.turn_id === params.turnId &&
+        payload.call_id === params.callId
+      ) {
+        return { payload };
+      }
+    }
+    return {};
+  } finally {
+    await handle.close();
+  }
+}
+
+function baseNativePatchFailureDiagnostic(
+  callId: string,
+  turnId: string,
+): CodexNativePatchFailureDiagnostic {
+  return {
+    schema: "openclaw.sandbox.write_diagnostic.v1",
+    operation: "apply_patch",
+    boundary: "codex_native_patch_apply_end_rollout",
+    phase: "native_patch_apply_end_observation",
+    fileChangeItemId: sanitizeNativePatchDiagnosticIdentifier(callId, "<redacted-call-id>"),
+    turnId: sanitizeNativePatchDiagnosticIdentifier(turnId, "<redacted-turn-id>"),
+    nativePatchApplyEndObserved: false,
+    nativePatchApplyEndScanBounded: true,
+  };
+}
+
+function sanitizeNativePatchFailureDiagnostic(
+  base: CodexNativePatchFailureDiagnostic,
+  payload: JsonObject,
+): CodexNativePatchFailureDiagnostic {
+  const stderrPreview = sanitizeNativePatchDiagnosticPreview(payload.stderr);
+  const stdoutPreview = sanitizeNativePatchDiagnosticPreview(payload.stdout);
+  return {
+    ...base,
+    nativePatchApplyEndObserved: true,
+    ...(typeof payload.status === "string"
+      ? { nativePatchApplyEndStatus: sanitizeNativePatchDiagnosticStatus(payload.status) }
+      : {}),
+    ...(typeof payload.success === "boolean"
+      ? { nativePatchApplyEndSuccess: payload.success }
+      : {}),
+    ...(stderrPreview ? { nativePatchApplyEndStderrPreview: stderrPreview } : {}),
+    ...(stdoutPreview ? { nativePatchApplyEndStdoutPreview: stdoutPreview } : {}),
+    nativePatchApplyEndChanges: sanitizeNativePatchDiagnosticChanges(payload.changes),
+    ...(!stderrPreview && typeof payload.stderr === "string"
+      ? { nativePatchApplyEndDiagnosticFallback: "unsafe_stderr_redacted" }
+      : {}),
+  };
+}
+
+function sanitizeNativePatchDiagnosticPreview(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const raw = value.trim();
+  if (!raw || isUnsafeNativePatchDiagnosticString(raw)) {
+    return undefined;
+  }
+  const redacted = raw
+    .replace(NATIVE_PATCH_DIAGNOSTIC_ABSOLUTE_PATH_RE, (match) => {
+      const trailing = match.match(/[),.;:!?]+$/u)?.[0] ?? "";
+      const pathPart = trailing ? match.slice(0, -trailing.length) : match;
+      return pathPart === "/workspace" || pathPart.startsWith("/workspace/")
+        ? `${pathPart}${trailing}`
+        : `<redacted-filechange-path>${trailing}`;
+    })
+    .trim();
+  if (
+    !redacted ||
+    NATIVE_PATCH_DIAGNOSTIC_UNSAFE_TEXT_RE.test(redacted) ||
+    NATIVE_PATCH_DIAGNOSTIC_UNIFIED_DIFF_RE.test(redacted)
+  ) {
+    return undefined;
+  }
+  return redacted.length <= NATIVE_PATCH_DIAGNOSTIC_PREVIEW_MAX_CHARS
+    ? redacted
+    : `${redacted.slice(0, NATIVE_PATCH_DIAGNOSTIC_PREVIEW_MAX_CHARS)}...(truncated)`;
+}
+
+function sanitizeNativePatchDiagnosticChanges(
+  value: unknown,
+): Array<{ path: string; kind: string }> {
+  if (!isJsonObject(value)) {
+    return [];
+  }
+  return Object.entries(value)
+    .slice(0, 32)
+    .flatMap(([rawPath, rawChange]) => {
+      const normalizedPath = sanitizeNativePatchDiagnosticPath(rawPath);
+      if (!normalizedPath) {
+        return [];
+      }
+      const change = isJsonObject(rawChange) ? rawChange : undefined;
+      const kind =
+        typeof change?.type === "string"
+          ? sanitizeNativePatchDiagnosticChangeKind(change.type)
+          : typeof change?.kind === "string"
+            ? sanitizeNativePatchDiagnosticChangeKind(change.kind)
+            : "unknown";
+      return [{ path: normalizedPath, kind }];
+    });
+}
+
+function sanitizeNativePatchDiagnosticPath(value: string): string | undefined {
+  const normalized = value.replaceAll("\\", "/").trim();
+  if (!normalized || normalized.includes("\0")) {
+    return undefined;
+  }
+  if (
+    !NATIVE_PATCH_DIAGNOSTIC_PATH_RE.test(normalized) ||
+    isUnsafeNativePatchDiagnosticString(normalized)
+  ) {
+    return "<redacted-filechange-path>";
+  }
+  if (path.isAbsolute(normalized)) {
+    return normalized === "/workspace" || normalized.startsWith("/workspace/")
+      ? normalized
+      : "<redacted-filechange-path>";
+  }
+  if (normalized.split("/").includes("..")) {
+    return "<redacted-filechange-path>";
+  }
+  return normalized;
+}
+
+function isCodexAppServerRolloutFileNameForThread(fileName: string, threadId: string): boolean {
+  const activeThreadId = threadId.trim();
+  if (!activeThreadId) {
+    return false;
+  }
+  const baseName = path.basename(fileName);
+  if (!baseName.startsWith("rollout-") || !baseName.endsWith(".jsonl")) {
+    return false;
+  }
+  if (baseName === `rollout-${activeThreadId}.jsonl`) {
+    return true;
+  }
+  const escapedThreadId = activeThreadId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(
+    `^rollout-\\d{4}-\\d{2}-\\d{2}T\\d{2}-\\d{2}-\\d{2}-${escapedThreadId}\\.jsonl$`,
+    "u",
+  ).test(baseName);
+}
+
+export function sanitizeNativePatchDiagnosticForEmission(
+  value: CodexNativePatchFailureDiagnostic,
+): CodexNativePatchFailureDiagnostic {
+  const stderrPreview = sanitizeNativePatchDiagnosticPreview(
+    value.nativePatchApplyEndStderrPreview,
+  );
+  const stdoutPreview = sanitizeNativePatchDiagnosticPreview(
+    value.nativePatchApplyEndStdoutPreview,
+  );
+  return {
+    schema: "openclaw.sandbox.write_diagnostic.v1",
+    operation: "apply_patch",
+    boundary: "codex_native_patch_apply_end_rollout",
+    phase: "native_patch_apply_end_observation",
+    fileChangeItemId: sanitizeNativePatchDiagnosticIdentifier(
+      value.fileChangeItemId,
+      "<redacted-call-id>",
+    ),
+    turnId: sanitizeNativePatchDiagnosticIdentifier(value.turnId, "<redacted-turn-id>"),
+    nativePatchApplyEndObserved: value.nativePatchApplyEndObserved,
+    ...(value.nativePatchApplyEndStatus
+      ? {
+          nativePatchApplyEndStatus: sanitizeNativePatchDiagnosticStatus(
+            value.nativePatchApplyEndStatus,
+          ),
+        }
+      : {}),
+    ...(typeof value.nativePatchApplyEndSuccess === "boolean"
+      ? { nativePatchApplyEndSuccess: value.nativePatchApplyEndSuccess }
+      : {}),
+    ...(stderrPreview ? { nativePatchApplyEndStderrPreview: stderrPreview } : {}),
+    ...(stdoutPreview ? { nativePatchApplyEndStdoutPreview: stdoutPreview } : {}),
+    ...(value.nativePatchApplyEndChanges
+      ? {
+          nativePatchApplyEndChanges: value.nativePatchApplyEndChanges
+            .slice(0, 32)
+            .map((change) => ({
+              path: sanitizeNativePatchDiagnosticPath(change.path) ?? "<redacted-filechange-path>",
+              kind: sanitizeNativePatchDiagnosticChangeKind(change.kind),
+            })),
+        }
+      : {}),
+    ...(value.nativePatchApplyEndDiagnosticFallback
+      ? {
+          nativePatchApplyEndDiagnosticFallback: NATIVE_PATCH_DIAGNOSTIC_FALLBACKS.has(
+            value.nativePatchApplyEndDiagnosticFallback,
+          )
+            ? value.nativePatchApplyEndDiagnosticFallback
+            : "diagnostic_scan_failed",
+        }
+      : {}),
+    nativePatchApplyEndScanBounded: true,
+  };
+}
+
+export function sanitizeNativePatchDiagnosticIdentifier(value: string, fallback: string): string {
+  const normalized = value.trim();
+  return NATIVE_PATCH_DIAGNOSTIC_ID_RE.test(normalized) &&
+    !isUnsafeNativePatchDiagnosticString(normalized)
+    ? normalized
+    : fallback;
+}
+
+function sanitizeNativePatchDiagnosticStatus(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  return NATIVE_PATCH_DIAGNOSTIC_STATUSES.has(normalized) ? normalized : "<redacted-status>";
+}
+
+function sanitizeNativePatchDiagnosticChangeKind(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  return NATIVE_PATCH_DIAGNOSTIC_CHANGE_KINDS.has(normalized)
+    ? normalized
+    : "<redacted-change-kind>";
+}
+
+function isUnsafeNativePatchDiagnosticString(value: string): boolean {
+  return (
+    NATIVE_PATCH_DIAGNOSTIC_UNSAFE_TEXT_RE.test(value) ||
+    NATIVE_PATCH_DIAGNOSTIC_UNIFIED_DIFF_RE.test(value)
+  );
 }

--- a/extensions/codex/src/app-server/startup-binding.test.ts
+++ b/extensions/codex/src/app-server/startup-binding.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readBoundedCodexNativePatchFailureDiagnostic } from "./notification-correlation.js";
 import {
   readCodexAppServerBinding,
   testCodexAppServerBindingStore,
@@ -58,6 +59,209 @@ describe("Codex app-server startup binding", () => {
       }),
     );
   }
+
+  it("reads a correlated native patch failure from a bounded fake rollout", async () => {
+    const agentDir = path.join(tempDir, "agent");
+    const codexHome = path.join(tempDir, "codex-home");
+    const rolloutDir = path.join(codexHome, "sessions", "2026", "07", "15");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-2026-07-15T00-00-00-thread-1.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "patch_apply_end",
+          turn_id: "turn-1",
+          call_id: "patch-1",
+          status: "failed",
+          success: false,
+          stderr: "cannot write /Users/private/source.ts",
+          stdout: "checked /workspace/src/source.ts",
+          changes: {
+            "src/source.ts": { type: "update" },
+            "/Users/private/secret.ts": { type: "add" },
+          },
+        },
+      })}\n`,
+    );
+
+    const diagnostic = await readBoundedCodexNativePatchFailureDiagnostic({
+      agentDir,
+      codexHome,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "patch-1",
+    });
+
+    expect(diagnostic).toMatchObject({
+      fileChangeItemId: "patch-1",
+      nativePatchApplyEndObserved: true,
+      nativePatchApplyEndStatus: "failed",
+      nativePatchApplyEndSuccess: false,
+      nativePatchApplyEndScanBounded: true,
+      nativePatchApplyEndStderrPreview: "cannot write <redacted-filechange-path>",
+      nativePatchApplyEndStdoutPreview: "checked /workspace/src/source.ts",
+      nativePatchApplyEndChanges: [
+        { path: "src/source.ts", kind: "update" },
+        { path: "<redacted-filechange-path>", kind: "add" },
+      ],
+    });
+    expect(JSON.stringify(diagnostic)).not.toContain("/Users/private");
+  });
+
+  it("stops native patch failure inspection at the configured line bound", async () => {
+    const agentDir = path.join(tempDir, "agent");
+    const codexHome = path.join(tempDir, "codex-home");
+    const rolloutDir = path.join(codexHome, "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-1.jsonl"),
+      [
+        JSON.stringify({
+          payload: {
+            type: "patch_apply_end",
+            turn_id: "turn-1",
+            call_id: "patch-1",
+            status: "failed",
+            stderr: "bounded failure",
+          },
+        }),
+        JSON.stringify({ payload: { type: "noise" } }),
+        JSON.stringify({ payload: { type: "newer_noise" } }),
+      ].join("\n"),
+    );
+
+    const diagnostic = await readBoundedCodexNativePatchFailureDiagnostic({
+      agentDir,
+      codexHome,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "patch-1",
+      limits: { maxLines: 1 },
+    });
+
+    expect(diagnostic).toMatchObject({
+      nativePatchApplyEndObserved: false,
+      nativePatchApplyEndDiagnosticFallback: "scan_line_limit",
+      nativePatchApplyEndScanBounded: true,
+    });
+  });
+
+  it("rejects a suffix-colliding rollout with matching turn and call ids", async () => {
+    const agentDir = path.join(tempDir, "agent");
+    const codexHome = path.join(tempDir, "codex-home");
+    const rolloutDir = path.join(codexHome, "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-2026-07-15T00-00-00-other-thread-1.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "patch_apply_end",
+          turn_id: "turn-1",
+          call_id: "patch-1",
+          status: "failed",
+          stderr: "must not correlate",
+        },
+      })}\n`,
+    );
+
+    const diagnostic = await readBoundedCodexNativePatchFailureDiagnostic({
+      agentDir,
+      codexHome,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "patch-1",
+    });
+
+    expect(diagnostic).toMatchObject({
+      nativePatchApplyEndObserved: false,
+      nativePatchApplyEndDiagnosticFallback: "rollout_unavailable",
+    });
+    expect(JSON.stringify(diagnostic)).not.toContain("must not correlate");
+  });
+
+  it.each(["diff --git a/src/a.ts b/src/a.ts", "--- a/src/a.ts", "+++ b/src/a.ts", "@@ -1 +1 @@"])(
+    "rejects unified-diff preview shape %s",
+    async (unsafePreview) => {
+      const agentDir = path.join(tempDir, "agent");
+      const codexHome = path.join(tempDir, "codex-home");
+      const rolloutDir = path.join(codexHome, "sessions");
+      await fs.mkdir(rolloutDir, { recursive: true });
+      await fs.writeFile(
+        path.join(rolloutDir, "rollout-thread-1.jsonl"),
+        `${JSON.stringify({
+          payload: {
+            type: "patch_apply_end",
+            turn_id: "turn-1",
+            call_id: "patch-1",
+            status: "failed",
+            stderr: unsafePreview,
+            stdout: unsafePreview,
+          },
+        })}\n`,
+      );
+
+      const diagnostic = await readBoundedCodexNativePatchFailureDiagnostic({
+        agentDir,
+        codexHome,
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "patch-1",
+      });
+
+      expect(diagnostic).toMatchObject({
+        nativePatchApplyEndObserved: true,
+        nativePatchApplyEndDiagnosticFallback: "unsafe_stderr_redacted",
+      });
+      expect(diagnostic.nativePatchApplyEndStderrPreview).toBeUndefined();
+      expect(diagnostic.nativePatchApplyEndStdoutPreview).toBeUndefined();
+      expect(JSON.stringify(diagnostic)).not.toContain(unsafePreview);
+    },
+  );
+
+  it("redacts secret-bearing ids, status, relative paths, and change kinds", async () => {
+    const agentDir = path.join(tempDir, "agent");
+    const codexHome = path.join(tempDir, "codex-home");
+    const rolloutDir = path.join(codexHome, "sessions");
+    const unsafeTurnId = "turn-TOKEN=turn-secret";
+    const unsafeCallId = "patch-PASSWORD=call-secret";
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-1.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "patch_apply_end",
+          turn_id: unsafeTurnId,
+          call_id: unsafeCallId,
+          status: "TOKEN=status-secret",
+          success: false,
+          changes: {
+            "src/TOKEN=path-secret.ts": { type: "PASSWORD=kind-secret" },
+          },
+        },
+      })}\n`,
+    );
+
+    const diagnostic = await readBoundedCodexNativePatchFailureDiagnostic({
+      agentDir,
+      codexHome,
+      threadId: "thread-1",
+      turnId: unsafeTurnId,
+      callId: unsafeCallId,
+    });
+
+    expect(diagnostic).toMatchObject({
+      fileChangeItemId: "<redacted-call-id>",
+      turnId: "<redacted-turn-id>",
+      nativePatchApplyEndObserved: true,
+      nativePatchApplyEndStatus: "<redacted-status>",
+      nativePatchApplyEndChanges: [
+        { path: "<redacted-filechange-path>", kind: "<redacted-change-kind>" },
+      ],
+    });
+    expect(JSON.stringify(diagnostic)).not.toMatch(
+      /turn-secret|call-secret|status-secret|path-secret|kind-secret/u,
+    );
+  });
 
   it("does not use a default byte limit when maxActiveTranscriptBytes is unset", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");


### PR DESCRIPTION
## Summary

- surface bounded/redacted diagnostics for native `apply_patch` failures before and after projection
- scan current-thread `patch_apply_end` rollout evidence after result construction, including a raw current-turn fallback when projector diagnostics are absent
- harden diagnostic redaction and add regression coverage for thread/call correlation, rollout caps, dedupe, and file-change bridge failure paths

## What Problem This Solves

Live Builder probes showed native Codex rollout evidence for failed `apply_patch`
operations, including `patch_apply_end` status/stderr/changes, while OpenClaw's
persisted trajectory only surfaced the later projection failure. That made the
actual native failure hard to diagnose and left source/runtime drift risky to
reason about.

This change makes OpenClaw surface bounded, redacted native `apply_patch`
diagnostics directly from current-thread/current-turn evidence, including the
raw rollout fallback shape observed in the live probe.

## Evidence

- Reviewer packet A for the main port returned `CHANGE_REQUESTED` for rollout
  thread matching and agent-local Codex home root issues.
- Reviewer packet B returned `PASS_WITH_NOTES` after rework; no required changes.
- Local checks after rebasing onto current `main`:
  - app-server attempt shard: 1 file, 132 tests passed
  - affected suite: 6 files, 318 tests passed
  - focused projector output-delta check: 2 tests passed
  - extension type-check passed
  - formatter and diff whitespace checks passed

## Verification

- `npx pnpm@11.2.2 exec vitest run --config test/vitest/vitest.extension-codex-app-server-attempt.config.ts`
  - passed before rebase; post-rebase local equivalent with `node_modules/.bin/vitest`: 1 file, 132 tests
- `npx pnpm@11.2.2 exec vitest run extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/startup-binding.test.ts extensions/codex/src/app-server/sandbox-exec-server.fs.test.ts src/agents/sandbox/fs-bridge.shell.test.ts`
  - passed before rebase; post-rebase local equivalent with `node_modules/.bin/vitest`: 6 files, 318 tests
- `npx pnpm@11.2.2 tsgo:extensions:test`
  - passed before rebase; post-rebase local equivalent: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `npx pnpm@11.2.2 exec oxfmt --check ...`
  - passed before rebase; post-rebase local equivalent: `node_modules/.bin/oxfmt --check ...`
- `git diff --check && git diff --cached --check`
  - passed before rebase; post-rebase `git diff --check` passed

## Review

- Design/source repair was Reviewer-gated on the `v2026.6.11` checkout.
- Main-port Reviewer packet A returned `CHANGE_REQUESTED` for rollout filename substring matching and the agent-local Codex sessions root.
- Packet B returned `PASS_WITH_NOTES` after exact thread rollout matching, corrected `${agentDir}/codex-home/sessions`, and added regressions for `thread-1` versus `thread-10` plus cross-thread raw fallback suppression.

## Boundary

This PR is source-back only. It does not activate runtime code, restart Gateway, run a Builder probe, fix the underlying native write failure, or approve merge/live rollout.
