### PR TITLE
fix(slack): conversation lookups no longer grow cache without bound

### DIFF
--- a/extensions/slack/src/channel-type.test.ts
+++ b/extensions/slack/src/channel-type.test.ts
@@ -178,6 +178,55 @@ describe("resolveSlackChannelType", () => {
     expect(conversationsInfoMock).not.toHaveBeenCalled();
   });
 
+  it("evicts least-recently-used conversation info entries after the cache limit", async () => {
+    const cacheMaxEntries = 1024;
+    const cfg = {
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+        },
+      },
+    } as never;
+
+    conversationsInfoMock.mockImplementation(async ({ channel }) => ({
+      channel: {
+        id: channel,
+      },
+    }));
+
+    for (let index = 0; index < cacheMaxEntries; index++) {
+      await resolveSlackConversationInfo({
+        cfg,
+        channelId: `C${index.toString().padStart(8, "0")}`,
+      });
+    }
+    expect(conversationsInfoMock).toHaveBeenCalledTimes(cacheMaxEntries);
+
+    await resolveSlackConversationInfo({
+      cfg,
+      channelId: "C00000000",
+    });
+    expect(conversationsInfoMock).toHaveBeenCalledTimes(cacheMaxEntries);
+
+    await resolveSlackConversationInfo({
+      cfg,
+      channelId: `C${cacheMaxEntries.toString().padStart(8, "0")}`,
+    });
+    expect(conversationsInfoMock).toHaveBeenCalledTimes(cacheMaxEntries + 1);
+
+    await resolveSlackConversationInfo({
+      cfg,
+      channelId: "C00000001",
+    });
+    expect(conversationsInfoMock).toHaveBeenCalledTimes(cacheMaxEntries + 2);
+
+    await resolveSlackConversationInfo({
+      cfg,
+      channelId: "C00000000",
+    });
+    expect(conversationsInfoMock).toHaveBeenCalledTimes(cacheMaxEntries + 2);
+  });
+
   it("preserves the channel-type wrapper contract", async () => {
     conversationsInfoMock.mockResolvedValueOnce({
       channel: {

--- a/extensions/slack/src/channel-type.ts
+++ b/extensions/slack/src/channel-type.ts
@@ -1,4 +1,5 @@
 // Slack plugin module implements channel type behavior.
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -13,7 +14,26 @@ export type SlackConversationInfo = {
   user?: string;
 };
 
+const SLACK_CONVERSATION_INFO_CACHE_MAX_ENTRIES = 1024;
 const SLACK_CONVERSATION_INFO_CACHE = new Map<string, SlackConversationInfo>();
+
+function getCachedSlackConversationInfo(cacheKey: string): SlackConversationInfo | undefined {
+  const cached = SLACK_CONVERSATION_INFO_CACHE.get(cacheKey);
+  if (cached) {
+    SLACK_CONVERSATION_INFO_CACHE.delete(cacheKey);
+    SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, cached);
+  }
+  return cached;
+}
+
+function setCachedSlackConversationInfo(
+  cacheKey: string,
+  conversationInfo: SlackConversationInfo,
+): void {
+  SLACK_CONVERSATION_INFO_CACHE.delete(cacheKey);
+  SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, conversationInfo);
+  pruneMapToMaxSize(SLACK_CONVERSATION_INFO_CACHE, SLACK_CONVERSATION_INFO_CACHE_MAX_ENTRIES);
+}
 
 export async function resolveSlackConversationInfo(params: {
   cfg: OpenClawConfig;
@@ -26,7 +46,7 @@ export async function resolveSlackConversationInfo(params: {
   }
   const account = resolveSlackAccount({ cfg: params.cfg, accountId: params.accountId });
   const cacheKey = `${account.accountId}:${channelId}`;
-  const cached = SLACK_CONVERSATION_INFO_CACHE.get(cacheKey);
+  const cached = getCachedSlackConversationInfo(cacheKey);
   if (cached) {
     return cached;
   }
@@ -42,7 +62,7 @@ export async function resolveSlackConversationInfo(params: {
       groupChannels.includes(`mpim:${channelIdLower}`))
   ) {
     const result = { type: "group" } as const;
-    SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+    setCachedSlackConversationInfo(cacheKey, result);
     return result;
   }
 
@@ -59,7 +79,7 @@ export async function resolveSlackConversationInfo(params: {
     })
   ) {
     const result = { type: "channel" } as const;
-    SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+    setCachedSlackConversationInfo(cacheKey, result);
     return result;
   }
 
@@ -70,7 +90,7 @@ export async function resolveSlackConversationInfo(params: {
   if (!token) {
     const result = { type: isNativeImChannel ? "dm" : "unknown" } as const;
     if (!isNativeImChannel) {
-      SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+      setCachedSlackConversationInfo(cacheKey, result);
     }
     return result;
   }
@@ -89,7 +109,7 @@ export async function resolveSlackConversationInfo(params: {
           : undefined;
       const result: SlackConversationInfo = user ? { type: "dm", user } : { type: "dm" };
       if (user) {
-        SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+        setCachedSlackConversationInfo(cacheKey, result);
       }
       return result;
     }
@@ -97,12 +117,12 @@ export async function resolveSlackConversationInfo(params: {
     const channel = info.channel as { is_im?: boolean; is_mpim?: boolean } | undefined;
     const type = channel?.is_im ? "dm" : channel?.is_mpim ? "group" : "channel";
     const result = { type } as const;
-    SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+    setCachedSlackConversationInfo(cacheKey, result);
     return result;
   } catch {
     const result = { type: isNativeImChannel ? "dm" : "unknown" } as const;
     if (!isNativeImChannel) {
-      SLACK_CONVERSATION_INFO_CACHE.set(cacheKey, result);
+      setCachedSlackConversationInfo(cacheKey, result);
     }
     return result;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where long-running Slack channel workers could keep every distinct conversation-info lookup in process memory indefinitely when many workspaces or channel IDs are resolved over time.

No linked issue. I checked the latest `origin/main` before the change and the Slack conversation-info cache was still an unbounded `Map`. I also searched open PRs for the exact cache symbol, the Slack channel-type path, `slack cache`, and `slack conversation`; I did not find an open PR handling this cache growth.

## Why This Change Was Made

The Slack conversation-info cache now has a 1024-entry LRU limit. Cache hits are promoted, every cache write goes through the bounded helper, and the oldest non-promoted entry is evicted before inserting a new distinct account/channel key beyond the limit.

This does not change Slack config, schema, persisted state, Slack API request shape, or channel classification rules; it only bounds the process-local metadata cache.

## User Impact

Long-running Slack deployments can continue resolving many channels without unbounded process-local memory growth from conversation metadata. Recently used conversation info remains cached, while stale entries are eligible for recomputation.

## Evidence

RED regression proof before the fix:

```text
FAIL  extensions/slack/src/channel-type.test.ts > resolveSlackChannelType > evicts least-recently-used conversation info entries after the cache limit
AssertionError: expected "vi.fn()" to be called 1026 times, but got 1025 times
```

Focused regression test after the fix:

```text
$ node scripts/run-vitest.mjs run extensions/slack/src/channel-type.test.ts
Test Files  1 passed (1)
Tests  7 passed (7)
```

Issue-path runtime proof using the real Slack conversation resolver without Slack client mocks:

```text
$ node --import tsx slack-cache-runtime-proof.mjs
Slack conversation info cache LRU runtime proof passed
warmed_entries=1024 inserted_extra_channel=1 evicted_channel=C00000001 promoted_channel=C00000000
```

Static checks:

```text
$ pnpm tsgo:extensions:test
result: pass

$ pnpm lint:extensions
result: pass
```

OpenClaw gateway startup smoke after the patch:

```text
=== GATEWAY READY
http server listening
ready
```
