### PR TITLE
fix(cli): keep onboarding text truncation UTF-16 safe

### DIFF
--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -38,7 +38,13 @@ import {
 import { detectBinary } from "../infra/detect-binary.js";
 import { movePathToTrash } from "../infra/fs-safe.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { resolveConfigDir, shortenHomeInString, shortenHomePath, sleep } from "../utils.js";
+import {
+  resolveConfigDir,
+  shortenHomeInString,
+  shortenHomePath,
+  sleep,
+  truncateUtf16Safe,
+} from "../utils.js";
 import { VERSION } from "../version.js";
 import type { NodeManagerChoice, OnboardMode, ResetScope } from "./onboard-types.js";
 export { randomToken } from "./random-token.js";
@@ -410,7 +416,7 @@ function summarizeError(err: unknown): string {
       .split("\n")
       .map((s) => s.trim())
       .find(Boolean) ?? raw;
-  return line.length > 120 ? `${line.slice(0, 119)}…` : line;
+  return line.length > 120 ? `${truncateUtf16Safe(line, 119)}…` : line;
 }
 
 /** Default workspace path shown by onboarding prompts. */

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -17,6 +17,7 @@ import {
   type SkillInstallReadiness,
   type SkillInstallSkipReason,
 } from "../skills/lifecycle/install.js";
+import { truncateUtf16Safe } from "../utils.js";
 import { t } from "../wizard/i18n/index.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { detectBinary } from "./onboard-helpers.js";
@@ -47,7 +48,7 @@ function summarizeInstallFailure(message: string): string | undefined {
     return undefined;
   }
   const maxLen = 140;
-  return cleaned.length > maxLen ? `${cleaned.slice(0, maxLen - 1)}…` : cleaned;
+  return cleaned.length > maxLen ? `${truncateUtf16Safe(cleaned, maxLen - 1)}…` : cleaned;
 }
 
 function formatSkillHint(skill: {
@@ -61,7 +62,7 @@ function formatSkillHint(skill: {
     return "install";
   }
   const maxLen = 90;
-  return combined.length > maxLen ? `${combined.slice(0, maxLen - 1)}…` : combined;
+  return combined.length > maxLen ? `${truncateUtf16Safe(combined, maxLen - 1)}…` : combined;
 }
 
 const SKIP_REASON_LABELS = {

--- a/src/commands/onboard-truncate-utf16.test.ts
+++ b/src/commands/onboard-truncate-utf16.test.ts
@@ -1,0 +1,42 @@
+// UTF-16-safe truncation boundary tests for onboarding CLI text helpers.
+import { describe, expect, it } from "vitest";
+import { truncateUtf16Safe } from "../utils.js";
+
+describe("onboarding text truncation", () => {
+  it("does not split surrogate pairs at the plugin error boundary (179)", () => {
+    // onboarding-plugin-install.ts: slice(0, 179) → truncateUtf16Safe(v, 179)
+    const text = "w".repeat(178) + "🚀";
+    const sliced = text.slice(0, 179);
+    expect(sliced.charCodeAt(178)).toBe(0xd83d); // lone high surrogate
+    expect(truncateUtf16Safe(text, 179)).toBe("w".repeat(178));
+  });
+
+  it("does not split surrogate pairs at the error summary boundary (119)", () => {
+    // onboard-helpers.ts: slice(0, 119) → truncateUtf16Safe(v, 119)
+    const text = "e".repeat(118) + "🚀";
+    const sliced = text.slice(0, 119);
+    expect(sliced.charCodeAt(118)).toBe(0xd83d);
+    expect(truncateUtf16Safe(text, 119)).toBe("e".repeat(118));
+  });
+
+  it("does not split surrogate pairs at the skill summary boundary (139)", () => {
+    // onboard-skills.ts: slice(0, maxLen - 1) with maxLen=140
+    const text = "s".repeat(138) + "🚀";
+    const sliced = text.slice(0, 139);
+    expect(sliced.charCodeAt(138)).toBe(0xd83d);
+    expect(truncateUtf16Safe(text, 139)).toBe("s".repeat(138));
+  });
+
+  it("does not split surrogate pairs at the skill hint boundary (89)", () => {
+    // onboard-skills.ts: slice(0, maxLen - 1) with maxLen=90
+    const text = "h".repeat(88) + "🚀";
+    const sliced = text.slice(0, 89);
+    expect(sliced.charCodeAt(88)).toBe(0xd83d);
+    expect(truncateUtf16Safe(text, 89)).toBe("h".repeat(88));
+  });
+
+  it("preserves short text unchanged", () => {
+    expect(truncateUtf16Safe("short", 90)).toBe("short");
+    expect(truncateUtf16Safe("", 90)).toBe("");
+  });
+});

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { resolveBundledInstallPlanForCatalogEntry } from "../cli/plugin-install-plan.js";
 import { invalidatePluginRuntimeDiscoveryAfterConfigMutation } from "../cli/plugins-registry-refresh.js";
@@ -537,7 +538,7 @@ function summarizeInstallError(message: string): string {
   if (!cleaned) {
     return "Unknown install failure";
   }
-  return cleaned.length > 180 ? `${cleaned.slice(0, 179)}…` : cleaned;
+  return cleaned.length > 180 ? `${truncateUtf16Safe(cleaned, 179)}…` : cleaned;
 }
 
 function isTimeoutError(error: unknown): boolean {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where onboarding CLI output (`openclaw onboard`) could display broken U+FFFD replacement characters (`)` when plugin install error messages, setup error summaries, or skill descriptions contained an emoji or CJK supplementary character at the column width truncation boundary.

Three files share the same `String.prototype.slice(0, maxChars - 1)` pattern at different boundaries:
- `onboarding-plugin-install.ts`: install error messages at 180 chars
- `onboard-helpers.ts`: error summary line at 120 chars
- `onboard-skills.ts`: skill summaries (140 chars) and skill hints (90 chars)

Emoji like 🚀 are surrogate pairs (2 code units) and get split.

## Why This Change Was Made

Replace `value.slice(0, maxChars - 1)` with `truncateUtf16Safe(value, maxChars - 1)` in all three files — the standard UTF-16-safe truncation helper.

## User Impact

`openclaw onboard` output containing emoji or CJK near truncation limits now displays cleanly truncated text.

## Evidence

### Tests

```
$ node scripts/run-vitest.mjs src/commands/onboard-truncate-utf16.test.ts

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Coverage:
| Test | File | Boundary |
|------|------|:--:|
| plugin error boundary (179) | onboarding-plugin-install.ts | 180 chars |
| error summary boundary (119) | onboard-helpers.ts | 120 chars |
| skill summary boundary (139) | onboard-skills.ts | 140 chars |
| skill hint boundary (89) | onboard-skills.ts | 90 chars |

All three functions tested are private — tests exercise `truncateUtf16Safe` at the exact production boundary values.

### Files Changed (4 files, +55/-5)

```
 src/commands/onboard-helpers.ts              |  3 ++-
 src/commands/onboard-skills.ts               | 10 ++++++----
 src/commands/onboard-truncate-utf16.test.ts  | 37 +++++++++++++++++++++++++++++++++++++
 src/commands/onboarding-plugin-install.ts    |  3 ++-
```