### PR TITLE
fix: session labels disappear after stale rollover

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -4198,6 +4198,54 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("preserves dashboard labels on implicit daily rollover", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date(2026, 0, 18, 5, 0, 0));
+      const storePath = await createStorePath("openclaw-stale-dashboard-label-");
+      const sessionKey = "agent:main:dashboard:labelled-session";
+      const existingSessionId = "stale-dashboard-labelled-session";
+      const transcriptPath = path.join(path.dirname(storePath), `${existingSessionId}.jsonl`);
+
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          label: "Other",
+          sessionId: existingSessionId,
+          updatedAt: new Date(2026, 0, 18, 3, 0, 0).getTime(),
+        },
+      });
+      await fs.writeFile(transcriptPath, '{"type":"message"}\n', "utf8");
+
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+      const result = await initSessionState({
+        ctx: {
+          Body: "hello",
+          RawBody: "hello",
+          CommandBody: "hello",
+          From: "user-stale-dashboard-label",
+          To: "bot",
+          ChatType: "direct",
+          SessionKey: sessionKey,
+          Provider: "webchat",
+          Surface: "webchat",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.resetTriggered).toBe(false);
+      expect(result.sessionId).not.toBe(existingSessionId);
+      expect(result.sessionEntry.label).toBe("Other");
+      expect(readSessionStoreForTest(storePath)[sessionKey]).toMatchObject({
+        label: "Other",
+        sessionId: result.sessionId,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("defers implicit daily rollover while the same session has an active run", async () => {
     vi.useFakeTimers();
     const existingSessionId = "active-stale-session";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -737,6 +737,7 @@ async function initSessionStateAttemptLocked(
       persistedAuthProfileOverrideSource = preservedSelection.authProfileOverrideSource;
       persistedAuthProfileOverrideCompactionCount =
         preservedSelection.authProfileOverrideCompactionCount;
+      persistedLabel = entry.label;
       // Behavior overrides carry across ANY new-session mint (explicit /new AND
       // implicit daily/idle rollover), mirroring the model/auth carry above
       // (#90119). Any persisted level is safe to forward — user `/think` or a
@@ -754,7 +755,6 @@ async function initSessionStateAttemptLocked(
     if (resetTriggered && entry) {
       // Explicit /new and /reset should rotate the underlying CLI conversation too.
       // Keep the model/auth choice, but force the next turn to mint a fresh CLI binding.
-      persistedLabel = entry.label;
       persistedSpawnedBy = entry.spawnedBy;
       persistedSpawnedWorkspaceDir = entry.spawnedWorkspaceDir;
       persistedSpawnedCwd = entry.spawnedCwd;


### PR DESCRIPTION
Closes #101451

## What Problem This Solves

Fixes an issue where users who label a Control UI/dashboard session could lose that label when the existing session becomes stale and the next ordinary turn rolls it over to a new session id.

## Why This Change Was Made

Session labels are user-owned session metadata, just like the model/auth and behavior fields already preserved through the shared new-session rollover path. This change carries the existing `label` through that shared rollover path so explicit resets and implicit stale/daily/idle rollovers preserve the same user-facing label without broadening the reset-service behavior.

## User Impact

Users can expect dashboard session labels to remain attached to the same session key after an implicit stale rollover instead of silently reverting to an unlabeled session.

## Evidence

- `pnpm test src/auto-reply/reply/session.test.ts` passed: 1 file, 136 tests.
- `TEMP=.tmp TMP=.tmp pnpm test src/gateway/server.sessions.reset-models.test.ts src/gateway/server.sessions.list-changed.test.ts` passed on Windows: 4 files, 68 tests.
- `git diff --check` passed.