### PR TITLE
fix(discord): prevent stale gateway error listeners after restart

### DIFF
--- a/extensions/discord/src/monitor/gateway-supervisor.test.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.test.ts
@@ -115,44 +115,20 @@ describe("createDiscordGatewaySupervisor", () => {
     supervisor.dispose();
   });
 
-  it("keeps suppressing late gateway errors after dispose", () => {
+  it("removes the gateway error listener on dispose", () => {
     const emitter = new EventEmitter();
-    const runtime = { error: vi.fn() };
     const supervisor = createDiscordGatewaySupervisor({
       gateway: { emitter },
       isDisallowedIntentsError: () => false,
-      runtime: runtime as never,
+      runtime: { error: vi.fn() } as never,
     });
 
-    supervisor.dispose();
-
-    emitter.emit("error", new Error("Max reconnect attempts (0) reached after close code 1005"));
-    expect(runtime.error).toHaveBeenCalledTimes(1);
-    expect(String(firstErrorArg(runtime))).toContain(
-      "suppressed late gateway reconnect-exhausted error after dispose",
-    );
-  });
-
-  it("dedupes identical late gateway errors after dispose", () => {
-    const emitter = new EventEmitter();
-    const runtime = { error: vi.fn() };
-    const supervisor = createDiscordGatewaySupervisor({
-      gateway: { emitter },
-      isDisallowedIntentsError: () => false,
-      runtime: runtime as never,
-    });
+    expect(emitter.listenerCount("error")).toBe(1);
 
     supervisor.dispose();
-    const first = new TypeError();
-    first.stack = "TypeError\n    at gatewayCrash (discord-gateway.js:12:34)";
-    const second = new TypeError();
-    second.stack = "TypeError\n    at gatewayCrash (discord-gateway.js:12:34)";
-    emitter.emit("error", first);
-    emitter.emit("error", second);
+    expect(emitter.listenerCount("error")).toBe(0);
 
-    expect(runtime.error).toHaveBeenCalledTimes(1);
-    expect(String(firstErrorArg(runtime))).toContain(
-      "suppressed late gateway fatal error after dispose: TypeError @ gatewayCrash (discord-gateway.js:12:34)",
-    );
+    supervisor.dispose();
+    expect(emitter.listenerCount("error")).toBe(0);
   });
 });

