### PR TITLE
fix #101083: fix IRC fatal reconnect status honesty

### DIFF
--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -1,5 +1,6 @@
 // Irc tests cover monitor plugin behavior.
 import net from "node:net";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { monitorIrcProvider, resolveIrcInboundTarget } from "./monitor.js";
 import { clearIrcRuntime, setIrcRuntime } from "./runtime.js";
@@ -50,6 +51,70 @@ async function startDisconnectingIrcServer(): Promise<DisconnectingIrcServer> {
           socket.write(":server 001 bot :welcome\r\n");
           if (connectionNumber === 1) {
             setTimeout(() => socket.destroy(), 10);
+          }
+        }
+      }
+    });
+    socket.on("close", () => {
+      sockets.delete(socket);
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback IRC server to bind a TCP port");
+  }
+
+  return {
+    port: address.port,
+    lines,
+    get connectionCount() {
+      return connectionCount;
+    },
+    close: async () => {
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+async function startFatalReconnectIrcServer(): Promise<DisconnectingIrcServer> {
+  const lines: string[] = [];
+  const sockets = new Set<net.Socket>();
+  let connectionCount = 0;
+
+  const server = net.createServer((socket) => {
+    const connectionNumber = ++connectionCount;
+    sockets.add(socket);
+    socket.setEncoding("utf8");
+    let buffer = "";
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      let idx = buffer.indexOf("\n");
+      while (idx !== -1) {
+        const line = buffer.slice(0, idx).replace(/\r$/, "");
+        buffer = buffer.slice(idx + 1);
+        idx = buffer.indexOf("\n");
+        lines.push(line);
+        if (line.startsWith("USER ")) {
+          if (connectionNumber === 1) {
+            socket.write(":server 001 bot :welcome\r\n");
+            setTimeout(() => socket.destroy(), 10);
+          } else {
+            socket.write(":server 464 bot :Password incorrect\r\n");
           }
         }
       }
@@ -142,6 +207,72 @@ describe("irc monitor reconnect", () => {
       );
 
       expect(server.connectionCount).toBeGreaterThanOrEqual(2);
+    } finally {
+      monitor?.stop();
+      await server.close();
+    }
+  });
+
+  it("marks the account disconnected when reconnect receives a fatal login error", async () => {
+    installMonitorRuntime();
+    const server = await startFatalReconnectIrcServer();
+    const config = {
+      channels: {
+        irc: {
+          host: "127.0.0.1",
+          port: server.port,
+          tls: false,
+          nick: "bot",
+          username: "bot",
+          realname: "OpenClaw",
+          channels: ["#openclaw"],
+        },
+      },
+    } as CoreConfig;
+    const statusPatches: Array<Partial<ChannelAccountSnapshot>> = [];
+    let monitor: { stop: () => void } | undefined;
+
+    try {
+      monitor = await monitorIrcProvider({
+        config,
+        statusSink: (patch) => {
+          statusPatches.push(patch);
+        },
+      });
+      await waitForIrcCondition(
+        () =>
+          statusPatches.some(
+            (patch) =>
+              patch.running === false &&
+              patch.connected === false &&
+              patch.lastError === "IRC login failed (464): Password incorrect",
+          ),
+        "expected IRC monitor to publish fatal reconnect failure status",
+      );
+
+      expect(server.connectionCount).toBeGreaterThanOrEqual(2);
+      expect(statusPatches).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            running: true,
+            connected: true,
+            lastError: null,
+          }),
+          expect.objectContaining({
+            running: false,
+            connected: false,
+            lastError: "IRC connection closed",
+          }),
+          expect.objectContaining({
+            running: false,
+            connected: false,
+            lastError: "IRC login failed (464): Password incorrect",
+            lastDisconnect: expect.objectContaining({
+              error: "IRC login failed (464): Password incorrect",
+            }),
+          }),
+        ]),
+      );
     } finally {
       monitor?.stop();
       await server.close();

--- a/extensions/irc/src/monitor.ts
+++ b/extensions/irc/src/monitor.ts
@@ -1,5 +1,6 @@
 // Irc plugin module implements monitor behavior.
 import { resolveLoggerBackedRuntime } from "openclaw/plugin-sdk/extension-shared";
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/status-helpers";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveIrcAccount } from "./accounts.js";
 import { connectIrcClient, type IrcClient } from "./client.js";
@@ -11,12 +12,27 @@ import type { RuntimeEnv } from "./runtime-api.js";
 import { getIrcRuntime } from "./runtime.js";
 import type { CoreConfig, IrcInboundMessage } from "./types.js";
 
+type IrcMonitorStatusPatch = Partial<
+  Pick<
+    ChannelAccountSnapshot,
+    | "running"
+    | "connected"
+    | "lastStartAt"
+    | "lastStopAt"
+    | "lastConnectedAt"
+    | "lastDisconnect"
+    | "lastError"
+    | "lastInboundAt"
+    | "lastOutboundAt"
+  >
+>;
+
 type IrcMonitorOptions = {
   accountId?: string;
   config?: CoreConfig;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
-  statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
+  statusSink?: (patch: IrcMonitorStatusPatch) => void;
   onMessage?: (message: IrcInboundMessage, client: IrcClient) => void | Promise<void>;
 };
 
@@ -65,6 +81,27 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
   let stopped = false;
   const monitorAbort = new AbortController();
   let removeAbortListener: (() => void) | null = null;
+
+  function publishConnectedStatus() {
+    const now = Date.now();
+    opts.statusSink?.({
+      running: true,
+      connected: true,
+      lastStartAt: now,
+      lastConnectedAt: now,
+      lastDisconnect: null,
+      lastError: null,
+    });
+  }
+
+  function publishDisconnectedStatus(error: string) {
+    opts.statusSink?.({
+      running: false,
+      connected: false,
+      lastDisconnect: { at: Date.now(), error },
+      lastError: error,
+    });
+  }
   if (opts.abortSignal) {
     const forwardAbort = () => monitorAbort.abort();
     if (opts.abortSignal.aborted) {
@@ -96,97 +133,108 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
     if (stopped || monitorAbort.signal.aborted) {
       return;
     }
-    const nextClient = await connectIrcClient(
-      buildIrcConnectOptions(account, {
-        channels: account.config.channels,
-        abortSignal: monitorAbort.signal,
-        onLine: (line) => {
-          if (core.logging.shouldLogVerbose()) {
-            logger.debug?.(`[${account.accountId}] << ${line}`);
-          }
-        },
-        onNotice: (text, target) => {
-          if (core.logging.shouldLogVerbose()) {
-            logger.debug?.(`[${account.accountId}] notice ${target ?? ""}: ${text}`);
-          }
-        },
-        onError: (error) => {
-          logger.error(`[${account.accountId}] IRC error: ${error.message}`);
-        },
-        onDisconnect: () => {
-          if (stopped || monitorAbort.signal.aborted) {
-            return;
-          }
-          client = null;
-          logger.warn?.(
-            `[${account.accountId}] IRC connection closed; reconnecting in ${IRC_MONITOR_RECONNECT_DELAY_MS}ms`,
-          );
-          scheduleReconnect();
-        },
-        onPrivmsg: async (event) => {
-          if (!client) {
-            return;
-          }
-          if (
-            normalizeLowercaseStringOrEmpty(event.senderNick) ===
-            normalizeLowercaseStringOrEmpty(client.nick)
-          ) {
-            return;
-          }
+    let nextClient: IrcClient;
+    try {
+      nextClient = await connectIrcClient(
+        buildIrcConnectOptions(account, {
+          channels: account.config.channels,
+          abortSignal: monitorAbort.signal,
+          onLine: (line) => {
+            if (core.logging.shouldLogVerbose()) {
+              logger.debug?.(`[${account.accountId}] << ${line}`);
+            }
+          },
+          onNotice: (text, target) => {
+            if (core.logging.shouldLogVerbose()) {
+              logger.debug?.(`[${account.accountId}] notice ${target ?? ""}: ${text}`);
+            }
+          },
+          onError: (error) => {
+            logger.error(`[${account.accountId}] IRC error: ${error.message}`);
+          },
+          onDisconnect: () => {
+            if (stopped || monitorAbort.signal.aborted) {
+              return;
+            }
+            client = null;
+            publishDisconnectedStatus("IRC connection closed");
+            logger.warn?.(
+              `[${account.accountId}] IRC connection closed; reconnecting in ${IRC_MONITOR_RECONNECT_DELAY_MS}ms`,
+            );
+            scheduleReconnect();
+          },
+          onPrivmsg: async (event) => {
+            if (!client) {
+              return;
+            }
+            if (
+              normalizeLowercaseStringOrEmpty(event.senderNick) ===
+              normalizeLowercaseStringOrEmpty(client.nick)
+            ) {
+              return;
+            }
 
-          const inboundTarget = resolveIrcInboundTarget({
-            target: event.target,
-            senderNick: event.senderNick,
-          });
-          const message: IrcInboundMessage = {
-            messageId: makeIrcMessageId(),
-            target: inboundTarget.target,
-            rawTarget: inboundTarget.rawTarget,
-            senderNick: event.senderNick,
-            senderUser: event.senderUser,
-            senderHost: event.senderHost,
-            text: event.text,
-            timestamp: Date.now(),
-            isGroup: inboundTarget.isGroup,
-          };
+            const inboundTarget = resolveIrcInboundTarget({
+              target: event.target,
+              senderNick: event.senderNick,
+            });
+            const message: IrcInboundMessage = {
+              messageId: makeIrcMessageId(),
+              target: inboundTarget.target,
+              rawTarget: inboundTarget.rawTarget,
+              senderNick: event.senderNick,
+              senderUser: event.senderUser,
+              senderHost: event.senderHost,
+              text: event.text,
+              timestamp: Date.now(),
+              isGroup: inboundTarget.isGroup,
+            };
 
-          core.channel.activity.record({
-            channel: "irc",
-            accountId: account.accountId,
-            direction: "inbound",
-            at: message.timestamp,
-          });
+            core.channel.activity.record({
+              channel: "irc",
+              accountId: account.accountId,
+              direction: "inbound",
+              at: message.timestamp,
+            });
 
-          if (opts.onMessage) {
-            await opts.onMessage(message, client);
-            return;
-          }
+            if (opts.onMessage) {
+              await opts.onMessage(message, client);
+              return;
+            }
 
-          await handleIrcInbound({
-            message,
-            account,
-            config: cfg,
-            runtime,
-            connectedNick: client.nick,
-            sendReply: async (target, text) => {
-              client?.sendPrivmsg(target, text);
-              opts.statusSink?.({ lastOutboundAt: Date.now() });
-              core.channel.activity.record({
-                channel: "irc",
-                accountId: account.accountId,
-                direction: "outbound",
-              });
-            },
-            statusSink: opts.statusSink,
-          });
-        },
-      }),
-    );
+            await handleIrcInbound({
+              message,
+              account,
+              config: cfg,
+              runtime,
+              connectedNick: client.nick,
+              sendReply: async (target, text) => {
+                client?.sendPrivmsg(target, text);
+                opts.statusSink?.({ lastOutboundAt: Date.now() });
+                core.channel.activity.record({
+                  channel: "irc",
+                  accountId: account.accountId,
+                  direction: "outbound",
+                });
+              },
+              statusSink: opts.statusSink,
+            });
+          },
+        }),
+      );
+    } catch (error) {
+      if (!stopped && !monitorAbort.signal.aborted) {
+        const message = error instanceof Error ? error.message : String(error);
+        publishDisconnectedStatus(message);
+      }
+      throw error;
+    }
     if (stopped || monitorAbort.signal.aborted) {
       nextClient.quit("shutdown");
       return;
     }
     client = nextClient;
+    publishConnectedStatus();
 
     logger.info(
       `[${account.accountId}] connected to ${account.host}:${account.port}${account.tls ? " (tls)" : ""} as ${nextClient.nick}`,
@@ -207,6 +255,7 @@ export async function monitorIrcProvider(opts: IrcMonitorOptions): Promise<{ sto
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
+      opts.statusSink?.({ running: false, connected: false, lastStopAt: Date.now() });
       client?.quit("shutdown");
       client = null;
     },


### PR DESCRIPTION
## Summary

- Publish IRC account lifecycle status from the monitor when it connects, disconnects, stops, or fails a reconnect attempt.
- Mark reconnect login failures as `running: false`, `connected: false`, and preserve the `IRC login failed (...)` message in `lastError`.
- Add a loopback IRC regression that connects once, drops the ready socket, then returns fatal numeric `464` on reconnect.

## What Problem This Solves

IRC accounts could stay visible as healthy after a post-ready socket close if the reconnect attempt hit a fatal login reply such as `464`. The reconnect failure was only logged and rescheduled; the account status sink never received `connected: false` or `lastError`, so status readers could continue treating the account as available from the old runtime state.

This patch fixes the status-honesty slice: the same reconnect failure now publishes a disconnected/error status through the account status sink.

## User Impact

Operators running an IRC channel can now see that the account is disconnected after a fatal reconnect login error instead of seeing a stale healthy state while IRC messages cannot flow.

- **Why it matters / User impact:** A configured IRC account can stop receiving/sending messages after a post-ready disconnect and fatal reconnect login reply; the user-visible status surface should show that outage instead of reporting the account as healthy.

## Origin / follow-up

Addresses the status-reporting part of #101083. The issue and ClawSweeper review identified a maintainer policy choice between terminal failure and capped retry. This PR intentionally takes the status-only first slice that the review listed as a viable narrow path.

## Competition / linked PR analysis

- `linked-open-prs-for-issue.json`: no linked open PRs for #101083.
- `public-contract-related-prs.json`: no related open PRs found for the IRC status contract terms scanned.
- The issue has `clawsweeper:no-new-fix-pr`, `needs-maintainer-review`, and `needs-product-decision`; this PR avoids the contested retry/backoff/terminal policy and only implements the low-risk status honesty slice called out in the review.

## Real behavior proof

- **Behavior or issue addressed:** IRC monitor status after a real post-ready reconnect path receives a fatal login reply. The regression server accepts the first IRC login with `001`, destroys the established TCP socket, then replies to the next login with numeric `464` so the production `connectIrcClient` rejection path is exercised through `monitorIrcProvider`.
- **Canonical reachability path:** User configures `channels.irc` host/port/nick → `resolveIrcAccount` builds the runtime IRC account → `monitorIrcProvider` calls `connectIrcClient` → IRC server sends `001` and later closes the ready socket → monitor `onDisconnect` schedules reconnect → same shipped `connectIrcClient` receives fatal IRC numeric `464` before ready → monitor catches the rejection and publishes account status through `createAccountStatusSink`.
- **Boundary crossed:** local-runtime plus local IRC protocol boundary. The proof crosses a real TCP socket between `monitorIrcProvider`/`connectIrcClient` and a loopback IRC server; it does not call the status helper directly or construct the fatal error by hand.
- **Shared helper / provider constraint check:** N/A — no provider numeric/config normalization or documented provider range is changed. The existing shared `ChannelAccountSnapshot` status fields are reused through the existing account status sink contract.
- **Real environment tested:** Linux source checkout in `/media/vdb/code/ai/aispace/openclaw-worktrees/issue-101083`, Node/Vitest through the repository runner, with a local TCP loopback IRC server built using `net.Server`.
- **Exact steps or command run after this patch:**

```shell
cd /media/vdb/code/ai/aispace/openclaw-worktrees/issue-101083
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-irc.config.ts extensions/irc/src/monitor.test.ts
pnpm tsgo:test:extensions
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/irc
```

- **Evidence after fix:**

```shell
RUN  v4.1.9 /media/vdb/code/ai/aispace/openclaw-worktrees/issue-101083

Test Files  1 passed (1)
     Tests  5 passed (5)
  Duration  16.01s
```

```shell
$ pnpm tsgo:extensions:test
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
```

```shell
[plugin-sdk boundary dts] fresh; skipping
[plugin-sdk package boundary dts] fresh; skipping
[qa-channel boundary dts] fresh; skipping
[discord boundary dts] fresh; skipping
[slack boundary dts] fresh; skipping
[whatsapp boundary dts] fresh; skipping
[telegram boundary dts] fresh; skipping
[plugin-sdk boundary root shims] fresh; skipping
```

Verification marker: `/media/vdb/code/ai/aispace/openclaw-issue-101083-evidence/verification-marker.json`

- committed head: `14f88ef7ba0e063bb6aa92031076328339f4d3aa`
- committed diff sha256: `0ea78a18a8e48214aff2f2f1f0689da3359b8205d0ea5cec5050d179c241dc4f`

- **Observed result after fix:** The loopback reconnect test observes status patches containing `running: true` / `connected: true` after the first `001`, `running: false` / `connected: false` after the ready socket closes, and `running: false` / `connected: false` with `lastError: "IRC login failed (464): Password incorrect"` after the fatal reconnect login reply.
- **What was not tested:** The proof uses a local loopback IRC server to exercise the same protocol and monitor boundary deterministically. Network-service behavior is not claimed here. Retry backoff and terminal failure were not tested because this PR intentionally does not change retry policy.
- **Fix classification:** Root cause fix for the status misreporting path.
- **Maintainer-ready confidence:** High for the status-honesty slice because the proof exercises the same monitor/client path described in #101083 and the diff does not change retry policy or message routing.
- **Patch quality notes:** The added catch is not a fallback or error-swallowing path; it records the rejected `connectIrcClient` error into account status and then rethrows so the existing reconnect scheduling behavior remains unchanged. Diff-size warnings are from rewriting the nested `connectIrcClient` call around a `try/catch`; functional changes remain limited to `extensions/irc/src/monitor.ts` plus its focused regression test.

## Review findings addressed

- The issue asked for an operator-visible failure signal when the post-ready reconnect path hits a fatal IRC login error.
- The ClawSweeper review specifically listed a status-only first slice as a viable narrow path while retry/backoff policy remains a maintainer decision.
- This PR adds loopback proof for the fatal reconnect path rather than relying only on source inspection.

## Regression Test Plan

- **Target test file:** `extensions/irc/src/monitor.test.ts`, run with `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-irc.config.ts extensions/irc/src/monitor.test.ts`.
- **Scenario locked in:** A loopback IRC server returns `001` on the first connection, destroys the ready socket, then returns fatal numeric `464` on reconnect; the test asserts connected, disconnected, and fatal-error status patches.
- **Why this is the smallest reliable guardrail:** The test uses the shipped monitor and IRC client over a TCP socket, so it covers the user-reachable reconnect boundary with deterministic local protocol input while leaving retry policy unchanged.

## Merge risk

- **Risk labels considered:** `merge-risk: message-delivery`, `merge-risk: compatibility`.
- **Risk explanation:** The changed behavior is status reporting for IRC account lifecycle; it can change what operators see while a socket is down or reconnect login fails. It does not change IRC message parsing, routing, outbound delivery, config shape, or reconnect timing.
- **Why acceptable:** Stale healthy status is the bug. Publishing `running: false`, `connected: false`, and the existing fatal login error is the minimal observable correction, and successful reconnects clear `lastError` and restore `connected: true`.

## Risk / Compatibility

Risk is limited to IRC account status reporting. The monitor now marks the account not running and not connected while the socket is down or a reconnect login fails; successful reconnects restore `running: true`, `connected: true`, and clear `lastError`. IRC connection setup, message routing, reconnect scheduling, and configuration are unchanged.

## What was not changed

- **What did NOT change:** This PR does not change retry backoff, retry cap, terminal-failure policy, IRC fatal-code classification, core channel snapshot model, provider routing, or message routing behavior; those areas remain unchanged.
- No retry backoff, retry cap, or terminal-failure policy was added.
- No IRC client fatal-code classification was changed.
- No core channel snapshot model was changed.
- No provider/model routing behavior was changed.

## Root Cause

- **Root cause:** The IRC monitor status sink was typed and used only for traffic timestamps. After a ready socket closed, the reconnect failure path caught fatal `connectIrcClient` rejections, logged the error, and scheduled another reconnect without publishing a disconnected/error status. Since the runtime status could still carry an earlier healthy `running` state, user-facing status could remain healthy while IRC was disconnected.
- **Why this is root-cause fix:** The fix updates the source-of-truth IRC monitor lifecycle boundary that observes both successful connects and reconnect failures. It publishes the existing connection outcome into the existing account status sink instead of adding a downstream status fallback, so all status readers receive the corrected lifecycle state from the owner of the IRC connection.
- **Architecture / source-of-truth check:** `extensions/irc/src/monitor.ts` owns the `connectIrcClient` lifecycle callbacks and is the first layer that knows whether the IRC socket is connected, disconnected, or failed before ready. `ChannelAccountSnapshot` already has `running`, `connected`, `lastConnectedAt`, `lastDisconnect`, and `lastError`, so the patch reuses the existing shared status model rather than adding a new core status contract.
