### PR TITLE
fix: continue after transient preflight compaction failures

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -1113,6 +1113,64 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "skipped");
   });
 
+  it.each([
+    ["timeout", "provider request timed out after 30000ms"],
+    ["provider 4xx", "provider returned HTTP 429"],
+    ["provider 5xx", "provider returned HTTP 503"],
+  ])("continues when required preflight compaction hits a %s failure", async (_label, reason) => {
+    const sessionFile = path.join(rootDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "x".repeat(5_000) } })}\n`,
+      "utf8",
+    );
+    registerMemoryFlushPlanResolverForTest(() => ({
+      softThresholdTokens: 1,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 0,
+      prompt: "Pre-compaction memory flush.\nNO_REPLY",
+      systemPrompt: "Write memory to memory/YYYY-MM-DD.md.",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedAgentSessionMock.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason,
+    });
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      sessionFile,
+      updatedAt: Date.now(),
+      totalTokens: 120,
+      totalTokensFresh: true,
+    };
+    const onCompactionNotice = vi.fn();
+
+    const entry = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
+      followupRun: createTestFollowupRun({
+        sessionId: "session",
+        sessionFile,
+        sessionKey: "agent:main:main",
+      }),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100,
+      sessionEntry,
+      sessionStore: { "agent:main:main": sessionEntry },
+      sessionKey: "agent:main:main",
+      storePath: path.join(rootDir, "sessions.json"),
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+      onCompactionNotice,
+    });
+
+    expect(entry).toBe(sessionEntry);
+    expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
+    expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+    expect(onCompactionNotice).toHaveBeenNthCalledWith(1, "start");
+    expect(onCompactionNotice).toHaveBeenNthCalledWith(2, "skipped");
+  });
+
   it("fails when required preflight context-engine compaction is deferred to background maintenance", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     await fs.writeFile(

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -204,12 +204,16 @@ function resolveEffectivePromptTokens(
 function isPreflightCompactionSkipReason(reason?: string): boolean {
   const classification = classifyCompactionReason(reason);
   // Preflight compaction is a guardrail, not a hard dependency. These classes
-  // mean the context engine found nothing useful to compact, so the reply should
-  // continue instead of surfacing a generic user-facing failure.
+  // either mean the context engine found nothing useful to compact or that the
+  // maintenance model failed before the real reply run started. The reply should
+  // continue and let the main run surface any remaining context/provider error.
   return (
     classification === "below_threshold" ||
     classification === "no_compactable_entries" ||
-    classification === "already_compacted_recently"
+    classification === "already_compacted_recently" ||
+    classification === "timeout" ||
+    classification === "provider_error_4xx" ||
+    classification === "provider_error_5xx"
   );
 }
 


### PR DESCRIPTION
Fixes #100778

### What Problem This Solves

Preflight compaction was treated as a hard dependency when the maintenance model hit transient provider failures such as timeouts, 429s, or 5xx responses. Because that error happened before the agent run started, the chat dispatch path could mark the session as failed and leave the Composer disabled.

### Why This Change Was Made

The preflight code already documents compaction as a guardrail. This change extends the existing skip/continue classification so transient provider failures let the main reply run proceed instead of throwing a pre-run dispatch error. Non-transient failures such as thread binding problems or auth profile mismatches still fail as before.

### User Impact

Users whose sessions approach the compaction threshold are no longer locked out by a transient preflight compaction model failure. If context or provider state still prevents the real reply, that error is handled by the normal agent run path instead of permanently disabling the Composer.

### Evidence

- `node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts` (50 passed)
- `git diff --check`
