### PR TITLE
fix(acp): use truncateUtf16Safe for event mapper error text truncation

### DIFF
--- a/src/acp/event-mapper.test.ts
+++ b/src/acp/event-mapper.test.ts
@@ -1,6 +1,6 @@
 /** Tests ACP tool-call location extraction limits. */
 import { describe, expect, it } from "vitest";
-import { extractToolCallLocations } from "./event-mapper.js";
+import { extractToolCallLocations, formatToolTitle } from "./event-mapper.js";
 
 describe("extractToolCallLocations", () => {
   it("enforces the global node visit cap across nested structures", () => {
@@ -16,5 +16,15 @@ describe("extractToolCallLocations", () => {
       throw new Error("expected bounded tool-call locations");
     }
     expect(locations).toEqual([{ path: "/tmp/file-0.txt" }, { path: "/tmp/file-1.txt" }]);
+  });
+});
+
+describe("formatToolTitle", () => {
+  it("does not split surrogate pairs when truncating argument values", () => {
+    const title = formatToolTitle("exec", {
+      command: `${"x".repeat(99)}🚀tail`,
+    });
+
+    expect(title).toBe(`exec: command: ${"x".repeat(99)}...`);
   });
 });

--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -14,6 +14,7 @@ import {
   normalizeOptionalString,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "../utils.js";
 
 type GatewayAttachment = {
   type: string;
@@ -309,7 +310,7 @@ export function formatToolTitle(
   }
   const parts = Object.entries(args).map(([key, value]) => {
     const raw = typeof value === "string" ? value : JSON.stringify(value);
-    const safe = raw.length > 100 ? `${raw.slice(0, 100)}...` : raw;
+    const safe = raw.length > 100 ? `${truncateUtf16Safe(raw, 100)}...` : raw;
     return `${key}: ${safe}`;
   });
   // Sanitize at the source so session updates and permission requests never

--- a/src/acp/event-mapper.ts
+++ b/src/acp/event-mapper.ts
@@ -14,7 +14,7 @@ import {
   normalizeOptionalString,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "../utils.js";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 type GatewayAttachment = {
   type: string;


### PR DESCRIPTION
## What Problem This Solves

ACP event mapper truncates error argument values with `.slice(0, 100)`. Tool call arguments and error text may contain CJK characters or emoji — a slice boundary in the middle of a surrogate pair produces U+FFFD in operator-visible warning messages.

## Why This Change Was Made

Replace `.slice(0, 100)` with `truncateUtf16Safe()`.

## Evidence

```diff
- const safe = raw.length > 100 ? `${raw.slice(0, 100)}...` : raw;
+ const safe = raw.length > 100 ? `${truncateUtf16Safe(raw, 100)}...` : raw;
```

Part of the UTF-16 safety sweep.

## Issue

N/A

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)