### PR TITLE
fix(scripts): handle package candidate resolver stream errors

### DIFF
--- a/scripts/resolve-openclaw-package-candidate.mjs
+++ b/scripts/resolve-openclaw-package-candidate.mjs
@@ -228,7 +228,8 @@ function run(command, args, options = {}) {
         : {}),
       detached: useProcessGroup,
     };
-    const child = spawn(command, args, {
+    const spawnImpl = options.spawnImpl ?? spawn;
+    const child = spawnImpl(command, args, {
       ...spawnOptions,
     });
     let timedOut = false;
@@ -243,6 +244,7 @@ function run(command, args, options = {}) {
         forceKillAt = undefined;
         killChild("SIGKILL");
       }, resolvedKillAfterMs);
+      killTimer.unref?.();
     };
     const timeout =
       resolvedTimeoutMs === undefined
@@ -253,21 +255,63 @@ function run(command, args, options = {}) {
           }, resolvedTimeoutMs);
     timeout?.unref?.();
     ACTIVE_CHILD_KILLERS.add(killChild);
+    let settled = false;
+    const rejectRun = (error, options = {}) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      if (killTimer && !options.keepKillTimer) {
+        clearTimeout(killTimer);
+        killTimer = undefined;
+        forceKillAt = undefined;
+      }
+      ACTIVE_CHILD_KILLERS.delete(killChild);
+      reject(error);
+    };
     let stdout = { text: "", truncatedChars: 0 };
     let stderr = { text: "", truncatedChars: 0 };
     if (options.capture) {
       child.stdout.on("data", (chunk) => {
         stdout = appendBoundedCommandOutput(stdout, chunk, COMMAND_STDOUT_CAPTURE_MAX_CHARS);
       });
+      child.stdout.on("error", (error) => {
+        const streamError = toLintErrorObject(error, "stdout stream error");
+        terminateChild();
+        rejectRun(
+          new Error(`${command} ${args.join(" ")} stdout stream error: ${streamError.message}`),
+          { keepKillTimer: true },
+        );
+      });
       child.stderr.on("data", (chunk) => {
         stderr = appendBoundedCommandOutput(stderr, chunk, COMMAND_STDERR_CAPTURE_MAX_CHARS);
       });
+      child.stderr.on("error", (error) => {
+        const streamError = toLintErrorObject(error, "stderr stream error");
+        terminateChild();
+        rejectRun(
+          new Error(`${command} ${args.join(" ")} stderr stream error: ${streamError.message}`),
+          { keepKillTimer: true },
+        );
+      });
     }
     child.on("error", (error) => {
-      ACTIVE_CHILD_KILLERS.delete(killChild);
-      reject(toLintErrorObject(error, "Non-Error rejection"));
+      rejectRun(toLintErrorObject(error, "Non-Error rejection"));
     });
     child.on("close", (status, signal) => {
+      if (settled) {
+        if (killTimer) {
+          clearTimeout(killTimer);
+          killTimer = undefined;
+          forceKillAt = undefined;
+        }
+        ACTIVE_CHILD_KILLERS.delete(killChild);
+        return;
+      }
+      settled = true;
       if (timeout) {
         clearTimeout(timeout);
       }

--- a/scripts/resolve-openclaw-package-candidate.mjs
+++ b/scripts/resolve-openclaw-package-candidate.mjs
@@ -256,7 +256,7 @@ function run(command, args, options = {}) {
     timeout?.unref?.();
     ACTIVE_CHILD_KILLERS.add(killChild);
     let settled = false;
-    const rejectRun = (error, options = {}) => {
+    const rejectRun = (error, rejectOptions = {}) => {
       if (settled) {
         return;
       }
@@ -264,7 +264,7 @@ function run(command, args, options = {}) {
       if (timeout) {
         clearTimeout(timeout);
       }
-      if (killTimer && !options.keepKillTimer) {
+      if (killTimer && !rejectOptions.keepKillTimer) {
         clearTimeout(killTimer);
         killTimer = undefined;
         forceKillAt = undefined;

--- a/scripts/resolve-openclaw-package-candidate.mjs
+++ b/scripts/resolve-openclaw-package-candidate.mjs
@@ -256,6 +256,10 @@ function run(command, args, options = {}) {
     timeout?.unref?.();
     ACTIVE_CHILD_KILLERS.add(killChild);
     let settled = false;
+    /**
+     * @param {Error} error
+     * @param {{ keepKillTimer?: boolean }} rejectOptions
+     */
     const rejectRun = (error, rejectOptions = {}) => {
       if (settled) {
         return;

--- a/test/scripts/resolve-openclaw-package-candidate.test.ts
+++ b/test/scripts/resolve-openclaw-package-candidate.test.ts
@@ -1,9 +1,11 @@
 // Resolve Openclaw Package Candidate tests cover resolve openclaw package candidate script behavior.
 import { execFile, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
 import { existsSync, readFileSync } from "node:fs";
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveWindowsTaskkillPath } from "../../scripts/lib/windows-taskkill.mjs";
@@ -461,6 +463,32 @@ describe("resolve-openclaw-package-candidate", () => {
       ),
     ).rejects.toThrow(/produced more than \d+ captured stdout chars/u);
   });
+
+  it.each(["stdout", "stderr"] as const)(
+    "rejects captured command %s stream errors",
+    async (streamName) => {
+      const child = new EventEmitter() as ReturnType<typeof spawn> & {
+        kill: ReturnType<typeof vi.fn>;
+        stderr: PassThrough;
+        stdout: PassThrough;
+      };
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      child.kill = vi.fn(() => true);
+      child.exitCode = null;
+      child.signalCode = null;
+      const spawnImpl = vi.fn(() => child);
+
+      const pending = runCommandForTest("fake-cmd", ["arg"], {
+        capture: true,
+        spawnImpl,
+      });
+      child[streamName].emit("error", new Error("EPIPE"));
+
+      await expect(pending).rejects.toThrow(`fake-cmd arg ${streamName} stream error: EPIPE`);
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    },
+  );
 
   it("clamps oversized package runner command timers before scheduling", async () => {
     await expect(


### PR DESCRIPTION
## Summary
- Add stdout and stderr stream error listeners for captured package candidate commands.
- Reject through the existing command failure promise path and terminate the child process when either captured stream errors.
- Collision check: open PR file search returned no PR modifying `scripts/resolve-openclaw-package-candidate.mjs` before opening.

## Verification
- `node scripts/run-vitest.mjs test/scripts/resolve-openclaw-package-candidate.test.ts -t "stream errors"` - passed, 1 file / 2 specs selected.
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.scripts.json scripts/resolve-openclaw-package-candidate.mjs test/scripts/resolve-openclaw-package-candidate.test.ts` - passed.
- `git diff --check` - passed.

## Real behavior proof
Behavior or issue addressed: The package candidate resolver now handles captured stdout and stderr readable stream errors instead of allowing an unhandled stream error to escape the command runner.

Real environment tested: Local OpenClaw checkout on Linux at commit 9e7ee61728, Node.js v22, executing the modified package candidate resolver command runner.

Exact steps or command run after this patch: Ran a Node terminal check that imports `runCommandForTest`, triggers stdout and stderr stream errors on a controlled child emitter, and records the command runner result.

Evidence after fix: Terminal output from the after-fix Node check:
```text
stdout_stream_error_rejected=true
stdout_child_signal=SIGTERM
stderr_stream_error_rejected=true
stderr_child_signal=SIGTERM
```

Observed result after fix: The output shows both stdout and stderr stream errors were converted into rejected command results, and each path requested child termination with SIGTERM.

What was not tested: No known gaps for this local branch behavior; a live npm package download was not exercised.
