### PR TITLE
refactor: localize file-private exports

### DIFF
--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -211,7 +211,7 @@ function parseProcessList(stdout: string): AcpxProcessInfo[] {
 }
 
 /** List host processes in the compact shape needed by ACPX cleanup. */
-export async function listPlatformProcesses(): Promise<AcpxProcessInfo[]> {
+async function listPlatformProcesses(): Promise<AcpxProcessInfo[]> {
   if (process.platform === "win32") {
     return [];
   }

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -1381,7 +1381,7 @@ export async function closeChromeMcpSession(profileName: string): Promise<boolea
 }
 
 /** Close every cached Chrome MCP session. */
-export async function stopAllChromeMcpSessions(): Promise<void> {
+async function stopAllChromeMcpSessions(): Promise<void> {
   const names = uniqueStrings([...sessions.keys()].map((key) => JSON.parse(key)[0] as string));
   for (const name of names) {
     await closeChromeMcpSession(name).catch(() => {});
@@ -1389,7 +1389,7 @@ export async function stopAllChromeMcpSessions(): Promise<void> {
 }
 
 /** List raw Chrome MCP pages for a profile. */
-export async function listChromeMcpPages(
+async function listChromeMcpPages(
   profileName: string,
   profileOptions?: string | ChromeMcpProfileOptions,
   options: ChromeMcpCallOptions = {},

--- a/extensions/discord/src/monitor/reply-safety.ts
+++ b/extensions/discord/src/monitor/reply-safety.ts
@@ -57,7 +57,7 @@ function stripDiscordInternalChannelLines(text: string): string {
   return kept.join("\n");
 }
 
-export function sanitizeDiscordFrontChannelText(text: string): string {
+function sanitizeDiscordFrontChannelText(text: string): string {
   const withoutToolCallBlocks = stripPlainTextToolCallBlocks(text);
   const withoutAssistantScaffolding = sanitizeAssistantVisibleText(withoutToolCallBlocks);
   const withoutResidualToolCallBlocks = stripPlainTextToolCallBlocks(withoutAssistantScaffolding);

--- a/extensions/discord/src/voice-message.ts
+++ b/extensions/discord/src/voice-message.ts
@@ -86,7 +86,7 @@ export type VoiceMessageMetadata = {
 /**
  * Get audio duration using ffprobe
  */
-export async function getAudioDuration(filePath: string): Promise<number> {
+async function getAudioDuration(filePath: string): Promise<number> {
   try {
     const stdout = await runFfprobe([
       "-v",
@@ -112,7 +112,7 @@ export async function getAudioDuration(filePath: string): Promise<number> {
  * Generate waveform data from audio file using ffmpeg
  * Returns base64 encoded byte array of amplitude samples (0-255)
  */
-export async function generateWaveform(filePath: string): Promise<string> {
+async function generateWaveform(filePath: string): Promise<string> {
   try {
     // Extract raw PCM and sample amplitude values
     return await generateWaveformFromPcm(filePath);

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -658,7 +658,7 @@ function tagPendingCommentaryText(content: TransportContentBlock[]): void {
 const DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com";
 
 /** Resolve the effective Anthropic API base URL from model or environment. */
-export function resolveAnthropicBaseUrl(baseUrl?: string): string {
+function resolveAnthropicBaseUrl(baseUrl?: string): string {
   return baseUrl?.trim() || process.env.ANTHROPIC_BASE_URL?.trim() || DEFAULT_ANTHROPIC_BASE_URL;
 }
 

--- a/src/agents/harness/compaction-recovery.ts
+++ b/src/agents/harness/compaction-recovery.ts
@@ -7,7 +7,7 @@
 import type { EmbeddedAgentCompactResult } from "../embedded-agent-runner/types.js";
 
 /** Returns whether a native harness failure reason indicates a recoverable binding issue. */
-export function isRecoverableNativeHarnessBindingReason(reason: unknown): boolean {
+function isRecoverableNativeHarnessBindingReason(reason: unknown): boolean {
   if (typeof reason !== "string") {
     return false;
   }

--- a/src/agents/sandbox/shared.ts
+++ b/src/agents/sandbox/shared.ts
@@ -26,7 +26,7 @@ export function slugifySessionKey(value: string) {
 }
 
 /** Resolves the per-session sandbox workspace directory under the configured sandbox root. */
-export function resolveSandboxWorkspaceDir(root: string, sessionKey: string) {
+function resolveSandboxWorkspaceDir(root: string, sessionKey: string) {
   const resolvedRoot = resolveUserPath(root);
   const slug = slugifySessionKey(sessionKey);
   return path.join(resolvedRoot, slug);

--- a/src/agents/timeout.ts
+++ b/src/agents/timeout.ts
@@ -9,7 +9,7 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-export const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;
+const DEFAULT_AGENT_TIMEOUT_SECONDS = 48 * 60 * 60;
 export const DEFAULT_AGENT_TIMEOUT_MS = DEFAULT_AGENT_TIMEOUT_SECONDS * 1000;
 
 const normalizeNumber = (value: unknown): number | undefined =>

--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -39,7 +39,7 @@ export function resolveModelFallbackOptions(
 }
 
 /** Resolves whether final-answer tags should be enforced for an embedded follow-up run. */
-export function resolveEnforceFinalTagWithResolver(
+function resolveEnforceFinalTagWithResolver(
   run: FollowupRun["run"],
   provider: string,
   model: string,

--- a/src/auto-reply/reply/agent-runner-usage-line.ts
+++ b/src/auto-reply/reply/agent-runner-usage-line.ts
@@ -15,7 +15,7 @@ import { buildUsageContract } from "../usage-bar/contract.js";
 import { loadUsageBarTemplate } from "../usage-bar/template.js";
 import { renderUsageBar } from "../usage-bar/translator.js";
 
-export const formatResponseUsageLine = (params: {
+const formatResponseUsageLine = (params: {
   usage?: {
     input?: number;
     output?: number;

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -36,9 +36,7 @@ export function formatActiveGoalContext(sessionEntry?: SessionEntry): string | u
   return `${ACTIVE_GOAL_CONTEXT_PREFIX}${boundedObjective}${ACTIVE_GOAL_CONTEXT_SUFFIX}`;
 }
 
-export function formatPendingSkillSuggestionContext(
-  sessionEntry?: SessionEntry,
-): string | undefined {
+function formatPendingSkillSuggestionContext(sessionEntry?: SessionEntry): string | undefined {
   const rawSkillName = normalizeOptionalString(sessionEntry?.pendingSkillSuggestion?.skillName);
   if (!rawSkillName) {
     return undefined;

--- a/src/auto-reply/reply/provider-request-error-classifier.ts
+++ b/src/auto-reply/reply/provider-request-error-classifier.ts
@@ -97,7 +97,7 @@ export function classifyProviderRequestError(
 }
 
 /** Detects provider errors that indicate invalid conversation/tool turn state. */
-export function isProviderConversationStateErrorMessage(message: string): boolean {
+function isProviderConversationStateErrorMessage(message: string): boolean {
   const lower = normalizeLowercaseStringOrEmpty(message);
   return (
     (lower.includes("custom tool call output is missing") && lower.includes("call id")) ||

--- a/src/cli/cron-cli/schedule-options.ts
+++ b/src/cli/cron-cli/schedule-options.ts
@@ -35,7 +35,7 @@ export type CronEditScheduleRequest =
   | { kind: "none" };
 
 /** Resolve explicit `--at`, `--every`, or `--cron` options for cron creation. */
-export function resolveCronCreateSchedule(options: ScheduleOptionInput): CronSchedule {
+function resolveCronCreateSchedule(options: ScheduleOptionInput): CronSchedule {
   const normalized = normalizeScheduleOptions(options);
   if (normalized.onExitCwd && !normalized.onExitCommand) {
     throw new Error("--on-exit-cwd requires --on-exit.");

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -19,7 +19,7 @@ import {
 import { killProcessTree } from "../../process/kill-tree.js";
 import { sleep } from "../../utils.js";
 
-export const DEFAULT_RESTART_HEALTH_TIMEOUT_MS = 60_000;
+const DEFAULT_RESTART_HEALTH_TIMEOUT_MS = 60_000;
 export const DEFAULT_RESTART_HEALTH_DELAY_MS = 500;
 export const DEFAULT_RESTART_HEALTH_ATTEMPTS = Math.ceil(
   DEFAULT_RESTART_HEALTH_TIMEOUT_MS / DEFAULT_RESTART_HEALTH_DELAY_MS,

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -404,7 +404,7 @@ async function guardGatewayRunSelectedConfig(
   }
 }
 
-export async function guardGatewayRunReset(params: GatewayRunGuardParams): Promise<boolean> {
+async function guardGatewayRunReset(params: GatewayRunGuardParams): Promise<boolean> {
   gatewayRunTargetSelectedByConfig = false;
   const envBeforeGuard = { ...process.env };
   try {

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -227,7 +227,7 @@ export async function writeBase64ToFile(
 }
 
 /** Require the node remote IP needed to validate URL-backed camera payloads. */
-export function requireNodeRemoteIp(remoteIp?: string): string {
+function requireNodeRemoteIp(remoteIp?: string): string {
   const normalized = remoteIp?.trim();
   if (!normalized) {
     throw new Error("camera URL payload requires node remoteIp");

--- a/src/cli/respawn-policy.ts
+++ b/src/cli/respawn-policy.ts
@@ -29,7 +29,7 @@ const GATEWAY_RUN_VALUE_FLAGS = [
 
 const INTERACTIVE_TTY_COMMANDS = new Set(["tui", "terminal", "chat"]);
 
-export function isInteractiveTtyCommandArgv(argv: string[]): boolean {
+function isInteractiveTtyCommandArgv(argv: string[]): boolean {
   const invocation = resolveCliArgvInvocation(argv);
   return invocation.primary !== null && INTERACTIVE_TTY_COMMANDS.has(invocation.primary);
 }

--- a/src/commands/doctor-skills.ts
+++ b/src/commands/doctor-skills.ts
@@ -40,7 +40,7 @@ function defaultGhConfigDiscoveryInput(): GhConfigDiscoveryInput {
 }
 
 /** Builds a GitHub CLI config-dir hint for eligible GitHub skill setups. */
-export function describeGhConfigDirHint(skills: SkillStatusEntry[]): string[] {
+function describeGhConfigDirHint(skills: SkillStatusEntry[]): string[] {
   return describeGhConfigDirHintFromDiscovery(skills, defaultGhConfigDiscoveryInput());
 }
 

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -323,7 +323,7 @@ export function buildStatusHealthRows(params: {
 }
 
 /** Formats event-loop latency/utilization health into one table detail string. */
-export function formatEventLoopHealthDetail(eventLoop: EventLoopHealthLike): string {
+function formatEventLoopHealthDetail(eventLoop: EventLoopHealthLike): string {
   const parts = [
     eventLoop.reasons.length > 0 ? `reasons ${eventLoop.reasons.join(",")}` : "healthy",
     `max ${Math.round(eventLoop.delayMaxMs)}ms`,

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -854,7 +854,7 @@ function mergeMissingExplicitValues(
   return { changed, value: changed ? next : currentValue };
 }
 
-export function injectExplicitlySetPaths(params: {
+function injectExplicitlySetPaths(params: {
   valueSource: unknown;
   persistedCandidate: unknown;
   explicitSetPaths?: readonly (readonly string[])[];

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -463,7 +463,7 @@ function resolveCronAwarenessText(params: {
         normalizeOptionalString(params.synthesizedText));
 }
 
-export function formatTargetCronDeliveryAwarenessText(text: string): string {
+function formatTargetCronDeliveryAwarenessText(text: string): string {
   return `A scheduled cron job delivered this message to this channel:\n${text}`;
 }
 
@@ -705,7 +705,7 @@ async function resolveCronDeliveryRouteSessionKey(params: {
 }
 
 /** Resolves the transcript mirror session for direct cron delivery. */
-export async function resolveDirectCronDeliverySessionKey(params: {
+async function resolveDirectCronDeliverySessionKey(params: {
   cfg: OpenClawConfig;
   job: CronJob;
   agentId: string;

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -104,7 +104,7 @@ function resolveIsolatedCronPromptCacheKey(params: {
 }
 
 /** Detects single-line cron prompts that look like shell commands or command invocations. */
-export function isCommandStyleCronMessage(message: string): boolean {
+function isCommandStyleCronMessage(message: string): boolean {
   const trimmed = message.trim();
   if (!trimmed || trimmed.includes("\n")) {
     return false;

--- a/src/cron/run-diagnostics.ts
+++ b/src/cron/run-diagnostics.ts
@@ -276,7 +276,7 @@ export function createCronRunDiagnosticsFromMissingWebSearchProvider(params: {
 }
 
 /** Extracts failed exec details from tool metadata into cron diagnostics. */
-export function createCronRunDiagnosticsFromExecDetails(
+function createCronRunDiagnosticsFromExecDetails(
   details: unknown,
   opts?: {
     nowMs?: () => number;
@@ -318,7 +318,7 @@ export function createCronRunDiagnosticsFromExecDetails(
 }
 
 /** Extracts tool-call failure diagnostics from an agent reply payload. */
-export function createCronRunDiagnosticsFromToolPayload(
+function createCronRunDiagnosticsFromToolPayload(
   payload: unknown,
   opts?: { nowMs?: () => number; finalStatus?: "ok" | "error" | "skipped" },
 ): CronRunDiagnostics | undefined {

--- a/src/daemon/restart-logs.ts
+++ b/src/daemon/restart-logs.ts
@@ -35,7 +35,7 @@ export function resolveGatewayLogPaths(env: GatewayServiceEnv): GatewayLogPaths 
   };
 }
 
-export function resolveMacLaunchAgentLogPaths(env: GatewayServiceEnv): GatewayLogPaths {
+function resolveMacLaunchAgentLogPaths(env: GatewayServiceEnv): GatewayLogPaths {
   const home = resolveHomeDir(env).replaceAll("\\", "/");
   const logDir = path.posix.join(home, "Library", "Logs", "openclaw");
   const prefix = resolveMacLaunchAgentLogPrefix(env);

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -32,8 +32,8 @@ export type GatewayServiceRuntime = {
   systemd?: GatewayServiceSystemdRuntime;
 };
 
-export const SYSTEMD_TASKS_CURRENT_WARNING_THRESHOLD = 200;
-export const SYSTEMD_MEMORY_CURRENT_WARNING_BYTES = 2 * 1024 * 1024 * 1024;
+const SYSTEMD_TASKS_CURRENT_WARNING_THRESHOLD = 200;
+const SYSTEMD_MEMORY_CURRENT_WARNING_BYTES = 2 * 1024 * 1024 * 1024;
 
 // EX_CONFIG (78) from sysexits.h. The generated systemd unit pins
 // RestartPreventExitStatus=78 (see systemd-unit.ts) so the gateway's
@@ -43,7 +43,7 @@ export const SYSTEMD_MEMORY_CURRENT_WARNING_BYTES = 2 * 1024 * 1024 * 1024;
 // is stale from earlier crashes and must not drive start-limit detection.
 const SYSTEMD_NO_RESTART_EXIT_STATUS = 78;
 
-export function isRiskySystemdKillMode(value: string | undefined): boolean {
+function isRiskySystemdKillMode(value: string | undefined): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(value);
   return normalized === "process" || normalized === "none";
 }

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -173,7 +173,7 @@ const CONTROL_UI_ROOT_PUBLIC_ASSETS = new Set([
 ]);
 
 /** Rewrites root-absolute Control UI public asset hrefs for configured base paths. */
-export function rewriteControlUiIndexHtmlPublicAssetHrefs(html: string, basePath: string): string {
+function rewriteControlUiIndexHtmlPublicAssetHrefs(html: string, basePath: string): string {
   const normalized = normalizeControlUiBasePath(basePath);
   if (!normalized) {
     return html;

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -60,7 +60,7 @@ export type GatewayProbeResult = {
   configSnapshot: unknown;
 };
 
-export const MIN_PROBE_TIMEOUT_MS = 250;
+const MIN_PROBE_TIMEOUT_MS = 250;
 export const MAX_TIMER_DELAY_MS = MAX_SAFE_TIMEOUT_DELAY_MS;
 const PAIRING_REQUIRED_PATTERN = /\bpairing required\b/i;
 const OPERATOR_READ_SCOPE = "operator.read";
@@ -193,14 +193,14 @@ function resolveProbeAuthSummary(params: {
   };
 }
 
-export function isPairingPendingProbeFailure(params: {
+function isPairingPendingProbeFailure(params: {
   error?: string | null;
   close?: GatewayProbeClose | null;
 }): boolean {
   return PAIRING_REQUIRED_PATTERN.test(params.close?.reason ?? params.error ?? "");
 }
 
-export function resolveGatewayProbeCapability(params: {
+function resolveGatewayProbeCapability(params: {
   auth?: Pick<GatewayProbeAuthSummary, "scopes"> | null;
   authMetadataPresent?: boolean;
   error?: string | null;

--- a/src/infra/heartbeat-cooldown.ts
+++ b/src/infra/heartbeat-cooldown.ts
@@ -23,7 +23,7 @@ export const DEFAULT_MIN_WAKE_SPACING_MS = 30_000;
 // flood window, the dispatcher logs a warning and forces the wake to defer to
 // the next scheduled tick. Tuned so a normal heartbeat that legitimately uses
 // `manual` retry doesn't trip it but a feedback loop does.
-export const DEFAULT_FLOOD_WINDOW_MS = 60_000;
+const DEFAULT_FLOOD_WINDOW_MS = 60_000;
 export const DEFAULT_FLOOD_THRESHOLD = 5;
 
 export type DeferDecision =

--- a/src/infra/npm-install-env.ts
+++ b/src/infra/npm-install-env.ts
@@ -325,12 +325,12 @@ export function createNpmProjectInstallEnv(
 }
 
 /** Returns true when caller env already pins npm's lifecycle script shell. */
-export function hasNpmScriptShellSetting(env: NodeJS.ProcessEnv): boolean {
+function hasNpmScriptShellSetting(env: NodeJS.ProcessEnv): boolean {
   return NPM_CONFIG_SCRIPT_SHELL_KEYS.some((key) => Boolean(env[key]?.trim()));
 }
 
 /** Resolves an absolute POSIX shell for npm lifecycle scripts when one is available. */
-export function resolvePosixNpmScriptShell(env: NodeJS.ProcessEnv): string | null {
+function resolvePosixNpmScriptShell(env: NodeJS.ProcessEnv): string | null {
   if (process.platform === "win32") {
     return null;
   }

--- a/src/infra/windows-encoding.ts
+++ b/src/infra/windows-encoding.ts
@@ -66,7 +66,7 @@ export function resolveWindowsConsoleEncoding(): string | null {
 }
 
 /** Resolves and caches the Windows system encoding used by legacy text files. */
-export function resolveWindowsSystemEncoding(): string | null {
+function resolveWindowsSystemEncoding(): string | null {
   if (process.platform !== "win32") {
     return null;
   }

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -19,8 +19,8 @@ import {
 import { redactSensitiveText } from "./redact.js";
 
 export const DIAGNOSTIC_STABILITY_BUNDLE_VERSION = 1;
-export const DEFAULT_DIAGNOSTIC_STABILITY_BUNDLE_LIMIT = MAX_DIAGNOSTIC_STABILITY_LIMIT;
-export const DEFAULT_DIAGNOSTIC_STABILITY_BUNDLE_RETENTION = 20;
+const DEFAULT_DIAGNOSTIC_STABILITY_BUNDLE_LIMIT = MAX_DIAGNOSTIC_STABILITY_LIMIT;
+const DEFAULT_DIAGNOSTIC_STABILITY_BUNDLE_RETENTION = 20;
 export const MAX_DIAGNOSTIC_STABILITY_BUNDLE_BYTES = 5 * 1024 * 1024;
 
 const SAFE_REASON_CODE = /^[A-Za-z0-9_.:-]{1,120}$/u;
@@ -1215,7 +1215,7 @@ function isMemoryPressureReason(reason: string): reason is DiagnosticMemoryPress
   return reason === "rss_threshold" || reason === "heap_threshold" || reason === "rss_growth";
 }
 
-export function listDiagnosticStabilityBundleFilesSync(
+function listDiagnosticStabilityBundleFilesSync(
   options: DiagnosticStabilityBundleLocationOptions = {},
 ): DiagnosticStabilityBundleFile[] {
   const dir = resolveDiagnosticStabilityBundleDir(options);

--- a/src/media-understanding/resolve.ts
+++ b/src/media-understanding/resolve.ts
@@ -23,7 +23,7 @@ import { normalizeMediaUnderstandingChatType, resolveMediaUnderstandingScope } f
 import type { MediaUnderstandingCapability } from "./types.js";
 
 /** Default per-provider media-understanding runtime timeout in milliseconds. */
-export const DEFAULT_MEDIA_RUNTIME_TIMEOUT_MS = 30_000;
+const DEFAULT_MEDIA_RUNTIME_TIMEOUT_MS = 30_000;
 const MIN_MEDIA_TIMEOUT_MS = 1000;
 
 /** Converts configured timeout seconds into a timer-safe millisecond deadline. */

--- a/src/provider-runtime/operation-retry.ts
+++ b/src/provider-runtime/operation-retry.ts
@@ -46,7 +46,7 @@ export function resolveTransientProviderRetryOptions(
   return options;
 }
 
-export function defaultTransientProviderRetryForStage(
+function defaultTransientProviderRetryForStage(
   stage: ProviderOperationRetryStage,
 ): TransientProviderRetryConfig | undefined {
   return stage === "create" ? undefined : true;
@@ -143,7 +143,7 @@ function hasTimeoutSignal(error: unknown, message: string): boolean {
   );
 }
 
-export function isTransientProviderOperationError(error: unknown, message: string): boolean {
+function isTransientProviderOperationError(error: unknown, message: string): boolean {
   const status = readErrorStatus(error);
   if (status !== undefined) {
     return status === 500 || status === 502 || status === 503 || status === 504;

--- a/src/shared/json-schema-defaults.ts
+++ b/src/shared/json-schema-defaults.ts
@@ -120,7 +120,7 @@ function compilesUnicodePattern(pattern: string): boolean {
 }
 
 /** Repair JSON Schema regex patterns that fail TypeBox's unicode RegExp compile. */
-export function repairJsonSchemaPatternForUnicodeRegExp(pattern: string): string {
+function repairJsonSchemaPatternForUnicodeRegExp(pattern: string): string {
   if (compilesUnicodePattern(pattern)) {
     return pattern;
   }

--- a/src/tui/theme/theme.ts
+++ b/src/tui/theme/theme.ts
@@ -78,7 +78,7 @@ function isLightBackground(): boolean {
 /** Whether the terminal has a light background. Exported for testing only. */
 export const lightMode = isLightBackground();
 
-export const darkPalette = {
+const darkPalette = {
   text: "#E8E3D5",
   dim: "#7B7F87",
   accent: "#F6C453",

--- a/src/tui/tui-waiting.ts
+++ b/src/tui/tui-waiting.ts
@@ -26,7 +26,7 @@ export function pickWaitingPhrase(tick: number, phrases = defaultWaitingPhrases)
 }
 
 /** Applies a moving highlight window to status text. */
-export function shimmerText(theme: MinimalTheme, text: string, tick: number) {
+function shimmerText(theme: MinimalTheme, text: string, tick: number) {
   const width = 6;
   const hi = (ch: string) => theme.bold(theme.accentSoft(ch));
 

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -309,7 +309,7 @@ function requestSessionPatch(
   });
 }
 
-export function requestSessionDelete(
+function requestSessionDelete(
   client: SessionRequestClient,
   key: string,
   options: SessionDeleteOptions = {},

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -1744,7 +1744,7 @@ export type ChatRunControlsProps = {
   showSecondary?: boolean;
 };
 
-export function renderChatPrimaryActions(props: ChatRunControlsProps) {
+function renderChatPrimaryActions(props: ChatRunControlsProps) {
   const hasComposedContent = Boolean(props.draft.trim() || props.hasAttachments);
   const storeDraftAndSend = () => {
     if (props.draft.trim()) {


### PR DESCRIPTION
## What Problem This Solves

The dead-export inventory still contained file-private helpers and constants across core, the Control UI, and bundled plugins. Keeping them exported expands module API surfaces without any cross-file consumer.

## Why This Change Was Made

Localize 50 values that are referenced only inside their defining module. This removes stale named exports while preserving the existing implementation and call paths.

## User Impact

No user-visible behavior change. Internal module boundaries are narrower and the unused-export report drops by 13 modules.

## Evidence

- `OPENCLAW_TESTBOX=1` Testbox `tbx_01kwyb4t91ykkycx7kbw0s23pn` (`silver-shrimp`)
- `pnpm check:changed`: passed on the final rebased 38-file patch in 10m38s
- targeted tests: 1,051 passed across 15 Vitest shards
- deadcode report: 3,611 -> 3,598 modules with unused exports
- autoreview: clean at 0.86, 0.88, and 0.88 confidence
- codebase-memory graph: 281,042 nodes / 1,136,583 edges
