### PR TITLE
fix(daemon): attach error listener to detached spawn in launchFallbackTaskScript

### DIFF
--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -24,7 +24,7 @@ const sleepMock = vi.hoisted(() =>
   }),
 );
 const childUnref = vi.hoisted(() => vi.fn());
-const spawn = vi.hoisted(() => vi.fn(() => ({ unref: childUnref })));
+const spawn = vi.hoisted(() => vi.fn(() => ({ on: vi.fn(), unref: childUnref })));
 type SpawnSyncResult = {
   pid: number;
   output: (string | null)[];

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -536,6 +536,7 @@ async function launchFallbackTaskScript(
       stdio: "ignore",
       windowsHide: true,
     });
+    child.on("error", () => {});
     child.unref();
     return;
   }
@@ -545,6 +546,7 @@ async function launchFallbackTaskScript(
     stdio: "ignore",
     windowsHide: true,
   });
+  child.on("error", () => {});
   child.unref();
 }
 


### PR DESCRIPTION
## What Problem This Solves

`launchFallbackTaskScript()` in `src/daemon/schtasks.ts` has two `spawn()` calls with `detached: true` and `child.unref()` but no `'error'` listener. When spawn fails (e.g. binary disappeared, permissions changed), Node.js emits an async `'error'` event on the ChildProcess. Without a listener, this becomes an unhandled error that crashes the parent process.

This is the same pattern identified and fixed in #101392 for `process-respawn.ts`.

## Why This Change Was Made

The two spawn sites in `launchFallbackTaskScript()`:
1. **Line 529**: spawns the detected scheduled task command directly  
2. **Line 543**: spawns `cmd.exe` with a generated script fallback

Both follow the same `detached: true → child.unref()` pattern without error handling. If the executable path is invalid (e.g. during update where the node binary was replaced), the async `'error'` event crashes the parent.

## Evidence

### Before: no error listener → unhandled crash

```
$ node -e "const{spawn}=require('child_process');spawn('/nonexistent',[],{detached:true,stdio:'ignore'})"
node:events:486
      throw er; // Unhandled 'error' event
      ^
Error: spawn /nonexistent ENOENT
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:292:12)
```

### After: error listener attached → graceful handling

```
$ node -e "
const {spawn} = require('child_process');
const child = spawn('/nonexistent', [], {detached: true, stdio: 'ignore'});
child.on('error', () => {});
console.log('OK: process does not crash');
"
OK: process does not crash
```

### Not tested

- `launchFallbackTaskScript` is not exported and requires Windows schtasks infrastructure — cannot verify through unit tests on Linux
- The spawn error listener pattern itself was validated and merged in canonical PR #101392

## Merge Risk

Low. The change only adds a no-op error listener before `child.unref()`. This follows the exact pattern from #101392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)