### PR TITLE
fix(feishu): support drive folder pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Feishu Drive folder pagination:** accept continuation tokens and bounded page sizes for shared-folder listings so agents can retrieve pages beyond the first without forwarding invalid root cursors. (#101249) Thanks @zhangguiping-xydt.
 - **Agent wait hard-timeout snapshots:** preserve canonical hard-timeout phase and timestamps when the outer `agent.wait` timer wins the retry-grace race, while leaving queue, draining, and restart-cancelled waits correctable. (#89367) Thanks @Pick-cat.
 - **Control UI typed approvals:** send `/approve` commands immediately through the authorized Gateway command path while an agent run is blocked instead of queueing the command behind that run. (#77672) Thanks @vincentkoc.
 - **Microsoft Teams Graph response bounds:** cap successful file-upload and chat JSON reads so oversized Microsoft Graph responses cannot be buffered without limit. (#97784) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Feishu Drive folder pagination:** accept continuation tokens and bounded page sizes for shared-folder listings so agents can retrieve pages beyond the first without forwarding invalid root cursors. (#101249) Thanks @zhangguiping-xydt.
 - **Agent wait hard-timeout snapshots:** preserve canonical hard-timeout phase and timestamps when the outer `agent.wait` timer wins the retry-grace race, while leaving queue, draining, and restart-cancelled waits correctable. (#89367) Thanks @Pick-cat.
 - **Control UI typed approvals:** send `/approve` commands immediately through the authorized Gateway command path while an agent run is blocked instead of queueing the command behind that run. (#77672) Thanks @vincentkoc.
 - **Microsoft Teams Graph response bounds:** cap successful file-upload and chat JSON reads so oversized Microsoft Graph responses cannot be buffered without limit. (#97784) Thanks @Alix-007.
@@ -138,6 +137,7 @@ Docs: https://docs.openclaw.ai
 - **iOS Watch replies:** persist queued quick replies in the gateway-scoped chat outbox and submit them through idempotent chat delivery, preventing losses, duplicates, and cross-gateway sends after reconnects. (#100031) Thanks @NianJiuZst.
 - **iOS Gateway auth retry:** restrict stored device-token retry to parsed loopback hosts and reject wildcard bind addresses, preventing remote lookalike hostnames from receiving trusted retry credentials. (#99859) Thanks @ly85206559.
 - **Bedrock Mantle discovery:** bound model-catalog fetch time and response size, and release rejected response bodies so stalled, oversized, or failed provider responses fall back safely. (#99961) Thanks @zhangguiping-xydt.
+- **Discord thread-title prompts:** truncate generated-title message and channel context on UTF-16 boundaries so emoji cannot leave malformed model prompt text. (#101551) Thanks @Alix-007.
 
 ## 2026.7.1
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatLinkPreview.kt
@@ -38,6 +38,7 @@ internal const val LINK_PREVIEW_IMAGE_MAX_DIMENSION = 600
 private const val LINK_PREVIEW_MAX_REDIRECTS = 3
 private const val LINK_PREVIEW_TIMEOUT_MILLIS = 6_000L
 private const val LINK_PREVIEW_CACHE_ENTRIES = 64
+private const val LINK_PREVIEW_IMAGE_CACHE_MAX_BYTES = 8 * 1024 * 1024
 private const val LINK_PREVIEW_IMAGE_CACHE_ENTRIES = 32
 private const val LINK_PREVIEW_ACCEPT = "text/html, application/xhtml+xml;q=0.9"
 private const val LINK_PREVIEW_IMAGE_ACCEPT = "image/*"
@@ -324,9 +325,22 @@ internal class LinkPreviewStore(
 
 internal class LinkPreviewImageStore(
   private val fetcher: suspend (String) -> LinkPreviewImageResult,
-  maxEntries: Int = LINK_PREVIEW_IMAGE_CACHE_ENTRIES,
+  maxBytes: Int = LINK_PREVIEW_IMAGE_CACHE_MAX_BYTES,
 ) {
-  private val cache = LruCache<String, LinkPreviewImageResult>(maxEntries)
+  // Every result pays at least one entry share, preserving the entry cap while loaded bitmaps
+  // also pay their full backing allocation.
+  private val minimumResultBytes = max(1, maxBytes / LINK_PREVIEW_IMAGE_CACHE_ENTRIES)
+  private val cache =
+    object : LruCache<String, LinkPreviewImageResult>(maxBytes) {
+      override fun sizeOf(
+        key: String,
+        value: LinkPreviewImageResult,
+      ): Int =
+        when (value) {
+          is LinkPreviewImageResult.Loaded -> value.bitmap.allocationByteCount.coerceAtLeast(minimumResultBytes)
+          LinkPreviewImageResult.Failed -> minimumResultBytes
+        }
+    }
 
   suspend fun get(url: String): LinkPreviewImageResult {
     cache.get(url)?.let { return it }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatLinkPreviewTest.kt
@@ -319,6 +319,84 @@ class ChatLinkPreviewTest {
     }
 
   @Test
+  fun imageCacheEvictsLeastRecentlyUsedBitmapByAllocatedBytes() =
+    runBlocking {
+      val first = Bitmap.createBitmap(20, 20, Bitmap.Config.ARGB_8888)
+      val second = Bitmap.createBitmap(20, 20, Bitmap.Config.ARGB_8888)
+      val fetchCounts = mutableMapOf<String, Int>()
+      val store =
+        LinkPreviewImageStore(
+          fetcher = { url ->
+            fetchCounts[url] = fetchCounts.getOrDefault(url, 0) + 1
+            LinkPreviewImageResult.Loaded(if (url == "first") first else second)
+          },
+          maxBytes = first.allocationByteCount,
+        )
+
+      try {
+        assertTrue(store.get("first") is LinkPreviewImageResult.Loaded)
+        assertTrue(store.get("second") is LinkPreviewImageResult.Loaded)
+        assertTrue(store.get("first") is LinkPreviewImageResult.Loaded)
+
+        assertEquals(2, fetchCounts["first"])
+        assertEquals(1, fetchCounts["second"])
+      } finally {
+        first.recycle()
+        second.recycle()
+      }
+    }
+
+  @Test
+  fun imageCacheBoundsNegativeResults() =
+    runBlocking {
+      val fetchCounts = mutableMapOf<String, Int>()
+      val store =
+        LinkPreviewImageStore(
+          fetcher = { url ->
+            fetchCounts[url] = fetchCounts.getOrDefault(url, 0) + 1
+            LinkPreviewImageResult.Failed
+          },
+          maxBytes = 2,
+        )
+
+      assertSame(LinkPreviewImageResult.Failed, store.get("first"))
+      assertSame(LinkPreviewImageResult.Failed, store.get("second"))
+      assertSame(LinkPreviewImageResult.Failed, store.get("third"))
+      assertSame(LinkPreviewImageResult.Failed, store.get("first"))
+
+      assertEquals(2, fetchCounts["first"])
+      assertEquals(1, fetchCounts["second"])
+      assertEquals(1, fetchCounts["third"])
+    }
+
+  @Test
+  fun imageCacheBoundsTinyLoadedResultsByEntryCount() =
+    runBlocking {
+      val tiny = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+      val maxEntries = 32
+      val fetchCounts = mutableMapOf<String, Int>()
+      val store =
+        LinkPreviewImageStore(
+          fetcher = { url ->
+            fetchCounts[url] = fetchCounts.getOrDefault(url, 0) + 1
+            LinkPreviewImageResult.Loaded(tiny)
+          },
+          maxBytes = tiny.allocationByteCount * maxEntries * 2,
+        )
+
+      try {
+        repeat(maxEntries + 1) { index ->
+          assertTrue(store.get("image-$index") is LinkPreviewImageResult.Loaded)
+        }
+        assertTrue(store.get("image-0") is LinkPreviewImageResult.Loaded)
+
+        assertEquals(2, fetchCounts["image-0"])
+      } finally {
+        tiny.recycle()
+      }
+    }
+
+  @Test
   fun imageContentTypeAllowlistAndBodyCapAreEnforced() =
     withServer { server ->
       server.enqueue(MockResponse().setHeader("Content-Type", "image/gif").setBody("GIF89a"))

--- a/extensions/feishu/skills/feishu-drive/SKILL.md
+++ b/extensions/feishu/skills/feishu-drive/SKILL.md
@@ -20,13 +20,27 @@ From URL `https://xxx.feishu.cn/drive/folder/ABC123` → `folder_token` = `ABC12
 { "action": "list" }
 ```
 
-Root directory (no folder_token).
+Requests the account root (no `folder_token`). Bot credentials normally have no root folder, so
+use a folder that has been shared with the bot instead.
 
 ```json
-{ "action": "list", "folder_token": "fldcnXXX" }
+{ "action": "list", "folder_token": "fldcnXXX", "page_size": 100 }
 ```
 
-Returns: files with token, name, type, url, timestamps.
+Returns one page of files with token, name, type, url, timestamps, and `next_page_token` when
+another page is available. To continue, pass the returned token with the same folder token:
+
+```json
+{
+  "action": "list",
+  "folder_token": "fldcnXXX",
+  "page_size": 100,
+  "page_token": "next-page-token"
+}
+```
+
+`page_size` must be between 1 and 200. Pagination requires a concrete shared `folder_token`;
+root-list cursors are not forwarded.
 
 ### Get File Info
 

--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -26,6 +26,18 @@ export const FeishuDriveSchema = Type.Union([
     folder_token: Type.Optional(
       Type.String({ description: "Folder token (optional, omit for root directory)" }),
     ),
+    page_size: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        maximum: 200,
+        description: "Items per folder page (1-200; requires folder_token)",
+      }),
+    ),
+    page_token: Type.Optional(
+      Type.String({
+        description: "Continuation token from a prior list result (requires the same folder_token)",
+      }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("info"),

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -62,6 +62,7 @@ function mockCallArg<T>(
 type FeishuDriveTool = {
   execute: (callId: string, input: Record<string, unknown>) => Promise<{ details?: unknown }>;
   name?: string;
+  parameters?: unknown;
 };
 
 type FeishuDriveToolFactory = (context: {
@@ -71,6 +72,26 @@ type FeishuDriveToolFactory = (context: {
 
 function firstToolFactory(mock: { mock: { calls: unknown[][] } }): FeishuDriveToolFactory {
   return mockCallArg<FeishuDriveToolFactory>(mock, 0, 0);
+}
+
+function buildDriveTool(): FeishuDriveTool {
+  const registerTool = vi.fn();
+  registerFeishuDriveTools(
+    createDriveToolApi({
+      config: {
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "app_id",
+            appSecret: "app_secret", // pragma: allowlist secret
+            tools: { drive: true },
+          },
+        },
+      },
+      registerTool,
+    }),
+  );
+  return firstToolFactory(registerTool)({ agentAccountId: undefined });
 }
 
 function firstLogMessage(mock: { mock: { calls: unknown[][] } }): string {
@@ -105,6 +126,25 @@ function expectRequestCall(
   if ("params" in expected) {
     expect(request.params).toEqual(expected.params);
   }
+}
+
+function schemaForAction(
+  schema: unknown,
+  action: string,
+): { properties?: Record<string, unknown> } {
+  const variants =
+    (schema as { anyOf?: unknown[]; oneOf?: unknown[] }).anyOf ??
+    (schema as { anyOf?: unknown[]; oneOf?: unknown[] }).oneOf ??
+    [];
+  const variant = variants.find((entry) => {
+    const actionSchema = (entry as { properties?: { action?: { const?: unknown } } }).properties
+      ?.action;
+    return actionSchema?.const === action;
+  });
+  if (!variant) {
+    throw new Error(`Missing schema variant for action ${action}`);
+  }
+  return variant as { properties?: Record<string, unknown> };
 }
 
 describe("registerFeishuDriveTools", () => {
@@ -358,6 +398,91 @@ describe("registerFeishuDriveTools", () => {
       true,
     );
     expect((replyCommentResult.details as { reply_id?: string }).reply_id).toBe("r4");
+  });
+
+  it("lists a folder continuation page when page_token is provided", async () => {
+    const listFiles = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        files: [{ token: "file_1", name: "File 1", type: "docx", url: "https://example.test/doc" }],
+        next_page_token: "page-3",
+      },
+    });
+    createFeishuToolClientMock.mockReturnValue({
+      drive: { file: { list: listFiles } },
+    });
+    const tool = buildDriveTool();
+    const listSchema = schemaForAction(tool.parameters, "list");
+    expect(listSchema.properties?.page_token).toMatchObject({ type: "string" });
+    expect(listSchema.properties?.page_size).toMatchObject({
+      type: "integer",
+      minimum: 1,
+      maximum: 200,
+    });
+
+    const result = await tool.execute("call-list-page-2", {
+      action: "list",
+      folder_token: "folder_1",
+      page_size: 25,
+      page_token: "page-2",
+    });
+
+    expect(listFiles).toHaveBeenCalledWith({
+      params: { folder_token: "folder_1", page_size: 25, page_token: "page-2" },
+    });
+    expect(result.details).toMatchObject({
+      files: [{ token: "file_1", name: "File 1", type: "docx", url: "https://example.test/doc" }],
+      next_page_token: "page-3",
+    });
+  });
+
+  it("normalizes folder pagination and suppresses it for root listings", async () => {
+    const listFiles = vi.fn().mockResolvedValue({ code: 0, data: { files: [] } });
+    createFeishuToolClientMock.mockReturnValue({ drive: { file: { list: listFiles } } });
+    const tool = buildDriveTool();
+
+    await tool.execute("call-list-normalized", {
+      action: "list",
+      folder_token: " folder_1 ",
+      page_size: "25",
+      page_token: "   ",
+    });
+    for (const [callId, folderToken] of [
+      ["call-list-root", undefined],
+      ["call-list-empty", "   "],
+      ["call-list-zero", " 0 "],
+    ] as const) {
+      await tool.execute(callId, {
+        action: "list",
+        folder_token: folderToken,
+        page_size: 25,
+        page_token: "page-2",
+      });
+    }
+
+    expect(listFiles).toHaveBeenNthCalledWith(1, {
+      params: { folder_token: "folder_1", page_size: 25 },
+    });
+    for (const callIndex of [2, 3, 4]) {
+      expect(listFiles).toHaveBeenNthCalledWith(callIndex, { params: {} });
+    }
+  });
+
+  it.each([0, 201, 1.5])("rejects invalid folder page_size %s", async (pageSize) => {
+    const listFiles = vi.fn();
+    createFeishuToolClientMock.mockReturnValue({ drive: { file: { list: listFiles } } });
+    const tool = buildDriveTool();
+
+    const result = await tool.execute("call-list-invalid-page-size", {
+      action: "list",
+      folder_token: "folder_1",
+      page_size: pageSize,
+    });
+
+    expect(result.details).toMatchObject({
+      error: "page_size must be a positive integer between 1 and 200",
+    });
+    expect(listFiles).not.toHaveBeenCalled();
   });
 
   it("defaults add_comment file_type to docx when omitted", async () => {

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -1,6 +1,7 @@
 // Feishu plugin module implements drive behavior.
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import { jsonResult } from "openclaw/plugin-sdk/tool-results";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
@@ -325,11 +326,27 @@ async function getRootFolderToken(client: Lark.Client): Promise<string> {
   return token;
 }
 
-async function listFolder(client: Lark.Client, folderToken?: string) {
-  // Filter out invalid folder_token values (empty, "0", etc.)
+async function listFolder(client: Lark.Client, params: Record<string, unknown> = {}) {
+  const folderToken =
+    typeof params.folder_token === "string" ? params.folder_token.trim() : undefined;
   const validFolderToken = folderToken && folderToken !== "0" ? folderToken : undefined;
+  const pageSize = readPositiveIntegerParam(params, "page_size", {
+    max: 200,
+    message: "page_size must be a positive integer between 1 and 200",
+  });
+  const pageToken = typeof params.page_token === "string" ? params.page_token.trim() : undefined;
+
+  // Bot credentials have no browsable root. A continuation cursor is only valid with the
+  // same concrete folder token that produced it, so do not forward pagination for root.
+  const listParams = validFolderToken
+    ? {
+        folder_token: validFolderToken,
+        ...(pageSize ? { page_size: pageSize } : {}),
+        ...(pageToken ? { page_token: pageToken } : {}),
+      }
+    : {};
   const res = await client.drive.file.list({
-    params: validFolderToken ? { folder_token: validFolderToken } : {},
+    params: listParams,
   });
   if (res.code !== 0) {
     throw new Error(res.msg);
@@ -766,7 +783,13 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
             });
             switch (p.action) {
               case "list":
-                return jsonResult(await listFolder(client, p.folder_token));
+                return jsonResult(
+                  await listFolder(client, {
+                    folder_token: p.folder_token,
+                    page_size: p.page_size,
+                    page_token: p.page_token,
+                  }),
+                );
               case "info":
                 return jsonResult(await getFileInfo(client, p.file_token));
               case "create_folder":

--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -2,6 +2,7 @@
 // Implements initialize, tools/list, tools/call, and notification handling.
 import crypto from "node:crypto";
 import { ContentBlockSchema, type ContentBlock } from "@modelcontextprotocol/sdk/types.js";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { runBeforeToolCallHook, type HookContext } from "../agents/agent-tools.before-tool-call.js";
 import {
   formatToolExecutionErrorMessage,
@@ -99,7 +100,11 @@ export async function handleMcpJsonRpc(params: {
       return jsonRpcResult(id, { tools: params.toolSchema });
     case "tools/call": {
       const toolName = typeof methodParams?.name === "string" ? methodParams.name.trim() : "";
-      const toolArgs = (methodParams?.arguments ?? {}) as Record<string, unknown>;
+      const rawToolArgs = methodParams?.arguments;
+      if (rawToolArgs !== undefined && !isRecord(rawToolArgs)) {
+        return jsonRpcError(id, -32602, "Invalid params: tools/call arguments must be an object");
+      }
+      const toolArgs = rawToolArgs ?? {};
       if (!toolName) {
         return jsonRpcResult(id, {
           content: [{ type: "text", text: "Tool not available: unknown" }],

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -1153,19 +1153,86 @@ describe("mcp loopback server", () => {
   });
 
   it("executes tools for loopback callers", async () => {
-    const cronExecute = vi.fn(async () => ({
+    const cronExecute = vi.fn<MockGatewayTool["execute"]>(async () => ({
       content: [{ type: "text", text: "CRON_EXECUTED" }],
     }));
+    const args = { action: "status" };
     mockScopedTools([makeMessageTool(), makeCronTool({ execute: cronExecute })]);
     const { runtime } = await startLoopbackServerForTest();
 
     const payload = await callMainSessionTool({
       token: runtime?.ownerToken,
       name: "cron",
+      args,
     });
 
     expect(cronExecute).toHaveBeenCalledTimes(1);
+    expect(getBeforeToolCallHookInput(0).params).toEqual(args);
+    expect(cronExecute.mock.calls[0]?.[1]).toEqual(args);
     expectMcpResultText(payload, "CRON_EXECUTED");
+  });
+
+  it.each([
+    ["null", null],
+    ["array", []],
+    ["string", "bad"],
+  ])("rejects %s tool call arguments before hooks or execution", async (_label, badArguments) => {
+    const execute = vi.fn<MockGatewayTool["execute"]>(async () => ({
+      content: [{ type: "text", text: "EXECUTED" }],
+    }));
+    mockScopedTools([makeMessageTool({ execute })]);
+    const { runtime, port } = await startLoopbackServerForTest();
+
+    const response = await sendRaw({
+      port,
+      token: runtime.ownerToken,
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "message", arguments: badArguments },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await readMcpPayload(response)).toEqual({
+      jsonrpc: "2.0",
+      id: 1,
+      error: {
+        code: -32602,
+        message: "Invalid params: tools/call arguments must be an object",
+      },
+    });
+    expect(runBeforeToolCallHookMock).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("keeps omitted tool call arguments as an empty object", async () => {
+    const execute = vi.fn<MockGatewayTool["execute"]>(async () => ({
+      content: [{ type: "text", text: "EXECUTED" }],
+    }));
+    mockScopedTools([makeMessageTool({ execute })]);
+    const { runtime, port } = await startLoopbackServerForTest();
+
+    const response = await sendRaw({
+      port,
+      token: runtime.ownerToken,
+      headers: jsonHeaders(),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "message" },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expectMcpResultText(await readMcpPayload(response), "EXECUTED");
+    expect(runBeforeToolCallHookMock).toHaveBeenCalledTimes(1);
+    expect(getBeforeToolCallHookInput(0).params).toEqual({});
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0]?.[1]).toEqual({});
   });
 
   it("preserves valid MCP content blocks returned by loopback tools", async () => {

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -4,7 +4,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { createOpenClawTestInstance } from "../../test/helpers/openclaw-test-instance.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { GatewayChatClient } from "./gateway-chat.js";
@@ -450,8 +450,8 @@ async function startGatewayModeTui(params: {
   }
 }
 
-describe("TUI PTY real backends", () => {
-  afterEach(async () => {
+describe.concurrent("TUI PTY real backends", () => {
+  afterAll(() => {
     for (const run of activeRuns.splice(0)) {
       run.dispose();
     }


### PR DESCRIPTION
## What Problem This Solves

Feishu Drive folder listings return `next_page_token`, but the `feishu_drive` tool could not accept that cursor, leaving every page after the first unreachable.

This replaces #101249 because its contributor branch is 159 main commits and 903 files behind; the repo-native maintainer sync repeatedly timed out on the oversized rebase. The original contribution and author credit are preserved here.

## Why This Change Was Made

- Add bounded `page_size` and `page_token` inputs to the existing `list` action.
- Normalize folder and cursor tokens and validate `page_size` at runtime, not only in the model schema.
- Scope cursors to a concrete shared folder; Feishu bot credentials have no browsable root, so pagination is not forwarded for omitted, blank, or `"0"` folder tokens.
- Document one-page continuation in the bundled Feishu Drive skill.

The change stays plugin-local and preserves the existing response shape. It does not broaden into automatic recursive pagination or the separate `info` lookup behavior tracked by #93928.

## User Impact

Agents can retrieve subsequent pages of a shared Feishu Drive folder by passing the returned `next_page_token` as `page_token` with the same `folder_token`. Invalid page sizes now fail before an API request.

## Evidence

- Upstream `@larksuiteoapi/node-sdk` source confirms `drive.file.list` accepts `folder_token`, `page_size`, and `page_token`, and returns `next_page_token` / `has_more`.
- Contributor gateway proof on #101249 exercised `/tools/invoke` through the bundled tool and captured the expected SDK-boundary continuation request.
- Sanitized AWS baseline: `cbx_e1b51e13a04a`, run `run_ef117899bd4c`; 16/16 Feishu Drive tests passed on the contributor head.
- `oxfmt` on all touched code/skill files; `git diff --check`; skill YAML frontmatter parse.
- Fresh GPT-5.5 autoreview of the complete replacement diff: clean, confidence 0.88.
- Exact replacement-head sanitized AWS and hosted CI/Testbox evidence will be posted before merge.

Closes the `list` continuation portion of #93928. Supersedes #101249.
