### PR TITLE
fix(mattermost): truncate inbound preview on code-point boundary

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -159,6 +159,7 @@ function createRuntimeCore(
     shouldHandleTextCommands?: () => boolean;
     textHasControlCommand?: (text?: string) => boolean;
     createInboundDebouncer?: typeof createInboundDebouncer;
+    verboseDebug?: (message: string) => void;
   } = {},
 ) {
   const dispatchPreparedForTest = vi.fn(
@@ -223,9 +224,9 @@ function createRuntimeCore(
       current: () => cfg,
     },
     logging: {
-      shouldLogVerbose: () => false,
+      shouldLogVerbose: () => Boolean(overrides.verboseDebug),
       getChildLogger: () => ({
-        debug: vi.fn(),
+        debug: overrides.verboseDebug ?? vi.fn(),
         info: vi.fn(),
         warn: vi.fn(),
         error: vi.fn(),
@@ -445,6 +446,53 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.MessageSid).toBe("post-inbound-system-event-regular");
     expect(ctx?.OriginatingChannel).toBe("mattermost");
     expect(ctx?.Provider).toBe("mattermost");
+  });
+
+  it("keeps verbose inbound previews on complete UTF-16 boundaries", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    const verboseDebug = vi.fn();
+    mockState.abortController = abortController;
+    mockState.runtimeCore = createRuntimeCore(testConfig, undefined, { verboseDebug });
+
+    const monitor = monitorMattermostProvider({
+      config: testConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "chan-1",
+        channel_name: "town-square",
+        channel_display_name: "Town Square",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-verbose-preview",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: `${"a".repeat(199)}😀tail`,
+          create_at: 1_714_000_000_000,
+        }),
+      },
+      broadcast: {
+        channel_id: "chan-1",
+        user_id: "user-1",
+      },
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(verboseDebug).toHaveBeenCalledWith(
+      `mattermost inbound: from=mattermost:channel:chan-1 len=205 preview="${"a".repeat(199)}"`,
+    );
   });
 
   it("dispatches a bare bot mention whose body is empty after normalization as a wake event", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -24,6 +24,7 @@ import {
   normalizeTrimmedStringList,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { getMattermostRuntime } from "../runtime.js";
 import {
   resolveMattermostAccount,
@@ -1677,7 +1678,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           agentId: route.agentId,
         });
 
-        const previewLine = bodyText.slice(0, 200).replace(/\n/g, "\\n");
+        const previewLine = truncateUtf16Safe(bodyText, 200).replace(/\n/g, "\\n");
         logVerboseMessage(
           `mattermost inbound: from=${ctxPayload.From} len=${bodyText.length} preview="${previewLine}"`,
         );


### PR DESCRIPTION
## What Problem This Solves

Fixes garbled verbose inbound previews in Mattermost when message bodies contain emoji or other astral characters near the 200-character preview limit. The verbose debug path used raw `bodyText.slice(0, 200)`, which can split a UTF-16 surrogate pair and leave a lone high surrogate in gateway logs.

**Concrete example:** A 205-code-unit message `${"a".repeat(199)}😀tail` hits the preview cap inside the emoji. `slice(0, 200)` keeps the emoji's high surrogate (`0xD83D`) but drops its low surrogate, producing mojibake in `mattermost inbound: … preview="…"` debug lines.

## Why This Change Was Made

Replaces `bodyText.slice(0, 200)` with `truncateUtf16Safe(bodyText, 200)` from `openclaw/plugin-sdk/text-utility-runtime` in the verbose inbound preview path (`extensions/mattermost/src/mattermost/monitor.ts:1681`).

## User Impact

**Before:** Verbose Mattermost inbound logging can show broken previews for emoji-heavy messages.

**After:** Previews truncate on complete UTF-16 boundaries; emoji at the cap boundary are excluded rather than split.

## Evidence

- `extensions/mattermost/src/mattermost/monitor.ts:27,1681–1683` — `truncateUtf16Safe` import and verbose preview wiring
- `packages/normalization-core/src/utf16-slice.ts` — shared `truncateUtf16Safe` implementation
- Diff: +52 / −3 in `monitor.ts` and `monitor.inbound-system-event.test.ts`

### Behavior proof

#### 1) Node runtime (`truncateUtf16Safe` vs raw `slice`, production helper)

Uses the exact test payload from `monitor.inbound-system-event.test.ts`:

```text
=== #101630 Mattermost verbose preview UTF-16 proof ===
Node: v22.22.0
body length (code units): 205
raw slice(0,200) length: 200
raw slice ends on high surrogate: true
truncateUtf16Safe(200) length: 199
safe preview matches test expectation: true
safe preview excludes split emoji: true
```

#### 2) Call-site regression through production monitor path

```text
$ pnpm test extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts -t "keeps verbose inbound previews" --reporter=verbose

 ✓ mattermost inbound user posts > keeps verbose inbound previews on complete UTF-16 boundaries 62ms

 Test Files  1 passed (1)
      Tests  1 passed | 10 skipped (11)
   Duration  4.65s

[test] passed 1 Vitest shard in 8.37s
```

Regression flow (`monitorMattermostProvider` websocket `posted` event → verbose debug):

1. Inbound message body = `${"a".repeat(199)}😀tail` (len **205** code units).
2. Verbose logger receives preview **`${"a".repeat(199)}`** — emoji excluded, not split.
3. Assertion: `verboseDebug` called with `preview="${"a".repeat(199)}"` (no lone surrogate).

Full touched file still green:

```text
$ pnpm test extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts --reporter=verbose
 Tests  11 passed (11)
```

**Proof gap:** No redacted live Mattermost websocket capture with verbose logging enabled in this environment.
