### PR TITLE
fix(ui): keep session/tool/card label truncation UTF-16 safe

### DIFF
--- a/ui/src/app/custom-theme.ts
+++ b/ui/src/app/custom-theme.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Control UI module implements custom theme behavior.
 import { z } from "zod";
 import { normalizeOptionalString } from "../lib/string-coerce.ts";
@@ -429,7 +430,7 @@ function describeThemeLabel(value: string | undefined) {
   if (!normalized) {
     return "Custom";
   }
-  return normalized.slice(0, 80);
+  return truncateUtf16Safe(normalized, 80);
 }
 
 export function normalizeTweakcnThemeUrl(input: string): TweakcnThemeResolution {

--- a/ui/src/lib/chat/tool-cards.ts
+++ b/ui/src/lib/chat/tool-cards.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Control UI chat domain owns pure tool-card extraction rules.
 import { extractCanvasFromText } from "../../../../src/chat/canvas-render.js";
 import {
@@ -238,7 +239,7 @@ export function formatCollapsedToolPreviewText(value: string | undefined): strin
   if (!normalized) {
     return undefined;
   }
-  return normalized.slice(0, 120);
+  return truncateUtf16Safe(normalized, 120);
 }
 
 function findFirstUnmatchedCard(

--- a/ui/src/lib/workboard/index.ts
+++ b/ui/src/lib/workboard/index.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { requestSessionCreate } from "../sessions/index.ts";
@@ -2192,7 +2193,9 @@ async function loadWorkboardInternal(
             taskRefreshError = confirmationResult.error;
           }
           nextUnfilteredCursor = pollResult?.nextUnfilteredCursor;
-          applyTaskSummariesToState(taskLinkState, taskSummaries, { missingTaskIds });
+          applyTaskSummariesToState(taskLinkState, taskSummaries, {
+            missingTaskIds,
+          });
           preserveLifecycleTaskRefreshFailure =
             params.taskRefresh === "linked" &&
             state.lifecycleTaskRefreshFailed &&
@@ -3167,7 +3170,9 @@ async function refreshWorkboardLifecycleTasks(
       }
       resetWorkboardLifecycleTaskConfirmations(state, { host: params.host });
       const recoveredTaskRefreshError = state.lifecycleTaskRefreshError;
-      setWorkboardLifecycleTaskRefreshFailed(state, false, { host: params.host });
+      setWorkboardLifecycleTaskRefreshFailed(state, false, {
+        host: params.host,
+      });
       state.lifecycleTaskRefreshError = null;
       if (
         recoveredTaskRefreshError !== null &&
@@ -3584,7 +3589,9 @@ export async function deleteWorkboardCard(params: {
   state.error = null;
   params.requestUpdate?.();
   try {
-    await params.client.request("workboard.cards.delete", { id: params.cardId });
+    await params.client.request("workboard.cards.delete", {
+      id: params.cardId,
+    });
     state.cards = removeCardAndReferences(state.cards, params.cardId);
   } catch (error) {
     state.error = formatError(error);
@@ -3658,7 +3665,9 @@ export async function dispatchWorkboard(params: {
     resetWorkboardLifecycleTaskConfirmations(state, { host: params.host });
     try {
       applyTaskSummariesToState(state, await listWorkboardTasks(params.client));
-      setWorkboardLifecycleTaskRefreshFailed(state, false, { host: params.host });
+      setWorkboardLifecycleTaskRefreshFailed(state, false, {
+        host: params.host,
+      });
       state.lifecycleTaskRefreshError = null;
       state.lastRefreshError = null;
     } catch (error) {
@@ -3712,7 +3721,7 @@ function buildCardSessionLabel(card: WorkboardCard): string {
     return `${title}${suffixText}`;
   }
   const titleMax = WORKBOARD_SESSION_LABEL_MAX_CHARS - suffixText.length;
-  return `${title.slice(0, titleMax - 3).trimEnd()}...${suffixText}`;
+  return `${truncateUtf16Safe(title, titleMax - 3).trimEnd()}...${suffixText}`;
 }
 
 function sanitizeSessionSegment(value: string | undefined, fallback: string): string {
@@ -3721,7 +3730,7 @@ function sanitizeSessionSegment(value: string | undefined, fallback: string): st
     .replace(/[^a-zA-Z0-9_-]/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "");
-  return (sanitized || fallback).slice(0, 96);
+  return truncateUtf16Safe(sanitized || fallback, 96);
 }
 
 function buildCardTaskSessionKey(card: WorkboardCard): string {
@@ -3839,7 +3848,11 @@ function taskIsActive(task: WorkboardTaskSummary | undefined): task is Workboard
 async function cancelWorkboardTaskRun(params: {
   client: GatewayBrowserClient;
   taskId: string;
-}): Promise<{ cancelled: boolean; missing: boolean; task: WorkboardTaskSummary | null }> {
+}): Promise<{
+  cancelled: boolean;
+  missing: boolean;
+  task: WorkboardTaskSummary | null;
+}> {
   const result = await params.client.request("tasks.cancel", {
     taskId: params.taskId,
     reason: "Stopped from Workboard.",

--- a/ui/src/pages/usage/view-details.ts
+++ b/ui/src/pages/usage/view-details.ts
@@ -1,8 +1,9 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Control UI view renders usage render details screen content.
 import { html, svg, nothing } from "lit";
 import { formatDurationCompact } from "../../../../src/infra/format-time/format-duration.ts";
-import { t } from "../../i18n/index.ts";
 import "../../components/tooltip.ts";
+import { t } from "../../i18n/index.ts";
 import { formatDateTimeMs, formatMs, formatTimeMs } from "../../lib/format.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import { parseToolSummary } from "./helpers.ts";
@@ -257,7 +258,7 @@ function renderSessionDetailPanel(
   onClose: () => void,
 ) {
   const label = session.label || session.key;
-  const displayLabel = label.length > 50 ? label.slice(0, 50) + "…" : label;
+  const displayLabel = label.length > 50 ? truncateUtf16Safe(label, 50) + "…" : label;
   const usage = session.usage;
 
   const hasRange = timeSeriesCursorStart !== null && timeSeriesCursorEnd !== null;
@@ -266,8 +267,14 @@ function renderSessionDetailPanel(
       ? computeFilteredUsage(usage, timeSeries.points, timeSeriesCursorStart, timeSeriesCursorEnd)
       : undefined;
   const headerStats = filteredUsage
-    ? { totalTokens: filteredUsage.totalTokens, totalCost: filteredUsage.totalCost }
-    : { totalTokens: usage?.totalTokens ?? 0, totalCost: usage?.totalCost ?? 0 };
+    ? {
+        totalTokens: filteredUsage.totalTokens,
+        totalCost: filteredUsage.totalCost,
+      }
+    : {
+        totalTokens: usage?.totalTokens ?? 0,
+        totalCost: usage?.totalCost ?? 0,
+      };
   const cursorIndicator = filteredUsage ? t("usage.details.filtered") : "";
 
   return html`

--- a/ui/src/pages/usage/view-overview.ts
+++ b/ui/src/pages/usage/view-overview.ts
@@ -1,8 +1,9 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 // Control UI view renders usage render overview screen content.
 import { html, nothing } from "lit";
 import { formatDurationCompact } from "../../../../src/infra/format-time/format-duration.ts";
-import { t } from "../../i18n/index.ts";
 import "../../components/tooltip.ts";
+import { t } from "../../i18n/index.ts";
 import { normalizeLowercaseStringOrEmpty } from "../../lib/string-coerce.ts";
 import {
   buildUsageCostWindows,
@@ -96,11 +97,13 @@ function renderFilterChips(
   const selectedSession =
     selectedSessions.length === 1 ? sessions.find((s) => s.key === selectedSessions[0]) : null;
   const sessionsLabel = selectedSession
-    ? (selectedSession.label || selectedSession.key).slice(0, 20) +
+    ? truncateUtf16Safe(selectedSession.label || selectedSession.key, 20) +
       ((selectedSession.label || selectedSession.key).length > 20 ? "…" : "")
     : selectedSessions.length === 1
       ? selectedSessions[0].slice(0, 8) + "…"
-      : t("usage.filters.sessionsCount", { count: String(selectedSessions.length) });
+      : t("usage.filters.sessionsCount", {
+          count: String(selectedSessions.length),
+        });
   const sessionsFullName = selectedSession
     ? selectedSession.label || selectedSession.key
     : selectedSessions.length === 1
@@ -196,7 +199,11 @@ function renderCostWindowComparison(
     return t("usage.costWindows.lastDays", { count: String(days) });
   };
   const cards = [
-    { label: t("usage.costWindows.selectedRange"), summary: range, range: true },
+    {
+      label: t("usage.costWindows.selectedRange"),
+      summary: range,
+      range: true,
+    },
     ...windows.map((summary) => ({
       label: labelForWindow(summary.days, summary.endDate),
       summary,
@@ -687,7 +694,9 @@ function renderUsageInsights(
 
   const costShare = (cost: number) =>
     showCostShares && totals.totalCost > 0
-      ? t("usage.overview.costShare", { percent: ((cost / totals.totalCost) * 100).toFixed(1) })
+      ? t("usage.overview.costShare", {
+          percent: ((cost / totals.totalCost) * 100).toFixed(1),
+        })
       : null;
   const costAttributionSub = (cost: number, tokens: number, messageCount?: number) =>
     [
@@ -787,7 +796,9 @@ function renderUsageInsights(
             title: t("usage.overview.sessions"),
             hint: t("usage.overview.sessionsHint"),
             value: sessionCount,
-            sub: t("usage.overview.sessionsInRange", { count: String(totalSessions) }),
+            sub: t("usage.overview.sessionsInRange", {
+              count: String(totalSessions),
+            }),
             className: "usage-summary-card--compact",
           })}
           ${renderSummaryStat({


### PR DESCRIPTION
## What Problem This Solves

Six Control UI label truncation sites use raw `.slice(0, N)` where the boundary can split emoji or CJK surrogate pairs:

- **view-overview**: session label @20
- **view-details**: session label @50
- **tool-cards**: card preview text @120
- **workboard**: card title + session segment @96
- **custom-theme**: theme name @80

## Why This Change Was Made

`truncateUtf16Safe` from `@openclaw/normalization-core/utf16-slice` is the canonical leaf helper.

## Evidence

### Branch prerun (commit ef303a22)

```
=== UI session label @20/50/120/96/80 boundaries ===
Raw .slice(0,20) ends: "x\ud83d" (dangling)
truncateUtf16Safe: len=19 | no U+FFFD: true
```

## Files Changed

| File | Change |
|------|--------|
| `ui/src/pages/usage/view-overview.ts` | `.slice(0, 20)` → `truncateUtf16Safe` + import |
| `ui/src/pages/usage/view-details.ts` | `.slice(0, 50)` → `truncateUtf16Safe` + import |
| `ui/src/lib/chat/tool-cards.ts` | `.slice(0, 120)` → `truncateUtf16Safe` + import |
| `ui/src/lib/workboard/index.ts` | 2× `.slice()` → `truncateUtf16Safe` + import |
| `ui/src/app/custom-theme.ts` | `.slice(0, 80)` → `truncateUtf16Safe` + import |
