### PR TITLE
fix(agents): keep prompt template descriptions UTF-16 safe

### DIFF
--- a/src/agents/sessions/prompt-templates.test.ts
+++ b/src/agents/sessions/prompt-templates.test.ts
@@ -1,0 +1,56 @@
+// Prompt template tests cover markdown discovery and fallback metadata.
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPromptTemplates } from "./prompt-templates.js";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("loadPromptTemplates", () => {
+  it("keeps fallback descriptions on a UTF-16 boundary", async () => {
+    const root = await makeTempDir("openclaw-prompt-templates-");
+    const promptsDir = join(root, "prompts");
+    await mkdir(promptsDir, { recursive: true });
+    await writeFile(join(promptsDir, "emoji.md"), `${"a".repeat(59)}\u{1f63e}tail\n`, "utf-8");
+
+    const templates = loadPromptTemplates({
+      cwd: root,
+      agentDir: join(root, "agent"),
+      promptPaths: [promptsDir],
+      includeDefaults: false,
+    });
+
+    expect(templates).toHaveLength(1);
+    expect(templates[0]?.description).toBe(`${"a".repeat(59)}...`);
+    expect(hasLoneSurrogate(templates[0]?.description ?? "")).toBe(false);
+  });
+});

--- a/src/agents/sessions/prompt-templates.ts
+++ b/src/agents/sessions/prompt-templates.ts
@@ -1,5 +1,6 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 /**
  * Prompt template discovery and loading.
  *
@@ -43,7 +44,7 @@ function loadTemplateFromFile(filePath: string, sourceInfo: SourceInfo): PromptT
       const firstLine = body.split("\n").find((line) => line.trim());
       if (firstLine) {
         // Truncate if too long
-        description = firstLine.slice(0, 60);
+        description = truncateUtf16Safe(firstLine, 60);
         if (firstLine.length > 60) {
           description += "...";
         }


### PR DESCRIPTION
## What Problem This Solves

Fixes prompt template fallback descriptions being truncated with raw UTF-16 slicing. When a markdown template has no frontmatter description, OpenClaw derives the description from the first non-empty body line; the previous `.slice(0, 60)` path could cut an emoji or other surrogate pair in half.

## Why This Change Was Made

Recent prompt, title, preview, and channel display truncation fixes use the shared `truncateUtf16Safe` helper for user-visible bounded text. This applies that existing helper to prompt template fallback descriptions while preserving the existing 60-character limit and `...` marker behavior.

## User Impact

Prompt template lists keep well-formed descriptions when template text contains emoji or non-BMP characters near the truncation boundary.

## Evidence

- `node scripts/run-vitest.mjs src/agents/sessions/prompt-templates.test.ts`
  - `src/agents/sessions/prompt-templates.test.ts` passed: 1 test passed.
- `git diff --check`
- `python .agents\skills\autoreview\scripts\autoreview --mode local --no-web-search`
  - `autoreview clean: no accepted/actionable findings reported`
- Base: latest `origin/main` at `60f0749b7f`