### PR TITLE
fix(agents): keep MCP server/tool name truncation UTF-16 safe

### DIFF
--- a/src/agents/agent-bundle-mcp-names.test.ts
+++ b/src/agents/agent-bundle-mcp-names.test.ts
@@ -70,4 +70,34 @@ describe("agent bundle MCP names", () => {
     expect(safeToolName.startsWith(`memory${TOOL_NAME_SEPARATOR}`)).toBe(true);
     expect(safeToolName.length).toBeLessThanOrEqual(64);
   });
+
+  it("preserves emoji surrogate pairs at truncation boundaries", () => {
+    // Truncation that lands between the two UTF-16 code units of an emoji
+    // must not split the pair into a lone surrogate.
+    const safeToolName = buildSafeToolName({
+      serverName: "srv",
+      // Build a tool name such that maxToolChars falls exactly inside an emoji's
+      // surrogate pair. The emoji 🧠 (U+1F9E0) is "🧠" (2 code units).
+      // maxToolChars = 64 - "srv".length - "__".length - 2 = 64 - 3 - 2 - 2 = 57
+      // We place the emoji at position 57 so raw .slice(0,57) would split it.
+      toolName: "a".repeat(56) + "🧠" + "b".repeat(30),
+      reservedNames: new Set(),
+    });
+
+    // Must never contain a lone surrogate half.
+    expect(safeToolName).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(safeToolName).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+    expect(safeToolName.length).toBeLessThanOrEqual(64);
+  });
+
+  it("preserves multi-byte emoji at server name truncation boundaries", () => {
+    const usedNames = new Set<string>();
+    // Server name with emoji positioned at the 30-char prefix boundary
+    const serverName = sanitizeServerName("a".repeat(29) + "🧠" + "b".repeat(10), usedNames);
+
+    // Must never contain a lone surrogate half.
+    expect(serverName).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+    expect(serverName).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+    expect(serverName.length).toBeLessThanOrEqual(30);
+  });
 });

--- a/src/agents/agent-bundle-mcp-names.ts
+++ b/src/agents/agent-bundle-mcp-names.ts
@@ -1,8 +1,9 @@
-/** Sanitizes MCP server/tool names into stable model-facing tool ids. */
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
+/** Sanitizes MCP server/tool names into stable model-facing tool ids. */
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 
 // Name sanitizers for tools exposed by bundle MCP servers. Provider/tool names
 // must fit model-facing schema limits while remaining stable and collision-free.
@@ -18,7 +19,7 @@ function sanitizeToolFragment(raw: string, fallback: string, maxChars?: number):
   if (!maxChars) {
     return providerSafe;
   }
-  return providerSafe.length > maxChars ? providerSafe.slice(0, maxChars) : providerSafe;
+  return providerSafe.length > maxChars ? truncateUtf16Safe(providerSafe, maxChars) : providerSafe;
 }
 
 /** Sanitize one MCP server name and reserve it in the provided set. */
@@ -28,7 +29,7 @@ export function sanitizeServerName(raw: string, usedNames: Set<string>): string 
   let n = 2;
   while (usedNames.has(normalizeLowercaseStringOrEmpty(candidate))) {
     const suffix = `-${n}`;
-    candidate = `${base.slice(0, Math.max(1, TOOL_NAME_MAX_PREFIX - suffix.length))}${suffix}`;
+    candidate = `${truncateUtf16Safe(base, Math.max(1, TOOL_NAME_MAX_PREFIX - suffix.length))}${suffix}`;
     n += 1;
   }
   usedNames.add(normalizeLowercaseStringOrEmpty(candidate));
@@ -59,7 +60,7 @@ export function buildSafeToolName(params: {
     1,
     TOOL_NAME_MAX_TOTAL - params.serverName.length - TOOL_NAME_SEPARATOR.length,
   );
-  const truncatedToolName = cleanedToolName.slice(0, maxToolChars);
+  const truncatedToolName = truncateUtf16Safe(cleanedToolName, maxToolChars);
   let candidateToolName = truncatedToolName || "tool";
   let candidate = `${params.serverName}${TOOL_NAME_SEPARATOR}${candidateToolName}`;
   let n = 2;
@@ -67,7 +68,7 @@ export function buildSafeToolName(params: {
     // Keep the suffix inside the total tool-name budget while preserving the
     // server prefix as the namespace boundary.
     const suffix = `-${n}`;
-    candidateToolName = `${(truncatedToolName || "tool").slice(0, Math.max(1, maxToolChars - suffix.length))}${suffix}`;
+    candidateToolName = `${truncateUtf16Safe(truncatedToolName || "tool", Math.max(1, maxToolChars - suffix.length))}${suffix}`;
     candidate = `${params.serverName}${TOOL_NAME_SEPARATOR}${candidateToolName}`;
     n += 1;
   }


### PR DESCRIPTION
## Summary

- AI-assisted with Claude Code; I inspected the changed production path and can explain the change.
- MCP server/tool name truncation in `sanitizeToolFragment`, `sanitizeServerName`, and `buildSafeToolName` now preserves UTF-16 boundaries when the 30-char prefix cap or 64-char total cap lands between the code units of an emoji or CJK surrogate pair.
- Uses the existing `truncateUtf16Safe` helper from `@openclaw/normalization-core/utf16-slice` instead of raw `.slice(0, N)` at four truncation sites.
- Intentionally out of scope: unrelated truncation sites in other modules, config changes, and any behavior outside this specific MCP name sanitization boundary.

## What Problem This Solves

MCP server and tool names that contain emoji or CJK characters can be split mid-surrogate-pair when the sanitized name exceeds the `TOOL_NAME_MAX_PREFIX` (30) or `TOOL_NAME_MAX_TOTAL` (64) caps. Raw `.slice(0, N)` operates on UTF-16 code units, so a truncation that lands between the two code units of an emoji produces a lone surrogate — a malformed Unicode string that downstream consumers may reject or render as a replacement character.

## Why This Change Was Made

The existing shared `truncateUtf16Safe` helper already handles this boundary correctly and is used by 15+ call sites across the codebase. The four truncation sites in `agent-bundle-mcp-names.ts` were among the remaining raw-slice sites in `src/agents/`.

## Evidence

- **Tests added**: 2 new test cases — "preserves emoji surrogate pairs at truncation boundaries" (buildSafeToolName) and "preserves multi-byte emoji at server name truncation boundaries" (sanitizeServerName). Both assert no lone surrogates in the output.
- **Existing tests**: 5/5 pass unchanged.
- **Test run**: `node scripts/run-vitest.mjs run src/agents/agent-bundle-mcp-names.test.ts` — 7 passed (5 existing + 2 new).
