### PR TITLE
fix(http-error-body): keep emoji / surrogate pairs intact during error body truncation

### DIFF
--- a/src/infra/http-error-body.test.ts
+++ b/src/infra/http-error-body.test.ts
@@ -97,39 +97,29 @@ describe("readResponseBodySnippet", () => {
     expect(result).toBe("");
   });
 
-  it("does not split surrogate pairs when truncating by maxChars (body-less path)", async () => {
-    // "a" (1 code unit) + 5×🦞 (10 code units) = 11 code units > maxChars=10
-    // .slice(0, 10) would cut between the surrogates of the 5th emoji
-    const text = "a" + "🦞".repeat(5);
-    const result = await readResponseBodySnippet(bodyLessResponse(text), {
+  it.each([
+    {
+      name: "body-less response under the byte limit",
+      response: () => bodyLessResponse("a" + "🦞".repeat(10)),
       maxBytes: 1024,
+    },
+    {
+      name: "body-less response truncated by the byte limit",
+      response: () => bodyLessResponse("a" + "🦞".repeat(10)),
+      maxBytes: 30,
+    },
+    {
+      name: "streamed response",
+      response: () =>
+        new Response(new Blob([new TextEncoder().encode("a" + "🦞".repeat(10))]).stream()),
+      maxBytes: 1024,
+    },
+  ])("preserves surrogate pairs for $name", async ({ response, maxBytes }) => {
+    const result = await readResponseBodySnippet(response(), {
+      maxBytes,
       maxChars: 10,
     });
-    for (let i = 0; i < result.length; i++) {
-      const cp = result.charCodeAt(i);
-      if (cp >= 0xd800 && cp <= 0xdbff) {
-        expect(result.charCodeAt(i + 1)).toBeGreaterThanOrEqual(0xdc00);
-        expect(result.charCodeAt(i + 1)).toBeLessThanOrEqual(0xdfff);
-      }
-    }
-    const lastCode = result.charCodeAt(result.length - 1);
-    expect(lastCode < 0xd800 || lastCode > 0xdbff).toBe(true);
-  });
 
-  it("does not split surrogate pairs in the stream path", async () => {
-    const text = "a" + "🦞".repeat(5);
-    const data = new TextEncoder().encode(text);
-    const response = new Response(new Blob([data]).stream());
-    const result = await readResponseBodySnippet(response, {
-      maxBytes: 1024,
-      maxChars: 10,
-    });
-    for (let i = 0; i < result.length; i++) {
-      const cp = result.charCodeAt(i);
-      if (cp >= 0xd800 && cp <= 0xdbff) {
-        expect(result.charCodeAt(i + 1)).toBeGreaterThanOrEqual(0xdc00);
-        expect(result.charCodeAt(i + 1)).toBeLessThanOrEqual(0xdfff);
-      }
-    }
+    expect(result).toBe("a" + "🦞".repeat(4));
   });
 });

--- a/src/infra/http-error-body.test.ts
+++ b/src/infra/http-error-body.test.ts
@@ -96,4 +96,40 @@ describe("readResponseBodySnippet", () => {
     });
     expect(result).toBe("");
   });
+
+  it("does not split surrogate pairs when truncating by maxChars (body-less path)", async () => {
+    // "a" (1 code unit) + 5×🦞 (10 code units) = 11 code units > maxChars=10
+    // .slice(0, 10) would cut between the surrogates of the 5th emoji
+    const text = "a" + "🦞".repeat(5);
+    const result = await readResponseBodySnippet(bodyLessResponse(text), {
+      maxBytes: 1024,
+      maxChars: 10,
+    });
+    for (let i = 0; i < result.length; i++) {
+      const cp = result.charCodeAt(i);
+      if (cp >= 0xd800 && cp <= 0xdbff) {
+        expect(result.charCodeAt(i + 1)).toBeGreaterThanOrEqual(0xdc00);
+        expect(result.charCodeAt(i + 1)).toBeLessThanOrEqual(0xdfff);
+      }
+    }
+    const lastCode = result.charCodeAt(result.length - 1);
+    expect(lastCode < 0xd800 || lastCode > 0xdbff).toBe(true);
+  });
+
+  it("does not split surrogate pairs in the stream path", async () => {
+    const text = "a" + "🦞".repeat(5);
+    const data = new TextEncoder().encode(text);
+    const response = new Response(new Blob([data]).stream());
+    const result = await readResponseBodySnippet(response, {
+      maxBytes: 1024,
+      maxChars: 10,
+    });
+    for (let i = 0; i < result.length; i++) {
+      const cp = result.charCodeAt(i);
+      if (cp >= 0xd800 && cp <= 0xdbff) {
+        expect(result.charCodeAt(i + 1)).toBeGreaterThanOrEqual(0xdc00);
+        expect(result.charCodeAt(i + 1)).toBeLessThanOrEqual(0xdfff);
+      }
+    }
+  });
 });

--- a/src/infra/http-error-body.ts
+++ b/src/infra/http-error-body.ts
@@ -1,3 +1,5 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
 export async function readResponseBodySnippet(
   response: Response,
   limits: { maxBytes: number; maxChars: number },
@@ -8,13 +10,14 @@ export async function readResponseBodySnippet(
       const text = await response.text();
       const encoded = new TextEncoder().encode(text);
       if (encoded.byteLength > limits.maxBytes) {
-        return new TextDecoder()
-          .decode(encoded.subarray(0, limits.maxBytes), {
+        return truncateUtf16Safe(
+          new TextDecoder().decode(encoded.subarray(0, limits.maxBytes), {
             stream: true,
-          })
-          .slice(0, limits.maxChars);
+          }),
+          limits.maxChars,
+        );
       }
-      return text.slice(0, limits.maxChars);
+      return truncateUtf16Safe(text, limits.maxChars);
     }
 
     const reader = body.getReader();
@@ -54,7 +57,10 @@ export async function readResponseBodySnippet(
       } catch {}
     }
 
-    return new TextDecoder().decode(Buffer.concat(chunks, total)).slice(0, limits.maxChars);
+    return truncateUtf16Safe(
+      new TextDecoder().decode(Buffer.concat(chunks, total)),
+      limits.maxChars,
+    );
   } catch {
     return "";
   }


### PR DESCRIPTION
## What Problem This Solves

`readResponseBodySnippet` in `src/infra/http-error-body.ts` truncates HTTP error response body text with `.slice(0, limits.maxChars)`, which counts UTF-16 code units. When an emoji straddles the cut boundary, `.slice()` produces a lone surrogate that renders as `�` in error diagnostics shown to users.

The sibling file `src/infra/http-body.ts` already imports and uses `truncateUtf16Safe` for the same kind of truncation (#101685), but `http-error-body.ts` was missed.

## Why This Change Was Made

Replace `.slice(0, limits.maxChars)` with `truncateUtf16Safe(text, limits.maxChars)` at all three call sites (body-less path × 2 + stream path × 1). This matches `src/infra/http-body.ts:317`.

## User Impact

Error diagnostics from MiniMax VLM and PDF native providers will no longer contain `�` when an emoji falls near the character truncation boundary.

## Evidence

The table-driven regression test asserts the exact surrogate-safe result across
all three reachable branches:

- body-less response below `maxBytes`
- body-less response truncated by `maxBytes`
- streamed response

Exact-head hosted CI is the execution gate for this contributor branch.

AI-assisted.
