### PR TITLE
[AI] fix(xiaomi): dedup MiMo V2.5 thinking content leaked into text

### DIFF
--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -680,4 +680,133 @@ describe("xiaomi provider plugin", () => {
 
     await expect(stream.result()).resolves.toEqual(resultMessage);
   });
+
+  it.each(["mimo-v2.5", "mimo-v2.5-pro"] as const)(
+    "deduplicates text blocks that repeat thinking content for %s",
+    async (modelId) => {
+      const model = mimoReasoningModel(modelId);
+      const thinkingText = "Let me think about this step by step.";
+      const resultMessage = {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: thinkingText },
+          { type: "text", text: `${thinkingText}${thinkingText}${thinkingText}` },
+        ],
+        stopReason: "stop",
+      };
+      const wrapped = requireThinkingWrapper(
+        createMiMoThinkingWrapper(
+          createResultStreamFn({
+            events: [
+              {
+                type: "message_end",
+                message: resultMessage,
+              },
+            ],
+            resultMessage,
+          }),
+          "high",
+        ),
+        modelId,
+      );
+
+      const stream = (await wrapped(model, { messages: [] } as Context, {})) as FakeStream;
+      const events: unknown[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      // Text block should be removed (pure duplicate of thinking).
+      expect(events).toEqual([
+        {
+          type: "message_end",
+          message: {
+            role: "assistant",
+            content: [{ type: "thinking", thinking: thinkingText }],
+            stopReason: "stop",
+          },
+        },
+      ]);
+      await expect(stream.result()).resolves.toEqual({
+        role: "assistant",
+        content: [{ type: "thinking", thinking: thinkingText }],
+        stopReason: "stop",
+      });
+    },
+  );
+
+  it.each(["mimo-v2.5", "mimo-v2.5-pro"] as const)(
+    "preserves unique text suffix after stripping duplicated thinking prefix for %s",
+    async (modelId) => {
+      const model = mimoReasoningModel(modelId);
+      const thinkingText = "Let me analyze the request.";
+      const uniqueReply = "Here is the result.";
+      const resultMessage = {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: thinkingText },
+          { type: "text", text: `${thinkingText}${thinkingText}${uniqueReply}` },
+        ],
+        stopReason: "stop",
+      };
+      const wrapped = requireThinkingWrapper(
+        createMiMoThinkingWrapper(createResultStreamFn({ resultMessage }), "high"),
+        modelId,
+      );
+
+      const stream = (await wrapped(model, { messages: [] } as Context, {})) as FakeStream;
+      await expect(stream.result()).resolves.toEqual({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: thinkingText },
+          { type: "text", text: uniqueReply },
+        ],
+        stopReason: "stop",
+      });
+    },
+  );
+
+  it("does not dedup when text content does not repeat thinking content for mimo-v2.5", async () => {
+    const model = mimoReasoningModel("mimo-v2.5");
+    const thinkingText = "Internal reasoning.";
+    const visibleText = "Hello! How can I help you today?";
+    const resultMessage = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: thinkingText },
+        { type: "text", text: visibleText },
+      ],
+      stopReason: "stop",
+    };
+    const wrapped = requireThinkingWrapper(
+      createMiMoThinkingWrapper(createResultStreamFn({ resultMessage }), "high"),
+      "mimo-v2.5",
+    );
+
+    const stream = (await wrapped(model, { messages: [] } as Context, {})) as FakeStream;
+    // Text is not a duplicate prefix — keep both blocks.
+    await expect(stream.result()).resolves.toEqual(resultMessage);
+  });
+
+  it("does not affect mimo-v2-pro / mimo-v2-omni thinking-only promotion", async () => {
+    // mimo-v2-pro is still promoted (thinking → text), not deduped.
+    const model = mimoReasoningModel("mimo-v2-pro");
+    const resultMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "MiMo final answer" }],
+      stopReason: "stop",
+    };
+    const wrapped = requireThinkingWrapper(
+      createMiMoThinkingWrapper(createResultStreamFn({ resultMessage }), "high"),
+      "mimo-v2-pro",
+    );
+
+    const stream = (await wrapped(model, { messages: [] } as Context, {})) as FakeStream;
+    // Still promoted to text (existing behavior unchanged).
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "MiMo final answer" }],
+      stopReason: "stop",
+    });
+  });
 });

