### PR TITLE
fix(codex): handle app-server stdio stream errors

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -422,6 +422,42 @@ describe("CodexAppServerClient", () => {
     await expect(harness.client.request("another/method")).rejects.toThrow("write EPIPE");
   });
 
+  it("handles stdout stream errors without crashing the process", async () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+
+    const pending = harness.client.request("test/method");
+    const readError = Object.assign(new Error("stdout pipe broke"), { code: "EIO" });
+
+    expect(() => harness.process.stdout.emit("error", readError)).not.toThrow();
+
+    await expect(pending).rejects.toThrow("stdout pipe broke");
+    await expect(harness.client.request("another/method")).rejects.toThrow("stdout pipe broke");
+  });
+
+  it("keeps RPC requests usable after stderr stream errors", async () => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const harness = createClientHarness();
+    clients.push(harness.client);
+
+    const pending = harness.client.request("test/method");
+    const firstRequest = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
+    const stderrError = Object.assign(new Error("stderr pipe broke"), { code: "EIO" });
+
+    expect(() => harness.process.stderr.emit("error", stderrError)).not.toThrow();
+    expect(warn).toHaveBeenCalledWith("codex app-server stderr stream failed", {
+      error: stderrError,
+    });
+
+    harness.send({ id: firstRequest.id, result: { ok: true } });
+    await expect(pending).resolves.toEqual({ ok: true });
+
+    const next = harness.client.request("another/method");
+    const secondRequest = JSON.parse(harness.writes[1] ?? "{}") as { id?: number };
+    harness.send({ id: secondRequest.id, result: { ok: "still-connected" } });
+    await expect(next).resolves.toEqual({ ok: "still-connected" });
+  });
+
   it("preserves redacted app-server stderr on exit errors", async () => {
     const harness = createClientHarness();
     clients.push(harness.client);

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -139,6 +139,12 @@ export class CodexAppServerClient {
     this.child = child;
     this.lines = createInterface({ input: child.stdout });
     this.lines.on("line", (line) => this.handleLine(line));
+    this.lines.on("error", (error) =>
+      this.closeWithError(error instanceof Error ? error : new Error(String(error))),
+    );
+    child.stdout.on("error", (error) =>
+      this.closeWithError(error instanceof Error ? error : new Error(String(error))),
+    );
     child.stderr.on("data", (chunk: Buffer | string) => {
       const text = chunk.toString("utf8");
       this.stderrTail = appendBoundedTail(this.stderrTail, text, CODEX_APP_SERVER_STDERR_TAIL_MAX);
@@ -146,6 +152,11 @@ export class CodexAppServerClient {
       if (trimmed) {
         embeddedAgentLog.debug(`codex app-server stderr: ${trimmed}`);
       }
+    });
+    // Codex reserves stderr for diagnostics; losing that stream must not tear
+    // down an otherwise healthy JSON-RPC connection on stdout.
+    child.stderr.on("error", (error) => {
+      embeddedAgentLog.warn("codex app-server stderr stream failed", { error });
     });
     child.once("error", (error) =>
       this.closeWithError(error instanceof Error ? error : new Error(String(error))),


### PR DESCRIPTION
## What Problem This Solves

Prevents asynchronous Codex app-server stdio stream errors from becoming unhandled Node errors that can terminate the gateway.

## Why This Change Was Made

`CodexAppServerClient` already owns child-process, exit, and stdin pipe failures. It did not own errors from the readline interface, stdout stream, or stderr stream.

The submitted patch treated all three streams as terminal. Maintainer review corrected that boundary:

- readline and stdout errors close the client, reject pending RPC requests, and preserve the original close reason;
- stderr errors are logged without closing an otherwise healthy RPC connection.

This matches the upstream Codex transport contract: `codex-rs/app-server-transport/src/transport/stdio.rs` carries newline-delimited JSON-RPC on stdout, while `codex-rs/app-server/src/lib.rs` configures tracing output on stderr.

## User Impact

A broken stdout RPC pipe now fails pending Codex requests cleanly instead of risking an unhandled process error. Losing only stderr diagnostics no longer aborts healthy Codex turns.

## Evidence

Focused local proof:

```text
Test Files  1 passed (1)
Tests       31 passed (31)
```

Testbox-through-Crabbox:

```text
provider: blacksmith-testbox
lease: tbx_01kwxzcqc0ah5kegxbk6b73z8p
focused Codex client tests: 31 passed
pnpm build: passed
pnpm check:changed: passed on the cleaned current-main branch
```

Fresh autoreview completed with no accepted or actionable findings. The test proves that stdout failure rejects pending and later requests, while stderr failure is logged and two consecutive RPC requests still resolve.
