### PR TITLE
refactor(memory): remove unused runtime facade exports

### DIFF
--- a/packages/memory-host-sdk/src/host/openclaw-runtime-io.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-io.ts
@@ -2,9 +2,6 @@
 
 export {
   CHARS_PER_TOKEN_ESTIMATE,
-  DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES,
-  DEFAULT_SQLITE_WAL_CHECKPOINT_INTERVAL_MS,
-  DEFAULT_SQLITE_WAL_TRUNCATE_INTERVAL_MS,
   applyWindowsSpawnProgramPolicy,
   configureSqliteConnectionPragmas,
   configureSqliteWalMaintenance,

--- a/packages/memory-host-sdk/src/host/openclaw-runtime-session.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-session.ts
@@ -3,8 +3,6 @@ import path from "node:path";
 
 export {
   canonicalizeMainSessionAlias,
-  clearConfigCache,
-  clearRuntimeConfigSnapshot,
   getRuntimeConfig,
   HEARTBEAT_PROMPT,
   HEARTBEAT_TOKEN,

--- a/packages/memory-host-sdk/src/host/openclaw-runtime.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime.ts
@@ -42,8 +42,6 @@ export { parseDurationMs } from "../../../../src/cli/parse-duration.js";
 export { withProgress, withProgressTotals } from "../../../../src/cli/progress.js";
 export { parseNonNegativeByteSize } from "../../../../src/config/byte-size.js";
 export {
-  clearConfigCache,
-  clearRuntimeConfigSnapshot,
   getRuntimeConfig,
   /** @deprecated Use getRuntimeConfig(), or pass the already loaded config through the call path. */
   loadConfig,
@@ -88,9 +86,6 @@ export { fetchWithSsrFGuard } from "../../../../src/infra/net/fetch-guard.js";
 export { shouldUseEnvHttpProxyForUrl } from "../../../../src/infra/net/proxy-env.js";
 export { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "../../../../src/infra/net/ssrf.js";
 export {
-  DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES,
-  DEFAULT_SQLITE_WAL_CHECKPOINT_INTERVAL_MS,
-  DEFAULT_SQLITE_WAL_TRUNCATE_INTERVAL_MS,
   configureSqliteConnectionPragmas,
   configureSqliteWalMaintenance,
 } from "../../../../src/infra/sqlite-wal.js";

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -2,8 +2,11 @@
 import fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { clearConfigCache, clearRuntimeConfigSnapshot } from "./openclaw-runtime-session.js";
 import {
   buildSessionEntry,
   listSessionFilesForAgent,

--- a/packages/memory-host-sdk/src/host/sqlite-wal.ts
+++ b/packages/memory-host-sdk/src/host/sqlite-wal.ts
@@ -1,9 +1,6 @@
 // Public SQLite WAL maintenance facade for memory database callers.
 
 export {
-  DEFAULT_SQLITE_WAL_AUTOCHECKPOINT_PAGES,
-  DEFAULT_SQLITE_WAL_CHECKPOINT_INTERVAL_MS,
-  DEFAULT_SQLITE_WAL_TRUNCATE_INTERVAL_MS,
   configureSqliteConnectionPragmas,
   configureSqliteWalMaintenance,
 } from "./openclaw-runtime-io.js";


### PR DESCRIPTION
## What Problem This Solves

The private memory host SDK retained runtime facade exports that had no production consumers. Config reset helpers were also routed through the session facade solely for one package-local test.

## Why This Change Was Made

Remove the unused SQLite WAL default and config reset re-exports. The package test now imports config reset helpers from the existing public runtime-config snapshot SDK subpath.

## User Impact

No user-visible behavior changes. The private memory host bridge exposes fewer unused core symbols and keeps test-only reset access on its canonical SDK seam.

## Evidence

- `pnpm check:changed` passed in Blacksmith Testbox `tbx_01kwy1zzdzt1wns6venftmwqxe`.
- Focused Testbox proof passed twice after live `main` rebases: 38 session-file tests and 8 package-boundary contract tests.
- `oxfmt --check` passed for all five changed files.
- Two fresh Codex autoreviews reported no actionable findings, each at 0.86 confidence.
- `git diff --check` passed.

AI-assisted: yes. The implementation and validation evidence were reviewed before submission; transcript attachment was declined.
