### PR TITLE
fix: resolve macOS dashboard token placeholders

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -31,6 +31,31 @@ actor GatewayEndpointStore {
 
     private static let envOverrideWarnings = LockIsolated((token: false, password: false))
 
+    private static func envPlaceholderName(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("${"), trimmed.hasSuffix("}") else { return nil }
+        let name = String(trimmed.dropFirst(2).dropLast())
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return name.isEmpty ? nil : name
+    }
+
+    private static func resolvedEnvPlaceholder(
+        _ raw: String,
+        env: [String: String],
+        launchdSnapshot: LaunchAgentPlistSnapshot?) -> String?
+    {
+        guard let name = self.envPlaceholderName(raw) else { return nil }
+        if let value = env[name]?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty {
+            return value
+        }
+        if let value = launchdSnapshot?.environment[name]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
+        {
+            return value
+        }
+        return nil
+    }
+
     struct Deps {
         let mode: @Sendable () async -> AppState.ConnectionMode
         let token: @Sendable () -> String?
@@ -157,7 +182,8 @@ actor GatewayEndpointStore {
         if !trimmed.isEmpty {
             if let configToken = self.resolveConfigToken(isRemote: isRemote, root: root),
                !configToken.isEmpty,
-               configToken != trimmed
+               configToken != trimmed,
+               self.envPlaceholderName(configToken) != "OPENCLAW_GATEWAY_TOKEN"
             {
                 self.warnEnvOverrideOnce(
                     kind: .token,
@@ -170,7 +196,22 @@ actor GatewayEndpointStore {
         if let configToken = self.resolveConfigToken(isRemote: isRemote, root: root),
            !configToken.isEmpty
         {
-            return configToken
+            if let resolved = self.resolvedEnvPlaceholder(
+                configToken,
+                env: env,
+                launchdSnapshot: isRemote ? nil : launchdSnapshot)
+            {
+                return resolved
+            }
+            if self.envPlaceholderName(configToken) != nil {
+                // The native app often starts outside the gateway service environment.
+                // Treat unresolved ${ENV} refs as absent so local launchd fallback can recover.
+                if isRemote {
+                    return nil
+                }
+            } else {
+                return configToken
+            }
         }
 
         if isRemote {
@@ -701,6 +742,11 @@ extension GatewayEndpointStore {
         if let token = tokenCandidate?.trimmingCharacters(in: .whitespacesAndNewlines),
            !token.isEmpty
         {
+            if let name = self.envPlaceholderName(token) {
+                throw NSError(domain: "Dashboard", code: 3, userInfo: [
+                    NSLocalizedDescriptionKey: "Gateway token placeholder ${\(name)} is not resolved",
+                ])
+            }
             fragmentItems.append(URLQueryItem(name: "token", value: token))
         }
         components.queryItems = nil

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -47,6 +47,33 @@ struct GatewayEndpointStoreTests {
         #expect(fallbackToken == "launchd-token")
     }
 
+    @Test func `resolve gateway token skips unresolved local config placeholder`() {
+        let snapshot = self.makeLaunchAgentSnapshot(
+            env: ["OPENCLAW_GATEWAY_TOKEN": "launchd-token"],
+            token: "launchd-token",
+            password: nil)
+        let root: [String: Any] = [
+            "gateway": [
+                "auth": [
+                    "token": "${OPENCLAW_GATEWAY_TOKEN}",
+                ],
+            ],
+        ]
+
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: false,
+            root: root,
+            env: [:],
+            launchdSnapshot: snapshot)
+        #expect(token == "launchd-token")
+
+        let config = GatewayEndpointStore._testLocalConfig(
+            root: root,
+            env: [:],
+            launchdSnapshot: snapshot)
+        #expect(config.token == "launchd-token")
+    }
+
     @Test func `resolve gateway token ignores launchd in remote mode`() {
         let snapshot = self.makeLaunchAgentSnapshot(
             env: ["OPENCLAW_GATEWAY_TOKEN": "launchd-token"],
@@ -297,6 +324,23 @@ struct GatewayEndpointStoreTests {
             authToken: "device-token")
         #expect(url.absoluteString == "http://127.0.0.1:18789/control/#token=device-token")
         #expect(url.query == nil)
+    }
+
+    @Test func `dashboard URL rejects unresolved token placeholder`() throws {
+        let config: GatewayConnection.Config = try (
+            url: #require(URL(string: "ws://127.0.0.1:18789")),
+            token: "${OPENCLAW_GATEWAY_TOKEN}",
+            password: nil)
+
+        do {
+            _ = try GatewayEndpointStore.dashboardURL(
+                for: config,
+                mode: .local,
+                localBasePath: "/control")
+            Issue.record("dashboard URL should not accept unresolved token placeholders")
+        } catch {
+            #expect(error.localizedDescription.contains("OPENCLAW_GATEWAY_TOKEN"))
+        }
     }
 
     @Test func `normalize gateway url adds default port for loopback ws`() {


### PR DESCRIPTION
Fixes #101286

## What Problem This Solves

Fixes an issue where macOS users opening the dashboard from the Dock or Finder could be locked out when `gateway.auth.token` was configured as `${OPENCLAW_GATEWAY_TOKEN}` and that environment variable only existed in the gateway LaunchAgent environment.

In that case the app treated the unresolved placeholder as the real token and opened a dashboard URL containing the encoded `${...}` string.

## Why This Change Was Made

The macOS endpoint resolver now treats `${ENV}` token values as environment placeholders instead of concrete tokens. It resolves them from the app environment or the local LaunchAgent snapshot, then falls back to the LaunchAgent token for local gateway configs.

The dashboard URL builder also rejects any unresolved token placeholder that reaches it, so the app no longer constructs a misleading `#token=${...}` URL.

## User Impact

Users who keep the gateway token in a LaunchAgent-scoped environment can open the dashboard from the macOS app without manually exporting the token into the GUI login environment.

If a placeholder still cannot be resolved, the app fails with a clear dashboard-token error instead of silently passing the placeholder to the dashboard.

## Evidence

- `git diff --check`
- `swiftc -parse apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift`
- Attempted `swift test --package-path apps/macos --filter GatewayEndpointStoreTests`; SwiftPM repeatedly stalled fetching `https://github.com/steipete/Peekaboo.git`, so the full package test could not complete in this environment.
