### PR TITLE
fix(browser): bound Chrome launch stderr diagnostics

### DIFF
--- a/extensions/browser/src/browser/bounded-utf8-tail.test.ts
+++ b/extensions/browser/src/browser/bounded-utf8-tail.test.ts
@@ -25,4 +25,13 @@ describe("bounded UTF-8 tail", () => {
     tail.clear();
     expect(tail.text()).toBe("");
   });
+
+  it("copies bytes out of caller-owned buffers", () => {
+    const tail = createBoundedUtf8Tail(4);
+    const source = Buffer.from("test");
+    tail.append(source);
+    source.fill(0);
+
+    expect(tail.text()).toBe("test");
+  });
 });

--- a/extensions/browser/src/browser/bounded-utf8-tail.test.ts
+++ b/extensions/browser/src/browser/bounded-utf8-tail.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { createBoundedUtf8Tail, decodeBoundedUtf8Tail } from "./bounded-utf8-tail.js";
+
+describe("bounded UTF-8 tail", () => {
+  it("keeps the newest bytes across several chunks", () => {
+    const tail = createBoundedUtf8Tail(8);
+    tail.append("older");
+    tail.append("-newest");
+
+    expect(tail.text()).toBe("r-newest");
+  });
+
+  it("drops a partial leading code point after byte truncation", () => {
+    const encoded = Buffer.from(`old🦞new`);
+
+    expect(decodeBoundedUtf8Tail(encoded, 5)).toBe("new");
+  });
+
+  it("replaces the retained tail when one chunk fills the limit", () => {
+    const tail = createBoundedUtf8Tail(4);
+    tail.append("old");
+    tail.append("123456");
+
+    expect(tail.text()).toBe("3456");
+    tail.clear();
+    expect(tail.text()).toBe("");
+  });
+});

--- a/extensions/browser/src/browser/bounded-utf8-tail.ts
+++ b/extensions/browser/src/browser/bounded-utf8-tail.ts
@@ -1,0 +1,57 @@
+/** Byte-bounded UTF-8 tail storage for browser subprocess diagnostics. */
+
+function decodeUtf8Tail(buffer: Buffer): string {
+  let start = 0;
+  while (start < buffer.length && (buffer[start]! & 0b1100_0000) === 0b1000_0000) {
+    start += 1;
+  }
+  return buffer.subarray(start).toString("utf8");
+}
+
+export function decodeBoundedUtf8Tail(buffer: Buffer, maxBytes: number): string {
+  if (maxBytes <= 0 || buffer.length === 0) {
+    return "";
+  }
+  const tail = buffer.length > maxBytes ? buffer.subarray(buffer.length - maxBytes) : buffer;
+  return decodeUtf8Tail(tail);
+}
+
+export function createBoundedUtf8Tail(maxBytes: number) {
+  let chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  return {
+    append(chunk: Buffer | string) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (buffer.length === 0 || maxBytes <= 0) {
+        return;
+      }
+      if (buffer.length >= maxBytes) {
+        chunks = [buffer.subarray(buffer.length - maxBytes)];
+        totalBytes = maxBytes;
+        return;
+      }
+
+      chunks.push(buffer);
+      totalBytes += buffer.length;
+      while (totalBytes > maxBytes) {
+        const first = chunks[0]!;
+        const overflowBytes = totalBytes - maxBytes;
+        if (overflowBytes < first.length) {
+          chunks[0] = first.subarray(overflowBytes);
+          totalBytes -= overflowBytes;
+          break;
+        }
+        chunks.shift();
+        totalBytes -= first.length;
+      }
+    },
+    text() {
+      return decodeUtf8Tail(Buffer.concat(chunks, totalBytes));
+    },
+    clear() {
+      chunks = [];
+      totalBytes = 0;
+    },
+  };
+}

