### PR TITLE
fix: make pruned tool result marker actionable

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts
@@ -1139,7 +1139,12 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
       baseFn as never,
       undefined,
-      { validateAnthropicTurns: true },
+      {
+        validateAnthropicTurns: true,
+        validateGeminiTurns: false,
+        preserveSignatures: false,
+        dropThinkingBlocks: false,
+      },
       "anthropic",
     );
 

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts
@@ -1117,6 +1117,48 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     expect(forwardedContext.messages).toBe(messages);
   });
 
+  it("replaces omitted Anthropic replay tool results with an actionable marker", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "toolResult",
+            toolUseId: "stale-call",
+            content: [{ type: "text", text: "stale output" }],
+          },
+        ],
+      } as never,
+    ];
+    const baseFn = vi.fn((_model: unknown, _context: unknown, _options: unknown) =>
+      createFakeStream({
+        events: [],
+        resultMessage: { role: "assistant", content: "ok" },
+      }),
+    );
+    const wrapped = wrapStreamFnSanitizeMalformedToolCalls(
+      baseFn as never,
+      undefined,
+      { validateAnthropicTurns: true },
+      "anthropic",
+    );
+
+    void wrapped({ api: "anthropic-messages" } as never, { messages } as never, {} as never);
+
+    const forwardedContext = baseFn.mock.calls[0]?.[1] as {
+      messages?: AgentMessage[];
+    };
+    expect(forwardedContext.messages?.[0]).toMatchObject({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "[tool result pruned to fit context budget - re-run the tool call to see fresh output]",
+        },
+      ],
+    });
+  });
+
   it("repairs OpenAI Responses pairing even when replay inputs do not change", () => {
     const messages: AgentMessage[] = [
       {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.ts
@@ -35,6 +35,8 @@ import { isRunnerToolCallBlockType } from "./attempt.tool-call-block-type.js";
 import { wrapStreamObjectEvents } from "./stream-wrapper.js";
 
 const BLANK_TOOL_CALL_NAME_DESCRIPTION = "blank tool name";
+const TOOL_RESULTS_OMITTED_PROMPT_TEXT =
+  "[tool result pruned to fit context budget - re-run the tool call to see fresh output]";
 
 type UnknownToolLoopGuardState = {
   lastUnknownToolName?: string;
@@ -574,7 +576,7 @@ function sanitizeAnthropicReplayToolResults(
 
     out.push({
       ...message,
-      content: [{ type: "text", text: "[tool results omitted]" }],
+      content: [{ type: "text", text: TOOL_RESULTS_OMITTED_PROMPT_TEXT }],
     } as AgentMessage);
   }
 


### PR DESCRIPTION
Refs #100529

### What Problem This Solves

When replay sanitation removes stale or over-budget tool-result blocks, the model currently sees a generic `[tool results omitted]` marker. That reads like an empty or corrupted tool response rather than an intentional context-budget pruning decision.

### Why This Change Was Made

This replaces the generic marker with an actionable prompt-visible message:

`[tool result pruned to fit context budget - re-run the tool call to see fresh output]`

That keeps the budgeting behavior unchanged while giving the model a clear recovery path.

### User Impact

Agents are less likely to misdiagnose pruned tool output as a broken tool or corrupted session. They can re-run the call when the omitted result is still needed.

### Evidence

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.tool-call-normalization.test.ts` (29 passed)
- `git diff --check`
