### PR TITLE
fix(gateway): handle session history stream errors

### DIFF
--- a/src/gateway/sessions-history-http.revocation.test.ts
+++ b/src/gateway/sessions-history-http.revocation.test.ts
@@ -190,7 +190,7 @@ async function openSessionHistoryStream(
   expect(handled).toBe(true);
   expect(transcriptUpdateHandler).toBeTypeOf("function");
 
-  return res;
+  return { req, res };
 }
 
 function emitTranscriptTextUpdate({
@@ -232,7 +232,7 @@ afterEach(() => {
 
 describe("session history SSE auth revocation", () => {
   it("closes the stream before delivering transcript updates after auth is revoked", async () => {
-    const res = await openSessionHistoryStream({ auth: { mode: "trusted-proxy" } as never });
+    const { res } = await openSessionHistoryStream({ auth: { mode: "trusted-proxy" } as never });
 
     expect(res.headers.get("content-type")).toContain("text/event-stream");
 
@@ -247,7 +247,7 @@ describe("session history SSE auth revocation", () => {
   });
 
   it("rechecks SSE auth against live proxy config instead of startup fallbacks", async () => {
-    const res = await openSessionHistoryStream(TRUSTED_PROXY_STARTUP_OPTIONS);
+    const { res } = await openSessionHistoryStream(TRUSTED_PROXY_STARTUP_OPTIONS);
 
     gatewayConfig = {};
 
@@ -260,7 +260,7 @@ describe("session history SSE auth revocation", () => {
   });
 
   it("skips SSE reauth for transcript updates outside this stream", async () => {
-    const res = await openSessionHistoryStream(TRUSTED_PROXY_STARTUP_OPTIONS);
+    const { res } = await openSessionHistoryStream(TRUSTED_PROXY_STARTUP_OPTIONS);
 
     authCheckCalls = 0;
     gatewayConfig = {};
@@ -275,5 +275,31 @@ describe("session history SSE auth revocation", () => {
     expect(authCheckCalls).toBe(0);
     expect(joined).not.toContain("other session");
     expect(res.writableEnded).toBe(false);
+  });
+
+  it("closes and unsubscribes when the request stream emits an error", async () => {
+    const { req, res } = await openSessionHistoryStream(TRUSTED_PROXY_STARTUP_OPTIONS);
+
+    expect(() => {
+      req.emit("error", new Error("client aborted with stream error"));
+    }).not.toThrow();
+
+    await vi.waitFor(() => {
+      expect(res.writableEnded).toBe(true);
+    });
+    expect(transcriptUpdateHandler).toBeUndefined();
+  });
+
+  it("closes and unsubscribes when the response stream emits an error", async () => {
+    const { res } = await openSessionHistoryStream(TRUSTED_PROXY_STARTUP_OPTIONS);
+
+    expect(() => {
+      res.emit("error", new Error("response socket write failed"));
+    }).not.toThrow();
+
+    await vi.waitFor(() => {
+      expect(res.writableEnded).toBe(true);
+    });
+    expect(transcriptUpdateHandler).toBeUndefined();
   });
 });

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -258,6 +258,11 @@ export async function handleSessionHistoryHttpRequest(
     }
   };
 
+  const closeStreamAfterError = (error: unknown) => {
+    log.warn("session history SSE stream emitted an error; closing stream", { error });
+    closeStream();
+  };
+
   const queueStreamWork = (work: () => Promise<void>) => {
     streamQueue = streamQueue
       .then(async () => {
@@ -377,6 +382,8 @@ export async function handleSessionHistoryHttpRequest(
       });
     });
   });
+  req.on("error", closeStreamAfterError);
+  res.on("error", closeStreamAfterError);
   req.on("close", cleanup);
   res.on("close", cleanup);
   res.on("finish", cleanup);


### PR DESCRIPTION
Closes #101539

## What Problem This Solves

Fixes an issue where users with an active session-history SSE stream could have the OpenClaw gateway process crash when the HTTP request or response stream emitted an `error` event after an abrupt client disconnect or socket failure.

## Why This Change Was Made

The session history SSE handler already cleans up on normal close and finish events, but did not subscribe to stream-level error events. This change handles both request and response stream errors at the SSE stream boundary, logs the failure, and reuses the existing close/cleanup path so transcript update subscriptions and heartbeat timers are released.

## User Impact

Operators can keep the gateway running when a session-history SSE client disconnects with a stream error. The affected stream is closed, while the server process remains alive for other clients and sessions.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/sessions-history-http.revocation.test.ts`

```text
[test] starting test/vitest/vitest.gateway.config.ts
[vitest] still running with no output for 30000ms (test/vitest/vitest.gateway.config.ts).
[test] passed 1 Vitest shard in 41.26s
```

- Production-function proof is included below.

## Real behavior proof

**Behavior addressed:** Session-history SSE request and response stream `error` events are handled without an unhandled EventEmitter exception, and the affected SSE stream is closed.
**Environment tested:** Linux repository checkout with Node and source TypeScript loaded through `node --import tsx`.
**Steps run after the patch:** Imported `handleSessionHistoryHttpRequest` from `src/gateway/sessions-history-http.ts`, opened two SSE streams backed by a temporary real session store, then emitted request and response stream errors through the actual handler-installed listeners.
**Evidence after fix:**

```text
[sessions-history-sse] session history SSE stream emitted an error; closing stream
[sessions-history-sse] session history SSE stream emitted an error; closing stream
{
  "usedProductionFunction": "handleSessionHistoryHttpRequest",
  "requestStream": {
    "handled": true,
    "errorListeners": 1,
    "errorEventDidNotThrow": true,
    "closedAfterError": true
  },
  "responseStream": {
    "handled": true,
    "errorListeners": 1,
    "errorEventDidNotThrow": true,
    "closedAfterError": true
  }
}
```

**Observed result after the fix:** Both request and response stream errors had installed listeners, did not throw, and closed the corresponding SSE response.
**Not tested:** A live browser or reverse-proxy disconnect against a long-running gateway process.

## Root Cause

The session-history SSE handler subscribed to `close` and `finish` stream lifecycle events, but did not subscribe to `error`. In Node.js, emitting an `error` event without a listener throws, so a stream error from a disconnected client could take down the process instead of closing only that stream.

## Regression Test Plan

Added coverage in `src/gateway/sessions-history-http.revocation.test.ts` for both request and response stream error events. Each case opens a session-history SSE stream, emits an `error`, verifies no throw, and verifies the stream is closed and unsubscribed.

## User-visible / Behavior Changes

Abrupt SSE client stream failures now close the affected history stream instead of crashing the gateway process.

## Security Impact

- New permissions: No
- Secrets handling changed: No
- New network calls: No
