### PR TITLE
fix(gateway): bound usage.cost all-agent fan-out concurrency to prevent SQLite starvation

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -519,4 +519,30 @@ describe("gateway usage helpers", () => {
       totals: { totalTokens: 10, totalCost: 1 },
     });
   });
+
+  it("caps usage.cost all-agent fan-out concurrency", async () => {
+    let inFlight = 0;
+    let peakConcurrency = 0;
+    vi.mocked(loadCostUsageSummaryFromCache).mockImplementation(async () => {
+      inFlight += 1;
+      peakConcurrency = Math.max(peakConcurrency, inFlight);
+      await new Promise<void>((r) => {
+        setTimeout(r, 5);
+      });
+      inFlight -= 1;
+      return costSummary({ totalTokens: 1, totalCost: 0 });
+    });
+
+    const respond = vi.fn();
+    const agents = Array.from({ length: 30 }, (_, i) => ({ id: `agent-${i}` }));
+    await usageHandlers["usage.cost"]({
+      respond,
+      params: { startDate: "2026-02-01", endDate: "2026-02-02", agentScope: "all" },
+      context: { getRuntimeConfig: () => ({ agents: { list: agents } }) },
+    } as unknown as Parameters<(typeof usageHandlers)["usage.cost"]>[0]);
+
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    expect(peakConcurrency).toBeLessThanOrEqual(12);
+    expect(respond.mock.calls[0]?.[1]?.totals?.totalTokens).toBe(30);
+  });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -864,19 +864,26 @@ async function loadAllAgentCostUsageSummary(params: {
   const agentIds = listAgentsForGateway(params.config).agents.map((agent) =>
     normalizeAgentId(agent.id),
   );
-  const summaries = await Promise.all(
-    agentIds.map((agentId) =>
-      loadCostUsageSummaryFromCache({
-        startMs: params.startMs,
-        endMs: params.endMs,
-        dailyUtcOffsetMinutes: params.dailyUtcOffsetMinutes,
-        config: params.config,
-        agentId,
-        requestRefresh: true,
-        refreshMode: "background",
-      }),
+  const result = await runTasksWithConcurrency({
+    tasks: agentIds.map(
+      (agentId) => async () =>
+        loadCostUsageSummaryFromCache({
+          startMs: params.startMs,
+          endMs: params.endMs,
+          dailyUtcOffsetMinutes: params.dailyUtcOffsetMinutes,
+          config: params.config,
+          agentId,
+          requestRefresh: true,
+          refreshMode: "background",
+        }),
     ),
-  );
+    limit: SESSIONS_USAGE_AGENT_LOAD_CONCURRENCY,
+    errorMode: "stop",
+  });
+  if (result.hasError) {
+    throw result.firstError;
+  }
+  const summaries = result.results;
   const dailyByDate = new Map<string, CostUsageTotals & { date: string }>();
   const totals = createEmptyCostUsageTotals();
   let cacheStatus: UsageCacheStatus | undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes https://github.com/openclaw/openclaw/issues/101552

`loadAllAgentCostUsageSummary` fans out `loadCostUsageSummaryFromCache` calls for every configured agent through an unbounded `Promise.all`. With 100+ agents this saturates the SQLite connection pool, causing `SQLITE_BUSY` timeouts or memory spikes that crash the gateway process.

## Why This Change Was Made

The sibling `sessions.usage` path already uses `runTasksWithConcurrency` with `SESSIONS_USAGE_AGENT_LOAD_CONCURRENCY = 12` to bound per-agent cache-load fan-out. This change applies the same pattern to `usage.cost`, reusing the same helper and concurrency limit that are already imported and proven in the same module.

## User Impact

- Large multi-agent deployments no longer risk gateway crashes when loading the usage dashboard
- Aggregation semantics and results are unchanged — only peak in-flight load is capped
- Error behavior: switched from `Promise.all` silent rejection to `errorMode: "stop"` fail-fast, consistent with `sessions.usage`

## Evidence

- `pnpm test src/gateway/server-methods/usage.test.ts` — 62 tests pass (2 files), including new concurrency-cap regression test
- `pnpm test src/gateway/server-methods/usage.sessions-usage.test.ts` — 42 tests pass, no regression
- New test creates 30 agents and verifies peak concurrency stays ≤ 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)