### PR TITLE
fix(cli): keep CLI display/approval truncation UTF-16 safe

### DIFF
--- a/src/cli/error-format.ts
+++ b/src/cli/error-format.ts
@@ -1,4 +1,5 @@
 // Reusable CLI error-message formatters that keep recovery hints consistent across commands.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatCliCommand } from "./command-format.js";
 
 const DEFAULT_GATEWAY_PORT_EXAMPLE = 18789;
@@ -59,7 +60,7 @@ export function formatStrictJsonParseFailure(params: { value: string; cause: unk
   const rawCause = params.cause instanceof Error ? params.cause.message : String(params.cause);
   const cause = rawCause.trim().replace(/[.。]+$/u, "");
   const preview =
-    params.value.length > 48 ? `${params.value.slice(0, 45).trimEnd()}...` : params.value;
+    params.value.length > 48 ? `${truncateUtf16Safe(params.value, 45).trimEnd()}...` : params.value;
   return [
     `Could not parse ${JSON.stringify(preview)} as JSON for --strict-json.`,
     `${cause}.`,

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -1,6 +1,7 @@
 // CLI for reading and mutating exec approval allowlists locally, via gateway, or via node.
 import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Command } from "commander";
 import JSON5 from "json5";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
@@ -180,7 +181,7 @@ function formatCliError(err: unknown): string {
   const msg = formatErrorMessage(err);
   const firstLine = msg.includes("\n") ? msg.split("\n")[0] : msg;
   const safe = sanitizeForLog(firstLine);
-  return safe.length > 300 ? `${safe.slice(0, 300)}...` : safe;
+  return safe.length > 300 ? `${truncateUtf16Safe(safe, 300)}...` : safe;
 }
 
 async function loadConfigForApprovalsTarget(params: {
@@ -306,8 +307,12 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
       : null,
   ].filter((part): part is string => part != null);
   const agents = file.agents ?? {};
-  const allowlistRows: Array<{ Target: string; Agent: string; Pattern: string; LastUsed: string }> =
-    [];
+  const allowlistRows: Array<{
+    Target: string;
+    Agent: string;
+    Pattern: string;
+    LastUsed: string;
+  }> = [];
   const now = Date.now();
   for (const [agentId, agent] of Object.entries(agents)) {
     const allowlist = Array.isArray(agent.allowlist) ? agent.allowlist : [];
@@ -333,7 +338,10 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
     { Field: "Hash", Value: snapshot.hash },
     { Field: "Version", Value: String(file.version ?? 1) },
     { Field: "Socket", Value: file.socket?.path ?? "default" },
-    { Field: "Defaults", Value: defaultsParts.length > 0 ? defaultsParts.join(", ") : "none" },
+    {
+      Field: "Defaults",
+      Value: defaultsParts.length > 0 ? defaultsParts.join(", ") : "none",
+    },
     { Field: "Agents", Value: String(Object.keys(agents).length) },
     { Field: "Allowlist", Value: String(allowlistRows.length) },
   ];
@@ -431,7 +439,16 @@ async function loadWritableAllowlistAgent(opts: ExecApprovalsCliOpts): Promise<{
   const agent = ensureAgent(file, agentKey);
   const allowlistEntries = Array.isArray(agent.allowlist) ? agent.allowlist : [];
 
-  return { nodeId, source, targetLabel, baseHash, file, agentKey, agent, allowlistEntries };
+  return {
+    nodeId,
+    source,
+    targetLabel,
+    baseHash,
+    file,
+    agentKey,
+    agent,
+    allowlistEntries,
+  };
 }
 
 type WritableAllowlistAgentContext = Awaited<ReturnType<typeof loadWritableAllowlistAgent>> & {
@@ -557,7 +574,14 @@ export function registerExecApprovalsCli(program: Command) {
           exitWithError(`Failed to parse approvals JSON: ${String(err)}`);
         }
         file.version = 1;
-        await saveSnapshotTargeted({ opts, source, nodeId, file, baseHash, targetLabel });
+        await saveSnapshotTargeted({
+          opts,
+          source,
+          nodeId,
+          file,
+          baseHash,
+          targetLabel,
+        });
       } catch (err) {
         defaultRuntime.error(formatCliError(err));
         defaultRuntime.exit(1);
@@ -595,7 +619,10 @@ export function registerExecApprovalsCli(program: Command) {
         defaultRuntime.log("Already allowlisted.");
         return false;
       }
-      allowlistEntries.push({ pattern: trimmedPattern, lastUsedAt: Date.now() });
+      allowlistEntries.push({
+        pattern: trimmedPattern,
+        lastUsedAt: Date.now(),
+      });
       agent.allowlist = allowlistEntries;
       file.agents = { ...file.agents, [agentKey]: agent };
       return true;

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -6,6 +6,7 @@ import { cancel, isCancel } from "@clack/prompts";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import {
   decorativeEmoji,
@@ -325,7 +326,11 @@ export async function handleReset(scope: ResetScope, workspaceDir: string, runti
     for (const [index, attestationPath] of resolveWorkspaceAttestationPaths(
       workspaceDir,
     ).entries()) {
-      if (await shouldRemoveWorkspaceAttestation(attestationPath, { trustUnknown: index === 0 })) {
+      if (
+        await shouldRemoveWorkspaceAttestation(attestationPath, {
+          trustUnknown: index === 0,
+        })
+      ) {
         await moveToTrash(attestationPath, runtime);
       }
     }
@@ -410,7 +415,7 @@ function summarizeError(err: unknown): string {
       .split("\n")
       .map((s) => s.trim())
       .find(Boolean) ?? raw;
-  return line.length > 120 ? `${line.slice(0, 119)}…` : line;
+  return line.length > 120 ? `${truncateUtf16Safe(line, 119)}…` : line;
 }
 
 /** Default workspace path shown by onboarding prompts. */

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { resolveBundledInstallPlanForCatalogEntry } from "../cli/plugin-install-plan.js";
 import { invalidatePluginRuntimeDiscoveryAfterConfigMutation } from "../cli/plugins-registry-refresh.js";
@@ -302,7 +303,9 @@ function resolveBundledLocalPath(params: {
   entry: OnboardingPluginInstallEntry;
   workspaceDir?: string;
 }): string | null {
-  const bundledSources = resolveBundledPluginSources({ workspaceDir: params.workspaceDir });
+  const bundledSources = resolveBundledPluginSources({
+    workspaceDir: params.workspaceDir,
+  });
   const npmSpec = params.entry.install.npmSpec?.trim();
   if (npmSpec) {
     return (
@@ -498,10 +501,14 @@ async function promptInstallChoice(params: {
 function formatDurationLabel(timeoutMs: number): string {
   if (timeoutMs % 60_000 === 0) {
     const minutes = timeoutMs / 60_000;
-    return t(minutes === 1 ? "common.minute" : "common.minutes", { count: minutes });
+    return t(minutes === 1 ? "common.minute" : "common.minutes", {
+      count: minutes,
+    });
   }
   const seconds = Math.round(timeoutMs / 1000);
-  return t(seconds === 1 ? "common.second" : "common.seconds", { count: seconds });
+  return t(seconds === 1 ? "common.second" : "common.seconds", {
+    count: seconds,
+  });
 }
 
 function formatPluginInstallProgress(label: string): string {
@@ -537,7 +544,7 @@ function summarizeInstallError(message: string): string {
   if (!cleaned) {
     return "Unknown install failure";
   }
-  return cleaned.length > 180 ? `${cleaned.slice(0, 179)}…` : cleaned;
+  return cleaned.length > 180 ? `${truncateUtf16Safe(cleaned, 179)}…` : cleaned;
 }
 
 function isTimeoutError(error: unknown): boolean {
@@ -1099,7 +1106,9 @@ export async function ensureOnboardingPluginInstalled(params: {
 }): Promise<OnboardingPluginInstallResult> {
   const { entry, prompter, runtime, workspaceDir } = params;
   let next = params.cfg;
-  const installOverride = resolvePluginInstallOverride({ pluginId: entry.pluginId });
+  const installOverride = resolvePluginInstallOverride({
+    pluginId: entry.pluginId,
+  });
   if (installOverride) {
     // Any install override mutates config/install records, so guard it with the
     // same write-mode check as normal installs.
@@ -1211,7 +1220,13 @@ export async function ensureOnboardingPluginInstalled(params: {
       );
     }
     next = addPluginLoadPath(enableResult.config, localPath);
-    next = await recordLocalPluginInstall({ cfg: next, entry, localPath, npmSpec, workspaceDir });
+    next = await recordLocalPluginInstall({
+      cfg: next,
+      entry,
+      localPath,
+      npmSpec,
+      workspaceDir,
+    });
     return await markOnboardingPluginInstalled(
       {
         cfg: next,
@@ -1457,7 +1472,13 @@ export async function ensureOnboardingPluginInstalled(params: {
         );
       }
       next = addPluginLoadPath(enableResult.config, localPath);
-      next = await recordLocalPluginInstall({ cfg: next, entry, localPath, npmSpec, workspaceDir });
+      next = await recordLocalPluginInstall({
+        cfg: next,
+        entry,
+        localPath,
+        npmSpec,
+        workspaceDir,
+      });
       return await markOnboardingPluginInstalled(
         {
           cfg: next,


### PR DESCRIPTION
## What Problem This Solves

Four CLI/onboarding call sites truncate user-provided text with raw `.slice(0, N)`:

- **cli/error-format**: JSON input preview @45 — user-provided CLI args
- **cli/exec-approvals-cli**: approval display text @300 — operator-visible messages
- **onboarding-plugin-install**: plugin descriptions @179 — plugin readme/spec text
- **onboard-helpers**: TUI display lines @119 — user-facing wizard text

All can contain emoji or CJK characters, producing U+FFFD in terminal output.

## Why This Change Was Made

`truncateUtf16Safe` from `@openclaw/normalization-core/utf16-slice` is the canonical leaf helper.

## Evidence

### Branch prerun (commit c601761c)

```
=== error-format @45 ===
Raw .slice(0,45) ends: "x\ud83d" (dangling)
truncateUtf16Safe: len=44 | no U+FFFD

=== exec-approvals @300 ===
Raw .slice(0,300) ends: "s\ud83d" (dangling)
truncateUtf16Safe: len=299 | no U+FFFD
```

## Files Changed

| File | Change |
|------|--------|
| `src/cli/error-format.ts` | `.slice(0, 45)` → `truncateUtf16Safe` + import |
| `src/cli/exec-approvals-cli.ts` | `.slice(0, 300)` → `truncateUtf16Safe` + import |
| `src/commands/onboarding-plugin-install.ts` | `.slice(0, 179)` → `truncateUtf16Safe` + import |
| `src/commands/onboard-helpers.ts` | `.slice(0, 119)` → `truncateUtf16Safe` + import |
