### PR TITLE
refactor(memory): localize unused host SDK exports

### DIFF
--- a/packages/memory-host-sdk/src/host/embedding-worker-errors.ts
+++ b/packages/memory-host-sdk/src/host/embedding-worker-errors.ts
@@ -8,14 +8,14 @@ export const LOCAL_EMBEDDING_WORKER_ERROR_CODES = {
 } as const;
 
 /** Error code union for local embedding worker failures. */
-export type LocalEmbeddingWorkerFailureCode =
+type LocalEmbeddingWorkerFailureCode =
   (typeof LOCAL_EMBEDDING_WORKER_ERROR_CODES)[keyof typeof LOCAL_EMBEDDING_WORKER_ERROR_CODES];
 
 /** Cause category for local embedding worker failures. */
 type LocalEmbeddingWorkerFailureReason = "exit" | "signal" | "process-error" | "ipc";
 
-/** Error shape used by callers that need retry/status decisions. */
-export type LocalEmbeddingWorkerFailureError = Error & {
+/** Error shape returned by the local embedding worker failure factory. */
+type LocalEmbeddingWorkerFailureError = Error & {
   code: LocalEmbeddingWorkerFailureCode;
   reason: LocalEmbeddingWorkerFailureReason;
   exitCode?: number | null;

--- a/packages/memory-host-sdk/src/host/fs-utils.ts
+++ b/packages/memory-host-sdk/src/host/fs-utils.ts
@@ -8,7 +8,6 @@ export {
   assertNoSymlinkParents,
   readRegularFile,
   statRegularFile,
-  type RegularFileStatResult,
 } from "@openclaw/fs-safe/advanced";
 export { walkDirectory, type WalkDirectoryEntry } from "@openclaw/fs-safe/walk";
 

--- a/packages/memory-host-sdk/src/host/node-llama.ts
+++ b/packages/memory-host-sdk/src/host/node-llama.ts
@@ -1,7 +1,7 @@
 // Minimal node-llama-cpp type facade used by the local embedding provider.
 
 /** Embedding vector returned by node-llama-cpp. */
-export type LlamaEmbedding = {
+type LlamaEmbedding = {
   vector: Float32Array | number[];
 };
 
@@ -21,7 +21,7 @@ export type LlamaModel = {
 };
 
 /** Options accepted by node-llama-cpp model file resolution. */
-export type ResolveModelFileOptions = {
+type ResolveModelFileOptions = {
   directory?: string;
   signal?: AbortSignal;
 };

--- a/packages/memory-host-sdk/src/host/retry-utils.test.ts
+++ b/packages/memory-host-sdk/src/host/retry-utils.test.ts
@@ -1,35 +1,10 @@
 // Memory Host SDK tests cover retry utils behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MAX_SAFE_TIMEOUT_DELAY_MS } from "../../../gateway-client/src/timeouts.js";
-import { resolveRetryConfig, retryAsync } from "./retry-utils.js";
+import { retryAsync } from "./retry-utils.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
-});
-
-describe("resolveRetryConfig", () => {
-  const defaults = {
-    attempts: 4,
-    minDelayMs: 0,
-    maxDelayMs: 0,
-    jitter: 0,
-  };
-
-  it("does not round malformed attempt counts", () => {
-    expect(resolveRetryConfig(defaults, { attempts: 1.5 }).attempts).toBe(4);
-    expect(resolveRetryConfig(defaults, { attempts: Number.POSITIVE_INFINITY }).attempts).toBe(4);
-    expect(resolveRetryConfig(defaults, { attempts: Number.NaN }).attempts).toBe(4);
-  });
-
-  it("caps oversized retry delays at the timer-safe ceiling", () => {
-    const config = resolveRetryConfig(defaults, {
-      minDelayMs: Number.MAX_SAFE_INTEGER,
-      maxDelayMs: Number.MAX_SAFE_INTEGER,
-    });
-
-    expect(config.minDelayMs).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
-    expect(config.maxDelayMs).toBe(MAX_SAFE_TIMEOUT_DELAY_MS);
-  });
 });
 
 describe("retryAsync", () => {
@@ -39,6 +14,22 @@ describe("retryAsync", () => {
     });
 
     await expect(retryAsync(run, Number.NaN, 0)).rejects.toThrow("boom");
+
+    expect(run).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back to the default attempt count for malformed option counts", async () => {
+    const run = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await expect(
+      retryAsync(run, {
+        attempts: 1.5,
+        minDelayMs: 0,
+        maxDelayMs: 0,
+      }),
+    ).rejects.toThrow("boom");
 
     expect(run).toHaveBeenCalledTimes(3);
   });

--- a/packages/memory-host-sdk/src/host/retry-utils.ts
+++ b/packages/memory-host-sdk/src/host/retry-utils.ts
@@ -2,7 +2,7 @@
 import { resolveSafeTimeoutDelayMs } from "../../../gateway-client/src/timeouts.js";
 
 /** Retry timing configuration with optional jitter. */
-export type RetryConfig = {
+type RetryConfig = {
   attempts?: number;
   minDelayMs?: number;
   maxDelayMs?: number;
@@ -10,7 +10,7 @@ export type RetryConfig = {
 };
 
 /** Retry callback payload. */
-export type RetryInfo = {
+type RetryInfo = {
   attempt: number;
   maxAttempts: number;
   delayMs: number;
@@ -19,7 +19,7 @@ export type RetryInfo = {
 };
 
 /** Retry options for retryAsync. */
-export type RetryOptions = RetryConfig & {
+type RetryOptions = RetryConfig & {
   label?: string;
   shouldRetry?: (err: unknown, attempt: number) => boolean;
   retryAfterMs?: (err: unknown) => number | undefined;
@@ -64,7 +64,7 @@ function resolveAttempts(value: unknown, fallback: number): number {
 }
 
 /** Resolve retry settings with clamped positive timeout values. */
-export function resolveRetryConfig(
+function resolveRetryConfig(
   defaults: Required<RetryConfig> = DEFAULT_RETRY_CONFIG,
   overrides?: RetryConfig,
 ): Required<RetryConfig> {

--- a/packages/memory-host-sdk/src/host/secret-input-utils.ts
+++ b/packages/memory-host-sdk/src/host/secret-input-utils.ts
@@ -1,10 +1,10 @@
 // Secret input parsing shared by memory provider config and gateway-resolved snapshots.
 
 /** Supported secret reference backing stores. */
-export type SecretRefSource = "env" | "file" | "exec";
+type SecretRefSource = "env" | "file" | "exec";
 
 /** Canonical secret reference shape used after gateway resolution. */
-export type SecretRef = {
+type SecretRef = {
   source: SecretRefSource;
   provider: string;
   id: string;

--- a/packages/memory-host-sdk/src/host/session-files.ts
+++ b/packages/memory-host-sdk/src/host/session-files.ts
@@ -34,7 +34,6 @@ import type { MemorySessionSyncTarget } from "./types.js";
 
 export {
   listSessionTranscriptCorpusEntriesForAgent,
-  type SessionTranscriptCorpusArtifactKind,
   type SessionTranscriptCorpusEntry,
 } from "./session-transcript-corpus.js";
 
@@ -241,7 +240,7 @@ function isCanonicalSessionsDirForAgent(sessionsDir: string, agentId: string): b
   );
 }
 
-export function loadSessionTranscriptClassificationForSessionsDir(
+function loadSessionTranscriptClassificationForSessionsDir(
   sessionsDir: string,
 ): SessionTranscriptClassification {
   const agentId = extractAgentIdFromSessionsDir(sessionsDir);

--- a/packages/memory-host-sdk/src/host/session-transcript-corpus.ts
+++ b/packages/memory-host-sdk/src/host/session-transcript-corpus.ts
@@ -18,7 +18,7 @@ import {
   type SessionEntry,
 } from "./openclaw-runtime-session.js";
 
-export type SessionTranscriptCorpusArtifactKind =
+type SessionTranscriptCorpusArtifactKind =
   | "active-session"
   | "archive-artifact"
   | "orphan-file-artifact";

--- a/packages/memory-host-sdk/src/host/string-utils.ts
+++ b/packages/memory-host-sdk/src/host/string-utils.ts
@@ -1,7 +1,7 @@
 // Small string normalization helpers kept local to memory-host-sdk for package
 // builds that should not depend on the full normalization package graph.
 /** Normalize a non-empty string or return null. */
-export function normalizeNullableString(value: unknown): string | null {
+function normalizeNullableString(value: unknown): string | null {
   if (typeof value !== "string") {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

The private memory host SDK still exposed implementation-only helper types and functions from internal modules. Those exports expanded the apparent package surface and kept dead-export analysis noisy even though no package entrypoint or plugin SDK contract used them.

## Why This Change Was Made

This maintainer-requested cleanup localizes the unused host-only declarations, removes redundant type re-exports, and tests retry normalization through the public `retryAsync` behavior instead of retaining a test-only helper export. Public memory host SDK entrypoints and runtime behavior are unchanged.

AI-assisted: yes. The changes were source-audited, tested, and reviewed; no agent transcript is attached.

## User Impact

No user-visible behavior changes. Maintainers get a smaller, more accurate internal API surface and cleaner dead-export results.

## Evidence

- Testbox `tbx_01kwxtkat8d7yd5af1xy75k17g`: `pnpm test:serial packages/memory-host-sdk/src/host` passed, 11 files and 57 tests.
- Testbox `tbx_01kwxtkat8d7yd5af1xy75k17g`: `pnpm check:changed` passed, including core and test types, core/package lint, import cycles, database-first, sidecar, webhook, and pairing guards.
- Targeted `oxfmt --check` passed for all 9 changed files.
- Fresh `deadcode:ts-unused` output contains zero hits for the touched host modules.
- Codebase-memory MCP graph refreshed against current `origin/main`: 280,398 nodes and 1,123,567 edges; graph UI healthy at `http://127.0.0.1:9749/`.
- Local and post-rebase branch autoreview with `gpt-5.5` at high reasoning both reported no actionable findings.
