### PR TITLE
fix(codex): allow tool-less /btw side questions

### DIFF
--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -762,7 +762,10 @@ describe("runCodexAppServerSideQuestion", () => {
   it.each([
     { name: "deny all", toolsAllow: [] },
     { name: "narrow allowlist", toolsAllow: ["message"] },
-  ])("rejects /btw before forking when effective toolsAllow is $name", async ({ toolsAllow }) => {
+  ])("forks a tool-less side thread when effective toolsAllow is $name", async ({ toolsAllow }) => {
+    const client = createFakeClient();
+    getSharedCodexAppServerClientMock.mockResolvedValue(client);
+
     await expect(
       runCodexAppServerSideQuestion(
         sideParams({
@@ -772,11 +775,22 @@ describe("runCodexAppServerSideQuestion", () => {
           toolsAllow,
         }),
       ),
-    ).rejects.toThrow(
-      "Codex-native /btw side-question mode is unavailable because the effective tool policy restricts Codex native tools for this session.",
-    );
+    ).resolves.toEqual({ text: "Side answer." });
 
-    expect(getSharedCodexAppServerClientMock).not.toHaveBeenCalled();
+    const forkParams = mockCall(client.request)[1] as Record<string, unknown> | undefined;
+    expect(forkParams?.config).toMatchObject({
+      "features.code_mode": false,
+      "features.code_mode_only": false,
+      "features.standalone_web_search": false,
+      web_search: "disabled",
+    });
+    expect(
+      client.request.mock.calls.some(([method]) => method === "thread/fork"),
+    ).toBe(true);
+    expect(
+      client.request.mock.calls.some(([method]) => method === "turn/start"),
+    ).toBe(true);
+    expect(createOpenClawCodingToolsMock).not.toHaveBeenCalled();
     expect(resolveCodexProviderWebSearchSupportForClientMock).not.toHaveBeenCalled();
   });
 

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -237,11 +237,6 @@ export async function runCodexAppServerSideQuestion(
     throw new Error(nativeExecutionBlock);
   }
   const nativeToolSurfaceEnabled = shouldEnableCodexAppServerNativeToolSurface(sideRunParams);
-  if (!nativeToolSurfaceEnabled) {
-    throw new Error(
-      "Codex-native /btw side-question mode is unavailable because the effective tool policy restricts Codex native tools for this session.",
-    );
-  }
   const client = await getLeasedSharedCodexAppServerClient({
     startOptions: appServer.start,
     timeoutMs: appServer.requestTimeoutMs,
@@ -797,7 +792,7 @@ async function createCodexSideToolBridge(input: {
     ({ id: input.params.model, provider: input.params.provider } as never);
   const messageToolProvider = resolveCodexMessageToolProvider(input.params);
   let tools: AnyAgentTool[] = [];
-  if (supportsModelTools(runtimeModel)) {
+  if (input.nativeToolSurfaceEnabled && supportsModelTools(runtimeModel)) {
     const createOpenClawCodingTools = (await import("openclaw/plugin-sdk/agent-harness"))
       .createOpenClawCodingTools;
     const sandboxSessionKey =


### PR DESCRIPTION
## What Problem This Solves

Codex-native /btw currently aborts before forking when the effective tool policy disables native Codex tools, even though /btw can still answer as a lightweight side conversation without tools. That makes harmless side questions fail on restricted sessions.

## Summary

- allow Codex /btw side questions to fork even when the effective tool policy disables the native Codex tool surface
- keep those restricted side threads tool-less by skipping OpenClaw tool bridge construction
- update regression coverage for deny-all and narrow toolsAllow policies

## Evidence

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-support.config.ts extensions/codex/src/app-server/side-question.test.ts --maxWorkers=1`
- Result: 1 test file passed, 46 tests passed
- `npm test -- --run extensions/codex/index.test.ts`
- Result: 1 test file passed, 10 tests passed
- Local runtime syntax checks passed for the active installed Codex side-question bundles with `node --check`

## Live Restricted /btw Proof

Ran against the real local Codex app-server, not a mocked test client:

- Source commit: `a4dd444efcab358b3d910d75177d7657cb248f96`
- Codex CLI: `codex-cli 0.142.5`
- Model: `gpt-5.4-mini`
- Parent thread: started and completed normally
- Side question policy: `toolsAllow: []`
- Side answer: `PROOFOK`
- Old policy abort observed: `false`
- App-server methods observed: `account/login/start`, `thread/start`, `turn/start`, `thread/fork`, `thread/inject_items`, side `turn/start`, `thread/unsubscribe`
- Server tool requests observed: `[]`
- `item/tool/call` request count: `0`
- Approval request count: `0`

Redacted proof excerpt:

```json
{
  "parentThreadStarted": true,
  "parentTurnStarted": true,
  "parentTurnCompleted": {
    "status": "completed",
    "turnId": "<redacted-turn>",
    "text": "PARENTREADY"
  },
  "restrictedToolsAllow": [],
  "sideAnswer": "PROOFOK",
  "markerObserved": true,
  "oldPolicyErrorSeen": false,
  "methods": [
    "account/login/start",
    "thread/start",
    "turn/start",
    "thread/fork",
    "thread/inject_items",
    "turn/start",
    "thread/unsubscribe"
  ],
  "forkObserved": true,
  "forkEphemeral": true,
  "forkConfig": {
    "features.hooks": false,
    "hooks.PreToolUse": [],
    "hooks.PostToolUse": [],
    "hooks.PermissionRequest": [],
    "hooks.Stop": [],
    "features.standalone_web_search": false,
    "web_search": "disabled",
    "features.code_mode": false,
    "features.code_mode_only": false
  },
  "serverRequestMethods": [],
  "itemToolCallRequestCount": 0,
  "approvalRequestCount": 0,
  "notificationTail": [
    {
      "method": "turn/completed",
      "threadId": "<redacted-thread>",
      "turnId": "<redacted-turn>",
      "status": "completed"
    }
  ]
}
```