### PR TITLE
fix: avoid sqlite ledger byte scan on append

### DIFF
--- a/src/acp/event-ledger.test.ts
+++ b/src/acp/event-ledger.test.ts
@@ -1,7 +1,8 @@
 /** Tests ACP event ledger recording, replay, retention, and SQLite migration. */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
 import {
@@ -246,6 +247,41 @@ describe("ACP event ledger", () => {
       await expect(
         ledger.readReplay({ sessionId: "session-1", sessionKey: "agent:main:work" }),
       ).resolves.toEqual({ complete: false, events: [] });
+    });
+  });
+
+  it("uses SQLite page stats instead of full table scans for byte retention estimates", async () => {
+    await withTempDir({ prefix: "openclaw-acp-ledger-" }, async (dir) => {
+      const prepareSpy = vi.spyOn(DatabaseSync.prototype, "prepare");
+      try {
+        const ledger = createSqliteAcpEventLedger({
+          path: path.join(dir, "openclaw.sqlite"),
+          maxSerializedBytes: Number.MAX_SAFE_INTEGER,
+        });
+        await ledger.startSession({
+          sessionId: "session-1",
+          sessionKey: "agent:main:work",
+          cwd: "/work",
+          complete: true,
+        });
+        await ledger.recordUpdate({
+          sessionId: "session-1",
+          sessionKey: "agent:main:work",
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tool-1",
+            status: "completed",
+            rawOutput: { content: "x".repeat(5_000) },
+          },
+        });
+
+        const preparedSql = prepareSpy.mock.calls.map(([sql]) => sql);
+        expect(preparedSql).toContain("PRAGMA page_count");
+        expect(preparedSql).toContain("PRAGMA page_size");
+        expect(preparedSql.some((sql) => sql.includes("SUM(length("))).toBe(false);
+      } finally {
+        prepareSpy.mockRestore();
+      }
     });
   });
 

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -18,6 +18,7 @@ const LEDGER_VERSION = 1;
 const DEFAULT_MAX_SESSIONS = 200;
 const DEFAULT_MAX_EVENTS_PER_SESSION = 5_000;
 const DEFAULT_MAX_SERIALIZED_BYTES = 16 * 1024 * 1024;
+const DEFAULT_SQLITE_PAGE_SIZE_BYTES = 4096;
 const FILE_LEDGER_LOCK_OPTIONS = {
   retries: {
     retries: 8,
@@ -537,6 +538,13 @@ function normalizeSqliteInteger(value: number | bigint | null): number {
   return typeof value === "number" ? value : 0;
 }
 
+function readSqlitePragmaInteger(db: DatabaseSync, name: "page_count" | "page_size"): number {
+  const row = db.prepare(`PRAGMA ${name}`).get() as
+    | Record<string, number | bigint | null>
+    | undefined;
+  return normalizeSqliteInteger(row?.[name] ?? null);
+}
+
 type AcpReplaySessionRow = {
   session_id: string;
   session_key: string;
@@ -682,16 +690,9 @@ function upsertSqliteSession(
 }
 
 function estimateSqliteLedgerBytes(db: DatabaseSync): number {
-  const row = db
-    .prepare(
-      `SELECT
-         COALESCE(SUM(length(session_id) + length(session_key) + length(cwd) + 32), 0) AS sessions,
-         (SELECT COALESCE(SUM(length(session_id) + length(session_key) + length(update_json) + COALESCE(length(run_id), 0) + 32), 0)
-            FROM acp_replay_events) AS events
-       FROM acp_replay_sessions`,
-    )
-    .get() as { sessions?: number | bigint; events?: number | bigint } | undefined;
-  return normalizeSqliteInteger(row?.sessions ?? 0) + normalizeSqliteInteger(row?.events ?? 0);
+  const pageCount = readSqlitePragmaInteger(db, "page_count");
+  const pageSize = readSqlitePragmaInteger(db, "page_size") || DEFAULT_SQLITE_PAGE_SIZE_BYTES;
+  return pageCount * pageSize;
 }
 
 function trimSqliteLedger(


### PR DESCRIPTION
Fixes #100622

### What Problem This Solves

The SQLite ACP event ledger estimated retention bytes by aggregating serialized column lengths from `acp_replay_sessions` and `acp_replay_events` on each append. As replay history grows, that turns active ledger writes into repeated full-table aggregate scans.

### Why This Change Was Made

This switches the byte estimate to SQLite metadata: `PRAGMA page_count` multiplied by `PRAGMA page_size`. That keeps the trimming decision O(1) with respect to replay row count and still tracks the backing database footprint closely enough for the existing retention threshold.

### User Impact

Long-running ACP sessions with large replay histories avoid repeated table scans during event recording, reducing write-path latency while preserving the existing trimming behavior.

### Evidence

- `node scripts/run-vitest.mjs src/acp/event-ledger.test.ts` (13 passed)
- `git diff --check`
