### PR TITLE
fix(android): bound link preview image cache

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
@@ -38,6 +38,7 @@ internal const val LINK_PREVIEW_IMAGE_MAX_DIMENSION = 600
 private const val LINK_PREVIEW_MAX_REDIRECTS = 3
 private const val LINK_PREVIEW_TIMEOUT_MILLIS = 6_000L
 private const val LINK_PREVIEW_CACHE_ENTRIES = 64
+private const val LINK_PREVIEW_IMAGE_CACHE_MAX_BYTES = 8 * 1024 * 1024
 private const val LINK_PREVIEW_IMAGE_CACHE_ENTRIES = 32
 private const val LINK_PREVIEW_ACCEPT = "text/html, application/xhtml+xml;q=0.9"
 private const val LINK_PREVIEW_IMAGE_ACCEPT = "image/*"
@@ -324,9 +325,22 @@ internal class LinkPreviewStore(
 
 internal class LinkPreviewImageStore(
   private val fetcher: suspend (String) -> LinkPreviewImageResult,
-  maxEntries: Int = LINK_PREVIEW_IMAGE_CACHE_ENTRIES,
+  maxBytes: Int = LINK_PREVIEW_IMAGE_CACHE_MAX_BYTES,
 ) {
-  private val cache = LruCache<String, LinkPreviewImageResult>(maxEntries)
+  // Every result pays at least one entry share, preserving the entry cap while loaded bitmaps
+  // also pay their full backing allocation.
+  private val minimumResultBytes = max(1, maxBytes / LINK_PREVIEW_IMAGE_CACHE_ENTRIES)
+  private val cache =
+    object : LruCache<String, LinkPreviewImageResult>(maxBytes) {
+      override fun sizeOf(
+        key: String,
+        value: LinkPreviewImageResult,
+      ): Int =
+        when (value) {
+          is LinkPreviewImageResult.Loaded -> value.bitmap.allocationByteCount.coerceAtLeast(minimumResultBytes)
+          LinkPreviewImageResult.Failed -> minimumResultBytes
+        }
+    }
 
   suspend fun get(url: String): LinkPreviewImageResult {
     cache.get(url)?.let { return it }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
@@ -319,6 +319,84 @@ class ChatLinkPreviewTest {
     }
 
   @Test
+  fun imageCacheEvictsLeastRecentlyUsedBitmapByAllocatedBytes() =
+    runBlocking {
+      val first = Bitmap.createBitmap(20, 20, Bitmap.Config.ARGB_8888)
+      val second = Bitmap.createBitmap(20, 20, Bitmap.Config.ARGB_8888)
+      val fetchCounts = mutableMapOf<String, Int>()
+      val store =
+        LinkPreviewImageStore(
+          fetcher = { url ->
+            fetchCounts[url] = fetchCounts.getOrDefault(url, 0) + 1
+            LinkPreviewImageResult.Loaded(if (url == "first") first else second)
+          },
+          maxBytes = first.allocationByteCount,
+        )
+
+      try {
+        assertTrue(store.get("first") is LinkPreviewImageResult.Loaded)
+        assertTrue(store.get("second") is LinkPreviewImageResult.Loaded)
+        assertTrue(store.get("first") is LinkPreviewImageResult.Loaded)
+
+        assertEquals(2, fetchCounts["first"])
+        assertEquals(1, fetchCounts["second"])
+      } finally {
+        first.recycle()
+        second.recycle()
+      }
+    }
+
+  @Test
+  fun imageCacheBoundsNegativeResults() =
+    runBlocking {
+      val fetchCounts = mutableMapOf<String, Int>()
+      val store =
+        LinkPreviewImageStore(
+          fetcher = { url ->
+            fetchCounts[url] = fetchCounts.getOrDefault(url, 0) + 1
+            LinkPreviewImageResult.Failed
+          },
+          maxBytes = 2,
+        )
+
+      assertSame(LinkPreviewImageResult.Failed, store.get("first"))
+      assertSame(LinkPreviewImageResult.Failed, store.get("second"))
+      assertSame(LinkPreviewImageResult.Failed, store.get("third"))
+      assertSame(LinkPreviewImageResult.Failed, store.get("first"))
+
+      assertEquals(2, fetchCounts["first"])
+      assertEquals(1, fetchCounts["second"])
+      assertEquals(1, fetchCounts["third"])
+    }
+
+  @Test
+  fun imageCacheBoundsTinyLoadedResultsByEntryCount() =
+    runBlocking {
+      val tiny = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+      val maxEntries = 32
+      val fetchCounts = mutableMapOf<String, Int>()
+      val store =
+        LinkPreviewImageStore(
+          fetcher = { url ->
+            fetchCounts[url] = fetchCounts.getOrDefault(url, 0) + 1
+            LinkPreviewImageResult.Loaded(tiny)
+          },
+          maxBytes = tiny.allocationByteCount * maxEntries * 2,
+        )
+
+      try {
+        repeat(maxEntries + 1) { index ->
+          assertTrue(store.get("image-$index") is LinkPreviewImageResult.Loaded)
+        }
+        assertTrue(store.get("image-0") is LinkPreviewImageResult.Loaded)
+
+        assertEquals(2, fetchCounts["image-0"])
+      } finally {
+        tiny.recycle()
+      }
+    }
+
+  @Test
   fun imageContentTypeAllowlistAndBodyCapAreEnforced() =
     withServer { server ->
       server.enqueue(MockResponse().setHeader("Content-Type", "image/gif").setBody("GIF89a"))


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #101396: the Android link-preview bitmap cache used the platform `LruCache` default size accounting, which counts entries rather than bitmap bytes. Thirty-two decoded 600 x 600 ARGB thumbnails could therefore retain roughly 44 MiB.

## Why This Change Was Made

The cache now has an 8 MiB byte budget and charges loaded images by `allocationByteCount`. Every result also pays at least one thirty-second of the budget, preserving the existing 32-entry ceiling for tiny bitmaps and negative results.

## User Impact

Expanded Android link previews keep their existing behavior while thumbnail memory retention stays bounded.

## Evidence

- Blacksmith Testbox `tbx_01kwxysn1wwe4a2r419yrtdr99`: focused `ChatLinkPreviewTest` passed.
- Same Testbox: Play and third-party Android unit tests, both debug APK assemblies, both lint lanes, benchmark assembly, and Android ktlint passed.
- Added regression coverage for bitmap-byte eviction, negative-result eviction, and the 32-entry ceiling for tiny loaded images.
- Fresh Codex autoreview: no actionable findings after adding the entry-count invariant.

No agent transcript attached; none was approved.
