### PR TITLE
fix(auto-reply): keep suppressed reply text preview truncation UTF-16 safe

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1,6 +1,5 @@
 // Tests dispatch-from-config runtime selection, hooks, and provider handoff.
 import { AsyncResource } from "node:async_hooks";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { clearAgentHarnesses, registerAgentHarness } from "../../agents/harness/registry.js";
 import type { ChannelMessagingAdapter } from "../../channels/plugins/types.core.js";
@@ -70,6 +69,9 @@ const mocks = vi.hoisted(() => ({
     handled: false,
     aborted: false,
   })),
+}));
+const globalMocks = vi.hoisted(() => ({
+  logVerbose: vi.fn(),
 }));
 const diagnosticMocks = vi.hoisted(() => ({
   logMessageDispatchCompleted: vi.fn(),
@@ -443,6 +445,14 @@ vi.mock("./abort.runtime.js", () => ({
     return `⚙️ Agent was aborted. Stopped ${stoppedSubagents} ${label}.`;
   },
 }));
+
+vi.mock("../../globals.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../globals.js")>();
+  return {
+    ...actual,
+    logVerbose: globalMocks.logVerbose,
+  };
+});
 
 vi.mock("../../logging/diagnostic.js", () => ({
   logMessageDispatchCompleted: diagnosticMocks.logMessageDispatchCompleted,
@@ -10206,6 +10216,32 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(result.sendPolicyDenied).toBe(true);
   });
 
+  it("keeps the suppressed reply log preview UTF-16 safe", async () => {
+    setNoAbort();
+    globalMocks.logVerbose.mockClear();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "deny",
+    };
+    const dispatcher = createDispatcher();
+    const text = `${"y".repeat(159)}🚀`;
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ SessionKey: "test:session" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver: async () => ({ text }),
+    });
+
+    const suppressedLog = globalMocks.logVerbose.mock.calls.find(([message]) =>
+      message.includes("final reply suppressed"),
+    )?.[0];
+    expect(suppressedLog).toContain("textChars=161");
+    expect(suppressedLog).toContain(`textPreview=${JSON.stringify("y".repeat(159))}`);
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
   it("does not mark allowed group silence eligible for no-visible fallback", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();
@@ -12759,25 +12795,5 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(replyResolver).toHaveBeenCalledTimes(1);
     expect(result.queuedFinal).toBe(true);
     expect(firstFinalReplyPayload(dispatcher)?.text).toBe("final reply");
-  });
-});
-
-describe("textPreview truncation", () => {
-  it("does not cut suppressed reply text preview with an emoji straddling the 160-char boundary", () => {
-    // formatSuppressedReplyPayloadForLog is private; the textPreview line is:
-    //   text ? truncateUtf16Safe(text.replace(/\s+/g, " "), 160) : undefined
-    // "🚀" is a surrogate pair (2 UTF-16 code units). Text of 159 'y' + the
-    // emoji has 161 code units. slice(0,160) splits the pair; truncateUtf16Safe
-    // backs out.
-    const text = "y".repeat(159) + "🚀";
-    // slice splits the surrogate pair at position 160
-    const sliced = text.replace(/\s+/g, " ").slice(0, 160);
-    expect(sliced.charCodeAt(159)).toBe(0xd83d); // lone high surrogate
-    // truncateUtf16Safe drops the incomplete pair
-    expect(truncateUtf16Safe(text.replace(/\s+/g, " "), 160)).toBe("y".repeat(159));
-  });
-
-  it("preserves text preview shorter than the limit unchanged", () => {
-    expect(truncateUtf16Safe("hello world", 160)).toBe("hello world");
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1,5 +1,6 @@
 // Tests dispatch-from-config runtime selection, hooks, and provider handoff.
 import { AsyncResource } from "node:async_hooks";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { clearAgentHarnesses, registerAgentHarness } from "../../agents/harness/registry.js";
 import type { ChannelMessagingAdapter } from "../../channels/plugins/types.core.js";
@@ -12758,5 +12759,25 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(replyResolver).toHaveBeenCalledTimes(1);
     expect(result.queuedFinal).toBe(true);
     expect(firstFinalReplyPayload(dispatcher)?.text).toBe("final reply");
+  });
+});
+
+describe("textPreview truncation", () => {
+  it("does not cut suppressed reply text preview with an emoji straddling the 160-char boundary", () => {
+    // formatSuppressedReplyPayloadForLog is private; the textPreview line is:
+    //   text ? truncateUtf16Safe(text.replace(/\s+/g, " "), 160) : undefined
+    // "🚀" is a surrogate pair (2 UTF-16 code units). Text of 159 'y' + the
+    // emoji has 161 code units. slice(0,160) splits the pair; truncateUtf16Safe
+    // backs out.
+    const text = "y".repeat(159) + "🚀";
+    // slice splits the surrogate pair at position 160
+    const sliced = text.replace(/\s+/g, " ").slice(0, 160);
+    expect(sliced.charCodeAt(159)).toBe(0xd83d); // lone high surrogate
+    // truncateUtf16Safe drops the incomplete pair
+    expect(truncateUtf16Safe(text.replace(/\s+/g, " "), 160)).toBe("y".repeat(159));
+  });
+
+  it("preserves text preview shorter than the limit unchanged", () => {
+    expect(truncateUtf16Safe("hello world", 160)).toBe("hello world");
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -377,7 +377,7 @@ function loadReplyMediaPathsRuntime() {
 function formatSuppressedReplyPayloadForLog(reply: ReplyPayload): string {
   const metadata = getReplyPayloadMetadata(reply);
   const text = normalizeOptionalString(reply.text);
-  const textPreview = text ? text.replace(/\s+/g, " ").slice(0, 160) : undefined;
+  const textPreview = text ? truncateUtf16Safe(text.replace(/\s+/g, " "), 160) : undefined;
   const sendableParts = resolveSendableOutboundReplyParts(reply);
   const richParts = [
     reply.presentation ? "presentation" : undefined,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where suppressed auto-reply log previews could contain broken U+FFFD replacement characters (`�`) when reply text contained an emoji or CJK supplementary character at the 160-character log truncation boundary.

`String.prototype.slice(0, 160)` cuts at UTF-16 code unit boundaries. Emoji like 🚀 are surrogate pairs (2 code units). When a pair straddles position 160, the lone high surrogate renders as `�` in log output. `truncateUtf16Safe` was already imported in this file (line 8) but unused at this call site.

## Why This Change Was Made

Replace `text.replace(...).slice(0, 160)` with `truncateUtf16Safe(text.replace(...), 160)` — the same helper already imported in this file. One-line, no new dependencies.

## User Impact

Suppressed auto-reply log previews containing emoji or CJK near the 160-character limit now display cleanly truncated text in logs.

## Evidence

### Tests



New tests:  and .

### Standalone proof (production helper, same head)

`formatSuppressedReplyPayloadForLog` is a private function — not exported for direct unit testing. The proof below exercises the exact `truncateUtf16Safe` helper at the same 160-char boundary used in the production code.

```
=== BEFORE fix: text.replace(/\s+/g, ' ').slice(0, 160) ===
  text.length: 161 (159 y's + surrogate-pair emoji)
  sliced last code unit: 0xd83d
  lone surrogate: true
  log would show: "yyy\ud83d" <- U+FFFD garbled

=== AFTER fix: truncateUtf16Safe(text.replace(/\s+/g, ' '), 160) ===
  safe.length: 159
  safe matches: true
  broken chars: NONE
```

### Files Changed (2 files, +22/-1)

```
 src/auto-reply/reply/dispatch-from-config.test.ts | 21 +++++++++++++++++++++
 dispatch-from-config.ts      |  2 +-
```

Trivially safe: same helper already imported at line 8, same UTF-16-safe pattern used across all other similar fixes.
