### PR TITLE
refactor(memory): localize host SDK helpers

### DIFF
--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -14,10 +14,7 @@ import {
   normalizeExtraMemoryPaths,
   remapChunkLines,
 } from "./internal.js";
-import {
-  DEFAULT_MEMORY_MULTIMODAL_MAX_FILE_BYTES,
-  type MemoryMultimodalSettings,
-} from "./multimodal.js";
+import { normalizeMemoryMultimodalSettings, type MemoryMultimodalSettings } from "./multimodal.js";
 
 type FileEntry = NonNullable<Awaited<ReturnType<typeof buildFileEntry>>>;
 type MultimodalIndexingChunk = NonNullable<
@@ -75,11 +72,7 @@ function expectEmbeddingInput(
   return chunk.embeddingInput;
 }
 
-const multimodal: MemoryMultimodalSettings = {
-  enabled: true,
-  modalities: ["image", "audio"],
-  maxFileBytes: DEFAULT_MEMORY_MULTIMODAL_MAX_FILE_BYTES,
-};
+const multimodal: MemoryMultimodalSettings = normalizeMemoryMultimodalSettings({ enabled: true });
 
 describe("memory host SDK package internals", () => {
   const getTmpDir = setupTempDirLifecycle("memory-package-");

--- a/packages/memory-host-sdk/src/host/multimodal.ts
+++ b/packages/memory-host-sdk/src/host/multimodal.ts
@@ -31,7 +31,7 @@ export type MemoryMultimodalSettings = {
 };
 
 /** Default max bytes for one multimodal memory file. */
-export const DEFAULT_MEMORY_MULTIMODAL_MAX_FILE_BYTES = 10 * 1024 * 1024;
+const DEFAULT_MEMORY_MULTIMODAL_MAX_FILE_BYTES = 10 * 1024 * 1024;
 
 /** Normalize user modality selections to supported modalities. */
 function normalizeMemoryMultimodalModalities(

--- a/packages/memory-host-sdk/src/host/openclaw-runtime-io.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-io.ts
@@ -23,13 +23,11 @@ export {
   runTasksWithConcurrency,
   shortenHomeInString,
   shortenHomePath,
-  shouldIgnoreWarning,
   splitShellArgs,
   truncateUtf16Safe,
 } from "./openclaw-runtime.js";
 
 export type {
-  ProcessWarning,
   ResolveWindowsSpawnProgramCandidateParams,
   ResolveWindowsSpawnProgramParams,
   SqliteConnectionPragmaOptions,

--- a/packages/memory-host-sdk/src/host/openclaw-runtime.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime.ts
@@ -99,11 +99,7 @@ export type {
   SqliteWalMaintenance,
   SqliteWalMaintenanceOptions,
 } from "../../../../src/infra/sqlite-wal.js";
-export {
-  installProcessWarningFilter,
-  shouldIgnoreWarning,
-} from "../../../../src/infra/warning-filter.js";
-export type { ProcessWarning } from "../../../../src/infra/warning-filter.js";
+export { installProcessWarningFilter } from "../../../../src/infra/warning-filter.js";
 export { redactSensitiveText } from "../../../../src/logging/redact.js";
 export { createSubsystemLogger } from "../../../../src/logging/subsystem.js";
 export { detectMime } from "@openclaw/media-core/mime";

--- a/packages/memory-host-sdk/src/host/remote-http.test.ts
+++ b/packages/memory-host-sdk/src/host/remote-http.test.ts
@@ -1,6 +1,6 @@
 // Memory Host SDK tests cover remote http behavior.
 import { describe, expect, it } from "vitest";
-import { MEMORY_REMOTE_TRUSTED_ENV_PROXY_MODE, withRemoteHttpResponse } from "./remote-http.js";
+import { withRemoteHttpResponse } from "./remote-http.js";
 
 describe("package withRemoteHttpResponse", () => {
   function makeFetchDeps({ useEnvProxy = false }: { useEnvProxy?: boolean } = {}) {
@@ -29,7 +29,7 @@ describe("package withRemoteHttpResponse", () => {
     });
 
     expect(deps.calls[0]).toHaveProperty("url", "https://memory.example/v1/embeddings");
-    expect(deps.calls[0]).toHaveProperty("mode", MEMORY_REMOTE_TRUSTED_ENV_PROXY_MODE);
+    expect(deps.calls[0]).toHaveProperty("mode", "trusted_env_proxy");
   });
 
   it("keeps strict guarded fetch mode when proxy env would not proxy the target", async () => {

--- a/packages/memory-host-sdk/src/host/remote-http.ts
+++ b/packages/memory-host-sdk/src/host/remote-http.ts
@@ -9,7 +9,7 @@ import type { SsrFPolicy } from "./ssrf-policy.js";
 // Remote memory HTTP wrapper that applies SSRF policy and releases guarded sockets.
 
 /** Proxy mode used only for URLs that the runtime classified as env-proxy safe. */
-export const MEMORY_REMOTE_TRUSTED_ENV_PROXY_MODE = "trusted_env_proxy";
+const MEMORY_REMOTE_TRUSTED_ENV_PROXY_MODE = "trusted_env_proxy";
 
 /** Build an SSRF allow policy from a configured remote base URL. */
 export const buildRemoteBaseUrlPolicy: (baseUrl: string) => SsrFPolicy | undefined =

--- a/packages/memory-host-sdk/src/host/sqlite.ts
+++ b/packages/memory-host-sdk/src/host/sqlite.ts
@@ -2,6 +2,7 @@
 import { createRequire } from "node:module";
 import type { DatabaseSync } from "node:sqlite";
 import { formatErrorMessage } from "./error-utils.js";
+import { installProcessWarningFilter } from "./openclaw-runtime-io.js";
 import {
   configureSqliteConnectionPragmas,
   configureSqliteWalMaintenance,
@@ -9,7 +10,6 @@ import {
   type SqliteWalMaintenance,
   type SqliteWalMaintenanceOptions,
 } from "./sqlite-wal.js";
-import { installProcessWarningFilter } from "./warning-filter.js";
 
 const require = createRequire(import.meta.url);
 const sqliteWalMaintenanceByDb = new WeakMap<DatabaseSync, SqliteWalMaintenance>();

--- a/packages/memory-host-sdk/src/host/warning-filter.ts
+++ b/packages/memory-host-sdk/src/host/warning-filter.ts
@@ -1,4 +1,0 @@
-// Public process warning filter facade for memory host callers.
-
-export { installProcessWarningFilter, shouldIgnoreWarning } from "./openclaw-runtime-io.js";
-export type { ProcessWarning } from "./openclaw-runtime-io.js";


### PR DESCRIPTION
## What Problem This Solves

The private memory-host package still exposed helpers that had no production
consumers, including a one-use warning-filter facade and constants used only by
their defining modules and tests.

## Why This Change Was Made

Delete the one-use facade, route its caller through the existing runtime IO
adapter, and localize the unused constants and warning-filter exports. Tests
continue to assert behavior through the surviving public helpers and values.

## User Impact

No user-visible behavior changes. The private memory-host surface is smaller and
has fewer internal forwarding layers.

## Evidence

- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/internal.test.ts packages/memory-host-sdk/src/host/remote-http.test.ts packages/memory-host-sdk/src/host/sqlite-vec.test.ts src/plugins/contracts/extension-package-project-boundaries.test.ts`
  - 4 test files, 29 tests passed
- `oxfmt --check` on all changed source/test files
- Fresh `deadcode:ts-unused`: no findings for the removed symbols or facade
- Full deadcode inventory: unused-file allowlist matched, dependency scan clean,
  duplicate scan clean
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 OPENCLAW_CHANGED_LANES_RAW_SYNC=1 pnpm check:changed`
  - passed on Blacksmith Testbox `tbx_01kwxzs3zfzr95pjhehhhadgvg`
  - https://github.com/openclaw/openclaw/actions/runs/28857273356
- Fresh local and branch autoreview: no findings
- Codebase-memory graph refreshed after the final rebase: 280,628 nodes /
  1,117,163 edges
- iOS Periphery all-app scan passed with no dead Swift findings:
  https://github.com/openclaw/openclaw/actions/runs/28857443707
