### PR TITLE
fix(codex): use truncateUtf16Safe for attempt notification text truncation

### DIFF
--- a/extensions/codex/src/app-server/attempt-notifications.test.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.test.ts
@@ -1,0 +1,20 @@
+// Attempt-notification tests cover Codex app-server envelope parsing and diagnostics.
+import { describe, expect, it } from "vitest";
+import { describeNotificationActivity } from "./attempt-notifications.js";
+
+describe("describeNotificationActivity", () => {
+  it("does not split surrogate pairs in assistant text previews", () => {
+    const details = describeNotificationActivity({
+      method: "rawResponseItem/completed",
+      params: {
+        item: {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: `${"x".repeat(236)}🚀tail` }],
+        },
+      },
+    });
+
+    expect(details?.lastAssistantTextPreview).toBe(`${"x".repeat(236)}...`);
+  });
+});

--- a/extensions/codex/src/app-server/attempt-notifications.ts
+++ b/extensions/codex/src/app-server/attempt-notifications.ts
@@ -1,6 +1,7 @@
 /**
  * Predicates and readers for Codex app-server notification envelopes.
  */
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   isJsonObject,
   type CodexServerNotification,
@@ -317,7 +318,7 @@ function readRawAssistantTextPreview(item: JsonObject): string | undefined {
   if (!text) {
     return undefined;
   }
-  return text.length > 240 ? `${text.slice(0, 237)}...` : text;
+  return text.length > 240 ? `${truncateUtf16Safe(text, 237)}...` : text;
 }
 
 /** Returns true for app-server error notifications that will retry. */
@@ -336,7 +337,10 @@ export function isTerminalTurnStatus(status: string | undefined): boolean {
  */
 export function isCodexTurnAbortMarkerNotification(
   notification: CodexServerNotification,
-  options: { currentPromptText?: string; currentPromptTexts?: readonly string[] } = {},
+  options: {
+    currentPromptText?: string;
+    currentPromptTexts?: readonly string[];
+  } = {},
 ): boolean {
   if (notification.method !== "rawResponseItem/completed" || !isJsonObject(notification.params)) {
     return false;

--- a/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-support.config.ts
@@ -7,6 +7,7 @@ export function createExtensionCodexAppServerAttemptSupportVitestConfig(
   return createScopedVitestConfig(
     [
       "extensions/codex/src/app-server/attempt-context.test.ts",
+      "extensions/codex/src/app-server/attempt-notifications.test.ts",
       "extensions/codex/src/app-server/attempt-results.test.ts",
       "extensions/codex/src/app-server/attempt-startup.test.ts",
       "extensions/codex/src/app-server/attempt-timeouts.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Codex attempt notifications truncate agent output with `.slice(0, 237)`. When the slice boundary lands mid-surrogate-pair (common with CJK characters or emoji in agent output), the U+FFFD replacement character appears in desktop notification text.

## Why This Change Was Made

Replace `.slice(0, 237)` with `truncateUtf16Safe()`.

## Evidence

```diff
- return text.length > 240 ? `${text.slice(0, 237)}...` : text;
+ return text.length > 240 ? `${truncateUtf16Safe(text, 237)}...` : text;
```

Part of the UTF-16 safety sweep following Alix-007 (#101311), wangmiao (#101421), and ly85206559 (#101029).

## Issue

N/A

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)