### PR TITLE
fix(tasks): keep completion failure reason truncation UTF-16 safe

### DIFF
--- a/src/tasks/task-completion-contract.test.ts
+++ b/src/tasks/task-completion-contract.test.ts
@@ -1,0 +1,29 @@
+// Task completion contract tests.
+import { expect, describe, it } from "vitest";
+import { truncateUtf16Safe } from "../utils.js";
+
+describe("normalizeCompletionFailureReason truncation", () => {
+  it("does not cut failure reason with an emoji straddling the 159-char boundary", () => {
+    // "🚀" is a surrogate pair (2 UTF-16 code units). A failure reason with
+    // 158 'z' + the emoji has 160 code units. slice(0,159) splits the pair;
+    // truncateUtf16Safe backs out to 158 code points.
+    const text = "z".repeat(158) + "🚀";
+    // slice splits the surrogate pair at position 159
+    const sliced = text.slice(0, 159);
+    expect(sliced.charCodeAt(158)).toBe(0xd83d); // lone high surrogate
+    // truncateUtf16Safe drops the incomplete pair
+    expect(truncateUtf16Safe(text, 159)).toBe("z".repeat(158));
+  });
+
+  it("preserves failure reason text shorter than the limit unchanged", () => {
+    expect(truncateUtf16Safe("task blocked: no provider", 159)).toBe("task blocked: no provider");
+    expect(truncateUtf16Safe("", 159)).toBe("");
+  });
+
+  it("truncates long failure reasons without broken surrogates", () => {
+    const long = "a".repeat(200);
+    const result = truncateUtf16Safe(long, 159);
+    expect(result).toBe("a".repeat(159));
+    expect(result.length).toBe(159);
+  });
+});

--- a/src/tasks/task-completion-contract.ts
+++ b/src/tasks/task-completion-contract.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "../utils.js";
 // Defines task terminal outcome contracts used by completion handling.
 import type { TaskTerminalOutcome } from "./task-registry.types.js";
 
@@ -25,7 +26,7 @@ function normalizeCompletionFailureReason(value: string | null | undefined): str
   if (!normalized) {
     return "";
   }
-  return normalized.length <= 160 ? normalized : `${normalized.slice(0, 159)}...`;
+  return normalized.length <= 160 ? normalized : `${truncateUtf16Safe(normalized, 159)}...`;
 }
 
 function matchesProgressOnlyPrefix(value: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where task completion failure reasons could render broken U+FFFD replacement characters (`�`) when the failure reason contained an emoji or CJK supplementary character at the 159-character truncation boundary.

`normalizeCompletionFailureReason` caps failure reasons at 160 chars via `normalized.slice(0, 159)`. `String.prototype.slice` cuts at UTF-16 code unit boundaries — emoji like 🚀 are surrogate pairs (2 code units) and get split.

## Why This Change Was Made

Replace `normalized.slice(0, 159)` with `truncateUtf16Safe(normalized, 159)` — the standard helper already used in `src/tasks/task-status.ts` (same directory).

## User Impact

Task completion failure reasons containing emoji or CJK near the 160-character limit now display cleanly truncated text.

## Evidence

### Tests

```
$ node scripts/run-vitest.mjs src/tasks/task-completion-contract.test.ts

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

### Files Changed (2 files, +31/-1)

```
 src/tasks/task-completion-contract.test.ts | 29 +++++++++++++++++++++++++++++
 src/tasks/task-completion-contract.ts      |  3 ++-
```