### PR TITLE
fix(qa): reuse cached image for web search smoke lane

### DIFF
--- a/test/e2e/qa-lab/runtime/docker-e2e-lane.fixture.test.ts
+++ b/test/e2e/qa-lab/runtime/docker-e2e-lane.fixture.test.ts
@@ -59,6 +59,21 @@ describe("QA Docker E2E lane fixture", () => {
     expect(updateRestartAuth.env.OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT).toBe("1500s");
   });
 
+  it("defaults the web search smoke lane to reuse the cached Docker image", () => {
+    const lane = resolveQaDockerE2eLane("openai-web-search-minimal", {});
+
+    expect(lane.script).toBe("scripts/e2e/openai-web-search-minimal-docker.sh");
+    expect(lane.env.OPENCLAW_SKIP_DOCKER_BUILD).toBe("1");
+  });
+
+  it("allows callers to override the web search smoke lane Docker build policy", () => {
+    const lane = resolveQaDockerE2eLane("openai-web-search-minimal", {
+      OPENCLAW_SKIP_DOCKER_BUILD: "0",
+    });
+
+    expect(lane.env.OPENCLAW_SKIP_DOCKER_BUILD).toBe("0");
+  });
+
   it("dispatches through bash without running Docker in fixture tests", () => {
     const spawn = vi.fn(() => ({ signal: null, status: 0 }));
 

--- a/test/e2e/qa-lab/runtime/docker-e2e-lane.fixture.ts
+++ b/test/e2e/qa-lab/runtime/docker-e2e-lane.fixture.ts
@@ -44,6 +44,9 @@ export const QA_DOCKER_E2E_LANES = {
     script: "scripts/e2e/openai-chat-tools-docker.sh",
   },
   "openai-web-search-minimal": {
+    env: (env) => ({
+      OPENCLAW_SKIP_DOCKER_BUILD: env.OPENCLAW_SKIP_DOCKER_BUILD ?? "1",
+    }),
     script: "scripts/e2e/openai-web-search-minimal-docker.sh",
   },
   openwebui: {


### PR DESCRIPTION
Related: #97340

## What Problem This Solves

Resolves a problem where QA Smoke CI could spend the entire scenario budget rebuilding the `openai-web-search-minimal` Docker image when running the native web_search smoke wrapper, causing the scenario to time out before reaching the assertions.

## Why This Change Was Made

The QA Docker lane wrapper now matches the regular Docker E2E plan for `openai-web-search-minimal` by defaulting `OPENCLAW_SKIP_DOCKER_BUILD` to `1` for that lane. The overlay still respects an explicit caller override, so maintainers can force a rebuild with `OPENCLAW_SKIP_DOCKER_BUILD=0` when needed.

## User Impact

No product behavior changes. Operators and maintainers should get a faster, less flaky QA smoke wrapper for the OpenAI native web_search scenario when a cached E2E image is already available.

## Evidence

- Before fix: in the #97340 QA Smoke CI artifact `qa-smoke-profile-telegram-2-of-2-28861430386-1`, `OpenAI native web_search request assertions` failed with `node timed out after 1800000ms`; the scenario log repeatedly reported `Docker build openai-web-search-minimal-build still running`.
- After fix: PR #101651 `QA Smoke CI (telegram 2/2)` passed on head `a81b4b6a64be132bbb49fdc073fa9d6498db7675`: https://github.com/openclaw/openclaw/actions/runs/28865855712/job/85615734409
- After-fix artifact: `qa-smoke-profile-telegram-2-of-2-28865855712-1` shows `OpenAI native web_search request assertions` with `status: pass` and the same wrapper path, `test/e2e/qa-lab/runtime/docker-e2e-lane.ts`.
- After-fix scenario log excerpt:

```text
$ node --import tsx test/e2e/qa-lab/runtime/docker-e2e-lane.ts --lane openai-web-search-minimal
Reusing Docker image: openclaw-openai-web-search-minimal-e2e
Running OpenAI web_search minimal reasoning Docker E2E...
```

- The after-fix run used the cached image path. It did not set `OPENCLAW_SKIP_DOCKER_BUILD=0`; the wrapper defaulted to reuse and the artifact log shows `Reusing Docker image`.
- `Real behavior proof` check passed: https://github.com/openclaw/openclaw/actions/runs/28867803213/job/85622323949
- `pnpm test -- test/e2e/qa-lab/runtime/docker-e2e-lane.fixture.test.ts` passed: 1 file, 8 tests.
- `pnpm test -- test/scripts/docker-e2e-plan.test.ts` passed: 1 file, 31 tests.
- `pnpm lint --threads=8` passed.
