### PR TITLE
fix(matrix): handle stdout/stderr stream errors in dependency commands

### DIFF
--- a/extensions/matrix/src/matrix/deps.test.ts
+++ b/extensions/matrix/src/matrix/deps.test.ts
@@ -194,15 +194,16 @@ describe("runFixedCommandWithTimeout", () => {
         stdout: PassThrough;
         stderr: PassThrough;
         exitCode: number | null;
-        kill: ReturnType<typeof vi.fn>;
+        kill: (signal?: NodeJS.Signals) => boolean;
       };
       proc.stdout = new PassThrough();
       proc.stderr = new PassThrough();
       proc.exitCode = null;
-      proc.kill = vi.fn(() => {
+      const killMock = vi.fn((_signal?: NodeJS.Signals) => {
         proc.exitCode = 143;
         return true;
       });
+      proc.kill = killMock;
       const spawnMock = vi.fn(() => proc);
 
       const resultPromise = runFixedCommandWithTimeout({
@@ -218,7 +219,7 @@ describe("runFixedCommandWithTimeout", () => {
         stdout: "",
         stderr: `${streamName} stream failed: EPIPE`,
       });
-      expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(killMock).toHaveBeenCalledWith("SIGTERM");
     }
   });
 });

--- a/extensions/matrix/src/matrix/deps.test.ts
+++ b/extensions/matrix/src/matrix/deps.test.ts
@@ -3,7 +3,7 @@ import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_pr
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, type MockInstance, vi } from "vitest";
 import {
   ensureMatrixCryptoRuntime,
   ensureMatrixSdkInstalled,
@@ -12,6 +12,8 @@ import {
 } from "./deps.js";
 
 const logStub = vi.fn();
+
+type ChildKill = (signal?: NodeJS.Signals | number) => boolean;
 
 async function importDepsWithSpawnMock(
   spawnMock: ReturnType<typeof vi.fn>,
@@ -256,10 +258,10 @@ describe("runFixedCommandWithTimeout", () => {
 
     for (const streamName of ["stdout", "stderr"] as const) {
       let proc: ChildProcessWithoutNullStreams | undefined;
-      let killSpy: ReturnType<typeof vi.spyOn> | undefined;
+      let killSpy: MockInstance<ChildKill> | undefined;
       try {
         const spawnMock = vi.fn(
-          (command: string, args: string[] | undefined, options: SpawnOptions | undefined) => {
+          (command: string, args: string[] | undefined, options: SpawnOptions) => {
             proc = actual.spawn(command, args ?? [], options) as ChildProcessWithoutNullStreams;
             return proc;
           },

--- a/extensions/matrix/src/matrix/deps.test.ts
+++ b/extensions/matrix/src/matrix/deps.test.ts
@@ -1,7 +1,9 @@
 // Matrix tests cover deps plugin behavior.
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
 import {
   ensureMatrixCryptoRuntime,
@@ -184,6 +186,40 @@ describe("runFixedCommandWithTimeout", () => {
     expect(Buffer.byteLength(result.stderr, "utf8")).toBe(MATRIX_COMMAND_OUTPUT_TAIL_BYTES);
     expect(result.stdout).toBe("a".repeat(MATRIX_COMMAND_OUTPUT_TAIL_BYTES));
     expect(result.stderr).toBe("b".repeat(MATRIX_COMMAND_OUTPUT_TAIL_BYTES));
+  });
+
+  it("fails cleanly when bootstrap command stdio streams error", async () => {
+    for (const streamName of ["stdout", "stderr"] as const) {
+      const proc = new EventEmitter() as EventEmitter & {
+        stdout: PassThrough;
+        stderr: PassThrough;
+        exitCode: number | null;
+        kill: ReturnType<typeof vi.fn>;
+      };
+      proc.stdout = new PassThrough();
+      proc.stderr = new PassThrough();
+      proc.exitCode = null;
+      proc.kill = vi.fn(() => {
+        proc.exitCode = 143;
+        return true;
+      });
+      const spawnMock = vi.fn(() => proc);
+
+      const resultPromise = runFixedCommandWithTimeout({
+        argv: ["matrix-bootstrap"],
+        cwd: process.cwd(),
+        timeoutMs: 10_000,
+        spawn: spawnMock,
+      });
+
+      expect(() => proc[streamName].emit("error", new Error("EPIPE"))).not.toThrow();
+      await expect(resultPromise).resolves.toStrictEqual({
+        code: 1,
+        stdout: "",
+        stderr: `${streamName} stream failed: EPIPE`,
+      });
+      expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+    }
   });
 });
 

--- a/extensions/matrix/src/matrix/deps.test.ts
+++ b/extensions/matrix/src/matrix/deps.test.ts
@@ -1,10 +1,9 @@
 // Matrix tests cover deps plugin behavior.
-import { EventEmitter } from "node:events";
+import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { PassThrough } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ensureMatrixCryptoRuntime,
   ensureMatrixSdkInstalled,
@@ -13,6 +12,70 @@ import {
 } from "./deps.js";
 
 const logStub = vi.fn();
+
+async function importDepsWithSpawnMock(
+  spawnMock: ReturnType<typeof vi.fn>,
+): Promise<typeof import("./deps.js")> {
+  vi.resetModules();
+  vi.doMock("node:child_process", async () => {
+    const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    return {
+      ...actual,
+      spawn: spawnMock,
+    };
+  });
+  return await import("./deps.js");
+}
+
+function waitForChildClose(proc: ChildProcessWithoutNullStreams) {
+  return new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("timed out waiting for matrix command child close"));
+    }, 5_000);
+    timer.unref?.();
+    proc.once("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, signal });
+    });
+  });
+}
+
+function waitForReadableData(stream: NodeJS.ReadableStream) {
+  return new Promise<void>((resolve, reject) => {
+    let cleanup = () => {};
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error("timed out waiting for matrix command child output"));
+    }, 5_000);
+    timer.unref?.();
+    cleanup = () => {
+      clearTimeout(timer);
+      stream.off("data", onData);
+      stream.off("error", onError);
+    };
+    const onData = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    stream.once("data", onData);
+    stream.once("error", onError);
+  });
+}
+
+function waitForReadableErrorDispatch() {
+  return new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.doUnmock("node:child_process");
+});
 
 function resolveTestNativeBindingFilename(): string | null {
   switch (process.platform) {
@@ -188,38 +251,77 @@ describe("runFixedCommandWithTimeout", () => {
     expect(result.stderr).toBe("b".repeat(MATRIX_COMMAND_OUTPUT_TAIL_BYTES));
   });
 
-  it("fails cleanly when bootstrap command stdio streams error", async () => {
+  it("settles real child stream errors after child close and terminates once", async () => {
+    const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+
     for (const streamName of ["stdout", "stderr"] as const) {
-      const proc = new EventEmitter() as EventEmitter & {
-        stdout: PassThrough;
-        stderr: PassThrough;
-        exitCode: number | null;
-        kill: (signal?: NodeJS.Signals) => boolean;
-      };
-      proc.stdout = new PassThrough();
-      proc.stderr = new PassThrough();
-      proc.exitCode = null;
-      const killMock = vi.fn((_signal?: NodeJS.Signals) => {
-        proc.exitCode = 143;
-        return true;
-      });
-      proc.kill = killMock;
-      const spawnMock = vi.fn(() => proc);
+      let proc: ChildProcessWithoutNullStreams | undefined;
+      let killSpy: ReturnType<typeof vi.spyOn> | undefined;
+      try {
+        const spawnMock = vi.fn(
+          (command: string, args: string[] | undefined, options: SpawnOptions | undefined) => {
+            proc = actual.spawn(command, args ?? [], options) as ChildProcessWithoutNullStreams;
+            return proc;
+          },
+        );
+        const { runFixedCommandWithTimeout: runWithMockedSpawn } =
+          await importDepsWithSpawnMock(spawnMock);
+        const exitListenersBefore = process.listenerCount("exit");
 
-      const resultPromise = runFixedCommandWithTimeout({
-        argv: ["matrix-bootstrap"],
-        cwd: process.cwd(),
-        timeoutMs: 10_000,
-        spawn: spawnMock,
-      });
+        const resultPromise = runWithMockedSpawn({
+          argv: [
+            process.execPath,
+            "-e",
+            [
+              "process.stdin.resume();",
+              'process.on("SIGTERM", () => {});',
+              'process.stdout.write("stdout ready\\n");',
+              'process.stderr.write("stderr ready\\n");',
+              "setInterval(() => {}, 1000);",
+            ].join(""),
+          ],
+          cwd: process.cwd(),
+          timeoutMs: 10_000,
+        });
+        if (!proc) {
+          throw new Error("expected matrix command helper to spawn a child process");
+        }
+        killSpy = vi.spyOn(proc, "kill");
+        const closePromise = waitForChildClose(proc);
+        await Promise.all([waitForReadableData(proc.stdout), waitForReadableData(proc.stderr)]);
+        let settled = false;
+        void resultPromise.then(() => {
+          settled = true;
+        });
+        const message = `synthetic parent ${streamName} read failure`;
 
-      expect(() => proc[streamName].emit("error", new Error("EPIPE"))).not.toThrow();
-      await expect(resultPromise).resolves.toStrictEqual({
-        code: 1,
-        stdout: "",
-        stderr: `${streamName} stream failed: EPIPE`,
-      });
-      expect(killMock).toHaveBeenCalledWith("SIGTERM");
+        proc[streamName].destroy(new Error(message));
+        await waitForReadableErrorDispatch();
+        expect(settled).toBe(false);
+        expect(process.listenerCount("exit")).toBe(exitListenersBefore + 1);
+        expect(killSpy).toHaveBeenCalledTimes(1);
+        expect(killSpy).toHaveBeenCalledWith("SIGTERM");
+
+        const duplicateStreamName = streamName === "stdout" ? "stderr" : "stdout";
+        proc[duplicateStreamName].destroy(new Error("duplicate parent readable failure"));
+        await waitForReadableErrorDispatch();
+        expect(killSpy).toHaveBeenCalledTimes(1);
+
+        const result = await resultPromise;
+        const close = await closePromise;
+
+        expect(result.code).toBe(1);
+        expect(result.stderr).toContain(`${streamName} stream failed: ${message}`);
+        expect(result.stderr).not.toContain("duplicate parent readable failure");
+        expect(close).toStrictEqual({ code: null, signal: "SIGKILL" });
+        expect(killSpy).toHaveBeenLastCalledWith("SIGKILL");
+        expect(process.listenerCount("exit")).toBe(exitListenersBefore);
+      } finally {
+        killSpy?.mockRestore();
+        if (proc && proc.exitCode === null && !proc.killed) {
+          proc.kill("SIGKILL");
+        }
+      }
     }
   });
 });

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -13,6 +13,7 @@ const REQUIRED_MATRIX_PACKAGES = [
 ];
 const MIN_MATRIX_CRYPTO_NATIVE_BINDING_BYTES = 1_000_000;
 export const MATRIX_COMMAND_OUTPUT_TAIL_BYTES = 64 * 1024;
+const MATRIX_STREAM_ERROR_KILL_GRACE_MS = 1_000;
 
 type MatrixCryptoRuntimeDeps = {
   requireFn?: (id: string) => unknown;
@@ -49,30 +50,6 @@ type CommandResult = {
   stderr: string;
 };
 
-type CommandReadable = {
-  on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
-  on(event: "error", listener: (error: Error) => void): unknown;
-};
-
-type CommandProcess = {
-  stdout?: CommandReadable | null;
-  stderr?: CommandReadable | null;
-  exitCode: number | null;
-  kill(signal?: NodeJS.Signals): boolean;
-  on(event: "error", listener: (error: Error) => void): unknown;
-  on(event: "close", listener: (code: number | null) => void): unknown;
-};
-
-type CommandSpawnFn = (
-  command: string,
-  args: string[],
-  options: {
-    cwd: string;
-    env: NodeJS.ProcessEnv;
-    stdio: ["ignore", "pipe", "pipe"];
-  },
-) => CommandProcess;
-
 let defaultMatrixCryptoRuntimeEnsurePromise: Promise<void> | null = null;
 
 function appendBoundedOutputTail(current: string, chunk: Buffer | string): string {
@@ -101,7 +78,6 @@ export async function runFixedCommandWithTimeout(params: {
   cwd: string;
   timeoutMs: number;
   env?: NodeJS.ProcessEnv;
-  spawn?: CommandSpawnFn;
 }): Promise<CommandResult> {
   return await new Promise((resolve) => {
     const [command, ...args] = params.argv;
@@ -114,11 +90,7 @@ export async function runFixedCommandWithTimeout(params: {
       return;
     }
 
-    const spawnFn: CommandSpawnFn =
-      params.spawn ??
-      ((spawnCommand, spawnArgs, spawnOptions) =>
-        spawn(spawnCommand, spawnArgs, spawnOptions) as unknown as CommandProcess);
-    const proc = spawnFn(command, args, {
+    const proc = spawn(command, args, {
       cwd: params.cwd,
       env: { ...process.env, ...params.env },
       stdio: ["ignore", "pipe", "pipe"],
@@ -128,6 +100,8 @@ export async function runFixedCommandWithTimeout(params: {
     let stderr = "";
     let settled = false;
     let timer: NodeJS.Timeout | null = null;
+    let streamKillTimer: NodeJS.Timeout | null = null;
+    let streamErrorMessage: string | null = null;
     const killChildOnExit = () => {
       if (!settled && proc.exitCode === null) {
         proc.kill("SIGTERM");
@@ -142,6 +116,9 @@ export async function runFixedCommandWithTimeout(params: {
       if (timer) {
         clearTimeout(timer);
       }
+      if (streamKillTimer) {
+        clearTimeout(streamKillTimer);
+      }
       process.off("exit", killChildOnExit);
       resolve(result);
     };
@@ -154,21 +131,28 @@ export async function runFixedCommandWithTimeout(params: {
       stderr = appendBoundedOutputTail(stderr, chunk);
     });
     const failReadableStream = (streamName: "stdout" | "stderr") => (error: Error) => {
+      if (settled || streamErrorMessage) {
+        return;
+      }
+      streamErrorMessage = `${streamName} stream failed: ${formatErrorMessage(error)}`;
       if (proc.exitCode === null) {
         proc.kill("SIGTERM");
       }
-      const message = `${streamName} stream failed: ${formatErrorMessage(error)}`;
-      finalize({
-        code: 1,
-        stdout,
-        stderr: stderr ? appendBoundedOutputTail(stderr, `\n${message}`) : message,
-      });
+      streamKillTimer = setTimeout(() => {
+        if (!settled && proc.exitCode === null) {
+          proc.kill("SIGKILL");
+        }
+      }, MATRIX_STREAM_ERROR_KILL_GRACE_MS);
+      streamKillTimer.unref?.();
     };
     proc.stdout?.on("error", failReadableStream("stdout"));
     proc.stderr?.on("error", failReadableStream("stderr"));
 
     timer = setTimeout(() => {
       proc.kill("SIGKILL");
+      if (streamErrorMessage) {
+        return;
+      }
       finalize({
         code: 124,
         stdout,
@@ -177,6 +161,9 @@ export async function runFixedCommandWithTimeout(params: {
     }, params.timeoutMs);
 
     proc.on("error", (err) => {
+      if (streamErrorMessage) {
+        return;
+      }
       finalize({
         code: 1,
         stdout,
@@ -185,10 +172,15 @@ export async function runFixedCommandWithTimeout(params: {
     });
 
     proc.on("close", (code) => {
+      const streamErrorStderr = streamErrorMessage
+        ? stderr
+          ? appendBoundedOutputTail(stderr, `\n${streamErrorMessage}`)
+          : streamErrorMessage
+        : stderr;
       finalize({
-        code: code ?? 1,
+        code: streamErrorMessage ? 1 : (code ?? 1),
         stdout,
-        stderr,
+        stderr: streamErrorStderr,
       });
     });
   });

--- a/extensions/matrix/src/matrix/deps.ts
+++ b/extensions/matrix/src/matrix/deps.ts
@@ -49,6 +49,30 @@ type CommandResult = {
   stderr: string;
 };
 
+type CommandReadable = {
+  on(event: "data", listener: (chunk: Buffer | string) => void): unknown;
+  on(event: "error", listener: (error: Error) => void): unknown;
+};
+
+type CommandProcess = {
+  stdout?: CommandReadable | null;
+  stderr?: CommandReadable | null;
+  exitCode: number | null;
+  kill(signal?: NodeJS.Signals): boolean;
+  on(event: "error", listener: (error: Error) => void): unknown;
+  on(event: "close", listener: (code: number | null) => void): unknown;
+};
+
+type CommandSpawnFn = (
+  command: string,
+  args: string[],
+  options: {
+    cwd: string;
+    env: NodeJS.ProcessEnv;
+    stdio: ["ignore", "pipe", "pipe"];
+  },
+) => CommandProcess;
+
 let defaultMatrixCryptoRuntimeEnsurePromise: Promise<void> | null = null;
 
 function appendBoundedOutputTail(current: string, chunk: Buffer | string): string {
@@ -77,6 +101,7 @@ export async function runFixedCommandWithTimeout(params: {
   cwd: string;
   timeoutMs: number;
   env?: NodeJS.ProcessEnv;
+  spawn?: CommandSpawnFn;
 }): Promise<CommandResult> {
   return await new Promise((resolve) => {
     const [command, ...args] = params.argv;
@@ -89,7 +114,11 @@ export async function runFixedCommandWithTimeout(params: {
       return;
     }
 
-    const proc = spawn(command, args, {
+    const spawnFn: CommandSpawnFn =
+      params.spawn ??
+      ((spawnCommand, spawnArgs, spawnOptions) =>
+        spawn(spawnCommand, spawnArgs, spawnOptions) as unknown as CommandProcess);
+    const proc = spawnFn(command, args, {
       cwd: params.cwd,
       env: { ...process.env, ...params.env },
       stdio: ["ignore", "pipe", "pipe"],
@@ -124,6 +153,19 @@ export async function runFixedCommandWithTimeout(params: {
     proc.stderr?.on("data", (chunk: Buffer | string) => {
       stderr = appendBoundedOutputTail(stderr, chunk);
     });
+    const failReadableStream = (streamName: "stdout" | "stderr") => (error: Error) => {
+      if (proc.exitCode === null) {
+        proc.kill("SIGTERM");
+      }
+      const message = `${streamName} stream failed: ${formatErrorMessage(error)}`;
+      finalize({
+        code: 1,
+        stdout,
+        stderr: stderr ? appendBoundedOutputTail(stderr, `\n${message}`) : message,
+      });
+    };
+    proc.stdout?.on("error", failReadableStream("stdout"));
+    proc.stderr?.on("error", failReadableStream("stderr"));
 
     timer = setTimeout(() => {
       proc.kill("SIGKILL");


### PR DESCRIPTION
## Summary

- add stdout/stderr `error` handlers to Matrix dependency bootstrap commands
- align the stream-error path with the established `src/node-host/invoke.ts` lifecycle pattern: record the first stream error, send one SIGTERM, keep the process-exit cleanup registered, escalate to SIGKILL if the child does not exit, and settle only from the child `close` event
- remove the production `spawn` override that an earlier revision of this branch added for testing; the runtime command path is fixed and takes no injection seam
- cover the stream-error lifecycle with a real spawned `node` child over real stdio pipes in a focused regression test
- collision check: no open PR found for the Matrix dependency command stream-error issue or `extensions/matrix/src/matrix/deps.ts`; the only fuzzy search hit was an unrelated Telegram PR

## Verification

- `node scripts/run-vitest.mjs extensions/matrix/src/matrix/deps.test.ts` — passed; 1 file, 10 tests passed
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/matrix/src/matrix/deps.ts extensions/matrix/src/matrix/deps.test.ts` — all files correctly formatted
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/matrix/src/matrix/deps.ts extensions/matrix/src/matrix/deps.test.ts` — no findings
- mutation check: changing the stream-error guard to allow duplicate stream errors made the focused test fail with `expected "kill" to be called 1 times, but got 2 times`; restoring the guard made the same test pass

## Real behavior proof

Behavior addressed: Matrix dependency command stdout/stderr stream errors no longer settle the command result before child close, no longer remove the process-exit cleanup early, and duplicate stream errors cannot trigger teardown twice.
Real environment tested: local Linux Node 22.22 source checkout; the regression test drives the real exported `runFixedCommandWithTimeout` helper with a real spawned `node` child process and real pipe-backed stdout/stderr.
Exact steps or command run after this patch: the test destroys the parent-side stdout/stderr Readable with an error while the real child is alive, then observes SIGTERM, SIGKILL escalation, and settlement from the child `close` event; command: `node scripts/run-vitest.mjs extensions/matrix/src/matrix/deps.test.ts`.
Evidence after fix: the real-child regression asserts no settlement before close, exactly one SIGTERM for duplicate stream errors, retained process-exit listener during shutdown, SIGKILL escalation, child close `{ code: null, signal: "SIGKILL" }`, and exit-listener cleanup after settlement.
Observed result after fix: `Test Files 1 passed (1); Tests 10 passed (10)`.
What was not tested: a live Matrix bootstrap download. The test injects the Readable error on the parent side because a real `download-lib.js` child cannot deterministically produce a parent read-side `error`: normal child exit, fd close, and SIGKILL surface as EOF/`close` on the parent read side, and EPIPE is a write-side failure.
