### PR TITLE
test(scripts): repoint native i18n pairing canary at surviving surface

### DIFF
--- a/test/scripts/native-app-i18n.test.ts
+++ b/test/scripts/native-app-i18n.test.ts
@@ -53,7 +53,7 @@ describe("native app i18n inventory", () => {
     expect(entries.some((entry) => entry.source === "$deviceModel · $appVersion")).toBe(true);
     expect(entries.some((entry) => entry.source === "Approval command copied")).toBe(true);
     expect(entries.some((entry) => entry.source === "Save Profile")).toBe(true);
-    expect(entries.some((entry) => entry.source === "Pairing required")).toBe(true);
+    expect(entries.some((entry) => entry.source === "Paired Devices")).toBe(true);
     expect(entries.some((entry) => entry.source === "Mute")).toBe(true);
     expect(entries.some((entry) => entry.source === "Creating...")).toBe(true);
     expect(entries.some((entry) => entry.source === "Permission required")).toBe(true);


### PR DESCRIPTION
Related: #101680

## What Problem This Solves

`test/scripts/native-app-i18n.test.ts` pins `"Pairing required"` as a canary string proving the native i18n collector sees real Android UI entries. #101680 deleted the legacy `ConnectTabScreen.kt` — the only live source of that string — and regenerated the i18n inventory, but the test canary was not updated. The `checks-node-compact-small-whole-2` shard now fails deterministically on `main` (passes at `cd86107a10~1`, fails at `cd86107a10`), which fails CI for every open PR merged against current `main`.

## Why This Change Was Made

One-line canary repoint: `"Pairing required"` → `"Paired Devices"` from `apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt`, a string on the canonical successor surface that the collector actually captures (`ui-named-argument`). Nearby candidates like `"Pairing needed"` and `"Pairing Gateway"` are `when`-branch/builder strings the collector intentionally ignores, verified by probing `collectNativeI18nEntries()` directly. All 53 source-literal canaries in the test were probed against `main` tip; this was the only break.

## User Impact

None — test-only. Unblocks CI for open PRs.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/native-app-i18n.test.ts` — 5/5 passing, run twice
- Bisect proof: test passes at `cd86107a10~1`, fails at `cd86107a10` and at current `origin/main` (`e591dcfa82`), reproduced twice each
- `oxfmt --check` clean
