### PR TITLE
fix(agents): refresh session progress marker during tool loop

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-context-guards.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-guards.ts
@@ -137,6 +137,8 @@ export function installEmbeddedAttemptContextGuards(input: {
       agent: activeSession.agent,
       contextWindowTokens: contextTokenBudget,
       ...midTurnPrecheckOptions,
+      sessionId: attempt.sessionId,
+      sessionKey: attempt.sessionKey,
     });
     removeLoopGuard = () => {
       removeToolResultGuard();
@@ -147,6 +149,8 @@ export function installEmbeddedAttemptContextGuards(input: {
       agent: activeSession.agent,
       contextWindowTokens: contextTokenBudget,
       ...midTurnPrecheckOptions,
+      sessionId: attempt.sessionId,
+      sessionKey: attempt.sessionKey,
     });
   }
 

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.test.ts
@@ -3,8 +3,9 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ContextEngine, ContextEngineRuntimeSettings } from "../../context-engine/types.js";
+import { markDiagnosticSessionProgress as _unused } from "../../logging/diagnostic.js";
 import { sanitizeToolUseResultPairing } from "../session-transcript-repair.js";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
@@ -20,6 +21,14 @@ import {
 
 const PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE =
   "Context overflow: estimated context size exceeds safe threshold during tool loop.";
+
+vi.mock("../../logging/diagnostic.js", async () => {
+  const actual = await vi.importActual("../../logging/diagnostic.js");
+  return {
+    ...(actual as Record<string, unknown>),
+    markDiagnosticSessionProgress: vi.fn(),
+  };
+});
 
 function makeUser(text: string): AgentMessage {
   return castAgentMessage({
@@ -192,6 +201,9 @@ describe("formatContextLimitTruncationNotice", () => {
 });
 
 describe("installToolResultContextGuard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
   it("passes through unchanged context when under the per-tool and total budget", async () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = [makeUser("hello"), makeToolResult("call_ok", "small output")];
@@ -488,6 +500,36 @@ describe("installToolResultContextGuard", () => {
     const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
 
     expect(transformed).toBe(contextForNextCall);
+  });
+
+  it("refreshes diagnostic progress marker when sessionId and sessionKey are provided", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [makeUser("hello"), makeToolResult("call_ok", "small")];
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 100_000,
+      sessionId: "test-sid",
+      sessionKey: "agent:main:test",
+    });
+    const result = await agent.transformContext?.(contextForNextCall, new AbortController().signal);
+    expect(result).toBeDefined();
+    const { markDiagnosticSessionProgress } = await import("../../logging/diagnostic.js");
+    expect(markDiagnosticSessionProgress).toHaveBeenCalledWith({
+      sessionId: "test-sid",
+      sessionKey: "agent:main:test",
+    });
+  });
+
+  it("does not call diagnostic progress marker when session identifiers are omitted", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [makeUser("hello")];
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 100_000,
+    });
+    await agent.transformContext?.(contextForNextCall, new AbortController().signal);
+    const { markDiagnosticSessionProgress } = await import("../../logging/diagnostic.js");
+    expect(markDiagnosticSessionProgress).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -8,6 +8,7 @@ import type {
   ContextEngineRuntimeSettings,
   ContextEngineSessionTarget,
 } from "../../context-engine/types.js";
+import { markDiagnosticSessionProgress } from "../../logging/diagnostic.js";
 import type { AgentMessage } from "../runtime/index.js";
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
@@ -469,6 +470,9 @@ export function installToolResultContextGuard(params: {
   agent: GuardableAgent;
   contextWindowTokens: number;
   midTurnPrecheck?: MidTurnPrecheckOptions;
+  /** Session identifiers used to refresh the diagnostic progress marker on every model call. */
+  sessionId?: string;
+  sessionKey?: string;
 }): () => void {
   const contextWindowTokens = Math.max(1, Math.floor(params.contextWindowTokens));
   const maxContextChars = Math.max(
@@ -557,6 +561,13 @@ export function installToolResultContextGuard(params: {
       })
     ) {
       throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
+    }
+
+    if (params.sessionId || params.sessionKey) {
+      markDiagnosticSessionProgress({
+        sessionId: params.sessionId!,
+        sessionKey: params.sessionKey!,
+      });
     }
 
     return contextMessages;


### PR DESCRIPTION
## What Problem This Solves

During tool-heavy agent sessions, the diagnostic system`s `state.lastActivity` is never refreshed after the initial user message or at any point during the tool loop. The tool loop processes assistant(toolUse) → toolResult cycles every 2-5 seconds, but `markDiagnosticSessionProgress` is only called from the auto-reply dispatch system — never from the embedded agent runner. When a session runs for more than ~5 minutes (the `STUCK_SESSION_PROGRESS_STALE_MS = 300s` threshold), the stuck session recovery mechanism falsely detects the session as stuck and aborts it with `stop=aborted, error="Request was aborted"`, even though the tool loop is actively making progress.

## Evidence

### Diagnostic log showing false abort during active tool loop
```
11:26:59  user message → state.lastActivity = 11:26:59
11:27:39  tool loop starts (assistant stop=toolUse, input=64876)
11:27:39  toolResult
... (48 tool cycles, each 2-5s)
11:30:21  toolResult  ← last successful cycle
11:33:12  stuck session recovery: sessionId=9498038b ... age=371s action=abort_embedded_run
         externalAbort=true, timedOut=false, idleTimedOut=false
```

The tool loop completed 48 cycles in ~200s (avg 4s/cycle) but `lastActivity` stayed at 11:26:59, causing diagnostic to falsely abort after 371s.

### Trajectory confirms external abort, not timeout
```json
"model.completed": {
  "aborted": true,
  "externalAbort": true,
  "timedOut": false,
  "idleTimedOut": false,
  "promptError": "This operation was aborted"
}
```

## The fix

Calls `markDiagnosticSessionProgress` from inside `installToolResultContextGuard` transformContext wrapper, which runs on **every** model call (including tool loop iterations) for **all** sessions, regardless of context engine. The progress marker ensures `state.lastActivity` reflects actual session activity.

- 1 import + ~5 lines added to `tool-result-context-guard.ts`
- 2 lines added to `attempt.ts` to pass `sessionId`/`sessionKey` to the guard
- `markDiagnosticSessionProgress` already exists and is tested; the same function is used by the auto-reply dispatch system

Through temporarily adding log prints locally, I observed that lastActivity was updated promptly after each tool call.
<img width="1575" height="390" alt="image" src="https://github.com/user-attachments/assets/d14b6492-431d-4047-b43c-87603fed10e5" />

## Verification
- Updates `lastActivity` on every `transformContext` invocation = every model call
- Covers both context-engine and non-context-engine sessions
- No behavioral changes beyond diagnostic state