### PR TITLE
fix(gateway): preserve UTF-16 plugin approval fields

### DIFF
--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -325,4 +325,25 @@ describe("applyPluginNodeInvokePolicy", () => {
 
     expect(result).toBeNull();
   });
+
+  it("does not cut approval title with an emoji straddling the truncation boundary", async () => {
+    // "🚀" is a surrogate pair (2 UTF-16 code units). A title with 79 'a'
+    // plus the emoji has 81 code units. slice(0, 80) splits between the
+    // high and low surrogate halves, leaving a lone surrogate that renders
+    // as U+FFFD in UI/frontend consumers of the approval payload.
+    //
+    // truncateUtf16Safe detects the incomplete pair and backs out to the
+    // previous whole character.
+    const title = "a".repeat(79) + "🚀";
+    const sliced = title.slice(0, 80);
+    // Lone surrogate: the high half (0xD83D) is left without its pair
+    expect(sliced.length).toBe(80);
+    const lastChar = sliced.charCodeAt(79);
+    expect(lastChar).toBe(0xd83d); // high surrogate, not a complete character
+
+    // truncateUtf16Safe drops the incomplete pair entirely
+    const { truncateUtf16Safe } = await import("../utils.js");
+    const safe = truncateUtf16Safe(title, 80);
+    expect(safe).toBe("a".repeat(79));
+  });
 });

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -119,11 +119,13 @@ function createDemoPolicy(handle: NodeInvokePolicyHandler): NodeInvokePolicyRegi
 
 function createApprovalRequestPolicy(params?: {
   timeoutMs?: number;
+  title?: string;
+  description?: string;
 }): NodeInvokePolicyRegistration {
   return createDemoPolicy(async (ctx: OpenClawPluginNodeInvokePolicyContext) => {
     const approval = await ctx.approvals?.request({
-      title: "Sensitive action",
-      description: "Needs approval",
+      title: params?.title ?? "Sensitive action",
+      description: params?.description ?? "Needs approval",
       ...(params?.timeoutMs === undefined ? {} : { timeoutMs: params.timeoutMs }),
     });
     return { ok: true, payload: approval ?? null };
@@ -326,24 +328,30 @@ describe("applyPluginNodeInvokePolicy", () => {
     expect(result).toBeNull();
   });
 
-  it("does not cut approval title with an emoji straddling the truncation boundary", async () => {
-    // "🚀" is a surrogate pair (2 UTF-16 code units). A title with 79 'a'
-    // plus the emoji has 81 code units. slice(0, 80) splits between the
-    // high and low surrogate halves, leaving a lone surrogate that renders
-    // as U+FFFD in UI/frontend consumers of the approval payload.
-    //
-    // truncateUtf16Safe detects the incomplete pair and backs out to the
-    // previous whole character.
-    const title = "a".repeat(79) + "🚀";
-    const sliced = title.slice(0, 80);
-    // Lone surrogate: the high half (0xD83D) is left without its pair
-    expect(sliced.length).toBe(80);
-    const lastChar = sliced.charCodeAt(79);
-    expect(lastChar).toBe(0xd83d); // high surrogate, not a complete character
+  it("keeps approval payload fields on UTF-16 boundaries", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    setDangerousDemoCommandRegistry([
+      createApprovalRequestPolicy({
+        title: `${"a".repeat(79)}🚀tail`,
+        description: `${"b".repeat(255)}🚀tail`,
+      }),
+    ]);
+    const { context } = createContext({
+      pluginApprovalManager: manager,
+      getApprovalClientConnIds: createApprovalClientLookup([
+        createApprovalClient({
+          connId: "conn-owner-approval",
+          clientId: "client-owner",
+          deviceId: "device-owner",
+        }),
+      ]),
+    });
+    const resultPromise = invokeDemoPolicy(context, createOperatorClient());
 
-    // truncateUtf16Safe drops the incomplete pair entirely
-    const { truncateUtf16Safe } = await import("../utils.js");
-    const safe = truncateUtf16Safe(title, 80);
-    expect(safe).toBe("a".repeat(79));
+    const record = await expectSinglePendingApproval(manager);
+    expect(record.request.title).toBe("a".repeat(79));
+    expect(record.request.description).toBe("b".repeat(255));
+
+    await expectApprovalResolution(resultPromise, manager, record);
   });
 });

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -11,6 +11,7 @@ import type {
   OpenClawPluginNodeInvokePolicyResult,
   OpenClawPluginNodeInvokeTransportResult,
 } from "../plugins/types.js";
+import { truncateUtf16Safe } from "../utils.js";
 import type { NodeSession } from "./node-registry.js";
 import { resolveApprovalRequestRecipientConnIds } from "./server-methods/approval-shared.js";
 import type { GatewayClient, GatewayRequestContext } from "./server-methods/types.js";
@@ -63,8 +64,8 @@ function createApprovalRuntime(params: {
       const timeoutMs = resolvePluginApprovalTimeoutMs(input.timeoutMs);
       const request: PluginApprovalRequestPayload = {
         pluginId: params.pluginId,
-        title: input.title.slice(0, 80),
-        description: input.description.slice(0, 256),
+        title: truncateUtf16Safe(input.title, 80),
+        description: truncateUtf16Safe(input.description, 256),
         severity: input.severity ?? "warning",
         toolName: normalizeOptionalString(input.toolName) ?? null,
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -2,6 +2,7 @@
 // Lets plugin policies gate dangerous node commands before transport dispatch.
 import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
 import { resolvePluginApprovalTimeoutMs } from "../infra/plugin-approvals.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
@@ -11,7 +12,6 @@ import type {
   OpenClawPluginNodeInvokePolicyResult,
   OpenClawPluginNodeInvokeTransportResult,
 } from "../plugins/types.js";
-import { truncateUtf16Safe } from "../utils.js";
 import type { NodeSession } from "./node-registry.js";
 import { resolveApprovalRequestRecipientConnIds } from "./server-methods/approval-shared.js";
 import type { GatewayClient, GatewayRequestContext } from "./server-methods/types.js";


### PR DESCRIPTION
## What Problem This Solves

Plugin approval titles and descriptions were capped with raw UTF-16 slicing. An emoji or other supplementary character crossing the 80/256-code-unit boundaries produced a lone surrogate in the gateway approval payload.

This clean current-main replacement supersedes #101478, whose branch accumulated repeated fixup commits, 301 unrelated changed files, and merge conflicts.

## Why This Change Was Made

The gateway node-invoke policy owner now uses the canonical normalization-core UTF-16 helper at the existing caps. The regression drives a real dangerous plugin policy through pending approval creation and inspects the stored request fields.

The original implementation commit and @wm0018 authorship are preserved.

## User Impact

Plugin approval prompts remain valid when capped text contains emoji or supplementary CJK characters. Approval routing, timeouts, and length limits are unchanged.

## Evidence

- `node scripts/crabbox-wrapper.mjs run -- corepack pnpm test src/gateway/node-invoke-plugin-policy.test.ts` — 28 tests passed across four gateway projects on Blacksmith Testbox `tbx_01kwy3bk8pkgs7d418tezxk73a` ([run](https://github.com/openclaw/openclaw/actions/runs/28860744356)).
- Fresh Codex autoreview: clean; no accepted/actionable findings, correctness 0.91.
- `oxfmt --check` on both touched files — passed.
- `git diff --check` — passed.
