### PR TITLE
fix(infra): log restart sentinel cleanup errors instead of silent catch

### DIFF
--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -224,7 +224,9 @@ export async function clearRestartSentinel(env: NodeJS.ProcessEnv = process.env)
       },
       { env },
     );
-  } catch {}
+  } catch (err) {
+    console.error("[openclaw] Failed to clear restart sentinel:", err);
+  }
   await removeLegacyRestartSentinel(env);
 }
 
@@ -235,7 +237,9 @@ function resolveLegacyRestartSentinelPath(env: NodeJS.ProcessEnv): string {
 async function removeLegacyRestartSentinel(env: NodeJS.ProcessEnv): Promise<void> {
   try {
     await rm(resolveLegacyRestartSentinelPath(env), { force: true });
-  } catch {}
+  } catch (err) {
+    console.error("[openclaw] Failed to remove legacy restart sentinel:", err);
+  }
 }
 
 async function importLegacyRestartSentinel(


### PR DESCRIPTION
## Summary

- 将 `clearRestartSentinel()` 和 `removeLegacyRestartSentinel()` 中的空 `catch {}` 改为记录错误
- 空 catch 块会静默吞噬数据库写入和文件删除的失败，导致过期 sentinel 标记遗留在数据库中
- 下次重启时可能错误触发意外的恢复流程

## Real behavior proof

**Behavior or issue addressed:** 两个 try-catch 块使用空 catch 吞噬了所有异常，使开发者无法发现清理 restart sentinel 时发生的错误。

**Real environment tested:** 本地 Linux 环境 (Node 22.21.0, SQLite)，通过强制破坏 SQLite 数据库和文件系统结构来触发清理失败路径。

**Scenario 1: SQLite 数据库损坏**
```
[openclaw] Failed to clear restart sentinel: Error: file is not a database
    at configureSqliteWalMaintenance (.../src/infra/sqlite-wal.ts:327:6)
    at configureSqliteConnectionPragmas (.../src/infra/sqlite-wal.ts:375:23)
    at openOpenClawStateDatabase (.../src/state/openclaw-state-db.ts:935:21)
    at runOpenClawStateWriteTransaction (.../src/state/openclaw-state-db.ts:961:20)
    at clearRestartSentinel (.../src/infra/restart-sentinel.ts:215:5)
    ...
}
```
修复前：此异常被 `catch {}` 静默吞噬，无任何输出。
修复后：错误信息和堆栈完整打印到 stderr。

**Scenario 2: State 目录被替换为文件（双重失败路径）**
```
[openclaw] Failed to clear restart sentinel: Error: ENOTDIR: not a directory
[openclaw] Failed to remove legacy restart sentinel: [Error: ENOTDIR: not a directory]
```
修复前：两条错误均被静默吞噬。
修复后：DB 清理和旧版文件清理的失败路径均独立打印错误日志。

**Exact steps or command run after this patch:**
使用 tsx 脚本强制破坏 SQLite 数据库和文件系统，直接调用 clearRestartSentinel() 触发真实错误。

**Evidence after fix:**
- 27 个现有单元测试全部通过
- 强制触发两种不同的清理失败场景，均正确输出 `[openclaw] Failed to ...` 日志

**What was not tested:**
- 未在生产环境 (Gateway) 中验证错误恢复流程
- console.error 的副作用本身不在单元测试中断言（但通过手动脚本确认了行为）

## Tests and validation

所有 27 个现有测试通过，未改动测试文件。

验证命令:
```
pnpm test src/infra/restart-sentinel.test.ts
```

## Risk checklist

- User-facing behavior change? → No, 仅增加日志输出
- Config/default surface change? → No
- Security-sensitive change? → No
- Compatibility concern? → No

AI-assisted: 使用 Claude Code 编写此修复。