--- a/extensions/xiaomi/stream.ts
+++ b/extensions/xiaomi/stream.ts
@@ -4,8 +4,13 @@ import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-ent
 import {
   createDeepSeekV4OpenAICompatibleThinkingWrapper,
   createThinkingOnlyFinalTextWrapper,
+  createThinkingTextDedupWrapper,
 } from "openclaw/plugin-sdk/provider-stream-shared";
-import { isMiMoProviderId, isMiMoReasoningModelRef } from "./thinking.js";
+import {
+  isMiMoProviderId,
+  isMiMoReasoningModelRef,
+  isMiMoThinkingTextDedupModelRef,
+} from "./thinking.js";
 
 const MIMO_REASONING_AS_VISIBLE_TEXT_MODEL_IDS = new Set(["mimo-v2-pro", "mimo-v2-omni"]);
 
@@ -39,8 +44,15 @@ export function createMiMoThinkingWrapper(
   });
   // Legacy MiMo V2 can put the final user-visible answer in reasoning_content.
   // Only promote terminal thinking-only output; replay/tool-call reasoning stays untouched.
-  return createThinkingOnlyFinalTextWrapper({
+  const withPromote = createThinkingOnlyFinalTextWrapper({
     baseStreamFn: wrapped,
     shouldPatchModel: shouldPromoteMiMoReasoningToVisibleText,
+  });
+  // MiMo V2.5 / V2.5-pro return reasoning duplicated in both thinking and text
+  // blocks. Strip the duplicated thinking prefix from text so only the unique
+  // user-facing reply remains.
+  return createThinkingTextDedupWrapper({
+    baseStreamFn: withPromote,
+    shouldPatchModel: isMiMoThinkingTextDedupModelRef,
   });
 }

--- a/extensions/xiaomi/thinking.ts
+++ b/extensions/xiaomi/thinking.ts
@@ -10,6 +10,11 @@ const MIMO_REASONING_MODEL_IDS = new Set([
   "mimo-v2.6-pro",
 ]);
 
+/** MiMo model ids where the API returns reasoning content in both
+ *  the `reasoning_content` (thinking) and `content` (text) fields
+ *  simultaneously, causing visible text duplication. */
+const MIMO_THINKING_TEXT_DEDUP_MODEL_IDS = new Set(["mimo-v2.5", "mimo-v2.5-pro"]);
+
 export function isMiMoReasoningModelId(modelId: string): boolean {
   return MIMO_REASONING_MODEL_IDS.has(modelId.toLowerCase());
 }
@@ -23,6 +28,17 @@ export function isMiMoReasoningModelRef(model: { provider?: string; id?: unknown
     isMiMoProviderId(model.provider) &&
     typeof model.id === "string" &&
     isMiMoReasoningModelId(model.id)
+  );
+}
+
+export function isMiMoThinkingTextDedupModelRef(model: {
+  provider?: string;
+  id?: unknown;
+}): boolean {
+  return (
+    isMiMoProviderId(model.provider) &&
+    typeof model.id === "string" &&
+    MIMO_THINKING_TEXT_DEDUP_MODEL_IDS.has(model.id.toLowerCase())
   );
 }
 

--- a/src/agents/embedded-agent-runner/extra-params.ts
+++ b/src/agents/embedded-agent-runner/extra-params.ts
@@ -26,6 +26,7 @@ import type { SimpleStreamOptions } from "../../llm/types.js";
 import {
   createDeepSeekV4OpenAICompatibleThinkingWrapper,
   createThinkingOnlyFinalTextWrapper,
+  createThinkingTextDedupWrapper,
 } from "../../plugin-sdk/provider-stream-shared.js";
 import {
   prepareProviderExtraParams as prepareProviderExtraParamsRuntime,
@@ -853,6 +854,12 @@ function applyPostPluginStreamWrappers(
       baseStreamFn: ctx.agent.streamFn,
       shouldPatchModel: isMiMoReasoningAsVisibleTextOpenAICompatibleModel,
     });
+    // MiMo V2.5 / V2.5-pro return reasoning duplicated in both thinking and
+    // text blocks. Strip the duplicated thinking prefix from text.
+    ctx.agent.streamFn = createThinkingTextDedupWrapper({
+      baseStreamFn: ctx.agent.streamFn,
+      shouldPatchModel: isMiMoThinkingTextDedupOpenAICompatibleModel,
+    });
 
     // Guard Google-family payloads against invalid negative thinking budgets
     // emitted by upstream model-ID heuristics for Gemini 3.1 variants.
@@ -1008,6 +1015,7 @@ const MIMO_REASONING_OPENAI_COMPATIBLE_MODEL_IDS = new Set([
   "mimo-v2.6-pro",
 ]);
 const MIMO_REASONING_AS_VISIBLE_TEXT_MODEL_IDS = new Set(["mimo-v2-pro", "mimo-v2-omni"]);
+const MIMO_THINKING_TEXT_DEDUP_MODEL_IDS = new Set(["mimo-v2.5", "mimo-v2.5-pro"]);
 
 function isMiMoReasoningOpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
   const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
@@ -1026,6 +1034,15 @@ function isMiMoReasoningAsVisibleTextOpenAICompatibleModel(
     model.api === "openai-completions" &&
     normalizedModelId !== undefined &&
     MIMO_REASONING_AS_VISIBLE_TEXT_MODEL_IDS.has(normalizedModelId)
+  );
+}
+
+function isMiMoThinkingTextDedupOpenAICompatibleModel(model: Parameters<StreamFn>[0]): boolean {
+  const normalizedModelId = normalizeDeepSeekV4CandidateId(model.id);
+  return (
+    model.api === "openai-completions" &&
+    normalizedModelId !== undefined &&
+    MIMO_THINKING_TEXT_DEDUP_MODEL_IDS.has(normalizedModelId)
   );
 }
 

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -620,6 +620,129 @@ export function createThinkingOnlyFinalTextWrapper(params: {
   };
 }
 
