### PR TITLE
fix(auth): clean OAuth contention diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **OAuth refresh contention diagnostics:** keep local lock paths out of user-facing refresh failures and avoid duplicate failure prefixes while preserving structured provider and profile classification. (#83383) Thanks @vincentkoc.
 - **Exec approval prompts:** keep background-disabled fallback warnings out of pending gateway/node approvals and show them only after a command actually runs in the foreground. (#78184) Thanks @vincentkoc.
 - **Agent wait hard-timeout snapshots:** preserve canonical hard-timeout phase and timestamps when the outer `agent.wait` timer wins the retry-grace race, while leaving queue, draining, and restart-cancelled waits correctable. (#89367) Thanks @Pick-cat.
 - **Control UI typed approvals:** send `/approve` commands immediately through the authorized Gateway command path while an agent run is blocked instead of queueing the command behind that run. (#77672) Thanks @vincentkoc.

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -77,9 +77,12 @@ export class OAuthManagerRefreshError extends OAuthRefreshFailureError {
       typeof params.cause === "object" && params.cause !== null
         ? (params.cause as { code?: unknown; lockPath?: unknown; cause?: unknown })
         : undefined;
-    const delegatedCause =
-      structuredCause?.code === "refresh_contention" && structuredCause.cause
-        ? structuredCause.cause
+    const isRefreshContention = structuredCause?.code === "refresh_contention";
+    // Keep the file-lock cause on structured fields only. Flattening it here
+    // exposes local lock paths in user-facing auth diagnostics.
+    const surfacedCause =
+      isRefreshContention && params.cause instanceof Error
+        ? new Error(params.cause.message)
         : params.cause;
     const storedCredential = params.refreshedStore.profiles[params.profileId];
     const secrets = collectOAuthCredentialSecrets(
@@ -87,12 +90,12 @@ export class OAuthManagerRefreshError extends OAuthRefreshFailureError {
       ...(params.attemptedCredentials ?? []),
       storedCredential?.type === "oauth" ? storedCredential : undefined,
     );
-    const causeMessage = formatRedactedOAuthRefreshError(params.cause, secrets);
+    const causeMessage = formatRedactedOAuthRefreshError(surfacedCause, secrets);
     super({
       provider: params.credential.provider,
       profileId: params.profileId,
       message: `OAuth token refresh failed for ${params.credential.provider}: ${causeMessage}`,
-      cause: createRedactedOAuthRefreshCause(delegatedCause, secrets),
+      cause: createRedactedOAuthRefreshCause(surfacedCause, secrets),
     });
     this.name = "OAuthManagerRefreshError";
     this.#credential = params.credential;

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -7,9 +7,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { resetFileLockStateForTest } from "../../infra/file-lock.js";
+import { FILE_LOCK_TIMEOUT_ERROR_CODE, resetFileLockStateForTest } from "../../infra/file-lock.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
+import { OAuthRefreshFailureError } from "./oauth-refresh-failure.js";
+import { buildRefreshContentionError } from "./oauth-refresh-lock-errors.js";
 import {
   OAUTH_AGENT_ENV_KEYS,
   createExpiredOauthStore,
@@ -214,6 +216,42 @@ describe("resolveApiKeyForProfile openai refresh fallback", () => {
       }),
     ).rejects.toThrow(/OAuth token refresh failed for openai/);
     expect(refreshProviderOAuthCredentialWithPluginMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces refresh contention once without local lock details", async () => {
+    const profileId = "openai:default";
+    saveAuthProfileStore(createExpiredOauthStore({ profileId, provider: "openai" }), agentDir, {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    });
+    const lockPath = path.join(agentDir, "oauth-refresh.lock");
+    const lockCause = Object.assign(new Error(`file lock timeout for ${lockPath}`), {
+      code: FILE_LOCK_TIMEOUT_ERROR_CODE,
+      lockPath,
+    });
+    refreshProviderOAuthCredentialWithPluginMock.mockRejectedValueOnce(
+      buildRefreshContentionError({ provider: "openai", profileId, cause: lockCause }),
+    );
+
+    const failure = await resolveApiKeyForProfile({
+      store: ensureAuthProfileStore(agentDir),
+      profileId,
+      agentDir,
+      forceRefresh: true,
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(OAuthRefreshFailureError);
+    expect(failure).toMatchObject({
+      provider: "openai",
+      profileId,
+      reason: null,
+      cause: { code: "refresh_contention", lockPath },
+    });
+    const message = failure instanceof Error ? failure.message : String(failure);
+    expect(message.match(/OAuth token refresh failed/g)).toHaveLength(1);
+    expect(message.match(/OAuth refresh failed \(refresh_contention\)/g)).toHaveLength(1);
+    expect(message).not.toContain(lockPath);
+    expect(message).not.toContain("file lock timeout");
   });
 
   it("does not fill an explicit empty default profile beside managed OpenAI OAuth", async () => {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -449,10 +449,6 @@ export async function resolveApiKeyForProfile(
         : loadAuthProfileStoreForSecretsRuntime(params.agentDir);
     const surfacedCause =
       error instanceof OAuthManagerRefreshError && error.cause ? error.cause : error;
-    const surfacedMessageError =
-      error instanceof OAuthManagerRefreshError && error.code === "refresh_contention"
-        ? error
-        : surfacedCause;
     if (isRefreshTokenReusedError(surfacedCause)) {
       const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir({
         agentDir: params.agentDir,
@@ -502,7 +498,7 @@ export async function resolveApiKeyForProfile(
       }
     }
 
-    const message = extractErrorMessage(surfacedMessageError);
+    const message = extractErrorMessage(surfacedCause);
     const hint = await formatAuthDoctorHint({
       cfg,
       store: refreshedStore,


### PR DESCRIPTION
## What Problem This Solves

OAuth refresh lock contention currently crosses two error-wrapping layers. The manager flattens the nested file-lock cause into its message, then the profile resolver surfaces the manager error itself and adds another `OAuth token refresh failed` prefix. Operators can therefore see a duplicated failure prefix plus an internal local lock path and `file lock timeout` detail.

This is a focused, current-main replay of #83383. The original branch is conflicting and cannot be updated by maintainers.

## Why This Change Was Made

- Keep the canonical contention message as the user-facing manager cause without flattening its nested file-lock cause.
- Retain `code: "refresh_contention"` and `lockPath` on the structured manager error for programmatic handling.
- Route contention through the same sanitized cause path as other refresh failures in the profile resolver, avoiding the second prefix.
- Preserve the current `OAuthRefreshFailureError` provider, profile, and reason classification added after the original PR was written.
- Add the regression to the existing OpenAI refresh-fallback integration suite rather than carrying over the stale branch's broad test-harness rewrites.

Contributor credit is preserved in the commit and changelog. The production diff is net-negative in lines.

## User Impact

When another OpenClaw process already holds an OpenAI OAuth refresh lock, the operator now sees one actionable `refresh_contention` failure. Local lock paths and the underlying file-lock timeout stay out of the user-facing message, while structured contention metadata remains available to code.

No config, storage, provider-routing, credential, or authorization behavior changes.

## Evidence

- Blacksmith Testbox `tbx_01kwy25q40ew4jxxbb54v1kmm0`: `pnpm test src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts src/agents/auth-profiles/oauth-manager.test.ts src/agents/auth-profiles/oauth-lock-timeout-classification.test.ts` — 3 files / 47 tests passed on the final formatted diff.
- Same Testbox: `pnpm check:changed` — core, coreTests, and docs lanes passed, including production/test typechecks, lint with 0 warnings/errors, policy guards, and cycle checks.
- Same Testbox: scoped `pnpm format:check` passed for all four changed files.
- Fresh `.agents/skills/autoreview/scripts/autoreview --mode local`: clean, no accepted/actionable findings; overall correctness 0.91.
- `git diff --check` passed.
- Resolver-level regression proves one outer refresh prefix, one contention message, no lock path or file-lock text, preserved provider/profile classification, and preserved structured contention code/path.

Source-blind live CLI proof was not claimed: the public auth CLI has no disposable command that creates an expired OAuth profile and holds its canonical refresh lock, and using a real provider credential is unnecessary for this deterministic diagnostic path.

## Related

- Replaces #83383.
- Builds on the auth redaction work from #82670.