--- a/extensions/discord/src/monitor/gateway-supervisor.test.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.test.ts
@@ -1,6 +1,17 @@
 // Discord tests cover gateway supervisor plugin behavior.
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
+
+const { gatewayLogError } = vi.hoisted(() => ({ gatewayLogError: vi.fn() }));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>();
+  return {
+    ...actual,
+    createSubsystemLogger: () => ({ error: gatewayLogError }),
+  };
+});
+
 import {
   classifyDiscordGatewayEvent,
   DiscordGatewayLifecycleError,
@@ -117,6 +128,7 @@ describe("createDiscordGatewaySupervisor", () => {
 
   it("keeps a single late error guard after repeated dispose", () => {
     const emitter = new EventEmitter();
+    gatewayLogError.mockClear();
 
     for (let index = 0; index < 3; index += 1) {
       const supervisor = createDiscordGatewaySupervisor({
@@ -128,9 +140,15 @@ describe("createDiscordGatewaySupervisor", () => {
       expect(emitter.listenerCount("error")).toBe(1);
       supervisor.dispose();
       expect(emitter.listenerCount("error")).toBe(1);
-      expect(() => emitter.emit("error", new Error(`late gateway error ${index}`))).not.toThrow();
+      const error = new Error(`late gateway error ${index}`);
+      expect(() => emitter.emit("error", error)).not.toThrow();
+      emitter.emit("error", error);
     }
 
     expect(emitter.listenerCount("error")).toBe(1);
+    expect(gatewayLogError).toHaveBeenCalledTimes(3);
+    expect(gatewayLogError).toHaveBeenLastCalledWith(
+      "suppressed late gateway error after dispose: Error: late gateway error 2",
+    );
   });
 });

--- a/extensions/discord/src/monitor/gateway-supervisor.test.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.test.ts
@@ -115,20 +115,22 @@ describe("createDiscordGatewaySupervisor", () => {
     supervisor.dispose();
   });
 
-  it("removes the gateway error listener on dispose", () => {
+  it("keeps a single late error guard after repeated dispose", () => {
     const emitter = new EventEmitter();
-    const supervisor = createDiscordGatewaySupervisor({
-      gateway: { emitter },
-      isDisallowedIntentsError: () => false,
-      runtime: { error: vi.fn() } as never,
-    });
+
+    for (let index = 0; index < 3; index += 1) {
+      const supervisor = createDiscordGatewaySupervisor({
+        gateway: { emitter },
+        isDisallowedIntentsError: () => false,
+        runtime: { error: vi.fn() } as never,
+      });
+
+      expect(emitter.listenerCount("error")).toBe(1);
+      supervisor.dispose();
+      expect(emitter.listenerCount("error")).toBe(1);
+      expect(() => emitter.emit("error", new Error(`late gateway error ${index}`))).not.toThrow();
+    }
 
     expect(emitter.listenerCount("error")).toBe(1);
-
-    supervisor.dispose();
-    expect(emitter.listenerCount("error")).toBe(0);
-
-    supervisor.dispose();
-    expect(emitter.listenerCount("error")).toBe(0);
   });
 });

--- a/extensions/discord/src/monitor/gateway-supervisor.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.ts
@@ -198,6 +198,7 @@ export function createDiscordGatewaySupervisor(params: {
       if (phase === "disposed") {
         return;
       }
+      emitter.off("error", onGatewayError);
       lifecycleHandler = undefined;
       phase = "disposed";
       pending.length = 0;

--- a/extensions/discord/src/monitor/gateway-supervisor.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.ts
@@ -1,6 +1,6 @@
 // Discord plugin module implements gateway supervisor behavior.
 import type { EventEmitter } from "node:events";
-import { danger } from "openclaw/plugin-sdk/runtime-env";
+import { createSubsystemLogger, danger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 
@@ -41,6 +41,7 @@ export type DiscordGatewaySupervisor = {
 
 type GatewaySupervisorPhase = "active" | "buffering" | "disposed" | "teardown";
 
+const discordGatewayLog = createSubsystemLogger("discord/gateway");
 const discordGatewayLateErrorGuards = new WeakMap<EventEmitter, (err: unknown) => void>();
 
 function removeDiscordGatewayLateErrorGuard(emitter: EventEmitter): void {
@@ -56,7 +57,17 @@ function ensureDiscordGatewayLateErrorGuard(emitter: EventEmitter): void {
   if (emitter.listenerCount("error") > 0) {
     return;
   }
-  const guard = () => undefined;
+  const seenMessages = new Set<string>();
+  // Keep the emitter safe after its supervisor is gone without retaining the disposed runtime.
+  // A module-owned logger preserves one diagnostic per distinct late error until the next start.
+  const guard = (err: unknown) => {
+    const message = formatDiscordGatewayErrorMessage(err);
+    if (seenMessages.has(message)) {
+      return;
+    }
+    seenMessages.add(message);
+    discordGatewayLog.error(`suppressed late gateway error after dispose: ${message}`);
+  };
   discordGatewayLateErrorGuards.set(emitter, guard);
   emitter.on("error", guard);
 }

--- a/extensions/discord/src/monitor/gateway-supervisor.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.ts
@@ -41,6 +41,26 @@ export type DiscordGatewaySupervisor = {
 
 type GatewaySupervisorPhase = "active" | "buffering" | "disposed" | "teardown";
 
+const discordGatewayLateErrorGuards = new WeakMap<EventEmitter, (err: unknown) => void>();
+
+function removeDiscordGatewayLateErrorGuard(emitter: EventEmitter): void {
+  const guard = discordGatewayLateErrorGuards.get(emitter);
+  if (!guard) {
+    return;
+  }
+  emitter.off("error", guard);
+  discordGatewayLateErrorGuards.delete(emitter);
+}
+
+function ensureDiscordGatewayLateErrorGuard(emitter: EventEmitter): void {
+  if (emitter.listenerCount("error") > 0) {
+    return;
+  }
+  const guard = () => undefined;
+  discordGatewayLateErrorGuards.set(emitter, guard);
+  emitter.on("error", guard);
+}
+
 function readFirstStackFrame(err: Error): string | undefined {
   const stack = err.stack;
   if (!stack) {
@@ -169,6 +189,7 @@ export function createDiscordGatewaySupervisor(params: {
         pending.push(event);
     }
   };
+  removeDiscordGatewayLateErrorGuard(emitter);
   emitter.on("error", onGatewayError);
 
   return {
@@ -199,6 +220,7 @@ export function createDiscordGatewaySupervisor(params: {
         return;
       }
       emitter.off("error", onGatewayError);
+      ensureDiscordGatewayLateErrorGuard(emitter);
       lifecycleHandler = undefined;
       phase = "disposed";
       pending.length = 0;

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -364,7 +364,7 @@ describe("monitorDiscordProvider", () => {
     expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
   });
 
-  it("disconnects the shared gateway and removes the error listener when startup fails before lifecycle begins", async () => {
+  it("disconnects the shared gateway and keeps a late error guard when startup fails before lifecycle begins", async () => {
     const disconnect = vi.fn();
     const emitter = new EventEmitter();
     const gateway = { emitter, disconnect, isConnected: false };
@@ -385,7 +385,10 @@ describe("monitorDiscordProvider", () => {
 
     expect(monitorLifecycleMock).not.toHaveBeenCalled();
     expect(disconnect).toHaveBeenCalledTimes(1);
-    expect(emitter.listenerCount("error")).toBe(0);
+    expect(emitter.listenerCount("error")).toBe(1);
+    expect(() =>
+      emitter.emit("error", new Error("late gateway error after cleanup")),
+    ).not.toThrow();
   });
 
   it("fails closed before lifecycle when Discord bot identity fetch rejects", async () => {

--- a/extensions/discord/src/monitor/provider.test.ts
+++ b/extensions/discord/src/monitor/provider.test.ts
@@ -364,7 +364,7 @@ describe("monitorDiscordProvider", () => {
     expect(createdBindingManagers[0]?.stop).toHaveBeenCalledTimes(1);
   });
 
-  it("disconnects the shared gateway and suppresses late gateway errors when startup fails before lifecycle begins", async () => {
+  it("disconnects the shared gateway and removes the error listener when startup fails before lifecycle begins", async () => {
     const disconnect = vi.fn();
     const emitter = new EventEmitter();
     const gateway = { emitter, disconnect, isConnected: false };
@@ -385,13 +385,7 @@ describe("monitorDiscordProvider", () => {
 
     expect(monitorLifecycleMock).not.toHaveBeenCalled();
     expect(disconnect).toHaveBeenCalledTimes(1);
-    expect(
-      emitter.emit("error", new Error("Max reconnect attempts (0) reached after code 1005")),
-    ).toBe(true);
-    expectMockLogContains(
-      runtime.error,
-      "suppressed late gateway reconnect-exhausted error after dispose",
-    );
+    expect(emitter.listenerCount("error")).toBe(0);
   });
 
   it("fails closed before lifecycle when Discord bot identity fetch rejects", async () => {


### PR DESCRIPTION
## What Problem This Solves

Restarting or cleaning up the Discord gateway supervisor removed the disposed listener from a shared EventEmitter but could leave two bad outcomes: retaining old supervisor/runtime closures across restart cycles, or removing the last `error` listener so a delayed gateway error crashed the process.

## Why This Change Was Made

The supervisor now owns one emitter-scoped late-error guard. Disposal removes the active supervisor listener and installs the guard only when no other error listener exists. A replacement supervisor removes the guard before attaching its active listener, so listener count stays bounded and no disposed runtime closure is retained.

The guard logs each distinct late error through the Discord gateway subsystem logger instead of silently swallowing it. Repeated identical late errors are deduplicated until the next supervisor starts.

## User Impact

Discord channel restart and startup-cleanup paths no longer accumulate stale gateway listeners or crash on delayed emitter errors. Operators retain a bounded diagnostic when a late gateway error occurs.

## Evidence

- Blacksmith Testbox `coral-crab` (`tbx_01kx2dacsrr1z0hjxenejbt9s5`): 72 focused Discord tests passed across gateway supervisor, provider, gateway monitor, and provider lifecycle suites.
- Blacksmith Testbox changed-surface gate passed: extension test typecheck, changed-file lint, database-first guard, media helper guard, runtime sidecar guard, and runtime import-cycle check.
- Two fresh autoreview passes after the refactor and rebase: no actionable findings.
- `git diff --check` passed.

The refactor preserves contributor authorship. Release-note context remains in this PR body for the release-owned changelog flow.
