### PR TITLE
fix(zalo): accept opaque string chat IDs

### DIFF
--- a/extensions/zalo/src/channel.directory.test.ts
+++ b/extensions/zalo/src/channel.directory.test.ts
@@ -54,4 +54,21 @@ describe("zalo directory", () => {
     expect(zaloPlugin.pairing?.normalizeAllowEntry?.("  zalo:123  ")).toBe("123");
     expect(zaloPlugin.messaging?.normalizeTarget?.("  zl:234  ")).toBe("234");
   });
+
+  it("recognizes opaque Bot API chat ids as direct targets", () => {
+    const looksLikeId = zaloPlugin.messaging?.targetResolver?.looksLikeId;
+    if (!looksLikeId) {
+      throw new Error("expected Zalo target resolver");
+    }
+
+    expect(looksLikeId("123456", "123456")).toBe(true);
+    expect(looksLikeId("3becaa50ae12474c1e03", "3becaa50ae12474c1e03")).toBe(true);
+    expect(looksLikeId("abc.xyz", "abc.xyz")).toBe(true);
+    expect(looksLikeId("zalo:49270a5f8f1c66423f0d", "49270a5f8f1c66423f0d")).toBe(true);
+    expect(looksLikeId("zalo:abc.xyz", "abc.xyz")).toBe(true);
+    expect(looksLikeId("zl:3becaa50ae12474c1e03", "3becaa50ae12474c1e03")).toBe(true);
+    expect(looksLikeId("zl:abc.xyz", "abc.xyz")).toBe(true);
+    expect(looksLikeId("support", "support")).toBe(true);
+    expect(looksLikeId("zalo:  ", "")).toBe(false);
+  });
 });

--- a/extensions/zalo/src/channel.ts
+++ b/extensions/zalo/src/channel.ts
@@ -30,10 +30,7 @@ import { createStaticReplyToModeResolver } from "openclaw/plugin-sdk/conversatio
 import { createChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
 import { listResolvedDirectoryUserEntriesFromAllowFrom } from "openclaw/plugin-sdk/directory-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import {
-  isNumericTargetId,
-  sendPayloadWithChunkedTextAndMedia,
-} from "openclaw/plugin-sdk/reply-payload";
+import { sendPayloadWithChunkedTextAndMedia } from "openclaw/plugin-sdk/reply-payload";
 import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
@@ -72,6 +69,11 @@ function normalizeZaloMessagingTarget(raw: string): string | undefined {
     return undefined;
   }
   return trimmed.replace(/^(zalo|zl):/i, "").trim();
+}
+
+function looksLikeZaloChatId(raw: string, normalized?: string): boolean {
+  const target = normalizeZaloMessagingTarget(normalized ?? raw);
+  return Boolean(target);
 }
 
 const loadZaloChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
@@ -234,7 +236,7 @@ export const zaloPlugin: ChannelPlugin<ResolvedZaloAccount, ZaloProbeResult> =
         normalizeTarget: normalizeZaloMessagingTarget,
         resolveOutboundSessionRoute: (params) => resolveZaloOutboundSessionRoute(params),
         targetResolver: {
-          looksLikeId: isNumericTargetId,
+          looksLikeId: looksLikeZaloChatId,
           hint: "<chatId>",
         },
       },


### PR DESCRIPTION
## What Problem This Solves

Zalo proactive sends reject valid nonnumeric Bot API `chat_id` strings before delivery because the channel uses the shared numeric-ID predicate. This closes #57594 and replaces #93689, whose contributor fork is too far behind `main` to update without publishing thousands of unrelated upstream files.

## Why This Change Was Made

- Zalo's official `sendMessage` contract defines `chat_id` as `String` and uses `abc.xyz` in its request example.
- The Zalo send path already forwards `chatId` as a string; only the pre-send resolver gate is wrong.
- The fix stays plugin-local and treats normalized nonblank Zalo chat IDs as opaque instead of guessing an undocumented regex grammar.
- Blank and prefix-only targets remain rejected. Shared target heuristics for other channels remain unchanged.

Contributor credit is preserved from #93689 via `Co-authored-by: Goutam Adwant <workwithgoutam@gmail.com>`.

## User Impact

`openclaw message send --channel zalo --target <chat_id>` now accepts valid string IDs such as the reported hex-like values and documented dotted values. Scheduled and scripted proactive Zalo notifications no longer fail with `Unknown target` solely because the upstream ID is nonnumeric.

## Evidence

- Official contract: https://bot.zaloplatforms.com/docs/apis/sendMessage/
- Source proof: current `main` and v2026.6.11 use `isNumericTargetId`; `extensions/zalo/src/send.ts` accepts and forwards string `chat_id` values.
- Sanitized direct AWS Crabbox: provider `aws`, lease `cbx_c5397d05acbb`, run `run_763782bdf491`, reviewed source head `e90bdb95bb69a53e419e8d8b60fc41fb07ec003d`.
- Focused tests: 34 passed across `extensions/zalo/src/channel.directory.test.ts`, `src/infra/outbound/target-normalization.test.ts`, and `src/infra/outbound/target-resolver.test.ts`.
- Real CLI path: `pnpm openclaw message send --channel zalo --target abc.xyz --message test --dry-run --json` returned `handledBy: "core"`, `to: "abc.xyz"`, and `via: "direct"`.
- Targeted oxfmt and `git diff --check` passed.
- Structured autoreview: clean, GPT-5.5 high, confidence 0.86.

Live credentialed Zalo delivery was not repeated; #57594 includes successful upstream API responses for the same nonnumeric IDs. The changed surface is the local resolver gate before send.

Closes #57594
Supersedes #93689
