### PR TITLE
fix: preserve session labels across rollover

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1291,6 +1291,48 @@ describe("initSessionState RawBody", () => {
     expect(result.sessionEntry.responseUsage).toBe("full");
   });
 
+  it("preserves user labels across dashboard session stale rollover (#101451)", async () => {
+    const root = await makeCaseDir("openclaw-dashboard-rollover-label-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:dashboard:8c0b2b68-05e1-4b25-a8c2-ef6f43a01f77";
+    const existingSessionId = "dashboard-session-before-rollover";
+    const staleStartedAt = Date.now() - 48 * 60 * 60 * 1000;
+
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: existingSessionId,
+        updatedAt: staleStartedAt,
+        sessionStartedAt: staleStartedAt,
+        lastInteractionAt: staleStartedAt,
+        label: "Other",
+        displayName: "Dashboard Chat",
+      },
+    });
+
+    const result = await initSessionState({
+      ctx: {
+        RawBody: "continue",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+      },
+      cfg: { session: { store: storePath } } as OpenClawConfig,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(false);
+    expect(result.sessionId).not.toBe(existingSessionId);
+    expect(result.sessionEntry.label).toBe("Other");
+    expect(result.sessionEntry.displayName).toBe("Dashboard Chat");
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      { label?: string; displayName?: string }
+    >;
+    expect(store[sessionKey]?.label).toBe("Other");
+    expect(store[sessionKey]?.displayName).toBe("Dashboard Chat");
+  });
+
   it("clears an auto-fallback model override on an implicit daily stale rollover (#90119)", async () => {
     // Counterpart: auto-created fallback overrides must still be cleared on a
     // daily rollover so stale sessions return to the configured default.

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -748,13 +748,14 @@ async function initSessionStateAttemptLocked(
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
       persistedResponseUsage = entry.responseUsage;
+      persistedLabel = entry.label;
+      persistedDisplayName = entry.displayName;
     }
     // When a reset trigger (/new, /reset) starts a new session, also rotate the
-    // underlying CLI conversation and carry forward spawn lineage/label.
+    // underlying CLI conversation and carry forward spawn lineage.
     if (resetTriggered && entry) {
       // Explicit /new and /reset should rotate the underlying CLI conversation too.
       // Keep the model/auth choice, but force the next turn to mint a fresh CLI binding.
-      persistedLabel = entry.label;
       persistedSpawnedBy = entry.spawnedBy;
       persistedSpawnedWorkspaceDir = entry.spawnedWorkspaceDir;
       persistedSpawnedCwd = entry.spawnedCwd;
@@ -763,7 +764,6 @@ async function initSessionStateAttemptLocked(
       persistedSpawnDepth = entry.spawnDepth;
       persistedSubagentRole = entry.subagentRole;
       persistedSubagentControlScope = entry.subagentControlScope;
-      persistedDisplayName = entry.displayName;
     }
   }
 


### PR DESCRIPTION
Related: #101483
Closes #101451

## What Problem This Solves

Fixes an issue where users' session labels and display names could disappear when a dashboard session became stale and rolled to a new session ID without an explicit reset.

## Why This Change Was Made

Sticky display metadata now follows the existing-entry rollover path shared by implicit and explicit rollovers, while spawn lineage remains explicit-reset-only. The original contributor PR accumulated verified fork-update ancestry that repeatedly became unmergeable as `main` advanced, so this clean maintainer branch preserves @ZengWen-DT's authorship with `Co-authored-by`.

## User Impact

Dashboard sessions keep their user-assigned label and display name across daily or idle rollover instead of reverting to an unlabeled session.

## Evidence

- The regression drives `initSessionState` against a persisted stale dashboard session, proves a new session ID is minted without an explicit reset, and verifies both fields remain in memory and on disk.
- Blacksmith Testbox `tbx_01kwxzcsqjvm7mmnkghy6b0bwg`, run https://github.com/openclaw/openclaw/actions/runs/28857273356: 136/136 focused session tests passed.
- Exact-tree hosted CI on the contributor branch: https://github.com/openclaw/openclaw/actions/runs/28859633491 passed.
- Fresh Codex autoreview: no accepted/actionable findings; correctness 0.82.
- Fresh exact-head hosted CI is required before landing this clean replacement.
