### PR TITLE
fix(daemon): attach error listener to detached spawn in launchd restart handoff

### DIFF
--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -36,7 +36,7 @@ function requireSpawnCall(callIndex = 0): SpawnCall {
 afterEach(() => {
   spawnMock.mockReset();
   unrefMock.mockReset();
-  spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+  spawnMock.mockReturnValue({ pid: 4242, on: vi.fn(), unref: unrefMock });
 });
 
 describe("scheduleDetachedLaunchdRestartHandoff", () => {
@@ -45,7 +45,7 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
       HOME: "/Users/test",
       OPENCLAW_PROFILE: "default",
     };
-    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+    spawnMock.mockReturnValue({ pid: 4242, on: vi.fn(), unref: unrefMock });
 
     const result = scheduleDetachedLaunchdRestartHandoff({
       env,
@@ -74,7 +74,7 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
   });
 
   it("passes the plain label separately for start-after-exit mode", () => {
-    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+    spawnMock.mockReturnValue({ pid: 4242, on: vi.fn(), unref: unrefMock });
 
     scheduleDetachedLaunchdRestartHandoff({
       env: {
@@ -96,7 +96,7 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
   });
 
   it("polls after bootout and falls back to kickstart on bootstrap failure for reload mode", () => {
-    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+    spawnMock.mockReturnValue({ pid: 4242, on: vi.fn(), unref: unrefMock });
 
     scheduleDetachedLaunchdRestartHandoff({
       env: {
@@ -120,7 +120,7 @@ describe("scheduleDetachedLaunchdRestartHandoff", () => {
   });
 
   it("sanitizes restart helper environment overrides before spawning", () => {
-    spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock });
+    spawnMock.mockReturnValue({ pid: 4242, on: vi.fn(), unref: unrefMock });
 
     scheduleDetachedLaunchdRestartHandoff({
       env: {

--- a/src/daemon/launchd-restart-handoff.ts
+++ b/src/daemon/launchd-restart-handoff.ts
@@ -248,6 +248,7 @@ export function scheduleDetachedLaunchdRestartHandoff(params: {
         env: restartEnv,
       },
     );
+    child.on("error", () => {});
     child.unref();
     return { ok: true, pid: child.pid ?? undefined };
   } catch (err) {


### PR DESCRIPTION
## What Problem This Solves

`scheduleDetachedLaunchdRestartHandoff()` in `src/daemon/launchd-restart-handoff.ts` spawns a detached `/bin/sh` child process with `child.unref()` but no `'error'` listener. When spawn fails, Node.js emits an async `'error'` event that crashes the parent.

Same pattern as #101392 for `process-respawn.ts`.

## Evidence

### Before: no error listener → unhandled crash
```
$ node -e "const{spawn}=require('child_process');spawn('/nonexistent',[],{detached:true,stdio:'ignore'})"
node:events:486
      throw er; // Unhandled 'error' event
      ^
Error: spawn /nonexistent ENOENT
```

### After: error listener attached → graceful handling
```
$ node -e "
const {spawn} = require('child_process');
const child = spawn('/nonexistent', [], {detached: true, stdio: 'ignore'});
child.on('error', () => {});
console.log('OK');
"
OK
```

### Test mock updated
All `spawnMock.mockReturnValue` calls in `launchd-restart-handoff.test.ts` updated to include `on: vi.fn()`.

## Merge Risk
Low. No-op error listener before `child.unref()`. Test mocks updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)