### PR TITLE
fix(infra): attach error listener to detached spawn in windows-task-restart

### DIFF
--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -97,11 +97,7 @@ describe("relaunchGatewayScheduledTask", () => {
     spawnMock.mockImplementation((_file: string, args: string[]) => {
       seenCommandArg = args[3];
       createdScriptPaths.add(decodeCmdPathArg(args[3]));
-      return { unref };
-    });
-
-    const result = relaunchGatewayScheduledTask({ OPENCLAW_PROFILE: "work" });
-    const cmdExePath = getWindowsCmdExePath();
+      return { on: vi.fn(), unref };
 
     expect(result.ok).toBe(true);
     expect(result.method).toBe("schtasks");
@@ -142,7 +138,7 @@ describe("relaunchGatewayScheduledTask", () => {
   it("prefers OPENCLAW_WINDOWS_TASK_NAME overrides", () => {
     spawnMock.mockImplementation((_file: string, args: string[]) => {
       createdScriptPaths.add(decodeCmdPathArg(args[3]));
-      return { unref: vi.fn() };
+      return { on: vi.fn(), unref: vi.fn() };
     });
 
     relaunchGatewayScheduledTask({
@@ -158,7 +154,7 @@ describe("relaunchGatewayScheduledTask", () => {
   it("escapes custom task names in the PowerShell running-task probe", () => {
     spawnMock.mockImplementation((_file: string, args: string[]) => {
       createdScriptPaths.add(decodeCmdPathArg(args[3]));
-      return { unref: vi.fn() };
+      return { on: vi.fn(), unref: vi.fn() };
     });
 
     relaunchGatewayScheduledTask({
@@ -190,7 +186,7 @@ describe("relaunchGatewayScheduledTask", () => {
     const metacharTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw&(restart)-"));
     createdTmpDirs.add(metacharTmpDir);
     resolvePreferredOpenClawTmpDirMock.mockReturnValue(metacharTmpDir);
-    spawnMock.mockReturnValue({ unref });
+    spawnMock.mockReturnValue({ on: vi.fn(), unref });
 
     relaunchGatewayScheduledTask({ OPENCLAW_PROFILE: "work" });
 
@@ -225,7 +221,7 @@ describe("relaunchGatewayScheduledTask", () => {
 
     spawnMock.mockImplementation((_file: string, args: string[]) => {
       createdScriptPaths.add(decodeCmdPathArg(args[3]));
-      return { unref: vi.fn() };
+      return { on: vi.fn(), unref: vi.fn() };
     });
 
     const result = relaunchGatewayScheduledTask({ OPENCLAW_PROFILE: "work" });

--- a/src/infra/windows-task-restart.test.ts
+++ b/src/infra/windows-task-restart.test.ts
@@ -98,6 +98,10 @@ describe("relaunchGatewayScheduledTask", () => {
       seenCommandArg = args[3];
       createdScriptPaths.add(decodeCmdPathArg(args[3]));
       return { on: vi.fn(), unref };
+    });
+
+    const result = relaunchGatewayScheduledTask({ OPENCLAW_PROFILE: "work" });
+    const cmdExePath = getWindowsCmdExePath();
 
     expect(result.ok).toBe(true);
     expect(result.method).toBe("schtasks");

--- a/src/infra/windows-task-restart.ts
+++ b/src/infra/windows-task-restart.ts
@@ -105,6 +105,7 @@ export function relaunchGatewayScheduledTask(env: NodeJS.ProcessEnv = process.en
       stdio: "ignore",
       windowsHide: true,
     });
+    child.on("error", () => {});
     child.unref();
     return {
       ok: true,


### PR DESCRIPTION
## What Problem This Solves

`relaunchGatewayScheduledTask()` in `src/infra/windows-task-restart.ts` spawns a detached child process with `child.unref()` but no `'error'` listener. When spawn fails (e.g. cmd.exe path invalid), Node.js emits an async `'error'` event that crashes the parent as an unhandled error.

Same pattern as #101392 for `process-respawn.ts`.

## Evidence

### Before: no error listener → unhandled crash
```
$ node -e "const{spawn}=require('child_process');spawn('/nonexistent',[],{detached:true,stdio:'ignore'})"
node:events:486
      throw er; // Unhandled 'error' event
      ^
Error: spawn /nonexistent ENOENT
```

### After: error listener attached → graceful handling
```
$ node -e "
const {spawn} = require('child_process');
const child = spawn('/nonexistent', [], {detached: true, stdio: 'ignore'});
child.on('error', () => {});
console.log('OK');
"
OK
```

### Test mock updated
All `spawnMock` return values in `windows-task-restart.test.ts` updated to include `on: vi.fn()`.

## Merge Risk
Low. No-op error listener before `child.unref()`. Test mocks updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)