### PR TITLE
fix(channels): use truncateUtf16Safe for thread binding name truncation

### DIFF
--- a/src/channels/thread-bindings-messages.test.ts
+++ b/src/channels/thread-bindings-messages.test.ts
@@ -1,0 +1,20 @@
+// Thread-binding message tests cover user-visible names and lifecycle text.
+import { describe, expect, it } from "vitest";
+import {
+  resolveThreadBindingIntroText,
+  resolveThreadBindingThreadName,
+} from "./thread-bindings-messages.js";
+
+describe("thread-binding names", () => {
+  it("does not split surrogate pairs at native name limits", () => {
+    const threadName = resolveThreadBindingThreadName({
+      label: `${"x".repeat(96)}🚀tail`,
+    });
+    const intro = resolveThreadBindingIntroText({
+      label: `${"x".repeat(99)}🚀tail`,
+    });
+
+    expect(threadName).toBe(`🤖 ${"x".repeat(96)}`);
+    expect(intro).toContain(`${"x".repeat(99)} session active`);
+  });
+});

--- a/src/channels/thread-bindings-messages.ts
+++ b/src/channels/thread-bindings-messages.ts
@@ -3,8 +3,8 @@
  * Keep text system-prefixed and compact because callers post it directly into user-visible threads.
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { prefixSystemMessage } from "../infra/system-message.js";
-import { truncateUtf16Safe } from "../utils.js";
 
 const DEFAULT_THREAD_BINDING_FAREWELL_TEXT =
   "Session ended. Messages here will no longer be routed.";

--- a/src/channels/thread-bindings-messages.ts
+++ b/src/channels/thread-bindings-messages.ts
@@ -4,6 +4,7 @@
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { prefixSystemMessage } from "../infra/system-message.js";
+import { truncateUtf16Safe } from "../utils.js";
 
 const DEFAULT_THREAD_BINDING_FAREWELL_TEXT =
   "Session ended. Messages here will no longer be routed.";
@@ -43,7 +44,7 @@ export function resolveThreadBindingThreadName(params: {
   const base = label || normalizeOptionalString(params.agentId) || "agent";
   const raw = `🤖 ${base}`.replace(/\s+/g, " ").trim();
   // Native channel thread names have tight limits; keep generated names bounded.
-  return raw.slice(0, 100);
+  return truncateUtf16Safe(raw, 100);
 }
 
 /** Builds the system-prefixed intro text posted when a thread binding becomes active. */
@@ -57,7 +58,7 @@ export function resolveThreadBindingIntroText(params: {
 }): string {
   const label = normalizeOptionalString(params.label);
   const base = label || normalizeOptionalString(params.agentId) || "agent";
-  const normalized = base.replace(/\s+/g, " ").trim().slice(0, 100) || "agent";
+  const normalized = truncateUtf16Safe(base.replace(/\s+/g, " ").trim(), 100) || "agent";
   const idleTimeoutMs = normalizeThreadBindingDurationMs(params.idleTimeoutMs);
   const maxAgeMs = normalizeThreadBindingDurationMs(params.maxAgeMs);
   const cwd = normalizeOptionalString(params.sessionCwd);


### PR DESCRIPTION
## What Problem This Solves

Thread binding names in `src/channels/thread-bindings-messages.ts` use `.slice(0, 100)` on text that includes emoji (🤖) and user-supplied agent labels. A slice boundary that lands in the middle of a surrogate pair (common with emoji and CJK characters) produces U+FFFD replacement characters in native channel thread names.

## Why This Change Was Made

Replace two `.slice(0, 100)` calls with `truncateUtf16Safe()`, which checks surrogate pairs before truncating. Same utility already used by 15+ files across the codebase.

## Evidence

### Code change (2 lines)

```diff
- const raw = `🤖 ${base}`.replace(/\s+/g, " ").trim();
- return raw.slice(0, 100);
+ return truncateUtf16Safe(raw, 100);

- const normalized = base.replace(/\s+/g, " ").trim().slice(0, 100) || "agent";
+ const normalized = truncateUtf16Safe(base.replace(/\s+/g, " ").trim(), 100) || "agent";
```

### Follows established pattern

`truncateUtf16Safe` is already used by discord, imessage, telegram, memory-core, harness, tools, and agent modules. This PR extends the same pattern to channel thread binding messages.

## Issue

N/A — proactive UTF-16 safety sweep following Alix-007 (#101311), wangmiao (#101421), and ly85206559 (#101029).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)