### PR TITLE
fix(gateway): keep dashboard titles UTF-16 safe

### DIFF
--- a/src/gateway/dashboard-session-title.test.ts
+++ b/src/gateway/dashboard-session-title.test.ts
@@ -39,12 +39,37 @@ function mockSessionUpdate(current: SessionEntry): void {
   });
 }
 
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
 describe("normalizeDashboardSessionTitle", () => {
   it("keeps the first content line and strips common wrappers", () => {
     expect(normalizeDashboardSessionTitle('```text\n"Release Planning"\n```')).toBe(
       "Release Planning",
     );
     expect(normalizeDashboardSessionTitle("Title:  Release   planning ")).toBe("Release planning");
+  });
+
+  it("keeps normalized titles on a UTF-16 boundary", () => {
+    const title = normalizeDashboardSessionTitle(`${"a".repeat(59)}\u{1f63e}tail`);
+
+    expect(title).toBe("a".repeat(59));
+    expect(hasLoneSurrogate(title ?? "")).toBe(false);
   });
 });
 
@@ -80,6 +105,20 @@ describe("maybeGenerateDashboardSessionTitle", () => {
     expect(await update?.({ ...baseEntry })).toEqual({
       displayName: "Release Planning",
     });
+  });
+
+  it("keeps utility title prompt input on a UTF-16 boundary", async () => {
+    await expect(
+      maybeGenerateDashboardSessionTitle({
+        ...titleParams(),
+        userMessage: `${"m".repeat(999)}\u{1f63e}tail`,
+      }),
+    ).resolves.toBe(true);
+
+    const call = generateConversationLabel.mock.calls[0]?.[0];
+    const userMessage = String(call?.userMessage);
+    expect(userMessage).toBe("m".repeat(999));
+    expect(hasLoneSurrogate(userMessage)).toBe(false);
   });
 
   it.each([

--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -4,6 +4,7 @@ import { updateSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import { truncateUtf16Safe } from "../utils.js";
 
 const DASHBOARD_SESSION_TITLE_MAX_CHARS = 60;
 const DASHBOARD_SESSION_TITLE_SOURCE_MAX_CHARS = 1_000;
@@ -48,7 +49,7 @@ export function normalizeDashboardSessionTitle(raw: string): string | null {
   }
   const unwrapped = firstLine.replace(/^\s*(?:title\s*:\s*)?/i, "").replace(/^["'`]+|["'`]+$/g, "");
   const normalized = unwrapped.replace(/\s+/g, " ").trim();
-  return normalized ? normalized.slice(0, DASHBOARD_SESSION_TITLE_MAX_CHARS) : null;
+  return normalized ? truncateUtf16Safe(normalized, DASHBOARD_SESSION_TITLE_MAX_CHARS) : null;
 }
 
 export async function maybeGenerateDashboardSessionTitle(params: {
@@ -80,7 +81,7 @@ export async function maybeGenerateDashboardSessionTitle(params: {
   dashboardTitleRequests.add(requestKey);
   try {
     const generated = await generateConversationLabel({
-      userMessage: sourceText.slice(0, DASHBOARD_SESSION_TITLE_SOURCE_MAX_CHARS),
+      userMessage: truncateUtf16Safe(sourceText, DASHBOARD_SESSION_TITLE_SOURCE_MAX_CHARS),
       prompt: DASHBOARD_SESSION_TITLE_PROMPT,
       cfg: params.cfg,
       agentId: params.agentId,


### PR DESCRIPTION
## What Problem This Solves

Fixes dashboard session title truncation paths that could cut UTF-16 surrogate pairs in half. Both the generated display title normalization and the utility-model prompt input limit previously used raw `.slice(...)`, which can leave malformed text when the boundary lands inside an emoji or other non-BMP character.

## Why This Change Was Made

Recent title and channel truncation fixes use the shared `truncateUtf16Safe` helper for user-visible text. This applies the same existing helper to dashboard session title generation without changing title limits or model-selection behavior.

## User Impact

Dashboard session titles and first-message title prompts stay well-formed when user messages or generated titles contain emoji or non-BMP characters near truncation boundaries.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/dashboard-session-title.test.ts`
  - `src/gateway/dashboard-session-title.test.ts` passed in the gateway shard: 48 tests passed.
- `git diff --check`
- `python .agents\skills\autoreview\scripts\autoreview --mode local --no-web-search`
  - `autoreview clean: no accepted/actionable findings reported`
- Base: latest `origin/main` at `2ba622ca30`