### PR TITLE
fix(session-memory): preserve sibling paths in logs

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -19,6 +19,17 @@ vi.mock("../../llm-slug-generator.js", () => ({
   generateSlugViaLLM: vi.fn().mockResolvedValue("simple-math"),
 }));
 
+const loggerMocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("../../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => loggerMocks,
+}));
+
 let handler: typeof import("./handler.js").default;
 let flushSessionMemoryWritesForTest: typeof import("./handler.js").flushSessionMemoryWritesForTest;
 let suiteWorkspaceRoot = "";
@@ -1011,5 +1022,24 @@ describe("session-memory hook", () => {
     const lines = memoryContent!.split("\n").filter((l) => l.startsWith("assistant:"));
     expect(lines).toEqual(["assistant: Done", "assistant: Done"]);
     expect(memoryContent).not.toContain("user: /new");
+  });
+
+  it("keeps sibling home-prefix paths intact in completion logs", async () => {
+    const fakeHome = path.join(suiteWorkspaceRoot, "user");
+    const siblingWorkspace = `${fakeHome}2`;
+    loggerMocks.info.mockClear();
+
+    await withEnvAsync(
+      { HOME: fakeHome, USERPROFILE: fakeHome, OPENCLAW_HOME: undefined },
+      async () => {
+        const { files } = await runNewWithPreviousSessionEntry({
+          tempDir: siblingWorkspace,
+          previousSessionEntry: { sessionId: "test-123" },
+        });
+        expect(loggerMocks.info).toHaveBeenCalledWith(
+          `Session context saved to ${path.join(siblingWorkspace, "memory", files[0]!)}`,
+        );
+      },
+    );
   });
 });

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -21,6 +21,7 @@ import {
   resolveAgentIdFromSessionKey,
   toAgentStoreSessionKey,
 } from "../../../routing/session-key.js";
+import { shortenHomePath } from "../../../utils.js";
 import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
@@ -249,7 +250,7 @@ async function saveSessionMemoryNow(event: Parameters<HookHandler>[0]): Promise<
     const memoryFilePath = path.join(memoryDir, filename);
     log.debug("Memory file path resolved", {
       filename,
-      path: memoryFilePath.replace(os.homedir(), "~"),
+      path: shortenHomePath(memoryFilePath),
     });
 
     const timeStr = localTimestamp.time;
@@ -282,7 +283,7 @@ async function saveSessionMemoryNow(event: Parameters<HookHandler>[0]): Promise<
     log.debug("Memory file written successfully");
 
     // Log completion (but don't send user-visible confirmation - it's internal housekeeping)
-    const relPath = memoryFilePath.replace(os.homedir(), "~");
+    const relPath = shortenHomePath(memoryFilePath);
     log.info(`Session context saved to ${relPath}`);
   } catch (err) {
     if (err instanceof Error) {


### PR DESCRIPTION
Related: #99114

## What Problem This Solves

Fixes an issue where session-memory diagnostic logs could display a corrupted path such as `~2/...` when a workspace only shared the home directory's textual prefix.

## Why This Change Was Made

Both session-memory log sites now use the existing boundary-aware home-path formatter. The regression drives the real hook and captures its completion log instead of only retesting the shared helper. The original fork branch was repeatedly rewritten while maintainer fixups were being applied, so this clean maintainer branch preserves @cxbAsDev's authorship with `Co-authored-by`.

## User Impact

Operators see the correct absolute workspace path in session-memory logs; real home descendants still use the compact home marker.

## Evidence

- Blacksmith Testbox `tbx_01kwxzy3h0m4zzx1757c0j4s20`, run https://github.com/openclaw/openclaw/actions/runs/28857431514: 30/30 focused hook tests passed.
- The production-path regression uses a sibling workspace and asserts the emitted completion log keeps the full path.
- Exact-tree hosted CI on the contributor branch: https://github.com/openclaw/openclaw/actions/runs/28859535274 passed.
- Fresh Codex autoreview: no accepted/actionable findings; correctness 0.87.
- Fresh exact-head hosted CI is required before landing this clean replacement.
