### PR TITLE
fix(ios): serialize screen recording finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Control UI typed approvals:** send `/approve` commands immediately through the authorized Gateway command path while an agent run is blocked instead of queueing the command behind that run. (#77672) Thanks @vincentkoc.
+- **iOS screen recording:** drain pending ReplayKit sample writes before finalizing the video, preventing `screen.record` from racing AVAssetWriter shutdown and crashing the app. (#99056)
 - **Microsoft Teams Graph response bounds:** cap successful file-upload and chat JSON reads so oversized Microsoft Graph responses cannot be buffered without limit. (#97784) Thanks @Alix-007.
 - **Packaged speech runtime:** stop treating package-backed `speech-core` as a bundled plugin sidecar, restoring TTS startup in npm installs while release checks keep true activation-bypassing facades package-complete. (#89899, #89425) Thanks @zhangguiping-xydt.
 - **Codex app-server protocol:** require app-server 0.142 or newer, remove pre-0.142 wire-shape compatibility, and teach Codex to retrieve deferred native `spawn_agent` through `tool_search` so native subagent task mirroring works on search-capable models. (#101221)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Control UI typed approvals:** send `/approve` commands immediately through the authorized Gateway command path while an agent run is blocked instead of queueing the command behind that run. (#77672) Thanks @vincentkoc.
-- **iOS screen recording:** drain pending ReplayKit sample writes before finalizing the video, preventing `screen.record` from racing AVAssetWriter shutdown and crashing the app. (#99056)
 - **Microsoft Teams Graph response bounds:** cap successful file-upload and chat JSON reads so oversized Microsoft Graph responses cannot be buffered without limit. (#97784) Thanks @Alix-007.
 - **Packaged speech runtime:** stop treating package-backed `speech-core` as a bundled plugin sidecar, restoring TTS startup in npm installs while release checks keep true activation-bypassing facades package-complete. (#89899, #89425) Thanks @zhangguiping-xydt.
 - **Codex app-server protocol:** require app-server 0.142 or newer, remove pre-0.142 wire-shape compatibility, and teach Codex to retrieve deferred native `spawn_agent` through `tool_search` so native subagent task mirroring works on search-capable models. (#101221)

--- a/apps/ios/Sources/Screen/ScreenRecordService.swift
+++ b/apps/ios/Sources/Screen/ScreenRecordService.swift
@@ -33,8 +33,10 @@ final class ScreenRecordService: @unchecked Sendable {
         @escaping CaptureCompletion)
         -> Void
     private let stopReplayKitCaptureAction: @Sendable (@escaping CaptureCompletion) -> Void
+    private let recordQueue: DispatchQueue
 
     init(
+        recordQueue: DispatchQueue = DispatchQueue(label: "ai.openclawfoundation.app.screenrecord"),
         startReplayKitCaptureAction: @escaping @Sendable (
             Bool,
             @escaping CaptureHandler,
@@ -53,6 +55,7 @@ final class ScreenRecordService: @unchecked Sendable {
             }
         })
     {
+        self.recordQueue = recordQueue
         self.startReplayKitCaptureAction = startReplayKitCaptureAction
         self.stopReplayKitCaptureAction = stopReplayKitCaptureAction
     }
@@ -89,9 +92,8 @@ final class ScreenRecordService: @unchecked Sendable {
             outPath: outPath)
 
         let state = CaptureState()
-        let recordQueue = DispatchQueue(label: "ai.openclawfoundation.app.screenrecord")
 
-        try await self.startCapture(state: state, config: config, recordQueue: recordQueue)
+        try await self.startCapture(state: state, config: config)
         do {
             try await Task.sleep(nanoseconds: UInt64(config.durationMs) * 1_000_000)
         } catch {
@@ -99,8 +101,7 @@ final class ScreenRecordService: @unchecked Sendable {
             throw error
         }
         try await self.stopCapture()
-        try self.finalizeCapture(state: state)
-        try await self.finishWriting(state: state)
+        try await self.finishCapture(state: state)
 
         return config.outURL.path
     }
@@ -149,16 +150,18 @@ final class ScreenRecordService: @unchecked Sendable {
 
     private func startCapture(
         state: CaptureState,
-        config: RecordConfig,
-        recordQueue: DispatchQueue) async throws
+        config: RecordConfig) async throws
     {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             let handler = self.makeCaptureHandler(
                 state: state,
-                config: config,
-                recordQueue: recordQueue)
+                config: config)
             let completion: @Sendable (Error?) -> Void = { error in
-                if let error { cont.resume(throwing: error) } else { cont.resume() }
+                if let error {
+                    cont.resume(throwing: error)
+                } else {
+                    cont.resume()
+                }
             }
 
             self.startReplayKitCaptureAction(
@@ -170,18 +173,19 @@ final class ScreenRecordService: @unchecked Sendable {
 
     private func makeCaptureHandler(
         state: CaptureState,
-        config: RecordConfig,
-        recordQueue: DispatchQueue) -> @Sendable (CMSampleBuffer, RPSampleBufferType, Error?) -> Void
+        config: RecordConfig) -> @Sendable (CMSampleBuffer, RPSampleBufferType, Error?) -> Void
     {
         { sample, type, error in
             let sampleBox = UncheckedSendableBox(value: sample)
             // ReplayKit can call the capture handler on a background queue.
             // Serialize writes to avoid queue asserts.
-            recordQueue.async {
+            self.recordQueue.async {
                 let sample = sampleBox.value
                 if let error {
                     state.withLock { state in
-                        if state.handlerError == nil { state.handlerError = error }
+                        if state.handlerError == nil {
+                            state.handlerError = error
+                        }
                     }
                     return
                 }
@@ -212,7 +216,9 @@ final class ScreenRecordService: @unchecked Sendable {
             }
             return false
         }
-        if shouldSkip { return }
+        if shouldSkip {
+            return
+        }
 
         if state.withLock({ $0.writer == nil }) {
             self.prepareWriter(sample: sample, state: state, config: config, pts: pts)
@@ -293,7 +299,9 @@ final class ScreenRecordService: @unchecked Sendable {
             }
         } catch {
             state.withLock { state in
-                if state.handlerError == nil { state.handlerError = error }
+                if state.handlerError == nil {
+                    state.handlerError = error
+                }
             }
         }
     }
@@ -317,40 +325,43 @@ final class ScreenRecordService: @unchecked Sendable {
                 cont.resume(returning: error)
             }
         }
-        if let stopError { throw stopError }
+        if let stopError {
+            throw stopError
+        }
     }
 
-    private func finalizeCapture(state: CaptureState) throws {
-        if let handlerErrorSnapshot = state.withLock({ $0.handlerError }) {
-            throw handlerErrorSnapshot
-        }
-        let writerSnapshot = state.withLock { $0.writer }
-        let videoInputSnapshot = state.withLock { $0.videoInput }
-        let audioInputSnapshot = state.withLock { $0.audioInput }
-        let sawVideoSnapshot = state.withLock { $0.sawVideo }
-        guard let writerSnapshot, let videoInputSnapshot, sawVideoSnapshot else {
-            throw ScreenRecordError.captureFailed("No frames captured")
-        }
-
-        videoInputSnapshot.markAsFinished()
-        audioInputSnapshot?.markAsFinished()
-        _ = writerSnapshot
-    }
-
-    private func finishWriting(state: CaptureState) async throws {
-        guard let writerSnapshot = state.withLock({ $0.writer }) else {
-            throw ScreenRecordError.captureFailed("Missing writer")
-        }
-        let writerBox = UncheckedSendableBox(value: writerSnapshot)
+    private func finishCapture(state: CaptureState) async throws {
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            writerBox.value.finishWriting {
-                let writer = writerBox.value
-                if let err = writer.error {
-                    cont.resume(throwing: ScreenRecordError.writeFailed(err.localizedDescription))
-                } else if writer.status != .completed {
-                    cont.resume(throwing: ScreenRecordError.writeFailed("Failed to finalize video"))
-                } else {
-                    cont.resume()
+            // ReplayKit has stopped, so finalization can queue behind every pending sample.
+            // AVAssetWriter requires all append calls to return before finishWriting starts.
+            self.recordQueue.async {
+                do {
+                    if let handlerError = state.withLock({ $0.handlerError }) {
+                        throw handlerError
+                    }
+                    let writer = state.withLock { $0.writer }
+                    let videoInput = state.withLock { $0.videoInput }
+                    let audioInput = state.withLock { $0.audioInput }
+                    let sawVideo = state.withLock { $0.sawVideo }
+                    guard let writer, let videoInput, sawVideo else {
+                        throw ScreenRecordError.captureFailed("No frames captured")
+                    }
+
+                    videoInput.markAsFinished()
+                    audioInput?.markAsFinished()
+                    let writerBox = UncheckedSendableBox(value: writer)
+                    writer.finishWriting {
+                        let writer = writerBox.value
+                        if let error = writer.error {
+                            cont.resume(throwing: ScreenRecordError.writeFailed(error.localizedDescription))
+                        } else if writer.status != .completed {
+                            cont.resume(throwing: ScreenRecordError.writeFailed("Failed to finalize video"))
+                        } else {
+                            cont.resume()
+                        }
+                    }
+                } catch {
+                    cont.resume(throwing: error)
                 }
             }
         }

--- a/apps/ios/Tests/ScreenRecordServiceTests.swift
+++ b/apps/ios/Tests/ScreenRecordServiceTests.swift
@@ -1,15 +1,23 @@
+import AVFoundation
 import Foundation
 import Testing
 @testable import OpenClaw
 
 private final class ScreenRecordServiceProbe: @unchecked Sendable {
     private let lock = NSLock()
+    private let sampleBuffer: CMSampleBuffer?
+    private var captureHandler: ScreenRecordService.CaptureHandler?
     private(set) var startCount = 0
     private(set) var stopCount = 0
 
-    func recordStart() {
+    init(sampleBuffer: CMSampleBuffer? = nil) {
+        self.sampleBuffer = sampleBuffer
+    }
+
+    func recordStart(handler: ScreenRecordService.CaptureHandler? = nil) {
         self.lock.lock()
         self.startCount += 1
+        self.captureHandler = handler
         self.lock.unlock()
     }
 
@@ -24,6 +32,55 @@ private final class ScreenRecordServiceProbe: @unchecked Sendable {
         defer { self.lock.unlock() }
         return (self.startCount, self.stopCount)
     }
+
+    func emitVideoSample() {
+        self.lock.lock()
+        let sampleBuffer = self.sampleBuffer
+        let captureHandler = self.captureHandler
+        self.lock.unlock()
+        if let sampleBuffer, let captureHandler {
+            captureHandler(sampleBuffer, .video, nil)
+        }
+    }
+}
+
+private func makeVideoSampleBuffer() throws -> CMSampleBuffer {
+    var pixelBuffer: CVPixelBuffer?
+    let pixelStatus = CVPixelBufferCreate(
+        kCFAllocatorDefault,
+        64,
+        64,
+        kCVPixelFormatType_32BGRA,
+        nil,
+        &pixelBuffer)
+    guard pixelStatus == kCVReturnSuccess, let pixelBuffer else {
+        throw ScreenRecordService.ScreenRecordError.captureFailed("Failed to create test pixel buffer")
+    }
+
+    var formatDescription: CMVideoFormatDescription?
+    let formatStatus = CMVideoFormatDescriptionCreateForImageBuffer(
+        allocator: kCFAllocatorDefault,
+        imageBuffer: pixelBuffer,
+        formatDescriptionOut: &formatDescription)
+    guard formatStatus == noErr, let formatDescription else {
+        throw ScreenRecordService.ScreenRecordError.captureFailed("Failed to create test format")
+    }
+
+    var timing = CMSampleTimingInfo(
+        duration: CMTime(value: 1, timescale: 30),
+        presentationTimeStamp: .zero,
+        decodeTimeStamp: .invalid)
+    var sampleBuffer: CMSampleBuffer?
+    let sampleStatus = CMSampleBufferCreateReadyWithImageBuffer(
+        allocator: kCFAllocatorDefault,
+        imageBuffer: pixelBuffer,
+        formatDescription: formatDescription,
+        sampleTiming: &timing,
+        sampleBufferOut: &sampleBuffer)
+    guard sampleStatus == noErr, let sampleBuffer else {
+        throw ScreenRecordService.ScreenRecordError.captureFailed("Failed to create test sample")
+    }
+    return sampleBuffer
 }
 
 @Suite(.serialized) struct ScreenRecordServiceTests {
@@ -95,5 +152,46 @@ private final class ScreenRecordServiceProbe: @unchecked Sendable {
         let counts = probe.counts()
         #expect(counts.start == 1)
         #expect(counts.stop == 1)
+    }
+
+    @Test func `record drains final sample before finishing writer`() async throws {
+        let probe = try ScreenRecordServiceProbe(sampleBuffer: makeVideoSampleBuffer())
+        let recordQueue = DispatchQueue(label: "ScreenRecordServiceTests.recordQueue")
+        recordQueue.suspend()
+        let stopped = AsyncStream<Void>.makeStream()
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("screen-record-final-sample-\(UUID().uuidString).mp4")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let recorder = ScreenRecordService(
+            recordQueue: recordQueue,
+            startReplayKitCaptureAction: { _, handler, completion in
+                probe.recordStart(handler: handler)
+                completion(nil)
+            },
+            stopReplayKitCaptureAction: { completion in
+                probe.recordStop()
+                probe.emitVideoSample()
+                completion(nil)
+                stopped.continuation.yield()
+                stopped.continuation.finish()
+            })
+
+        let recordingTask = Task {
+            try await recorder.record(
+                screenIndex: nil,
+                durationMs: 250,
+                fps: 5,
+                includeAudio: false,
+                outPath: outputURL.path)
+        }
+        for await _ in stopped.stream {
+            break
+        }
+        recordQueue.resume()
+
+        let path = try await recordingTask.value
+        #expect(path == outputURL.path)
+        #expect(try (Data(contentsOf: outputURL)).isEmpty == false)
     }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes #99056.

The remaining `screen.record` crash path could finish `AVAssetWriter` while ReplayKit sample callbacks were still queued. The callbacks append samples on `recordQueue`, but the old success path finalized the writer immediately after `stopCapture` returned without first draining that queue. Apple's `AVAssetWriter` contract requires every sample append to return before `finishWriting` starts.

The contacts half of #99056 was already fixed by #99475; this change addresses the remaining screen-recording failure.

## Why This Change Was Made

Finalization now runs on the same serial queue as sample processing. After ReplayKit reports capture stopped, the finish operation queues behind every pending sample, then marks the inputs finished and starts `finishWriting`.

The regression test suspends the writer queue, delivers a final video sample as stop completes, and proves the recording waits for that sample and emits a nonempty mp4 instead of finalizing early. This matches the queue ownership already used by the macOS screen recorder.

## User Impact

Invoking `screen.record` on an iOS node no longer races ReplayKit's final sample delivery against AVAssetWriter shutdown, avoiding the reported app termination and node disconnect.

## Evidence

- Xcode 26.5, iPhone 17 Pro simulator on iOS 26.5: `ScreenRecordServiceTests` passed 4/4, including the queued-final-sample regression.
- `swiftformat --lint --config config/swiftformat apps/ios/Sources/Screen/ScreenRecordService.swift apps/ios/Tests/ScreenRecordServiceTests.swift`
- `swiftlint lint --strict --config apps/ios/.swiftlint.yml apps/ios/Sources/Screen/ScreenRecordService.swift apps/ios/Tests/ScreenRecordServiceTests.swift`
- Blacksmith Testbox `tbx_01kwxzc9k3j9jhjtag9ffvx0wt`: scoped `check:changed` passed.
- Fresh autoreview: no accepted or actionable findings.
- Apple contract checked in the Xcode 26.5 SDK: `AVAssetWriter.finishWriting` requires all `append` calls to return first; ReplayKit's stop completion runs after capture has stopped.
