### PR TITLE
fix(tts-local-cli): cap local CLI speech outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Local CLI TTS output bounds:** cap child stdout and generated or converted audio at 50 MiB and stderr diagnostics at 1 MiB, terminating runaway commands before they can exhaust Gateway memory. (#101510) Thanks @mikasa0818.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Local CLI TTS output bounds:** cap child stdout and generated or converted audio at 50 MiB and stderr diagnostics at 1 MiB, terminating runaway commands before they can exhaust Gateway memory. (#101510) Thanks @mikasa0818.
 - **Browser actions on Node 24:** keep browser request cancellation bound to the client and response lifetime instead of Node 24.16+'s prematurely aborted body-stream signal, preventing valid POST actions from failing after JSON parsing. Thanks @obviyus and @vincentkoc.
 - **SecretRef model credentials:** keep resolved provider secrets behind process-local sentinels through auth storage, stream setup, SDK configuration, and managed local-provider probing, then inject plaintext only at the final network or provider-plugin boundary while retaining exact-value log redaction. (#102008, #102009)
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -870,6 +870,7 @@ Reply -> TTS enabled?
     <ParamField path="env" type="Record<string, string>">Optional environment overrides for the command.</ParamField>
 
     Command stdout and generated or converted audio are limited to 50 MiB. Diagnostic stderr is limited to 1 MiB. OpenClaw terminates the command and fails synthesis when either limit is exceeded.
+
   </Accordion>
 
   <Accordion title="Microsoft (no API key)">

--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -868,6 +868,8 @@ Reply -> TTS enabled?
     <ParamField path="timeoutMs" type="number">Command timeout in milliseconds. Default `120000`.</ParamField>
     <ParamField path="cwd" type="string">Optional command working directory.</ParamField>
     <ParamField path="env" type="Record<string, string>">Optional environment overrides for the command.</ParamField>
+
+    Command stdout and generated or converted audio are limited to 50 MiB. Diagnostic stderr is limited to 1 MiB. OpenClaw terminates the command and fails synthesis when either limit is exceeded.
   </Accordion>
 
   <Accordion title="Microsoft (no API key)">

--- a/extensions/tts-local-cli/speech-provider-stream-error.test.ts
+++ b/extensions/tts-local-cli/speech-provider-stream-error.test.ts
@@ -38,6 +38,7 @@ function createMockChild(): MockChild {
 }
 
 const TEST_CFG = {} as OpenClawConfig;
+const MIB = 1024 * 1024;
 
 type SpeechTarget = SpeechSynthesisRequest["target"];
 
@@ -190,6 +191,25 @@ describe("CLI TTS provider stream error handling", () => {
 
     await expect(promise).rejects.toThrow(
       "CLI TTS exit 1: partial diagnostic; CLI TTS stderr stream error: EIO: diagnostics stream broken",
+    );
+  });
+
+  it.each([
+    { stream: "stdout", chunkBytes: MIB, repeats: 51, limitBytes: 50 * MIB },
+    { stream: "stderr", chunkBytes: MIB / 2, repeats: 3, limitBytes: MIB },
+  ] as const)("terminates the child when $stream exceeds its byte cap", async (testCase) => {
+    const child = createMockChild();
+    const { promise } = await startSpeech({ child });
+    const chunk = Buffer.alloc(testCase.chunkBytes);
+
+    for (let index = 0; index < testCase.repeats; index += 1) {
+      child[testCase.stream].emit("data", chunk);
+    }
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    child.emit("close", null);
+
+    await expect(promise).rejects.toThrow(
+      `CLI TTS ${testCase.stream} exceeded ${testCase.limitBytes} bytes`,
     );
   });
 

--- a/extensions/tts-local-cli/speech-provider.test.ts
+++ b/extensions/tts-local-cli/speech-provider.test.ts
@@ -1,5 +1,5 @@
 // Tts Local Cli tests cover speech provider plugin behavior.
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -22,6 +22,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 import { buildCliSpeechProvider } from "./speech-provider.js";
 
 const TEST_CFG = {} as OpenClawConfig;
+const MAX_AUDIO_OUTPUT_BYTES = 50 * 1024 * 1024;
 
 function createCliFixture(): { dir: string; script: string } {
   const dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-tts-test-"));
@@ -260,6 +261,93 @@ describe("buildCliSpeechProvider", () => {
       rmSync(fixture.dir, { recursive: true, force: true });
     }
   });
+
+  it("rejects oversized CLI output files before reading them", async () => {
+    const fixture = createCliFixture();
+    try {
+      writeFileSync(
+        fixture.script,
+        `
+import { truncateSync, writeFileSync } from "node:fs";
+const outIndex = process.argv.indexOf("--out");
+const outputPath = process.argv[outIndex + 1];
+writeFileSync(outputPath, "");
+truncateSync(outputPath, ${MAX_AUDIO_OUTPUT_BYTES + 1});
+`,
+      );
+
+      await expect(
+        synthesize({
+          providerConfig: baseProviderConfig(fixture.script, {
+            args: [fixture.script, "--out", "{{OutputPath}}"],
+            outputFormat: "wav",
+          }),
+        }),
+      ).rejects.toThrow(`File exceeds ${MAX_AUDIO_OUTPUT_BYTES} bytes`);
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-file CLI output artifacts", async () => {
+    const fixture = createCliFixture();
+    try {
+      writeFileSync(
+        fixture.script,
+        `
+import { mkdirSync } from "node:fs";
+const outIndex = process.argv.indexOf("--out");
+mkdirSync(process.argv[outIndex + 1]);
+`,
+      );
+
+      await expect(
+        synthesize({
+          providerConfig: baseProviderConfig(fixture.script, {
+            args: [fixture.script, "--out", "{{OutputPath}}"],
+            outputFormat: "wav",
+          }),
+        }),
+      ).rejects.toThrow("path must be a regular file");
+    } finally {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["voice-note", "telephony"] as const)(
+    "rejects oversized ffmpeg output for %s synthesis",
+    async (mode) => {
+      const fixture = createCliFixture();
+      runFfmpegMock.mockImplementation(async (args) => {
+        const outputPath = args.at(-1);
+        if (typeof outputPath !== "string") {
+          throw new Error("missing ffmpeg output path");
+        }
+        writeFileSync(outputPath, "");
+        truncateSync(outputPath, MAX_AUDIO_OUTPUT_BYTES + 1);
+      });
+      try {
+        const providerConfig = baseProviderConfig(fixture.script, {
+          args: [fixture.script, "--out", "{{OutputPath}}"],
+          outputFormat: "wav",
+        });
+        const run =
+          mode === "voice-note"
+            ? synthesize({ providerConfig, target: "voice-note" })
+            : buildCliSpeechProvider().synthesizeTelephony?.({
+                text: "phone reply",
+                cfg: TEST_CFG,
+                providerConfig,
+                providerOverrides: {},
+                timeoutMs: 1000,
+              });
+
+        await expect(run).rejects.toThrow(`File exceeds ${MAX_AUDIO_OUTPUT_BYTES} bytes`);
+      } finally {
+        rmSync(fixture.dir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.each(["synthesize", "synthesizeTelephony"] as const)(
     "keeps %s debug previews free of lone surrogates",

--- a/extensions/tts-local-cli/speech-provider.ts
+++ b/extensions/tts-local-cli/speech-provider.ts
@@ -1,10 +1,13 @@
 // Tts Local Cli provider module implements model/runtime integration.
 import { spawn } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import path from "node:path";
 import { runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
-import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
+import {
+  readRegularFileSync,
+  writeExternalFileWithinRoot,
+} from "openclaw/plugin-sdk/security-runtime";
 import type {
   SpeechProviderConfig,
   SpeechProviderPlugin,
@@ -30,6 +33,8 @@ type CliConfig = {
 };
 
 const DEFAULT_TIMEOUT_MS = 120_000;
+const MAX_AUDIO_OUTPUT_BYTES = 50 * 1024 * 1024;
+const MAX_CLI_STDERR_BYTES = 1024 * 1024;
 
 function asObject(value: unknown): Record<string, unknown> | undefined {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -172,6 +177,38 @@ function getFileExt(format: string): string {
   return ".mp3";
 }
 
+function readAudioFile(filePath: string): Buffer {
+  return readRegularFileSync({ filePath, maxBytes: MAX_AUDIO_OUTPUT_BYTES }).buffer;
+}
+
+function createBoundedBuffer(label: string, maxBytes: number) {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  let limitError: Error | undefined;
+
+  return {
+    append(chunk: Buffer | string): Error | undefined {
+      if (limitError) {
+        return limitError;
+      }
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      const nextTotal = totalBytes + buffer.byteLength;
+      if (nextTotal > maxBytes) {
+        limitError = new Error(`${label} exceeded ${maxBytes} bytes (${nextTotal} bytes received)`);
+        chunks.length = 0;
+        totalBytes = 0;
+        return limitError;
+      }
+      chunks.push(buffer);
+      totalBytes = nextTotal;
+      return undefined;
+    },
+    concat(): Buffer {
+      return Buffer.concat(chunks, totalBytes);
+    },
+  };
+}
+
 async function runCli(params: {
   command: string;
   args: string[];
@@ -231,15 +268,25 @@ async function runCli(params: {
       terminateFor(new Error(`CLI TTS timed out after ${params.timeoutMs}ms`));
     }, params.timeoutMs);
 
-    const stdoutChunks: Buffer[] = [];
-    const stderrChunks: Buffer[] = [];
-    proc.stdout.on("data", (c) => stdoutChunks.push(c));
+    const stdout = createBoundedBuffer("CLI TTS stdout", MAX_AUDIO_OUTPUT_BYTES);
+    const stderr = createBoundedBuffer("CLI TTS stderr", MAX_CLI_STDERR_BYTES);
+    proc.stdout.on("data", (chunk: Buffer) => {
+      const error = stdout.append(chunk);
+      if (error) {
+        terminateFor(error);
+      }
+    });
     proc.stdout.on("error", (e) => {
       // A generated file is authoritative when present. Remember stdout
       // failure so only the stdout-audio fallback is rejected after close.
       stdoutError ??= new Error(`CLI TTS stdout stream error: ${e.message}`);
     });
-    proc.stderr.on("data", (c) => stderrChunks.push(c));
+    proc.stderr.on("data", (chunk: Buffer) => {
+      const error = stderr.append(chunk);
+      if (error) {
+        terminateFor(error);
+      }
+    });
     proc.stderr.on("error", (e) => {
       stderrError ??= new Error(`CLI TTS stderr stream error: ${e.message}`);
     });
@@ -260,36 +307,37 @@ async function runCli(params: {
         return reject(terminalFailure);
       }
       if (code !== 0) {
-        const stderr = Buffer.concat(stderrChunks).toString("utf8");
+        const stderrText = stderr.concat().toString("utf8");
         const diagnostic = stderrError
-          ? [stderr, stderrError.message].filter(Boolean).join("; ")
-          : stderr;
+          ? [stderrText, stderrError.message].filter(Boolean).join("; ")
+          : stderrText;
         return reject(new Error(`CLI TTS exit ${code}: ${diagnostic}`));
       }
 
       const audioFile = findAudioFile(params.outputDir, params.filePrefix);
       if (audioFile) {
-        if (!existsSync(audioFile)) {
-          return reject(new Error(`CLI TTS: output file not found at ${audioFile}`));
-        }
         const format = detectFormat(audioFile);
         if (!format) {
           return reject(new Error(`CLI TTS: unknown format for ${audioFile}`));
         }
-        return resolve({
-          buffer: readFileSync(audioFile),
-          actualFormat: format,
-          audioPath: audioFile,
-        });
+        try {
+          return resolve({
+            buffer: readAudioFile(audioFile),
+            actualFormat: format,
+            audioPath: audioFile,
+          });
+        } catch (error) {
+          return reject(error instanceof Error ? error : new Error(String(error)));
+        }
       }
 
       if (stdoutError) {
         return reject(stdoutError);
       }
-      const stdout = Buffer.concat(stdoutChunks);
-      if (stdout.length > 0) {
+      const stdoutBuffer = stdout.concat();
+      if (stdoutBuffer.length > 0) {
         // Assume WAV for stdout output; could be MP3 but caller should convert if needed
-        return resolve({ buffer: stdout, actualFormat: "wav" });
+        return resolve({ buffer: stdoutBuffer, actualFormat: "wav" });
       }
       reject(new Error("CLI TTS produced no output"));
     });
@@ -302,13 +350,28 @@ async function runCli(params: {
   });
 }
 
+async function runFfmpegToBuffer(params: {
+  args: string[];
+  outputDir: string;
+  outputFileName: string;
+}): Promise<Buffer> {
+  const outputPath = path.join(params.outputDir, params.outputFileName);
+  await writeExternalFileWithinRoot({
+    rootDir: params.outputDir,
+    path: params.outputFileName,
+    write: async (tempPath) => {
+      await runFfmpeg([...params.args, tempPath]);
+    },
+  });
+  return readAudioFile(outputPath);
+}
+
 async function convertAudio(
   inputPath: string,
   outputDir: string,
   target: OutputFormat,
 ): Promise<Buffer> {
   const outputFileName = `converted${getFileExt(target)}`;
-  const outputPath = path.join(outputDir, outputFileName);
   const args = ["-y", "-i", inputPath];
   if (target === "opus") {
     args.push("-c:a", "libopus", "-b:a", "64k", "-f", "opus");
@@ -317,41 +380,26 @@ async function convertAudio(
   } else {
     args.push("-c:a", "libmp3lame", "-b:a", "128k", "-f", "mp3");
   }
-  await writeExternalFileWithinRoot({
-    rootDir: outputDir,
-    path: outputFileName,
-    write: async (tempPath) => {
-      await runFfmpeg([...args, tempPath]);
-    },
-  });
-  return readFileSync(outputPath);
+  return await runFfmpegToBuffer({ args, outputDir, outputFileName });
 }
 
 async function convertToRawPcm(inputPath: string, outputDir: string): Promise<Buffer> {
   // Output raw 16kHz mono 16-bit little-endian PCM (no WAV headers)
   const outputFileName = "telephony.pcm";
-  const outputPath = path.join(outputDir, outputFileName);
-  await writeExternalFileWithinRoot({
-    rootDir: outputDir,
-    path: outputFileName,
-    write: async (tempPath) => {
-      await runFfmpeg([
-        "-y",
-        "-i",
-        inputPath,
-        "-c:a",
-        "pcm_s16le",
-        "-ar",
-        "16000",
-        "-ac",
-        "1",
-        "-f",
-        "s16le",
-        tempPath,
-      ]);
-    },
-  });
-  return readFileSync(outputPath);
+  const args = [
+    "-y",
+    "-i",
+    inputPath,
+    "-c:a",
+    "pcm_s16le",
+    "-ar",
+    "16000",
+    "-ac",
+    "1",
+    "-f",
+    "s16le",
+  ];
+  return await runFfmpegToBuffer({ args, outputDir, outputFileName });
 }
 
 export function buildCliSpeechProvider(): SpeechProviderPlugin {


### PR DESCRIPTION
## What Problem This Solves

The Local CLI TTS provider accumulated child stdout and stderr without a byte limit and read CLI/ffmpeg artifacts into memory without a size bound. A noisy or misconfigured local command could therefore grow Gateway memory until the process became unstable.

## Why This Change Was Made

This branch was rebuilt on current `main` so it preserves the newer close-owned timeout and stream-error lifecycle. The final implementation:

- caps audio stdout and generated/converted audio artifacts at 50 MiB;
- caps stderr diagnostics at 1 MiB;
- terminates overflowing children through the existing terminal-failure path with SIGKILL escalation;
- uses the shared fs-safe bounded regular-file reader for CLI and ffmpeg artifacts; and
- unifies speech and telephony conversion output reads behind one bounded helper.

The limits remain private to the owning plugin. No config, provider-routing, speech-core, or plugin SDK surface changes.

## User Impact

Normal Local CLI speech, voice-note conversion, and telephony conversion are unchanged. Runaway output now fails synthesis deterministically instead of consuming unbounded memory. The fixed limits are documented in the TTS reference.

## Evidence

- Blacksmith Testbox `tbx_01kx39tb8aypbfva51mkpnvgmd`: `corepack pnpm test extensions/tts-local-cli` — 22/22 passed.
- Blacksmith Testbox `tbx_01kx39tek6078fqtkq67e9wxbq`: remote changed gate passed, including extension production/test typechecks, lint, repository guards, and import-cycle checks.
- Live Testbox attempt `tbx_01kx39gj5bcb1t4m7v9y94xwxd` reached the real provider path but the image had no system ffmpeg.
- Narrow host fallback: `OPENCLAW_LIVE_TEST=1 node scripts/run-vitest.mjs extensions/tts-local-cli/speech-provider.test.ts` — 13/13 passed with a real child process and real ffmpeg conversion.
- Fresh Codex autoreview after the final code change: clean, confidence 0.93.

Regression coverage includes stdout overflow, stderr overflow, oversized sparse CLI artifacts, non-file artifacts, and oversized speech and telephony ffmpeg outputs.
