### PR TITLE
fix(google-meet): handle stdout/stderr stream errors in local audio bridge

### DIFF
--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -435,7 +435,7 @@ function stubMeetArtifactsApi() {
 
 type TestBridgeProcess = {
   stdin?: { write(chunk: unknown): unknown } | null;
-  stdout?: { on(event: "data", listener: (chunk: unknown) => void): unknown } | null;
+  stdout?: PassThrough | null;
   stderr: PassThrough;
   killed: boolean;
   kill: ReturnType<typeof vi.fn>;
@@ -4138,7 +4138,7 @@ describe("google-meet plugin", () => {
     const outputStdinWrites: Buffer[] = [];
     const makeProcess = (stdio: {
       stdin?: { write(chunk: unknown): unknown } | null;
-      stdout?: { on(event: "data", listener: (chunk: unknown) => void): unknown } | null;
+      stdout?: PassThrough | null;
     }): TestBridgeProcess => {
       const proc = new EventEmitter() as unknown as TestBridgeProcess;
       proc.stdin = stdio.stdin;
@@ -4246,6 +4246,91 @@ describe("google-meet plugin", () => {
     await handle.stop();
   });
 
+  it("stops the Chrome agent audio bridge when child stdio streams error", async () => {
+    const sttSession = {
+      connect: vi.fn(async () => {}),
+      sendAudio: vi.fn(),
+      close: vi.fn(),
+      isConnected: vi.fn(() => true),
+    };
+    const provider: RealtimeTranscriptionProviderPlugin = {
+      id: "openai",
+      label: "OpenAI",
+      defaultModel: "gpt-4o-transcribe",
+      autoSelectOrder: 1,
+      resolveConfig: ({ rawConfig }) => rawConfig,
+      isConfigured: () => true,
+      createSession: () => sttSession,
+    };
+    const inputStdout = new PassThrough();
+    const inputStderr = new PassThrough();
+    const outputStderr = new PassThrough();
+    const makeProcess = (stdio: {
+      stdin?: { write(chunk: unknown): unknown } | null;
+      stdout?: PassThrough | null;
+      stderr: PassThrough;
+    }): TestBridgeProcess => {
+      const proc = new EventEmitter() as unknown as TestBridgeProcess;
+      proc.stdin = stdio.stdin;
+      proc.stdout = stdio.stdout;
+      proc.stderr = stdio.stderr;
+      proc.killed = false;
+      proc.kill = vi.fn(() => {
+        proc.killed = true;
+        return true;
+      });
+      return proc;
+    };
+    const outputStdin = new Writable({
+      write(_chunk, _encoding, done) {
+        done();
+      },
+    });
+    const outputProcess = makeProcess({
+      stdin: outputStdin,
+      stdout: null,
+      stderr: outputStderr,
+    });
+    const inputProcess = makeProcess({
+      stdin: null,
+      stdout: inputStdout,
+      stderr: inputStderr,
+    });
+    const spawnMock = vi.fn().mockReturnValueOnce(outputProcess).mockReturnValueOnce(inputProcess);
+
+    const handle = await startCommandAgentAudioBridge({
+      config: resolveGoogleMeetConfig({
+        realtime: { provider: "openai", agentId: "jay", introMessage: "" },
+      }),
+      fullConfig: {} as never,
+      runtime: {} as never,
+      meetingSessionId: "meet-1",
+      inputCommand: ["capture-meet"],
+      outputCommand: ["play-meet"],
+      logger: noopLogger,
+      providers: [provider],
+      spawn: spawnMock,
+    });
+
+    expect(() => inputStdout.emit("error", new Error("EPIPE"))).not.toThrow();
+    expect(noopLogger.warn).toHaveBeenCalledWith(
+      "[google-meet] audio input command stdout failed: EPIPE",
+    );
+    expect(handle.getHealth().bridgeClosed).toBe(true);
+    expect(sttSession.close).toHaveBeenCalled();
+    expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+
+    expect(() => inputStderr.emit("error", new Error("stderr EPIPE"))).not.toThrow();
+    expect(() => outputStderr.emit("error", new Error("output EPIPE"))).not.toThrow();
+    expect(noopLogger.warn).toHaveBeenCalledWith(
+      "[google-meet] audio input command stderr failed: stderr EPIPE",
+    );
+    expect(noopLogger.warn).toHaveBeenCalledWith(
+      "[google-meet] audio output command stderr failed: output EPIPE",
+    );
+  });
+
   it("preserves telephony TTS output formats when routing Google Meet agent audio", () => {
     const ulaw = Buffer.from([0xff, 0x7f, 0x00]);
     const pcmBridgeConfig = resolveGoogleMeetConfig({ chrome: { audioFormat: "pcm16-24khz" } });
@@ -4299,7 +4384,7 @@ describe("google-meet plugin", () => {
     const replacementOutputStdinWrites: Buffer[] = [];
     const makeProcess = (stdio: {
       stdin?: { write(chunk: unknown): unknown } | null;
-      stdout?: { on(event: "data", listener: (chunk: unknown) => void): unknown } | null;
+      stdout?: PassThrough | null;
     }): TestBridgeProcess => {
       const proc = new EventEmitter() as unknown as TestBridgeProcess;
       proc.stdin = stdio.stdin;
@@ -4406,6 +4491,7 @@ describe("google-meet plugin", () => {
     expect(replacementOutputStdinWrites).toEqual([Buffer.from([6, 7])]);
     outputProcess.emit("error", new Error("stale output process failed after clear"));
     outputStdin.emit("error", new Error("stale output pipe closed after clear"));
+    outputProcess.stderr.emit("error", new Error("stale output stderr closed after clear"));
     expect(bridge.close).not.toHaveBeenCalled();
     expect(bridge.acknowledgeMark).toHaveBeenCalled();
     expect(bridge.triggerGreeting).not.toHaveBeenCalled();
@@ -4497,6 +4583,77 @@ describe("google-meet plugin", () => {
     expect(replacementOutputProcess.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
+  it("stops the Chrome realtime audio bridge when child stdout errors", async () => {
+    const bridge = {
+      connect: vi.fn(async () => {}),
+      sendAudio: vi.fn(),
+      setMediaTimestamp: vi.fn(),
+      handleBargeIn: vi.fn(),
+      submitToolResult: vi.fn(),
+      acknowledgeMark: vi.fn(),
+      close: vi.fn(),
+      triggerGreeting: vi.fn(),
+      isConnected: vi.fn(() => true),
+    };
+    const provider: RealtimeVoiceProviderPlugin = {
+      id: "openai",
+      label: "OpenAI",
+      autoSelectOrder: 1,
+      resolveConfig: ({ rawConfig }) => rawConfig,
+      isConfigured: () => true,
+      createBridge: () => bridge,
+    };
+    const inputStdout = new PassThrough();
+    const makeProcess = (stdio: {
+      stdin?: { write(chunk: unknown): unknown } | null;
+      stdout?: PassThrough | null;
+    }): TestBridgeProcess => {
+      const proc = new EventEmitter() as unknown as TestBridgeProcess;
+      proc.stdin = stdio.stdin;
+      proc.stdout = stdio.stdout;
+      proc.stderr = new PassThrough();
+      proc.killed = false;
+      proc.kill = vi.fn(() => {
+        proc.killed = true;
+        return true;
+      });
+      return proc;
+    };
+    const outputProcess = makeProcess({
+      stdin: new Writable({
+        write(_chunk, _encoding, done) {
+          done();
+        },
+      }),
+      stdout: null,
+    });
+    const inputProcess = makeProcess({ stdin: null, stdout: inputStdout });
+    const spawnMock = vi.fn().mockReturnValueOnce(outputProcess).mockReturnValueOnce(inputProcess);
+
+    const handle = await startCommandRealtimeAudioBridge({
+      config: resolveGoogleMeetConfig({
+        realtime: { strategy: "bidi", provider: "openai", model: "gpt-realtime" },
+      }),
+      fullConfig: { models: { providers: {} } } as never,
+      runtime: {} as never,
+      meetingSessionId: "meet-1",
+      inputCommand: ["capture-meet"],
+      outputCommand: ["play-meet"],
+      logger: noopLogger,
+      providers: [provider],
+      spawn: spawnMock,
+    });
+
+    expect(() => inputStdout.emit("error", new Error("EPIPE"))).not.toThrow();
+    expect(noopLogger.warn).toHaveBeenCalledWith(
+      "[google-meet] audio input command stdout failed: EPIPE",
+    );
+    expect(handle.getHealth().bridgeClosed).toBe(true);
+    expect(bridge.close).toHaveBeenCalled();
+    expect(inputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(outputProcess.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
   it("defaults Chrome command-pair realtime to agent-driven talk-back", async () => {
     vi.useFakeTimers();
     try {
@@ -4528,7 +4685,7 @@ describe("google-meet plugin", () => {
       const inputStdout = new PassThrough();
       const makeProcess = (stdio: {
         stdin?: { write(chunk: unknown): unknown } | null;
-        stdout?: { on(event: "data", listener: (chunk: unknown) => void): unknown } | null;
+        stdout?: PassThrough | null;
       }): TestBridgeProcess => {
         const proc = new EventEmitter() as unknown as TestBridgeProcess;
         proc.stdin = stdio.stdin;
@@ -4715,7 +4872,7 @@ describe("google-meet plugin", () => {
     });
     const makeProcess = (stdio: {
       stdin?: { write(chunk: unknown): unknown } | null;
-      stdout?: { on(event: "data", listener: (chunk: unknown) => void): unknown } | null;
+      stdout?: PassThrough | null;
     }): TestBridgeProcess => {
       const proc = new EventEmitter() as unknown as TestBridgeProcess;
       proc.stdin = stdio.stdin;

--- a/extensions/google-meet/src/realtime.process.test.ts
+++ b/extensions/google-meet/src/realtime.process.test.ts
@@ -1,0 +1,131 @@
+// Google Meet realtime tests cover real local command-pair substitute processes.
+import { spawn as spawnChildProcess, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { RealtimeTranscriptionProviderPlugin } from "openclaw/plugin-sdk/realtime-transcription";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveGoogleMeetConfig } from "./config.js";
+import { startCommandAgentAudioBridge } from "./realtime.js";
+
+const tempDirs: string[] = [];
+const spawnedChildren: ChildProcess[] = [];
+
+function writeBridgeCommand(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "openclaw-google-meet-bridge-"));
+  tempDirs.push(dir);
+  const scriptPath = path.join(dir, "bridge-command.mjs");
+  writeFileSync(
+    scriptPath,
+    [
+      "process.on('SIGTERM', () => {",
+      "  process.exit(0);",
+      "});",
+      "process.stdin.resume();",
+      "setInterval(() => {}, 1000);",
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return scriptPath;
+}
+
+function makeRecordingSpawn(): NonNullable<
+  Parameters<typeof startCommandAgentAudioBridge>[0]["spawn"]
+> {
+  return (command, args, options) => {
+    const child = spawnChildProcess(command, args, options);
+    spawnedChildren.push(child);
+    return child as ReturnType<
+      NonNullable<Parameters<typeof startCommandAgentAudioBridge>[0]["spawn"]>
+    >;
+  };
+}
+
+afterEach(() => {
+  for (const child of spawnedChildren.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+  vi.restoreAllMocks();
+});
+
+describe("startCommandAgentAudioBridge real process stream errors", () => {
+  it("contains a forced local command-pair stdout stream error through bridge stop", async () => {
+    const bridgeScript = writeBridgeCommand();
+    const sttSession = {
+      connect: vi.fn(async () => {}),
+      sendAudio: vi.fn(),
+      close: vi.fn(),
+      isConnected: vi.fn(() => true),
+    };
+    const provider: RealtimeTranscriptionProviderPlugin = {
+      id: "openai",
+      label: "OpenAI",
+      defaultModel: "gpt-4o-transcribe",
+      autoSelectOrder: 1,
+      resolveConfig: ({ rawConfig }) => rawConfig,
+      isConfigured: () => true,
+      createSession: () => sttSession,
+    };
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    const handle = await startCommandAgentAudioBridge({
+      config: resolveGoogleMeetConfig({
+        chrome: { audioFormat: "pcm16-24khz" },
+        realtime: { provider: "openai", agentId: "jay", introMessage: "" },
+      }),
+      fullConfig: {} as never,
+      runtime: {} as never,
+      meetingSessionId: "meet-1",
+      inputCommand: [process.execPath, bridgeScript, "capture"],
+      outputCommand: [process.execPath, bridgeScript, "play"],
+      logger: logger as never,
+      providers: [provider],
+      spawn: makeRecordingSpawn(),
+    });
+    const [outputProcess, inputProcess] = spawnedChildren;
+    if (!inputProcess || !outputProcess) {
+      throw new Error("Expected Google Meet bridge to spawn input and output child processes");
+    }
+    const inputClosed = once(inputProcess, "close");
+    const outputClosed = once(outputProcess, "close");
+    const originalInputKill = inputProcess.kill.bind(inputProcess);
+    const originalOutputKill = outputProcess.kill.bind(outputProcess);
+    const inputKillSpy = vi
+      .spyOn(inputProcess, "kill")
+      .mockImplementation((signal) => originalInputKill(signal));
+    const outputKillSpy = vi
+      .spyOn(outputProcess, "kill")
+      .mockImplementation((signal) => originalOutputKill(signal));
+
+    inputProcess.stdout?.destroy(new Error("EPIPE from real bridge input stdout"));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    inputProcess.stderr?.destroy(new Error("duplicate stderr EPIPE"));
+
+    await Promise.all([inputClosed, outputClosed]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[google-meet] audio input command stdout failed: EPIPE from real bridge input stdout",
+    );
+    expect(handle.getHealth().bridgeClosed).toBe(true);
+    expect(sttSession.close).toHaveBeenCalledTimes(1);
+    expect(inputKillSpy.mock.calls.filter(([signal]) => signal === "SIGTERM")).toHaveLength(1);
+    expect(outputKillSpy.mock.calls.filter(([signal]) => signal === "SIGTERM")).toHaveLength(1);
+    console.info(
+      `[proof] local command-pair substitute stopped after forced input stdout stream error; inputPid=${
+        inputProcess.pid ?? "unknown"
+      } outputPid=${outputProcess.pid ?? "unknown"}`,
+    );
+  });
+});

--- a/extensions/google-meet/src/realtime.ts
+++ b/extensions/google-meet/src/realtime.ts
@@ -52,8 +52,14 @@ type BridgeProcess = {
   pid?: number;
   killed?: boolean;
   stdin?: Writable | null;
-  stdout?: { on(event: "data", listener: (chunk: Buffer | string) => void): unknown } | null;
-  stderr?: { on(event: "data", listener: (chunk: Buffer | string) => void): unknown } | null;
+  stdout?: {
+    on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+    on(event: "error", listener: (error: Error) => void): unknown;
+  } | null;
+  stderr?: {
+    on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+    on(event: "error", listener: (error: Error) => void): unknown;
+  } | null;
   kill(signal?: NodeJS.Signals): boolean;
   on(
     event: "exit",
@@ -613,6 +619,8 @@ export async function startCommandAgentAudioBridge(params: {
   inputProcess.stderr?.on("data", (chunk) => {
     params.logger.debug?.(`[google-meet] audio input: ${String(chunk).trim()}`);
   });
+  inputProcess.stdout?.on("error", fail("audio input command stdout"));
+  inputProcess.stderr?.on("error", fail("audio input command stderr"));
   outputProcess.on("error", fail("audio output command"));
   outputProcess.stdin?.on?.("error", fail("audio output command"));
   outputProcess.on("exit", (code, signal) => {
@@ -624,6 +632,7 @@ export async function startCommandAgentAudioBridge(params: {
   outputProcess.stderr?.on("data", (chunk) => {
     params.logger.debug?.(`[google-meet] audio output: ${String(chunk).trim()}`);
   });
+  outputProcess.stderr?.on("error", fail("audio output command stderr"));
 
   const writeOutputAudio = (audio: Buffer) => {
     const suppression = recordGoogleMeetOutputActivity({
@@ -927,6 +936,12 @@ export async function startCommandRealtimeAudioBridge(params: {
     proc.stderr?.on("data", (chunk) => {
       params.logger.debug?.(`[google-meet] audio output: ${String(chunk).trim()}`);
     });
+    proc.stderr?.on("error", (error: Error) => {
+      if (proc !== outputProcess) {
+        return;
+      }
+      fail("audio output command stderr")(error);
+    });
   };
   const clearOutputPlayback = () => {
     if (stopped) {
@@ -995,8 +1010,18 @@ export async function startCommandRealtimeAudioBridge(params: {
         )}, peak=${stats.peak})`,
       );
     });
+    bargeInInputProcess.stdout?.on("error", (error: Error) => {
+      params.logger.warn(
+        `[google-meet] human barge-in input stdout failed: ${formatErrorMessage(error)}`,
+      );
+    });
     bargeInInputProcess.stderr?.on("data", (chunk) => {
       params.logger.debug?.(`[google-meet] barge-in input: ${String(chunk).trim()}`);
+    });
+    bargeInInputProcess.stderr?.on("error", (error: Error) => {
+      params.logger.warn(
+        `[google-meet] human barge-in input stderr failed: ${formatErrorMessage(error)}`,
+      );
     });
     bargeInInputProcess.on("error", (error) => {
       params.logger.warn(`[google-meet] human barge-in input failed: ${formatErrorMessage(error)}`);
@@ -1020,6 +1045,8 @@ export async function startCommandRealtimeAudioBridge(params: {
   inputProcess.stderr?.on("data", (chunk) => {
     params.logger.debug?.(`[google-meet] audio input: ${String(chunk).trim()}`);
   });
+  inputProcess.stdout?.on("error", fail("audio input command stdout"));
+  inputProcess.stderr?.on("error", fail("audio input command stderr"));
 
   const resolved = resolveGoogleMeetRealtimeProvider({
     config: params.config,


### PR DESCRIPTION
## Summary

- add stdout/stderr `error` handlers for Google Meet command audio bridge child streams
- stop the bridge through the existing failure path when primary audio input/output streams error; the `stop` path is idempotent (`stopped` guard), so duplicate stream errors cannot tear down twice or kill twice
- cover agent and realtime bridge stream errors with focused regressions, plus a real spawned local command-pair substitute driven through the real exported `startCommandAgentAudioBridge`
- collision check: no open PR found for the Google Meet local audio bridge stream-error issue or `extensions/google-meet/src/realtime.ts`

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/google-meet/index.test.ts -t "stops the Chrome agent audio bridge|stops the Chrome realtime audio bridge|pipes Chrome command-pair audio through the realtime provider"` — passed; 1 file, 3 tests passed, 100 skipped
- `node scripts/run-vitest.mjs extensions/google-meet/src/realtime.process.test.ts -- --reporter=verbose` — passed; 1 file, 1 test passed (real local child-process proof)
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/google-meet/src/realtime.process.test.ts` — passed
- `git diff --check` — passed
- mutation check: removing the stdout error handler made the real-process test fail with an unhandled `EPIPE from real bridge input stdout`; restoring the handler made it pass

## Real behavior proof

Behavior addressed: Google Meet local command-pair audio bridge stdout stream errors are contained by the existing bridge fail/stop path, without an unhandled stream error or repeated teardown.
Real environment tested: local Linux Node source checkout; the proof wires two real local substitute command processes through `startCommandAgentAudioBridge` with real child pipes. It is not a live Google Meet call and not the default SoX/CoreAudio/BlackHole device chain.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/google-meet/src/realtime.process.test.ts -- --reporter=verbose`.
Evidence after fix: `[proof] local command-pair substitute stopped after forced input stdout stream error; inputPid=3847906 outputPid=3847905`; `Test Files 1 passed (1); Tests 1 passed (1)`.
Observed result after fix: a forced stdout stream error on the real spawned input command logs through `audio input command stdout failed`, bridge health reports `bridgeClosed=true`, the STT session closes exactly once, and both input/output command processes emit `close` after a single SIGTERM each.
What was not tested: a live Google Meet/Chrome audio device run and the default macOS SoX/CoreAudio `BlackHole 2ch` commands — this Linux environment has no `sox` binary and no CoreAudio/BlackHole device, so the closest honest local proof is a real substitute command pair driving the real exported bridge function.
