### PR TITLE
Bound model pricing cache size

### DIFF
--- a/src/gateway/model-pricing-cache-state.ts
+++ b/src/gateway/model-pricing-cache-state.ts
@@ -24,6 +24,8 @@ export type CachedModelPricing = {
 
 type GatewayModelPricingHealthSource = "openrouter" | "litellm" | "bootstrap" | "refresh";
 
+export const GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES = 4096;
+
 export type GatewayModelPricingHealth = {
   state: "ok" | "degraded" | "disabled";
   sources: Array<{
@@ -58,11 +60,44 @@ function modelPricingCacheKey(provider: string, model: string): string {
     : `${providerId}/${modelId}`;
 }
 
+function buildBoundedGatewayModelPricingCache(
+  nextPricing: Map<string, CachedModelPricing>,
+): Map<string, CachedModelPricing> {
+  const bounded = new Map<string, CachedModelPricing>();
+  for (const [key] of cachedPricing) {
+    if (nextPricing.has(key)) {
+      bounded.set(key, nextPricing.get(key)!);
+    }
+  }
+  for (const [key, pricing] of nextPricing) {
+    if (!bounded.has(key)) {
+      bounded.set(key, pricing);
+    }
+  }
+  for (const key of bounded.keys()) {
+    if (bounded.size <= GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES) {
+      break;
+    }
+    bounded.delete(key);
+  }
+  return bounded;
+}
+
+function getCachedGatewayModelPricingEntry(key: string): CachedModelPricing | undefined {
+  const pricing = cachedPricing.get(key);
+  if (!pricing) {
+    return undefined;
+  }
+  cachedPricing.delete(key);
+  cachedPricing.set(key, pricing);
+  return pricing;
+}
+
 export function replaceGatewayModelPricingCache(
   nextPricing: Map<string, CachedModelPricing>,
   nextCachedAt = Date.now(),
 ): void {
-  cachedPricing = nextPricing;
+  cachedPricing = buildBoundedGatewayModelPricingCache(nextPricing);
   cachedAt = nextCachedAt;
 }
 
@@ -134,7 +169,7 @@ export function getCachedGatewayModelPricing(params: {
     return undefined;
   }
   const key = modelPricingCacheKey(provider, model);
-  const direct = key ? cachedPricing.get(key) : undefined;
+  const direct = key ? getCachedGatewayModelPricingEntry(key) : undefined;
   if (direct) {
     return direct;
   }
@@ -143,7 +178,7 @@ export function getCachedGatewayModelPricing(params: {
   if (normalizedKey === key) {
     return undefined;
   }
-  return normalizedKey ? cachedPricing.get(normalizedKey) : undefined;
+  return normalizedKey ? getCachedGatewayModelPricingEntry(normalizedKey) : undefined;
 }
 
 export function getGatewayModelPricingCacheMeta(): {

--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -59,7 +59,12 @@ vi.mock("../plugins/manifest-metadata-scan.js", async (importOriginal) => {
   };
 });
 
-import { getGatewayModelPricingHealth } from "./model-pricing-cache-state.js";
+import {
+  GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES,
+  getGatewayModelPricingCacheMeta,
+  getGatewayModelPricingHealth,
+  replaceGatewayModelPricingCache,
+} from "./model-pricing-cache-state.js";
 import {
   resetGatewayModelPricingCacheForTest,
   collectConfiguredModelPricingRefs,
@@ -97,6 +102,24 @@ function requireAbortSignal(signal: RequestInit["signal"] | undefined): AbortSig
   return signal;
 }
 
+function createCachedModelPricing(index: number): CachedModelPricing {
+  return {
+    input: index,
+    output: index + 1,
+    cacheRead: 0,
+    cacheWrite: 0,
+  };
+}
+
+function createCachedModelPricingMap(count: number): Map<string, CachedModelPricing> {
+  return new Map(
+    Array.from({ length: count }, (_, index): [string, CachedModelPricing] => [
+      modelKey("custom", `model-${index}`),
+      createCachedModelPricing(index),
+    ]),
+  );
+}
+
 describe("model-pricing-cache", () => {
   beforeEach(() => {
     resetGatewayModelPricingCacheForTest();
@@ -110,6 +133,52 @@ describe("model-pricing-cache", () => {
     resetGatewayModelPricingCacheForTest();
     loggingState.rawConsole = null;
     resetLogger();
+  });
+
+  it("bounds replacement cache size and evicts the oldest pricing rows", () => {
+    replaceGatewayModelPricingCache(
+      createCachedModelPricingMap(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES + 2),
+      123,
+    );
+
+    expect(getGatewayModelPricingCacheMeta()).toEqual({
+      cachedAt: 123,
+      ttlMs: 0,
+      size: GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES,
+    });
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-0" })).toBeUndefined();
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-1" })).toBeUndefined();
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-2" })).toEqual(
+      createCachedModelPricing(2),
+    );
+  });
+
+  it("keeps recently used pricing rows when a refreshed cache exceeds the cap", () => {
+    replaceGatewayModelPricingCache(
+      createCachedModelPricingMap(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES),
+      123,
+    );
+
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-0" })).toEqual(
+      createCachedModelPricing(0),
+    );
+
+    replaceGatewayModelPricingCache(
+      createCachedModelPricingMap(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES + 1),
+      456,
+    );
+
+    expect(getGatewayModelPricingCacheMeta().size).toBe(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES);
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-0" })).toEqual(
+      createCachedModelPricing(0),
+    );
+    expect(getCachedGatewayModelPricing({ provider: "custom", model: "model-1" })).toBeUndefined();
+    expect(
+      getCachedGatewayModelPricing({
+        provider: "custom",
+        model: `model-${GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES}`,
+      }),
+    ).toEqual(createCachedModelPricing(GATEWAY_MODEL_PRICING_CACHE_MAX_ENTRIES));
   });
 
   it("collects configured model refs across defaults, aliases, overrides, and media tools", () => {


### PR DESCRIPTION
## What Problem This Solves

Closes #101543.

The gateway model-pricing cache could retain an unbounded number of pricing rows, which risks long-running processes accumulating pricing metadata until heap pressure or OOM.

## Why This Change Was Made

Adds a fixed upper bound to the in-memory model-pricing cache at the state boundary so every replacement path is capped consistently. Cache reads now refresh insertion order, and refresh replacements preserve recently used rows before trimming old entries.

## User Impact

Long-running gateway processes now keep model-pricing cache memory bounded while preserving normal pricing lookups for recently used models.

## Evidence

- `node scripts/run-vitest.mjs run src/gateway/model-pricing-cache.test.ts`
- `git diff --check origin/main..HEAD`