### PR TITLE
fix(context-engine): bound deferred turn maintenance with the compaction safety timeout

### DIFF
--- a/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
+++ b/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
@@ -1,9 +1,14 @@
 // Covers safety timeouts around embedded-agent compaction calls.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { CompactResult, ContextEngine } from "../context-engine/types.js";
+import type {
+  CompactResult,
+  ContextEngine,
+  ContextEngineMaintenanceResult,
+} from "../context-engine/types.js";
 import {
   compactContextEngineWithSafetyTimeout,
   compactWithSafetyTimeout,
+  maintainContextEngineWithSafetyTimeout,
   resolveCompactionTimeoutMs,
 } from "./embedded-agent-runner/compaction-safety-timeout.js";
 
@@ -303,6 +308,91 @@ describe("compactContextEngineWithSafetyTimeout", () => {
     });
 
     await expect(compactContextEngineWithSafetyTimeout({ compact }, baseParams, 30)).rejects.toBe(
+      error,
+    );
+  });
+});
+
+describe("maintainContextEngineWithSafetyTimeout", () => {
+  type MaintainFn = NonNullable<ContextEngine["maintain"]>;
+  const baseParams: Parameters<MaintainFn>[0] = {
+    sessionId: "session-1",
+    sessionFile: "/tmp/session-1.jsonl",
+  };
+  const settledResult: ContextEngineMaintenanceResult = {
+    changed: false,
+    bytesFreed: 0,
+    rewrittenEntries: 0,
+  };
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("bounds a hung plugin maintain() and rejects with a timeout error", async () => {
+    vi.useFakeTimers();
+    const maintain = vi.fn<MaintainFn>(() => new Promise<ContextEngineMaintenanceResult>(() => {}));
+
+    const pending = maintainContextEngineWithSafetyTimeout({ maintain }, baseParams, 30);
+    const assertion = expect(pending).rejects.toThrow("Maintenance timed out");
+
+    await vi.advanceTimersByTimeAsync(30);
+    await assertion;
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("returns the plugin maintain() result when it settles in time", async () => {
+    const maintain = vi.fn<MaintainFn>(async () => settledResult);
+
+    await expect(
+      maintainContextEngineWithSafetyTimeout({ maintain }, baseParams, 30),
+    ).resolves.toBe(settledResult);
+  });
+
+  it("rejects promptly when the caller abort signal (e.g. shutdown) fires before the timeout", async () => {
+    // The wait is bounded by a caller abort (gateway shutdown) as well as the
+    // timeout, so the worker unblocks immediately instead of waiting the full
+    // budget. The signal is intentionally not forwarded into maintain()'s params.
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const reason = new Error("shutdown");
+    const maintain = vi.fn<MaintainFn>(
+      (params) => new Promise<ContextEngineMaintenanceResult>(() => void params),
+    );
+
+    const onCancel = vi.fn();
+    const pending = maintainContextEngineWithSafetyTimeout(
+      { maintain },
+      baseParams,
+      EMBEDDED_COMPACTION_TIMEOUT_MS,
+      { abortSignal: controller.signal, onCancel },
+    );
+    const assertion = expect(pending).rejects.toBe(reason);
+
+    expect(maintain).toHaveBeenCalledTimes(1);
+    // maintain() receives only its declared params, never an injected abortSignal.
+    expect(maintain.mock.calls[0]?.[0]).not.toHaveProperty("abortSignal");
+
+    controller.abort(reason);
+    await assertion;
+    // onCancel fires on release so the host can close the rewrite gate.
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("preserves a thrown plugin maintain() error", async () => {
+    const error = new Error("engine maintenance failed");
+    const maintain = vi.fn<MaintainFn>(async () => {
+      throw error;
+    });
+
+    await expect(maintainContextEngineWithSafetyTimeout({ maintain }, baseParams, 30)).rejects.toBe(
       error,
     );
   });

--- a/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
+++ b/src/agents/embedded-agent-runner.compaction-safety-timeout.test.ts
@@ -362,9 +362,7 @@ describe("maintainContextEngineWithSafetyTimeout", () => {
     vi.useFakeTimers();
     const controller = new AbortController();
     const reason = new Error("shutdown");
-    const maintain = vi.fn<MaintainFn>(
-      (params) => new Promise<ContextEngineMaintenanceResult>(() => void params),
-    );
+    const maintain = vi.fn<MaintainFn>(() => new Promise<ContextEngineMaintenanceResult>(() => {}));
 
     const onCancel = vi.fn();
     const pending = maintainContextEngineWithSafetyTimeout(

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -728,6 +728,22 @@ export async function loadCompactHooksHarness(): Promise<{
             abortSignal ? { abortSignal } : undefined,
           ),
       ),
+      // Mirror the real wrapper: bound the engine's maintain() with the (mocked)
+      // safety timeout. The signal is only the outer wait abort, never threaded
+      // into maintain()'s params.
+      maintainContextEngineWithSafetyTimeout: vi.fn(
+        (
+          contextEngine: { maintain: (params: Record<string, unknown>) => Promise<unknown> },
+          params: Record<string, unknown>,
+          timeoutMs?: number,
+          opts?: { abortSignal?: AbortSignal; onCancel?: () => void },
+        ) =>
+          compactWithSafetyTimeoutMock(() => contextEngine.maintain(params), timeoutMs, {
+            label: "Maintenance",
+            ...(opts?.abortSignal ? { abortSignal: opts.abortSignal } : {}),
+            ...(opts?.onCancel ? { onCancel: opts.onCancel } : {}),
+          }),
+      ),
     };
   });
 

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -176,7 +176,7 @@ export const maybeCompactAgentHarnessSessionMock: Mock<
 async function runCompactWithSafetyTimeoutMock(
   compact: () => Promise<unknown>,
   _timeoutMs?: number,
-  opts?: { abortSignal?: AbortSignal; onCancel?: () => void },
+  opts?: { abortSignal?: AbortSignal; onCancel?: () => void; label?: string },
 ): Promise<unknown> {
   const abortSignal = opts?.abortSignal;
   if (!abortSignal) {

--- a/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
+++ b/src/agents/embedded-agent-runner/compaction-safety-timeout.ts
@@ -3,7 +3,11 @@
  */
 import { finiteSecondsToTimerSafeMilliseconds } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { CompactResult, ContextEngine } from "../../context-engine/types.js";
+import type {
+  CompactResult,
+  ContextEngine,
+  ContextEngineMaintenanceResult,
+} from "../../context-engine/types.js";
 import { createAbortError, mergeAbortSignals } from "../../infra/abort-signal.js";
 import { withTimeout } from "../../node-host/with-timeout.js";
 
@@ -31,6 +35,8 @@ export async function compactWithSafetyTimeout<T>(
   opts?: {
     abortSignal?: AbortSignal;
     onCancel?: () => void;
+    /** Timeout-error label; the reject message is `${label} timed out`. */
+    label?: string;
   },
 ): Promise<T> {
   let canceled = false;
@@ -93,7 +99,7 @@ export async function compactWithSafetyTimeout<T>(
       }
     },
     timeoutMs,
-    "Compaction",
+    opts?.label ?? "Compaction",
   );
 }
 
@@ -134,4 +140,38 @@ export function compactContextEngineWithSafetyTimeout(
     timeoutMs,
     abortSignal ? { abortSignal } : undefined,
   );
+}
+
+/** Parameters for a single {@link ContextEngine.maintain} invocation. */
+type ContextEngineMaintainParams = Parameters<NonNullable<ContextEngine["maintain"]>>[0];
+
+/**
+ * Invoke a plugin-owned {@link ContextEngine.maintain} bounded by the same
+ * finite safety timeout that protects {@link ContextEngine.compact}.
+ *
+ * Deferred turn maintenance previously awaited `maintain()` with no timeout.
+ * Because `ContextEngine` is a public plugin SDK seam (`registerContextEngine`)
+ * and this call gates the session's next turn via
+ * `waitForDeferredTurnMaintenanceForSession`, a slow or hung plugin `maintain()`
+ * would freeze that session's future turns indefinitely. This wrapper bounds the
+ * call by `timeoutMs`; on timeout it rejects with a "Maintenance timed out" error
+ * so the caller's existing failure handling runs instead of hanging, and a
+ * caller `abortSignal` (e.g. gateway shutdown) rejects the wait promptly. Unlike
+ * `compact()`, the signal is not threaded into `maintain()`'s params: `maintain`
+ * has no `abortSignal` contract, and adding a host field would risk strict
+ * engines that reject unknown params. Bounding the wait is enough to release the
+ * session; a cooperating engine's in-flight work simply completes in the
+ * background.
+ */
+export function maintainContextEngineWithSafetyTimeout(
+  contextEngine: Pick<Required<ContextEngine>, "maintain">,
+  params: ContextEngineMaintainParams,
+  timeoutMs: number = EMBEDDED_COMPACTION_TIMEOUT_MS,
+  opts?: { abortSignal?: AbortSignal; onCancel?: () => void },
+): Promise<ContextEngineMaintenanceResult> {
+  return compactWithSafetyTimeout(() => contextEngine.maintain(params), timeoutMs, {
+    label: "Maintenance",
+    ...(opts?.abortSignal ? { abortSignal: opts.abortSignal } : {}),
+    ...(opts?.onCancel ? { onCancel: opts.onCancel } : {}),
+  });
 }

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -172,6 +172,33 @@ describe("buildContextEngineMaintenanceRuntimeContext", () => {
     });
   });
 
+  it("refuses transcript rewrites once the release signal has aborted", async () => {
+    // A maintenance run abandoned by the safety timeout must not rewrite the
+    // transcript afterward, or a stale rewrite could race the next turn.
+    const controller = new AbortController();
+    controller.abort();
+    const runtimeContext = buildContextEngineMaintenanceRuntimeContext({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sessionFile: "/tmp/session.jsonl",
+      rewriteReleaseSignal: controller.signal,
+    });
+
+    const result = await runtimeContext.rewriteTranscriptEntries?.({
+      replacements: [
+        { entryId: "entry-1", message: { role: "user", content: "hi", timestamp: 1 } },
+      ],
+    });
+
+    expect(result).toEqual({
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+      reason: "maintenance-released",
+    });
+    expect(rewriteTranscriptEntriesInRuntimeTranscriptMock).not.toHaveBeenCalled();
+  });
+
   it("reuses the active session manager when one is provided", async () => {
     const sessionManager = { appendMessage: vi.fn() } as unknown as Parameters<
       typeof buildContextEngineMaintenanceRuntimeContext
@@ -482,6 +509,7 @@ describe("runContextEngineMaintenance", () => {
         ],
       },
       config: { session: { writeLock: { acquireTimeoutMs: 75_000 } } },
+      abortSignal: expect.any(AbortSignal),
     });
   });
 
