### PR TITLE
fix(agents): keep tool/command display truncation UTF-16 safe

### DIFF
--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -6,6 +6,7 @@ import {
   normalizeOptionalLowercaseString,
   type FastMode,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 import { ACP_TURN_TIMEOUT_DETAIL_CODE } from "../../acp/control-plane/manager.turn-timeout.js";
 import { formatAcpErrorChain } from "../../acp/runtime/errors.js";
@@ -1023,7 +1024,11 @@ function resolveAcpLifecycleEndFields(
     resultStatus,
   );
   if (terminalReason === "timed_out") {
-    return { aborted: true, stopReason: "timeout", status: "timed_out" } as const;
+    return {
+      aborted: true,
+      stopReason: "timeout",
+      status: "timed_out",
+    } as const;
   }
   if (terminalReason === "cancelled") {
     return { aborted: true, stopReason: "stop", status: "cancelled" } as const;
@@ -1162,7 +1167,7 @@ function resolvePresentProxyEnvKeys(env: NodeJS.ProcessEnv = process.env): strin
 }
 
 function sanitizeAcpDiagnosticText(value: string): string {
-  return redactSensitiveText(value).replace(/\s+/g, " ").trim().slice(0, 240);
+  return truncateUtf16Safe(redactSensitiveText(value).replace(/\s+/g, " ").trim(), 240);
 }
 
 function acpRuntimeEventDiagnostics(event: AcpRuntimeEvent): Record<string, unknown> {
@@ -1303,7 +1308,11 @@ export function emitAcpLifecycleError(params: {
     params.terminalOutcome === "blocked"
       ? ({ livenessState: "blocked" } as const)
       : terminalReason === "timed_out"
-        ? ({ aborted: true, stopReason: "timeout", status: "timed_out" } as const)
+        ? ({
+            aborted: true,
+            stopReason: "timeout",
+            status: "timed_out",
+          } as const)
         : resolveAgentRunAbortLifecycleFields(params.abortSignal);
   const emit = params.auditOnly ? emitAgentAuditEvent : emitAgentEvent;
   emit({

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -48,6 +48,7 @@ import {
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import OpenAI, { AzureOpenAI } from "openai";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
 import type {
@@ -133,7 +134,9 @@ const OPENAI_CODEX_RESPONSES_PROVIDERS = new Set(["openai"]);
 const log = createSubsystemLogger("openai-transport");
 const loggedOpenAIStrictToolDowngradeDiagnosticKeys = new Set<string>();
 
-type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
+type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & {
+  id?: string;
+};
 type OpenAIResponsesReasoningReplayMetadata = {
   v: 1;
   source: "openai-responses";
@@ -462,7 +465,7 @@ function stringifyRedactedPayload(value: unknown): string {
       return "<empty>";
     }
     const redacted = redactSensitiveText(encoded, { mode: "tools" });
-    return redacted.length > 8000 ? `${redacted.slice(0, 8000)}…<truncated>` : redacted;
+    return redacted.length > 8000 ? `${truncateUtf16Safe(redacted, 8000)}…<truncated>` : redacted;
   } catch {
     return "<unserializable>";
   }
@@ -470,7 +473,7 @@ function stringifyRedactedPayload(value: unknown): string {
 
 function stringifyRedactedEvent(value: unknown): string {
   const redacted = stringifyRedactedPayload(value);
-  return redacted.length > 2000 ? `${redacted.slice(0, 2000)}…<truncated>` : redacted;
+  return redacted.length > 2000 ? `${truncateUtf16Safe(redacted, 2000)}…<truncated>` : redacted;
 }
 
 type ResponsesFailedNoDetailsObservation = {
@@ -830,7 +833,10 @@ function isInvalidEncryptedContentError(error: unknown): boolean {
   );
 }
 
-function stripEncryptedContentFields(value: unknown): { value: unknown; changed: boolean } {
+function stripEncryptedContentFields(value: unknown): {
+  value: unknown;
+  changed: boolean;
+} {
   if (!value || typeof value !== "object") {
     return { value, changed: false };
   }
@@ -1061,7 +1067,11 @@ function parseTextSignature(
   }
   if (signature.startsWith("{")) {
     try {
-      const parsed = JSON.parse(signature) as { v?: unknown; id?: unknown; phase?: unknown };
+      const parsed = JSON.parse(signature) as {
+        v?: unknown;
+        id?: unknown;
+        phase?: unknown;
+      };
       if (parsed.v === 1) {
         const id = typeof parsed.id === "string" ? parsed.id : undefined;
         const phase =
@@ -1176,14 +1186,20 @@ function convertResponsesMessages(
       if (typeof msg.content === "string") {
         messages.push(
           buildResponsesInputMessage("user", [
-            { type: "input_text", text: sanitizeTransportPayloadText(msg.content) },
+            {
+              type: "input_text",
+              text: sanitizeTransportPayloadText(msg.content),
+            },
           ]),
         );
       } else {
         const content = (
           msg.content.map((item) =>
             item.type === "text"
-              ? { type: "input_text", text: sanitizeTransportPayloadText(item.text) }
+              ? {
+                  type: "input_text",
+                  text: sanitizeTransportPayloadText(item.text),
+                }
               : {
                   type: "input_image",
                   detail: "auto",
@@ -1464,8 +1480,16 @@ async function processResponsesStream(
     // block now and replay the withheld text as one delta.
     currentBlock = { type: "text", text: pendingMessageText };
     output.content.push(currentBlock);
-    stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
-    stream.push({ type: "text_delta", contentIndex: blockIndex(), delta: pendingMessageText });
+    stream.push({
+      type: "text_start",
+      contentIndex: blockIndex(),
+      partial: output,
+    });
+    stream.push({
+      type: "text_delta",
+      contentIndex: blockIndex(),
+      delta: pendingMessageText,
+    });
     pendingMessageText = null;
   };
   const appendCompletedResponseTextItem = (item: Record<string, unknown>) => {
@@ -1502,7 +1526,11 @@ async function processResponsesStream(
     };
     output.content.push(block);
     lastTextBlock = { block, index: blockIndex(), phase };
-    stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+    stream.push({
+      type: "text_start",
+      contentIndex: blockIndex(),
+      partial: output,
+    });
     stream.push({
       type: "text_end",
       contentIndex: blockIndex(),
@@ -1520,7 +1548,11 @@ async function processResponsesStream(
       partialJson: stringifyJsonLike(item.arguments, "{}"),
     };
     output.content.push(block);
-    stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+    stream.push({
+      type: "toolcall_start",
+      contentIndex: blockIndex(),
+      partial: output,
+    });
     stream.push({
       type: "toolcall_end",
       contentIndex: blockIndex(),
@@ -1598,7 +1630,11 @@ async function processResponsesStream(
         currentItem = item;
         currentBlock = { type: "thinking", thinking: "" };
         output.content.push(currentBlock);
-        stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+        stream.push({
+          type: "thinking_start",
+          contentIndex: blockIndex(),
+          partial: output,
+        });
       } else if (item.type === "message") {
         currentItem = item;
         if (lastTextBlock) {
@@ -1607,7 +1643,11 @@ async function processResponsesStream(
         } else {
           currentBlock = { type: "text", text: "" };
           output.content.push(currentBlock);
-          stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+          stream.push({
+            type: "text_start",
+            contentIndex: blockIndex(),
+            partial: output,
+          });
         }
       } else if (item.type === "function_call") {
         currentItem = item;
@@ -1619,7 +1659,11 @@ async function processResponsesStream(
           partialJson: stringifyJsonLike(item.arguments),
         };
         output.content.push(currentBlock);
-        stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+        stream.push({
+          type: "toolcall_start",
+          contentIndex: blockIndex(),
+          partial: output,
+        });
       }
     } else if (type === "response.reasoning_summary_text.delta") {
       if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
@@ -1693,7 +1737,11 @@ async function processResponsesStream(
         const content = Array.isArray(item.content) ? item.content : [];
         const finalText = content
           .map((part) => {
-            const contentPart = part as { type?: string; text?: string; refusal?: string };
+            const contentPart = part as {
+              type?: string;
+              text?: string;
+              refusal?: string;
+            };
             return isResponsesTextContentPartType(contentPart.type)
               ? (contentPart.text ?? "")
               : (contentPart.refusal ?? "");
@@ -1734,7 +1782,11 @@ async function processResponsesStream(
             // text_end below.
             currentBlock = { type: "text", text: "" };
             output.content.push(currentBlock);
-            stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+            stream.push({
+              type: "text_start",
+              contentIndex: blockIndex(),
+              partial: output,
+            });
           }
           currentBlock.text = finalText;
           currentBlock.textSignature = encodeTextSignatureV1(stringifyUnknown(item.id), phase);
@@ -1776,7 +1828,10 @@ async function processResponsesStream(
             input_tokens?: number;
             output_tokens?: number;
             total_tokens?: number;
-            input_tokens_details?: { cached_tokens?: number; cache_write_tokens?: number };
+            input_tokens_details?: {
+              cached_tokens?: number;
+              cache_write_tokens?: number;
+            };
             output_tokens_details?: { reasoning_tokens?: number };
             service_tier?: ResponseCreateParamsStreaming["service_tier"];
             status?: string;
@@ -2007,7 +2062,10 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
   return (model, context, options) => {
     const responsesOptions = options as OpenAIResponsesOptions | undefined;
     const eventStream = createAssistantMessageEventStream();
-    const stream = eventStream as unknown as { push(event: unknown): void; end(): void };
+    const stream = eventStream as unknown as {
+      push(event: unknown): void;
+      end(): void;
+    };
     void (async () => {
       const output: MutableAssistantOutput = {
         role: "assistant" as const,
@@ -2107,7 +2165,11 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
         if (output.stopReason === "aborted" || output.stopReason === "error") {
           throw new Error("An unknown error occurred");
         }
-        stream.push({ type: "done", reason: output.stopReason as never, message: output as never });
+        stream.push({
+          type: "done",
+          reason: output.stopReason as never,
+          message: output as never,
+        });
         stream.end();
       } catch (error) {
         log.warn(
@@ -2115,7 +2177,11 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
             summarizeOpenAITransportError(error),
         );
         assignTransportErrorDetails(output, error, options?.signal);
-        stream.push({ type: "error", reason: output.stopReason as never, error: output as never });
+        stream.push({
+          type: "error",
+          reason: output.stopReason as never,
+          error: output as never,
+        });
         stream.end();
       } finally {
         firstEventAbort?.dispose();
@@ -2373,7 +2439,9 @@ export function buildOpenAIResponsesParams(
     prompt_cache_key: promptCacheKey,
     prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
     ...(isCodexResponses
-      ? { instructions: resolveOpenAICodexResponsesInstructions(model, context) }
+      ? {
+          instructions: resolveOpenAICodexResponsesInstructions(model, context),
+        }
       : {}),
     ...(metadata ? { metadata } : {}),
   };
@@ -2464,7 +2532,10 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
   return (model, context, options) => {
     const responsesOptions = options as OpenAIResponsesOptions | undefined;
     const eventStream = createAssistantMessageEventStream();
-    const stream = eventStream as unknown as { push(event: unknown): void; end(): void };
+    const stream = eventStream as unknown as {
+      push(event: unknown): void;
+      end(): void;
+    };
     void (async () => {
       const output: MutableAssistantOutput = {
         role: "assistant" as const,
@@ -2560,7 +2631,11 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
         if (output.stopReason === "aborted" || output.stopReason === "error") {
           throw new Error("An unknown error occurred");
         }
-        stream.push({ type: "done", reason: output.stopReason as never, message: output as never });
+        stream.push({
+          type: "done",
+          reason: output.stopReason as never,
+          message: output as never,
+        });
         stream.end();
       } catch (error) {
         log.warn(
@@ -2568,7 +2643,11 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
             summarizeOpenAITransportError(error),
         );
         assignTransportErrorDetails(output, error, options?.signal);
-        stream.push({ type: "error", reason: output.stopReason as never, error: output as never });
+        stream.push({
+          type: "error",
+          reason: output.stopReason as never,
+          error: output as never,
+        });
         stream.end();
       } finally {
         firstEventAbort?.dispose();
@@ -2746,7 +2825,10 @@ function buildOpenAICompletionsClientConfig(
 export function createOpenAICompletionsTransportStreamFn(): StreamFn {
   return (model, context, options) => {
     const eventStream = createAssistantMessageEventStream();
-    const stream = eventStream as unknown as { push(event: unknown): void; end(): void };
+    const stream = eventStream as unknown as {
+      push(event: unknown): void;
+      end(): void;
+    };
     void (async () => {
       const output: MutableAssistantOutput = {
         role: "assistant" as const,
@@ -2913,7 +2995,11 @@ async function processOpenAICompletionsStream(
         ...(reasoningDelta.signature ? { thinkingSignature: reasoningDelta.signature } : {}),
       };
       output.content.push(currentBlock);
-      pushStreamEvent({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+      pushStreamEvent({
+        type: "thinking_start",
+        contentIndex: blockIndex(),
+        partial: output,
+      });
     }
     currentBlock.thinking += reasoningDelta.text;
     pushStreamEvent({
@@ -2928,7 +3014,11 @@ async function processOpenAICompletionsStream(
       finishCurrentBlock();
       currentBlock = { type: "text", text: "" };
       output.content.push(currentBlock);
-      pushStreamEvent({ type: "text_start", contentIndex: blockIndex(), partial: output });
+      pushStreamEvent({
+        type: "text_start",
+        contentIndex: blockIndex(),
+        partial: output,
+      });
     }
     currentBlock.text += text;
     pushStreamEvent({
@@ -3133,7 +3223,11 @@ async function processOpenAICompletionsStream(
     }
     const choiceDelta =
       choice.delta ??
-      (choice as unknown as { message?: ChatCompletionChunk["choices"][number]["delta"] }).message;
+      (
+        choice as unknown as {
+          message?: ChatCompletionChunk["choices"][number]["delta"];
+        }
+      ).message;
     if (!choiceDelta) {
       emitReasoningUsageActivity(hasReasoningUsageActivity);
       await cooperativeScheduler.afterEvent();
@@ -3563,7 +3657,11 @@ function getCompletionsReasoningDeltas(
       }
       if (detail.type === "reasoning.text") {
         usedReasoningThinkingDetails = true;
-        pushDelta({ kind: "thinking", signature: "reasoning_details", text: detail.text });
+        pushDelta({
+          kind: "thinking",
+          signature: "reasoning_details",
+          text: detail.text,
+        });
         continue;
       }
       if (typeof detail.type === "string" && visibleTypes.has(detail.type)) {
@@ -4023,7 +4121,12 @@ function injectToolCallThoughtSignatures(
     if ((msg as { role?: string }).role !== "assistant") {
       continue;
     }
-    const source = msg as { api?: string; provider?: string; model?: string; content?: unknown };
+    const source = msg as {
+      api?: string;
+      provider?: string;
+      model?: string;
+      content?: unknown;
+    };
     if (!Array.isArray(source.content)) {
       continue;
     }
@@ -4207,7 +4310,10 @@ function getReasoningContentReplayModelIdCandidates(modelId: unknown): string[] 
 
 function shouldPreserveReasoningContentReplay(
   model: OpenAIModeModel,
-  compat: { requiresReasoningContentOnAssistantMessages: boolean; thinkingFormat: string },
+  compat: {
+    requiresReasoningContentOnAssistantMessages: boolean;
+    thinkingFormat: string;
+  },
 ): boolean {
   if (
     compat.requiresReasoningContentOnAssistantMessages ||
@@ -4247,7 +4353,10 @@ function shouldTrustReasoningContentReplayMetadata(model: OpenAIModeModel): bool
 // strip them for stock OpenAI before a follow-up request hits the wire.
 function sanitizeCompletionsReasoningReplayFields(
   messages: unknown,
-  options: { preserveOpenRouterReasoning: boolean; preserveReasoningContent: boolean },
+  options: {
+    preserveOpenRouterReasoning: boolean;
+    preserveReasoningContent: boolean;
+  },
 ): void {
   if (!Array.isArray(messages)) {
     return;

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -11,6 +11,7 @@ import {
   uniqueStrings,
   uniqueValues,
 } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
@@ -1131,7 +1132,7 @@ function compactDirectoryDescription(description: string): string {
   if (normalized.length <= 180) {
     return normalized;
   }
-  return `${normalized.slice(0, 177).trimEnd()}...`;
+  return `${truncateUtf16Safe(normalized, 177).trimEnd()}...`;
 }
 
 function formatToolDirectoryIdentifier(value: string | undefined): string | undefined {
@@ -1640,7 +1641,10 @@ function findEntryByExactId(
   const entry = catalog.entries.find((candidate) => candidate.id === needle);
   if (!entry) {
     throw new ToolInputError(
-      formatUnknownToolIdError(needle, catalog.entries, { ...errorOptions, exactIdOnly: true }),
+      formatUnknownToolIdError(needle, catalog.entries, {
+        ...errorOptions,
+        exactIdOnly: true,
+      }),
     );
   }
   return entry;
@@ -1981,7 +1985,11 @@ export function addClientToolsToToolCatalog(params: {
     entries: params.tools.map((tool) => toCatalogEntry(tool, "client")),
     append: true,
   });
-  return { tools: [], compacted: params.tools.length > 0, catalogToolCount: params.tools.length };
+  return {
+    tools: [],
+    compacted: params.tools.length > 0,
+    catalogToolCount: params.tools.length,
+  };
 }
 
 function toJsonSafe(value: unknown): unknown {
@@ -2289,7 +2297,14 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
         onUpdate?: AgentToolUpdateCallback,
       ): Promise<AgentToolResult<unknown>> =>
         jsonResult(
-          await runCodeMode({ toolCallId, ctx, code: readCode(args), config, signal, onUpdate }),
+          await runCodeMode({
+            toolCallId,
+            ctx,
+            code: readCode(args),
+            config,
+            signal,
+            onUpdate,
+          }),
         ),
     },
     {
@@ -2322,7 +2337,9 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
       parameters: Type.Object({
         id: Type.String({ description: "Tool search result id or tool name." }),
         args: Type.Optional(
-          Type.Record(Type.String(), Type.Unknown(), { description: "Tool input." }),
+          Type.Record(Type.String(), Type.Unknown(), {
+            description: "Tool input.",
+          }),
         ),
       }),
       execute: async (

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -9,6 +9,7 @@ import {
   normalizeOptionalString,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
 import { isRestartEnabled } from "../../config/commands.flags.js";
 import { parseConfigJson5, resolveConfigSnapshotHash } from "../../config/io.js";
@@ -466,7 +467,8 @@ export function createGatewayTool(opts?: {
           normalizeOptionalString(opts?.agentSessionKey) ??
           normalizeOptionalString(params.sessionKey);
         const delayMs = readNonNegativeIntegerParam(params, "delayMs");
-        const reason = normalizeOptionalString(params.reason)?.slice(0, 200);
+        const rawReason = normalizeOptionalString(params.reason);
+        const reason = rawReason ? truncateUtf16Safe(rawReason, 200) : undefined;
         const note = normalizeOptionalString(params.note);
         const continuationMessage = normalizeOptionalString(params.continuationMessage);
         // Extract channel + threadId for routing after restart.
@@ -559,7 +561,13 @@ export function createGatewayTool(opts?: {
         if (!baseHash) {
           throw new Error("Missing baseHash from config snapshot.");
         }
-        return { raw, baseHash, snapshotConfig, replacePaths, ...resolveGatewayWriteMeta() };
+        return {
+          raw,
+          baseHash,
+          snapshotConfig,
+          replacePaths,
+          ...resolveGatewayWriteMeta(),
+        };
       };
 
       if (action === "config.get") {
@@ -603,7 +611,10 @@ export function createGatewayTool(opts?: {
           note,
           restartDelayMs,
         });
-        return jsonResult({ ok: true, result: stripConfigWriteResultPayload(result) });
+        return jsonResult({
+          ok: true,
+          result: stripConfigWriteResultPayload(result),
+        });
       }
       if (action === "config.patch") {
         const { raw, baseHash, snapshotConfig, sessionKey, note, restartDelayMs, replacePaths } =
@@ -622,7 +633,10 @@ export function createGatewayTool(opts?: {
           restartDelayMs,
           ...(replacePaths ? { replacePaths } : {}),
         });
-        return jsonResult({ ok: true, result: stripConfigWriteResultPayload(result) });
+        return jsonResult({
+          ok: true,
+          result: stripConfigWriteResultPayload(result),
+        });
       }
       if (action === "update.run") {
         const { sessionKey, note, restartDelayMs } = resolveGatewayWriteMeta();


### PR DESCRIPTION
## What Problem This Solves

Four agent-module call sites truncate text with raw `.slice(0, N)` where the boundary can land mid-surrogate-pair — producing U+FFFD in:

- **tool-search**: directory descriptions (177-code-unit boundary)
- **gateway-tool**: restart `reason` parameter (200-code-unit boundary)
- **openai-transport-stream**: redacted tool-argument/event payloads (8000/2000)
- **command/attempt-execution**: ACP diagnostic text (240-code-unit boundary)

All of these truncate user-visible or agent-generated text that may contain emoji or CJK supplementary characters.

## Why This Change Was Made

`truncateUtf16Safe` from `@openclaw/normalization-core/utf16-slice` is the canonical leaf helper.

## Evidence

### Branch prerun (commit eb05889e)

```
=== gateway-tool reason @200 ===
Raw .slice ends: "rrrr\ud83d" (dangling high surrogate)
truncateUtf16Safe: "rrr" | len: 199 | no U+FFFD

=== transport payload @8000 ===
Raw .slice ends: "pp\ud83c"
truncateUtf16Safe: len: 7999 | no U+FFFD

=== ACP diagnostic @240 ===
Raw .slice ends: "dd\ud83d"
truncateUtf16Safe: len: 239 | no U+FFFD

=== tool-search directory @177 ===
Raw .slice ends: "dd\ud83d"
truncateUtf16Safe: len: 176 | no U+FFFD
```

## Files Changed

| File | Change |
|------|--------|
| `src/agents/tool-search.ts` | `compactDirectoryDescription` @177: `.slice(0, 177)` → `truncateUtf16Safe` |
| `src/agents/tools/gateway-tool.ts` | Restart `reason` @200: `?.slice(0, 200)` → `truncateUtf16Safe` |
| `src/agents/openai-transport-stream.ts` | Redacted payload @8000 + event @2000: `.slice()` → `truncateUtf16Safe` |
| `src/agents/command/attempt-execution.ts` | ACP diagnostic @240: `.slice(0, 240)` → `truncateUtf16Safe` |
