### PR TITLE
fix(discord): keep persona names UTF-16 safe

### DIFF
--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -79,6 +79,24 @@ function objectArgAt(
   return value as Record<string, unknown>;
 }
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("deliverDiscordReply", () => {
   const runtime = {} as RuntimeEnv;
   const cfg = {
@@ -571,5 +589,40 @@ describe("deliverDiscordReply", () => {
     const session = recordField(params.session, "session");
     expect(session.key).toBe("agent:main:subagent:child");
     expect(session.agentId).toBe("main");
+  });
+
+  it("keeps bound thread persona names on a UTF-16 boundary", async () => {
+    const threadBindings = {
+      listBySessionKey: vi.fn(() => [
+        {
+          accountId: "default",
+          channelId: "parent-1",
+          threadId: "thread-1",
+          targetSessionKey: "agent:main:subagent:child",
+          agentId: "main",
+          label: `${"a".repeat(76)}\u{1f63e}tail`,
+          webhookId: "wh_1",
+          webhookToken: "tok_1",
+        },
+      ]),
+    };
+
+    await deliverDiscordReply({
+      replies: [{ text: "Hello from subagent" }],
+      target: "channel:thread-1",
+      token: "token",
+      accountId: "default",
+      runtime,
+      cfg,
+      textLimit: 2000,
+      sessionKey: "agent:main:subagent:child",
+      threadBindings,
+      kind: "final",
+    });
+
+    const identity = recordField(firstDeliverParams().identity, "identity");
+    const name = String(identity.name);
+    expect(name).toHaveLength(79);
+    expect(hasLoneSurrogate(name)).toBe(false);
   });
 });

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -17,6 +17,7 @@ import type { ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { RequestClient } from "../internal/discord.js";
 import { sendMessageDiscord, sendVoiceMessageDiscord } from "../send.js";
 import type { DiscordAllowedMentions } from "../send.shared.js";
@@ -71,8 +72,9 @@ function resolveBindingIdentity(
     return undefined;
   }
   const baseLabel = binding.label?.trim() || binding.agentId;
+  const displayName = (`🤖 ${baseLabel}`.trim() || "🤖 agent");
   const identity: OutboundIdentity = {
-    name: (`🤖 ${baseLabel}`.trim() || "🤖 agent").slice(0, 80),
+    name: truncateUtf16Safe(displayName, 80),
   };
   try {
     const avatar = resolveAgentAvatar(cfg, binding.agentId);

--- a/extensions/discord/src/monitor/thread-bindings.persona.test.ts
+++ b/extensions/discord/src/monitor/thread-bindings.persona.test.ts
@@ -6,6 +6,24 @@ import {
 } from "./thread-bindings.persona.js";
 import type { ThreadBindingRecord } from "./thread-bindings.types.js";
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("thread binding persona", () => {
   it("prefers explicit label and prefixes with gear", () => {
     expect(resolveThreadBindingPersona({ label: "codex thread", agentId: "codex" })).toBe(
@@ -31,5 +49,24 @@ describe("thread binding persona", () => {
       label: "codex-thread",
     } satisfies ThreadBindingRecord;
     expect(resolveThreadBindingPersonaFromRecord(record)).toBe("⚙️ codex-thread");
+  });
+  it("keeps thread binding webhook personas on a UTF-16 boundary", () => {
+    const record = {
+      accountId: "default",
+      channelId: "parent-1",
+      threadId: "thread-1",
+      targetKind: "acp",
+      targetSessionKey: "agent:codex:acp:session-1",
+      agentId: "codex",
+      boundBy: "system",
+      boundAt: Date.now(),
+      lastActivityAt: Date.now(),
+      label: `${"a".repeat(77)}\u{1f63e}tail`,
+    } satisfies ThreadBindingRecord;
+
+    const persona = resolveThreadBindingPersonaFromRecord(record);
+
+    expect(persona.length).toBeLessThanOrEqual(80);
+    expect(hasLoneSurrogate(persona)).toBe(false);
   });
 });

--- a/extensions/discord/src/monitor/thread-bindings.persona.ts
+++ b/extensions/discord/src/monitor/thread-bindings.persona.ts
@@ -1,5 +1,6 @@
 // Discord plugin module implements thread bindings.persona behavior.
 import { SYSTEM_MARK } from "openclaw/plugin-sdk/text-chunking";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ThreadBindingRecord } from "./thread-bindings.types.js";
 
 const THREAD_BINDING_PERSONA_MAX_CHARS = 80;
@@ -15,7 +16,7 @@ function normalizePersonaLabel(value: string | undefined): string | undefined {
 export function resolveThreadBindingPersona(params: { label?: string; agentId?: string }): string {
   const base =
     normalizePersonaLabel(params.label) || normalizePersonaLabel(params.agentId) || "agent";
-  return `${SYSTEM_MARK} ${base}`.slice(0, THREAD_BINDING_PERSONA_MAX_CHARS);
+  return truncateUtf16Safe(`${SYSTEM_MARK} ${base}`, THREAD_BINDING_PERSONA_MAX_CHARS);
 }
 
 export function resolveThreadBindingPersonaFromRecord(record: ThreadBindingRecord): string {

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -39,6 +39,24 @@ function mockObjectArg(
   return value as Record<string, unknown>;
 }
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 beforeAll(async () => {
   ({ normalizeDiscordOutboundTarget } = await import("./normalize.js"));
   ({ discordOutbound } = await import("./outbound-adapter.js"));
@@ -237,6 +255,31 @@ describe("discordOutbound", () => {
       messageId: "msg-webhook-1",
       channelId: "thread-1",
     });
+  });
+
+  it("keeps webhook persona usernames on a UTF-16 boundary", async () => {
+    mockDiscordBoundThreadManager(hoisted);
+
+    await discordOutbound.sendText?.({
+      cfg: {},
+      to: "channel:parent-1",
+      text: "hello from persona",
+      accountId: "default",
+      threadId: "thread-1",
+      identity: {
+        name: `${"a".repeat(79)}\u{1f63e}tail`,
+      },
+    });
+
+    const options = mockObjectArg(
+      hoisted.sendWebhookMessageDiscordMock,
+      "sendWebhookMessageDiscord",
+      0,
+      1,
+    );
+    const username = String(options.username);
+    expect(username).toHaveLength(79);
+    expect(hasLoneSurrogate(username)).toBe(false);
   });
 
   it("falls back to bot send for silent delivery on bound threads", async () => {

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -12,6 +12,7 @@ import {
   normalizeOptionalString,
   normalizeOptionalStringifiedId,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { chunkDiscordTextWithMode } from "./chunk.js";
 import { notifyDiscordInboundEventOutboundPayloadSuccess } from "./inbound-event-delivery.js";
 import { isLikelyDiscordVideoMedia } from "./media-detection.js";
@@ -54,7 +55,7 @@ function resolveDiscordWebhookIdentity(params: {
 }): { username?: string; avatarUrl?: string } {
   const usernameRaw = normalizeOptionalString(params.identity?.name);
   const fallbackUsername = normalizeOptionalString(params.binding.label) ?? params.binding.agentId;
-  const username = (usernameRaw || fallbackUsername || "").slice(0, 80) || undefined;
+  const username = truncateUtf16Safe(usernameRaw || fallbackUsername || "", 80) || undefined;
   const avatarUrl = normalizeOptionalString(params.identity?.avatarUrl);
   return { username, avatarUrl };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes Discord bound-thread persona names and webhook usernames being truncated with raw UTF-16 slicing. When a name limit cuts through an emoji or other surrogate pair, the previous `.slice(0, 80)` paths could leave a lone surrogate in the Discord display name.

## Why This Change Was Made

Discord already uses `truncateUtf16Safe` for nearby thread-title and response-summary truncation. This applies the same helper to all three persona-name paths that still used raw slicing: bound-thread reply identity, outbound webhook persona username resolution, and thread-binding intro webhook persona names.

## User Impact

Users with emoji or non-BMP characters in agent/thread labels get clean Discord persona names instead of malformed replacement characters or invalid UTF-16 edge cases when names are truncated.

## Evidence

- `node scripts/run-vitest.mjs extensions/discord/src/monitor/thread-bindings.persona.test.ts extensions/discord/src/monitor/reply-delivery.test.ts extensions/discord/src/outbound-adapter.test.ts`
  - Passed 3 files / 69 tests after adding the missing thread-binding persona coverage.
- `git diff --check`
- `python .agents\skills\autoreview\scripts\autoreview --mode local --no-web-search`
  - `autoreview clean: no accepted/actionable findings reported`

Still needed for ClawSweeper proof label:

- Redacted live Discord proof showing a boundary emoji persona name renders cleanly after the fix.