### PR TITLE
refactor(memory): trim unused host SDK exports

### DIFF
--- a/packages/memory-host-sdk/src/host/config-utils.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.ts
@@ -13,7 +13,7 @@ export { splitShellArgs } from "./openclaw-runtime-io.js";
 // Shared OpenClaw config helpers used by memory host, QMD, and agent context code.
 
 /** Chat shape used by memory send-policy matching. */
-export type ChatType = "direct" | "group" | "channel";
+type ChatType = "direct" | "group" | "channel";
 /** Memory backend selected by user config. */
 export type MemoryBackend = "builtin" | "qmd";
 /** Citation injection behavior for memory search results. */
@@ -24,16 +24,16 @@ export type MemoryQmdSearchMode = "query" | "search" | "vsearch";
 export type MemoryQmdStartupMode = "off" | "idle" | "immediate";
 
 /** Action returned by a session send-policy rule. */
-export type SessionSendPolicyAction = "allow" | "deny";
+type SessionSendPolicyAction = "allow" | "deny";
 /** Match criteria for one memory send-policy rule. */
-export type SessionSendPolicyMatch = {
+type SessionSendPolicyMatch = {
   channel?: string;
   chatType?: ChatType;
   keyPrefix?: string;
   rawKeyPrefix?: string;
 };
 /** One ordered rule in session send-policy config. */
-export type SessionSendPolicyRule = {
+type SessionSendPolicyRule = {
   action: SessionSendPolicyAction;
   match?: SessionSendPolicyMatch;
 };
@@ -58,14 +58,14 @@ export type MemoryQmdMcporterConfig = {
 };
 
 /** QMD session export config. */
-export type MemoryQmdSessionConfig = {
+type MemoryQmdSessionConfig = {
   enabled?: boolean;
   exportDir?: string;
   retentionDays?: number;
 };
 
 /** QMD update, debounce, startup, and timeout config. */
-export type MemoryQmdUpdateConfig = {
+type MemoryQmdUpdateConfig = {
   interval?: string;
   debounceMs?: number;
   onBoot?: boolean;
@@ -79,7 +79,7 @@ export type MemoryQmdUpdateConfig = {
 };
 
 /** Search and injection limits for QMD memory results. */
-export type MemoryQmdLimitsConfig = {
+type MemoryQmdLimitsConfig = {
   maxResults?: number;
   maxSnippetChars?: number;
   maxInjectedChars?: number;
@@ -102,14 +102,14 @@ export type MemoryQmdConfig = {
 };
 
 /** Top-level memory config shared by host and runtime callers. */
-export type MemoryConfig = {
+type MemoryConfig = {
   backend?: MemoryBackend;
   citations?: MemoryCitationsMode;
   qmd?: MemoryQmdConfig;
 };
 
 /** Per-agent memory search enablement and extra collection paths. */
-export type MemorySearchConfig = {
+type MemorySearchConfig = {
   enabled?: boolean;
   extraPaths?: string[];
   qmd?: {
@@ -118,13 +118,13 @@ export type MemorySearchConfig = {
 };
 
 /** Agent context limits that bound memory file reads. */
-export type AgentContextLimitsConfig = {
+type AgentContextLimitsConfig = {
   memoryGetMaxChars?: number;
   memoryGetDefaultLines?: number;
 };
 
 /** Secret reference accepted by provider header config. */
-export type SecretInput =
+type SecretInput =
   | string
   | {
       source: string;
@@ -262,7 +262,7 @@ function legacyStateDirs(homedir: () => string): string[] {
 }
 
 /** Resolve the current state root while preserving shipped legacy installs when present. */
-export function resolveStateDir(
+function resolveStateDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
 ): string {

--- a/packages/memory-host-sdk/src/host/embeddings.ts
+++ b/packages/memory-host-sdk/src/host/embeddings.ts
@@ -16,14 +16,7 @@ type DisposableResource = {
   dispose?: () => Promise<void> | void;
 };
 
-export type {
-  EmbeddingProvider,
-  EmbeddingProviderFallback,
-  EmbeddingProviderId,
-  EmbeddingProviderOptions,
-  EmbeddingProviderRequest,
-  GeminiTaskType,
-} from "./embeddings.types.js";
+export type { EmbeddingProvider } from "./embeddings.types.js";
 
 export { DEFAULT_LOCAL_MODEL } from "./embedding-defaults.js";
 

--- a/packages/memory-host-sdk/src/host/openclaw-runtime-io.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-io.ts
@@ -22,10 +22,7 @@ export {
 } from "./openclaw-runtime.js";
 
 export type {
-  ResolveWindowsSpawnProgramParams,
   SqliteConnectionPragmaOptions,
   SqliteWalMaintenance,
   SqliteWalMaintenanceOptions,
-  WindowsSpawnInvocation,
-  WindowsSpawnProgram,
 } from "./openclaw-runtime.js";

--- a/packages/memory-host-sdk/src/host/openclaw-runtime.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime.ts
@@ -7,7 +7,6 @@ export {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../../../src/agents/agent-scope.js";
-export { requireApiKey, resolveApiKeyForProvider } from "../../../../src/agents/model-auth.js";
 export { stripInternalRuntimeContext } from "../../../../src/agents/internal-runtime-context.js";
 export { DEFAULT_AGENT_COMPACTION_RESERVE_TOKENS_FLOOR } from "../../../../src/agents/agent-settings.js";
 export {
@@ -82,9 +81,6 @@ export { isVerbose, setVerbose } from "../../../../src/globals.js";
 // IO, network, and logging helpers.
 export { isExecCompletionEvent } from "../../../../src/infra/heartbeat-events-filter.js";
 export { root } from "../../../../src/infra/fs-safe.js";
-export { fetchWithSsrFGuard } from "../../../../src/infra/net/fetch-guard.js";
-export { shouldUseEnvHttpProxyForUrl } from "../../../../src/infra/net/proxy-env.js";
-export { ssrfPolicyFromHttpBaseUrlAllowedHostname } from "../../../../src/infra/net/ssrf.js";
 export {
   configureSqliteConnectionPragmas,
   configureSqliteWalMaintenance,
@@ -157,10 +153,5 @@ export {
 export {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
-} from "../../../../src/plugin-sdk/windows-spawn.js";
-export type {
-  ResolveWindowsSpawnProgramParams,
-  WindowsSpawnInvocation,
-  WindowsSpawnProgram,
 } from "../../../../src/plugin-sdk/windows-spawn.js";
 export { resolveGlobalSingleton } from "../../../../src/shared/global-singleton.js";

--- a/packages/memory-host-sdk/src/host/windows-spawn.ts
+++ b/packages/memory-host-sdk/src/host/windows-spawn.ts
@@ -4,8 +4,3 @@ export {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
 } from "./openclaw-runtime-io.js";
-export type {
-  ResolveWindowsSpawnProgramParams,
-  WindowsSpawnInvocation,
-  WindowsSpawnProgram,
-} from "./openclaw-runtime-io.js";


### PR DESCRIPTION
## What Problem This Solves

The private memory host SDK retained unused type and helper exports across config, embedding, runtime, IO, and Windows spawn facades. Those forwards enlarged internal surfaces and kept redundant export chains alive without callers.

## Why This Change Was Made

- make config-only helper types and `resolveStateDir` private to `config-utils.ts`
- remove unused embedding type forwards from the internal `embeddings.ts` facade
- remove duplicate auth and network forwards from the broad runtime facade; focused auth/network modules remain canonical
- remove unused Windows spawn type forwards across the private runtime IO and spawn facades

No package export map or public plugin SDK subpath changes.

## User Impact

No runtime behavior change. The patch reduces private memory-host surface area by 24 net lines and leaves the narrower canonical facades intact.

## Evidence

- `OPENCLAW_TESTBOX=1` delegated Testbox `tbx_01kwy4szfk4r90zbrnmwbtha57`
- `pnpm check:changed -- packages/memory-host-sdk/src/host/config-utils.ts packages/memory-host-sdk/src/host/embeddings.ts packages/memory-host-sdk/src/host/openclaw-runtime.ts packages/memory-host-sdk/src/host/openclaw-runtime-io.ts packages/memory-host-sdk/src/host/windows-spawn.ts`
  - core and core-test typecheck passed
  - changed-file lint passed with 0 warnings/errors
  - runtime import cycles: 0
  - database-first and repository guardrails passed
- fresh `deadcode:ts-unused` report dropped from 3,640 to 3,633 lines; all findings for the five touched modules disappeared
- fresh Codex autoreview after rebasing: no actionable findings, confidence 0.87
- refreshed codebase-memory graph: 281,015 nodes / 1,138,375 edges
