### PR TITLE
refactor: remove obsolete chat display mocks

### DIFF
--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -232,31 +232,7 @@ vi.mock("../../lib/agents/tools-effective.ts", () => ({
 }));
 
 vi.mock("../../lib/agents/display.ts", () => ({
-  isRenderableControlUiAvatarUrl: (value: string) =>
-    /^data:image\//i.test(value) || (value.startsWith("/") && !value.startsWith("//")),
   assistantAvatarFallbackUrl: () => "apple-touch-icon.png",
-  resolveChatAvatarRenderUrl: (
-    candidate: string | null | undefined,
-    agent: { identity?: { avatar?: string; avatarUrl?: string } },
-  ) => {
-    const isRenderableControlUiAvatarUrl = (value: string) =>
-      /^data:image\//i.test(value) || (value.startsWith("/") && !value.startsWith("//"));
-    if (typeof candidate === "string" && candidate.startsWith("blob:")) {
-      return candidate;
-    }
-    for (const value of [candidate, agent.identity?.avatarUrl, agent.identity?.avatar]) {
-      if (typeof value === "string" && isRenderableControlUiAvatarUrl(value)) {
-        return value;
-      }
-    }
-    return null;
-  },
-  resolveAssistantTextAvatar: (value: string | null | undefined) => {
-    if (!value) {
-      return null;
-    }
-    return value.length <= 3 ? value : null;
-  },
 }));
 
 function renderQueue(params: {

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -77,48 +77,6 @@ function pointerClick(element: Element) {
   element.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
 }
 
-vi.mock("../../../lib/agents/display.ts", () => {
-  const isRenderableControlUiAvatarUrl = (value: string) =>
-    /^data:image\//i.test(value) || (value.startsWith("/") && !value.startsWith("//"));
-
-  return {
-    assistantAvatarFallbackUrl: () => "/openclaw-molty.png",
-    isRenderableControlUiAvatarUrl,
-    resolveAssistantTextAvatar: (value: string | null | undefined) => {
-      const trimmed = value?.trim();
-      if (!trimmed || trimmed === "A") {
-        return null;
-      }
-      if (trimmed.startsWith("blob:") || isRenderableControlUiAvatarUrl(trimmed)) {
-        return null;
-      }
-      if (
-        trimmed.length > 8 ||
-        /\s/.test(trimmed) ||
-        /[\\/.:]/.test(trimmed) ||
-        /[\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/u.test(trimmed)
-      ) {
-        return null;
-      }
-      return trimmed;
-    },
-    resolveChatAvatarRenderUrl: (
-      candidate: string | null | undefined,
-      agent: { identity?: { avatar?: string; avatarUrl?: string } },
-    ) => {
-      if (typeof candidate === "string" && candidate.startsWith("blob:")) {
-        return candidate;
-      }
-      for (const value of [candidate, agent.identity?.avatarUrl, agent.identity?.avatar]) {
-        if (typeof value === "string" && isRenderableControlUiAvatarUrl(value)) {
-          return value;
-        }
-      }
-      return null;
-    },
-  };
-});
-
 vi.mock("./chat-avatar.ts", () => ({
   renderChatAvatar: (role: string) => {
     const element = document.createElement("div");


### PR DESCRIPTION
Related: #101647

## What Problem This Solves

Removes stale Control UI test mocks that modeled helper exports no longer exposed by the chat display module.

## Why This Change Was Made

The chat message tests no longer reach the display module, so their mock was removed. The chat view tests retain only the fallback asset mock and exercise the canonical avatar helpers directly.

## User Impact

No user-visible behavior change. Tests now reflect the current module ownership without duplicating avatar logic.

## Evidence

- Focused Testbox run: 2 files, 209 tests passed.
- Testbox: `tbx_01kwyatxdvb64ncvbn9ertg6fa`
- Actions run: https://github.com/openclaw/openclaw/actions/runs/28868305075
- `git diff --check`: passed.
- Codex autoreview: no actionable findings.
