### PR TITLE
refactor(ui): remove stale helper exports

### DIFF
--- a/ui/config/control-ui-chunking.ts
+++ b/ui/config/control-ui-chunking.ts
@@ -1,5 +1,5 @@
 // Control UI config module wires control ui chunking behavior.
-export function normalizeModuleId(id: string): string {
+function normalizeModuleId(id: string): string {
   return id.replace(/\\/g, "/");
 }
 

--- a/ui/src/app/control-ui-chunking.test.ts
+++ b/ui/src/app/control-ui-chunking.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { controlUiManualChunk, normalizeModuleId } from "../../config/control-ui-chunking.ts";
+import { controlUiManualChunk } from "../../config/control-ui-chunking.ts";
 
 describe("Control UI build chunking", () => {
   it("groups stable runtime dependencies into bounded chunks", () => {
@@ -26,9 +26,6 @@ describe("Control UI build chunking", () => {
   });
 
   it("normalizes Windows module paths before package matching", () => {
-    expect(normalizeModuleId(String.raw`C:\repo\ui\node_modules\highlight.js\lib\core.js`)).toBe(
-      "C:/repo/ui/node_modules/highlight.js/lib/core.js",
-    );
     expect(controlUiManualChunk(String.raw`C:\repo\ui\node_modules\highlight.js\lib\core.js`)).toBe(
       "markdown-runtime",
     );

--- a/ui/src/app/theme.test.ts
+++ b/ui/src/app/theme.test.ts
@@ -1,6 +1,6 @@
 // Control UI tests cover theme behavior.
 import { describe, expect, it, vi } from "vitest";
-import { parseThemeSelection, resolveSystemTheme, resolveTheme } from "./theme.ts";
+import { parseThemeSelection, resolveTheme } from "./theme.ts";
 
 describe("resolveTheme", () => {
   it("resolves named theme families when mode is provided", () => {
@@ -11,14 +11,6 @@ describe("resolveTheme", () => {
   it("uses system preference when mode is system", () => {
     vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: true }));
     expect(resolveTheme("knot", "system")).toBe("openknot-light");
-    vi.unstubAllGlobals();
-  });
-});
-
-describe("resolveSystemTheme", () => {
-  it("mirrors the active preferred color scheme", () => {
-    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: true }));
-    expect(resolveSystemTheme()).toBe("light");
     vi.unstubAllGlobals();
   });
 });

--- a/ui/src/app/theme.ts
+++ b/ui/src/app/theme.ts
@@ -37,10 +37,6 @@ function prefersLightScheme(): boolean {
   return globalThis.matchMedia("(prefers-color-scheme: light)").matches;
 }
 
-export function resolveSystemTheme(): ResolvedTheme {
-  return prefersLightScheme() ? "light" : "dark";
-}
-
 export function parseThemeSelection(
   themeRaw: unknown,
   modeRaw: unknown,

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -11,8 +11,8 @@ import {
   formatUnknownText,
   parseSessionKeyParts,
   setUiTimeFormatPreference,
-  stripThinkingTags,
 } from "./format.ts";
+import { stripThinkingTags } from "./strip-thinking-tags.ts";
 
 describe("formatAgo", () => {
   it("returns 'in <1m' for timestamps less than 60s in the future", () => {

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -5,7 +5,6 @@ import { formatRelativeTimestamp } from "../../../src/infra/format-time/format-r
 import { t } from "../i18n/index.ts";
 
 export { formatRelativeTimestamp, formatDurationHuman };
-export { stripThinkingTags } from "../lib/strip-thinking-tags.ts";
 
 export function formatUnknownText(
   value: unknown,


### PR DESCRIPTION
## What Problem This Solves

The Control UI still exposed three internal helper seams that have no production consumers: a chunk-path normalizer, a duplicate system-theme resolver, and a formatting-barrel re-export.

## Why This Change Was Made

Remove the dead theme function, keep the chunk normalizer private to its build owner, and import `stripThinkingTags` from its canonical module in tests. Behavior coverage remains on the public chunking and theme paths.

## User Impact

No user-visible behavior change. The Control UI has a smaller internal API and less duplicate test-only surface.

## Evidence

- 3 targeted UI test files, 44 tests passed
- Targeted oxfmt check passed for all 6 changed files
- Fresh `deadcode:ts-unused` output no longer reports the 3 affected modules
- `corepack pnpm check:changed` passed on Testbox-through-Crabbox `tbx_01kwxym8g8zk042t91cmzft456`
- Fresh local and post-rebase branch autoreviews: no actionable findings
