### PR TITLE
fix: lower successful agent stop completion logs

### DIFF
--- a/src/agents/agent-command.ingress-diagnostics.test.ts
+++ b/src/agents/agent-command.ingress-diagnostics.test.ts
@@ -63,6 +63,63 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+describe("resolveAgentRunLifecycleEndLogLevel", () => {
+  it("logs successful stop and tool-use metadata at info", () => {
+    expect(
+      testing.resolveAgentRunLifecycleEndLogLevel({
+        aborted: false,
+        stopReason: "stop",
+      }),
+    ).toBe("info");
+    expect(
+      testing.resolveAgentRunLifecycleEndLogLevel({
+        aborted: false,
+        stopReason: "toolUse",
+      }),
+    ).toBe("info");
+  });
+
+  it("does not log ordinary end-turn completions", () => {
+    expect(
+      testing.resolveAgentRunLifecycleEndLogLevel({
+        aborted: false,
+        stopReason: "end_turn",
+      }),
+    ).toBeUndefined();
+    expect(testing.resolveAgentRunLifecycleEndLogLevel({ aborted: false })).toBeUndefined();
+  });
+
+  it("keeps timeout metadata out of error severity", () => {
+    expect(
+      testing.resolveAgentRunLifecycleEndLogLevel({
+        aborted: true,
+        stopReason: "timeout",
+      }),
+    ).toBe("warn");
+    expect(
+      testing.resolveAgentRunLifecycleEndLogLevel({
+        stopReason: "stop",
+        timeoutPhase: "provider",
+        providerStarted: true,
+      }),
+    ).toBe("warn");
+  });
+
+  it("logs cancelled and failed endings at error", () => {
+    expect(
+      testing.resolveAgentRunLifecycleEndLogLevel({
+        aborted: true,
+        stopReason: "stop",
+      }),
+    ).toBe("error");
+    expect(
+      testing.resolveAgentRunLifecycleEndLogLevel({
+        stopReason: "error",
+      }),
+    ).toBe("error");
+  });
+});
+
 function makeResult(overrides?: Record<string, unknown>) {
   return {
     payloads: [{ text: "hello", mediaUrl: "" }],

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -73,6 +73,7 @@ import {
   resolveMessageChannel,
 } from "../utils/message-channel.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
+import { buildAgentRunTerminalOutcome } from "./agent-run-terminal-outcome.js";
 import { resolveAgentRuntimeConfig } from "./agent-runtime-config.js";
 import {
   clearAutoFallbackPrimaryProbeSelection,
@@ -249,6 +250,37 @@ function parseAgentCommandModelRef(
 
 type AttemptExecutionRuntime = typeof import("./command/attempt-execution.runtime.js");
 type AgentAttemptResult = Awaited<ReturnType<AttemptExecutionRuntime["runAgentAttempt"]>>;
+
+function resolveAgentRunLifecycleEndLogLevel(meta: {
+  aborted?: unknown;
+  error?: unknown;
+  stopReason?: unknown;
+  livenessState?: unknown;
+  timeoutPhase?: unknown;
+  providerStarted?: unknown;
+}): "info" | "warn" | "error" | undefined {
+  const status =
+    meta.stopReason === "timeout" || meta.timeoutPhase
+      ? "timeout"
+      : meta.aborted === true || meta.error || meta.stopReason === "error"
+        ? "error"
+        : "ok";
+  const outcome = buildAgentRunTerminalOutcome({
+    status,
+    error: meta.error,
+    stopReason: meta.stopReason,
+    livenessState: meta.livenessState,
+    timeoutPhase: meta.timeoutPhase,
+    providerStarted: meta.providerStarted,
+  });
+  if (!outcome.stopReason || outcome.stopReason === "end_turn") {
+    return undefined;
+  }
+  if (outcome.reason === "completed") {
+    return "info";
+  }
+  return outcome.status === "timeout" ? "warn" : "error";
+}
 
 function applyAgentRunAbortMetadata<T extends { meta: object }>(
   result: T,
@@ -1874,8 +1906,9 @@ async function agentCommandInternal(
         }
         attemptLifecycleState.lifecycleEnded = true;
         const stopReason = runResult.meta.stopReason;
-        if (stopReason && stopReason !== "end_turn") {
-          console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
+        const logLevel = resolveAgentRunLifecycleEndLogLevel(runResult.meta);
+        if (logLevel) {
+          log[logLevel](`[agent] run ${runId} ended with stopReason=${stopReason}`);
         }
         emitAgentEvent({
           runId,
@@ -2736,6 +2769,7 @@ export const testing = {
   resolveAgentRuntimeConfig,
   prepareAgentCommandExecution,
   resolveExplicitAgentCommandSessionKey,
+  resolveAgentRunLifecycleEndLogLevel,
   ingressDiagnosticChannel,
   emitIngressModelUsageDiagnostic,
 };


### PR DESCRIPTION
Closes #101678

## What Problem This Solves

Fixes an issue where successful agent runs could emit lifecycle completion logs at error severity when the run ended with normal provider metadata such as `stopReason=stop`.

This was noisy for operators because clean completions could look like failures in error-level monitoring.

## Why This Change Was Made

Agent lifecycle end logging now uses the existing normalized terminal outcome classification before choosing a log level: completed outcomes log at info, timeout outcomes log at warn, and cancelled/failed outcomes remain error-level. The lifecycle event payload is unchanged; this PR only changes the severity used for the completion log line.

Risk note: this touches agent-run observability, so the regression coverage keeps cancelled, failed, and timeout endings out of the successful-completion path.

## User Impact

Successful agent completions no longer pollute error-level logs just because the provider reports `stopReason=stop`. Operators should see fewer false-positive error alerts while real failed, cancelled, aborted, and timeout outcomes remain visible at elevated severity.

## Evidence

Live behavior proof with local DeepSeek (`deepseek/deepseek-v4-pro`) after the fix:

```text
$ set -a; source <local-openclaw-env>; set +a; pnpm openclaw --log-level error agent --local --model deepseek/deepseek-v4-pro --session-key agent:main:issue-101678-proof-errorlevel --message "Reply exactly: OPENCLAW_STOP_ERRORLEVEL_OK" --json --timeout 180 >after.stdout 2>after.stderr
completion-log-matches=after.stdout:0
after.stderr:0
reply-match=4
stop-reason-match=2
```

The JSON output contained the expected assistant reply and successful completion metadata:

```json
"finalAssistantVisibleText": "OPENCLAW_STOP_ERRORLEVEL_OK"
"stopReason": "stop"
"completion": {
  "stopReason": "stop",
  "finishReason": "stop"
}
```

Focused validation:

```text
node scripts/run-vitest.mjs src/agents/agent-command.ingress-diagnostics.test.ts
Test Files  1 passed (1)
Tests  17 passed (17)

node scripts/run-vitest.mjs src/agents/agent-run-terminal-outcome.test.ts
Test Files  1 passed (1)
Tests  16 passed (16)

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
passed

node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
passed

pnpm exec oxfmt --check --threads=1 src/agents/agent-command.ts src/agents/agent-command.ingress-diagnostics.test.ts
All matched files use the correct format.

git diff --check
passed

pnpm build
passed
```

AI-assisted: AI-assisted implementation and validation; proof run manually.
