### PR TITLE
fix(signal): add error listener to daemon stdout/stderr streams

### DIFF
--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -1,7 +1,8 @@
 // Signal tests cover daemon plugin behavior.
+import { EventEmitter } from "node:events";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { testApi } from "./daemon.js";
 
 describe("signal daemon args", () => {
@@ -44,5 +45,30 @@ describe("signal daemon log classification", () => {
   it("still surfaces signal-cli failures as errors", () => {
     expect(testApi.classifySignalCliLogLine("ERROR DaemonCommand - startup failed")).toBe("error");
     expect(testApi.classifySignalCliLogLine("SEVERE Manager - database exception")).toBe("error");
+  });
+});
+
+describe("bindSignalCliOutput", () => {
+  it("registers an error listener on the stream to prevent crash on broken pipe", () => {
+    const stream = new EventEmitter() as NodeJS.ReadableStream;
+    const onSpy = vi.spyOn(stream, "on");
+
+    testApi.bindSignalCliOutput({
+      stream,
+      log: vi.fn(),
+      error: vi.fn(),
+    });
+
+    expect(onSpy).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+
+  it("does not throw when the stream emits an error", () => {
+    const stream = new EventEmitter() as NodeJS.ReadableStream;
+    const log = vi.fn();
+    const err = vi.fn();
+
+    testApi.bindSignalCliOutput({ stream, log, error: err });
+
+    expect(() => stream.emit("error", new Error("pipe broken"))).not.toThrow();
   });
 });

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -63,6 +63,9 @@ function bindSignalCliOutput(params: {
   log: (message: string) => void;
   error: (message: string) => void;
 }): void {
+  // ponytail: no-op error handler prevents Node crash on broken pipe.
+  // The stream is consumed fire-and-forget — there is nothing to reject.
+  params.stream?.on("error", () => {});
   params.stream?.on("data", (data) => {
     for (const line of data.toString().split(/\r?\n/)) {
       const kind = classifySignalCliLogLine(line);
@@ -178,4 +181,5 @@ export const testApi = {
   buildDaemonArgs,
   classifySignalCliLogLine,
   resolveSignalCliConfigPath,
+  bindSignalCliOutput,
 } as const;


### PR DESCRIPTION
## Summary

**Problem:** `bindSignalCliOutput()` attaches a `.on("data")` listener to child process stdout/stderr streams but never registers an error handler. If the signal-cli daemon process's pipe breaks (process crash, abrupt termination), the `error` event emitted on the readable stream goes unhandled, crashing the gateway process.

**Solution:** Add a no-op `.on("error")` listener before the `.on("data")` listener on each stream. The streams are consumed fire-and-forget — there is nothing to reject.

**What changed:**
- `extensions/signal/src/daemon.ts:66` — no-op error handler in `bindSignalCliOutput`
- `extensions/signal/src/daemon.test.ts` — 2 new tests verifying error listener registration and graceful error handling

**What did NOT change:** No behavioral change on the happy path. No config/env change. No user-visible behavior.

## What Problem This Solves

The Signal extension spawns a `signal-cli daemon` child process and pipes its stdout/stderr for log forwarding via `bindSignalCliOutput()`. This function registers data listeners to classify and forward log lines. However, when the signal-cli process terminates abruptly (crash, OOM kill, SIGKILL), the broken pipe causes the readable stream to emit an `error` event. Without an error listener, Node.js throws an unhandled exception, crashing the parent gateway process.

This is the same class of issue as the `ChildProcess` stream error listener fixes contributed by csbAsDev and others — missing error handlers on fire-and-forget child process I/O streams.

## Root Cause

`extensions/signal/src/daemon.ts:61-76`: `bindSignalCliOutput` registers a `.on("data")` listener on the stream but never registers `.on("error")`. Node.js `Readable` emits an `error` event when the underlying resource is broken; unhandled `error` events throw and crash the process.

## Real behavior proof

**Behavior addressed:** `bindSignalCliOutput()` now registers a no-op error handler on child process stdout/stderr streams, preventing unhandled exception crashes when a pipe breaks.

**Real environment tested:** Linux x64 (kernel 4.19.112), Node.js v24.13.1, OpenClaw main@78399a194c

**Exact steps or command run after this patch:**

The proof below uses the **actual patched function** from `daemon.ts` (`testApi.bindSignalCliOutput`) with a real child process stdout stream, destroyed with error — exactly the mechanism that triggers when a signal-cli process pipe breaks.

**Before** (child stdout WITHOUT error listener):
```bash
npx tsx -e "import { spawn } from 'node:child_process'; const child = spawn('node', ['-e','setInterval(()=>{},86400)']); child.stdout.on('data', () => {}); child.stdout.destroy(new Error('EPIPE')); setTimeout(() => {}, 1000);"
```

**After** (child stdout THROUGH patched `bindSignalCliOutput`):
```bash
npx tsx -e "import { spawn } from 'node:child_process'; import { testApi } from './extensions/signal/src/daemon'; const child = spawn('node', ['-e','setInterval(()=>{},86400)']); testApi.bindSignalCliOutput({stream:child.stdout,log:()=>{},error:()=>{}}); child.stdout.destroy(new Error('EPIPE')); setTimeout(() => console.log('Survived'), 500);"
```

**Observed result after the fix:** Stream error no longer crashes the process; error is caught by the no-op listener in `bindSignalCliOutput`.

**After-fix evidence:**
```
--- BEFORE: child stdout without error listener ---
node:events:486
      throw er; // Unhandled 'error' event
      ^
Error: EPIPE
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:170:8)
Node.js v24.13.1
Exit: 1 (crash)

--- AFTER: child stdout through patched bindSignalCliOutput ---
Survived
Exit: 0 (no crash)
```

**What was not tested:** Real signal-cli process crash (requires OS process termination). End-to-end gateway restart through supervisor.

## Risk checklist

**Risk level:** Low

- **merge-risk:** Low — +1 line no-op error handler, no behavioral change on success
- **Risk mitigation:** No-op handler pattern is standard for fire-and-forget stream consumption; 6 tests pass (was 4, +2 new)
- **User-visible behavior change?** No
- **Config/env/migration change?** No
- **Security/auth/network change?** No