### PR TITLE
fix(plugins): bound before_tool_call hook with a default timeout

### DIFF
--- a/src/plugins/hooks.before-tool-call.test.ts
+++ b/src/plugins/hooks.before-tool-call.test.ts
@@ -1,7 +1,7 @@
 /** Tests before-tool-call hook ordering, mutation, and cancellation behavior. */
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createHookRunner } from "./hooks.js";
-import { addStaticTestHooks } from "./hooks.test-fixtures.js";
+import { addStaticTestHooks, createMockPluginRegistry } from "./hooks.test-fixtures.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
 import type { PluginHookToolContext } from "./types.js";
 import type { PluginHookBeforeToolCallResult } from "./types.js";
@@ -252,5 +252,31 @@ describe("before_tool_call hook merger — requireApproval", () => {
   ] as const)("$name", async ({ hooks, expected }) => {
     const result = await runBeforeToolCallWithHooks(registry, hooks);
     expectRequireApprovalResult(result, expected);
+  });
+});
+
+describe("before_tool_call hook runner — timeout", () => {
+  it("times out a hung handler and, being fail-closed, rejects so the tool call is denied", async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = vi.fn(() => new Promise(() => {}));
+      const logger = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+      const runner = createHookRunner(
+        createMockPluginRegistry([{ hookName: "before_tool_call", handler }]),
+        // Matches the global runner (hook-runner-global.ts): before_tool_call is
+        // fail-closed, so a timed-out handler throws instead of silently allowing.
+        { logger, failurePolicyByHook: { before_tool_call: "fail-closed" } },
+      );
+
+      const run = runner.runBeforeToolCall({ toolName: "bash", params: {} }, stubCtx);
+      const rejection = expect(run).rejects.toThrow(
+        "before_tool_call handler from test-plugin failed: timed out after 15000ms",
+      );
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/plugins/hooks.before-tool-call.test.ts
+++ b/src/plugins/hooks.before-tool-call.test.ts
@@ -1,5 +1,6 @@
 /** Tests before-tool-call hook ordering, mutation, and cancellation behavior. */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveToolExecutionErrorKind } from "../agents/tool-result-error.js";
 import { createHookRunner } from "./hooks.js";
 import { addStaticTestHooks, createMockPluginRegistry } from "./hooks.test-fixtures.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
@@ -275,6 +276,31 @@ describe("before_tool_call hook runner — timeout", () => {
 
       await vi.advanceTimersByTimeAsync(15_000);
       await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the timeout identity so the tool result reports timed_out, not failed", async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = vi.fn(() => new Promise(() => {}));
+      const logger = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+      const runner = createHookRunner(
+        createMockPluginRegistry([{ hookName: "before_tool_call", handler }]),
+        { logger, failurePolicyByHook: { before_tool_call: "fail-closed" } },
+      );
+
+      const run = runner.runBeforeToolCall({ toolName: "bash", params: {} }, stubCtx);
+      const captured = run.then(
+        () => undefined,
+        (err: unknown) => err,
+      );
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      // Classify with the real downstream helper: a plain Error would fall back
+      // to "failed" and misreport the new budget expiry.
+      expect(resolveToolExecutionErrorKind(await captured)).toBe("timed_out");
     } finally {
       vi.useRealTimers();
     }

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -160,13 +160,9 @@ const DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, 
   message_sending: 15_000,
   reply_payload_sending: 15_000,
   resolve_exec_env: 15_000,
-  // before_tool_call gates every tool call (block / requireApproval). It is
-  // fail-closed (hook-runner-global.ts), so a timeout throws and the tool is
-  // denied rather than silently allowed. Without a budget an unresponsive
-  // handler leaves the tool call awaited forever, and the only backstop is the
-  // run-level lane idle watchdog (default agent timeout, up to 48h), which does
-  // not cancel the stuck hook — wedging that session's turn far longer than any
-  // sibling modifying hook.
+  // before_tool_call is fail-closed (hook-runner-global.ts): a timeout denies the
+  // tool call instead of silently allowing it. Without a budget an unresponsive
+  // handler wedges the turn, and the lane idle watchdog does not cancel it.
   before_tool_call: 15_000,
 };
 
@@ -511,7 +507,12 @@ export function createHookRunner(
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
-        reject(new Error(`timed out after ${timeoutMs}ms`));
+        // Named so fail-closed hook timeouts keep their timeout identity: the
+        // tool-result classifier keys on name/code, and a plain Error would
+        // surface a budget expiry as `failed` instead of `timed_out`.
+        const error = new Error(`timed out after ${timeoutMs}ms`);
+        error.name = "TimeoutError";
+        reject(error);
       }, timeoutMs);
       if (optionsResult.unref) {
         timer.unref?.();

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -160,6 +160,14 @@ const DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, 
   message_sending: 15_000,
   reply_payload_sending: 15_000,
   resolve_exec_env: 15_000,
+  // before_tool_call gates every tool call (block / requireApproval). It is
+  // fail-closed (hook-runner-global.ts), so a timeout throws and the tool is
+  // denied rather than silently allowed. Without a budget an unresponsive
+  // handler leaves the tool call awaited forever, and the only backstop is the
+  // run-level lane idle watchdog (default agent timeout, up to 48h), which does
+  // not cancel the stuck hook — wedging that session's turn far longer than any
+  // sibling modifying hook.
+  before_tool_call: 15_000,
 };
 
 type ModifyingHookPolicy<K extends PluginHookName, TResult> = {


### PR DESCRIPTION
## What Problem This Solves

The hooks listed in `DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK`
(`src/plugins/hooks.ts`) each carry a default 15s budget —
`before_agent_run`, `before_agent_start`, `before_agent_finalize`,
`before_prompt_build`, `resolve_exec_env` — but `before_tool_call`, which gates
every tool call (block / requireApproval), is absent from the table.

Because `before_tool_call` has no budget, a plugin handler that hangs (or is very
slow) leaves the tool call awaited forever with no per-hook timeout. The only
backstop is the run-level lane idle watchdog, which fires at the configured agent
timeout — up to the 48h default (`DEFAULT_AGENT_TIMEOUT_MS`) — and does not cancel
the stuck hook, so it wedges that session's turn far longer than the sibling
modifying hooks in the table and leaves the original handler promise pending.

## Why This Change Was Made

`before_tool_call` is already registered fail-closed in
`src/plugins/hook-runner-global.ts`, and `runBeforeToolCallHook` converts any
thrown hook error into a denied tool call. So a per-hook timeout is safe and
non-regressive: on timeout the hook error propagates and the tool call is
**denied**, never silently allowed. Adding `before_tool_call: 15_000` to the same
table brings it in line with its sibling modifying hooks and converts an
effectively unbounded wedge into a bounded, fail-closed denial.

## Compatibility

This changes default behavior for existing plugins: a `before_tool_call` handler
that legitimately runs longer than 15s will now have its tool call **denied**
(fail-closed) after the budget instead of the caller waiting for it to finish.
The 15s default matches the sibling modifying-hook budgets
(`before_agent_run` / `before_agent_start` / `before_agent_finalize` etc.), and a
gating hook is expected to be fast, so it should be safe for typical plugins — but
it is a maintainer-visible tradeoff, so I've flagged it rather than assumed it. If
a different budget or a per-hook override / opt-out is preferred, this can be made
configurable.

## User Impact

A hung or slow `before_tool_call` plugin handler can no longer wedge a session's
turn for hours. After 15s the tool call is denied (fail-closed) and the run
proceeds to its normal error handling, instead of blocking the lane until the
agent timeout.

## Evidence

**Real-behavior proof (real wall-clock timers, no mocks of the timeout
mechanism).** A hung `before_tool_call` handler (`() => new Promise(() => {})`)
was driven through the shipped production runner factories with real timers, and
the tool call was denied at ~15s:

```
=== BEFORE (current main: before_tool_call has no timeout budget) ===
t=0.00s   tool call issued; hung before_tool_call handler running
t=17.01s  settled=pending  (handler invoked 1x)
RESULT: still PENDING after 17.01s — no per-hook bound. On main the only
        backstop is the lane idle watchdog (up to 48h), so the turn is wedged.

=== AFTER (fix: real global runner, default 15s + fail-closed) ===
t=0.00s   tool call issued; hung before_tool_call handler running
t=15.03s  tool call DENIED (promise rejected)
          error: [hooks] before_tool_call handler from proof-hung-plugin
                 failed: timed out after 15000ms
RESULT: PASS — hung before_tool_call denied at ~15s (elapsed 15.03s,
        timeout-message=true, fail-closed deny=true)
```

- **AFTER** boots the real global hook runner via
  `initializeGlobalHookRunner` (`src/plugins/hook-runner-global.ts`) — the exact
  wiring the gateway uses — with **no per-call overrides**: both the 15s budget
  (the added `DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK` entry) and the
  deny-on-timeout come from shipped code. The hung handler is denied after a real
  ~15s with the `timed out after 15000ms` hook error.
- **BEFORE** uses the same production `createHookRunner` with no positive budget
  for `before_tool_call` (faithful to current main, where the key is absent):
  the same hung handler is still pending after 17s — past where the fix denies —
  confirming today's unbounded wedge.

**Unit test.** New test in `src/plugins/hooks.before-tool-call.test.ts`: a hung
`before_tool_call` handler under the fail-closed policy (matching the global
runner) times out at 15s and the run **rejects** (tool denied), with the expected
`timed out after 15000ms` hook error. The existing `before_tool_call`
ordering/mutation/approval tests and the adjacent `hook-runner-global` /
`hooks.security` / `hooks.before-agent-finalize` suites pass locally
(`node scripts/run-vitest.mjs <files>`). Changed-lane lint/typecheck/test gates
run in CI.
