### PR TITLE
fix: ignore mirror usage for compaction tokens

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createAssistantMessageEventStream } from "../../llm.js";
-import type { AssistantMessage, Model, StreamFn } from "../../llm.js";
+import type { AssistantMessage, Model, StreamFn, Usage } from "../../llm.js";
 import {
   calculateContextTokens,
   compact,
@@ -42,6 +42,19 @@ describe("calculateContextTokens", () => {
     ).toBe(927_907);
   });
 
+  it("normalizes OpenAI-style usage fields without producing NaN", () => {
+    expect(
+      calculateContextTokens({
+        input: 0,
+        output: 0,
+        total: 41_000,
+        prompt_tokens: 40_000,
+        completion_tokens: 1_000,
+        cache: { read: 500, write: 250 },
+      } as unknown as Usage),
+    ).toBe(41_000);
+  });
+
   it("estimates the transcript instead of using aggregate billing when context is unavailable", () => {
     const estimate = estimateContextTokens([
       { role: "user", content: "hello", timestamp: 0 },
@@ -69,6 +82,56 @@ describe("calculateContextTokens", () => {
     expect(estimate.tokens).toBeGreaterThan(0);
     expect(estimate.usageTokens).toBe(0);
     expect(estimate.lastUsageIndex).toBeNull();
+  });
+
+  it("ignores delivery-mirror usage when selecting the latest context snapshot", () => {
+    const estimate = estimateContextTokens([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real answer" }],
+        api: "anthropic-messages",
+        provider: "anthropic",
+        model: "claude-fable-5",
+        usage: {
+          input: 12,
+          output: 100,
+          cacheRead: 1_000,
+          cacheWrite: 0,
+          contextUsage: {
+            state: "available",
+            promptTokens: 1_012,
+            totalTokens: 1_112,
+          },
+          totalTokens: 1_112,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        },
+        stopReason: "stop",
+        timestamp: 0,
+      },
+      { role: "user", content: "next", timestamp: 1 },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "mirrored answer" }],
+        api: "openclaw-internal",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        usage: {
+          input: 0,
+          output: 0,
+          total_tokens: 99_999,
+          prompt_tokens: 90_000,
+          completion_tokens: 9_999,
+          cache: { read: 0, write: 0 },
+        } as unknown as Usage,
+        stopReason: "stop",
+        timestamp: 2,
+      },
+    ]);
+
+    expect(estimate.usageTokens).toBe(1_112);
+    expect(estimate.tokens).toBeGreaterThan(1_112);
+    expect(estimate.tokens).toBeLessThan(99_999);
+    expect(estimate.lastUsageIndex).toBe(0);
   });
 
   it("uses the previous exact snapshot and estimates only the unavailable tail", () => {

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -146,17 +146,63 @@ export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
   keepRecentTokens: 20000,
 };
 
+function readNonNegativeToken(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function readPositiveToken(value: unknown): number | undefined {
+  const token = readNonNegativeToken(value);
+  return token !== undefined && token > 0 ? token : undefined;
+}
+
+function readTokenComponent(...values: unknown[]): number {
+  for (const value of values) {
+    const token = readPositiveToken(value);
+    if (token !== undefined) {
+      return token;
+    }
+  }
+  for (const value of values) {
+    const token = readNonNegativeToken(value);
+    if (token !== undefined) {
+      return token;
+    }
+  }
+  return 0;
+}
+
 /** Calculate total context tokens from provider usage. */
 export function calculateContextTokens(usage: Usage): number {
   if (usage.contextUsage?.state === "available") {
-    return usage.contextUsage.totalTokens;
+    const contextTokens = readPositiveToken(usage.contextUsage.totalTokens);
+    if (contextTokens !== undefined) {
+      return contextTokens;
+    }
   }
-  return usage.totalTokens || usage.input + usage.output + usage.cacheRead + usage.cacheWrite;
+  const record = usage as unknown as Record<string, unknown>;
+  const totalTokens =
+    readPositiveToken(record.totalTokens) ??
+    readPositiveToken(record.total_tokens) ??
+    readPositiveToken(record.total);
+  if (totalTokens !== undefined) {
+    return totalTokens;
+  }
+  const cache = record.cache as Record<string, unknown> | undefined;
+  const summed =
+    readTokenComponent(record.input, record.prompt_tokens) +
+    readTokenComponent(record.output, record.completion_tokens) +
+    readTokenComponent(record.cacheRead, cache?.read) +
+    readTokenComponent(record.cacheWrite, cache?.write);
+  if (summed > 0 && Number.isFinite(summed)) {
+    return summed;
+  }
+  return 0;
 }
 function getAssistantUsage(msg: AgentMessage): Usage | undefined {
   if (msg.role === "assistant" && "usage" in msg) {
     const assistantMsg = msg;
     if (
+      assistantMsg.model !== "delivery-mirror" &&
       assistantMsg.stopReason !== "aborted" &&
       assistantMsg.stopReason !== "error" &&
       assistantMsg.usage
@@ -223,6 +269,18 @@ export function estimateContextTokens(messages: AgentMessage[]): ContextUsageEst
   }
 
   const usageTokens = calculateContextTokens(usageInfo.usage);
+  if (!Number.isFinite(usageTokens) || usageTokens <= 0) {
+    let estimated = 0;
+    for (const message of messages) {
+      estimated += estimateTokens(message);
+    }
+    return {
+      tokens: estimated,
+      usageTokens: 0,
+      trailingTokens: estimated,
+      lastUsageIndex: null,
+    };
+  }
   let trailingTokens = 0;
   for (let i = usageInfo.index + 1; i < messages.length; i++) {
     trailingTokens += estimateTokens(messages[i]);

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -391,6 +391,58 @@ describe("readTranscriptFileState", () => {
     expect(state.getLeafId()).toBe("compact-1");
   });
 
+  it("normalizes missing compaction token telemetry instead of rejecting the boundary", async () => {
+    const root = await makeRoot("openclaw-transcript-state-null-compaction-tokens-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "old question" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "old answer" }] },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "compact-1",
+          parentId: "assistant-1",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          summary: "summary",
+          firstKeptEntryId: "assistant-1",
+          tokensBefore: null,
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const compaction = state.getEntries().find((entry) => entry.type === "compaction");
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual([
+      "user-1",
+      "assistant-1",
+      "compact-1",
+    ]);
+    expect(state.getLeafId()).toBe("compact-1");
+    expect(compaction).toMatchObject({ tokensBefore: 0 });
+  });
+
   it("skips JSON-valid non-object rows", async () => {
     const root = await makeRoot("openclaw-transcript-state-null-row-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/embedded-agent-runner/transcript-file-state.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.ts
@@ -242,11 +242,13 @@ function isSessionEntry(entry: FileEntry): entry is SessionEntry {
         summary?: unknown;
         tokensBefore?: unknown;
       };
-      return (
-        isString(candidate.firstKeptEntryId) &&
-        typeof candidate.summary === "string" &&
-        typeof candidate.tokensBefore === "number"
-      );
+      if (!isString(candidate.firstKeptEntryId) || typeof candidate.summary !== "string") {
+        return false;
+      }
+      if (typeof candidate.tokensBefore !== "number" || !Number.isFinite(candidate.tokensBefore)) {
+        candidate.tokensBefore = 0;
+      }
+      return true;
     }
     case "custom":
       return isString((entry as { customType?: unknown }).customType);


### PR DESCRIPTION
Fixes #100982

### What Problem This Solves

Delivery mirror assistant rows could be selected as the latest usage source for compaction pre-counts. When their synthetic usage was zeroed or shaped like OpenAI usage, `tokensBefore` could become `0` or `NaN`/`null`. Runtime transcript loading then rejected the compaction row because `tokensBefore` was not a number, so the compaction boundary was lost and sessions kept replaying the raw transcript.

### Why This Change Was Made

This fixes both sides of the failure:

- `delivery-mirror` assistant messages are no longer considered usage sources for context-token estimation.
- Context-token usage now normalizes OpenAI-style `total_tokens`/`prompt_tokens` fields and falls back to content estimates when usage is non-positive.
- Runtime transcript loading keeps compaction rows with valid `summary` and `firstKeptEntryId` even when `tokensBefore` telemetry is missing, normalizing that telemetry to `0`.

### User Impact

Safeguard compaction can reclaim context again for sessions that contain delivery mirror rows, including existing transcripts that already have `tokensBefore: null` compaction records.

### Evidence

- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts` (8 passed)
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/transcript-file-state.test.ts` (26 passed)
- `git diff --check`
