### PR TITLE
fix(ai): omit text-only replay image parts

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -571,6 +571,102 @@ describe("OpenAI-compatible completions params", () => {
     });
   });
 
+  it("omits replayed user image_url parts for text-only models", async () => {
+    let capturedMessages: Array<{ role?: string; content?: unknown }> | undefined;
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "browser snapshot text" },
+              { type: "image_url", image_url: { url: "data:image/png;base64,aW1n" } },
+            ],
+            timestamp: 1,
+          },
+        ],
+      } as never,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: typeof capturedMessages }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedMessages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "browser snapshot text" }],
+      },
+    ]);
+  });
+
+  it("keeps image-bearing tool results textual for text-only models", async () => {
+    let capturedMessages:
+      | Array<{ role?: string; content?: unknown; tool_call_id?: string }>
+      | undefined;
+    const stream = streamOpenAICompletions(
+      model,
+      {
+        messages: [
+          {
+            role: "assistant",
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            content: [
+              { type: "toolCall", id: "call_snapshot", name: "browser_snapshot", arguments: {} },
+            ],
+            timestamp: 1,
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_snapshot",
+            toolName: "browser_snapshot",
+            content: [
+              { type: "text", text: "snapshot text" },
+              { type: "image", mimeType: "image/png", data: "aW1n" },
+            ],
+            isError: false,
+            timestamp: 2,
+          },
+        ],
+      } as never,
+      {
+        apiKey: "sk-test",
+        onPayload(payload) {
+          capturedMessages = (payload as { messages?: typeof capturedMessages }).messages;
+          throw new Error("stop before network");
+        },
+      },
+    );
+
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(capturedMessages?.find((message) => message.role === "tool")).toMatchObject({
+      role: "tool",
+      content: "snapshot text\n(tool image omitted: model does not support images)",
+      tool_call_id: "call_snapshot",
+    });
+    expect(capturedMessages?.some((message) => Array.isArray(message.content))).toBe(false);
+  });
+
   it("does not reread an unreadable tool inventory length", async () => {
     let capturedPayload: Record<string, unknown> | undefined;
     const tools = new Proxy([], {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1016,6 +1016,7 @@ export function convertMessages(
   }
 
   let lastRole: string | null = null;
+  const supportsImageInput = model.input.includes("image");
 
   for (let i = 0; i < transformedMessages.length; i++) {
     const msg = transformedMessages[i];
@@ -1044,8 +1045,8 @@ export function convertMessages(
         }
         params.push(userParam);
       } else {
-        const content: ChatCompletionContentPart[] = msg.content.map(
-          (item): ChatCompletionContentPart => {
+        const content: ChatCompletionContentPart[] = msg.content
+          .map((item): ChatCompletionContentPart => {
             if (item.type === "text") {
               return {
                 type: "text",
@@ -1058,8 +1059,8 @@ export function convertMessages(
                 url: `data:${item.mimeType};base64,${item.data}`,
               },
             } satisfies ChatCompletionContentPartImage;
-          },
-        );
+          })
+          .filter((item) => supportsImageInput || item.type !== "image_url");
         if (content.length === 0) {
           continue;
         }
@@ -1204,7 +1205,7 @@ export function convertMessages(
         }
         params.push(toolResultMsg);
 
-        if (hasImages && model.input.includes("image")) {
+        if (hasImages && supportsImageInput) {
           for (const block of toolMsg.content) {
             if (isImageContentBlock(block)) {
               imageBlocks.push({


### PR DESCRIPTION
## What Problem This Solves

Fixes KRA-4550: text-only OpenAI-compatible models such as DeepSeek were receiving replayed image parts from prior user/tool turns. That made the test-bench model treat tool outputs as images and degraded effective testing.

## Why This Change Was Made

`openai-completions` already knows whether a model accepts image input through `model.input`. The request conversion path now applies that contract consistently:

- text-only models keep replay text and omit `image_url` parts
- image-capable models still receive image attachments
- image-bearing tool results still include a textual placeholder for text-only models

## User Impact

DeepSeek/OpenAI-compatible text-only agents should stay text-visible during long test-bench runs instead of replaying browser/tool screenshots back into the model as image content.

## Evidence

- `node scripts/run-vitest.mjs packages/ai/src/providers/openai-completions.test.ts`
  - 1 test file passed
  - 43 tests passed
- `git diff --check origin/main...HEAD`
