### PR TITLE
fix: prevent session history stream errors from crashing gateway

### DIFF
--- a/src/gateway/sessions-history-http.revocation.test.ts
+++ b/src/gateway/sessions-history-http.revocation.test.ts
@@ -2,7 +2,7 @@
  * HTTP session history revocation tests.
  */
 import { EventEmitter } from "node:events";
-import type { IncomingMessage, ServerResponse } from "node:http";
+import { createServer, request, type IncomingMessage, type ServerResponse } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 let transcriptUpdateHandler:
@@ -152,6 +152,7 @@ class MockRes extends EventEmitter {
   writes: string[] = [];
   writableEnded = false;
   socket = new EventEmitter();
+  closeOnNextWrite = false;
 
   setHeader(name: string, value: string) {
     this.headers.set(name.toLowerCase(), value);
@@ -159,6 +160,10 @@ class MockRes extends EventEmitter {
 
   write(chunk: string) {
     this.writes.push(chunk);
+    if (this.closeOnNextWrite) {
+      this.closeOnNextWrite = false;
+      this.emit("close");
+    }
     return true;
   }
 
@@ -178,8 +183,16 @@ class MockRes extends EventEmitter {
 async function openSessionHistoryStream(
   options: Parameters<typeof handleSessionHistoryHttpRequest>[2],
 ) {
+  return (await openSessionHistoryStreamPair(options)).res;
+}
+
+async function openSessionHistoryStreamPair(
+  options: Parameters<typeof handleSessionHistoryHttpRequest>[2],
+  params?: { closeOnFirstWrite?: boolean; expectSubscribed?: boolean },
+) {
   const req = new MockReq(SESSION_HISTORY_URL);
   const res = new MockRes();
+  res.closeOnNextWrite = params?.closeOnFirstWrite === true;
 
   const handled = await handleSessionHistoryHttpRequest(
     req as unknown as IncomingMessage,
@@ -188,9 +201,103 @@ async function openSessionHistoryStream(
   );
 
   expect(handled).toBe(true);
+  if (params?.expectSubscribed === false) {
+    expect(transcriptUpdateHandler).toBeUndefined();
+  } else {
+    expect(transcriptUpdateHandler).toBeTypeOf("function");
+  }
+
+  return { req, res };
+}
+
+async function withRealNodeSessionHistoryStream(
+  run: (pair: { req: IncomingMessage; res: ServerResponse }) => Promise<void>,
+) {
+  let resolvePair: (pair: { req: IncomingMessage; res: ServerResponse }) => void;
+  const pairPromise = new Promise<{ req: IncomingMessage; res: ServerResponse }>((resolve) => {
+    resolvePair = resolve;
+  });
+  let resolveHandled: (handled: boolean) => void;
+  let rejectHandled: (error: unknown) => void;
+  const handledPromise = new Promise<boolean>((resolve, reject) => {
+    resolveHandled = resolve;
+    rejectHandled = reject;
+  });
+  const server = createServer((req, res) => {
+    resolvePair({ req, res });
+    void handleSessionHistoryHttpRequest(req, res, TRUSTED_PROXY_STARTUP_OPTIONS).then(
+      resolveHandled,
+      rejectHandled,
+    );
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const handleListenError = (error: Error) => reject(error);
+    server.once("error", handleListenError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", handleListenError);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected TCP test server address");
+  }
+
+  const clientResponsePromise = new Promise<IncomingMessage>((resolve, reject) => {
+    const clientRequest = request(
+      {
+        host: "127.0.0.1",
+        port: address.port,
+        path: SESSION_HISTORY_URL,
+        method: "GET",
+        headers: {
+          accept: "text/event-stream",
+          authorization: "Bearer token",
+          "x-openclaw-scopes": "operator.read",
+        },
+      },
+      resolve,
+    );
+    clientRequest.once("error", reject);
+    clientRequest.end();
+  });
+
+  const pair = await pairPromise;
+  const clientResponse = await clientResponsePromise;
+  clientResponse.resume();
+  expect(await handledPromise).toBe(true);
   expect(transcriptUpdateHandler).toBeTypeOf("function");
 
-  return res;
+  try {
+    await run(pair);
+  } finally {
+    clientResponse.destroy();
+    pair.res.destroy();
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+function emitErrorOnNextTick(emitter: EventEmitter, error: Error): Promise<void> {
+  return new Promise((resolve, reject) => {
+    process.nextTick(() => {
+      try {
+        emitter.emit("error", error);
+        resolve();
+      } catch (emitError) {
+        reject(emitError instanceof Error ? emitError : new Error(String(emitError)));
+      }
+    });
+  });
 }
 
 function emitTranscriptTextUpdate({
@@ -275,5 +382,75 @@ describe("session history SSE auth revocation", () => {
     expect(authCheckCalls).toBe(0);
     expect(joined).not.toContain("other session");
     expect(res.writableEnded).toBe(false);
+  });
+
+  it("closes and cleans up the SSE stream when the request stream emits an error", async () => {
+    const { req, res } = await openSessionHistoryStreamPair(TRUSTED_PROXY_STARTUP_OPTIONS);
+
+    expect(() => req.emit("error", new Error("request stream failed"))).not.toThrow();
+
+    expect(res.writableEnded).toBe(true);
+    expect(transcriptUpdateHandler).toBeUndefined();
+    expect(req.listenerCount("error")).toBe(0);
+    expect(res.listenerCount("error")).toBe(0);
+  });
+
+  it("cleans up SSE resources when the response stream emits an error", async () => {
+    const { req, res } = await openSessionHistoryStreamPair(TRUSTED_PROXY_STARTUP_OPTIONS);
+
+    expect(() => res.emit("error", new Error("response stream failed"))).not.toThrow();
+
+    expect(transcriptUpdateHandler).toBeUndefined();
+    expect(req.listenerCount("error")).toBe(1);
+    expect(res.listenerCount("error")).toBe(1);
+
+    emitTranscriptTextUpdate({
+      text: "post-response-error update",
+      messageId: "m-response-error",
+    });
+    expect(res.writes.join("")).not.toContain("post-response-error update");
+
+    res.emit("close");
+    expect(req.listenerCount("error")).toBe(0);
+    expect(res.listenerCount("error")).toBe(0);
+  });
+
+  it("keeps real Node stream errors handled while a request failure ends the response", async () => {
+    await withRealNodeSessionHistoryStream(async ({ req, res }) => {
+      expect(req.listenerCount("error")).toBeGreaterThan(0);
+      expect(res.listenerCount("error")).toBeGreaterThan(0);
+
+      expect(() => req.emit("error", new Error("request stream failed"))).not.toThrow();
+      expect(res.writableEnded).toBe(true);
+
+      await expect(
+        emitErrorOnNextTick(res, new Error("response failed during end flush")),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  it("keeps real Node response errors handled until the ended response closes", async () => {
+    await withRealNodeSessionHistoryStream(async ({ res }) => {
+      expect(() => res.emit("error", new Error("response stream failed"))).not.toThrow();
+      expect(transcriptUpdateHandler).toBeUndefined();
+
+      res.end();
+
+      await expect(
+        emitErrorOnNextTick(res, new Error("response failed after end")),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  it("does not create SSE resources after an initial write closes the stream", async () => {
+    const { req, res } = await openSessionHistoryStreamPair(TRUSTED_PROXY_STARTUP_OPTIONS, {
+      closeOnFirstWrite: true,
+      expectSubscribed: false,
+    });
+
+    expect(res.writes.join("")).toBe("retry: 1000\n\n");
+    expect(transcriptUpdateHandler).toBeUndefined();
+    expect(req.listenerCount("error")).toBe(0);
+    expect(res.listenerCount("error")).toBe(0);
   });
 });

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -228,40 +228,97 @@ export async function handleSessionHistoryHttpRequest(
     cursor,
   });
   sentHistory = sseState.snapshot();
+  let streamStopped = false;
+  let streamQueue = Promise.resolve();
+  const streamResources: {
+    heartbeat?: ReturnType<typeof setInterval>;
+    unsubscribe?: () => void;
+  } = {};
+
+  function releaseStreamResources() {
+    if (streamStopped) {
+      return;
+    }
+    streamStopped = true;
+    if (streamResources.heartbeat) {
+      clearInterval(streamResources.heartbeat);
+    }
+    if (streamResources.unsubscribe) {
+      streamResources.unsubscribe();
+    }
+  }
+
+  function detachStreamListeners() {
+    req.off("close", handleRequestStreamClose);
+    req.off("error", handleRequestStreamError);
+    res.off("close", handleResponseStreamClose);
+    res.off("finish", handleResponseStreamFinish);
+    res.off("error", handleResponseStreamError);
+  }
+
+  function closeStream() {
+    releaseStreamResources();
+    if (!res.writableEnded && !res.destroyed) {
+      res.end();
+    }
+  }
+
+  function handleRequestStreamClose() {
+    releaseStreamResources();
+    req.off("close", handleRequestStreamClose);
+    req.off("error", handleRequestStreamError);
+  }
+
+  function handleRequestStreamError(error: Error) {
+    // Node HTTP streams emit process-fatal `error` events without listeners.
+    // Request-side failures mean the SSE owner should release and end locally.
+    log.warn("session history SSE request stream errored; closing stream", { error });
+    closeStream();
+  }
+
+  function handleResponseStreamFinish() {
+    releaseStreamResources();
+    // `finish` only means Node handed the response bytes to the OS. Keep the
+    // error listener until `close` so a late flush failure stays stream-local.
+    res.off("finish", handleResponseStreamFinish);
+  }
+
+  function handleResponseStreamClose() {
+    releaseStreamResources();
+    detachStreamListeners();
+  }
+
+  function handleResponseStreamError(error: Error) {
+    // The response stream is already failing, so only release local resources;
+    // writing an end frame here can re-enter the errored ServerResponse.
+    log.warn("session history SSE response stream errored; cleaning up stream", { error });
+    releaseStreamResources();
+  }
+  const isStreamClosed = () => streamStopped || res.writableEnded || res.destroyed;
+
+  req.on("close", handleRequestStreamClose);
+  req.on("error", handleRequestStreamError);
+  res.on("close", handleResponseStreamClose);
+  res.on("finish", handleResponseStreamFinish);
+  res.on("error", handleResponseStreamError);
+
   setSseHeaders(res);
   res.write("retry: 1000\n\n");
+  if (isStreamClosed()) {
+    return true;
+  }
   sseWrite(res, "history", {
     sessionKey: target.canonicalKey,
     ...sentHistory,
   });
-
-  let cleanedUp = false;
-  let streamQueue = Promise.resolve();
-
-  const cleanup = () => {
-    if (cleanedUp) {
-      return;
-    }
-    cleanedUp = true;
-    if (heartbeat) {
-      clearInterval(heartbeat);
-    }
-    if (unsubscribe) {
-      unsubscribe();
-    }
-  };
-
-  const closeStream = () => {
-    cleanup();
-    if (!res.writableEnded) {
-      res.end();
-    }
-  };
+  if (isStreamClosed()) {
+    return true;
+  }
 
   const queueStreamWork = (work: () => Promise<void>) => {
     streamQueue = streamQueue
       .then(async () => {
-        if (cleanedUp || res.writableEnded) {
+        if (streamStopped || res.writableEnded) {
           return;
         }
         await work();
@@ -295,7 +352,7 @@ export async function handleSessionHistoryHttpRequest(
     return authorizeOperatorScopesForMethod("chat.history", requestedScopes).allowed;
   };
 
-  const heartbeat: ReturnType<typeof setInterval> | undefined = setInterval(() => {
+  streamResources.heartbeat = setInterval(() => {
     queueStreamWork(async () => {
       if (!(await isStreamStillAuthorized())) {
         closeStream();
@@ -307,7 +364,7 @@ export async function handleSessionHistoryHttpRequest(
     });
   }, 15_000);
 
-  const unsubscribe: (() => void) | undefined = onInternalSessionTranscriptUpdate((update) => {
+  streamResources.unsubscribe = onInternalSessionTranscriptUpdate((update) => {
     // Filter to candidate sessions synchronously before enqueueing any async
     // work. Transcript updates use a global fan-out listener, so every
     // transcript write in the gateway would otherwise append a Promise-chain
@@ -377,8 +434,5 @@ export async function handleSessionHistoryHttpRequest(
       });
     });
   });
-  req.on("close", cleanup);
-  res.on("close", cleanup);
-  res.on("finish", cleanup);
   return true;
 }


### PR DESCRIPTION
Closes #101539

## What Problem This Solves

Fixes an issue where users or operators with an open session-history SSE stream could have the Gateway process crash if the underlying HTTP request or response stream emitted an `error` event, such as during an abrupt client disconnect or stream failure.

## Why This Change Was Made

The session-history SSE handler now owns request and response stream errors locally: request-side failures close the SSE response and release stream resources, while response-side failures release local resources without writing again to an already-failing response. The handler installs those listeners before the first SSE write and avoids creating heartbeat/subscription resources if the stream closes during initial writes.

Risk note: this touches the Gateway session-history SSE lifecycle, so the validation covers normal JSON/SSE reads, request/response error cleanup, early-close cleanup, and a real Gateway readback from a DeepSeek-backed transcript.

AI-assisted: implementation and verification were prepared with AI assistance; proof was run manually.

## User Impact

Gateway session-history streaming is more resilient to abrupt HTTP stream failures. Existing REST and SSE history behavior is unchanged for healthy clients, while failed streams are cleaned up without taking down the Gateway process.

## Evidence

Premise / before:

```text
node -e "const {EventEmitter}=require('node:events'); const e=new EventEmitter(); e.emit('error', new Error('probe'));"
```

Observed on Node 24.18.0: exit code 1 with `Unhandled 'error' event`, matching Node's documented EventEmitter behavior for `error` events without listeners. The current session-history SSE handler had only `close`/`finish` cleanup listeners on the HTTP streams before this patch.

Focused tests:

```text
node scripts/run-vitest.mjs src/gateway/sessions-history-http.test.ts src/gateway/sessions-history-http.revocation.test.ts
[test] passed 2 Vitest shards in 25.66s
```

Typecheck / lint / build / hygiene:

```text
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-oxlint.mjs src/gateway/sessions-history-http.ts src/gateway/sessions-history-http.revocation.test.ts
pnpm build
[build-all] phase timings: total 126.3s

git diff --check
# no output
```

Real behavior proof:

```text
OPENCLAW_STATE_DIR=<temp-state> OPENCLAW_CONFIG_PATH=<temp-state>/openclaw.json \
  pnpm openclaw agent --local --model deepseek/deepseek-v4-pro \
  --session-key agent:main:issue-101539-proof \
  --message "Reply exactly: OPENCLAW_101539_PROOF" --json --timeout 180
```

Observed: provider `deepseek`, model `deepseek-v4-pro`, final visible text `OPENCLAW_101539_PROOF`, stop reason `stop`.

Then, on the final amended commit, I started a temporary Gateway against that same state and queried the affected HTTP surface:

```text
GET /sessions/agent%3Amain%3Aissue-101539-proof/history?limit=1
{
  "status": 200,
  "sessionKey": "agent:main:issue-101539-proof",
  "provider": "deepseek",
  "model": "deepseek-v4-pro",
  "visibleText": "OPENCLAW_101539_PROOF",
  "hasMore": true
}

GET /sessions/agent%3Amain%3Aissue-101539-proof/history?limit=1
Accept: text/event-stream
{
  "sseStatus": 200,
  "sseContentType": "text/event-stream; charset=utf-8",
  "firstEventHeader": "retry: 1000|event: history",
  "afterAbortStatus": 200
}
```

Review:

```text
.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported
```

Maintainer repair and final-head proof:

- Kept the response `error` listener attached after `finish` until `close`, preventing a delayed error during `res.end()` flush from becoming process-fatal.
- Added real Node HTTP and `ServerResponse` regressions for request failure, response failure, delayed end-flush failure, and initial-write close.
- `node scripts/run-vitest.mjs src/gateway/sessions-history-http.test.ts src/gateway/sessions-history-http.revocation.test.ts`: 52/52 passed.
- `OPENCLAW_TESTBOX=1 pnpm check:changed`: passed on Blacksmith Testbox `tbx_01kwy51e481axqn4x41apnv2bz`.
- Fresh autoreview: clean, no accepted or actionable findings.
- Final repaired head: `cd2fca393558346c0d4b24bcfca18f7aefac8e26`.
