### PR TITLE
fix(msteams): bound User Token service JSON response reads to prevent OOM

### DIFF
--- a/extensions/msteams/src/monitor-handler.sso.test.ts
+++ b/extensions/msteams/src/monitor-handler.sso.test.ts
@@ -156,6 +156,27 @@ describe("handleSigninTokenExchangeInvoke", () => {
     }
     expect(calls).toHaveLength(0);
   });
+
+  it("returns error when User Token service returns malformed JSON", async () => {
+    const fetchImpl: MSTeamsSsoFetch = async () => {
+      return new Response("not-valid-json", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const { sso } = createSsoDeps({ fetchImpl });
+
+    const result = await handleSigninTokenExchangeInvoke({
+      value: { id: "flow-1", connectionName: "GraphConnection", token: "exchangeable-token" },
+      user: { userId: "aad-user-guid", channelId: "msteams" },
+      deps: sso,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.message).toContain("invalid JSON from User Token service");
+    }
+  });
 });
 
 describe("handleSigninVerifyStateInvoke", () => {

--- a/extensions/msteams/src/sso.ts
+++ b/extensions/msteams/src/sso.ts
@@ -24,6 +24,7 @@
  * that ack; these helpers encapsulate token exchange and persistence.
  */
 
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import type { MSTeamsAccessTokenProvider } from "./attachments/types.js";
 import { readMSTeamsHttpErrorDetail } from "./http-error.js";
 import type { MSTeamsSsoTokenStore } from "./sso-token-store.js";
@@ -130,7 +131,7 @@ async function callUserTokenService(
   }
   let parsed: unknown;
   try {
-    parsed = await response.json();
+    parsed = await readProviderJsonResponse(response, "msteams.sso-user-token");
   } catch {
     return { error: "invalid JSON from User Token service", status: response.status };
   }


### PR DESCRIPTION
Related: #95218, #96322, #96495, #96889

## What Problem This Solves

Fixes an issue where the MSTeams SSO `callUserTokenService` path uses
unbounded `response.json()` to parse the Bot Framework User Token
service authorization success body. A misbehaving, compromised, or
self-hosted User Token service endpoint can stream an arbitrarily
large JSON response, causing the gateway process to buffer it all
into memory — leading to memory pressure or OOM on the Teams SSO
token-exchange path.

The shared bounded JSON reader (#95218) already covers the main
provider pipeline, image generation (#96495), video generation
(#96889), and the MiniMax OAuth path (#96322). The MSTeams SSO User
Token service call was missed in those rounds and is closed here.

## Why This Change Was Made

Replace `response.json()` with
`readProviderJsonResponse(response, "msteams.sso-user-token")` —
the same shared helper already used across the codebase. This
enforces a **16 MiB default cap** and, on overflow, cancels the
underlying stream and throws a bounded error
(`msteams.sso-user-token: JSON response exceeds 16777216 bytes`).
Malformed-JSON error messages are preserved for backward
compatibility.

No new abstraction — reuses the existing `plugin-sdk` bounded reader.
The error-response path (`readMSTeamsHttpErrorDetail`) already used
the bounded `extractProviderErrorDetail` helper and is unchanged.

## User Impact

No user-visible impact for normal operation. Operators who configure
MSTeams SSO against a self-hosted or proxied User Token service
endpoint are now protected against oversized authorization responses
instead of silently buffering them unbounded.

## Evidence

### Unit tests

The in-repo Vitest suite for the MSTeams SSO handler passes in full
(6/6), covering the happy path, HTTP service errors, missing-user
rejection, and the new malformed-JSON error path.

```
 ✓ extensions/msteams/src/monitor-handler.sso.test.ts (6 tests) 76ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
```

### Error response path already bounded

`readMSTeamsHttpErrorDetail` (called on non-OK responses) delegates
to `extractProviderErrorDetail` from `plugin-sdk/provider-http`,
which uses the same bounded reader.

### L2 — Real behavior proof: oversized JSON capped at 16 MiB

A proof script (`evidence/pr-101585/oversized-json-proof.ts`) exercises
the exact `readProviderJsonResponse` call used in this fix with a
16.96 MiB JSON payload (well over the 16 MiB `PROVIDER_JSON_RESPONSE_MAX_BYTES`
default) to confirm the bounded reader cancels the stream before
buffering the full response.

```
Oversized JSON payload: 16.96 MiB (17784699 bytes, 139811 entries)

========== AFTER FIX: readProviderJsonResponse ==========
✅ PASS: bounded reader rejected oversized JSON in 7.1 ms
   → Error: msteams.sso-user-token: JSON response exceeds 16777216 bytes

========== BEFORE FIX: response.json() ==========
response.json() buffered 16.96 MiB successfully in 51.9 ms
   → Parsed 139811 entries — no byte cap, full buffering
   ❌ RISK: a malicious or compromised User Token service can stream
      unlimited data, causing memory pressure / OOM on the gateway.
```

**Result**: After this fix, an oversized User Token service JSON response
is detected at 16 MiB and the underlying stream is cancelled immediately
(7.1 ms). Before this fix, `response.json()` would buffer the entire
untrusted payload uncontested (51.9 ms for 16.96 MiB; no upper bound).

### What was not tested

- End-to-end integration against a live Bot Framework User Token service
  endpoint (requires AAD app registration and Teams client context).
- The `handleSigninVerifyStateInvoke` path — it calls the same
  `callUserTokenService` helper and is covered by the same
  `readProviderJsonResponse` swap; the regression test focuses on
  `handleSigninTokenExchangeInvoke` as the more exercised code path.

AI-assisted.
