### PR TITLE
fix(gateway): bound all-agent usage cache concurrency

### DIFF
--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -520,22 +520,35 @@ describe("gateway usage helpers", () => {
     });
   });
 
-  it("usage.cost all-agent scope bounds concurrency to COST_USAGE_AGENT_LOAD_CONCURRENCY", async () => {
-    const agentCount = 25;
+  it("bounds usage.cost all-agent cache loads", async () => {
+    const agentCount = 13;
     const concurrencyLimit = 12;
+    let releaseLoads!: () => void;
+    const loadsReleased = new Promise<void>((resolve) => {
+      releaseLoads = resolve;
+    });
+    let resolveFirstBatchStarted!: () => void;
+    const firstBatchStarted = new Promise<void>((resolve) => {
+      resolveFirstBatchStarted = resolve;
+    });
+    let started = 0;
     let inFlight = 0;
     let peakInFlight = 0;
 
     vi.mocked(loadCostUsageSummaryFromCache).mockImplementation(async () => {
-      inFlight++;
+      started += 1;
+      inFlight += 1;
       peakInFlight = Math.max(peakInFlight, inFlight);
-      await new Promise<void>((r) => { setTimeout(r, 0); });
-      inFlight--;
+      if (started === concurrencyLimit) {
+        resolveFirstBatchStarted();
+      }
+      await loadsReleased;
+      inFlight -= 1;
       return costSummary({ totalTokens: 1, totalCost: 0 });
     });
 
     const respond = vi.fn();
-    await usageHandlers["usage.cost"]({
+    const request = usageHandlers["usage.cost"]({
       respond,
       params: { startDate: "2026-02-01", endDate: "2026-02-02", agentScope: "all" },
       context: {
@@ -547,8 +560,14 @@ describe("gateway usage helpers", () => {
       },
     } as unknown as Parameters<(typeof usageHandlers)["usage.cost"]>[0]);
 
-    expect(peakInFlight).toBeLessThanOrEqual(concurrencyLimit);
-    expect(peakInFlight).toBe(concurrencyLimit);
+    await firstBatchStarted;
+    const startedBeforeRelease = started;
+    const peakBeforeRelease = peakInFlight;
+    releaseLoads();
+    await request;
+
+    expect(startedBeforeRelease).toBe(concurrencyLimit);
+    expect(peakBeforeRelease).toBe(concurrencyLimit);
     expect(respond).toHaveBeenCalledWith(
       true,
       expect.objectContaining({

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -519,4 +519,42 @@ describe("gateway usage helpers", () => {
       totals: { totalTokens: 10, totalCost: 1 },
     });
   });
+
+  it("usage.cost all-agent scope bounds concurrency to COST_USAGE_AGENT_LOAD_CONCURRENCY", async () => {
+    const agentCount = 25;
+    const concurrencyLimit = 12;
+    let inFlight = 0;
+    let peakInFlight = 0;
+
+    vi.mocked(loadCostUsageSummaryFromCache).mockImplementation(async () => {
+      inFlight++;
+      peakInFlight = Math.max(peakInFlight, inFlight);
+      await new Promise<void>((r) => { setTimeout(r, 0); });
+      inFlight--;
+      return costSummary({ totalTokens: 1, totalCost: 0 });
+    });
+
+    const respond = vi.fn();
+    await usageHandlers["usage.cost"]({
+      respond,
+      params: { startDate: "2026-02-01", endDate: "2026-02-02", agentScope: "all" },
+      context: {
+        getRuntimeConfig: () => ({
+          agents: {
+            list: Array.from({ length: agentCount }, (_, i) => ({ id: `agent-${i}` })),
+          },
+        }),
+      },
+    } as unknown as Parameters<(typeof usageHandlers)["usage.cost"]>[0]);
+
+    expect(peakInFlight).toBeLessThanOrEqual(concurrencyLimit);
+    expect(peakInFlight).toBe(concurrencyLimit);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        totals: expect.objectContaining({ totalTokens: agentCount }),
+      }),
+      undefined,
+    );
+  });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -65,6 +65,7 @@ import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 const COST_USAGE_CACHE_TTL_MS = 30_000;
 const COST_USAGE_CACHE_MAX = 256;
 const SESSIONS_USAGE_AGENT_LOAD_CONCURRENCY = 12;
+const COST_USAGE_AGENT_LOAD_CONCURRENCY = 12;
 
 type DateRange = { startMs: number; endMs: number };
 // Keep validation and parsed timestamps in one result so handlers cannot forward
@@ -864,19 +865,26 @@ async function loadAllAgentCostUsageSummary(params: {
   const agentIds = listAgentsForGateway(params.config).agents.map((agent) =>
     normalizeAgentId(agent.id),
   );
-  const summaries = await Promise.all(
-    agentIds.map((agentId) =>
-      loadCostUsageSummaryFromCache({
-        startMs: params.startMs,
-        endMs: params.endMs,
-        dailyUtcOffsetMinutes: params.dailyUtcOffsetMinutes,
-        config: params.config,
-        agentId,
-        requestRefresh: true,
-        refreshMode: "background",
-      }),
+  const agentLoadResult = await runTasksWithConcurrency({
+    tasks: agentIds.map(
+      (agentId) => () =>
+        loadCostUsageSummaryFromCache({
+          startMs: params.startMs,
+          endMs: params.endMs,
+          dailyUtcOffsetMinutes: params.dailyUtcOffsetMinutes,
+          config: params.config,
+          agentId,
+          requestRefresh: true,
+          refreshMode: "background",
+        }),
     ),
-  );
+    limit: COST_USAGE_AGENT_LOAD_CONCURRENCY,
+    errorMode: "stop",
+  });
+  if (agentLoadResult.hasError) {
+    throw agentLoadResult.firstError;
+  }
+  const summaries = agentLoadResult.results;
   const dailyByDate = new Map<string, CostUsageTotals & { date: string }>();
   const totals = createEmptyCostUsageTotals();
   let cacheStatus: UsageCacheStatus | undefined;

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -64,8 +64,7 @@ import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
 const COST_USAGE_CACHE_MAX = 256;
-const SESSIONS_USAGE_AGENT_LOAD_CONCURRENCY = 12;
-const COST_USAGE_AGENT_LOAD_CONCURRENCY = 12;
+const USAGE_AGENT_LOAD_CONCURRENCY = 12;
 
 type DateRange = { startMs: number; endMs: number };
 // Keep validation and parsed timestamps in one result so handlers cannot forward
@@ -878,7 +877,7 @@ async function loadAllAgentCostUsageSummary(params: {
           refreshMode: "background",
         }),
     ),
-    limit: COST_USAGE_AGENT_LOAD_CONCURRENCY,
+    limit: USAGE_AGENT_LOAD_CONCURRENCY,
     errorMode: "stop",
   });
   if (agentLoadResult.hasError) {
@@ -1288,7 +1287,7 @@ export const usageHandlers: GatewayRequestHandlers = {
           dailyUtcOffsetMinutes,
         }),
       })),
-      limit: SESSIONS_USAGE_AGENT_LOAD_CONCURRENCY,
+      limit: USAGE_AGENT_LOAD_CONCURRENCY,
       errorMode: "stop",
     });
     if (agentLoadResult.hasError) {


### PR DESCRIPTION
## What Problem This Solves

`usage.cost` with `agentScope: "all"` started one usage-cost cache load for
every configured agent through an unbounded `Promise.all`. Large multi-agent
deployments could therefore multiply cache reads, transcript enumeration, and
background refresh work at once.

Fixes #101552.

## Why This Change Was Made

- The sibling `sessions.usage` path already bounds the same class of per-agent
  usage-cache work.
- Both paths now share `USAGE_AGENT_LOAD_CONCURRENCY = 12`.
- `errorMode: "stop"` plus rethrowing `firstError` preserves the original
  `Promise.all` failure behavior.
- The handler remains the correct owner boundary because it creates the
  all-agent fan-out.

The issue originally described SQLite connection-pool starvation. Direct
inspection of `loadCostUsageSummaryFromCache` shows filesystem-backed usage
cache and transcript work instead, so this PR intentionally uses the narrower
source-backed wording.

## User Impact

- All-agent cost reports still include every configured agent and preserve the
  same aggregation result.
- No more than 12 per-agent cache loads run concurrently.
- A failed per-agent load still fails the request instead of returning partial
  totals.
- No configuration, API, or persisted-data shape changes.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-methods/usage.test.ts`
  (2 files, 62 tests passed)
- `node scripts/run-oxlint.mjs src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.test.ts`
- `./node_modules/.bin/oxfmt --check src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.test.ts`
- `git diff --check`
- Blacksmith Testbox `tbx_01kwyrv80bmm6hxj5xxyyatsdb`:
  `pnpm check:changed` passed
- Fresh branch autoreview found no actionable issues

The regression test uses a deterministic promise gate. It proves that only 12
of 13 configured agent loads start before release, then verifies all 13 totals
are aggregated after the gate opens.
