### PR TITLE
[AI] fix(feishu): use formatErrorMessage for sender name resolution error log

### DIFF
--- a/extensions/feishu/src/bot-sender-name.ts
+++ b/extensions/feishu/src/bot-sender-name.ts
@@ -4,6 +4,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createFeishuClient } from "./client.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -131,7 +132,7 @@ export async function resolveFeishuSenderName(params: {
       log(`feishu: permission error resolving sender name: code=${permErr.code}`);
       return { permissionError: permErr };
     }
-    log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${String(err)}`);
+    log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${formatErrorMessage(err)}`);
     return {};
   }
 }

--- a/extensions/feishu/src/bot-sender-name.ts
+++ b/extensions/feishu/src/bot-sender-name.ts
@@ -1,10 +1,10 @@
 // Feishu plugin module implements bot sender name behavior.
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
 } from "openclaw/plugin-sdk/number-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createFeishuClient } from "./client.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -132,7 +132,9 @@ export async function resolveFeishuSenderName(params: {
       log(`feishu: permission error resolving sender name: code=${permErr.code}`);
       return { permissionError: permErr };
     }
-    log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${formatErrorMessage(err)}`);
+    log(
+      `feishu: failed to resolve sender name for ${normalizedSenderId}: ${formatErrorMessage(err)}`,
+    );
     return {};
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu sender name resolution errors leak API credentials into gateway logs. When `resolveFeishuSenderName` fails, `String(err)` at `bot-sender-name.ts:134` preserves raw Feishu API error text that may contain `app_secret`, `tenant_access_token`, or Bearer tokens.

## Why This Change Was Made

Replace `String(err)` with `formatErrorMessage(err)` from the plugin SDK. `formatErrorMessage` (at `src/infra/errors.ts:69-113`) calls `redactSensitiveText` before returning, which redacts recognized secret patterns including `app_secret` (listed at `src/logging/redact.ts:32`) and token-bearing terms. Five sibling Feishu files (`probe.ts`, `tool-result.ts`, `drive.ts`, `bitable.ts`, `monitor.comment.ts`) already use `formatErrorMessage` for the same reason. The change is +2/-1 in a single file.

## User Impact

None. Error log output is semantically identical for debugging but no longer leaks credential names.

## Evidence

**Environment**: Linux x86_64, Node v24.13.1, OpenClaw 2026.6.11, branch `fix/feishu-format-error-sender-name`, commit `6c7fded68c`.

**Before/after — simulated Feishu sender name resolution failure** (`bot-sender-name.ts:134` exact log pattern):

```
$ node --import tsx -e "
import { formatErrorMessage } from 'openclaw/plugin-sdk/error-runtime';
const e = new Error('HTTP 400: {\"error\":\"invalid app_secret\",\"code\":-1}');
console.log('String(err):       ', String(e));
console.log('formatErrorMessage:', formatErrorMessage(e));
"
String(err):        Error: HTTP 400: {"error":"invalid app_secret","code":-1}
formatErrorMessage: Error: HTTP 400: {"error":"invalid app_***","code":-1}
```

**Full source code evidence — security chain:**

`formatErrorMessage(err)` in `src/infra/errors.ts:112-113`:
```typescript
  // Security: best-effort token redaction before returning/logging.
  return redactSensitiveText(formatted);
```

`app_secret` is a recognized sensitive key in `src/logging/redact.ts:32`:
```typescript
const FORM_BODY_SENSITIVE_KEYS: ReadonlySet<string> = new Set([
  ...
  "app_secret",
  ...
]);
```

**Unit tests:**

```console
$ node scripts/run-vitest.mjs extensions/feishu/src/bot-sender-name.test.ts --run
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**What was NOT tested**: Live Feishu gateway with real sender-name lookup failure (requires running gateway with valid Feishu app credentials and a managed gateway instance). The code path is structurally identical to the 5 sibling files already proven in production.
