### PR TITLE
fix(commitments): keep emoji / surrogate pairs intact during terminal output truncation

### DIFF
--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -2,6 +2,7 @@
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -24,7 +25,7 @@ const STATUS_VALUES = new Set<CommitmentStatus>([
 ]);
 
 function truncate(value: string, maxChars: number): string {
-  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}…`;
+  return value.length <= maxChars ? value : `${truncateUtf16Safe(value, maxChars - 1)}…`;
 }
 
 function safe(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

The commitment list formatter in `src/commands/commitments.ts` truncates table cells with `.slice()` which counts UTF-16 code units. When a surrogate-pair character (emoji) straddles the cut boundary, `.slice()` produces a lone surrogate (e.g. `\ud83d`) that renders as `�` in `openclaw commitments` CLI output.

This is user-visible: commitment descriptions are user-provided text that can contain emoji near the column width boundary of 16 characters (id) or 90 characters (suggested text).

## Why This Change Was Made

Replace `.slice()` with `truncateUtf16Safe()` from `@openclaw/normalization-core/utf16-slice` so truncation counts full code points instead of UTF-16 code units. This matches the already-merged PR #101517 (session-cost-usage).

## User Impact

`openclaw commitments` table cells no longer show `�` when commitment descriptions contain emoji near column boundaries.

## Evidence

**Real environment tested:** local OpenClaw source checkout, Node v24.13.1, PR head.

**Exact steps after this patch:**

```
node --import tsx -e "
const { truncateUtf16Safe } = await import('@openclaw/normalization-core/utf16-slice');
const content = 'y'.repeat(78) + '\u{1F680}xx';
const before = content.slice(0, 79) + '…';
const after = truncateUtf16Safe(content, 79) + '…';
const t = (s) => /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(s);
console.log('BEFORE (.slice 79):', JSON.stringify(before.slice(-12)), 'lone:', t(before));
console.log('AFTER  (truncateUtf16Safe 79):', JSON.stringify(after.slice(-12)), 'lone:', t(after));
"
```

**Evidence after fix:**

```
BEFORE (.slice 79):           "yyyyyyyyyy\ud83d…"  lone: true
AFTER  (truncateUtf16Safe 79): "yyyyyyyyyyy…"       lone: false
```

**Observed result after fix:** `truncateUtf16Safe` preserves full code points; no lone surrogate reaches terminal output. Cell width caps are unchanged — the broken surrogate is dropped cleanly rather than rendered as `�`.

**What was not tested:** full `openclaw commitments` end-to-end run on exact PR head (production CLI uses installed binary).

## Regression Test Plan

```
node scripts/run-vitest.mjs src/commands/commitments.test.ts --run
  Test Files  1 passed (1)
       Tests  8 passed (8)
```

AI-assisted.
