### PR TITLE
fix(infra): add NaN guard for unparseable timestamps from external inputs

### DIFF
--- a/src/agents/cli-credentials.ts
+++ b/src/agents/cli-credentials.ts
@@ -312,10 +312,13 @@ function readCodexKeychainCredentials(options?: {
 
     // No explicit expiry stored; treat as fresh for an hour from last_refresh or now.
     const lastRefreshRaw = parsed.last_refresh;
-    const lastRefresh =
+    let lastRefresh =
       typeof lastRefreshRaw === "string" || typeof lastRefreshRaw === "number"
         ? new Date(lastRefreshRaw).getTime()
         : Date.now();
+    if (Number.isNaN(lastRefresh)) {
+      lastRefresh = Date.now();
+    }
     const fallbackExpiry =
       resolveCodexFallbackExpiryMs(lastRefresh) ?? resolveCodexFallbackExpiryMs();
     const expires = decodeJwtExpiryMs(accessToken) ?? fallbackExpiry;

--- a/src/agents/sessions/agent-session.ts
+++ b/src/agents/sessions/agent-session.ts
@@ -2073,9 +2073,10 @@ export class AgentSession {
     // compaction boundary. This prevents a stale pre-compaction usage/error
     // from retriggering compaction on the first prompt after compaction.
     const compactionEntry = getLatestCompactionEntry(this.sessionManager.getBranch());
+    const compactionMs =
+      compactionEntry !== null ? new Date(compactionEntry.timestamp).getTime() : Number.NaN;
     const assistantIsFromBeforeCompaction =
-      compactionEntry !== null &&
-      assistantMessage.timestamp <= new Date(compactionEntry.timestamp).getTime();
+      Number.isFinite(compactionMs) && assistantMessage.timestamp <= compactionMs;
     if (assistantIsFromBeforeCompaction) {
       return false;
     }
@@ -2120,9 +2121,9 @@ export class AgentSession {
       // trigger compaction right after one just finished.
       const usageMsg = messages[estimate.lastUsageIndex];
       if (
-        compactionEntry &&
+        Number.isFinite(compactionMs) &&
         usageMsg.role === "assistant" &&
-        usageMsg.timestamp <= new Date(compactionEntry.timestamp).getTime()
+        usageMsg.timestamp <= compactionMs
       ) {
         return false;
       }

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -2700,9 +2700,14 @@ export class SessionManager {
     const stack: SessionTreeNode[] = [...roots];
     while (stack.length > 0) {
       const node = stack.pop()!;
-      node.children.sort(
-        (a, b) => new Date(a.entry.timestamp).getTime() - new Date(b.entry.timestamp).getTime(),
-      );
+      node.children.sort((a, b) => {
+        const aTs = new Date(a.entry.timestamp).getTime();
+        const bTs = new Date(b.entry.timestamp).getTime();
+        if (Number.isNaN(aTs) && Number.isNaN(bTs)) return 0;
+        if (Number.isNaN(aTs)) return 1;
+        if (Number.isNaN(bTs)) return -1;
+        return aTs - bTs;
+      });
       stack.push(...node.children);
     }
 

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -2703,9 +2703,15 @@ export class SessionManager {
       node.children.sort((a, b) => {
         const aTs = new Date(a.entry.timestamp).getTime();
         const bTs = new Date(b.entry.timestamp).getTime();
-        if (Number.isNaN(aTs) && Number.isNaN(bTs)) return 0;
-        if (Number.isNaN(aTs)) return 1;
-        if (Number.isNaN(bTs)) return -1;
+        if (Number.isNaN(aTs) && Number.isNaN(bTs)) {
+          return 0;
+        }
+        if (Number.isNaN(aTs)) {
+          return 1;
+        }
+        if (Number.isNaN(bTs)) {
+          return -1;
+        }
         return aTs - bTs;
       });
       stack.push(...node.children);

--- a/src/infra/provider-usage.fetch.claude.ts
+++ b/src/infra/provider-usage.fetch.claude.ts
@@ -38,18 +38,20 @@ function buildClaudeUsageWindows(data: ClaudeUsageResponse): UsageWindow[] {
   const windows: UsageWindow[] = [];
 
   if (data.five_hour?.utilization !== undefined) {
+    const resetMs = new Date(data.five_hour.resets_at ?? "").getTime();
     windows.push({
       label: "5h",
       usedPercent: clampPercent(data.five_hour.utilization),
-      resetAt: data.five_hour.resets_at ? new Date(data.five_hour.resets_at).getTime() : undefined,
+      resetAt: Number.isFinite(resetMs) ? resetMs : undefined,
     });
   }
 
   if (data.seven_day?.utilization !== undefined) {
+    const resetMs = new Date(data.seven_day.resets_at ?? "").getTime();
     windows.push({
       label: "Week",
       usedPercent: clampPercent(data.seven_day.utilization),
-      resetAt: data.seven_day.resets_at ? new Date(data.seven_day.resets_at).getTime() : undefined,
+      resetAt: Number.isFinite(resetMs) ? resetMs : undefined,
     });
   }
 
@@ -72,10 +74,11 @@ function buildClaudeUsageWindows(data: ClaudeUsageResponse): UsageWindow[] {
       continue;
     }
     knownLabels.add(label.toLowerCase());
+    const resetMs = new Date(limit.resets_at ?? "").getTime();
     windows.push({
       label,
       usedPercent: clampPercent(limit.percent ?? 0),
-      resetAt: limit.resets_at ? new Date(limit.resets_at).getTime() : undefined,
+      resetAt: Number.isFinite(resetMs) ? resetMs : undefined,
     });
   }
 

--- a/src/infra/provider-usage.fetch.zai.ts
+++ b/src/infra/provider-usage.fetch.zai.ts
@@ -71,7 +71,8 @@ export async function fetchZaiUsage(
 
   for (const limit of limits) {
     const percent = clampPercent(limit.percentage || 0);
-    const nextReset = limit.nextResetTime ? new Date(limit.nextResetTime).getTime() : undefined;
+    const resetMs = new Date(limit.nextResetTime ?? "").getTime();
+    const nextReset = Number.isFinite(resetMs) ? resetMs : undefined;
     let windowLabel = "Limit";
     if (limit.unit === 1) {
       windowLabel = `${limit.number}d`;


### PR DESCRIPTION
## What Problem This Solves

`new Date(input).getTime()` returns `NaN` for strings like `"not-a-date"`, empty string, or other unparseable inputs. Several call sites used only truthy guards (`input ? ...`), which pass `NaN` through when the string is non-empty but not a valid date.

This is the same class of bug fixed in #99420 (merged).

## Files Fixed

| File | Site | Input Source |
|------|------|-------------|
| `provider-usage.fetch.claude.ts` | 3 `resetAt` fields | External Claude API response |
| `provider-usage.fetch.zai.ts` | 1 `nextReset` field | External Z.ai API response |
| `cli-credentials.ts` | `last_refresh` timestamp | macOS keychain (external) |
| `agent-session.ts` | 2 compaction comparisons | Internal session metadata |
| `session-manager.ts` | sort comparator | Internal session data |

## Evidence

### Before: truthy guard passes NaN through

```
input="2026-07-07T00:00:00Z" -> 1783382400000  (valid)
input="not-a-date"           -> NaN             (corrupt!)
input=""                     -> undefined
input=undefined              -> undefined
```

### After: Number.isFinite guard catches NaN

```
input="2026-07-07T00:00:00Z" -> 1783382400000  (valid)
input="not-a-date"           -> undefined       (safe fallback)
input=""                     -> undefined
input=undefined              -> undefined
```

## Merge Risk

Zero behavioral change for valid inputs. Only difference: previously-unhandled `NaN` values are now caught and safely replaced with `undefined`/`Date.now()`/correct sort position, matching the fallback behavior used throughout the codebase.

## Not tested

- Cannot test against live Claude/Z.ai APIs
- `cli-credentials.ts` path requires macOS keychain — pattern tested with synthetic inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)