### PR TITLE
fix(file-transfer): handle child output stream errors

### DIFF
--- a/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
@@ -1,4 +1,5 @@
 // File Transfer tests cover dir fetch child-output failures.
+import crypto from "node:crypto";
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -49,9 +50,9 @@ describe("dir.fetch child output lifecycle", () => {
   it.runIf(process.platform !== "win32")(
     "returns READ_ERROR when real tar archive stdout fails",
     async () => {
-      const tmpRoot = await fs.realpath(
-        await fs.mkdtemp(path.join(os.tmpdir(), "dir-fetch-stream-error-")),
-      );
+      const tempPath = path.join(os.tmpdir(), `dir-fetch-stream-error-${crypto.randomUUID()}`);
+      await fs.mkdir(tempPath);
+      const tmpRoot = await fs.realpath(tempPath);
       await fs.writeFile(path.join(tmpRoot, "payload.bin"), Buffer.alloc(1024 * 1024, 1));
       vi.resetModules();
       vi.doMock("node:child_process", async (importOriginal) => {

--- a/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.stream-errors.test.ts
@@ -1,0 +1,128 @@
+// File Transfer tests cover dir fetch child-output failures.
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type MockChild = EventEmitter & {
+  kill: ReturnType<typeof vi.fn>;
+  stderr: EventEmitter;
+  stdin: EventEmitter & { end: () => void };
+  stdout: EventEmitter;
+};
+
+function mockSpawn(script: (child: MockChild) => void, startOnStdin = false) {
+  return vi.fn(() => {
+    const child = new EventEmitter() as MockChild;
+    child.kill = vi.fn();
+    child.stderr = new EventEmitter();
+    child.stdin = new EventEmitter() as MockChild["stdin"];
+    child.stdout = new EventEmitter();
+    child.stdin.end = () => {
+      if (startOnStdin) {
+        queueMicrotask(() => script(child));
+      }
+    };
+    if (!startOnStdin) {
+      queueMicrotask(() => script(child));
+    }
+    return child;
+  });
+}
+
+async function importWithSpawn(spawnMock: ReturnType<typeof vi.fn>) {
+  vi.resetModules();
+  vi.doMock("node:child_process", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("node:child_process")>();
+    return { ...actual, spawn: spawnMock };
+  });
+  return await import("./dir-fetch.js");
+}
+
+afterEach(() => {
+  vi.doUnmock("node:child_process");
+  vi.resetModules();
+});
+
+describe("dir.fetch child output lifecycle", () => {
+  it.runIf(process.platform !== "win32")(
+    "returns READ_ERROR when real tar archive stdout fails",
+    async () => {
+      const tmpRoot = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "dir-fetch-stream-error-")),
+      );
+      await fs.writeFile(path.join(tmpRoot, "payload.bin"), Buffer.alloc(1024 * 1024, 1));
+      vi.resetModules();
+      vi.doMock("node:child_process", async (importOriginal) => {
+        const actual = await importOriginal<typeof import("node:child_process")>();
+        return {
+          ...actual,
+          spawn: vi.fn(
+            (
+              command: string,
+              args: readonly string[],
+              options: Parameters<typeof actual.spawn>[2],
+            ) => {
+              const child = actual.spawn(command, [...args], options);
+              if (command === "/usr/bin/tar" && args[0] === "-czf") {
+                const stdout = child.stdout;
+                if (!stdout) {
+                  throw new Error("expected piped tar stdout");
+                }
+                queueMicrotask(() => stdout.destroy(new Error("injected archive read failure")));
+              }
+              return child;
+            },
+          ),
+        };
+      });
+
+      try {
+        const { handleDirFetch } = await import("./dir-fetch.js");
+        await expect(handleDirFetch({ path: tmpRoot })).resolves.toMatchObject({
+          ok: false,
+          code: "READ_ERROR",
+          message: "tar command failed",
+        });
+      } finally {
+        await fs.rm(tmpRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("stops a broken du read and falls back to capped tar", async () => {
+    const spawnMock = mockSpawn((child) => {
+      child.stdout.emit("error", new Error("du read failed"));
+      child.emit("close", 0);
+    });
+    const { testing } = await importWithSpawn(spawnMock);
+
+    await expect(testing.preflightDu("/tmp/project", 1024)).resolves.toBe(true);
+    expect(spawnMock.mock.results[0]?.value.kill).toHaveBeenCalledOnce();
+  });
+
+  it("fails tar entry listing closed on stdout errors", async () => {
+    const spawnMock = mockSpawn((child) => {
+      child.stdout.emit("data", Buffer.from("partial.txt\n"));
+      child.stdout.emit("error", new Error("listing read failed"));
+      child.emit("close", 0);
+    }, true);
+    const { testing } = await importWithSpawn(spawnMock);
+
+    await expect(testing.listTarEntries(Buffer.from("archive"))).resolves.toBeNull();
+    expect(spawnMock.mock.results[0]?.value.kill).toHaveBeenCalledOnce();
+  });
+
+  it("fails archive creation closed on stdout errors", async () => {
+    const spawnMock = mockSpawn((child) => {
+      child.stdout.emit("data", Buffer.from("partial archive"));
+      child.stdout.emit("error", new Error("archive read failed"));
+      child.emit("close", 0);
+    });
+    const { testing } = await importWithSpawn(spawnMock);
+
+    await expect(testing.createTarArchive("/tmp/project", 1024)).resolves.toBe("ERROR");
+    expect(spawnMock.mock.results[0]?.value.kill).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/file-transfer/src/node-host/dir-fetch.ts
+++ b/extensions/file-transfer/src/node-host/dir-fetch.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import crypto from "node:crypto";
 import path from "node:path";
 import { root as fsRoot } from "openclaw/plugin-sdk/security-runtime";
+import { consumeChildOutput } from "../shared/child-output.js";
 import {
   classifyFsSafeReadError,
   readAbsolutePath,
@@ -75,82 +76,188 @@ async function preflightDu(dirPath: string, maxBytes: number): Promise<boolean> 
   return new Promise((resolve) => {
     const du = spawn("du", ["-sk", dirPath], { stdio: ["ignore", "pipe", "ignore"] });
     let output = "";
-    du.stdout.on("data", (chunk: Buffer) => {
-      output += chunk.toString();
+    let settled = false;
+    const finish = (withinBudget: boolean): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(withinBudget);
+    };
+    const stopChild = (): void => {
+      try {
+        du.kill("SIGKILL");
+      } catch {
+        /* gone */
+      }
+    };
+    consumeChildOutput(du.stdout, {
+      onData: (chunk) => {
+        output += chunk.toString();
+      },
+      onError: () => {
+        // `du` is an optional heuristic. Stop this broken read and let the
+        // capped tar stream remain authoritative rather than crashing host.
+        stopChild();
+        finish(true);
+      },
     });
     du.on("close", (code) => {
       if (code !== 0) {
         // du failed; be permissive and let tar catch the overflow
-        resolve(true);
+        finish(true);
         return;
       }
       const match = /^(\d+)/.exec(output.trim());
       if (!match) {
-        resolve(true);
+        finish(true);
         return;
       }
       const sizeKb = Number.parseInt(match[1], 10);
-      resolve(sizeKb <= heuristicKb);
+      finish(sizeKb <= heuristicKb);
     });
     du.on("error", () => {
       // du not available; skip preflight
-      resolve(true);
+      finish(true);
     });
   });
 }
 
-async function listTarEntries(tarBuffer: Buffer): Promise<string[]> {
+async function listTarEntries(tarBuffer: Buffer): Promise<string[] | null> {
   // Async spawn so a slow `tar -tzf` doesn't park the node-host event
   // loop for up to 10s. Other in-flight requests continue to be served.
-  return new Promise<string[]>((resolve) => {
+  return new Promise<string[] | null>((resolve) => {
     const child = spawn("tar", ["-tzf", "-"], { stdio: ["pipe", "pipe", "ignore"] });
     let stdoutBuf = "";
-    let aborted = false;
-    const watchdog = setTimeout(() => {
-      aborted = true;
+    let settled = false;
+    const finish = (entries: string[] | null): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(watchdog);
+      resolve(entries);
+    };
+    const stopChild = (): void => {
       try {
         child.kill("SIGKILL");
       } catch {
         /* gone */
       }
-      resolve([]);
+    };
+    const watchdog = setTimeout(() => {
+      stopChild();
+      finish(null);
     }, 10_000);
-    child.stdout.on("data", (chunk: Buffer) => {
-      stdoutBuf += chunk.toString();
-      // Bound buffer growth — pathological archives shouldn't OOM us.
-      if (stdoutBuf.length > 32 * 1024 * 1024) {
-        aborted = true;
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          /* gone */
+    consumeChildOutput(child.stdout, {
+      onData: (chunk) => {
+        if (settled) {
+          return;
         }
-        clearTimeout(watchdog);
-        resolve([]);
-      }
+        stdoutBuf += chunk.toString();
+        // Bound buffer growth — pathological archives shouldn't OOM us.
+        if (stdoutBuf.length > 32 * 1024 * 1024) {
+          stopChild();
+          finish(null);
+        }
+      },
+      onError: () => {
+        stopChild();
+        finish(null);
+      },
     });
     child.on("close", (code) => {
-      clearTimeout(watchdog);
-      if (aborted) {
+      if (settled) {
         return;
       }
       if (code !== 0) {
-        resolve([]);
+        finish(null);
         return;
       }
       const lines = stdoutBuf
         .split("\n")
         .map((line) => line.replace(/\\/gu, "/").replace(/^\.\//u, "").replace(/\/$/u, ""))
         .filter((line) => line.length > 0);
-      resolve(lines);
+      finish(lines);
     });
     child.on("error", () => {
-      clearTimeout(watchdog);
-      if (!aborted) {
-        resolve([]);
+      finish(null);
+    });
+    child.stdin.on("error", (error: NodeJS.ErrnoException) => {
+      if (settled && error.code === "EPIPE") {
+        return;
       }
+      stopChild();
+      finish(null);
     });
     child.stdin.end(tarBuffer);
+  });
+}
+
+type TarArchiveResult = Buffer | "TOO_LARGE" | "TIMEOUT" | "ERROR";
+
+async function createTarArchive(
+  canonicalPath: string,
+  maxBytes: number,
+): Promise<TarArchiveResult> {
+  const tarBin = process.platform !== "win32" ? "/usr/bin/tar" : "tar";
+  const tarArgs = ["-czf", "-", "-C", canonicalPath, "."];
+  const timeoutMs = 60_000;
+
+  return await new Promise<TarArchiveResult>((resolve) => {
+    // stderr is not consumed or returned; ignoring it avoids an unnecessary
+    // pipe and follows Node's stdio guidance for discarded child output.
+    const child = spawn(tarBin, tarArgs, { stdio: ["ignore", "pipe", "ignore"] });
+    const chunks: Buffer[] = [];
+    let totalBytes = 0;
+    let settled = false;
+    const finish = (result: TarArchiveResult): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(watchdog);
+      resolve(result);
+    };
+    const stopChild = (signal: NodeJS.Signals): void => {
+      try {
+        child.kill(signal);
+      } catch {
+        /* gone */
+      }
+    };
+    const watchdog = setTimeout(() => {
+      stopChild("SIGKILL");
+      finish("TIMEOUT");
+    }, timeoutMs);
+
+    consumeChildOutput(child.stdout, {
+      onData: (chunk) => {
+        if (settled) {
+          return;
+        }
+        totalBytes += chunk.byteLength;
+        if (totalBytes > maxBytes) {
+          stopChild("SIGTERM");
+          finish("TOO_LARGE");
+          return;
+        }
+        chunks.push(chunk);
+      },
+      onError: () => {
+        stopChild("SIGKILL");
+        finish("ERROR");
+      },
+    });
+    child.on("close", (code) => {
+      if (settled) {
+        return;
+      }
+      finish(code === 0 ? Buffer.concat(chunks) : "ERROR");
+    });
+    child.on("error", () => {
+      finish("ERROR");
+    });
   });
 }
 
@@ -257,69 +364,10 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
   // requires a `find ! -name '.*' | tar -T -` pipeline; deferred to v2.
   // For now we always archive everything in the directory.
   void includeDotfiles;
-  const tarArgs: string[] = ["-czf", "-", "-C", canonical, "."];
-
   // Capture tar output with a hard byte cap and a wall-clock timeout.
   // SIGTERM if the byte cap is exceeded; SIGKILL if the timeout fires
   // (covers tar hanging on a slow filesystem or symlink loop).
-  const TAR_HARD_TIMEOUT_MS = 60_000;
-  const tarBuffer = await new Promise<Buffer | "TOO_LARGE" | "TIMEOUT" | "ERROR">((resolve) => {
-    const tarBin = process.platform !== "win32" ? "/usr/bin/tar" : "tar";
-    const child = spawn(tarBin, tarArgs, {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    const chunks: Buffer[] = [];
-    let totalBytes = 0;
-    let aborted = false;
-
-    const watchdog = setTimeout(() => {
-      if (aborted) {
-        return;
-      }
-      aborted = true;
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        /* already gone */
-      }
-      resolve("TIMEOUT");
-    }, TAR_HARD_TIMEOUT_MS);
-
-    child.stdout.on("data", (chunk: Buffer) => {
-      if (aborted) {
-        return;
-      }
-      totalBytes += chunk.byteLength;
-      if (totalBytes > maxBytes) {
-        aborted = true;
-        clearTimeout(watchdog);
-        child.kill("SIGTERM");
-        resolve("TOO_LARGE");
-        return;
-      }
-      chunks.push(chunk);
-    });
-
-    child.on("close", (code) => {
-      clearTimeout(watchdog);
-      if (aborted) {
-        return;
-      }
-      if (code !== 0) {
-        resolve("ERROR");
-        return;
-      }
-      resolve(Buffer.concat(chunks));
-    });
-
-    child.on("error", () => {
-      clearTimeout(watchdog);
-      if (!aborted) {
-        resolve("ERROR");
-      }
-    });
-  });
+  const tarBuffer = await createTarArchive(canonical, maxBytes);
 
   if (tarBuffer === "TOO_LARGE") {
     return {
@@ -350,6 +398,14 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
   const tarBase64 = tarBuffer.toString("base64");
   const tarBytes = tarBuffer.byteLength;
   const entries = await listTarEntries(tarBuffer);
+  if (entries === null) {
+    return {
+      ok: false,
+      code: "READ_ERROR",
+      message: "tar entry listing failed",
+      canonicalPath: canonical,
+    };
+  }
 
   return {
     ok: true,
@@ -361,3 +417,9 @@ export async function handleDirFetch(params: DirFetchParams): Promise<DirFetchRe
     entries,
   };
 }
+
+export const testing = {
+  createTarArchive,
+  listTarEntries,
+  preflightDu,
+};

--- a/extensions/file-transfer/src/shared/child-output.ts
+++ b/extensions/file-transfer/src/shared/child-output.ts
@@ -1,0 +1,15 @@
+// File Transfer helpers keep child-process output consumption error-aware.
+import type { Readable } from "node:stream";
+
+export function consumeChildOutput(
+  stream: Readable,
+  handlers: {
+    onData: (chunk: Buffer) => void;
+    onError: (error: Error) => void;
+  },
+): void {
+  // Child stdout/stderr are independent EventEmitters: child `error`/`close`
+  // cannot absorb a pipe error, so every consumed output owns both outcomes.
+  stream.on("data", handlers.onData);
+  stream.on("error", handlers.onError);
+}

--- a/extensions/file-transfer/src/shared/node-invoke-policy.stream-errors.test.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.stream-errors.test.ts
@@ -1,0 +1,73 @@
+// File Transfer tests cover archive-policy child-output failures.
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type MockChild = EventEmitter & {
+  kill: ReturnType<typeof vi.fn>;
+  stderr: EventEmitter;
+  stdin: EventEmitter & { end: () => void };
+  stdout: EventEmitter;
+};
+
+function mockTarSpawn(script: (child: MockChild) => void) {
+  return vi.fn(() => {
+    const child = new EventEmitter() as MockChild;
+    child.kill = vi.fn();
+    child.stderr = new EventEmitter();
+    child.stdin = new EventEmitter() as MockChild["stdin"];
+    child.stdout = new EventEmitter();
+    child.stdin.end = () => queueMicrotask(() => script(child));
+    return child;
+  });
+}
+
+async function importWithSpawn(spawnMock: ReturnType<typeof vi.fn>) {
+  vi.resetModules();
+  vi.doMock("node:child_process", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("node:child_process")>();
+    return { ...actual, spawn: spawnMock };
+  });
+  return await import("./node-invoke-policy.js");
+}
+
+afterEach(() => {
+  vi.doUnmock("node:child_process");
+  vi.resetModules();
+});
+
+describe("dir.fetch archive policy output lifecycle", () => {
+  it("fails archive listing closed on stdout errors", async () => {
+    const spawnMock = mockTarSpawn((child) => {
+      child.stdout.emit("data", Buffer.from("partial.txt\n"));
+      child.stdout.emit("error", new Error("policy listing read failed"));
+      child.emit("close", 0);
+    });
+    const { testing } = await importWithSpawn(spawnMock);
+
+    await expect(
+      testing.listDirFetchArchiveEntries({
+        tarBase64: Buffer.from("archive").toString("base64"),
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      code: "ARCHIVE_ENTRIES_UNREADABLE",
+      reason: "tar -tzf stdout error: Error: policy listing read failed",
+    });
+    expect(spawnMock.mock.results[0]?.value.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("keeps complete archive entries authoritative after diagnostic stderr errors", async () => {
+    const spawnMock = mockTarSpawn((child) => {
+      child.stderr.emit("error", new Error("diagnostics unavailable"));
+      child.stdout.emit("data", Buffer.from("./ok.txt\n"));
+      child.emit("close", 0);
+    });
+    const { testing } = await importWithSpawn(spawnMock);
+
+    await expect(
+      testing.listDirFetchArchiveEntries({
+        tarBase64: Buffer.from("archive").toString("base64"),
+      }),
+    ).resolves.toEqual({ ok: true, entries: ["ok.txt"] });
+  });
+});

--- a/extensions/file-transfer/src/shared/node-invoke-policy.ts
+++ b/extensions/file-transfer/src/shared/node-invoke-policy.ts
@@ -7,6 +7,7 @@ import type {
   OpenClawPluginNodeInvokePolicyResult,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { appendFileTransferAudit, type FileTransferAuditOp } from "./audit.js";
+import { consumeChildOutput } from "./child-output.js";
 import {
   FILE_TRANSFER_NODE_INVOKE_COMMANDS,
   type FileTransferNodeInvokeCommand,
@@ -375,30 +376,45 @@ async function listDirFetchArchiveEntries(
         reason: "tar -tzf timed out",
       });
     }, DIR_FETCH_ARCHIVE_LIST_TIMEOUT_MS);
-    child.stdout.on("data", (chunk: Buffer) => {
-      if (settled) {
-        return;
-      }
-      outputBytes += chunk.byteLength;
-      if (outputBytes > DIR_FETCH_ARCHIVE_LIST_MAX_OUTPUT_BYTES) {
+    consumeChildOutput(child.stdout, {
+      onData: (chunk) => {
+        if (settled) {
+          return;
+        }
+        outputBytes += chunk.byteLength;
+        if (outputBytes > DIR_FETCH_ARCHIVE_LIST_MAX_OUTPUT_BYTES) {
+          stopChild();
+          finish({
+            ok: false,
+            code: "ARCHIVE_ENTRIES_UNREADABLE",
+            reason: "tar -tzf output too large",
+          });
+          return;
+        }
+        const lines = `${pending}${chunk.toString()}`.split("\n");
+        pending = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!appendLine(line)) {
+            return;
+          }
+        }
+      },
+      onError: (error) => {
         stopChild();
         finish({
           ok: false,
           code: "ARCHIVE_ENTRIES_UNREADABLE",
-          reason: "tar -tzf output too large",
+          reason: `tar -tzf stdout error: ${String(error)}`,
         });
-        return;
-      }
-      const lines = `${pending}${chunk.toString()}`.split("\n");
-      pending = lines.pop() ?? "";
-      for (const line of lines) {
-        if (!appendLine(line)) {
-          return;
-        }
-      }
+      },
     });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr = appendBoundedTextTail(stderr, chunk, DIR_FETCH_ARCHIVE_LIST_STDERR_TAIL_CHARS);
+    consumeChildOutput(child.stderr, {
+      onData: (chunk) => {
+        stderr = appendBoundedTextTail(stderr, chunk, DIR_FETCH_ARCHIVE_LIST_STDERR_TAIL_CHARS);
+      },
+      onError: (error) => {
+        stderr = `[stderr unavailable: ${String(error)}]`;
+      },
     });
     child.on("close", (code) => {
       if (settled) {
@@ -945,3 +961,7 @@ export function createFileTransferNodeInvokePolicy(): OpenClawPluginNodeInvokePo
     handle: handleFileTransferInvoke,
   };
 }
+
+export const testing = {
+  listDirFetchArchiveEntries,
+};

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
@@ -86,9 +86,102 @@ describe("validateTarUncompressedBudget", () => {
       });
     },
   );
+
+  it("fails closed when tar stdout cannot be read", async () => {
+    vi.resetModules();
+    const spawnMock = mockTarSpawn((child) => {
+      child.stdout.emit("data", Buffer.from("partial"));
+      child.stdout.emit("error", new Error("budget read failed"));
+      child.emit("close", 0);
+    });
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      return { ...actual, spawn: spawnMock };
+    });
+
+    try {
+      const { testing } = await import("./dir-fetch-tool.js");
+      await expect(testing.validateTarUncompressedBudget(Buffer.from("x"))).resolves.toEqual({
+        ok: false,
+        reason: "tar uncompressed budget validation stdout error: Error: budget read failed",
+      });
+      expect(spawnMock.mock.results[0]?.value.kill).toHaveBeenCalledWith("SIGKILL");
+    } finally {
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
+  });
+
+  it("keeps complete budget output authoritative after diagnostic stderr errors", async () => {
+    vi.resetModules();
+    const spawnMock = mockTarSpawn((child) => {
+      child.stderr.emit("error", new Error("diagnostics unavailable"));
+      child.stdout.emit("data", Buffer.alloc(16));
+      child.emit("close", 0);
+    });
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      return { ...actual, spawn: spawnMock };
+    });
+
+    try {
+      const { testing } = await import("./dir-fetch-tool.js");
+      await expect(testing.validateTarUncompressedBudget(Buffer.from("x"), 32)).resolves.toEqual({
+        ok: true,
+      });
+    } finally {
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
+  });
 });
 
 describe("dir.fetch tar validation", () => {
+  it("fails tar listing closed when stdout cannot be read", async () => {
+    vi.resetModules();
+    const spawnMock = mockTarSpawn((child) => {
+      child.stdout.emit("data", Buffer.from("partial.txt\n"));
+      child.stdout.emit("error", new Error("listing read failed"));
+      child.emit("close", 0);
+    });
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      return { ...actual, spawn: spawnMock };
+    });
+
+    try {
+      const { testing } = await import("./dir-fetch-tool.js");
+      await expect(testing.preValidateTarball(Buffer.from("x"))).resolves.toEqual({
+        ok: false,
+        reason: "tar -tzf stdout error: Error: listing read failed",
+      });
+      expect(spawnMock.mock.results[0]?.value.kill).toHaveBeenCalledWith("SIGKILL");
+    } finally {
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
+  });
+
+  it("keeps successful unpack authoritative after diagnostic stderr errors", async () => {
+    vi.resetModules();
+    const spawnMock = mockTarSpawn((child) => {
+      child.stderr.emit("error", new Error("diagnostics unavailable"));
+      child.emit("close", 0);
+    });
+    vi.doMock("node:child_process", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:child_process")>();
+      return { ...actual, spawn: spawnMock };
+    });
+
+    try {
+      const { testing } = await import("./dir-fetch-tool.js");
+      await expect(testing.unpackTar(Buffer.from("x"), tmpRoot)).resolves.toBeUndefined();
+    } finally {
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
+  });
+
   it("ignores late stdin EPIPE after tar listing has already settled", async () => {
     vi.resetModules();
     vi.doMock("node:child_process", async (importOriginal) => {

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-store";
 import { appendFileTransferAudit } from "../shared/audit.js";
+import { consumeChildOutput } from "../shared/child-output.js";
 import { IMAGE_MIME_INLINE_SET, mimeFromExtension } from "../shared/mime.js";
 import { humanSize, readBoolean, readClampedInt } from "../shared/params.js";
 import {
@@ -114,9 +115,22 @@ async function listTarOutputLines<T>(input: {
       stopChild();
       finish({ ok: false, reason: `${input.label} timed out` });
     }, 30_000);
-    child.stdout.on("data", consumeChunk);
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr = appendBoundedTextTail(stderr, chunk, TAR_STDERR_TAIL_CHARS);
+    consumeChildOutput(child.stdout, {
+      onData: consumeChunk,
+      onError: (error) => {
+        stopChild();
+        finish({ ok: false, reason: `${input.label} stdout error: ${String(error)}` });
+      },
+    });
+    consumeChildOutput(child.stderr, {
+      onData: (chunk) => {
+        stderr = appendBoundedTextTail(stderr, chunk, TAR_STDERR_TAIL_CHARS);
+      },
+      onError: (error) => {
+        // stderr is diagnostic only; preserve that fact for a later nonzero
+        // close without invalidating complete stdout validation data.
+        stderr = `[stderr unavailable: ${String(error)}]`;
+      },
     });
     child.on("close", (code) => {
       if (settled) {
@@ -291,9 +305,25 @@ export async function validateTarUncompressedBudget(
       finish({ ok: false, reason: "tar uncompressed budget validation timed out" });
     }, TAR_UNPACK_TIMEOUT_MS);
 
-    child.stdout.on("data", (chunk: Buffer) => {
-      totalBytes += chunk.byteLength;
-      if (totalBytes > maxBytes) {
+    consumeChildOutput(child.stdout, {
+      onData: (chunk) => {
+        if (settled) {
+          return;
+        }
+        totalBytes += chunk.byteLength;
+        if (totalBytes > maxBytes) {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            /* gone */
+          }
+          finish({
+            ok: false,
+            reason: `archive expands past uncompressed budget ${maxBytes} bytes`,
+          });
+        }
+      },
+      onError: (error) => {
         try {
           child.kill("SIGKILL");
         } catch {
@@ -301,15 +331,17 @@ export async function validateTarUncompressedBudget(
         }
         finish({
           ok: false,
-          reason: `archive expands past uncompressed budget ${maxBytes} bytes`,
+          reason: `tar uncompressed budget validation stdout error: ${String(error)}`,
         });
-      }
+      },
     });
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderr += chunk.toString();
-      if (stderr.length > 4096) {
-        stderr = stderr.slice(-4096);
-      }
+    consumeChildOutput(child.stderr, {
+      onData: (chunk) => {
+        stderr = appendBoundedTextTail(stderr, chunk, TAR_STDERR_TAIL_CHARS);
+      },
+      onError: (error) => {
+        stderr = `[stderr unavailable: ${String(error)}]`;
+      },
     });
     child.on("close", (code) => {
       if (settled) {
@@ -411,8 +443,15 @@ async function unpackTar(tarBuffer: Buffer, destDir: string): Promise<void> {
       }
       fail(new Error(`tar unpack timed out after ${TAR_UNPACK_TIMEOUT_MS}ms`));
     }, TAR_UNPACK_TIMEOUT_MS);
-    child.stderr.on("data", (chunk: Buffer) => {
-      stderrOut = appendBoundedTextTail(stderrOut, chunk, TAR_STDERR_TAIL_CHARS);
+    consumeChildOutput(child.stderr, {
+      onData: (chunk) => {
+        stderrOut = appendBoundedTextTail(stderrOut, chunk, TAR_STDERR_TAIL_CHARS);
+      },
+      onError: (error) => {
+        // Extraction success is authoritative; a diagnostic read failure only
+        // replaces stderr context if tar later exits nonzero.
+        stderrOut = `[stderr unavailable: ${String(error)}]`;
+      },
     });
     child.on("close", (code) => {
       if (code !== 0) {
@@ -656,5 +695,6 @@ export function createDirFetchTool(): AnyAgentTool {
 
 export const testing = {
   preValidateTarball,
+  unpackTar,
   validateTarUncompressedBudget,
 };


### PR DESCRIPTION
## What Problem This Solves

File Transfer's `dir.fetch` subprocesses consumed child stdout/stderr without handling output-stream `error` events. A read failure could therefore crash the process, accept a partial archive listing, or accept incomplete archive bytes.

This clean replacement supersedes #101346, #101347, and #101437 while preserving the original contributor's credit.

## Why This Change Was Made

Node child output pipes are independent streams: child `close`/`error` does not replace handling the stream's own `error` event. The implementation now applies one invariant across the node host, gateway tar validation/unpack, and node-invoke archive policy:

- data-bearing stdout failures stop the child and fail closed;
- diagnostic stderr failures retain an unavailable-diagnostics marker while complete stdout plus a successful exit remains authoritative;
- output that is intentionally discarded uses `stdio: "ignore"` rather than creating an unused pipe;
- competing stream/process/timeout events settle each operation only once.

The behavior follows Node's child-process stdio and stream error contracts:

- https://nodejs.org/api/child_process.html#optionsstdio
- https://nodejs.org/api/stream.html#event-error

Contributor credit: the bug reports and initial fixes came from @sunlit-deng; the replacement commit includes their coauthor trailer.

## User Impact

`dir.fetch` no longer risks an uncaught output-stream error. Partial archive data and partial entry lists are rejected, while loss of diagnostic stderr alone does not turn an otherwise complete successful operation into a false failure.

## Evidence

- Blacksmith Testbox `tbx_01kwy3x7d2b12ghqdzj9mg473n`: 5 focused files, 41 tests passed.
- Real `/usr/bin/tar` happy path creates and verifies the fetched gzip archive.
- A real `handleDirFetch` call with a live tar stdout stream destroyed by an injected read error returns `READ_ERROR` without crashing or returning partial bytes.
- Focused regressions prove exact outcomes for `du` preflight, archive listing, archive bytes, diagnostic stderr, gateway validation/unpack, and node-invoke policy.
- `check:changed` passed production/test extension types, lint (0 warnings/errors), import-cycle checks, and structural guards on the same Testbox lease.
- Fresh structured autoreview: clean, no accepted/actionable findings (0.96 confidence). Root changelog intentionally unchanged under the current release-owned changelog gate.

Hosted run: https://github.com/openclaw/openclaw/actions/runs/28861274587
