### PR TITLE
fix(cron): resolve run Open Chat sessions

### DIFF
--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -35,7 +35,7 @@ function makeCronSession(entry = makeSessionEntry()): MutableCronSession {
 }
 
 describe("createPersistCronSessionEntry", () => {
-  it("persists isolated cron state only under the stable cron session key", async () => {
+  it("persists isolated cron state under both stable and run-specific session keys", async () => {
     const cronSession = makeCronSession(
       makeSessionEntry({
         sessionFile: await createTranscriptFile(),
@@ -52,7 +52,7 @@ describe("createPersistCronSessionEntry", () => {
         const store: Record<string, SessionEntry> = {};
         update(store);
         expect(store["agent:main:cron:job"]).toBe(cronSession.sessionEntry);
-        expect(store["agent:main:cron:job:run:run-session-id"]).toBeUndefined();
+        expect(store["agent:main:cron:job:run:run-session-id"]).toBe(cronSession.sessionEntry);
       },
     );
 
@@ -60,13 +60,14 @@ describe("createPersistCronSessionEntry", () => {
       isFastTestEnv: false,
       cronSession,
       agentSessionKey: "agent:main:cron:job",
+      runSessionKey: "agent:main:cron:job:run:run-session-id",
       updateSessionStore,
     });
 
     await persist();
 
     expect(cronSession.store["agent:main:cron:job"]).toBe(cronSession.sessionEntry);
-    expect(cronSession.store["agent:main:cron:job:run:run-session-id"]).toBeUndefined();
+    expect(cronSession.store["agent:main:cron:job:run:run-session-id"]).toBe(cronSession.sessionEntry);
   });
 
   it("does not register cron sessions as resumable until the transcript exists", async () => {

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -77,6 +77,7 @@ export function createPersistCronSessionEntry(params: {
   isFastTestEnv: boolean;
   cronSession: MutableCronSession;
   agentSessionKey: string;
+  runSessionKey?: string;
   updateSessionStore: UpdateSessionStore;
 }): PersistCronSessionEntry {
   return async () => {
@@ -134,12 +135,27 @@ export function createPersistCronSessionEntry(params: {
         });
       }
       store[params.agentSessionKey] = committedEntry;
+      if (
+        params.runSessionKey &&
+        params.runSessionKey !== params.agentSessionKey &&
+        persistedEntry.sessionId
+      ) {
+        // Keep cron run-log Open Chat links resolvable to the transcript they logged.
+        store[params.runSessionKey] = committedEntry;
+      }
     });
     // The storage projection may intentionally omit resume identity until its
     // transcript exists. Keep that projection out of the active run object.
     params.cronSession.sessionEntry = mergedLiveEntry;
     params.cronSession.initialSessionEntry = structuredClone(committedEntry);
     params.cronSession.store[params.agentSessionKey] = committedEntry;
+    if (
+      params.runSessionKey &&
+      params.runSessionKey !== params.agentSessionKey &&
+      persistedEntry.sessionId
+    ) {
+      params.cronSession.store[params.runSessionKey] = committedEntry;
+    }
   };
 }
 

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -676,6 +676,7 @@ async function prepareCronRunContext(params: {
     isFastTestEnv: params.isFastTestEnv,
     cronSession,
     agentSessionKey,
+    runSessionKey,
     updateSessionStore: async (storePath, update) => {
       const { updateSessionStore } = await loadSessionStoreRuntime();
       await updateSessionStore(storePath, update);


### PR DESCRIPTION
## What Problem This Solves

Closes #88002.

Cron run history records the run-specific session key (`agent:...:cron:<job>:run:<runSessionId>`), but the session store only persisted the stable cron session key. The Control UI "Open Chat" button could deep-link to a run key that had no stored session entry, so the redirected chat was wrong or missing.

## Why This Change Was Made

`prepareCronRunContext` already computes both keys. The persistence helper now receives the run-specific key and writes the committed session projection under both the stable cron key and the run-specific alias once a real `sessionId` exists. The alias points at the same transcript-backed committed entry, so existing stable cron resume behavior stays unchanged.

## User Impact

Opening a historical cron run from Control UI now lands on that run's recorded transcript instead of an unrelated or unresolved session.

## Evidence

```text
$ cd /root/openclaw-contrib/worktrees/cron-open-chat-session
$ OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/isolated-agent/run-session-state.test.ts --reporter verbose --maxWorkers 1
 ✓  cron  src/cron/isolated-agent/run-session-state.test.ts > createPersistCronSessionEntry > restores resumable cron fields once the transcript exists 1ms
 ✓  cron  src/cron/isolated-agent/run-session-state.test.ts > createPersistCronSessionEntry > persists explicit session-bound cron state under the requested session key 1ms
 ✓  cron  src/cron/isolated-agent/run-session-state.test.ts > createPersistCronSessionEntry > does not let an older concurrent run reclaim a persisted lifecycle revision 4ms
 ✓  cron  src/cron/isolated-agent/run-session-state.test.ts > createPersistCronSessionEntry > does not replace a lifecycle revision while its owner is admitted 3ms
 ✓  cron  src/cron/isolated-agent/run-session-state.test.ts > createPersistCronSessionEntry > claims an initial row after a concurrent pin and rename 2ms
 ✓  cron  src/cron/isolated-agent/run-session-state.test.ts > createPersistCronSessionEntry > preserves a concurrent 'pin and rename' during cron persistence 1ms
 ✓  cron  src/cron/isolated-agent/run-session-state.test.ts > createPersistCronSessionEntry > preserves a concurrent 'unpin and clear the label' during cron persistence 1ms
 ✓  cron  src/cron/isolated-agent/run-session-state.test.ts > createPersistCronSessionEntry > does not restore session policy cleared while a cron run is active 1ms
 ✓  cron  src/cron/isolated-agent/run-session-state.test.ts > createPersistCronSessionEntry > adopts rotated run transcript metadata before persisting session-bound cron state 1ms
 Test Files  1 passed (1)
      Tests  11 passed (11)
   Duration  12.11s (transform 11.32s, setup 7.42s, import 403ms, tests 1.73s, environment 0ms)

$ git diff --check -- src/cron/isolated-agent/run-session-state.ts src/cron/isolated-agent/run.ts src/cron/isolated-agent/run-session-state.test.ts
# exit 0
```

## Real behavior proof (redacted)

Published visible proof artifact: https://graceful-ponder-78cr.here.now/

What the proof shows:

- a cron run-history row carries `sessionKey = agent:main:cron:proof-job:run:proof-run-20260707`
- Open Chat builds `/chat?session=agent%3Amain%3Acron%3Aproof-job%3Arun%3Aproof-run-20260707`, matching `ui/src/pages/cron/view.ts` (`searchForSession(entry.sessionKey)`)
- the run-specific key resolves to the selected run transcript and shares the same transcript file as the stable cron key

```json
{
  "result": "PASS",
  "proof": "run-history Open Chat uses runLog.sessionKey; the run-specific key resolves to the selected run transcript when persisted as an alias",
  "openChatHref": "/chat?session=agent%3Amain%3Acron%3Aproof-job%3Arun%3Aproof-run-20260707",
  "runLogSessionKey": "agent:main:cron:proof-job:run:proof-run-20260707",
  "resolvedSessionId": "proof-session-id",
  "stableAndRunKeysShareTranscript": true,
  "transcriptContains": "cron proof selected run transcript",
  "persistedKeys": [
    "agent:main:cron:proof-job",
    "agent:main:cron:proof-job:run:proof-run-20260707"
  ],
  "tempHome": "/tmp/openclaw-cron-open-chat-proof-hn98x_l_"
}
```
