### PR TITLE
fix(discord): keep thread title prompts UTF-16 safe

### DIFF
--- a/extensions/discord/src/monitor/thread-title.generate.test.ts
+++ b/extensions/discord/src/monitor/thread-title.generate.test.ts
@@ -22,6 +22,24 @@ function firstCompletionArgs(): Parameters<
   return firstCall[0];
 }
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 beforeAll(async () => {
   ({ generateThreadTitle } = await import("./thread-title.js"));
 });
@@ -198,6 +216,24 @@ describe("generateThreadTitle", () => {
     expect(completionArgs.options?.signal).toBeInstanceOf(AbortSignal);
     expect(completionArgs.options).not.toHaveProperty("temperature");
     expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
+  });
+
+  it("keeps truncated prompt fields on UTF-16 boundaries", async () => {
+    await generateThreadTitle({
+      cfg: EMPTY_DISCORD_TEST_CONFIG,
+      agentId: "main",
+      messageText: `${"m".repeat(599)}😀tail`,
+      channelName: `${"n".repeat(119)}😀tail`,
+      channelDescription: `${"d".repeat(319)}😀tail`,
+    });
+
+    const message = firstCompletionArgs().context.messages.at(0);
+    const content = typeof message?.content === "string" ? message.content : "";
+
+    expect(hasLoneSurrogate(content)).toBe(false);
+    expect(content).toContain(`${"m".repeat(599)}...`);
+    expect(content).toContain(`${"n".repeat(119)}...`);
+    expect(content).toContain(`${"d".repeat(319)}...`);
   });
 
   it("clamps completion budget to the selected model output cap", async () => {

--- a/extensions/discord/src/monitor/thread-title.ts
+++ b/extensions/discord/src/monitor/thread-title.ts
@@ -6,6 +6,7 @@ import {
   extractAssistantText,
   prepareSimpleCompletionModelForAgent,
 } from "openclaw/plugin-sdk/simple-completion-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { withAbortTimeout } from "./timeouts.js";
 
 const DEFAULT_THREAD_TITLE_TIMEOUT_MS = 60_000;
@@ -51,9 +52,8 @@ export async function generateThreadTitle(params: {
   }
 
   try {
-    const promptText = truncateThreadTitleSourceText(sourceText);
-    const userMessage = buildThreadTitleUserMessage({
-      sourceText: promptText,
+    const userMessage = buildThreadTitleCompletionUserMessage({
+      sourceText,
       channelName: params.channelName,
       channelDescription: params.channelDescription,
     });
@@ -104,11 +104,12 @@ async function completeThreadTitle(params: {
   });
 }
 
-function buildThreadTitleUserMessage(params: {
+function buildThreadTitleCompletionUserMessage(params: {
   sourceText: string;
   channelName?: string;
   channelDescription?: string;
 }): string {
+  const sourceText = truncateThreadTitleSourceText(params.sourceText);
   const channelName = normalizeTitleContextField(
     params.channelName,
     MAX_THREAD_TITLE_CHANNEL_NAME_CHARS,
@@ -124,7 +125,7 @@ function buildThreadTitleUserMessage(params: {
   if (channelDescription) {
     messageLines.push(`Channel description: ${channelDescription}`);
   }
-  messageLines.push(`Message:\n${params.sourceText}`);
+  messageLines.push(`Message:\n${sourceText}`);
   return messageLines.join("\n\n");
 }
 
@@ -132,7 +133,7 @@ function truncateThreadTitleSourceText(sourceText: string): string {
   if (sourceText.length <= MAX_THREAD_TITLE_SOURCE_CHARS) {
     return sourceText;
   }
-  return `${sourceText.slice(0, MAX_THREAD_TITLE_SOURCE_CHARS)}...`;
+  return `${truncateUtf16Safe(sourceText, MAX_THREAD_TITLE_SOURCE_CHARS)}...`;
 }
 
 function resolveThreadTitleTimeoutMs(timeoutMs: number | undefined): number {
@@ -201,5 +202,5 @@ function normalizeTitleContextField(raw: string | undefined, maxChars: number): 
   if (singleLine.length <= maxChars) {
     return singleLine;
   }
-  return `${singleLine.slice(0, maxChars)}...`;
+  return `${truncateUtf16Safe(singleLine, maxChars)}...`;
 }


### PR DESCRIPTION
Related: #101307

## What Problem This Solves

Fixes an issue where Discord users generating automatic thread titles could send malformed prompt text when a message, channel name, or channel description hit its character cap in the middle of an emoji.

## Why This Change Was Made

All three bounded prompt fields now use OpenClaw's shared UTF-16-safe truncation helper. The formatter remains private, and the regression exercises the actual title-generation completion path rather than adding a test-only production export.

The original contributor branch became ancestry-corrupted and could not be rewritten through GitHub's maintainer-edit path, so this clean maintainer branch preserves the contributor's authorship via `Co-authored-by`.

## User Impact

Discord thread-title generation keeps the same limits and ellipsis behavior while avoiding dangling UTF-16 surrogate halves in model prompts.

## Evidence

- Regression drives `generateThreadTitle` with split-surrogate boundaries in message text, channel name, and channel description, then inspects the real completion prompt.
- Fresh Codex autoreview: clean, correctness 0.86.
- Canonical `oxfmt --check` for both touched files: passed.
- `git diff --check`: passed.
- Fresh exact-head hosted CI will be required before landing.
