### PR TITLE
fix(agents): clean up ls cancellation listeners

### DIFF
--- a/src/agents/sessions/tools/ls.test.ts
+++ b/src/agents/sessions/tools/ls.test.ts
@@ -1,6 +1,6 @@
 // ls tool tests cover deterministic directory listings and safe limit
 // normalization for agent-visible file enumeration.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createLsToolDefinition, type LsOperations } from "./ls.js";
 
 function operations(entries: string[]): LsOperations {
@@ -18,6 +18,18 @@ function textContent(
 ): string {
   const first = result.content[0];
   return first?.type === "text" ? (first.text ?? "") : "";
+}
+
+function trackAbortListener(signal: AbortSignal) {
+  const add = vi.spyOn(signal, "addEventListener");
+  const remove = vi.spyOn(signal, "removeEventListener");
+  return {
+    expectReleased() {
+      const listener = add.mock.calls.find(([type]) => type === "abort")?.[1];
+      expect(listener).toBeDefined();
+      expect(remove).toHaveBeenCalledWith("abort", listener);
+    },
+  };
 }
 
 describe("ls tool", () => {
@@ -50,5 +62,75 @@ describe("ls tool", () => {
 
     expect(textContent(result)).toBe("alpha.txt\nbeta.txt");
     expect(result.details).toBeUndefined();
+  });
+
+  it.each([
+    {
+      name: "missing path",
+      operations: { ...operations([]), exists: () => false },
+      error: "Path not found: /workspace",
+    },
+    {
+      name: "non-directory path",
+      operations: {
+        ...operations([]),
+        stat: () => ({ isDirectory: () => false }),
+      },
+      error: "Not a directory: /workspace",
+    },
+    {
+      name: "directory read failure",
+      operations: {
+        ...operations([]),
+        readdir: () => {
+          throw new Error("permission denied");
+        },
+      },
+      error: "Cannot read directory: permission denied",
+    },
+  ])("releases the abort listener after $name", async ({ operations: ops, error }) => {
+    const tool = createLsToolDefinition("/workspace", { operations: ops });
+    const controller = new AbortController();
+    const listener = trackAbortListener(controller.signal);
+
+    await expect(
+      tool.execute("call-1", {}, controller.signal, undefined, {} as never),
+    ).rejects.toThrow(error);
+
+    listener.expectReleased();
+  });
+
+  it("releases the abort listener after success", async () => {
+    const tool = createLsToolDefinition("/workspace", { operations: operations(["alpha.txt"]) });
+    const controller = new AbortController();
+    const listener = trackAbortListener(controller.signal);
+
+    await expect(
+      tool.execute("call-1", {}, controller.signal, undefined, {} as never),
+    ).resolves.toBeDefined();
+
+    listener.expectReleased();
+  });
+
+  it("settles once and releases the listener when aborted during an operation", async () => {
+    let finishExists: (() => void) | undefined;
+    const tool = createLsToolDefinition("/workspace", {
+      operations: {
+        ...operations([]),
+        exists: () =>
+          new Promise<boolean>((resolve) => {
+            finishExists = () => resolve(true);
+          }),
+      },
+    });
+    const controller = new AbortController();
+    const listener = trackAbortListener(controller.signal);
+    const result = tool.execute("call-1", {}, controller.signal, undefined, {} as never);
+
+    controller.abort();
+
+    await expect(result).rejects.toThrow("Operation aborted");
+    listener.expectReleased();
+    finishExists?.();
   });
 });

--- a/src/agents/sessions/tools/ls.ts
+++ b/src/agents/sessions/tools/ls.ts
@@ -117,110 +117,118 @@ export function createLsToolDefinition(
       void toolCallId;
       void onUpdate;
       void ctx;
-      return new Promise((resolve, reject) => {
-        if (signal?.aborted) {
-          reject(new Error("Operation aborted"));
-          return;
-        }
+      if (signal?.aborted) {
+        throw new Error("Operation aborted");
+      }
 
-        const onAbort = () => reject(new Error("Operation aborted"));
-        signal?.addEventListener("abort", onAbort, { once: true });
+      const runListing = async () => {
+        try {
+          const dirPath = resolveToCwd(path || ".", cwd);
+          const effectiveLimit = normalizePositiveLimit(limit, DEFAULT_LIMIT);
 
-        void (async () => {
-          try {
-            const dirPath = resolveToCwd(path || ".", cwd);
-            const effectiveLimit = normalizePositiveLimit(limit, DEFAULT_LIMIT);
-
-            // Check if path exists.
-            if (!(await ops.exists(dirPath))) {
-              reject(new Error(`Path not found: ${dirPath}`));
-              return;
-            }
-
-            // Check if path is a directory.
-            const stat = await ops.stat(dirPath);
-            if (!stat.isDirectory()) {
-              reject(new Error(`Not a directory: ${dirPath}`));
-              return;
-            }
-
-            // Read directory entries.
-            let entries: string[];
-            try {
-              entries = await ops.readdir(dirPath);
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error);
-              reject(new Error(`Cannot read directory: ${message}`));
-              return;
-            }
-
-            // Sort alphabetically, case-insensitive.
-            entries.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
-
-            // Format entries with directory indicators.
-            const results: string[] = [];
-            let entryLimitReached = false;
-            for (const entry of entries) {
-              if (results.length >= effectiveLimit) {
-                entryLimitReached = true;
-                break;
-              }
-
-              const fullPath = nodePath.join(dirPath, entry);
-              let suffix = "";
-              try {
-                const entryStat = await ops.stat(fullPath);
-                if (entryStat.isDirectory()) {
-                  suffix = "/";
-                }
-              } catch {
-                // Skip entries we cannot stat.
-                continue;
-              }
-              results.push(entry + suffix);
-            }
-
-            signal?.removeEventListener("abort", onAbort);
-
-            if (results.length === 0) {
-              resolve({
-                content: [{ type: "text", text: "(empty directory)" }],
-                details: undefined,
-              });
-              return;
-            }
-
-            const rawOutput = results.join("\n");
-            // Apply byte truncation. There is no separate line limit because entry count is already capped.
-            const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
-            let output = truncation.content;
-            const details: LsToolDetails = {};
-            // Build actionable notices for truncation and entry limits.
-            const notices: string[] = [];
-            if (entryLimitReached) {
-              notices.push(
-                `${effectiveLimit} entries limit reached. Use limit=${effectiveLimit * 2} for more`,
-              );
-              details.entryLimitReached = effectiveLimit;
-            }
-            if (truncation.truncated) {
-              notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
-              details.truncation = truncation;
-            }
-            if (notices.length > 0) {
-              output += `\n\n[${notices.join(". ")}]`;
-            }
-
-            resolve({
-              content: [{ type: "text", text: output }],
-              details: Object.keys(details).length > 0 ? details : undefined,
-            });
-          } catch (e: unknown) {
-            signal?.removeEventListener("abort", onAbort);
-            reject(toErrorObject(e, "Non-Error rejection"));
+          // Check if path exists.
+          if (!(await ops.exists(dirPath))) {
+            throw new Error(`Path not found: ${dirPath}`);
           }
-        })();
+
+          // Check if path is a directory.
+          const stat = await ops.stat(dirPath);
+          if (!stat.isDirectory()) {
+            throw new Error(`Not a directory: ${dirPath}`);
+          }
+
+          // Read directory entries.
+          let entries: string[];
+          try {
+            entries = await ops.readdir(dirPath);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            throw new Error(`Cannot read directory: ${message}`, { cause: error });
+          }
+
+          // Sort alphabetically, case-insensitive.
+          entries.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+
+          // Format entries with directory indicators.
+          const results: string[] = [];
+          let entryLimitReached = false;
+          for (const entry of entries) {
+            if (results.length >= effectiveLimit) {
+              entryLimitReached = true;
+              break;
+            }
+
+            const fullPath = nodePath.join(dirPath, entry);
+            let suffix = "";
+            try {
+              const entryStat = await ops.stat(fullPath);
+              if (entryStat.isDirectory()) {
+                suffix = "/";
+              }
+            } catch {
+              // Skip entries we cannot stat.
+              continue;
+            }
+            results.push(entry + suffix);
+          }
+
+          if (results.length === 0) {
+            return {
+              content: [{ type: "text" as const, text: "(empty directory)" }],
+              details: undefined,
+            };
+          }
+
+          const rawOutput = results.join("\n");
+          // Apply byte truncation. There is no separate line limit because entry count is already capped.
+          const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
+          let output = truncation.content;
+          const details: LsToolDetails = {};
+          // Build actionable notices for truncation and entry limits.
+          const notices: string[] = [];
+          if (entryLimitReached) {
+            notices.push(
+              `${effectiveLimit} entries limit reached. Use limit=${effectiveLimit * 2} for more`,
+            );
+            details.entryLimitReached = effectiveLimit;
+          }
+          if (truncation.truncated) {
+            notices.push(`${formatSize(DEFAULT_MAX_BYTES)} limit reached`);
+            details.truncation = truncation;
+          }
+          if (notices.length > 0) {
+            output += `\n\n[${notices.join(". ")}]`;
+          }
+
+          return {
+            content: [{ type: "text" as const, text: output }],
+            details: Object.keys(details).length > 0 ? details : undefined,
+          };
+        } catch (e: unknown) {
+          throw toErrorObject(e, "Non-Error rejection");
+        }
+      };
+
+      if (!signal) {
+        return await runListing();
+      }
+
+      // Race the listing with cancellation, but always detach the listener when either wins.
+      let onAbort: (() => void) | undefined;
+      const abortPromise = new Promise<never>((_resolve, reject) => {
+        onAbort = () => reject(new Error("Operation aborted"));
+        signal.addEventListener("abort", onAbort, { once: true });
+        if (signal.aborted) {
+          onAbort();
+        }
       });
+      try {
+        return await Promise.race([runListing(), abortPromise]);
+      } finally {
+        if (onAbort) {
+          signal.removeEventListener("abort", onAbort);
+        }
+      }
     },
     renderCall(args, theme, context) {
       const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);


### PR DESCRIPTION
## What Problem This Solves

The `ls` agent tool retained its abort listener on missing paths, non-directory paths, and directory-read failures. The original fix in #101514 covered those exits but left cancellation cleanup spread across multiple branches.

Related: #101514

## Why This Change Was Made

Run directory listing and cancellation as two promises with one `finally` cleanup owner. This removes branch-specific listener management, preserves underlying read errors as causes, and keeps the original contributor's fix while avoiding the fork's stale-main ancestry.

## User Impact

Repeated failed or cancelled `ls` tool calls no longer retain abort listeners. In-flight cancellation still rejects promptly.

## Evidence

- Blacksmith Testbox `tbx_01kwy2be4afvagx8aebrr9sc9b`: focused `ls` suite, 7/7 passing.
- Same Testbox: broad `check:changed` passed, including core and test typechecks, all core lint shards, and repository guards.
- GitHub Actions run 28860470237 passed for the identical two-file tree before the clean ancestry replacement.
- Fresh autoreview after the final type/lint correction: no actionable findings, correctness 0.92.

Co-authored-by: 0668001336 <wang.lizhang@xydigit.com>
