### PR TITLE
refactor(ui): remove duplicate helper paths

### DIFF
--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -7,10 +7,10 @@ import {
   subtitleForRoute,
   titleForRoute,
 } from "./app-navigation.ts";
+import { normalizePath } from "./app-route-paths.ts";
 import {
   inferBasePathFromPathname,
   normalizeBasePath,
-  normalizePath,
   pathForRoute,
   routeIdFromPath,
   type RouteId,

--- a/ui/src/app-routes.ts
+++ b/ui/src/app-routes.ts
@@ -83,13 +83,11 @@ export async function startApplicationRouter(
 }
 
 export {
-  APP_ROUTE_DEFINITIONS,
   APP_ROUTE_IDS,
   inferBasePathFromPathname,
   isRouteId,
   locationForRoute,
   normalizeBasePath,
-  normalizePath,
   pathForRoute,
   routeIdFromPath,
   type RouteId,

--- a/ui/src/app/user-identity.ts
+++ b/ui/src/app/user-identity.ts
@@ -39,10 +39,6 @@ export function normalizeLocalUserIdentity(
   };
 }
 
-export function hasLocalUserIdentity(identity: LocalUserIdentity): boolean {
-  return Boolean(identity.name || identity.avatar);
-}
-
 export function resolveLocalUserName(
   input?: Partial<LocalUserIdentity> | null,
   fallback = "You",

--- a/ui/src/lib/agents/display.test.ts
+++ b/ui/src/lib/agents/display.test.ts
@@ -9,9 +9,7 @@ import {
   assistantAvatarFallbackUrl,
   buildAgentContext,
   formatBytes,
-  resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
-  sortLocaleStrings,
 } from "./display.ts";
 
 describe("formatBytes", () => {
@@ -61,60 +59,6 @@ describe("resolveEffectiveModelFallbacks", () => {
     };
 
     expect(resolveEffectiveModelFallbacks(entryModel, defaultModel)).toStrictEqual([]);
-  });
-});
-
-describe("resolveConfiguredCronModelSuggestions", () => {
-  it("collects defaults primary/fallbacks, alias map keys, and per-agent model entries", () => {
-    const result = resolveConfiguredCronModelSuggestions({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-5.2",
-            fallbacks: ["google/gemini-2.5-pro", "openai/gpt-5.2-mini"],
-          },
-          models: {
-            "anthropic/claude-sonnet-4-5": { alias: "smart" },
-            "openai/gpt-5.2": { alias: "main" },
-          },
-        },
-        list: {
-          writer: {
-            model: { primary: "xai/grok-4", fallbacks: ["openai/gpt-5.2-mini"] },
-          },
-          planner: {
-            model: "google/gemini-2.5-flash",
-          },
-        },
-      },
-    });
-
-    expect(result).toEqual([
-      "anthropic/claude-sonnet-4-5",
-      "google/gemini-2.5-flash",
-      "google/gemini-2.5-pro",
-      "openai/gpt-5.2",
-      "openai/gpt-5.2-mini",
-      "xai/grok-4",
-    ]);
-  });
-
-  it("returns empty array for invalid or missing config shape", () => {
-    expect(resolveConfiguredCronModelSuggestions(null)).toStrictEqual([]);
-    expect(resolveConfiguredCronModelSuggestions({})).toStrictEqual([]);
-    expect(
-      resolveConfiguredCronModelSuggestions({ agents: { defaults: { model: "" } } }),
-    ).toStrictEqual([]);
-  });
-});
-
-describe("sortLocaleStrings", () => {
-  it("sorts values using localeCompare without relying on Array.prototype.toSorted", () => {
-    expect(sortLocaleStrings(["z", "b", "a"])).toEqual(["a", "b", "z"]);
-  });
-
-  it("accepts any iterable input, including sets", () => {
-    expect(sortLocaleStrings(new Set(["beta", "alpha"]))).toEqual(["alpha", "beta"]);
   });
 });
 

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -121,7 +121,7 @@ const FALLBACK_TOOL_SECTIONS: AgentToolSection[] = [
   },
 ];
 
