### PR TITLE
fix(line): strip internal tool-trace banners from outbound text

### DIFF
--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -109,6 +109,114 @@ describe("deliverLineAutoReply", () => {
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
     expect(createQuickReplyItems).not.toHaveBeenCalled();
+    expect(result.visibleReplySent).toBe(true);
+  });
+
+  it("sanitizes internal traces on the inbound auto-reply path", async () => {
+    const processLineMessage = vi.fn((text: string) => ({ text, flexMessages: [] }));
+    const { deps, replyMessageLine } = createDeps({ processLineMessage });
+    const text = [
+      "Done.",
+      '<tool_call>{"name":"read","arguments":{"path":"secret"}}</tool_call>',
+      "⚠️ 🛠️ `search repos (agent)` failed",
+    ].join("\n");
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text },
+      lineData: {},
+      deps,
+    });
+
+    expect(processLineMessage).toHaveBeenCalledWith("Done.");
+    expect(replyMessageLine).toHaveBeenCalledWith("token", [{ type: "text", text: "Done." }], {
+      cfg: LINE_TEST_CFG,
+      accountId: "acc",
+    });
+    expect(result).toEqual({
+      status: "delivered",
+      replyTokenUsed: true,
+      visibleReplySent: true,
+    });
+  });
+
+  it("suppresses an internal-only auto-reply without consuming the reply token", async () => {
+    const processLineMessage = vi.fn((text: string) => ({ text, flexMessages: [] }));
+    const { deps, replyMessageLine, pushMessageLine, pushMessagesLine } = createDeps({
+      processLineMessage,
+    });
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: "⚠️ 🛠️ `search repos (agent)` failed" },
+      lineData: {},
+      deps,
+    });
+
+    expect(processLineMessage).not.toHaveBeenCalled();
+    expect(replyMessageLine).not.toHaveBeenCalled();
+    expect(pushMessageLine).not.toHaveBeenCalled();
+    expect(pushMessagesLine).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "delivered",
+      replyTokenUsed: false,
+      visibleReplySent: false,
+    });
+  });
+
+  it("preserves literal tool traces in fenced auto-reply text", async () => {
+    const text = [
+      "Example:",
+      "```text",
+      "⚠️ 🛠️ `search repos (agent)` failed",
+      '<tool_call>{"name":"read"}</tool_call>',
+      "```",
+    ].join("\n");
+    const { deps, replyMessageLine } = createDeps();
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text },
+      lineData: {},
+      deps,
+    });
+
+    expect(replyMessageLine).toHaveBeenCalledWith("token", [{ type: "text", text }], {
+      cfg: LINE_TEST_CFG,
+      accountId: "acc",
+    });
+    expect(result.visibleReplySent).toBe(true);
+  });
+
+  it("tags a later chunk failure after the reply batch without replaying delivered text", async () => {
+    const pushError = new Error("later push failed");
+    const pushMessageLine = vi.fn(async () => {
+      throw pushError;
+    });
+    const { deps, replyMessageLine } = createDeps({
+      chunkMarkdownText: () => ["1", "2", "3", "4", "5", "6"],
+      pushMessageLine: pushMessageLine as LineAutoReplyDeps["pushMessageLine"],
+    });
+
+    await expect(
+      deliverLineAutoReply({
+        ...baseDeliveryParams,
+        payload: { text: "six chunks" },
+        lineData: {},
+        deps,
+      }),
+    ).rejects.toMatchObject({
+      message: "later push failed",
+      sentBeforeError: true,
+      visibleReplySent: true,
+    });
+
+    expect(replyMessageLine).toHaveBeenCalledTimes(1);
+    expect(pushMessageLine).toHaveBeenCalledTimes(1);
+    expect(pushMessageLine).toHaveBeenCalledWith("line:user:1", "6", {
+      cfg: LINE_TEST_CFG,
+      accountId: "acc",
+    });
   });
 
   it("truncates flex altText on a surrogate boundary", async () => {
@@ -149,7 +257,10 @@ describe("deliverLineAutoReply", () => {
 
     const result = await deliverLineAutoReply({
       ...baseDeliveryParams,
-      payload: { channelData: { line: lineData } },
+      payload: {
+        text: "⚠️ 🛠️ `search repos (agent)` failed",
+        channelData: { line: lineData },
+      },
       lineData,
       deps,
     });
@@ -168,6 +279,7 @@ describe("deliverLineAutoReply", () => {
     );
     expect(pushMessagesLine).not.toHaveBeenCalled();
     expect(createQuickReplyItems).toHaveBeenCalledWith(["A"]);
+    expect(result.visibleReplySent).toBe(true);
   });
 
   it("uses fallback text for quick-reply-only payloads", async () => {
@@ -204,6 +316,7 @@ describe("deliverLineAutoReply", () => {
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
     expect(pushMessagesLine).not.toHaveBeenCalled();
+    expect(result.visibleReplySent).toBe(true);
   });
 
   it("sends rich messages before quick-reply text so quick replies remain visible", async () => {
@@ -286,6 +399,7 @@ describe("deliverLineAutoReply", () => {
     // signal dispatch uses to keep the sent text yet still report the failure.
     expect(result).toMatchObject({
       status: "partial",
+      visibleReplySent: true,
       error: { sentBeforeError: true, visibleReplySent: true },
     });
     expect(result.replyTokenUsed).toBe(true);

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -3,6 +3,7 @@ import type { messagingApi } from "@line/bot-sdk";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { FlexContainer } from "./flex-templates.js";
 import type { ProcessedLineMessage } from "./markdown-to-line.js";
@@ -44,8 +45,8 @@ type LineAutoReplyDeps = {
 >;
 
 type LineAutoReplyDeliveryResult =
-  | { status: "delivered"; replyTokenUsed: boolean }
-  | { status: "partial"; replyTokenUsed: boolean; error: Error };
+  | { status: "delivered"; replyTokenUsed: boolean; visibleReplySent: boolean }
+  | { status: "partial"; replyTokenUsed: boolean; visibleReplySent: true; error: Error };
 
 function markLineVisibleDeliveryError(error: unknown): Error {
   if (error instanceof Error && Object.isExtensible(error)) {
@@ -70,16 +71,38 @@ export async function deliverLineAutoReply(params: {
 }): Promise<LineAutoReplyDeliveryResult> {
   const { payload, lineData, replyToken, accountId, to, textLimit, deps } = params;
   let replyTokenUsed = params.replyTokenUsed;
+  let visibleReplySent = false;
+
+  const sendVisible = async <T>(send: () => Promise<T>): Promise<T> => {
+    try {
+      const result = await send();
+      visibleReplySent = true;
+      return result;
+    } catch (error) {
+      if (visibleReplySent) {
+        throw markLineVisibleDeliveryError(error);
+      }
+      throw error;
+    }
+  };
+  const replyVisible: LineAutoReplyDeps["replyMessageLine"] = (...args) =>
+    sendVisible(() => deps.replyMessageLine(...args));
+  const pushTextVisible: LineAutoReplyDeps["pushMessageLine"] = (...args) =>
+    sendVisible(() => deps.pushMessageLine(...args));
+  const pushQuickRepliesVisible: LineAutoReplyDeps["pushTextMessageWithQuickReplies"] = (...args) =>
+    sendVisible(() => deps.pushTextMessageWithQuickReplies(...args));
 
   const pushLineMessages = async (messages: messagingApi.Message[]): Promise<void> => {
     if (messages.length === 0) {
       return;
     }
     for (let i = 0; i < messages.length; i += 5) {
-      await deps.pushMessagesLine(to, messages.slice(i, i + 5), {
-        cfg: params.cfg,
-        accountId,
-      });
+      await sendVisible(() =>
+        deps.pushMessagesLine(to, messages.slice(i, i + 5), {
+          cfg: params.cfg,
+          accountId,
+        }),
+      );
     }
   };
 
@@ -95,7 +118,7 @@ export async function deliverLineAutoReply(params: {
     if (allowReplyToken && replyToken && !replyTokenUsed) {
       const replyBatch = remaining.slice(0, 5);
       try {
-        await deps.replyMessageLine(replyToken, replyBatch, {
+        await replyVisible(replyToken, replyBatch, {
           cfg: params.cfg,
           accountId,
         });
@@ -135,8 +158,11 @@ export async function deliverLineAutoReply(params: {
     richMessages.push(deps.createLocationMessage(lineData.location));
   }
 
-  const processed = payload.text
-    ? deps.processLineMessage(payload.text)
+  // Inbound auto-replies bypass the channel outbound adapter, so enforce the
+  // same assistant-visible boundary here before Markdown can create LINE UI.
+  const visibleText = payload.text ? sanitizeAssistantVisibleText(payload.text) : "";
+  const processed = visibleText
+    ? deps.processLineMessage(visibleText)
     : { text: "", flexMessages: [] };
 
   for (const flexMsg of processed.flexMessages) {
@@ -176,10 +202,11 @@ export async function deliverLineAutoReply(params: {
       replyTokenUsed,
       cfg: params.cfg,
       accountId,
-      replyMessageLine: deps.replyMessageLine,
-      pushMessageLine: deps.pushMessageLine,
-      pushTextMessageWithQuickReplies: deps.pushTextMessageWithQuickReplies,
+      replyMessageLine: replyVisible,
+      pushMessageLine: pushTextVisible,
+      pushTextMessageWithQuickReplies: pushQuickRepliesVisible,
       createTextMessageWithQuickReplies: deps.createTextMessageWithQuickReplies,
+      onReplyError: deps.onReplyError,
     });
     replyTokenUsed = nextReplyTokenUsed;
     if (!sendRichBeforeText) {
@@ -198,6 +225,7 @@ export async function deliverLineAutoReply(params: {
       return {
         status: "partial",
         replyTokenUsed,
+        visibleReplySent: true,
         error: markLineVisibleDeliveryError(richMediaError),
       };
     }
@@ -212,9 +240,9 @@ export async function deliverLineAutoReply(params: {
         replyTokenUsed,
         cfg: params.cfg,
         accountId,
-        replyMessageLine: deps.replyMessageLine,
-        pushMessageLine: deps.pushMessageLine,
-        pushTextMessageWithQuickReplies: deps.pushTextMessageWithQuickReplies,
+        replyMessageLine: replyVisible,
+        pushMessageLine: pushTextVisible,
+        pushTextMessageWithQuickReplies: pushQuickRepliesVisible,
         createTextMessageWithQuickReplies: deps.createTextMessageWithQuickReplies,
         onReplyError: deps.onReplyError,
       });
@@ -233,5 +261,5 @@ export async function deliverLineAutoReply(params: {
     }
   }
 
-  return { status: "delivered", replyTokenUsed };
+  return { status: "delivered", replyTokenUsed, visibleReplySent };
 }

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -245,10 +245,11 @@ export async function monitorLineProvider(
                     // Text reached the user but a rich/media bubble did not.
                     // Surface the tagged partial failure after adopting the
                     // consumed reply-token state so later blocks in this turn
-                    // route correctly; recordChannelRuntimeState is skipped
-                    // because this delivery was not a clean success.
+                    // route correctly without retrying text the user already saw.
                     throw deliveryResult.error;
                   }
+
+                  return { visibleReplySent: deliveryResult.visibleReplySent };
                 },
                 onError: (err, info) => {
                   runtime.error?.(danger(`line ${info.kind} reply failed: ${String(err)}`));

--- a/extensions/line/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/line/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,19 @@
+// LINE outbound must strip assistant internal tool-trace scaffolding, matching
+// the sibling channel fixes tracked under #90684 (Slack / Signal / Matrix /
+// Feishu / Mattermost / Telegram / Google Chat / QQBot / IRC / SMS).
+import { describe, expect, it } from "vitest";
+import { linePlugin } from "./channel.js";
+
+describe("line outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(linePlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(linePlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+  });
+});

--- a/extensions/line/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/line/src/outbound-tool-trace-sanitize.test.ts
@@ -1,19 +1,29 @@
-// LINE outbound must strip assistant internal tool-trace scaffolding, matching
-// the sibling channel fixes tracked under #90684 (Slack / Signal / Matrix /
-// Feishu / Mattermost / Telegram / Google Chat / QQBot / IRC / SMS).
 import { describe, expect, it } from "vitest";
-import { linePlugin } from "./channel.js";
+import { lineOutboundAdapter } from "./outbound.js";
 
 describe("line outbound sanitizeText", () => {
-  it("strips internal tool-trace banners before outbound delivery", () => {
-    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+  const sanitize = (text: string) =>
+    lineOutboundAdapter.sanitizeText?.({ text, payload: { text } });
 
-    expect(linePlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe("Done.");
+  it("strips internal tool traces before standard outbound delivery", () => {
+    const text = [
+      "Done.",
+      '<tool_call>{"name":"read","arguments":{"path":"secret"}}</tool_call>',
+      "⚠️ 🛠️ `search repos (agent)` failed",
+    ].join("\n");
+
+    expect(sanitize(text)).toBe("Done.");
   });
 
-  it("preserves ordinary assistant prose while sanitizing", () => {
-    const text = "The pipeline has 3 open deals.";
+  it("preserves literal tool-trace examples in fenced code", () => {
+    const text = [
+      "Example:",
+      "```text",
+      "⚠️ 🛠️ `search repos (agent)` failed",
+      '<tool_call>{"name":"read"}</tool_call>',
+      "```",
+    ].join("\n");
 
-    expect(linePlugin.outbound?.sanitizeText?.({ text, payload: { text } })).toBe(text);
+    expect(sanitize(text)).toBe(text);
   });
 });

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/channel-send-result";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { ChannelPlugin, ResolvedLineAccount } from "./channel-api.js";
 import { resolveLineOutboundMedia, type LineOutboundMediaResolved } from "./outbound-media.js";
@@ -82,6 +83,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
   deliveryMode: "direct",
   chunker: (text, limit) => getLineRuntime().channel.text.chunkMarkdownText(text, limit),
   textChunkLimit: 5000,
+  sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
   sendPayload: async ({ to, payload, accountId, cfg, onDeliveryResult }) => {
     const runtime = getLineRuntime();
     const outboundRuntime = await loadLineOutboundRuntime();

--- a/extensions/line/src/reply-chunks.test.ts
+++ b/extensions/line/src/reply-chunks.test.ts
@@ -137,6 +137,41 @@ describe("sendLineReplyChunks", () => {
     expect(createTextMessageWithQuickReplies).not.toHaveBeenCalled();
   });
 
+  it("does not replay a successful reply batch when a later push fails", async () => {
+    const {
+      replyMessageLine,
+      pushMessageLine,
+      pushTextMessageWithQuickReplies,
+      createTextMessageWithQuickReplies,
+    } = createReplyChunksHarness();
+    const pushError = new Error("later push failed");
+    const onReplyError = vi.fn();
+    pushMessageLine.mockRejectedValueOnce(pushError);
+
+    await expect(
+      sendLineReplyChunks({
+        to: "line:group:1",
+        chunks: ["1", "2", "3", "4", "5", "6"],
+        replyToken: "token",
+        replyTokenUsed: false,
+        cfg: LINE_TEST_CFG,
+        replyMessageLine,
+        pushMessageLine,
+        pushTextMessageWithQuickReplies,
+        createTextMessageWithQuickReplies,
+        onReplyError,
+      }),
+    ).rejects.toBe(pushError);
+
+    expect(replyMessageLine).toHaveBeenCalledTimes(1);
+    expect(pushMessageLine).toHaveBeenCalledTimes(1);
+    expect(pushMessageLine).toHaveBeenCalledWith("line:group:1", "6", {
+      cfg: LINE_TEST_CFG,
+      accountId: undefined,
+    });
+    expect(onReplyError).not.toHaveBeenCalled();
+  });
+
   it("falls back to push flow when replying fails", async () => {
     const {
       replyMessageLine,

--- a/extensions/line/src/reply-chunks.ts
+++ b/extensions/line/src/reply-chunks.ts
@@ -44,6 +44,7 @@ export async function sendLineReplyChunks(
   }
 
   if (params.replyToken && !replyTokenUsed) {
+    let replySucceeded = false;
     try {
       const replyBatch = params.chunks.slice(0, 5);
       const remaining = params.chunks.slice(replyBatch.length);
@@ -66,6 +67,7 @@ export async function sendLineReplyChunks(
         accountId: params.accountId,
       });
       replyTokenUsed = true;
+      replySucceeded = true;
 
       for (const [i, chunk] of remaining.entries()) {
         const isLastChunk = i === remaining.length - 1;
@@ -84,6 +86,10 @@ export async function sendLineReplyChunks(
 
       return { replyTokenUsed };
     } catch (err) {
+      // A later push failure must not replay chunks that already used the reply token.
+      if (replySucceeded) {
+        throw err;
+      }
       params.onReplyError?.(err);
       replyTokenUsed = true;
     }

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -288,6 +288,17 @@ describe("LINE send helpers", () => {
     });
   });
 
+  it("preserves literal internal-looking text in low-level sends", async () => {
+    const text = "⚠️ 🛠️ `search repos (agent)` failed";
+
+    await sendModule.sendMessageLine("line:user:U123", text, { cfg: LINE_TEST_CFG });
+
+    expect(pushMessageMock).toHaveBeenCalledWith({
+      to: "U123",
+      messages: [{ type: "text", text }],
+    });
+  });
+
   it("sends video with explicit image preview URL", async () => {
     await sendModule.sendMessageLine("line:user:U100", "Video", {
       cfg: LINE_TEST_CFG,


### PR DESCRIPTION
Part of #90684

## What Problem This Solves

LINE replies could expose internal assistant tool-trace banners to end users. The normal inbound auto-reply path also bypassed the generic outbound adapter, so adding the adapter hook alone did not cover the primary LINE reply path.

## Why This Change Was Made

This applies the shared `sanitizeAssistantVisibleText` boundary in both LINE delivery paths: the standard outbound adapter and inbound auto-reply delivery before Markdown conversion. Internal-only text is suppressed without consuming a reply token, while rich content and fenced examples remain intact.

The delivery result now carries whether visible output was actually sent, so dispatch can distinguish suppressed output from a user-visible reply. The reply-chunk fallback also tracks a successful reply-token batch and will not replay it if a later push chunk fails.

## User Impact

LINE users no longer see internal tool-trace banners in bot replies. Normal prose, fenced examples, rich content, reply-token fallback, and chunked delivery remain supported. A later push failure no longer duplicates an already-delivered reply batch.

## Evidence

- Blacksmith Testbox `tbx_01kxhbsb7dvp09f3qx22bjaxbc`
- Focused LINE delivery suite: 4 files, 37 tests passed
- Full LINE suite: 27 files, 325 tests passed
- `pnpm check:changed`: production TypeScript, lint, formatting, SDK baselines, storage/media/runtime guards, and import-cycle checks passed; extension-test TypeScript reproduced the untouched `main` failure fixed by #107808
- Targeted Oxfmt check passed for all eight changed files
- Live loopback HTTP proof through the production LINE auto-reply orchestration:
  - sanitized visible reply reached the wire
  - reply batch succeeded, a later push returned HTTP 503, and the reply batch was not replayed
  - internal-only output produced zero HTTP requests
- Fresh whole-PR autoreview after conflict resolution: no actionable findings, patch correct at 0.90 confidence
- Hosted exact-head merge-ref CI: https://github.com/openclaw/openclaw/actions/runs/29373316329

Live proof output:

```json
{"scenario":"LINE reply batch then failed push over HTTP","sanitizedChunkInput":"Visible answer.","wireAttemptsBeforeFailure":2,"replayedReplyBatch":false,"internalOnlyRequests":0}
```

Known gap: no credentialed round-trip against the external LINE service. The loopback proof exercised the production delivery orchestration and real HTTP request/failure semantics.
