### PR TITLE
fix: preserve zero model-call token telemetry

### DIFF
--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -2515,6 +2515,35 @@ describe("diagnostics-otel service", () => {
     await service.stop?.(ctx);
   });
 
+  test("exports zero GenAI usage attributes on model usage spans", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
+    await service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "model.usage",
+      provider: "anthropic",
+      model: "claude-sonnet",
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        promptTokens: 0,
+        total: 0,
+      },
+      durationMs: 25,
+    });
+    await flushDiagnosticEvents();
+
+    const modelUsageOptions = startedSpanOptions("openclaw.model.usage");
+    expect(modelUsageOptions?.attributes?.["gen_ai.usage.input_tokens"]).toBe(0);
+    expect(modelUsageOptions?.attributes?.["gen_ai.usage.output_tokens"]).toBe(0);
+    expect(modelUsageOptions?.attributes?.["gen_ai.usage.cache_read.input_tokens"]).toBe(0);
+    expect(modelUsageOptions?.attributes?.["gen_ai.usage.cache_creation.input_tokens"]).toBe(0);
+    await service.stop?.(ctx);
+  });
+
   test("exports GenAI client operation duration histogram without diagnostic identifiers", async () => {
     const service = createDiagnosticsOtelService();
     const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { metrics: true });
@@ -2833,6 +2862,79 @@ describe("diagnostics-otel service", () => {
     });
     expect(firstSpanEndTime("openclaw.tool.execution")).toBeTypeOf("number");
     expect(telemetryState.tracer.setSpanContext).not.toHaveBeenCalled();
+    await service.stop?.(ctx);
+  });
+
+  test("keeps zero usage attributes on model call spans", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
+    await service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "model.call.completed",
+      runId: "run-1",
+      callId: "call-1",
+      provider: "anthropic",
+      model: "claude-sonnet",
+      contextTokenBudget: 100,
+      durationMs: 80,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoningTokens: 0,
+        promptTokens: 0,
+        total: 0,
+      },
+    });
+    await flushDiagnosticEvents();
+
+    const modelSpanAttributes = firstSpanAttributes("openclaw.model.call");
+    expect(modelSpanAttributes["openclaw.model_call.usage.input_tokens"]).toBe(0);
+    expect(modelSpanAttributes["openclaw.model_call.usage.output_tokens"]).toBe(0);
+    expect(modelSpanAttributes["openclaw.model_call.usage.cache_read_input_tokens"]).toBe(0);
+    expect(modelSpanAttributes["openclaw.model_call.usage.cache_creation_input_tokens"]).toBe(0);
+    expect(modelSpanAttributes["openclaw.model_call.usage.reasoning_output_tokens"]).toBe(0);
+    expect(modelSpanAttributes["openclaw.model_call.usage.prompt_tokens"]).toBe(0);
+    expect(modelSpanAttributes["openclaw.model_call.usage.total_tokens"]).toBe(0);
+    expect(modelSpanAttributes["gen_ai.usage.input_tokens"]).toBe(0);
+    expect(modelSpanAttributes["gen_ai.usage.output_tokens"]).toBe(0);
+    expect(modelSpanAttributes["gen_ai.usage.cache_read.input_tokens"]).toBe(0);
+    expect(modelSpanAttributes["gen_ai.usage.cache_creation.input_tokens"]).toBe(0);
+    expect(modelSpanAttributes["openclaw.model_call.context_token_budget"]).toBe(100);
+    expect(modelSpanAttributes["openclaw.model_call.context_utilization"]).toBe(0);
+    await service.stop?.(ctx);
+  });
+
+  test("exports bounded context utilization on zero-output model call spans", async () => {
+    const service = createDiagnosticsOtelService();
+    const ctx = createOtelContext(OTEL_TEST_ENDPOINT, { traces: true });
+    await service.start(ctx);
+
+    emitDiagnosticEvent({
+      type: "model.call.completed",
+      runId: "run-1",
+      callId: "call-1",
+      provider: "anthropic",
+      model: "claude-sonnet",
+      contextTokenBudget: 100,
+      durationMs: 80,
+      usage: {
+        input: 100,
+        output: 0,
+        cacheRead: 25,
+        promptTokens: 125,
+        total: 125,
+      },
+    });
+    await flushDiagnosticEvents();
+
+    const modelSpanAttributes = firstSpanAttributes("openclaw.model.call");
+    expect(modelSpanAttributes["openclaw.model_call.usage.output_tokens"]).toBe(0);
+    expect(modelSpanAttributes["gen_ai.usage.output_tokens"]).toBe(0);
+    expect(modelSpanAttributes["openclaw.model_call.context_token_budget"]).toBe(100);
+    expect(modelSpanAttributes["openclaw.model_call.context_utilization"]).toBe(1);
     await service.stop?.(ctx);
   });
 

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -527,12 +527,27 @@ function positiveFiniteNumber(value: number | undefined): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
 }
 
