### PR TITLE
fix(gateway): suppress MCP notification responses

### DIFF
--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -998,6 +998,40 @@ describe("mcp loopback server", () => {
     expect(resolveGatewayScopedToolsMock).not.toHaveBeenCalled();
   });
 
+  it("suppresses reserved-harness errors for notifications", async () => {
+    const { runtime, port } = await startLoopbackServerForTest();
+    const headers = {
+      "content-type": "application/json",
+      "x-session-key": "agent:main:harness:codex:supervision:native-thread",
+    };
+    const notificationResponse = await sendRaw({
+      port,
+      token: runtime.ownerToken,
+      headers,
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list" }),
+    });
+    const mixedResponse = await sendRaw({
+      port,
+      token: runtime.ownerToken,
+      headers,
+      body: JSON.stringify([
+        { jsonrpc: "2.0", method: "tools/list" },
+        { jsonrpc: "2.0", id: 42, method: "tools/list" },
+      ]),
+    });
+
+    expect(notificationResponse.status).toBe(202);
+    await expect(notificationResponse.text()).resolves.toBe("");
+    expect(mixedResponse.status).toBe(200);
+    await expect(mixedResponse.json()).resolves.toEqual([
+      expect.objectContaining({
+        id: 42,
+        error: { code: -32600, message: expect.stringContaining("reserved") },
+      }),
+    ]);
+    expect(resolveGatewayScopedToolsMock).not.toHaveBeenCalled();
+  });
+
   it("allows an existing unlocked legacy harness-prefixed context", async () => {
     const { runtime } = await startLoopbackServerForTest();
     const sessionKey = "agent:main:harness:legacy-notes";
@@ -2902,6 +2936,26 @@ describe("mcp loopback server", () => {
     expect(payload[1]?.result?.tools?.map((tool) => tool.name)).toContain("message");
   });
 
+  it("returns an invalid request for an empty batch before harness policy", async () => {
+    const { runtime, port } = await startLoopbackServerForTest();
+    const response = await sendRaw({
+      port,
+      token: runtime.ownerToken,
+      headers: {
+        "content-type": "application/json",
+        "x-session-key": "agent:main:harness:codex:supervision:native-thread",
+      },
+      body: "[]",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      id: null,
+      error: { code: -32600, message: "Invalid Request" },
+    });
+    expect(resolveGatewayScopedToolsMock).not.toHaveBeenCalled();
+  });
+
   it("returns 202 with an empty body for JSON-RPC notifications", async () => {
     server = await startMcpLoopbackServer(0);
     const runtime = getActiveMcpLoopbackRuntime();
@@ -2916,7 +2970,7 @@ describe("mcp loopback server", () => {
     await expect(response.text()).resolves.toBe("");
   });
 
-  it("does not resolve tools for tools/list notification-only requests", async () => {
+  it("suppresses internal errors for notification-only requests", async () => {
     resolveGatewayScopedToolsMock.mockImplementation(() => {
       throw new Error("tool resolution exploded");
     });
@@ -2931,29 +2985,27 @@ describe("mcp loopback server", () => {
 
     expect(response.status).toBe(202);
     await expect(response.text()).resolves.toBe("");
-    expect(resolveGatewayScopedToolsMock).not.toHaveBeenCalled();
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(1);
   });
 
-  it.each(["notifications/initialized", "notifications/cancelled"])(
-    "does not resolve tools for %s notification-only requests",
-    async (method) => {
-      resolveGatewayScopedToolsMock.mockImplementation(() => {
-        throw new Error("tool resolution exploded");
-      });
-      server = await startMcpLoopbackServer(0);
-      const runtime = getActiveMcpLoopbackRuntime();
-      const response = await sendRaw({
-        port: server.port,
-        token: runtime?.ownerToken,
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ jsonrpc: "2.0", method }),
-      });
+  it("returns only request responses for mixed batches", async () => {
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+    const response = await sendRaw({
+      port: server.port,
+      token: runtime?.ownerToken,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([
+        { jsonrpc: "2.0", method: "tools/list" },
+        { jsonrpc: "2.0", id: 42, method: "tools/list" },
+      ]),
+    });
+    const payload = (await response.json()) as Array<{ id?: unknown }>;
 
-      expect(response.status).toBe(202);
-      await expect(response.text()).resolves.toBe("");
-      expect(resolveGatewayScopedToolsMock).not.toHaveBeenCalled();
-    },
-  );
+    expect(response.status).toBe(200);
+    expect(payload).toHaveLength(1);
+    expect(payload[0]?.id).toBe(42);
+  });
 
   it("dispatches tools/call notifications without returning a response", async () => {
     const execute = vi.fn(async () => ({

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -2885,6 +2885,48 @@ describe("mcp loopback server", () => {
     await expect(response.text()).resolves.toBe("");
   });
 
+  it("does not resolve tools for tools/list notification-only requests", async () => {
+    resolveGatewayScopedToolsMock.mockImplementation(() => {
+      throw new Error("tool resolution exploded");
+    });
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+    const response = await sendRaw({
+      port: server.port,
+      token: runtime?.ownerToken,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list" }),
+    });
+
+    expect(response.status).toBe(202);
+    await expect(response.text()).resolves.toBe("");
+    expect(resolveGatewayScopedToolsMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches tools/call notifications without returning a response", async () => {
+    const execute = vi.fn(async () => ({
+      content: [{ type: "text", text: "ok" }],
+    }));
+    mockScopedTools([makeMessageTool({ execute })]);
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+    const response = await sendRaw({
+      port: server.port,
+      token: runtime?.ownerToken,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { name: "message", arguments: { body: "hello" } },
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    await expect(response.text()).resolves.toBe("");
+    expect(resolveGatewayScopedToolsMock).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
   it("returns 413 instead of resetting oversized request bodies", async () => {
     server = await ensureMcpLoopbackServer(0);
     const runtime = getActiveMcpLoopbackRuntime();

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -2881,11 +2881,10 @@ describe("mcp loopback server", () => {
     resolveGatewayScopedToolsMock.mockImplementation(() => {
       throw new Error("tool resolution exploded");
     });
-    server = await startMcpLoopbackServer(0);
-    const runtime = getActiveMcpLoopbackRuntime();
+    const { runtime, port } = await startLoopbackServerForTest();
     const response = await sendRaw({
-      port: server.port,
-      token: runtime?.ownerToken,
+      port,
+      token: runtime.ownerToken,
       headers: { "content-type": "application/json" },
       body: JSON.stringify([
         { jsonrpc: "2.0", method: "tools/list" },
@@ -2957,11 +2956,10 @@ describe("mcp loopback server", () => {
   });
 
   it("returns 202 with an empty body for JSON-RPC notifications", async () => {
-    server = await startMcpLoopbackServer(0);
-    const runtime = getActiveMcpLoopbackRuntime();
+    const { runtime, port } = await startLoopbackServerForTest();
     const response = await sendRaw({
-      port: server.port,
-      token: runtime?.ownerToken,
+      port,
+      token: runtime.ownerToken,
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list" }),
     });
@@ -2974,11 +2972,10 @@ describe("mcp loopback server", () => {
     resolveGatewayScopedToolsMock.mockImplementation(() => {
       throw new Error("tool resolution exploded");
     });
-    server = await startMcpLoopbackServer(0);
-    const runtime = getActiveMcpLoopbackRuntime();
+    const { runtime, port } = await startLoopbackServerForTest();
     const response = await sendRaw({
-      port: server.port,
-      token: runtime?.ownerToken,
+      port,
+      token: runtime.ownerToken,
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list" }),
     });
@@ -2989,11 +2986,10 @@ describe("mcp loopback server", () => {
   });
 
   it("returns only request responses for mixed batches", async () => {
-    server = await startMcpLoopbackServer(0);
-    const runtime = getActiveMcpLoopbackRuntime();
+    const { runtime, port } = await startLoopbackServerForTest();
     const response = await sendRaw({
-      port: server.port,
-      token: runtime?.ownerToken,
+      port,
+      token: runtime.ownerToken,
       headers: { "content-type": "application/json" },
       body: JSON.stringify([
         { jsonrpc: "2.0", method: "tools/list" },
@@ -3012,11 +3008,10 @@ describe("mcp loopback server", () => {
       content: [{ type: "text", text: "ok" }],
     }));
     mockScopedTools([makeMessageTool({ execute })]);
-    server = await startMcpLoopbackServer(0);
-    const runtime = getActiveMcpLoopbackRuntime();
+    const { runtime, port } = await startLoopbackServerForTest();
     const response = await sendRaw({
-      port: server.port,
-      token: runtime?.ownerToken,
+      port,
+      token: runtime.ownerToken,
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         jsonrpc: "2.0",

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -2843,6 +2843,37 @@ describe("mcp loopback server", () => {
     });
   });
 
+  it("does not include notifications in internal-error batch responses", async () => {
+    resolveGatewayScopedToolsMock.mockImplementation(() => {
+      throw new Error("tool resolution exploded");
+    });
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+    const response = await sendRaw({
+      port: server.port,
+      token: runtime?.ownerToken,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify([
+        { jsonrpc: "2.0", method: "tools/list" },
+        { jsonrpc: "2.0", id: 42, method: "tools/list" },
+      ]),
+    });
+    const payload = (await response.json()) as Array<{
+      id?: unknown;
+      error?: { code?: number; message?: string };
+    }>;
+
+    expect(response.status).toBe(500);
+    expect(payload).toHaveLength(1);
+    expect(payload[0]).toMatchObject({
+      id: 42,
+      error: {
+        code: -32603,
+        message: "Internal error",
+      },
+    });
+  });
+
   it("returns invalid request errors for malformed batch entries without resetting the request", async () => {
     server = await ensureMcpLoopbackServer(0);
     const runtime = getActiveMcpLoopbackRuntime();

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -2871,6 +2871,20 @@ describe("mcp loopback server", () => {
     expect(payload[1]?.result?.tools?.map((tool) => tool.name)).toContain("message");
   });
 
+  it("returns 202 with an empty body for JSON-RPC notifications", async () => {
+    server = await startMcpLoopbackServer(0);
+    const runtime = getActiveMcpLoopbackRuntime();
+    const response = await sendRaw({
+      port: server.port,
+      token: runtime?.ownerToken,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list" }),
+    });
+
+    expect(response.status).toBe(202);
+    await expect(response.text()).resolves.toBe("");
+  });
+
   it("returns 413 instead of resetting oversized request bodies", async () => {
     server = await ensureMcpLoopbackServer(0);
     const runtime = getActiveMcpLoopbackRuntime();

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -2903,6 +2903,27 @@ describe("mcp loopback server", () => {
     expect(resolveGatewayScopedToolsMock).not.toHaveBeenCalled();
   });
 
+  it.each(["notifications/initialized", "notifications/cancelled"])(
+    "does not resolve tools for %s notification-only requests",
+    async (method) => {
+      resolveGatewayScopedToolsMock.mockImplementation(() => {
+        throw new Error("tool resolution exploded");
+      });
+      server = await startMcpLoopbackServer(0);
+      const runtime = getActiveMcpLoopbackRuntime();
+      const response = await sendRaw({
+        port: server.port,
+        token: runtime?.ownerToken,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", method }),
+      });
+
+      expect(response.status).toBe(202);
+      await expect(response.text()).resolves.toBe("");
+      expect(resolveGatewayScopedToolsMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("dispatches tools/call notifications without returning a response", async () => {
     const execute = vi.fn(async () => ({
       content: [{ type: "text", text: "ok" }],

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -95,7 +95,17 @@ function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
 }
 
 function isJsonRpcNotification(message: JsonRpcRequest): boolean {
-  return !Object.prototype.hasOwnProperty.call(message, "id");
+  return !Object.hasOwn(message, "id");
+}
+
+function isResponseOnlyJsonRpcNotification(message: unknown): message is JsonRpcRequest {
+  return (
+    isJsonRpcRequest(message) && isJsonRpcNotification(message) && message.method === "tools/list"
+  );
+}
+
+function isResponseOnlyJsonRpcNotificationBatch(messages: unknown[]): boolean {
+  return messages.every(isResponseOnlyJsonRpcNotification);
 }
 
 function jsonRpcInternalError(parsed: JsonRpcRequest | JsonRpcRequest[] | undefined) {
@@ -211,6 +221,12 @@ async function startMcpLoopbackServer(port = 0): Promise<{
         const body = await readMcpHttpBody(req, { timeoutMs: resolveMcpHttpBodyTimeoutMs() });
         parsed = parseMcpJsonBody(body);
         const messages = Array.isArray(parsed) ? parsed : [parsed];
+        if (isResponseOnlyJsonRpcNotificationBatch(messages)) {
+          markMcpLoopbackRequestClassified(cliRequestCaptureHandle);
+          res.writeHead(202);
+          res.end();
+          return;
+        }
         cliCaptureHandles = messages.map((message) => {
           if (
             !cliRequestCaptureHandle ||

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -94,6 +94,10 @@ function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
   return isRecord(message) && message.jsonrpc === "2.0" && typeof message.method === "string";
 }
 
+function isJsonRpcNotification(message: JsonRpcRequest): boolean {
+  return !Object.prototype.hasOwnProperty.call(message, "id");
+}
+
 function jsonRpcInternalError(parsed: JsonRpcRequest | JsonRpcRequest[] | undefined) {
   if (Array.isArray(parsed)) {
     return parsed.map((message) =>
@@ -368,7 +372,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           } finally {
             markMcpLoopbackToolCallFinished(cliCaptureHandle);
           }
-          if (response !== null) {
+          if (response !== null && !isJsonRpcNotification(message)) {
             const responseToolName =
               message.method === "tools/call" && isRecord(message.params)
                 ? message.params.name

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -115,9 +115,13 @@ function isPreResolutionJsonRpcNotificationBatch(messages: unknown[]): boolean {
 
 function jsonRpcInternalError(parsed: JsonRpcRequest | JsonRpcRequest[] | undefined) {
   if (Array.isArray(parsed)) {
-    return parsed.map((message) =>
-      jsonRpcError(readJsonRpcRequestId(message), -32603, "Internal error"),
-    );
+    const responses = parsed
+      .filter((message) => !isJsonRpcRequest(message) || !isJsonRpcNotification(message))
+      .map((message) => jsonRpcError(readJsonRpcRequestId(message), -32603, "Internal error"));
+    return responses.length === 0 ? null : responses;
+  }
+  if (isJsonRpcRequest(parsed) && isJsonRpcNotification(parsed)) {
+    return null;
   }
   return jsonRpcError(readJsonRpcRequestId(parsed), -32603, "Internal error");
 }
@@ -440,8 +444,14 @@ async function startMcpLoopbackServer(port = 0): Promise<{
             res.writeHead(400, { "Content-Type": "application/json" });
             res.end(JSON.stringify(jsonRpcError(null, -32700, "Parse error")));
           } else {
-            res.writeHead(500, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(jsonRpcInternalError(parsed)));
+            const internalError = jsonRpcInternalError(parsed);
+            if (internalError === null) {
+              res.writeHead(202);
+              res.end();
+            } else {
+              res.writeHead(500, { "Content-Type": "application/json" });
+              res.end(JSON.stringify(internalError));
+            }
           }
         }
       } finally {

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -74,9 +74,9 @@ function isMcpJsonParseError(error: unknown): error is Error & { code: "mcp_json
   );
 }
 
-function parseMcpJsonBody(body: string): JsonRpcRequest | JsonRpcRequest[] {
+function parseMcpJsonBody(body: string): unknown {
   try {
-    return JSON.parse(body) as JsonRpcRequest | JsonRpcRequest[];
+    return JSON.parse(body) as unknown;
   } catch (error) {
     throw createMcpJsonParseError(error);
   }
@@ -94,36 +94,27 @@ function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
   return isRecord(message) && message.jsonrpc === "2.0" && typeof message.method === "string";
 }
 
-function isJsonRpcNotification(message: JsonRpcRequest): boolean {
-  return !Object.hasOwn(message, "id");
+function shouldSendJsonRpcResponse(message: unknown): boolean {
+  return !isJsonRpcRequest(message) || Object.hasOwn(message, "id");
 }
 
-function isPreResolutionJsonRpcNotification(message: unknown): message is JsonRpcRequest {
-  if (!isJsonRpcRequest(message) || !isJsonRpcNotification(message)) {
-    return false;
-  }
-  return (
-    message.method === "tools/list" ||
-    message.method === "notifications/initialized" ||
-    message.method === "notifications/cancelled"
+function collectJsonRpcResponses<T>(
+  messages: unknown[],
+  createResponse: (message: unknown) => T,
+): T[] {
+  return messages.filter(shouldSendJsonRpcResponse).map(createResponse);
+}
+
+function jsonRpcInternalError(parsed: unknown) {
+  const isBatch = Array.isArray(parsed);
+  const messages = isBatch ? parsed : [parsed];
+  const responses = collectJsonRpcResponses(messages, (message) =>
+    jsonRpcError(readJsonRpcRequestId(message), -32603, "Internal error"),
   );
-}
-
-function isPreResolutionJsonRpcNotificationBatch(messages: unknown[]): boolean {
-  return messages.every(isPreResolutionJsonRpcNotification);
-}
-
-function jsonRpcInternalError(parsed: JsonRpcRequest | JsonRpcRequest[] | undefined) {
-  if (Array.isArray(parsed)) {
-    const responses = parsed
-      .filter((message) => !isJsonRpcRequest(message) || !isJsonRpcNotification(message))
-      .map((message) => jsonRpcError(readJsonRpcRequestId(message), -32603, "Internal error"));
-    return responses.length === 0 ? null : responses;
-  }
-  if (isJsonRpcRequest(parsed) && isJsonRpcNotification(parsed)) {
+  if (responses.length === 0) {
     return null;
   }
-  return jsonRpcError(readJsonRpcRequestId(parsed), -32603, "Internal error");
+  return isBatch ? responses : responses[0];
 }
 
 function shouldLogMcpLoopbackTraffic(): boolean {
@@ -224,18 +215,18 @@ async function startMcpLoopbackServer(port = 0): Promise<{
     const cliRequestCaptureHandle = markMcpLoopbackRequestStarted(cliCaptureKey);
     const requestAbort = createRequestAbortSignal(req, res);
     void (async () => {
-      let parsed: JsonRpcRequest | JsonRpcRequest[] | undefined;
+      let parsed: unknown;
       let cliCaptureHandles: Array<ReturnType<typeof markMcpLoopbackToolCallStarted>> = [];
       try {
         const body = await readMcpHttpBody(req, { timeoutMs: resolveMcpHttpBodyTimeoutMs() });
         parsed = parseMcpJsonBody(body);
-        const messages = Array.isArray(parsed) ? parsed : [parsed];
-        if (isPreResolutionJsonRpcNotificationBatch(messages)) {
+        if (Array.isArray(parsed) && parsed.length === 0) {
           markMcpLoopbackRequestClassified(cliRequestCaptureHandle);
-          res.writeHead(202);
-          res.end();
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(jsonRpcError(null, -32600, "Invalid Request")));
           return;
         }
+        const messages = Array.isArray(parsed) ? parsed : [parsed];
         cliCaptureHandles = messages.map((message) => {
           if (
             !cliRequestCaptureHandle ||
@@ -281,13 +272,18 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           (!harnessEntry ||
             isAgentHarnessSessionStoreEntryProtected(requestContext.sessionKey, harnessEntry))
         ) {
-          const errors = messages.map((message) =>
+          const errors = collectJsonRpcResponses(messages, (message) =>
             jsonRpcError(
               readJsonRpcRequestId(message),
               -32600,
               AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE,
             ),
           );
+          if (errors.length === 0) {
+            res.writeHead(202);
+            res.end();
+            return;
+          }
           const payload = Array.isArray(parsed)
             ? JSON.stringify(errors)
             : JSON.stringify(errors[0]);
@@ -397,7 +393,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
           } finally {
             markMcpLoopbackToolCallFinished(cliCaptureHandle);
           }
-          if (response !== null && !isJsonRpcNotification(message)) {
+          if (response !== null && shouldSendJsonRpcResponse(message)) {
             const responseToolName =
               message.method === "tools/call" && isRecord(message.params)
                 ? message.params.name

--- a/src/gateway/mcp-http.ts
+++ b/src/gateway/mcp-http.ts
@@ -98,14 +98,19 @@ function isJsonRpcNotification(message: JsonRpcRequest): boolean {
   return !Object.hasOwn(message, "id");
 }
 
-function isResponseOnlyJsonRpcNotification(message: unknown): message is JsonRpcRequest {
+function isPreResolutionJsonRpcNotification(message: unknown): message is JsonRpcRequest {
+  if (!isJsonRpcRequest(message) || !isJsonRpcNotification(message)) {
+    return false;
+  }
   return (
-    isJsonRpcRequest(message) && isJsonRpcNotification(message) && message.method === "tools/list"
+    message.method === "tools/list" ||
+    message.method === "notifications/initialized" ||
+    message.method === "notifications/cancelled"
   );
 }
 
-function isResponseOnlyJsonRpcNotificationBatch(messages: unknown[]): boolean {
-  return messages.every(isResponseOnlyJsonRpcNotification);
+function isPreResolutionJsonRpcNotificationBatch(messages: unknown[]): boolean {
+  return messages.every(isPreResolutionJsonRpcNotification);
 }
 
 function jsonRpcInternalError(parsed: JsonRpcRequest | JsonRpcRequest[] | undefined) {
@@ -221,7 +226,7 @@ async function startMcpLoopbackServer(port = 0): Promise<{
         const body = await readMcpHttpBody(req, { timeoutMs: resolveMcpHttpBodyTimeoutMs() });
         parsed = parseMcpJsonBody(body);
         const messages = Array.isArray(parsed) ? parsed : [parsed];
-        if (isResponseOnlyJsonRpcNotificationBatch(messages)) {
+        if (isPreResolutionJsonRpcNotificationBatch(messages)) {
           markMcpLoopbackRequestClassified(cliRequestCaptureHandle);
           res.writeHead(202);
           res.end();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where MCP clients sending JSON-RPC notifications would receive response bodies, contrary to the MCP Streamable HTTP contract.

## Why This Change Was Made

The MCP loopback HTTP server now applies one response-eligibility rule everywhere a JSON-RPC result can be produced: normal dispatch, reserved harness errors, and internal errors. Valid id-less notifications are still processed, including side-effecting `tools/call` notifications, but are omitted from response bodies. Id-bearing requests, explicit `id: null` requests, and malformed entries retain responses. An empty batch is rejected as one invalid request before harness/tool resolution.

This replaces the earlier method-specific pre-resolution allowlist with a central protocol boundary, so notification behavior does not depend on the requested method or the error path taken.

## User Impact

MCP clients can use fire-and-forget notifications without receiving protocol-invalid JSON-RPC responses. Mixed batches return only request/error responses, while notification side effects still run.

Release-note context lives here; the root changelog remains release-owned.

## Evidence

- Exact reviewed head: `2ca9dce26eb2f2f534ec480a48942165039f7e32`
- Patch-identical Blacksmith Testbox proof: [run 29488844106](https://github.com/openclaw/openclaw/actions/runs/29488844106), stable patch id `8219d6de3201105a66503841b683a3611897ebc3`
- `src/gateway/mcp-http.test.ts`: 94/94 tests passed over the real loopback HTTP server.
- Targeted formatting and oxlint passed.
- Fresh aggregate autoreview passed with no accepted or actionable findings (patch correct 0.93).
- Coverage includes notification-only success and error paths, `tools/call` execution without a response, mixed request/notification batches, malformed entries, explicit `id: null`, reserved harness errors, internal errors, and empty batches.

Contributor credit preserved for @xingzhou0818 / @zhangguiping-xydt.
