### PR TITLE
fix(chat): keep proof decision out of actor closure

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
@@ -1048,23 +1048,25 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
             bindings: [self.gatewayID, id])
         else { return .unavailable }
         guard sqlite3_changes(db) > 0 else { return .unavailable }
-        let isProven = self.canonicalMessageProofHub.lockProofDecision(for: messageKey)
-        defer { self.canonicalMessageProofHub.unlockProofDecision() }
         let result: OpenClawChatOutboxUpdateResult
-        if isProven {
-            committed = self.execute(db, sql: "COMMIT", bindings: [])
-            result = committed ? .confirmed : .unavailable
-        } else {
-            guard self.removeCachedMessage(
-                db,
-                sessionKey: sessionKey,
-                agentID: Self.transcriptCacheAgentID(
+        do {
+            let isProven = self.canonicalMessageProofHub.lockProofDecision(for: messageKey)
+            defer { self.canonicalMessageProofHub.unlockProofDecision() }
+            if isProven {
+                committed = self.execute(db, sql: "COMMIT", bindings: [])
+                result = committed ? .confirmed : .unavailable
+            } else {
+                guard self.removeCachedMessage(
+                    db,
                     sessionKey: sessionKey,
-                    agentID: agentID),
-                idempotencyKey: messageKey)
-            else { return .unavailable }
-            committed = self.execute(db, sql: "COMMIT", bindings: [])
-            result = committed ? .updated : .unavailable
+                    agentID: Self.transcriptCacheAgentID(
+                        sessionKey: sessionKey,
+                        agentID: agentID),
+                    idempotencyKey: messageKey)
+                else { return .unavailable }
+                committed = self.execute(db, sql: "COMMIT", bindings: [])
+                result = committed ? .updated : .unavailable
+            }
         }
         if result == .confirmed {
             self.emitOutboxChange(.confirmed(id: id))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTranscriptCache.swift
@@ -72,10 +72,13 @@ private final class CanonicalMessageProofHub: @unchecked Sendable {
     /// Serializes the final cancellation decision and SQLite commit with
     /// synchronous canonical observation. Evidence recorded before this lock
     /// wins; evidence after it observes a completed cancellation.
-    func withProofDecision<T>(for key: String, _ body: (Bool) -> T) -> T {
+    func lockProofDecision(for key: String) -> Bool {
         self.lock.lock()
-        defer { self.lock.unlock() }
-        return body(self.keys.contains(key))
+        return self.keys.contains(key)
+    }
+
+    func unlockProofDecision() {
+        self.lock.unlock()
     }
 }
 
@@ -1028,11 +1031,11 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
             sessionKey = foundSessionKey
             agentID = foundAgentID
         case .missing:
-            return self.canonicalMessageProofHub.withProofDecision(for: messageKey) { isProven in
-                committed = self.execute(db, sql: "COMMIT", bindings: [])
-                guard committed else { return .unavailable }
-                return isProven ? .confirmed : .missing
-            }
+            let isProven = self.canonicalMessageProofHub.lockProofDecision(for: messageKey)
+            defer { self.canonicalMessageProofHub.unlockProofDecision() }
+            committed = self.execute(db, sql: "COMMIT", bindings: [])
+            guard committed else { return .unavailable }
+            return isProven ? .confirmed : .missing
         case .unavailable:
             return .unavailable
         }
@@ -1045,11 +1048,13 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
             bindings: [self.gatewayID, id])
         else { return .unavailable }
         guard sqlite3_changes(db) > 0 else { return .unavailable }
-        let result = self.canonicalMessageProofHub.withProofDecision(for: messageKey) { isProven in
-            if isProven {
-                committed = self.execute(db, sql: "COMMIT", bindings: [])
-                return committed ? OpenClawChatOutboxUpdateResult.confirmed : .unavailable
-            }
+        let isProven = self.canonicalMessageProofHub.lockProofDecision(for: messageKey)
+        defer { self.canonicalMessageProofHub.unlockProofDecision() }
+        let result: OpenClawChatOutboxUpdateResult
+        if isProven {
+            committed = self.execute(db, sql: "COMMIT", bindings: [])
+            result = committed ? .confirmed : .unavailable
+        } else {
             guard self.removeCachedMessage(
                 db,
                 sessionKey: sessionKey,
@@ -1059,7 +1064,7 @@ public actor OpenClawChatSQLiteTranscriptCache: OpenClawChatTranscriptCache,
                 idempotencyKey: messageKey)
             else { return .unavailable }
             committed = self.execute(db, sql: "COMMIT", bindings: [])
-            return committed ? .updated : .unavailable
+            result = committed ? .updated : .unavailable
         }
         if result == .confirmed {
             self.emitOutboxChange(.confirmed(id: id))


### PR DESCRIPTION
## What Problem This Solves

Swift 6.2 strict concurrency rejects `OpenClawChatSQLiteTranscriptCache.cancelCommand` because the closure passed to `CanonicalMessageProofHub.withProofDecision` captures actor-isolated SQLite state and actor methods. The failing diagnostic is `sending 'db' risks causing data races`, and it blocks `GatewayEndpointStoreTests`, the `OpenClaw` product build, and packaged app verification from current `main`.

The fix keeps the same final cancellation synchronization semantics, but replaces the closure helper with explicit `lockProofDecision` / `unlockProofDecision` calls. That keeps the final proof decision, SQLite commit, and cache removal inside the same synchronized region while leaving actor-isolated work in the actor method body.

## Summary

- replace the closure-based proof-decision helper with explicit lock/unlock calls
- preserve lock coverage around proof decision, SQLite commit, and cache cleanup
- avoid passing actor-isolated SQLite state through a synchronous nonisolated closure under Swift 6.2

## Evidence

Validated on the rebased head `ed57e6a07e4fe1d452db9f78ec18a56725eed1f5`, based on current `main` `9614129c2bfb877411780b3568c3a0bc7db0d099`:

- `swift test --package-path apps/macos --filter ChatTranscriptCacheIdentityTests` (6 tests passed)
- `swift test --package-path apps/macos --filter WebChatSwiftUISmokeTests` (2 tests passed)
- `swift test --package-path apps/shared/OpenClawKit --filter ChatTranscriptCacheStoreTests` (39 tests passed)
- `swift test --package-path apps/macos --filter GatewayEndpointStoreTests` (42 tests passed)
- `swift build --package-path apps/macos --product OpenClaw`
- `git diff --check`

This refresh is rebase-only over the existing one-file actor-isolation fix.
