### PR TITLE
refactor(memory): trim unused Windows spawn exports

### DIFF
--- a/packages/memory-host-sdk/src/host/openclaw-runtime-io.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-io.ts
@@ -2,7 +2,6 @@
 
 export {
   CHARS_PER_TOKEN_ESTIMATE,
-  applyWindowsSpawnProgramPolicy,
   configureSqliteConnectionPragmas,
   configureSqliteWalMaintenance,
   root,
@@ -14,9 +13,7 @@ export {
   redactSensitiveText,
   resolveGlobalSingleton,
   resolveUserPath,
-  resolveWindowsExecutablePath,
   resolveWindowsSpawnProgram,
-  resolveWindowsSpawnProgramCandidate,
   runTasksWithConcurrency,
   shortenHomeInString,
   shortenHomePath,
@@ -25,14 +22,10 @@ export {
 } from "./openclaw-runtime.js";
 
 export type {
-  ResolveWindowsSpawnProgramCandidateParams,
   ResolveWindowsSpawnProgramParams,
   SqliteConnectionPragmaOptions,
   SqliteWalMaintenance,
   SqliteWalMaintenanceOptions,
-  WindowsSpawnCandidateResolution,
   WindowsSpawnInvocation,
   WindowsSpawnProgram,
-  WindowsSpawnProgramCandidate,
-  WindowsSpawnResolution,
 } from "./openclaw-runtime.js";

--- a/packages/memory-host-sdk/src/host/openclaw-runtime.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime.ts
@@ -155,19 +155,12 @@ export {
   truncateUtf16Safe,
 } from "../../../../src/utils.js";
 export {
-  applyWindowsSpawnProgramPolicy,
   materializeWindowsSpawnProgram,
-  resolveWindowsExecutablePath,
   resolveWindowsSpawnProgram,
-  resolveWindowsSpawnProgramCandidate,
 } from "../../../../src/plugin-sdk/windows-spawn.js";
 export type {
-  ResolveWindowsSpawnProgramCandidateParams,
   ResolveWindowsSpawnProgramParams,
-  WindowsSpawnCandidateResolution,
   WindowsSpawnInvocation,
   WindowsSpawnProgram,
-  WindowsSpawnProgramCandidate,
-  WindowsSpawnResolution,
 } from "../../../../src/plugin-sdk/windows-spawn.js";
 export { resolveGlobalSingleton } from "../../../../src/shared/global-singleton.js";


### PR DESCRIPTION
## What Problem This Solves

The private memory host runtime bridge still forwarded seven low-level Windows spawn candidate symbols that had no package or repository consumers.

## Why This Change Was Made

Remove the unused candidate-resolution functions and types from the broad runtime and IO facades. The supported memory-host Windows spawn facade keeps its high-level program resolution/materialization API unchanged.

## User Impact

No user-visible behavior changes. The private memory host bridge exposes a smaller, more accurate Windows spawn surface.

## Evidence

- `ts-unused-exports` identified exactly the seven removed symbols in `openclaw-runtime-io.ts`.
- Blacksmith Testbox `tbx_01kwy3qtz3r2cyh9hcgr4ze7x1`:
  - `pnpm check:changed -- packages/memory-host-sdk/src/host/openclaw-runtime-io.ts packages/memory-host-sdk/src/host/openclaw-runtime.ts` passed.
  - 23 QMD process tests and 8 package-boundary contract tests passed after the final live-main rebase.
  - `oxfmt --check` passed for both changed files.
  - unused-file and dependency scans passed; all five duplicate scan lanes reported zero clones.
  - plugin boundary summary reported zero eligible compatibility removals and zero unused reserved imports.
- Fresh Codex autoreview reported no actionable findings at 0.87 confidence.
- Fresh iOS Periphery dead-code scan passed: https://github.com/openclaw/openclaw/actions/runs/28861053671
- Android private-declaration and UI exported-singleton scans found no actionable dead code.
- `git diff --check` passed.

AI-assisted: yes. The implementation and validation evidence were reviewed before submission; transcript attachment was declined.
