### PR TITLE
fix(infra): keep heartbeat/push message preview truncation UTF-16 safe

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -7,6 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   hasOutboundReplyContent,
   isReasoningReplyPayload,
@@ -782,7 +783,10 @@ function resolveHeartbeatReasoningPayloads(
       continue;
     }
 
-    const deliverablePayload: ReplyPayload = { ...payload, text: formattedText };
+    const deliverablePayload: ReplyPayload = {
+      ...payload,
+      text: formattedText,
+    };
     delete deliverablePayload.isReasoning;
     delete deliverablePayload.mediaUrl;
     delete deliverablePayload.mediaUrls;
@@ -862,7 +866,10 @@ function isStreamErrorFallbackPlaceholderOnly(text: string): boolean {
 
 const TRAILING_HEARTBEAT_NOTIFY_FALSE_RE = /(?:^|[\r\n])[ \t]*notify=false[ \t]*(?:\r?\n[ \t]*)*$/i;
 
-function stripTrailingHeartbeatNotifyFalse(text: string): { text: string; silent: boolean } {
+function stripTrailingHeartbeatNotifyFalse(text: string): {
+  text: string;
+  silent: boolean;
+} {
   const match = TRAILING_HEARTBEAT_NOTIFY_FALSE_RE.exec(text);
   if (!match) {
     return { text, silent: false };
@@ -1719,7 +1726,9 @@ export async function runHeartbeatOnce(opts: {
       });
       return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
     }
-    const isolatedStore = loadSessionStore(isolatedStorePath, { skipCache: true });
+    const isolatedStore = loadSessionStore(isolatedStorePath, {
+      skipCache: true,
+    });
     const staleIsolatedEntry = staleIsolatedSessionKey
       ? isolatedStore[staleIsolatedSessionKey]
       : undefined;
@@ -1820,7 +1829,10 @@ export async function runHeartbeatOnce(opts: {
         if (!heartbeatRunOwnsPendingFinalDelivery(current, startedAt)) {
           return false;
         }
-        store[sessionKey] = { ...current, ...CLEARED_PENDING_FINAL_DELIVERY_FIELDS };
+        store[sessionKey] = {
+          ...current,
+          ...CLEARED_PENDING_FINAL_DELIVERY_FIELDS,
+        };
         return true;
       },
       // No pending to clear is the common case; avoid rewriting the store then.
@@ -2007,7 +2019,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "ok-token",
         reason: opts.reason,
-        preview: heartbeatToolResponse.summary.slice(0, 200),
+        preview: truncateUtf16Safe(heartbeatToolResponse.summary, 200),
         durationMs: Date.now() - startedAt,
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
         accountId: delivery.accountId,
@@ -2161,7 +2173,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "duplicate",
-        preview: normalized.text.slice(0, 200),
+        preview: truncateUtf16Safe(normalized.text, 200),
         durationMs: Date.now() - startedAt,
         hasMedia: false,
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
@@ -2190,7 +2202,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "skipped",
         reason: delivery.reason ?? "no-target",
-        preview: previewText?.slice(0, 200),
+        preview: previewText ? truncateUtf16Safe(previewText, 200) : undefined,
         durationMs: Date.now() - startedAt,
         hasMedia: mediaUrls.length > 0,
         accountId: delivery.accountId,
@@ -2210,7 +2222,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "alerts-disabled",
-        preview: previewText?.slice(0, 200),
+        preview: previewText ? truncateUtf16Safe(previewText, 200) : undefined,
         durationMs: Date.now() - startedAt,
         channel: delivery.channel,
         hasMedia: mediaUrls.length > 0,
@@ -2233,7 +2245,7 @@ export async function runHeartbeatOnce(opts: {
         emitHeartbeatEvent({
           status: "skipped",
           reason: readiness.reason,
-          preview: previewText?.slice(0, 200),
+          preview: previewText ? truncateUtf16Safe(previewText, 200) : undefined,
           durationMs: Date.now() - startedAt,
           hasMedia: mediaUrls.length > 0,
           channel: delivery.channel,
@@ -2317,7 +2329,7 @@ export async function runHeartbeatOnce(opts: {
       to: delivery.to,
       ...(deliveredAgentRunFailure ? { reason: "agent-runner-failure" } : {}),
       ...(!deliveredAgentRunFailure && !visibleSendSucceeded ? { reason: send.reason } : {}),
-      preview: previewText?.slice(0, 200),
+      preview: previewText ? truncateUtf16Safe(previewText, 200) : undefined,
       durationMs: Date.now() - startedAt,
       hasMedia: mediaUrls.length > 0,
       channel: delivery.channel,

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -836,31 +836,31 @@ describe("push APNs send semantics", () => {
       environment: "production",
       transport: "relay",
     });
+  });
 
-    it("does not split surrogate pairs when truncating non-JSON error bodies", async () => {
-      const { send, registration, auth } = createDirectApnsSendFixture({
-        nodeId: "ios-node-surrogate-reason",
-        environment: "sandbox",
-        sendResult: {
-          status: 400,
-          apnsId: "apns-surrogate-reason-id",
-          body: "x".repeat(199) + "🚀tail",
-        },
-      });
-
-      const result = await sendApnsAlert({
-        registration,
-        nodeId: "ios-node-surrogate-reason",
-        title: "Wake",
-        body: "Ping",
-        auth,
-        requestSender: send,
-      });
-
-      const record = requireRecord(result, "APNs result");
-      expect(record.reason).not.toContain("�");
-      expect(record.ok).toBe(false);
-      expect(record.status).toBe(400);
+  it("does not split surrogate pairs when truncating non-JSON error bodies", async () => {
+    const { send, registration, auth } = createDirectApnsSendFixture({
+      nodeId: "ios-node-surrogate-reason",
+      environment: "sandbox",
+      sendResult: {
+        status: 400,
+        apnsId: "apns-surrogate-reason-id",
+        body: "x".repeat(199) + "🚀tail",
+      },
     });
+
+    const result = await sendApnsAlert({
+      registration,
+      nodeId: "ios-node-surrogate-reason",
+      title: "Wake",
+      body: "Ping",
+      auth,
+      requestSender: send,
+    });
+
+    const record = requireRecord(result, "APNs result");
+    expect(record.reason).not.toContain("�");
+    expect(record.ok).toBe(false);
+    expect(record.status).toBe(400);
   });
 });

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -345,7 +345,10 @@ describe("push APNs send semantics", () => {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
     try {
-      proxyHandle = await startProxy({ enabled: true, proxyUrl: proxy.proxyUrl });
+      proxyHandle = await startProxy({
+        enabled: true,
+        proxyUrl: proxy.proxyUrl,
+      });
       const { registration, auth } = createDirectApnsSendFixture({
         nodeId: "ios-node-proxied-alert",
         environment: "sandbox",
@@ -402,7 +405,10 @@ describe("push APNs send semantics", () => {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
     try {
-      proxyHandle = await startProxy({ enabled: true, proxyUrl: proxy.proxyUrl });
+      proxyHandle = await startProxy({
+        enabled: true,
+        proxyUrl: proxy.proxyUrl,
+      });
       const { registration, auth } = createDirectApnsSendFixture({
         nodeId: "ios-node-proxied-error-body",
         environment: "sandbox",
@@ -829,6 +835,32 @@ describe("push APNs send semantics", () => {
       status: 202,
       environment: "production",
       transport: "relay",
+    });
+
+    it("does not split surrogate pairs when truncating non-JSON error bodies", async () => {
+      const { send, registration, auth } = createDirectApnsSendFixture({
+        nodeId: "ios-node-surrogate-reason",
+        environment: "sandbox",
+        sendResult: {
+          status: 400,
+          apnsId: "apns-surrogate-reason-id",
+          body: "x".repeat(199) + "🚀tail",
+        },
+      });
+
+      const result = await sendApnsAlert({
+        registration,
+        nodeId: "ios-node-surrogate-reason",
+        title: "Wake",
+        body: "Ping",
+        auth,
+        requestSender: send,
+      });
+
+      const record = requireRecord(result, "APNs result");
+      expect(record.reason).not.toContain("�");
+      expect(record.ok).toBe(false);
+      expect(record.status).toBe(400);
     });
   });
 });

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -7,6 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveStateDir } from "../config/paths.js";
 import type { DeviceIdentity } from "./device-identity.js";
 import { formatErrorMessage, toErrorObject } from "./errors.js";
@@ -211,9 +212,9 @@ function parseReason(body: string): string | undefined {
     const parsed = JSON.parse(trimmed) as { reason?: unknown };
     return typeof parsed.reason === "string" && parsed.reason.trim().length > 0
       ? parsed.reason.trim()
-      : trimmed.slice(0, 200);
+      : truncateUtf16Safe(trimmed, 200);
   } catch {
-    return trimmed.slice(0, 200);
+    return truncateUtf16Safe(trimmed, 200);
   }
 }
 
@@ -291,7 +292,10 @@ function normalizeRelayOrigin(value: unknown): string | undefined {
 }
 
 function normalizeDirectRegistration(
-  record: Partial<DirectApnsRegistration> & { nodeId?: unknown; token?: unknown },
+  record: Partial<DirectApnsRegistration> & {
+    nodeId?: unknown;
+    token?: unknown;
+  },
 ): DirectApnsRegistration | null {
   if (typeof record.nodeId !== "string" || typeof record.token !== "string") {
     return null;
@@ -525,7 +529,10 @@ export async function loadApnsRegistrations(
   baseDir?: string,
 ): Promise<Array<{ nodeId: string; registration: ApnsRegistration }>> {
   const state = await loadRegistrationsState(baseDir);
-  const registrations: Array<{ nodeId: string; registration: ApnsRegistration }> = [];
+  const registrations: Array<{
+    nodeId: string;
+    registration: ApnsRegistration;
+  }> = [];
   for (const nodeId of nodeIds) {
     const normalizedNodeId = normalizeNodeId(nodeId);
     if (!normalizedNodeId) {
@@ -790,7 +797,12 @@ function toPushMetadata(params: {
   kind: "push.test" | "node.wake";
   nodeId: string;
   reason?: string;
-}): { kind: "push.test" | "node.wake"; nodeId: string; ts: number; reason?: string } {
+}): {
+  kind: "push.test" | "node.wake";
+  nodeId: string;
+  ts: number;
+  reason?: string;
+} {
   return {
     kind: params.kind,
     nodeId: params.nodeId,


### PR DESCRIPTION
## What Problem This Solves

Heartbeat event emission and APNs push error parsing both truncate user-generated text with `.slice(0, 200)`. When the 200-code-unit boundary lands mid-surrogate-pair (common with emoji and CJK supplementary characters in user messages or notification bodies), the dangling high surrogate renders as U+FFFD in operator-visible heartbeat events and APNs error diagnostics.

## Why This Change Was Made

`truncateUtf16Safe` from `@openclaw/normalization-core/utf16-slice` is the canonical leaf helper already shipped in the plugin SDK and used across the codebase. Using the leaf import keeps the dependency graph minimal.

## Evidence

### Vitest — APNs parseReason surrogate-pair regression

Calls `sendApnsAlert` (the exact production path through `parseReason`) with an error body containing emoji straddling the 200-code-unit boundary. Asserts no U+FFFD in the returned reason.

```
$ node scripts/run-vitest.mjs src/infra/push-apns.test.ts

 Test Files  1 passed (1)
      Tests  15 passed (15)
```

### Surrogate boundary proof (branch head f70268b9)

Heartbeat preview: 6 `emitHeartbeatEvent` call sites (`heartbeatToolResponse.summary`, `normalized.text`, 4× `previewText`) — all at 200 code units, all switched to `truncateUtf16Safe`.

APNs error body: `parseReason` fallback paths use `truncateUtf16Safe(trimmed, 200)` instead of `trimmed.slice(0, 200)`.

```
=== Heartbeat preview @200 ===
Raw .slice(0,200) ends: "xxxx\ud83d" (dangling high surrogate → U+FFFD)
truncateUtf16Safe(..., 200): len=199 | no U+FFFD

=== APNs error body @200 ===
Raw .slice(0,200) ends: "\ud83d" (dangling)
truncateUtf16Safe(..., 200): no U+FFFD
```

## Files Changed

| File | Change |
|------|--------|
| `src/infra/heartbeat-runner.ts` | 6 preview truncation sites → `truncateUtf16Safe` |
| `src/infra/push-apns.ts` | 2 error-body truncation sites → `truncateUtf16Safe` |
| `src/infra/push-apns.test.ts` | +1 surrogate-pair regression test (at correct describe scope) |
