### PR TITLE
fix(channels): prevent metadata caches from growing without bound

### DIFF
--- a/extensions/discord/src/monitor/message-channel-info.ts
+++ b/extensions/discord/src/monitor/message-channel-info.ts
@@ -1,4 +1,5 @@
 // Discord plugin module implements message channel info behavior.
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -26,7 +27,7 @@ type DiscordMessageWithChannelId = Message & {
 
 const DISCORD_CHANNEL_INFO_CACHE_TTL_MS = 5 * 60 * 1000;
 const DISCORD_CHANNEL_INFO_NEGATIVE_CACHE_TTL_MS = 30 * 1000;
-export const DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES = 1000;
+const DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES = 1000;
 const DISCORD_CHANNEL_INFO_CACHE = new Map<
   string,
   { value: DiscordChannelInfo | null; expiresAt: number }
@@ -49,17 +50,7 @@ function cacheDiscordChannelInfo(
   const expiresAt = resolveDiscordChannelInfoCacheExpiresAt(ttlMs, nowMs);
   if (expiresAt !== undefined) {
     DISCORD_CHANNEL_INFO_CACHE.set(channelId, { value, expiresAt });
-    trimDiscordChannelInfoCache();
-  }
-}
-
-function trimDiscordChannelInfoCache(): void {
-  while (DISCORD_CHANNEL_INFO_CACHE.size > DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES) {
-    const oldestKey = DISCORD_CHANNEL_INFO_CACHE.keys().next().value;
-    if (oldestKey === undefined) {
-      return;
-    }
-    DISCORD_CHANNEL_INFO_CACHE.delete(oldestKey);
+    pruneMapToMaxSize(DISCORD_CHANNEL_INFO_CACHE, DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES);
   }
 }
 

--- a/extensions/discord/src/monitor/message-channel-info.ts
+++ b/extensions/discord/src/monitor/message-channel-info.ts
@@ -26,6 +26,7 @@ type DiscordMessageWithChannelId = Message & {
 
 const DISCORD_CHANNEL_INFO_CACHE_TTL_MS = 5 * 60 * 1000;
 const DISCORD_CHANNEL_INFO_NEGATIVE_CACHE_TTL_MS = 30 * 1000;
+export const DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES = 1000;
 const DISCORD_CHANNEL_INFO_CACHE = new Map<
   string,
   { value: DiscordChannelInfo | null; expiresAt: number }
@@ -48,6 +49,17 @@ function cacheDiscordChannelInfo(
   const expiresAt = resolveDiscordChannelInfoCacheExpiresAt(ttlMs, nowMs);
   if (expiresAt !== undefined) {
     DISCORD_CHANNEL_INFO_CACHE.set(channelId, { value, expiresAt });
+    trimDiscordChannelInfoCache();
+  }
+}
+
+function trimDiscordChannelInfoCache(): void {
+  while (DISCORD_CHANNEL_INFO_CACHE.size > DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES) {
+    const oldestKey = DISCORD_CHANNEL_INFO_CACHE.keys().next().value;
+    if (oldestKey === undefined) {
+      return;
+    }
+    DISCORD_CHANNEL_INFO_CACHE.delete(oldestKey);
   }
 }
 

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -47,6 +47,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
 });
 
 let resetDiscordChannelInfoCacheForTest: typeof import("./message-utils.js").resetDiscordChannelInfoCacheForTest;
+let DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES: typeof import("./message-utils.js").DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES;
 let resolveDiscordChannelInfo: typeof import("./message-utils.js").resolveDiscordChannelInfo;
 let resolveDiscordMessageChannelId: typeof import("./message-utils.js").resolveDiscordMessageChannelId;
 let resolveDiscordMessageText: typeof import("./message-utils.js").resolveDiscordMessageText;
