### PR TITLE
fix(memory): preserve UTF-16 chunk boundaries

### DIFF
--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -235,6 +235,7 @@ describe("memory host SDK package internals", () => {
 
     const chunks = chunkMarkdown(text, { tokens: 10, overlap: 0 });
 
+    expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.map((chunk) => chunk.text).join("")).toBe(text);
     for (const chunk of chunks) {
       expect(() => encodeURIComponent(chunk.text)).not.toThrow();

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -226,7 +226,18 @@ describe("memory host SDK package internals", () => {
       overlap: 0,
     });
     for (const chunk of surrogateChunks) {
-      expect(chunk.text).not.toContain("\uFFFD");
+      expect(() => encodeURIComponent(chunk.text)).not.toThrow();
+    }
+  });
+
+  it("preserves a surrogate pair at the coarse split boundary", () => {
+    const text = `${"a".repeat(39)}🌸${"b".repeat(39)}`;
+
+    const chunks = chunkMarkdown(text, { tokens: 10, overlap: 0 });
+
+    expect(chunks.map((chunk) => chunk.text).join("")).toBe(text);
+    for (const chunk of chunks) {
+      expect(() => encodeURIComponent(chunk.text)).not.toThrow();
     }
   });
 

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -454,25 +454,23 @@ export function chunkMarkdown(
       // Second pass: if a segment's *weighted* size still exceeds the budget
       // (happens for CJK-heavy text where 1 char ≈ 1 token), re-split it at
       // chunking.tokens so the chunk stays within the token budget.
-      for (let start = 0; start < line.length; start += maxChars) {
-        const coarse = line.slice(start, start + maxChars);
+      for (let start = 0; start < line.length; ) {
+        const coarseEnd = includeTrailingLowSurrogate(
+          line,
+          Math.min(start + maxChars, line.length),
+        );
+        const coarse = line.slice(start, coarseEnd);
         if (estimateStringChars(coarse) > maxChars) {
           const fineStep = Math.max(1, chunking.tokens);
           for (let j = 0; j < coarse.length; ) {
-            let end = Math.min(j + fineStep, coarse.length);
-            // Avoid splitting inside a UTF-16 surrogate pair (CJK Extension B+).
-            if (end < coarse.length) {
-              const code = coarse.charCodeAt(end - 1);
-              if (code >= 0xd800 && code <= 0xdbff) {
-                end += 1; // include the low surrogate
-              }
-            }
+            const end = includeTrailingLowSurrogate(coarse, Math.min(j + fineStep, coarse.length));
             segments.push(coarse.slice(j, end));
             j = end; // advance cursor to the adjusted boundary
           }
         } else {
           segments.push(coarse);
         }
+        start = coarseEnd;
       }
     }
     for (const segment of segments) {
@@ -487,6 +485,16 @@ export function chunkMarkdown(
   }
   flush();
   return chunks;
+}
+
+// A high surrogate at the cut belongs with the following low surrogate; advancing
+// together keeps both the current and next chunk valid UTF-16.
+function includeTrailingLowSurrogate(value: string, end: number): number {
+  if (end >= value.length) {
+    return value.length;
+  }
+  const lastCodeUnit = value.charCodeAt(end - 1);
+  return lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? end + 1 : end;
 }
 
 /**

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -25,6 +25,7 @@ import {
   detectMime,
   estimateStringChars,
   runTasksWithConcurrency,
+  truncateUtf16Safe,
 } from "./openclaw-runtime-io.js";
 import {
   resolveCanonicalRootMemoryFile,
@@ -455,22 +456,22 @@ export function chunkMarkdown(
       // (happens for CJK-heavy text where 1 char ≈ 1 token), re-split it at
       // chunking.tokens so the chunk stays within the token budget.
       for (let start = 0; start < line.length; ) {
-        const coarseEnd = includeTrailingLowSurrogate(
-          line,
-          Math.min(start + maxChars, line.length),
-        );
-        const coarse = line.slice(start, coarseEnd);
+        const coarse = truncateUtf16Safe(line.slice(start), maxChars);
         if (estimateStringChars(coarse) > maxChars) {
           const fineStep = Math.max(1, chunking.tokens);
           for (let j = 0; j < coarse.length; ) {
-            const end = includeTrailingLowSurrogate(coarse, Math.min(j + fineStep, coarse.length));
+            let end = Math.min(j + fineStep, coarse.length);
+            const lastCodeUnit = coarse.charCodeAt(end - 1);
+            if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff && end < coarse.length) {
+              end += 1;
+            }
             segments.push(coarse.slice(j, end));
-            j = end; // advance cursor to the adjusted boundary
+            j = end;
           }
         } else {
           segments.push(coarse);
         }
-        start = coarseEnd;
+        start += coarse.length;
       }
     }
     for (const segment of segments) {
@@ -485,16 +486,6 @@ export function chunkMarkdown(
   }
   flush();
   return chunks;
-}
-
-// A high surrogate at the cut belongs with the following low surrogate; advancing
-// together keeps both the current and next chunk valid UTF-16.
-function includeTrailingLowSurrogate(value: string, end: number): number {
-  if (end >= value.length) {
-    return value.length;
-  }
-  const lastCodeUnit = value.charCodeAt(end - 1);
-  return lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff ? end + 1 : end;
 }
 
 /**


### PR DESCRIPTION
## What Problem This Solves

Fixes #65782. Long memory lines could be split between the high and low code units of a supplementary Unicode character. The resulting malformed UTF-16 chunks could later fail encoding or embedding requests.

Supersedes #65783 with a current-main, narrowly scoped fix. That older PR also introduced a partial sanitizer across selected embedding paths; the sanitizer was incomplete and duplicated policy that needs one canonical owner.

## Why This Change Was Made

The memory chunker now uses the shared UTF-16-safe truncation primitive for its coarse boundary. It backs off before a split surrogate pair, so the next segment starts with the complete character while the original character budget remains intact.

The contributor's regression coverage was retained and tightened around both mixed CJK supplementary characters and an exact coarse-boundary emoji case. Contributor credit is preserved in the test commit.

## User Impact

Memory indexing preserves supplementary Unicode characters such as emoji and CJK Extension B characters without creating malformed chunks. Existing chunk budgets and reconstruction behavior remain unchanged.

## Evidence

- `node scripts/crabbox-wrapper.mjs run -- corepack pnpm test packages/memory-host-sdk/src/host/internal.test.ts` — 10 tests passed on Blacksmith Testbox `tbx_01kwy2nvkm0x97aqfyb601crsp` ([run](https://github.com/openclaw/openclaw/actions/runs/28860114520)).
- Fresh Codex autoreview: clean; no accepted/actionable findings, correctness 0.87.
- `git diff --check` — passed.
- `oxfmt` on both touched files — passed.
