### PR TITLE
fix(gateway): keep plugin approval text UTF-16 safe

### DIFF
--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -119,11 +119,13 @@ function createDemoPolicy(handle: NodeInvokePolicyHandler): NodeInvokePolicyRegi
 
 function createApprovalRequestPolicy(params?: {
   timeoutMs?: number;
+  title?: string;
+  description?: string;
 }): NodeInvokePolicyRegistration {
   return createDemoPolicy(async (ctx: OpenClawPluginNodeInvokePolicyContext) => {
     const approval = await ctx.approvals?.request({
-      title: "Sensitive action",
-      description: "Needs approval",
+      title: params?.title ?? "Sensitive action",
+      description: params?.description ?? "Needs approval",
       ...(params?.timeoutMs === undefined ? {} : { timeoutMs: params.timeoutMs }),
     });
     return { ok: true, payload: approval ?? null };
@@ -324,5 +326,32 @@ describe("applyPluginNodeInvokePolicy", () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  it("keeps approval payload fields on UTF-16 boundaries", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    setDangerousDemoCommandRegistry([
+      createApprovalRequestPolicy({
+        title: `${"a".repeat(79)}🚀tail`,
+        description: `${"b".repeat(255)}🚀tail`,
+      }),
+    ]);
+    const { context } = createContext({
+      pluginApprovalManager: manager,
+      getApprovalClientConnIds: createApprovalClientLookup([
+        createApprovalClient({
+          connId: "conn-owner-approval",
+          clientId: "client-owner",
+          deviceId: "device-owner",
+        }),
+      ]),
+    });
+    const resultPromise = invokeDemoPolicy(context, createOperatorClient());
+
+    const record = await expectSinglePendingApproval(manager);
+    expect(record.request.title).toBe("a".repeat(79));
+    expect(record.request.description).toBe("b".repeat(255));
+
+    await expectApprovalResolution(resultPromise, manager, record);
   });
 });

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -2,6 +2,7 @@
 // Lets plugin policies gate dangerous node commands before transport dispatch.
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
 import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
@@ -63,8 +64,8 @@ function createApprovalRuntime(params: {
       const timeoutMs = resolvePluginApprovalTimeoutMs(input.timeoutMs);
       const request: PluginApprovalRequestPayload = {
         pluginId: params.pluginId,
-        title: input.title.slice(0, 80),
-        description: input.description.slice(0, 256),
+        title: truncateUtf16Safe(input.title, 80),
+        description: truncateUtf16Safe(input.description, 256),
         severity: input.severity ?? "warning",
         toolName: normalizeOptionalString(input.toolName) ?? null,
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,


### PR DESCRIPTION
Related: #101478

## What Problem This Solves

Fixes an issue where plugin approval titles or descriptions could contain a malformed replacement character when an emoji crossed the existing gateway text limit.

## Why This Change Was Made

The plugin node-policy approval boundary now uses the shared dependency-free UTF-16 truncation primitive at the unchanged 80/256 limits. The regression drives the real policy, inspects the stored pending request, and resolves it. The original fork's verified-update ancestry repeatedly became unmergeable as `main` advanced, so this clean maintainer branch preserves @wm0018's authorship with `Co-authored-by`.

## User Impact

Control UI, TUI, MCP, and channel approval surfaces receive valid text when plugin-supplied approval fields contain boundary emoji.

## Evidence

- Blacksmith Testbox `tbx_01kwy0z2t99qj4rsgnjffx7q7c`, run https://github.com/openclaw/openclaw/actions/runs/28858481794: 28/28 gateway matrix tests passed.
- The regression asserts both stored fields are UTF-16 safe and the pending request resolves successfully.
- Fresh Codex autoreview: no accepted/actionable findings; correctness 0.87.
- Fresh exact-head hosted CI is required before landing this clean replacement.
