### PR TITLE
fix(diagnostics-otel): metrics and logs posted to the traces endpoint when the shared OTLP endpoint is signal-qualified

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -89,6 +89,19 @@ and export only when `diagnostics.otel.logs` is explicitly `true`. Log export
 defaults to OTLP; set `diagnostics.otel.logsExporter` to `stdout` for JSONL on
 stdout, or `both` for both.
 
+<Note>
+The shared `endpoint` and `OTEL_EXPORTER_OTLP_ENDPOINT` are bases for all
+enabled signals. OpenClaw appends `/v1/traces`, `/v1/metrics`, or `/v1/logs`
+to root and custom collector paths. For compatibility with hosted frontends,
+a shared endpoint already ending in one of those signal paths keeps that path
+for its matching signal and replaces the terminal segment for the others.
+
+Signal-specific `tracesEndpoint`, `metricsEndpoint`, and `logsEndpoint`
+settings, plus their matching `OTEL_EXPORTER_OTLP_*_ENDPOINT` fallbacks, are
+passed to the exporter as exact URLs. OpenClaw does not append or rewrite their
+paths.
+</Note>
+
 ## Which processes export
 
 - **Gateway** starts the exporter at startup and exports from the Gateway

--- a/extensions/diagnostics-otel/src/service-exporter.ts
+++ b/extensions/diagnostics-otel/src/service-exporter.ts
@@ -18,21 +18,35 @@ export function normalizeEndpoint(endpoint?: string): string | undefined {
   return trimmed ? trimmed.replace(/\/+$/, "") : undefined;
 }
 