--- a/extensions/browser/src/browser/bounded-utf8-tail.ts
+++ b/extensions/browser/src/browser/bounded-utf8-tail.ts
@@ -17,7 +17,7 @@ export function decodeBoundedUtf8Tail(buffer: Buffer, maxBytes: number): string 
 }
 
 export function createBoundedUtf8Tail(maxBytes: number) {
-  let chunks: Buffer[] = [];
+  const storage = Buffer.allocUnsafe(Math.max(0, maxBytes));
   let totalBytes = 0;
 
   return {
@@ -27,30 +27,23 @@ export function createBoundedUtf8Tail(maxBytes: number) {
         return;
       }
       if (buffer.length >= maxBytes) {
-        chunks = [buffer.subarray(buffer.length - maxBytes)];
+        buffer.copy(storage, 0, buffer.length - maxBytes);
         totalBytes = maxBytes;
         return;
       }
 
-      chunks.push(buffer);
-      totalBytes += buffer.length;
-      while (totalBytes > maxBytes) {
-        const first = chunks[0]!;
-        const overflowBytes = totalBytes - maxBytes;
-        if (overflowBytes < first.length) {
-          chunks[0] = first.subarray(overflowBytes);
-          totalBytes -= overflowBytes;
-          break;
-        }
-        chunks.shift();
-        totalBytes -= first.length;
+      const overflowBytes = Math.max(0, totalBytes + buffer.length - maxBytes);
+      if (overflowBytes > 0) {
+        storage.copyWithin(0, overflowBytes, totalBytes);
+        totalBytes -= overflowBytes;
       }
+      buffer.copy(storage, totalBytes);
+      totalBytes += buffer.length;
     },
     text() {
-      return decodeUtf8Tail(Buffer.concat(chunks, totalBytes));
+      return decodeUtf8Tail(storage.subarray(0, totalBytes));
     },
     clear() {
-      chunks = [];
       totalBytes = 0;
     },
   };

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -29,6 +29,7 @@ import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { redactToolPayloadText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { asRecord } from "../record-shared.js";
+import { createBoundedUtf8Tail, decodeBoundedUtf8Tail } from "./bounded-utf8-tail.js";
 import { redactCdpUrl } from "./cdp.helpers.js";
 import type { ChromeMcpSnapshotNode } from "./chrome-mcp.snapshot.js";
 import type { BrowserTab } from "./client.types.js";
@@ -170,15 +171,7 @@ let chromeMcpProcessCleanupDepsForTest: ChromeMcpProcessCleanupDeps | null = nul
 
 /** Decode a bounded UTF-8-safe stderr tail for Chrome MCP diagnostics. */
 export function decodeChromeMcpStderrTail(buffer: Buffer): string {
-  if (buffer.length <= CHROME_MCP_STDERR_MAX_BYTES) {
-    return buffer.toString("utf8").trim();
-  }
-
-  let start = buffer.length - CHROME_MCP_STDERR_MAX_BYTES;
-  while (start < buffer.length && (buffer[start] & 0xc0) === 0x80) {
-    start++;
-  }
-  return buffer.subarray(start).toString("utf8").trim();
+  return decodeBoundedUtf8Tail(buffer, CHROME_MCP_STDERR_MAX_BYTES).trim();
 }
 
 function asPages(value: unknown): ChromeMcpStructuredPage[] {
@@ -480,25 +473,12 @@ function drainStderr(transport: StdioClientTransport): () => string {
   if (!stream) {
     return () => "";
   }
-  const chunks: Buffer[] = [];
-  let totalBytes = 0;
+  const tail = createBoundedUtf8Tail(CHROME_MCP_STDERR_MAX_BYTES);
   stream.on("data", (chunk: Buffer | string) => {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    const capped =
-      buffer.length > CHROME_MCP_STDERR_MAX_BYTES
-        ? buffer.subarray(buffer.length - CHROME_MCP_STDERR_MAX_BYTES)
-        : buffer;
-    chunks.push(capped);
-    totalBytes += capped.length;
-    while (totalBytes > CHROME_MCP_STDERR_MAX_BYTES && chunks.length > 1) {
-      const dropped = chunks.shift();
-      if (dropped) {
-        totalBytes -= dropped.length;
-      }
-    }
+    tail.append(chunk);
   });
   stream.on("error", () => {});
-  return () => decodeChromeMcpStderrTail(Buffer.concat(chunks));
+  return () => tail.text().trim();
 }
 
 function redactChromeMcpDiagnosticText(text: string): string {

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -805,7 +805,7 @@ describe("chrome.ts internal", () => {
       }
     });
 
-    it("clears stale singleton locks and retries once after profile-in-use launch failure", async () => {
+    it("clears stale singleton locks even when the profile-in-use marker rolls out of the stderr tail", async () => {
       const configPath = path.join(tmpDir, "openclaw.json");
       await fsp.writeFile(
         configPath,
@@ -838,6 +838,7 @@ describe("chrome.ts internal", () => {
       let spawnCalls = 0;
       const firstProc = makeFakeProc();
       const secondProc = makeFakeProc();
+      const laterStderr = Buffer.alloc(70 * 1024, "x");
       mockExpiredLaunchPollingClock();
       spawnMock.mockImplementation(() => {
         spawnCalls += 1;
@@ -847,6 +848,7 @@ describe("chrome.ts internal", () => {
               "data",
               Buffer.from("The profile appears to be in use by another Chromium process"),
             );
+            firstProc.stderr.emit("data", laterStderr);
           });
           return firstProc;
         }
@@ -1123,7 +1125,7 @@ describe("chrome.ts internal", () => {
       }
     });
 
-    it("keeps only a bounded stderr tail when launch fails after large stderr", async () => {
+    it("keeps only a bounded UTF-8-safe newest stderr tail when launch fails after large stderr", async () => {
       const executablePath = path.join(tmpDir, "chrome");
       await fsp.writeFile(executablePath, "");
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
@@ -1135,15 +1137,16 @@ describe("chrome.ts internal", () => {
       });
       const fakeProc = makeFakeProc();
       const oldMarker = "older-stderr-marker";
-      const recentMarker = "recent-stderr-marker";
-      const repeatedRecentTail = Array.from(
-        { length: 128 },
-        (_value, index) => `${recentMarker}-${index}\n${"x".repeat(1024)}\n`,
-      ).join("");
+      const newestMarker = "newest-stderr-marker";
+      const splitEmoji = Buffer.from("🦞");
+      const newestLine = Buffer.from(`\n${newestMarker}\n`);
+      const tailMaxBytes = 64 * 1024;
+      const filler = Buffer.alloc(tailMaxBytes + 2 - splitEmoji.length - newestLine.length, "x");
       spawnMock.mockImplementation(() => {
         void Promise.resolve().then(() => {
           fakeProc.stderr.emit("data", Buffer.from(`${oldMarker}\n`));
-          fakeProc.stderr.emit("data", Buffer.from(repeatedRecentTail));
+          fakeProc.stderr.emit("data", splitEmoji.subarray(0, 2));
+          fakeProc.stderr.emit("data", Buffer.concat([splitEmoji.subarray(2), filler, newestLine]));
         });
         return fakeProc;
       });
@@ -1169,9 +1172,54 @@ describe("chrome.ts internal", () => {
       expect(message).toContain("Chrome stderr:");
       const stderrHint = message.split("Chrome stderr:\n")[1] ?? "";
       expect(stderrHint).not.toContain(oldMarker);
-      expect(stderrHint).toContain(recentMarker);
+      expect(stderrHint).toContain(newestMarker);
+      expect(stderrHint).not.toContain("�");
       expect(stderrHint.length).toBeLessThanOrEqual(CHROME_STDERR_HINT_MAX_CHARS);
       expect(fakeProc.kill).toHaveBeenCalledWith("SIGKILL");
+    });
+
+    it("keeps early missing-display diagnostics for launch hints after the stderr tail rolls", async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "linux" });
+      try {
+        const executablePath = path.join(tmpDir, "chrome");
+        await fsp.writeFile(executablePath, "");
+        vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+          const s = String(p);
+          if (s === executablePath || s.endsWith("Local State") || s.endsWith("Preferences")) {
+            return true;
+          }
+          return false;
+        });
+        const fakeProc = makeFakeProc();
+        spawnMock.mockImplementation(() => {
+          void Promise.resolve().then(() => {
+            fakeProc.stderr.emit("data", Buffer.from("Missing X server or $DISPLAY\n"));
+            fakeProc.stderr.emit("data", Buffer.alloc(70 * 1024, "x"));
+          });
+          return fakeProc;
+        });
+        mockExpiredLaunchPollingClock();
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ECONNREFUSED")));
+
+        const profile = { ...makeProfile(55558), executablePath } as ResolvedBrowserProfile;
+        let message = "";
+        try {
+          await launchOpenClawChrome(
+            makeResolved({ headless: false, localLaunchTimeoutMs: 1 }),
+            profile,
+          );
+        } catch (err) {
+          message = err instanceof Error ? err.message : String(err);
+        }
+
+        expect(message).toContain("No DISPLAY/X server was detected");
+        const stderrHint = message.split("Chrome stderr:\n")[1] ?? "";
+        expect(stderrHint).not.toContain("$DISPLAY");
+        expect(fakeProc.kill).toHaveBeenCalledWith("SIGKILL");
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform });
+      }
     });
 
     it("uses the configured local launch timeout while waiting for CDP discovery", async () => {

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -57,6 +57,7 @@ vi.mock("./cdp-timeouts.js", async () => {
   };
 });
 
+import { CHROME_STDERR_HINT_MAX_CHARS } from "./cdp-timeouts.js";
 import {
   buildOpenClawChromeLaunchArgs,
   getChromeWebSocketUrl,
@@ -1122,6 +1123,57 @@ describe("chrome.ts internal", () => {
       }
     });
 
+    it("keeps only a bounded stderr tail when launch fails after large stderr", async () => {
+      const executablePath = path.join(tmpDir, "chrome");
+      await fsp.writeFile(executablePath, "");
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (s === executablePath || s.endsWith("Local State") || s.endsWith("Preferences")) {
+          return true;
+        }
+        return false;
+      });
+      const fakeProc = makeFakeProc();
+      const oldMarker = "older-stderr-marker";
+      const recentMarker = "recent-stderr-marker";
+      const repeatedRecentTail = Array.from(
+        { length: 128 },
+        (_value, index) => `${recentMarker}-${index}\n${"x".repeat(1024)}\n`,
+      ).join("");
+      spawnMock.mockImplementation(() => {
+        void Promise.resolve().then(() => {
+          fakeProc.stderr.emit("data", Buffer.from(`${oldMarker}\n`));
+          fakeProc.stderr.emit("data", Buffer.from(repeatedRecentTail));
+        });
+        return fakeProc;
+      });
+      let now = 1_000_000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          now += 10_000;
+          throw new Error("ECONNREFUSED");
+        }),
+      );
+
+      const profile = { ...makeProfile(55557), executablePath } as ResolvedBrowserProfile;
+      let message = "";
+      try {
+        await launchOpenClawChrome(makeResolved({ localLaunchTimeoutMs: 1 }), profile);
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+
+      expect(message).toMatch(/Failed to start Chrome CDP/);
+      expect(message).toContain("Chrome stderr:");
+      const stderrHint = message.split("Chrome stderr:\n")[1] ?? "";
+      expect(stderrHint).not.toContain(oldMarker);
+      expect(stderrHint).toContain(recentMarker);
+      expect(stderrHint.length).toBeLessThanOrEqual(CHROME_STDERR_HINT_MAX_CHARS);
+      expect(fakeProc.kill).toHaveBeenCalledWith("SIGKILL");
+    });
+
     it("uses the configured local launch timeout while waiting for CDP discovery", async () => {
       const executablePath = path.join(tmpDir, "chrome");
       await fsp.writeFile(executablePath, "");
@@ -1538,19 +1590,17 @@ describe("chrome.ts internal", () => {
     });
 
     it("buffers stderr chunks when Chrome emits diagnostics while CDP comes up", async () => {
-      // Covers onStderr (pushing chunks to stderrChunks) plus the
+      // Covers onStderr (appending chunks to the bounded stderr tail) plus the
       // stderrHint truthy branch on failure.
       const configDir = await fsp.mkdtemp(path.join(os.tmpdir(), "openclaw-redact-off-"));
       const configPath = path.join(configDir, "openclaw.json");
       await fsp.writeFile(configPath, JSON.stringify({ logging: { redactSensitive: "off" } }));
       vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+      const executablePath = path.join(configDir, "chrome-stderr-existing");
+      await fsp.writeFile(executablePath, "");
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
         const s = String(p);
-        if (
-          s.includes("Google Chrome") ||
-          s.includes("google-chrome") ||
-          s.includes("/usr/bin/chromium")
-        ) {
+        if (s === executablePath) {
           return true;
         }
         if (s.endsWith("Local State") || s.endsWith("Preferences")) {
@@ -1575,6 +1625,7 @@ describe("chrome.ts internal", () => {
         cdpPort: 54321,
         cdpUrl: "http://127.0.0.1:54321",
         cdpIsLoopback: true,
+        executablePath,
       } as unknown as ResolvedBrowserProfile;
       const resolved = {
         headless: true,

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -89,6 +89,7 @@ const CHROME_SINGLETON_LOCK_PATHS = [
 const CHROME_SINGLETON_IN_USE_PATTERN = /profile appears to be in use by another chromium process/i;
 const CHROME_MISSING_DISPLAY_PATTERN = /missing x server|\$DISPLAY/i;
 const CHROME_GRACEFUL_CLOSE_COMMAND_TIMEOUT_MS = 500;
+const CHROME_LAUNCH_STDERR_TAIL_MAX_BYTES = 64 * 1024;
 const CHROME_HTTP_DISCOVERY_FAILURE_CODES = new Set([
   "ssrf_blocked",
   "http_unreachable",
@@ -132,6 +133,45 @@ function diagnosticShowsChromeHttpDiscovery(diagnostic: ChromeCdpDiagnostic | nu
     return true;
   }
   return !CHROME_HTTP_DISCOVERY_FAILURE_CODES.has(diagnostic.code);
+}
+
+function createBoundedBufferTail(maxBytes: number) {
+  let chunks: Buffer[] = [];
+  let totalBytes = 0;
+
+  const trim = () => {
+    while (totalBytes > maxBytes && chunks.length > 0) {
+      const overflowBytes = totalBytes - maxBytes;
+      const first = chunks[0]!;
+      if (overflowBytes >= first.length) {
+        chunks.shift();
+        totalBytes -= first.length;
+        continue;
+      }
+      chunks[0] = first.subarray(overflowBytes);
+      totalBytes -= overflowBytes;
+      break;
+    }
+  };
+
+  return {
+    append(chunk: Buffer | string) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (buffer.length === 0 || maxBytes <= 0) {
+        return;
+      }
+      chunks.push(buffer);
+      totalBytes += buffer.length;
+      trim();
+    },
+    toString() {
+      return Buffer.concat(chunks, totalBytes).toString("utf8");
+    },
+    clear() {
+      chunks = [];
+      totalBytes = 0;
+    },
+  };
 }
 
 function processExists(pid: number): boolean {
@@ -1052,12 +1092,12 @@ export async function launchOpenClawChrome(
   const launchOnceAndWait = async (allowSingletonRecovery: boolean): Promise<RunningChrome> => {
     const proc = spawnOnce();
 
-    // Collect stderr for diagnostics in case Chrome fails to start.
-    // The listener is removed on success to avoid unbounded memory growth
-    // from a long-lived Chrome process that emits periodic warnings.
-    const stderrChunks: Buffer[] = [];
-    const onStderr = (chunk: Buffer) => {
-      stderrChunks.push(chunk);
+    // Keep a bounded stderr tail for diagnostics in case Chrome fails to start.
+    // The listener is removed on success to avoid retaining output from a
+    // long-lived Chrome process that emits periodic warnings.
+    const stderrTail = createBoundedBufferTail(CHROME_LAUNCH_STDERR_TAIL_MAX_BYTES);
+    const onStderr = (chunk: Buffer | string) => {
+      stderrTail.append(chunk);
     };
     proc.stderr?.on("data", onStderr);
 
@@ -1098,8 +1138,7 @@ export async function launchOpenClawChrome(
         if (launchHttpReachable) {
           log.debug(diagnosticText);
         } else {
-          const stderrOutput =
-            normalizeOptionalString(Buffer.concat(stderrChunks).toString("utf8")) ?? "";
+          const stderrOutput = normalizeOptionalString(stderrTail.toString()) ?? "";
           const redactedStderrOutput = redactToolPayloadText(stderrOutput);
           if (
             allowSingletonRecovery &&
@@ -1144,9 +1183,9 @@ export async function launchOpenClawChrome(
       };
     } finally {
       // Chrome started successfully or launch failed — detach the stderr listener
-      // and release the buffer.
+      // and release the bounded tail buffer.
       proc.stderr?.off("data", onStderr);
-      stderrChunks.length = 0;
+      stderrTail.clear();
     }
   };
 

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -21,6 +21,7 @@ import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { redactToolPayloadText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CONFIG_DIR } from "../utils.js";
+import { createBoundedUtf8Tail } from "./bounded-utf8-tail.js";
 import { hasChromeProxyControlArg, omitChromeProxyEnv } from "./browser-proxy-mode.js";
 import { assertManagedProxyAllowsCdpUrl } from "./cdp-proxy-bypass.js";
 import {
@@ -141,56 +142,8 @@ type ChromeLaunchStderrSignals = {
   missingDisplay: boolean;
 };
 
-function utf8BoundaryStart(buffer: Buffer): number {
-  let start = 0;
-  while (start < buffer.length && (buffer[start]! & 0b1100_0000) === 0b1000_0000) {
-    start += 1;
-  }
-  return start;
-}
-
-function createBoundedBufferTail(maxBytes: number) {
-  let chunks: Buffer[] = [];
-  let totalBytes = 0;
-
-  const trim = () => {
-    while (totalBytes > maxBytes && chunks.length > 0) {
-      const overflowBytes = totalBytes - maxBytes;
-      const first = chunks[0]!;
-      if (overflowBytes >= first.length) {
-        chunks.shift();
-        totalBytes -= first.length;
-        continue;
-      }
-      chunks[0] = first.subarray(overflowBytes);
-      totalBytes -= overflowBytes;
-      break;
-    }
-  };
-
-  return {
-    append(chunk: Buffer | string) {
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      if (buffer.length === 0 || maxBytes <= 0) {
-        return;
-      }
-      chunks.push(buffer);
-      totalBytes += buffer.length;
-      trim();
-    },
-    toString() {
-      const buffer = Buffer.concat(chunks, totalBytes);
-      return buffer.subarray(utf8BoundaryStart(buffer)).toString("utf8");
-    },
-    clear() {
-      chunks = [];
-      totalBytes = 0;
-    },
-  };
-}
-
 function createChromeLaunchStderrDiagnostics(maxBytes: number) {
-  const tail = createBoundedBufferTail(maxBytes);
+  const tail = createBoundedUtf8Tail(maxBytes);
   const signals: ChromeLaunchStderrSignals = {
     singletonInUse: false,
     missingDisplay: false,
@@ -213,7 +166,7 @@ function createChromeLaunchStderrDiagnostics(maxBytes: number) {
       }
     },
     toString() {
-      return tail.toString();
+      return tail.text();
     },
     signals(): ChromeLaunchStderrSignals {
       return { ...signals };

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -90,6 +90,7 @@ const CHROME_SINGLETON_IN_USE_PATTERN = /profile appears to be in use by another
 const CHROME_MISSING_DISPLAY_PATTERN = /missing x server|\$DISPLAY/i;
 const CHROME_GRACEFUL_CLOSE_COMMAND_TIMEOUT_MS = 500;
 const CHROME_LAUNCH_STDERR_TAIL_MAX_BYTES = 64 * 1024;
+const CHROME_STDERR_MARKER_SCAN_TAIL_CHARS = 256;
 const CHROME_HTTP_DISCOVERY_FAILURE_CODES = new Set([
   "ssrf_blocked",
   "http_unreachable",
@@ -135,6 +136,19 @@ function diagnosticShowsChromeHttpDiscovery(diagnostic: ChromeCdpDiagnostic | nu
   return !CHROME_HTTP_DISCOVERY_FAILURE_CODES.has(diagnostic.code);
 }
 
+type ChromeLaunchStderrSignals = {
+  singletonInUse: boolean;
+  missingDisplay: boolean;
+};
+
+function utf8BoundaryStart(buffer: Buffer): number {
+  let start = 0;
+  while (start < buffer.length && (buffer[start]! & 0b1100_0000) === 0b1000_0000) {
+    start += 1;
+  }
+  return start;
+}
+
 function createBoundedBufferTail(maxBytes: number) {
   let chunks: Buffer[] = [];
   let totalBytes = 0;
@@ -165,11 +179,50 @@ function createBoundedBufferTail(maxBytes: number) {
       trim();
     },
     toString() {
-      return Buffer.concat(chunks, totalBytes).toString("utf8");
+      const buffer = Buffer.concat(chunks, totalBytes);
+      return buffer.subarray(utf8BoundaryStart(buffer)).toString("utf8");
     },
     clear() {
       chunks = [];
       totalBytes = 0;
+    },
+  };
+}
+
+function createChromeLaunchStderrDiagnostics(maxBytes: number) {
+  const tail = createBoundedBufferTail(maxBytes);
+  const signals: ChromeLaunchStderrSignals = {
+    singletonInUse: false,
+    missingDisplay: false,
+  };
+  let markerScanTail = "";
+
+  const updateSignals = (chunkText: string) => {
+    const scanText = `${markerScanTail}${chunkText}`;
+    signals.singletonInUse ||= CHROME_SINGLETON_IN_USE_PATTERN.test(scanText);
+    signals.missingDisplay ||= CHROME_MISSING_DISPLAY_PATTERN.test(scanText);
+    markerScanTail = scanText.slice(-CHROME_STDERR_MARKER_SCAN_TAIL_CHARS);
+  };
+
+  return {
+    append(chunk: Buffer | string) {
+      tail.append(chunk);
+      const chunkText = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : chunk;
+      if (chunkText.length > 0) {
+        updateSignals(chunkText);
+      }
+    },
+    toString() {
+      return tail.toString();
+    },
+    signals(): ChromeLaunchStderrSignals {
+      return { ...signals };
+    },
+    clear() {
+      tail.clear();
+      signals.singletonInUse = false;
+      signals.missingDisplay = false;
+      markerScanTail = "";
     },
   };
 }
@@ -705,6 +758,7 @@ async function ensureManagedChromePortAvailable(
 
 function chromeLaunchHints(params: {
   stderrOutput: string;
+  stderrSignals?: ChromeLaunchStderrSignals;
   resolved: ResolvedBrowserConfig;
   profile: ResolvedBrowserProfile;
   launchOptions?: ManagedBrowserHeadlessOptions;
@@ -718,12 +772,18 @@ function chromeLaunchHints(params: {
     params.profile,
     params.launchOptions,
   );
-  if (CHROME_MISSING_DISPLAY_PATTERN.test(params.stderrOutput) && !headlessMode.headless) {
+  const missingDisplay =
+    params.stderrSignals?.missingDisplay ??
+    CHROME_MISSING_DISPLAY_PATTERN.test(params.stderrOutput);
+  if (missingDisplay && !headlessMode.headless) {
     hints.push(
       "No DISPLAY/X server was detected. Set OPENCLAW_BROWSER_HEADLESS=1, remove the headed override, start Xvfb, or run the Gateway in a desktop session.",
     );
   }
-  if (CHROME_SINGLETON_IN_USE_PATTERN.test(params.stderrOutput)) {
+  const singletonInUse =
+    params.stderrSignals?.singletonInUse ??
+    CHROME_SINGLETON_IN_USE_PATTERN.test(params.stderrOutput);
+  if (singletonInUse) {
     hints.push(
       `The Chromium profile "${params.profile.name}" is locked. Stop the existing browser or remove stale Singleton* lock files under ~/.openclaw/browser/${params.profile.name}/user-data.`,
     );
@@ -1095,9 +1155,11 @@ export async function launchOpenClawChrome(
     // Keep a bounded stderr tail for diagnostics in case Chrome fails to start.
     // The listener is removed on success to avoid retaining output from a
     // long-lived Chrome process that emits periodic warnings.
-    const stderrTail = createBoundedBufferTail(CHROME_LAUNCH_STDERR_TAIL_MAX_BYTES);
+    const stderrDiagnostics = createChromeLaunchStderrDiagnostics(
+      CHROME_LAUNCH_STDERR_TAIL_MAX_BYTES,
+    );
     const onStderr = (chunk: Buffer | string) => {
-      stderrTail.append(chunk);
+      stderrDiagnostics.append(chunk);
     };
     proc.stderr?.on("data", onStderr);
 
@@ -1138,11 +1200,12 @@ export async function launchOpenClawChrome(
         if (launchHttpReachable) {
           log.debug(diagnosticText);
         } else {
-          const stderrOutput = normalizeOptionalString(stderrTail.toString()) ?? "";
+          const stderrOutput = normalizeOptionalString(stderrDiagnostics.toString()) ?? "";
+          const stderrSignals = stderrDiagnostics.signals();
           const redactedStderrOutput = redactToolPayloadText(stderrOutput);
           if (
             allowSingletonRecovery &&
-            CHROME_SINGLETON_IN_USE_PATTERN.test(stderrOutput) &&
+            stderrSignals.singletonInUse &&
             clearStaleChromeSingletonLocks(userDataDir)
           ) {
             log.warn(
@@ -1152,9 +1215,15 @@ export async function launchOpenClawChrome(
             return await launchOnceAndWait(false);
           }
           const stderrHint = redactedStderrOutput
-            ? `\nChrome stderr:\n${redactedStderrOutput.slice(0, CHROME_STDERR_HINT_MAX_CHARS)}`
+            ? `\nChrome stderr:\n${redactedStderrOutput.slice(-CHROME_STDERR_HINT_MAX_CHARS)}`
             : "";
-          const launchHints = chromeLaunchHints({ stderrOutput, resolved, profile, launchOptions });
+          const launchHints = chromeLaunchHints({
+            stderrOutput,
+            stderrSignals,
+            resolved,
+            profile,
+            launchOptions,
+          });
           try {
             proc.kill("SIGKILL");
           } catch {
@@ -1185,7 +1254,7 @@ export async function launchOpenClawChrome(
       // Chrome started successfully or launch failed — detach the stderr listener
       // and release the bounded tail buffer.
       proc.stderr?.off("data", onStderr);
-      stderrTail.clear();
+      stderrDiagnostics.clear();
     }
   };
 


### PR DESCRIPTION
## What Problem This Solves

- **Fixes an issue where users could hit Chrome launch failures or stuck startup while OpenClaw retained the entire Chrome launch stderr stream in memory before diagnostics were rendered.**
- **Affected surface / workflow:** Managed Chrome startup in `extensions/browser/src/browser/chrome.ts`, specifically the launch path that waits for CDP readiness and includes stderr diagnostics when startup fails.
- **Root cause, in product terms:** The original PR correctly moved stderr retention toward a bounded 64 KiB launch buffer, but the retained tail became the only source for stale Singleton-lock recovery, missing-display/profile-lock hints, and final rendered diagnostics. Early recovery markers could roll out of the tail, the displayed 2,000 characters came from the start of the retained tail instead of the newest failure output, and byte trimming could start inside a UTF-8 character.
- **Why it matters / User impact:** Chrome startup failures should keep OpenClaw memory bounded without regressing existing retry/hint behavior or showing stale/malformed diagnostics. Users still need the latest redacted Chrome failure output plus existing recovery guidance.

## Why This Change Was Made

- **Fix classification:** Root cause fix.
- **Complete shipped solution:** The launch path now stores stderr through a bounded diagnostics accumulator: it keeps the 64 KiB byte tail for redacted display, tracks recovery/hint signals while chunks stream, renders the newest display slice with `slice(-CHROME_STDERR_HINT_MAX_CHARS)`, and drops leading continuation bytes before UTF-8 decoding so diagnostics do not start with replacement characters after a boundary trim.
- **Why this is root-cause fix:** The memory bound remains at the stderr collection boundary, while the downstream behavior that previously depended on the full stderr stream now has independent bounded state for the facts it needs. This fixes the correctness regressions instead of widening the retained buffer or adding an after-the-fact fallback.
- **Source of truth boundary:** `launchOpenClawChrome` remains the owner of managed-Chrome launch diagnostics and retry decisions. The source of truth for the public diagnostic size cap remains `CHROME_STDERR_HINT_MAX_CHARS`; this patch only changes the private launch-time stderr retention and signal tracking that feed that existing diagnostic path.
- **Scope boundary / what did not change:** No dependency, workflow, public API, config, schema, launch-timeout, retry-count, Chrome launch argument, CDP readiness probing, browser selection, redaction policy, displayed diagnostic cap, or post-success Chrome stderr behavior changes. The listener is still detached and the retained diagnostics state is cleared when the launch attempt exits.
- **Compatibility, merge-risk, or maintainer-decision notes:** No public API, user config, schema, protocol, wire/data format, default value, or migration contract changes. This is an internal managed-Chrome launch diagnostic behavior fix. A real managed-Chrome failure proof has now been supplied for the current head, using a locally installed Chrome executable and the actual `launchOpenClawChrome` implementation.
- **Risk labels considered:** `merge-risk: availability`.
- **Risk explanation:** Browser startup failure handling is availability-sensitive: a regression could disable stale-lock recovery, hide missing-display/profile-lock hints, or show stale/malformed stderr during Chrome launch failures.
- **Why acceptable:** The patch narrows that availability risk by preserving recovery/hint facts independently from the bounded display tail, rendering the newest stderr slice, and adding focused regressions for the exact retry/hint/display/UTF-8 cases requested by the maintainer. It does not change launch arguments, CDP probing, retry count, timeouts, public configuration, or post-success Chrome behavior.
- **Related open PR scan / contract boundary:** `init-pr` detected no linked issues for this PR, and this repair does not define or extend a public contract. No competing contract PR is needed to own the private stderr-retention behavior; the source of truth remains `launchOpenClawChrome`.
- **Out of scope boundary:** Public browser configuration semantics, Chrome executable discovery, CDP diagnostic protocol behavior, and redaction policy are out of scope for this code repair. The real binary proof below covers the managed-Chrome launch-failure diagnostic path; OS-specific stale Singleton lock and missing-DISPLAY setup remain covered by the deterministic focused regressions.

## User Impact

- **Users/operators/developers can now:** Hit noisy Chrome launch failures with bounded stderr memory while still getting the newest redacted stderr tail and the existing stale-lock / missing-display guidance when those markers appeared earlier in the stream.
- **Existing behavior preserved:** Stale Chromium Singleton lock recovery still runs from the original marker, missing-display/profile-lock hints still render, stderr is still redacted before display, and the displayed hint remains capped by `CHROME_STDERR_HINT_MAX_CHARS`.
- **What was not tested or remains unavailable:** Real binary proof is complete for the managed-Chrome launch-failure reporting path on Windows using Chromium's `--crash-test` startup flag through the actual Chrome binary. Additional live OS/session setups for Linux missing-DISPLAY and active stale Singleton lock are not part of this local proof run; the marker-specific behavior for those cases is covered by focused regressions because the code change is the bounded stderr retention/signaling layer, not platform setup or Chrome lock creation.

## Evidence

- **Environment:** Windows Git Bash task worktree; Node v22.17.0; pnpm v11.2.2. After syncing current `origin/main`, local proof and validation were rerun against PR head `7fe9bfcf83588d142380ce1e14ef9c827414310c`. The real Chrome proof used an explicit local live-proof opt-in with a prepared Windows environment and a direct managed-Chrome launch attempt.
- **Main sync:** `daily_fix.sh check-main-drift` reported `sync_main_required=true`; `daily_fix.sh sync-main` replayed the two PR commits onto current `origin/main`, then the validations below were rerun.
- **Remote checks after sync:** Current PR head `7fe9bfcf83588d142380ce1e14ef9c827414310c` settled with `FAIL 0 / PENDING 0 / PASS 69 / SKIPPED 30` after the sync push.
- **Commands run after this patch:**
  - `CI=1 NO_COLOR=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-browser.config.ts extensions/browser/src/browser/chrome.internal.test.ts --reporter=verbose` — exit 0.
  - `pnpm exec oxfmt --check --threads=1 extensions/browser/src/browser/chrome.ts extensions/browser/src/browser/chrome.internal.test.ts` — exit 0; output included `All matched files use the correct format.`
  - `pnpm exec oxlint extensions/browser/src/browser/chrome.ts extensions/browser/src/browser/chrome.internal.test.ts --deny-warnings` — exit 0.
  - `git diff --check` — exit 0.
  - A one-off proof harness ran with `OPENCLAW_HOME`, `OPENCLAW_CONFIG_PATH`, and `OPENCLAW_REAL_CHROME_EXE` set for an isolated local Chrome proof environment — exit 0. The harness imported `launchOpenClawChrome` from the current PR head, used a locally installed real Chrome executable (not mocked `child_process.spawn`), launched managed Chrome with `--crash-test`, and waited for CDP on an OpenClaw-managed loopback port.
- **Real managed-Chrome launch-failure proof:**
  - Result: expected managed Chrome launch failure.
  - Observed `Failed to start Chrome CDP`: yes.
  - Observed redacted `Chrome stderr:` section: yes.
  - Sanitized excerpt:

    ```text
    Failed to start Chrome CDP on port 53652 for profile "daily-fix-proof-14652". CDP diagnostic: http_unreachable after 11ms; cdp=http://127.0.0.1:53652; fetch failed: connect ECONNREFUSED 127.0.0.1:53652.
    Chrome stderr:
    :549] Component extension Chrome PDF Viewer (mhjfbmdgcfjbbpaeojofohoefgiehjai) installing/upgrading from '' to 1
    [8088:15584:0708/114050.176:VERBOSE1:extensions\browser\extension_registrar.cc:547] AddComponentExtension Google Hangouts
    [8088:15584:0708/114050.176:VERBOSE1:extensions\browser\extension_registrar.cc:549] Component extension Google Hangouts (nkeimhogjdpnpccoofpliimaahmaaome) installing/upgrading from '' to 1.3.26
    [8088:15584:0708/114050.185:VERBOSE1:chrome\browser\profiles\profile_manager.cc:2065] ForceSigninCheck: 0, 0, 1
    DevTools listening on ws://127.0.0.1:53652/devtools/browser/822007d2-dd8e-4053-9637-8a7a57c9e7dc
    [0708/114050.201:ERROR:third_party\crashpad\crashpad\client\crashpad_client_win.cc:142] crash server failed to launch, self-terminating
    ```

- **Key results / observations:** The focused browser Vitest file now covers the maintainer-requested cases: early Singleton marker plus more than 64 KiB of later stderr still triggers stale-lock retry; final/newest stderr marker is displayed; split multibyte trimming does not introduce `�`; early missing-display marker plus later tail rollover still produces the display hint. The real Chrome proof confirms the current head still reports managed-Chrome launch failure through the actual `launchOpenClawChrome` path with a redacted stderr section.
- **Review findings addressed, if any:**
  - `RF-001` / `RF-007` maintainer changes requested — fixed in code and covered by the focused browser Vitest regressions listed above.
  - `RF-002` / `RF-003` / `RF-004` / `RF-006` real behavior proof requests — supplied via the real managed-Chrome launch-failure proof above for current head `7fe9bfcf83588d142380ce1e14ef9c827414310c`.
  - `RF-005` availability-sensitive path — risk is called out above; focused regressions cover stale-lock recovery, missing-display hint preservation, newest stderr rendering, and UTF-8-safe trimming.
- **Regression guardrail:** `extensions/browser/src/browser/chrome.internal.test.ts` now exercises early Singleton recovery after tail rollover, missing-display hint preservation after tail rollover, newest output rendering, and UTF-8 split-boundary trimming.
- **Patch quality notes:** Production diff remains limited to `extensions/browser/src/browser/chrome.ts`; tests remain in the existing browser internal test file. The added `fs.existsSync` `return true` / `return false` branches are test-only fixture path controls, and the added `catch` blocks only capture the expected launch error message for assertions. No local debug files, lockfiles, generated artifacts, or dependency changes are included.
- **Maintainer-ready confidence:** High: the maintainer-requested code repair is covered by focused current-head regressions, and the current head now includes a real managed-Chrome launch-failure proof instead of relying on mocked Vitest coverage as the behavior proof.
