### PR TITLE
fix(infra): attach error listener to detached spawn in update handoff

### DIFF
--- a/src/infra/update-managed-service-handoff.test.ts
+++ b/src/infra/update-managed-service-handoff.test.ts
@@ -26,6 +26,7 @@ import {
 const { spawnMock } = vi.hoisted(() => ({
   spawnMock: vi.fn(() => ({
     pid: 24680,
+    on: vi.fn(),
     unref: vi.fn(),
   })),
 }));

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -734,6 +734,7 @@ export async function startManagedServiceUpdateHandoff(params: {
     detached: true,
     stdio: "ignore",
   });
+  child.on("error", () => {});
   child.unref();
 
   return {


### PR DESCRIPTION
## What Problem This Solves

`startManagedServiceUpdateHandoff()` in `src/infra/update-managed-service-handoff.ts` spawns a detached child process with `child.unref()` but no `'error'` listener. When spawn fails (e.g. execPath invalid, permissions changed), Node.js emits an async `'error'` event on the ChildProcess. Without a listener, this crashes the parent as an unhandled error.

This is the same pattern identified and fixed in #101392 for `process-respawn.ts`.

## Why This Change Was Made

The spawn at line 731 creates a detached handoff process during managed service updates. If the executable path is invalid, the async `'error'` event crashes the parent gateway.

## Evidence

### Before: no error listener → unhandled crash

```
$ node -e "const{spawn}=require('child_process');spawn('/nonexistent',[],{detached:true,stdio:'ignore'})"
node:events:486
      throw er; // Unhandled 'error' event
      ^
Error: spawn /nonexistent ENOENT
```

### After: error listener attached → graceful handling

```
$ node -e "
const {spawn} = require('child_process');
const child = spawn('/nonexistent', [], {detached: true, stdio: 'ignore'});
child.on('error', () => {});
console.log('OK: process does not crash');
"
OK: process does not crash
```

### Test mock updated

Updated `spawnMock` in `update-managed-service-handoff.test.ts` to include `on: vi.fn()` in the return value — required because the production code now calls `child.on("error", ...)`.

## Merge Risk

Low. The change adds a no-op error listener before `child.unref()`. Test mock updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)