### PR TITLE
fix(parallel): keep normalized search fields UTF-16 safe

### DIFF
--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -8,6 +8,7 @@ import {
   wrapWebContent,
 } from "openclaw/plugin-sdk/provider-web-search";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 
 // Internal-only bounds (the model-facing tool schema declares its own copies).
 const PARALLEL_MAX_SEARCH_COUNT = 40;
@@ -58,7 +59,7 @@ export function normalizeParallelObjective(value: string | undefined): string | 
   }
   return trimmed.length <= PARALLEL_MAX_OBJECTIVE_CHARS
     ? trimmed
-    : trimmed.slice(0, PARALLEL_MAX_OBJECTIVE_CHARS);
+    : truncateUtf16Safe(trimmed, PARALLEL_MAX_OBJECTIVE_CHARS);
 }
 
 export function normalizeParallelClientModel(value: string | undefined): string | undefined {
@@ -68,7 +69,7 @@ export function normalizeParallelClientModel(value: string | undefined): string 
   }
   return trimmed.length <= PARALLEL_CLIENT_MODEL_MAX_LENGTH
     ? trimmed
-    : trimmed.slice(0, PARALLEL_CLIENT_MODEL_MAX_LENGTH);
+    : truncateUtf16Safe(trimmed, PARALLEL_CLIENT_MODEL_MAX_LENGTH);
 }
 
 // Parallel's API caps each entry at 200 chars and accepts up to 5 queries. We
@@ -90,7 +91,7 @@ export function normalizeParallelSearchQueries(value: unknown): string[] {
     const capped =
       trimmed.length <= PARALLEL_MAX_SEARCH_QUERY_CHARS
         ? trimmed
-        : trimmed.slice(0, PARALLEL_MAX_SEARCH_QUERY_CHARS);
+        : truncateUtf16Safe(trimmed, PARALLEL_MAX_SEARCH_QUERY_CHARS);
     if (seen.has(capped)) {
       continue;
     }

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -64,6 +64,8 @@ import { testing } from "../test-api.js";
 import { createParallelWebSearchProvider as createContractParallelWebSearchProvider } from "../web-search-contract-api.js";
 import { createParallelWebSearchProvider } from "./parallel-web-search-provider.js";
 
+const loneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/;
+
 describe("parallel web search provider", () => {
   beforeEach(() => {
     endpointMockState.calls = [];
@@ -254,6 +256,9 @@ describe("parallel web search provider", () => {
     expect(testing.normalizeParallelObjective(undefined)).toBeUndefined();
     expect(testing.normalizeParallelObjective("")).toBeUndefined();
     expect((testing.normalizeParallelObjective("x".repeat(6000)) ?? "").length).toBe(5000);
+    const boundary = testing.normalizeParallelObjective(`${"x".repeat(4999)}\u{1f63e}tail`);
+    expect(boundary).toBe("x".repeat(4999));
+    expect(loneHighSurrogate.test(boundary ?? "")).toBe(false);
   });
 
   it("normalizes search_queries: trim, drop blanks, dedupe, cap length, cap count", () => {
@@ -270,6 +275,14 @@ describe("parallel web search provider", () => {
     expect(testing.normalizeParallelSearchQueries(undefined)).toEqual([]);
     expect(testing.normalizeParallelSearchQueries("openclaw github")).toEqual([]);
     expect(testing.normalizeParallelSearchQueries(["x".repeat(250)])).toEqual(["x".repeat(200)]);
+    expect(testing.normalizeParallelSearchQueries([`${"x".repeat(199)}\u{1f63e}tail`])).toEqual([
+      "x".repeat(199),
+    ]);
+    expect(
+      loneHighSurrogate.test(
+        testing.normalizeParallelSearchQueries([`${"x".repeat(199)}\u{1f63e}tail`])[0] ?? "",
+      ),
+    ).toBe(false);
     const six = ["a", "b", "c", "d", "e", "f"];
     expect(testing.normalizeParallelSearchQueries(six)).toEqual(["a", "b", "c", "d", "e"]);
   });
@@ -289,6 +302,9 @@ describe("parallel web search provider", () => {
     expect(testing.normalizeParallelClientModel("  gpt-5.5  ")).toBe("gpt-5.5");
     expect(testing.normalizeParallelClientModel(undefined)).toBeUndefined();
     expect((testing.normalizeParallelClientModel("a".repeat(200)) ?? "").length).toBe(100);
+    const boundary = testing.normalizeParallelClientModel(`${"m".repeat(99)}\u{1f63e}tail`);
+    expect(boundary).toBe("m".repeat(99));
+    expect(loneHighSurrogate.test(boundary ?? "")).toBe(false);
   });
 
   it("normalizes the Parallel /v1/search response shape", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes Parallel search normalization paths that could cut UTF-16 surrogate pairs in half when applying API field limits. The `objective`, `search_queries[]`, and `client_model` fields all have hard character caps and previously used raw `.slice(...)` truncation.

## Why This Change Was Made

Recent bounded text fixes use the shared `truncateUtf16Safe` helper for model-facing and user-provided text. This applies that existing helper to Parallel's request normalization while preserving the same field limits and request shape.

## User Impact

Parallel search requests remain well-formed when objectives, search queries, or client model identifiers contain emoji or non-BMP characters near truncation boundaries.

## Evidence

- `node scripts/run-vitest.mjs extensions/parallel/src/parallel-web-search-provider.test.ts`
  - `extensions/parallel/src/parallel-web-search-provider.test.ts` passed: 29 tests passed.
- `git diff --check`
- `python .agents\skills\autoreview\scripts\autoreview --mode local --no-web-search`
  - `autoreview clean: no accepted/actionable findings reported`
- Base: latest `origin/main` at `4e29b2f5ab`