+function nonNegativeFiniteNumber(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
 function assignPositiveNumberAttr(
   attrs: Record<string, string | number | boolean>,
   key: string,
   value: number | undefined,
 ): void {
   const normalized = positiveFiniteNumber(value);
+  if (normalized !== undefined) {
+    attrs[key] = normalized;
+  }
+}
+
+function assignNonNegativeNumberAttr(
+  attrs: Record<string, string | number | boolean>,
+  key: string,
+  value: number | undefined,
+): void {
+  const normalized = nonNegativeFiniteNumber(value);
   if (normalized !== undefined) {
     attrs[key] = normalized;
   }
@@ -574,11 +589,28 @@ function modelCallPromptTokens(usage: {
   if (typeof usage.promptTokens === "number" && Number.isFinite(usage.promptTokens)) {
     return usage.promptTokens;
   }
+  const hasPromptPart = [usage.input, usage.cacheRead, usage.cacheWrite].some(
+    (value) => typeof value === "number" && Number.isFinite(value),
+  );
+  if (!hasPromptPart) {
+    return undefined;
+  }
   const input = usage.input ?? 0;
   const cacheRead = usage.cacheRead ?? 0;
   const cacheWrite = usage.cacheWrite ?? 0;
-  const total = input + cacheRead + cacheWrite;
-  return total > 0 ? total : undefined;
+  return input + cacheRead + cacheWrite;
+}
+
+function modelCallContextUtilization(
+  usage: ModelCallLifecycleDiagnosticEvent["usage"],
+  contextTokenBudget: number | undefined,
+): number | undefined {
+  const promptTokens = nonNegativeFiniteNumber(usage ? modelCallPromptTokens(usage) : undefined);
+  const tokenBudget = positiveFiniteNumber(contextTokenBudget);
+  if (promptTokens === undefined || tokenBudget === undefined) {
+    return undefined;
+  }
+  return Math.min(1, promptTokens / tokenBudget);
 }
 
 function assignModelCallPromptStatsAttrs(
@@ -599,6 +631,22 @@ function assignModelCallPromptStatsAttrs(
   ] as const) {
     assignNumberAttr(attrs, key, value);
   }
+}
+
+function assignModelCallContextAttrs(
+  attrs: Record<string, string | number | boolean>,
+  evt: Pick<ModelCallLifecycleDiagnosticEvent, "contextTokenBudget" | "usage">,
+): void {
+  assignPositiveNumberAttr(
+    attrs,
+    "openclaw.model_call.context_token_budget",
+    evt.contextTokenBudget,
+  );
+  assignNonNegativeNumberAttr(
+    attrs,
+    "openclaw.model_call.context_utilization",
+    modelCallContextUtilization(evt.usage, evt.contextTokenBudget),
+  );
 }
 
 function assignModelCallUsageAttrs(
@@ -623,7 +671,7 @@ function assignModelCallUsageAttrs(
     ["gen_ai.usage.cache_read.input_tokens", usage.cacheRead],
     ["gen_ai.usage.cache_creation.input_tokens", usage.cacheWrite],
   ] as const) {
-    assignPositiveNumberAttr(attrs, key, value);
+    assignNonNegativeNumberAttr(attrs, key, value);
   }
 }
 
@@ -2655,14 +2703,14 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
           "openclaw.tokens.total": usage.total ?? 0,
         };
         assignGenAiSpanIdentityAttrs(spanAttrs, evt);
-        assignPositiveNumberAttr(spanAttrs, "gen_ai.usage.input_tokens", genAiInputTokens);
-        assignPositiveNumberAttr(spanAttrs, "gen_ai.usage.output_tokens", usage.output);
-        assignPositiveNumberAttr(
+        assignNonNegativeNumberAttr(spanAttrs, "gen_ai.usage.input_tokens", genAiInputTokens);
+        assignNonNegativeNumberAttr(spanAttrs, "gen_ai.usage.output_tokens", usage.output);
+        assignNonNegativeNumberAttr(
           spanAttrs,
           "gen_ai.usage.cache_read.input_tokens",
           usage.cacheRead,
         );
-        assignPositiveNumberAttr(
+        assignNonNegativeNumberAttr(
           spanAttrs,
           "gen_ai.usage.cache_creation.input_tokens",
           usage.cacheWrite,
@@ -3495,6 +3543,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         }
         assignModelCallSizeTimingAttrs(spanAttrs, evt);
         assignModelCallPromptStatsAttrs(spanAttrs, evt);
+        assignModelCallContextAttrs(spanAttrs, evt);
         assignModelCallUsageAttrs(spanAttrs, evt);
         assignOtelModelContentAttributes(spanAttrs, modelContent, contentCapturePolicy);
         const span =
@@ -3549,6 +3598,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         }
         assignModelCallSizeTimingAttrs(spanAttrs, evt);
         assignModelCallPromptStatsAttrs(spanAttrs, evt);
+        assignModelCallContextAttrs(spanAttrs, evt);
         assignModelCallUsageAttrs(spanAttrs, evt);
         assignOtelModelContentAttributes(spanAttrs, modelContent, contentCapturePolicy);
         const span =


### PR DESCRIPTION
Fixes #100113

## What Problem This Solves

Fixes an issue where operators inspecting model-call traces could not distinguish an observed zero-output completion from missing usage telemetry when a provider returned `usage.output: 0`.

The missing zero also hid the context-exhaustion signature where prompt tokens are at or beyond the model-call context budget and the completion emits no output.

## Why This Change Was Made

Model-call and model-usage span attributes now preserve finite non-negative token counts instead of filtering them through positive-only normalization. Model-call spans also include a bounded `openclaw.model_call.context_utilization` value derived from prompt tokens and the existing context token budget so near-limit zero-output calls remain queryable.

Positive-only normalization remains in place for byte and timing fields where zero should still be treated as absent.

## User Impact

Operators can now query OpenClaw and GenAI OTEL span attributes for explicit zero token counts and identify context-limit zero-output completions without relying on content capture or provider logs.

## Evidence

- `git diff --check`
- `node scripts/run-vitest.mjs extensions/diagnostics-otel/src/service.test.ts` (`109 passed`)
