### PR TITLE
fix(edit): tool rejects native edit arrays wrapped by XML-RPC transport

### DIFF
--- a/src/agents/sessions/tools/edit.test.ts
+++ b/src/agents/sessions/tools/edit.test.ts
@@ -243,6 +243,23 @@ describe("edit tool", () => {
     await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("after\n");
   });
 
+  it("unwraps XML-RPC-style { item: ... } edit entries before validation", async () => {
+    const filePath = await createTempFile("before\n");
+    const tool = createEditTool(tmpDir);
+    const prepared = tool.prepareArguments?.({
+      path: filePath,
+      edits: [{ item: { oldText: "before", newText: "after" } }],
+    });
+
+    expect(prepared).toEqual({
+      path: filePath,
+      edits: [{ oldText: "before", newText: "after" }],
+    });
+    expect(Value.Check(tool.parameters, prepared)).toBe(true);
+    await tool.execute("call-xmlrpc", prepared as never, undefined);
+    await expect(fs.readFile(filePath, "utf-8")).resolves.toBe("after\n");
+  });
+
   it("renders previews through custom edit operations", async () => {
     // Preview rendering must use injected operations so remote/sandbox files are
     // shown without accidentally reading from the host filesystem.

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -130,11 +130,31 @@ function prepareEditArguments(input: unknown): EditToolInput {
 
   const edits = Array.isArray(args.edits)
     ? args.edits.map((edit) => {
-        if (!edit || typeof edit !== "object" || Array.isArray(edit)) {
-          return edit;
+        // XML-RPC-style array serialization wraps each element in { item: ... }.
+        // Unwrap it before extracting the strict edit fields.
+        let candidate = edit;
+        if (
+          candidate &&
+          typeof candidate === "object" &&
+          !Array.isArray(candidate) &&
+          "item" in candidate
+        ) {
+          const wrapper = candidate as Record<string, unknown>;
+          const inner = wrapper.item;
+          if (
+            inner &&
+            typeof inner === "object" &&
+            !Array.isArray(inner) &&
+            ("oldText" in inner || "newText" in inner)
+          ) {
+            candidate = inner;
+          }
         }
-        const candidate = edit as Record<string, unknown>;
-        return { oldText: candidate.oldText, newText: candidate.newText };
+        if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+          return candidate;
+        }
+        const record = candidate as Record<string, unknown>;
+        return { oldText: record.oldText, newText: record.newText };
       })
     : args.edits;
 


### PR DESCRIPTION
Closes #75152

## What Problem This Solves

Fixes an issue where users calling the `edit` tool through an XML-RPC-style transport would see validation errors like `edits.0: must be object`, `edits.0: must have required properties oldText, newText`, and `edits.0: must not have additional properties` even when the caller supplied a well-formed native array of edits.

## Why This Change Was Made

Some transports serialize array elements as `{ item: { oldText, newText } }` instead of plain `{ oldText, newText }` objects. The edit tool's argument normalizer already handled JSON-string-encoded arrays and legacy top-level `oldText`/`newText` arguments, but it did not unwrap this transport wrapper, so the strict schema saw an object with only an `item` property and rejected it. The normalizer now unwraps `{ item: ... }` entries that contain edit fields before applying the strict schema.

## User Impact

Users can now pass edit arrays through transports that wrap array elements without seeing spurious validation failures. The edit tool remains strict about its public schema and continues to strip model-added metadata.

## Evidence

### Unit-test regression

Added a regression test that passes `{ edits: [{ item: { oldText: "before", newText: "after" } }] }` through `prepareArguments`, validates it against the tool schema, and executes the edit successfully.

```text
✓ src/agents/sessions/tools/edit.test.ts (24 tests)
```

### Real behavior proof (after fix)

Ran a standalone script that feeds the XML-RPC-wrapped shape directly into `createEditTool` and exercises `prepareArguments` plus `execute`. The output below shows the wrapped input being normalized, the strict schema validating successfully, and the target file being updated.

```text
$ npx tsx scripts/proof-edit-xmlrpc.mts
Input shape: {
  "path": "/tmp/openclaw-edit-xmlrpc-proof-ScIckU/demo.txt",
  "edits": [
    {
      "item": {
        "oldText": "original content",
        "newText": "updated content"
      }
    }
  ]
}
Prepared args: {
  "path": "/tmp/openclaw-edit-xmlrpc-proof-ScIckU/demo.txt",
  "edits": [
    {
      "oldText": "original content",
      "newText": "updated content"
    }
  ]
}
Schema check passes: true
Final file content: "updated content\n"
```

### Code quality

Formatting and lint on the changed files:

```text
Finished in 39ms on 2 files using 1 threads.  # oxfmt
Found 0 warnings and 0 errors.              # oxlint
```