### PR TITLE
fix(config): cap legacy toolsBySender deprecation warning cache with shared dedupe helper

### DIFF
--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -413,8 +413,15 @@ describe("resolveToolsBySender", () => {
     expect(warningMeta?.code).toBe("OPENCLAW_TOOLS_BY_SENDER_UNTYPED_KEY");
   });
 
-  describe("legacy key warning dedupe eviction", () => {
+  describe("legacy key warning dedupe cache", () => {
     let resolveToolsBySenderFn: typeof resolveToolsBySender;
+
+    const resolveFreshConfig = (legacyKey: string) => {
+      resolveToolsBySenderFn({
+        toolsBySender: { [legacyKey]: { allow: ["read"] }, "*": { deny: ["exec"] } },
+        senderId: "some-id",
+      });
+    };
 
     beforeEach(async () => {
       vi.resetModules();
@@ -422,61 +429,25 @@ describe("resolveToolsBySender", () => {
       resolveToolsBySenderFn = mod.resolveToolsBySender;
     });
 
-    it("evicts old legacy keys when the dedupe cache reaches its cap", () => {
+    it("refreshes recent keys across config snapshots and re-warns evicted keys", () => {
       const warningSpy = vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
 
-      // Fill the cache by feeding 4097 distinct legacy keys through resolveToolsBySender.
-      // The 4097th key pushes past the 4096 cap, evicting the oldest entry.
-      for (let i = 1; i <= 4097; i++) {
-        resolveToolsBySenderFn({
-          toolsBySender: { [`legacy-key-${i}`]: { allow: ["read"] }, "*": { deny: ["exec"] } },
-          senderId: "some-id",
-        });
+      for (let i = 0; i < 4096; i++) {
+        resolveFreshConfig(`legacy-key-${i}`);
       }
+      expect(warningSpy).toHaveBeenCalledTimes(4096);
 
-      // "legacy-key-1" was the first key added; it should have been evicted.
-      const callsBefore = warningSpy.mock.calls.length;
-      resolveToolsBySenderFn({
-        toolsBySender: { "legacy-key-1": { allow: ["read"] }, "*": { deny: ["exec"] } },
-        senderId: "some-id",
-      });
-      // Re-resolving the evicted key emits a fresh warning.
-      expect(warningSpy.mock.calls.length).toBeGreaterThan(callsBefore);
-    });
+      resolveFreshConfig("legacy-key-0");
+      expect(warningSpy).toHaveBeenCalledTimes(4096);
 
-    it("keeps frequently accessed legacy keys from being evicted", () => {
-      const warningSpy = vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
+      resolveFreshConfig("overflow-key");
+      expect(warningSpy).toHaveBeenCalledTimes(4097);
 
-      // Seed the cache with 4095 entries (keys 2..4096).
-      for (let i = 2; i <= 4096; i++) {
-        resolveToolsBySenderFn({
-          toolsBySender: { [`legacy-key-${i}`]: { allow: ["read"] }, "*": { deny: ["exec"] } },
-          senderId: "some-id",
-        });
-      }
+      resolveFreshConfig("legacy-key-0");
+      expect(warningSpy).toHaveBeenCalledTimes(4097);
 
-      // Touch "legacy-key-1" 42 times to promote its recency in the LRU cache.
-      for (let i = 0; i < 42; i++) {
-        resolveToolsBySenderFn({
-          toolsBySender: { "legacy-key-1": { allow: ["read"] }, "*": { deny: ["exec"] } },
-          senderId: "some-id",
-        });
-      }
-      // Cache now at 4096 entries (keys 2..4096 + key-1).
-
-      // Push past the cap — key-1 was recently touched, so it should survive eviction.
-      resolveToolsBySenderFn({
-        toolsBySender: { "extra-key": { allow: ["read"] }, "*": { deny: ["exec"] } },
-        senderId: "some-id",
-      });
-
-      // Re-resolve "legacy-key-1" — should NOT emit a fresh warning (still cached).
-      const callsBefore = warningSpy.mock.calls.length;
-      resolveToolsBySenderFn({
-        toolsBySender: { "legacy-key-1": { allow: ["read"] }, "*": { deny: ["exec"] } },
-        senderId: "some-id",
-      });
-      expect(warningSpy.mock.calls.length).toBe(callsBefore);
+      resolveFreshConfig("legacy-key-1");
+      expect(warningSpy).toHaveBeenCalledTimes(4098);
     });
   });
 });

--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -1,5 +1,5 @@
 // Verifies group-policy normalization and runtime resolution.
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "./config.js";
 import {
   resolveChannelGroupPolicy,
@@ -411,5 +411,72 @@ describe("resolveToolsBySender", () => {
     const [warningMessage, warningMeta] = firstWarningCall(warningSpy);
     expect(String(warningMessage)).toContain(`toolsBySender key "${legacyKey}"`);
     expect(warningMeta?.code).toBe("OPENCLAW_TOOLS_BY_SENDER_UNTYPED_KEY");
+  });
+
+  describe("legacy key warning dedupe eviction", () => {
+    let resolveToolsBySenderFn: typeof resolveToolsBySender;
+
+    beforeEach(async () => {
+      vi.resetModules();
+      const mod = await import("./group-policy.js");
+      resolveToolsBySenderFn = mod.resolveToolsBySender;
+    });
+
+    it("evicts old legacy keys when the dedupe cache reaches its cap", () => {
+      const warningSpy = vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
+
+      // Fill the cache by feeding 4097 distinct legacy keys through resolveToolsBySender.
+      // The 4097th key pushes past the 4096 cap, evicting the oldest entry.
+      for (let i = 1; i <= 4097; i++) {
+        resolveToolsBySenderFn({
+          toolsBySender: { [`legacy-key-${i}`]: { allow: ["read"] }, "*": { deny: ["exec"] } },
+          senderId: "some-id",
+        });
+      }
+
+      // "legacy-key-1" was the first key added; it should have been evicted.
+      const callsBefore = warningSpy.mock.calls.length;
+      resolveToolsBySenderFn({
+        toolsBySender: { "legacy-key-1": { allow: ["read"] }, "*": { deny: ["exec"] } },
+        senderId: "some-id",
+      });
+      // Re-resolving the evicted key emits a fresh warning.
+      expect(warningSpy.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+
+    it("keeps frequently accessed legacy keys from being evicted", () => {
+      const warningSpy = vi.spyOn(process, "emitWarning").mockImplementation(() => undefined);
+
+      // Seed the cache with 4095 entries (keys 2..4096).
+      for (let i = 2; i <= 4096; i++) {
+        resolveToolsBySenderFn({
+          toolsBySender: { [`legacy-key-${i}`]: { allow: ["read"] }, "*": { deny: ["exec"] } },
+          senderId: "some-id",
+        });
+      }
+
+      // Touch "legacy-key-1" 42 times to promote its recency in the LRU cache.
+      for (let i = 0; i < 42; i++) {
+        resolveToolsBySenderFn({
+          toolsBySender: { "legacy-key-1": { allow: ["read"] }, "*": { deny: ["exec"] } },
+          senderId: "some-id",
+        });
+      }
+      // Cache now at 4096 entries (keys 2..4096 + key-1).
+
+      // Push past the cap — key-1 was recently touched, so it should survive eviction.
+      resolveToolsBySenderFn({
+        toolsBySender: { "extra-key": { allow: ["read"] }, "*": { deny: ["exec"] } },
+        senderId: "some-id",
+      });
+
+      // Re-resolve "legacy-key-1" — should NOT emit a fresh warning (still cached).
+      const callsBefore = warningSpy.mock.calls.length;
+      resolveToolsBySenderFn({
+        toolsBySender: { "legacy-key-1": { allow: ["read"] }, "*": { deny: ["exec"] } },
+        senderId: "some-id",
+      });
+      expect(warningSpy.mock.calls.length).toBe(callsBefore);
+    });
   });
 });

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -1,9 +1,10 @@
-// Normalizes group-policy config for channel and runtime decisions.
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { ChannelId } from "../channels/plugins/channel-id.types.js";
+// Normalizes group-policy config for channel and runtime decisions.
+import { createDedupeCache } from "../infra/dedupe.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { normalizeAccountId } from "../routing/session-key.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";
@@ -72,7 +73,8 @@ type CompiledSenderPolicy = {
   wildcard?: GroupToolPolicyConfig;
 };
 
-const warnedLegacyToolsBySenderKeys = new Set<string>();
+// Bounded dedupe cache for legacy toolsBySender deprecation warnings.
+const legacyKeyDedupe = createDedupeCache({ ttlMs: 0, maxSize: 4096 });
 const compiledToolsBySenderCache = new WeakMap<
   GroupToolPolicyBySenderConfig,
   CompiledSenderPolicy
@@ -137,10 +139,9 @@ function normalizeLegacySenderKey(value: string): string {
 
 function warnLegacyToolsBySenderKey(rawKey: string) {
   const trimmed = rawKey.trim();
-  if (!trimmed || warnedLegacyToolsBySenderKeys.has(trimmed)) {
+  if (!trimmed || legacyKeyDedupe.check(trimmed)) {
     return;
   }
-  warnedLegacyToolsBySenderKeys.add(trimmed);
   process.emitWarning(
     `toolsBySender key "${trimmed}" is deprecated. Use explicit prefixes (channel:, id:, e164:, username:, name:). Legacy unprefixed keys are matched as id only.`,
     {

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -1,9 +1,9 @@
+// Normalizes group-policy config for channel and runtime decisions.
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import type { ChannelId } from "../channels/plugins/channel-id.types.js";
-// Normalizes group-policy config for channel and runtime decisions.
 import { createDedupeCache } from "../infra/dedupe.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { normalizeAccountId } from "../routing/session-key.js";
@@ -73,8 +73,12 @@ type CompiledSenderPolicy = {
   wildcard?: GroupToolPolicyConfig;
 };
 
-// Bounded dedupe cache for legacy toolsBySender deprecation warnings.
-const legacyKeyDedupe = createDedupeCache({ ttlMs: 0, maxSize: 4096 });
+const MAX_WARNED_LEGACY_TOOLS_BY_SENDER_KEYS = 4096;
+// Warning state spans fresh config snapshots; bounding it means evicted legacy keys can re-warn.
+const warnedLegacyToolsBySenderKeys = createDedupeCache({
+  ttlMs: 0,
+  maxSize: MAX_WARNED_LEGACY_TOOLS_BY_SENDER_KEYS,
+});
 const compiledToolsBySenderCache = new WeakMap<
   GroupToolPolicyBySenderConfig,
   CompiledSenderPolicy
@@ -139,7 +143,7 @@ function normalizeLegacySenderKey(value: string): string {
 
 function warnLegacyToolsBySenderKey(rawKey: string) {
   const trimmed = rawKey.trim();
-  if (!trimmed || legacyKeyDedupe.check(trimmed)) {
+  if (!trimmed || warnedLegacyToolsBySenderKeys.check(trimmed)) {
     return;
   }
   process.emitWarning(


### PR DESCRIPTION
## What Problem This Solves

Long-running gateways retained every distinct legacy untyped `toolsBySender` warning key in a module-level `Set`. Fresh config snapshots can compile new policy objects over the lifetime of one process, so the warning-only state could grow without bound.

## Why This Change Was Made

The warning owner now uses the existing `createDedupeCache` helper with no TTL and a named 4,096-entry cap. This preserves process-lifetime suppression for recently used legacy keys, refreshes recency when a fresh config snapshot encounters one again, and evicts only the least-recently-used key when the cap is exceeded.

The maintainer fixup also:

- restores the module header to the file header;
- names and documents the cache's process-snapshot ownership and intentional re-warning trade-off;
- replaces two verbose, weak regressions with one exact fresh-config lifecycle test covering retained and evicted keys.

## User Impact

Below 4,096 distinct legacy keys, warning behavior is unchanged. Above the cap, memory remains bounded and a sufficiently old evicted key can emit its deprecation warning again. Sender matching, policy precedence, config schema, persistence, and plugin APIs are unchanged.

## Evidence

- Exact PR head: `cd68be490429b5b40deadb4b86bc4ff85394d1d9`.
- [GitHub CI run 29071440478](https://github.com/openclaw/openclaw/actions/runs/29071440478): all selected build, type, lint, guard, contract, and Node test jobs passed.
- [Runtime-config job 86293685250](https://github.com/openclaw/openclaw/actions/runs/29071440478/job/86293685250): `src/config/group-policy.test.ts` passed 20/20; the project passed 172 files and 2,207 tests.
- Direct 100,000-key proof through the real shared helper: old `Set` size 100,000; bounded cache size 4,096.
- Fresh Codex autoreview on the final two-file head: no accepted/actionable findings, confidence 0.91.
- `scripts/pr review-validate-artifacts 101696` and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 101696` passed.

AI-assisted: original change built with Codex; maintainer fixup and proof completed with Codex.

