### PR TITLE
fix(infra): cap session-maintenance-warning dedupe cache with LRU eviction

### DIFF
--- a/src/infra/session-maintenance-warning.test.ts
+++ b/src/infra/session-maintenance-warning.test.ts
@@ -59,7 +59,7 @@ function createParams(
 
 function expectedMaintenanceWarning(reasonText: string): string {
   return (
-    `⚠️ Session maintenance warning: this active session would be evicted (${reasonText}). ` +
+    `\u26A0\uFE0F Session maintenance warning: this active session would be evicted (${reasonText}). ` +
     `Maintenance is set to warn-only, so nothing was reset. ` +
     `To enforce cleanup, set \`session.maintenance.mode: "enforce"\` or increase the limits.`
   );

--- a/src/infra/session-maintenance-warning.test.ts
+++ b/src/infra/session-maintenance-warning.test.ts
@@ -256,8 +256,10 @@ describe("deliverSessionMaintenanceWarning", () => {
     });
 
     // Fill the cache so every slot holds a unique session.
+    // Seed with the same context pattern buildWarningContext produces so the
+    // later params1 lookup can only succeed via eviction, not a context miss.
     for (let i = 1; i < maxEntries; i++) {
-      setWarnedContextForKeyTestOnly(`session:${i}`, `ctx-${i}`);
+      setWarnedContextForKeyTestOnly(`session:${i}`, `session:${i}|1000|100|prune`);
     }
     // session:0 is not yet cached, so this delivers.
     await deliverSessionMaintenanceWarning(params0);

--- a/src/infra/session-maintenance-warning.test.ts
+++ b/src/infra/session-maintenance-warning.test.ts
@@ -34,8 +34,6 @@ type SessionMaintenanceWarningModule = typeof import("./session-maintenance-warn
 
 let deliverSessionMaintenanceWarning: SessionMaintenanceWarningModule["deliverSessionMaintenanceWarning"];
 let resetSessionMaintenanceWarningForTests: SessionMaintenanceWarningModule["testing"]["resetSessionMaintenanceWarningForTests"];
-let cacheMeta: SessionMaintenanceWarningModule["testing"]["cacheMeta"];
-let setWarnedContextForKeyTestOnly: SessionMaintenanceWarningModule["testing"]["setWarnedContextForKeyTestOnly"];
 
 function createParams(
   overrides: Partial<Parameters<typeof deliverSessionMaintenanceWarning>[0]> = {},
@@ -96,11 +94,7 @@ describe("deliverSessionMaintenanceWarning", () => {
     }));
     ({
       deliverSessionMaintenanceWarning,
-      testing: {
-        resetSessionMaintenanceWarningForTests,
-        cacheMeta,
-        setWarnedContextForKeyTestOnly,
-      },
+      testing: { resetSessionMaintenanceWarningForTests },
     } = await import("./session-maintenance-warning.js"));
   });
 
@@ -111,7 +105,13 @@ describe("deliverSessionMaintenanceWarning", () => {
     process.env.NODE_ENV = "development";
     resetSessionMaintenanceWarningForTests();
     mocks.resolveSessionAgentId.mockClear();
-    mocks.deliveryContextFromSession.mockClear();
+    mocks.deliveryContextFromSession.mockReset();
+    mocks.deliveryContextFromSession.mockReturnValue({
+      channel: "mobilechat",
+      to: "+15550001",
+      accountId: "acct-1",
+      threadId: "thread-1",
+    });
     mocks.normalizeMessageChannel.mockClear();
     mocks.isDeliverableMessageChannel.mockClear();
     mocks.deliverOutboundPayloads.mockClear();
@@ -242,45 +242,37 @@ describe("deliverSessionMaintenanceWarning", () => {
     expect(firstSystemEventCall()?.[0]).toContain(`older than ${expected}`);
   });
 
-  it("evicts the least-recently-used context entry once the cache exceeds its cap", async () => {
-    const maxEntries = cacheMeta.MAX_WARNED_CONTEXTS;
-    const params0 = createParams({
-      sessionKey: "session:0",
-      warning: {
-        activeSessionKey: "session:0",
-        pruneAfterMs: 1_000,
-        maxEntries: 100,
-        wouldPrune: true,
-        wouldCap: false,
-      } as never,
-    });
+  it("keeps a recently used context while evicting the least-recently-used entry", async () => {
+    const maxEntries = 4096;
+    const createSessionParams = (sessionKey: string) =>
+      createParams({
+        sessionKey,
+        warning: {
+          activeSessionKey: sessionKey,
+          pruneAfterMs: 1_000,
+          maxEntries: 100,
+          wouldPrune: true,
+          wouldCap: false,
+        } as never,
+      });
+    mocks.deliveryContextFromSession.mockReturnValue(undefined as never);
 
-    // Fill the cache so every slot holds a unique session.
-    // Seed with the same context pattern buildWarningContext produces so the
-    // later params1 lookup can only succeed via eviction, not a context miss.
-    for (let i = 1; i < maxEntries; i++) {
-      setWarnedContextForKeyTestOnly(`session:${i}`, `session:${i}|1000|100|prune`);
+    for (let i = 0; i < maxEntries; i++) {
+      await deliverSessionMaintenanceWarning(createSessionParams(`session:${i}`));
     }
-    // session:0 is not yet cached, so this delivers.
-    await deliverSessionMaintenanceWarning(params0);
-    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(4096);
 
-    // Insert one more — the least-recently-used entry (session:1) is evicted.
-    setWarnedContextForKeyTestOnly("session:extra", "ctx-extra");
+    // A duplicate read promotes session:0 from the LRU head without re-delivering.
+    await deliverSessionMaintenanceWarning(createSessionParams("session:0"));
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(4096);
 
-    // session:1 was evicted, so this must deliver again.
-    const params1 = createParams({
-      sessionKey: "session:1",
-      warning: {
-        activeSessionKey: "session:1",
-        pruneAfterMs: 1_000,
-        maxEntries: 100,
-        wouldPrune: true,
-        wouldCap: false,
-      } as never,
-    });
-    await deliverSessionMaintenanceWarning(params1);
-    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(2);
+    // Overflow evicts session:1 instead of the recently used session:0.
+    await deliverSessionMaintenanceWarning(createSessionParams("session:extra"));
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(4097);
+    await deliverSessionMaintenanceWarning(createSessionParams("session:0"));
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(4097);
+    await deliverSessionMaintenanceWarning(createSessionParams("session:1"));
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(4098);
   });
 
   it("re-delivers when the warning context changes for the same session", async () => {

--- a/src/infra/session-maintenance-warning.test.ts
+++ b/src/infra/session-maintenance-warning.test.ts
@@ -34,6 +34,8 @@ type SessionMaintenanceWarningModule = typeof import("./session-maintenance-warn
 
 let deliverSessionMaintenanceWarning: SessionMaintenanceWarningModule["deliverSessionMaintenanceWarning"];
 let resetSessionMaintenanceWarningForTests: SessionMaintenanceWarningModule["testing"]["resetSessionMaintenanceWarningForTests"];
+let cacheMeta: SessionMaintenanceWarningModule["testing"]["cacheMeta"];
+let setWarnedContextForKeyTestOnly: SessionMaintenanceWarningModule["testing"]["setWarnedContextForKeyTestOnly"];
 
 function createParams(
   overrides: Partial<Parameters<typeof deliverSessionMaintenanceWarning>[0]> = {},
@@ -57,7 +59,7 @@ function createParams(
 
 function expectedMaintenanceWarning(reasonText: string): string {
   return (
-    `\u26A0\uFE0F Session maintenance warning: this active session would be evicted (${reasonText}). ` +
+    `⚠️ Session maintenance warning: this active session would be evicted (${reasonText}). ` +
     `Maintenance is set to warn-only, so nothing was reset. ` +
     `To enforce cleanup, set \`session.maintenance.mode: "enforce"\` or increase the limits.`
   );
@@ -94,7 +96,11 @@ describe("deliverSessionMaintenanceWarning", () => {
     }));
     ({
       deliverSessionMaintenanceWarning,
-      testing: { resetSessionMaintenanceWarningForTests },
+      testing: {
+        resetSessionMaintenanceWarningForTests,
+        cacheMeta,
+        setWarnedContextForKeyTestOnly,
+      },
     } = await import("./session-maintenance-warning.js"));
   });
 
@@ -234,5 +240,64 @@ describe("deliverSessionMaintenanceWarning", () => {
     await deliverSessionMaintenanceWarning(params);
 
     expect(firstSystemEventCall()?.[0]).toContain(`older than ${expected}`);
+  });
+
+  it("evicts the least-recently-used context entry once the cache exceeds its cap", async () => {
+    const maxEntries = cacheMeta.MAX_WARNED_CONTEXTS;
+    const params0 = createParams({
+      sessionKey: "session:0",
+      warning: {
+        activeSessionKey: "session:0",
+        pruneAfterMs: 1_000,
+        maxEntries: 100,
+        wouldPrune: true,
+        wouldCap: false,
+      } as never,
+    });
+
+    // Fill the cache so every slot holds a unique session.
+    for (let i = 1; i < maxEntries; i++) {
+      setWarnedContextForKeyTestOnly(`session:${i}`, `ctx-${i}`);
+    }
+    // session:0 is not yet cached, so this delivers.
+    await deliverSessionMaintenanceWarning(params0);
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+
+    // Insert one more — the least-recently-used entry (session:1) is evicted.
+    setWarnedContextForKeyTestOnly("session:extra", "ctx-extra");
+
+    // session:1 was evicted, so this must deliver again.
+    const params1 = createParams({
+      sessionKey: "session:1",
+      warning: {
+        activeSessionKey: "session:1",
+        pruneAfterMs: 1_000,
+        maxEntries: 100,
+        wouldPrune: true,
+        wouldCap: false,
+      } as never,
+    });
+    await deliverSessionMaintenanceWarning(params1);
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-delivers when the warning context changes for the same session", async () => {
+    const sessionKey = `agent:${randomUUID()}:main`;
+    const params = createParams({ sessionKey });
+    await deliverSessionMaintenanceWarning(params);
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+
+    const changedParams = createParams({
+      sessionKey,
+      warning: {
+        activeSessionKey: sessionKey,
+        pruneAfterMs: 86_400_000,
+        maxEntries: 500,
+        wouldPrune: true,
+        wouldCap: true,
+      } as never,
+    });
+    await deliverSessionMaintenanceWarning(changedParams);
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/infra/session-maintenance-warning.ts
+++ b/src/infra/session-maintenance-warning.ts
@@ -6,6 +6,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
+import { pruneMapToMaxSize } from "./map-size.js";
 import { buildOutboundSessionContext } from "./outbound/session-context.js";
 import { enqueueSystemEvent } from "./system-events.js";
 
@@ -18,34 +19,19 @@ type WarningParams = {
   warning: SessionMaintenanceWarning;
 };
 
-// Cap the dedupe cache so a long-running gateway does not retain every
-// warned session key indefinitely. 4 096 entries covers hundreds of
-// active sessions with distinct warning contexts; the LRU touch on read
-// keeps frequently re-warned keys from being evicted prematurely.
+// Bound process-lifetime dedupe while keeping several agents' default 500-session
+// windows resident. Eviction can re-emit one warning for an old session.
 const MAX_WARNED_CONTEXTS = 4096;
 const warnedContexts = new Map<string, string>();
 
-function getWarnedContext(sessionKey: string): string | undefined {
-  const contextKey = warnedContexts.get(sessionKey);
-  if (contextKey !== undefined) {
-    // LRU touch so frequently re-warned sessions stay in the cache.
-    warnedContexts.delete(sessionKey);
-    warnedContexts.set(sessionKey, contextKey);
-  }
-  return contextKey;
-}
-
-function setWarnedContext(sessionKey: string, contextKey: string): void {
-  if (warnedContexts.has(sessionKey)) {
-    warnedContexts.delete(sessionKey);
-  } else if (warnedContexts.size >= MAX_WARNED_CONTEXTS) {
-    // Evict the least-recently-used entry (Map iterates in insertion order).
-    const oldest = warnedContexts.keys().next().value;
-    if (oldest !== undefined) {
-      warnedContexts.delete(oldest);
-    }
-  }
+function shouldSuppressWarning(sessionKey: string, contextKey: string): boolean {
+  const duplicate = warnedContexts.get(sessionKey) === contextKey;
+  // Refresh insertion order even for suppressed duplicates; otherwise active sessions
+  // become eviction candidates and can receive repeated warnings under key churn.
+  warnedContexts.delete(sessionKey);
   warnedContexts.set(sessionKey, contextKey);
+  pruneMapToMaxSize(warnedContexts, MAX_WARNED_CONTEXTS);
+  return duplicate;
 }
 
 const log = createSubsystemLogger("session-maintenance-warning");
@@ -59,16 +45,8 @@ function resetSessionMaintenanceWarningForTests() {
   messageRuntimeLoader.clear();
 }
 
-const testingCacheMeta = { MAX_WARNED_CONTEXTS };
-
-function setWarnedContextForKeyTestOnly(sessionKey: string, contextKey: string): void {
-  setWarnedContext(sessionKey, contextKey);
-}
-
 export const testing = {
   resetSessionMaintenanceWarningForTests,
-  cacheMeta: testingCacheMeta,
-  setWarnedContextForKeyTestOnly,
 } as const;
 
 const loadDeliverRuntime = messageRuntimeLoader.load;
@@ -148,12 +126,11 @@ export async function deliverSessionMaintenanceWarning(params: WarningParams): P
   }
 
   const contextKey = buildWarningContext(params);
-  if (getWarnedContext(params.sessionKey) === contextKey) {
-    return;
-  }
   // Dedupe by effective warning context so repeated maintenance scans do not
   // spam the same session, but changed limits still produce a fresh warning.
-  setWarnedContext(params.sessionKey, contextKey);
+  if (shouldSuppressWarning(params.sessionKey, contextKey)) {
+    return;
+  }
 
   const text = buildWarningText(params.warning);
   const target = resolveWarningDeliveryTarget(params.entry);

--- a/src/infra/session-maintenance-warning.ts
+++ b/src/infra/session-maintenance-warning.ts
@@ -18,7 +18,36 @@ type WarningParams = {
   warning: SessionMaintenanceWarning;
 };
 
+// Cap the dedupe cache so a long-running gateway does not retain every
+// warned session key indefinitely. 4 096 entries covers hundreds of
+// active sessions with distinct warning contexts; the LRU touch on read
+// keeps frequently re-warned keys from being evicted prematurely.
+const MAX_WARNED_CONTEXTS = 4096;
 const warnedContexts = new Map<string, string>();
+
+function getWarnedContext(sessionKey: string): string | undefined {
+  const contextKey = warnedContexts.get(sessionKey);
+  if (contextKey !== undefined) {
+    // LRU touch so frequently re-warned sessions stay in the cache.
+    warnedContexts.delete(sessionKey);
+    warnedContexts.set(sessionKey, contextKey);
+  }
+  return contextKey;
+}
+
+function setWarnedContext(sessionKey: string, contextKey: string): void {
+  if (warnedContexts.has(sessionKey)) {
+    warnedContexts.delete(sessionKey);
+  } else if (warnedContexts.size >= MAX_WARNED_CONTEXTS) {
+    // Evict the least-recently-used entry (Map iterates in insertion order).
+    const oldest = warnedContexts.keys().next().value;
+    if (oldest !== undefined) {
+      warnedContexts.delete(oldest);
+    }
+  }
+  warnedContexts.set(sessionKey, contextKey);
+}
+
 const log = createSubsystemLogger("session-maintenance-warning");
 const messageRuntimeLoader = createLazyPromiseLoader(
   () => import("../channels/message/runtime.js"),
@@ -30,8 +59,16 @@ function resetSessionMaintenanceWarningForTests() {
   messageRuntimeLoader.clear();
 }
 
+const testingCacheMeta = { MAX_WARNED_CONTEXTS };
+
+function setWarnedContextForKeyTestOnly(sessionKey: string, contextKey: string): void {
+  setWarnedContext(sessionKey, contextKey);
+}
+
 export const testing = {
   resetSessionMaintenanceWarningForTests,
+  cacheMeta: testingCacheMeta,
+  setWarnedContextForKeyTestOnly,
 } as const;
 
 const loadDeliverRuntime = messageRuntimeLoader.load;
@@ -111,12 +148,12 @@ export async function deliverSessionMaintenanceWarning(params: WarningParams): P
   }
 
   const contextKey = buildWarningContext(params);
-  if (warnedContexts.get(params.sessionKey) === contextKey) {
+  if (getWarnedContext(params.sessionKey) === contextKey) {
     return;
   }
   // Dedupe by effective warning context so repeated maintenance scans do not
   // spam the same session, but changed limits still produce a fresh warning.
-  warnedContexts.set(params.sessionKey, contextKey);
+  setWarnedContext(params.sessionKey, contextKey);
 
   const text = buildWarningText(params.warning);
   const target = resolveWarningDeliveryTarget(params.entry);


### PR DESCRIPTION
## What Problem This Solves

Fixes unbounded memory growth in session maintenance warning deduplication. The `warnedContexts` Map accumulated every warned session key forever with no eviction, TTL, or size cap. A long-running gateway process would retain entries for every session that ever triggered a maintenance warning.

## Why This Change Was Made

Added a 4 096-entry LRU cache with touch-on-read. Oldest untouched entries are evicted on overflow; frequently re-warned sessions are promoted to MRU on access. The public `deliverSessionMaintenanceWarning` API is unchanged — only caller (`src/auto-reply/reply/session.ts:1004`) needs no modification.

## User Impact

No change for gateways handling fewer than 4 096 distinct warned sessions. Gateways exceeding the cap may see one extra warning per evicted entry — a bounded trade-off versus the prior unbounded growth.

## Evidence

- 6 live-proof invariants proved through real `deliverSessionMaintenanceWarning` production code (4 106 sessions, cap boundary verified)
- 16/16 unit tests passed including LRU eviction and context-change tests
- `pnpm oxlint src/infra/session-maintenance-warning.ts` — 0 errors

AI-assisted: built with Codex