### PR TITLE
fix(mattermost): cap outbound and monitor resource caches

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-resources.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.test.ts
@@ -149,6 +149,63 @@ describe("mattermost monitor resources", () => {
     });
   });
 
+  it.each(["channel", "user"] as const)(
+    "bounds the %s cache without refreshing insertion order on reads",
+    async (kind) => {
+      const fetchResource = kind === "channel" ? fetchMattermostChannel : fetchMattermostUser;
+      fetchResource.mockImplementation(async (_client, id: string) => ({ id }));
+      const resources = createMattermostMonitorResources({
+        accountId: "default",
+        callbackUrl: "https://openclaw.test/callback",
+        client: {} as never,
+        logger: {},
+        mediaMaxBytes: 1024,
+        saveRemoteMedia: vi.fn(),
+        mediaKindFromMime: () => "document",
+      });
+      const resolve = kind === "channel" ? resources.resolveChannelInfo : resources.resolveUserInfo;
+
+      for (let index = 0; index < 1000; index += 1) {
+        await resolve(`${kind}-${index}`);
+      }
+      await resolve(`${kind}-0`);
+      await resolve(`${kind}-1000`);
+      await resolve(`${kind}-0`);
+      await resolve(`${kind}-1000`);
+
+      const requestedIds = fetchResource.mock.calls.map((call) => call[1]);
+      expect(requestedIds.filter((id) => id === `${kind}-0`)).toHaveLength(2);
+      expect(requestedIds.filter((id) => id === `${kind}-1000`)).toHaveLength(1);
+    },
+  );
+
+  it.each([
+    { kind: "channel" as const, ttlMs: 5 * 60_000 },
+    { kind: "user" as const, ttlMs: 10 * 60_000 },
+  ])("expires cached $kind lookups at their TTL", async ({ kind, ttlMs }) => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const fetchResource = kind === "channel" ? fetchMattermostChannel : fetchMattermostUser;
+    fetchResource.mockImplementation(async (_client, id: string) => ({ id }));
+    const resources = createMattermostMonitorResources({
+      accountId: "default",
+      callbackUrl: "https://openclaw.test/callback",
+      client: {} as never,
+      logger: {},
+      mediaMaxBytes: 1024,
+      saveRemoteMedia: vi.fn(),
+      mediaKindFromMime: () => "document",
+    });
+    const resolve = kind === "channel" ? resources.resolveChannelInfo : resources.resolveUserInfo;
+
+    await resolve(`${kind}-1`);
+    now.mockReturnValue(1_000 + ttlMs - 1);
+    await resolve(`${kind}-1`);
+    now.mockReturnValue(1_000 + ttlMs);
+    await resolve(`${kind}-1`);
+
+    expect(fetchResource).toHaveBeenCalledTimes(2);
+  });
+
   it("does not reuse cached lookups while the process clock is invalid", async () => {
     fetchMattermostChannel
       .mockResolvedValueOnce({ id: "chan-1", name: "old" })

--- a/extensions/mattermost/src/mattermost/monitor-resources.ts
+++ b/extensions/mattermost/src/mattermost/monitor-resources.ts
@@ -1,5 +1,6 @@
 // Mattermost plugin module implements monitor resources behavior.
 import { formatInboundMediaUnavailableText } from "openclaw/plugin-sdk/channel-inbound";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import {
   asDateTimestampMs,
   resolveExpiresAtMsFromDurationMs,
@@ -43,6 +44,7 @@ export function formatMattermostInboundMediaText(params: {
 
 const CHANNEL_CACHE_TTL_MS = 5 * 60_000;
 const USER_CACHE_TTL_MS = 10 * 60_000;
+const MONITOR_RESOURCE_CACHE_MAX_ENTRIES = 1000;
 
 type SaveRemoteMedia = (params: {
   url: string;
@@ -98,7 +100,11 @@ export function createMattermostMonitorResources(params: {
   ): void => {
     const expiresAt = resolveExpiresAtMsFromDurationMs(ttlMs, { nowMs: rawNowMs });
     if (expiresAt !== undefined) {
+      // Concurrent misses can resolve the same key out of order. Reinsert on
+      // writes so the cap keeps the most recently resolved resources.
+      cache.delete(key);
       cache.set(key, { value, expiresAt });
+      pruneMapToMaxSize(cache, MONITOR_RESOURCE_CACHE_MAX_ENTRIES);
     }
   };
 

--- a/extensions/mattermost/src/mattermost/send.test.ts
+++ b/extensions/mattermost/src/mattermost/send.test.ts
@@ -744,3 +744,93 @@ describe("sendMessageMattermost user-first resolution", () => {
     expect(retryCall?.[2]?.initialDelayMs).toBe(1000);
   });
 });
+
+describe("sendMessageMattermost outbound cache bounds", () => {
+  const baseUrl = "https://mattermost.example.com";
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockState.resolveMattermostAccount.mockReturnValue({
+      accountId: "default",
+      botToken: "default-token",
+      baseUrl,
+      config: {},
+    });
+    mockState.createMattermostClient.mockReturnValue({});
+    mockState.createMattermostPost.mockResolvedValue({ id: "post-id" });
+    mockState.createMattermostDirectChannelWithRetry.mockImplementation(
+      async (_client, userIds: string[]) => ({ id: `dm-${userIds[1]}` }),
+    );
+    mockState.fetchMattermostMe.mockResolvedValue({ id: "bot-id" });
+    mockState.fetchMattermostUserByUsername.mockImplementation(
+      async (_client, username: string) => ({
+        id: `user-${username}`,
+      }),
+    );
+    mockState.fetchMattermostUserTeams.mockResolvedValue([{ id: "team-id" }]);
+    mockState.fetchMattermostChannelByName.mockImplementation(
+      async (_client, _teamId: string, name: string) => ({ id: `channel-${name}` }),
+    );
+    ({ sendMessageMattermost } = await import("./send.js"));
+  });
+
+  const send = async (to: string, token: string) =>
+    await sendMessageMattermost(to, "hello", {
+      cfg: TEST_CFG,
+      botToken: token,
+      baseUrl,
+    });
+
+  it("bounds DM channel entries without refreshing insertion order on reads", async () => {
+    const token = "dm-cache-token";
+    for (let index = 0; index < 1024; index += 1) {
+      await send(`user:user-${index}`, token);
+    }
+    await send("user:user-0", token);
+    await send("user:user-1024", token);
+    await send("user:user-0", token);
+    await send("user:user-1024", token);
+
+    expect(mockState.createMattermostDirectChannelWithRetry).toHaveBeenCalledTimes(1026);
+  });
+
+  it("bounds username entries and retains the newest resolved target", async () => {
+    const token = "username-cache-token";
+    for (let index = 0; index < 1024; index += 1) {
+      await send(`@name-${index}`, token);
+    }
+    await send("@name-0", token);
+    await send("@name-1024", token);
+    await send("@name-0", token);
+    await send("@name-1024", token);
+
+    expect(mockState.fetchMattermostUserByUsername).toHaveBeenCalledTimes(1026);
+    expect(mockState.createMattermostDirectChannelWithRetry).toHaveBeenCalledTimes(1026);
+  });
+
+  it("bounds channel-name entries and retains the newest resolved target", async () => {
+    const token = "channel-cache-token";
+    for (let index = 0; index < 1024; index += 1) {
+      await send(`#channel-${index}`, token);
+    }
+    await send("#channel-0", token);
+    await send("#channel-1024", token);
+    await send("#channel-0", token);
+    await send("#channel-1024", token);
+
+    expect(mockState.fetchMattermostChannelByName).toHaveBeenCalledTimes(1026);
+  });
+
+  it("bounds bot-user entries independently from DM channel entries", async () => {
+    for (let index = 0; index < 64; index += 1) {
+      await send(`user:user-${index}`, `bot-cache-token-${index}`);
+    }
+    await send("user:probe-before-overflow", "bot-cache-token-0");
+    await send("user:user-64", "bot-cache-token-64");
+    await send("user:probe-after-overflow", "bot-cache-token-0");
+    await send("user:newest-probe", "bot-cache-token-64");
+
+    expect(mockState.fetchMattermostMe).toHaveBeenCalledTimes(66);
+  });
+});

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -4,6 +4,7 @@ import {
   type MessageReceipt,
   type MessageReceiptPartKind,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -67,10 +68,20 @@ type MattermostTarget =
   | { kind: "channel-name"; name: string }
   | { kind: "user"; id?: string; username?: string };
 
+const MATTERMOST_BOT_USER_CACHE_MAX_ENTRIES = 64;
+const MATTERMOST_TARGET_CACHE_MAX_ENTRIES = 1024;
 const botUserCache = new Map<string, MattermostUser>();
 const userByNameCache = new Map<string, MattermostUser>();
 const channelByNameCache = new Map<string, string>();
 const dmChannelCache = new Map<string, string>();
+
+function cacheOutboundEntry<K, V>(cache: Map<K, V>, key: K, value: V, maxEntries: number): void {
+  // Cache reads stay insertion ordered; only a newly resolved value refreshes
+  // recency before the oldest retained entry is pruned.
+  cache.delete(key);
+  cache.set(key, value);
+  pruneMapToMaxSize(cache, maxEntries);
+}
 
 const getCore = () => getMattermostRuntime();
 
@@ -203,7 +214,7 @@ async function resolveBotUser(
   }
   const client = createMattermostClient({ baseUrl, botToken: token, allowPrivateNetwork });
   const user = await fetchMattermostMe(client);
-  botUserCache.set(key, user);
+  cacheOutboundEntry(botUserCache, key, user, MATTERMOST_BOT_USER_CACHE_MAX_ENTRIES);
   return user;
 }
 
@@ -225,7 +236,7 @@ async function resolveUserIdByUsername(params: {
     allowPrivateNetwork: params.allowPrivateNetwork,
   });
   const user = await fetchMattermostUserByUsername(client, username);
-  userByNameCache.set(key, user);
+  cacheOutboundEntry(userByNameCache, key, user, MATTERMOST_TARGET_CACHE_MAX_ENTRIES);
   return user.id;
 }
 
@@ -252,7 +263,12 @@ async function resolveChannelIdByName(params: {
     try {
       const channel = await fetchMattermostChannelByName(client, team.id, name);
       if (channel?.id) {
-        channelByNameCache.set(key, channel.id);
+        cacheOutboundEntry(
+          channelByNameCache,
+          key,
+          channel.id,
+          MATTERMOST_TARGET_CACHE_MAX_ENTRIES,
+        );
         return channel.id;
       }
     } catch {
@@ -344,7 +360,7 @@ async function resolveTargetChannelId(params: ResolveTargetChannelIdParams): Pro
   });
   params.onDmChannelResolution?.(resolution);
   const channel = await resolution;
-  dmChannelCache.set(dmKey, channel.id);
+  cacheOutboundEntry(dmChannelCache, dmKey, channel.id, MATTERMOST_TARGET_CACHE_MAX_ENTRIES);
   return channel.id;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Mattermost kept six process-local resource caches without cardinality bounds:

- per-monitor channel and user lookups;
- outbound bot identity, username, channel-name, and DM-channel lookups.

Long-lived gateways that encounter many distinct servers, credentials, channels, or users could therefore retain those entries indefinitely. The opaque-target classifier is no longer part of this PR because #103258 already landed its canonical cap on `main`.

## Why This Change Was Made

The remaining cache owners now use the shared `pruneMapToMaxSize` plugin SDK helper after successful writes:

| Cache | Maximum entries |
| --- | ---: |
| Monitor channel | 1,000 |
| Monitor user | 1,000 |
| Outbound bot identity | 64 |
| Outbound username | 1,024 |
| Outbound channel name | 1,024 |
| Outbound DM channel | 1,024 |

Reads intentionally do not refresh insertion order. A newly resolved write moves that key to the newest position before pruning, which also gives deterministic behavior when concurrent misses resolve out of order. Existing five-minute channel and ten-minute user TTL behavior is unchanged.

## User Impact

Mattermost gateways now keep these lookup caches within fixed memory bounds. Eviction is transparent: a later lookup follows the existing API-resolution path and repopulates the entry. Configuration, routing, send behavior, and public plugin APIs are unchanged.

## Evidence

- Exact repaired head: `4486068b493f2c7289b2b8015ade713d349415f9`.
- Deterministic regressions fill every cache to its cap, prove the oldest entry is evicted, and prove the newest entry remains cached.
- Monitor tests cover both channel and user caches and the exact TTL boundary.
- Fresh post-rebase Codex autoreview: no accepted or actionable findings, confidence 0.90.
- Hosted CI run `29072789577`: 43 jobs succeeded and 12 conditional jobs skipped, with no failures.
- CodeQL Critical Quality run `29072789602`: the selected channel-runtime boundary passed.
- Blacksmith Testbox-through-Crabbox run `29073327959` (`tbx_01kx5am65jxqh2wswd42ms2cwe`): both touched files passed, 2 files / 48 tests.

- [x] AI-assisted
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
