### PR TITLE
test: remove stale native i18n sentinel

### DIFF
--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -53,7 +53,6 @@ describe("native app i18n inventory", () => {
     expect(entries.some((entry) => entry.source === "$deviceModel · $appVersion")).toBe(true);
     expect(entries.some((entry) => entry.source === "Approval command copied")).toBe(true);
     expect(entries.some((entry) => entry.source === "Save Profile")).toBe(true);
-    expect(entries.some((entry) => entry.source === "Pairing required")).toBe(true);
     expect(entries.some((entry) => entry.source === "Mute")).toBe(true);
     expect(entries.some((entry) => entry.source === "Creating...")).toBe(true);
     expect(entries.some((entry) => entry.source === "Permission required")).toBe(true);


### PR DESCRIPTION
## What Problem This Solves

PR #101680 removed the superseded Android connect surface that supplied the exact native-i18n source string `Pairing required`, but the tooling test still required that removed source. This makes the compact tooling shard fail on current `main` and on otherwise unrelated PR merge refs.

## Why This Change Was Made

Remove only the stale exact-source sentinel. The inventory still retains many stable Android and Apple source assertions, while the remaining pairing-related production strings differ from the deleted source and continue to be collected normally.

## User Impact

No runtime behavior changes. Native i18n inventory tests once again describe current production sources.

## Evidence

- Testbox `tbx_01kwy98tqfsh88xjfvx3wprp8a`: `pnpm test test/scripts/native-app-i18n.test.ts` — 5 tests passed.
- `git diff --check` — passed.
- Fresh autoreview — clean, 0.99 confidence.

Follow-up to #101680.