@@ -56,6 +57,7 @@ let resolveReferencedReplyMediaList: typeof import("./message-utils.js").resolve
 
 beforeAll(async () => {
   ({
+    DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES,
     resetDiscordChannelInfoCacheForTest,
     resolveDiscordChannelInfo,
     resolveDiscordMessageChannelId,
@@ -1223,6 +1225,26 @@ describe("resolveDiscordChannelInfo", () => {
     });
     expect(second).toEqual(first);
     expect(fetchChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps cached channel info entries", async () => {
+    const fetchChannel = vi.fn(async (channelId: string) => ({
+      type: ChannelType.GuildText,
+      name: `name-${channelId}`,
+    }));
+    const client = { fetchChannel } as unknown as Client;
+
+    for (let index = 0; index <= DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES; index += 1) {
+      await resolveDiscordChannelInfo(client, `channel-${index}`);
+    }
+    await resolveDiscordChannelInfo(client, "channel-0");
+    await resolveDiscordChannelInfo(client, `channel-${DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES}`);
+
+    expect(fetchChannel).toHaveBeenCalledTimes(DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES + 2);
+    expect(fetchChannel).toHaveBeenNthCalledWith(
+      DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES + 2,
+      "channel-0",
+    );
   });
 
   it("negative-caches missing channels", async () => {

--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -47,7 +47,6 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
 });
 
 let resetDiscordChannelInfoCacheForTest: typeof import("./message-utils.js").resetDiscordChannelInfoCacheForTest;
-let DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES: typeof import("./message-utils.js").DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES;
 let resolveDiscordChannelInfo: typeof import("./message-utils.js").resolveDiscordChannelInfo;
 let resolveDiscordMessageChannelId: typeof import("./message-utils.js").resolveDiscordMessageChannelId;
 let resolveDiscordMessageText: typeof import("./message-utils.js").resolveDiscordMessageText;
@@ -57,7 +56,6 @@ let resolveReferencedReplyMediaList: typeof import("./message-utils.js").resolve
 
 beforeAll(async () => {
   ({
-    DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES,
     resetDiscordChannelInfoCacheForTest,
     resolveDiscordChannelInfo,
     resolveDiscordMessageChannelId,
@@ -1228,23 +1226,21 @@ describe("resolveDiscordChannelInfo", () => {
   });
 
   it("caps cached channel info entries", async () => {
+    const cacheEntryLimit = 1000;
     const fetchChannel = vi.fn(async (channelId: string) => ({
       type: ChannelType.GuildText,
       name: `name-${channelId}`,
     }));
     const client = { fetchChannel } as unknown as Client;
 
-    for (let index = 0; index <= DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES; index += 1) {
+    for (let index = 0; index <= cacheEntryLimit; index += 1) {
       await resolveDiscordChannelInfo(client, `channel-${index}`);
     }
     await resolveDiscordChannelInfo(client, "channel-0");
-    await resolveDiscordChannelInfo(client, `channel-${DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES}`);
+    await resolveDiscordChannelInfo(client, `channel-${cacheEntryLimit}`);
 
-    expect(fetchChannel).toHaveBeenCalledTimes(DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES + 2);
-    expect(fetchChannel).toHaveBeenNthCalledWith(
-      DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES + 2,
-      "channel-0",
-    );
+    expect(fetchChannel).toHaveBeenCalledTimes(cacheEntryLimit + 2);
+    expect(fetchChannel).toHaveBeenNthCalledWith(cacheEntryLimit + 2, "channel-0");
   });
 
   it("negative-caches missing channels", async () => {

--- a/extensions/discord/src/monitor/message-utils.ts
+++ b/extensions/discord/src/monitor/message-utils.ts
@@ -1,5 +1,6 @@
 // Discord helper module supports message utils behavior.
 export {
+  DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES,
   resetDiscordChannelInfoCacheForTest,
   resolveDiscordChannelInfo,
   resolveDiscordMessageChannelId,

--- a/extensions/discord/src/monitor/message-utils.ts
+++ b/extensions/discord/src/monitor/message-utils.ts
@@ -1,6 +1,5 @@
 // Discord helper module supports message utils behavior.
 export {
-  DISCORD_CHANNEL_INFO_CACHE_MAX_ENTRIES,
   resetDiscordChannelInfoCacheForTest,
   resolveDiscordChannelInfo,
   resolveDiscordMessageChannelId,

--- a/extensions/nextcloud-talk/src/room-info.test.ts
+++ b/extensions/nextcloud-talk/src/room-info.test.ts
@@ -79,6 +79,47 @@ describe("nextcloud talk room info", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
+  it("caps cached room info entries", async () => {
+    const cacheEntryLimit = 1000;
+    fetchWithSsrFGuard.mockImplementation(async () => ({
+      response: jsonResponse({
+        ocs: {
+          data: {
+            type: 1,
+          },
+        },
+      }),
+      release: vi.fn(async () => {}),
+    }));
+    const account = {
+      accountId: "acct-cache-cap",
+      baseUrl: "https://nc.example.com",
+      config: {
+        apiUser: "bot",
+        apiPassword: "secret",
+      },
+    } as never;
+
+    for (let index = 0; index <= cacheEntryLimit; index += 1) {
+      await resolveNextcloudTalkRoomKind({
+        account,
+        roomToken: `room-${index}`,
+      });
+    }
+    await resolveNextcloudTalkRoomKind({ account, roomToken: "room-0" });
+    const callsAfterOldestRetry = fetchWithSsrFGuard.mock.calls.length;
+    await resolveNextcloudTalkRoomKind({
+      account,
+      roomToken: `room-${cacheEntryLimit}`,
+    });
+
+    expect(callsAfterOldestRetry).toBe(cacheEntryLimit + 2);
+    expect(fetchWithSsrFGuard.mock.calls).toHaveLength(callsAfterOldestRetry);
+    expect(fetchWithSsrFGuard.mock.calls.at(-1)?.[0]).toMatchObject({
+      url: "https://nc.example.com/ocs/v2.php/apps/spreed/api/v4/room/room-0",
+    });
+  });
+
   it("normalizes signed decimal room type strings through the shared parser", async () => {
     fetchWithSsrFGuard.mockResolvedValue({
       response: jsonResponse({

--- a/extensions/nextcloud-talk/src/room-info.ts
+++ b/extensions/nextcloud-talk/src/room-info.ts
@@ -1,4 +1,5 @@
 // Nextcloud Talk plugin module implements room info behavior.
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
@@ -9,6 +10,7 @@ import { resolveNextcloudTalkApiCredentials } from "./api-credentials.js";
 
 const ROOM_CACHE_TTL_MS = 5 * 60 * 1000;
 const ROOM_CACHE_ERROR_TTL_MS = 30 * 1000;
+const ROOM_CACHE_MAX_ENTRIES = 1000;
 
 const roomCache = new Map<
   string,
@@ -23,6 +25,14 @@ export const testing = {
 
 function resolveRoomCacheKey(params: { accountId: string; roomToken: string }) {
   return `${params.accountId}:${params.roomToken}`;
+}
+
+function cacheRoomInfo(
+  key: string,
+  value: { kind?: "direct" | "group"; fetchedAt: number; error?: string },
+): void {
+  roomCache.set(key, value);
+  pruneMapToMaxSize(roomCache, ROOM_CACHE_MAX_ENTRIES);
 }
 
 function coerceRoomType(value: unknown): number | undefined {
@@ -96,7 +106,7 @@ export async function resolveNextcloudTalkRoomKind(params: {
     });
     try {
       if (!response.ok) {
-        roomCache.set(key, {
+        cacheRoomInfo(key, {
           fetchedAt: Date.now(),
           error: `status:${response.status}`,
         });
@@ -111,13 +121,13 @@ export async function resolveNextcloudTalkRoomKind(params: {
       }>(response, "Nextcloud Talk room info failed");
       const type = coerceRoomType(payload.ocs?.data?.type);
       const kind = resolveRoomKindFromType(type);
-      roomCache.set(key, { fetchedAt: Date.now(), kind });
+      cacheRoomInfo(key, { fetchedAt: Date.now(), kind });
       return kind;
     } finally {
       await release();
     }
   } catch (err) {
-    roomCache.set(key, {
+    cacheRoomInfo(key, {
       fetchedAt: Date.now(),
       error: formatErrorMessage(err),
     });


### PR DESCRIPTION
Related: #101662

## What Problem This Solves

Fixes an issue where long-lived Discord and Nextcloud Talk processes could retain
one metadata-cache entry for every unique channel or room they observed, allowing
those process-local Maps to grow without a fixed upper bound.

## Why This Change Was Made

Each channel owner now caps its existing metadata cache at 1000 entries through
the shared `pruneMapToMaxSize` plugin SDK helper. Existing TTL, negative-cache,
request, error, and SSRF-policy behavior remains unchanged.

The related same-author Nextcloud Talk fragment from #101662 was consolidated
here so the two small fixes land as one focused review unit, as encouraged by
`VISION.md`.

## User Impact

Long-running channel processes keep these metadata caches bounded while retaining
the newest entries. An evicted entry is fetched normally when it is needed again.

## Evidence

- Discord `message-utils.test.ts`: 49/49 passed.
- Nextcloud Talk `room-info.test.ts`: 8/8 passed.
- `oxfmt --check` and `git diff --check`: passed.
- Fresh structured autoreview: clean, confidence 0.88.
- Testbox-through-Crabbox `tbx_01kwybm52cwzvxb4qb6w7hsvar`:
  `pnpm check:changed` passed on the byte-identical rebased repair tree.
