### PR TITLE
fix(zalouser): keep outbound message text truncation UTF-16 safe

### DIFF
--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -26,7 +26,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { sleep } from "openclaw/plugin-sdk/text-utility-runtime";
+import { sleep, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeZaloReactionIcon } from "./reaction.js";
 import { createZalouserSendReceipt } from "./send-receipt.js";
 import type {
@@ -1238,7 +1238,7 @@ export async function sendZaloTextMessage(
             contentType: media.contentType,
             kind: media.kind,
           });
-          const payloadText = (text || options.caption || "").slice(0, 2000);
+          const payloadText = truncateUtf16Safe(text || options.caption || "", 2000);
           const textStyles = clampTextStyles(payloadText, options.textStyles);
 
           if (media.kind === "audio") {
@@ -1313,7 +1313,7 @@ export async function sendZaloTextMessage(
           };
         }
 
-        const payloadText = text.slice(0, 2000);
+        const payloadText = truncateUtf16Safe(text, 2000);
         const textStyles = clampTextStyles(payloadText, options.textStyles);
         const response = await api.sendMessage(
           textStyles ? { msg: payloadText, styles: textStyles } : payloadText,
@@ -1334,7 +1334,10 @@ export async function sendZaloTextMessage(
         return {
           ok: false,
           error: toErrorMessage(error),
-          receipt: createZalouserSendReceipt({ threadId: trimmedThreadId, kind: "unknown" }),
+          receipt: createZalouserSendReceipt({
+            threadId: trimmedThreadId,
+            kind: "unknown",
+          }),
         };
       }
     },
@@ -1466,7 +1469,10 @@ export async function sendZaloLink(
     return {
       ok: false,
       error: "No URL provided",
-      receipt: createZalouserSendReceipt({ threadId: trimmedThreadId, kind: "card" }),
+      receipt: createZalouserSendReceipt({
+        threadId: trimmedThreadId,
+        kind: "card",
+      }),
     };
   }
 
@@ -1497,7 +1503,10 @@ export async function sendZaloLink(
     return {
       ok: false,
       error: toErrorMessage(error),
-      receipt: createZalouserSendReceipt({ threadId: trimmedThreadId, kind: "card" }),
+      receipt: createZalouserSendReceipt({
+        threadId: trimmedThreadId,
+        kind: "card",
+      }),
     };
   }
 }


### PR DESCRIPTION
## What Problem This Solves

The Zalouser plugin truncates outbound message text with `.slice(0, 2000)` in two send paths — media messages and plain text messages. Zalo users in Vietnam commonly use emoji in messages. When the 2000-code-unit boundary lands mid-surrogate-pair, the dangling surrogate renders as U+FFFD in the message delivered to the Zalo recipient.

This is the highest-impact fix in the UTF-16 series — unlike log/display truncation, these sites directly affect **production user messages** sent through the Zalo platform.

## Why This Change Was Made

`truncateUtf16Safe` is already available via `openclaw/plugin-sdk/text-utility-runtime` — the same SDK module the file already imports from for `sleep`.

## Evidence

### Branch prerun (commit cef6cca7)

```
=== Zalo media message @2000 boundary ===
Raw .slice(0,2000) with "z".repeat(1998) + "🚀": Safe ends "z🚀" | len: 2000 | no U+FFFD: true

=== Zalo text message @2000 CJK within limit ===
1000 CJK chars → truncateUtf16Safe: len=1000 (unchanged, within limit)
```

## Files Changed

| File | Change |
|------|--------|
| `extensions/zalouser/src/zalo-js.ts` | +`truncateUtf16Safe` import; 2 `.slice(0, 2000)` → `truncateUtf16Safe(...)` |
