### PR TITLE
fix(gateway): limit concurrent usage queries to prevent SQLite starvation

### DIFF
--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -869,6 +869,7 @@ async function loadAllAgentCostUsageSummary(params: {
   const SUMMARIES_CONCURRENCY = 8;
   const summariesResult = await runTasksWithConcurrency({
     limit: SUMMARIES_CONCURRENCY,
+    errorMode: "stop",
     tasks: agentIds.map(
       (agentId) => () =>
         loadCostUsageSummaryFromCache({
@@ -882,6 +883,9 @@ async function loadAllAgentCostUsageSummary(params: {
         }),
     ),
   });
+  if (summariesResult.hasError) {
+    throw summariesResult.firstError;
+  }
   const summaries = summariesResult.results;
   const dailyByDate = new Map<string, CostUsageTotals & { date: string }>();
   const totals = createEmptyCostUsageTotals();

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -864,19 +864,25 @@ async function loadAllAgentCostUsageSummary(params: {
   const agentIds = listAgentsForGateway(params.config).agents.map((agent) =>
     normalizeAgentId(agent.id),
   );
-  const summaries = await Promise.all(
-    agentIds.map((agentId) =>
-      loadCostUsageSummaryFromCache({
-        startMs: params.startMs,
-        endMs: params.endMs,
-        dailyUtcOffsetMinutes: params.dailyUtcOffsetMinutes,
-        config: params.config,
-        agentId,
-        requestRefresh: true,
-        refreshMode: "background",
-      }),
+  // Cap concurrent usage queries so large multi-agent deployments don't
+  // saturate the SQLite connection pool when the usage dashboard loads.
+  const SUMMARIES_CONCURRENCY = 8;
+  const summariesResult = await runTasksWithConcurrency({
+    limit: SUMMARIES_CONCURRENCY,
+    tasks: agentIds.map(
+      (agentId) => () =>
+        loadCostUsageSummaryFromCache({
+          startMs: params.startMs,
+          endMs: params.endMs,
+          dailyUtcOffsetMinutes: params.dailyUtcOffsetMinutes,
+          config: params.config,
+          agentId,
+          requestRefresh: true,
+          refreshMode: "background",
+        }),
     ),
-  );
+  });
+  const summaries = summariesResult.results;
   const dailyByDate = new Map<string, CostUsageTotals & { date: string }>();
   const totals = createEmptyCostUsageTotals();
   let cacheStatus: UsageCacheStatus | undefined;


### PR DESCRIPTION
## What Problem This Solves

Fixes #101552: `Promise.all` over all agent usage queries created an unbounded array of concurrent database operations. For deployments with 100+ agents, this instantly saturated the SQLite WAL lock and connection pool, causing `SQLITE_BUSY` timeouts or memory spikes when the usage dashboard loaded.

## Why This Change Was Made

Replaced `Promise.all` with `runTasksWithConcurrency({ limit: 8 })` to cap simultaneous usage queries against the shared state database. This prevents SQLite starvation while keeping dashboard load times reasonable.

## User Impact

- Large multi-agent deployments no longer crash or timeout when opening the usage dashboard
- Dashboard load time slightly increases for very large agent counts (expected and acceptable)

## Evidence

- [x] `pnpm test src/gateway/server-methods/usage.test.ts` — 60 tests pass
- [x] `oxlint` passes
- [x] `runTasksWithConcurrency` is already imported and used elsewhere in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
