### PR TITLE
fix(exec): keep pending approval warnings truthful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Exec approval prompts:** keep background-disabled fallback warnings out of pending gateway/node approvals and show them only after a command actually runs in the foreground. (#78184) Thanks @vincentkoc.
 - **Control UI typed approvals:** send `/approve` commands immediately through the authorized Gateway command path while an agent run is blocked instead of queueing the command behind that run. (#77672) Thanks @vincentkoc.
 - **Microsoft Teams Graph response bounds:** cap successful file-upload and chat JSON reads so oversized Microsoft Graph responses cannot be buffered without limit. (#97784) Thanks @Alix-007.
 - **Packaged speech runtime:** stop treating package-backed `speech-core` as a bundled plugin sidecar, restoring TTS startup in npm installs while release checks keep true activation-bypassing facades package-complete. (#89899, #89425) Thanks @zhangguiping-xydt.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -168,7 +168,7 @@ To hard-disable exec, deny it via tool policy (`tools.deny: ["exec"]` or per-age
 
 Sandboxed agents can require per-request approval before `exec` runs on the gateway or node host. See [Exec approvals](/tools/exec-approvals) for the policy, allowlist, and UI flow.
 
-When approvals are required, the exec tool returns immediately with `status: "approval-pending"` and an approval id. Once approved (or denied / timed out), the Gateway emits command progress and completion system events only for approved runs (`Exec running` / `Exec finished`). Denied or timed-out approvals are terminal and do not wake the agent session with a denial system event.
+When a human approval is required, node-host and non-native gateway flows return immediately with `status: "approval-pending"` and an approval id. Native chat and Web UI gateway flows can instead wait inline and return the final command result after approval. An `approval-pending` result means the command has not started, so foreground fallback warnings appear only if the approved command actually runs inline. Approved asynchronous runs emit command progress and completion system events (`Exec running` / `Exec finished`); denied or timed-out approvals are terminal and do not wake the agent session with a denial system event.
 
 On channels with native approval cards/buttons, the agent should rely on that native UI first and only include a manual `/approve` command when the tool result explicitly says chat approvals are unavailable or manual approval is the only path.
 

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -136,6 +136,26 @@ describe("exec foreground failures", () => {
     tempDirs.cleanup();
   });
 
+  it("keeps the background fallback warning when gateway exec actually runs inline", async () => {
+    mockSuccessfulSpawn();
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      allowBackground: false,
+    });
+
+    const result = await tool.execute("call-background-disabled-foreground", {
+      command: "echo ok",
+      background: true,
+    });
+
+    expect(result.details.status).toBe("completed");
+    expect(requireTextContent(result)).toContain(
+      "Warning: background execution is disabled; running synchronously.",
+    );
+  });
+
   it("returns a failed text result when the default timeout is exceeded", async () => {
     const tool = createExecTool({
       security: "full",

--- a/src/agents/bash-tools.exec-host-node-phases.ts
+++ b/src/agents/bash-tools.exec-host-node-phases.ts
@@ -39,7 +39,7 @@ import {
 } from "../infra/system-run-command.js";
 import { addSafeTimeoutDelayGraceMs } from "../utils/timer-delay.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
-import { renderExecOutputText } from "./bash-tools.exec-output.js";
+import { renderExecUpdateText } from "./bash-tools.exec-output.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -225,6 +225,7 @@ export function formatNodeRunToolResult(params: {
   raw: unknown;
   startedAt: number;
   cwd: string | undefined;
+  warnings?: string[];
 }): AgentToolResult<ExecToolDetails> {
   const payload =
     params.raw && typeof params.raw === "object"
@@ -241,7 +242,10 @@ export function formatNodeRunToolResult(params: {
     content: [
       {
         type: "text",
-        text: renderExecOutputText(stdout || stderr || errorText),
+        text: renderExecUpdateText({
+          tailText: stdout || stderr || errorText,
+          warnings: params.warnings ?? [],
+        }),
       },
     ],
     details: {
@@ -404,7 +408,12 @@ export async function invokeNodeSystemRunDirect(params: {
       notifyOnExit: params.request.notifyOnExit,
     }),
   );
-  return formatNodeRunToolResult({ raw, startedAt, cwd: params.request.workdir });
+  return formatNodeRunToolResult({
+    raw,
+    startedAt,
+    cwd: params.request.workdir,
+    warnings: [...params.request.warnings, ...(params.request.foregroundWarnings ?? [])],
+  });
 }
 
 /** Prepares a node-host system run using remote prepare support or local fallback. */

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -14,6 +14,7 @@ import {
   resolveExecApprovalUnavailableDecisions,
 } from "../infra/exec-approvals.js";
 import { defaultExecAutoReviewer, type ExecAutoReviewInput } from "../infra/exec-auto-review.js";
+import { tail } from "./bash-process-registry.js";
 import {
   buildExecApprovalRequesterContext,
   buildExecApprovalTurnSourceContext,
@@ -29,7 +30,6 @@ import {
   shouldSkipNodeApprovalPrepare,
 } from "./bash-tools.exec-host-node-phases.js";
 import type { ExecuteNodeHostCommandParams } from "./bash-tools.exec-host-node.types.js";
-import { tail } from "./bash-process-registry.js";
 import * as execHostShared from "./bash-tools.exec-host-shared.js";
 import {
   DEFAULT_NOTIFY_TAIL_CHARS,
@@ -483,5 +483,10 @@ export async function executeNodeHostCommand(
           scopes: APPROVED_NODE_INVOKE_SCOPES,
         })
       : await callGatewayTool("node.invoke", { timeoutMs: target.invokeTimeoutMs }, invoke);
-  return formatNodeRunToolResult({ raw, startedAt, cwd: params.workdir });
+  return formatNodeRunToolResult({
+    raw,
+    startedAt,
+    cwd: params.workdir,
+    warnings: [...params.warnings, ...(params.foregroundWarnings ?? [])],
+  });
 }

--- a/src/agents/bash-tools.exec-host-node.types.ts
+++ b/src/agents/bash-tools.exec-host-node.types.ts
@@ -38,6 +38,8 @@ export type ExecuteNodeHostCommandParams = {
   defaultTimeoutSec: number;
   approvalRunningNoticeMs: number;
   warnings: string[];
+  /** Warnings that apply only when the command runs inline, never while approval is pending. */
+  foregroundWarnings?: string[];
   notifySessionKey?: string;
   notifyOnExit?: boolean;
   trustedSafeBinDirs?: ReadonlySet<string>;

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -657,6 +657,37 @@ describe("exec approvals", () => {
     expect(calls).toContain("node.invoke");
   });
 
+  it("keeps the background fallback warning when node exec actually runs inline", async () => {
+    vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+      if (method === "node.invoke") {
+        const invoke = params as { command?: string };
+        if (invoke.command === "system.run") {
+          return { payload: { success: true, stdout: "node-ok" } };
+        }
+      }
+      return { ok: true };
+    });
+
+    const tool = createExecTool({
+      host: "node",
+      ask: "off",
+      security: "full",
+      allowBackground: false,
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call-node-background-disabled", {
+      command: "echo ok",
+      background: true,
+    });
+
+    expect(result.details.status).toBe("completed");
+    expect(getResultText(result)).toContain(
+      "Warning: background execution is disabled; running synchronously.",
+    );
+    expect(getResultText(result)).toContain("node-ok");
+  });
+
   it("honors ask=off for elevated gateway exec without prompting", async () => {
     const calls: string[] = [];
     vi.mocked(callGatewayTool).mockImplementation(async (method) => {
@@ -940,6 +971,49 @@ describe("exec approvals", () => {
     expect(calls).toContain("exec.approval.request");
     expect(calls).toContain("exec.approval.waitDecision");
   });
+
+  it.each(["gateway", "node"] as const)(
+    "keeps background fallback warnings out of pending %s approvals",
+    async (host) => {
+      let approvalRequest: Record<string, unknown> | undefined;
+      vi.mocked(callGatewayTool).mockImplementation(async (method, _opts, params) => {
+        if (method === "node.invoke") {
+          const invoke = params as { command?: string };
+          if (invoke.command === "system.run.prepare") {
+            return buildPreparedSystemRunPayload(params);
+          }
+        }
+        if (method === "exec.approvals.node.get") {
+          return { file: { version: 1, agents: {} } };
+        }
+        if (method === "exec.approval.request") {
+          approvalRequest = params as Record<string, unknown>;
+          return acceptedApprovalResponse(params);
+        }
+        if (method === "exec.approval.waitDecision") {
+          return { decision: "deny" };
+        }
+        return { ok: true };
+      });
+
+      const tool = createExecTool({
+        host,
+        ask: "always",
+        security: "full",
+        allowBackground: false,
+        approvalRunningNoticeMs: 0,
+      });
+
+      const result = await tool.execute(`call-${host}-background-approval`, {
+        command: "echo ok",
+        background: true,
+      });
+
+      expect(result.details.status).toBe("approval-pending");
+      expect(getResultText(result)).not.toContain("background execution is disabled");
+      expect(approvalRequest?.warningText).toBeUndefined();
+    },
+  );
 
   it("starts an internal agent follow-up after approved gateway exec completes without an external route", async () => {
     const agentCalls: Array<Record<string, unknown>> = [];

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1583,9 +1583,10 @@ export function createExecTool(
       let execCommandOverride: string | undefined;
       const backgroundRequested = params.background === true;
       const yieldRequested = typeof params.yieldMs === "number";
-      if (!allowBackground && (backgroundRequested || yieldRequested)) {
-        warnings.push("Warning: background execution is disabled; running synchronously.");
-      }
+      const foregroundFallbackWarning =
+        !allowBackground && (backgroundRequested || yieldRequested)
+          ? "Warning: background execution is disabled; running synchronously."
+          : undefined;
       const yieldWindow = allowBackground
         ? backgroundRequested
           ? 0
@@ -1885,6 +1886,7 @@ export function createExecTool(
             defaultTimeoutSec,
             approvalRunningNoticeMs,
             warnings,
+            foregroundWarnings: foregroundFallbackWarning ? [foregroundFallbackWarning] : [],
             notifySessionKey,
             notifyOnExit,
             trustedSafeBinDirs,
@@ -1945,6 +1947,12 @@ export function createExecTool(
           if (gatewayResult.allowWithoutEnforcedCommand) {
             execCommandOverride = undefined;
           }
+        }
+
+        // Pending approvals have not started the command. Add fallback warnings only
+        // after approval routing proves this call will execute in the foreground.
+        if (foregroundFallbackWarning) {
+          warnings.push(foregroundFallbackWarning);
         }
 
         const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;


### PR DESCRIPTION
Related: #78184

## What Problem This Solves

Fixes an issue where users requesting background or yielded exec while the `process` tool was unavailable would see “running synchronously” inside a gateway or node approval-pending prompt, even though the command had not started.

## Why This Change Was Made

This is a maintainer replay of the useful runtime portion of #78184. It keeps foreground-only warnings separate from approval-time warnings, adds them only once execution will actually run inline, and makes node completion rendering preserve the same warnings as gateway completion rendering.

The replay deliberately excludes the original Doctor repair that added `process`/`edit` grants to restricted profiles; that would silently broaden existing authorization policy. It also replaces the original blanket approval docs with the current contract: native gateway approval can wait inline, while node and non-native gateway approvals return pending and complete asynchronously.

## User Impact

Pending approval cards now describe only the approval state and no longer imply that a command is already executing. If an approved or unguarded command truly falls back to foreground execution, the user still sees the background-disabled warning. No config, migration, protocol, or approval-authority surface changes.

## Evidence

- Testbox `tbx_01kwy0fhy32t821vwnbe3exev3`: `pnpm test src/agents/bash-tools.exec.approval-id.test.ts src/agents/bash-tools.exec-foreground-failures.test.ts src/agents/bash-tools.exec-host-node.test.ts` — 3 files, 95 tests passed.
- Same Testbox: `pnpm check:changed` — selected `core`, `coreTests`, and `docs`; production/test typechecks, lint (0 warnings/errors), docs/policy guards, and import-cycle checks passed.
- Same Testbox: scoped `pnpm format:check` — all 8 changed files correctly formatted.
- Fresh Codex autoreview after formatting: clean, no accepted/actionable findings, correctness 0.93.
- `git diff --check` passed at commit `ae9f9e72f5f041fce5c7525b3f1dca8080a35b72`.