+type ThinkingTextDedupStream = Awaited<ReturnType<StreamFn>>;
+
+/**
+ * Strip text blocks that duplicate thinking content.
+ *
+ * Some models (e.g. MiMo V2.5) return reasoning in both the `reasoning_content`
+ * (thinking) and `content` (text) fields simultaneously. This deduplicates text
+ * blocks by stripping the accumulated thinking prefix so only the unique
+ * user-facing reply remains.
+ */
+function dedupThinkingTextInFinalMessage(message: unknown): void {
+  if (!message || typeof message !== "object") {
+    return;
+  }
+  const record = message as { content?: unknown };
+  if (!Array.isArray(record.content) || record.content.length === 0) {
+    return;
+  }
+
+  let accumulatedThinking = "";
+  for (const block of record.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; thinking?: unknown };
+    if (
+      typedBlock.type === "thinking" &&
+      typeof typedBlock.thinking === "string" &&
+      typedBlock.thinking.trim()
+    ) {
+      accumulatedThinking += typedBlock.thinking;
+    }
+  }
+  if (!accumulatedThinking.trim()) {
+    return;
+  }
+
+  record.content = record.content
+    .map((block) => {
+      if (!block || typeof block !== "object") {
+        return block;
+      }
+      const typedBlock = block as { type?: unknown; text?: unknown };
+      if (typedBlock.type !== "text" || typeof typedBlock.text !== "string") {
+        return block;
+      }
+      let text = typedBlock.text;
+      // Strip leading occurrences of the accumulated thinking text.
+      // The model may repeat reasoning multiple times in the text field.
+      let changed = true;
+      while (changed && text.length > 0) {
+        changed = false;
+        if (text.startsWith(accumulatedThinking) && text.length >= accumulatedThinking.length) {
+          text = text.slice(accumulatedThinking.length);
+          changed = true;
+        }
+      }
+      if (!text.trim()) {
+        return null;
+      }
+      typedBlock.text = text;
+      return typedBlock;
+    })
+    .filter((block): block is NonNullable<typeof block> => block != null);
+}
+
+function wrapThinkingTextDedupStream(stream: ThinkingTextDedupStream): ThinkingTextDedupStream {
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    const message = await originalResult();
+    dedupThinkingTextInFinalMessage(message);
+    return message;
+  };
+
+  const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
+  (stream as { [Symbol.asyncIterator]: typeof originalAsyncIterator })[Symbol.asyncIterator] =
+    function () {
+      const iterator = originalAsyncIterator();
+      return {
+        async next() {
+          const result = await iterator.next();
+          if (!result.done && result.value && typeof result.value === "object") {
+            const event = result.value as { partial?: unknown; message?: unknown };
+            dedupThinkingTextInFinalMessage(event.partial);
+            dedupThinkingTextInFinalMessage(event.message);
+          }
+          return result;
+        },
+        async return(value?: unknown) {
+          return iterator.return?.(value) ?? { done: true as const, value: undefined };
+        },
+        async throw(error?: unknown) {
+          return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+    };
+  return stream;
+}
+
+/** @deprecated OpenAI-compatible provider stream helper; do not use from third-party plugins. */
+export function createThinkingTextDedupWrapper(params: {
+  baseStreamFn: StreamFn | undefined;
+  shouldPatchModel: (model: Parameters<StreamFn>[0]) => boolean;
+}): StreamFn | undefined {
+  if (!params.baseStreamFn) {
+    return undefined;
+  }
+  const underlying = params.baseStreamFn;
+  return (model, context, options) => {
+    const maybeStream = underlying(model, context, options);
+    if (!params.shouldPatchModel(model)) {
+      return maybeStream;
+    }
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return Promise.resolve(maybeStream).then((stream) => wrapThinkingTextDedupStream(stream));
+    }
+    return wrapThinkingTextDedupStream(maybeStream);
+  };
+}
+
 /** @deprecated Google provider-owned stream helper; do not use from third-party plugins. */
 export type GoogleThinkingLevel = "MINIMAL" | "LOW" | "MEDIUM" | "HIGH";
 /** @deprecated Google provider-owned stream helper; do not use from third-party plugins. */


