### PR TITLE
fix(telegram): guard message_reaction handler against missing chat field

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.test.ts
@@ -55,34 +55,3 @@ describe("buildTelegramInboundDebounceKey", () => {
     expect(buildTelegramInboundDebounceConversationKey({ chatId: 7 })).toBe("7");
   });
 });
-
-describe("message_reaction chat guard", () => {
-  it("guards reaction without chat field (negative control proves crash)", () => {
-    // Pre-fix handler without chat guard — crashes on missing chat.
-    const buggy = (reaction: unknown): string | null => {
-      if (!reaction) {
-        return null;
-      }
-      const r = reaction as { chat?: { id?: number }; message_id?: number };
-      return `telegram:${r.chat!.id}:msg_${r.message_id}`;
-    };
-    expect(() => {
-      buggy({ message_id: 789 });
-    }).toThrow(TypeError);
-
-    // Post-fix handler with chat guard — returns null safely.
-    const safe = (reaction: unknown): string | null => {
-      if (!reaction) {
-        return null;
-      }
-      const r = reaction as { chat?: { id?: number }; message_id?: number };
-      if (!r?.chat) {
-        return null;
-      }
-      return `telegram:${r.chat.id}:msg_${r.message_id}`;
-    };
-    expect(safe({ message_id: 789 })).toBeNull();
-    expect(safe({ chat: { id: 123 }, message_id: 456 })).toBe("telegram:123:msg_456");
-    expect(safe(null)).toBeNull();
-  });
-});

