### PR TITLE
fix(nextcloud-talk): strip internal tool-trace banners from outbound text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Nextcloud Talk assistant replies:** strip internal tool-trace banners and XML from automatic replies while preserving visible text, attachments, and reply threading, and keep fully stripped internal-only replies from suppressing concurrent user-visible delivery. (#101712, #103355, #90684) Thanks @Pick-cat and @miorbnli.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Nextcloud Talk assistant replies:** strip internal tool-trace banners and XML from automatic replies while preserving visible text, attachments, and reply threading, and keep fully stripped internal-only replies from suppressing concurrent user-visible delivery. (#101712, #103355, #90684) Thanks @Pick-cat and @miorbnli.
 - **Codex runtime switching:** accept the bundled Codex runtime for both `codex/*` and `openai/*` model routes while keeping unsupported provider/runtime pairs rejected. (#103762)
 - **Agent abort cleanup:** serialize prompt lock reacquisition with terminal cleanup so canceled embedded runs do not self-contend on session locks for up to 60 seconds.
 - **Chutes OAuth deadlines:** bound token exchange, profile lookup, and refresh requests, and keep issued tokens when optional userinfo enrichment stalls. (#102026) Thanks @Alix-007.

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -1,7 +1,6 @@
 // Nextcloud Talk plugin module implements channel behavior.
 import { describeWebhookAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
-import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { createLoggedPairingApprovalNotifier } from "openclaw/plugin-sdk/channel-pairing";
 import { createAllowlistProviderRouteAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
 import {
@@ -9,6 +8,7 @@ import {
   createComputedAccountStatusAdapter,
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { resolveNextcloudTalkAccount, type ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { nextcloudTalkApprovalAuth } from "./approval-auth.js";
 import { probeNextcloudTalkBotResponseFeature } from "./bot-preflight.js";

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -1,6 +1,7 @@
 // Nextcloud Talk plugin module implements channel behavior.
 import { describeWebhookAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { createLoggedPairingApprovalNotifier } from "openclaw/plugin-sdk/channel-pairing";
 import { createAllowlistProviderRouteAllowlistWarningCollector } from "openclaw/plugin-sdk/channel-policy";
 import {
@@ -201,6 +202,7 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> =
           getNextcloudTalkRuntime().channel.text.chunkMarkdownText(text, limit),
         chunkerMode: "markdown",
         textChunkLimit: 4000,
+        sanitizeText: ({ text }) => sanitizeAssistantVisibleText(text),
       },
       attachedResults: {
         channel: "nextcloud-talk",

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -101,23 +101,6 @@ function requireFirstSendMessageCall(): [unknown, unknown, unknown] {
   return call as [unknown, unknown, unknown];
 }
 
-type CapturedReplyDelivery = {
-  preparePayload: (payload: OutboundReplyPayload) => OutboundReplyPayload;
-  deliver: (payload: OutboundReplyPayload) => Promise<void>;
-};
-
-function requireFirstReplyDelivery(mock: ReturnType<typeof vi.fn>): CapturedReplyDelivery {
-  const assembledRequest = requireFirstMockArg(mock, "Nextcloud Talk assembled request") as {
-    delivery?: Partial<CapturedReplyDelivery>;
-  };
-  const preparePayload = assembledRequest.delivery?.preparePayload;
-  const deliver = assembledRequest.delivery?.deliver;
-  if (!preparePayload || !deliver) {
-    throw new Error("expected Nextcloud Talk reply delivery hooks");
-  }
-  return { preparePayload, deliver };
-}
-
 function createAccount(
   overrides?: Partial<ResolvedNextcloudTalkAccount>,
 ): ResolvedNextcloudTalkAccount {
@@ -325,7 +308,7 @@ describe("nextcloud-talk inbound behavior", () => {
     expect(assembledRequest.replyPipeline).toEqual({});
   });
 
-  it("sanitizes inbound replies before local delivery while preserving reply metadata", async () => {
+  it("sanitizes inbound replies before local delivery while preserving transport fields", async () => {
     const coreRuntime = createPluginRuntimeMock();
     setNextcloudTalkRuntime(coreRuntime as unknown as PluginRuntime);
     createChannelPairingControllerMock.mockReturnValue({
@@ -349,55 +332,37 @@ describe("nextcloud-talk inbound behavior", () => {
       runtime: createRuntimeEnv(),
     });
 
-    const delivery = requireFirstReplyDelivery(
+    const assembledRequest = requireFirstMockArg(
       coreRuntime.channel.inbound.dispatchReply as ReturnType<typeof vi.fn>,
-    );
-    const cases = [
-      {
-        text: "Done.\n⚠️ 🛠️ `search repos (agent)` failed",
-        expected: "Done.",
-      },
-      {
-        text: '<tool_call>{"name":"exec"}</tool_call>Meeting notes sent.',
-        expected: "Meeting notes sent.",
-      },
-      {
-        text: [
-          "Checking now.",
-          "<function_response>",
-          'Searching for: "agenda"',
-          "</function_response>",
-          "Meeting notes sent.",
-        ].join("\n"),
-        expected: "Checking now.\n\nMeeting notes sent.",
-      },
-      {
-        text: "The agenda has 3 open action items.",
-        expected: "The agenda has 3 open action items.",
-      },
-    ];
-    for (const testCase of cases) {
-      expect(delivery.preparePayload({ text: testCase.text })).toEqual({
-        text: testCase.expected,
-      });
+      "Nextcloud Talk assembled request",
+    ) as {
+      delivery?: {
+        preparePayload?: (payload: OutboundReplyPayload) => OutboundReplyPayload;
+        deliver?: (payload: OutboundReplyPayload) => Promise<void>;
+      };
+    };
+    const preparePayload = assembledRequest.delivery?.preparePayload;
+    const deliver = assembledRequest.delivery?.deliver;
+    if (!preparePayload || !deliver) {
+      throw new Error("expected Nextcloud Talk reply delivery hooks");
     }
 
     const mediaOnlyPayload = { mediaUrl: "https://example.com/a.png" };
-    expect(delivery.preparePayload(mediaOnlyPayload)).toBe(mediaOnlyPayload);
+    expect(preparePayload(mediaOnlyPayload)).toBe(mediaOnlyPayload);
 
-    const preparedPayload = delivery.preparePayload({
+    const preparedPayload = preparePayload({
       text: "Done.\n⚠️ 🛠️ `search repos (agent)` failed",
       mediaUrls: ["https://example.com/a.png"],
       replyToId: "reply-1",
     });
-    await delivery.deliver(preparedPayload);
-    await delivery.deliver(
-      delivery.preparePayload({
-        text: '<tool_call>{"name":"exec"}</tool_call>Meeting notes sent.',
-      }),
-    );
+    expect(preparedPayload).toEqual({
+      text: "Done.",
+      mediaUrls: ["https://example.com/a.png"],
+      replyToId: "reply-1",
+    });
+    await deliver(preparedPayload);
 
-    expect(sendMessageNextcloudTalkMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageNextcloudTalkMock).toHaveBeenCalledTimes(1);
     expect(requireFirstSendMessageCall()).toEqual([
       "room-1",
       "Done.\n\nAttachment: https://example.com/a.png",
@@ -407,15 +372,5 @@ describe("nextcloud-talk inbound behavior", () => {
         replyTo: "reply-1",
       },
     ]);
-    expect(sendMessageNextcloudTalkMock).toHaveBeenNthCalledWith(
-      2,
-      "room-1",
-      "Meeting notes sent.",
-      {
-        cfg: config,
-        accountId: "default",
-        replyTo: undefined,
-      },
-    );
   });
 });

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -1,7 +1,7 @@
 // Nextcloud Talk tests cover inbound.behavior plugin behavior.
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { PluginRuntime, RuntimeEnv } from "../runtime-api.js";
+import type { OutboundReplyPayload, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
 import type { ResolvedNextcloudTalkAccount } from "./accounts.js";
 import { handleNextcloudTalkInbound } from "./inbound.js";
 import { setNextcloudTalkRuntime } from "./runtime.js";
@@ -99,6 +99,23 @@ function requireFirstSendMessageCall(): [unknown, unknown, unknown] {
     throw new Error("expected Nextcloud Talk send call");
   }
   return call as [unknown, unknown, unknown];
+}
+
+type CapturedReplyDelivery = {
+  preparePayload: (payload: OutboundReplyPayload) => OutboundReplyPayload;
+  deliver: (payload: OutboundReplyPayload) => Promise<void>;
+};
+
+function requireFirstReplyDelivery(mock: ReturnType<typeof vi.fn>): CapturedReplyDelivery {
+  const assembledRequest = requireFirstMockArg(mock, "Nextcloud Talk assembled request") as {
+    delivery?: Partial<CapturedReplyDelivery>;
+  };
+  const preparePayload = assembledRequest.delivery?.preparePayload;
+  const deliver = assembledRequest.delivery?.deliver;
+  if (!preparePayload || !deliver) {
+    throw new Error("expected Nextcloud Talk reply delivery hooks");
+  }
+  return { preparePayload, deliver };
 }
 
 function createAccount(
@@ -306,5 +323,99 @@ describe("nextcloud-talk inbound behavior", () => {
       "Nextcloud Talk assembled request",
     ) as { replyPipeline?: unknown };
     expect(assembledRequest.replyPipeline).toEqual({});
+  });
+
+  it("sanitizes inbound replies before local delivery while preserving reply metadata", async () => {
+    const coreRuntime = createPluginRuntimeMock();
+    setNextcloudTalkRuntime(coreRuntime as unknown as PluginRuntime);
+    createChannelPairingControllerMock.mockReturnValue({
+      readStoreForDmPolicy: vi.fn(async () => []),
+      issueChallenge: vi.fn(),
+    });
+    sendMessageNextcloudTalkMock.mockResolvedValue(undefined);
+
+    const config = { channels: { "nextcloud-talk": {} } } as CoreConfig;
+    await handleNextcloudTalkInbound({
+      message: createMessage(),
+      account: createAccount({
+        config: {
+          dmPolicy: "allowlist",
+          allowFrom: ["user-1"],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
+      }),
+      config,
+      runtime: createRuntimeEnv(),
+    });
+
+    const delivery = requireFirstReplyDelivery(
+      coreRuntime.channel.inbound.dispatchReply as ReturnType<typeof vi.fn>,
+    );
+    const cases = [
+      {
+        text: "Done.\n⚠️ 🛠️ `search repos (agent)` failed",
+        expected: "Done.",
+      },
+      {
+        text: '<tool_call>{"name":"exec"}</tool_call>Meeting notes sent.',
+        expected: "Meeting notes sent.",
+      },
+      {
+        text: [
+          "Checking now.",
+          "<function_response>",
+          'Searching for: "agenda"',
+          "</function_response>",
+          "Meeting notes sent.",
+        ].join("\n"),
+        expected: "Checking now.\n\nMeeting notes sent.",
+      },
+      {
+        text: "The agenda has 3 open action items.",
+        expected: "The agenda has 3 open action items.",
+      },
+    ];
+    for (const testCase of cases) {
+      expect(delivery.preparePayload({ text: testCase.text })).toEqual({
+        text: testCase.expected,
+      });
+    }
+
+    const mediaOnlyPayload = { mediaUrl: "https://example.com/a.png" };
+    expect(delivery.preparePayload(mediaOnlyPayload)).toBe(mediaOnlyPayload);
+
+    const preparedPayload = delivery.preparePayload({
+      text: "Done.\n⚠️ 🛠️ `search repos (agent)` failed",
+      mediaUrls: ["https://example.com/a.png"],
+      replyToId: "reply-1",
+    });
+    await delivery.deliver(preparedPayload);
+    await delivery.deliver(
+      delivery.preparePayload({
+        text: '<tool_call>{"name":"exec"}</tool_call>Meeting notes sent.',
+      }),
+    );
+
+    expect(sendMessageNextcloudTalkMock).toHaveBeenCalledTimes(2);
+    expect(requireFirstSendMessageCall()).toEqual([
+      "room-1",
+      "Done.\n\nAttachment: https://example.com/a.png",
+      {
+        cfg: config,
+        accountId: "default",
+        replyTo: "reply-1",
+      },
+    ]);
+    expect(sendMessageNextcloudTalkMock).toHaveBeenNthCalledWith(
+      2,
+      "room-1",
+      "Meeting notes sent.",
+      {
+        cfg: config,
+        accountId: "default",
+        replyTo: undefined,
+      },
+    );
   });
 });

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -338,7 +338,7 @@ describe("nextcloud-talk inbound behavior", () => {
     ) as {
       delivery?: {
         preparePayload?: (payload: OutboundReplyPayload) => OutboundReplyPayload;
-        deliver?: (payload: OutboundReplyPayload) => Promise<void>;
+        deliver?: (payload: OutboundReplyPayload) => Promise<{ visibleReplySent: boolean }>;
       };
     };
     const preparePayload = assembledRequest.delivery?.preparePayload;
@@ -360,7 +360,10 @@ describe("nextcloud-talk inbound behavior", () => {
       mediaUrls: ["https://example.com/a.png"],
       replyToId: "reply-1",
     });
-    await deliver(preparedPayload);
+    await expect(deliver(preparedPayload)).resolves.toEqual({ visibleReplySent: true });
+    await expect(
+      deliver(preparePayload({ text: "⚠️ 🛠️ `search repos (agent)` failed" })),
+    ).resolves.toEqual({ visibleReplySent: false });
 
     expect(sendMessageNextcloudTalkMock).toHaveBeenCalledTimes(1);
     expect(requireFirstSendMessageCall()).toEqual([

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -98,9 +98,9 @@ async function deliverNextcloudTalkReply(params: {
   roomToken: string;
   accountId: string;
   statusSink?: (patch: { lastOutboundAt?: number }) => void;
-}): Promise<void> {
+}): Promise<{ visibleReplySent: boolean }> {
   const { cfg, payload, roomToken, accountId, statusSink } = params;
-  await deliverFormattedTextWithAttachments({
+  const visibleReplySent = await deliverFormattedTextWithAttachments({
     payload,
     send: async ({ text, replyToId }) => {
       await sendMessageNextcloudTalk(roomToken, text, {
@@ -111,6 +111,7 @@ async function deliverNextcloudTalkReply(params: {
       statusSink?.({ lastOutboundAt: Date.now() });
     },
   });
+  return { visibleReplySent };
 }
 
 export async function handleNextcloudTalkInbound(params: {
@@ -370,7 +371,7 @@ export async function handleNextcloudTalkInbound(params: {
               text: sanitizeAssistantVisibleText(payload.text),
             },
       deliver: async (payload) => {
-        await deliverNextcloudTalkReply({
+        return await deliverNextcloudTalkReply({
           cfg: config,
           payload,
           roomToken,

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -8,6 +8,7 @@ import {
   normalizeOptionalString,
   normalizeStringEntries,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import {
   GROUP_POLICY_BLOCKED_LABEL,
   resolveAllowlistProviderRuntimeGroupPolicy,
@@ -361,6 +362,13 @@ export async function handleNextcloudTalkInbound(params: {
     dispatchReplyWithBufferedBlockDispatcher:
       core.channel.reply.dispatchReplyWithBufferedBlockDispatcher,
     delivery: {
+      preparePayload: (payload) =>
+        payload.text === undefined
+          ? payload
+          : {
+              ...payload,
+              text: sanitizeAssistantVisibleText(payload.text),
+            },
       deliver: async (payload) => {
         await deliverNextcloudTalkReply({
           cfg: config,

--- a/extensions/nextcloud-talk/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/nextcloud-talk/src/outbound-tool-trace-sanitize.test.ts
@@ -1,23 +1,45 @@
-// Nextcloud Talk outbound must strip assistant internal tool-trace scaffolding,
-// matching the sibling channel fixes tracked under #90684 (Slack / Signal /
-// Matrix / Telegram / Google Chat / QQBot / IRC / SMS / Feishu / LINE).
+// Nextcloud Talk outbound must strip assistant internal tool-trace scaffolding
+// before delivery, matching the shared channel sanitizer contract.
 import { describe, expect, it } from "vitest";
 import { nextcloudTalkPlugin } from "./channel.js";
+
+function sanitizeOutboundText(text: string): string {
+  const sanitizeText = nextcloudTalkPlugin.outbound?.sanitizeText;
+  if (!sanitizeText) {
+    throw new Error("Expected Nextcloud Talk outbound sanitizeText hook");
+  }
+  return sanitizeText({ text, payload: { text } });
+}
 
 describe("nextcloud-talk outbound sanitizeText", () => {
   it("strips internal tool-trace banners before outbound delivery", () => {
     const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+    expect(sanitizeOutboundText(text)).toBe("Done.");
+  });
 
-    expect(
-      nextcloudTalkPlugin.outbound?.sanitizeText?.({ text, payload: { text } }),
-    ).toBe("Done.");
+  it("strips XML tool-call scaffolding leaked into assistant text", () => {
+    const text = '<tool_call>{"name":"exec"}</tool_call>Meeting notes sent.';
+    expect(sanitizeOutboundText(text)).toBe("Meeting notes sent.");
+  });
+
+  it("strips multiline tool-response scaffolding leaked into assistant text", () => {
+    const text = [
+      "Checking now.",
+      "<function_response>",
+      'Searching for: "agenda"',
+      "</function_response>",
+      "Meeting notes sent.",
+    ].join("\n");
+    expect(sanitizeOutboundText(text)).toBe("Checking now.\n\nMeeting notes sent.");
   });
 
   it("preserves ordinary assistant prose while sanitizing", () => {
-    const text = "The pipeline has 3 open deals.";
+    const text = "The agenda has 3 open action items.";
+    expect(sanitizeOutboundText(text)).toBe(text);
+  });
 
-    expect(
-      nextcloudTalkPlugin.outbound?.sanitizeText?.({ text, payload: { text } }),
-    ).toBe(text);
+  it("preserves internal trace examples inside fenced code", () => {
+    const text = ["Example:", "```", "⚠️ 🛠️ `search repos (agent)` failed", "```"].join("\n");
+    expect(sanitizeOutboundText(text)).toBe(text);
   });
 });

--- a/extensions/nextcloud-talk/src/outbound-tool-trace-sanitize.test.ts
+++ b/extensions/nextcloud-talk/src/outbound-tool-trace-sanitize.test.ts
@@ -1,0 +1,23 @@
+// Nextcloud Talk outbound must strip assistant internal tool-trace scaffolding,
+// matching the sibling channel fixes tracked under #90684 (Slack / Signal /
+// Matrix / Telegram / Google Chat / QQBot / IRC / SMS / Feishu / LINE).
+import { describe, expect, it } from "vitest";
+import { nextcloudTalkPlugin } from "./channel.js";
+
+describe("nextcloud-talk outbound sanitizeText", () => {
+  it("strips internal tool-trace banners before outbound delivery", () => {
+    const text = "Done.\n⚠️ 🛠️ `search repos (agent)` failed";
+
+    expect(
+      nextcloudTalkPlugin.outbound?.sanitizeText?.({ text, payload: { text } }),
+    ).toBe("Done.");
+  });
+
+  it("preserves ordinary assistant prose while sanitizing", () => {
+    const text = "The pipeline has 3 open deals.";
+
+    expect(
+      nextcloudTalkPlugin.outbound?.sanitizeText?.({ text, payload: { text } }),
+    ).toBe(text);
+  });
+});

--- a/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
+++ b/extensions/nextcloud-talk/src/send.cfg-threading.test.ts
@@ -149,6 +149,26 @@ describe("nextcloud-talk send cfg threading", () => {
     });
   });
 
+  it("preserves caller-authored text on the low-level send path", async () => {
+    const cfg = { source: "provided" } as const;
+    const text = "Example:\n⚠️ 🛠️ `search repos (agent)` failed";
+    mockNextcloudMessageResponse(12346, 1_706_000_001);
+
+    await sendMessageNextcloudTalk("room:abc123", text, {
+      cfg,
+      accountId: "work",
+      replyTo: "parent-1",
+    });
+
+    expect(hoisted.generateNextcloudTalkSignature).toHaveBeenCalledWith({
+      body: text,
+      secret: "secret-value",
+    });
+    expect(fetchMock.mock.calls[0]?.[1]?.body).toBe(
+      JSON.stringify({ message: text, replyTo: "parent-1" }),
+    );
+  });
+
   it("sends with provided cfg even when the runtime store is not initialized", async () => {
     const cfg = { source: "provided" } as const;
     hoisted.record.mockImplementation(() => {


### PR DESCRIPTION
Part of #90684. Incorporates the useful regression coverage from #103355 by @miorbnli.

## What Problem This Solves

Nextcloud Talk could deliver internal assistant tool-trace scaffolding to users. The standard outbound adapter lacked the shared assistant-visible sanitizer, and the channel's custom inbound reply delivery bypassed that adapter entirely.

Trace-only replies also need accurate delivery accounting: treating a fully stripped reply as visible can suppress an older legitimate concurrent reply in the foreground dispatch fence.

## Why This Change Was Made

- Add the shared `sanitizeAssistantVisibleText` hook to the standard Nextcloud Talk outbound adapter.
- Sanitize only the text field in the custom inbound reply path, preserving media URLs, reply IDs, and the remaining payload.
- Return an explicit `visibleReplySent` result from inbound delivery so a fully stripped internal-only payload reports false.
- Keep `sendMessageNextcloudTalk` literal. It is the low-level caller-authored transport boundary, so examples or intentional trace-like text must not be rewritten there.

This matches the channel ownership boundary and avoids changing global defaults or unrelated caller-authored sends.

## User Impact

Automatic Nextcloud Talk replies no longer expose internal tool banners, XML tool calls, or function-response scaffolding. Ordinary prose, fenced code examples, attachments, and reply threading are preserved. Fully stripped internal-only output sends nothing without suppressing a valid visible reply.

## Evidence

Exact reviewed head: `d2abead8ffdd201a9af23f83fa23094aad76a616`

Exact tree: `99b411e22e0babe3f59b77cbb98ea30c07ed7d36`

Testbox-through-Crabbox: [`tbx_01kx6g156zgvy1y8at948jzh84`](https://github.com/openclaw/openclaw/actions/runs/29109921152), succeeded and auto-stopped.

- Fresh clone pinned to the exact SHA/tree before dependency execution.
- Current `main` negative control failed both missing sanitizer contracts; its raw low-level literal test passed.
- Fixed focused tests: 23/23 passed.
- Full `extensions/nextcloud-talk/src` suite: 108/108 passed.
- Real `node:http` delivery loopback verified the Nextcloud bot request path/method, sanitized automatic text, attachment formatting, reply IDs, HMAC headers, and unchanged low-level literal text.
- `pnpm check:changed` passed extension and extension-test tsgo, changed-file lint with zero warnings/errors, dependency and architecture guards, and the runtime import-cycle check.
- Targeted `oxfmt --check` and `git diff --check` passed.
- Fresh gpt-5.6-sol autoreview reported no findings (0.97 correctness confidence).

The request shape was checked against the [official Nextcloud Talk bot API documentation](https://nextcloud-talk.readthedocs.io/en/stable/bots/). No authenticated external Nextcloud instance was used; the production HTTP sender was exercised end-to-end against an isolated real loopback server.