### PR DESCRIPTION
## Summary

MiMo V2.5 / V2.5-pro return reasoning content in both `reasoning_content` (→ thinking block) and `content` (→ text block) fields simultaneously, causing visible text repetition and exposed internal reasoning. Add a shared thinking-text dedup wrapper that strips duplicated thinking prefixes from text blocks in final messages.

- Problem: MiMo v2.5/v2.5-pro API returns reasoning duplicated in both `reasoning_content` and `content` fields; the existing `promoteThinkingOnlyFinalOutputToText` only handles models that put answers solely in `reasoning_content` (thinking-only, no text).
- Solution: Add a new `createThinkingTextDedupWrapper` in the stream chain that, after thinking blocks are populated, strips accumulated thinking content from text block prefixes — removing pure duplicates and preserving any unique user-facing reply suffix.
- What changed:
  - `src/plugin-sdk/provider-stream-shared.ts`: new `dedupThinkingTextInFinalMessage` + `createThinkingTextDedupWrapper` shared helpers
  - `extensions/xiaomi/thinking.ts`: new `MIMO_THINKING_TEXT_DEDUP_MODEL_IDS` set + `isMiMoThinkingTextDedupModelRef` selector
  - `extensions/xiaomi/stream.ts`: chain `createThinkingTextDedupWrapper` into `createMiMoThinkingWrapper`
  - `src/agents/embedded-agent-runner/extra-params.ts`: core fallback path for custom proxy routes
  - `extensions/xiaomi/index.test.ts`: 4 new test cases covering dedup scenarios
- What did NOT change: `mimo-v2-pro`/`mimo-v2-omni` thinking-only promotion behavior; tool-call replay paths; DeepSeek thinking wrapper; other provider families.

## Change Type & Scope

### Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

### Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue

- Related to #101570

## Motivation

Users of MiMo V2.5 / V2.5-pro models experience severe text repetition (3-6x) and exposed internal reasoning in agent replies. The provider API also returns `repetition_truncation` errors when the duplicated content overflows. The issue reporter confirmed this affects multiple OpenClaw versions (2026.5.20 through 2026.7.1-beta.2) and persists across `/new` session resets.

The existing `createThinkingOnlyFinalTextWrapper` handles legacy MiMo models (v2-pro, v2-omni) that put final answers ONLY in `reasoning_content` with empty text blocks. The V2.5 generation changed API behavior to emit content in both fields simultaneously, requiring a different fix.

## Review Contract

```text
Ref: #101570
Surface: Provider stream wrappers (xiaomi plugin + core fallback)

Bug: MiMo V2.5/V2.5-pro reasoning content leaks into visible text, causing 3-6x repetition
Cause: API returns reasoning in both `reasoning_content` (→ thinking block) and `content`
       (→ text block). The `promoteThinkingOnlyFinalOutputToText` wrapper only fires
       when there is NO visible text, so the dual-output case passes through unchanged.
       Confidence: clear.
Provenance:
  introduced by: MiMo V2.5 API behavior change (upstream provider)
  made visible by: 8cc1aee9d8 — fix(xiaomi): surface MiMo reasoning-only finals (#60304)
  Confidence: clear

Best fix: Add a dedup wrapper after the thinking promotion wrapper in the stream chain.
  This is the narrowest fix — it only fires for models in the dedup set, does not
  change the thinking promotion path, and keeps the logic in the provider stream
  wrapper layer where all other MiMo stream transforms live.
Refactor: No — the current wrapper composition chain is the right place.
Proof: Unit tests with mocked streams (xiaomi + provider-stream-shared suites).
       Real API proof requires a MiMo API key.
Risk: The dedup uses simple string prefix matching; if the MiMo API response format
      diverges further, the prefix heuristic could fail. The wrapper is
      model-gated so other providers are unaffected.
```

