### PR TITLE
test(shared): add unit tests for tilde path expansion

### DIFF
--- a/src/shared/tilde-path.test.ts
+++ b/src/shared/tilde-path.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("node:os", () => ({
+  homedir: () => "/home/testuser",
+}));
+
+import { expandTildePath } from "./tilde-path.js";
+
+describe("expandTildePath", () => {
+  it('expands bare "~" to the home directory', () => {
+    expect(expandTildePath("~")).toBe("/home/testuser");
+  });
+
+  it('expands "~/path" to "<home>/path"', () => {
+    expect(expandTildePath("~/documents")).toBe("/home/testuser/documents");
+  });
+
+  it('expands "~name" to "<home>/name"', () => {
+    expect(expandTildePath("~otheruser")).toBe("/home/testuser/otheruser");
+  });
+
+  it("returns non-tilde paths unchanged", () => {
+    expect(expandTildePath("/absolute/path")).toBe("/absolute/path");
+    expect(expandTildePath("relative/path")).toBe("relative/path");
+  });
+
+  it("handles leading/trailing whitespace", () => {
+    expect(expandTildePath("  ~/foo  ")).toBe("/home/testuser/foo");
+  });
+
+  it("returns trimmed non-tilde path with whitespace", () => {
+    expect(expandTildePath("  /foo  ")).toBe("/foo");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(expandTildePath("")).toBe("");
+  });
+
+  it("handles whitespace-only input", () => {
+    expect(expandTildePath("   ")).toBe("");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The `expandTildePath` utility in `src/shared/tilde-path.ts` has no dedicated unit tests, leaving the home-directory path expansion logic unverified against regressions.

## Why This Change Was Made

Adds comprehensive unit test coverage for tilde path expansion, covering:
- Bare `~` → home directory
- `~/path` → `<home>/path`
- `~name` → `<home>/name`
- Non-tilde paths returned unchanged
- Leading/trailing whitespace handling
- Empty and whitespace-only input

## User Impact

- Purely additive: one new test file, no production code changes
- No risk of breaking existing behavior

## Evidence

```
$ npx vitest run src/shared/tilde-path.test.ts --reporter=verbose

 ✓ expandTildePath > expands bare "~" to the home directory
 ✓ expandTildePath > expands "~/path" to "<home>/path"
 ✓ expandTildePath > expands "~name" to "<home>/name"
 ✓ expandTildePath > returns non-tilde paths unchanged
 ✓ expandTildePath > handles leading/trailing whitespace
 ✓ expandTildePath > returns trimmed non-tilde path with whitespace
 ✓ expandTildePath > returns empty string for empty input
 ✓ expandTildePath > handles whitespace-only input

 Test Files  1 passed (1)
      Tests  8 passed (8)
```