-export const PROFILE_OPTIONS = [
+const PROFILE_OPTIONS = [
   { id: "minimal", label: "Minimal" },
   { id: "coding", label: "Coding" },
   { id: "messaging", label: "Messaging" },
@@ -207,8 +207,6 @@ export function normalizeAgentLabel(agent: {
 export function assistantAvatarFallbackUrl(basePath: string): string {
   return controlUiPublicAssetPath("apple-touch-icon.png", basePath);
 }
-
-export { resolveAssistantTextAvatar };
 
 function resolveAgentTextAvatar(
   agent: { identity?: { emoji?: string; avatar?: string } },
@@ -390,114 +388,6 @@ export function resolveEffectiveModelFallbacks(
   defaultModel?: unknown,
 ): string[] | null {
   return resolveModelFallbacks(entryModel) ?? resolveModelFallbacks(defaultModel);
-}
-
-function addModelId(target: Set<string>, value: unknown) {
-  if (typeof value !== "string") {
-    return;
-  }
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return;
-  }
-  target.add(trimmed);
-}
-
-function addModelConfigIds(target: Set<string>, modelConfig: unknown) {
-  if (!modelConfig) {
-    return;
-  }
-  if (typeof modelConfig === "string") {
-    addModelId(target, modelConfig);
-    return;
-  }
-  if (typeof modelConfig !== "object") {
-    return;
-  }
-  const record = modelConfig as Record<string, unknown>;
-  addModelId(target, record.primary);
-  addModelId(target, record.model);
-  addModelId(target, record.id);
-  addModelId(target, record.value);
-  const fallbacks = Array.isArray(record.fallbacks)
-    ? record.fallbacks
-    : Array.isArray(record.fallback)
-      ? record.fallback
-      : [];
-  for (const fallback of fallbacks) {
-    addModelId(target, fallback);
-  }
-}
-
-export function sortLocaleStrings(values: Iterable<string>): string[] {
-  const sorted = Array.from(values);
-  const buffer = Array.from({ length: sorted.length }, () => "");
-
-  const merge = (left: number, middle: number, right: number): void => {
-    let i = left;
-    let j = middle;
-    let k = left;
-    while (i < middle && j < right) {
-      buffer[k++] = sorted[i].localeCompare(sorted[j]) <= 0 ? sorted[i++] : sorted[j++];
-    }
-    while (i < middle) {
-      buffer[k++] = sorted[i++];
-    }
-    while (j < right) {
-      buffer[k++] = sorted[j++];
-    }
-    for (let idx = left; idx < right; idx += 1) {
-      sorted[idx] = buffer[idx];
-    }
-  };
-
-  const sortRange = (left: number, right: number): void => {
-    if (right - left <= 1) {
-      return;
-    }
-
-    const middle = (left + right) >>> 1;
-    sortRange(left, middle);
-    sortRange(middle, right);
-    merge(left, middle, right);
-  };
-
-  sortRange(0, sorted.length);
-  return sorted;
-}
-
-export function resolveConfiguredCronModelSuggestions(
-  configForm: Record<string, unknown> | null,
-): string[] {
-  if (!configForm || typeof configForm !== "object") {
-    return [];
-  }
-  const agents = (configForm as { agents?: unknown }).agents;
-  if (!agents || typeof agents !== "object") {
-    return [];
-  }
-  const out = new Set<string>();
-  const defaults = (agents as { defaults?: unknown }).defaults;
-  if (defaults && typeof defaults === "object") {
-    const defaultsRecord = defaults as Record<string, unknown>;
-    addModelConfigIds(out, defaultsRecord.model);
-    const defaultsModels = defaultsRecord.models;
-    if (defaultsModels && typeof defaultsModels === "object") {
-      for (const modelId of Object.keys(defaultsModels as Record<string, unknown>)) {
-        addModelId(out, modelId);
-      }
-    }
-  }
-  const list = (agents as { list?: unknown }).list;
-  if (list && typeof list === "object") {
-    for (const entry of Object.values(list as Record<string, unknown>)) {
-      if (!entry || typeof entry !== "object") {
-        continue;
-      }
-      addModelConfigIds(out, (entry as Record<string, unknown>).model);
-    }
-  }
-  return sortLocaleStrings(out);
 }
 
 export function parseFallbackList(value: string): string[] {

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -9,6 +9,7 @@ import {
   loadCronRuns,
   loadMoreCronRuns,
   normalizeCronFormState,
+  resolveConfiguredCronModelSuggestions,
   runCronJob,
   startCronEdit,
   startCronClone,
@@ -108,6 +109,48 @@ type EmptyCronListResponse = {
 };
 
 describe("cron controller", () => {
+  it("collects configured model suggestions from defaults and per-agent entries", () => {
+    expect(
+      resolveConfiguredCronModelSuggestions({
+        agents: {
+          defaults: {
+            model: {
+              primary: "openai/gpt-5.2",
+              fallbacks: ["google/gemini-2.5-pro", "openai/gpt-5.2-mini"],
+            },
+            models: {
+              "anthropic/claude-sonnet-4-5": { alias: "smart" },
+              "openai/gpt-5.2": { alias: "main" },
+            },
+          },
+          list: {
+            writer: {
+              model: { primary: "xai/grok-4", fallbacks: ["openai/gpt-5.2-mini"] },
+            },
+            planner: {
+              model: "google/gemini-2.5-flash",
+            },
+          },
+        },
+      }),
+    ).toEqual([
+      "anthropic/claude-sonnet-4-5",
+      "google/gemini-2.5-flash",
+      "google/gemini-2.5-pro",
+      "openai/gpt-5.2",
+      "openai/gpt-5.2-mini",
+      "xai/grok-4",
+    ]);
+  });
+
+  it("returns no configured model suggestions for invalid or missing config", () => {
+    expect(resolveConfiguredCronModelSuggestions(null)).toStrictEqual([]);
+    expect(resolveConfiguredCronModelSuggestions({})).toStrictEqual([]);
+    expect(
+      resolveConfiguredCronModelSuggestions({ agents: { defaults: { model: "" } } }),
+    ).toStrictEqual([]);
+  });
+
   it("loads model suggestions from the configured model view", async () => {
     const request = vi.fn(async () => ({
       models: [

--- a/ui/src/pages/chat/chat-avatar.ts
+++ b/ui/src/pages/chat/chat-avatar.ts
@@ -8,12 +8,9 @@ import {
   resolveLocalUserAvatarUrl,
   resolveLocalUserName,
 } from "../../app/user-identity.ts";
-import {
-  assistantAvatarFallbackUrl,
-  resolveAssistantTextAvatar,
-} from "../../lib/agents/display.ts";
+import { assistantAvatarFallbackUrl } from "../../lib/agents/display.ts";
 import type { AssistantIdentity } from "../../lib/assistant-identity.ts";
-import { isRenderableControlUiAvatarUrl } from "../../lib/avatar.ts";
+import { isRenderableControlUiAvatarUrl, resolveAssistantTextAvatar } from "../../lib/avatar.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import {
   DEFAULT_AGENT_ID,

--- a/ui/src/pages/chat/components/chat-message.ts
+++ b/ui/src/pages/chat/components/chat-message.ts
@@ -3,6 +3,7 @@ import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { until } from "lit/directives/until.js";
 import { resolveLocalUserName } from "../../../app/user-identity.ts";
+import { renderCopyAsMarkdownButton } from "../../../components/copy-button.ts";
 import { icons, type IconName } from "../../../components/icons.ts";
 import {
   toSanitizedMarkdownHtml,
@@ -18,17 +19,6 @@ import type {
   NormalizedMessage,
   ToolCard,
 } from "../../../lib/chat/chat-types.ts";
-import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
-import { resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
-import { resolveUiHourCycleOptions } from "../../../lib/format.ts";
-import { openExternalUrlSafe } from "../../../lib/open-external-url.ts";
-import { stripThinkingTags } from "../../../lib/strip-thinking-tags.ts";
-import { detectTextDirection } from "../../../lib/text-direction.ts";
-import { getSafeLocalStorage } from "../../../local-storage.ts";
-import type { SidebarContent } from "./chat-sidebar.ts";
-export { resolveAssistantTextAvatar } from "../../../lib/agents/display.ts";
-import { renderCopyAsMarkdownButton } from "../../../components/copy-button.ts";
-import "../../../components/tooltip.ts";
 import {
   extractThinkingCached,
   formatReasoningMarkdown,
@@ -45,8 +35,17 @@ import {
   formatCollapsedToolSummaryText,
   isToolCardError,
 } from "../../../lib/chat/tool-cards.ts";
+import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
+import { resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
+import { resolveUiHourCycleOptions } from "../../../lib/format.ts";
 import { formatCompactTokenCount } from "../../../lib/format.ts";
+import "../../../components/tooltip.ts";
+import { openExternalUrlSafe } from "../../../lib/open-external-url.ts";
+import { stripThinkingTags } from "../../../lib/strip-thinking-tags.ts";
+import { detectTextDirection } from "../../../lib/text-direction.ts";
+import { getSafeLocalStorage } from "../../../local-storage.ts";
 import { renderChatAvatar } from "../chat-avatar.ts";
+import type { SidebarContent } from "./chat-sidebar.ts";
 import {
   renderExpandedToolCardContent,
   renderRawOutputToggle,

--- a/ui/src/pages/chat/components/chat-welcome.ts
+++ b/ui/src/pages/chat/components/chat-welcome.ts
@@ -1,11 +1,8 @@
 // Control UI chat module implements chat welcome behavior.
 import { html } from "lit";
 import { t } from "../../../i18n/index.ts";
-import {
-  assistantAvatarFallbackUrl,
-  resolveAssistantTextAvatar,
-} from "../../../lib/agents/display.ts";
-import { resolveChatAvatarRenderUrl } from "../../../lib/avatar.ts";
+import { assistantAvatarFallbackUrl } from "../../../lib/agents/display.ts";
+import { resolveAssistantTextAvatar, resolveChatAvatarRenderUrl } from "../../../lib/avatar.ts";
 
 type ChatWelcomeProps = {
   assistantName: string;


### PR DESCRIPTION
## What Problem This Solves

Removes redundant Control UI helper paths that duplicated canonical implementations or exposed unused compatibility-style facades.

## Why This Change Was Made

The cron model suggestion resolver now has one implementation and one owner, with its behavior tests colocated there. Unused identity and route exports were deleted, and chat avatar callers now import the canonical avatar helper directly.

## User Impact

No intended user-visible behavior change. The Control UI has fewer duplicate code paths and a smaller internal API surface.

## Evidence

- Targeted UI tests: 6 files, 183 tests passed.
- Core and core-test typecheck lanes passed.
- Changed-surface guards passed: conflict markers, changelog, wildcard tests, duplicate coverage, dependency pins, package patches, and temporary-file checks.
- Scoped Oxlint across all 9 touched files: 0 warnings, 0 errors.
- `git diff --check`: passed.
- Dead-code analyzer findings: 3,635 -> 3,622.
- Refreshed codebase graph: 281,052 nodes / 1,138,939 edges.
- Fresh local and branch autoreviews: no findings.
- The broad `check:changed` lint phase was not usable as branch proof: Testbox traversed `packages/speech-core/node_modules/openclaw/**` and reported 3,760 unrelated dependency/generated-tree errors after the relevant guards and typecheck lanes had passed.

No changelog entry: internal refactor only.
