### PR TITLE
fix(feishu): support drive folder pagination

### DIFF
--- a/extensions/feishu/skills/feishu-drive/SKILL.md
+++ b/extensions/feishu/skills/feishu-drive/SKILL.md
@@ -20,13 +20,27 @@ From URL `https://xxx.feishu.cn/drive/folder/ABC123` → `folder_token` = `ABC12
 { "action": "list" }
 ```
 
-Root directory (no folder_token).
+Requests the account root (no `folder_token`). Bot credentials normally have no root folder, so
+use a folder that has been shared with the bot instead.
 
 ```json
-{ "action": "list", "folder_token": "fldcnXXX" }
+{ "action": "list", "folder_token": "fldcnXXX", "page_size": 100 }
 ```
 
-Returns: files with token, name, type, url, timestamps.
+Returns one page of files with token, name, type, url, timestamps, and `next_page_token` when
+another page is available. To continue, pass the returned token with the same folder token:
+
+```json
+{
+  "action": "list",
+  "folder_token": "fldcnXXX",
+  "page_size": 100,
+  "page_token": "next-page-token"
+}
+```
+
+`page_size` must be between 1 and 200. Pagination requires a concrete shared `folder_token`;
+root-list cursors are not forwarded.
 
 ### Get File Info
 

--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -26,6 +26,18 @@ export const FeishuDriveSchema = Type.Union([
     folder_token: Type.Optional(
       Type.String({ description: "Folder token (optional, omit for root directory)" }),
     ),
+    page_size: Type.Optional(
+      Type.Integer({
+        minimum: 1,
+        maximum: 200,
+        description: "Items per folder page (1-200; requires folder_token)",
+      }),
+    ),
+    page_token: Type.Optional(
+      Type.String({
+        description: "Continuation token from a prior list result (requires the same folder_token)",
+      }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("info"),

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -62,6 +62,7 @@ function mockCallArg<T>(
 type FeishuDriveTool = {
   execute: (callId: string, input: Record<string, unknown>) => Promise<{ details?: unknown }>;
   name?: string;
+  parameters?: unknown;
 };
 
 type FeishuDriveToolFactory = (context: {
@@ -71,6 +72,26 @@ type FeishuDriveToolFactory = (context: {
 
 function firstToolFactory(mock: { mock: { calls: unknown[][] } }): FeishuDriveToolFactory {
   return mockCallArg<FeishuDriveToolFactory>(mock, 0, 0);
+}
+
+function buildDriveTool(): FeishuDriveTool {
+  const registerTool = vi.fn();
+  registerFeishuDriveTools(
+    createDriveToolApi({
+      config: {
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "app_id",
+            appSecret: "app_secret", // pragma: allowlist secret
+            tools: { drive: true },
+          },
+        },
+      },
+      registerTool,
+    }),
+  );
+  return firstToolFactory(registerTool)({ agentAccountId: undefined });
 }
 
 function firstLogMessage(mock: { mock: { calls: unknown[][] } }): string {
@@ -105,6 +126,25 @@ function expectRequestCall(
   if ("params" in expected) {
     expect(request.params).toEqual(expected.params);
   }
+}
+
+function schemaForAction(
+  schema: unknown,
+  action: string,
+): { properties?: Record<string, unknown> } {
+  const variants =
+    (schema as { anyOf?: unknown[]; oneOf?: unknown[] }).anyOf ??
+    (schema as { anyOf?: unknown[]; oneOf?: unknown[] }).oneOf ??
+    [];
+  const variant = variants.find((entry) => {
+    const actionSchema = (entry as { properties?: { action?: { const?: unknown } } }).properties
+      ?.action;
+    return actionSchema?.const === action;
+  });
+  if (!variant) {
+    throw new Error(`Missing schema variant for action ${action}`);
+  }
+  return variant as { properties?: Record<string, unknown> };
 }
 
 describe("registerFeishuDriveTools", () => {
@@ -358,6 +398,91 @@ describe("registerFeishuDriveTools", () => {
       true,
     );
     expect((replyCommentResult.details as { reply_id?: string }).reply_id).toBe("r4");
+  });
+
+  it("lists a folder continuation page when page_token is provided", async () => {
+    const listFiles = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        files: [{ token: "file_1", name: "File 1", type: "docx", url: "https://example.test/doc" }],
+        next_page_token: "page-3",
+      },
+    });
+    createFeishuToolClientMock.mockReturnValue({
+      drive: { file: { list: listFiles } },
+    });
+    const tool = buildDriveTool();
+    const listSchema = schemaForAction(tool.parameters, "list");
+    expect(listSchema.properties?.page_token).toMatchObject({ type: "string" });
+    expect(listSchema.properties?.page_size).toMatchObject({
+      type: "integer",
+      minimum: 1,
+      maximum: 200,
+    });
+
+    const result = await tool.execute("call-list-page-2", {
+      action: "list",
+      folder_token: "folder_1",
+      page_size: 25,
+      page_token: "page-2",
+    });
+
+    expect(listFiles).toHaveBeenCalledWith({
+      params: { folder_token: "folder_1", page_size: 25, page_token: "page-2" },
+    });
+    expect(result.details).toMatchObject({
+      files: [{ token: "file_1", name: "File 1", type: "docx", url: "https://example.test/doc" }],
+      next_page_token: "page-3",
+    });
+  });
+
+  it("normalizes folder pagination and suppresses it for root listings", async () => {
+    const listFiles = vi.fn().mockResolvedValue({ code: 0, data: { files: [] } });
+    createFeishuToolClientMock.mockReturnValue({ drive: { file: { list: listFiles } } });
+    const tool = buildDriveTool();
+
+    await tool.execute("call-list-normalized", {
+      action: "list",
+      folder_token: " folder_1 ",
+      page_size: "25",
+      page_token: "   ",
+    });
+    for (const [callId, folderToken] of [
+      ["call-list-root", undefined],
+      ["call-list-empty", "   "],
+      ["call-list-zero", " 0 "],
+    ] as const) {
+      await tool.execute(callId, {
+        action: "list",
+        folder_token: folderToken,
+        page_size: 25,
+        page_token: "page-2",
+      });
+    }
+
+    expect(listFiles).toHaveBeenNthCalledWith(1, {
+      params: { folder_token: "folder_1", page_size: 25 },
+    });
+    for (const callIndex of [2, 3, 4]) {
+      expect(listFiles).toHaveBeenNthCalledWith(callIndex, { params: {} });
+    }
+  });
+
+  it.each([0, 201, 1.5])("rejects invalid folder page_size %s", async (pageSize) => {
+    const listFiles = vi.fn();
+    createFeishuToolClientMock.mockReturnValue({ drive: { file: { list: listFiles } } });
+    const tool = buildDriveTool();
+
+    const result = await tool.execute("call-list-invalid-page-size", {
+      action: "list",
+      folder_token: "folder_1",
+      page_size: pageSize,
+    });
+
+    expect(result.details).toMatchObject({
+      error: "page_size must be a positive integer between 1 and 200",
+    });
+    expect(listFiles).not.toHaveBeenCalled();
   });
 
   it("defaults add_comment file_type to docx when omitted", async () => {

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -1,6 +1,7 @@
 // Feishu plugin module implements drive behavior.
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import { jsonResult } from "openclaw/plugin-sdk/tool-results";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
@@ -325,11 +326,27 @@ async function getRootFolderToken(client: Lark.Client): Promise<string> {
   return token;
 }
 
-async function listFolder(client: Lark.Client, folderToken?: string) {
-  // Filter out invalid folder_token values (empty, "0", etc.)
+async function listFolder(client: Lark.Client, params: Record<string, unknown> = {}) {
+  const folderToken =
+    typeof params.folder_token === "string" ? params.folder_token.trim() : undefined;
   const validFolderToken = folderToken && folderToken !== "0" ? folderToken : undefined;
+  const pageSize = readPositiveIntegerParam(params, "page_size", {
+    max: 200,
+    message: "page_size must be a positive integer between 1 and 200",
+  });
+  const pageToken = typeof params.page_token === "string" ? params.page_token.trim() : undefined;
+
+  // Bot credentials have no browsable root. A continuation cursor is only valid with the
+  // same concrete folder token that produced it, so do not forward pagination for root.
+  const listParams = validFolderToken
+    ? {
+        folder_token: validFolderToken,
+        ...(pageSize ? { page_size: pageSize } : {}),
+        ...(pageToken ? { page_token: pageToken } : {}),
+      }
+    : {};
   const res = await client.drive.file.list({
-    params: validFolderToken ? { folder_token: validFolderToken } : {},
+    params: listParams,
   });
   if (res.code !== 0) {
     throw new Error(res.msg);
@@ -766,7 +783,13 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
             });
             switch (p.action) {
               case "list":
-                return jsonResult(await listFolder(client, p.folder_token));
+                return jsonResult(
+                  await listFolder(client, {
+                    folder_token: p.folder_token,
+                    page_size: p.page_size,
+                    page_token: p.page_token,
+                  }),
+                );
               case "info":
                 return jsonResult(await getFileInfo(client, p.file_token));
               case "create_folder":


### PR DESCRIPTION
## What Problem This Solves

Feishu Drive folder listings return `next_page_token`, but the `feishu_drive` tool could not accept that cursor, leaving every page after the first unreachable.

This is the clean current-main replacement for #101249 and #101567. The original contributor branch was 159 main commits and 903 files behind; the first replacement then inherited merge-base noise when the verified GitHub commit path appended its rebased tree. This branch contains exactly the four intended Feishu files in one co-authored commit.

## Why This Change Was Made

- Add bounded `page_size` and `page_token` inputs to the existing `list` action.
- Normalize folder and cursor tokens and validate `page_size` at runtime, not only in the model schema.
- Scope cursors to a concrete shared folder; Feishu bot credentials have no browsable root, so pagination is not forwarded for omitted, blank, or `"0"` folder tokens.
- Document one-page continuation in the bundled Feishu Drive skill.

The change stays plugin-local and preserves the existing response shape. It does not broaden into automatic recursive pagination or the separate `info` lookup behavior tracked by #93928.

## User Impact

Agents can retrieve subsequent pages of a shared Feishu Drive folder by passing the returned `next_page_token` as `page_token` with the same `folder_token`. Invalid page sizes fail before an API request.

## Evidence

- Upstream `@larksuiteoapi/node-sdk` source confirms `drive.file.list` accepts `folder_token`, `page_size`, and `page_token`, and returns `next_page_token` / `has_more`.
- Contributor gateway proof on #101249 exercised `/tools/invoke` through the bundled tool and captured the expected SDK-boundary continuation request.
- Identical four-file tree proof on sanitized AWS: `cbx_5bcffb4b507b`, run `run_5b84b967a00e`; 20/20 Feishu Drive tests passed.
- `oxfmt` on all touched files; `git diff --check`; skill YAML frontmatter parse.
- Fresh GPT-5.5 autoreview of this exact four-file bundle: clean, confidence 0.86.
- Source-blind behavior validation: continuation and blank-cursor clauses passed from the public Gateway capture; invalid-size and root live clauses were blocked by unavailable credentials/harness and are covered by remote automated proof.
- Exact commit-head sanitized AWS and hosted CI/Testbox evidence will be posted before merge.

Closes the `list` continuation portion of #93928. Supersedes #101249 and #101567.