## Real Behavior Proof

**Behavior addressed**: MiMo V2.5/V2.5-pro assistant messages contain duplicated thinking content in text blocks, causing visible repetition.

**Real environment tested**: Linux Node 22, branch `fix/mimo-thinking-text-dedup-101570`, unit tests only (no live MiMo API key available).

**Exact steps or command run after this patch**:

```bash
$ node scripts/run-vitest.mjs extensions/xiaomi/index.test.ts --run
$ node scripts/run-vitest.mjs src/plugin-sdk/provider-stream-shared.test.ts --run
```

**Evidence after fix**:

```console
$ node scripts/run-vitest.mjs extensions/xiaomi/index.test.ts --run
 Test Files  1 passed (1)
      Tests  25 passed (25)

$ node scripts/run-vitest.mjs src/plugin-sdk/provider-stream-shared.test.ts --run
 Test Files  1 passed (1)
      Tests  61 passed (61)
```

Test coverage matrix:

| Scenario | Model | Expected | Status |
|----------|-------|----------|--------|
| thinking + text (pure duplicate ×3) | mimo-v2.5 | text block removed | ✅ |
| thinking + text (pure duplicate ×3) | mimo-v2.5-pro | text block removed | ✅ |
| thinking + text with unique suffix | mimo-v2.5 | suffix preserved | ✅ |
| thinking + text with unique suffix | mimo-v2.5-pro | suffix preserved | ✅ |
| thinking + independent text | mimo-v2.5 | both blocks kept | ✅ |
| thinking-only (no text) | mimo-v2-pro | promoted to text | ✅ |
| thinking-only (no text) | mimo-v2.5-pro | unchanged | ✅ |
| thinking + toolCall | mimo-v2.5-pro | unchanged | ✅ |

**Observed result after fix**:

- Pure duplicate text blocks are removed from the content array
- Text blocks with unique suffixes are preserved with only the duplicated prefix stripped
- Non-duplicate text blocks pass through unchanged
- Existing `mimo-v2-pro`/`mimo-v2-omni` thinking promotion behavior is intact

**What was not tested**:

- Live MiMo V2.5 API round-trip (requires MiMo API key)
- Streaming delta-level dedup (current implementation operates on final messages and message_end events)
- Interaction with `frequency_penalty` / `repetition_truncation` provider errors

## Risks and Mitigations

- **Highest risk area**: The prefix-based dedup heuristic may not match all MiMo V2.5 response patterns. If the API emits reasoning slightly differently between the two fields, the prefix match could miss partial duplicates.
- **Mitigation**: The wrapper is narrowly gated to `mimo-v2.5` and `mimo-v2.5-pro` only. If the dedup fails, the fallback is the current (broken) behavior — no worse than before.
- **Compatibility impact**: None. The wrapper only activates for two specific model IDs via `shouldPatchModel`. All other providers and models are unaffected.

## Security Impact

- [x] New permissions/capabilities? No
- [x] Secrets/tokens handling changed? No
- [x] New/changed network calls? No
- [x] Command/tool execution surface changed? No
- [x] Data access scope changed? No

## Compatibility / Migration

- [x] Backward compatible? Yes
- [x] Config/env changes? No
- [x] Migration needed? No

## Human Verification

- **Verified scenarios**: Pure duplicate removal, suffix preservation, independent text passthrough, thinking-only promotion unchanged, tool-call messages unaffected, both model IDs (v2.5, v2.5-pro)
- **Edge cases checked**: Accumulated thinking from multiple thinking blocks, empty thinking content, text shorter than thinking prefix
- **What you did NOT verify**: Live MiMo API responses, streaming delta events (event-level dedup applies same logic as final message), multi-turn conversation with tool calls

## AI Assistance

- **AI-assisted**: Yes
- **Co-Authored-By**: Claude <noreply@anthropic.com>
- **Human confirmed understanding of code changes**: Yes
- **AI prompts / session excerpts**: Analyzed issue #101570 root cause via source code provenance, designed dedup wrapper following existing `createThinkingOnlyFinalTextWrapper` pattern, implemented shared helper in `provider-stream-shared.ts` plus xiaomi plugin integration, wrote 4 test scenarios covering full behavior matrix.

---

Related to #101570
