### PR TITLE
fix(feishu): cap sender-name and streaming token caches

### DIFF
--- a/extensions/feishu/src/bot-sender-name.test.ts
+++ b/extensions/feishu/src/bot-sender-name.test.ts
@@ -1,6 +1,6 @@
 // Feishu tests cover bot sender name plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveFeishuSenderName } from "./bot-sender-name.js";
+import { resetFeishuSenderNameCacheForTests, resolveFeishuSenderName } from "./bot-sender-name.js";
 import { FeishuConfigSchema } from "./config-schema.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
@@ -35,6 +35,7 @@ function mockUserNames(...names: string[]): ReturnType<typeof vi.fn> {
 describe("resolveFeishuSenderName", () => {
   afterEach(() => {
     vi.useRealTimers();
+    resetFeishuSenderNameCacheForTests();
     createFeishuClientMock.mockReset();
   });
 
@@ -64,5 +65,21 @@ describe("resolveFeishuSenderName", () => {
     ).resolves.toEqual({ name: "Grace" });
 
     expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts oldest sender name cache entries once the cache exceeds its cap", async () => {
+    const get = mockUserNames(...Array.from({ length: 502 }, (_, index) => `User ${index}`));
+
+    await resolveFeishuSenderName({ account, senderId: "ou_first", log: vi.fn() });
+    expect(get).toHaveBeenCalledTimes(1);
+
+    for (let i = 1; i <= 500; i += 1) {
+      await resolveFeishuSenderName({ account, senderId: `ou_fill_${i}`, log: vi.fn() });
+    }
+    expect(get).toHaveBeenCalledTimes(501);
+
+    get.mockClear();
+    await resolveFeishuSenderName({ account, senderId: "ou_first", log: vi.fn() });
+    expect(get).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/feishu/src/bot-sender-name.ts
+++ b/extensions/feishu/src/bot-sender-name.ts
@@ -1,3 +1,4 @@
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 // Feishu plugin module implements bot sender name behavior.
 import {
   asDateTimestampMs,
@@ -29,7 +30,16 @@ const FEISHU_SCOPE_CORRECTIONS: Record<string, string> = {
   "contact:contact.base:readonly": "contact:user.base:readonly",
 };
 const SENDER_NAME_TTL_MS = 10 * 60 * 1000;
+const SENDER_NAME_CACHE_MAX_ENTRIES = 500;
 const senderNameCache = new Map<string, { name: string; expireAt: number }>();
+
+function cacheFeishuSenderName(senderId: string, name: string, expireAt: number): void {
+  if (senderNameCache.has(senderId)) {
+    senderNameCache.delete(senderId);
+  }
+  senderNameCache.set(senderId, { name, expireAt });
+  pruneMapToMaxSize(senderNameCache, SENDER_NAME_CACHE_MAX_ENTRIES);
+}
 
 function correctFeishuScopeInUrl(url: string): string {
   let corrected = url;
@@ -116,7 +126,7 @@ export async function resolveFeishuSenderName(params: {
     if (name) {
       const expireAt = resolveExpiresAtMsFromDurationMs(SENDER_NAME_TTL_MS);
       if (expireAt !== undefined) {
-        senderNameCache.set(normalizedSenderId, { name, expireAt });
+        cacheFeishuSenderName(normalizedSenderId, name, expireAt);
       }
       return { name };
     }
@@ -134,4 +144,8 @@ export async function resolveFeishuSenderName(params: {
     log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${String(err)}`);
     return {};
   }
+}
+
+export function resetFeishuSenderNameCacheForTests(): void {
+  senderNameCache.clear();
 }

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FEISHU_JSON_MAX_BYTES } from "./json-response.js";
 import {
   FeishuStreamingSession,
+  resetFeishuStreamingTokenCacheForTests,
   type FeishuStreamingFetch,
   mergeStreamingText,
   resolveStreamingCardSendMode,
@@ -208,6 +209,7 @@ function setStreamingSessionInternals(
 describe("FeishuStreamingSession", () => {
   beforeEach(() => {
     vi.useRealTimers();
+    resetFeishuStreamingTokenCacheForTests();
   });
 
   afterEach(async () => {
@@ -855,6 +857,42 @@ describe("FeishuStreamingSession", () => {
 
     expect(authTokens).toEqual(["token-1", "token-2"]);
     dateNow.mockRestore();
+  });
+
+  it("evicts oldest streaming token cache entries once the cache exceeds its cap", async () => {
+    const { authTokens, client, deps } = mockStreamingTokenStart((token) => ({
+      code: 0,
+      msg: "ok",
+      tenant_access_token: token,
+      expire: 7200,
+    }));
+
+    await new FeishuStreamingSession(
+      client,
+      { appId: "app-first", appSecret: "secret" },
+      undefined,
+      deps,
+    ).start("chat_id", "open_id");
+    expect(authTokens).toHaveLength(1);
+
+    for (let i = 1; i <= 256; i += 1) {
+      await new FeishuStreamingSession(
+        client,
+        { appId: `app-fill-${i}`, appSecret: "secret" },
+        undefined,
+        deps,
+      ).start("chat_id", "open_id");
+    }
+    expect(authTokens).toHaveLength(257);
+
+    authTokens.length = 0;
+    await new FeishuStreamingSession(
+      client,
+      { appId: "app-first", appSecret: "secret" },
+      undefined,
+      deps,
+    ).start("chat_id", "open_id");
+    expect(authTokens).toEqual(["token-1"]);
   });
 });
 

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Client } from "@larksuiteoapi/node-sdk";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import {
   asDateTimestampMs,
   resolveDateTimestampMs,
@@ -62,6 +63,7 @@ const STREAMING_SIGNIFICANT_DELTA_CHARS = 18;
 const FEISHU_STREAMING_TOKEN_DEFAULT_LIFETIME_SECONDS = 7200;
 
 // Token cache (keyed by domain + appId)
+const STREAMING_TOKEN_CACHE_MAX_ENTRIES = 256;
 const tokenCache = new Map<string, { token: string; expiresAt: number }>();
 
 function resolveStreamingTokenExpiresAt(value: unknown, nowMs = Date.now()): number {
@@ -142,10 +144,14 @@ async function getToken(creds: Credentials, deps?: FeishuStreamingDeps): Promise
   if (data.code !== 0 || !data.tenant_access_token) {
     throw new Error(`Token error: ${data.msg}`);
   }
+  if (tokenCache.has(key)) {
+    tokenCache.delete(key);
+  }
   tokenCache.set(key, {
     token: data.tenant_access_token,
     expiresAt: resolveStreamingTokenExpiresAt(data.expire, now),
   });
+  pruneMapToMaxSize(tokenCache, STREAMING_TOKEN_CACHE_MAX_ENTRIES);
   return data.tenant_access_token;
 }
 
@@ -221,6 +227,10 @@ export function resolveStreamingCardSendMode(options?: StreamingStartOptions) {
 }
 
 /** Streaming card session manager */
+export function resetFeishuStreamingTokenCacheForTests(): void {
+  tokenCache.clear();
+}
+
 export class FeishuStreamingSession {
   private client: Client;
   private creds: Credentials;


### PR DESCRIPTION
## What Problem This Solves

Fixes two unbounded in-process Maps in the Feishu plugin:

1. **`senderNameCache`** — sender display name lookups with no eviction under high message volume.
2. **`tokenCache`** — streaming-card tenant access token cache with no eviction.

## Why This Change Was Made

Applies `pruneMapToMaxSize` after each cache write: sender names capped at **500**, streaming tokens at **256**, both with LRU eviction.

## User Impact

Long-lived Feishu gateways get bounded in-process cache memory for sender names and streaming tenant tokens. Behavior is unchanged until each cap is exceeded; oldest entries are evicted.

## Evidence

- `extensions/feishu/src/bot-sender-name.ts:33–41` — `SENDER_NAME_CACHE_MAX_ENTRIES = 500`, prune after each `.set`
- `extensions/feishu/src/streaming-card.ts:66–67,147–154` — `STREAMING_TOKEN_CACHE_MAX_ENTRIES = 256`, prune after token cache write
- Diff: production changes in `bot-sender-name.ts` and `streaming-card.ts`; regressions in matching `*.test.ts`

### Behavior proof

#### 1) Call-site regression tests (real Vitest stdout)

```text
$ pnpm test extensions/feishu/src/bot-sender-name.test.ts extensions/feishu/src/streaming-card.test.ts --reporter=verbose

 ✓ resolveFeishuSenderName > evicts oldest sender name cache entries once the cache exceeds its cap 3ms
 ✓ FeishuStreamingSession > evicts oldest streaming token cache entries once the cache exceeds its cap 41ms

 Test Files  2 passed (2)
      Tests  25 passed (25)
   Duration  2.22s (transform 1.01s, setup 20ms, import 1.97s, tests 160ms, environment 0ms)

[test] passed 1 Vitest shard in 5.70s
```

Existing streaming-card bound proofs in the same run still pass (oversized tenant-token / card-create JSON rejected before full buffer):

```text
[feishu streaming-card bound proof] token over-cap: bytes_pulled=18874430 cap=16777216 canceled=true
[feishu streaming-card bound proof] card-create over-cap: bytes_pulled=19923006 cap=16777216 canceled=true
```

**Proof gap:** No redacted live Feishu gateway traffic or tenant-token fetch logs in this validation environment.
