### PR TITLE
fix(imessage): handle one-shot cli stream errors

### DIFF
--- a/extensions/imessage/src/actions.runtime.test.ts
+++ b/extensions/imessage/src/actions.runtime.test.ts
@@ -41,6 +41,23 @@ function mockSpawnJsonResponse(payload: Record<string, unknown> = { success: tru
   });
 }
 
+function mockSpawnStreamError(stream: "stdout" | "stderr", message: string) {
+  spawnMock.mockImplementationOnce(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter & { setEncoding: (encoding: string) => void };
+      stderr: EventEmitter & { setEncoding: (encoding: string) => void };
+      kill: (signal: string) => void;
+    };
+    child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+    child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+    child.kill = vi.fn();
+    queueMicrotask(() => {
+      child[stream].emit("error", new Error(message));
+    });
+    return child;
+  });
+}
+
 function mockRpcChatList(chats: Array<Record<string, unknown>>) {
   const request = vi.fn().mockResolvedValue({ chats });
   const stop = vi.fn().mockResolvedValue(undefined);
@@ -82,6 +99,26 @@ describe("imessage actions runtime", () => {
       { stdio: ["ignore", "pipe", "pipe"] },
     );
   });
+
+  it.each(["stdout", "stderr"] as const)(
+    "rejects cleanly when one-shot imsg %s stream errors",
+    async (stream) => {
+      mockSpawnStreamError(stream, `${stream} failed`);
+
+      await expect(
+        imessageActionsRuntime.sendReaction({
+          chatGuid: "iMessage;+;chat0000",
+          messageId: "message-guid",
+          reaction: "like",
+          options: {
+            cliPath: "imsg",
+            dbPath: "/tmp/messages.db",
+            chatGuid: "iMessage;+;chat0000",
+          },
+        }),
+      ).rejects.toThrow(`${stream} failed`);
+    },
+  );
 
   it("drops cached chats.list entries when the current clock is not a valid date timestamp", async () => {
     vi.spyOn(Date, "now").mockReturnValueOnce(1_700_000_000_000).mockReturnValueOnce(Number.NaN);

--- a/extensions/imessage/src/actions.runtime.ts
+++ b/extensions/imessage/src/actions.runtime.ts
@@ -246,6 +246,20 @@ async function runIMessageCliJson(
     child.stderr.on("data", (chunk) => {
       stderr = appendIMessageCliStderrTail(stderr, chunk);
     });
+    const failFromStreamError = (error: unknown): void => {
+      if (settled) {
+        clearTimers();
+        return;
+      }
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // The helper may already be gone.
+      }
+      fail(error instanceof Error ? error : new Error(String(error)));
+    };
+    child.stdout.on("error", failFromStreamError);
+    child.stderr.on("error", failFromStreamError);
     child.on("error", (error) => {
       if (settled) {
         clearTimers();

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -647,6 +647,20 @@ async function runIMessageCliJson(
     child.stderr.on("data", (chunk) => {
       stderr = appendIMessageCliStderrTail(stderr, chunk);
     });
+    const failFromStreamError = (error: unknown): void => {
+      if (settled) {
+        clearTimers();
+        return;
+      }
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // The helper may already be gone.
+      }
+      fail(error instanceof Error ? error : new Error(String(error)));
+    };
+    child.stdout.on("error", failFromStreamError);
+    child.stderr.on("error", failFromStreamError);
     child.on("error", (error) => {
       if (settled) {
         clearTimers();


### PR DESCRIPTION
## What Problem This Solves

The iMessage one-shot `imsg` helpers listen for `data`, child `error`, and `close`, but not for `error` events from the child's piped stdout/stderr streams. If a wrapper, SSH bridge, or local pipe emits a stream error, Node can surface an unhandled error or leave the caller waiting for the timeout path instead of rejecting with the actual failure.

Related #75438; this covers the remaining one-shot stdout/stderr read-stream side of iMessage child process failures.

## Why This Change Was Made

The send and private-action helpers each have their own `runIMessageCliJson` implementation. Both now attach stdout/stderr stream error handlers immediately after the existing `data` listeners, terminate the helper process best-effort, and reject through the same settled/timeout cleanup path used by child process failures.

## User Impact

Broken iMessage CLI wrappers or pipe failures now fail the affected send/action promptly with the stream error instead of crashing the gateway or hiding the real cause behind a generic timeout.

## Evidence

```text
$ cd /root/openclaw-contrib/worktrees/imessage-stdio-errors
$ OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-imessage.config.ts imessage/src/actions.runtime.test.ts --reporter verbose --maxWorkers 1
 ✓  extension-imessage  extensions/imessage/src/actions.runtime.test.ts > findChatGuid cross-format identifier resolution > returns null for a phone number that does not exist in chats.list 0ms
 ✓  extension-imessage  extensions/imessage/src/actions.runtime.test.ts > findChatGuid cross-format identifier resolution > does not cross-match different phone numbers via the prefix-stripping path 0ms
 ✓  extension-imessage  extensions/imessage/src/actions.runtime.test.ts > findChatGuid cross-format identifier resolution > does not match a DM target against a group's chat_identifier 0ms
 ✓  extension-imessage  extensions/imessage/src/actions.runtime.test.ts > normalizeDirectChatIdentifier > strips the iMessage;-; prefix 2ms
 ✓  extension-imessage  extensions/imessage/src/actions.runtime.test.ts > normalizeDirectChatIdentifier > strips the SMS;-; prefix 0ms
 ✓  extension-imessage  extensions/imessage/src/actions.runtime.test.ts > normalizeDirectChatIdentifier > strips the any;-; prefix 0ms
 ✓  extension-imessage  extensions/imessage/src/actions.runtime.test.ts > normalizeDirectChatIdentifier > matches case-insensitively 0ms
 ✓  extension-imessage  extensions/imessage/src/actions.runtime.test.ts > normalizeDirectChatIdentifier > leaves group identifiers (iMessage;+;chat...) unchanged 0ms
 ✓  extension-imessage  extensions/imessage/src/actions.runtime.test.ts > normalizeDirectChatIdentifier > leaves bare values unchanged 0ms
 Test Files  1 passed (1)
      Tests  21 passed (21)
   Duration  16.08s (transform 14.49s, setup 8.58s, import 2.60s, tests 1.77s, environment 0ms)

$ git diff --check -- extensions/imessage/src/actions.runtime.ts extensions/imessage/src/actions.runtime.test.ts extensions/imessage/src/send.ts
# exit 0
```
