### PR TITLE
docs(changelog): credit Discord thread title fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Docs: https://docs.openclaw.ai
 - **iOS Watch replies:** persist queued quick replies in the gateway-scoped chat outbox and submit them through idempotent chat delivery, preventing losses, duplicates, and cross-gateway sends after reconnects. (#100031) Thanks @NianJiuZst.
 - **iOS Gateway auth retry:** restrict stored device-token retry to parsed loopback hosts and reject wildcard bind addresses, preventing remote lookalike hostnames from receiving trusted retry credentials. (#99859) Thanks @ly85206559.
 - **Bedrock Mantle discovery:** bound model-catalog fetch time and response size, and release rejected response bodies so stalled, oversized, or failed provider responses fall back safely. (#99961) Thanks @zhangguiping-xydt.
+- **Discord thread-title prompts:** truncate generated-title message and channel context on UTF-16 boundaries so emoji cannot leave malformed model prompt text. (#101551) Thanks @Alix-007.
 
 ## 2026.7.1
 


### PR DESCRIPTION
Related: #101551
Related: #101307

## What Problem This Solves

The clean Discord thread-title UTF-16 fix landed through #101551 with @Alix-007 preserved as a commit co-author, but its required Unreleased changelog credit was missing.

## Why This Change Was Made

Add the single release-note line for the already-landed user-visible fix and explicitly thank the original contributor. No runtime or test code changes.

## User Impact

No additional runtime behavior change. The Unreleased changelog now accurately records the Discord prompt-truncation fix and contributor credit.

## Evidence

- `git diff --check`: passed.
- `node scripts/check-changelog-attributions.mjs CHANGELOG.md`: passed.
- Fresh Codex autoreview of this one-line delta: clean, correctness 0.95.
- Current `main` already contains the source and completion-path regression from #101551 at `9fb24032215`.
