### PR TITLE
fix(android): stop saved gateway reconnect CI flake

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -612,19 +612,17 @@ class GatewayBootstrapAuthTest {
       ),
     )
     prefs.gatewayRegistry.setActive(savedEndpoint.stableId)
-    prefs.saveGatewayCredentials(savedEndpoint.stableId, token = "shared-token")
+    prefs.saveGatewayCredentials(savedEndpoint.stableId, token = "initial-token")
     val runtime = NodeRuntime(app, prefs)
 
-    runtime.connect(
-      GatewayEndpoint.manual(host = "127.0.0.1", port = 18789),
-      NodeRuntime.GatewayConnectAuth(token = "initial-token", bootstrapToken = null, password = null),
-    )
+    waitForDesiredConnection(runtime, "nodeSession")
+    prefs.saveGatewayCredentials(savedEndpoint.stableId, token = "shared-token")
     runtime.disconnect()
     assertNull(desiredConnection(runtime, "nodeSession"))
 
     runtime.refreshGatewayConnection()
 
-    val desired = desiredConnection(runtime, "nodeSession") ?: error("Expected desired node connection")
+    val desired = waitForDesiredConnection(runtime, "nodeSession")
     val endpoint = readField<GatewayEndpoint>(desired, "endpoint")
     assertEquals("127.0.0.1", endpoint.host)
     assertEquals(18789, endpoint.port)
@@ -1193,6 +1191,17 @@ class GatewayBootstrapAuthTest {
   ): Any? {
     val session = readField<GatewaySession>(runtime, sessionFieldName)
     return readField(session, "desired")
+  }
+
+  private fun waitForDesiredConnection(
+    runtime: NodeRuntime,
+    sessionFieldName: String,
+  ): Any {
+    repeat(50) {
+      desiredConnection(runtime, sessionFieldName)?.let { return it }
+      Thread.sleep(10)
+    }
+    error("Expected desired connection for $sessionFieldName")
   }
 
   private fun invokeMaybeStartOperatorSessionAfterNodeConnect(


### PR DESCRIPTION
## What Problem This Solves

Resolves an Android CI flake where the saved-gateway reconnect test could fail when runtime auto-connect raced the test's explicit connection setup.

## Why This Change Was Made

The test now follows the real runtime lifecycle: await the saved gateway's automatic connection, rotate its stored credential, disconnect, refresh, and await the new desired connection. This removes the duplicate test-owned connection without weakening the reconnect assertion.

## User Impact

No runtime behavior changes. Android PRs get deterministic coverage that refresh reconnects the saved endpoint with current stored credentials.

## Evidence

- Before: the same assertion failed on two independent Android CI runs: https://github.com/openclaw/openclaw/actions/runs/28841974007/job/85537799245 and https://github.com/openclaw/openclaw/actions/runs/28844741412/job/85546010186.
- Focused Play-flavor unit test passed on Blacksmith Testbox through Crabbox, `tbx_01kwxxm7jg9b2qgmzhmzkkn0mv`.
- Fresh structured autoreview: no accepted/actionable findings.
