### PR TITLE
fix: keep bounded text truncation UTF-16 safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Bounded text rendering:** keep surrogate pairs intact when truncating CLI tables and errors, agent diagnostics, heartbeat/push previews, HTTP snippets, and bundled plugin text, preventing malformed UTF-16 output at emoji boundaries. Thanks @lsr911, @maweibin, and @wm0018.
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.
 - **OAuth refresh contention diagnostics:** keep local lock paths out of user-facing refresh failures and avoid duplicate failure prefixes while preserving structured provider and profile classification. (#83383) Thanks @vincentkoc.
 - **Exec approval prompts:** keep background-disabled fallback warnings out of pending gateway/node approvals and show them only after a command actually runs in the foreground. (#78184) Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Bounded text rendering:** keep surrogate pairs intact when truncating CLI tables and errors, agent diagnostics, heartbeat/push previews, HTTP snippets, and bundled plugin text, preventing malformed UTF-16 output at emoji boundaries. Thanks @lsr911, @maweibin, and @wm0018.
 - **Lean local model shell access:** keep `exec` directly visible beside the default structured Tool Search controls so coding-tuned local models can use their shell fallback instead of searching for missing domain tools. (#87587) Thanks @vincentkoc.
 - **OAuth refresh contention diagnostics:** keep local lock paths out of user-facing refresh failures and avoid duplicate failure prefixes while preserving structured provider and profile classification. (#83383) Thanks @vincentkoc.
 - **Exec approval prompts:** keep background-disabled fallback warnings out of pending gateway/node approvals and show them only after a command actually runs in the foreground. (#78184) Thanks @vincentkoc.

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -61,6 +61,16 @@ vi.mock("openclaw/plugin-sdk/session-store-runtime", async () => {
 });
 
 describe("active-memory plugin", () => {
+  it("keeps previous-message query context UTF-16 well-formed", () => {
+    const query = testing.buildSearchQuery({
+      latestUserMessage: "why?",
+      recentTurns: [{ role: "user", text: `${"x".repeat(119)}🚀tail` }],
+    });
+
+    expect(query).toBe(`${"x".repeat(119)} why?`);
+    expect(query).not.toContain("\uD83D");
+  });
+
   const hooks: Record<string, Function> = {};
   const hookOptions: Record<string, Record<string, unknown> | undefined> = {};
   const registeredCommands: Record<string, any> = {};

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -2735,11 +2735,10 @@ function buildSearchQuery(params: {
   if (!previousUser) {
     return latest || clampSearchQuery(params.latestUserMessage);
   }
-  const context = clampSearchQuery(
-    normalizeSearchQueryText(stripRecalledContextNoise(previousUser.text)),
-  )
-    .slice(0, 120)
-    .trim();
+  const context = truncateUtf16Safe(
+    clampSearchQuery(normalizeSearchQueryText(stripRecalledContextNoise(previousUser.text))),
+    120,
+  ).trim();
   return clampSearchQuery(context ? `${context} ${latest}` : latest);
 }
 
@@ -3755,6 +3754,7 @@ export default definePluginEntry({
 });
 
 const testing = {
+  buildSearchQuery,
   buildCacheKey,
   buildCircuitBreakerKey,
   buildMetadata,

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2955,7 +2955,7 @@ describe("memory plugin e2e", () => {
     const fakeRows = [
       {
         id: fakeUuid1,
-        text: "User prefers dark mode",
+        text: `${"x".repeat(59)}🚀tail`,
         category: "preference",
         vector: [0.1],
         importance: 0.8,
@@ -3035,6 +3035,8 @@ describe("memory plugin e2e", () => {
       const text = result.content?.[0]?.text ?? "";
       expect(text).toContain(fakeUuid1);
       expect(text).toContain(fakeUuid2);
+      expect(text).toContain(`- [${fakeUuid1}] ${"x".repeat(59)}...`);
+      expect(text).not.toContain("\uD83D");
       // Ensure truncated 8-char prefix alone is NOT the format used
       expect(text).not.toMatch(/\[890e1fae\]/);
       expect(text).not.toMatch(/\[a1b2c3d4\]/);

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -1658,7 +1658,7 @@ export default definePluginEntry({
           });
 
           return {
-            content: [{ type: "text", text: `Stored: "${text.slice(0, 100)}..."` }],
+            content: [{ type: "text", text: `Stored: "${truncateUtf16Safe(text, 100)}..."` }],
             details: { action: "created", id: entry.id },
           };
         },
@@ -1709,7 +1709,7 @@ export default definePluginEntry({
             }
 
             const list = results
-              .map((r) => `- [${r.entry.id}] ${r.entry.text.slice(0, 60)}...`)
+              .map((r) => `- [${r.entry.id}] ${truncateUtf16Safe(r.entry.text, 60)}...`)
               .join("\n");
 
             // Strip vector data for serialization

--- a/extensions/zalouser/src/zalo-js.credentials.test.ts
+++ b/extensions/zalouser/src/zalo-js.credentials.test.ts
@@ -32,8 +32,15 @@ import {
   sendZaloLink,
   sendZaloReaction,
   startZaloQrLogin,
+  testing,
   waitForZaloQrLogin,
 } from "./zalo-js.js";
+
+describe("Zalo payload bounds", () => {
+  it("keeps the 2,000-code-unit transport payload UTF-16 well-formed", () => {
+    expect(testing.truncatePayloadText(`${"x".repeat(1_999)}🚀tail`)).toBe("x".repeat(1_999));
+  });
+});
 
 type StoredCredentialFile = {
   imei: string;

--- a/extensions/zalouser/src/zalo-js.ts
+++ b/extensions/zalouser/src/zalo-js.ts
@@ -26,7 +26,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { sleep } from "openclaw/plugin-sdk/text-utility-runtime";
+import { sleep, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeZaloReactionIcon } from "./reaction.js";
 import { createZalouserSendReceipt } from "./send-receipt.js";
 import type {
@@ -986,7 +986,12 @@ function toInboundMessage(message: Message, ownUserId?: string): ZaloInboundMess
   };
 }
 
+function truncatePayloadText(text: string): string {
+  return truncateUtf16Safe(text, 2000);
+}
+
 export const testing = {
+  truncatePayloadText,
   toInboundMessage,
   readCachedGroupContext,
   writeCachedGroupContext,
@@ -1238,7 +1243,7 @@ export async function sendZaloTextMessage(
             contentType: media.contentType,
             kind: media.kind,
           });
-          const payloadText = (text || options.caption || "").slice(0, 2000);
+          const payloadText = truncatePayloadText(text || options.caption || "");
           const textStyles = clampTextStyles(payloadText, options.textStyles);
 
           if (media.kind === "audio") {
@@ -1313,7 +1318,7 @@ export async function sendZaloTextMessage(
           };
         }
 
-        const payloadText = text.slice(0, 2000);
+        const payloadText = truncatePayloadText(text);
         const textStyles = clampTextStyles(payloadText, options.textStyles);
         const response = await api.sendMessage(
           textStyles ? { msg: payloadText, styles: textStyles } : payloadText,

--- a/src/agents/command/attempt-execution.error-propagation.test.ts
+++ b/src/agents/command/attempt-execution.error-propagation.test.ts
@@ -123,6 +123,18 @@ describe("ACP diagnostic events", () => {
     expect(String(event?.data.text)).not.toContain("sk-abcdefghijklmnopqrstuvwxyz123456");
   });
 
+  it("keeps bounded ACP diagnostics UTF-16 well-formed", () => {
+    emitAcpRuntimeEvent({
+      runId: "run-utf16-status",
+      event: {
+        type: "status",
+        text: `${"x".repeat(239)}🚀tail`,
+      },
+    });
+
+    expect(captured[0]?.data.text).toBe("x".repeat(239));
+  });
+
   it("keeps audit-only ACP lifecycle and runtime events off the shared bus", () => {
     const secret = "private ACP cause chain";
     const auditEvents: AgentEventPayload[] = [];

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -6,6 +6,7 @@ import {
   normalizeOptionalLowercaseString,
   type FastMode,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 import { ACP_TURN_TIMEOUT_DETAIL_CODE } from "../../acp/control-plane/manager.turn-timeout.js";
 import { formatAcpErrorChain } from "../../acp/runtime/errors.js";
@@ -1162,7 +1163,7 @@ function resolvePresentProxyEnvKeys(env: NodeJS.ProcessEnv = process.env): strin
 }
 
 function sanitizeAcpDiagnosticText(value: string): string {
-  return redactSensitiveText(value).replace(/\s+/g, " ").trim().slice(0, 240);
+  return truncateUtf16Safe(redactSensitiveText(value).replace(/\s+/g, " ").trim(), 240);
 }
 
 function acpRuntimeEventDiagnostics(event: AcpRuntimeEvent): Record<string, unknown> {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -142,6 +142,15 @@ function expectRecordFields(record: unknown, expected: Record<string, unknown>) 
 }
 
 describe("openai transport stream", () => {
+  it("keeps bounded redacted diagnostics UTF-16 well-formed", () => {
+    const payload = testing.stringifyRedactedPayload(`${"x".repeat(7_998)}🚀tail`);
+    const event = testing.stringifyRedactedEvent(`${"x".repeat(1_998)}🚀tail`);
+
+    expect(payload).toContain(`${"x".repeat(7_998)}…<truncated>`);
+    expect(event).toContain(`${"x".repeat(1_998)}…<truncated>`);
+    expect(payload).not.toContain("\uD83D");
+    expect(event).not.toContain("\uD83D");
+  });
   it("fails Azure Responses streams when headers arrive but no first event follows", async () => {
     vi.useFakeTimers();
     try {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -48,6 +48,7 @@ import {
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import OpenAI, { AzureOpenAI } from "openai";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions.js";
 import type {
@@ -462,7 +463,7 @@ function stringifyRedactedPayload(value: unknown): string {
       return "<empty>";
     }
     const redacted = redactSensitiveText(encoded, { mode: "tools" });
-    return redacted.length > 8000 ? `${redacted.slice(0, 8000)}…<truncated>` : redacted;
+    return redacted.length > 8000 ? `${truncateUtf16Safe(redacted, 8000)}…<truncated>` : redacted;
   } catch {
     return "<unserializable>";
   }
@@ -470,7 +471,7 @@ function stringifyRedactedPayload(value: unknown): string {
 
 function stringifyRedactedEvent(value: unknown): string {
   const redacted = stringifyRedactedPayload(value);
-  return redacted.length > 2000 ? `${redacted.slice(0, 2000)}…<truncated>` : redacted;
+  return redacted.length > 2000 ? `${truncateUtf16Safe(redacted, 2000)}…<truncated>` : redacted;
 }
 
 type ResponsesFailedNoDetailsObservation = {
@@ -4529,5 +4530,7 @@ export const testing = {
   summarizeResponsesFailedNoDetailsObservation,
   summarizeResponsesPayload,
   summarizeResponsesTools,
+  stringifyRedactedEvent,
+  stringifyRedactedPayload,
 };
 export { testing as __testing };

--- a/src/agents/subagent-registry-helpers.test.ts
+++ b/src/agents/subagent-registry-helpers.test.ts
@@ -114,4 +114,21 @@ describe("logAnnounceGiveUp", () => {
     );
     logSpy.mockRestore();
   });
+
+  it("keeps bounded delivery errors UTF-16 well-formed", () => {
+    const logSpy = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
+    const entry = createRunEntry({
+      delivery: {
+        status: "failed",
+        lastError: `${"x".repeat(1_999)}🚀tail`,
+      },
+    });
+
+    logAnnounceGiveUp(entry, "expiry");
+
+    const line = String(logSpy.mock.calls[0]?.[0]);
+    expect(line).toContain(`${"x".repeat(1_999)}…`);
+    expect(line).not.toContain("\uD83D");
+    logSpy.mockRestore();
+  });
 });

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -5,6 +5,7 @@
  */
 import fsSync, { promises as fs } from "node:fs";
 import path from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES } from "../config/agent-limits.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveAgentIdFromSessionKey, resolveStorePath } from "../config/sessions.js";
@@ -76,7 +77,9 @@ export function resolveAnnounceRetryDelayMs(retryCount: number) {
 
 function formatAnnounceGiveUpLogField(value: string): string {
   const normalized = value.replace(/\s+/g, " ").trim();
-  return JSON.stringify(normalized.length > 2_000 ? `${normalized.slice(0, 2_000)}…` : normalized);
+  return JSON.stringify(
+    normalized.length > 2_000 ? `${truncateUtf16Safe(normalized, 2_000)}…` : normalized,
+  );
 }
 
 /** Logs a sanitized final give-up line for failed subagent announce delivery. */

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -67,6 +67,18 @@ function mockCall(mock: { mock: { calls: unknown[][] } }, index = 0): unknown[] 
 }
 
 describe("Tool Search", () => {
+  it("keeps bounded directory descriptions UTF-16 well-formed", () => {
+    const sessionId = "session-utf16-directory";
+    const config = { tools: { toolSearch: { enabled: true, mode: "directory" } } } as never;
+    const searchTool = fakeTool(TOOL_SEARCH_RAW_TOOL_NAME, "search");
+    const target = pluginTool("fake_utf16", `${"x".repeat(176)}🚀tail`);
+    applyToolSchemaDirectoryCatalog({ tools: [searchTool, target], config, sessionId });
+
+    const directory = buildToolSchemaDirectoryPrompt({ sessionId, config });
+
+    expect(directory).toContain(`${"x".repeat(176)}...`);
+    expect(directory).not.toContain("\uD83D");
+  });
   afterEach(() => {
     testing.setToolSearchCodeModeSupportedForTest(undefined);
     testing.setToolSearchMinCodeTimeoutMsForTest(undefined);

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -11,6 +11,7 @@ import {
   uniqueStrings,
   uniqueValues,
 } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
@@ -1132,7 +1133,7 @@ function compactDirectoryDescription(description: string): string {
   if (normalized.length <= 180) {
     return normalized;
   }
-  return `${normalized.slice(0, 177).trimEnd()}...`;
+  return `${truncateUtf16Safe(normalized, 177).trimEnd()}...`;
 }
 
 function formatToolDirectoryIdentifier(value: string | undefined): string | undefined {

--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -224,6 +224,20 @@ describe("gateway tool restart continuation", () => {
     });
   });
 
+  it("keeps the bounded restart reason UTF-16 well-formed", async () => {
+    const tool = createGatewayTool({
+      agentSessionKey: "agent:main:main",
+      config: {},
+    });
+
+    await tool.execute?.("tool-call-utf16", {
+      action: "restart",
+      reason: `${"x".repeat(199)}🚀tail`,
+    });
+
+    expect(requireScheduledRestartArgs().reason).toBe("x".repeat(199));
+  });
+
   it("uses the runtime session, not model-supplied params, for scheduler ownership and sentinel routing (#86742)", async () => {
     const tool = createGatewayTool({
       agentSessionKey: "agent:main:session-A",

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -9,6 +9,7 @@ import {
   normalizeOptionalString,
   readStringValue,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
 import { isRestartEnabled } from "../../config/commands.flags.js";
 import { parseConfigJson5, resolveConfigSnapshotHash } from "../../config/io.js";
@@ -466,7 +467,8 @@ export function createGatewayTool(opts?: {
           normalizeOptionalString(opts?.agentSessionKey) ??
           normalizeOptionalString(params.sessionKey);
         const delayMs = readNonNegativeIntegerParam(params, "delayMs");
-        const reason = normalizeOptionalString(params.reason)?.slice(0, 200);
+        const rawReason = normalizeOptionalString(params.reason);
+        const reason = rawReason ? truncateUtf16Safe(rawReason, 200) : undefined;
         const note = normalizeOptionalString(params.note);
         const continuationMessage = normalizeOptionalString(params.continuationMessage);
         // Extract channel + threadId for routing after restart.

--- a/src/cli/error-format.test.ts
+++ b/src/cli/error-format.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { formatStrictJsonParseFailure } from "./error-format.js";
+
+describe("formatStrictJsonParseFailure", () => {
+  it("keeps the bounded JSON preview UTF-16 well-formed", () => {
+    const value = `${"x".repeat(44)}🚀tail`;
+
+    const message = formatStrictJsonParseFailure({ value, cause: "invalid token" });
+
+    expect(message).toContain(`${"x".repeat(44)}...`);
+    expect(message).not.toContain("\uD83D");
+  });
+});

--- a/src/cli/error-format.ts
+++ b/src/cli/error-format.ts
@@ -1,4 +1,5 @@
 // Reusable CLI error-message formatters that keep recovery hints consistent across commands.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatCliCommand } from "./command-format.js";
 
 const DEFAULT_GATEWAY_PORT_EXAMPLE = 18789;
@@ -59,7 +60,7 @@ export function formatStrictJsonParseFailure(params: { value: string; cause: unk
   const rawCause = params.cause instanceof Error ? params.cause.message : String(params.cause);
   const cause = rawCause.trim().replace(/[.。]+$/u, "");
   const preview =
-    params.value.length > 48 ? `${params.value.slice(0, 45).trimEnd()}...` : params.value;
+    params.value.length > 48 ? `${truncateUtf16Safe(params.value, 45).trimEnd()}...` : params.value;
   return [
     `Could not parse ${JSON.stringify(preview)} as JSON for --strict-json.`,
     `${cause}.`,

--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -6,6 +6,14 @@ import * as execApprovals from "../infra/exec-approvals.js";
 import type { ExecApprovalsFile } from "../infra/exec-approvals.js";
 import { registerExecApprovalsCli, testing } from "./exec-approvals-cli.js";
 
+describe("exec approvals CLI error formatting", () => {
+  it("keeps the bounded first line UTF-16 well-formed", () => {
+    const message = testing.formatCliError(`${"x".repeat(299)}🚀tail\nignored`);
+
+    expect(message).toBe(`${"x".repeat(299)}...`);
+  });
+});
+
 const mocks = vi.hoisted(() => {
   const runtimeErrors: string[] = [];
   const stringifyArgs = (args: unknown[]) => args.map((value) => String(value)).join(" ");

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -1,6 +1,7 @@
 // CLI for reading and mutating exec approval allowlists locally, via gateway, or via node.
 import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { Command } from "commander";
 import JSON5 from "json5";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
@@ -180,7 +181,7 @@ function formatCliError(err: unknown): string {
   const msg = formatErrorMessage(err);
   const firstLine = msg.includes("\n") ? msg.split("\n")[0] : msg;
   const safe = sanitizeForLog(firstLine);
-  return safe.length > 300 ? `${safe.slice(0, 300)}...` : safe;
+  return safe.length > 300 ? `${truncateUtf16Safe(safe, 300)}...` : safe;
 }
 
 async function loadConfigForApprovalsTarget(params: {
@@ -634,5 +635,6 @@ export function registerExecApprovalsCli(program: Command) {
 }
 
 export const testing = {
+  formatCliError,
   readStdin,
 };

--- a/src/commands/audit.test.ts
+++ b/src/commands/audit.test.ts
@@ -40,4 +40,25 @@ describe("audit command parsing", () => {
     expect(row).toContain("main\\nforged");
     expect(row).toContain("run\\tcolumn");
   });
+
+  it("keeps truncated audit cells UTF-16 well-formed", () => {
+    const [, row] = testApi.formatAuditRows([
+      {
+        eventId: "event-utf16",
+        sequence: 1,
+        sourceSequence: 1,
+        occurredAt: 0,
+        kind: "tool_action",
+        action: "tool.action.finished",
+        status: "failed",
+        actor: { type: "agent", id: "main" },
+        agentId: `${"x".repeat(16)}🚀tail`,
+        runId: "run-utf16",
+        redaction: "metadata_only",
+      },
+    ]);
+
+    expect(row).toContain(`${"x".repeat(16)}…`);
+    expect(row).not.toContain("\uD83D");
+  });
 });

--- a/src/commands/audit.ts
+++ b/src/commands/audit.ts
@@ -1,5 +1,6 @@
 /** Operator CLI for bounded metadata-only run/tool audit pages. */
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type {
   AuditEvent,
   AuditListParams,
@@ -63,7 +64,9 @@ function short(value: string | undefined, maxChars: number): string {
   if (!sanitized) {
     return "-";
   }
-  return sanitized.length <= maxChars ? sanitized : `${sanitized.slice(0, maxChars - 1)}…`;
+  return sanitized.length <= maxChars
+    ? sanitized
+    : `${truncateUtf16Safe(sanitized, maxChars - 1)}…`;
 }
 
 function formatAuditRows(events: AuditEvent[]): string[] {

--- a/src/commands/commitments.test.ts
+++ b/src/commands/commitments.test.ts
@@ -204,6 +204,17 @@ describe("commitments command", () => {
     expect(row?.indexOf("pending")).toBe(header?.indexOf("Status"));
   });
 
+  it("keeps truncated table cells UTF-16 well-formed", async () => {
+    mocks.listCommitments.mockResolvedValue([commitment({ id: `${"x".repeat(14)}🚀tail` })]);
+    const { runtime, logs } = createRuntime();
+
+    await commitmentsListCommand({}, runtime);
+
+    const row = logs.map(stripAnsi).find((line) => line.startsWith("x"));
+    expect(row?.slice(0, 16)).toBe(`${"x".repeat(14)}… `);
+    expect(row).not.toContain("\uD83D");
+  });
+
   it("writes list JSON to runtime stdout instead of log output", async () => {
     const { runtime, logs, stdout } = createRuntime();
 

--- a/src/commands/commitments.ts
+++ b/src/commands/commitments.ts
@@ -2,6 +2,7 @@
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -24,7 +25,7 @@ const STATUS_VALUES = new Set<CommitmentStatus>([
 ]);
 
 function truncate(value: string, maxChars: number): string {
-  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}…`;
+  return value.length <= maxChars ? value : `${truncateUtf16Safe(value, maxChars - 1)}…`;
 }
 
 function safe(value: string): string {

--- a/src/commands/flows.test.ts
+++ b/src/commands/flows.test.ts
@@ -162,6 +162,29 @@ describe("flows commands", () => {
     });
   });
 
+  it("keeps truncated text rows UTF-16 well-formed", async () => {
+    await withTaskFlowCommandStateDir(async () => {
+      createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: `${"x".repeat(18)}🚀tail`,
+        goal: "Inspect a PR cluster",
+        status: "running",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+      const runtime = createRuntime();
+
+      await flowsListCommand({}, runtime);
+
+      const output = vi
+        .mocked(runtime.log)
+        .mock.calls.map(([line]) => String(line))
+        .join("\n");
+      expect(output).toContain(`${"x".repeat(18)}…`);
+      expect(output).not.toContain("\uD83D");
+    });
+  });
+
   it("shows one TaskFlow as JSON through the runtime JSON writer", async () => {
     await withTaskFlowCommandStateDir(async () => {
       const flow = createManagedTaskFlow({

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -1,6 +1,7 @@
 /** CLI commands for listing, inspecting, and cancelling TaskFlow records. */
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -32,9 +33,9 @@ function truncate(value: string, maxChars: number) {
     return value;
   }
   if (maxChars <= 1) {
-    return value.slice(0, maxChars);
+    return truncateUtf16Safe(value, maxChars);
   }
-  return `${value.slice(0, maxChars - 1)}…`;
+  return `${truncateUtf16Safe(value, maxChars - 1)}…`;
 }
 
 function safeFlowDisplayText(value: string | undefined, maxChars?: number): string {

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -19,9 +19,16 @@ import {
   resolveControlUiLinks,
   resolveLocalControlUiProbeLinks,
   summarizeExistingConfig,
+  testing,
   validateGatewayPasswordInput,
   waitForGatewayReachable,
 } from "./onboard-helpers.js";
+
+describe("onboard error summaries", () => {
+  it("keeps the bounded first line UTF-16 well-formed", () => {
+    expect(testing.summarizeError(`${"x".repeat(118)}🚀tail\nignored`)).toBe(`${"x".repeat(118)}…`);
+  });
+});
 
 const mocks = vi.hoisted(() => ({
   movePathToTrash: vi.fn(async (targetPath: string) => `${targetPath}.trashed`),

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -6,6 +6,7 @@ import { cancel, isCancel } from "@clack/prompts";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import {
   decorativeEmoji,
@@ -410,8 +411,10 @@ function summarizeError(err: unknown): string {
       .split("\n")
       .map((s) => s.trim())
       .find(Boolean) ?? raw;
-  return line.length > 120 ? `${line.slice(0, 119)}…` : line;
+  return line.length > 120 ? `${truncateUtf16Safe(line, 119)}…` : line;
 }
+
+export const testing = { summarizeError };
 
 /** Default workspace path shown by onboarding prompts. */
 export const DEFAULT_WORKSPACE = DEFAULT_AGENT_WORKSPACE_DIR;

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -38,7 +38,16 @@ vi.mock("./onboard-helpers.js", () => ({
   resolveNodeManagerOptions: mocks.resolveNodeManagerOptions,
 }));
 
-import { setupSkills } from "./onboard-skills.js";
+import { setupSkills, testing } from "./onboard-skills.js";
+
+describe("skill onboarding text bounds", () => {
+  it("keeps install failures and hints UTF-16 well-formed", () => {
+    expect(testing.summarizeInstallFailure(`${"x".repeat(138)}🚀tail`)).toBe(`${"x".repeat(138)}…`);
+    expect(testing.formatSkillHint({ description: `${"x".repeat(88)}🚀tail`, install: [] })).toBe(
+      `${"x".repeat(88)}…`,
+    );
+  });
+});
 
 function createBundledSkill(params: {
   name: string;

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -4,6 +4,7 @@
  * It reports workspace skill readiness, offers safe dependency installs, and
  * leaves per-skill credentials to the agent when a skill actually needs them.
  */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveBrewExecutable } from "../infra/brew.js";
@@ -47,7 +48,7 @@ function summarizeInstallFailure(message: string): string | undefined {
     return undefined;
   }
   const maxLen = 140;
-  return cleaned.length > maxLen ? `${cleaned.slice(0, maxLen - 1)}…` : cleaned;
+  return cleaned.length > maxLen ? `${truncateUtf16Safe(cleaned, maxLen - 1)}…` : cleaned;
 }
 
 function formatSkillHint(skill: {
@@ -61,8 +62,10 @@ function formatSkillHint(skill: {
     return "install";
   }
   const maxLen = 90;
-  return combined.length > maxLen ? `${combined.slice(0, maxLen - 1)}…` : combined;
+  return combined.length > maxLen ? `${truncateUtf16Safe(combined, maxLen - 1)}…` : combined;
 }
+
+export const testing = { formatSkillHint, summarizeInstallFailure };
 
 const SKIP_REASON_LABELS = {
   brew: "Homebrew",

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -116,7 +116,13 @@ vi.mock("../utils/with-timeout.js", () => ({
   withTimeout,
 }));
 
-import { ensureOnboardingPluginInstalled } from "./onboarding-plugin-install.js";
+import { ensureOnboardingPluginInstalled, testing } from "./onboarding-plugin-install.js";
+
+describe("plugin install error summaries", () => {
+  it("keeps bounded terminal text UTF-16 well-formed", () => {
+    expect(testing.summarizeInstallError(`${"x".repeat(178)}🚀tail`)).toBe(`${"x".repeat(178)}…`);
+  });
+});
 
 function requireCapturedPrompt<T>(captured: T | undefined): T {
   if (!captured) {

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { resolveBundledInstallPlanForCatalogEntry } from "../cli/plugin-install-plan.js";
 import { invalidatePluginRuntimeDiscoveryAfterConfigMutation } from "../cli/plugins-registry-refresh.js";
@@ -537,8 +538,10 @@ function summarizeInstallError(message: string): string {
   if (!cleaned) {
     return "Unknown install failure";
   }
-  return cleaned.length > 180 ? `${cleaned.slice(0, 179)}…` : cleaned;
+  return cleaned.length > 180 ? `${truncateUtf16Safe(cleaned, 179)}…` : cleaned;
 }
+
+export const testing = { summarizeInstallError };
 
 function isTimeoutError(error: unknown): boolean {
   return error instanceof Error && error.message === "timeout";

--- a/src/commands/status-all/gateway.test.ts
+++ b/src/commands/status-all/gateway.test.ts
@@ -23,6 +23,16 @@ describe("summarizeLogTail", () => {
 
     expect(lines).toEqual(["[openai] token refresh 401 invalid_grant · re-auth required"]);
   });
+
+  it("keeps bounded OAuth diagnostics UTF-16 well-formed", () => {
+    const lines = summarizeLogTail([
+      "[openai] Token refresh failed: 500 {",
+      `"error":${JSON.stringify({ code: "upstream", message: `${"x".repeat(50)}🚀tail` })}`,
+      "}",
+    ]);
+
+    expect(lines).toEqual([`[openai] token refresh 500 upstream · ${"x".repeat(50)}…`]);
+  });
 });
 
 describe("readFileTailLines", () => {

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -2,6 +2,7 @@
 // Summaries compact repeated auth/runtime failures while preserving enough context for operators.
 
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { classifyOAuthRefreshFailureReason } from "../../agents/auth-profiles/oauth-refresh-failure.js";
 import { readGatewayLogTailLines } from "../../daemon/diagnostics.js";
 
@@ -27,7 +28,7 @@ function shorten(message: string, maxLen: number): string {
   if (cleaned.length <= maxLen) {
     return cleaned;
   }
-  return `${cleaned.slice(0, Math.max(0, maxLen - 1))}…`;
+  return `${truncateUtf16Safe(cleaned, Math.max(0, maxLen - 1))}…`;
 }
 
 function normalizeGwsLine(line: string): string {

--- a/src/infra/env.test.ts
+++ b/src/infra/env.test.ts
@@ -128,6 +128,27 @@ describe("logAcceptedEnvOption", () => {
 
     expect(loggerMocks.info).not.toHaveBeenCalled();
   });
+
+  it("keeps bounded non-secret values UTF-16 well-formed", async () => {
+    withEnv(
+      {
+        VITEST: "",
+        NODE_ENV: "development",
+        OPENCLAW_UTF16_TEST_ENV: `${"x".repeat(159)}🚀tail`,
+      },
+      () => {
+        logAcceptedEnvOption({
+          key: "OPENCLAW_UTF16_TEST_ENV",
+          description: "UTF-16 test",
+        });
+      },
+    );
+
+    await vi.waitFor(() => expect(loggerMocks.info).toHaveBeenCalledTimes(1));
+    expect(loggerMocks.info).toHaveBeenCalledWith(
+      `env: OPENCLAW_UTF16_TEST_ENV=${"x".repeat(159)}… (UTF-16 test)`,
+    );
+  });
 });
 
 describe("normalizeEnv", () => {

--- a/src/infra/env.ts
+++ b/src/infra/env.ts
@@ -1,5 +1,6 @@
 // Normalizes env flag values and logs env warnings lazily.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { SubsystemLogger } from "../logging/subsystem.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
 
@@ -36,7 +37,7 @@ function formatEnvValue(value: string, redact?: boolean): string {
   if (singleLine.length <= 160) {
     return singleLine;
   }
-  return `${singleLine.slice(0, 160)}…`;
+  return `${truncateUtf16Safe(singleLine, 160)}…`;
 }
 
 /** Logs an accepted env option once, with optional redaction for sensitive values. */

--- a/src/infra/heartbeat-runner.tool-response.test.ts
+++ b/src/infra/heartbeat-runner.tool-response.test.ts
@@ -14,7 +14,7 @@ import {
 import { markReplyPayloadForSourceSuppressionDelivery } from "../auto-reply/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { getLastHeartbeatEvent, resetHeartbeatEventsForTest } from "./heartbeat-events.js";
-import { runHeartbeatOnce, type HeartbeatDeps } from "./heartbeat-runner.js";
+import { runHeartbeatOnce, testing, type HeartbeatDeps } from "./heartbeat-runner.js";
 import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
 import {
   seedMainSessionStore,
@@ -22,6 +22,13 @@ import {
 } from "./heartbeat-runner.test-utils.js";
 
 installHeartbeatRunnerTestRuntime();
+
+describe("heartbeat event previews", () => {
+  it("keeps the 200-code-unit preview UTF-16 well-formed", () => {
+    expect(testing.truncateHeartbeatPreview(`${"x".repeat(199)}🚀tail`)).toBe("x".repeat(199));
+    expect(testing.truncateHeartbeatPreview(undefined)).toBeUndefined();
+  });
+});
 
 describe("runHeartbeatOnce heartbeat response tool", () => {
   const TELEGRAM_GROUP = "-1001234567890";

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -7,6 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   hasOutboundReplyContent,
   isReasoningReplyPayload,
@@ -861,6 +862,10 @@ function isStreamErrorFallbackPlaceholderOnly(text: string): boolean {
 }
 
 const TRAILING_HEARTBEAT_NOTIFY_FALSE_RE = /(?:^|[\r\n])[ \t]*notify=false[ \t]*(?:\r?\n[ \t]*)*$/i;
+
+function truncateHeartbeatPreview(value: string | undefined): string | undefined {
+  return value ? truncateUtf16Safe(value, 200) : undefined;
+}
 
 function stripTrailingHeartbeatNotifyFalse(text: string): { text: string; silent: boolean } {
   const match = TRAILING_HEARTBEAT_NOTIFY_FALSE_RE.exec(text);
@@ -2007,7 +2012,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "ok-token",
         reason: opts.reason,
-        preview: heartbeatToolResponse.summary.slice(0, 200),
+        preview: truncateHeartbeatPreview(heartbeatToolResponse.summary),
         durationMs: Date.now() - startedAt,
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
         accountId: delivery.accountId,
@@ -2161,7 +2166,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "duplicate",
-        preview: normalized.text.slice(0, 200),
+        preview: truncateHeartbeatPreview(normalized.text),
         durationMs: Date.now() - startedAt,
         hasMedia: false,
         channel: delivery.channel !== "none" ? delivery.channel : undefined,
@@ -2190,7 +2195,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "skipped",
         reason: delivery.reason ?? "no-target",
-        preview: previewText?.slice(0, 200),
+        preview: truncateHeartbeatPreview(previewText),
         durationMs: Date.now() - startedAt,
         hasMedia: mediaUrls.length > 0,
         accountId: delivery.accountId,
@@ -2210,7 +2215,7 @@ export async function runHeartbeatOnce(opts: {
       emitHeartbeatEvent({
         status: "skipped",
         reason: "alerts-disabled",
-        preview: previewText?.slice(0, 200),
+        preview: truncateHeartbeatPreview(previewText),
         durationMs: Date.now() - startedAt,
         channel: delivery.channel,
         hasMedia: mediaUrls.length > 0,
@@ -2233,7 +2238,7 @@ export async function runHeartbeatOnce(opts: {
         emitHeartbeatEvent({
           status: "skipped",
           reason: readiness.reason,
-          preview: previewText?.slice(0, 200),
+          preview: truncateHeartbeatPreview(previewText),
           durationMs: Date.now() - startedAt,
           hasMedia: mediaUrls.length > 0,
           channel: delivery.channel,
@@ -2317,7 +2322,7 @@ export async function runHeartbeatOnce(opts: {
       to: delivery.to,
       ...(deliveredAgentRunFailure ? { reason: "agent-runner-failure" } : {}),
       ...(!deliveredAgentRunFailure && !visibleSendSucceeded ? { reason: send.reason } : {}),
-      preview: previewText?.slice(0, 200),
+      preview: truncateHeartbeatPreview(previewText),
       durationMs: Date.now() - startedAt,
       hasMedia: mediaUrls.length > 0,
       channel: delivery.channel,
@@ -2344,6 +2349,8 @@ export async function runHeartbeatOnce(opts: {
     heartbeatTyping?.onCleanup?.();
   }
 }
+
+export const testing = { truncateHeartbeatPreview };
 
 export function startHeartbeatRunner(opts: {
   cfg?: OpenClawConfig;

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -235,6 +235,12 @@ describe("readResponseTextSnippet", () => {
       options: { maxBytes: 7, maxChars: 50 },
       expected: "1234567…",
     },
+    {
+      name: "keeps character-limited snippets UTF-16 well-formed",
+      response: new Response(makeStream([new TextEncoder().encode("ab🚀tail")])),
+      options: { maxBytes: 64, maxChars: 3 },
+      expected: "ab…",
+    },
   ] as const)("$name", async ({ response, options, expected }) => {
     await expectReadResponseTextSnippetCase({ response, options, expected });
   });

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { clearTimeout as clearNodeTimeout, setTimeout as setNodeTimeout } from "node:timers";
 import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "./errors.js";
 import { parseStrictNonNegativeInteger } from "./parse-finite-number.js";
 
@@ -313,7 +314,7 @@ export async function readResponseTextSnippet(
     return undefined;
   }
   if (collapsed.length > maxChars) {
-    return `${collapsed.slice(0, maxChars)}…`;
+    return `${truncateUtf16Safe(collapsed, maxChars)}…`;
   }
   return prefix.truncated ? `${collapsed}…` : collapsed;
 }

--- a/src/infra/push-apns.test.ts
+++ b/src/infra/push-apns.test.ts
@@ -831,4 +831,27 @@ describe("push APNs send semantics", () => {
       transport: "relay",
     });
   });
+
+  it("keeps bounded non-JSON error reasons UTF-16 well-formed", async () => {
+    const { send, registration, auth } = createDirectApnsSendFixture({
+      nodeId: "ios-node-utf16-reason",
+      environment: "sandbox",
+      sendResult: {
+        status: 400,
+        apnsId: "apns-utf16-reason-id",
+        body: `${"x".repeat(199)}🚀tail`,
+      },
+    });
+
+    const result = await sendApnsAlert({
+      registration,
+      nodeId: "ios-node-utf16-reason",
+      title: "Wake",
+      body: "Ping",
+      auth,
+      requestSender: send,
+    });
+
+    expect(requireRecord(result, "APNs result").reason).toBe("x".repeat(199));
+  });
 });

--- a/src/infra/push-apns.ts
+++ b/src/infra/push-apns.ts
@@ -7,6 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveStateDir } from "../config/paths.js";
 import type { DeviceIdentity } from "./device-identity.js";
 import { formatErrorMessage, toErrorObject } from "./errors.js";
@@ -211,9 +212,9 @@ function parseReason(body: string): string | undefined {
     const parsed = JSON.parse(trimmed) as { reason?: unknown };
     return typeof parsed.reason === "string" && parsed.reason.trim().length > 0
       ? parsed.reason.trim()
-      : trimmed.slice(0, 200);
+      : truncateUtf16Safe(trimmed, 200);
   } catch {
-    return trimmed.slice(0, 200);
+    return truncateUtf16Safe(trimmed, 200);
   }
 }
 

--- a/src/tasks/task-completion-contract.test.ts
+++ b/src/tasks/task-completion-contract.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { resolveRequiredCompletionDeliveryFailureTerminalResult } from "./task-completion-contract.js";
+
+describe("task completion delivery failures", () => {
+  it("keeps the bounded failure reason UTF-16 well-formed", () => {
+    const result = resolveRequiredCompletionDeliveryFailureTerminalResult(
+      `${"x".repeat(158)}🚀tail`,
+    );
+
+    expect(result.terminalSummary).toContain(`${"x".repeat(158)}...`);
+    expect(result.terminalSummary).not.toContain("\uD83D");
+  });
+});

--- a/src/tasks/task-completion-contract.ts
+++ b/src/tasks/task-completion-contract.ts
@@ -1,4 +1,5 @@
 // Defines task terminal outcome contracts used by completion handling.
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { TaskTerminalOutcome } from "./task-registry.types.js";
 
 /** Terminal fields required when a mandatory detached task completion is invalid. */
@@ -25,7 +26,7 @@ function normalizeCompletionFailureReason(value: string | null | undefined): str
   if (!normalized) {
     return "";
   }
-  return normalized.length <= 160 ? normalized : `${normalized.slice(0, 159)}...`;
+  return normalized.length <= 160 ? normalized : `${truncateUtf16Safe(normalized, 159)}...`;
 }
 
 function matchesProgressOnlyPrefix(value: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Several bounded CLI, diagnostics, logging, push, plugin, and memory surfaces truncate text by raw UTF-16 code-unit index. A limit can therefore split a surrogate pair and emit a lone surrogate, producing malformed text at transport and display boundaries.

This consolidates the useful fixes from #101605, #101606, #101609, #101612, #101613, #101614, #101616, #101619, #101622, #101623, #101625, #101628, #101631, and #101633. #101615 closed independently during review.

## Why This Change Was Made

All affected callers now use the existing canonical `truncateUtf16Safe` helper while preserving their current UTF-16 code-unit limits and output shapes. The patch removes one-off truncation proposals, keeps ownership at each caller, and adds caller-level regression tests instead of helper-only coverage.

Contributor credit is preserved in the commit metadata and this PR body for @lsr911, @maweibin, and @wm0018. Release-note context stays here because `CHANGELOG.md` is release-owned.

## User Impact

Bounded text no longer ends with a lone surrogate when the cutoff lands inside an emoji or other supplementary-plane character. ASCII and already-short text remain unchanged, and every existing numeric cap retains its UTF-16 code-unit semantics.

## Evidence

- Blacksmith Testbox `tbx_01kwy7jsz75zc8zwr6bw4kfx24`: 8 focused Vitest shards, 862 tests passed.
- Blacksmith Testbox: `pnpm check:changed` passed, including core/extension typechecks, lint, import-cycle and DB guards.
- Fresh autoreview: no accepted or actionable findings.
- `git diff --check` passed.
- Exact-head CI run [28866358979](https://github.com/openclaw/openclaw/actions/runs/28866358979) passed.

Supersedes #101622 and the overlapping UTF-16 truncation PRs listed above.
