### PR TITLE
fix(tlon): cap channel history cache namespaces

### DIFF
--- a/extensions/tlon/src/monitor/history.test.ts
+++ b/extensions/tlon/src/monitor/history.test.ts
@@ -1,0 +1,45 @@
+// Tlon tests cover channel history cache behavior.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cacheMessage,
+  getChannelHistory,
+  MAX_CACHED_CHANNEL_HISTORY_NAMESPACES,
+  testing,
+} from "./history.js";
+
+describe("tlon monitor history cache", () => {
+  beforeEach(() => {
+    testing.clearMessageCacheForTests();
+  });
+
+  it("caps cached channel history namespaces and evicts the oldest channel", async () => {
+    for (let index = 0; index <= MAX_CACHED_CHANNEL_HISTORY_NAMESPACES; index += 1) {
+      cacheMessage(`group/channel-${index}`, {
+        author: "~zod",
+        content: `message ${index}`,
+        timestamp: index,
+      });
+    }
+
+    expect(testing.getCachedChannelCountForTests()).toBe(
+      MAX_CACHED_CHANNEL_HISTORY_NAMESPACES,
+    );
+    expect(testing.hasCachedChannelForTests("group/channel-0")).toBe(false);
+    expect(testing.hasCachedChannelForTests("group/channel-1")).toBe(true);
+
+    const api = { scry: vi.fn(async () => []) };
+    await expect(getChannelHistory(api, "group/channel-0", 1)).resolves.toEqual([]);
+    expect(api.scry).toHaveBeenCalledWith(
+      "/channels/v4/group/channel-0/posts/newest/1/outline.json",
+    );
+
+    const cached = await getChannelHistory(api, "group/channel-1", 1);
+    expect(cached).toEqual([
+      {
+        author: "~zod",
+        content: "message 1",
+        timestamp: 1,
+      },
+    ]);
+  });
+});

--- a/extensions/tlon/src/monitor/history.ts
+++ b/extensions/tlon/src/monitor/history.ts
@@ -49,15 +49,30 @@ function createHistoryEntryFromMemo(params: {
 
 const messageCache = new Map<string, TlonHistoryEntry[]>();
 const MAX_CACHED_MESSAGES = 100;
+export const MAX_CACHED_CHANNEL_HISTORY_NAMESPACES = 100;
+
+function cachedMessagesForChannel(channelNest: string): TlonHistoryEntry[] {
+  const cached = messageCache.get(channelNest);
+  if (cached) {
+    messageCache.delete(channelNest);
+    messageCache.set(channelNest, cached);
+    return cached;
+  }
+
+  const cache: TlonHistoryEntry[] = [];
+  messageCache.set(channelNest, cache);
+  while (messageCache.size > MAX_CACHED_CHANNEL_HISTORY_NAMESPACES) {
+    const oldestChannelNest = messageCache.keys().next().value;
+    if (oldestChannelNest === undefined) {
+      break;
+    }
+    messageCache.delete(oldestChannelNest);
+  }
+  return cache;
+}
 
 export function cacheMessage(channelNest: string, message: TlonHistoryEntry) {
-  if (!messageCache.has(channelNest)) {
-    messageCache.set(channelNest, []);
-  }
-  const cache = messageCache.get(channelNest);
-  if (!cache) {
-    return;
-  }
+  const cache = cachedMessagesForChannel(channelNest);
   cache.unshift(message);
   if (cache.length > MAX_CACHED_MESSAGES) {
     cache.pop();
@@ -225,3 +240,17 @@ export async function fetchThreadHistory(
     return [];
   }
 }
+
+export const testing = {
+  clearMessageCacheForTests() {
+    messageCache.clear();
+  },
+  getCachedChannelCountForTests() {
+    return messageCache.size;
+  },
+  hasCachedChannelForTests(channelNest: string) {
+    return messageCache.has(channelNest);
+  },
+};
+
+export { testing as __testing };


### PR DESCRIPTION
## Summary
- Cap the number of cached Tlon channel history namespaces so long-running monitors cannot retain unbounded channel entries.
- Keep the existing per-channel message cap while evicting the oldest channel namespace when the namespace cap is exceeded.
- Collision check: open PR changed-files had no PR modifying `extensions/tlon/src/monitor/history.ts` or its new focused test before opening.

## Verification
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts extensions/tlon/src/monitor/history.test.ts -t "caps cached channel history namespaces"` - passed, 1 file / 1 spec selected.
- `./node_modules/.bin/oxlint extensions/tlon/src/monitor/history.ts extensions/tlon/src/monitor/history.test.ts` - passed.
- `git diff --check` - passed.

## Real behavior proof
Behavior or issue addressed: Tlon channel history caching now bounds the number of retained channel namespaces instead of allowing every observed channel nest to remain cached for the life of the process.

Real environment tested: Local OpenClaw checkout on Linux at commit a59426dd54, Node.js v22, executing the modified Tlon history cache module.

Exact steps or command run after this patch: Ran a Node terminal check that imports the branch module, inserts one more channel namespace than the configured limit, and records the retained namespace count plus oldest/newest channel presence.

Evidence after fix: Terminal output from the after-fix Node check:
```text
max_channel_history_namespaces=100
cached_channel_history_namespaces=100
oldest_channel_present=false
newest_channel_present=true
```

Observed result after fix: The output shows the cache stays at the configured namespace cap, evicts the oldest channel namespace, and keeps the newest inserted channel namespace.

What was not tested: No known gaps for this local branch behavior; live Tlon network history fetching was not exercised.
