### PR TITLE
fix(session-cost-usage): keep emoji / surrogate pairs intact during first user message truncation

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -2721,6 +2721,47 @@ describe("session cost usage", () => {
     });
   });
 
+  it("does not split surrogate pairs when truncating the first user message during discovery", async () => {
+    const root = await makeSessionCostRoot("discover-utf16-first-msg");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // "a" (1 code unit) + 50 🦞 (100 code units) = 101 code units > 100
+    // .slice(0, 100) would cut between the surrogates of the last emoji
+    const content = "a" + "🦞".repeat(50);
+    const sessionFile = path.join(sessionsDir, "sess-emoji.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-21T17:47:00.000Z",
+        message: { role: "user", content },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const sessions = await discoverAllSessions();
+      expect(sessions).toHaveLength(1);
+      const msg = sessions[0]?.firstUserMessage;
+      expect(msg).toBeDefined();
+
+      // Must not include a dangling high surrogate
+      for (let i = 0; i < msg!.length; i++) {
+        const cp = msg!.charCodeAt(i);
+        if (cp >= 0xd800 && cp <= 0xdbff) {
+          // High surrogate must be followed by a low surrogate
+          expect(msg!.charCodeAt(i + 1)).toBeGreaterThanOrEqual(0xdc00);
+          expect(msg!.charCodeAt(i + 1)).toBeLessThanOrEqual(0xdfff);
+        }
+      }
+
+      // After safe truncation, the last code unit should not be a lone surrogate
+      const lastCode = msg!.charCodeAt(msg!.length - 1);
+      expect(lastCode < 0xd800 || lastCode > 0xdbff).toBe(true);
+    });
+  });
+
   it("falls back to archived reset transcripts for per-session detail queries", async () => {
     const root = await makeSessionCostRoot("session-archive-fallback");
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -2160,7 +2160,7 @@ export async function discoverAllSessions(params?: {
             if (message?.role === "user") {
               const content = message.content;
               if (typeof content === "string") {
-                firstUserMessage = content.slice(0, 100);
+                firstUserMessage = truncateUtf16Safe(content, 100);
               } else if (Array.isArray(content)) {
                 for (const block of content) {
                   if (
@@ -2170,7 +2170,7 @@ export async function discoverAllSessions(params?: {
                   ) {
                     const text = (block as Record<string, unknown>).text;
                     if (typeof text === "string") {
-                      firstUserMessage = text.slice(0, 100);
+                      firstUserMessage = truncateUtf16Safe(text, 100);
                     }
                     break;
                   }


### PR DESCRIPTION
## What Problem This Solves

`discoverAllSessions` in `src/infra/session-cost-usage.ts` truncates the first user message with `.slice(0, 100)`, which counts UTF-16 code units. When an emoji (e.g. 🦞) straddles the cut boundary at position 100, `.slice()` produces a lone surrogate (e.g. `\uD83E`) that renders as `�` in session titles, session list API responses, and usage CLI output.

The file already imports `truncateUtf16Safe` (added by #101517 for `loadSessionLogs`), but the two `.slice(0, 100)` calls in `discoverAllSessions` were missed.

## Why This Change Was Made

Replace `.slice(0, 100)` with `truncateUtf16Safe(text, 100)` so the truncation avoids splitting surrogate pairs at the boundary. This matches:
- The same file `loadSessionLogs` already using `truncateUtf16Safe` (line 2756)
- The 12 other UTF-16 safe truncation PRs merged in July 2026

## User Impact

Session titles derived from the first user message (when no explicit label is set) will no longer contain `�` replacement characters when an emoji falls near the 100-char boundary.

## Evidence

**Real environment tested:** local OpenClaw source checkout, Node v24.

**Exact steps after this patch:**

```js
// Simulate: user first message = "a" + 50×🦞 = 101 code units (>100)
// .slice(0, 100) cuts between the surrogates of the last emoji
const msg = "a" + "🦞".repeat(50);
const before = msg.slice(0, 100);
const loneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(before);
console.log("BEFORE: last code unit = U+" + before.charCodeAt(99).toString(16), "lone surrogate:", loneHighSurrogate);
// BEFORE: last code unit = U+d83e lone surrogate: true
```

**Regression test:** `pnpm test -- src/infra/session-cost-usage.test.ts`

```
 ✓ does not split surrogate pairs when truncating the first user message during discovery
 Test Files  1 passed (1)
      Tests  68 passed (68)
```

**What was not tested:** other truncation sites in the same file remain unchanged and are already covered by existing tests.

AI-assisted.