@@ -639,6 +667,7 @@ describe("runContextEngineMaintenance", () => {
               ],
             },
             config: { session: { writeLock: { acquireTimeoutMs: 91_000 } } },
+            abortSignal: expect.any(AbortSignal),
           }),
         );
 
@@ -1609,6 +1638,68 @@ describe("runContextEngineMaintenance", () => {
             "Background task failed: Context engine turn maintenance",
           ),
         );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  it("bounds a hung plugin maintain() so it fails and unblocks the next turn", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-", async () => {
+      vi.useFakeTimers();
+      try {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
+        resetSystemEventsForTest();
+
+        const sessionKey = "agent:main:session-hang";
+        // A plugin maintain() that never settles on its own; only the host
+        // safety timeout can end it.
+        const maintain = vi.fn(
+          async () =>
+            await new Promise<{
+              changed: boolean;
+              bytesFreed: number;
+              rewrittenEntries: number;
+            }>(() => {}),
+        );
+        const backgroundEngine = {
+          info: {
+            id: "test",
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+        } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+
+        await runContextEngineMaintenance({
+          contextEngine: backgroundEngine,
+          sessionId: "session-hang",
+          sessionKey,
+          sessionFile: "/tmp/session-hang.jsonl",
+          reason: "turn",
+        });
+        await waitForAssertion(() => expect(maintain).toHaveBeenCalledTimes(1));
+
+        // Without the safety timeout the worker (and any awaiter of the
+        // deferred run) would hang here forever. Advancing past the budget (the
+        // default EMBEDDED_COMPACTION_TIMEOUT_MS) must surface a failure and let
+        // the wait resolve.
+        await vi.advanceTimersByTimeAsync(180_000);
+        await waitForAssertion(() =>
+          expectSystemEventContaining(
+            sessionKey,
+            "Background task failed: Context engine turn maintenance",
+          ),
+        );
+        await expect(waitForDeferredTurnMaintenanceForSession(sessionKey)).resolves.toBeUndefined();
       } finally {
         vi.useRealTimers();
       }

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -31,6 +31,10 @@ import {
   updateTaskNotifyPolicyForOwner,
 } from "../../tasks/task-owner-access.js";
 import { findActiveSessionTask } from "../session-async-task-status.js";
+import {
+  maintainContextEngineWithSafetyTimeout,
+  resolveCompactionTimeoutMs,
+} from "./compaction-safety-timeout.js";
 import { resolveContextEngineCapabilities } from "./context-engine-capabilities.js";
 import { log } from "./logger.js";
 import {
@@ -314,6 +318,13 @@ export function buildContextEngineMaintenanceRuntimeContext(params: {
   config?: OpenClawConfig;
   purpose?: string;
   contextEnginePluginId?: string;
+  /**
+   * Aborts once the host has stopped waiting for this maintenance run (safety
+   * timeout or shutdown). A slow/non-cooperating engine that keeps running past
+   * that point must not rewrite the transcript, or a stale rewrite could land
+   * under the next same-session turn that the released wait already let start.
+   */
+  rewriteReleaseSignal?: AbortSignal;
 }): ContextEngineRuntimeContext {
   return {
     ...params.runtimeContext,
@@ -327,6 +338,16 @@ export function buildContextEngineMaintenanceRuntimeContext(params: {
     }),
     ...(params.allowDeferredCompactionExecution ? { allowDeferredCompactionExecution: true } : {}),
     rewriteTranscriptEntries: async (request) => {
+      if (params.rewriteReleaseSignal?.aborted) {
+        // Maintenance was already abandoned (timeout/shutdown); refuse the late
+        // rewrite so it cannot race the next turn's transcript.
+        return {
+          changed: false,
+          bytesFreed: 0,
+          rewrittenEntries: 0,
+          reason: "maintenance-released",
+        };
+      }
       if (params.sessionManager) {
         const sessionManager = params.sessionManager;
         const rewriteSessionManagerEntries = () =>
@@ -348,6 +369,7 @@ export function buildContextEngineMaintenanceRuntimeContext(params: {
           },
           request,
           config: params.config,
+          ...(params.rewriteReleaseSignal ? { abortSignal: params.rewriteReleaseSignal } : {}),
         });
       return await rewriteRuntimeTranscriptEntries();
     },
@@ -367,30 +389,48 @@ async function executeContextEngineMaintenance(params: {
   agentId?: string;
   executionMode: "foreground" | "background";
   config?: OpenClawConfig;
+  abortSignal?: AbortSignal;
 }): Promise<ContextEngineMaintenanceResult | undefined> {
-  if (typeof params.contextEngine.maintain !== "function") {
+  const engine = params.contextEngine;
+  if (typeof engine.maintain !== "function") {
     return undefined;
   }
-  const result = await params.contextEngine.maintain({
-    sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
-    sessionFile: params.sessionFile,
-    runtimeSettings: params.runtimeSettings,
-    runtimeContext: buildContextEngineMaintenanceRuntimeContext({
+  // Aborts the moment the host stops waiting for maintenance (safety timeout or
+  // shutdown, via the wrapper's onCancel) so an abandoned engine cannot rewrite
+  // the transcript after the released wait let the next same-session turn start.
+  // On normal completion it stays unaborted; the engine is done and nothing more
+  // calls the rewrite helper.
+  const releaseController = new AbortController();
+  // Bound the plugin-owned maintain() with the same finite safety timeout that
+  // protects compact(): ContextEngine is a public SDK seam and this call gates
+  // the session's next turn, so a hung engine must surface a timeout (handled by
+  // callers) instead of freezing the session indefinitely.
+  const result = await maintainContextEngineWithSafetyTimeout(
+    { maintain: engine.maintain.bind(engine) },
+    {
       sessionId: params.sessionId,
       sessionKey: params.sessionKey,
       sessionFile: params.sessionFile,
-      sessionManager: params.executionMode === "background" ? undefined : params.sessionManager,
-      withSessionManagerRewriteLock:
-        params.executionMode === "background" ? undefined : params.withSessionManagerRewriteLock,
-      runtimeContext: params.runtimeContext,
-      agentId: params.agentId,
-      allowDeferredCompactionExecution: params.executionMode === "background",
-      config: params.config,
-      purpose: `context-engine.${params.reason}.maintenance`,
-      contextEnginePluginId: resolveContextEngineOwnerPluginId(params.contextEngine),
-    }),
-  });
+      runtimeSettings: params.runtimeSettings,
+      runtimeContext: buildContextEngineMaintenanceRuntimeContext({
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+        sessionManager: params.executionMode === "background" ? undefined : params.sessionManager,
+        withSessionManagerRewriteLock:
+          params.executionMode === "background" ? undefined : params.withSessionManagerRewriteLock,
+        runtimeContext: params.runtimeContext,
+        agentId: params.agentId,
+        allowDeferredCompactionExecution: params.executionMode === "background",
+        config: params.config,
+        purpose: `context-engine.${params.reason}.maintenance`,
+        contextEnginePluginId: resolveContextEngineOwnerPluginId(engine),
+        rewriteReleaseSignal: releaseController.signal,
+      }),
+    },
+    resolveCompactionTimeoutMs(params.config),
+    { abortSignal: params.abortSignal, onCancel: () => releaseController.abort() },
+  );
   if (result.changed) {
     log.info(
       `[context-engine] maintenance(${params.reason}) changed transcript ` +
@@ -468,6 +508,7 @@ async function runDeferredTurnMaintenanceWorker(params: {
       agentId: params.agentId,
       config: params.config,
       executionMode: "background",
+      abortSignal: shutdownAbort.abortSignal,
     });
     if (longRunningTimer) {
       clearTimeout(longRunningTimer);

--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -415,4 +415,73 @@ describe("rewriteTranscriptEntriesInRuntimeTranscript", () => {
       cleanup();
     }
   });
+
+  it("abandons the rewrite before persisting when the release signal is aborted", async () => {
+    // A deferred maintenance rewrite that was already waiting on the write lock
+    // when the safety timeout fired must not commit its mutation afterward.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-rewrite-runtime-"));
+    const storePath = path.join(dir, "sessions.json");
+    const sessionManager = SessionManager.create(dir, dir);
+    const entryIds = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "run tool", timestamp: 1 }),
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: createTextContent("before rewrite"),
+        isError: false,
+        timestamp: 2,
+      }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("summarized"),
+        timestamp: 3,
+      }),
+    ]);
+    const sessionFile = requireString(sessionManager.getSessionFile(), "persisted session file");
+    const sessionId = path.basename(sessionFile, ".jsonl");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({ "agent:main:test": { sessionFile, sessionId, updatedAt: 10 } }),
+      "utf8",
+    );
+    const toolResultEntryId = entryIds[1];
+    const listener = vi.fn();
+    const cleanup = onSessionTranscriptUpdate(listener);
+    const controller = new AbortController();
+    controller.abort();
+
+    try {
+      const result = await rewriteTranscriptEntriesInRuntimeTranscript({
+        scope: { agentId: "main", sessionId, sessionKey: "agent:main:test", storePath },
+        request: {
+          replacements: [
+            {
+              entryId: toolResultEntryId,
+              message: createToolResultReplacement("exec", "[runtime rewrite]", 2),
+            },
+          ],
+        },
+        abortSignal: controller.signal,
+      });
+
+      expect(result).toEqual({
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+        reason: "maintenance-released",
+      });
+      // The lock is acquired and released, but nothing is persisted or emitted.
+      expect(acquireSessionWriteLockMock).toHaveBeenCalled();
+      expect(acquireSessionWriteLockReleaseMock).toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+      const session = SessionManager.open(sessionFile);
+      const branchMessages = getBranchMessages(session);
+      expect((branchMessages[1] as Extract<AgentMessage, { role: "toolResult" }>).content).toEqual([
+        { type: "text", text: "before rewrite" },
+      ]);
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/src/agents/embedded-agent-runner/transcript-rewrite.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.ts
@@ -437,6 +437,13 @@ export async function rewriteTranscriptEntriesInRuntimeTranscript(params: {
   scope: RuntimeTranscriptScope;
   request: TranscriptRewriteRequest;
   config?: SessionWriteLockAcquireTimeoutConfig;
+  /**
+   * Abandons the rewrite before it persists when aborted. Deferred maintenance
+   * passes its release signal so a rewrite that was already waiting on the write
+   * lock when the maintenance safety timeout fired cannot commit a stale mutation
+   * after the released wait let the next same-session turn start.
+   */
+  abortSignal?: AbortSignal;
 }): Promise<TranscriptRewriteResult> {
   let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
   try {
@@ -446,6 +453,11 @@ export async function rewriteTranscriptEntriesInRuntimeTranscript(params: {
       ...resolveSessionWriteLockOptions(params.config),
     });
     const state = await readTranscriptFileState(target.sessionFile);
+    if (params.abortSignal?.aborted) {
+      // Released (timeout/shutdown) while waiting on the lock — abandon before
+      // persisting so a stale rewrite cannot land after the next turn started.
+      return { changed: false, bytesFreed: 0, rewrittenEntries: 0, reason: "maintenance-released" };
+    }
     const result = rewriteTranscriptEntriesInState({
       state,
       replacements: params.request.replacements,


### PR DESCRIPTION
## What Problem This Solves

Deferred context-engine turn maintenance awaited the plugin-owned
`ContextEngine.maintain()` with no timeout. The deferred run is exposed through
`waitForDeferredTurnMaintenanceForSession()`, which the embedded agent run path
awaits before the session's next turn can start. Because `ContextEngine` is a
public plugin SDK seam (`registerContextEngine`), a third-party engine whose
`maintain()` hangs — e.g. waiting on a stuck model summarization call or a
wedged subprocess — would block that session's future turns indefinitely, with
no error and no recovery short of a gateway restart. The session simply goes
silent after a turn.

`ContextEngine.compact()` is already bounded by a finite host safety timeout
(`compaction-safety-timeout.ts`); `maintain()` was the untreated sibling on the
same seam.

## Why This Change Was Made

This mirrors the existing compaction protection rather than inventing new
policy. `maintain()` now runs through `maintainContextEngineWithSafetyTimeout`,
which reuses the same generic wrapper and the same host-resolved budget
(`resolveCompactionTimeoutMs` / `EMBEDDED_COMPACTION_TIMEOUT_MS`). On timeout the
call rejects, and the deferred worker's existing `try/catch` records the task as
failed and returns — releasing the lane so the next turn proceeds. A caller abort
signal (gateway shutdown) rejects the wait promptly and routes through the
existing cancel branch. It is a bounded, logged failure, not a silent drop.

Unlike `compact()`, the abort signal is not threaded into `maintain()`'s params:
`maintain` has no `abortSignal` contract, and injecting a host field would risk
strict context-engine plugins that reject unknown params (the registry's
strict-param retry only strips the known legacy fields). Bounding the wait is
sufficient to release the session; a cooperating engine's in-flight work simply
finishes in the background. No SDK type change.

Because a released engine can still run in the background, a release signal also
guards the maintenance transcript-rewrite path: `rewriteTranscriptEntries()`
no-ops if it is called after release, and — for a rewrite that was already
waiting on the session write lock when the timeout fired — the runtime rewrite
re-checks the signal after acquiring the lock and before persisting, so an
abandoned maintenance run cannot commit a stale transcript mutation under the
next same-session turn.

## User Impact

A hung or slow plugin context engine can no longer permanently freeze a
session's future turns. The stuck maintenance surfaces as a failed background
task after the safety budget, and the session keeps responding.

## Evidence

- New unit tests (fake timers) for `maintainContextEngineWithSafetyTimeout`: a
  hung `maintain()` rejects with "Maintenance timed out", results pass through
  when settled in time, a caller abort (shutdown) rejects the wait promptly
  without injecting an `abortSignal` into `maintain()`'s params, and thrown
  engine errors are preserved.
- New integration test in `context-engine-maintenance.test.ts`: a plugin
  `maintain()` that never settles is bounded — after the budget the deferred
  task surfaces "Background task failed" and
  `waitForDeferredTurnMaintenanceForSession` resolves (the session unblocks). A
  companion test asserts the release-gated rewrite guard turns a late
  `rewriteTranscriptEntries()` into a no-op.
- New test in `transcript-rewrite.test.ts`: an in-flight runtime rewrite whose
  release signal is aborted acquires and releases the write lock but persists
  nothing and leaves the transcript unchanged.
- Local: the three changed test files pass via `node scripts/run-vitest.mjs`
  (56 tests). Changed-lane lint/typecheck/test gates run in CI.