-function resolveOtelUrl(endpoint: string | undefined, path: string): string | undefined {
-  if (!endpoint) {
-    return undefined;
-  }
+const SIGNAL_QUALIFIED_OTLP_PATH_PATTERN = /\/v1\/(traces|metrics|logs)$/iu;
+
+function appendOrReplaceSignalPath(value: string, path: string): string {
+  const base = value.replace(/\/+$/u, "");
+  return SIGNAL_QUALIFIED_OTLP_PATH_PATTERN.test(base)
+    ? base.replace(SIGNAL_QUALIFIED_OTLP_PATH_PATTERN, `/${path}`)
+    : `${base}/${path}`;
+}
+
+function resolveSharedOtelUrl(endpoint: string, path: string): string {
   const endpointWithoutQueryOrFragment = endpoint.split(/[?#]/, 1)[0] ?? endpoint;
-  if (/\/v1\/(?:traces|metrics|logs)$/i.test(endpointWithoutQueryOrFragment)) {
+  const matchedSignal = endpointWithoutQueryOrFragment
+    .replace(/\/+$/u, "")
+    .match(SIGNAL_QUALIFIED_OTLP_PATH_PATTERN)?.[1];
+  const requestedSignal = path.slice(path.lastIndexOf("/") + 1);
+  if (matchedSignal?.toLowerCase() === requestedSignal.toLowerCase()) {
     return endpoint;
   }
   if (/[?#]/u.test(endpoint)) {
     const url = new URL(endpoint);
-    const basePath = url.pathname.replace(/\/+$/u, "");
-    url.pathname = `${basePath}/${path}`;
+    url.pathname = appendOrReplaceSignalPath(url.pathname, path);
     return url.toString();
   }
-  return `${endpoint}/${path}`;
+  return appendOrReplaceSignalPath(endpoint, path);
+}
+
+function normalizeSignalEndpoint(endpoint?: string): string | undefined {
+  const trimmed = endpoint?.trim();
+  return trimmed || undefined;
 }
 
 export function resolveSignalOtelUrl(params: {
@@ -42,8 +56,8 @@ export function resolveSignalOtelUrl(params: {
   endpoint?: string;
   path: string;
 }): string | undefined {
-  const endpoint =
-    normalizeEndpoint(params.signalEndpoint ?? params.signalEnvEndpoint) ?? params.endpoint;
+  const signalEndpoint = normalizeSignalEndpoint(params.signalEndpoint ?? params.signalEnvEndpoint);
+  const endpoint = signalEndpoint ?? params.endpoint;
   // OTLP parses nonblank env values verbatim even when explicit config takes precedence.
   const signalEnvEndpoint = params.signalEnvEndpoint?.trim() ? params.signalEnvEndpoint : undefined;
   const sharedEnvEndpoint = params.sharedEnvEndpoint?.trim() ? params.sharedEnvEndpoint : undefined;
@@ -52,7 +66,9 @@ export function resolveSignalOtelUrl(params: {
     ? `${consumedSharedEnvEndpoint}${consumedSharedEnvEndpoint.endsWith("/") ? "" : "/"}${params.path}`
     : undefined;
   const resolvedEndpoint =
-    endpoint && URL.canParse(endpoint) ? resolveOtelUrl(endpoint, params.path) : endpoint;
+    endpoint && URL.canParse(endpoint) && !signalEndpoint
+      ? resolveSharedOtelUrl(endpoint, params.path)
+      : endpoint;
 
   for (const candidate of [
     endpoint,

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -9,6 +9,8 @@
 // Collector-boundary cases start the real NodeSDK, so teardown restores every global SDK
 // registration; otherwise a shutdown provider would poison later real-SDK cases.
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { context, diag, DiagLogLevel, metrics, propagation, trace } from "@opentelemetry/api";
@@ -36,6 +38,10 @@ import {
 
 const PRELOAD_ENV = "OPENCLAW_OTEL_PRELOADED";
 const ENDPOINT_ENV_KEYS = [
+  "OTEL_SDK_DISABLED",
+  "OTEL_TRACES_EXPORTER",
+  "OTEL_METRICS_EXPORTER",
+  "OTEL_LOGS_EXPORTER",
   "OTEL_EXPORTER_OTLP_ENDPOINT",
   "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
   "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
@@ -178,6 +184,154 @@ function captureOtelDiagnostics(): string[] {
   );
   return messages;
 }
+
+async function startOtlpReceiver() {
+  const requests: Array<{
+    contentType: string | undefined;
+    method: string | undefined;
+    url: string;
+  }> = [];
+  const server = createServer((request, response) => {
+    request.resume();
+    request.on("end", () => {
+      requests.push({
+        contentType: request.headers["content-type"],
+        method: request.method,
+        url: request.url ?? "",
+      });
+      response.writeHead(200, { "content-type": "application/x-protobuf" });
+      response.end();
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    endpoint: `http://127.0.0.1:${port}`,
+    requests,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeIdleConnections();
+      });
+    },
+  };
+}
+
+function releasePreloadedOtelGlobals() {
+  context.disable();
+  logs.disable();
+  metrics.disable();
+  propagation.disable();
+  trace.disable();
+  process.env[PRELOAD_ENV] = "0";
+}
+
+async function emitRealSdkSignals() {
+  trace.getTracer("openclaw-otel-routing-test").startSpan("routing-test").end();
+  metrics.getMeter("openclaw-otel-routing-test").createCounter("openclaw.routing.test").add(1);
+  emit({
+    type: "log.record",
+    level: "INFO",
+    message: "OTLP routing test",
+  });
+  await waitForDiagnosticEventsDrained();
+}
+
+const SHARED_ENDPOINT_ROUTING_CASES = [
+  {
+    label: "root",
+    suffix: "",
+    expected: ["/v1/traces", "/v1/metrics", "/v1/logs"],
+  },
+  {
+    label: "trailing-slash root",
+    suffix: "/",
+    expected: ["/v1/traces", "/v1/metrics", "/v1/logs"],
+  },
+  {
+    label: "custom collector path",
+    suffix: "/api/public/otel",
+    expected: [
+      "/api/public/otel/v1/traces",
+      "/api/public/otel/v1/metrics",
+      "/api/public/otel/v1/logs",
+    ],
+  },
+  {
+    label: "signal-qualified collector path",
+    suffix: "/api/public/otel/v1/traces",
+    expected: [
+      "/api/public/otel/v1/traces",
+      "/api/public/otel/v1/metrics",
+      "/api/public/otel/v1/logs",
+    ],
+  },
+] as const;
+
+test.each(SHARED_ENDPOINT_ROUTING_CASES)(
+  "routes real exporters from a shared $label endpoint",
+  async ({ suffix, expected }) => {
+    const receiver = await startOtlpReceiver();
+    releasePreloadedOtelGlobals();
+    const { service, ctx } = await startOtelService({
+      endpoint: `${receiver.endpoint}${suffix}`,
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+
+    try {
+      await emitRealSdkSignals();
+      await service.stop?.(ctx);
+
+      expect(new Set(receiver.requests.map((request) => request.url))).toEqual(new Set(expected));
+      expect(
+        receiver.requests.every(
+          (request) =>
+            request.method === "POST" && request.contentType === "application/x-protobuf",
+        ),
+      ).toBe(true);
+    } finally {
+      await service.stop?.(ctx);
+      await receiver.close();
+    }
+  },
+  30_000,
+);
+
+test("uses real signal-specific exporter endpoints verbatim", async () => {
+  const receiver = await startOtlpReceiver();
+  releasePreloadedOtelGlobals();
+  const traceEndpoint = `${receiver.endpoint}/custom-traces?tenant=red`;
+  const metricEndpoint = `${receiver.endpoint}/custom-metrics/`;
+  const logEndpoint = `${receiver.endpoint}/v1/traces`;
+  const { service, ctx } = await startOtelService({
+    endpoint: `${receiver.endpoint}/shared-unused`,
+    traces: true,
+    metrics: true,
+    logs: true,
+    configure: (serviceContext) => {
+      serviceContext.config.diagnostics!.otel!.tracesEndpoint = traceEndpoint;
+      serviceContext.config.diagnostics!.otel!.metricsEndpoint = metricEndpoint;
+      serviceContext.config.diagnostics!.otel!.logsEndpoint = logEndpoint;
+    },
+  });
+
+  try {
+    await emitRealSdkSignals();
+    await service.stop?.(ctx);
+
+    expect(new Set(receiver.requests.map((request) => request.url))).toEqual(
+      new Set(["/custom-traces?tenant=red", "/custom-metrics/", "/v1/traces"]),
+    );
+  } finally {
+    await service.stop?.(ctx);
+    await receiver.close();
+  }
+}, 30_000);
 
 // Covers all three completeTrackedLifecycleSpan owners: run.completed,
 // harness.run.completed, and message.processed. The mocked suite cannot tell the two id

--- a/extensions/diagnostics-otel/src/service.test.ts
+++ b/extensions/diagnostics-otel/src/service.test.ts
@@ -1797,6 +1797,25 @@ describe("diagnostics-otel service", () => {
     expect(firstExporterOptions(traceExporterCtor).url).toBe(expected);
   });
 
+  test("routes every signal from a shared signal-qualified endpoint", async () => {
+    await startOtelService({
+      endpoint: "https://collector.example.com/api/public/otel/v1/traces?tenant=red",
+      traces: true,
+      metrics: true,
+      logs: true,
+    });
+
+    expect(firstExporterOptions(traceExporterCtor).url).toBe(
+      "https://collector.example.com/api/public/otel/v1/traces?tenant=red",
+    );
+    expect(firstExporterOptions(metricExporterCtor).url).toBe(
+      "https://collector.example.com/api/public/otel/v1/metrics?tenant=red",
+    );
+    expect(firstExporterOptions(logExporterCtor).url).toBe(
+      "https://collector.example.com/api/public/otel/v1/logs?tenant=red",
+    );
+  });
+
   test("applies flush interval to trace batching", async () => {
     await startOtelService({
       traces: true,
@@ -1829,24 +1848,26 @@ describe("diagnostics-otel service", () => {
       metrics: true,
       logs: true,
       configure: (ctx) => {
-        ctx.config.diagnostics!.otel!.tracesEndpoint = "https://trace.example.com/otlp";
-        ctx.config.diagnostics!.otel!.metricsEndpoint = "https://metric.example.com/v1/metrics";
-        ctx.config.diagnostics!.otel!.logsEndpoint = "https://log.example.com/otlp";
+        ctx.config.diagnostics!.otel!.tracesEndpoint = "https://trace.example.com/custom";
+        ctx.config.diagnostics!.otel!.metricsEndpoint =
+          "https://metric.example.com/v1/traces?tenant=red";
+        ctx.config.diagnostics!.otel!.logsEndpoint = "https://log.example.com/otlp/";
       },
     });
 
     const traceOptions = firstExporterOptions(traceExporterCtor);
     const metricOptions = firstExporterOptions(metricExporterCtor);
     const logOptions = firstExporterOptions(logExporterCtor);
-    expect(traceOptions.url).toBe("https://trace.example.com/otlp/v1/traces");
-    expect(metricOptions.url).toBe("https://metric.example.com/v1/metrics");
-    expect(logOptions.url).toBe("https://log.example.com/otlp/v1/logs");
+    expect(traceOptions.url).toBe("https://trace.example.com/custom");
+    expect(metricOptions.url).toBe("https://metric.example.com/v1/traces?tenant=red");
+    expect(logOptions.url).toBe("https://log.example.com/otlp/");
   });
 
   test("uses signal-specific OTLP env endpoints when config is unset", async () => {
-    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "https://trace-env.example.com/v1/traces";
-    process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "https://metric-env.example.com/otlp";
-    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "https://log-env.example.com/otlp";
+    process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "https://trace-env.example.com/custom";
+    process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT =
+      "https://metric-env.example.com/v1/traces?tenant=red";
+    process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "https://log-env.example.com/otlp/";
 
     await startOtelService({
       traces: true,
@@ -1857,9 +1878,9 @@ describe("diagnostics-otel service", () => {
     const traceOptions = firstExporterOptions(traceExporterCtor);
     const metricOptions = firstExporterOptions(metricExporterCtor);
     const logOptions = firstExporterOptions(logExporterCtor);
-    expect(traceOptions.url).toBe("https://trace-env.example.com/v1/traces");
-    expect(metricOptions.url).toBe("https://metric-env.example.com/otlp/v1/metrics");
-    expect(logOptions.url).toBe("https://log-env.example.com/otlp/v1/logs");
+    expect(traceOptions.url).toBe("https://trace-env.example.com/custom");
+    expect(metricOptions.url).toBe("https://metric-env.example.com/v1/traces?tenant=red");
+    expect(logOptions.url).toBe("https://log-env.example.com/otlp/");
   });
 
   test("ignores malformed shared OTLP env when valid signal endpoints shadow it", async () => {


### PR DESCRIPTION
Closes #98886

## What Problem This Solves

Fixes an issue where operators using one shared OTLP HTTP endpoint could send metrics and logs to the traces route when that endpoint already ended in `/v1/traces`. Collectors then rejected the mismatched protobuf payload, so those signals never arrived.

## Why This Change Was Made

The root cause was loss of endpoint-source identity in `resolveSignalOtelUrl`: shared and signal-specific endpoints were collapsed before routing, and any terminal `/v1/{traces,metrics,logs}` path was then preserved for every signal.

The canonical fix stays at the diagnostics OTLP exporter boundary:

- Shared endpoints are routed per signal. Roots, trailing-slash roots, and custom base paths append `/v1/<signal>`.
- A shared endpoint already ending in `/v1/<signal>` keeps the matching route and replaces that terminal signal for the other exporters.
- Signal-specific config and `OTEL_EXPORTER_OTLP_*_ENDPOINT` values are passed through verbatim.
- Existing URL validation, TLS trust, proxy, and fail-closed behavior is unchanged.

This matches the stable OTLP exporter contract and the installed OpenTelemetry JS `0.221.0` implementation: the shared endpoint is a base, while signal-specific endpoints are used as supplied. The change does not absorb protocol, shutdown, recorder, or health work.

## User Impact

Traces, metrics, and logs now reach their canonical OTLP HTTP routes when a shared endpoint is configured, including hosted collector URLs such as `/api/public/otel/v1/traces`. Operators who configure signal-specific endpoints keep exact URL control, including custom paths, query strings, and trailing slashes.

Release-note context: this is a user-visible diagnostics routing fix. The behavior and upgrade note are documented in `docs/gateway/opentelemetry.md`; no contributor `CHANGELOG.md` entry is included.

## Evidence

- Exact PR head: `0db11215280089981113f527cee017aa543082fa`.
- Focused local proof: `223/223` tests passed across `service.test.ts` and `service.otlp-export.test.ts`; `git diff --check`, targeted `oxfmt`, and branch autoreview passed with no accepted/actionable findings.
- Real exporter/receiver seam: an ephemeral HTTP receiver observed protobuf POSTs for traces, metrics, and logs from shared roots, trailing-slash roots, custom paths, and shared `/api/public/otel/v1/traces`; signal-specific endpoints were observed exactly as configured.
- AWS Crabbox exact-tree proof: provider `aws`, lease `cbx_8c8770d483bb`, run `run_26c824aa42b3` matched changed-file and lockfile SHA-256 values, then passed `223/223` tests and formatting.
- AWS changed gate: run `run_da265682deb0` passed conflict, env-var, max-lines, attribution, extension-boundary, dependency, format, Plugin SDK, deprecated API, plugin-boundary, and patch guards. Its only failure was the repository-wide dead-export scan on untouched `src/config/**`.
- Baseline comparison: run `run_2f4eb562555a` reproduced the identical dead-export failure on base `9ef94e4ef93c73c0d3331f1546128b1e95b6bfce`, proving it is independent of this PR.
- Remote build environment: the hydrated checkout lacked the root `pretty-ms` link; a frozen reinstall then hit the unchanged base lockfile's missing `@oxc-parser/binding-android-arm-eabi@0.128.0` entry. Hosted exact-head CI passed, including `build-artifacts`, `check-lint`, and `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/31028619754.
- Cleanup: lease `cbx_8c8770d483bb` was released, and the subsequent AWS lease list was empty.
- LOC: production `+27/-11` (net `+16`), tests `+187/-12` (net `+175`), docs `+13/-0`.