--- a/extensions/telegram/src/bot-handlers.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.test.ts
@@ -57,33 +57,32 @@ describe("buildTelegramInboundDebounceKey", () => {
 });
 
 describe("message_reaction chat guard", () => {
-  it("returns null for reaction without chat (guard prevents TypeError)", () => {
-    // Real production guard pattern from bot-handlers.runtime.ts L2006:
-    //   if (!reaction?.chat) return;
-    const handle = (reaction: unknown): string | null => {
-      if (!reaction) return null;
-      const r = reaction as { chat?: { id?: number }; message_id?: number };
-      if (!r?.chat) return null;
-      return `telegram:${r.chat.id}:msg_${r.message_id}`;
-    };
-
-    // Reaction without chat → guarded, returns null
-    expect(handle({ message_id: 789 })).toBeNull();
-
-    // Normal reaction → produces key
-    expect(handle({ chat: { id: 123 }, message_id: 456 })).toBe("telegram:123:msg_456");
-
-    // Null reaction → existing guard
-    expect(handle(null)).toBeNull();
-  });
-
-  it("crashes without the guard (negative control)", () => {
-    const handleBuggy = (reaction: unknown): string | null => {
-      if (!reaction) return null;
+  it("guards reaction without chat field (negative control proves crash)", () => {
+    // Pre-fix handler without chat guard — crashes on missing chat.
+    const buggy = (reaction: unknown): string | null => {
+      if (!reaction) {
+        return null;
+      }
       const r = reaction as { chat?: { id?: number }; message_id?: number };
       return `telegram:${r.chat!.id}:msg_${r.message_id}`;
     };
+    expect(() => {
+      buggy({ message_id: 789 });
+    }).toThrow(TypeError);
 
-    expect(() => handleBuggy({ message_id: 789 })).toThrow(TypeError);
+    // Post-fix handler with chat guard — returns null safely.
+    const safe = (reaction: unknown): string | null => {
+      if (!reaction) {
+        return null;
+      }
+      const r = reaction as { chat?: { id?: number }; message_id?: number };
+      if (!r?.chat) {
+        return null;
+      }
+      return `telegram:${r.chat.id}:msg_${r.message_id}`;
+    };
+    expect(safe({ message_id: 789 })).toBeNull();
+    expect(safe({ chat: { id: 123 }, message_id: 456 })).toBe("telegram:123:msg_456");
+    expect(safe(null)).toBeNull();
   });
 });

--- a/extensions/telegram/src/bot-handlers.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.test.ts
@@ -55,3 +55,35 @@ describe("buildTelegramInboundDebounceKey", () => {
     expect(buildTelegramInboundDebounceConversationKey({ chatId: 7 })).toBe("7");
   });
 });
+
+describe("message_reaction chat guard", () => {
+  it("returns null for reaction without chat (guard prevents TypeError)", () => {
+    // Real production guard pattern from bot-handlers.runtime.ts L2006:
+    //   if (!reaction?.chat) return;
+    const handle = (reaction: unknown): string | null => {
+      if (!reaction) return null;
+      const r = reaction as { chat?: { id?: number }; message_id?: number };
+      if (!r?.chat) return null;
+      return `telegram:${r.chat.id}:msg_${r.message_id}`;
+    };
+
+    // Reaction without chat → guarded, returns null
+    expect(handle({ message_id: 789 })).toBeNull();
+
+    // Normal reaction → produces key
+    expect(handle({ chat: { id: 123 }, message_id: 456 })).toBe("telegram:123:msg_456");
+
+    // Null reaction → existing guard
+    expect(handle(null)).toBeNull();
+  });
+
+  it("crashes without the guard (negative control)", () => {
+    const handleBuggy = (reaction: unknown): string | null => {
+      if (!reaction) return null;
+      const r = reaction as { chat?: { id?: number }; message_id?: number };
+      return `telegram:${r.chat!.id}:msg_${r.message_id}`;
+    };
+
+    expect(() => handleBuggy({ message_id: 789 })).toThrow(TypeError);
+  });
+});

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2003,6 +2003,9 @@ export const registerTelegramHandlers = ({
       if (!reaction) {
         return;
       }
+      if (!reaction?.chat) {
+        return;
+      }
       if (shouldSkipUpdate(ctx)) {
         return;
       }

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -4797,6 +4797,35 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("returns early for message_reaction without chat", async () => {
+    onSpy.mockClear();
+    enqueueSystemEventSpy.mockClear();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"], reactionNotifications: "all" },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message_reaction") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      update: { update_id: 499 },
+      messageReaction: {
+        message_id: 42,
+        user: { id: 9, first_name: "Ada" },
+        date: 1736380800,
+        old_reaction: [],
+        new_reaction: [{ type: "emoji", emoji: THUMBS_UP_EMOJI }],
+      },
+    });
+
+    expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
+  });
+
   it("enqueues system event for reaction", async () => {
     onSpy.mockClear();
     enqueueSystemEventSpy.mockClear();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Telegram `message_reaction` update without a `chat` field would crash the handler with `TypeError: Cannot read properties of undefined (reading 'id')`, breaking the entire `message_reaction` event processing loop. Other inbound paths in the same handler already use optional chaining (`msg?.chat?.id`, `user?.id`), but `reaction.chat` was accessed without any guard.

## Why This Change Was Made

The handler already guards `!reaction` but `reaction.chat` is independently nullable in Bot API updates. Added `if (!reaction?.chat) return;` before the first `reaction.chat` access, matching the established guard pattern used throughout sibling update handlers.

## User Impact

Telegram reaction processing survives Bot API updates that omit the `chat` field. Previously a single malformed reaction update would crash the `message_reaction` handler and block all subsequent reactions until gateway restart.

## Evidence

**Registered handler regression test (real handler path):**

```
node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts -t \"message_reaction\"

 RUN  v4.1.9

 Test Files  1 passed (1)
      Tests  2 passed | 94 skipped (96)
   Duration  55.90s
```

- `returns early for message_reaction without chat` — invokes `getOnHandler(\"message_reaction\")` and asserts the real registered handler returns without throwing and without enqueueing a system event.
- `enqueues system event for reaction` — existing sibling test confirming the normal reaction path still works.

The previous copied-helper regression test in `bot-handlers.runtime.test.ts` has been removed; the guard is now covered by the registered handler path, so CI will catch regressions if the production handler loses the guard.

**Terminal transcript (real handler call, post-fix):**

```
await handler({
  update: { update_id: 499 },
  messageReaction: {
    message_id: 42,
    user: { id: 9, first_name: \"Ada\" },
    date: 1736380800,
    old_reaction: [],
    new_reaction: [{ type: \"emoji\", emoji: \"👍\" }],
  },
});
expect(enqueueSystemEventSpy).not.toHaveBeenCalled();
// PASS — no TypeError, no spurious enqueue
```

**Format:** `oxfmt` clean.

**Patch:** 3 source lines added (runtime guard); test moved from copied helper to registered handler regression.