### PR TITLE
fix(line): cap user profile cache

### DIFF
--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -1,6 +1,8 @@
 // Line tests cover send plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import "./user-profile-cache.js";
+import { resetLineUserProfileCacheForTests } from "./user-profile-cache.test-helpers.js";
 
 const {
   pushMessageMock,
@@ -114,6 +116,7 @@ describe("LINE send helpers", () => {
 
   beforeEach(() => {
     vi.setSystemTime(fixedSentAt);
+    resetLineUserProfileCacheForTests();
     pushMessageMock.mockReset();
     replyMessageMock.mockReset();
     showLoadingAnimationMock.mockReset();
@@ -451,6 +454,62 @@ describe("LINE send helpers", () => {
       pictureUrl: "https://example.com/peter.jpg",
     });
     expect(second).toEqual(first);
+    expect(getProfileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts oldest profile cache entries once the cache exceeds its cap", async () => {
+    getProfileMock.mockImplementation(async (userId: string) => ({
+      displayName: `User ${userId}`,
+      pictureUrl: undefined,
+    }));
+
+    // Production inbound path resolves names through getUserDisplayName → getUserProfile.
+    const firstUserId = "U-first";
+    await expect(sendModule.getUserDisplayName(firstUserId, { cfg: LINE_TEST_CFG })).resolves.toBe(
+      `User ${firstUserId}`,
+    );
+    expect(getProfileMock).toHaveBeenCalledTimes(1);
+
+    for (let i = 1; i <= 1024; i += 1) {
+      await sendModule.getUserDisplayName(`U-fill-${i}`, { cfg: LINE_TEST_CFG });
+    }
+    expect(getProfileMock).toHaveBeenCalledTimes(1025);
+
+    getProfileMock.mockClear();
+    await expect(sendModule.getUserDisplayName(firstUserId, { cfg: LINE_TEST_CFG })).resolves.toBe(
+      `User ${firstUserId}`,
+    );
+    expect(getProfileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps recently touched profile entries under the cache cap", async () => {
+    getProfileMock.mockImplementation(async (userId: string) => ({
+      displayName: `User ${userId}`,
+      pictureUrl: undefined,
+    }));
+
+    await sendModule.getUserDisplayName("U-keep", { cfg: LINE_TEST_CFG });
+    for (let i = 1; i <= 1023; i += 1) {
+      await sendModule.getUserDisplayName(`U-fill-${i}`, { cfg: LINE_TEST_CFG });
+    }
+    expect(getProfileMock).toHaveBeenCalledTimes(1024);
+
+    // Touch moves U-keep to newest insertion order before the next write prunes.
+    await sendModule.getUserDisplayName("U-keep", { cfg: LINE_TEST_CFG });
+    expect(getProfileMock).toHaveBeenCalledTimes(1024);
+
+    await sendModule.getUserDisplayName("U-new", { cfg: LINE_TEST_CFG });
+    expect(getProfileMock).toHaveBeenCalledTimes(1025);
+
+    getProfileMock.mockClear();
+    await expect(sendModule.getUserDisplayName("U-keep", { cfg: LINE_TEST_CFG })).resolves.toBe(
+      "User U-keep",
+    );
+    expect(getProfileMock).toHaveBeenCalledTimes(0);
+
+    await expect(sendModule.getUserDisplayName("U-fill-1", { cfg: LINE_TEST_CFG })).resolves.toBe(
+      "User U-fill-1",
+    );
     expect(getProfileMock).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -11,6 +11,7 @@ import { resolveLineChannelAccessToken } from "./channel-access-token.js";
 import { validateLineMediaUrl } from "./outbound-media.js";
 import { createLineSendReceipt } from "./send-receipt.js";
 import type { LineSendResult } from "./types.js";
+import { readCachedLineUserProfile, writeCachedLineUserProfile } from "./user-profile-cache.js";
 
 type Message = messagingApi.Message;
 type TextMessage = messagingApi.TextMessage;
@@ -23,12 +24,6 @@ type FlexContainer = messagingApi.FlexContainer;
 type TemplateMessage = messagingApi.TemplateMessage;
 type QuickReply = messagingApi.QuickReply;
 type QuickReplyItem = messagingApi.QuickReplyItem;
-
-const userProfileCache = new Map<
-  string,
-  { displayName: string; pictureUrl?: string; fetchedAt: number }
->();
-const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000;
 
 interface LineSendOpts {
   cfg: OpenClawConfig;
@@ -496,9 +491,9 @@ export async function getUserProfile(
   const useCache = opts.useCache ?? true;
 
   if (useCache) {
-    const cached = userProfileCache.get(userId);
-    if (cached && Date.now() - cached.fetchedAt < PROFILE_CACHE_TTL_MS) {
-      return { displayName: cached.displayName, pictureUrl: cached.pictureUrl };
+    const cached = readCachedLineUserProfile(userId);
+    if (cached) {
+      return cached;
     }
   }
 
@@ -511,10 +506,7 @@ export async function getUserProfile(
       pictureUrl: profile.pictureUrl,
     };
 
-    userProfileCache.set(userId, {
-      ...result,
-      fetchedAt: Date.now(),
-    });
+    writeCachedLineUserProfile(userId, result);
 
     return result;
   } catch (err) {

--- a/extensions/line/src/user-profile-cache.test-helpers.ts
+++ b/extensions/line/src/user-profile-cache.test-helpers.ts
@@ -1,0 +1,13 @@
+// Test-only helpers for the LINE user profile cache.
+const LINE_USER_PROFILE_CACHE_TEST_API = Symbol.for("openclaw.lineUserProfileCacheTestApi");
+
+type LineUserProfileCacheTestApi = {
+  reset(): void;
+};
+
+export function resetLineUserProfileCacheForTests(): void {
+  const api = (globalThis as Record<PropertyKey, unknown>)[LINE_USER_PROFILE_CACHE_TEST_API] as
+    | LineUserProfileCacheTestApi
+    | undefined;
+  api?.reset();
+}

--- a/extensions/line/src/user-profile-cache.ts
+++ b/extensions/line/src/user-profile-cache.ts
@@ -1,0 +1,49 @@
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
+
+const LINE_USER_PROFILE_CACHE_MAX_ENTRIES = 1024;
+const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000;
+const LINE_USER_PROFILE_CACHE_TEST_API = Symbol.for("openclaw.lineUserProfileCacheTestApi");
+
+type LineUserProfileCacheEntry = {
+  displayName: string;
+  pictureUrl?: string;
+  fetchedAt: number;
+};
+
+const userProfileCache = new Map<string, LineUserProfileCacheEntry>();
+
+type LineUserProfileCacheTestApi = {
+  reset(): void;
+};
+
+(globalThis as Record<PropertyKey, unknown>)[LINE_USER_PROFILE_CACHE_TEST_API] = {
+  reset() {
+    userProfileCache.clear();
+  },
+} satisfies LineUserProfileCacheTestApi;
+
+function touchLineUserProfileCache(userId: string, value: LineUserProfileCacheEntry): void {
+  // Delete + set refreshes Map insertion order so active users survive pruneMapToMaxSize
+  // eviction (same LRU-on-access pattern as Slack conversation-info cache).
+  userProfileCache.delete(userId);
+  userProfileCache.set(userId, value);
+  pruneMapToMaxSize(userProfileCache, LINE_USER_PROFILE_CACHE_MAX_ENTRIES);
+}
+
+export function readCachedLineUserProfile(
+  userId: string,
+): { displayName: string; pictureUrl?: string } | undefined {
+  const cached = userProfileCache.get(userId);
+  if (!cached || Date.now() - cached.fetchedAt >= PROFILE_CACHE_TTL_MS) {
+    return undefined;
+  }
+  touchLineUserProfileCache(userId, cached);
+  return { displayName: cached.displayName, pictureUrl: cached.pictureUrl };
+}
+
+export function writeCachedLineUserProfile(
+  userId: string,
+  profile: { displayName: string; pictureUrl?: string },
+): void {
+  touchLineUserProfileCache(userId, { ...profile, fetchedAt: Date.now() });
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an unbounded in-process `userProfileCache` in the LINE send path (`extensions/line/src/send.ts`). Profile lookups are cached for 5 minutes (TTL) but had no entry-count cap, so gateways serving many distinct LINE users accumulate Map entries indefinitely until process restart.

**Concrete scenario:** A LINE gateway processing inbound messages from 10 000 distinct users over several hours caches each `getUserProfile` result. With no size cap, the cache grows without bound.

## Why This Change Was Made

Adds a 1 024-entry cap via the existing `pruneMapToMaxSize` helper from `openclaw/plugin-sdk/collection-runtime`, matching Slack / Discord / Nextcloud Talk channel caches.

`touchLineUserProfileCache` deletes + sets so Map insertion order refreshes on both write and TTL-valid read hits (same LRU-on-access pattern as `extensions/slack/src/channel-type.ts`). Active users stay under the cap; idle oldest-inserted entries evict first.

No config/env knobs. TTL behavior is unchanged.

## User Impact

**Before:** Long-lived LINE gateways accumulate one `userProfileCache` entry per distinct user indefinitely.

**After:** Cache stays at ≤ 1 024 entries. Recently touched profiles survive eviction; untouched oldest entries are pruned. First 1 024 distinct users behave as before until the cap is exceeded.

## Evidence

- `extensions/line/src/send.ts` — `LINE_USER_PROFILE_CACHE_MAX_ENTRIES = 1024`, `touchLineUserProfileCache` (delete + set + `pruneMapToMaxSize`) on write and TTL hit
- `extensions/line/src/monitor.ts` — inbound path calls `getUserDisplayName` → `getUserProfile`
- Sibling pattern: `extensions/slack/src/channel-type.ts` (`getCachedSlackConversationInfo` / `setCachedSlackConversationInfo`)
- Shared helper: `src/infra/map-size.ts` via `openclaw/plugin-sdk/collection-runtime` (`pruneMapToMaxSize`)
- Regression: `extensions/line/src/send.test.ts`
  - eviction past cap via `getUserDisplayName`
  - recently touched entry retained under cap

### Caller-path Vitest

```bash
node scripts/run-vitest.mjs extensions/line/src/send.test.ts --reporter=verbose
```

```text
 ✓ |extension-line| extensions/line/src/send.test.ts > LINE send helpers > caches profile results by default 0ms
 ✓ |extension-line| extensions/line/src/send.test.ts > LINE send helpers > evicts oldest profile cache entries once the cache exceeds its cap 8ms
 ✓ |extension-line| extensions/line/src/send.test.ts > LINE send helpers > keeps recently touched profile entries under the cache cap 9ms

 Test Files  1 passed (1)
      Tests  18 passed (18)
[test] passed 1 Vitest shard in 8.64s
```

## Real behavior proof

- **Behavior or issue addressed:** LINE user-profile Map no longer grows without bound; active entries refresh insertion order so they survive pruning.
- **Canonical reachability path:**

```text
LINE inbound webhook (monitor)
  → getUserDisplayName(userId)
  → getUserProfile(userId)
  → touchLineUserProfileCache (delete + set)
  → pruneMapToMaxSize(userProfileCache, 1024)
```

- **Boundary crossed:** local-runtime; production `getUserDisplayName` / `getUserProfile` / `touchLineUserProfileCache` through the real unmocked `pruneMapToMaxSize` from `openclaw/plugin-sdk/collection-runtime`. Only `@line/bot-sdk` `MessagingApiClient.getProfile` is stubbed (no live LINE credentials in this environment). There is no DI seam for the Messaging API client; production constructs `new messagingApi.MessagingApiClient(...)` inside `createLineMessagingClient`.
- **Shared helper / provider constraint check:** Cap and LRU-on-access match Slack conversation-info and other channel `pruneMapToMaxSize` caches. No new config/env surface.
- **Real environment tested:** macOS Darwin 24.3.0 arm64, Node v22.22.0, pnpm 11.2.2, branch `fix/line-cap-user-profile-cache` rebased onto `upstream/main` (head `72708ef81051498a04177d33a5e57dc21903b3ec`).
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/line/src/send.test.ts --reporter=verbose

# Standalone production-path proof (real send.ts cache + real pruneMapToMaxSize;
# only MessagingApiClient.getProfile stubbed via Node module loader):
OPENCLAW_ROOT=/tmp/openclaw-pr-fixes/101741 \
  node --import tsx \
  --import /tmp/line-user-profile-cache-proof/register-line-bot-sdk-stub.mjs \
  /tmp/line-user-profile-cache-proof/line-user-profile-cache-proof.mts
```

- **Evidence after fix (Vitest):**

```text
 ✓ caches profile results by default
 ✓ evicts oldest profile cache entries once the cache exceeds its cap 8ms
 ✓ keeps recently touched profile entries under the cache cap 9ms
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

- **Evidence after fix (standalone, non-Vitest production path):**

```text
{"proof":"line-user-profile-cache-cap","root":"/tmp/openclaw-pr-fixes/101741","boundary":"@line/bot-sdk MessagingApiClient.getProfile stub only","production":["getUserDisplayName","getUserProfile","touchLineUserProfileCache","pruneMapToMaxSize"],"liveLineGateway":false}
{"step":"eviction","ok":true,"detail":"U-first evicted after 1024 newer inserts; refetch required"}
{"step":"lru-retention","ok":true,"detail":"U-keep survived prune after touch; U-fill-1 evicted"}
{"RESULT":"pass","liveLineGateway":false}
```

Regression flow (caller path `getUserDisplayName`):

1. Resolve `U-first` → 1 API call, cached
2. Resolve `U-fill-1` … `U-fill-1024` → 1 024 more API calls; `U-first` evicted at cap
3. Resolve `U-first` again → 1 API call (eviction proven)

LRU retention flow:

1. Fill cache to 1 024 including `U-keep`
2. Touch `U-keep` (0 extra API calls; insertion order refreshed)
3. Insert `U-new` → oldest untouched (`U-fill-1`) evicted; `U-keep` still cached (0 API calls)

- **What was not tested:** Live LINE gateway / Messaging API with real channel access tokens. No redacted live LINE webhook transcript under sustained distinct-user traffic. Optional supplemental proof: gateway log showing cache size stabilizing at ≤ 1 024 under real LINE inbound load.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor / Grok)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
